### PR TITLE
host: publish agent profile to the relay on first ANNOUNCE

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -119,24 +119,23 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
-def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+def _build_agent_profile(agent_metadata: dict) -> dict:
     """Build the publishable profile sent with the first ANNOUNCE of a connection.
 
-    Only project-level skills are published: skill discovery also picks up
-    ~/.co/skills (the operator's personal toolbox), which must not leak into
-    the public directory. Locations are filesystem paths and stay private,
-    same as the prompt summary.
+    Only project-level skills are published (skill.location is the discovery
+    category: project/user/builtin): discovery also picks up ~/.co/skills —
+    the operator's personal toolbox, which must not leak into the public
+    directory. The prompt summary stays private for the same reason.
     """
     profile = {"alias": agent_metadata["name"]}
     if agent_metadata.get("tools"):
         profile["tools"] = agent_metadata["tools"]
     if agent_metadata.get("model"):
         profile["model"] = agent_metadata["model"]
-    project_root = str(project_dir.resolve())
     profile["skills"] = [
         {"name": s["name"], "description": s.get("description", "")}
         for s in agent_metadata.get("skills", [])
-        if str(Path(s["location"]).resolve()).startswith(project_root)
+        if s.get("location") == "project"
     ]
     return profile
 
@@ -463,7 +462,7 @@ def host(
         )
         on_startup, on_shutdown = _create_relay_lifespan(
             relay_url, addr_data, summary, port, relay_session_runner,
-            profile=_build_agent_profile(agent_metadata, Path.cwd()),
+            profile=_build_agent_profile(agent_metadata),
         )
 
     app = asgi_create_app(

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -119,6 +119,28 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
+def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+    """Build the publishable profile sent with the first ANNOUNCE of a connection.
+
+    Only project-level skills are published: skill discovery also picks up
+    ~/.co/skills (the operator's personal toolbox), which must not leak into
+    the public directory. Locations are filesystem paths and stay private,
+    same as the prompt summary.
+    """
+    profile = {"alias": agent_metadata["name"]}
+    if agent_metadata.get("tools"):
+        profile["tools"] = agent_metadata["tools"]
+    if agent_metadata.get("model"):
+        profile["model"] = agent_metadata["model"]
+    project_root = str(project_dir.resolve())
+    profile["skills"] = [
+        {"name": s["name"], "description": s.get("description", "")}
+        for s in agent_metadata.get("skills", [])
+        if str(Path(s["location"]).resolve()).startswith(project_root)
+    ]
+    return profile
+
+
 def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
     """Create route handler dict for ASGI app.
 
@@ -231,7 +253,7 @@ def _print_host_banner(
     console.print()
 
 
-def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner):
+def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner, *, profile: dict | None = None):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
     Args:
@@ -240,6 +262,8 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         summary: Summary text for relay announcement
         port: HTTP port for endpoint discovery
         relay_session_runner: async (send_msg, recv_msg) -> None, runs protocol for one relay session
+        profile: publishable display info, sent with the first ANNOUNCE of each
+                 connection; the relay persists it, so heartbeats don't carry it
 
     Returns:
         Tuple of (on_startup, on_shutdown) async callbacks
@@ -253,7 +277,9 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         async def relay_loop():
             while True:
                 ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                announce_msg = announce.create_announce_message(
+                    addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
+                )
                 await relay.serve_loop(
                     ws, announce_msg,
                     addr_data=addr_data, session_handler=relay_session_runner,
@@ -436,7 +462,8 @@ def host(
             enable_ping=False,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
-            relay_url, addr_data, summary, port, relay_session_runner
+            relay_url, addr_data, summary, port, relay_session_runner,
+            profile=_build_agent_profile(agent_metadata, Path.cwd()),
         )
 
     app = asgi_create_app(

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -106,21 +106,21 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
-    def test_profile_publishes_project_skills_only(self, tmp_path):
+    def test_profile_publishes_project_skills_only(self):
         """Published profile carries display fields only: project-level skills,
-        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
-        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        no user/builtin skills (location is the discovery category, not a
+        path), no prompt summary."""
         profile = host_module._build_agent_profile({
             "name": "test_agent",
             "tools": ["search"],
             "model": "co/gemini-2.5-flash",
             "summary": "private prompt summary",
             "skills": [
-                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
-                {"name": "linkedin-login", "description": "Operator skill",
-                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+                {"name": "deploy-smoke", "description": "Smoke test", "location": "project"},
+                {"name": "linkedin-login", "description": "Operator skill", "location": "user"},
+                {"name": "commit", "description": "Built-in skill", "location": "builtin"},
             ],
-        }, tmp_path)
+        })
 
         assert profile == {
             "alias": "test_agent",

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -106,6 +106,44 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
+    def test_profile_publishes_project_skills_only(self, tmp_path):
+        """Published profile carries display fields only: project-level skills,
+        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
+        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        profile = host_module._build_agent_profile({
+            "name": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "summary": "private prompt summary",
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
+                {"name": "linkedin-login", "description": "Operator skill",
+                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+            ],
+        }, tmp_path)
+
+        assert profile == {
+            "alias": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "skills": [{"name": "deploy-smoke", "description": "Smoke test"}],
+        }
+
+    def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
+        """Hosted agents publish their profile with the relay ANNOUNCE."""
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path):
+            with patch('connectonion.address.load', return_value=mock_addr):
+                with patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())) as mock_relay:
+                    with patch('uvicorn.run'):
+                        with patch.object(host_module, '_print_host_banner'):
+                            host_module.host(create_mock_agent, port=8080)
+
+        profile = mock_relay.call_args.kwargs["profile"]
+        assert profile["alias"]
+        assert "summary" not in profile
+
     def test_host_starts_relay_with_default_url(self, tmp_path, create_mock_agent):
         """Test that host() uses default relay URL (from config)."""
         mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}


### PR DESCRIPTION
## Problem
A `host()` agent connects to the relay and is reachable, but the online directory has nothing to show for it — no name, tools, or skills.

## Change
`host()` builds a publishable **profile** from agent metadata and sends it with the **first ANNOUNCE of each connection**:

```python
{alias, tools, model, skills: [{name, description}]}
```

The relay persists it through the existing durable profile path (oo-api), so heartbeats don't carry it — `create_announce_message` has supported `profile=` since March, so the wire format needs no changes and this diff is +68/−3.

## Privacy
Only **project-level** skills (`<project>/.co/skills/`) are published. Skill discovery also picks up `~/.co/skills` — the operator's personal toolbox; live testing showed a real machine would have published 62 skills (37KB), exposing which platforms the operator automates. Skill filesystem locations and the prompt summary stay private for the same reason.

## Why durable profile, not in-memory metadata
An earlier revision of this branch published a runtime `metadata` payload refreshed on every heartbeat and held in the relay's memory. Skills are publishable content — large, soon with SKILL.md bodies — and belong in the durable channel, sent once per connection. The in-memory registry keeps doing exactly its job: liveness + endpoints.

## Pairing
oo-api #16 (relay serves the profile with agent records) · oo-chat #14 / connectonion-ts #5 (read it).

## Tests
`test_host_relay.py`: project-only skill filtering (user-level skills, locations, and summary excluded), profile passed to the relay lifespan. Full unit suite: 1925 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)