### PR TITLE
feat: Add on_stop_signal event (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ ConnectOnion is a Python framework for creating AI agents with automatic activit
 - **Tool Factory** (`connectonion/tool_factory.py`): Converts Python functions to OpenAI-compatible tool schemas automatically
 - **Logger** (`connectonion/logger.py`): Unified logging facade (terminal + plain text + YAML sessions) with `quiet` and `log` parameters
 - **Console** (`connectonion/console.py`): Low-level terminal output with Rich formatting (used internally by Logger)
-- **Events** (`connectonion/events.py:11`): Lifecycle hooks (after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete)
+- **Events** (`connectonion/events.py:11`): Lifecycle hooks (after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete, on_stop_signal)
 - **Trust System** (`connectonion/network/trust/`): Three-level verification (open/careful/strict) with custom policy support
 - **XRay Debug** (`connectonion/xray.py:32`): Runtime context injection for interactive debugging with `@xray` decorator
 

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -44,6 +44,7 @@ from .core import (
     after_tools,
     on_error,
     on_complete,
+    on_stop_signal,
 )
 from .logger import Logger
 from .llm_do import llm_do
@@ -130,4 +131,5 @@ __all__ = [
     "after_tools",
     "on_error",
     "on_complete",
+    "on_stop_signal",
 ]

--- a/connectonion/core/__init__.py
+++ b/connectonion/core/__init__.py
@@ -33,6 +33,7 @@ from .events import (
     after_tools,
     on_error,
     on_complete,
+    on_stop_signal,
 )
 from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
 from .tool_registry import ToolRegistry
@@ -57,6 +58,7 @@ __all__ = [
     "after_tools",
     "on_error",
     "on_complete",
+    "on_stop_signal",
     "create_tool_from_function",
     "extract_methods_from_instance",
     "is_class_instance",

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -82,7 +82,8 @@ class Agent:
             'after_each_tool': [],     # Fires after EACH tool (don't add messages here!)
             'after_tools': [],         # Fires ONCE after ALL tools (safe for messages)
             'on_error': [],
-            'on_complete': []
+            'on_complete': [],
+            'on_stop_signal': []
         }
 
         # Register plugin events (flatten list of lists)
@@ -391,6 +392,7 @@ class Agent:
 
             # Check if plugin set stop_signal (stop loop, wait for user input)
             if self.current_session.pop('stop_signal', None):
+                self._invoke_events('on_stop_signal')
                 return "What would you like me to do?"
 
         # Hit max iterations

--- a/connectonion/core/events.py
+++ b/connectonion/core/events.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: None (standalone module) | imported by [agent.py, __init__.py] | tested by [tests/test_events.py]
   Data flow: Wrapper functions tag event handlers with _event_type attribute → Agent organizes handlers by type → Agent invokes handlers at specific lifecycle points passing agent instance
   State/Effects: Event handlers receive agent instance and can modify agent.current_session (messages, trace, etc.)
-  Integration: exposes on_agent_ready(), after_user_input(), before_iteration(), after_iteration(), before_llm(), after_llm(), before_each_tool(), before_tools(), after_each_tool(), after_tools(), on_error(), on_complete()
+  Integration: exposes on_agent_ready(), after_user_input(), before_iteration(), after_iteration(), before_llm(), after_llm(), before_each_tool(), before_tools(), after_each_tool(), after_tools(), on_error(), on_complete(), on_stop_signal()
   Performance: Minimal overhead - just function attribute checking and iteration over handler lists
   Errors: Event handler exceptions propagate and stop agent execution (fail fast)
 """
@@ -314,4 +314,26 @@ def on_complete(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]
     """
     for fn in funcs:
         fn._event_type = 'on_complete'  # type: ignore
+    return funcs[0] if len(funcs) == 1 else list(funcs)
+
+
+def on_stop_signal(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]:
+    """
+    Mark function(s) as on_stop_signal event handlers.
+
+    Fires when stop_signal is set in the session, before the iteration loop exits.
+    Use for: cleanup of interrupted operations, saving checkpoints, rolling back
+    partial changes, notifying user of interruption.
+
+    Supports both decorator and wrapper syntax:
+        @on_stop_signal
+        def cleanup(agent):
+            rollback_partial_changes()
+            save_checkpoint(agent.current_session)
+            print("⚠️  Operation interrupted - state saved")
+
+        on_events=[on_stop_signal(handler1, handler2)]
+    """
+    for fn in funcs:
+        fn._event_type = 'on_stop_signal'  # type: ignore
     return funcs[0] if len(funcs) == 1 else list(funcs)

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -61,19 +61,20 @@ agent = Agent(
 
 ## Event Types
 
-| Event | When It Runs | Fires | Use For |
-|-------|--------------|-------|---------|
-| `after_user_input` | After user provides input | Once per turn | Add context, timestamps, initialize turn state |
-| `before_iteration` | Before each iteration starts | Once per iteration | Poll IO, check mode changes, setup |
-| `before_llm` | Before each LLM call | Multiple per turn | Modify messages for each LLM call |
-| `after_llm` | After LLM responds | Multiple per turn | Log LLM calls, analyze responses |
-| `before_tools` | Before ALL tools in round | Once per round | Prepare shared context for all tools |
-| `before_each_tool` | Before tool execution | Per tool call | Validate args, approval checks (no message changes!) |
-| `after_each_tool` | After each tool completes | Per tool call | Log performance, side effects (no message changes!) |
-| `after_tools` | After ALL tools in round | Once per round | Add reflection, **ONLY place safe to modify messages** |
-| `on_error` | When tool fails | Per tool error | Custom error handling, retries |
-| `after_iteration` | End of iteration (after tools) | Once per iteration | Checkpoints, stop loop via `stop_loop_result` |
-| `on_complete` | After agent finishes | Once per input() | Metrics, cleanup, final summary |
+| Event              | When It Runs                   | Fires              | Use For                                                |
+| ------------------ | ------------------------------ | ------------------ | ------------------------------------------------------ |
+| `after_user_input` | After user provides input      | Once per turn      | Add context, timestamps, initialize turn state         |
+| `before_iteration` | Before each iteration starts   | Once per iteration | Poll IO, check mode changes, setup                     |
+| `before_llm`       | Before each LLM call           | Multiple per turn  | Modify messages for each LLM call                      |
+| `after_llm`        | After LLM responds             | Multiple per turn  | Log LLM calls, analyze responses                       |
+| `before_tools`     | Before ALL tools in round      | Once per round     | Prepare shared context for all tools                   |
+| `before_each_tool` | Before tool execution          | Per tool call      | Validate args, approval checks (no message changes!)   |
+| `after_each_tool`  | After each tool completes      | Per tool call      | Log performance, side effects (no message changes!)    |
+| `after_tools`      | After ALL tools in round       | Once per round     | Add reflection, **ONLY place safe to modify messages** |
+| `on_error`         | When tool fails                | Per tool error     | Custom error handling, retries                         |
+| `after_iteration`  | End of iteration (after tools) | Once per iteration | Checkpoints, stop loop via `stop_loop_result`          |
+| `on_stop_signal`   | When stop_signal is set        | Once per stop      | Cleanup interrupted ops, save checkpoints, rollback    |
+| `on_complete`      | After agent finishes           | Once per input()   | Metrics, cleanup, final summary                        |
 
 > **Note on message injection:** Use `after_tools` (not `after_each_tool`) when adding messages to ensure compatibility with all LLM providers. Anthropic Claude requires tool results to immediately follow tool_calls.
 
@@ -116,6 +117,7 @@ TURN START
 │   ├─ after_llm
 │   └─ (no after_iteration - not continuing)
 │
+├─ on_stop_signal                ← if interrupted by stop_signal
 └─ on_complete                   ← turn ends
 ```
 
@@ -390,6 +392,39 @@ agent.input("Search for Python")
 - Send task completion notifications
 - Log total execution time
 - Update external systems
+
+### Interrupted Operation Cleanup (on_stop_signal)
+
+Use `on_stop_signal` to clean up when an operation is interrupted via `stop_signal`:
+
+```python
+from connectonion import Agent, on_stop_signal
+
+def cleanup_on_stop(agent):
+    """Clean up when operation is interrupted"""
+    trace = agent.current_session['trace']
+    pending_tools = [t for t in trace if t.get('status') == 'running']
+
+    if pending_tools:
+        print(f"⚠️  Interrupted with {len(pending_tools)} pending operations")
+
+    # Save checkpoint so work can be resumed
+    print("💾 Saving checkpoint...")
+
+agent = Agent(
+    "assistant",
+    tools=[search],
+    on_events=[on_stop_signal(cleanup_on_stop)]
+)
+```
+
+**Use cases for `on_stop_signal`:**
+
+- Rollback partial changes
+- Save checkpoints for resumption
+- Clean up temporary resources
+- Notify user of interruption
+- Log interrupted operations
 
 ### Session Statistics
 

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -13,7 +13,7 @@ Components under test:
 
 import pytest
 from unittest.mock import Mock
-from connectonion import Agent, after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete
+from connectonion import Agent, after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete, on_stop_signal
 from connectonion.core.llm import LLMResponse, ToolCall
 from connectonion.core.usage import TokenUsage
 
@@ -376,6 +376,7 @@ class TestEventSystem:
         assert after_tools(handler)._event_type == 'after_tools'
         assert on_error(handler)._event_type == 'on_error'
         assert on_complete(handler)._event_type == 'on_complete'
+        assert on_stop_signal(handler)._event_type == 'on_stop_signal'
 
     def test_event_validation_rejects_non_callable(self):
         """Test that non-callable events are rejected with clear error"""
@@ -596,6 +597,13 @@ class TestNewEventSyntax:
         assert handler6._event_type == 'on_error'
         assert handler7._event_type == 'on_complete'
 
+        @on_stop_signal
+        def handler8(agent):
+            pass
+
+        assert callable(handler8)
+        assert handler8._event_type == 'on_stop_signal'
+
     def test_wrapper_multiple_args_returns_list(self):
         """Test before_each_tool(fn1, fn2) returns list"""
 
@@ -731,3 +739,208 @@ class TestNewEventSyntax:
 
         # Should fire in registration order
         assert calls == ['handler1', 'handler2', 'handler3']
+
+
+class TestOnStopSignalEvent:
+    """Test on_stop_signal event behavior"""
+
+    def test_on_stop_signal_fires_when_stop_signal_set(self):
+        """Test on_stop_signal fires when plugin sets stop_signal in session"""
+        calls = []
+
+        def set_stop(agent):
+            agent.current_session['stop_signal'] = 'User rejected'
+
+        def track_stop(agent):
+            calls.append('on_stop_signal')
+
+        agent = Agent(
+            "test",
+            tools=[search],
+            model="gpt-4o-mini",
+            on_events=[
+                after_tools(set_stop),
+                on_stop_signal(track_stop)
+            ]
+        )
+
+        result = agent.input("Search for Python")
+
+        # on_stop_signal should fire exactly once
+        assert len(calls) == 1
+        assert calls == ['on_stop_signal']
+        # Agent should return the stop message
+        assert result == "What would you like me to do?"
+
+    def test_on_stop_signal_handler_receives_agent(self):
+        """Test on_stop_signal handler receives agent instance with session data"""
+        received_agents = []
+
+        def set_stop(agent):
+            agent.current_session['stop_signal'] = 'Interrupted'
+
+        def check_agent(agent):
+            received_agents.append(agent)
+            # Verify agent has expected attributes
+            assert hasattr(agent, 'name')
+            assert hasattr(agent, 'current_session')
+            assert hasattr(agent, 'tools')
+            assert hasattr(agent, 'llm')
+            assert agent.name == "test"
+            assert agent.current_session is not None
+            assert 'trace' in agent.current_session
+            assert 'messages' in agent.current_session
+
+        agent = Agent(
+            "test",
+            tools=[search],
+            model="gpt-4o-mini",
+            on_events=[
+                after_tools(set_stop),
+                on_stop_signal(check_agent)
+            ]
+        )
+
+        agent.input("Search for Python")
+
+        assert len(received_agents) == 1
+
+    def test_on_stop_signal_wrapper_sets_event_type(self):
+        """Test on_stop_signal wrapper correctly sets _event_type attribute"""
+
+        def handler(agent):
+            pass
+
+        wrapped = on_stop_signal(handler)
+
+        assert hasattr(wrapped, '_event_type')
+        assert wrapped._event_type == 'on_stop_signal'
+        assert callable(wrapped)
+
+    def test_on_stop_signal_decorator_syntax(self):
+        """Test @on_stop_signal decorator syntax works"""
+
+        @on_stop_signal
+        def cleanup(agent):
+            pass
+
+        assert callable(cleanup)
+        assert hasattr(cleanup, '_event_type')
+        assert cleanup._event_type == 'on_stop_signal'
+
+    def test_on_stop_signal_multiple_handlers_fire_in_order(self):
+        """Test multiple on_stop_signal handlers fire in registration order"""
+        calls = []
+
+        def set_stop(agent):
+            agent.current_session['stop_signal'] = 'Stopped'
+
+        def handler1(agent):
+            calls.append('handler1')
+
+        def handler2(agent):
+            calls.append('handler2')
+
+        def handler3(agent):
+            calls.append('handler3')
+
+        agent = Agent(
+            "test",
+            tools=[search],
+            model="gpt-4o-mini",
+            on_events=[
+                after_tools(set_stop),
+                on_stop_signal(handler1),
+                on_stop_signal(handler2),
+                on_stop_signal(handler3)
+            ]
+        )
+
+        agent.input("Search for Python")
+
+        # All handlers should fire in order
+        assert calls == ['handler1', 'handler2', 'handler3']
+
+    def test_on_stop_signal_does_not_fire_without_stop_signal(self):
+        """Test on_stop_signal does NOT fire during normal completion"""
+        calls = []
+
+        def track_stop(agent):
+            calls.append('on_stop_signal')
+
+        agent = Agent(
+            "test",
+            model="gpt-4o-mini",
+            on_events=[on_stop_signal(track_stop)]
+        )
+
+        # Normal input without any stop_signal being set
+        agent.input("test prompt")
+
+        # Should not fire
+        assert len(calls) == 0
+
+    def test_on_stop_signal_exception_propagates(self):
+        """Test that on_stop_signal handler exceptions propagate (fail fast)"""
+
+        def set_stop(agent):
+            agent.current_session['stop_signal'] = 'Stopped'
+
+        def failing_handler(agent):
+            raise RuntimeError("Cleanup failed")
+
+        agent = Agent(
+            "test",
+            tools=[search],
+            model="gpt-4o-mini",
+            on_events=[
+                after_tools(set_stop),
+                on_stop_signal(failing_handler)
+            ]
+        )
+
+        # Exception should propagate from the event handler
+        with pytest.raises(RuntimeError, match="Cleanup failed"):
+            agent.input("Search for Python")
+
+    def test_on_stop_signal_can_modify_session(self):
+        """Test on_stop_signal handler can modify session state"""
+
+        def set_stop(agent):
+            agent.current_session['stop_signal'] = 'User rejected'
+
+        def save_checkpoint(agent):
+            agent.current_session['checkpoint_saved'] = True
+            agent.current_session['interrupted_at_iteration'] = agent.current_session.get('iteration', 0)
+
+        agent = Agent(
+            "test",
+            tools=[search],
+            model="gpt-4o-mini",
+            on_events=[
+                after_tools(set_stop),
+                on_stop_signal(save_checkpoint)
+            ]
+        )
+
+        agent.input("Search for Python")
+
+        # Verify handler could modify session
+        assert agent.current_session['checkpoint_saved'] is True
+        assert 'interrupted_at_iteration' in agent.current_session
+
+    def test_on_stop_signal_with_wrapper_multiple_args(self):
+        """Test on_stop_signal(fn1, fn2) returns list with correct _event_type"""
+
+        def handler1(agent):
+            pass
+
+        def handler2(agent):
+            pass
+
+        result = on_stop_signal(handler1, handler2)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]._event_type == 'on_stop_signal'
+        assert result[1]._event_type == 'on_stop_signal'


### PR DESCRIPTION
## Summary

Add event that fires when `stop_signal` is set, enabling cleanup of interrupted operations.

Closes #109

## Motivation

When `stop_signal` is set (agent.py line 388), the iteration loop stops but there's no cleanup hook. Plugins may need to clean up partial operations, save checkpoints, roll back changes, or notify the user.

## Changes

- **`connectonion/core/events.py`** — New `on_stop_signal()` wrapper function (supports decorator + multi-arg syntax)
- **`connectonion/core/agent.py`** — Register `on_stop_signal` in event registry; invoke before loop exit
- **`connectonion/core/__init__.py`** — Export `on_stop_signal`
- **`connectonion/__init__.py`** — Export `on_stop_signal`
- **`CLAUDE.md`** — Updated events list
- **`docs/concepts/events.md`** — Added table row, lifecycle diagram entry, and usage example
- **`tests/unit/test_events.py`** — 9 new tests + 2 updated existing tests

## API

```python
from connectonion import Agent, on_stop_signal

@on_stop_signal
def cleanup(agent):
    rollback_partial_changes()
    save_checkpoint(agent.current_session)
    print('⚠️  Operation interrupted - state saved')

agent = Agent('my_agent', tools=[...], on_events=[cleanup])
```

## Tests

All 38 event tests pass (9 new + 29 existing). Zero regressions.

```
tests/unit/test_events.py: 38 passed in 0.56s
```

**Edge cases tested:**
- Fires when `stop_signal` is set ✅
- Does NOT fire during normal completion ✅
- Multiple handlers fire in registration order ✅
- Handler exceptions propagate (fail-fast) ✅
- Handlers can modify session state ✅
- Decorator and wrapper syntax both work ✅
- Multi-arg wrapper returns list ✅