### PR TITLE
deploy: named template deploys + per-skill --skills paths + nodejs in co-ai image

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -163,22 +163,26 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                     continue
                 tar.add(path, arcname=str(rel), recursive=False)
         for skills_path in skills_paths:
+            # A path is either one skill (has SKILL.md) or a directory of skills.
+            arc_prefix = Path(".co") / "skills"
+            if (skills_path / "SKILL.md").exists():
+                arc_prefix = arc_prefix / skills_path.name
             _add_directory_to_tarball(
                 tar,
                 skills_path,
-                Path(".co") / "skills",
+                arc_prefix,
                 _load_deploy_ignore_patterns(skills_path),
             )
     return tarball
 
 
-def _deploy_template_project(template: str, skills: list[str]) -> bool:
+def _deploy_template_project(template: str, skills: list[str], name: str | None = None) -> bool:
     """Create a temporary template project, deploy it, and clean up on success."""
     temp_root = Path.cwd() / ".tmp" / "connectonion-deploy"
     if temp_root.exists():
         shutil.rmtree(temp_root)
     temp_root.mkdir(parents=True)
-    project_name = f"{template}-agent"
+    project_name = name or f"{template}-agent"
     project_dir = temp_root / project_name
 
     console.print(f"[cyan]Creating temporary {template} project...[/cyan]")
@@ -403,10 +407,13 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     return deploy_success
 
 
-def handle_deploy(template: str | None = None, skills: list[str] | None = None):
+def handle_deploy(template: str | None = None, skills: list[str] | None = None, name: str | None = None):
     """Deploy agent to ConnectOnion Cloud."""
     skills = skills or []
     if template:
         absolute_skills = [str(Path(s).expanduser().resolve()) for s in skills]
-        return _deploy_template_project(template, absolute_skills)
+        return _deploy_template_project(template, absolute_skills, name)
+    if name:
+        console.print("[red]--name only applies to template deploys; project name comes from .co/host.yaml[/red]")
+        return False
     return _deploy_current_project(skills)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -99,11 +99,12 @@ def create(
 @app.command()
 def deploy(
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
-    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skills directory to bundle into .co/skills/ (repeatable)"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (repeatable)"),
+    name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy(template=template, skills=skills)
+    handle_deploy(template=template, skills=skills, name=name)
 
 
 @app.command()

--- a/connectonion/cli/templates/co-ai/Dockerfile
+++ b/connectonion/cli/templates/co-ai/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth nodejs && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m playwright install --with-deps chrome

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -145,6 +145,14 @@ That creates `.tmp/connectonion-deploy/co-ai-agent`, deploys it, and cleans it u
 after success. Any template supported by `co create --template <name>` uses the
 same flow.
 
+`--name` sets the project name (and URL) for a template deploy, so different
+skill combinations of the same base template can run side by side:
+
+```bash
+co deploy --template co-ai --name linkedin-agent \
+  --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
+```
+
 ### Skills
 
 The deployed agent loads skills from `.co/skills/` via the normal loader.
@@ -156,13 +164,14 @@ The deployed agent loads skills from `.co/skills/` via the normal loader.
   co skills copy <name>          # lands in .co/skills/<name>/
   co deploy
   ```
-- **External skills** — to bundle any skills folder that lives outside the
-  project, pass `--skills PATH`
-  (repeatable). The folder contents are copied into the container's
-  `.co/skills/` (your working tree is untouched); on a name clash, later paths
-  win:
+- **External skills** — to bundle skills that live outside the project, pass
+  `--skills PATH` (repeatable). A path that is itself a skill (contains
+  `SKILL.md`) lands at `.co/skills/<dirname>/`; a directory of skills has its
+  contents copied into `.co/skills/`. Your working tree is untouched; on a
+  name clash, later paths win:
   ```bash
   co deploy --skills /Users/changxing/project/OnCourse/platform/social-media-management-skills
+  co deploy --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
   ```
 
 > Your local `~/.claude/skills` are **not** auto-deployed. `co deploy` ships the

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -318,6 +318,36 @@ class TestDeploySkillsPackaging:
         assert ".co/skills/world/SKILL.md" in names        # second --skills dir merged
         assert ".co/skills/.git/config" not in names       # dotfiles skipped
 
+    def test_single_skill_dir_nests_under_its_name(self, tmp_path):
+        import tarfile
+        from connectonion.cli.commands.deploy_commands import _build_tarball
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._make_repo(repo)
+
+        skill = tmp_path / "linkedin-login"
+        (skill / "scripts").mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: linkedin-login\n---\nlog in\n")
+        (skill / "scripts" / "fill.js").write_text("x\n")
+
+        tarball = _build_tarball(repo, [skill])
+        names = set(tarfile.open(tarball).getnames())
+
+        assert ".co/skills/linkedin-login/SKILL.md" in names
+        assert ".co/skills/linkedin-login/scripts/fill.js" in names
+        assert ".co/skills/SKILL.md" not in names          # not flattened
+
+    def test_name_without_template_errors_clearly(self):
+        runner = ArgparseCliRunner()
+        with runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+
+            result = runner.invoke(cli, ['deploy', '--name', 'other-name'])
+            assert "--name only applies to template deploys" in result.output
+
     def test_missing_skills_path_errors_clearly(self):
         runner = ArgparseCliRunner()
         with runner.isolated_filesystem():


### PR DESCRIPTION
Stacked on #152.

Makes `co deploy --template co-ai --name <agent> --skills <skill>...` a full replacement for hand-built agent projects (the LinkedIn agent path):

1. **`--name`** — template deploys were hardcoded to `{template}-agent`, so two different skill combinations could not coexist; they overwrote each other's deployment. `--name` sets the project name (and URL); default unchanged.
2. **Per-skill `--skills` paths** — a `--skills` path that is itself a skill (contains `SKILL.md`) now lands at `.co/skills/<dirname>/` instead of being flattened into `.co/skills/` (where multiple skills' `SKILL.md` collided). Directory-of-skills paths keep the existing behavior, so both granularities work.
3. **nodejs in the co-ai image** — skills ship node scripts (`linkedin-article-submit` runs `parse-markdown.js` via bash). This was the only difference between the hand-written LinkedIn Dockerfile and the template one.

Verified end to end: `co deploy --template co-ai --name linkedin-skills --skills .../linkedin-login --skills .../linkedin-post-writer --skills .../linkedin-post-submit` deploys a working hosted agent with exactly those three skills under `.co/skills/`.

Tests: 22/22 in `tests/e2e/cli/test_cli_deploy.py` (two new: single-skill nesting, `--name` without `--template` errors).