### PR TITLE
docs: switch max iterations page to violet theme

### DIFF
--- a/docs-site/app/max-iterations/page.tsx
+++ b/docs-site/app/max-iterations/page.tsx
@@ -98,17 +98,17 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200">
+      <header className="bg-gray-900 border-b border-gray-800">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div className="flex items-center">
-              <Link href="/" className="flex items-center text-gray-600 hover:text-gray-900 mr-8">
+              <Link href="/" className="flex items-center text-gray-400 hover:text-white mr-8">
                 <ChevronLeft className="w-5 h-5 mr-1" />
                 Back to Docs
               </Link>
-              <h1 className="text-2xl font-bold text-gray-900">max_iterations Guide</h1>
+              <h1 className="text-2xl font-bold text-white">max_iterations Guide</h1>
             </div>
           </div>
         </div>
@@ -117,7 +117,7 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}
-        <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl p-8 mb-12 text-white">
+        <div className="bg-gradient-to-r from-violet-900/20 to-purple-900/20 border border-violet-500/30 rounded-2xl p-8 mb-12 text-white">
           <div className="max-w-3xl">
             <h2 className="text-3xl font-bold mb-4">Control Your Agent's Power</h2>
             <p className="text-xl mb-6">
@@ -143,13 +143,13 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
 
         {/* What Are Iterations */}
         <section className="mb-12">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">What Are Iterations?</h2>
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <p className="text-gray-700 mb-4">
+          <h2 className="text-2xl font-bold text-white mb-4">What Are Iterations?</h2>
+          <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+            <p className="text-gray-300 mb-4">
               Think of iterations as "attempts" - how many times your agent can use tools to complete a task.
             </p>
-            <div className="bg-gray-50 rounded-lg p-4 font-mono text-sm">
-              <div className="text-gray-600">
+            <div className="bg-gray-800 rounded-lg p-4 font-mono text-sm">
+              <div className="text-gray-300">
                 # Your agent tries to complete the task<br/>
                 # Iteration 1: "I need to search for info" → calls search tool<br/>
                 # Iteration 2: "Now I'll calculate something" → calls calculate tool<br/>
@@ -162,20 +162,20 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
 
         {/* Quick Start */}
         <section className="mb-12">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">Quick Start - Super Simple</h2>
-          
+          <h2 className="text-2xl font-bold text-white mb-4">Quick Start - Super Simple</h2>
+
           <div className="grid md:grid-cols-3 gap-6">
             {/* Basic Usage */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 The Basics (90% of cases)
               </h3>
-              <pre className="bg-gray-50 rounded p-3 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-3 text-sm overflow-x-auto mb-3">
                 <code>{examples.basic}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.basic, 'basic')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'basic' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -187,16 +187,16 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
             </div>
 
             {/* Complex Tasks */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 When You Need More Power
               </h3>
-              <pre className="bg-gray-50 rounded p-3 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-3 text-sm overflow-x-auto mb-3">
                 <code>{examples.complex}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.complex, 'complex')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'complex' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -208,16 +208,16 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
             </div>
 
             {/* Override */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 Quick Override for One Task
               </h3>
-              <pre className="bg-gray-50 rounded p-3 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-3 text-sm overflow-x-auto mb-3">
                 <code>{examples.override}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.override, 'override')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'override' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -232,23 +232,23 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
 
         {/* Real Examples */}
         <section className="mb-12">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">Real Examples</h2>
-          
+          <h2 className="text-2xl font-bold text-white mb-4">Real Examples</h2>
+
           <div className="space-y-6">
             {/* Calculator Example */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 Simple Calculator Bot
               </h3>
-              <p className="text-gray-600 mb-3">
+              <p className="text-gray-300 mb-3">
                 Calculator needs very few iterations - math is straightforward.
               </p>
-              <pre className="bg-gray-50 rounded p-4 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-4 text-sm overflow-x-auto mb-3">
                 <code>{examples.calculator}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.calculator, 'calculator')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'calculator' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -260,16 +260,16 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
             </div>
 
             {/* Error Message */}
-            <div className="bg-yellow-50 rounded-lg border border-yellow-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-rose-900/20 rounded-lg border border-rose-500/30 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 What Happens When You Hit The Limit?
               </h3>
-              <div className="bg-white rounded p-4 font-mono text-sm mb-3">
-                <span className="text-red-600">
+              <div className="bg-gray-900 rounded p-4 font-mono text-sm mb-3">
+                <span className="text-red-400">
                   "Task incomplete: Maximum iterations (10) reached."
                 </span>
               </div>
-              <p className="text-gray-700">
+              <p className="text-gray-300">
                 <strong>Solution:</strong> Simply increase max_iterations for that agent or specific task!
               </p>
             </div>
@@ -277,27 +277,27 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
         </section>
 
         {/* Cool Tricks */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4 flex items-center">
-            <Lightbulb className="w-6 h-6 mr-2 text-yellow-500" />
-            Cool Tricks & Advanced Patterns
-          </h2>
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold text-white mb-4 flex items-center">
+              <Lightbulb className="w-6 h-6 mr-2 text-purple-400" />
+              Cool Tricks & Advanced Patterns
+            </h2>
 
           <div className="grid md:grid-cols-2 gap-6">
             {/* Auto-Retry */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 Trick 1: Auto-Retry with Higher Limit
               </h3>
-              <p className="text-gray-600 mb-3">
+              <p className="text-gray-300 mb-3">
                 Automatically increases iterations if task fails.
               </p>
-              <pre className="bg-gray-50 rounded p-3 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-3 text-sm overflow-x-auto mb-3">
                 <code>{examples.autoRetry}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.autoRetry, 'autoRetry')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'autoRetry' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -309,19 +309,19 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
             </div>
 
             {/* Self-Adjusting */}
-            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+            <div className="bg-gray-900 rounded-lg border border-gray-700 p-6">
+              <h3 className="text-lg font-semibold text-white mb-3">
                 Trick 2: Self-Adjusting Agent
               </h3>
-              <p className="text-gray-600 mb-3">
+              <p className="text-gray-300 mb-3">
                 Agent that learns optimal iterations from history.
               </p>
-              <pre className="bg-gray-50 rounded p-3 text-sm overflow-x-auto mb-3">
+              <pre className="bg-gray-800 rounded p-3 text-sm overflow-x-auto mb-3">
                 <code>{examples.selfAdjusting}</code>
               </pre>
               <button
                 onClick={() => copyToClipboard(examples.selfAdjusting, 'selfAdjusting')}
-                className="flex items-center text-sm text-blue-600 hover:text-blue-700"
+                className="flex items-center text-sm text-purple-400 hover:text-purple-300"
               >
                 {copiedSection === 'selfAdjusting' ? (
                   <Check className="w-4 h-4 mr-1" />
@@ -335,80 +335,80 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
         </section>
 
         {/* Quick Reference Table */}
-        <section className="mb-12">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4 flex items-center">
-            <Gauge className="w-6 h-6 mr-2" />
-            Quick Reference
-          </h2>
-          
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
+          <section className="mb-12">
+            <h2 className="text-2xl font-bold text-white mb-4 flex items-center">
+              <Gauge className="w-6 h-6 mr-2 text-purple-400" />
+              Quick Reference
+            </h2>
+
+          <div className="bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
+            <table className="min-w-full divide-y divide-gray-700">
+              <thead className="bg-gray-800">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
                     What You're Doing
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
                     Iterations
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
                     Example
                   </th>
                 </tr>
               </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
+              <tbody className="bg-gray-900 divide-y divide-gray-800">
                 <tr>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">
                     Simple Q&A
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     3-5
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     "What's the weather?"
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">
                     Calculations
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     5-10
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     "Calculate my taxes"
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">
                     Multi-step tasks
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     10-20
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     "Search and summarize"
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">
                     Complex workflows
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     20-40
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     "Analyze all data and generate report"
                   </td>
                 </tr>
                 <tr>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-white">
                     Research projects
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     30-50
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-400">
                     "Research topic from multiple sources"
                   </td>
                 </tr>
@@ -419,14 +419,14 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
 
         {/* One Minute Summary */}
         <section className="mb-12">
-          <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-lg border border-green-200 p-8">
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+          <div className="bg-gradient-to-r from-violet-900/20 to-purple-900/20 rounded-lg border border-violet-500/30 p-8">
+            <h2 className="text-2xl font-bold text-white mb-4">
               ⏱️ The One-Minute Summary
             </h2>
-            <ol className="space-y-2 text-gray-700">
+            <ol className="space-y-2 text-gray-300">
               <li className="flex items-start">
                 <span className="font-bold mr-2">1.</span>
-                Most agents are fine with default <code className="bg-white px-2 py-1 rounded">max_iterations=10</code>
+                Most agents are fine with default <code className="bg-gray-900 px-2 py-1 rounded">max_iterations=10</code>
               </li>
               <li className="flex items-start">
                 <span className="font-bold mr-2">2.</span>
@@ -434,7 +434,7 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
               </li>
               <li className="flex items-start">
                 <span className="font-bold mr-2">3.</span>
-                Override per-task when needed: <code className="bg-white px-2 py-1 rounded">agent.input(prompt, max_iterations=X)</code>
+                Override per-task when needed: <code className="bg-gray-900 px-2 py-1 rounded">agent.input(prompt, max_iterations=X)</code>
               </li>
               <li className="flex items-start">
                 <span className="font-bold mr-2">4.</span>
@@ -445,18 +445,18 @@ result = smart_input(agent, "Complex task")  # Auto-adjusts!`,
                 Advanced: Build smart agents that adjust limits automatically
               </li>
             </ol>
-            <p className="mt-6 text-lg font-semibold">
+            <p className="mt-6 text-lg font-semibold text-gray-200">
               That's it! You now know everything about iteration control. Start simple, adjust when needed! 🚀
             </p>
           </div>
         </section>
 
         {/* Navigation */}
-        <div className="flex justify-between items-center pt-8 border-t border-gray-200">
-          <Link href="/xray" className="text-blue-600 hover:text-blue-700 font-medium">
+        <div className="flex justify-between items-center pt-8 border-t border-gray-800">
+          <Link href="/xray" className="text-purple-400 hover:text-purple-300 font-medium">
             ← Previous: Xray Debugging
           </Link>
-          <Link href="/prompts" className="text-blue-600 hover:text-blue-700 font-medium">
+          <Link href="/prompts" className="text-purple-400 hover:text-purple-300 font-medium">
             Next: System Prompts →
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- rework max-iterations guide to use violet gradients and accents
- update copy buttons, icons, summary card, and navigation to purple palette
- convert error callout to rose tones for consistency

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)
- `npx playwright --version` (fails: 403 Forbidden installing package)


------
https://chatgpt.com/codex/tasks/task_e_68a2ac6db0348333b72b5e203d6aa6fa