### PR TITLE
Add execution control, fix relay disconnections, IO inheritance

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -13,6 +13,7 @@ import os
 import sys
 import time
 import base64
+from contextvars import ContextVar
 from typing import List, Optional, Dict, Any, Callable, Union
 from pathlib import Path
 from .llm import LLM, create_llm, TokenUsage
@@ -26,6 +27,10 @@ from ..debug.decorators import (
 from ..logger import Logger
 from .tool_executor import execute_and_record_tools, execute_single_tool
 from .events import EventHandler
+
+
+# ContextVar so child agents created during tool execution inherit parent IO
+_parent_io: ContextVar = ContextVar('_parent_io', default=None)
 
 
 class Agent:
@@ -55,7 +60,8 @@ class Agent:
         self.current_session = None
 
         # I/O to client (None locally, injected by host() for WebSocket)
-        self.io = None
+        # Child agents inherit parent IO via ContextVar
+        self.io = _parent_io.get()
 
         # Session storage (None locally, injected by host() for persistence)
         self.storage = None
@@ -325,11 +331,18 @@ class Agent:
         # Invoke after_user_input events
         self._invoke_events('after_user_input')
 
+        # Propagate IO to child agents via ContextVar
+        _token = _parent_io.set(self.io) if self.io else None
+
         # Process
         self.current_session['iteration'] = 0  # Reset iteration for this turn
-        result = self._run_iteration_loop(
-            max_iterations or self.max_iterations
-        )
+        try:
+            result = self._run_iteration_loop(
+                max_iterations or self.max_iterations
+            )
+        finally:
+            if _token is not None:
+                _parent_io.reset(_token)
 
         # Calculate duration
         duration = time.time() - turn_start

--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -28,7 +28,7 @@ Related Files:
 LLM-Note:
   Dependencies: imports from [json, asyncio, typing, websockets]
   Data flow: connect() → /ws/announce → serve_loop() → INPUT → task_handler → OUTPUT
-  State/Effects: WebSocket connection to relay | heartbeat every 60s
+  State/Effects: WebSocket connection to relay | concurrent heartbeat every 60s | ping_interval=20s
   Integration: exposes connect(), send_announce(), wait_for_task(), serve_loop()
 """
 
@@ -55,7 +55,11 @@ async def connect(relay_url: str = "wss://oo.openonion.ai"):
     ws_url = f"{relay_url.rstrip('/')}/ws/announce"
     # TODO: Future connection metadata (observed_ip, ICE candidates) should be
     #       attached to ANNOUNCE so relay can return best endpoints to clients.
-    return await websockets.connect(ws_url)
+    return await websockets.connect(
+        ws_url,
+        ping_interval=20,
+        ping_timeout=20,
+    )
 
 
 async def send_announce(websocket, announce_message: Dict[str, Any]):
@@ -150,7 +154,7 @@ async def serve_loop(
     websocket,
     announce_message: Dict[str, Any],
     task_handler,
-    heartbeat_interval: int = 300,
+    heartbeat_interval: int = 60,
     addr_data: Dict[str, Any] = None
 ):
     """
@@ -158,7 +162,7 @@ async def serve_loop(
 
     This handles:
     - Initial ANNOUNCE
-    - Periodic heartbeat ANNOUNCE (every 60s) with fresh signature
+    - Concurrent heartbeat ANNOUNCE (every 60s) — runs independently of task processing
     - Receiving and processing TASK messages
     - Sending responses
 
@@ -187,45 +191,52 @@ async def serve_loop(
     endpoints = announce_message.get("endpoints", [])
     relay_url = announce_message.get("relay")
 
-    # Main loop
-    while True:
+    async def _heartbeat():
+        """Send periodic heartbeat ANNOUNCEs, independent of task processing."""
+        while True:
+            await asyncio.sleep(heartbeat_interval)
+            try:
+                if addr_data:
+                    fresh_announce = announce_module.create_announce_message(
+                        addr_data, summary, endpoints=endpoints, relay=relay_url
+                    )
+                    await send_announce(websocket, fresh_announce)
+                else:
+                    announce_message["timestamp"] = int(asyncio.get_event_loop().time())
+                    await send_announce(websocket, announce_message)
+                console.print(f"{prefix} [red]♥[/red]")
+            except websockets.exceptions.ConnectionClosed:
+                break
+
+    heartbeat_task = asyncio.create_task(_heartbeat())
+
+    try:
+        while True:
+            try:
+                task = await wait_for_task(websocket)
+
+                if task.get("type") == "INPUT":
+                    console.print(f"{prefix} [dim]Input received[/dim]")
+
+                    result = await task_handler(task["prompt"])
+
+                    output_message = {
+                        "type": "OUTPUT",
+                        "input_id": task["input_id"],
+                        "result": result
+                    }
+                    await websocket.send(json.dumps(output_message))
+                    console.print(f"{prefix} [green]Output sent[/green]")
+
+                elif task.get("type") == "ERROR":
+                    console.print(f"{prefix} [red]Relay error: {task.get('error')}[/red]")
+
+            except websockets.exceptions.ConnectionClosed:
+                console.print(f"{prefix} [dim]Relay disconnected[/dim]")
+                break
+    finally:
+        heartbeat_task.cancel()
         try:
-            # Wait for message with timeout to allow heartbeat
-            task = await wait_for_task(websocket, timeout=heartbeat_interval)
-
-            # Handle INPUT message
-            if task.get("type") == "INPUT":
-                console.print(f"{prefix} [dim]Input received[/dim]")
-
-                # Process with handler
-                result = await task_handler(task["prompt"])
-
-                # Send OUTPUT response
-                output_message = {
-                    "type": "OUTPUT",
-                    "input_id": task["input_id"],
-                    "result": result
-                }
-                await websocket.send(json.dumps(output_message))
-                console.print(f"{prefix} [green]Output sent[/green]")
-
-            elif task.get("type") == "ERROR":
-                console.print(f"{prefix} [red]Relay error: {task.get('error')}[/red]")
-
-        except asyncio.TimeoutError:
-            # Time for heartbeat ANNOUNCE - create fresh message with new timestamp and signature
-            if addr_data:
-                # Re-create message with fresh timestamp and signature
-                fresh_announce = announce_module.create_announce_message(
-                    addr_data, summary, endpoints=endpoints, relay=relay_url
-                )
-                await send_announce(websocket, fresh_announce)
-            else:
-                # Fallback: just update timestamp (signature will be invalid)
-                announce_message["timestamp"] = int(asyncio.get_event_loop().time())
-                await send_announce(websocket, announce_message)
-            console.print(f"{prefix} [red]♥[/red]")
-
-        except websockets.exceptions.ConnectionClosed:
-            console.print(f"{prefix} [dim]Relay disconnected[/dim]")
-            break
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -24,5 +24,6 @@ from .prefer_write_tool import prefer_write_tool
 from .ulw import ulw, handle_ulw_mode_change
 from .skills import skills, skill
 from .subagents import subagents, task
+from .execution_control import execution_control
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'execution_control']

--- a/connectonion/useful_plugins/execution_control.py
+++ b/connectonion/useful_plugins/execution_control.py
@@ -1,0 +1,67 @@
+"""
+Execution Control plugin - Pause/Resume/Stop agent execution via WebSocket.
+
+Checks for control messages at each iteration boundary (before_iteration).
+Pause blocks the agent thread until resume or stop is received.
+Stop uses the existing stop_signal mechanism.
+
+Protocol:
+    Client → Server:  {type: 'EXECUTION_CONTROL', action: 'pause'|'resume'|'stop'}
+    Server → Client:  {type: 'EXECUTION_STATE', state: 'running'|'paused'|'stopped'}
+
+Usage:
+    from connectonion import Agent
+    from connectonion.useful_plugins import execution_control
+
+    agent = Agent("worker", plugins=[execution_control])
+    host(agent)
+"""
+
+import time
+from typing import TYPE_CHECKING
+from ..core.events import before_iteration
+
+if TYPE_CHECKING:
+    from ..core.agent import Agent
+
+
+def _drain_control_messages(agent: 'Agent') -> str | None:
+    """Drain all pending EXECUTION_CONTROL messages, return the last action."""
+    action = None
+    for msg in agent.io.receive_all('EXECUTION_CONTROL'):
+        action = msg.get('action')
+    return action
+
+
+@before_iteration
+def check_execution_control(agent: 'Agent') -> None:
+    """Check for pause/resume/stop signals at iteration boundaries."""
+    if not agent.io:
+        return
+
+    action = _drain_control_messages(agent)
+
+    if action == 'stop':
+        agent.current_session['stop_signal'] = 'User requested stop.'
+        agent.io.send({'type': 'EXECUTION_STATE', 'state': 'stopped'})
+        return
+
+    if action == 'pause':
+        agent.io.send({'type': 'EXECUTION_STATE', 'state': 'paused'})
+
+        while True:
+            time.sleep(0.2)
+            inner_action = _drain_control_messages(agent)
+            if inner_action == 'resume':
+                agent.io.send({'type': 'EXECUTION_STATE', 'state': 'running'})
+                return
+            if inner_action == 'stop':
+                agent.current_session['stop_signal'] = 'User requested stop.'
+                agent.io.send({'type': 'EXECUTION_STATE', 'state': 'stopped'})
+                return
+            # Check if connection closed while paused
+            if agent.io.receive_all('io_closed'):
+                return
+
+
+execution_control = [check_execution_control]

--- a/tests/unit/test_agent_io_inheritance.py
+++ b/tests/unit/test_agent_io_inheritance.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for Agent IO inheritance via ContextVar.
+
+When host() sets agent.io, child agents created inside tools should
+automatically inherit the parent's IO via ContextVar propagation.
+"""
+
+import pytest
+from unittest.mock import Mock
+from connectonion.core.agent import Agent, _parent_io
+from tests.utils.mock_helpers import MockLLM, LLMResponseBuilder
+
+
+class TestIOInheritance:
+
+    def test_io_defaults_to_none(self):
+        """Agent.io defaults to None when no parent IO is set."""
+        agent = Agent(name="test", llm=MockLLM(), log=False)
+        assert agent.io is None
+
+    def test_io_inherits_from_context_var(self):
+        """Agent.io picks up parent IO from ContextVar."""
+        mock_io = Mock()
+        token = _parent_io.set(mock_io)
+        try:
+            agent = Agent(name="child", llm=MockLLM(), log=False)
+            assert agent.io is mock_io
+        finally:
+            _parent_io.reset(token)
+
+    def test_io_propagated_during_input(self):
+        """When agent.io is set, calling input() propagates IO to ContextVar."""
+        mock_io = Mock()
+        captured_io = []
+
+        def capture_tool() -> str:
+            """Capture current IO context. Returns: status"""
+            captured_io.append(_parent_io.get())
+            return "done"
+
+        agent = Agent(
+            name="parent",
+            llm=MockLLM(responses=[
+                LLMResponseBuilder.tool_call_response("capture_tool", {}),
+                LLMResponseBuilder.text_response("done"),
+            ]),
+            tools=[capture_tool],
+            log=False,
+        )
+        agent.io = mock_io
+
+        agent.input("test")
+
+        assert len(captured_io) == 1
+        assert captured_io[0] is mock_io
+
+    def test_io_context_cleaned_up_after_input(self):
+        """ContextVar is reset after input() returns."""
+        mock_io = Mock()
+        agent = Agent(
+            name="parent",
+            llm=MockLLM(responses=[LLMResponseBuilder.text_response("hi")]),
+            log=False,
+        )
+        agent.io = mock_io
+
+        agent.input("test")
+
+        # ContextVar should be reset to default (None)
+        assert _parent_io.get() is None
+
+    def test_no_io_no_propagation(self):
+        """When agent.io is None, ContextVar is not touched."""
+        agent = Agent(
+            name="test",
+            llm=MockLLM(responses=[LLMResponseBuilder.text_response("hi")]),
+            log=False,
+        )
+        assert agent.io is None
+
+        agent.input("test")
+
+        assert _parent_io.get() is None

--- a/tests/unit/test_execution_control.py
+++ b/tests/unit/test_execution_control.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for execution_control plugin — Pause/Resume/Stop agent execution.
+
+Tests cover:
+- Pause blocks agent until resume
+- Stop sets stop_signal on agent session
+- No-op when agent has no IO
+- Drain multiple control messages (last action wins)
+- Connection close during pause exits gracefully
+"""
+
+import time
+import threading
+import pytest
+from unittest.mock import Mock, MagicMock
+from connectonion.useful_plugins.execution_control import (
+    check_execution_control,
+    _drain_control_messages,
+    execution_control,
+)
+
+
+def make_agent_with_io(messages=None):
+    """Create a mock agent with IO that returns queued control messages."""
+    agent = Mock()
+    agent.current_session = {}
+    agent.io = Mock()
+
+    queued = list(messages) if messages else []
+
+    def receive_all(msg_type):
+        if msg_type == 'EXECUTION_CONTROL':
+            result = list(queued)
+            queued.clear()
+            return result
+        if msg_type == 'io_closed':
+            return []
+        return []
+
+    agent.io.receive_all = Mock(side_effect=receive_all)
+    agent.io.send = Mock()
+    return agent
+
+
+class TestDrainControlMessages:
+
+    def test_returns_last_action(self):
+        agent = make_agent_with_io([
+            {'action': 'pause'},
+            {'action': 'resume'},
+        ])
+        action = _drain_control_messages(agent)
+        assert action == 'resume'
+
+    def test_returns_none_when_empty(self):
+        agent = make_agent_with_io([])
+        action = _drain_control_messages(agent)
+        assert action is None
+
+    def test_single_message(self):
+        agent = make_agent_with_io([{'action': 'stop'}])
+        action = _drain_control_messages(agent)
+        assert action == 'stop'
+
+
+class TestCheckExecutionControl:
+
+    def test_noop_without_io(self):
+        """Plugin does nothing when agent has no IO (local execution)."""
+        agent = Mock()
+        agent.io = None
+        # Should not raise
+        check_execution_control(agent)
+
+    def test_stop_sets_stop_signal(self):
+        agent = make_agent_with_io([{'action': 'stop'}])
+        check_execution_control(agent)
+
+        assert agent.current_session.get('stop_signal') == 'User requested stop.'
+        agent.io.send.assert_called_once_with({
+            'type': 'EXECUTION_STATE', 'state': 'stopped'
+        })
+
+    def test_no_action_is_noop(self):
+        agent = make_agent_with_io([])
+        check_execution_control(agent)
+
+        assert 'stop_signal' not in agent.current_session
+        agent.io.send.assert_not_called()
+
+    def test_pause_then_resume(self):
+        """Pause blocks, resume unblocks and sends running state."""
+        agent = Mock()
+        agent.current_session = {}
+        agent.io = Mock()
+
+        call_count = 0
+        paused_event = threading.Event()
+
+        def receive_all(msg_type):
+            nonlocal call_count
+            if msg_type == 'EXECUTION_CONTROL':
+                call_count += 1
+                if call_count == 1:
+                    # First call: initial drain — return pause
+                    return [{'action': 'pause'}]
+                if call_count == 2:
+                    # Second call: inside pause loop — wait a bit, then resume
+                    paused_event.set()
+                    time.sleep(0.05)
+                    return [{'action': 'resume'}]
+                return []
+            if msg_type == 'io_closed':
+                return []
+            return []
+
+        agent.io.receive_all = Mock(side_effect=receive_all)
+        agent.io.send = Mock()
+
+        # Run in thread since pause blocks
+        t = threading.Thread(target=check_execution_control, args=(agent,))
+        t.start()
+
+        # Wait for pause to be reached
+        paused_event.wait(timeout=2)
+        t.join(timeout=3)
+
+        assert not t.is_alive(), "Handler should have returned after resume"
+
+        # Should have sent paused then running
+        calls = [c[0][0] for c in agent.io.send.call_args_list]
+        assert {'type': 'EXECUTION_STATE', 'state': 'paused'} in calls
+        assert {'type': 'EXECUTION_STATE', 'state': 'running'} in calls
+
+    def test_pause_then_stop(self):
+        """Stop during pause sets stop_signal and exits."""
+        agent = Mock()
+        agent.current_session = {}
+        agent.io = Mock()
+
+        call_count = 0
+
+        def receive_all(msg_type):
+            nonlocal call_count
+            if msg_type == 'EXECUTION_CONTROL':
+                call_count += 1
+                if call_count == 1:
+                    return [{'action': 'pause'}]
+                if call_count == 2:
+                    return [{'action': 'stop'}]
+                return []
+            if msg_type == 'io_closed':
+                return []
+            return []
+
+        agent.io.receive_all = Mock(side_effect=receive_all)
+        agent.io.send = Mock()
+
+        t = threading.Thread(target=check_execution_control, args=(agent,))
+        t.start()
+        t.join(timeout=3)
+
+        assert not t.is_alive()
+        assert agent.current_session.get('stop_signal') == 'User requested stop.'
+
+        calls = [c[0][0] for c in agent.io.send.call_args_list]
+        assert {'type': 'EXECUTION_STATE', 'state': 'paused'} in calls
+        assert {'type': 'EXECUTION_STATE', 'state': 'stopped'} in calls
+
+
+class TestPluginExport:
+
+    def test_execution_control_is_list(self):
+        assert isinstance(execution_control, list)
+        assert len(execution_control) == 1
+
+    def test_handler_has_event_type(self):
+        handler = execution_control[0]
+        assert hasattr(handler, '_event_type')
+        assert handler._event_type == 'before_iteration'

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -42,8 +42,11 @@ class TestRelayConnection:
 
             result = await relay.connect()
 
-            # Should connect to production relay
-            mock_connect.assert_called_once_with("wss://oo.openonion.ai/ws/announce")
+            mock_connect.assert_called_once_with(
+                "wss://oo.openonion.ai/ws/announce",
+                ping_interval=20,
+                ping_timeout=20,
+            )
             assert result == mock_ws
 
     @pytest.mark.asyncio
@@ -56,8 +59,11 @@ class TestRelayConnection:
 
             result = await relay.connect(custom_url)
 
-            # Base URL should have /ws/announce appended
-            mock_connect.assert_called_once_with("ws://localhost:8000/ws/announce")
+            mock_connect.assert_called_once_with(
+                "ws://localhost:8000/ws/announce",
+                ping_interval=20,
+                ping_timeout=20,
+            )
             assert result == mock_ws
 
     @pytest.mark.asyncio
@@ -342,35 +348,31 @@ class TestServeLoop:
             assert error_printed
 
     @pytest.mark.asyncio
-    async def test_serve_loop_heartbeat_on_timeout(self):
-        """Test that heartbeat ANNOUNCE is sent after timeout."""
+    async def test_serve_loop_heartbeat_runs_concurrently(self):
+        """Test that heartbeat ANNOUNCE is sent concurrently while waiting for tasks."""
         mock_ws = AsyncMock()
         announce_msg = {
             "type": "ANNOUNCE",
             "address": "0xtest",
+            "summary": "test",
+            "endpoints": [],
             "timestamp": 12345
         }
 
-        # First recv: timeout (for heartbeat), second recv: ConnectionClosed to exit
-        async def recv_with_timeout_then_close():
-            # First call raises TimeoutError
-            if not hasattr(recv_with_timeout_then_close, 'called'):
-                recv_with_timeout_then_close.called = True
-                raise asyncio.TimeoutError()
-            # Second call closes connection
+        # recv blocks for a bit then closes — heartbeat should fire during the wait
+        async def slow_recv_then_close():
+            await asyncio.sleep(0.15)
             raise websockets.exceptions.ConnectionClosed(None, None)
 
-        mock_ws.recv.side_effect = recv_with_timeout_then_close
+        mock_ws.recv.side_effect = slow_recv_then_close
 
         async def dummy_handler(prompt):
             return "response"
 
         with patch('rich.console.Console.print'):
-            with patch('asyncio.get_event_loop') as mock_loop:
-                mock_loop.return_value.time.return_value = 99999
-                await relay.serve_loop(mock_ws, announce_msg, dummy_handler, heartbeat_interval=1)
+            await relay.serve_loop(mock_ws, announce_msg, dummy_handler, heartbeat_interval=0.05)
 
-        # Should have sent at least 2 ANNOUNCEs (initial + heartbeat)
+        # Should have sent initial ANNOUNCE + at least 1 heartbeat
         announce_count = sum(
             1 for call in mock_ws.send.call_args_list
             if json.loads(call[0][0]).get("type") == "ANNOUNCE"
@@ -398,37 +400,47 @@ class TestServeLoop:
             assert closed_printed
 
     @pytest.mark.asyncio
-    async def test_serve_loop_custom_heartbeat_interval(self):
-        """Test that serve_loop accepts custom heartbeat interval without errors."""
+    async def test_serve_loop_heartbeat_during_task_processing(self):
+        """Test that heartbeats continue while a task is being processed."""
         mock_ws = AsyncMock()
-        announce_msg = {"type": "ANNOUNCE", "address": "0xtest", "timestamp": 1}
+        announce_msg = {
+            "type": "ANNOUNCE",
+            "address": "0xtest",
+            "summary": "test",
+            "endpoints": [],
+            "timestamp": 1,
+        }
 
-        # Simulate timeout after custom interval
+        input_msg = {
+            "type": "INPUT",
+            "input_id": "task1",
+            "prompt": "slow task",
+        }
+
         call_count = 0
 
-        async def recv_with_custom_interval():
+        async def recv_sequence():
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                # First call: timeout (triggers heartbeat)
-                raise asyncio.TimeoutError()
-            else:
-                # Second call: close connection
-                raise websockets.exceptions.ConnectionClosed(None, None)
+                return json.dumps(input_msg)
+            raise websockets.exceptions.ConnectionClosed(None, None)
 
-        mock_ws.recv.side_effect = recv_with_custom_interval
+        mock_ws.recv.side_effect = recv_sequence
 
-        async def dummy_handler(prompt):
-            return "response"
+        async def slow_handler(prompt):
+            # Simulate slow LLM call — heartbeat should fire during this
+            await asyncio.sleep(0.15)
+            return "done"
 
         with patch('rich.console.Console.print'):
-            with patch('asyncio.get_event_loop') as mock_loop:
-                mock_loop.return_value.time.return_value = 99999
-                # Should complete without error with custom interval
-                await relay.serve_loop(mock_ws, announce_msg, dummy_handler, heartbeat_interval=120)
+            await relay.serve_loop(mock_ws, announce_msg, slow_handler, heartbeat_interval=0.05)
 
-        # Verify serve_loop ran and sent heartbeat
-        assert call_count >= 2, "Should have handled timeout and then connection close"
+        # Should have sent: initial ANNOUNCE + at least 1 heartbeat + OUTPUT
+        sent_types = [json.loads(c[0][0]).get("type") for c in mock_ws.send.call_args_list]
+        assert sent_types[0] == "ANNOUNCE"
+        assert "OUTPUT" in sent_types
+        assert sent_types.count("ANNOUNCE") >= 2, "Heartbeat should fire during slow task"
 
 
 class TestRelayIntegration:


### PR DESCRIPTION
## Summary
- **Execution control plugin** (`useful_plugins/execution_control.py`): Pause/Resume/Stop agent execution at iteration boundaries via WebSocket `EXECUTION_CONTROL` messages
- **Relay WebSocket fix** (`network/relay.py`): Heartbeat now runs as concurrent `asyncio.create_task`, independent of task processing. Adds `ping_interval=20s` and reduces heartbeat interval from 300s to 60s. Fixes disconnections during long LLM calls.
- **IO inheritance** (`core/agent.py`): Child agents created inside tools auto-inherit parent's WebSocket IO via `ContextVar`, enabling streaming output from sub-agents

## Test plan
- [x] 10 tests for execution_control (drain, stop, pause→resume, pause→stop, no-op, export)
- [x] 5 tests for IO inheritance (default, inherit, propagate, cleanup, no-op)
- [x] 21 relay tests updated (concurrent heartbeat, heartbeat during task processing)
- [x] All 36 new/updated tests pass