### PR TITLE
fix: strip <system-reminder> tags from chat messages

### DIFF
--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -20,7 +20,27 @@ Streaming-only event types (llm_call, llm_result, compact, etc.) are not
 reconstructed — they're live-only feedback and don't survive reconnect by design.
 """
 
+import re
+
 from ....useful_plugins.runtime_input import RUNTIME_INPUT_FRAME_PREFIX
+
+# Regex to strip <system-reminder>...</system-reminder> blocks (internal Claude
+# API markers) that plugins inject into messages. These are intended only for
+# the LLM and must not appear in user-visible chat UI. Non-greedy match with
+# surrounding whitespace to avoid leaving bare newlines.
+_SYSTEM_REMINDER_RE = re.compile(r'\s*<system-reminder>.*?</system-reminder>\s*', re.DOTALL)
+
+
+def _strip_system_reminders(content: str) -> str:
+    """Remove <system-reminder>...</system-reminder> blocks from a string.
+
+    Returns the cleaned string with surrounding whitespace normalised.
+    Non-string values (e.g. list content blocks) are returned unchanged.
+    """
+    if not isinstance(content, str):
+        return content
+    stripped = _SYSTEM_REMINDER_RE.sub('', content)
+    return stripped.strip()
 
 
 def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
@@ -84,7 +104,7 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
             'name': name,
             'args': entry.get('args'),
             'status': ui_status,
-            'result': entry.get('result'),
+            'result': _strip_system_reminders(entry.get('result', '')),
             'timing_ms': entry.get('timing_ms'),
         }
 
@@ -124,6 +144,11 @@ def session_to_chat_items(session: dict) -> list[dict]:
             content = msg.get('content', '')
             if isinstance(content, str) and content.startswith(RUNTIME_INPUT_FRAME_PREFIX):
                 content = content[len(RUNTIME_INPUT_FRAME_PREFIX):]
+            content = _strip_system_reminders(content)
+            if not content:
+                # Entire message was just a <system-reminder> block — suppress the bubble.
+                user_count += 1
+                continue
             items_ui.append({'id': f"msg-{msg_idx}", 'type': 'user', 'content': content})
             user_count += 1
             if user_count < len(turn_entries):
@@ -132,7 +157,9 @@ def session_to_chat_items(session: dict) -> list[dict]:
                     if item_ui:
                         items_ui.append(item_ui)
         elif role == 'assistant' and msg.get('content'):
-            items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': msg.get('content', '')})
+            content = _strip_system_reminders(msg.get('content', ''))
+            if content:
+                items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': content})
 
     # Fallback: if no user_input markers found in trace, append all remaining trace
     # entries at the end so the data isn't silently dropped (older sessions).

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -145,11 +145,10 @@ def session_to_chat_items(session: dict) -> list[dict]:
             if isinstance(content, str) and content.startswith(RUNTIME_INPUT_FRAME_PREFIX):
                 content = content[len(RUNTIME_INPUT_FRAME_PREFIX):]
             content = _strip_system_reminders(content)
-            if not content:
-                # Entire message was just a <system-reminder> block — suppress the bubble.
-                user_count += 1
-                continue
-            items_ui.append({'id': f"msg-{msg_idx}", 'type': 'user', 'content': content})
+            # A message that was nothing but a <system-reminder> gets no bubble, but it
+            # still opened a turn — its trace entries below must render either way.
+            if content:
+                items_ui.append({'id': f"msg-{msg_idx}", 'type': 'user', 'content': content})
             user_count += 1
             if user_count < len(turn_entries):
                 for trace_idx, entry in turn_entries[user_count]:

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -717,6 +717,87 @@ class TestSessionToChatItems:
 
         assert items == []
 
+    # ------------------------------------------------------------------
+    # <system-reminder> tag stripping
+    # ------------------------------------------------------------------
+
+    def test_strip_system_reminder_from_user_msg(self):
+        """Message containing only a <system-reminder> block emits no chat item."""
+        session = {
+            'messages': [
+                {'role': 'user', 'content': '<system-reminder>\n<build-context>\n</system-reminder>'},
+                {'role': 'assistant', 'content': 'OK'},
+            ],
+            'trace': [],
+        }
+
+        items = session_to_chat_items(session)
+
+        # The user bubble should be suppressed entirely; only the assistant response remains.
+        assert len(items) == 1
+        assert items[0]['type'] == 'agent'
+
+    def test_strip_system_reminder_inline(self):
+        """Real text + trailing system-reminder block → only real text remains."""
+        session = {
+            'messages': [
+                {
+                    'role': 'user',
+                    'content': (
+                        'Deploy the app'
+                        '<system-reminder>\n<build-context>\n</system-reminder>'
+                    ),
+                },
+            ],
+            'trace': [],
+        }
+
+        items = session_to_chat_items(session)
+
+        assert len(items) == 1
+        assert items[0]['type'] == 'user'
+        assert items[0]['content'] == 'Deploy the app'
+
+    def test_strip_does_not_affect_assistant_msg(self):
+        """Assistant message mentioning 'system-reminder' in normal text is unchanged."""
+        session = {
+            'messages': [
+                {'role': 'assistant', 'content': 'The system reminder feature is working fine.'},
+            ],
+            'trace': [],
+        }
+
+        items = session_to_chat_items(session)
+
+        assert len(items) == 1
+        assert items[0]['type'] == 'agent'
+        assert items[0]['content'] == 'The system reminder feature is working fine.'
+
+    def test_strip_system_reminder_from_tool_result(self):
+        """Tool result containing <system-reminder> is stripped."""
+        session = {
+            'messages': [],
+            'trace': [
+                {
+                    'type': 'tool_result',
+                    'tool_id': 't1',
+                    'name': 'bash',
+                    'result': (
+                        'file content'
+                        '<system-reminder>tool reminder</system-reminder>'
+                    ),
+                    'status': 'success',
+                    'timing_ms': 10,
+                },
+            ],
+        }
+
+        items = session_to_chat_items(session)
+
+        assert len(items) == 1
+        assert items[0]['type'] == 'tool_call'
+        assert items[0]['result'] == 'file content'
+
     def test_generates_unique_ids(self):
         """Generates unique IDs for each item."""
         session = {

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -798,6 +798,36 @@ class TestSessionToChatItems:
         assert items[0]['type'] == 'tool_call'
         assert items[0]['result'] == 'file content'
 
+    def test_suppressed_user_bubble_still_renders_its_tool_calls(self):
+        """A reminder-only message loses its bubble, never the turn's tool calls.
+
+        The message still opened a turn, so its trace entries have to render —
+        otherwise stripping the reminder silently deletes the tool calls from
+        the transcript, which is worse than the stray bubble it replaced.
+        """
+        session = {
+            'messages': [
+                {'role': 'user', 'content': '<system-reminder>injected</system-reminder>'},
+                {'role': 'assistant', 'content': 'done'},
+            ],
+            'trace': [
+                {'type': 'user_input', 'content': 'x'},
+                {
+                    'type': 'tool_result',
+                    'tool_id': 't1',
+                    'name': 'bash',
+                    'result': 'ls output',
+                    'status': 'success',
+                    'timing_ms': 10,
+                },
+            ],
+        }
+
+        items = session_to_chat_items(session)
+
+        assert [i['type'] for i in items] == ['tool_call', 'agent']
+        assert items[0]['name'] == 'bash'
+
     def test_generates_unique_ids(self):
         """Generates unique IDs for each item."""
         session = {


### PR DESCRIPTION
## Summary
- Added _strip_system_reminders() regex function to remove <system-reminder>...</system-reminder> blocks
- Applied in session_to_chat_items() on user messages, assistant messages, and tool_result entries
- Empty messages after stripping are suppressed entirely (no empty bubble)
- Follows same pattern as RUNTIME_INPUT_FRAME_PREFIX stripping
- Added 4 test cases covering: pure-reminder suppression, inline reminder stripping, assistant text preservation, and tool_result stripping

Fixes #138

## Test Plan
- [x] pytest tests/ -x -q passes