### PR TITLE
Add hosted co-ai deploy skills

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -56,13 +56,18 @@ GLOBAL_CO_DIR = Path.home() / ".co"
 
 
 def create_coding_agent(
+    name: str = "oo",
     model: str = "co/gemini-3-flash-preview",
     max_iterations: int = 100,
     auto_approve: bool = False,
+    co_dir: Path | None = None,
+    browser_headless: bool = False,
+    browser_channel: str | None = None,
 ) -> Agent:
     todo = TodoList()
     file_tools = FileTools()
-    browser = BrowserAutomation(headless=True)
+    browser = BrowserAutomation(headless=browser_headless, browser_channel=browser_channel)
+    agent_co_dir = co_dir or GLOBAL_CO_DIR
 
     tools = [
         file_tools,
@@ -95,14 +100,14 @@ def create_coding_agent(
     plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, ulw, image_result_formatter, runtime_input]
 
     agent = Agent(
-        name="oo",
+        name=name,
         tools=tools,
         plugins=plugins,
         on_events=[],
         system_prompt=system_prompt,
         model=model,
         max_iterations=max_iterations,
-        co_dir=GLOBAL_CO_DIR,
+        co_dir=agent_co_dir,
     )
 
     return agent

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [rich.console, cli/browser_agent/browser.execute_browser_command] | imported by [cli/main.py via handle_browser()] | requires Playwright installation | tested by [tests/e2e/cli/test_cli_browser.py]
   Data flow: receives command: str from CLI parser (e.g., "screenshot localhost:3000") → calls execute_browser_command(command) → browser agent parses command and executes via Playwright → returns result string → prints to console via rich.Console
   State/Effects: no persistent state | launches headless browser via Playwright | may create screenshot files in current directory | writes to stdout via rich.Console | browser process lifecycle managed by browser_agent module
-  Integration: exposes handle_browser(command) | called from main.py via --browser flag or 'browser' subcommand | delegates to browser_agent/browser.execute_browser_command() | supports commands like "screenshot URL", "navigate URL", "click selector"
+  Integration: exposes handle_browser(command) | called from main.py via the 'browser' subcommand | delegates to browser_agent/browser.execute_browser_command() | supports commands like "screenshot URL", "navigate URL", "click selector"
   Performance: browser launch overhead (1-3s) | Playwright operations vary by command | screenshot generation is fast (<1s)
   Errors: fails if Playwright not installed | fails if browser launch fails | fails if invalid command syntax | prints error to console but doesn't raise exception
 """
@@ -17,7 +17,7 @@ console = Console()
 def handle_browser(command: str, headless: bool = False):
     """Execute browser automation commands - guide browser to do something.
 
-    This is an alternative to the -b flag. Both 'co -b' and 'co browser' are supported.
+    This is exposed as the 'co browser' subcommand.
 
     Args:
         command: The browser command to execute

--- a/connectonion/cli/commands/deploy_co_ai.py
+++ b/connectonion/cli/commands/deploy_co_ai.py
@@ -1,0 +1,329 @@
+"""Build co-ai deploy packages and resolve deploy-time skills/env."""
+
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+from dotenv import dotenv_values
+
+from connectonion import __version__
+
+
+CO_AI_ENTRYPOINT = "agent.py"
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = PACKAGE_ROOT.parent
+DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+DEPLOY_ENV_KEY_ALLOWLIST = (
+    "OPENONION_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GROQ_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CONNECTONION_API_KEY",
+)
+
+
+class DeployConfigError(Exception):
+    """Raised when deploy configuration is invalid before upload."""
+
+
+@dataclass
+class DeployPackage:
+    tarball_path: Path
+    entrypoint: str
+
+
+def parse_skill_names(raw_skills: list[str] | None) -> list[str]:
+    """Parse repeated/comma-separated --skills values."""
+    if not raw_skills:
+        return []
+
+    names = []
+    for value in raw_skills:
+        for part in value.split(","):
+            name = part.strip()
+            if name:
+                names.append(name)
+    return names
+
+
+def validate_deploy_name(name: str) -> str:
+    """Validate a deploy name that becomes part of the hosted agent URL."""
+    if not name or not DEPLOY_NAME_PATTERN.match(name):
+        raise DeployConfigError(
+            "Invalid deploy name. Use lowercase letters, numbers, and hyphens; "
+            "start and end with a letter or number."
+        )
+    return name
+
+
+def _filter_allowed_env(values: dict) -> dict:
+    return {
+        key: value
+        for key, value in values.items()
+        if key in DEPLOY_ENV_KEY_ALLOWLIST and value not in (None, "")
+    }
+
+
+def load_deploy_env_vars(env_file: str | Path) -> dict:
+    """Load env vars for deploy without dumping the full shell environment."""
+    env_vars = {}
+
+    global_env = Path.home() / ".co" / "keys.env"
+    if global_env.exists():
+        env_vars.update(_filter_allowed_env(dotenv_values(global_env)))
+
+    env_vars.update({
+        key: value
+        for key in DEPLOY_ENV_KEY_ALLOWLIST
+        if (value := os.environ.get(key))
+    })
+
+    env_path = Path(env_file)
+    if env_path.exists():
+        env_vars.update({
+            key: value
+            for key, value in dotenv_values(env_path).items()
+            if value is not None
+        })
+
+    return env_vars
+
+
+def resolve_deploy_skill(name: str, project_dir: Path) -> Path:
+    """Resolve a deploy skill directory by project > user > built-in priority."""
+    candidates = [
+        project_dir / ".co" / "skills" / name,
+        Path.home() / ".co" / "skills" / name,
+        Path(__file__).parent.parent / "co_ai" / "skills" / "builtin" / name,
+    ]
+    for skill_dir in candidates:
+        if (skill_dir / "SKILL.md").exists():
+            return skill_dir
+
+    raise DeployConfigError(
+        f"Skill not found: {name}. Run `co skills discover && co skills copy {name}` first."
+    )
+
+
+def discover_deploy_skill_names(project_dir: Path) -> list[str]:
+    """Discover deployable project/user skill names with project priority."""
+    names = []
+    seen = set()
+    for skills_dir in (project_dir / ".co" / "skills", Path.home() / ".co" / "skills"):
+        if not skills_dir.exists():
+            continue
+        for skill_dir in sorted(skills_dir.iterdir(), key=lambda path: path.name):
+            if skill_dir.name in seen:
+                continue
+            if (skill_dir / "SKILL.md").exists():
+                names.append(skill_dir.name)
+                seen.add(skill_dir.name)
+    return names
+
+
+def _write_co_ai_entrypoint(
+    path: Path,
+    *,
+    model: str,
+    max_iterations: int,
+    agent_name: str,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    model_literal = json.dumps(model)
+    name_literal = json.dumps(agent_name)
+    lines = [
+        "import sys",
+        "from pathlib import Path",
+        "",
+        "PACKAGE_ROOT = Path(__file__).resolve().parent",
+        "sys.path.insert(0, str(PACKAGE_ROOT))",
+        "CO_DIR = PACKAGE_ROOT / \".co\"",
+        "",
+        "from connectonion import host",
+        "from connectonion.cli.co_ai.agent import create_coding_agent",
+        "",
+        "",
+        "def create_agent():",
+        "    return create_coding_agent(",
+        f"        name={name_literal},",
+        f"        model={model_literal},",
+        f"        max_iterations={max_iterations},",
+        "        co_dir=CO_DIR,",
+        "        browser_headless=False,",
+        "        browser_channel=\"chrome\",",
+    ]
+    lines.extend([
+        "    )",
+        "",
+        "",
+        "host(create_agent, trust=\"careful\", co_dir=CO_DIR)",
+        "",
+    ])
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_co_ai_host_yaml(staging_dir: Path, *, agent_name: str) -> None:
+    host_yaml = staging_dir / ".co" / "host.yaml"
+    host_yaml.parent.mkdir(parents=True, exist_ok=True)
+    host_yaml.write_text(
+        "\n".join([
+            f"name: {agent_name}",
+            f"entrypoint: {CO_AI_ENTRYPOINT}",
+            "env: .env",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+
+def _make_tarball(source_dir: Path, tarball_path: Path) -> None:
+    with tarfile.open(tarball_path, "w:gz") as tar:
+        for path in sorted(source_dir.rglob("*")):
+            tar.add(path, arcname=str(path.relative_to(source_dir)), recursive=False)
+
+
+def _copy_connectonion_package(staging_dir: Path) -> None:
+    shutil.copytree(
+        PACKAGE_ROOT,
+        staging_dir / "connectonion",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".pytest_cache"),
+    )
+
+
+def _read_runtime_dependencies() -> list[str] | None:
+    """Read connectonion's runtime dependencies from the source pyproject.toml.
+
+    The deploy package vendors the connectonion source, so requirements only
+    needs the third-party dependencies — not connectonion itself (installing it
+    from PyPI would shadow the vendored source with a possibly different build).
+    Returns None when deploying from a pip install (no source pyproject), where
+    the vendored package already matches the published version.
+    """
+    pyproject = PROJECT_ROOT / "pyproject.toml"
+    if not pyproject.exists():
+        return None
+    match = re.search(
+        r"^dependencies\s*=\s*\[(.*?)\]",
+        pyproject.read_text(encoding="utf-8"),
+        re.DOTALL | re.MULTILINE,
+    )
+    if not match:
+        return None
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def _write_co_ai_requirements(
+    staging_dir: Path,
+    *,
+    skill_requirements: list[Path] | None = None,
+) -> None:
+    runtime_deps = _read_runtime_dependencies()
+    lines = list(runtime_deps) if runtime_deps else [f"connectonion=={__version__}"]
+    for requirement_path in sorted(skill_requirements or []):
+        content = requirement_path.read_text(encoding="utf-8").strip()
+        if content:
+            lines.append("")
+            lines.append(f"# {requirement_path.relative_to(staging_dir).as_posix()}")
+            lines.extend(content.splitlines())
+    (staging_dir / "requirements.txt").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_co_ai_dockerfile(staging_dir: Path) -> None:
+    lines = [
+        "FROM python:3.11-slim",
+        "WORKDIR /app",
+        "ENV PYTHONUNBUFFERED=1",
+        "ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright",
+        "COPY requirements.txt .",
+        "RUN pip install --no-cache-dir -r requirements.txt",
+        "RUN apt-get update && apt-get install -y --no-install-recommends xvfb xauth && rm -rf /var/lib/apt/lists/*",
+        "RUN python -m playwright install --with-deps chrome",
+        "COPY . .",
+        "ENV PORT=8000",
+        f"CMD [\"xvfb-run\", \"-a\", \"python\", \"{CO_AI_ENTRYPOINT}\"]",
+        "",
+    ]
+    (staging_dir / "Dockerfile").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _select_deploy_skill_names(project_dir: Path, *, skills: list[str], all_skills: bool) -> list[str]:
+    deploy_skill_names = []
+    seen_skill_names = set()
+    for skill_name in discover_deploy_skill_names(project_dir) if all_skills else []:
+        deploy_skill_names.append(skill_name)
+        seen_skill_names.add(skill_name)
+    for skill_name in skills:
+        if skill_name not in seen_skill_names:
+            deploy_skill_names.append(skill_name)
+            seen_skill_names.add(skill_name)
+    return deploy_skill_names
+
+
+def _copy_deploy_skills(staging_dir: Path, project_dir: Path, skill_names: list[str]) -> list[Path]:
+    skill_requirement_files = []
+    for skill_name in skill_names:
+        source = resolve_deploy_skill(skill_name, project_dir)
+        destination = staging_dir / ".co" / "skills" / skill_name
+        if destination.exists():
+            shutil.rmtree(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, destination)
+        requirements_file = destination / "requirements.txt"
+        if requirements_file.exists():
+            skill_requirement_files.append(requirements_file)
+    return skill_requirement_files
+
+
+def create_co_ai_deploy_package(
+    *,
+    project_dir: Path,
+    skills: list[str],
+    all_skills: bool,
+    project_name: str,
+    model: str,
+    max_iterations: int,
+) -> DeployPackage:
+    """Build a co-ai deploy tarball."""
+    temp_dir = Path(tempfile.mkdtemp())
+    tarball_path = temp_dir / "agent.tar.gz"
+    staging_dir = temp_dir / "staging"
+    staging_dir.mkdir()
+
+    deploy_skill_names = _select_deploy_skill_names(
+        project_dir,
+        skills=skills,
+        all_skills=all_skills,
+    )
+
+    _copy_connectonion_package(staging_dir)
+    _write_co_ai_entrypoint(
+        staging_dir / CO_AI_ENTRYPOINT,
+        model=model,
+        max_iterations=max_iterations,
+        agent_name=project_name,
+    )
+    _write_co_ai_host_yaml(staging_dir, agent_name=project_name)
+
+    skill_requirement_files = _copy_deploy_skills(staging_dir, project_dir, deploy_skill_names)
+
+    _write_co_ai_requirements(
+        staging_dir,
+        skill_requirements=skill_requirement_files,
+    )
+    _write_co_ai_dockerfile(staging_dir)
+
+    _make_tarball(staging_dir, tarball_path)
+    return DeployPackage(tarball_path=tarball_path, entrypoint=CO_AI_ENTRYPOINT)

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -1,31 +1,118 @@
 """
 Purpose: Deploy agent projects to ConnectOnion Cloud with git archive packaging and env vars
 LLM-Note:
-  Dependencies: imports from [os, subprocess, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → validates git repo and .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → git archive creates tarball of HEAD → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Dependencies: imports from [json, re, subprocess, tempfile, time, yaml, requests, pathlib, rich.console, deploy_co_ai] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
+  Data flow: handle_deploy() → resolves project vs co-ai template → load_api_key() loads OPENONION_API_KEY → reads optional host.yaml/env → builds project git archive or generated co-ai package → POST to /api/v1/deploy with tarball + project_name + env vars/secrets → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | does not modify project files
-  Integration: exposes handle_deploy() for CLI | expects git repo with .co/host.yaml (name, entrypoint, env) | uses Bearer token auth | returns void (prints results)
+  Integration: exposes handle_deploy() for CLI | project deploy expects git repo with .co/host.yaml | co-ai deploy can generate a self-contained package from selected skills | uses Bearer token auth | returns void (prints results)
   Performance: git archive is fast | network timeout 600s for upload, 10s for status checks | polls every 3s up to 100 times (~5 min)
   Errors: fails if not git repo | fails if not ConnectOnion project (no host.yaml) | fails if no API key | prints backend error messages
 """
 
 import json
-import os
 import re
 import subprocess
 import tempfile
 import time
-import yaml
-import requests
 from pathlib import Path
-from rich.console import Console
-from dotenv import dotenv_values
 
+import requests
+import yaml
+from rich.console import Console
+
+from .deploy_co_ai import (
+    CO_AI_ENTRYPOINT,
+    DEPLOY_ENV_KEY_ALLOWLIST,
+    DeployConfigError,
+    DeployPackage,
+    create_co_ai_deploy_package,
+    discover_deploy_skill_names,
+    load_deploy_env_vars,
+    parse_skill_names,
+    resolve_deploy_skill,
+    validate_deploy_name,
+)
 from .project_cmd_lib import load_api_key
 
 console = Console()
 
 API_BASE = "https://oo.openonion.ai"
+
+__all__ = [
+    "CO_AI_ENTRYPOINT",
+    "DEPLOY_ENV_KEY_ALLOWLIST",
+    "DeployConfigError",
+    "DeployPackage",
+    "create_deploy_package",
+    "discover_deploy_skill_names",
+    "handle_deploy",
+    "load_deploy_env_vars",
+    "parse_skill_names",
+    "resolve_deploy_skill",
+    "resolve_deploy_template",
+    "validate_deploy_name",
+]
+
+
+def _archive_git_head(project_dir: Path, tarball_path: Path, *, gzip: bool) -> None:
+    fmt = "tar.gz" if gzip else "tar"
+    subprocess.run(
+        ["git", "archive", f"--format={fmt}", "-o", str(tarball_path), "HEAD"],
+        cwd=project_dir,
+        check=True,
+    )
+
+
+def create_deploy_package(
+    *,
+    project_dir: Path,
+    template: str,
+    skills: list[str],
+    all_skills: bool = False,
+    project_name: str,
+    entrypoint: str,
+    model: str,
+    max_iterations: int,
+) -> DeployPackage:
+    """Build the tarball sent to the deploy API."""
+    if template == "project":
+        temp_dir = Path(tempfile.mkdtemp())
+        tarball_path = temp_dir / "agent.tar.gz"
+        _archive_git_head(project_dir, tarball_path, gzip=True)
+        return DeployPackage(tarball_path=tarball_path, entrypoint=entrypoint)
+
+    if template == "co-ai":
+        return create_co_ai_deploy_package(
+            project_dir=project_dir,
+            skills=skills,
+            all_skills=all_skills,
+            project_name=project_name,
+            model=model,
+            max_iterations=max_iterations,
+        )
+
+    raise DeployConfigError("Unsupported deploy template. Use 'project' or 'co-ai'.")
+
+
+def resolve_deploy_template(
+    template: str,
+    skill_names: list[str],
+    project_dir: Path,
+    *,
+    all_skills: bool = False,
+) -> str:
+    """Resolve the user-facing deploy mode."""
+    if template == "auto":
+        if skill_names or all_skills:
+            return "co-ai"
+        if (project_dir / ".git").exists() or (project_dir / ".co" / "host.yaml").exists():
+            return "project"
+        return "co-ai"
+
+    if template in ("project", "co-ai"):
+        return template
+
+    raise DeployConfigError("Unsupported deploy template. Use 'auto', 'project', or 'co-ai'.")
 
 
 def _check_host_export(entrypoint: str) -> bool:
@@ -52,23 +139,51 @@ def _check_host_export(entrypoint: str) -> bool:
     return False
 
 
-def handle_deploy():
+def handle_deploy(
+    name: str | None = None,
+    template: str = "auto",
+    skills: list[str] | None = None,
+    all_skills: bool = False,
+    model: str = "co/gemini-3-flash-preview",
+    max_iterations: int = 100,
+):
     """Deploy agent to ConnectOnion Cloud."""
     console.print("\n[cyan]Deploying to ConnectOnion Cloud...[/cyan]\n")
 
     project_dir = Path.cwd()
+    skill_names = parse_skill_names(skills)
 
-    # Must be a git repo
-    if not (project_dir / ".git").exists():
-        console.print("[red]Not a git repository. Run 'git init' first.[/red]")
+    try:
+        deploy_template = resolve_deploy_template(
+            template,
+            skill_names,
+            project_dir,
+            all_skills=all_skills,
+        )
+    except DeployConfigError as e:
+        console.print(f"[red]{e}[/red]")
         return
 
-    # Must be a ConnectOnion project
+    if deploy_template == "project" and skill_names:
+        console.print("[red]--skills requires --template co-ai[/red]")
+        return
+    if deploy_template == "project" and all_skills:
+        console.print("[red]--all-skills requires --template co-ai[/red]")
+        return
+
     host_yaml_path = Path(".co") / "host.yaml"
+    config = {}
 
-    if not host_yaml_path.exists():
-        console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
-        return
+    if deploy_template == "project":
+        # Must be a git repo
+        if not (project_dir / ".git").exists():
+            console.print("[red]Not a git repository. Run 'git init' first.[/red]")
+            return
+
+        # Must be a ConnectOnion project
+        if not host_yaml_path.exists():
+            console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
+            return
 
     # Must have API key
     api_key = load_api_key()
@@ -76,45 +191,63 @@ def handle_deploy():
         console.print("[red]No API key. Run 'co auth' first.[/red]")
         return
 
-    # Load config from host.yaml
-    with open(host_yaml_path, 'r') as f:
-        config = yaml.safe_load(f) or {}
-    project_name = config.get("name", "unnamed-agent")
+    if host_yaml_path.exists():
+        with open(host_yaml_path, 'r') as f:
+            config = yaml.safe_load(f) or {}
+
+    if name is not None:
+        project_name = validate_deploy_name(name)
+    elif deploy_template == "co-ai":
+        project_name = "co-ai"
+    else:
+        project_name = config.get("name", "unnamed-agent")
     env_file = config.get("env", ".env")
-    entrypoint = config.get("entrypoint", "agent.py")
+    entrypoint = config.get("entrypoint", "agent.py" if deploy_template == "project" else CO_AI_ENTRYPOINT)
 
-    # Validate entrypoint exists
-    if not Path(entrypoint).exists():
-        console.print(f"[red]Entrypoint not found: {entrypoint}[/red]")
-        console.print("[dim]Set 'entrypoint' in .co/host.yaml[/dim]")
-        return
+    if deploy_template == "project":
+        # Validate entrypoint exists
+        if not Path(entrypoint).exists():
+            console.print(f"[red]Entrypoint not found: {entrypoint}[/red]")
+            console.print("[dim]Set 'entrypoint' in .co/host.yaml[/dim]")
+            return
 
-    # Validate entrypoint exports ASGI app via host()
-    if not _check_host_export(entrypoint):
-        console.print(f"[red]Entrypoint '{entrypoint}' does not export an ASGI app.[/red]")
-        console.print()
-        console.print("[yellow]To deploy, your agent must call host():[/yellow]")
-        console.print()
-        console.print("  [cyan]from connectonion import Agent, host[/cyan]")
-        console.print()
-        console.print("  [cyan]agent = Agent('my-agent', ...)[/cyan]")
-        console.print("  [cyan]host(agent)  # Starts HTTP server[/cyan]")
-        console.print()
-        console.print("[dim]See: https://docs.connectonion.com/deploy[/dim]")
-        return
+        # Validate entrypoint exports ASGI app via host()
+        if not _check_host_export(entrypoint):
+            console.print(f"[red]Entrypoint '{entrypoint}' does not export an ASGI app.[/red]")
+            console.print()
+            console.print("[yellow]To deploy, your agent must call host():[/yellow]")
+            console.print()
+            console.print("  [cyan]from connectonion import Agent, host[/cyan]")
+            console.print()
+            console.print("  [cyan]agent = Agent('my-agent', ...)[/cyan]")
+            console.print("  [cyan]host(agent)  # Starts HTTP server[/cyan]")
+            console.print()
+            console.print("[dim]See: https://docs.connectonion.com/deploy[/dim]")
+            return
 
     # Load env vars from .env (user's API keys, config for the agent container)
-    env_vars = dotenv_values(env_file) if Path(env_file).exists() else {}
+    env_vars = load_deploy_env_vars(env_file)
+    if deploy_template == "co-ai" and api_key and "OPENONION_API_KEY" not in env_vars:
+        env_vars["OPENONION_API_KEY"] = api_key
 
-    # Create tarball from git
-    tarball_path = Path(tempfile.mkdtemp()) / "agent.tar.gz"
-    subprocess.run(
-        ["git", "archive", "--format=tar.gz", "-o", str(tarball_path), "HEAD"],
-        cwd=project_dir,
-        check=True,
-    )
+    try:
+        package = create_deploy_package(
+            project_dir=project_dir,
+            template=deploy_template,
+            skills=skill_names,
+            all_skills=all_skills,
+            project_name=project_name,
+            entrypoint=entrypoint,
+            model=model,
+            max_iterations=max_iterations,
+        )
+    except DeployConfigError as e:
+        console.print(f"[red]{e}[/red]")
+        return
 
     # Show package size
+    tarball_path = package.tarball_path
+    upload_entrypoint = package.entrypoint
     tarball_size = tarball_path.stat().st_size
     if tarball_size < 1024:
         size_str = f"{tarball_size} B"
@@ -130,14 +263,16 @@ def handle_deploy():
 
     # Upload
     console.print("Uploading...")
+    serialized_env_vars = json.dumps(env_vars)
     with open(tarball_path, "rb") as f:
         response = requests.post(
             f"{API_BASE}/api/v1/deploy",
             files={"package": ("agent.tar.gz", f, "application/gzip")},
             data={
                 "project_name": project_name,
-                "env_vars": json.dumps(env_vars),
-                "entrypoint": entrypoint,
+                "secrets": serialized_env_vars,
+                "entrypoint": upload_entrypoint,
+                "runtime": "local",
             },
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=600,  # 10 minutes for docker build

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,9 +4,9 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
-  Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
+  Errors: typer.Exit() on --version | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
 
 import typer
@@ -97,10 +97,24 @@ def create(
 
 
 @app.command()
-def deploy():
+def deploy(
+    name: Optional[str] = typer.Option(None, "--name", "-n", help="Cloud project/agent name for this deployment"),
+    template: str = typer.Option("auto", "--template", help="Deploy template: auto, project, or co-ai"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", "--skill", help="Skill names for co-ai deploy; repeat or comma-separate"),
+    all_skills: bool = typer.Option(False, "--all-skills", help="Deploy all project and user skills with co-ai"),
+    model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model for co-ai deploy"),
+    max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations for co-ai deploy"),
+):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy()
+    handle_deploy(
+        name=name,
+        template=template,
+        skills=skills,
+        all_skills=all_skills,
+        model=model,
+        max_iterations=max_iterations,
+    )
 
 
 @app.command()

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -34,6 +34,7 @@ import uvicorn
 import websockets
 from rich.console import Console
 
+from ... import __version__
 from ... import address
 from .. import announce, relay
 from ..asgi import create_app as asgi_create_app
@@ -117,6 +118,36 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
                    for s in raw_skills],
     }
     return metadata, sample
+
+
+def _build_relay_profile(agent_metadata: dict, summary: str) -> dict:
+    """Build publishable relay profile metadata from hosted agent metadata."""
+    agent_name = str(agent_metadata.get("name") or "agent")
+    profile = {
+        "alias": agent_name,
+        "name": agent_name,
+        "bio": (summary or "")[:1000],
+        "version": __version__,
+        "model": str(agent_metadata.get("model") or ""),
+        "tools": [str(tool_name) for tool_name in agent_metadata.get("tools", [])],
+        "skills": [],
+    }
+
+    for skill in agent_metadata.get("skills", []):
+        if not isinstance(skill, dict):
+            continue
+        skill_name = skill.get("name")
+        if not skill_name:
+            continue
+        item = {
+            "name": str(skill_name),
+            "description": str(skill.get("description") or "")[:1000],
+        }
+        if skill.get("location"):
+            item["location"] = str(skill["location"])
+        profile["skills"].append(item)
+
+    return profile
 
 
 def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
@@ -231,7 +262,15 @@ def _print_host_banner(
     console.print()
 
 
-def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner):
+def _create_relay_lifespan(
+    relay_url: str,
+    addr_data: dict,
+    summary: str,
+    port: int,
+    relay_session_runner,
+    *,
+    profile: dict | None = None,
+):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
     Args:
@@ -240,6 +279,7 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         summary: Summary text for relay announcement
         port: HTTP port for endpoint discovery
         relay_session_runner: async (send_msg, recv_msg) -> None, runs protocol for one relay session
+        profile: Optional publishable metadata for frontend/directory display
 
     Returns:
         Tuple of (on_startup, on_shutdown) async callbacks
@@ -253,7 +293,13 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         async def relay_loop():
             while True:
                 ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                announce_msg = announce.create_announce_message(
+                    addr_data,
+                    summary,
+                    endpoints=endpoints,
+                    relay=relay_url,
+                    profile=profile,
+                )
                 await relay.serve_loop(
                     ws, announce_msg,
                     addr_data=addr_data, session_handler=relay_session_runner,
@@ -400,6 +446,7 @@ def host(
         address.save(addr_data, co_dir)
 
     agent_metadata["address"] = addr_data['address']
+    relay_profile = _build_relay_profile(agent_metadata, summary)
 
     storage = SessionStorage()
 
@@ -436,7 +483,12 @@ def host(
             enable_ping=False,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
-            relay_url, addr_data, summary, port, relay_session_runner
+            relay_url,
+            addr_data,
+            summary,
+            port,
+            relay_session_runner,
+            profile=relay_profile,
         )
 
     app = asgi_create_app(

--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -193,6 +193,7 @@ async def serve_loop(
     summary = announce_message.get("summary", "")
     endpoints = announce_message.get("endpoints", [])
     relay_url = announce_message.get("relay")
+    profile = announce_message.get("profile")
 
     sessions: Dict[str, asyncio.Queue] = {}
 
@@ -227,7 +228,11 @@ async def serve_loop(
             # Stay in the loop.
             if addr_data:
                 fresh_announce = announce_module.create_announce_message(
-                    addr_data, summary, endpoints=endpoints, relay=relay_url
+                    addr_data,
+                    summary,
+                    endpoints=endpoints,
+                    relay=relay_url,
+                    profile=profile,
                 )
                 await send_announce(websocket, fresh_announce)
             else:

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -82,59 +82,79 @@ if TYPE_CHECKING:
 class SkillInfo:
     name: str
     description: str
-    location: str  # project | claude-project | user | claude-user | builtin
+    location: str  # project | user | builtin
 
 
 # =============================================================================
 # SKILL DISCOVERY
 # =============================================================================
 
-def _get_skill_paths(skill_name: str) -> List[Path]:
+def _get_skill_paths(
+    skill_name: str,
+    co_dir: Optional[Path] = None,
+    project_dir: Optional[Path] = None,
+) -> List[Path]:
     """Get potential paths for a skill in priority order.
 
     Priority:
-    1. .co/skills/skill-name/SKILL.md (project-level)
-    2. ~/.co/skills/skill-name/SKILL.md (user-level)
-    3. builtin skills (bundled with ConnectOnion)
+    1. agent co_dir/skills/skill-name/SKILL.md (hosted/project agent)
+    2. cwd .co/skills/skill-name/SKILL.md (local fallback)
+    3. ~/.co/skills/skill-name/SKILL.md (user-level)
+    4. builtin skills (bundled with ConnectOnion)
 
     Args:
         skill_name: Skill name (e.g., "commit")
+        co_dir: Agent .co directory, when available
+        project_dir: Project root, when available
 
     Returns:
         List of Path objects in priority order
     """
     paths = []
     home = Path.home()
+    seen = set()
 
-    # 1. Project-level ConnectOnion: .co/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
+    def add(path: Path) -> None:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            paths.append(path)
 
-    # 2. Project-level Claude Code: .claude/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.claude' / 'skills' / skill_name / 'SKILL.md')
+    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
+    co_base = co_dir or (base / '.co')
 
-    # 3. User-level ConnectOnion: ~/.co/skills/skill-name/SKILL.md
-    paths.append(home / '.co' / 'skills' / skill_name / 'SKILL.md')
+    # 1. Agent/project-level ConnectOnion skills
+    add(co_base / 'skills' / skill_name / 'SKILL.md')
 
-    # 4. User-level Claude Code: ~/.claude/skills/skill-name/SKILL.md
-    paths.append(home / '.claude' / 'skills' / skill_name / 'SKILL.md')
+    # 2. cwd fallback for local usage that has no agent.co_dir
+    add(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
 
-    # 5. Built-in: connectonion/cli/co_ai/skills/builtin/skill-name/SKILL.md
+    # 3. User-level skills
+    add(home / '.co' / 'skills' / skill_name / 'SKILL.md')
+
+    # 4. Built-in skills
     builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
-    paths.append(builtin_base / skill_name / 'SKILL.md')
+    add(builtin_base / skill_name / 'SKILL.md')
 
     return paths
 
 
-def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
+def _load_skill(
+    skill_name: str,
+    co_dir: Optional[Path] = None,
+    project_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
     """Load skill from filesystem.
 
     Args:
         skill_name: Skill name (e.g., "commit")
+        co_dir: Agent .co directory, when available
+        project_dir: Project root, when available
 
     Returns:
         Dict with 'path', 'frontmatter', 'instructions' or None if not found
     """
-    for path in _get_skill_paths(skill_name):
+    for path in _get_skill_paths(skill_name, co_dir=co_dir, project_dir=project_dir):
         if path.exists():
             content = path.read_text()
             frontmatter, instructions = _parse_skill_content(content)
@@ -177,7 +197,7 @@ def _parse_skill_content(content: str) -> tuple[Dict[str, Any], str]:
 
 
 def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Path] = None) -> List['SkillInfo']:
-    """Discover all available skills from ConnectOnion and Claude Code directories.
+    """Discover all available ConnectOnion skills.
 
     Args:
         co_dir: Path to .co directory (defaults to cwd/.co)
@@ -195,9 +215,7 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
 
     search_paths = [
         ('project', co_base / 'skills'),
-        ('claude-project', base / '.claude' / 'skills'),
         ('user', Path.home() / '.co' / 'skills'),
-        ('claude-user', Path.home() / '.claude' / 'skills'),
         ('builtin', builtin_base),
     ]
 
@@ -321,7 +339,8 @@ def handle_skill_invocation(agent: 'Agent') -> None:
         return
 
     # Load skill
-    skill = _load_skill(skill_name)
+    co_dir = getattr(agent, 'co_dir', None)
+    skill = _load_skill(skill_name, co_dir=co_dir)
     if not skill:
         # Skill not found - don't interfere
         return
@@ -364,7 +383,8 @@ def skill(agent: 'Agent', name: str) -> str:
     Returns:
         Skill instructions for the agent to follow
     """
-    skill_data = _load_skill(name)
+    co_dir = getattr(agent, 'co_dir', None)
+    skill_data = _load_skill(name, co_dir=co_dir)
     if not skill_data:
         co_dir = getattr(agent, 'co_dir', None)
         available = _discover_all_skills(co_dir=co_dir)

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -62,13 +62,19 @@ class BrowserAutomation:
     This ensures session persistence even if the process crashes.
     """
 
-    def __init__(self, use_chrome_profile: bool = True, headless: bool = False):
+    def __init__(
+        self,
+        use_chrome_profile: bool = True,
+        headless: bool = False,
+        browser_channel: str | None = None,
+    ):
         """Initialize browser automation.
 
         Args:
             use_chrome_profile: If True, uses your Chrome cookies/sessions.
                                Chrome must be closed before running.
             headless: If True, browser runs without visible window (default True).
+            browser_channel: Optional Playwright browser channel, such as "chrome".
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
@@ -78,7 +84,12 @@ class BrowserAutomation:
         self.use_chrome_profile = use_chrome_profile
         self._screenshots = []
         self._headless = headless
+        self._browser_channel = browser_channel
         self.screenshots_dir = str(SCREENSHOTS_DIR)
+
+    def _install_hint(self) -> str:
+        browser = self._browser_channel or "chromium"
+        return f"Browser tools not installed. Run: pip install playwright && playwright install {browser}"
 
     def open_browser(self, headless: bool = None) -> str:
         """Open a new browser window.
@@ -91,7 +102,7 @@ class BrowserAutomation:
         if headless is None:
             headless = self._headless
         if not PLAYWRIGHT_AVAILABLE:
-            return "Browser tools not installed. Run: pip install playwright && playwright install chromium"
+            return self._install_hint()
 
         if self.browser:
             return "Browser already open"
@@ -109,10 +120,14 @@ class BrowserAutomation:
         # See: https://github.com/microsoft/playwright/issues/31736
         # Can test removing this in the future if cookie issues persist
 
-        # Use Google Chrome instead of Chromium for better X.com compatibility
-        chrome_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-        if not os.path.exists(chrome_path):
-            chrome_path = None  # Fall back to Chromium if Chrome not installed
+        # Use Google Chrome instead of Chromium for better X.com compatibility.
+        # Hosted co-ai passes browser_channel="chrome"; local macOS keeps the
+        # existing explicit Chrome path fallback for developer convenience.
+        chrome_path = None
+        if self._browser_channel is None:
+            candidate = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+            if os.path.exists(candidate):
+                chrome_path = candidate
 
         # Session persistence: use ONLY user_data_dir (simple approach)
         # - Persistent Chrome profile at ~/.co/browser_profile/
@@ -121,13 +136,20 @@ class BrowserAutomation:
         # - No need for storage_state.json complexity (browser-use uses that for portability)
 
         # Launch browser with browser-use anti-detection config (see browser_config.py)
+        launch_options = {
+            "headless": headless,
+            "args": CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
+            "ignore_default_args": IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
+            "timeout": 120000,
+        }
+        if self._browser_channel:
+            launch_options["channel"] = self._browser_channel
+        elif chrome_path:
+            launch_options["executable_path"] = chrome_path
+
         self.browser = self.playwright.chromium.launch_persistent_context(
             str(profile_dir),  # Persistent profile at ~/.co/browser_profile/
-            headless=headless,
-            executable_path=chrome_path,
-            args=CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
-            ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
-            timeout=120000,
+            **launch_options,
         )
 
         self.page = self.browser.new_page()
@@ -463,7 +485,7 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
             Base64 encoded image data with system reminder for full-page screenshots
         """
         if not PLAYWRIGHT_AVAILABLE:
-            return 'Browser tools not installed. Run: pip install playwright && playwright install chromium'
+            return self._install_hint()
 
         if not self.page:
             return "Browser not open"
@@ -682,5 +704,3 @@ SYSTEM REMINDER: Full-page screenshots provide an overview of the entire page bu
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
-
-

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -844,12 +844,18 @@ Deploy your agent to ConnectOnion Cloud.
 **Basic usage:**
 ```bash
 co deploy
+co deploy --skills ship-feature,review-pr
+co deploy --skill ship-feature
+co deploy --name agent-4-linkedin --skills linkedin
 ```
 
 **Requirements:**
-- Git repository with committed code
-- `.co/host.yaml` (created by `co create` or `co init`)
 - Authenticated (`co auth`)
+- `co deploy --skills ...` or `co deploy --skill ...` deploys hosted `co ai` directly and bundles selected skills
+- Selected skill `requirements.txt` files are installed in the hosted co-ai image
+- co-ai deploy uploads project `.env` values plus allowed API keys from `~/.co/keys.env` and the current shell environment
+- `--name` creates a distinct cloud project/agent identity; use lowercase letters, numbers, and hyphens
+- Project deploys require a git repository, `.co/host.yaml`, and an entrypoint that calls `host()`
 
 **Example:**
 ```bash

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -20,11 +20,19 @@ Get your agent running in production.
 Deploy to ConnectOnion Cloud with one command.
 
 ```bash
-cd my-agent
-git init && git add -A && git commit -m "Initial commit"
 co auth  # If not already authenticated
-co deploy
+co deploy --skills ship-feature,review-pr
+co deploy --skill ship-feature
+co deploy --name agent-4-linkedin --skills linkedin
 ```
+
+This deploys the built-in `co ai` coding agent with the selected skills. `--skill` is a singular alias for `--skills`. No project `agent.py`, `.co/host.yaml`, or git commit is required for this co-ai path.
+
+```bash
+co deploy --skills ship-feature --skills review-pr --model co/gemini-3-flash-preview
+```
+
+To deploy a traditional project agent instead, run `co deploy` from a ConnectOnion project with `.co/host.yaml` and a committed `host(...)` entrypoint, or pass `--template project`.
 
 **Output:**
 ```
@@ -47,22 +55,24 @@ Container logs:
 
 URL format: `{project_name}-{your_address[:10]}.agents.openonion.ai`
 
-Re-deploying the same project updates the same URL (like Heroku).
+Re-deploying the same project name updates the same URL. Use `--name` for separate co-ai deployments such as `agent-4-linkedin` and `agent-4-sales`.
 
 ### Requirements
 
-- Git repository with committed code
-- `.co/host.yaml` (created by `co create` or `co init`)
 - Authenticated (`co auth`)
-- Entrypoint must call `host()` (exports the ASGI app for the container)
+- `co deploy --skills ...` resolves skills from project `.co/skills/`, user `~/.co/skills/`, then built-in co-ai skills
+- If a selected skill has `requirements.txt`, those Python dependencies are installed during the co-ai image build
+- co-ai deploy env collection reads project `.env`, global `~/.co/keys.env`, and allowed API keys from the current process environment
+- `--name` must use lowercase letters, numbers, and hyphens because it becomes part of the hosted agent URL
+- Project deploys require a git repository, `.co/host.yaml`, and an entrypoint that calls `host()`
 
 ### How It Works
 
 ```
 co deploy
-  ├─ Validate: git repo? .co/host.yaml? API key? entrypoint has host()?
-  ├─ Package: git archive HEAD → tarball
-  ├─ Collect: load env vars from .env
+  ├─ Choose mode: project if in a ConnectOnion project, otherwise co-ai
+  ├─ Package: project git archive OR generated co-ai package
+  ├─ Collect: load env vars from project .env, ~/.co/keys.env, and allowed API key env vars
   ├─ Upload: POST tarball + project_name + env_vars + entrypoint to API
   ├─ Build: backend builds Docker image, installs dependencies
   ├─ Run: starts container with your env vars injected
@@ -70,11 +80,13 @@ co deploy
   └─ Done: returns agent URL + container logs
 ```
 
+For `co deploy --skills ...`, packaging creates a temporary self-contained co-ai app with the current ConnectOnion package source, `requirements.txt`, a generated `.co/deploy/co_ai_entrypoint.py`, and the selected `.co/skills/<name>/` directories. If a selected skill contains `requirements.txt`, the generated root `requirements.txt` references it. It does not read or modify your working tree except for resolving project-level skills if present.
+
 **Step by step:**
 
-1. **Validate locally** — checks that you're in a git repo, `.co/host.yaml` exists, you have an `OPENONION_API_KEY`, and your entrypoint file calls `host()`
-2. **Package source** — runs `git archive` on HEAD to create a tarball (only committed files are included)
-3. **Collect env vars** — reads your `.env` file (API keys, database URLs, etc.) to inject into the container
+1. **Validate locally** — checks that you have an `OPENONION_API_KEY`; project deploys also check git, `.co/host.yaml`, and `host()`
+2. **Package source** — creates a generated co-ai package, or runs `git archive` for project deploys
+3. **Collect env vars** — reads project `.env`, selected API keys from `~/.co/keys.env`, and selected API keys from the shell environment to inject into the container
 4. **Upload** — sends the tarball, project name, entrypoint path, and env vars to the deploy API
 5. **Build & run** — the backend builds a Docker image from your source, installs `requirements.txt`, and starts the container
 6. **Poll status** — CLI checks deployment status every 3 seconds until the container is running or fails

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -15,10 +15,12 @@ Components under test:
 """
 
 import os
+import json
 import shutil
 import tempfile
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 import pytest
 
@@ -60,6 +62,145 @@ class TestCliDeploy:
 
             result = self.runner.invoke(cli, ['deploy'])
             assert "Not a ConnectOnion project" in result.output
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    def test_deploy_with_skills_auto_uses_co_ai_without_project_scaffold(self, mock_get, mock_post):
+        """Test --skills deploys co-ai without requiring git or .co/host.yaml."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            from connectonion.cli.commands import deploy_commands
+
+            Path("package.tar.gz").write_bytes(b"package")
+
+            captured = {}
+
+            def fake_create_package(**kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    tarball_path=Path("package.tar.gz"),
+                    entrypoint="agent.py",
+                )
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"id": "abc123", "url": "https://test-agent.agents.openonion.ai"},
+            )
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"status": "running", "url": "https://test-agent.agents.openonion.ai"},
+            )
+
+            with patch.object(deploy_commands, "create_deploy_package", side_effect=fake_create_package):
+                with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                    result = self.runner.invoke(
+                        cli,
+                        [
+                            "deploy",
+                            "--name", "agent-4-linkedin",
+                            "--skill", "alpha,beta",
+                            "--skills", "gamma",
+                            "--model", "co/test-model",
+                            "--max-iterations", "44",
+                        ],
+                    )
+
+            assert result.exit_code == 0
+            assert captured["template"] == "co-ai"
+            assert captured["skills"] == ["alpha", "beta", "gamma"]
+            assert captured["project_name"] == "agent-4-linkedin"
+            assert captured["model"] == "co/test-model"
+            assert captured["max_iterations"] == 44
+            upload_data = mock_post.call_args.kwargs["data"]
+            assert upload_data["project_name"] == "agent-4-linkedin"
+            assert upload_data["entrypoint"] == "agent.py"
+            assert upload_data["runtime"] == "local"
+            assert json.loads(upload_data["secrets"])["OPENONION_API_KEY"] == "test-token"
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    def test_deploy_with_all_skills_auto_uses_co_ai_without_project_scaffold(self, mock_get, mock_post):
+        """Test --all-skills deploys co-ai and asks package builder to include all local skills."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            from connectonion.cli.commands import deploy_commands
+
+            Path("package.tar.gz").write_bytes(b"package")
+            captured = {}
+
+            def fake_create_package(**kwargs):
+                captured.update(kwargs)
+                return SimpleNamespace(
+                    tarball_path=Path("package.tar.gz"),
+                    entrypoint="agent.py",
+                )
+
+            mock_post.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"id": "abc123", "url": "https://test-agent.agents.openonion.ai"},
+            )
+            mock_get.return_value = MagicMock(
+                status_code=200,
+                json=lambda: {"status": "running", "url": "https://test-agent.agents.openonion.ai"},
+            )
+
+            with patch.object(deploy_commands, "create_deploy_package", side_effect=fake_create_package):
+                with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                    result = self.runner.invoke(cli, ["deploy", "--name", "agent-full", "--all-skills"])
+
+            assert result.exit_code == 0
+            assert captured["template"] == "co-ai"
+            assert captured["skills"] == []
+            assert captured["all_skills"] is True
+            assert captured["project_name"] == "agent-full"
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_removed_browser_option(self, mock_post):
+        """Test --browser is no longer a deploy option."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--skills', 'alpha', '--browser'])
+
+            combined_output = result.output + result.stderr
+            assert result.exit_code != 0
+            assert "--browser" in combined_output
+            mock_post.assert_not_called()
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_skills_without_co_ai_template(self, mock_post):
+        """Test --skills is scoped to the co-ai deploy template."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".git")
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--skills', 'alpha'])
+
+            assert "--skills requires --template co-ai" in result.output
+            mock_post.assert_not_called()
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_rejects_all_skills_without_co_ai_template(self, mock_post):
+        """Test --all-skills is scoped to the co-ai deploy template."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".git")
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text('from connectonion import host\nhost(None)\n')
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy', '--template', 'project', '--all-skills'])
+
+            assert "--all-skills requires --template co-ai" in result.output
+            mock_post.assert_not_called()
 
     @SKIP_NO_GIT
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
@@ -225,5 +366,3 @@ class TestCliDeploy:
                 result = self.runner.invoke(cli, ['deploy'])
 
             assert "Deploy failed" in result.output
-
-

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -1,0 +1,56 @@
+"""Tests for BrowserAutomation launch configuration."""
+
+import connectonion.useful_tools.browser_tools.browser as browser_mod
+
+
+class FakePage:
+    def set_default_navigation_timeout(self, timeout):
+        self.navigation_timeout = timeout
+
+    def set_viewport_size(self, size):
+        self.viewport_size = size
+
+    def add_init_script(self, script):
+        self.init_script = script
+
+
+class FakeContext:
+    def __init__(self):
+        self.page = FakePage()
+
+    def new_page(self):
+        return self.page
+
+
+def test_open_browser_uses_explicit_playwright_channel(monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeChromium:
+        def launch_persistent_context(self, user_data_dir, **kwargs):
+            captured["user_data_dir"] = user_data_dir
+            captured["kwargs"] = kwargs
+            return FakeContext()
+
+    class FakeSyncPlaywright:
+        def start(self):
+            return type("FakePlaywright", (), {"chromium": FakeChromium()})()
+
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True, browser_channel="chrome")
+
+    result = browser.open_browser()
+
+    assert "Browser opened with persistent profile" in result
+    assert captured["kwargs"]["headless"] is True
+    assert captured["kwargs"]["channel"] == "chrome"
+    assert "executable_path" not in captured["kwargs"]
+
+
+def test_browser_install_hint_matches_explicit_channel(monkeypatch):
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", False)
+    browser = browser_mod.BrowserAutomation(browser_channel="chrome")
+
+    assert "playwright install chrome" in browser.open_browser()

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -1,0 +1,284 @@
+"""Tests for deploy command packaging helpers."""
+
+import json
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import deploy_commands
+
+
+def _run_git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "test@test.com")
+    _run_git(repo, "config", "user.name", "Test")
+    (repo / ".co").mkdir()
+    (repo / ".co" / "host.yaml").write_text("name: demo\nentrypoint: agent.py\n", encoding="utf-8")
+    (repo / "agent.py").write_text("print('project agent')\n", encoding="utf-8")
+    _run_git(repo, "add", ".")
+    _run_git(repo, "commit", "-m", "init")
+
+
+def _write_skill(root: Path, name: str, body: str = "Body", requirements: str | None = None) -> Path:
+    skill_dir = root / ".co" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {name} skill\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "helper.txt").write_text("helper\n", encoding="utf-8")
+    if requirements is not None:
+        (skill_dir / "requirements.txt").write_text(requirements, encoding="utf-8")
+    return skill_dir
+
+
+def test_parse_skill_names_accepts_repeated_and_comma_separated_values():
+    assert deploy_commands.parse_skill_names(["alpha,beta", " gamma "]) == ["alpha", "beta", "gamma"]
+
+
+def test_resolve_deploy_skill_prefers_project_over_user_and_builtin(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    project_skill = _write_skill(project, "alpha", "project")
+    _write_skill(user_home, "alpha", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    assert deploy_commands.resolve_deploy_skill("alpha", project) == project_skill
+
+
+def test_discover_deploy_skill_names_lists_project_then_user_with_project_priority(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    _write_skill(project, "alpha", "project")
+    _write_skill(project, "shared", "project")
+    _write_skill(user_home, "beta", "user")
+    _write_skill(user_home, "shared", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    assert deploy_commands.discover_deploy_skill_names(project) == ["alpha", "shared", "beta"]
+
+
+def test_create_co_ai_deploy_package_with_all_skills_copies_project_and_user_skills(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    user_home = tmp_path / "home"
+    project.mkdir()
+    user_home.mkdir()
+    _write_skill(project, "alpha", "project")
+    _write_skill(project, "shared", "project")
+    _write_skill(user_home, "beta", "user")
+    _write_skill(user_home, "shared", "user")
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=[],
+        all_skills=True,
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        shared = tar.extractfile(".co/skills/shared/SKILL.md").read().decode("utf-8")
+
+    assert ".co/skills/alpha/SKILL.md" in names
+    assert ".co/skills/beta/SKILL.md" in names
+    assert ".co/skills/shared/SKILL.md" in names
+    assert "project" in shared
+    assert "user" not in shared
+
+
+def test_create_co_ai_deploy_package_is_self_contained_and_chrome_enabled_by_default(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "alpha")
+    before = sorted(str(p.relative_to(project)) for p in project.rglob("*"))
+    monkeypatch.chdir(project)
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["alpha"],
+        all_skills=False,
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    after = sorted(str(p.relative_to(project)) for p in project.rglob("*"))
+    assert after == before
+    assert package.entrypoint == "agent.py"
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        assert "agent.py" in names
+        assert ".co/host.yaml" in names
+        assert ".co/skills/alpha/SKILL.md" in names
+        assert ".co/skills/alpha/helper.txt" in names
+        assert "connectonion/cli/co_ai/agent.py" in names
+        assert "requirements.txt" in names
+        assert "Dockerfile" in names
+        entrypoint = tar.extractfile("agent.py").read().decode("utf-8")
+        host_yaml = tar.extractfile(".co/host.yaml").read().decode("utf-8")
+        requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
+        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
+
+    assert "create_coding_agent" in entrypoint
+    assert "PACKAGE_ROOT = Path(__file__).resolve().parent" in entrypoint
+    assert "sys.path.insert(0, str(PACKAGE_ROOT))" in entrypoint
+    assert "CO_DIR = PACKAGE_ROOT / \".co\"" in entrypoint
+    assert entrypoint.index("sys.path.insert") < entrypoint.index("from connectonion import host")
+    assert "model=\"co/test-model\"" in entrypoint
+    assert "max_iterations=33" in entrypoint
+    assert "name=\"demo\"" in entrypoint
+    assert "auto_approve=True" not in entrypoint
+    assert "browser_headless=False" in entrypoint
+    assert "browser_channel=\"chrome\"" in entrypoint
+    assert "co_dir=CO_DIR" in entrypoint
+    assert "host(create_agent, trust=\"careful\", co_dir=CO_DIR)" in entrypoint
+    assert "name: demo" in host_yaml
+    assert "entrypoint: agent.py" in host_yaml
+    assert "connectonion==" not in requirements  # vendored, not pip-installed
+    assert "playwright" in requirements  # third-party runtime deps listed instead
+    assert "-r .co/skills" not in requirements
+    assert "apt-get install -y --no-install-recommends xvfb xauth" in dockerfile
+    assert "RUN python -m playwright install --with-deps chrome" in dockerfile
+    assert "CMD [\"xvfb-run\", \"-a\", \"python\", \"agent.py\"]" in dockerfile
+
+
+def test_create_co_ai_deploy_package_local_runtime_generates_chrome_dockerfile(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "linkedin")
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["linkedin"],
+        all_skills=False,
+        project_name="agent-4-linkedin",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        assert "Dockerfile" in names
+        entrypoint = tar.extractfile("agent.py").read().decode("utf-8")
+        dockerfile = tar.extractfile("Dockerfile").read().decode("utf-8")
+
+    assert package.entrypoint == "agent.py"
+    assert "browser_channel=\"chrome\"" in entrypoint
+    assert "FROM python:3.11-slim" in dockerfile
+    assert "COPY requirements.txt ." in dockerfile
+    assert "COPY . ." in dockerfile
+    assert "RUN pip install --no-cache-dir -r requirements.txt" in dockerfile
+    assert "apt-get install -y --no-install-recommends xvfb xauth" in dockerfile
+    assert "python -m playwright install --with-deps chrome" in dockerfile
+    assert "CMD [\"xvfb-run\", \"-a\", \"python\", \"agent.py\"]" in dockerfile
+
+
+def test_create_co_ai_deploy_package_installs_skill_requirements(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    _write_skill(project, "image-gen", requirements="google-genai>=1.0\nPillow>=10\n")
+
+    package = deploy_commands.create_deploy_package(
+        project_dir=project,
+        template="co-ai",
+        skills=["image-gen"],
+        all_skills=False,
+        project_name="demo",
+        entrypoint="agent.py",
+        model="co/test-model",
+        max_iterations=33,
+    )
+
+    with tarfile.open(package.tarball_path, "r:gz") as tar:
+        names = set(tar.getnames())
+        requirements = tar.extractfile("requirements.txt").read().decode("utf-8")
+        skill_requirements = tar.extractfile(".co/skills/image-gen/requirements.txt").read().decode("utf-8")
+
+    assert ".co/skills/image-gen/requirements.txt" in names
+    assert "connectonion==" not in requirements  # vendored, not pip-installed
+    assert "playwright" in requirements  # third-party runtime deps listed instead
+    assert "google-genai>=1.0" in requirements
+    assert "Pillow>=10" in requirements
+    assert "-r .co/skills/image-gen/requirements.txt" not in requirements
+    assert "google-genai>=1.0" in skill_requirements
+
+
+def test_create_co_ai_deploy_package_fails_before_upload_when_skill_missing(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+
+    with pytest.raises(deploy_commands.DeployConfigError, match="Skill not found: missing"):
+        deploy_commands.create_deploy_package(
+            project_dir=project,
+            template="co-ai",
+            skills=["missing"],
+            all_skills=False,
+            project_name="demo",
+            entrypoint="agent.py",
+            model="co/test-model",
+            max_iterations=33,
+        )
+
+
+@pytest.mark.parametrize("name", ["agent-4-linkedin", "co-ai", "a1"])
+def test_validate_deploy_name_accepts_url_safe_names(name):
+    assert deploy_commands.validate_deploy_name(name) == name
+
+
+@pytest.mark.parametrize("name", ["Agent 4", "agent_4", "-agent", "agent-", ""])
+def test_validate_deploy_name_rejects_names_that_break_agent_urls(name):
+    with pytest.raises(deploy_commands.DeployConfigError):
+        deploy_commands.validate_deploy_name(name)
+
+
+def test_load_deploy_env_vars_merges_project_global_and_allowed_shell_keys(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    project.mkdir()
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text(
+        "OPENONION_API_KEY=global-openonion\n"
+        "GEMINI_API_KEY=global-gemini\n"
+        "RANDOM_SECRET=do-not-upload\n",
+        encoding="utf-8",
+    )
+    env_file = project / ".env"
+    env_file.write_text(
+        "GEMINI_API_KEY=project-gemini\n"
+        "PROJECT_SETTING=enabled\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+    for key in deploy_commands.DEPLOY_ENV_KEY_ALLOWLIST:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "shell-google")
+    monkeypatch.setenv("RANDOM_SECRET", "shell-secret")
+
+    env_vars = deploy_commands.load_deploy_env_vars(env_file)
+
+    assert env_vars["OPENONION_API_KEY"] == "global-openonion"
+    assert env_vars["GEMINI_API_KEY"] == "project-gemini"
+    assert env_vars["GOOGLE_API_KEY"] == "shell-google"
+    assert env_vars["PROJECT_SETTING"] == "enabled"
+    assert "RANDOM_SECRET" not in env_vars

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -122,6 +122,46 @@ class TestHostRelayConnection:
                             call_args = mock_relay.call_args
                             assert call_args[0][0] == "wss://oo.openonion.ai"
 
+    def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
+        """Test host ANNOUNCE profile includes agent metadata for frontend display."""
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path):
+            with patch('connectonion.address.load', return_value=mock_addr):
+                with patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())) as mock_relay:
+                    with patch('uvicorn.run'):
+                        with patch.object(host_module, '_print_host_banner'):
+                            host_module.host(create_mock_agent, relay_url="ws://test")
+
+                            profile = mock_relay.call_args.kwargs["profile"]
+                            assert profile["alias"] == "test_agent"
+                            assert profile["name"] == "test_agent"
+                            assert profile["model"] == "test-model"
+                            assert profile["tools"] == []
+                            assert profile["skills"] == []
+
+    def test_build_relay_profile_includes_skills_tools_and_version(self):
+        metadata = {
+            "name": "agent-4-linkedin",
+            "model": "co/test-model",
+            "tools": ["bash", "skill"],
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke-test deployed co-ai", "location": "project"}
+            ],
+        }
+
+        profile = host_module._build_relay_profile(metadata, "Deployed co-ai agent")
+
+        assert profile["alias"] == "agent-4-linkedin"
+        assert profile["name"] == "agent-4-linkedin"
+        assert profile["bio"] == "Deployed co-ai agent"
+        assert profile["model"] == "co/test-model"
+        assert profile["version"]
+        assert profile["tools"] == ["bash", "skill"]
+        assert profile["skills"] == [
+            {"name": "deploy-smoke", "description": "Smoke-test deployed co-ai", "location": "project"}
+        ]
+
     def test_host_starts_relay_with_custom_url(self, tmp_path, create_mock_agent):
         """Test that host() uses custom relay URL."""
         mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -245,7 +245,7 @@ class TestSkillInvocation:
         handle_skill_invocation(agent)
 
         # Skill should be loaded
-        mock_load.assert_called_once_with('commit')
+        mock_load.assert_called_once_with('commit', co_dir=None)
 
         # Message should be replaced with instructions
         assert agent.current_session['messages'][-1]['content'] == 'Create a git commit'
@@ -285,6 +285,61 @@ class TestSkillInvocation:
         # Should not crash, just return
         # Message should not be replaced
         assert agent.current_session['messages'][-1]['content'] == '/nonexistent'
+
+    def test_handle_skill_invocation_loads_from_agent_co_dir_when_cwd_differs(self, tmp_path, monkeypatch):
+        """Test deployed agents load slash skills from agent.co_dir, not only cwd."""
+        project = tmp_path / "project"
+        co_dir = project / ".co"
+        skill_dir = co_dir / "skills" / "deploy-smoke"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: deploy-smoke\n"
+            "description: Smoke deploy skill\n"
+            "tools: []\n"
+            "---\n\n"
+            "DEPLOY_SMOKE_SKILL_ACTIVE_2026_06_01\n",
+            encoding="utf-8",
+        )
+
+        other_cwd = tmp_path / "other"
+        other_cwd.mkdir()
+        monkeypatch.chdir(other_cwd)
+
+        agent = FakeAgent()
+        agent.co_dir = co_dir
+        agent.current_session['messages'] = [
+            {'role': 'user', 'content': '/deploy-smoke'}
+        ]
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session['messages'][-1]['content'] == "DEPLOY_SMOKE_SKILL_ACTIVE_2026_06_01"
+
+    def test_handle_skill_invocation_ignores_claude_skills(self, tmp_path, monkeypatch):
+        """Test runtime skill loading does not treat Claude skills as ConnectOnion skills."""
+        skill_dir = tmp_path / ".claude" / "skills" / "claude-only"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: claude-only\n"
+            "description: Claude-only skill\n"
+            "tools: []\n"
+            "---\n\n"
+            "SHOULD_NOT_LOAD\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        agent = FakeAgent()
+        agent.current_session['messages'] = [
+            {'role': 'user', 'content': '/claude-only'}
+        ]
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session['messages'][-1]['content'] == "/claude-only"
 
 
 class TestCleanup:


### PR DESCRIPTION
Clean re-do of #145, branched from `main`.

#145 was based on `codex/co-ai-remote-login-tool` instead of `main`, so it pulled in 15 unrelated remote-login commits (login handoff, QR, credential tools) plus planning-doc churn. This PR contains **only** the hosted co-ai deploy-skills changes.

## Scope
- `deploy_co_ai.py` / `deploy_commands.py` / `cli/main.py`: hosted co-ai deploy packaging, runtime modes, all-skills selection, Xvfb support
- `agent.py`: `create_coding_agent` gains `name` / `co_dir` / `browser_headless` / `browser_channel` params (deploy-only; no login tools)
- `server.py` / `relay.py` / `skills.py` / `tool_approval` / `ulw.py` / `browser.py`: supporting deploy changes
- deploy docs + tests

The remote-login work stays in its own branch/PR (`codex/co-ai-remote-login-tool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)