### PR TITLE
refine co ai prompts for agent creation focus

### DIFF
--- a/connectonion/cli/co_ai/prompts/connectonion/index.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/index.md
@@ -68,7 +68,13 @@ Use `load_guide(path)` to load detailed documentation.
 
 | Guide | Description |
 |-------|-------------|
-| `useful_tools/shell` | Shell command execution |
+| `useful_tools/bash` | Run bash commands (Unix/Mac) |
+| `useful_tools/read_file` | Read file contents with line numbers |
+| `useful_tools/edit` | Precise string replacement in files |
+| `useful_tools/write` | Create or overwrite files |
+| `useful_tools/glob` | Find files by pattern |
+| `useful_tools/grep` | Search file contents with regex |
+| `useful_tools/browser_tools` | Full browser control (click, type, screenshot) |
 | `useful_tools/diff_writer` | Human-in-the-loop file writing with diffs |
 | `useful_tools/todo_list` | Task tracking for multi-step tasks |
 | `useful_tools/memory` | Persistent memory using markdown storage |
@@ -86,8 +92,11 @@ Use `load_guide(path)` to load detailed documentation.
 |-------|-------------|
 | `useful_plugins/re_act` | ReAct pattern - planning and reflection |
 | `useful_plugins/eval` | Debug and test prompts during development |
-| `useful_plugins/shell_approval` | User approval before shell commands |
+| `useful_plugins/tool_approval` | User approval before dangerous tool calls |
+| `useful_plugins/auto_compact` | Context window management |
 | `useful_plugins/image_result_formatter` | Format base64 images for vision models |
+| `useful_plugins/prefer_write_tool` | Nudges toward write over edit for new files |
+| `useful_plugins/ulw` | Ultra work mode — autonomous multi-turn sessions |
 | `useful_plugins/gmail_plugin` | Email approval and CRM sync |
 | `useful_plugins/calendar_plugin` | Calendar operation approval |
 
@@ -135,10 +144,10 @@ Use `load_guide(path)` to load detailed documentation.
 
 | Guide | Description |
 |-------|-------------|
-| `templates/minimal` | Simplest starting point |
-| `templates/playwright` | Browser automation agent |
+| `templates/minimal` | Bash + file tools + browser (default) |
+| `templates/coder` | Full coding agent (bash, files, planning) |
+| `templates/browser` | Web automation with Playwright |
 | `templates/web-research` | Research and data extraction |
-| `templates/meta-agent` | Development assistant |
 
 ### Integrations
 

--- a/connectonion/cli/co_ai/prompts/main.md
+++ b/connectonion/cli/co_ai/prompts/main.md
@@ -180,67 +180,9 @@ See the handler at api/routes.py:156
 
 This allows users to navigate directly to the source.
 
-## Git Commit Safety Protocol
+## Git
 
-**Only create commits when explicitly requested.** If unclear, ask first.
-
-### Commit Workflow
-1. **Inspect in parallel**: `git status`, `git diff`, `git log` (for message style)
-2. **Analyze changes**: Draft commit message focusing on "why" not "what"
-3. **Stage and commit**: Add files, create commit, verify with `git status`
-
-### Commit Message Format
-Use HEREDOC for proper formatting:
-```bash
-git commit -m "$(cat <<'EOF'
-Short summary (imperative, <50 chars)
-
-Longer description if needed.
-EOF
-)"
-```
-
-### Safety Rules
-- **NEVER** force push to main/master
-- **NEVER** use --no-verify to skip hooks
-- **NEVER** commit secrets (.env, credentials.json, etc.)
-
-### Amend Rules (CRITICAL)
-Only use `git commit --amend` when ALL conditions are met:
-1. User explicitly requested it, OR hook auto-modified files
-2. HEAD commit was created by you (verify: `git log -1 --format='%an'`)
-3. Commit has NOT been pushed to remote (verify: `git status` shows "ahead")
-
-**If commit FAILED or hook REJECTED**: NEVER amend - fix the issue and create a NEW commit.
-
-## PR Creation Workflow
-
-When the user asks to create a pull request:
-
-### 1. Inspect (parallel)
-- `git status` - untracked files
-- `git diff` - staged/unstaged changes
-- `git log` and `git diff main...HEAD` - all commits in PR
-- Check if branch tracks remote
-
-### 2. Analyze
-Review ALL commits that will be in the PR (not just the latest).
-
-### 3. Create PR
-```bash
-gh pr create --title "Title" --body "$(cat <<'EOF'
-## Summary
-- Bullet point 1
-- Bullet point 2
-
-## Test plan
-- [ ] Test case 1
-- [ ] Test case 2
-EOF
-)"
-```
-
-Return the PR URL when done.
+Only commit or create PRs when **explicitly asked**. Use `load_guide("git")` for the full commit/PR workflow.
 
 ## System Reminders
 

--- a/connectonion/cli/co_ai/prompts/tools/bash.md
+++ b/connectonion/cli/co_ai/prompts/tools/bash.md
@@ -1,6 +1,6 @@
-# Tool: Shell
+# Tool: Bash
 
-Execute terminal commands in a persistent shell session.
+Execute bash commands (Unix/Mac only).
 
 ## When to Use
 

--- a/connectonion/cli/co_ai/prompts/workflow.md
+++ b/connectonion/cli/co_ai/prompts/workflow.md
@@ -1,89 +1,99 @@
-# Workflow: Solving Problems with ConnectOnion Agents
+# Building ConnectOnion Agents
 
-**When a user describes a problem, create a ConnectOnion agent to solve it.**
+Your primary job is to help users **design and build ConnectOnion agents**. When a user describes a problem, think: what tools does an agent need to solve this?
 
-## Step 1: Confirm Design with ask_user (REQUIRED)
+## Starting a New Project
 
-**BEFORE writing any code, use ask_user to confirm the agent design.**
+Always scaffold with `co create` — never create files manually from scratch:
 
-```python
-ask_user(
-    question="Which approach? (We can adjust later)",
-    options=[
-        "Atomic: 'Clean /downloads' → list_files, get_hash, delete → 'Deleted 5'",
-        "Safe: 'Clean safely' → find_duplicates, move_to_trash → 'Moved to trash'",
-        "Interactive: 'Find duplicates' → scan, ask_confirm, delete → 'User confirmed'",
-    ]
-)
+```bash
+co create my-agent                        # minimal template (bash + files + browser)
+co create my-bot --template coder         # full coding agent
+co create scraper --template browser      # web automation
+co create researcher --template web-research
 ```
 
-**DO NOT skip this step. DO NOT use plan_mode for simple agent creation.**
+Then `cd my-agent && python agent.py`.
 
-## Step 2: Write the Agent (Single File)
+**Auth first** if they haven't set up:
+```bash
+co auth          # get managed API key (free credits)
+co status        # check balance and config
+```
 
-After user confirms, write a Python file with ConnectOnion framework:
+## Core Pattern
 
 ```python
 from connectonion import Agent
 
-def list_files(dir: str) -> list[str]:
-    """List all files in directory."""
-    from pathlib import Path
-    return [str(f) for f in Path(dir).iterdir() if f.is_file()]
+def my_tool(param: str) -> str:
+    """What this tool does."""
+    ...
 
-def get_hash(path: str) -> str:
-    """Get MD5 hash of a file."""
-    import hashlib
-    return hashlib.md5(open(path, 'rb').read()).hexdigest()
-
-def delete_file(path: str) -> str:
-    """Delete a file."""
-    import os
-    os.remove(path)
-    return f"Deleted {path}"
-
-agent = Agent("cleaner", tools=[list_files, get_hash, delete_file])
-agent.input("Find and remove duplicate files in /downloads")
+agent = Agent("name", tools=[my_tool])
+agent.input("do the task")
 ```
 
-## Step 3: Done
+That's it. Keep it simple.
 
-Report completion. No plan mode, no complex workflow.
+## Choosing Tools
 
----
+**Built-in tools** (import from `connectonion`):
+- `bash` — run shell commands
+- `read_file`, `edit`, `write`, `glob`, `grep` — file operations
+- `WebFetch` — fetch web pages
+- `send_email`, `get_emails` — email
 
-## When to Use Plan Mode (NOT for agent creation)
+**Browser tools** (import from `connectonion.useful_tools.browser_tools`):
+- `BrowserAutomation` — full browser control (click, type, screenshot)
 
-Reserve `enter_plan_mode()` for:
-- Multi-file refactors
-- Architecture changes
-- Complex features with unclear requirements
-- Tasks touching 5+ files
+**Custom tools** — plain Python functions with type hints and docstrings
 
-**Do NOT use plan mode for:**
-- Creating a single ConnectOnion agent
-- Simple file operations
-- Clear, well-defined tasks
+## When to Ask vs Just Do
 
----
+**Just write the agent** when the task is clear:
+- "create an agent that monitors my inbox" → write it
+- "build a file organizer" → write it
 
-## NEVER DO THIS
+**Ask first** when there's a real choice that changes the design:
+```python
+ask_user(
+    question="How should duplicates be handled?",
+    options=["Move to trash", "Delete permanently", "Ask me each time"]
+)
+```
+
+Don't ask for confirmation before every agent. Ask when the answer changes what you build.
+
+## Agent Design Principles
+
+- **Atomic tools**: each function does ONE thing
+- **No argparse**: agents don't need CLI argument parsing
+- **No try/except**: let errors surface naturally
+- **Function over class**: prefer plain functions as tools
+- **YAGNI**: don't build features the user didn't ask for
+
+## Templates
+
+Use `co create --template <name>` to scaffold:
+- `minimal` — bash + file tools + browser
+- `coder` — full coding agent (bash, files, planning)
+- `browser` — web automation with Playwright
+- `web-research` — web scraping and research
+
+## Hosting an Agent
 
 ```python
-# BAD: Standalone script with argparse
-import argparse
-import hashlib
-def main():
-    parser = argparse.ArgumentParser()
-    # ... hardcoded logic ...
+from connectonion import host
 
-# BAD: Using plan_mode for simple agent creation
-enter_plan_mode()  # Overkill for a single-file agent
+host(create_agent, trust="open")  # Local dev
+host(create_agent, trust="careful")  # Web deployment
 ```
 
-## Key Rules
+## Plan Mode
 
-1. **ask_user FIRST** - Confirm design before coding
-2. **from connectonion import Agent** - Always use the framework
-3. **Atomic tools** - Each function does ONE thing
-4. **No plan_mode for agents** - Just ask_user → write → done
+Use `enter_plan_mode()` only for:
+- Multi-file refactors or architecture changes
+- Tasks touching 5+ files with unclear requirements
+
+**Not** for creating a single agent file.


### PR DESCRIPTION
## Summary
- Remove duplicated git/PR workflow from `main.md` (already in `git.md` as a loadable guide)
- Rewrite `workflow.md`: use `co create` as starting point, add CLI commands guidance (`co auth`, `co status`), less rigid `ask_user` gate
- Update `index.md`: fix stale template names (playwright/meta-agent → coder/browser), add missing tools (bash, read_file, edit, write, glob, grep, BrowserAutomation) and plugins (tool_approval, auto_compact, ulw, prefer_write_tool)
- Rename `shell.md` → `bash.md` so the assembler actually loads it for the `bash` tool

## Test plan
- [ ] Run `co ai` and ask it to create a new agent — should suggest `co create` first
- [ ] Ask about git — should load guide rather than having it inline
- [ ] Ask about browser automation — should mention `BrowserAutomation` from useful_tools
- [ ] Check tool prompt loading: bash tool now correctly picks up `bash.md`

Closes #72