### PR TITLE
docs: add gemini-3.5-flash to supported models

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@ agent = Agent(name="bot", model="co/gemini-2.5-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
+- `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -79,6 +79,10 @@ agent = Agent("assistant", model="o4-mini")         # Your key
 
 #### Gemini 3 (Newest - State-of-the-Art Reasoning)
 ```python
+# Latest Gemini 3.5 Flash
+agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
+agent = Agent("assistant", model="gemini-3.5-flash")     # Your key
+
 # Most intelligent model family with state-of-the-art reasoning
 agent = Agent("assistant", model="co/gemini-3-pro-preview")  # Managed
 agent = Agent("assistant", model="gemini-3-pro-preview")     # Your key
@@ -190,6 +194,7 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | gpt-4o | 128K tokens |
 | o4-mini | 128K tokens |
 | **Google** | |
+| gemini-3.5-flash | 1M tokens |
 | gemini-3-pro-preview | 1M tokens |
 | gemini-3-flash-preview | 1M tokens |
 | gemini-2.5-pro | 2M tokens |
@@ -218,6 +223,7 @@ All prices are **per 1M tokens** and match official provider pricing:
 
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
+| gemini-3.5-flash | $1.50 | $9.00 | Latest Gemini 3.5 Flash |
 | gemini-3-pro-preview | $2.00 | $12.00 | State-of-the-art reasoning |
 | gemini-3-flash-preview | $0.50 | $3.00 | Fastest Gemini 3 |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |


### PR DESCRIPTION
Adds `gemini-3.5-flash` to the SDK model docs:
- `docs/concepts/models.md` — usage snippet + context-window table + pricing table
- `docs/api.md` — available `co/` models list

Pricing $1.50 / $9.00 per 1M, 1M context — matches oo-api `llm/billing.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)