### PR TITLE
Add browser-use integration: browser_use_agent and BrowserUseTools

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -58,6 +58,8 @@ from .useful_tools import (
     pick, yes_no, autocomplete, TodoList, SlashCommand,
     # Claude Code-style file tools
     read_file, edit, multi_edit, glob, grep, write,
+    browser_use_agent,
+    BrowserUseTools,
 )
 from .network import connect, RemoteAgent, Response, host, create_app, IO
 from .network import relay, announce
@@ -108,6 +110,9 @@ __all__ = [
     "glob",
     "grep",
     "write",
+    # Browser automation
+    "browser_use_agent",
+    "BrowserUseTools",
     # Networking
     "connect",
     "RemoteAgent",

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -24,6 +24,8 @@ from .terminal import yes_no, autocomplete
 from .todo_list import TodoList
 from .slash_command import SlashCommand
 from .ask_user import ask_user
+from .browser_use_agent import browser_use_agent
+from .browser_use_tools import BrowserUseTools
 
 # Claude Code-style file tools
 from .file_tools import (
@@ -63,6 +65,8 @@ __all__ = [
     "TodoList",
     "SlashCommand",
     "ask_user",
+    "browser_use_agent",
+    "BrowserUseTools",
     # Claude Code-style file tools
     "FileTools",
     "read_file",

--- a/connectonion/useful_tools/browser_use_agent.py
+++ b/connectonion/useful_tools/browser_use_agent.py
@@ -1,0 +1,68 @@
+"""
+Purpose: AI-driven browser automation tool using the browser-use library with ConnectOnion's LLM provider
+LLM-Note:
+  Dependencies: imports from [browser_use, asyncio, os] | imported by [useful_tools/__init__.py] | tested by [tests/unit/test_browser_use.py]
+  Data flow: browser_use(task) → ChatOpenAI pointed at ConnectOnion proxy → BrowserAgent.run() → returns final_result() string
+  State/Effects: launches a Playwright browser (headless by default) | makes real HTTP requests | no local file persistence
+  Integration: exposes browser_use(task) function | requires `pip install browser-use` + `playwright install chromium`
+  Performance: each call spawns a browser session | async internally, wrapped with asyncio.run()
+  Errors: raises ImportError with install hint if browser-use not installed | browser errors propagate
+
+AI-driven browser automation using ConnectOnion's LLM provider.
+
+Usage:
+    from connectonion.useful_tools.browser_use import browser_use
+
+    agent = Agent("researcher", tools=[browser_use])
+
+    # Agent can now instruct the browser to do anything:
+    # browser_use("Go to github.com/openonion/connectonion and get the star count")
+    # browser_use("Search Google for Python tutorials, return the top 3 titles")
+
+    # Or with custom options:
+    # browser_use("...", headless=False, model="co/gemini-2.5-pro")
+
+Requires:
+    pip install browser-use
+    playwright install chromium
+"""
+
+import asyncio
+import os
+
+
+def browser_use_agent(task: str, headless: bool = True, model: str = "co/gemini-2.5-flash") -> str:
+    """Run a browser task using AI-driven automation and return the result.
+
+    Args:
+        task: Natural language description of what to do in the browser
+              (e.g. "Search Google for 'connectonion' and return the top 3 results")
+        headless: Run browser in headless mode, default True. Set False to watch it work.
+        model: LLM model for browser decisions. Supports any ConnectOnion model (co/*)
+               or any OpenAI-compatible model. Default: co/gemini-2.5-flash
+
+    Returns:
+        Result of the browser task as a string
+    """
+    from browser_use import Agent as BrowserAgent
+    from browser_use.llm.openai.chat import ChatOpenAI
+
+    api_key = os.environ.get("OPENONION_API_KEY") or os.environ.get("CONNECTONION_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    base_url = os.environ.get("OPENONION_BASE_URL", "https://oo.openonion.ai/v1")
+
+    is_gemini = "gemini" in model.lower()
+    llm = ChatOpenAI(
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        remove_min_items_from_schema=True,
+        frequency_penalty=None if is_gemini else 0.3,
+    )
+
+    browser_agent = BrowserAgent(task=task, llm=llm)
+
+    async def _run():
+        history = await browser_agent.run()
+        return history.final_result() or str(history)
+
+    return asyncio.run(_run())

--- a/connectonion/useful_tools/browser_use_tools.py
+++ b/connectonion/useful_tools/browser_use_tools.py
@@ -1,0 +1,210 @@
+"""
+Purpose: Auto-generated ConnectOnion tools from browser-use's full action registry
+LLM-Note:
+  Dependencies: imports from [browser_use] | imported by [useful_tools/__init__.py]
+  Data flow: _register_actions() reads Tools().registry → generates sync method per action → agent calls methods → _act() → registry.execute_action() → BrowserSession
+  State/Effects: persistent BrowserSession with all watchdogs | methods auto-generated at init | watchdog events queued for agent via get_events()
+  Integration: exposes BrowserTools class — every browser-use action becomes a ConnectOnion tool automatically | new browser-use actions appear without code changes
+
+Browser automation — all browser-use actions as ConnectOnion tools, auto-generated from
+the registry. When browser-use adds new actions, they appear automatically.
+
+Usage:
+    from connectonion.useful_tools.browser import BrowserTools
+
+    browser = BrowserTools()
+    agent = Agent("researcher", tools=[browser])
+
+    # All browser-use actions available:
+    # browser.navigate("https://example.com")
+    # browser.get_content()        → page text + [index] numbers
+    # browser.click(21)            → click element [21]
+    # browser.input(3, "query")    → type into element [3]
+    # browser.search("python")     → web search
+    # browser.scroll()             → scroll down
+    # browser.evaluate("document.title")  → run JS
+    # browser.screenshot()         → take screenshot
+    # browser.get_events()         → check watchdog notifications
+    # ... every other browser-use action, automatically
+
+    browser.close()
+
+Requires:
+    pip install browser-use
+    playwright install chromium
+"""
+
+import asyncio
+import threading
+
+# Actions that require special LLM params or are ConnectOnion-level concerns — skip auto-gen
+_SKIP_ACTIONS = {"done", "extract", "upload_file", "write_file", "replace_file", "read_file", "close"}
+
+
+class BrowserUseTools:
+    """All browser-use actions as ConnectOnion tools. Auto-generated from the registry."""
+
+    def __init__(self, headless: bool = True):
+        """Initialize browser session and auto-generate tool methods.
+
+        Args:
+            headless: Run without visible window (default: True). Set False to watch.
+        """
+        self.headless = headless
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+        self._session = None
+        self._tools = None
+        self._event_queue = []
+        self._run(self._start())
+        self._register_actions()
+
+    def _run(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+
+    async def _start(self):
+        from browser_use.browser.session import BrowserSession
+        from browser_use.browser.profile import BrowserProfile
+        from browser_use.tools.service import Tools
+        from browser_use.browser.events import FileDownloadedEvent, BrowserErrorEvent
+
+        profile = BrowserProfile(headless=self.headless)
+        self._session = BrowserSession(browser_profile=profile)
+        self._tools = Tools()
+        await self._session.start()
+
+        # Bridge watchdog events → agent-readable queue
+        self._session.event_bus.on(FileDownloadedEvent, self._on_download)
+        self._session.event_bus.on(BrowserErrorEvent, self._on_browser_error)
+
+    async def _on_download(self, event):
+        self._event_queue.append(
+            f"Download complete: {event.file_name} → {event.path} ({event.file_type or 'unknown type'})"
+        )
+
+    async def _on_browser_error(self, event):
+        self._event_queue.append(f"Browser error [{event.error_type}]: {event.message}")
+
+    def _act(self, action_name: str, params: dict) -> str:
+        async def _exec():
+            result = await self._tools.registry.execute_action(
+                action_name=action_name,
+                params=params,
+                browser_session=self._session,
+            )
+            if result.error:
+                return f"Error: {result.error}"
+            return result.extracted_content or result.long_term_memory or "Done"
+
+        return self._run(_exec())
+
+    def _register_actions(self):
+        """Read browser-use's registry and create a tool method for every action."""
+        from pydantic_core import PydanticUndefined
+
+        for action_name, action in self._tools.registry.registry.actions.items():
+            if action_name in _SKIP_ACTIONS:
+                continue
+            method = self._make_method(action_name, action)
+            setattr(self, action_name, method)
+
+    def _make_method(self, action_name, action):
+        """Generate a properly-typed sync method from a browser-use action."""
+        from pydantic_core import PydanticUndefined
+
+        fields = action.param_model.model_fields
+
+        # NoParamsAction has only a dummy 'description' field — treat as zero-arg
+        is_no_params = list(fields.keys()) == ["description"]
+        if is_no_params:
+            fields = {}
+
+        defaults = {}
+        param_parts = []
+        kwargs_parts = []
+
+        for name, info in fields.items():
+            has_default = info.default is not PydanticUndefined
+            if has_default:
+                defaults[name] = info.default
+                param_parts.append(f"{name}=_defaults['{name}']")
+            else:
+                param_parts.append(name)
+            kwargs_parts.append(f'"{name}": {name}')
+
+        param_str = ", ".join(param_parts)
+        kwargs_str = ", ".join(kwargs_parts)
+
+        if fields:
+            code = (
+                f"def {action_name}({param_str}) -> str:\n"
+                f"    return _self._act('{action_name}', {{{kwargs_str}}})"
+            )
+        else:
+            code = f"def {action_name}() -> str:\n    return _self._act('{action_name}', {{}})"
+
+        ns = {"_self": self, "_defaults": defaults}
+        exec(code, ns)
+        fn = ns[action_name]
+
+        # Set type annotations so ConnectOnion's tool_factory builds the correct schema
+        fn.__annotations__ = {k: v.annotation for k, v in fields.items()} | {"return": str}
+
+        # Build docstring from action description + field descriptions
+        doc_lines = [action.description or f"Browser action: {action_name}."]
+        arg_docs = [(k, v.description) for k, v in fields.items() if v.description]
+        if arg_docs:
+            doc_lines.append("\nArgs:")
+            for field_name, field_desc in arg_docs:
+                doc_lines.append(f"    {field_name}: {field_desc}")
+        doc_lines.append("\nReturns:\n    Result or confirmation message")
+        fn.__doc__ = "\n".join(doc_lines)
+
+        return fn
+
+    # ── Special methods not in the registry ─────────────────────────────────
+
+    def get_content(self) -> str:
+        """Get current page content with interactive element indices.
+        Indices like [21] can be passed to click() and input().
+        Always call get_content() after navigation to get fresh indices.
+
+        Returns:
+            Page text with numbered interactive elements
+        """
+        return self._run(self._session.get_state_as_text())
+
+    def get_events(self) -> str:
+        """Check for watchdog notifications (completed downloads, browser errors).
+        Call this periodically if you expect downloads or errors.
+
+        Returns:
+            Recent browser events, or 'No events' if none
+        """
+        if not self._event_queue:
+            return "No events"
+        events = list(self._event_queue)
+        self._event_queue.clear()
+        return "\n".join(events)
+
+    def current_url(self) -> str:
+        """Get the current page URL.
+
+        Returns:
+            Current URL string
+        """
+        async def _url():
+            return await self._session.get_current_page_url()
+
+        return self._run(_url())
+
+    def close(self) -> str:
+        """Close the browser and release all resources.
+
+        Returns:
+            Confirmation message
+        """
+        self._run(self._session.kill())
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        return "Browser closed"


### PR DESCRIPTION
## Summary

- **`browser_use_agent(task)`** — AI-driven browser automation using ConnectOnion's LLM proxy (`co/gemini-2.5-flash` by default). Pass any `co/*` model via the `model` param.
- **`BrowserUseTools`** — auto-generates ALL browser-use registry actions as ConnectOnion tools (navigate, click, scroll, screenshot, search, evaluate JS, etc.). New browser-use actions appear automatically without code changes.
- Watchdog events (downloads, browser errors) are bridged to the agent via `get_events()` queue.

## Usage

```python
# Simple: one-shot task
from connectonion import browser_use_agent
result = browser_use_agent("Go to github.com and get the trending repos")

# Advanced: agent controls individual browser actions
from connectonion.useful_tools import BrowserUseTools
browser = BrowserUseTools()
agent = Agent("researcher", tools=[browser])
browser.close()
```

## Test plan
- [ ] `browser_use_agent("search for connectonion on google")` returns a result
- [ ] `BrowserUseTools().navigate("https://example.com")` navigates successfully
- [ ] `BrowserUseTools().get_content()` returns page text with `[N]` indices
- [ ] `BrowserUseTools().close()` cleans up Chrome process