### PR TITLE
Dispatch browser calls to one thread; bound forwarder waits; persist screenshots into replay

### DIFF
--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -91,6 +91,18 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
     return None
 
 
+def _append_trace_items(items_ui: list[dict], entry: dict, idx: int) -> None:
+    """Append a trace entry's ChatItem(s): the item itself, plus a standalone
+    image bubble when the entry carries an image (mirrors the live agent_image
+    event so replayed history shows screenshots too)."""
+    item_ui = _trace_entry_to_item_ui(entry, idx)
+    if item_ui:
+        items_ui.append(item_ui)
+    image = entry.get('image')
+    if image:
+        items_ui.append({'id': f"img-{idx}", 'type': 'agent', 'content': '', 'images': [image]})
+
+
 def session_to_chat_items(session: dict) -> list[dict]:
     """Convert session → ChatItem[] for UI rendering, interleaved chronologically by turn.
 
@@ -128,9 +140,7 @@ def session_to_chat_items(session: dict) -> list[dict]:
             user_count += 1
             if user_count < len(turn_entries):
                 for trace_idx, entry in turn_entries[user_count]:
-                    item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-                    if item_ui:
-                        items_ui.append(item_ui)
+                    _append_trace_items(items_ui, entry, trace_idx)
         elif role == 'assistant' and msg.get('content'):
             items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': msg.get('content', '')})
 
@@ -138,8 +148,6 @@ def session_to_chat_items(session: dict) -> list[dict]:
     # entries at the end so the data isn't silently dropped (older sessions).
     if len(turn_entries) == 1 and turn_entries[0]:
         for trace_idx, entry in turn_entries[0]:
-            item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-            if item_ui:
-                items_ui.append(item_ui)
+            _append_trace_items(items_ui, entry, trace_idx)
 
     return items_ui

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -130,11 +130,15 @@ class WebSocketIO(IO):
             self._cursor = 0
 
     def _wait_for_msgs_from_agent(self, cursor, stop_event=None):
-        """Block until new agent messages available or finished. Returns (messages, done)."""
+        """Wait up to ~1s for new agent messages. Returns (messages, done).
+
+        Must return promptly even with no news: this runs on the event loop's
+        shared default executor, and a forwarder for an idle session (agent
+        blocked in receive()) would otherwise pin a pool thread forever —
+        enough idle sessions exhaust the pool and starve every new connection.
+        """
         with self._agent_condition:
-            while len(self._msgs_from_agent) <= cursor and not self._finished:
-                if stop_event and stop_event.is_set():
-                    return [], True
+            if len(self._msgs_from_agent) <= cursor and not self._finished:
                 self._agent_condition.wait(timeout=1.0)
             if stop_event and stop_event.is_set():
                 return [], True

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -95,6 +95,11 @@ def _format_image_result(agent: 'Agent') -> None:
         if agent.io:
             agent.io.send_image(data_url)
 
+        # Keep the data URL on the trace (not sent to the LLM) so session replay
+        # can re-emit the image into chat_items. Without this, the shortened
+        # result below is the only trace record and screenshots vanish whenever
+        # the client rebuilds its UI from the server's canonical history.
+        trace_entry['image'] = data_url
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -23,8 +23,12 @@ Features:
 
 import os
 import base64
+import functools
+import inspect
 import json
 import platform
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, List, Dict, Any
@@ -1396,3 +1400,28 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
+
+
+# Playwright's sync API binds to the thread that started it and raises
+# "Cannot switch to a different thread" from any other. Servers like host()
+# run each agent turn on an arbitrary threadpool thread, so consecutive turns
+# crash the shared browser. Route every public method through one dedicated
+# worker thread: playwright starts there and every later call lands there.
+def _dispatch_to_browser_thread(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        executor = self.__dict__.get("_browser_executor")
+        if executor is None:
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="browser")
+            self._browser_executor = executor
+            self._browser_thread = executor.submit(threading.current_thread).result()
+        if threading.current_thread() is self._browser_thread:
+            return method(self, *args, **kwargs)
+        return executor.submit(method, self, *args, **kwargs).result()
+
+    return wrapper
+
+
+for _name, _method in list(vars(BrowserAutomation).items()):
+    if not _name.startswith("_") and inspect.isfunction(_method):
+        setattr(BrowserAutomation, _name, _dispatch_to_browser_thread(_method))

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -735,6 +735,31 @@ class TestSessionToChatItems:
         ids = [item['id'] for item in items]
         assert len(ids) == len(set(ids))  # All unique
 
+    def test_emits_image_bubble_for_screenshot(self):
+        """A tool_result carrying an image (set by image_result_formatter) replays
+        as a tool_call item plus a standalone agent image bubble, so screenshots
+        survive a rebuild from server history instead of vanishing."""
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        session = {
+            'messages': [
+                {'role': 'user', 'content': 'screenshot'},
+                {'role': 'assistant', 'content': 'done'},
+            ],
+            'trace': [
+                {'type': 'user_input', 'turn': 1},
+                {'type': 'tool_result', 'tool_id': 't1', 'name': 'take_screenshot',
+                 'status': 'success', 'result': "Tool 'take_screenshot' returned image (image/png)",
+                 'image': data_url},
+            ],
+        }
+
+        items = session_to_chat_items(session)
+        types = [i['type'] for i in items]
+        assert types == ['user', 'tool_call', 'agent', 'agent']
+        img_item = items[2]
+        assert img_item['images'] == [data_url]
+        assert img_item['content'] == ''
+
 
 class TestReconnectionScenarios:
     """End-to-end reconnection scenario tests."""

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -295,10 +295,13 @@ class TestFormatImageResult:
         _format_image_result(agent)
 
         # Trace result should be shortened
-        trace_result = agent.current_session['trace'][0]['result']
+        trace_entry = agent.current_session['trace'][0]
+        trace_result = trace_entry['result']
         assert 'screenshot' in trace_result
         assert 'image/png' in trace_result
         assert len(trace_result) < 100  # Much shorter than original
+        # Full data URL is retained out-of-band so session replay can re-emit it.
+        assert trace_entry['image'] == 'data:image/png;base64,' + 'A' * 1000
 
     def test_sends_image_to_io_when_available(self):
         """Image tool results are model-visible and sent to frontend IO."""

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -265,3 +265,44 @@ class TestHighLevelAPI:
 
         thread.join(timeout=1)
         assert result is False
+
+    def test_wait_for_msgs_returns_promptly_when_idle(self):
+        """_wait_for_msgs_from_agent runs on the event loop's shared default
+        executor; on an idle io (agent blocked in receive(), no new messages)
+        it must return within ~1s instead of looping forever, or each idle
+        session pins a pool thread until the pool starves every new connection."""
+        import time
+        io = WebSocketIO()
+
+        start = time.monotonic()
+        msgs, done = io._wait_for_msgs_from_agent(0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 3.0
+        assert msgs == []
+        assert done is False
+
+    async def test_idle_forwarder_does_not_starve_other_io(self):
+        """One io stuck idle must not block another io's event delivery when
+        the executor has a single thread (worst-case pool contention)."""
+        import asyncio
+        from concurrent.futures import ThreadPoolExecutor
+
+        loop = asyncio.get_event_loop()
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
+
+        idle_io = WebSocketIO()
+        busy_io = WebSocketIO()
+        busy_io.send({"type": "thinking"})
+
+        async def read_one(io):
+            async for event in io.read_msgs_from_agent():
+                return event
+
+        idle_task = asyncio.create_task(read_one(idle_io))
+        await asyncio.sleep(0.1)  # let the idle forwarder grab the only thread
+
+        event = await asyncio.wait_for(read_one(busy_io), timeout=5.0)
+        assert event["type"] == "thinking"
+
+        idle_task.cancel()


### PR DESCRIPTION
Stacked on #151.

Three fixes from debugging the hosted LinkedIn agent:

1. **`browser: dispatch all public methods to one dedicated thread`** — Playwright objects are not thread-safe; calls coming in from different executor threads corrupted state. All public browser methods now dispatch to a single dedicated thread.
2. **`io: bound forwarder wait so idle sessions don't pin executor threads`** — idle sessions were holding executor threads forever in the forwarder wait.
3. **`session: persist screenshot images into replayed chat_items`** — screenshots survived only in the live stream; replays after reconnect lost them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)