### PR TITLE
[codex] Add hosted co-ai deploy skills

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,15 @@
 # Implementation Plan
 
+## Lightweight co-ai Deploy Browser Flag
+
+1. [x] Record the current deploy task and target behavior in project control docs.
+2. [x] Add failing package-builder tests for generated `agent.py`, `.co/host.yaml`, and default no-Chrome behavior.
+3. [x] Add failing CLI coverage for `--browser` plumbing.
+4. [x] Implement generated project-scaffold packaging and browser-only Chrome Dockerfile behavior.
+5. [x] Run focused deploy tests, syntax checks, and diff hygiene checks.
+6. [x] Real deploy a browser co-ai agent, verify Chrome on the server, and remove old co-ai/linkedin containers/images.
+7. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Remove Generic Tool Approval Skip Flag
 
 1. [x] Remove the generic `session["skip_tool_approval"]` bypass branch from `check_approval()`.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,16 @@
 # Implementation Plan
 
+## Deploy Timeout and Package Build Simplification
+
+1. [x] Confirm 524 root cause from current code path: POST `/api/v1/deploy` awaited SSH upload, Docker build/run, Caddy route update, and cleanup.
+2. [x] Change oo-api deploy POST to create a deployment row and return `deploying` before slow build work.
+3. [x] Detach the slow deploy build from the POST request and preserve status polling via the existing status endpoint.
+4. [x] Remove forced Docker `--no-cache` from backend deploy builds.
+5. [x] Simplify the generated co-ai Dockerfile so it copies only install/runtime inputs instead of `COPY . .`.
+6. [x] Run focused deploy tests and syntax/diff checks.
+7. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the local fix result.
+8. [x] Deploy oo-api change to production and verify real `co deploy` no longer 524s.
+
 ## Hosted co-ai Browser Uses Chrome Channel
 
 1. [x] Confirm the current deploy path installs/uses default Playwright Chromium.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,13 @@
 # Implementation Plan
 
+## Remove Claude Runtime Skills From co-ai
+
+1. [x] Remove `.claude/skills` from runtime `_get_skill_paths()`.
+2. [x] Remove `.claude/skills` from runtime `_discover_all_skills()`.
+3. [x] Add a regression test that a Claude-only skill is not invoked by slash command.
+4. [x] Run focused skills/deploy tests, syntax checks, and diff hygiene checks.
+5. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Require co-ai User Approval by Default
 
 1. [x] Remove default `auto_approve=True` from generated co-ai deploy entrypoints.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,124 @@
 # Implementation Plan
 
+## Hosted co-ai Browser Uses Chrome Channel
+
+1. [x] Confirm the current deploy path installs/uses default Playwright Chromium.
+2. [x] Add an explicit browser channel option to `BrowserAutomation`.
+3. [x] Wire hosted co-ai deploys to `browser_channel="chrome"`.
+4. [x] Install Chrome in generated co-ai Dockerfile.
+5. [x] Install selected skill `requirements.txt` dependencies during co-ai image build.
+6. [x] Upload allowed API keys from project/global/shell env sources for co-ai deploy.
+7. [x] Make `auto_approve=True` actually bypass tool approval without enabling ULW continuation.
+8. [x] Add/update focused tests.
+9. [x] Run focused tests and syntax checks.
+10. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## co-ai Deploy Installs Packaged Source
+
+1. [x] Identify that co-ai deploy still installs published `connectonion==version` instead of the packaged local source.
+2. [x] Add local package metadata to the co-ai staging package.
+3. [x] Change co-ai generated requirements/Dockerfile to install the local package and its declared dependencies.
+4. [x] Update package-builder tests.
+5. [x] Run focused deploy tests and syntax checks.
+6. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## co-ai Deploy Browser Runtime
+
+1. [x] Confirm the deployed browser failure is caused by package/runtime image construction.
+2. [x] Generate a co-ai-specific Dockerfile that installs Playwright Chromium during image build.
+3. [x] Add package-builder regression coverage for the generated Dockerfile.
+4. [x] Run focused deploy tests and syntax checks.
+5. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Restored Running Session Stop State
+
+1. [x] Inspect the restored-session UI state and loading derivation.
+2. [x] Add SDK-side local settling for restored running items when `stop()` is called.
+3. [x] Add oo-chat loading derivation from active restored UI items.
+4. [x] Add focused regression coverage and run builds/lints.
+5. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Chat Input Stop Button
+
+1. [x] Inspect current chat input and SDK lifecycle to find the narrow stop boundary.
+2. [x] Add a non-destructive `stop()` method in the SDK that closes the active WebSocket and returns local state to idle.
+3. [x] Wire `stop` through `useAgentForHuman`, `useAgentSDK`, `Chat`, and `ChatInput`.
+4. [x] Render stop in the send-button position while loading.
+5. [x] Run TypeScript builds/lints and diff hygiene checks.
+6. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Deployed Slash Skills Use Agent co_dir
+
+1. [x] Add a failing plugin regression test for slash invocation loading from `agent.co_dir` when cwd differs.
+2. [x] Update skill path resolution so `_load_skill()` accepts `co_dir` / project context and preserves cwd fallback.
+3. [x] Route `handle_skill_invocation()` and the `skill()` tool through the agent-aware loader.
+4. [x] Make generated co-ai deploy entrypoints pass an absolute package `.co` path.
+5. [x] Run focused skills, co-ai, and deploy tests plus diff hygiene checks.
+6. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Frontend Reads Relay Profile for Hosted co-ai
+
+1. [x] Add a failing TypeScript SDK regression test for relay profile metadata when direct `/info` is unreachable.
+2. [x] Update SDK endpoint/type handling to read `/api/relay/agents/{address}/profile`, normalize tools/skills, and merge it with direct `/info`.
+3. [x] Update `oo-chat`'s `use-agent-info` hook with the same relay-profile fallback and normalization.
+4. [x] Align Python relay profile tools with the SDK string-array shape and update focused Python tests.
+5. [x] Run targeted SDK, frontend lint, Python tests, and diff hygiene checks.
+6. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Named co-ai Deploys Publish Relay Profile Metadata
+
+1. [x] Add failing tests for `co deploy --name ... --skills ...` propagating the name into upload data and the generated entrypoint.
+2. [x] Add failing tests for `create_coding_agent(name=...)` and relay profile construction from hosted agent metadata.
+3. [x] Implement name validation, CLI option plumbing, generated entrypoint name injection, and agent factory naming.
+4. [x] Publish relay `profile` in host ANNOUNCE and relay heartbeat messages.
+5. [x] Run targeted tests, syntax checks, and diff hygiene checks.
+6. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Deploy Env Vars Sent to Backend Secrets Field
+
+1. [x] Add a failing CLI regression test proving `co deploy --skills ...` sends `OPENONION_API_KEY` in the `secrets` form field.
+2. [x] Update the deploy upload payload to send both `secrets` and `env_vars` with the same JSON payload.
+3. [x] Run targeted deploy tests and syntax/diff hygiene checks.
+4. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## co-ai Deploy EntryPoint Imports Packaged Source
+
+1. [x] Add a failing test that generated co-ai entrypoint prepends package root to `sys.path` before importing `connectonion`.
+2. [x] Update generated entrypoint content to calculate `/app` from `.co/deploy/co_ai_entrypoint.py` and insert it at `sys.path[0]`.
+3. [x] Run deploy/co-ai tests, syntax checks, and diff hygiene checks.
+4. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
+## Direct co-ai Deploy Without Project Scaffold
+
+1. [x] Add failing tests that `co deploy --skills ...` selects co-ai and does not require git or `.co/host.yaml`.
+2. [x] Add failing tests that co-ai packaging contains generated entrypoint, selected skills, package source, and generated `requirements.txt`.
+3. [x] Add failing tests that explicit `--template project --skills ...` is rejected.
+4. [x] Implement template auto-detection and separate validation paths for project vs co-ai deploy.
+5. [x] Replace co-ai packaging's git archive base with a self-contained temporary package.
+6. [x] Update deploy docs and control files.
+7. [x] Run targeted tests, syntax checks, and diff hygiene checks.
+
+## Login Handoff Privacy and Cleanup
+
+1. [x] Record the hosted-browser boundary: do not rely on live Playwright objects across turns.
+2. [x] Update login prompt guidance so QR and credential handoffs wait and continue in the same turn.
+3. [x] Update cleanup guidance so `close_browser` runs after success, failure, or abandonment.
+4. [x] Add prompt regression coverage for same-turn login handoff behavior.
+5. [x] Store submitted credentials on the current Agent instance instead of returning raw values to the model.
+6. [x] Add `type_saved_login_credential` so password typing does not expose the password in `keyboard_type(...)`.
+7. [x] Add co ai login cleanup on completion so the server-side browser is closed even if the model forgets.
+
+## co-ai Deploy Template
+
+1. [x] Add failing tests for `co deploy --template co-ai --skills ...` argument handling and upload payload.
+2. [x] Add failing tests for co-ai package construction: generated entrypoint, selected skill directories, and no working-tree writes.
+3. [x] Add failing tests for missing skills and invalid `--skills` usage.
+4. [x] Add failing tests for `create_coding_agent(co_dir=..., browser_headless=True)`.
+5. [x] Implement CLI parameters, package builder helpers, skill resolution, and co-ai entrypoint generation.
+6. [x] Update co-ai agent factory options for deploy-safe `co_dir` and headless browser behavior.
+7. [x] Run targeted tests, syntax checks, and diff hygiene checks.
+8. [x] Update `STATUS.md`, `TASKS.md`, and this plan with the result.
+
 ## PR #143 Remote Login Review
 
 1. [x] Add tests that fail while `remote_login` still performs tool-side judgment or direct user prompting.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,16 @@
 # Implementation Plan
 
+## Explicit All-Skills co-ai Deploy
+
+1. [x] Add failing tests for discovering all project/user deploy skill names with project priority.
+2. [x] Add failing package-builder coverage for `all_skills=True`.
+3. [x] Add failing CLI coverage for `co deploy --all-skills` auto-selecting co-ai.
+4. [x] Add failing CLI coverage rejecting `--template project --all-skills`.
+5. [x] Implement `discover_deploy_skill_names()` and wire `all_skills` through package creation.
+6. [x] Add the `--all-skills` Typer option and deploy handler validation.
+7. [x] Run focused deploy tests, syntax checks, and diff hygiene checks.
+8. [x] Update `TASKS.md`, `STATUS.md`, and this plan.
+
 ## Deploy Timeout and Package Build Simplification
 
 1. [x] Confirm 524 root cause from current code path: POST `/api/v1/deploy` awaited SSH upload, Docker build/run, Caddy route update, and cleanup.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,13 @@
 # Implementation Plan
 
+## Require co-ai User Approval by Default
+
+1. [x] Remove default `auto_approve=True` from generated co-ai deploy entrypoints.
+2. [x] Remove default `auto_approve=True` from local `co ai` web server startup.
+3. [x] Add regression assertions for generated entrypoints and web startup kwargs.
+4. [x] Run focused co-ai/deploy approval tests, syntax checks, and diff hygiene checks.
+5. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Split co-ai Deploy Packaging Helpers
 
 1. [x] Add a dedicated `deploy_co_ai.py` module for co-ai deploy package construction and deploy-time skill/env helpers.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,14 @@
 # Implementation Plan
 
+## Remove Generic Tool Approval Skip Flag
+
+1. [x] Remove the generic `session["skip_tool_approval"]` bypass branch from `check_approval()`.
+2. [x] Update ULW to rely only on `mode == "ulw"`.
+3. [x] Update documentation/comments that described `skip_tool_approval`.
+4. [x] Add/update tests proving the old flag does not bypass approval while ULW still does.
+5. [x] Run focused approval/ULW/co-ai/deploy tests plus syntax/diff checks.
+6. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Remove co-ai Auto-Approve Hook
 
 1. [x] Inspect `tool_approval` constants and co-ai tool wiring to confirm which tools require user approval.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,14 @@
 # Implementation Plan
 
+## Remove co-ai Auto-Approve Hook
+
+1. [x] Inspect `tool_approval` constants and co-ai tool wiring to confirm which tools require user approval.
+2. [x] Remove `_enable_auto_approve` from `connectonion/cli/co_ai/agent.py`.
+3. [x] Remove `auto_approve` from `create_coding_agent()`.
+4. [x] Update tests to assert co-ai no longer exposes/registers the auto-approve hook.
+5. [x] Run focused co-ai, deploy, approval, and ULW tests plus syntax/diff checks.
+6. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Remove Claude Runtime Skills From co-ai
 
 1. [x] Remove `.claude/skills` from runtime `_get_skill_paths()`.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,15 @@
 # Implementation Plan
 
+## co-ai Deploy Runtime v4
+
+1. [x] Record the new runtime/browser default in project control docs.
+2. [x] Add failing ConnectOnion tests for default Chrome packaging, removed `--browser`, and `--runtime pypi` manifest packaging.
+3. [x] Implement CLI/package changes in ConnectOnion.
+4. [x] Add failing oo-api tests for materializing pypi runtime deploy packages.
+5. [x] Implement oo-api pypi runtime materialization.
+6. [x] Run focused tests, syntax checks, and diff hygiene checks across touched repos.
+7. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the final result.
+
 ## Lightweight co-ai Deploy Browser Flag
 
 1. [x] Record the current deploy task and target behavior in project control docs.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,5 +1,12 @@
 # Implementation Plan
 
+## Split co-ai Deploy Packaging Helpers
+
+1. [x] Add a dedicated `deploy_co_ai.py` module for co-ai deploy package construction and deploy-time skill/env helpers.
+2. [x] Update `deploy_commands.py` to import/re-export those helpers while retaining project deploy packaging and upload orchestration.
+3. [x] Run focused deploy tests, syntax checks, and diff hygiene checks.
+4. [x] Update `TASKS.md`, `STATUS.md`, and this plan with the result.
+
 ## Explicit All-Skills co-ai Deploy
 
 1. [x] Add failing tests for discovering all project/user deploy skill names with project priority.

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,13 +7,16 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: splitting co-ai deploy package-building helpers out of `connectonion/cli/commands/deploy_commands.py` without changing deploy behavior.
+- Current focus: making local and hosted co-ai route dangerous tool calls through user approval by default instead of blanket auto-approving.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
 - Refactor complete: co-ai deploy package construction, selected/all skill resolution, generated entrypoint/Dockerfile creation, and deploy env loading now live in `connectonion/cli/commands/deploy_co_ai.py`.
 - Compatibility note: `deploy_commands.py` still imports/re-exports the deploy helper names used by existing tests and callers.
+- Current approval correction: generated hosted co-ai entrypoints and local `co ai` web startup no longer pass `auto_approve=True` by default.
+- The `skip_tool_approval` flag remains available for explicit modes such as ULW, but deploy/web startup should not set it implicitly.
+- Verification confirmed the approval correction with focused deploy, co-ai startup, tool approval, and ULW tests.
 - New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
 - Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
 - Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
@@ -103,6 +106,9 @@ Last updated: 2026-06-02
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_tool_approval.py::TestNoIO::test_skip_tool_approval_flag_skips_web_approval tests/unit/test_ulw.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/co_ai/main.py connectonion/cli/co_ai/agent.py connectonion/cli/commands/deploy_co_ai.py connectonion/useful_plugins/tool_approval/approval.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_skills_without_co_ai_template tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_all_skills_without_co_ai_template -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/commands/deploy_co_ai.py`
 - `git diff --check`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,11 +7,16 @@ Last updated: 2026-06-01
 - Repository: `openonion/connectonion`
 - Active branch: `codex/co-ai-remote-login-tool`
 - Active PR: `#143` (`[codex] Add remote login tool to co ai`)
-- Current focus: finishing hosted co-ai deploy for the two active scenarios: server-side Chrome/headless browser automation and selected skills packaged into the co-ai deploy.
+- Current focus: fixing real deploy 524 timeout and simplifying the co-ai deploy build path without changing the user-facing deploy flow.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
+- New deploy timeout finding: `oo-api` POST `/api/v1/deploy` awaited the entire slow deploy path: package extraction, rsync to GCE, Docker build, Docker run, Caddy route update, old-version cleanup. That matches the Cloudflare 524 at `Uploading...`.
+- Fix in `oo-api`: POST `/api/v1/deploy` now creates the deployment row and returns `status=deploying` quickly; the slow build/run path runs in a detached asyncio task and updates the existing deployment status.
+- Backend build simplification: `docker build --no-cache` was removed so repeated deploys can use Docker layer cache.
+- co-ai package simplification: generated Dockerfile no longer uses `COPY . .` before installation; it copies package metadata, `connectonion/`, and `.co/` explicitly before installing requirements and Chrome.
+- Production verification passed: after redeploying `oo-api`, real `co deploy --name agent-4-linkedin --skills deploy-smoke` moved from `Uploading...` to `Building...` and completed with `https://agent-4-linkedin-0x92f834c6.agents.openonion.ai`.
 - Current frontend finding: deployed co-ai relays successfully and host ANNOUNCE can publish profile metadata, but the frontend falls back to address-only display because its agent-info hook does not read `/api/relay/agents/{address}/profile`.
 - SDK finding: `connectonion-ts` has the same direct-`/info` dependency in `fetchAgentInfo()`, so consumers also lose name/skills/tools when relay endpoints are reachable only through `/ws/input`.
 - Fix: `connectonion-ts.fetchAgentInfo()` and `oo-chat`'s `useAgentInfo()` now read relay profile metadata from `/api/relay/agents/{address}/profile` and use it as the fallback display source.
@@ -98,6 +103,10 @@ Last updated: 2026-06-01
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py tests/unit/test_tool_approval.py::TestNoIO::test_skip_tool_approval_flag_skips_web_approval tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/co_ai/agent.py connectonion/useful_tools/browser_tools/browser.py connectonion/useful_plugins/tool_approval/approval.py`
 - `git diff --check`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `python3 -m pytest tests/test_deploy.py -q` in `/Users/yfshuu/coding/openonion/oo-api`
+- `python3 -c "compile(...)"` syntax check for `oo-api/deploy/routes.py`, `oo-api/deploy/service.py`, and `connectonion/cli/commands/deploy_commands.py`
+- `git diff --check` in both `connectonion` and `oo-api`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py -q`
 - `/opt/homebrew/bin/python3 -m pytest tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/commands/deploy_commands.py`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,11 +7,20 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: removing the generic `skip_tool_approval` approval bypass while preserving explicit ULW mode behavior.
+- Current focus: lightweight co-ai deploy browser flag implementation and production verification are complete.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
+- New deploy target: co-ai deploy should generate a normal deploy project inside the temporary tarball (`agent.py`, `.co/host.yaml`, selected `.co/skills/*`, and `requirements.txt`) instead of requiring the user to create those files.
+- New browser boundary: `co deploy --skills foo` should not install Chrome, while `co deploy --skills linkedin-post --browser` should generate a Dockerfile that installs Google Chrome and make the generated agent use `browser_channel="chrome"`.
+- Implementation result: generated co-ai deploy packages now use root `agent.py` plus `.co/host.yaml`, and upload `entrypoint=agent.py`.
+- Default non-browser co-ai packages no longer include a Dockerfile or Chrome install; selected skill `requirements.txt` contents are inlined into root `requirements.txt` so the existing `oo-api` generic Dockerfile can install them before `COPY . .`.
+- Browser co-ai packages include a Dockerfile that installs Google Chrome during build and generated `agent.py` passes `browser_channel="chrome"`.
+- `--browser` is wired through CLI/package creation and rejected for explicit `--template project`.
+- Real production deploy passed: `co deploy --name agent-4-linkedin --skills deploy-smoke --browser` created active deployment `15c33c6a`.
+- Server verification passed for `agent-4-linkedin-0x92f834c6-15c33c6a`: container is running, `/usr/bin/google-chrome` exists, Chrome reports `Google Chrome 148.0.7778.215`, `xvfb-run` exists, and Playwright launched `channel="chrome"` successfully.
+- Cleanup result: deploy API and server state now show only `agent-4-linkedin-0x92f834c6-15c33c6a` for the `co-ai` / `agent-4-linkedin` cleanup scope; old `co-ai` and old `agent-4-linkedin` containers/images/deploy dirs were removed.
 - Refactor complete: co-ai deploy package construction, selected/all skill resolution, generated entrypoint/Dockerfile creation, and deploy env loading now live in `connectonion/cli/commands/deploy_co_ai.py`.
 - Compatibility note: `deploy_commands.py` still imports/re-exports the deploy helper names used by existing tests and callers.
 - Current approval correction: generated hosted co-ai entrypoints and local `co ai` web startup no longer pass `auto_approve=True` by default.
@@ -112,6 +121,14 @@ Last updated: 2026-06-02
 ## Verification
 
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_tool_approval.py tests/unit/test_ulw.py tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py -q`
+- `python3 -m pytest tests/unit/test_deploy_commands.py -q`
+- `python3 -m pytest tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m pytest tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py -q`
+- `python3 -m py_compile connectonion/cli/commands/deploy_co_ai.py connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py`
+- `git diff --check`
+- Real deploy: `PYTHONPATH=/Users/yfshuu/coding/openonion/connectonion /opt/homebrew/bin/python3 -m connectonion.cli.main deploy --name agent-4-linkedin --skills deploy-smoke --browser`
+- Server verification: `docker exec agent-4-linkedin-0x92f834c6-15c33c6a google-chrome --version`
+- Server verification: Playwright launched `chromium.launch(channel="chrome", headless=True, args=["--no-sandbox"])` and printed `PLAYWRIGHT_CHROME_OK 148.0.7778.215`.
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/tool_approval/__init__.py connectonion/useful_plugins/tool_approval/constants.py connectonion/useful_plugins/ulw.py connectonion/cli/co_ai/agent.py`
 - `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py tests/unit/test_tool_approval.py::TestToolClassification tests/unit/test_tool_approval.py::TestDangerousTools tests/unit/test_ulw.py -q`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: removing Claude Code skill directories from co-ai runtime skill loading while keeping ConnectOnion `.co/skills` behavior.
+- Current focus: removing the co-ai auto-approve hook while preserving explicit ULW approval skipping.
 
 ## Working Tree Notes
 
@@ -18,6 +18,9 @@ Last updated: 2026-06-02
 - The `skip_tool_approval` flag remains available for explicit modes such as ULW, but deploy/web startup should not set it implicitly.
 - Verification confirmed the approval correction with focused deploy, co-ai startup, tool approval, and ULW tests.
 - Runtime skills correction complete: co-ai slash skill loading and runtime discovery no longer read `.claude/skills`; Claude skills must be copied into `.co/skills` before runtime/deploy usage.
+- Approval inspection: `tool_approval.constants.DANGEROUS_TOOLS` includes shell/run tools, file edit tools, background/task control, external communication, and delete/remove tools, so web-mode co-ai does have real tool calls that should request user approval.
+- co-ai auto-approve cleanup complete: `create_coding_agent()` no longer exposes an `auto_approve` option or registers an `_enable_auto_approve` hook.
+- Explicit ULW mode remains the only current code path in co-ai's plugin stack that sets `skip_tool_approval=True`.
 - New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
 - Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
 - Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
@@ -107,6 +110,9 @@ Last updated: 2026-06-02
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py tests/unit/test_tool_approval.py::TestToolClassification tests/unit/test_tool_approval.py::TestDangerousTools tests/unit/test_ulw.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/co_ai/agent.py connectonion/cli/co_ai/main.py connectonion/cli/commands/deploy_co_ai.py connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/ulw.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_skills.py tests/unit/test_deploy_commands.py -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/skills.py connectonion/cli/commands/deploy_co_ai.py connectonion/cli/commands/deploy_commands.py`
 - `git diff --check`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: making local and hosted co-ai route dangerous tool calls through user approval by default instead of blanket auto-approving.
+- Current focus: removing Claude Code skill directories from co-ai runtime skill loading while keeping ConnectOnion `.co/skills` behavior.
 
 ## Working Tree Notes
 
@@ -17,6 +17,7 @@ Last updated: 2026-06-02
 - Current approval correction: generated hosted co-ai entrypoints and local `co ai` web startup no longer pass `auto_approve=True` by default.
 - The `skip_tool_approval` flag remains available for explicit modes such as ULW, but deploy/web startup should not set it implicitly.
 - Verification confirmed the approval correction with focused deploy, co-ai startup, tool approval, and ULW tests.
+- Runtime skills correction complete: co-ai slash skill loading and runtime discovery no longer read `.claude/skills`; Claude skills must be copied into `.co/skills` before runtime/deploy usage.
 - New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
 - Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
 - Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
@@ -106,6 +107,9 @@ Last updated: 2026-06-02
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_skills.py tests/unit/test_deploy_commands.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/skills.py connectonion/cli/commands/deploy_co_ai.py connectonion/cli/commands/deploy_commands.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_tool_approval.py::TestNoIO::test_skip_tool_approval_flag_skips_web_approval tests/unit/test_ulw.py -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/co_ai/main.py connectonion/cli/co_ai/agent.py connectonion/cli/commands/deploy_co_ai.py connectonion/useful_plugins/tool_approval/approval.py`
 - `git diff --check`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,7 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: removing the co-ai auto-approve hook while preserving explicit ULW approval skipping.
+- Current focus: removing the generic `skip_tool_approval` approval bypass while preserving explicit ULW mode behavior.
 
 ## Working Tree Notes
 
@@ -15,12 +15,13 @@ Last updated: 2026-06-02
 - Refactor complete: co-ai deploy package construction, selected/all skill resolution, generated entrypoint/Dockerfile creation, and deploy env loading now live in `connectonion/cli/commands/deploy_co_ai.py`.
 - Compatibility note: `deploy_commands.py` still imports/re-exports the deploy helper names used by existing tests and callers.
 - Current approval correction: generated hosted co-ai entrypoints and local `co ai` web startup no longer pass `auto_approve=True` by default.
-- The `skip_tool_approval` flag remains available for explicit modes such as ULW, but deploy/web startup should not set it implicitly.
+- Legacy note: `skip_tool_approval` previously existed for explicit modes such as ULW, but deploy/web startup no longer sets it.
 - Verification confirmed the approval correction with focused deploy, co-ai startup, tool approval, and ULW tests.
 - Runtime skills correction complete: co-ai slash skill loading and runtime discovery no longer read `.claude/skills`; Claude skills must be copied into `.co/skills` before runtime/deploy usage.
 - Approval inspection: `tool_approval.constants.DANGEROUS_TOOLS` includes shell/run tools, file edit tools, background/task control, external communication, and delete/remove tools, so web-mode co-ai does have real tool calls that should request user approval.
 - co-ai auto-approve cleanup complete: `create_coding_agent()` no longer exposes an `auto_approve` option or registers an `_enable_auto_approve` hook.
-- Explicit ULW mode remains the only current code path in co-ai's plugin stack that sets `skip_tool_approval=True`.
+- Explicit ULW mode now relies on `mode == "ulw"` instead of setting `skip_tool_approval=True`.
+- Generic approval skip cleanup complete: `tool_approval` ignores `session["skip_tool_approval"]`; ULW relies on `mode == "ulw"` instead.
 - New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
 - Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
 - Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
@@ -110,6 +111,9 @@ Last updated: 2026-06-02
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_tool_approval.py tests/unit/test_ulw.py tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/tool_approval/__init__.py connectonion/useful_plugins/tool_approval/constants.py connectonion/useful_plugins/ulw.py connectonion/cli/co_ai/agent.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py tests/unit/test_tool_approval.py::TestToolClassification tests/unit/test_tool_approval.py::TestDangerousTools tests/unit/test_ulw.py -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/co_ai/agent.py connectonion/cli/co_ai/main.py connectonion/cli/commands/deploy_co_ai.py connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/ulw.py`
 - `git diff --check`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,11 +7,15 @@ Last updated: 2026-06-01
 - Repository: `openonion/connectonion`
 - Active branch: `codex/co-ai-remote-login-tool`
 - Active PR: `#143` (`[codex] Add remote login tool to co ai`)
-- Current focus: fixing real deploy 524 timeout and simplifying the co-ai deploy build path without changing the user-facing deploy flow.
+- Current focus: adding an explicit all-skills opt-in for hosted co-ai deploy while keeping default deploy behavior conservative.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
+- New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
+- Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
+- Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
+- `--all-skills` auto-selects co-ai deploy in `--template auto` mode and is rejected with `--template project`.
 - New deploy timeout finding: `oo-api` POST `/api/v1/deploy` awaited the entire slow deploy path: package extraction, rsync to GCE, Docker build, Docker run, Caddy route update, old-version cleanup. That matches the Cloudflare 524 at `Uploading...`.
 - Fix in `oo-api`: POST `/api/v1/deploy` now creates the deployment row and returns `status=deploying` quickly; the slow build/run path runs in a detached asyncio task and updates the existing deployment status.
 - Backend build simplification: `docker build --no-cache` was removed so repeated deploys can use Docker layer cache.
@@ -97,6 +101,9 @@ Last updated: 2026-06-01
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_skills_without_co_ai_template tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_all_skills_without_co_ai_template -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/co_ai/agent.py connectonion/useful_tools/browser_tools/browser.py`
 - `git diff --check`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,19 +7,18 @@ Last updated: 2026-06-02
 - Repository: `openonion/connectonion`
 - Active branch: `codex/deploy-co-ai-skills`
 - Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
-- Current focus: lightweight co-ai deploy browser flag implementation and production verification are complete.
+- Current focus: co-ai deploy runtime v4 implementation is complete locally.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
-- New deploy target: co-ai deploy should generate a normal deploy project inside the temporary tarball (`agent.py`, `.co/host.yaml`, selected `.co/skills/*`, and `requirements.txt`) instead of requiring the user to create those files.
-- New browser boundary: `co deploy --skills foo` should not install Chrome, while `co deploy --skills linkedin-post --browser` should generate a Dockerfile that installs Google Chrome and make the generated agent use `browser_channel="chrome"`.
-- Implementation result: generated co-ai deploy packages now use root `agent.py` plus `.co/host.yaml`, and upload `entrypoint=agent.py`.
-- Default non-browser co-ai packages no longer include a Dockerfile or Chrome install; selected skill `requirements.txt` contents are inlined into root `requirements.txt` so the existing `oo-api` generic Dockerfile can install them before `COPY . .`.
-- Browser co-ai packages include a Dockerfile that installs Google Chrome during build and generated `agent.py` passes `browser_channel="chrome"`.
-- `--browser` is wired through CLI/package creation and rejected for explicit `--template project`.
-- Real production deploy passed: `co deploy --name agent-4-linkedin --skills deploy-smoke --browser` created active deployment `15c33c6a`.
-- Server verification passed for `agent-4-linkedin-0x92f834c6-15c33c6a`: container is running, `/usr/bin/google-chrome` exists, Chrome reports `Google Chrome 148.0.7778.215`, `xvfb-run` exists, and Playwright launched `channel="chrome"` successfully.
+- Current v4 deploy behavior: deploy `--browser` is removed; hosted co-ai deploys include browser/Chrome support by default.
+- Current v3/local behavior: `co deploy --skills foo` uses `--runtime local`, builds a self-contained source package, writes `agent.py`, `.co/host.yaml`, selected `.co/skills/*`, `requirements.txt`, and a Chrome-installing Dockerfile, and uploads `entrypoint=agent.py`.
+- Current v4/pypi behavior: `co deploy --skills foo --runtime pypi` uploads only `manifest.json` plus selected `.co/skills/*`; `oo-api` materializes `agent.py`, `.co/host.yaml`, `requirements.txt`, and a Chrome-installing Dockerfile after extraction.
+- Project deploy remains the legacy `.co/host.yaml` / git archive path and rejects `--runtime pypi`.
+- The previous `--browser` opt-in design is superseded; `co deploy --browser` now fails as an unknown option.
+- Prior production browser verification used `co deploy --name agent-4-linkedin --skills deploy-smoke --browser` for active deployment `15c33c6a`; that command form is no longer current after v4.
+- Server verification for that deployment confirmed `/usr/bin/google-chrome`, `Google Chrome 148.0.7778.215`, `xvfb-run`, and Playwright channel `chrome`.
 - Cleanup result: deploy API and server state now show only `agent-4-linkedin-0x92f834c6-15c33c6a` for the `co-ai` / `agent-4-linkedin` cleanup scope; old `co-ai` and old `agent-4-linkedin` containers/images/deploy dirs were removed.
 - Refactor complete: co-ai deploy package construction, selected/all skill resolution, generated entrypoint/Dockerfile creation, and deploy env loading now live in `connectonion/cli/commands/deploy_co_ai.py`.
 - Compatibility note: `deploy_commands.py` still imports/re-exports the deploy helper names used by existing tests and callers.
@@ -120,13 +119,17 @@ Last updated: 2026-06-02
 
 ## Verification
 
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/commands/deploy_co_ai.py`
+- `python3 -m pytest tests/test_deploy.py -q` in `/Users/yfshuu/coding/openonion/oo-api`
+- `PYTHONPYCACHEPREFIX=/tmp/oo-api-pycache python3 -m py_compile deploy/service.py deploy/routes.py` in `/Users/yfshuu/coding/openonion/oo-api`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_tool_approval.py tests/unit/test_ulw.py tests/unit/test_co_ai_agent_main.py tests/unit/test_deploy_commands.py -q`
 - `python3 -m pytest tests/unit/test_deploy_commands.py -q`
 - `python3 -m pytest tests/e2e/cli/test_cli_deploy.py -q`
 - `python3 -m pytest tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py -q`
 - `python3 -m py_compile connectonion/cli/commands/deploy_co_ai.py connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py`
 - `git diff --check`
-- Real deploy: `PYTHONPATH=/Users/yfshuu/coding/openonion/connectonion /opt/homebrew/bin/python3 -m connectonion.cli.main deploy --name agent-4-linkedin --skills deploy-smoke --browser`
+- Prior real deploy before v4 removed `--browser`: `PYTHONPATH=/Users/yfshuu/coding/openonion/connectonion /opt/homebrew/bin/python3 -m connectonion.cli.main deploy --name agent-4-linkedin --skills deploy-smoke --browser`
 - Server verification: `docker exec agent-4-linkedin-0x92f834c6-15c33c6a google-chrome --version`
 - Server verification: Playwright launched `chromium.launch(channel="chrome", headless=True, args=["--no-sandbox"])` and printed `PLAYWRIGHT_CHROME_OK 148.0.7778.215`.
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/tool_approval/__init__.py connectonion/useful_plugins/tool_approval/constants.py connectonion/useful_plugins/ulw.py connectonion/cli/co_ai/agent.py`

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,12 +7,68 @@ Last updated: 2026-06-01
 - Repository: `openonion/connectonion`
 - Active branch: `codex/co-ai-remote-login-tool`
 - Active PR: `#143` (`[codex] Add remote login tool to co ai`)
-- Current focus: Login handoff behavior. Browser automation tools open and inspect login pages; QR login sends the QR screenshot through `send_qr_to_user`; credential login sends a structured account/password `ask_user` through `send_credentials_form_to_user`.
+- Current focus: finishing hosted co-ai deploy for the two active scenarios: server-side Chrome/headless browser automation and selected skills packaged into the co-ai deploy.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
-- This iteration should stay scoped to `remote_login`, its directly coupled prompt/tests, and local server restart verification.
+- Current frontend finding: deployed co-ai relays successfully and host ANNOUNCE can publish profile metadata, but the frontend falls back to address-only display because its agent-info hook does not read `/api/relay/agents/{address}/profile`.
+- SDK finding: `connectonion-ts` has the same direct-`/info` dependency in `fetchAgentInfo()`, so consumers also lose name/skills/tools when relay endpoints are reachable only through `/ws/input`.
+- Fix: `connectonion-ts.fetchAgentInfo()` and `oo-chat`'s `useAgentInfo()` now read relay profile metadata from `/api/relay/agents/{address}/profile` and use it as the fallback display source.
+- Fix: profile tools are normalized on the frontend/SDK from either `["bash"]` or `[{name: "bash"}]`, and Python host profile publication now emits the SDK-preferred string array.
+- Direct `/info` remains best effort and address-verified; it can enrich profile metadata but no longer decides whether hosted relay agents show name/skills/tools.
+- New runtime finding: local frontend shows `agent-4-linkedin` and `/deploy-smoke`, but invoking `/deploy-smoke` still allowed the model to run ordinary coding tools before outputting the smoke marker.
+- Suspected root cause: `setup_skills()` discovers metadata using `agent.co_dir`, while `handle_skill_invocation()` loads slash skills through `Path.cwd()/.co/skills`; hosted deployment can have a different cwd than the packaged `.co` directory.
+- Fix: skills plugin slash invocation and the runtime `skill()` tool now resolve `agent.co_dir/skills` first, then fall back to cwd/user/builtin paths.
+- Fix: generated co-ai deploy entrypoints now define `CO_DIR = PACKAGE_ROOT / ".co"` and pass that absolute package path into both `create_coding_agent()` and `host()`.
+- Connection instability finding: local dev logs show `/api/auth` responses ranging from sub-second to 37 seconds, and the SDK has a fixed 30-second `CONNECTED` timeout. That explains intermittent "Authentication timed out" during cold or slow handshakes, but it is separate from skill loading correctness.
+- Current UI finding: `ChatInput` receives `isLoading` from `Chat`, but does not destructure or use it, so the send button remains an arrow instead of switching to a stop button while the agent is running.
+- Stop boundary decision: first implementation should close the client WebSocket and return local UI state to idle without clearing the transcript. Python worker thread cancellation needs a separate backend protocol and is not part of this UI fix.
+- Fix: `connectonion-ts` now exposes `RemoteAgent.stop()` and `useAgentForHuman().stop()`, closing the active WebSocket, removing the optimistic thinking placeholder, and returning local status to idle without clearing existing chat items.
+- Fix: `oo-chat` now wires `stop` through `useAgentSDK`, the session page, `Chat`, and `ChatInput`.
+- Fix: the send button now renders a stop icon while `isLoading` is true and calls the stop handler from the same button position.
+- Local dev note: after rebuilding `connectonion-ts`, the stale copied `oo-chat/node_modules/connectonion` package had to be removed and reinstalled with `npm install --install-links` so Next.js used the new `stop()` type/runtime.
+- Current UI regression: restored sessions can contain `tool_call: running` while the live SDK status has already returned to `idle`/`connected`, so `oo-chat` renders the disabled send arrow instead of the stop button.
+- Root cause: `useAgentSDK()` derives `isLoading` only from SDK `isProcessing`, not from active persisted `cleanUI` items.
+- Runtime note: the previous visible running command was `playwright install chromium`, which pointed to a separate hosted co-ai browser-runtime packaging issue; that deploy package now installs the browser during image build.
+- Fix: `useAgentSDK()` now treats restored active `thinking`, `tool_call`, `intent`, `eval`, and `compact` items as loading.
+- Fix: `RemoteAgent.stop()` now settles restored running local UI items before returning to idle, so the stop button does not stay stuck after the user stops a recovered session.
+- Local browser verification: reloading the current `localhost:3000` session showed an enabled `Stop response` button while the restored transcript still contained active work.
+- Current hosted browser finding: co-ai packages do not include a Dockerfile, so `oo-api` injects its generic Python Dockerfile and only installs `requirements.txt`.
+- Root cause: Python `playwright` is installed, but Chromium browser binaries and OS dependencies are not installed during image build, so the agent falls back to runtime `playwright install chromium` attempts.
+- Fix direction: generate a co-ai-specific Dockerfile inside the deploy package that installs the required Playwright browser before starting the app.
+- Fix: co-ai deploy packages now include a generated Dockerfile that installs Python requirements, runs `python -m playwright install --with-deps chrome`, copies the package, and starts `.co/deploy/co_ai_entrypoint.py`.
+- Project deploy packaging remains unchanged; only the co-ai deploy path writes this Dockerfile into the temporary package.
+- Follow-up packaging issue: co-ai generated `requirements.txt` still points at `connectonion=={version}`, so Docker build installs dependency metadata from the published package and then runtime imports the packaged source via `sys.path`.
+- Desired correction: include local project metadata in the co-ai package and install `.` from the package during Docker build, so source, package data, and declared dependencies all come from the same packaged revision.
+- Fix: co-ai deploy packages now copy `pyproject.toml`, `README.md`, and `LICENSE` when available, and generated `requirements.txt` installs `.` instead of `connectonion=={version}`.
+- Fix: the generated co-ai Dockerfile now copies the package before `pip install -r requirements.txt`, so the Docker build installs the packaged source and its declared dependencies before installing Playwright Chrome.
+- Fallback: when the CLI is running from an installed package without local project metadata, co-ai packaging still falls back to `connectonion=={version}` rather than failing.
+- Current browser runtime correction: default Playwright Chromium is acceptable for many automation tasks, but hosted co-ai login flows should prefer branded Google Chrome where available.
+- Risk note: Chrome channel improves browser compatibility but does not guarantee bypassing login risk systems; headless mode, automation control, fresh profiles, and cloud IPs can still be detected.
+- Fix: `BrowserAutomation` now accepts an explicit `browser_channel`, and hosted co-ai generated entrypoints pass `browser_headless=True` plus `browser_channel="chrome"`.
+- Fix: `create_coding_agent()` accepts `co_dir`, `browser_headless`, and `browser_channel`, while local `co ai` keeps the existing visible browser behavior by default.
+- Deploy UX: `co deploy --skill foo` is now accepted as a singular alias for `co deploy --skills foo`; comma-separated and repeated skill values are still supported.
+- Deploy skill dependency fix: when a selected skill directory contains `requirements.txt`, the generated co-ai root `requirements.txt` references it, so dependencies such as Gemini image-generation packages can install during Docker build.
+- Deploy env fix: co-ai deploy now merges project `.env`, allowed API keys from global `~/.co/keys.env`, and allowed API keys from the current process environment, while still avoiding a full shell-environment dump.
+- Auto-approval fix: `create_coding_agent(auto_approve=True)` now marks each turn with `skip_tool_approval`, and the tool approval plugin respects that flag without switching the session into ULW continuation mode.
+- Deferred artifact note: high-volume image output still needs a separate artifact/static-file delivery design; current deploy work only ensures skill code, dependencies, and keys reach the container.
+- Current deploy UX finding: direct co-ai deploy defaults the backend project name to `co-ai` and `create_coding_agent()` hardcodes `Agent("oo")`, so separate co-ai deployments cannot be named as distinct agents yet.
+- Fix: `co deploy --name/-n` sets the cloud project name for co-ai deploys and is written into the generated co-ai entrypoint as `create_coding_agent(name=...)`.
+- Fix: `host()` now builds a relay profile from hosted agent metadata and includes it in signed ANNOUNCE messages; relay heartbeat re-announces preserve the same profile.
+- Frontend expectation after redeploy: `/api/relay/agents/{address}/profile` should return `profile.name` / `profile.alias`, `skills`, `tools`, `model`, and `version`, so chat/directory UI no longer needs to fall back to address-only display.
+- Real deploy finding: `co deploy --skills deploy-smoke` uploaded and built, but container startup imported `connectonion` from site-packages and failed because the PyPI version lacks the new `create_coding_agent(co_dir=...)` parameter.
+- Root cause: the generated entrypoint lives under `/app/.co/deploy`, so Python's default `sys.path[0]` is `/app/.co/deploy`, not `/app`; the packaged source directory is not preferred unless the entrypoint inserts the package root.
+- Fix: generated co-ai entrypoint now prepends `/app` to `sys.path` before importing `connectonion`.
+- New real deploy finding: remote logs now show imports from `/app/connectonion`, then fail with `OPENONION_API_KEY not found in environment`.
+- Root cause: the production `oo-api` deploy route takes a `secrets` form field and only parses `secrets` into Docker `-e` env vars, while the CLI currently sends the JSON under `env_vars`.
+- Fix: CLI deploy now sends the same serialized env-var JSON under both `env_vars` and `secrets`.
+- The first co-ai deploy implementation still inherited project deploy prerequisites. This iteration removes those prerequisites for co-ai deploy while keeping explicit project deploy backwards-compatible.
+- Current direct co-ai deploy behavior: `co deploy --skills ...` builds a self-contained temporary co-ai package and does not require git, `.co/host.yaml`, or `agent.py`.
+- The login handoff task is complete; this iteration is scoped to deploy CLI/package builder behavior and the directly coupled co-ai agent factory options.
+- Default `co deploy` must remain backwards-compatible with project `.co/host.yaml` deployment.
+- The new co-ai deploy path should avoid backend API changes by constructing a temporary tarball overlay containing `.co/deploy/co_ai_entrypoint.py` and selected `.co/skills/*` directories.
+- Prior login-handoff notes below are retained as historical context for the active branch.
 - Local runtime issue observed: `remote_login` starts a second Playwright sync context inside the websocket/async runtime and fails with "using Playwright Sync API inside the asyncio loop"; the agent then falls back to browser tools and `wait_for_manual_login`.
 - Design correction: do not put browser/process/login lifecycle inside `remote_login`; the browser tool owns browser context and process behavior.
 - Remote-agent assumption: the user cannot see the server-side browser window, so QR login must send the QR screenshot through oo-chat as a user action request.
@@ -30,9 +86,73 @@ Last updated: 2026-06-01
 - Local oo-chat integration note: the local npm package copy under `oo-chat/node_modules/connectonion` was patched to match the SDK source fix because oo-chat was still loading the published `connectonion@0.1.4` store implementation.
 - Local oo-chat now depends on `file:../connectonion-ts` and no longer uses `transpilePackages: ['connectonion']`; this keeps local dev on the fixed SDK while avoiding the Turbopack/CommonJS `require is not defined` path.
 - Browser cleanup follow-up: `close_browser` is now a login/browser-flow handoff tool. It calls the existing `agent.browse.close()` after login succeeds or the login flow is abandoned, so the persistent profile is saved and the server-side browser process is released.
+- Browser lifecycle boundary: do not reuse live Playwright browser objects across hosted turns. Each turn may get a fresh Agent/tool instance; persistent browser profile/cookies carry login state across turns, while QR and credential handoffs wait inside the active turn.
+- Credential privacy fix: `send_credentials_form_to_user` now stores credentials only on the current Agent instance and returns no raw username/password. The agent must focus the relevant field and call `type_saved_login_credential(field="username"|"password")`, so password values do not appear in `keyboard_type(...)` tool arguments, trace rows, or UI.
+- Cleanup safety net: co ai now registers a login cleanup `on_complete` plugin that closes the server-side browser after a login handoff turn if the model did not explicitly call `close_browser`.
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/co_ai/agent.py connectonion/useful_tools/browser_tools/browser.py`
+- `git diff --check`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_browser_automation.py tests/unit/test_tool_approval.py::TestNoIO::test_skip_tool_approval_flag_skips_web_approval tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/co_ai/agent.py connectonion/useful_tools/browser_tools/browser.py connectonion/useful_plugins/tool_approval/approval.py`
+- `git diff --check`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py -q`
+- `/opt/homebrew/bin/python3 -m pytest tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/commands/deploy_commands.py`
+- `git diff --check`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py -q`
+- `/opt/homebrew/bin/python3 -m pytest tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/commands/deploy_commands.py`
+- `npm run build` in `connectonion-ts`
+- `npm test -- tests/remote-agent-stop.test.jsx --runInBand` in `connectonion-ts`
+- `npm install --install-links` in `oo-chat` after rebuilding the local SDK dependency
+- `npm run lint -- components/chat/use-agent-sdk.ts components/chat/chat-input.tsx components/chat/chat.tsx components/chat/types.ts 'app/[address]/[sessionId]/page.tsx'` in `oo-chat` (passed with existing warnings for `<img>` and unused props)
+- `npm run build` in `oo-chat`
+- Browser check at `http://localhost:3000/0xde16917a4129ccb4029cd422b75c4582bf8173c3d4a6c11b7164074231765e85/76cff8ba-6b8e-4390-b49d-6fd7c8b7eade`: after reload, the restored active UI rendered an enabled `Stop response` button.
+- `git diff --check` in `connectonion`
+- `git -C /Users/yfshuu/coding/openonion/connectonion-ts diff --check`
+- `git -C /Users/yfshuu/coding/openonion/oo-chat diff --check`
+- `npm test -- tests/endpoint.test.ts --runInBand` in `connectonion-ts`
+- `npm run build` in `connectonion-ts`
+- `npm test -- tests/remote-agent-stop.test.jsx --runInBand` in `connectonion-ts`
+- `npm run lint -- components/chat/chat-input.tsx components/chat/chat.tsx components/chat/types.ts components/chat/use-agent-sdk.ts 'app/[address]/[sessionId]/page.tsx' hooks/use-agent-info.ts` in `oo-chat` (passed with existing warnings for `<img>` and unused props)
+- `npm run build` in `oo-chat`
+- Browser smoke at `http://localhost:3000/0x23dab67914ca9eb8c01e838e638ad9c5327f8c7b60752fca4a798837dff249b0/7cee4ca7-d5ca-435c-8443-f465ef6afed8`: after sending a prompt, button label changed to `Stop response`; after clicking stop, it returned to `Send message`.
+- Browser check at `http://localhost:3000/0xde16917a4129ccb4029cd422b75c4582bf8173c3d4a6c11b7164074231765e85/76cff8ba-6b8e-4390-b49d-6fd7c8b7eade`: after reload, the restored active UI rendered an enabled `Stop response` button.
+- `git diff --check` in `connectonion`
+- `git -C /Users/yfshuu/coding/openonion/connectonion-ts diff --check`
+- `git -C /Users/yfshuu/coding/openonion/oo-chat diff --check`
+- Note: `npm test -- tests/connect.test.ts --runInBand` in `connectonion-ts` is not usable in the current package because Jest is not configured to transform TypeScript test files; the stop regression uses the package's built `dist` output from a `.jsx` Jest test instead.
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_skills.py tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/e2e/cli/test_cli_deploy.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/useful_plugins/skills.py connectonion/cli/commands/deploy_commands.py`
+- `npm run build` in `connectonion-ts`
+- `npm run lint -- hooks/use-agent-info.ts components/chat/types.ts` in `oo-chat`
+- `npm run build` in `oo-chat`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_host_relay.py::TestHostRelayConnection::test_build_relay_profile_includes_skills_tools_and_version tests/unit/test_host_relay.py::TestHostRelayConnection::test_host_passes_profile_to_relay_lifespan -q`
+- `git diff --check` in `connectonion`
+- `git -C /Users/yfshuu/coding/openonion/connectonion-ts diff --check`
+- `git -C /Users/yfshuu/coding/openonion/oo-chat diff --check`
+- Note: `npm run lint -- src/connect/endpoint.ts src/connect/types.ts` in `connectonion-ts` is not usable because that package currently has no ESLint config; `npm run build` passed instead.
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_host_relay.py::TestHostRelayConnection::test_host_passes_profile_to_relay_lifespan tests/unit/test_host_relay.py::TestHostRelayConnection::test_build_relay_profile_includes_skills_tools_and_version tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/unit/test_host_relay.py tests/unit/test_relay.py tests/unit/test_announce.py tests/e2e/cli/test_cli_deploy.py -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py connectonion/cli/co_ai/agent.py connectonion/network/host/server.py connectonion/network/relay.py`
+- `git diff --check`
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m py_compile connectonion/cli/commands/deploy_commands.py`
+- `git diff --check`
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m py_compile connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py connectonion/cli/co_ai/agent.py`
+- `git diff --check`
+- `python3 -m pytest tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold -q`
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m py_compile connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py`
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/e2e/cli/test_cli_deploy.py -q`
+- `git diff --check`
+- `python3 -m pytest tests/unit/test_deploy_commands.py tests/unit/test_co_ai_agent_main.py tests/e2e/cli/test_cli_deploy.py -q`
+- `python3 -m py_compile connectonion/cli/commands/deploy_commands.py connectonion/cli/main.py connectonion/cli/co_ai/agent.py`
+- `git diff --check`
 - `python3 -m pytest tests/unit/test_remote_login_tool.py tests/unit/test_co_ai_agent_main.py`
 - `python3 -m py_compile connectonion/useful_tools/remote_login.py connectonion/cli/co_ai/agent.py`
 - `git diff --check`
@@ -49,6 +169,9 @@ Last updated: 2026-06-01
 - `python3 -m pytest tests/unit/test_login_handoff_tools.py tests/unit/test_co_ai_agent_main.py::test_create_coding_agent tests/unit/test_co_ai_prompts_assembler.py::test_login_handoff_prompt_allows_user_mediated_credential_login`
 - `python3 -m pytest tests/unit/test_login_handoff_tools.py tests/unit/test_co_ai_agent_main.py tests/unit/test_co_ai_prompts_assembler.py tests/unit/test_ask_user.py tests/unit/test_tool_executor.py tests/unit/test_image_result_formatter.py tests/unit/test_co_ai_tools_misc.py`
 - `python3 -m py_compile connectonion/useful_tools/login_handoff.py connectonion/useful_tools/__init__.py connectonion/cli/co_ai/agent.py`
+- `python3 -m pytest tests/unit/test_login_handoff_tools.py tests/unit/test_co_ai_agent_main.py::test_create_coding_agent tests/unit/test_co_ai_prompts_assembler.py::test_login_handoff_prompt_allows_user_mediated_credential_login -q`
+- `python3 -m py_compile connectonion/useful_tools/login_handoff.py connectonion/cli/co_ai/plugins/login_cleanup.py connectonion/cli/co_ai/agent.py`
+- `git diff --check`
 - Local LinkedIn smoke after restart: co ai used `open_browser`, `go_to`, and `send_credentials_form_to_user`; oo-chat rendered separate `账号` and `密码` fields.
 - oo-chat component check: `npx eslint components/chat/chat-ask-user.tsx`
 - SDK persistence smoke: simulated a 200k-character base64 image through oo-chat's loaded `connectonion/dist/react/store.js`; persisted localStorage payload stayed small and contained no `data:image/png;base64`.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,17 +1,19 @@
 # Project Status
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 ## Baseline
 
 - Repository: `openonion/connectonion`
-- Active branch: `codex/co-ai-remote-login-tool`
-- Active PR: `#143` (`[codex] Add remote login tool to co ai`)
-- Current focus: adding an explicit all-skills opt-in for hosted co-ai deploy while keeping default deploy behavior conservative.
+- Active branch: `codex/deploy-co-ai-skills`
+- Active PR: `#145` (`[codex] Add hosted co-ai deploy skills`)
+- Current focus: splitting co-ai deploy package-building helpers out of `connectonion/cli/commands/deploy_commands.py` without changing deploy behavior.
 
 ## Working Tree Notes
 
 - `AGENTS.md` and `test-deploy/` were present before this status baseline.
+- Refactor complete: co-ai deploy package construction, selected/all skill resolution, generated entrypoint/Dockerfile creation, and deploy env loading now live in `connectonion/cli/commands/deploy_co_ai.py`.
+- Compatibility note: `deploy_commands.py` still imports/re-exports the deploy helper names used by existing tests and callers.
 - New deploy UX: `co deploy --all-skills` now explicitly packages all project `.co/skills` and user `~/.co/skills` skills into a hosted co-ai deploy.
 - Default behavior remains conservative: `co deploy --skills foo` packages only the selected skill names plus bundled built-ins.
 - Duplicate skill names prefer project `.co/skills` over user `~/.co/skills`.
@@ -101,6 +103,9 @@ Last updated: 2026-06-01
 
 ## Verification
 
+- `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_skills_without_co_ai_template tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_all_skills_without_co_ai_template -q`
+- `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py connectonion/cli/commands/deploy_co_ai.py`
+- `git diff --check`
 - `/opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_skills_without_co_ai_template tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_all_skills_without_co_ai_template -q`
 - `/opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py`
 - `git diff --check`

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,11 +1,46 @@
 # Tasks
 
+## Current Task: co-ai Deploy Runtime v4
+
+Status: complete
+
+Context:
+
+- The previous browser deploy design made Chrome opt-in with `--browser`.
+- The requested behavior is now stricter and simpler: hosted co-ai deploys should include browser/Chrome support by default, with no compatibility `--browser` option.
+- A new v4 lightweight runtime should exist alongside the current local-source package path, so users can deploy co-ai from the published PyPI runtime and upload only selected skills plus a small manifest.
+
+Scope:
+
+- Remove the deploy `--browser` CLI option and related compatibility handling.
+- Make the existing co-ai deploy package path always generate Chrome-enabled `agent.py` and Dockerfile behavior.
+- Add `--runtime local|pypi` for co-ai deploys, defaulting to `local` so the current self-contained package path remains available as v3.
+- Make `--runtime pypi` build a lightweight manifest-plus-skills package for server-side materialization.
+- Update `oo-api` so it can materialize the pypi runtime package into a normal deploy project during build.
+
+Expected result:
+
+- `co deploy --skills foo` uses the local-source co-ai runtime and includes Chrome by default.
+- `co deploy --skills foo --runtime pypi` uploads only manifest metadata and selected skills; the backend builds a normal runtime package using published `connectonion`.
+- `co deploy --browser` is no longer accepted.
+- Project deploy behavior remains unchanged unless `--runtime pypi` is explicitly passed, which should be rejected for project deploys.
+
+Result:
+
+- Removed the deploy `--browser` option from the CLI and handler path.
+- Added `--runtime local|pypi` for co-ai deploys, defaulting to `local`.
+- Local co-ai deploy packages still upload a self-contained source package, but now always generate Chrome-enabled `agent.py` and Dockerfile behavior.
+- PyPI runtime co-ai deploy packages upload only `manifest.json` and selected `.co/skills/*` directories.
+- `oo-api` now materializes PyPI runtime manifests into normal deploy projects during extraction: `agent.py`, `.co/host.yaml`, `requirements.txt`, and a Chrome-installing Dockerfile.
+- Project deploy remains the existing git archive / `.co/host.yaml` path and rejects `--runtime pypi`.
+
 ## Current Task: Lightweight co-ai Deploy Browser Flag
 
 Status: complete
 
 Context:
 
+- Superseded by `co-ai Deploy Runtime v4`: hosted co-ai deploys now include Chrome by default and deploy `--browser` is removed.
 - co-ai deploy should still upload a normal deploy package for the existing `oo-api` backend.
 - Users should not need to create `.co/host.yaml`, `agent.py`, or a handwritten `host(...)` entrypoint for co-ai deploy.
 - The CLI should generate those project-scaffold files only inside the temporary tarball, not in the user's working tree.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,35 @@
 # Tasks
 
+## Current Task: Require co-ai User Approval by Default
+
+Status: complete
+
+Context:
+
+- The hosted co-ai deploy entrypoint currently passes `auto_approve=True`, which sets `skip_tool_approval=True` on each turn.
+- That bypasses the existing chat approval flow for dangerous tools.
+- The safer default for both local web co-ai and hosted co-ai is to send approval requests to the connected user.
+
+Scope:
+
+- Stop enabling `auto_approve` by default in generated co-ai deploy entrypoints.
+- Stop enabling `auto_approve` by default in local `co ai` web server startup.
+- Keep the lower-level `skip_tool_approval` mechanism for explicit modes such as ULW.
+- Add regression assertions so generated deploy packages and web startup do not silently re-enable auto approval.
+
+Expected result:
+
+- Dangerous hosted/local co-ai tool calls should route through the existing user approval UI when an IO client is connected.
+- No blanket auto-approval is enabled by default.
+
+Result:
+
+- Generated co-ai deploy entrypoints no longer pass `auto_approve=True`.
+- Local `co ai` web startup no longer passes `auto_approve=True`.
+- Existing `skip_tool_approval` behavior remains for explicit modes/plugins such as ULW.
+- Added regression assertions for deploy entrypoint generation and local web startup kwargs.
+- Focused deploy/co-ai/approval/ULW tests, syntax checks, and diff hygiene checks pass.
+
 ## Current Task: Split co-ai Deploy Packaging Helpers
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,34 @@
 # Tasks
 
+## Current Task: Deploy Timeout and Package Build Simplification
+
+Status: complete
+
+Context:
+
+- `co deploy --name agent-4-linkedin --skills deploy-smoke` failed at `Uploading...` with Cloudflare 524.
+- The backend deploy API was doing the full Docker build/run path inside the POST request, so Cloudflare could time out before the CLI reached its existing status polling loop.
+- The co-ai generated Dockerfile also copied the entire package before dependency installation, which makes Docker layer caching less useful for repeated deploys.
+
+Scope:
+
+- Keep the CLI/status-polling contract simple: POST returns a deployment id and `deploying`, then CLI polls status.
+- Move slow backend build/run work out of the POST response path.
+- Remove unnecessary cache busting from deploy builds.
+- Keep the co-ai deploy package self-contained and compatible with selected skills.
+
+Expected result:
+
+- Deploy POST should return quickly with `status=deploying` instead of waiting for Docker build.
+- Repeated deploys should have a better chance of reusing Docker layers.
+- CLI remains the same user flow: upload, then poll until running or failed.
+
+Result:
+
+- Local implementation and focused tests are complete.
+- `oo-api` production was deployed with the detached deploy task fix.
+- Real `co deploy --name agent-4-linkedin --skills deploy-smoke` no longer 524s at `Uploading...`; it entered `Building...` and completed successfully.
+
 ## Current Task: Hosted co-ai Browser Uses Chrome Channel
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,41 @@
 # Tasks
 
+## Current Task: Lightweight co-ai Deploy Browser Flag
+
+Status: complete
+
+Context:
+
+- co-ai deploy should still upload a normal deploy package for the existing `oo-api` backend.
+- Users should not need to create `.co/host.yaml`, `agent.py`, or a handwritten `host(...)` entrypoint for co-ai deploy.
+- The CLI should generate those project-scaffold files only inside the temporary tarball, not in the user's working tree.
+- Browser deployments need Google Chrome in the container, but non-browser skill deploys should stay lightweight.
+
+Scope:
+
+- Generate a normal-looking co-ai deploy package with `agent.py`, `.co/host.yaml`, selected `.co/skills/*`, and `requirements.txt`.
+- Add/keep `--browser` CLI plumbing so only browser deploys generate a Dockerfile that installs Google Chrome and select `browser_channel="chrome"`.
+- Keep default `co deploy --skills foo` lightweight for non-browser skills such as image generation.
+- Verify with focused tests and a real deploy, then confirm the server container has Chrome only for the browser deployment path.
+- After successful verification, remove old remote `co-ai` / `agent-4-linkedin` containers/images so only the latest verified image remains.
+
+Expected result:
+
+- `co deploy --skills foo` creates a lightweight generated co-ai project package without Chrome installation.
+- `co deploy --skills linkedin-post --browser` creates a generated co-ai project package with a Chrome-installing Dockerfile.
+- The generated files live only in the tarball and do not modify the user's project directory.
+- The deployed browser agent runs on the server with Google Chrome available.
+
+Result:
+
+- co-ai deploy packages now generate a normal deploy scaffold inside the tarball: `agent.py`, `.co/host.yaml`, selected `.co/skills/*`, and `requirements.txt`.
+- Default `co deploy --skills foo` packages no Dockerfile and no Chrome install; skill requirements are inlined into root `requirements.txt` so the existing `oo-api` generic Dockerfile can install them.
+- `co deploy --skills foo --browser` adds a generated Dockerfile that installs Google Chrome with Playwright and makes the generated agent use `browser_channel="chrome"`.
+- `--browser` is rejected for explicit `--template project`.
+- Production browser deploy succeeded for `agent-4-linkedin` after the directly related `oo-api` Docker build timeout fix.
+- Server verification confirmed the latest container has `/usr/bin/google-chrome`, `Google Chrome 148.0.7778.215`, `xvfb-run`, and Playwright can launch channel `chrome`.
+- Old `co-ai` and old `agent-4-linkedin` versions were removed; only `agent-4-linkedin-0x92f834c6-15c33c6a` remains on the server for those patterns.
+
 ## Current Task: Remove Generic Tool Approval Skip Flag
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,6 +1,403 @@
 # Tasks
 
-## Current Task: Login Handoff Tool Boundary
+## Current Task: Hosted co-ai Browser Uses Chrome Channel
+
+Status: complete
+
+Context:
+
+- Hosted co-ai browser automation currently installs/uses Playwright Chromium for deploy.
+- Login-heavy workflows are more compatible when running against branded Google Chrome's stable channel where available.
+- Playwright supports branded browser channels such as `chrome`, but Chrome must be installed in the container and selected at launch.
+- Using Chrome improves compatibility but does not make automation invisible; cloud IP, headless mode, automation flags, and new profiles can still trigger login risk systems.
+
+Scope:
+
+- Add a browser channel option to `BrowserAutomation`.
+- Pass `browser_channel="chrome"` for deployed co-ai.
+- Install Chrome, not default Chromium, in the generated co-ai Dockerfile.
+- Keep local co ai behavior unchanged unless a browser channel is explicitly provided.
+- Add focused tests for deploy entrypoint/package generation and co-ai agent factory wiring.
+
+Expected result:
+
+- New `co deploy --skills ...` co-ai containers install Google Chrome during image build.
+- Hosted co-ai browser tools launch via Playwright's `chrome` channel.
+- Local co ai can still use the existing local Chrome path/fallback behavior.
+
+Result:
+
+- Added `browser_channel` support to `BrowserAutomation` and `create_coding_agent()`.
+- Hosted co-ai generated entrypoints now pass `browser_headless=True` and `browser_channel="chrome"`.
+- Generated co-ai Dockerfiles now install the Playwright Chrome channel with `python -m playwright install --with-deps chrome`.
+- `co deploy --skill ...` is accepted as a singular alias for `--skills ...`; repeated/comma-separated skill parsing remains unchanged.
+- Selected skill `requirements.txt` files are referenced from the generated root `requirements.txt`, so skill-specific Python dependencies install during image build.
+- co-ai deploy env collection now merges project `.env`, allowed API keys from global `~/.co/keys.env`, and allowed API keys from the current process environment without dumping the whole shell environment.
+- `auto_approve=True` now sets the session `skip_tool_approval` flag, and the approval plugin respects that flag without switching to ULW mode.
+- Focused tests cover the generated deploy package, skill dependency wiring, env-var merge behavior, co-ai factory wiring, CLI skill alias behavior, BrowserAutomation launch options, and approval skip behavior.
+
+## Previous Task: co-ai Deploy Installs Packaged Source
+
+Status: complete
+
+Context:
+
+- The previous browser-runtime fix added a co-ai Dockerfile and Playwright Chromium install step, but it still left `requirements.txt` as `connectonion=={version}`.
+- That means Docker build installs dependencies from the published PyPI package, then runtime imports the packaged `/app/connectonion` source through `sys.path`.
+- This can drift: newly added co-ai source, package data, or dependency declarations may not match the published package used during build.
+- The co-ai deploy package should install the packaged local source itself, including the current `pyproject.toml` dependencies.
+
+Scope:
+
+- Add package metadata needed to install the packaged local ConnectOnion source.
+- Change co-ai generated `requirements.txt` to install the local package.
+- Keep the co-ai Dockerfile installing dependencies from the generated requirements file, then installing Playwright Chromium.
+- Keep project deploy behavior unchanged.
+- Update package-builder regression coverage.
+
+Expected result:
+
+- `co deploy --skills ...` builds a co-ai image from the exact local packaged source.
+- Hosted co-ai has the current package code, package data, and declared dependencies installed.
+- Hosted co-ai browser tools still get Chromium installed at image-build time.
+
+Result:
+
+- co-ai deploy packages now include local package metadata (`pyproject.toml`, plus README/LICENSE when available) alongside the packaged `connectonion/` source.
+- Generated co-ai `requirements.txt` installs `.` when local metadata is available, so Docker build installs the packaged source and its declared dependencies.
+- The co-ai Dockerfile copies the full package before `pip install -r requirements.txt`, then installs Playwright Chromium during image build.
+- If the CLI is running from an installed package without local project metadata, the package builder keeps the previous `connectonion=={version}` fallback.
+
+## Previous Task: co-ai Deploy Browser Runtime
+
+Status: complete
+
+Context:
+
+- The current hosted co-ai session failed the user's browser request before normal page automation and then tried to run `playwright install chromium` through Bash.
+- `oo-api` adds a generic Dockerfile only when the package does not include one; that generated Dockerfile only installs Python requirements and does not install Playwright browser binaries or OS dependencies.
+- The co-ai deploy package currently includes browser tools, so the package should provide a deploy-specific Dockerfile that installs Chromium during image build.
+
+Scope:
+
+- Add a generated Dockerfile to co-ai deploy packages only.
+- Install Python requirements first, then run `python -m playwright install --with-deps chromium` at build time.
+- Keep project deploy behavior unchanged.
+- Add package-builder regression coverage.
+
+Expected result:
+
+- `co deploy --skills ...` builds a co-ai image with Playwright Chromium already installed.
+- Hosted co-ai browser tools should not need to call `playwright install chromium` at runtime.
+
+Result:
+
+- co-ai deploy packages now include a generated Dockerfile.
+- The generated Dockerfile installs Python requirements and runs `python -m playwright install --with-deps chromium` during image build.
+- Project deploy behavior is unchanged; this Dockerfile is only generated for the co-ai deploy package path.
+- Added package-builder coverage proving the Dockerfile is included and contains the Chromium install step.
+
+## Previous Task: Restored Running Session Stop State
+
+Status: complete
+
+Context:
+
+- A restored chat session can show a tool card still marked `RUNNING` while the input button remains the disabled send arrow.
+- The current chat loading state only follows the live SDK `status`, so a page refresh/reconnect can lose the visible stop affordance even though persisted UI still contains active work.
+- In the current hosted co-ai session, the visible running item is a `Bash` tool running `playwright install chromium`; the browser dependency problem is separate, but the frontend should still present a stop control for the active restored item.
+
+Scope:
+
+- Derive oo-chat loading state from both live SDK processing and active restored UI items.
+- Make `RemoteAgent.stop()` settle locally running UI items so clicking stop does not leave the page stuck in loading state.
+- Add focused SDK regression coverage for stopping restored running items.
+
+Expected result:
+
+- A restored session with `tool_call: running`, `thinking: running`, `intent: analyzing`, `eval: evaluating`, or `compact: compacting` shows the stop button.
+- Clicking stop returns the local UI to idle without clearing the transcript.
+
+Result:
+
+- `oo-chat` now derives `isLoading` from both live SDK `isProcessing` and active restored UI items.
+- `RemoteAgent.stop()` now settles restored running local UI items as stopped/error/done before returning to idle.
+- Added focused SDK regression coverage for stopping restored running items.
+- Reloading the current local session now shows the `Stop response` button while the restored UI still contains active work.
+
+## Previous Task: Chat Input Stop Button
+
+Status: complete
+
+Context:
+
+- During hosted agent execution, the input send button remains an inactive arrow instead of switching to a visible stop control.
+- Users need a local stop affordance in the send-button position, matching normal chat UX.
+- The current backend does not expose safe thread cancellation, so first implementation should stop the client-side active stream by closing the current WebSocket and returning UI state to idle without clearing the transcript.
+
+Scope:
+
+- Add a `stop()` method to the TypeScript remote agent/react hook layer.
+- Wire `stop` through `oo-chat`'s `useAgentSDK`, `Chat`, and `ChatInput`.
+- Render the send button as a stop button while loading.
+- Keep text entry and existing message history intact.
+
+Expected result:
+
+- While an agent response is running, the send button position shows a stop icon.
+- Clicking it stops the current client stream and returns the UI to idle without deleting the conversation.
+
+Result:
+
+- Added `RemoteAgent.stop()` in the TypeScript SDK to close the active WebSocket, clear the optimistic thinking placeholder, settle local input state, and return the client UI to idle without clearing the transcript.
+- Exposed `stop()` through `useAgentForHuman()` and `oo-chat`'s `useAgentSDK()`.
+- Wired `onStop` through the chat page, `Chat`, and `ChatInput`.
+- `ChatInput` now switches the send-button position from arrow to stop icon while `isLoading` is true.
+- Added a focused SDK regression test for client-side stop behavior.
+
+## Previous Task: Deployed Slash Skills Use Agent co_dir
+
+Status: complete
+
+Context:
+
+- The deployed page now shows `agent-4-linkedin` and `/deploy-smoke`, proving relay profile metadata reaches the frontend.
+- Invoking `/deploy-smoke` still let the model run normal coding tools before outputting the marker, which means the backend slash-skill interceptor did not reliably load the deployed `.co/skills/deploy-smoke/SKILL.md`.
+- Skill discovery for metadata uses `agent.co_dir`, but the slash invocation loader still searches `Path.cwd()/.co/skills`, which can diverge in hosted deployments.
+- The connection also shows intermittent `Authentication timed out`; current evidence points to slow relay/agent handshake and auth retries, but the immediate correctness bug is slash skill routing.
+
+Scope:
+
+- Add a failing test proving `/deploy-smoke` loads from `agent.co_dir` even when process cwd is somewhere else.
+- Update the skills plugin so slash invocation and the `skill()` tool load skills from the same `co_dir` source as metadata discovery.
+- Keep existing local cwd behavior as a fallback.
+- Verify focused skills tests and deploy-related tests.
+
+Expected result:
+
+- Hosted `co ai` slash skills use the packaged `.co/skills` directory and replace `/deploy-smoke` with the skill instructions before the LLM runs.
+- The smoke skill no longer triggers exploratory `ls/read_file` behavior just to discover skill files.
+
+Result:
+
+- Added a regression test that reproduces the hosted case: process cwd differs from `agent.co_dir`, and `/deploy-smoke` must still load from `agent.co_dir/skills/deploy-smoke/SKILL.md`.
+- Updated the skills plugin path resolver so slash invocation and the `skill()` tool load from `agent.co_dir` first, then cwd, user skills, and built-ins.
+- Updated generated co-ai deploy entrypoints to pass `CO_DIR = PACKAGE_ROOT / ".co"` so hosted agents use the package's `.co` directory even if cwd changes.
+- Local cwd behavior remains as a fallback for normal local agents.
+
+## Previous Task: Frontend Reads Relay Profile for Hosted co-ai
+
+Status: complete
+
+Context:
+
+- Hosted co-ai now publishes relay profile metadata, and named deploys can set the deployed agent identity.
+- The chat landing page still renders address-only because `oo-chat` and the TypeScript SDK only read relay endpoints, then try direct agent `/info` for name/tools/skills.
+- For hosted relay traffic, direct `/info` may be unreachable or stale from the browser, while `/api/relay/agents/{address}/profile` is the stable metadata path.
+
+Scope:
+
+- Teach the TypeScript SDK and `oo-chat` agent-info hook to read relay profile metadata.
+- Normalize profile `tools` so both current object-shaped payloads and string arrays render correctly.
+- Keep direct `/info` as a best-effort enrichment path, without making UI metadata depend on it.
+- Align hosted Python profile tools with the SDK's `string[]` shape while retaining frontend tolerance for older deployed profiles.
+
+Expected result:
+
+- A deployed co-ai page can show the deploy name, selected skills, tools, model, and version from relay profile even if direct `/info` cannot be reached.
+- Existing direct `/info` metadata still wins when it is available and address-verified.
+- The dashboard/chat address-only fallback is reserved for agents that truly have no relay profile.
+
+Result:
+
+- `connectonion-ts.fetchAgentInfo()` now reads `/api/relay/agents/{address}/profile`, normalizes skills/tools, and returns profile metadata when direct `/info` cannot be reached.
+- `oo-chat`'s `useAgentInfo()` now uses the same relay-profile fallback, so the landing page/sidebar/settings can render name, skills, tools, model, and version from relay metadata.
+- Direct `/info` remains a best-effort enrichment path and no longer gates metadata or online status.
+- Hosted Python relay profiles now publish `tools` as a string array, matching SDK/frontend expectations; the frontend still accepts older `{name: ...}` tool objects.
+
+## Previous Task: Named co-ai Deploys Publish Relay Profile Metadata
+
+Status: complete
+
+Context:
+
+- Hosted co-ai deploy now starts and connects through the relay, but the frontend only shows the address because the host ANNOUNCE does not publish profile metadata.
+- The deployed co-ai agent name is still hardcoded as `oo`, and the deploy project name defaults to `co-ai`, so repeated co-ai deploys refresh the same dashboard/app identity.
+- The desired UX is `co deploy --name agent-4-linkedin --skills ...`: deploy co-ai with selected skills, use the name for backend project identity, Agent metadata, and relay profile display.
+
+Scope:
+
+- Add a lightweight deploy name option that works with co-ai deploys and is safe for agent URLs.
+- Pass the selected deploy name into the generated co-ai entrypoint and `create_coding_agent()`.
+- Publish relay profile metadata from `host()` using the already extracted agent metadata so frontend/directory/profile endpoints can show name, skills, tools, model, and version.
+- Keep existing `co deploy --skills ...` behavior compatible, defaulting to `co-ai` when no name is provided.
+
+Expected result:
+
+- `co deploy --name agent-4-linkedin --skills deploy-smoke` uploads with `project_name=agent-4-linkedin`.
+- The generated hosted co-ai Agent has `agent.name == "agent-4-linkedin"`.
+- Relay ANNOUNCE includes profile metadata, so the frontend can render a name and available skills/tools instead of address-only UI.
+
+Result:
+
+- Added `co deploy --name/-n` and validate it for URL-safe lowercase letters, numbers, and hyphens.
+- Direct co-ai deploy still defaults to `co-ai`, but `--name agent-4-linkedin` now sets the upload `project_name`, generated entrypoint agent name, and hosted Agent name.
+- `create_coding_agent(name=...)` now accepts custom names while local `co ai` keeps the default `oo`.
+- `host()` now publishes a signed relay profile built from agent metadata: alias/name, bio, version, model, tools, and skills.
+- Relay heartbeat re-announces preserve the profile payload instead of dropping it on refresh.
+
+## Previous Task: Deploy Env Vars Sent to Backend Secrets Field
+
+Status: complete
+
+Context:
+
+- Real co-ai deploy now imports packaged source from `/app/connectonion`, so the previous site-packages import bug is fixed.
+- The remote container now fails at startup with `ValueError: OPENONION_API_KEY not found in environment`.
+- The CLI sends environment variables as multipart field `env_vars`, but the production `oo-api` deploy route accepts `secrets` and the deploy service only parses `secrets` into `docker run -e ...`.
+
+Scope:
+
+- Update the CLI deploy upload payload so env vars are sent in the backend-compatible `secrets` field.
+- Keep sending `env_vars` as a compatibility field for any backend version that already expects it.
+- Add regression coverage for co-ai deploy passing `OPENONION_API_KEY` through the upload payload.
+
+Expected result:
+
+- `co deploy --skills ...` uploads `OPENONION_API_KEY` in the field the current deploy backend injects into the Docker container.
+- Existing project deploy payload behavior remains compatible.
+
+Result:
+
+- CLI deploy now serializes env vars once and sends the JSON under both `env_vars` and `secrets`.
+- This keeps compatibility with the SDK-side `env_vars` naming while matching the production `oo-api` backend that reads `secrets` for Docker env injection.
+- Added regression coverage proving `co deploy --skills ...` includes `OPENONION_API_KEY` in `secrets`.
+
+## Previous Task: co-ai Deploy EntryPoint Imports Packaged Source
+
+Status: complete
+
+Context:
+
+- Real `co deploy --skills deploy-smoke` reached the deploy server and built a container, but startup failed.
+- Traceback showed `/app/.co/deploy/co_ai_entrypoint.py` imported `connectonion.cli.co_ai.agent` from `/usr/local/lib/python3.11/site-packages/connectonion`, not the packaged `/app/connectonion` source.
+- The installed PyPI version did not yet include `create_coding_agent(co_dir=...)`, causing `TypeError: unexpected keyword argument 'co_dir'`.
+
+Scope:
+
+- Update the generated co-ai entrypoint so it prepends the deployment package root (`/app`) to `sys.path` before importing `connectonion`.
+- Add regression coverage proving the generated entrypoint prefers packaged source over site-packages.
+- Keep the direct co-ai deploy UX and project deploy behavior unchanged.
+
+Expected result:
+
+- Deployed co-ai containers import the generated package source from `/app/connectonion`.
+- The `create_coding_agent(co_dir=..., browser_headless=True)` entrypoint works before these changes are published to PyPI.
+
+Result:
+
+- Generated co-ai entrypoints now calculate `PACKAGE_ROOT = Path(__file__).resolve().parents[2]` and insert it at the front of `sys.path` before importing `connectonion`.
+- This makes `/app/connectonion` take precedence over `/usr/local/lib/python*/site-packages/connectonion` inside the deployed container.
+- Added regression coverage to ensure the `sys.path` insertion happens before `from connectonion import host`.
+
+## Previous Task: Direct co-ai Deploy Without Project Scaffold
+
+Status: complete
+
+Context:
+
+- The first co-ai deploy implementation still inherited project deploy assumptions: git repo, `.co/host.yaml`, and a committed project file.
+- The intended UX is to deploy hosted `co ai` directly by attaching selected skills, without preparing or committing a separate agent entrypoint.
+
+Scope:
+
+- Make `co deploy --skills <name>` select co-ai deployment automatically.
+- Let co-ai deployment run from any directory without git, `.co/host.yaml`, or `agent.py`.
+- Build a self-contained temporary co-ai package with generated entrypoint, selected skills, package source, and a minimal `requirements.txt`.
+- Keep explicit `--template project` behavior as the backwards-compatible project deploy path.
+- Update tests and docs to match the direct co-ai deploy UX.
+
+Expected result:
+
+- `co deploy --skills alpha,beta` deploys co-ai directly.
+- `co deploy --template co-ai --skills alpha` also works without project files.
+- Existing `co deploy` inside a normal ConnectOnion project continues to deploy the project.
+- Explicit `co deploy --template project --skills alpha` is rejected because project deploys do not consume skills.
+
+Result:
+
+- `co deploy --skills ...` now auto-selects co-ai deploy and does not require git, `.co/host.yaml`, or `agent.py`.
+- `co deploy --template co-ai --skills ...` uses the same direct co-ai path.
+- `co deploy` in a git/ConnectOnion project still follows the project deploy path.
+- Explicit `--template project --skills ...` is rejected.
+- Co-ai deploy packages are self-contained: current ConnectOnion package source, generated `requirements.txt`, generated `.co/deploy/co_ai_entrypoint.py`, and selected skills are written only into the temporary tarball staging directory.
+
+## Previous Task: Login Handoff Privacy and Cleanup
+
+Status: complete
+
+Context:
+
+- Hosted `co ai` creates fresh Agent/tool instances for new requests, so the frontend chat session should not rely on a live Playwright browser object surviving across turns.
+- The lightweight architecture is to complete QR or credential handoff inside the current tool loop, then close the server-side browser when the login flow ends.
+- Local LinkedIn testing showed the model used `keyboard_type(text="...")` for the submitted password, exposing it in trace/UI.
+- The model also ended after a failed login without explicitly calling `close_browser`.
+
+Scope:
+
+- Keep `send_qr_to_user` and `send_credentials_form_to_user` as blocking user handoff tools.
+- Update prompt guidance so the model does not end the turn by asking the user to message later after scanning or entering credentials.
+- Require `close_browser` after login success, failure, or abandonment.
+- Do not return raw credentials from the credential handoff.
+- Add a narrow tool that types saved credentials into the focused browser field without exposing their values in tool arguments.
+- Add a co ai completion cleanup safety net for login handoff turns.
+- Avoid session-scoped browser registries, browser workers, or core runtime changes.
+
+Result:
+
+- Login prompt guidance now says to keep handoffs inside the same turn and continue checking browser state after the handoff returns.
+- QR and credential tool docs now explicitly prohibit ending the turn with "tell me later" style instructions.
+- Cleanup guidance now covers success, failure, and abandonment.
+- `send_credentials_form_to_user` stores credentials on the current Agent instance and returns only instructions, not credential values.
+- `type_saved_login_credential(field="username"|"password")` types the saved value into the focused browser field without putting the secret in trace args.
+- co ai registers a login cleanup `on_complete` plugin that closes the browser after a login handoff turn when needed.
+- Added regression coverage for same-turn login lifecycle, hidden credential typing, and automatic login cleanup.
+
+## Previous Task: co-ai Deploy Template
+
+Status: complete
+
+Context:
+
+- `co deploy` currently deploys a complete project agent by reading `.co/host.yaml`, validating that its entrypoint calls `host(...)`, packaging `git archive HEAD`, and uploading that tarball.
+- The desired flow is to deploy a hosted `co ai` coding agent from CLI arguments, then add selected skills with `--skills`, without requiring users to maintain a full deployable agent entrypoint in the project.
+
+Scope:
+
+- Keep `co deploy` default behavior backwards-compatible.
+- Add `co deploy --template co-ai --skills ...` as a separate deploy path.
+- Generate a temporary co-ai host entrypoint only inside the deployment package.
+- Package selected skills from project `.co/skills`, user `~/.co/skills`, or built-in co-ai skills.
+- Add focused tests for CLI argument behavior, package contents, missing skills, and co-ai agent factory options.
+
+Expected result:
+
+- `co deploy` continues to deploy the project configured by `.co/host.yaml`.
+- `co deploy --template co-ai --skills alpha,beta` uploads a tarball with the generated co-ai entrypoint and selected `.co/skills/*` directories.
+- The user working tree is not modified by co-ai deploy packaging.
+- Missing skills stop deployment before upload with a clear suggestion to run `co skills discover && co skills copy <name>`.
+- Deployed co-ai agents can use project `.co` state and headless browser automation.
+
+Result:
+
+- Added `--template`, `--skills`, `--model`, and `--max-iterations` options to `co deploy`.
+- Kept the default `project` deploy path compatible with existing `.co/host.yaml` and `host(...)` validation.
+- Added co-ai deploy packaging that starts from `git archive HEAD`, overlays `.co/deploy/co_ai_entrypoint.py`, and copies selected skill directories into `.co/skills/`.
+- Added skill resolution priority: project `.co/skills`, user `~/.co/skills`, then built-in co-ai skills.
+- Updated `create_coding_agent()` with deploy-safe `co_dir` and `browser_headless` options.
+- Updated deploy documentation for the new co-ai template path.
+
+## Previous Task: Login Handoff Tool Boundary
 
 Status: complete
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,35 @@
 # Tasks
 
+## Current Task: Remove Generic Tool Approval Skip Flag
+
+Status: complete
+
+Context:
+
+- `tool_approval.check_approval()` still honored `session["skip_tool_approval"]` as a generic bypass.
+- co-ai no longer sets that flag, but keeping the generic branch makes future accidental bypasses easy.
+- ULW can be represented directly by `session["mode"] == "ulw"`; `tool_approval` already has an explicit ULW branch.
+
+Scope:
+
+- Remove the generic `skip_tool_approval` bypass from `tool_approval`.
+- Stop ULW from setting or clearing `skip_tool_approval`.
+- Update tests so the old flag no longer bypasses approval.
+- Keep explicit `mode == "ulw"` approval behavior.
+
+Expected result:
+
+- No generic session flag can bypass tool approvals.
+- Only explicit approval modes and configured permissions control approval behavior.
+
+Result:
+
+- Removed the generic `skip_tool_approval` bypass branch from `tool_approval.check_approval()`.
+- ULW no longer sets or clears `skip_tool_approval`; it relies on `mode == "ulw"`.
+- Updated tool approval, constants, and ULW comments/docs to remove skip-flag semantics.
+- Added/updated tests proving a stale `skip_tool_approval=True` still sends `approval_needed`.
+- Focused approval/ULW/co-ai/deploy tests, syntax checks, and diff hygiene checks pass.
+
 ## Current Task: Remove co-ai Auto-Approve Hook
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,29 @@
 # Tasks
 
+## Current Task: Explicit All-Skills co-ai Deploy
+
+Status: complete
+
+Context:
+
+- Local `co ai` discovers every project/user/builtin skill and can show many skills, such as 59 skills on the developer machine.
+- Hosted `co deploy --skills deploy-smoke` intentionally packages only explicitly selected skills plus bundled built-ins, so it showed fewer skills.
+- Users need an explicit opt-in when they really want local project/user skills deployed wholesale.
+
+Scope:
+
+- Add a clear `--all-skills` CLI flag for co-ai deploy.
+- Keep default deploy behavior conservative: do not upload all local user skills unless explicitly requested.
+- Discover all project `.co/skills/*/SKILL.md` and user `~/.co/skills/*/SKILL.md` directories with project priority on duplicate names.
+- Keep `--all-skills` scoped to the co-ai deploy template.
+
+Result:
+
+- `co deploy --name agent-full --all-skills` now auto-selects co-ai deploy and packages all project/user skills.
+- `co deploy --template project --all-skills` is rejected before upload.
+- Explicit `--skills ...` remains supported and can be combined with discovered all-skills names without duplicating packages.
+- Focused deploy CLI/package tests pass.
+
 ## Current Task: Deploy Timeout and Package Build Simplification
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,34 @@
 # Tasks
 
+## Current Task: Remove Claude Runtime Skills From co-ai
+
+Status: complete
+
+Context:
+
+- ConnectOnion runtime skills should come from `.co/skills`, user `~/.co/skills`, and bundled built-ins.
+- Claude Code skills may be discoverable/copyable through CLI migration commands, but they should not be loaded automatically by co-ai runtime or hosted deploy behavior.
+- Runtime skill discovery currently includes `.claude/skills`, which can unexpectedly expose unrelated Claude workflows.
+
+Scope:
+
+- Remove `.claude/skills` from runtime skill path resolution.
+- Remove `.claude/skills` from runtime skill discovery metadata.
+- Add a regression test proving slash invocation does not load a Claude-only skill.
+- Keep `co skills discover/copy` behavior out of scope.
+
+Expected result:
+
+- co-ai runtime and hosted co-ai only load ConnectOnion skills from `.co/skills`, `~/.co/skills`, and built-ins.
+- Claude skills must be explicitly copied into `.co/skills` before runtime/deploy usage.
+
+Result:
+
+- Runtime skill path resolution no longer checks project, cwd, or user `.claude/skills`.
+- Runtime skill discovery no longer lists `.claude/skills`.
+- Added a regression test proving `/claude-only` is ignored when it exists only under `.claude/skills`.
+- Focused skills/deploy tests, syntax checks, and diff hygiene checks pass.
+
 ## Current Task: Require co-ai User Approval by Default
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,34 @@
 # Tasks
 
+## Current Task: Split co-ai Deploy Packaging Helpers
+
+Status: complete
+
+Context:
+
+- `connectonion/cli/commands/deploy_commands.py` grew large after the co-ai deploy work.
+- The new co-ai-specific packaging logic is separable from the legacy project deploy upload/polling flow.
+- Tests still import helper functions through `deploy_commands`, so the split should preserve that compatibility surface.
+
+Scope:
+
+- Move co-ai deploy packaging, skills discovery, skill resolution, generated entrypoint/Dockerfile, and deploy env loading into a dedicated module.
+- Keep `deploy_commands.py` focused on CLI orchestration, project git archive packaging, upload, and deploy status polling.
+- Preserve existing `deploy_commands` helper imports through re-exported names.
+- Do not change deploy behavior.
+
+Expected result:
+
+- `deploy_commands.py` is materially shorter and easier to review.
+- Existing deploy tests continue to pass without behavior changes.
+
+Result:
+
+- Added `connectonion/cli/commands/deploy_co_ai.py` for co-ai deploy packaging, deploy-time skills/env handling, generated entrypoint, generated requirements, and generated Dockerfile logic.
+- `deploy_commands.py` now keeps project deploy archive creation, template resolution, upload, and status polling.
+- Existing helper names are still importable from `deploy_commands.py`.
+- Focused deploy tests, syntax checks, and diff hygiene checks pass.
+
 ## Current Task: Explicit All-Skills co-ai Deploy
 
 Status: complete

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,5 +1,37 @@
 # Tasks
 
+## Current Task: Remove co-ai Auto-Approve Hook
+
+Status: complete
+
+Context:
+
+- `create_coding_agent(auto_approve=True)` added an `_enable_auto_approve` hook that set `skip_tool_approval=True`.
+- That hook bypasses the existing web approval flow for dangerous tools.
+- Code inspection confirms dangerous tools exist in `tool_approval.constants.DANGEROUS_TOOLS`: shell/run tools, write/edit tools, background/task control, external communication, and delete/remove tools.
+- The separate ULW mode still explicitly uses `skip_tool_approval` as part of its autonomous mode behavior.
+
+Scope:
+
+- Remove the co-ai `_enable_auto_approve` hook.
+- Remove the `auto_approve` argument from `create_coding_agent()`.
+- Keep generic `skip_tool_approval` behavior for explicit ULW mode.
+- Add/update tests proving co-ai no longer exposes or registers the auto-approve hook.
+
+Expected result:
+
+- co-ai never bypasses approval through an agent-factory option.
+- Dangerous tools continue to require approval in web mode unless an explicit mode such as ULW is active.
+
+Result:
+
+- Removed `_enable_auto_approve` from `connectonion/cli/co_ai/agent.py`.
+- Removed the `auto_approve` parameter from `create_coding_agent()`.
+- Updated co-ai tests to assert the factory no longer exposes `auto_approve` and no auto-approve hook is registered.
+- Confirmed real approval-gated tools from `DANGEROUS_TOOLS`: shell/run, write/edit, background/task control, external communication, and delete/remove tools.
+- Kept explicit ULW `skip_tool_approval` behavior unchanged.
+- Focused co-ai/deploy/approval/ULW tests, syntax checks, and diff hygiene checks pass.
+
 ## Current Task: Remove Claude Runtime Skills From co-ai
 
 Status: complete

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -44,7 +44,7 @@ from .tools import (
 )
 from .skills import skill
 from .plugins import login_cleanup, system_reminder
-from connectonion import Agent, bash, TodoList
+from connectonion import Agent, bash, TodoList, after_user_input
 from connectonion.useful_tools import (
     close_browser,
     send_credentials_form_to_user,
@@ -61,14 +61,24 @@ PROMPTS_DIR = Path(__file__).parent / "prompts"
 GLOBAL_CO_DIR = Path.home() / ".co"
 
 
+@after_user_input
+def _enable_auto_approve(agent: Agent) -> None:
+    agent.current_session["skip_tool_approval"] = True
+
+
 def create_coding_agent(
+    name: str = "oo",
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
     auto_approve: bool = False,
+    co_dir: Path | None = None,
+    browser_headless: bool = False,
+    browser_channel: str | None = None,
 ) -> Agent:
     todo = TodoList()
     file_tools = FileTools()
-    browser = BrowserAutomation(headless=False)
+    browser = BrowserAutomation(headless=browser_headless, browser_channel=browser_channel)
+    agent_co_dir = co_dir or GLOBAL_CO_DIR
 
     tools = [
         file_tools,
@@ -103,16 +113,18 @@ def create_coding_agent(
 
     # Use SDK's subagents plugin instead of custom task implementation
     plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, ulw, image_result_formatter, runtime_input, login_cleanup]
+    if auto_approve:
+        plugins.insert(0, [_enable_auto_approve])
 
     agent = Agent(
-        name="oo",
+        name=name,
         tools=tools,
         plugins=plugins,
         on_events=[],
         system_prompt=system_prompt,
         model=model,
         max_iterations=max_iterations,
-        co_dir=GLOBAL_CO_DIR,
+        co_dir=agent_co_dir,
     )
     agent.browse = browser
     # This browser helper blocks on stdin, which is wrong for co ai's websocket

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -44,7 +44,7 @@ from .tools import (
 )
 from .skills import skill
 from .plugins import login_cleanup, system_reminder
-from connectonion import Agent, bash, TodoList, after_user_input
+from connectonion import Agent, bash, TodoList
 from connectonion.useful_tools import (
     close_browser,
     send_credentials_form_to_user,
@@ -61,16 +61,10 @@ PROMPTS_DIR = Path(__file__).parent / "prompts"
 GLOBAL_CO_DIR = Path.home() / ".co"
 
 
-@after_user_input
-def _enable_auto_approve(agent: Agent) -> None:
-    agent.current_session["skip_tool_approval"] = True
-
-
 def create_coding_agent(
     name: str = "oo",
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
-    auto_approve: bool = False,
     co_dir: Path | None = None,
     browser_headless: bool = False,
     browser_channel: str | None = None,
@@ -113,8 +107,6 @@ def create_coding_agent(
 
     # Use SDK's subagents plugin instead of custom task implementation
     plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, ulw, image_result_formatter, runtime_input, login_cleanup]
-    if auto_approve:
-        plugins.insert(0, [_enable_auto_approve])
 
     agent = Agent(
         name=name,

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -10,7 +10,7 @@ This file provides the `start_server()` function that:
 Architecture:
 - Uses agent factory pattern for stateless agent creation
 - Trust level set to "careful" for web deployment
-- Auto-approve mode for web usage (no terminal prompts)
+- Web usage routes dangerous tool approvals through the connected chat client
 
 Used by:
 - CLI command: `co ai` (see cli/main.py)
@@ -61,7 +61,6 @@ def start_server(
         return create_coding_agent(
             model=model,
             max_iterations=max_iterations,
-            auto_approve=True,  # Always auto-approve in web mode
         )
 
     # Use global ~/.co/ for consistent identity across all co ai sessions

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [rich.console, cli/browser_agent/browser.execute_browser_command] | imported by [cli/main.py via handle_browser()] | requires Playwright installation | tested by [tests/e2e/cli/test_cli_browser.py]
   Data flow: receives command: str from CLI parser (e.g., "screenshot localhost:3000") → calls execute_browser_command(command) → browser agent parses command and executes via Playwright → returns result string → prints to console via rich.Console
   State/Effects: no persistent state | launches headless browser via Playwright | may create screenshot files in current directory | writes to stdout via rich.Console | browser process lifecycle managed by browser_agent module
-  Integration: exposes handle_browser(command) | called from main.py via --browser flag or 'browser' subcommand | delegates to browser_agent/browser.execute_browser_command() | supports commands like "screenshot URL", "navigate URL", "click selector"
+  Integration: exposes handle_browser(command) | called from main.py via the 'browser' subcommand | delegates to browser_agent/browser.execute_browser_command() | supports commands like "screenshot URL", "navigate URL", "click selector"
   Performance: browser launch overhead (1-3s) | Playwright operations vary by command | screenshot generation is fast (<1s)
   Errors: fails if Playwright not installed | fails if browser launch fails | fails if invalid command syntax | prints error to console but doesn't raise exception
 """
@@ -17,7 +17,7 @@ console = Console()
 def handle_browser(command: str, headless: bool = False):
     """Execute browser automation commands - guide browser to do something.
 
-    This is an alternative to the -b flag. Both 'co -b' and 'co browser' are supported.
+    This is exposed as the 'co browser' subcommand.
 
     Args:
         command: The browser command to execute

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -1,0 +1,295 @@
+"""Build co-ai deploy packages and resolve deploy-time skills/env."""
+
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from connectonion import __version__
+
+
+CO_AI_ENTRYPOINT = ".co/deploy/co_ai_entrypoint.py"
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = PACKAGE_ROOT.parent
+DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+DEPLOY_ENV_KEY_ALLOWLIST = (
+    "OPENONION_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CONNECTONION_API_KEY",
+)
+
+
+class DeployConfigError(Exception):
+    """Raised when deploy configuration is invalid before upload."""
+
+
+@dataclass
+class DeployPackage:
+    tarball_path: Path
+    entrypoint: str
+
+
+def parse_skill_names(raw_skills: list[str] | None) -> list[str]:
+    """Parse repeated/comma-separated --skills values."""
+    if not raw_skills:
+        return []
+
+    names = []
+    for value in raw_skills:
+        for part in value.split(","):
+            name = part.strip()
+            if name:
+                names.append(name)
+    return names
+
+
+def validate_deploy_name(name: str) -> str:
+    """Validate a deploy name that becomes part of the hosted agent URL."""
+    if not name or not DEPLOY_NAME_PATTERN.match(name):
+        raise DeployConfigError(
+            "Invalid deploy name. Use lowercase letters, numbers, and hyphens; "
+            "start and end with a letter or number."
+        )
+    return name
+
+
+def _filter_allowed_env(values: dict) -> dict:
+    return {
+        key: value
+        for key, value in values.items()
+        if key in DEPLOY_ENV_KEY_ALLOWLIST and value not in (None, "")
+    }
+
+
+def load_deploy_env_vars(env_file: str | Path) -> dict:
+    """Load env vars for deploy without dumping the full shell environment."""
+    env_vars = {}
+
+    global_env = Path.home() / ".co" / "keys.env"
+    if global_env.exists():
+        env_vars.update(_filter_allowed_env(dotenv_values(global_env)))
+
+    env_vars.update({
+        key: value
+        for key in DEPLOY_ENV_KEY_ALLOWLIST
+        if (value := os.environ.get(key))
+    })
+
+    env_path = Path(env_file)
+    if env_path.exists():
+        env_vars.update({
+            key: value
+            for key, value in dotenv_values(env_path).items()
+            if value is not None
+        })
+
+    return env_vars
+
+
+def resolve_deploy_skill(name: str, project_dir: Path) -> Path:
+    """Resolve a deploy skill directory by project > user > built-in priority."""
+    candidates = [
+        project_dir / ".co" / "skills" / name,
+        Path.home() / ".co" / "skills" / name,
+        Path(__file__).parent.parent / "co_ai" / "skills" / "builtin" / name,
+    ]
+    for skill_dir in candidates:
+        if (skill_dir / "SKILL.md").exists():
+            return skill_dir
+
+    raise DeployConfigError(
+        f"Skill not found: {name}. Run `co skills discover && co skills copy {name}` first."
+    )
+
+
+def discover_deploy_skill_names(project_dir: Path) -> list[str]:
+    """Discover deployable project/user skill names with project priority."""
+    names = []
+    seen = set()
+    for skills_dir in (project_dir / ".co" / "skills", Path.home() / ".co" / "skills"):
+        if not skills_dir.exists():
+            continue
+        for skill_dir in sorted(skills_dir.iterdir(), key=lambda path: path.name):
+            if skill_dir.name in seen:
+                continue
+            if (skill_dir / "SKILL.md").exists():
+                names.append(skill_dir.name)
+                seen.add(skill_dir.name)
+    return names
+
+
+def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agent_name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    model_literal = json.dumps(model)
+    name_literal = json.dumps(agent_name)
+    path.write_text(
+        "\n".join([
+            "import sys",
+            "from pathlib import Path",
+            "",
+            "PACKAGE_ROOT = Path(__file__).resolve().parents[2]",
+            "sys.path.insert(0, str(PACKAGE_ROOT))",
+            "CO_DIR = PACKAGE_ROOT / \".co\"",
+            "",
+            "from connectonion import host",
+            "from connectonion.cli.co_ai.agent import create_coding_agent",
+            "",
+            "",
+            "def create_agent():",
+            "    return create_coding_agent(",
+            f"        name={name_literal},",
+            f"        model={model_literal},",
+            f"        max_iterations={max_iterations},",
+            "        auto_approve=True,",
+            "        co_dir=CO_DIR,",
+            "        browser_headless=True,",
+            "        browser_channel=\"chrome\",",
+            "    )",
+            "",
+            "",
+            "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
+def _make_tarball(source_dir: Path, tarball_path: Path) -> None:
+    with tarfile.open(tarball_path, "w:gz") as tar:
+        for path in sorted(source_dir.rglob("*")):
+            tar.add(path, arcname=str(path.relative_to(source_dir)))
+
+
+def _copy_connectonion_package(staging_dir: Path) -> None:
+    shutil.copytree(
+        PACKAGE_ROOT,
+        staging_dir / "connectonion",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache"),
+    )
+
+
+def _copy_connectonion_project_metadata(staging_dir: Path) -> bool:
+    """Copy local package metadata when deploying from a source checkout."""
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return False
+
+    shutil.copy2(pyproject, staging_dir / "pyproject.toml")
+    for filename in ("README.md", "LICENSE"):
+        source = PROJECT_ROOT / filename
+        if source.exists():
+            shutil.copy2(source, staging_dir / filename)
+    return True
+
+
+def _write_co_ai_requirements(
+    staging_dir: Path,
+    *,
+    install_local_package: bool,
+    skill_requirements: list[Path] | None = None,
+) -> None:
+    lines = ["." if install_local_package else f"connectonion=={__version__}"]
+    for requirement_path in sorted(skill_requirements or []):
+        lines.append(f"-r {requirement_path.relative_to(staging_dir).as_posix()}")
+    (staging_dir / "requirements.txt").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_co_ai_dockerfile(staging_dir: Path, *, install_local_package: bool) -> None:
+    lines = [
+        "FROM python:3.11-slim",
+        "WORKDIR /app",
+        "ENV PYTHONUNBUFFERED=1",
+        "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+    ]
+    if install_local_package:
+        lines.extend([
+            "COPY pyproject.toml README.md requirements.txt ./",
+            "COPY connectonion ./connectonion",
+            "COPY .co ./.co",
+        ])
+    else:
+        lines.extend([
+            "COPY requirements.txt ./",
+            "COPY connectonion ./connectonion",
+            "COPY .co ./.co",
+        ])
+    lines.extend([
+        "RUN pip install --no-cache-dir -r requirements.txt",
+        "RUN python -m playwright install --with-deps chrome",
+        "ENV PORT=8000",
+        f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
+        "",
+    ])
+    (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
+
+
+def create_co_ai_deploy_package(
+    *,
+    project_dir: Path,
+    skills: list[str],
+    all_skills: bool,
+    project_name: str,
+    model: str,
+    max_iterations: int,
+) -> DeployPackage:
+    """Build a self-contained co-ai deploy tarball."""
+    temp_dir = Path(tempfile.mkdtemp())
+    tarball_path = temp_dir / "agent.tar.gz"
+    staging_dir = temp_dir / "staging"
+    staging_dir.mkdir()
+
+    _copy_connectonion_package(staging_dir)
+    install_local_package = _copy_connectonion_project_metadata(staging_dir)
+    _write_co_ai_entrypoint(
+        staging_dir / CO_AI_ENTRYPOINT,
+        model=model,
+        max_iterations=max_iterations,
+        agent_name=project_name,
+    )
+
+    deploy_skill_names = []
+    seen_skill_names = set()
+    for skill_name in discover_deploy_skill_names(project_dir) if all_skills else []:
+        deploy_skill_names.append(skill_name)
+        seen_skill_names.add(skill_name)
+    for skill_name in skills:
+        if skill_name not in seen_skill_names:
+            deploy_skill_names.append(skill_name)
+            seen_skill_names.add(skill_name)
+
+    skill_requirement_files = []
+    for skill_name in deploy_skill_names:
+        source = resolve_deploy_skill(skill_name, project_dir)
+        destination = staging_dir / ".co" / "skills" / skill_name
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, destination)
+        requirements_file = destination / "requirements.txt"
+        if requirements_file.exists():
+            skill_requirement_files.append(requirements_file)
+
+    _write_co_ai_requirements(
+        staging_dir,
+        install_local_package=install_local_package,
+        skill_requirements=skill_requirement_files,
+    )
+    _write_co_ai_dockerfile(staging_dir, install_local_package=install_local_package)
+
+    _make_tarball(staging_dir, tarball_path)
+    return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -176,7 +176,7 @@ def _write_co_ai_entrypoint(
         f"        model={model_literal},",
         f"        max_iterations={max_iterations},",
         "        co_dir=CO_DIR,",
-        "        browser_headless=True,",
+        "        browser_headless=False,",
         "        browser_channel=\"chrome\",",
     ]
     lines.extend([
@@ -257,10 +257,11 @@ def _write_co_ai_dockerfile(staging_dir: Path) -> None:
         "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
         "COPY requirements.txt .",
         "RUN pip install --no-cache-dir -r requirements.txt",
+        "RUN apt-get update && apt-get install -y --no-install-recommends xvfb xauth && rm -rf /var/lib/apt/lists/*",
         "RUN python -m playwright install --with-deps chrome",
         "COPY . .",
         "ENV PORT=8000",
-        f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
+        f"CMD [\"xvfb-run\", \"-a\", \"python\", \"{CO_AI_ENTRYPOINT}\"]",
         "",
     ]
     (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -152,7 +152,6 @@ def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agen
             f"        name={name_literal},",
             f"        model={model_literal},",
             f"        max_iterations={max_iterations},",
-            "        auto_approve=True,",
             "        co_dir=CO_DIR,",
             "        browser_headless=True,",
             "        browser_channel=\"chrome\",",

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -9,6 +9,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+import requests
 from dotenv import dotenv_values
 
 from connectonion import __version__
@@ -39,6 +40,23 @@ class DeployConfigError(Exception):
 class DeployPackage:
     tarball_path: Path
     entrypoint: str
+
+
+def resolve_connectonion_pypi_version() -> str:
+    """Resolve the latest published ConnectOnion version from PyPI."""
+    try:
+        response = requests.get("https://pypi.org/pypi/connectonion/json", timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException as exc:
+        raise DeployConfigError(
+            f"Could not resolve latest connectonion version from PyPI for --runtime pypi: {exc}"
+        ) from exc
+
+    version = str(data.get("info", {}).get("version") or "").strip()
+    if not version:
+        raise DeployConfigError("Could not resolve latest connectonion version from PyPI for --runtime pypi.")
+    return version
 
 
 def parse_skill_names(raw_skills: list[str] | None) -> list[str]:
@@ -136,7 +154,6 @@ def _write_co_ai_entrypoint(
     model: str,
     max_iterations: int,
     agent_name: str,
-    browser: bool,
 ) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     model_literal = json.dumps(model)
@@ -160,9 +177,8 @@ def _write_co_ai_entrypoint(
         f"        max_iterations={max_iterations},",
         "        co_dir=CO_DIR,",
         "        browser_headless=True,",
+        "        browser_channel=\"chrome\",",
     ]
-    if browser:
-        lines.append("        browser_channel=\"chrome\",")
     lines.extend([
         "    )",
         "",
@@ -250,33 +266,7 @@ def _write_co_ai_dockerfile(staging_dir: Path) -> None:
     (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
 
 
-def create_co_ai_deploy_package(
-    *,
-    project_dir: Path,
-    skills: list[str],
-    all_skills: bool,
-    project_name: str,
-    model: str,
-    max_iterations: int,
-    browser: bool = False,
-) -> DeployPackage:
-    """Build a self-contained co-ai deploy tarball."""
-    temp_dir = Path(tempfile.mkdtemp())
-    tarball_path = temp_dir / "agent.tar.gz"
-    staging_dir = temp_dir / "staging"
-    staging_dir.mkdir()
-
-    _copy_connectonion_package(staging_dir)
-    _copy_connectonion_project_metadata(staging_dir)
-    _write_co_ai_entrypoint(
-        staging_dir / CO_AI_ENTRYPOINT,
-        model=model,
-        max_iterations=max_iterations,
-        agent_name=project_name,
-        browser=browser,
-    )
-    _write_co_ai_host_yaml(staging_dir, agent_name=project_name)
-
+def _select_deploy_skill_names(project_dir: Path, *, skills: list[str], all_skills: bool) -> list[str]:
     deploy_skill_names = []
     seen_skill_names = set()
     for skill_name in discover_deploy_skill_names(project_dir) if all_skills else []:
@@ -286,9 +276,12 @@ def create_co_ai_deploy_package(
         if skill_name not in seen_skill_names:
             deploy_skill_names.append(skill_name)
             seen_skill_names.add(skill_name)
+    return deploy_skill_names
 
+
+def _copy_deploy_skills(staging_dir: Path, project_dir: Path, skill_names: list[str]) -> list[Path]:
     skill_requirement_files = []
-    for skill_name in deploy_skill_names:
+    for skill_name in skill_names:
         source = resolve_deploy_skill(skill_name, project_dir)
         destination = staging_dir / ".co" / "skills" / skill_name
         if destination.exists():
@@ -298,13 +291,93 @@ def create_co_ai_deploy_package(
         requirements_file = destination / "requirements.txt"
         if requirements_file.exists():
             skill_requirement_files.append(requirements_file)
+    return skill_requirement_files
+
+
+def _write_pypi_runtime_manifest(
+    staging_dir: Path,
+    *,
+    runtime_version: str,
+    agent_name: str,
+    model: str,
+    max_iterations: int,
+    skills: list[str],
+) -> None:
+    manifest = {
+        "runtime": "pypi",
+        "runtime_package": "connectonion",
+        "runtime_version": runtime_version,
+        "agent_name": agent_name,
+        "entrypoint": CO_AI_ENTRYPOINT,
+        "model": model,
+        "max_iterations": max_iterations,
+        "browser": True,
+        "skills": skills,
+    }
+    (staging_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def create_co_ai_deploy_package(
+    *,
+    project_dir: Path,
+    skills: list[str],
+    all_skills: bool,
+    project_name: str,
+    model: str,
+    max_iterations: int,
+    runtime: str = "local",
+    runtime_version: str | None = None,
+) -> DeployPackage:
+    """Build a co-ai deploy tarball."""
+    if runtime not in ("local", "pypi"):
+        raise DeployConfigError("Unsupported co-ai runtime. Use 'local' or 'pypi'.")
+
+    temp_dir = Path(tempfile.mkdtemp())
+    tarball_path = temp_dir / "agent.tar.gz"
+    staging_dir = temp_dir / "staging"
+    staging_dir.mkdir()
+
+    deploy_skill_names = _select_deploy_skill_names(
+        project_dir,
+        skills=skills,
+        all_skills=all_skills,
+    )
+
+    if runtime == "pypi":
+        if not runtime_version:
+            raise DeployConfigError("Missing PyPI runtime version for --runtime pypi.")
+        _write_pypi_runtime_manifest(
+            staging_dir,
+            runtime_version=runtime_version,
+            agent_name=project_name,
+            model=model,
+            max_iterations=max_iterations,
+            skills=deploy_skill_names,
+        )
+        _copy_deploy_skills(staging_dir, project_dir, deploy_skill_names)
+        _make_tarball(staging_dir, tarball_path)
+        return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)
+
+    _copy_connectonion_package(staging_dir)
+    _copy_connectonion_project_metadata(staging_dir)
+    _write_co_ai_entrypoint(
+        staging_dir / CO_AI_ENTRYPOINT,
+        model=model,
+        max_iterations=max_iterations,
+        agent_name=project_name,
+    )
+    _write_co_ai_host_yaml(staging_dir, agent_name=project_name)
+
+    skill_requirement_files = _copy_deploy_skills(staging_dir, project_dir, deploy_skill_names)
 
     _write_co_ai_requirements(
         staging_dir,
         skill_requirements=skill_requirement_files,
     )
-    if browser:
-        _write_co_ai_dockerfile(staging_dir)
+    _write_co_ai_dockerfile(staging_dir)
 
     _make_tarball(staging_dir, tarball_path)
     return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -14,7 +14,7 @@ from dotenv import dotenv_values
 from connectonion import __version__
 
 
-CO_AI_ENTRYPOINT = ".co/deploy/co_ai_entrypoint.py"
+CO_AI_ENTRYPOINT = "agent.py"
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 PROJECT_ROOT = PACKAGE_ROOT.parent
 DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
@@ -130,35 +130,57 @@ def discover_deploy_skill_names(project_dir: Path) -> list[str]:
     return names
 
 
-def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agent_name: str) -> None:
+def _write_co_ai_entrypoint(
+    path: Path,
+    *,
+    model: str,
+    max_iterations: int,
+    agent_name: str,
+    browser: bool,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     model_literal = json.dumps(model)
     name_literal = json.dumps(agent_name)
-    path.write_text(
+    lines = [
+        "import sys",
+        "from pathlib import Path",
+        "",
+        "PACKAGE_ROOT = Path(__file__).resolve().parent",
+        "sys.path.insert(0, str(PACKAGE_ROOT))",
+        "CO_DIR = PACKAGE_ROOT / \".co\"",
+        "",
+        "from connectonion import host",
+        "from connectonion.cli.co_ai.agent import create_coding_agent",
+        "",
+        "",
+        "def create_agent():",
+        "    return create_coding_agent(",
+        f"        name={name_literal},",
+        f"        model={model_literal},",
+        f"        max_iterations={max_iterations},",
+        "        co_dir=CO_DIR,",
+        "        browser_headless=True,",
+    ]
+    if browser:
+        lines.append("        browser_channel=\"chrome\",")
+    lines.extend([
+        "    )",
+        "",
+        "",
+        "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
+        "",
+    ])
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_co_ai_host_yaml(staging_dir: Path, *, agent_name: str) -> None:
+    host_yaml = staging_dir / ".co" / "host.yaml"
+    host_yaml.parent.mkdir(parents=True, exist_ok=True)
+    host_yaml.write_text(
         "\n".join([
-            "import sys",
-            "from pathlib import Path",
-            "",
-            "PACKAGE_ROOT = Path(__file__).resolve().parents[2]",
-            "sys.path.insert(0, str(PACKAGE_ROOT))",
-            "CO_DIR = PACKAGE_ROOT / \".co\"",
-            "",
-            "from connectonion import host",
-            "from connectonion.cli.co_ai.agent import create_coding_agent",
-            "",
-            "",
-            "def create_agent():",
-            "    return create_coding_agent(",
-            f"        name={name_literal},",
-            f"        model={model_literal},",
-            f"        max_iterations={max_iterations},",
-            "        co_dir=CO_DIR,",
-            "        browser_headless=True,",
-            "        browser_channel=\"chrome\",",
-            "    )",
-            "",
-            "",
-            "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
+            f"name: {agent_name}",
+            f"entrypoint: {CO_AI_ENTRYPOINT}",
+            "env: .env",
             "",
         ]),
         encoding="utf-8",
@@ -196,44 +218,35 @@ def _copy_connectonion_project_metadata(staging_dir: Path) -> bool:
 def _write_co_ai_requirements(
     staging_dir: Path,
     *,
-    install_local_package: bool,
     skill_requirements: list[Path] | None = None,
 ) -> None:
-    lines = ["." if install_local_package else f"connectonion=={__version__}"]
+    lines = [f"connectonion=={__version__}"]
     for requirement_path in sorted(skill_requirements or []):
-        lines.append(f"-r {requirement_path.relative_to(staging_dir).as_posix()}")
+        content = requirement_path.read_text(encoding="utf-8").strip()
+        if content:
+            lines.append("")
+            lines.append(f"# {requirement_path.relative_to(staging_dir).as_posix()}")
+            lines.extend(content.splitlines())
     (staging_dir / "requirements.txt").write_text(
         "\n".join(lines) + "\n",
         encoding="utf-8",
     )
 
 
-def _write_co_ai_dockerfile(staging_dir: Path, *, install_local_package: bool) -> None:
+def _write_co_ai_dockerfile(staging_dir: Path) -> None:
     lines = [
         "FROM python:3.11-slim",
         "WORKDIR /app",
         "ENV PYTHONUNBUFFERED=1",
         "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
-    ]
-    if install_local_package:
-        lines.extend([
-            "COPY pyproject.toml README.md requirements.txt ./",
-            "COPY connectonion ./connectonion",
-            "COPY .co ./.co",
-        ])
-    else:
-        lines.extend([
-            "COPY requirements.txt ./",
-            "COPY connectonion ./connectonion",
-            "COPY .co ./.co",
-        ])
-    lines.extend([
+        "COPY requirements.txt .",
         "RUN pip install --no-cache-dir -r requirements.txt",
         "RUN python -m playwright install --with-deps chrome",
+        "COPY . .",
         "ENV PORT=8000",
         f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
         "",
-    ])
+    ]
     (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
 
 
@@ -245,6 +258,7 @@ def create_co_ai_deploy_package(
     project_name: str,
     model: str,
     max_iterations: int,
+    browser: bool = False,
 ) -> DeployPackage:
     """Build a self-contained co-ai deploy tarball."""
     temp_dir = Path(tempfile.mkdtemp())
@@ -253,13 +267,15 @@ def create_co_ai_deploy_package(
     staging_dir.mkdir()
 
     _copy_connectonion_package(staging_dir)
-    install_local_package = _copy_connectonion_project_metadata(staging_dir)
+    _copy_connectonion_project_metadata(staging_dir)
     _write_co_ai_entrypoint(
         staging_dir / CO_AI_ENTRYPOINT,
         model=model,
         max_iterations=max_iterations,
         agent_name=project_name,
+        browser=browser,
     )
+    _write_co_ai_host_yaml(staging_dir, agent_name=project_name)
 
     deploy_skill_names = []
     seen_skill_names = set()
@@ -285,10 +301,10 @@ def create_co_ai_deploy_package(
 
     _write_co_ai_requirements(
         staging_dir,
-        install_local_package=install_local_package,
         skill_requirements=skill_requirement_files,
     )
-    _write_co_ai_dockerfile(staging_dir, install_local_package=install_local_package)
+    if browser:
+        _write_co_ai_dockerfile(staging_dir)
 
     _make_tarball(staging_dir, tarball_path)
     return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -1,185 +1,57 @@
 """
 Purpose: Deploy agent projects to ConnectOnion Cloud with git archive packaging and env vars
 LLM-Note:
-  Dependencies: imports from [os, subprocess, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → validates git repo and .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → git archive creates tarball of HEAD → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Dependencies: imports from [json, re, subprocess, tempfile, time, yaml, requests, pathlib, rich.console, deploy_co_ai] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
+  Data flow: handle_deploy() → resolves project vs co-ai template → load_api_key() loads OPENONION_API_KEY → reads optional host.yaml/env → builds project git archive or generated co-ai package → POST to /api/v1/deploy with tarball + project_name + env vars/secrets → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | does not modify project files
-  Integration: exposes handle_deploy() for CLI | expects git repo with .co/host.yaml (name, entrypoint, env) | uses Bearer token auth | returns void (prints results)
+  Integration: exposes handle_deploy() for CLI | project deploy expects git repo with .co/host.yaml | co-ai deploy can generate a self-contained package from selected skills | uses Bearer token auth | returns void (prints results)
   Performance: git archive is fast | network timeout 600s for upload, 10s for status checks | polls every 3s up to 100 times (~5 min)
   Errors: fails if not git repo | fails if not ConnectOnion project (no host.yaml) | fails if no API key | prints backend error messages
 """
 
 import json
-import os
 import re
-import shutil
 import subprocess
-import tarfile
 import tempfile
 import time
-import yaml
-import requests
-from dataclasses import dataclass
 from pathlib import Path
-from rich.console import Console
-from dotenv import dotenv_values
 
-from connectonion import __version__
+import requests
+import yaml
+from rich.console import Console
+
+from .deploy_co_ai import (
+    CO_AI_ENTRYPOINT,
+    DEPLOY_ENV_KEY_ALLOWLIST,
+    DeployConfigError,
+    DeployPackage,
+    create_co_ai_deploy_package,
+    discover_deploy_skill_names,
+    load_deploy_env_vars,
+    parse_skill_names,
+    resolve_deploy_skill,
+    validate_deploy_name,
+)
 from .project_cmd_lib import load_api_key
 
 console = Console()
 
 API_BASE = "https://oo.openonion.ai"
-CO_AI_ENTRYPOINT = ".co/deploy/co_ai_entrypoint.py"
-PACKAGE_ROOT = Path(__file__).resolve().parents[2]
-PROJECT_ROOT = PACKAGE_ROOT.parent
-DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
-DEPLOY_ENV_KEY_ALLOWLIST = (
-    "OPENONION_API_KEY",
-    "OPENAI_API_KEY",
-    "ANTHROPIC_API_KEY",
-    "GEMINI_API_KEY",
-    "GOOGLE_API_KEY",
-    "GROQ_API_KEY",
-    "XAI_API_KEY",
-    "OPENROUTER_API_KEY",
-    "CONNECTONION_API_KEY",
-)
 
-
-class DeployConfigError(Exception):
-    """Raised when deploy configuration is invalid before upload."""
-
-
-@dataclass
-class DeployPackage:
-    tarball_path: Path
-    entrypoint: str
-
-
-def parse_skill_names(raw_skills: list[str] | None) -> list[str]:
-    """Parse repeated/comma-separated --skills values."""
-    if not raw_skills:
-        return []
-
-    names = []
-    for value in raw_skills:
-        for part in value.split(","):
-            name = part.strip()
-            if name:
-                names.append(name)
-    return names
-
-
-def validate_deploy_name(name: str) -> str:
-    """Validate a deploy name that becomes part of the hosted agent URL."""
-    if not name or not DEPLOY_NAME_PATTERN.match(name):
-        raise DeployConfigError(
-            "Invalid deploy name. Use lowercase letters, numbers, and hyphens; "
-            "start and end with a letter or number."
-        )
-    return name
-
-
-def _filter_allowed_env(values: dict) -> dict:
-    return {
-        key: value
-        for key, value in values.items()
-        if key in DEPLOY_ENV_KEY_ALLOWLIST and value not in (None, "")
-    }
-
-
-def load_deploy_env_vars(env_file: str | Path) -> dict:
-    """Load env vars for deploy without dumping the full shell environment."""
-    env_vars = {}
-
-    global_env = Path.home() / ".co" / "keys.env"
-    if global_env.exists():
-        env_vars.update(_filter_allowed_env(dotenv_values(global_env)))
-
-    env_vars.update({
-        key: value
-        for key in DEPLOY_ENV_KEY_ALLOWLIST
-        if (value := os.environ.get(key))
-    })
-
-    env_path = Path(env_file)
-    if env_path.exists():
-        env_vars.update({
-            key: value
-            for key, value in dotenv_values(env_path).items()
-            if value is not None
-        })
-
-    return env_vars
-
-
-def resolve_deploy_skill(name: str, project_dir: Path) -> Path:
-    """Resolve a deploy skill directory by project > user > built-in priority."""
-    candidates = [
-        project_dir / ".co" / "skills" / name,
-        Path.home() / ".co" / "skills" / name,
-        Path(__file__).parent.parent / "co_ai" / "skills" / "builtin" / name,
-    ]
-    for skill_dir in candidates:
-        if (skill_dir / "SKILL.md").exists():
-            return skill_dir
-
-    raise DeployConfigError(
-        f"Skill not found: {name}. Run `co skills discover && co skills copy {name}` first."
-    )
-
-
-def discover_deploy_skill_names(project_dir: Path) -> list[str]:
-    """Discover deployable project/user skill names with project priority."""
-    names = []
-    seen = set()
-    for skills_dir in (project_dir / ".co" / "skills", Path.home() / ".co" / "skills"):
-        if not skills_dir.exists():
-            continue
-        for skill_dir in sorted(skills_dir.iterdir(), key=lambda path: path.name):
-            if skill_dir.name in seen:
-                continue
-            if (skill_dir / "SKILL.md").exists():
-                names.append(skill_dir.name)
-                seen.add(skill_dir.name)
-    return names
-
-
-def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agent_name: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    model_literal = json.dumps(model)
-    name_literal = json.dumps(agent_name)
-    path.write_text(
-        "\n".join([
-            "import sys",
-            "from pathlib import Path",
-            "",
-            "PACKAGE_ROOT = Path(__file__).resolve().parents[2]",
-            "sys.path.insert(0, str(PACKAGE_ROOT))",
-            "CO_DIR = PACKAGE_ROOT / \".co\"",
-            "",
-            "from connectonion import host",
-            "from connectonion.cli.co_ai.agent import create_coding_agent",
-            "",
-            "",
-            "def create_agent():",
-            "    return create_coding_agent(",
-            f"        name={name_literal},",
-            f"        model={model_literal},",
-            f"        max_iterations={max_iterations},",
-            "        auto_approve=True,",
-            "        co_dir=CO_DIR,",
-            "        browser_headless=True,",
-            "        browser_channel=\"chrome\",",
-            "    )",
-            "",
-            "",
-            "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
-            "",
-        ]),
-        encoding="utf-8",
-    )
+__all__ = [
+    "CO_AI_ENTRYPOINT",
+    "DEPLOY_ENV_KEY_ALLOWLIST",
+    "DeployConfigError",
+    "DeployPackage",
+    "create_deploy_package",
+    "discover_deploy_skill_names",
+    "handle_deploy",
+    "load_deploy_env_vars",
+    "parse_skill_names",
+    "resolve_deploy_skill",
+    "resolve_deploy_template",
+    "validate_deploy_name",
+]
 
 
 def _archive_git_head(project_dir: Path, tarball_path: Path, *, gzip: bool) -> None:
@@ -189,78 +61,6 @@ def _archive_git_head(project_dir: Path, tarball_path: Path, *, gzip: bool) -> N
         cwd=project_dir,
         check=True,
     )
-
-
-def _make_tarball(source_dir: Path, tarball_path: Path) -> None:
-    with tarfile.open(tarball_path, "w:gz") as tar:
-        for path in sorted(source_dir.rglob("*")):
-            tar.add(path, arcname=str(path.relative_to(source_dir)))
-
-
-def _copy_connectonion_package(staging_dir: Path) -> None:
-    shutil.copytree(
-        PACKAGE_ROOT,
-        staging_dir / "connectonion",
-        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache"),
-    )
-
-
-def _copy_connectonion_project_metadata(staging_dir: Path) -> bool:
-    """Copy local package metadata when deploying from a source checkout."""
-    pyproject = PROJECT_ROOT / "pyproject.toml"
-    if not pyproject.exists():
-        return False
-
-    shutil.copy2(pyproject, staging_dir / "pyproject.toml")
-    for filename in ("README.md", "LICENSE"):
-        source = PROJECT_ROOT / filename
-        if source.exists():
-            shutil.copy2(source, staging_dir / filename)
-    return True
-
-
-def _write_co_ai_requirements(
-    staging_dir: Path,
-    *,
-    install_local_package: bool,
-    skill_requirements: list[Path] | None = None,
-) -> None:
-    lines = ["." if install_local_package else f"connectonion=={__version__}"]
-    for requirement_path in sorted(skill_requirements or []):
-        lines.append(f"-r {requirement_path.relative_to(staging_dir).as_posix()}")
-    (staging_dir / "requirements.txt").write_text(
-        "\n".join(lines) + "\n",
-        encoding="utf-8",
-    )
-
-
-def _write_co_ai_dockerfile(staging_dir: Path, *, install_local_package: bool) -> None:
-    lines = [
-        "FROM python:3.11-slim",
-        "WORKDIR /app",
-        "ENV PYTHONUNBUFFERED=1",
-        "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
-    ]
-    if install_local_package:
-        lines.extend([
-            "COPY pyproject.toml README.md requirements.txt ./",
-            "COPY connectonion ./connectonion",
-            "COPY .co ./.co",
-        ])
-    else:
-        lines.extend([
-            "COPY requirements.txt ./",
-            "COPY connectonion ./connectonion",
-            "COPY .co ./.co",
-        ])
-    lines.extend([
-        "RUN pip install --no-cache-dir -r requirements.txt",
-        "RUN python -m playwright install --with-deps chrome",
-        "ENV PORT=8000",
-        f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
-        "",
-    ])
-    (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
 
 
 def create_deploy_package(
@@ -275,59 +75,23 @@ def create_deploy_package(
     max_iterations: int,
 ) -> DeployPackage:
     """Build the tarball sent to the deploy API."""
-    temp_dir = Path(tempfile.mkdtemp())
-    tarball_path = temp_dir / "agent.tar.gz"
-
     if template == "project":
+        temp_dir = Path(tempfile.mkdtemp())
+        tarball_path = temp_dir / "agent.tar.gz"
         _archive_git_head(project_dir, tarball_path, gzip=True)
         return DeployPackage(tarball_path=tarball_path, entrypoint=entrypoint)
 
-    if template != "co-ai":
-        raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
+    if template == "co-ai":
+        return create_co_ai_deploy_package(
+            project_dir=project_dir,
+            skills=skills,
+            all_skills=all_skills,
+            project_name=project_name,
+            model=model,
+            max_iterations=max_iterations,
+        )
 
-    staging_dir = temp_dir / "staging"
-    staging_dir.mkdir()
-
-    _copy_connectonion_package(staging_dir)
-    install_local_package = _copy_connectonion_project_metadata(staging_dir)
-    _write_co_ai_entrypoint(
-        staging_dir / CO_AI_ENTRYPOINT,
-        model=model,
-        max_iterations=max_iterations,
-        agent_name=project_name,
-    )
-
-    deploy_skill_names = []
-    seen_skill_names = set()
-    for skill_name in discover_deploy_skill_names(project_dir) if all_skills else []:
-        deploy_skill_names.append(skill_name)
-        seen_skill_names.add(skill_name)
-    for skill_name in skills:
-        if skill_name not in seen_skill_names:
-            deploy_skill_names.append(skill_name)
-            seen_skill_names.add(skill_name)
-
-    skill_requirement_files = []
-    for skill_name in deploy_skill_names:
-        source = resolve_deploy_skill(skill_name, project_dir)
-        destination = staging_dir / ".co" / "skills" / skill_name
-        if destination.exists():
-            shutil.rmtree(destination)
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(source, destination)
-        requirements_file = destination / "requirements.txt"
-        if requirements_file.exists():
-            skill_requirement_files.append(requirements_file)
-
-    _write_co_ai_requirements(
-        staging_dir,
-        install_local_package=install_local_package,
-        skill_requirements=skill_requirement_files,
-    )
-    _write_co_ai_dockerfile(staging_dir, install_local_package=install_local_package)
-
-    _make_tarball(staging_dir, tarball_path)
-    return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)
+    raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
 
 
 def resolve_deploy_template(

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -29,6 +29,7 @@ from .deploy_co_ai import (
     discover_deploy_skill_names,
     load_deploy_env_vars,
     parse_skill_names,
+    resolve_connectonion_pypi_version,
     resolve_deploy_skill,
     validate_deploy_name,
 )
@@ -48,6 +49,7 @@ __all__ = [
     "handle_deploy",
     "load_deploy_env_vars",
     "parse_skill_names",
+    "resolve_connectonion_pypi_version",
     "resolve_deploy_skill",
     "resolve_deploy_template",
     "validate_deploy_name",
@@ -69,20 +71,26 @@ def create_deploy_package(
     template: str,
     skills: list[str],
     all_skills: bool = False,
-    browser: bool = False,
+    runtime: str = "local",
     project_name: str,
     entrypoint: str,
     model: str,
     max_iterations: int,
 ) -> DeployPackage:
     """Build the tarball sent to the deploy API."""
+    if runtime not in ("local", "pypi"):
+        raise DeployConfigError("Unsupported co-ai runtime. Use 'local' or 'pypi'.")
+
     if template == "project":
+        if runtime != "local":
+            raise DeployConfigError("--runtime pypi requires --template co-ai")
         temp_dir = Path(tempfile.mkdtemp())
         tarball_path = temp_dir / "agent.tar.gz"
         _archive_git_head(project_dir, tarball_path, gzip=True)
         return DeployPackage(tarball_path=tarball_path, entrypoint=entrypoint)
 
     if template == "co-ai":
+        runtime_version = resolve_connectonion_pypi_version() if runtime == "pypi" else None
         return create_co_ai_deploy_package(
             project_dir=project_dir,
             skills=skills,
@@ -90,7 +98,8 @@ def create_deploy_package(
             project_name=project_name,
             model=model,
             max_iterations=max_iterations,
-            browser=browser,
+            runtime=runtime,
+            runtime_version=runtime_version,
         )
 
     raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
@@ -102,9 +111,12 @@ def resolve_deploy_template(
     project_dir: Path,
     *,
     all_skills: bool = False,
+    runtime: str = "local",
 ) -> str:
     """Resolve the user-facing deploy mode."""
     if template == "auto":
+        if runtime == "pypi":
+            return "co-ai"
         if skill_names or all_skills:
             return "co-ai"
         if (project_dir / ".git").exists() or (project_dir / ".co" / "host.yaml").exists():
@@ -144,9 +156,9 @@ def _check_host_export(entrypoint: str) -> bool:
 def handle_deploy(
     name: str | None = None,
     template: str = "auto",
+    runtime: str = "local",
     skills: list[str] | None = None,
     all_skills: bool = False,
-    browser: bool = False,
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
 ):
@@ -156,12 +168,17 @@ def handle_deploy(
     project_dir = Path.cwd()
     skill_names = parse_skill_names(skills)
 
+    if runtime not in ("local", "pypi"):
+        console.print("[red]Unsupported co-ai runtime. Use 'local' or 'pypi'.[/red]")
+        return
+
     try:
         deploy_template = resolve_deploy_template(
             template,
             skill_names,
             project_dir,
             all_skills=all_skills,
+            runtime=runtime,
         )
     except DeployConfigError as e:
         console.print(f"[red]{e}[/red]")
@@ -173,8 +190,8 @@ def handle_deploy(
     if deploy_template == "project" and all_skills:
         console.print("[red]--all-skills requires --template co-ai[/red]")
         return
-    if deploy_template == "project" and browser:
-        console.print("[red]--browser requires --template co-ai[/red]")
+    if deploy_template == "project" and runtime != "local":
+        console.print("[red]--runtime pypi requires --template co-ai[/red]")
         return
 
     host_yaml_path = Path(".co") / "host.yaml"
@@ -240,9 +257,9 @@ def handle_deploy(
         package = create_deploy_package(
             project_dir=project_dir,
             template=deploy_template,
+            runtime=runtime,
             skills=skill_names,
             all_skills=all_skills,
-            browser=browser,
             project_name=project_name,
             entrypoint=entrypoint,
             model=model,
@@ -280,6 +297,7 @@ def handle_deploy(
                 "env_vars": serialized_env_vars,
                 "secrets": serialized_env_vars,
                 "entrypoint": upload_entrypoint,
+                "runtime": runtime,
             },
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=600,  # 10 minutes for docker build

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -12,20 +12,299 @@ LLM-Note:
 import json
 import os
 import re
+import shutil
 import subprocess
+import tarfile
 import tempfile
 import time
 import yaml
 import requests
+from dataclasses import dataclass
 from pathlib import Path
 from rich.console import Console
 from dotenv import dotenv_values
 
+from connectonion import __version__
 from .project_cmd_lib import load_api_key
 
 console = Console()
 
 API_BASE = "https://oo.openonion.ai"
+CO_AI_ENTRYPOINT = ".co/deploy/co_ai_entrypoint.py"
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = PACKAGE_ROOT.parent
+DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+DEPLOY_ENV_KEY_ALLOWLIST = (
+    "OPENONION_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CONNECTONION_API_KEY",
+)
+
+
+class DeployConfigError(Exception):
+    """Raised when deploy configuration is invalid before upload."""
+
+
+@dataclass
+class DeployPackage:
+    tarball_path: Path
+    entrypoint: str
+
+
+def parse_skill_names(raw_skills: list[str] | None) -> list[str]:
+    """Parse repeated/comma-separated --skills values."""
+    if not raw_skills:
+        return []
+
+    names = []
+    for value in raw_skills:
+        for part in value.split(","):
+            name = part.strip()
+            if name:
+                names.append(name)
+    return names
+
+
+def validate_deploy_name(name: str) -> str:
+    """Validate a deploy name that becomes part of the hosted agent URL."""
+    if not name or not DEPLOY_NAME_PATTERN.match(name):
+        raise DeployConfigError(
+            "Invalid deploy name. Use lowercase letters, numbers, and hyphens; "
+            "start and end with a letter or number."
+        )
+    return name
+
+
+def _filter_allowed_env(values: dict) -> dict:
+    return {
+        key: value
+        for key, value in values.items()
+        if key in DEPLOY_ENV_KEY_ALLOWLIST and value not in (None, "")
+    }
+
+
+def load_deploy_env_vars(env_file: str | Path) -> dict:
+    """Load env vars for deploy without dumping the full shell environment."""
+    env_vars = {}
+
+    global_env = Path.home() / ".co" / "keys.env"
+    if global_env.exists():
+        env_vars.update(_filter_allowed_env(dotenv_values(global_env)))
+
+    env_vars.update({
+        key: value
+        for key in DEPLOY_ENV_KEY_ALLOWLIST
+        if (value := os.environ.get(key))
+    })
+
+    env_path = Path(env_file)
+    if env_path.exists():
+        env_vars.update({
+            key: value
+            for key, value in dotenv_values(env_path).items()
+            if value is not None
+        })
+
+    return env_vars
+
+
+def resolve_deploy_skill(name: str, project_dir: Path) -> Path:
+    """Resolve a deploy skill directory by project > user > built-in priority."""
+    candidates = [
+        project_dir / ".co" / "skills" / name,
+        Path.home() / ".co" / "skills" / name,
+        Path(__file__).parent.parent / "co_ai" / "skills" / "builtin" / name,
+    ]
+    for skill_dir in candidates:
+        if (skill_dir / "SKILL.md").exists():
+            return skill_dir
+
+    raise DeployConfigError(
+        f"Skill not found: {name}. Run `co skills discover && co skills copy {name}` first."
+    )
+
+
+def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agent_name: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    model_literal = json.dumps(model)
+    name_literal = json.dumps(agent_name)
+    path.write_text(
+        "\n".join([
+            "import sys",
+            "from pathlib import Path",
+            "",
+            "PACKAGE_ROOT = Path(__file__).resolve().parents[2]",
+            "sys.path.insert(0, str(PACKAGE_ROOT))",
+            "CO_DIR = PACKAGE_ROOT / \".co\"",
+            "",
+            "from connectonion import host",
+            "from connectonion.cli.co_ai.agent import create_coding_agent",
+            "",
+            "",
+            "def create_agent():",
+            "    return create_coding_agent(",
+            f"        name={name_literal},",
+            f"        model={model_literal},",
+            f"        max_iterations={max_iterations},",
+            "        auto_approve=True,",
+            "        co_dir=CO_DIR,",
+            "        browser_headless=True,",
+            "        browser_channel=\"chrome\",",
+            "    )",
+            "",
+            "",
+            "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
+def _archive_git_head(project_dir: Path, tarball_path: Path, *, gzip: bool) -> None:
+    fmt = "tar.gz" if gzip else "tar"
+    subprocess.run(
+        ["git", "archive", f"--format={fmt}", "-o", str(tarball_path), "HEAD"],
+        cwd=project_dir,
+        check=True,
+    )
+
+
+def _make_tarball(source_dir: Path, tarball_path: Path) -> None:
+    with tarfile.open(tarball_path, "w:gz") as tar:
+        for path in sorted(source_dir.rglob("*")):
+            tar.add(path, arcname=str(path.relative_to(source_dir)))
+
+
+def _copy_connectonion_package(staging_dir: Path) -> None:
+    shutil.copytree(
+        PACKAGE_ROOT,
+        staging_dir / "connectonion",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache"),
+    )
+
+
+def _copy_connectonion_project_metadata(staging_dir: Path) -> bool:
+    """Copy local package metadata when deploying from a source checkout."""
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return False
+
+    shutil.copy2(pyproject, staging_dir / "pyproject.toml")
+    for filename in ("README.md", "LICENSE"):
+        source = PROJECT_ROOT / filename
+        if source.exists():
+            shutil.copy2(source, staging_dir / filename)
+    return True
+
+
+def _write_co_ai_requirements(
+    staging_dir: Path,
+    *,
+    install_local_package: bool,
+    skill_requirements: list[Path] | None = None,
+) -> None:
+    lines = ["." if install_local_package else f"connectonion=={__version__}"]
+    for requirement_path in sorted(skill_requirements or []):
+        lines.append(f"-r {requirement_path.relative_to(staging_dir).as_posix()}")
+    (staging_dir / "requirements.txt").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_co_ai_dockerfile(staging_dir: Path) -> None:
+    (staging_dir / "Dockerfile").write_text(
+        "\n".join([
+            "FROM python:3.11-slim",
+            "WORKDIR /app",
+            "ENV PYTHONUNBUFFERED=1",
+            "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+            "COPY . .",
+            "RUN pip install --no-cache-dir -r requirements.txt",
+            "RUN python -m playwright install --with-deps chrome",
+            "ENV PORT=8000",
+            f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
+def create_deploy_package(
+    *,
+    project_dir: Path,
+    template: str,
+    skills: list[str],
+    project_name: str,
+    entrypoint: str,
+    model: str,
+    max_iterations: int,
+) -> DeployPackage:
+    """Build the tarball sent to the deploy API."""
+    temp_dir = Path(tempfile.mkdtemp())
+    tarball_path = temp_dir / "agent.tar.gz"
+
+    if template == "project":
+        _archive_git_head(project_dir, tarball_path, gzip=True)
+        return DeployPackage(tarball_path=tarball_path, entrypoint=entrypoint)
+
+    if template != "co-ai":
+        raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
+
+    staging_dir = temp_dir / "staging"
+    staging_dir.mkdir()
+
+    _copy_connectonion_package(staging_dir)
+    install_local_package = _copy_connectonion_project_metadata(staging_dir)
+    _write_co_ai_dockerfile(staging_dir)
+    _write_co_ai_entrypoint(
+        staging_dir / CO_AI_ENTRYPOINT,
+        model=model,
+        max_iterations=max_iterations,
+        agent_name=project_name,
+    )
+
+    skill_requirement_files = []
+    for skill_name in skills:
+        source = resolve_deploy_skill(skill_name, project_dir)
+        destination = staging_dir / ".co" / "skills" / skill_name
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, destination)
+        requirements_file = destination / "requirements.txt"
+        if requirements_file.exists():
+            skill_requirement_files.append(requirements_file)
+
+    _write_co_ai_requirements(
+        staging_dir,
+        install_local_package=install_local_package,
+        skill_requirements=skill_requirement_files,
+    )
+
+    _make_tarball(staging_dir, tarball_path)
+    return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)
+
+
+def resolve_deploy_template(template: str, skill_names: list[str], project_dir: Path) -> str:
+    """Resolve the user-facing deploy mode."""
+    if template == "auto":
+        if skill_names:
+            return "co-ai"
+        if (project_dir / ".git").exists() or (project_dir / ".co" / "host.yaml").exists():
+            return "project"
+        return "co-ai"
+
+    if template in ("project", "co-ai"):
+        return template
+
+    raise DeployConfigError("Unsupported deploy template. Use 'auto', 'project', or 'co-ai'.")
 
 
 def _check_host_export(entrypoint: str) -> bool:
@@ -52,23 +331,42 @@ def _check_host_export(entrypoint: str) -> bool:
     return False
 
 
-def handle_deploy():
+def handle_deploy(
+    name: str | None = None,
+    template: str = "auto",
+    skills: list[str] | None = None,
+    model: str = "co/gemini-3-flash-preview",
+    max_iterations: int = 100,
+):
     """Deploy agent to ConnectOnion Cloud."""
     console.print("\n[cyan]Deploying to ConnectOnion Cloud...[/cyan]\n")
 
     project_dir = Path.cwd()
+    skill_names = parse_skill_names(skills)
 
-    # Must be a git repo
-    if not (project_dir / ".git").exists():
-        console.print("[red]Not a git repository. Run 'git init' first.[/red]")
+    try:
+        deploy_template = resolve_deploy_template(template, skill_names, project_dir)
+    except DeployConfigError as e:
+        console.print(f"[red]{e}[/red]")
         return
 
-    # Must be a ConnectOnion project
+    if deploy_template == "project" and skill_names:
+        console.print("[red]--skills requires --template co-ai[/red]")
+        return
+
     host_yaml_path = Path(".co") / "host.yaml"
+    config = {}
 
-    if not host_yaml_path.exists():
-        console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
-        return
+    if deploy_template == "project":
+        # Must be a git repo
+        if not (project_dir / ".git").exists():
+            console.print("[red]Not a git repository. Run 'git init' first.[/red]")
+            return
+
+        # Must be a ConnectOnion project
+        if not host_yaml_path.exists():
+            console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
+            return
 
     # Must have API key
     api_key = load_api_key()
@@ -76,45 +374,62 @@ def handle_deploy():
         console.print("[red]No API key. Run 'co auth' first.[/red]")
         return
 
-    # Load config from host.yaml
-    with open(host_yaml_path, 'r') as f:
-        config = yaml.safe_load(f) or {}
-    project_name = config.get("name", "unnamed-agent")
+    if host_yaml_path.exists():
+        with open(host_yaml_path, 'r') as f:
+            config = yaml.safe_load(f) or {}
+
+    if name is not None:
+        project_name = validate_deploy_name(name)
+    elif deploy_template == "co-ai":
+        project_name = "co-ai"
+    else:
+        project_name = config.get("name", "unnamed-agent")
     env_file = config.get("env", ".env")
-    entrypoint = config.get("entrypoint", "agent.py")
+    entrypoint = config.get("entrypoint", "agent.py" if deploy_template == "project" else CO_AI_ENTRYPOINT)
 
-    # Validate entrypoint exists
-    if not Path(entrypoint).exists():
-        console.print(f"[red]Entrypoint not found: {entrypoint}[/red]")
-        console.print("[dim]Set 'entrypoint' in .co/host.yaml[/dim]")
-        return
+    if deploy_template == "project":
+        # Validate entrypoint exists
+        if not Path(entrypoint).exists():
+            console.print(f"[red]Entrypoint not found: {entrypoint}[/red]")
+            console.print("[dim]Set 'entrypoint' in .co/host.yaml[/dim]")
+            return
 
-    # Validate entrypoint exports ASGI app via host()
-    if not _check_host_export(entrypoint):
-        console.print(f"[red]Entrypoint '{entrypoint}' does not export an ASGI app.[/red]")
-        console.print()
-        console.print("[yellow]To deploy, your agent must call host():[/yellow]")
-        console.print()
-        console.print("  [cyan]from connectonion import Agent, host[/cyan]")
-        console.print()
-        console.print("  [cyan]agent = Agent('my-agent', ...)[/cyan]")
-        console.print("  [cyan]host(agent)  # Starts HTTP server[/cyan]")
-        console.print()
-        console.print("[dim]See: https://docs.connectonion.com/deploy[/dim]")
-        return
+        # Validate entrypoint exports ASGI app via host()
+        if not _check_host_export(entrypoint):
+            console.print(f"[red]Entrypoint '{entrypoint}' does not export an ASGI app.[/red]")
+            console.print()
+            console.print("[yellow]To deploy, your agent must call host():[/yellow]")
+            console.print()
+            console.print("  [cyan]from connectonion import Agent, host[/cyan]")
+            console.print()
+            console.print("  [cyan]agent = Agent('my-agent', ...)[/cyan]")
+            console.print("  [cyan]host(agent)  # Starts HTTP server[/cyan]")
+            console.print()
+            console.print("[dim]See: https://docs.connectonion.com/deploy[/dim]")
+            return
 
     # Load env vars from .env (user's API keys, config for the agent container)
-    env_vars = dotenv_values(env_file) if Path(env_file).exists() else {}
+    env_vars = load_deploy_env_vars(env_file)
+    if deploy_template == "co-ai" and api_key and "OPENONION_API_KEY" not in env_vars:
+        env_vars["OPENONION_API_KEY"] = api_key
 
-    # Create tarball from git
-    tarball_path = Path(tempfile.mkdtemp()) / "agent.tar.gz"
-    subprocess.run(
-        ["git", "archive", "--format=tar.gz", "-o", str(tarball_path), "HEAD"],
-        cwd=project_dir,
-        check=True,
-    )
+    try:
+        package = create_deploy_package(
+            project_dir=project_dir,
+            template=deploy_template,
+            skills=skill_names,
+            project_name=project_name,
+            entrypoint=entrypoint,
+            model=model,
+            max_iterations=max_iterations,
+        )
+    except DeployConfigError as e:
+        console.print(f"[red]{e}[/red]")
+        return
 
     # Show package size
+    tarball_path = package.tarball_path
+    upload_entrypoint = package.entrypoint
     tarball_size = tarball_path.stat().st_size
     if tarball_size < 1024:
         size_str = f"{tarball_size} B"
@@ -130,14 +445,16 @@ def handle_deploy():
 
     # Upload
     console.print("Uploading...")
+    serialized_env_vars = json.dumps(env_vars)
     with open(tarball_path, "rb") as f:
         response = requests.post(
             f"{API_BASE}/api/v1/deploy",
             files={"package": ("agent.tar.gz", f, "application/gzip")},
             data={
                 "project_name": project_name,
-                "env_vars": json.dumps(env_vars),
-                "entrypoint": entrypoint,
+                "env_vars": serialized_env_vars,
+                "secrets": serialized_env_vars,
+                "entrypoint": upload_entrypoint,
             },
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=600,  # 10 minutes for docker build

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -130,6 +130,22 @@ def resolve_deploy_skill(name: str, project_dir: Path) -> Path:
     )
 
 
+def discover_deploy_skill_names(project_dir: Path) -> list[str]:
+    """Discover deployable project/user skill names with project priority."""
+    names = []
+    seen = set()
+    for skills_dir in (project_dir / ".co" / "skills", Path.home() / ".co" / "skills"):
+        if not skills_dir.exists():
+            continue
+        for skill_dir in sorted(skills_dir.iterdir(), key=lambda path: path.name):
+            if skill_dir.name in seen:
+                continue
+            if (skill_dir / "SKILL.md").exists():
+                names.append(skill_dir.name)
+                seen.add(skill_dir.name)
+    return names
+
+
 def _write_co_ai_entrypoint(path: Path, *, model: str, max_iterations: int, agent_name: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     model_literal = json.dumps(model)
@@ -252,6 +268,7 @@ def create_deploy_package(
     project_dir: Path,
     template: str,
     skills: list[str],
+    all_skills: bool = False,
     project_name: str,
     entrypoint: str,
     model: str,
@@ -280,8 +297,18 @@ def create_deploy_package(
         agent_name=project_name,
     )
 
-    skill_requirement_files = []
+    deploy_skill_names = []
+    seen_skill_names = set()
+    for skill_name in discover_deploy_skill_names(project_dir) if all_skills else []:
+        deploy_skill_names.append(skill_name)
+        seen_skill_names.add(skill_name)
     for skill_name in skills:
+        if skill_name not in seen_skill_names:
+            deploy_skill_names.append(skill_name)
+            seen_skill_names.add(skill_name)
+
+    skill_requirement_files = []
+    for skill_name in deploy_skill_names:
         source = resolve_deploy_skill(skill_name, project_dir)
         destination = staging_dir / ".co" / "skills" / skill_name
         if destination.exists():
@@ -303,10 +330,16 @@ def create_deploy_package(
     return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)
 
 
-def resolve_deploy_template(template: str, skill_names: list[str], project_dir: Path) -> str:
+def resolve_deploy_template(
+    template: str,
+    skill_names: list[str],
+    project_dir: Path,
+    *,
+    all_skills: bool = False,
+) -> str:
     """Resolve the user-facing deploy mode."""
     if template == "auto":
-        if skill_names:
+        if skill_names or all_skills:
             return "co-ai"
         if (project_dir / ".git").exists() or (project_dir / ".co" / "host.yaml").exists():
             return "project"
@@ -346,6 +379,7 @@ def handle_deploy(
     name: str | None = None,
     template: str = "auto",
     skills: list[str] | None = None,
+    all_skills: bool = False,
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
 ):
@@ -356,13 +390,21 @@ def handle_deploy(
     skill_names = parse_skill_names(skills)
 
     try:
-        deploy_template = resolve_deploy_template(template, skill_names, project_dir)
+        deploy_template = resolve_deploy_template(
+            template,
+            skill_names,
+            project_dir,
+            all_skills=all_skills,
+        )
     except DeployConfigError as e:
         console.print(f"[red]{e}[/red]")
         return
 
     if deploy_template == "project" and skill_names:
         console.print("[red]--skills requires --template co-ai[/red]")
+        return
+    if deploy_template == "project" and all_skills:
+        console.print("[red]--all-skills requires --template co-ai[/red]")
         return
 
     host_yaml_path = Path(".co") / "host.yaml"
@@ -429,6 +471,7 @@ def handle_deploy(
             project_dir=project_dir,
             template=deploy_template,
             skills=skill_names,
+            all_skills=all_skills,
             project_name=project_name,
             entrypoint=entrypoint,
             model=model,

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -69,6 +69,7 @@ def create_deploy_package(
     template: str,
     skills: list[str],
     all_skills: bool = False,
+    browser: bool = False,
     project_name: str,
     entrypoint: str,
     model: str,
@@ -89,6 +90,7 @@ def create_deploy_package(
             project_name=project_name,
             model=model,
             max_iterations=max_iterations,
+            browser=browser,
         )
 
     raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
@@ -144,6 +146,7 @@ def handle_deploy(
     template: str = "auto",
     skills: list[str] | None = None,
     all_skills: bool = False,
+    browser: bool = False,
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
 ):
@@ -169,6 +172,9 @@ def handle_deploy(
         return
     if deploy_template == "project" and all_skills:
         console.print("[red]--all-skills requires --template co-ai[/red]")
+        return
+    if deploy_template == "project" and browser:
+        console.print("[red]--browser requires --template co-ai[/red]")
         return
 
     host_yaml_path = Path(".co") / "host.yaml"
@@ -236,6 +242,7 @@ def handle_deploy(
             template=deploy_template,
             skills=skill_names,
             all_skills=all_skills,
+            browser=browser,
             project_name=project_name,
             entrypoint=entrypoint,
             model=model,

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -218,22 +218,33 @@ def _write_co_ai_requirements(
     )
 
 
-def _write_co_ai_dockerfile(staging_dir: Path) -> None:
-    (staging_dir / "Dockerfile").write_text(
-        "\n".join([
-            "FROM python:3.11-slim",
-            "WORKDIR /app",
-            "ENV PYTHONUNBUFFERED=1",
-            "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
-            "COPY . .",
-            "RUN pip install --no-cache-dir -r requirements.txt",
-            "RUN python -m playwright install --with-deps chrome",
-            "ENV PORT=8000",
-            f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
-            "",
-        ]),
-        encoding="utf-8",
-    )
+def _write_co_ai_dockerfile(staging_dir: Path, *, install_local_package: bool) -> None:
+    lines = [
+        "FROM python:3.11-slim",
+        "WORKDIR /app",
+        "ENV PYTHONUNBUFFERED=1",
+        "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+    ]
+    if install_local_package:
+        lines.extend([
+            "COPY pyproject.toml README.md requirements.txt ./",
+            "COPY connectonion ./connectonion",
+            "COPY .co ./.co",
+        ])
+    else:
+        lines.extend([
+            "COPY requirements.txt ./",
+            "COPY connectonion ./connectonion",
+            "COPY .co ./.co",
+        ])
+    lines.extend([
+        "RUN pip install --no-cache-dir -r requirements.txt",
+        "RUN python -m playwright install --with-deps chrome",
+        "ENV PORT=8000",
+        f"CMD [\"python\", \"{CO_AI_ENTRYPOINT}\"]",
+        "",
+    ])
+    (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
 
 
 def create_deploy_package(
@@ -262,7 +273,6 @@ def create_deploy_package(
 
     _copy_connectonion_package(staging_dir)
     install_local_package = _copy_connectonion_project_metadata(staging_dir)
-    _write_co_ai_dockerfile(staging_dir)
     _write_co_ai_entrypoint(
         staging_dir / CO_AI_ENTRYPOINT,
         model=model,
@@ -287,6 +297,7 @@ def create_deploy_package(
         install_local_package=install_local_package,
         skill_requirements=skill_requirement_files,
     )
+    _write_co_ai_dockerfile(staging_dir, install_local_package=install_local_package)
 
     _make_tarball(staging_dir, tarball_path)
     return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,9 +4,9 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
-  Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
+  Errors: typer.Exit() on --version | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
 
 import typer
@@ -100,9 +100,9 @@ def create(
 def deploy(
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Cloud project/agent name for this deployment"),
     template: str = typer.Option("auto", "--template", help="Deploy template: auto, project, or co-ai"),
+    runtime: str = typer.Option("local", "--runtime", help="co-ai runtime: local or pypi"),
     skills: Optional[List[str]] = typer.Option(None, "--skills", "--skill", help="Skill names for co-ai deploy; repeat or comma-separate"),
     all_skills: bool = typer.Option(False, "--all-skills", help="Deploy all project and user skills with co-ai"),
-    browser: bool = typer.Option(False, "--browser", help="Install/use Google Chrome for hosted co-ai browser automation"),
     model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model for co-ai deploy"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations for co-ai deploy"),
 ):
@@ -111,9 +111,9 @@ def deploy(
     handle_deploy(
         name=name,
         template=template,
+        runtime=runtime,
         skills=skills,
         all_skills=all_skills,
-        browser=browser,
         model=model,
         max_iterations=max_iterations,
     )

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -97,10 +97,16 @@ def create(
 
 
 @app.command()
-def deploy():
+def deploy(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Cloud project/agent name for this deployment"),
+    template: str = typer.Option("auto", "--template", help="Deploy template: auto, project, or co-ai"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", "--skill", help="Skill names for co-ai deploy; repeat or comma-separate"),
+    model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model for co-ai deploy"),
+    max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations for co-ai deploy"),
+):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy()
+    handle_deploy(name=name, template=template, skills=skills, model=model, max_iterations=max_iterations)
 
 
 @app.command()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -102,6 +102,7 @@ def deploy(
     template: str = typer.Option("auto", "--template", help="Deploy template: auto, project, or co-ai"),
     skills: Optional[List[str]] = typer.Option(None, "--skills", "--skill", help="Skill names for co-ai deploy; repeat or comma-separate"),
     all_skills: bool = typer.Option(False, "--all-skills", help="Deploy all project and user skills with co-ai"),
+    browser: bool = typer.Option(False, "--browser", help="Install/use Google Chrome for hosted co-ai browser automation"),
     model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model for co-ai deploy"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations for co-ai deploy"),
 ):
@@ -112,6 +113,7 @@ def deploy(
         template=template,
         skills=skills,
         all_skills=all_skills,
+        browser=browser,
         model=model,
         max_iterations=max_iterations,
     )

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -101,12 +101,20 @@ def deploy(
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Cloud project/agent name for this deployment"),
     template: str = typer.Option("auto", "--template", help="Deploy template: auto, project, or co-ai"),
     skills: Optional[List[str]] = typer.Option(None, "--skills", "--skill", help="Skill names for co-ai deploy; repeat or comma-separate"),
+    all_skills: bool = typer.Option(False, "--all-skills", help="Deploy all project and user skills with co-ai"),
     model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model for co-ai deploy"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations for co-ai deploy"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy(name=name, template=template, skills=skills, model=model, max_iterations=max_iterations)
+    handle_deploy(
+        name=name,
+        template=template,
+        skills=skills,
+        all_skills=all_skills,
+        model=model,
+        max_iterations=max_iterations,
+    )
 
 
 @app.command()

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -34,6 +34,7 @@ import uvicorn
 import websockets
 from rich.console import Console
 
+from ... import __version__
 from ... import address
 from .. import announce, relay
 from ..asgi import create_app as asgi_create_app
@@ -117,6 +118,36 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
                    for s in raw_skills],
     }
     return metadata, sample
+
+
+def _build_relay_profile(agent_metadata: dict, summary: str) -> dict:
+    """Build publishable relay profile metadata from hosted agent metadata."""
+    agent_name = str(agent_metadata.get("name") or "agent")
+    profile = {
+        "alias": agent_name,
+        "name": agent_name,
+        "bio": (summary or "")[:1000],
+        "version": __version__,
+        "model": str(agent_metadata.get("model") or ""),
+        "tools": [str(tool_name) for tool_name in agent_metadata.get("tools", [])],
+        "skills": [],
+    }
+
+    for skill in agent_metadata.get("skills", []):
+        if not isinstance(skill, dict):
+            continue
+        skill_name = skill.get("name")
+        if not skill_name:
+            continue
+        item = {
+            "name": str(skill_name),
+            "description": str(skill.get("description") or "")[:1000],
+        }
+        if skill.get("location"):
+            item["location"] = str(skill["location"])
+        profile["skills"].append(item)
+
+    return profile
 
 
 def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
@@ -231,7 +262,15 @@ def _print_host_banner(
     console.print()
 
 
-def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner):
+def _create_relay_lifespan(
+    relay_url: str,
+    addr_data: dict,
+    summary: str,
+    port: int,
+    relay_session_runner,
+    *,
+    profile: dict | None = None,
+):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
     Args:
@@ -240,6 +279,7 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         summary: Summary text for relay announcement
         port: HTTP port for endpoint discovery
         relay_session_runner: async (send_msg, recv_msg) -> None, runs protocol for one relay session
+        profile: Optional publishable metadata for frontend/directory display
 
     Returns:
         Tuple of (on_startup, on_shutdown) async callbacks
@@ -253,7 +293,13 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         async def relay_loop():
             while True:
                 ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                announce_msg = announce.create_announce_message(
+                    addr_data,
+                    summary,
+                    endpoints=endpoints,
+                    relay=relay_url,
+                    profile=profile,
+                )
                 await relay.serve_loop(
                     ws, announce_msg,
                     addr_data=addr_data, session_handler=relay_session_runner,
@@ -400,6 +446,7 @@ def host(
         address.save(addr_data, co_dir)
 
     agent_metadata["address"] = addr_data['address']
+    relay_profile = _build_relay_profile(agent_metadata, summary)
 
     storage = SessionStorage()
 
@@ -436,7 +483,12 @@ def host(
             enable_ping=False,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
-            relay_url, addr_data, summary, port, relay_session_runner
+            relay_url,
+            addr_data,
+            summary,
+            port,
+            relay_session_runner,
+            profile=relay_profile,
         )
 
     app = asgi_create_app(

--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -193,6 +193,7 @@ async def serve_loop(
     summary = announce_message.get("summary", "")
     endpoints = announce_message.get("endpoints", [])
     relay_url = announce_message.get("relay")
+    profile = announce_message.get("profile")
 
     sessions: Dict[str, asyncio.Queue] = {}
 
@@ -227,7 +228,11 @@ async def serve_loop(
             # Stay in the loop.
             if addr_data:
                 fresh_announce = announce_module.create_announce_message(
-                    addr_data, summary, endpoints=endpoints, relay=relay_url
+                    addr_data,
+                    summary,
+                    endpoints=endpoints,
+                    relay=relay_url,
+                    profile=profile,
                 )
                 await send_announce(websocket, fresh_announce)
             else:

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -89,52 +89,77 @@ class SkillInfo:
 # SKILL DISCOVERY
 # =============================================================================
 
-def _get_skill_paths(skill_name: str) -> List[Path]:
+def _get_skill_paths(
+    skill_name: str,
+    co_dir: Optional[Path] = None,
+    project_dir: Optional[Path] = None,
+) -> List[Path]:
     """Get potential paths for a skill in priority order.
 
     Priority:
-    1. .co/skills/skill-name/SKILL.md (project-level)
-    2. ~/.co/skills/skill-name/SKILL.md (user-level)
-    3. builtin skills (bundled with ConnectOnion)
+    1. agent co_dir/skills/skill-name/SKILL.md (hosted/project agent)
+    2. cwd .co/skills/skill-name/SKILL.md (local fallback)
+    3. ~/.co/skills/skill-name/SKILL.md (user-level)
+    4. builtin skills (bundled with ConnectOnion)
 
     Args:
         skill_name: Skill name (e.g., "commit")
+        co_dir: Agent .co directory, when available
+        project_dir: Project root, when available
 
     Returns:
         List of Path objects in priority order
     """
     paths = []
     home = Path.home()
+    seen = set()
 
-    # 1. Project-level ConnectOnion: .co/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
+    def add(path: Path) -> None:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            paths.append(path)
 
-    # 2. Project-level Claude Code: .claude/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.claude' / 'skills' / skill_name / 'SKILL.md')
+    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
+    co_base = co_dir or (base / '.co')
 
-    # 3. User-level ConnectOnion: ~/.co/skills/skill-name/SKILL.md
-    paths.append(home / '.co' / 'skills' / skill_name / 'SKILL.md')
+    # 1. Agent/project-level ConnectOnion skills
+    add(co_base / 'skills' / skill_name / 'SKILL.md')
 
-    # 4. User-level Claude Code: ~/.claude/skills/skill-name/SKILL.md
-    paths.append(home / '.claude' / 'skills' / skill_name / 'SKILL.md')
+    # 2. Project-level Claude Code skills
+    add(base / '.claude' / 'skills' / skill_name / 'SKILL.md')
 
-    # 5. Built-in: connectonion/cli/co_ai/skills/builtin/skill-name/SKILL.md
+    # 3. cwd fallback for local usage that has no agent.co_dir
+    add(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
+    add(Path.cwd() / '.claude' / 'skills' / skill_name / 'SKILL.md')
+
+    # 4. User-level skills
+    add(home / '.co' / 'skills' / skill_name / 'SKILL.md')
+    add(home / '.claude' / 'skills' / skill_name / 'SKILL.md')
+
+    # 5. Built-in skills
     builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
-    paths.append(builtin_base / skill_name / 'SKILL.md')
+    add(builtin_base / skill_name / 'SKILL.md')
 
     return paths
 
 
-def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
+def _load_skill(
+    skill_name: str,
+    co_dir: Optional[Path] = None,
+    project_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
     """Load skill from filesystem.
 
     Args:
         skill_name: Skill name (e.g., "commit")
+        co_dir: Agent .co directory, when available
+        project_dir: Project root, when available
 
     Returns:
         Dict with 'path', 'frontmatter', 'instructions' or None if not found
     """
-    for path in _get_skill_paths(skill_name):
+    for path in _get_skill_paths(skill_name, co_dir=co_dir, project_dir=project_dir):
         if path.exists():
             content = path.read_text()
             frontmatter, instructions = _parse_skill_content(content)
@@ -321,7 +346,8 @@ def handle_skill_invocation(agent: 'Agent') -> None:
         return
 
     # Load skill
-    skill = _load_skill(skill_name)
+    co_dir = getattr(agent, 'co_dir', None)
+    skill = _load_skill(skill_name, co_dir=co_dir)
     if not skill:
         # Skill not found - don't interfere
         return
@@ -364,7 +390,8 @@ def skill(agent: 'Agent', name: str) -> str:
     Returns:
         Skill instructions for the agent to follow
     """
-    skill_data = _load_skill(name)
+    co_dir = getattr(agent, 'co_dir', None)
+    skill_data = _load_skill(name, co_dir=co_dir)
     if not skill_data:
         co_dir = getattr(agent, 'co_dir', None)
         available = _discover_all_skills(co_dir=co_dir)

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
 class SkillInfo:
     name: str
     description: str
-    location: str  # project | claude-project | user | claude-user | builtin
+    location: str  # project | user | builtin
 
 
 # =============================================================================
@@ -126,18 +126,13 @@ def _get_skill_paths(
     # 1. Agent/project-level ConnectOnion skills
     add(co_base / 'skills' / skill_name / 'SKILL.md')
 
-    # 2. Project-level Claude Code skills
-    add(base / '.claude' / 'skills' / skill_name / 'SKILL.md')
-
-    # 3. cwd fallback for local usage that has no agent.co_dir
+    # 2. cwd fallback for local usage that has no agent.co_dir
     add(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
-    add(Path.cwd() / '.claude' / 'skills' / skill_name / 'SKILL.md')
 
-    # 4. User-level skills
+    # 3. User-level skills
     add(home / '.co' / 'skills' / skill_name / 'SKILL.md')
-    add(home / '.claude' / 'skills' / skill_name / 'SKILL.md')
 
-    # 5. Built-in skills
+    # 4. Built-in skills
     builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
     add(builtin_base / skill_name / 'SKILL.md')
 
@@ -202,7 +197,7 @@ def _parse_skill_content(content: str) -> tuple[Dict[str, Any], str]:
 
 
 def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Path] = None) -> List['SkillInfo']:
-    """Discover all available skills from ConnectOnion and Claude Code directories.
+    """Discover all available ConnectOnion skills.
 
     Args:
         co_dir: Path to .co directory (defaults to cwd/.co)
@@ -220,9 +215,7 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
 
     search_paths = [
         ('project', co_base / 'skills'),
-        ('claude-project', base / '.claude' / 'skills'),
         ('user', Path.home() / '.co' / 'skills'),
-        ('claude-user', Path.home() / '.claude' / 'skills'),
         ('builtin', builtin_base),
     ]
 

--- a/connectonion/useful_plugins/tool_approval/__init__.py
+++ b/connectonion/useful_plugins/tool_approval/__init__.py
@@ -111,7 +111,7 @@ Architecture - Unified Permission System Lifecycle:
     │                                                                         │
     │ 3. TOOL EXECUTION (@before_each_tool)                                   │
     │    check_approval()                                                     │
-    │    ├─ Check skip flags (no_io, skip_tool_approval)                      │
+    │    ├─ Check IO and explicit mode state                                  │
     │    ├─ Check mode (safe/plan/accept_edits)                               │
     │    ├─ Iterate permissions dict:                                         │
     │    │  ├─ matches_permission_pattern(tool_name, args, key)               │
@@ -166,7 +166,7 @@ Architecture - Unified Permission System Lifecycle:
 
 Integration with other plugins:
     - skills plugin: grants turn-scoped permissions, snapshots/restores
-    - ulw plugin: sets skip_tool_approval=True to bypass all checks
+    - ulw plugin: uses mode='ulw' to bypass approval checks
     - tool_approval: owns matches_permission_pattern() for validation
     - co_ai CLI: includes tool_approval by default for WebSocket agent
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -408,6 +408,14 @@ def check_approval(agent: 'Agent') -> None:
     # Check unified permissions from session
     # =================================================================
     pending = agent.current_session.get('pending_tool')
+
+    if agent.current_session.get('skip_tool_approval'):
+        tool_name = pending['name'] if pending else 'unknown'
+        tool_args = pending.get('arguments', {}) if pending else {}
+        if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+            agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'auto approve')
+        return
+
     if pending:
         tool_name = pending['name']
         tool_args = pending['arguments']

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -44,7 +44,7 @@ Mode System (session['mode']):
         - Used for: rapid editing with approval only for risky ops
 
     ulw (handled by ulw plugin):
-        - Sets skip_tool_approval=True → bypasses all checks
+        - Handled explicitly by mode='ulw'
         - Used for: unlimited write access (trusted scenarios)
 
 Unified Permissions (session['permissions']):
@@ -399,8 +399,6 @@ def check_approval(agent: 'Agent') -> None:
         'plan': Only read-only tools allowed, exit_plan_and_implement needs approval
         'accept_edits': File edit tools auto-approved, other dangerous tools need approval
 
-    Other plugins can set session['skip_tool_approval'] = True to bypass all checks.
-
     Raises:
         ValueError: If tool rejected or blocked by mode
     """
@@ -408,13 +406,6 @@ def check_approval(agent: 'Agent') -> None:
     # Check unified permissions from session
     # =================================================================
     pending = agent.current_session.get('pending_tool')
-
-    if agent.current_session.get('skip_tool_approval'):
-        tool_name = pending['name'] if pending else 'unknown'
-        tool_args = pending.get('arguments', {}) if pending else {}
-        if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
-            agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'auto approve')
-        return
 
     if pending:
         tool_name = pending['name']
@@ -473,7 +464,7 @@ def check_approval(agent: 'Agent') -> None:
                     return
 
     # =================================================================
-    # Check if another plugin requested to skip approvals (e.g., ulw)
+    # Check explicit autonomous modes.
     # =================================================================
     if agent.current_session.get('mode') == 'ulw':
         pending = agent.current_session.get('pending_tool')
@@ -748,9 +739,6 @@ def handle_mode_change(agent: 'Agent', mode: str) -> None:
     old_mode = _get_mode(agent)
     if old_mode == mode:
         return  # No change
-
-    # Clear skip_tool_approval when switching to a mode we handle
-    agent.current_session.pop('skip_tool_approval', None)
 
     _set_mode(agent, mode)
     _log(agent, f"[cyan]Mode changed: {old_mode} → {mode}[/cyan]")

--- a/connectonion/useful_plugins/tool_approval/constants.py
+++ b/connectonion/useful_plugins/tool_approval/constants.py
@@ -33,8 +33,8 @@ Tool Classification:
 #   - 'plan': Read-only tools only, exit_plan_and_implement shows plan for approval
 #   - 'accept_edits': File edit tools auto-approved, other dangerous tools need approval
 #
-# Other modes (handled by separate plugins via skip_tool_approval flag):
-#   - 'ulw': Handled by ulw plugin - sets skip_tool_approval=True
+# Other modes handled by separate plugins:
+#   - 'ulw': Handled by ulw plugin and approved explicitly by mode
 #
 # Mode can be changed by:
 #   - User: via WebSocket { type: 'mode_change', mode: '...' }

--- a/connectonion/useful_plugins/ulw.py
+++ b/connectonion/useful_plugins/ulw.py
@@ -2,15 +2,15 @@
 Purpose: ULW (Ultra Light Work) plugin - autonomous agent mode with turn-based checkpoints
 LLM-Note:
   Dependencies: imports from [core/events.py] | imported by [useful_plugins/__init__.py]
-  Data flow: mode_change to 'ulw' → set skip_tool_approval=True → on_complete fires → continue until max turns
-  State/Effects: sets mode, ulw_turns, ulw_turns_used, skip_tool_approval in session
-  Integration: communicates with tool_approval via skip_tool_approval flag in session
+  Data flow: mode_change to 'ulw' → set mode='ulw' → on_complete fires → continue until max turns
+  State/Effects: sets mode, ulw_turns, ulw_turns_used in session
+  Integration: communicates with tool_approval via mode='ulw' in session
   Errors: no explicit error handling, agent.input() failures propagate
 
 ULW Mode - Ultra Light Work.
 
 When in ULW mode:
-1. All tool approvals are skipped (via skip_tool_approval flag)
+1. All tool approvals are skipped while session mode is 'ulw'
 2. Agent keeps working until max turns reached
 3. At checkpoint, user can continue, switch mode, or stop
 
@@ -55,7 +55,6 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
     - mode = 'ulw'
     - ulw_turns = max turns before checkpoint
     - ulw_turns_used = 0
-    - skip_tool_approval = True (tells tool_approval to skip all checks)
 
     Args:
         agent: Agent instance
@@ -67,7 +66,6 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
     agent.current_session['mode'] = 'ulw'
     agent.current_session['ulw_turns'] = turns or ULW_DEFAULT_TURNS
     agent.current_session['ulw_turns_used'] = 0
-    agent.current_session['skip_tool_approval'] = True
 
     # Notify frontend
     if agent.io:
@@ -79,9 +77,8 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
 def _exit_ulw_mode(agent: 'Agent', new_mode: str = 'safe') -> None:
     """Exit ULW mode and switch to another mode.
 
-    Cleans up ULW state and clears skip_tool_approval flag.
+    Cleans up ULW state.
     """
-    agent.current_session.pop('skip_tool_approval', None)
     agent.current_session.pop('ulw_turns', None)
     agent.current_session.pop('ulw_turns_used', None)
     agent.current_session['mode'] = new_mode

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -62,13 +62,19 @@ class BrowserAutomation:
     This ensures session persistence even if the process crashes.
     """
 
-    def __init__(self, use_chrome_profile: bool = True, headless: bool = False):
+    def __init__(
+        self,
+        use_chrome_profile: bool = True,
+        headless: bool = False,
+        browser_channel: str | None = None,
+    ):
         """Initialize browser automation.
 
         Args:
             use_chrome_profile: If True, uses your Chrome cookies/sessions.
                                Chrome must be closed before running.
             headless: If True, browser runs without visible window (default True).
+            browser_channel: Optional Playwright browser channel, such as "chrome".
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
@@ -78,7 +84,12 @@ class BrowserAutomation:
         self.use_chrome_profile = use_chrome_profile
         self._screenshots = []
         self._headless = headless
+        self._browser_channel = browser_channel
         self.screenshots_dir = str(SCREENSHOTS_DIR)
+
+    def _install_hint(self) -> str:
+        browser = self._browser_channel or "chromium"
+        return f"Browser tools not installed. Run: pip install playwright && playwright install {browser}"
 
     def open_browser(self, headless: bool = None) -> str:
         """Open a new browser window.
@@ -91,7 +102,7 @@ class BrowserAutomation:
         if headless is None:
             headless = self._headless
         if not PLAYWRIGHT_AVAILABLE:
-            return "Browser tools not installed. Run: pip install playwright && playwright install chromium"
+            return self._install_hint()
 
         if self.browser:
             return "Browser already open"
@@ -109,10 +120,14 @@ class BrowserAutomation:
         # See: https://github.com/microsoft/playwright/issues/31736
         # Can test removing this in the future if cookie issues persist
 
-        # Use Google Chrome instead of Chromium for better X.com compatibility
-        chrome_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-        if not os.path.exists(chrome_path):
-            chrome_path = None  # Fall back to Chromium if Chrome not installed
+        # Use Google Chrome instead of Chromium for better X.com compatibility.
+        # Hosted co-ai passes browser_channel="chrome"; local macOS keeps the
+        # existing explicit Chrome path fallback for developer convenience.
+        chrome_path = None
+        if self._browser_channel is None:
+            candidate = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+            if os.path.exists(candidate):
+                chrome_path = candidate
 
         # Session persistence: use ONLY user_data_dir (simple approach)
         # - Persistent Chrome profile at ~/.co/browser_profile/
@@ -121,13 +136,20 @@ class BrowserAutomation:
         # - No need for storage_state.json complexity (browser-use uses that for portability)
 
         # Launch browser with browser-use anti-detection config (see browser_config.py)
+        launch_options = {
+            "headless": headless,
+            "args": CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
+            "ignore_default_args": IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
+            "timeout": 120000,
+        }
+        if self._browser_channel:
+            launch_options["channel"] = self._browser_channel
+        elif chrome_path:
+            launch_options["executable_path"] = chrome_path
+
         self.browser = self.playwright.chromium.launch_persistent_context(
             str(profile_dir),  # Persistent profile at ~/.co/browser_profile/
-            headless=headless,
-            executable_path=chrome_path,
-            args=CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
-            ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
-            timeout=120000,
+            **launch_options,
         )
 
         self.page = self.browser.new_page()
@@ -463,7 +485,7 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
             Base64 encoded image data with system reminder for full-page screenshots
         """
         if not PLAYWRIGHT_AVAILABLE:
-            return 'Browser tools not installed. Run: pip install playwright && playwright install chromium'
+            return self._install_hint()
 
         if not self.page:
             return "Browser not open"
@@ -682,5 +704,3 @@ SYSTEM REMINDER: Full-page screenshots provide an overview of the entire page bu
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
-
-

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -844,12 +844,18 @@ Deploy your agent to ConnectOnion Cloud.
 **Basic usage:**
 ```bash
 co deploy
+co deploy --skills ship-feature,review-pr
+co deploy --skill ship-feature
+co deploy --name agent-4-linkedin --skills linkedin
 ```
 
 **Requirements:**
-- Git repository with committed code
-- `.co/host.yaml` (created by `co create` or `co init`)
 - Authenticated (`co auth`)
+- `co deploy --skills ...` or `co deploy --skill ...` deploys hosted `co ai` directly and bundles selected skills
+- Selected skill `requirements.txt` files are installed in the hosted co-ai image
+- co-ai deploy uploads project `.env` values plus allowed API keys from `~/.co/keys.env` and the current shell environment
+- `--name` creates a distinct cloud project/agent identity; use lowercase letters, numbers, and hyphens
+- Project deploys require a git repository, `.co/host.yaml`, and an entrypoint that calls `host()`
 
 **Example:**
 ```bash

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -20,11 +20,19 @@ Get your agent running in production.
 Deploy to ConnectOnion Cloud with one command.
 
 ```bash
-cd my-agent
-git init && git add -A && git commit -m "Initial commit"
 co auth  # If not already authenticated
-co deploy
+co deploy --skills ship-feature,review-pr
+co deploy --skill ship-feature
+co deploy --name agent-4-linkedin --skills linkedin
 ```
+
+This deploys the built-in `co ai` coding agent with the selected skills. `--skill` is a singular alias for `--skills`. No project `agent.py`, `.co/host.yaml`, or git commit is required for this co-ai path.
+
+```bash
+co deploy --skills ship-feature --skills review-pr --model co/gemini-3-flash-preview
+```
+
+To deploy a traditional project agent instead, run `co deploy` from a ConnectOnion project with `.co/host.yaml` and a committed `host(...)` entrypoint, or pass `--template project`.
 
 **Output:**
 ```
@@ -47,22 +55,24 @@ Container logs:
 
 URL format: `{project_name}-{your_address[:10]}.agents.openonion.ai`
 
-Re-deploying the same project updates the same URL (like Heroku).
+Re-deploying the same project name updates the same URL. Use `--name` for separate co-ai deployments such as `agent-4-linkedin` and `agent-4-sales`.
 
 ### Requirements
 
-- Git repository with committed code
-- `.co/host.yaml` (created by `co create` or `co init`)
 - Authenticated (`co auth`)
-- Entrypoint must call `host()` (exports the ASGI app for the container)
+- `co deploy --skills ...` resolves skills from project `.co/skills/`, user `~/.co/skills/`, then built-in co-ai skills
+- If a selected skill has `requirements.txt`, those Python dependencies are installed during the co-ai image build
+- co-ai deploy env collection reads project `.env`, global `~/.co/keys.env`, and allowed API keys from the current process environment
+- `--name` must use lowercase letters, numbers, and hyphens because it becomes part of the hosted agent URL
+- Project deploys require a git repository, `.co/host.yaml`, and an entrypoint that calls `host()`
 
 ### How It Works
 
 ```
 co deploy
-  ├─ Validate: git repo? .co/host.yaml? API key? entrypoint has host()?
-  ├─ Package: git archive HEAD → tarball
-  ├─ Collect: load env vars from .env
+  ├─ Choose mode: project if in a ConnectOnion project, otherwise co-ai
+  ├─ Package: project git archive OR generated co-ai package
+  ├─ Collect: load env vars from project .env, ~/.co/keys.env, and allowed API key env vars
   ├─ Upload: POST tarball + project_name + env_vars + entrypoint to API
   ├─ Build: backend builds Docker image, installs dependencies
   ├─ Run: starts container with your env vars injected
@@ -70,11 +80,13 @@ co deploy
   └─ Done: returns agent URL + container logs
 ```
 
+For `co deploy --skills ...`, packaging creates a temporary self-contained co-ai app with the current ConnectOnion package source, `requirements.txt`, a generated `.co/deploy/co_ai_entrypoint.py`, and the selected `.co/skills/<name>/` directories. If a selected skill contains `requirements.txt`, the generated root `requirements.txt` references it. It does not read or modify your working tree except for resolving project-level skills if present.
+
 **Step by step:**
 
-1. **Validate locally** — checks that you're in a git repo, `.co/host.yaml` exists, you have an `OPENONION_API_KEY`, and your entrypoint file calls `host()`
-2. **Package source** — runs `git archive` on HEAD to create a tarball (only committed files are included)
-3. **Collect env vars** — reads your `.env` file (API keys, database URLs, etc.) to inject into the container
+1. **Validate locally** — checks that you have an `OPENONION_API_KEY`; project deploys also check git, `.co/host.yaml`, and `host()`
+2. **Package source** — creates a generated co-ai package, or runs `git archive` for project deploys
+3. **Collect env vars** — reads project `.env`, selected API keys from `~/.co/keys.env`, and selected API keys from the shell environment to inject into the container
 4. **Upload** — sends the tarball, project name, entrypoint path, and env vars to the deploy API
 5. **Build & run** — the backend builds a Docker image from your source, installs `requirements.txt`, and starts the container
 6. **Poll status** — CLI checks deployment status every 3 seconds until the container is running or fails

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -79,7 +79,7 @@ class TestCliDeploy:
                 captured.update(kwargs)
                 return SimpleNamespace(
                     tarball_path=Path("package.tar.gz"),
-                    entrypoint=".co/deploy/co_ai_entrypoint.py",
+                    entrypoint="agent.py",
                 )
 
             mock_post.return_value = MagicMock(
@@ -100,6 +100,7 @@ class TestCliDeploy:
                             "--name", "agent-4-linkedin",
                             "--skill", "alpha,beta",
                             "--skills", "gamma",
+                            "--browser",
                             "--model", "co/test-model",
                             "--max-iterations", "44",
                         ],
@@ -111,9 +112,10 @@ class TestCliDeploy:
             assert captured["project_name"] == "agent-4-linkedin"
             assert captured["model"] == "co/test-model"
             assert captured["max_iterations"] == 44
+            assert captured["browser"] is True
             upload_data = mock_post.call_args.kwargs["data"]
             assert upload_data["project_name"] == "agent-4-linkedin"
-            assert upload_data["entrypoint"] == ".co/deploy/co_ai_entrypoint.py"
+            assert upload_data["entrypoint"] == "agent.py"
             assert json.loads(upload_data["secrets"])["OPENONION_API_KEY"] == "test-token"
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
@@ -131,7 +133,7 @@ class TestCliDeploy:
                 captured.update(kwargs)
                 return SimpleNamespace(
                     tarball_path=Path("package.tar.gz"),
-                    entrypoint=".co/deploy/co_ai_entrypoint.py",
+                    entrypoint="agent.py",
                 )
 
             mock_post.return_value = MagicMock(
@@ -152,6 +154,24 @@ class TestCliDeploy:
             assert captured["skills"] == []
             assert captured["all_skills"] is True
             assert captured["project_name"] == "agent-full"
+            assert captured["browser"] is False
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_browser_without_co_ai_template(self, mock_post):
+        """Test --browser is scoped to generated co-ai deploys."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".git")
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--browser'])
+
+            assert "--browser requires --template co-ai" in result.output
+            mock_post.assert_not_called()
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
     def test_deploy_rejects_skills_without_co_ai_template(self, mock_post):

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -117,6 +117,43 @@ class TestCliDeploy:
             assert json.loads(upload_data["secrets"])["OPENONION_API_KEY"] == "test-token"
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    def test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold(self, mock_get, mock_post):
+        """Test --all-skills deploys co-ai and asks package builder to include all local skills."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            from connectonion.cli.commands import deploy_commands
+
+            Path("package.tar.gz").write_bytes(b"package")
+            captured = {}
+
+            def fake_create_package(**kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    tarball_path=Path("package.tar.gz"),
+                    entrypoint=".co/deploy/co_ai_entrypoint.py",
+                )
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"id": "abc123", "url": "https://test-agent.agents.openonion.ai"},
+            )
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"status": "running", "url": "https://test-agent.agents.openonion.ai"},
+            )
+
+            with patch.object(deploy_commands, "create_deploy_package", side_effect=fake_create_package):
+                with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                    result = self.runner.invoke(cli, ["deploy", "--name", "agent-full", "--all-skills"])
+
+            assert result.exit_code == 0
+            assert captured["template"] == "co-ai"
+            assert captured["skills"] == []
+            assert captured["all_skills"] is True
+            assert captured["project_name"] == "agent-full"
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
     def test_deploy_rejects_skills_without_co_ai_template(self, mock_post):
         """Test --skills is scoped to the co-ai deploy template."""
         with self.runner.isolated_filesystem():
@@ -131,6 +168,23 @@ class TestCliDeploy:
                 result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--skills', 'alpha'])
 
             assert "--skills requires --template co-ai" in result.output
+            mock_post.assert_not_called()
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_all_skills_without_co_ai_template(self, mock_post):
+        """Test --all-skills is scoped to the co-ai deploy template."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".git")
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--all-skills'])
+
+            assert "--all-skills requires --template co-ai" in result.output
             mock_post.assert_not_called()
 
     @SKIP_NO_GIT

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -100,7 +100,6 @@ class TestCliDeploy:
                             "--name", "agent-4-linkedin",
                             "--skill", "alpha,beta",
                             "--skills", "gamma",
-                            "--browser",
                             "--model", "co/test-model",
                             "--max-iterations", "44",
                         ],
@@ -112,10 +111,11 @@ class TestCliDeploy:
             assert captured["project_name"] == "agent-4-linkedin"
             assert captured["model"] == "co/test-model"
             assert captured["max_iterations"] == 44
-            assert captured["browser"] is True
+            assert captured["runtime"] == "local"
             upload_data = mock_post.call_args.kwargs["data"]
             assert upload_data["project_name"] == "agent-4-linkedin"
             assert upload_data["entrypoint"] == "agent.py"
+            assert upload_data["runtime"] == "local"
             assert json.loads(upload_data["secrets"])["OPENONION_API_KEY"] == "test-token"
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
@@ -154,11 +154,67 @@ class TestCliDeploy:
             assert captured["skills"] == []
             assert captured["all_skills"] is True
             assert captured["project_name"] == "agent-full"
-            assert captured["browser"] is False
+            assert captured["runtime"] == "local"
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
-    def test_deploy_rejects_browser_without_co_ai_template(self, mock_post):
-        """Test --browser is scoped to generated co-ai deploys."""
+    def test_deploy_rejects_removed_browser_option(self, mock_post):
+        """Test --browser is no longer a deploy option."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--skills', 'alpha', '--browser'])
+
+            combined_output = result.output + result.stderr
+            assert result.exit_code != 0
+            assert "--browser" in combined_output
+            mock_post.assert_not_called()
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    def test_deploy_with_pypi_runtime_uses_co_ai_lightweight_package(self, mock_get, mock_post):
+        """Test --runtime pypi is passed to the co-ai package builder and backend."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            from connectonion.cli.commands import deploy_commands
+
+            Path("package.tar.gz").write_bytes(b"package")
+            captured = {}
+
+            def fake_create_package(**kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    tarball_path=Path("package.tar.gz"),
+                    entrypoint="agent.py",
+                )
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"id": "abc123", "url": "https://agent-image.agents.openonion.ai"},
+            )
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"status": "running", "url": "https://agent-image.agents.openonion.ai"},
+            )
+
+            with patch.object(deploy_commands, "create_deploy_package", side_effect=fake_create_package):
+                with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                    result = self.runner.invoke(
+                        cli,
+                        ["deploy", "--name", "agent-image", "--skills", "image-gen", "--runtime", "pypi"],
+                    )
+
+            assert result.exit_code == 0
+            assert captured["template"] == "co-ai"
+            assert captured["runtime"] == "pypi"
+            assert captured["skills"] == ["image-gen"]
+            upload_data = mock_post.call_args.kwargs["data"]
+            assert upload_data["runtime"] == "pypi"
+            assert upload_data["entrypoint"] == "agent.py"
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_pypi_runtime_without_co_ai_template(self, mock_post):
+        """Test --runtime pypi is scoped to generated co-ai deploys."""
         with self.runner.isolated_filesystem():
             from connectonion.cli.main import cli
 
@@ -168,9 +224,9 @@ class TestCliDeploy:
             Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
 
             with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
-                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--browser'])
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--runtime', 'pypi'])
 
-            assert "--browser requires --template co-ai" in result.output
+            assert "--runtime pypi requires --template co-ai" in result.output
             mock_post.assert_not_called()
 
     @patch('connectonion.cli.commands.deploy_commands.requests.post')

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -15,10 +15,12 @@ Components under test:
 """
 
 import os
+import json
 import shutil
 import tempfile
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 import pytest
 
@@ -60,6 +62,76 @@ class TestCliDeploy:
 
             result = self.runner.invoke(cli, ['deploy'])
             assert "Not a ConnectOnion project" in result.output
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    def test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold(self, mock_get, mock_post):
+        """Test --skills deploys co-ai without requiring git or .co/host.yaml."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            from connectonion.cli.commands import deploy_commands
+
+            Path("package.tar.gz").write_bytes(b"package")
+
+            captured = {}
+
+            def fake_create_package(**kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    tarball_path=Path("package.tar.gz"),
+                    entrypoint=".co/deploy/co_ai_entrypoint.py",
+                )
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"id": "abc123", "url": "https://test-agent.agents.openonion.ai"},
+            )
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"status": "running", "url": "https://test-agent.agents.openonion.ai"},
+            )
+
+            with patch.object(deploy_commands, "create_deploy_package", side_effect=fake_create_package):
+                with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                    result = self.runner.invoke(
+                        cli,
+                        [
+                            "deploy",
+                            "--name", "agent-4-linkedin",
+                            "--skill", "alpha,beta",
+                            "--skills", "gamma",
+                            "--model", "co/test-model",
+                            "--max-iterations", "44",
+                        ],
+                    )
+
+            assert result.exit_code == 0
+            assert captured["template"] == "co-ai"
+            assert captured["skills"] == ["alpha", "beta", "gamma"]
+            assert captured["project_name"] == "agent-4-linkedin"
+            assert captured["model"] == "co/test-model"
+            assert captured["max_iterations"] == 44
+            upload_data = mock_post.call_args.kwargs["data"]
+            assert upload_data["project_name"] == "agent-4-linkedin"
+            assert upload_data["entrypoint"] == ".co/deploy/co_ai_entrypoint.py"
+            assert json.loads(upload_data["secrets"])["OPENONION_API_KEY"] == "test-token"
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_skills_without_co_ai_template(self, mock_post):
+        """Test --skills is scoped to the co-ai deploy template."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".git")
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--skills', 'alpha'])
+
+            assert "--skills requires --template co-ai" in result.output
+            mock_post.assert_not_called()
 
     @SKIP_NO_GIT
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
@@ -225,5 +297,3 @@ class TestCliDeploy:
                 result = self.runner.invoke(cli, ['deploy'])
 
             assert "Deploy failed" in result.output
-
-

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -1,0 +1,56 @@
+"""Tests for BrowserAutomation launch configuration."""
+
+import connectonion.useful_tools.browser_tools.browser as browser_mod
+
+
+class FakePage:
+    def set_default_navigation_timeout(self, timeout):
+        self.navigation_timeout = timeout
+
+    def set_viewport_size(self, size):
+        self.viewport_size = size
+
+    def add_init_script(self, script):
+        self.init_script = script
+
+
+class FakeContext:
+    def __init__(self):
+        self.page = FakePage()
+
+    def new_page(self):
+        return self.page
+
+
+def test_open_browser_uses_explicit_playwright_channel(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeChromium:
+        def launch_persistent_context(self, user_data_dir, **kwargs):
+            captured["user_data_dir"] = user_data_dir
+            captured["kwargs"] = kwargs
+            return FakeContext()
+
+    class FakeSyncPlaywright:
+        def start(self):
+            return type("FakePlaywright", (), {"chromium": FakeChromium()})()
+
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True, browser_channel="chrome")
+
+    result = browser.open_browser()
+
+    assert "Browser opened with persistent profile" in result
+    assert captured["kwargs"]["headless"] is True
+    assert captured["kwargs"]["channel"] == "chrome"
+    assert "executable_path" not in captured["kwargs"]
+
+
+def test_browser_install_hint_matches_explicit_channel(monkeypatch):
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", False)
+    browser = browser_mod.BrowserAutomation(browser_channel="chrome")
+
+    assert "playwright install chrome" in browser.open_browser()

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -43,6 +43,49 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     assert "wait_for_manual_login" not in agent.tools._tools
     assert agent.browse is agent.tools.get_instance("browserautomation")
     assert agent.tools.get_instance("browserautomation")._headless is False
+    assert agent_mod._enable_auto_approve in agent.events["after_user_input"]
+    agent.current_session = {}
+    agent_mod._enable_auto_approve(agent)
+    assert agent.current_session["skip_tool_approval"] is True
+
+
+def test_create_coding_agent_accepts_deploy_co_dir_and_headless_browser(monkeypatch, tmp_path):
+    class FakeLLM:
+        model = "fake-model"
+
+    deploy_co_dir = tmp_path / ".co"
+    monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr(agent_mod, "assemble_prompt", lambda *a, **k: "BASE")
+    monkeypatch.setattr(agent_mod, "load_project_context", lambda *a, **k: "")
+
+    agent = agent_mod.create_coding_agent(
+        model="fake",
+        max_iterations=9,
+        co_dir=deploy_co_dir,
+        browser_headless=True,
+        browser_channel="chrome",
+    )
+
+    assert agent.co_dir == deploy_co_dir
+    assert agent.tools.get_instance("browserautomation")._headless is True
+    assert agent.tools.get_instance("browserautomation")._browser_channel == "chrome"
+
+
+def test_create_coding_agent_accepts_custom_name(monkeypatch, tmp_path):
+    class FakeLLM:
+        model = "fake-model"
+
+    monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr(agent_mod, "assemble_prompt", lambda *a, **k: "BASE")
+    monkeypatch.setattr(agent_mod, "load_project_context", lambda *a, **k: "")
+
+    agent = agent_mod.create_coding_agent(
+        name="agent-4-linkedin",
+        model="fake",
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.name == "agent-4-linkedin"
 
 
 def test_start_server_calls_host(monkeypatch):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -112,3 +112,4 @@ def test_start_server_calls_host(monkeypatch):
     # factory should create agent with given params
     called["factory"]()
     assert created and created[0][1]["model"] == "m1"
+    assert "auto_approve" not in created[0][1]

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -11,6 +11,7 @@ Components under test:
 
 
 from types import SimpleNamespace
+import inspect
 
 import connectonion.cli.co_ai.agent as agent_mod
 import connectonion.cli.co_ai.main as main_mod
@@ -25,7 +26,7 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     monkeypatch.setattr(agent_mod, "load_project_context", lambda *a, **k: "CTX")
     monkeypatch.setattr(agent_mod, "GLOBAL_CO_DIR", tmp_path / ".co")
 
-    agent = agent_mod.create_coding_agent(model="fake", max_iterations=5, auto_approve=True)
+    agent = agent_mod.create_coding_agent(model="fake", max_iterations=5)
 
     assert agent.name == "oo"
     assert agent.max_iterations == 5
@@ -43,10 +44,12 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     assert "wait_for_manual_login" not in agent.tools._tools
     assert agent.browse is agent.tools.get_instance("browserautomation")
     assert agent.tools.get_instance("browserautomation")._headless is False
-    assert agent_mod._enable_auto_approve in agent.events["after_user_input"]
-    agent.current_session = {}
-    agent_mod._enable_auto_approve(agent)
-    assert agent.current_session["skip_tool_approval"] is True
+    assert "auto_approve" not in inspect.signature(agent_mod.create_coding_agent).parameters
+    assert all(
+        handler.__name__ != "_enable_auto_approve"
+        for handlers in agent.events.values()
+        for handler in handlers
+    )
 
 
 def test_create_coding_agent_accepts_deploy_co_dir_and_headless_browser(monkeypatch, tmp_path):

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -149,7 +149,7 @@ def test_create_co_ai_deploy_package_is_self_contained_and_chrome_enabled_by_def
     assert "max_iterations=33" in entrypoint
     assert "name=\"demo\"" in entrypoint
     assert "auto_approve=True" not in entrypoint
-    assert "browser_headless=True" in entrypoint
+    assert "browser_headless=False" in entrypoint
     assert "browser_channel=\"chrome\"" in entrypoint
     assert "co_dir=CO_DIR" in entrypoint
     assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
@@ -157,8 +157,9 @@ def test_create_co_ai_deploy_package_is_self_contained_and_chrome_enabled_by_def
     assert "entrypoint: agent.py" in host_yaml
     assert requirements.startswith("connectonion==")
     assert "-r .co/skills" not in requirements
+    assert "apt-get install -y --no-install-recommends xvfb xauth" in dockerfile
     assert "RUN python -m playwright install --with-deps chrome" in dockerfile
-    assert "CMD [\"python\", \"agent.py\"]" in dockerfile
+    assert "CMD [\"xvfb-run\", \"-a\", \"python\", \"agent.py\"]" in dockerfile
 
 
 def test_create_co_ai_deploy_package_local_runtime_generates_chrome_dockerfile(tmp_path):
@@ -189,8 +190,9 @@ def test_create_co_ai_deploy_package_local_runtime_generates_chrome_dockerfile(t
     assert "COPY requirements.txt ." in dockerfile
     assert "COPY . ." in dockerfile
     assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
+    assert "apt-get install -y --no-install-recommends xvfb xauth" in dockerfile
     assert "python -m playwright install --with-deps chrome" in dockerfile
-    assert "CMD [\"python\", \"agent.py\"]" in dockerfile
+    assert "CMD [\"xvfb-run\", \"-a\", \"python\", \"agent.py\"]" in dockerfile
 
 
 def test_create_co_ai_pypi_runtime_package_uploads_manifest_and_selected_skills_only(tmp_path, monkeypatch):

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -121,24 +121,25 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
 
     after = sorted(str(p.relative_to(project)) for p in project.rglob("*"))
     assert after == before
-    assert package.entrypoint == ".co/deploy/co_ai_entrypoint.py"
+    assert package.entrypoint == "agent.py"
 
     with tarfile.open(package.tarball_path, "r:gz") as tar:
         names = set(tar.getnames())
-        assert ".co/deploy/co_ai_entrypoint.py" in names
+        assert "agent.py" in names
+        assert ".co/host.yaml" in names
         assert ".co/skills/alpha/SKILL.md" in names
         assert ".co/skills/alpha/helper.txt" in names
         assert "connectonion/cli/co_ai/agent.py" in names
         assert "pyproject.toml" in names
         assert "README.md" in names
         assert "requirements.txt" in names
-        assert "Dockerfile" in names
-        entrypoint = tar.extractfile(".co/deploy/co_ai_entrypoint.py").read().decode("utf-8")
+        assert "Dockerfile" not in names
+        entrypoint = tar.extractfile("agent.py").read().decode("utf-8")
+        host_yaml = tar.extractfile(".co/host.yaml").read().decode("utf-8")
         requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
-        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
 
     assert "create_coding_agent" in entrypoint
-    assert "PACKAGE_ROOT = Path(__file__).resolve().parents[2]" in entrypoint
+    assert "PACKAGE_ROOT = Path(__file__).resolve().parent" in entrypoint
     assert "sys.path.insert(0, str(PACKAGE_ROOT))" in entrypoint
     assert "CO_DIR = PACKAGE_ROOT / \".co\"" in entrypoint
     assert entrypoint.index("sys.path.insert") < entrypoint.index("from connectonion import host")
@@ -147,18 +148,46 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
     assert "name=\"demo\"" in entrypoint
     assert "auto_approve=True" not in entrypoint
     assert "browser_headless=True" in entrypoint
-    assert "browser_channel=\"chrome\"" in entrypoint
+    assert "browser_channel=\"chrome\"" not in entrypoint
     assert "co_dir=CO_DIR" in entrypoint
     assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
-    assert requirements == ".\n"
+    assert "name: demo" in host_yaml
+    assert "entrypoint: agent.py" in host_yaml
+    assert requirements.startswith("connectonion==")
+    assert "-r .co/skills" not in requirements
+
+
+def test_create_co_ai_deploy_package_with_browser_generates_chrome_dockerfile(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "linkedin")
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["linkedin"],
+        all_skills=False,
+        project_name="agent-4-linkedin",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+        browser=True,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        assert "Dockerfile" in names
+        entrypoint = tar.extractfile("agent.py").read().decode("utf-8")
+        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
+
+    assert package.entrypoint == "agent.py"
+    assert "browser_channel=\"chrome\"" in entrypoint
     assert "FROM python:3.11-slim" in dockerfile
-    assert "COPY pyproject.toml README.md requirements.txt ./" in dockerfile
-    assert "COPY connectonion ./connectonion" in dockerfile
-    assert "COPY .co ./.co" in dockerfile
-    assert "COPY . ." not in dockerfile
+    assert "COPY requirements.txt ." in dockerfile
+    assert "COPY . ." in dockerfile
     assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
     assert "python -m playwright install --with-deps chrome" in dockerfile
-    assert "CMD [\"python\", \".co/deploy/co_ai_entrypoint.py\"]" in dockerfile
+    assert "CMD [\"python\", \"agent.py\"]" in dockerfile
 
 
 def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):
@@ -183,7 +212,10 @@ def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):
         skill_requirements = tar.extractfile(".co/skills/image-gen/requirements.txt").read().decode("utf-8")
 
     assert ".co/skills/image-gen/requirements.txt" in names
-    assert requirements == ".\n-r .co/skills/image-gen/requirements.txt\n"
+    assert requirements.startswith("connectonion==")
+    assert "google-genai>=1.0" in requirements
+    assert "Pillow>=10" in requirements
+    assert "-r .co/skills/image-gen/requirements.txt" not in requirements
     assert "google-genai>=1.0" in skill_requirements
 
 

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -1,0 +1,193 @@
+"""Tests for deploy command packaging helpers."""
+
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import deploy_commands
+
+
+def _run_git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "test@test.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / ".co").mkdir()
+    (repo / ".co" / "host.yaml").write_text("name: demo\nentrypoint: agent.py\n", encoding="utf-8")
+    (repo / "agent.py").write_text("print('project agent')\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "init")
+
+
+def _write_skill(root: Path, name: str, body: str = "Body", requirements: str | None = None) -> Path:
+    skill_dir = root / ".co" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} skill\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "helper.txt").write_text("helper\n", encoding="utf-8")
+    if requirements is not None:
+        (skill_dir / "requirements.txt").write_text(requirements, encoding="utf-8")
+    return skill_dir
+
+
+def test_parse_skill_names_accepts_repeated_and_comma_separated_values():
+    assert deploy_commands.parse_skill_names(["alpha,beta", " gamma "]) == ["alpha", "beta", "gamma"]
+
+
+def test_resolve_deploy_skill_prefers_project_over_user_and_builtin(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    project_skill = _write_skill(project, "alpha", "project")
+    _write_skill(user_home, "alpha", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    assert deploy_commands.resolve_deploy_skill("alpha", project) == project_skill
+
+
+def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "alpha")
+    before = sorted(str(p.relative_to(project)) for p in project.rglob("*"))
+    monkeypatch.chdir(project)
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["alpha"],
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    after = sorted(str(p.relative_to(project)) for p in project.rglob("*"))
+    assert after == before
+    assert package.entrypoint == ".co/deploy/co_ai_entrypoint.py"
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        assert ".co/deploy/co_ai_entrypoint.py" in names
+        assert ".co/skills/alpha/SKILL.md" in names
+        assert ".co/skills/alpha/helper.txt" in names
+        assert "connectonion/cli/co_ai/agent.py" in names
+        assert "pyproject.toml" in names
+        assert "README.md" in names
+        assert "requirements.txt" in names
+        assert "Dockerfile" in names
+        entrypoint = tar.extractfile(".co/deploy/co_ai_entrypoint.py").read().decode("utf-8")
+        requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
+        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
+
+    assert "create_coding_agent" in entrypoint
+    assert "PACKAGE_ROOT = Path(__file__).resolve().parents[2]" in entrypoint
+    assert "sys.path.insert(0, str(PACKAGE_ROOT))" in entrypoint
+    assert "CO_DIR = PACKAGE_ROOT / \".co\"" in entrypoint
+    assert entrypoint.index("sys.path.insert") < entrypoint.index("from connectonion import host")
+    assert "model=\"co/test-model\"" in entrypoint
+    assert "max_iterations=33" in entrypoint
+    assert "name=\"demo\"" in entrypoint
+    assert "browser_headless=True" in entrypoint
+    assert "browser_channel=\"chrome\"" in entrypoint
+    assert "co_dir=CO_DIR" in entrypoint
+    assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
+    assert requirements == ".\n"
+    assert "FROM python:3.11-slim" in dockerfile
+    assert "COPY . ." in dockerfile
+    assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
+    assert "python -m playwright install --with-deps chrome" in dockerfile
+    assert "CMD [\"python\", \".co/deploy/co_ai_entrypoint.py\"]" in dockerfile
+
+
+def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "image-gen", requirements="google-genai>=1.0\nPillow>=10\n")
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["image-gen"],
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
+        skill_requirements = tar.extractfile(".co/skills/image-gen/requirements.txt").read().decode("utf-8")
+
+    assert ".co/skills/image-gen/requirements.txt" in names
+    assert requirements == ".\n-r .co/skills/image-gen/requirements.txt\n"
+    assert "google-genai>=1.0" in skill_requirements
+
+
+def test_create_co_ai_deploy_package_fails_before_upload_when_skill_missing(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(deploy_commands.DeployConfigError, match="Skill not found: missing"):
+        deploy_commands.create_deploy_package(
+            project_dir=project,
+            template="co-ai",
+            skills=["missing"],
+            project_name="demo",
+            entrypoint="agent.py",
+            model="co/test-model",
+            max_iterations=33,
+        )
+
+
+@pytest.mark.parametrize("name", ["agent-4-linkedin", "co-ai", "a1"])
+def test_validate_deploy_name_accepts_url_safe_names(name):
+    assert deploy_commands.validate_deploy_name(name) == name
+
+
+@pytest.mark.parametrize("name", ["Agent 4", "agent_4", "-agent", "agent-", ""])
+def test_validate_deploy_name_rejects_names_that_break_agent_urls(name):
+    with pytest.raises(deploy_commands.DeployConfigError):
+        deploy_commands.validate_deploy_name(name)
+
+
+def test_load_deploy_env_vars_merges_project_global_and_allowed_shell_keys(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    project.mkdir()
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text(
+        "OPENONION_API_KEY=global-openonion\n"
+        "GEMINI_API_KEY=global-gemini\n"
+        "RANDOM_SECRET=do-not-upload\n",
+        encoding="utf-8",
+    )
+    env_file = project / ".env"
+    env_file.write_text(
+        "GEMINI_API_KEY=project-gemini\n"
+        "PROJECT_SETTING=enabled\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+    for key in deploy_commands.DEPLOY_ENV_KEY_ALLOWLIST:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "shell-google")
+    monkeypatch.setenv("RANDOM_SECRET", "shell-secret")
+
+    env_vars = deploy_commands.load_deploy_env_vars(env_file)
+
+    assert env_vars["OPENONION_API_KEY"] == "global-openonion"
+    assert env_vars["GEMINI_API_KEY"] == "project-gemini"
+    assert env_vars["GOOGLE_API_KEY"] == "shell-google"
+    assert env_vars["PROJECT_SETTING"] == "enabled"
+    assert "RANDOM_SECRET" not in env_vars

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -145,6 +145,7 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
     assert "model=\"co/test-model\"" in entrypoint
     assert "max_iterations=33" in entrypoint
     assert "name=\"demo\"" in entrypoint
+    assert "auto_approve=True" not in entrypoint
     assert "browser_headless=True" in entrypoint
     assert "browser_channel=\"chrome\"" in entrypoint
     assert "co_dir=CO_DIR" in entrypoint

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -54,6 +54,53 @@ def test_resolve_deploy_skill_prefers_project_over_user_and_builtin(tmp_path, mo
     assert deploy_commands.resolve_deploy_skill("alpha", project) == project_skill
 
 
+def test_discover_deploy_skill_names_lists_project_then_user_with_project_priority(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    _write_skill(project, "alpha", "project")
+    _write_skill(project, "shared", "project")
+    _write_skill(user_home, "beta", "user")
+    _write_skill(user_home, "shared", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    assert deploy_commands.discover_deploy_skill_names(project) == ["alpha", "shared", "beta"]
+
+
+def test_create_co_ai_deploy_package_with_all_skills_copies_project_and_user_skills(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    _write_skill(project, "alpha", "project")
+    _write_skill(project, "shared", "project")
+    _write_skill(user_home, "beta", "user")
+    _write_skill(user_home, "shared", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=[],
+        all_skills=True,
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        shared = tar.extractfile(".co/skills/shared/SKILL.md").read().decode("utf-8")
+
+    assert ".co/skills/alpha/SKILL.md" in names
+    assert ".co/skills/beta/SKILL.md" in names
+    assert ".co/skills/shared/SKILL.md" in names
+    assert "project" in shared
+    assert "user" not in shared
+
+
 def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(tmp_path, monkeypatch):
     project = tmp_path / "project"
     project.mkdir()
@@ -65,6 +112,7 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
         project_dir=project,
         template="co-ai",
         skills=["alpha"],
+        all_skills=False,
         project_name="demo",
         entrypoint="agent.py",
         model="co/test-model",
@@ -121,6 +169,7 @@ def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):
         project_dir=project,
         template="co-ai",
         skills=["image-gen"],
+        all_skills=False,
         project_name="demo",
         entrypoint="agent.py",
         model="co/test-model",
@@ -146,6 +195,7 @@ def test_create_co_ai_deploy_package_fails_before_upload_when_skill_missing(tmp_
             project_dir=project,
             template="co-ai",
             skills=["missing"],
+            all_skills=False,
             project_name="demo",
             entrypoint="agent.py",
             model="co/test-model",

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -1,5 +1,6 @@
 """Tests for deploy command packaging helpers."""
 
+import json
 import os
 import subprocess
 import tarfile
@@ -101,7 +102,7 @@ def test_create_co_ai_deploy_package_with_all_skills_copies_project_and_user_ski
     assert "user" not in shared
 
 
-def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(tmp_path, monkeypatch):
+def test_create_co_ai_deploy_package_is_self_contained_and_chrome_enabled_by_default(tmp_path, monkeypatch):
     project = tmp_path / "project"
     project.mkdir()
     _write_skill(project, "alpha")
@@ -133,10 +134,11 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
         assert "pyproject.toml" in names
         assert "README.md" in names
         assert "requirements.txt" in names
-        assert "Dockerfile" not in names
+        assert "Dockerfile" in names
         entrypoint = tar.extractfile("agent.py").read().decode("utf-8")
         host_yaml = tar.extractfile(".co/host.yaml").read().decode("utf-8")
         requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
+        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
 
     assert "create_coding_agent" in entrypoint
     assert "PACKAGE_ROOT = Path(__file__).resolve().parent" in entrypoint
@@ -148,16 +150,18 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
     assert "name=\"demo\"" in entrypoint
     assert "auto_approve=True" not in entrypoint
     assert "browser_headless=True" in entrypoint
-    assert "browser_channel=\"chrome\"" not in entrypoint
+    assert "browser_channel=\"chrome\"" in entrypoint
     assert "co_dir=CO_DIR" in entrypoint
     assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
     assert "name: demo" in host_yaml
     assert "entrypoint: agent.py" in host_yaml
     assert requirements.startswith("connectonion==")
     assert "-r .co/skills" not in requirements
+    assert "RUN python -m playwright install --with-deps chrome" in dockerfile
+    assert "CMD [\"python\", \"agent.py\"]" in dockerfile
 
 
-def test_create_co_ai_deploy_package_with_browser_generates_chrome_dockerfile(tmp_path):
+def test_create_co_ai_deploy_package_local_runtime_generates_chrome_dockerfile(tmp_path):
     project = tmp_path / "project"
     project.mkdir()
     _write_skill(project, "linkedin")
@@ -171,7 +175,6 @@ def test_create_co_ai_deploy_package_with_browser_generates_chrome_dockerfile(tm
         entrypoint="agent.py",
         model="co/test-model",
         max_iterations=33,
-        browser=True,
     )
 
     with tarfile.open(package.tarball_path, "r:gz") as tar:
@@ -188,6 +191,56 @@ def test_create_co_ai_deploy_package_with_browser_generates_chrome_dockerfile(tm
     assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
     assert "python -m playwright install --with-deps chrome" in dockerfile
     assert "CMD [\"python\", \"agent.py\"]" in dockerfile
+
+
+def test_create_co_ai_pypi_runtime_package_uploads_manifest_and_selected_skills_only(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "image-gen", requirements="google-genai>=1.0\nPillow>=10\n")
+    monkeypatch.setattr(
+        deploy_commands,
+        "resolve_connectonion_pypi_version",
+        lambda: "0.9.9",
+        raising=False,
+    )
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        runtime="pypi",
+        skills=["image-gen"],
+        all_skills=False,
+        project_name="agent-image",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    assert package.entrypoint == "agent.py"
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        manifest = json.loads(tar.extractfile("manifest.json").read().decode("utf-8"))
+        skill_requirements = tar.extractfile(".co/skills/image-gen/requirements.txt").read().decode("utf-8")
+
+    assert manifest == {
+        "runtime": "pypi",
+        "runtime_package": "connectonion",
+        "runtime_version": "0.9.9",
+        "agent_name": "agent-image",
+        "entrypoint": "agent.py",
+        "model": "co/test-model",
+        "max_iterations": 33,
+        "browser": True,
+        "skills": ["image-gen"],
+    }
+    assert ".co/skills/image-gen/SKILL.md" in names
+    assert ".co/skills/image-gen/helper.txt" in names
+    assert "google-genai>=1.0" in skill_requirements
+    assert "agent.py" not in names
+    assert ".co/host.yaml" not in names
+    assert "Dockerfile" not in names
+    assert "requirements.txt" not in names
+    assert "connectonion/cli/co_ai/agent.py" not in names
 
 
 def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -103,7 +103,10 @@ def test_create_co_ai_deploy_package_is_self_contained_without_project_scaffold(
     assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
     assert requirements == ".\n"
     assert "FROM python:3.11-slim" in dockerfile
-    assert "COPY . ." in dockerfile
+    assert "COPY pyproject.toml README.md requirements.txt ./" in dockerfile
+    assert "COPY connectonion ./connectonion" in dockerfile
+    assert "COPY .co ./.co" in dockerfile
+    assert "COPY . ." not in dockerfile
     assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
     assert "python -m playwright install --with-deps chrome" in dockerfile
     assert "CMD [\"python\", \".co/deploy/co_ai_entrypoint.py\"]" in dockerfile

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -122,6 +122,46 @@ class TestHostRelayConnection:
                             call_args = mock_relay.call_args
                             assert call_args[0][0] == "wss://oo.openonion.ai"
 
+    def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
+        """Test host ANNOUNCE profile includes agent metadata for frontend display."""
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path):
+            with patch('connectonion.address.load', return_value=mock_addr):
+                with patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())) as mock_relay:
+                    with patch('uvicorn.run'):
+                        with patch.object(host_module, '_print_host_banner'):
+                            host_module.host(create_mock_agent, relay_url="ws://test")
+
+                            profile = mock_relay.call_args.kwargs["profile"]
+                            assert profile["alias"] == "test_agent"
+                            assert profile["name"] == "test_agent"
+                            assert profile["model"] == "test-model"
+                            assert profile["tools"] == []
+                            assert profile["skills"] == []
+
+    def test_build_relay_profile_includes_skills_tools_and_version(self):
+        metadata = {
+            "name": "agent-4-linkedin",
+            "model": "co/test-model",
+            "tools": ["bash", "skill"],
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke-test deployed co-ai", "location": "project"}
+            ],
+        }
+
+        profile = host_module._build_relay_profile(metadata, "Deployed co-ai agent")
+
+        assert profile["alias"] == "agent-4-linkedin"
+        assert profile["name"] == "agent-4-linkedin"
+        assert profile["bio"] == "Deployed co-ai agent"
+        assert profile["model"] == "co/test-model"
+        assert profile["version"]
+        assert profile["tools"] == ["bash", "skill"]
+        assert profile["skills"] == [
+            {"name": "deploy-smoke", "description": "Smoke-test deployed co-ai", "location": "project"}
+        ]
+
     def test_host_starts_relay_with_custom_url(self, tmp_path, create_mock_agent):
         """Test that host() uses custom relay URL."""
         mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -316,6 +316,31 @@ class TestSkillInvocation:
 
         assert agent.current_session['messages'][-1]['content'] == "DEPLOY_SMOKE_SKILL_ACTIVE_2026_06_01"
 
+    def test_handle_skill_invocation_ignores_claude_skills(self, tmp_path, monkeypatch):
+        """Test runtime skill loading does not treat Claude skills as ConnectOnion skills."""
+        skill_dir = tmp_path / ".claude" / "skills" / "claude-only"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: claude-only\n"
+            "description: Claude-only skill\n"
+            "tools: []\n"
+            "---\n\n"
+            "SHOULD_NOT_LOAD\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        agent = FakeAgent()
+        agent.current_session['messages'] = [
+            {'role': 'user', 'content': '/claude-only'}
+        ]
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session['messages'][-1]['content'] == "/claude-only"
+
 
 class TestCleanup:
     """Tests for cleanup on turn end."""

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -245,7 +245,7 @@ class TestSkillInvocation:
         handle_skill_invocation(agent)
 
         # Skill should be loaded
-        mock_load.assert_called_once_with('commit')
+        mock_load.assert_called_once_with('commit', co_dir=None)
 
         # Message should be replaced with instructions
         assert agent.current_session['messages'][-1]['content'] == 'Create a git commit'
@@ -285,6 +285,36 @@ class TestSkillInvocation:
         # Should not crash, just return
         # Message should not be replaced
         assert agent.current_session['messages'][-1]['content'] == '/nonexistent'
+
+    def test_handle_skill_invocation_loads_from_agent_co_dir_when_cwd_differs(self, tmp_path, monkeypatch):
+        """Test deployed agents load slash skills from agent.co_dir, not only cwd."""
+        project = tmp_path / "project"
+        co_dir = project / ".co"
+        skill_dir = co_dir / "skills" / "deploy-smoke"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: deploy-smoke\n"
+            "description: Smoke deploy skill\n"
+            "tools: []\n"
+            "---\n\n"
+            "DEPLOY_SMOKE_SKILL_ACTIVE_2026_06_01\n",
+            encoding="utf-8",
+        )
+
+        other_cwd = tmp_path / "other"
+        other_cwd.mkdir()
+        monkeypatch.chdir(other_cwd)
+
+        agent = FakeAgent()
+        agent.co_dir = co_dir
+        agent.current_session['messages'] = [
+            {'role': 'user', 'content': '/deploy-smoke'}
+        ]
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session['messages'][-1]['content'] == "DEPLOY_SMOKE_SKILL_ACTIVE_2026_06_01"
 
 
 class TestCleanup:

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -128,8 +128,8 @@ class TestNoIO:
         # Should not raise (skips approval)
         check_approval(agent)
 
-    def test_skip_tool_approval_flag_skips_web_approval(self):
-        """Auto-approved agents should not block on WebSocket approval."""
+    def test_skip_tool_approval_flag_does_not_skip_web_approval(self):
+        """Generic skip_tool_approval is ignored; explicit modes own bypass behavior."""
         io = FakeIO()
         agent = FakeAgent(io=io)
         agent.current_session['skip_tool_approval'] = True
@@ -138,9 +138,11 @@ class TestNoIO:
             'arguments': {'command': 'python script.py', 'description': 'Run script'}
         }
 
-        check_approval(agent)
+        with pytest.raises(ValueError, match="Connection closed while waiting for approval"):
+            check_approval(agent)
 
-        assert io.sent == []
+        assert io.sent
+        assert io.sent[0]['type'] == 'approval_needed'
 
 
 class TestSafeTools:
@@ -707,7 +709,7 @@ class TestPollModeChanges:
 
         assert agent.current_session['mode'] == 'ulw'
         assert agent.current_session['ulw_turns'] == 50
-        assert agent.current_session['skip_tool_approval'] is True
+        assert 'skip_tool_approval' not in agent.current_session
 
     def test_poll_mode_changes_handles_multiple_signals(self):
         """poll_mode_changes should process multiple mode_change signals."""

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -128,6 +128,20 @@ class TestNoIO:
         # Should not raise (skips approval)
         check_approval(agent)
 
+    def test_skip_tool_approval_flag_skips_web_approval(self):
+        """Auto-approved agents should not block on WebSocket approval."""
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['skip_tool_approval'] = True
+        agent.current_session['pending_tool'] = {
+            'name': 'bash',
+            'arguments': {'command': 'python script.py', 'description': 'Run script'}
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+
 
 class TestSafeTools:
     """Test safe tools skip approval."""

--- a/tests/unit/test_ulw.py
+++ b/tests/unit/test_ulw.py
@@ -37,7 +37,7 @@ def test_mode_change_defaults_to_100_turns():
     assert agent.current_session['mode'] == 'ulw'
     assert agent.current_session['ulw_turns'] == ULW_DEFAULT_TURNS
     assert agent.current_session['ulw_turns_used'] == 0
-    assert agent.current_session['skip_tool_approval'] is True
+    assert 'skip_tool_approval' not in agent.current_session
 
 
 def test_mode_change_uses_explicit_turns():
@@ -97,7 +97,6 @@ def test_keep_working_at_max_with_switch_mode_exits_to_new_mode():
     agent.current_session['ulw_turns_used'] = 1
     ulw_keep_working(agent)
     assert agent.current_session['mode'] == 'review'
-    assert 'skip_tool_approval' not in agent.current_session
     assert 'ulw_turns' not in agent.current_session
     assert agent.input_calls == []
 
@@ -173,5 +172,4 @@ def test_inject_prompt_replaces_existing_prompt_section():
     agent.current_session['ulw_prompt'] = 'new goal'
     inject_ulw_prompt(agent)
     assert agent.current_session['messages'][0]['content'] == 'base\n\n[Prompt]\nnew goal'
-
 


### PR DESCRIPTION
## Summary
- add hosted co-ai deploy packaging with selected skills and named agents
- simplify co-ai deploy Dockerfile inputs and keep package builds cache-friendly
- add explicit --all-skills opt-in for packaging project/user skills

## Why
This keeps project deploy backward-compatible while allowing users to deploy the built-in co-ai agent with selected or all local skills, without requiring a project entrypoint.

## Validation
- /opt/homebrew/bin/python3 -m pytest tests/unit/test_deploy_commands.py tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_skills_without_co_ai_template tests/e2e/cli/test_cli_deploy.py::TestCliDeploy::test_deploy_rejects_all_skills_without_co_ai_template -q
- /opt/homebrew/bin/python3 -m py_compile connectonion/cli/main.py connectonion/cli/commands/deploy_commands.py
- git diff --check
- production smoke: co deploy --name agent-4-linkedin --skills deploy-smoke completed after oo-api deploy timeout fix