### PR TITLE
Hosted agents: relay profile, browser thread safety, template deploys with skills

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -2,9 +2,9 @@
 Purpose: Deploy agent projects to ConnectOnion Cloud with local packaging and env vars
 LLM-Note:
   Dependencies: imports from [fnmatch, json, os, re, shutil, subprocess, tarfile, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → optionally creates a temporary template project via co create → validates .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | template deploy creates/deletes a temporary project on success | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | normal deploy does not modify project files
-  Integration: exposes handle_deploy() for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | uses Bearer token auth | returns bool success
+  Integration: exposes handle_deploy(template, skills, name) for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | --name only valid with --template (otherwise the name comes from host.yaml) | uses Bearer token auth | returns bool success
   Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s up to 100 times (~5 min)
   Errors: fails if not ConnectOnion project (no host.yaml) | fails if no API key | prints backend error messages
 """
@@ -163,22 +163,26 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                     continue
                 tar.add(path, arcname=str(rel), recursive=False)
         for skills_path in skills_paths:
+            # A path is either one skill (has SKILL.md) or a directory of skills.
+            arc_prefix = Path(".co") / "skills"
+            if (skills_path / "SKILL.md").exists():
+                arc_prefix = arc_prefix / skills_path.name
             _add_directory_to_tarball(
                 tar,
                 skills_path,
-                Path(".co") / "skills",
+                arc_prefix,
                 _load_deploy_ignore_patterns(skills_path),
             )
     return tarball
 
 
-def _deploy_template_project(template: str, skills: list[str]) -> bool:
+def _deploy_template_project(template: str, skills: list[str], name: str | None = None) -> bool:
     """Create a temporary template project, deploy it, and clean up on success."""
     temp_root = Path.cwd() / ".tmp" / "connectonion-deploy"
     if temp_root.exists():
         shutil.rmtree(temp_root)
     temp_root.mkdir(parents=True)
-    project_name = f"{template}-agent"
+    project_name = name or f"{template}-agent"
     project_dir = temp_root / project_name
 
     console.print(f"[cyan]Creating temporary {template} project...[/cyan]")
@@ -403,10 +407,13 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     return deploy_success
 
 
-def handle_deploy(template: str | None = None, skills: list[str] | None = None):
+def handle_deploy(template: str | None = None, skills: list[str] | None = None, name: str | None = None):
     """Deploy agent to ConnectOnion Cloud."""
     skills = skills or []
     if template:
         absolute_skills = [str(Path(s).expanduser().resolve()) for s in skills]
-        return _deploy_template_project(template, absolute_skills)
+        return _deploy_template_project(template, absolute_skills, name)
+    if name:
+        console.print("[red]--name only applies to template deploys; project name comes from .co/host.yaml[/red]")
+        return False
     return _deploy_current_project(skills)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills with one or more paths, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills repeatable, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
   Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
@@ -96,19 +96,15 @@ def create(
     handle_create(name=name, ai=None, key=key, template=template, description=description, yes=yes)
 
 
-@app.command(context_settings={"allow_extra_args": True})
+@app.command()
 def deploy(
-    ctx: typer.Context,
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
-    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (accepts multiple paths)"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (repeatable: --skills a --skills b)"),
     name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    # Click options take one value each; the extra positionals collected by
-    # allow_extra_args are the rest of `--skills a b c`.
-    all_skills = (skills or []) + list(ctx.args)
-    handle_deploy(template=template, skills=all_skills, name=name)
+    handle_deploy(template=template, skills=skills, name=name)
 
 
 @app.command()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills with one or more paths, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
   Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
@@ -96,14 +96,19 @@ def create(
     handle_create(name=name, ai=None, key=key, template=template, description=description, yes=yes)
 
 
-@app.command()
+@app.command(context_settings={"allow_extra_args": True})
 def deploy(
+    ctx: typer.Context,
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
-    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skills directory to bundle into .co/skills/ (repeatable)"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (accepts multiple paths)"),
+    name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy(template=template, skills=skills)
+    # Click options take one value each; the extra positionals collected by
+    # allow_extra_args are the rest of `--skills a b c`.
+    all_skills = (skills or []) + list(ctx.args)
+    handle_deploy(template=template, skills=all_skills, name=name)
 
 
 @app.command()

--- a/connectonion/cli/templates/co-ai/Dockerfile
+++ b/connectonion/cli/templates/co-ai/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth nodejs && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m playwright install --with-deps chrome

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -274,15 +274,33 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         endpoints = announce.get_endpoints(port)
 
         async def relay_loop():
+            # Long-lived supervisor: keep the agent registered on the relay across ANY
+            # transient failure. serve_loop returns on a clean disconnect, but connect()
+            # or serve_loop can also RAISE — a network blip surfaces as OSError, the relay
+            # redeploys, DNS hiccups, a frame is malformed. For a connection meant to live
+            # for days those are normal operation, not bugs. So catch everything except
+            # cancellation, log, back off, and reconnect. Without this, the first
+            # non-ConnectionClosed error escapes the loop and silently kills relay_task:
+            # the agent keeps serving DIRECT connections but never announces again, so its
+            # relay registration goes stale and it becomes unreachable via the relay until
+            # the process is restarted.
+            relay_console = Console()
             while True:
-                ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(
-                    addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
-                )
-                await relay.serve_loop(
-                    ws, announce_msg,
-                    addr_data=addr_data, session_handler=relay_session_runner,
-                )
+                try:
+                    ws = await relay.connect(relay_url)
+                    announce_msg = announce.create_announce_message(
+                        addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
+                    )
+                    await relay.serve_loop(
+                        ws, announce_msg,
+                        addr_data=addr_data, session_handler=relay_session_runner,
+                    )
+                except asyncio.CancelledError:
+                    raise  # shutdown — propagate so on_shutdown can await it cleanly
+                except Exception as exc:
+                    relay_console.print(
+                        f"[magenta]\\[host][/magenta] [dim]relay connection error ({exc!r}); reconnecting in 1s[/dim]"
+                    )
                 await asyncio.sleep(1)
 
         relay_task = asyncio.create_task(relay_loop())
@@ -449,8 +467,13 @@ def host(
     if relay_url:
         # Pre-bind run_ws_session's host-wide deps so relay only needs to pass
         # (send_msg, recv_msg). Each call = one client session full lifecycle
-        # (auth → INPUT/OUTPUT cycles → disconnect). enable_ping=False because
-        # relay handles keep-alive via its own ANNOUNCE heartbeat.
+        # (auth → INPUT/OUTPUT cycles → disconnect). enable_ping=True: the 30s PING
+        # is the CLIENT-session keepalive — it's forwarded through the relay to the
+        # browser so the SDK's 60s-silence monitor doesn't declare the connection
+        # dead and reconnect. The relay's ANNOUNCE heartbeat is a different thing
+        # (it only keeps the agent↔relay link alive; it never reaches the client),
+        # so it can't substitute for the PING. Without this, idle relay sessions
+        # churn (silence → reconnect) every ~60s.
         relay_session_runner = partial(run_ws_session,
             route_handlers=route_handlers,
             storage=storage,
@@ -458,7 +481,7 @@ def host(
             trust=trust_agent,
             blacklist=blacklist,
             whitelist=whitelist,
-            enable_ping=False,
+            enable_ping=True,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
             relay_url, addr_data, summary, port, relay_session_runner,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -3,7 +3,7 @@ Purpose: Host agent as HTTP/WebSocket server with trust-based access control
 LLM-Note:
   Dependencies: imports from [network/asgi/, network/host/ws_router/ (run_ws_session), network/trust/, network/host/session/, network/host/auth.py, network/host/http_router.py, network/announce.py, network/relay.py] | imported by [network/__init__.py as host()] | tested by [tests/network/test_host.py]
   Data flow: host(create_agent, port, trust) → _create_route_handlers() wraps all routes → asgi_create_app() creates FastAPI/Starlette app → uvicorn.run() starts server → each request calls create_agent() for fresh instance → executes via input_handler()/ws_input() → returns result + session | trust enforcement via extract_and_authenticate() at request boundary
-  State/Effects: starts HTTP server on specified port | creates .co/logs/ directory | stores sessions in SessionStorage (in-memory with TTL) | optionally announces to relay server | each request gets fresh agent instance (no state bleeding)
+  State/Effects: starts HTTP server on specified port | creates .co/logs/ directory | stores sessions in SessionStorage (in-memory with TTL) | optionally announces to relay server, publishing a display profile (alias/tools/model + project-level skills only — user/builtin skills stay private) with the first ANNOUNCE of each connection | each request gets fresh agent instance (no state bleeding)
   Integration: exposes host(create_agent, port=8000, trust=None, result_ttl=3600, relay_url="wss://oo.openonion.ai") | creates ASGI app with routes: POST /input, GET /sessions, GET /sessions/{id}, GET /health, GET /info, WebSocket /ws, admin endpoints | trust accepts: "open"/"careful"/"strict" (level), markdown string (policy), or Agent (custom verifier)
   Performance: factory pattern creates fresh agent per request (thread-safe) | SessionStorage auto-expires old results via TTL | WebSocket supports real-time bidirectional I/O | relay connection runs in background thread
   Errors: trust errors return 401/403 via extract_and_authenticate() | missing sessions return None (404) | raises if port already in use
@@ -119,6 +119,28 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
+def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+    """Build the publishable profile sent with the first ANNOUNCE of a connection.
+
+    Only project-level skills are published: skill discovery also picks up
+    ~/.co/skills (the operator's personal toolbox), which must not leak into
+    the public directory. Locations are filesystem paths and stay private,
+    same as the prompt summary.
+    """
+    profile = {"alias": agent_metadata["name"]}
+    if agent_metadata.get("tools"):
+        profile["tools"] = agent_metadata["tools"]
+    if agent_metadata.get("model"):
+        profile["model"] = agent_metadata["model"]
+    project_root = str(project_dir.resolve())
+    profile["skills"] = [
+        {"name": s["name"], "description": s.get("description", "")}
+        for s in agent_metadata.get("skills", [])
+        if str(Path(s["location"]).resolve()).startswith(project_root)
+    ]
+    return profile
+
+
 def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
     """Create route handler dict for ASGI app.
 
@@ -231,7 +253,7 @@ def _print_host_banner(
     console.print()
 
 
-def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner):
+def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner, *, profile: dict | None = None):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
     Args:
@@ -240,6 +262,8 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         summary: Summary text for relay announcement
         port: HTTP port for endpoint discovery
         relay_session_runner: async (send_msg, recv_msg) -> None, runs protocol for one relay session
+        profile: publishable display info, sent with the first ANNOUNCE of each
+                 connection; the relay persists it, so heartbeats don't carry it
 
     Returns:
         Tuple of (on_startup, on_shutdown) async callbacks
@@ -253,7 +277,9 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         async def relay_loop():
             while True:
                 ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                announce_msg = announce.create_announce_message(
+                    addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
+                )
                 await relay.serve_loop(
                     ws, announce_msg,
                     addr_data=addr_data, session_handler=relay_session_runner,
@@ -436,7 +462,8 @@ def host(
             enable_ping=False,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
-            relay_url, addr_data, summary, port, relay_session_runner
+            relay_url, addr_data, summary, port, relay_session_runner,
+            profile=_build_agent_profile(agent_metadata, Path.cwd()),
         )
 
     app = asgi_create_app(

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -119,24 +119,23 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
-def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+def _build_agent_profile(agent_metadata: dict) -> dict:
     """Build the publishable profile sent with the first ANNOUNCE of a connection.
 
-    Only project-level skills are published: skill discovery also picks up
-    ~/.co/skills (the operator's personal toolbox), which must not leak into
-    the public directory. Locations are filesystem paths and stay private,
-    same as the prompt summary.
+    Only project-level skills are published (skill.location is the discovery
+    category: project/user/builtin): discovery also picks up ~/.co/skills —
+    the operator's personal toolbox, which must not leak into the public
+    directory. The prompt summary stays private for the same reason.
     """
     profile = {"alias": agent_metadata["name"]}
     if agent_metadata.get("tools"):
         profile["tools"] = agent_metadata["tools"]
     if agent_metadata.get("model"):
         profile["model"] = agent_metadata["model"]
-    project_root = str(project_dir.resolve())
     profile["skills"] = [
         {"name": s["name"], "description": s.get("description", "")}
         for s in agent_metadata.get("skills", [])
-        if str(Path(s["location"]).resolve()).startswith(project_root)
+        if s.get("location") == "project"
     ]
     return profile
 
@@ -463,7 +462,7 @@ def host(
         )
         on_startup, on_shutdown = _create_relay_lifespan(
             relay_url, addr_data, summary, port, relay_session_runner,
-            profile=_build_agent_profile(agent_metadata, Path.cwd()),
+            profile=_build_agent_profile(agent_metadata),
         )
 
     app = asgi_create_app(

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -2,7 +2,7 @@
 Purpose: Convert session storage format to ChatItems wire format for frontend rendering
 LLM-Note:
   Dependencies: imports from [useful_plugins/runtime_input.py for RUNTIME_INPUT_FRAME_PREFIX] | imported by [host/http_router.py, host/ws_router/agent_io.py, host/ws_router/connect.py, host/session/__init__.py] | tested by [tests/unit/test_host_session.py]
-  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking
+  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking | trace entries carrying an 'image' also emit a standalone agent image bubble, mirroring the live agent_image event so replays keep screenshots
   State/Effects: pure function, no side effects
   Integration: exposes session_to_chat_items(session) → list[dict] | used by http_router and ws_router when delivering server_newer state and OUTPUT
   Performance: O(n) where n = messages + trace entries
@@ -91,6 +91,18 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
     return None
 
 
+def _append_trace_items(items_ui: list[dict], entry: dict, idx: int) -> None:
+    """Append a trace entry's ChatItem(s): the item itself, plus a standalone
+    image bubble when the entry carries an image (mirrors the live agent_image
+    event so replayed history shows screenshots too)."""
+    item_ui = _trace_entry_to_item_ui(entry, idx)
+    if item_ui:
+        items_ui.append(item_ui)
+    image = entry.get('image')
+    if image:
+        items_ui.append({'id': f"img-{idx}", 'type': 'agent', 'content': '', 'images': [image]})
+
+
 def session_to_chat_items(session: dict) -> list[dict]:
     """Convert session → ChatItem[] for UI rendering, interleaved chronologically by turn.
 
@@ -128,9 +140,7 @@ def session_to_chat_items(session: dict) -> list[dict]:
             user_count += 1
             if user_count < len(turn_entries):
                 for trace_idx, entry in turn_entries[user_count]:
-                    item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-                    if item_ui:
-                        items_ui.append(item_ui)
+                    _append_trace_items(items_ui, entry, trace_idx)
         elif role == 'assistant' and msg.get('content'):
             items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': msg.get('content', '')})
 
@@ -138,8 +148,6 @@ def session_to_chat_items(session: dict) -> list[dict]:
     # entries at the end so the data isn't silently dropped (older sessions).
     if len(turn_entries) == 1 and turn_entries[0]:
         for trace_idx, entry in turn_entries[0]:
-            item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-            if item_ui:
-                items_ui.append(item_ui)
+            _append_trace_items(items_ui, entry, trace_idx)
 
     return items_ui

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -2,7 +2,7 @@
 Purpose: Handle the CONNECT message — Ed25519 signature auth, session merge, status decision, optional reattach to a still-running agent
 LLM-Note:
   Dependencies: imports from [..session (merge_sessions, session_to_chat_items via lazy local import), ...trust.ws_admin (get_onboard_requirements), .agent_io (resume_forwarding), uuid, rich.console] | imported by [.session as part of CONNECT dispatch]
-  Data flow: route_handlers["auth"] verifies sig → if forbidden + onboard methods configured: send ONBOARD_REQUIRED | else if other err: send ERROR | else: populate conn (authenticated/identity/session_id/session) → merge_sessions if stored exists → registry status check (running/connected/new) → send CONNECTED → if running: io.rewind_to(last_msg_id) + resume_forwarding (returns (io, task))
+  Data flow: route_handlers["auth"] verifies sig → if forbidden + onboard methods configured: stash conn['pending_connect'] + send ONBOARD_REQUIRED | else if other err: send ERROR | else: establish_connection(): populate conn (authenticated/identity/session_id/session) → merge_sessions if stored exists → registry status check (running/connected/new) → send CONNECTED → if running: io.rewind_to(last_msg_id) + resume_forwarding (returns (io, task)) | establish_connection is also called by the session loop after a successful onboard, with the onboard-verified identity (no CONNECT replay — its signature may have aged past the 5-minute window)
   State/Effects: mutates conn dict in place (authenticated, identity, session_id, session) | calls registry.update_ping when reattaching to 'connected'
   Integration: handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist) → returns (io, forward_task) for reattach or None
   Performance: one storage.get + optional merge_sessions per CONNECT | one registry.get for status decision
@@ -27,6 +27,11 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         trust_agent = route_handlers["trust_agent"]
         onboard_info = get_onboard_requirements(trust_agent)
         if onboard_info:
+            # Stash the CONNECT so a successful onboard can finish establishing
+            # this connection (establish_connection) — the client must not need
+            # a second CONNECT, whose signature may have aged past the 5-minute
+            # window by the time an invite code or payment lands.
+            conn["pending_connect"] = data
             await send_msg({"type": "ONBOARD_REQUIRED", "identity": identity, **onboard_info})
             return
 
@@ -35,6 +40,15 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         await send_msg({"type": "ERROR", "message": err})
         return
 
+    return await establish_connection(data, identity, send_msg, conn, storage, registry)
+
+
+async def establish_connection(data, identity, send_msg, conn, storage, registry):
+    """Post-auth half of CONNECT: populate conn, merge sessions, send CONNECTED.
+
+    Called by handle_connect and, after a successful onboard, with the stashed
+    pending CONNECT — the identity is then the one verified on ONBOARD_SUBMIT.
+    """
     conn["authenticated"] = True
     conn["identity"] = identity
     session_id = data.get("session_id") or str(uuid.uuid4())

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -13,7 +13,7 @@ import uuid
 
 from rich.console import Console
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
-from .connect import handle_connect
+from .connect import handle_connect, establish_connection
 from .agent_io import start_agent
 from .ping import ping_loop
 
@@ -56,7 +56,16 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 await send_msg({"type": "SESSION_STATUS", "session_id": sid, "status": status})
 
             elif msg_type == "ONBOARD_SUBMIT":
-                await handle_onboard_submit(data, send_msg, route_handlers)
+                identity = await handle_onboard_submit(data, send_msg, route_handlers)
+                pending_connect = conn.pop("pending_connect", None)
+                if identity and pending_connect:
+                    # Finish the CONNECT the trust gate interrupted: the client
+                    # is a contact now and resumes its input once CONNECTED lands.
+                    result = await establish_connection(
+                        pending_connect, identity, send_msg, conn, storage, registry
+                    )
+                    if result:
+                        active_io, forward_task = result
             elif msg_type and msg_type.startswith("ADMIN_"):
                 await handle_admin_message(data, send_msg, route_handlers)
 

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: agent calls io.send(event) → auto-stamps id (UUID) and ts if missing → enqueues for async forwarder | client message → enqueued for agent | read_msgs_from_agent() async-iterates outgoing for forwarding to client | send_to_agent() pushes incoming messages to agent
   State/Effects: maintains incoming + outgoing channels (async-safe) | finished flag prevents sends after close | unblocks agent's blocking receive on close
   Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs for mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
-  Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread
+  Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread | _wait_for_msgs_from_agent waits at most ~1s so idle-session forwarders don't pin executor-pool threads
   Errors: closed IO unblocks pending receive() so agent thread doesn't hang | no exceptions raised — channel coordination handled internally
 """
 
@@ -130,11 +130,15 @@ class WebSocketIO(IO):
             self._cursor = 0
 
     def _wait_for_msgs_from_agent(self, cursor, stop_event=None):
-        """Block until new agent messages available or finished. Returns (messages, done)."""
+        """Wait up to ~1s for new agent messages. Returns (messages, done).
+
+        Must return promptly even with no news: this runs on the event loop's
+        shared default executor, and a forwarder for an idle session (agent
+        blocked in receive()) would otherwise pin a pool thread forever —
+        enough idle sessions exhaust the pool and starve every new connection.
+        """
         with self._agent_condition:
-            while len(self._msgs_from_agent) <= cursor and not self._finished:
-                if stop_event and stop_event.is_set():
-                    return [], True
+            if len(self._msgs_from_agent) <= cursor and not self._finished:
                 self._agent_condition.wait(timeout=1.0)
             if stop_event and stop_event.is_set():
                 return [], True

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -1,6 +1,6 @@
 """WebSocket admin and onboard message handlers.
 
-Purpose: Verify signed websocket frames for ONBOARD_SUBMIT and ADMIN_* actions, then mutate trust state (verify invite/payment, promote/demote/block/unblock, super-admin add/remove) and stream back ONBOARD_SUCCESS / ADMIN_RESULT / ERROR responses.
+Purpose: Verify signed websocket frames for ONBOARD_SUBMIT and ADMIN_* actions, then mutate trust state (verify invite/payment, promote/demote/block/unblock, super-admin add/remove) and stream back ONBOARD_SUCCESS / ADMIN_RESULT / ERROR responses. handle_onboard_submit returns the verified identity so the session loop can finish the trust-gated CONNECT.
 LLM-Note:
   Dependencies: imports from [rich.console] | imported by [network/host/ws_router/session.py (handle_admin_message, handle_onboard_submit), network/host/ws_router/connect.py (get_onboard_requirements during CONNECT)] | tested by [tests/network/test_ws_admin.py, tests/integration/test_onboard_flow.py]
   Data flow:
@@ -39,7 +39,7 @@ def get_onboard_requirements(trust_agent) -> dict | None:
 
 
 async def handle_onboard_submit(data, send_msg, route_handlers):
-    """Handle ONBOARD_SUBMIT message from client."""
+    """Handle ONBOARD_SUBMIT message from client. Returns the verified identity on success."""
     trust_agent = route_handlers["trust_agent"]
 
     _, identity, sig_valid, err = route_handlers["auth"](data, "open")
@@ -65,7 +65,7 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
                 "level": actual_level,
                 "message": f"Invite code verified. You are now a {actual_level}."
             })
-            return
+            return identity
         else:
             console.print(f"[red]✗[/red] Invalid invite code [cyan]{invite_code}[/cyan] from {identity[:16]}...")
             await send_msg({"type": "ERROR", "message": "Invalid invite code"})
@@ -81,7 +81,7 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
                 "level": actual_level,
                 "message": f"Payment verified. You are now a {actual_level}."
             })
-            return
+            return identity
         else:
             console.print(f"[red]✗[/red] Insufficient payment [cyan]${payment}[/cyan] from {identity[:16]}...")
             await send_msg({"type": "ERROR", "message": "Insufficient payment"})

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -26,5 +26,6 @@ from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
 from .human_jitter import human_jitter
+from .no_progress_guard import no_progress_guard
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter', 'no_progress_guard']

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -27,5 +27,6 @@ from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
 from .human_jitter import human_jitter
 from .no_progress_guard import no_progress_guard
+from .bind_browser_session import bind_browser_session
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter', 'no_progress_guard']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter', 'no_progress_guard', 'bind_browser_session']

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -25,5 +25,6 @@ from .ulw import ulw, handle_ulw_mode_change
 from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
+from .human_jitter import human_jitter
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter']

--- a/connectonion/useful_plugins/bind_browser_session.py
+++ b/connectonion/useful_plugins/bind_browser_session.py
@@ -1,0 +1,44 @@
+"""
+LLM-Note: Bind-browser-session plugin.
+
+Purpose: tell the shared BrowserAutomation which session (chat panel) the current
+agent turn belongs to, so each session drives its own browser tab instead of all
+sessions fighting over one page (A navigates and B's page jumps / closes).
+
+Data flow: before_each_tool -> read agent.current_session['session_id'] -> hand it
+to the BrowserAutomation instance via agent.tools.browserautomation._bind_session(),
+which stashes it in a thread-local that the browser's dispatch decorator reads to
+route the call to that session's tab (creating it on first use).
+
+Why before_each_tool: it fires on the agent's own thread right before each tool
+runs — the same thread the browser dispatch decorator later reads the binding from.
+Per-tool is cheap and keeps the binding correct across multi-turn sessions.
+
+Why a plugin (not connectonion core): session routing stays opt-in and out of core —
+an agent enables multi-tab isolation by adding this to plugins, exactly like
+human_jitter. Agents without it (or with no browser) are unaffected: the key stays
+None and the browser uses a single shared tab (original behaviour).
+
+State/Effects: writes a thread-local on the agent thread; no agent state. Best-effort
+— if there is no browser tool or no session_id, it does nothing.
+"""
+
+from typing import TYPE_CHECKING
+
+from ..core.events import before_each_tool
+
+if TYPE_CHECKING:
+    from ..core.agent import Agent
+
+
+def _bind_session(agent: "Agent") -> None:
+    browser = getattr(agent.tools, "browserautomation", None)
+    if browser is None:
+        return
+    session_id = (agent.current_session or {}).get("session_id")
+    browser._bind_session(session_id)
+
+
+# Plugin is an event list. before_each_tool runs on the agent thread just before a
+# tool executes, which is where the browser dispatch decorator reads the binding.
+bind_browser_session = [before_each_tool(_bind_session)]

--- a/connectonion/useful_plugins/human_jitter.py
+++ b/connectonion/useful_plugins/human_jitter.py
@@ -1,0 +1,69 @@
+"""
+LLM-Note: Human mouse-jitter plugin.
+
+Purpose: Make a browser agent's clicks look human. Right before any click* tool
+runs, wander the mouse through a few random points on the page, so the click is
+preceded by organic motion instead of an instant teleport-and-click.
+
+Data flow: before_each_tool event -> read agent.current_session['pending_tool'] ->
+if its name starts with 'click', grab the BrowserAutomation instance off the tool
+registry (agent.tools.browserautomation) and dispatch jitter() onto the browser's
+single worker thread (Playwright is not thread-safe).
+
+Why before_each_tool (not after_tools): this is the only hook that fires
+synchronously between "LLM picked a click tool" and "Playwright performs the click",
+which is exactly where pre-click motion belongs.
+
+Why a plugin (not baked into BrowserAutomation.click): jitter is non-deterministic
+and opt-in. Forcing it on every browser user would make clicks non-reproducible for
+tests and agents that don't want it. Agents opt in with plugins=[human_jitter].
+
+State/Effects: moves the mouse cursor via Playwright; no agent state. Best-effort —
+if the page is mid-navigation when jitter reads the viewport, the click must still
+proceed, so that transient failure is caught and logged, never raised.
+"""
+
+import random
+import time
+from typing import TYPE_CHECKING
+
+from ..core.events import before_each_tool
+
+if TYPE_CHECKING:
+    from ..core.agent import Agent
+
+
+def jitter(page):
+    """Wander the mouse through a few random points on the page.
+
+    Must run on the browser's worker thread (Playwright is single-threaded).
+    """
+    w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    x = random.uniform(w * 0.2, w * 0.8)
+    y = random.uniform(h * 0.2, h * 0.8)
+    page.mouse.move(x, y, steps=random.randint(8, 16))
+    for _ in range(random.randint(2, 4)):
+        x = min(max(x + random.uniform(-120, 120), 1), w - 1)
+        y = min(max(y + random.uniform(-90, 90), 1), h - 1)
+        page.mouse.move(x, y, steps=random.randint(6, 14))
+        time.sleep(random.uniform(0.03, 0.12))
+
+
+def _jitter_before_click(agent: "Agent"):
+    pending = agent.current_session.get("pending_tool") or {}
+    if not pending.get("name", "").startswith("click"):
+        return
+    browser = getattr(agent.tools, "browserautomation", None)
+    if browser is None or getattr(browser, "page", None) is None:
+        return
+    try:
+        browser._executor.submit(jitter, browser.page).result()
+    except Exception as e:
+        # Jitter is cosmetic; a mid-navigation page (viewport read throws) must not
+        # block the click the agent actually asked for.
+        agent.logger.print(f"[dim]human_jitter skipped: {e}[/dim]")
+
+
+# Plugin is an event list. before_each_tool is the only hook between tool selection
+# and tool execution, so it's where pre-click motion has to go.
+human_jitter = [before_each_tool(_jitter_before_click)]

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -8,7 +8,8 @@ frontend IO when available.
 Data flow: after_tools event -> scan successful tool_result trace entries ->
 detect image data URL or raw base64 -> replace the matching tool message with a
 short placeholder -> insert a user message containing image_url -> shorten the
-trace result.
+trace result, keeping the data URL on trace_entry['image'] so session replay
+(host/session/ui.py) can re-emit the screenshot into chat_items.
 
 State/Effects: mutates agent.current_session["messages"] and trace entries;
 optionally calls agent.io.send_image(data_url). Non-image tool results are ignored.
@@ -95,6 +96,11 @@ def _format_image_result(agent: 'Agent') -> None:
         if agent.io:
             agent.io.send_image(data_url)
 
+        # Keep the data URL on the trace (not sent to the LLM) so session replay
+        # can re-emit the image into chat_items. Without this, the shortened
+        # result below is the only trace record and screenshots vanish whenever
+        # the client rebuilds its UI from the server's canonical history.
+        trace_entry['image'] = data_url
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -55,6 +55,39 @@ def _is_base64_image(text: str) -> tuple[bool, str, str]:
     return False, "", ""
 
 
+# How many recent screenshots stay fully visible to the LLM. Older ones are stale
+# page state — useless to the model but they grow the context without bound over a
+# long browser task. Anthropic computer-use keeps the last few tool_result images
+# the same way (_maybe_filter_to_n_most_recent_images).
+KEEP_LAST_N_SCREENSHOTS = 3
+
+
+def _is_image_message(message: dict) -> bool:
+    """True if the message carries an image_url block (a screenshot we inserted)."""
+    content = message.get('content')
+    return isinstance(content, list) and any(
+        isinstance(part, dict) and part.get('type') == 'image_url'
+        for part in content
+    )
+
+
+def _elide_old_screenshots(messages: list, keep_last: int) -> None:
+    """Keep only the last `keep_last` screenshots in the LLM context; replace the
+    image_url block of older ones with a short text placeholder.
+
+    Only the LLM context (agent.current_session['messages']) is touched — each
+    trace_entry['image'] keeps the full data URL, so session replay still re-emits
+    every screenshot to the frontend. Idempotent: an already-elided message no
+    longer has an image_url block, so re-running skips it.
+    """
+    image_indices = [i for i, m in enumerate(messages) if _is_image_message(m)]
+    for i in image_indices[:-keep_last]:
+        messages[i] = {
+            "role": messages[i].get("role", "user"),
+            "content": "[earlier screenshot removed to bound context]",
+        }
+
+
 def _format_image_result(agent: 'Agent') -> None:
     """Replace image tool result text with a multimodal image message."""
     trace = agent.current_session.get('trace', [])
@@ -103,6 +136,10 @@ def _format_image_result(agent: 'Agent') -> None:
         trace_entry['image'] = data_url
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
+
+    # Slide the window: at most KEEP_LAST_N_SCREENSHOTS screenshots stay visible to
+    # the LLM. Runs every turn so the context stays bounded over a long browser task.
+    _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
 
 
 # Plugin is an event list

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -20,7 +20,7 @@ tests/e2e/test_image_formatter_plugin.py.
 
 import re
 from typing import TYPE_CHECKING
-from ..core.events import after_tools
+from ..core.events import after_tools, before_llm
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -142,6 +142,29 @@ def _format_image_result(agent: 'Agent') -> None:
     _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
 
 
-# Plugin is an event list
-# Uses after_tools because message modification can only happen after all tools finish
-image_result_formatter = [after_tools(_format_image_result)]
+def _sanitize_image_urls(agent: 'Agent') -> None:
+    """Before each LLM call, replace any image_url part whose URL isn't a real
+    data:/http(s) image with a short text note, in place.
+
+    A stale placeholder otherwise reaches the provider and 400s the whole turn:
+    oo-chat strips screenshots to '[image]' for localStorage, and an emptied URL can
+    survive a session round-trip — Gemini then rejects "Unsupported file URI type".
+    Validating here (the before_llm boundary) makes the agent immune to any source.
+    """
+    for msg in agent.current_session.get('messages', []):
+        content = msg.get('content')
+        if not isinstance(content, list):
+            continue
+        for i, part in enumerate(content):
+            if isinstance(part, dict) and part.get('type') == 'image_url':
+                url = (part.get('image_url') or {}).get('url', '')
+                if not (isinstance(url, str) and url.startswith(('data:image/', 'http://', 'https://'))):
+                    content[i] = {'type': 'text', 'text': '[image unavailable]'}
+
+
+# Plugin is an event list.
+# - after_tools: turn a screenshot tool result into a model-visible image message
+#   and slide the screenshot window (message modification must happen after tools).
+# - before_llm: drop stale/invalid image_url parts right before the LLM call, so a
+#   round-tripped placeholder never 400s the provider.
+image_result_formatter = [after_tools(_format_image_result), before_llm(_sanitize_image_urls)]

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -55,13 +55,6 @@ def _is_base64_image(text: str) -> tuple[bool, str, str]:
     return False, "", ""
 
 
-# How many recent screenshots stay fully visible to the LLM. Older ones are stale
-# page state — useless to the model but they grow the context without bound over a
-# long browser task. Anthropic computer-use keeps the last few tool_result images
-# the same way (_maybe_filter_to_n_most_recent_images).
-KEEP_LAST_N_SCREENSHOTS = 3
-
-
 def _is_image_message(message: dict) -> bool:
     """True if the message carries an image_url block (a screenshot we inserted)."""
     content = message.get('content')
@@ -137,9 +130,10 @@ def _format_image_result(agent: 'Agent') -> None:
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 
-    # Slide the window: at most KEEP_LAST_N_SCREENSHOTS screenshots stay visible to
-    # the LLM. Runs every turn so the context stays bounded over a long browser task.
-    _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
+    # Slide the window: keep only the last 3 screenshots visible to the LLM. Older ones
+    # are stale page state that grow context without bound over a long browser task
+    # (Anthropic computer-use trims tool_result images the same way). Runs every turn.
+    _elide_old_screenshots(messages, 3)
 
 
 def _sanitize_image_urls(agent: 'Agent') -> None:

--- a/connectonion/useful_plugins/no_progress_guard.py
+++ b/connectonion/useful_plugins/no_progress_guard.py
@@ -1,0 +1,72 @@
+"""
+LLM-Note: No-progress guard plugin.
+
+Purpose: Stop the agent loop early when it makes the exact same tool call(s)
+several iterations in a row — a stuck loop doing the same thing (the classic
+browser-agent failure: screenshot -> same dead click -> screenshot -> ...).
+max_iterations is the slow-drift backstop; this catches tight loops before they
+burn the budget and pile screenshots into the context.
+
+Data flow: after_iteration -> read the most recent assistant tool_calls ->
+build a signature (tool names + arguments, call ids stripped) -> compare to the
+previous iteration's signature stored in current_session -> if identical for
+`max_repeats` consecutive iterations, set stop_signal so the loop halts and asks
+the user what to do next.
+
+State/Effects: reads/writes current_session['_noprogress_sig'] and
+['_noprogress_count']; sets current_session['stop_signal'] when stuck. Touches
+nothing else.
+
+Note: the signature compares the whole set of tool calls in an iteration, so a
+loop that varies any argument (e.g. a different selector each try) is treated as
+progress and not stopped — max_iterations covers that drift. This guard targets
+byte-identical repetition only, which keeps false positives near zero.
+"""
+
+import json
+from ..core.events import after_iteration
+
+
+def _last_tool_signature(messages):
+    """Signature of the most recent assistant tool_calls, call ids stripped."""
+    for message in reversed(messages):
+        if message.get('role') == 'assistant' and message.get('tool_calls'):
+            return json.dumps(
+                [
+                    [tc['function']['name'], tc['function'].get('arguments', '')]
+                    for tc in message['tool_calls']
+                ],
+                sort_keys=True,
+            )
+    return None
+
+
+def no_progress_guard(max_repeats: int = 3):
+    """Plugin: halt the loop when the same tool call(s) repeat `max_repeats` times
+    in a row.
+
+    Args:
+        max_repeats: consecutive identical iterations that trigger the stop
+            (default 3 — the third identical call halts).
+    """
+
+    def _check(agent):
+        session = agent.current_session
+        signature = _last_tool_signature(session['messages'])
+        if signature is None:
+            return
+
+        if signature == session.get('_noprogress_sig'):
+            session['_noprogress_count'] = session.get('_noprogress_count', 1) + 1
+        else:
+            session['_noprogress_sig'] = signature
+            session['_noprogress_count'] = 1
+
+        if session['_noprogress_count'] >= max_repeats:
+            agent.logger.print(
+                f"[yellow]No-progress guard: same tool call repeated "
+                f"{max_repeats}x — stopping the loop.[/yellow]"
+            )
+            session['stop_signal'] = True
+
+    return [after_iteration(_check)]

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -27,9 +27,7 @@ import functools
 import inspect
 import json
 import platform
-import random
 import threading
-import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -96,24 +94,6 @@ def _browser_proxy_from_env():
     if p.password:
         proxy["password"] = urllib.parse.unquote(p.password)
     return proxy
-
-
-def _human_mouse_move(page, x: float, y: float) -> None:
-    """Move the cursor to (x, y) like a hand would — gradual, slightly bent, with a small
-    overshoot — instead of one teleport. (x, y) are absolute page-viewport coordinates.
-
-    Used before a real captcha click so the motion INTO the target looks human. Playwright
-    tracks the current cursor internally, so each mouse.move interpolates from wherever the
-    cursor is now through `steps` intermediate (trusted) mousemove events.
-    """
-    # approach a point near the target first, so the path bends instead of going dead straight
-    page.mouse.move(x + random.uniform(-60, 60), y + random.uniform(-45, 45),
-                    steps=random.randint(12, 22))
-    time.sleep(random.uniform(0.04, 0.12))
-    # small overshoot, then settle onto the target
-    page.mouse.move(x + random.uniform(-5, 5), y + random.uniform(-5, 5),
-                    steps=random.randint(6, 12))
-    page.mouse.move(x, y, steps=random.randint(3, 6))
 
 
 @_public_methods_run_on_browser_thread
@@ -317,13 +297,20 @@ class BrowserAutomation:
             return element.locator
         return f"Could not find element matching: {description}"
 
-    def click_element_by_selector(self, selector: str, index: int = 0, text: str = "") -> str:
+    def click_element_by_selector(self, selector: str, index: int = 0, text: str = "", frame_url_contains: str = "", frame_name: str = "") -> str:
         """Click an element using a CSS selector via Playwright locator().
 
         Use when a workflow has a stable selector such as an aria-label,
         role-compatible attribute, or data-testid. `index` is zero-based.
         If `text` is provided, only visible elements with exactly that text are
         considered.
+
+        Set frame_url_contains or frame_name to resolve the selector inside a page
+        frame, including cross-origin iframes (e.g. a reCAPTCHA checkbox) that
+        main-page selectors can't reach. The click goes through Playwright's input
+        layer either way, so the event is trusted (isTrusted) — a JS el.click()
+        is not. Frame targeting applies to the selector path; `text` matching is
+        main-frame only.
         """
         if not self.page:
             return "Browser not open"
@@ -371,14 +358,32 @@ class BrowserAutomation:
             self.page.wait_for_timeout(1000)
             return f"Clicked element {index + 1}/{count} matching selector: {selector} with text: {text}"
 
-        locator = self.page.locator(selector)
-        count = locator.count()
-        if count == 0:
-            return f"No element found for selector: {selector}"
-        if index < 0 or index >= count:
-            return f"Selector matched {count} elements; index {index} is out of range"
+        if frame_url_contains or frame_name:
+            # Resolve inside matching page frames so cross-origin iframes (e.g. a
+            # reCAPTCHA checkbox) the main-page DOM can't reach are clickable.
+            candidates = []
+            for frame in self.page.frames:
+                url = getattr(frame, "url", "") or ""
+                name = getattr(frame, "name", "") or ""
+                if frame_url_contains and frame_url_contains not in url:
+                    continue
+                if frame_name and frame_name != name:
+                    continue
+                loc = frame.locator(selector)
+                candidates.extend(loc.nth(i) for i in range(loc.count()))
+            where = f" in frames matching {(frame_url_contains or frame_name)!r}"
+        else:
+            loc = self.page.locator(selector)
+            candidates = [loc.nth(i) for i in range(loc.count())]
+            where = ""
 
-        target = locator.nth(index)
+        count = len(candidates)
+        if count == 0:
+            return f"No element found for selector: {selector}{where}"
+        if index < 0 or index >= count:
+            return f"Selector matched {count} elements{where}; index {index} is out of range"
+
+        target = candidates[index]
         box = target.bounding_box()
         if box:
             self.page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
@@ -387,7 +392,7 @@ class BrowserAutomation:
 
         self._save_context()
         self.page.wait_for_timeout(1000)
-        return f"Clicked element {index + 1}/{count} matching selector: {selector}"
+        return f"Clicked element {index + 1}/{count} matching selector: {selector}{where}"
 
     def count_elements_by_selector(self, selector: str) -> str:
         """Count elements matching a CSS selector via Playwright locator()."""
@@ -561,72 +566,6 @@ class BrowserAutomation:
                 "file": str(path),
                 "click_selector": click_selector,
                 "text": text,
-                "index": index,
-                "frame": {"index": frame_index, "name": name, "url": url},
-            },
-            indent=2,
-            ensure_ascii=False,
-        )
-
-    def click_in_frame(
-        self,
-        selector: str,
-        frame_url_contains: str = "",
-        frame_name: str = "",
-        index: int = 0,
-    ) -> str:
-        """Click an element inside a page frame with a real (trusted) mouse event.
-
-        Iterates page frames, so it reaches cross-origin iframes (e.g. a reCAPTCHA
-        "I'm not a robot" checkbox) that main-page DOM access and run_page_script
-        cannot. The click goes through Playwright's input layer, so the event is
-        isTrusted — unlike a JS `el.click()`, which bot checks reject. Narrow the
-        frame with frame_url_contains or frame_name; `selector` is resolved inside
-        each matching frame.
-        """
-        if not self.page:
-            return "Browser not open"
-
-        matches = []
-        for frame_index, frame in enumerate(self.page.frames):
-            url = getattr(frame, "url", "") or ""
-            raw_name = getattr(frame, "name", "") or ""
-            name = raw_name() if callable(raw_name) else raw_name
-            if frame_url_contains and frame_url_contains not in url:
-                continue
-            if frame_name and frame_name != name:
-                continue
-            locator = frame.locator(selector)
-            for locator_index in range(locator.count()):
-                matches.append((frame_index, name, url, locator.nth(locator_index)))
-
-        if not matches:
-            return f"No element found for selector: {selector} in matching frames"
-        if index < 0 or index >= len(matches):
-            return f"Selector matched {len(matches)} element(s); index {index} is out of range"
-
-        frame_index, name, url, target = matches[index]
-        # Human approach: move the cursor to the element like a hand (gradual, off-centre
-        # landing) then a real trusted click, instead of Playwright's instant move-and-click.
-        try:
-            target.scroll_into_view_if_needed(timeout=5000)
-            box = target.bounding_box()
-        except Exception:
-            box = None
-        if box:
-            tx = box["x"] + box["width"] * random.uniform(0.35, 0.65)
-            ty = box["y"] + box["height"] * random.uniform(0.35, 0.65)
-            _human_mouse_move(self.page, tx, ty)
-            self.page.mouse.click(tx, ty)
-        else:
-            target.click(force=True)
-        self._save_context()
-        self.page.wait_for_timeout(1000)
-        return json.dumps(
-            {
-                "ok": True,
-                "clicked": True,
-                "selector": selector,
                 "index": index,
                 "frame": {"index": frame_index, "name": name, "url": url},
             },

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -65,12 +65,6 @@ def _current_session_key():
     return getattr(_session_binding, "key", None)
 
 
-# Context-level methods that must NOT auto-create a tab before they run:
-# open_browser creates the tab itself after launching the context; close/save_state
-# operate on the whole context, and a fresh tab right before teardown is wrong.
-_NO_TAB_METHODS = {"open_browser", "close", "save_state"}
-
-
 # Playwright's sync API binds to the thread that started it and raises
 # "Cannot switch to a different thread" from any other. Servers like host()
 # run each agent turn on an arbitrary threadpool thread, so consecutive turns
@@ -87,7 +81,10 @@ def _runs_on_browser_thread(method):
 
         def run():
             _session_binding.key = key      # propagate onto the worker thread
-            if method.__name__ not in _NO_TAB_METHODS:
+            # Context-level methods must NOT auto-create a tab: open_browser makes the
+            # tab itself after launching the context; close/save_state act on the whole
+            # context, where a fresh tab right before teardown is wrong.
+            if method.__name__ not in {"open_browser", "close", "save_state"}:
                 self._ensure_page(key)      # this session gets / keeps its own tab
             return method(self, *args, **kwargs)
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -28,6 +28,7 @@ import inspect
 import json
 import platform
 import threading
+import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -53,17 +54,46 @@ except ImportError:
 # Path to the browser agent system prompt
 
 
+# Carries "which session is the current call for" from the agent thread (set by the
+# bind_browser_session plugin via _bind_session) to the browser worker thread. A
+# threading.local so concurrent agent threads never clobber each other's key; when
+# no plugin sets it the key is None and every call shares one tab (current behaviour).
+_session_binding = threading.local()
+
+
+def _current_session_key():
+    return getattr(_session_binding, "key", None)
+
+
+# Context-level methods that must NOT auto-create a tab before they run:
+# open_browser creates the tab itself after launching the context; close/save_state
+# operate on the whole context, and a fresh tab right before teardown is wrong.
+_NO_TAB_METHODS = {"open_browser", "close", "save_state"}
+
+
 # Playwright's sync API binds to the thread that started it and raises
 # "Cannot switch to a different thread" from any other. Servers like host()
 # run each agent turn on an arbitrary threadpool thread, so consecutive turns
 # crash the shared browser. Route every public method through the instance's
 # dedicated worker thread: playwright starts there and every call lands there.
+#
+# The wrapper also routes per session: it reads the caller thread's session key,
+# propagates it onto the worker thread, and ensures that session's own tab exists
+# before the method runs (so self.page resolves to the right tab).
 def _runs_on_browser_thread(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        if threading.current_thread() is self._executor_thread:
+        key = _current_session_key()  # read on the caller (agent) thread
+
+        def run():
+            _session_binding.key = key      # propagate onto the worker thread
+            if method.__name__ not in _NO_TAB_METHODS:
+                self._ensure_page(key)      # this session gets / keeps its own tab
             return method(self, *args, **kwargs)
-        return self._executor.submit(method, self, *args, **kwargs).result()
+
+        if threading.current_thread() is self._executor_thread:
+            return run()
+        return self._executor.submit(run).result()
 
     return wrapper
 
@@ -128,7 +158,14 @@ class BrowserAutomation:
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
-        self.page: Optional[Page] = None
+        # One tab per session (chat panel) in the shared context, so concurrent
+        # sessions don't navigate over each other. Key = session_id (None = no
+        # session bound = single shared tab, the original single-page behaviour).
+        self._pages: Dict[Optional[str], "Page"] = {}
+        self._page_used: Dict[Optional[str], float] = {}   # key -> last-use monotonic ts (LRU/TTL)
+        self._page_url: Dict[Optional[str], str] = {}      # key -> last url (restore a reclaimed tab)
+        self._tab_idle_ttl = 3600.0   # reclaim a tab after 60 min idle (a panel left untouched)
+        self._max_tabs = 10           # backstop cap; a few real panels never hit it
         self.current_url: str = ""
         self.form_data: Dict[str, Any] = {}
         self.use_chrome_profile = use_chrome_profile
@@ -154,6 +191,105 @@ class BrowserAutomation:
             return True
         except Exception:
             return False
+
+    @property
+    def page(self):
+        """The Playwright tab for the session this call belongs to.
+
+        Each session (chat panel) gets its own tab in the shared, single-login
+        context, so concurrent sessions don't navigate over each other. The session
+        key is set by the bind_browser_session plugin on the agent thread and
+        propagated onto the worker thread by the dispatch decorator; both threads
+        read it from the same threading.local. Returns None until the tab is created
+        (so the existing `if not self.page: ...` guards still read "browser not open").
+        """
+        return self._pages.get(_current_session_key())
+
+    @page.setter
+    def page(self, value):
+        """Set the current session's tab. Internal flows create tabs via
+        _ensure_page; this setter keeps `self.page = <page>` working for callers
+        and tests that inject a page directly (it writes the current session's slot)."""
+        key = _current_session_key()
+        self._pages[key] = value
+        self._page_used[key] = time.monotonic()
+
+    def _bind_session(self, session_id) -> None:
+        """Record, on the CALLER (agent) thread, which session the next browser
+        calls on this thread belong to. Underscore-prefixed so it is neither
+        dispatched to the worker thread nor exposed to the LLM as a tool; the
+        bind_browser_session plugin calls it before each tool, and the dispatch
+        decorator reads the binding to route to the right tab."""
+        _session_binding.key = session_id
+
+    def _ensure_page(self, key) -> None:
+        """Make sure session `key` has a live tab, then reclaim abandoned ones.
+
+        Reused by two callers, always on the worker thread: the dispatch decorator
+        (before every tab-using tool, so self.page resolves to this session's tab)
+        and open_browser (to create the first tab after launching the context).
+
+        Creates the tab in the shared context (restored to its last URL), stamps its
+        last-use time, then reclaims. No-op until the context is open; harmless if the
+        tab already exists.
+
+        Reclaim bounds memory but never closes the active `key`: first tabs idle past
+        _tab_idle_ttl (a panel untouched for an hour), then — only if still over
+        _max_tabs — the least-recently-used ones as a runaway backstop. A reclaimed
+        session transparently gets a fresh restored tab next call (no "target closed").
+        """
+        if not self.browser:
+            return
+
+        page = self._pages.get(key)
+        if page is None or (callable(getattr(page, "is_closed", None)) and page.is_closed()):
+            page = self.browser.new_page()
+            page.set_default_navigation_timeout(60000)
+            page.set_viewport_size({"width": 1920, "height": 1200})
+            # Hide automation indicators (defense in depth; also set via launch args).
+            page.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+            )
+            restore_url = self._page_url.get(key)
+            if restore_url:  # a reclaimed session comes back to where it was
+                try:
+                    page.goto(restore_url, wait_until="domcontentloaded", timeout=30000)
+                except Exception:
+                    pass
+            self._pages[key] = page
+        self._page_used[key] = time.monotonic()
+
+        now = time.monotonic()
+        for k in [k for k, t in list(self._page_used.items())
+                  if k != key and now - t > self._tab_idle_ttl]:
+            self._close_tab(k)
+        if len(self._pages) > self._max_tabs:
+            lru_first = sorted(
+                (k for k in self._pages if k != key),
+                key=lambda k: self._page_used.get(k, 0.0),
+            )
+            for k in lru_first[: len(self._pages) - self._max_tabs]:
+                self._close_tab(k)
+
+    def _close_tab(self, key) -> Optional[str]:
+        """Close one session's tab, remembering its URL so the session can resume.
+
+        Reused by two callers: _ensure_page's reclaim (best-effort, ignores the
+        return) and close() (surfaces the return as a cleanup warning). Returns an
+        error string if the page would not close, else None."""
+        page = self._pages.pop(key, None)
+        self._page_used.pop(key, None)
+        if page is None:
+            return None
+        try:
+            self._page_url[key] = page.url
+        except Exception:
+            pass
+        try:
+            page.close()
+        except Exception as exc:
+            return f"close page failed: {exc}"
+        return None
 
     def open_browser(self, headless: bool = None, force: bool = False) -> str:
         """Open a new browser window.
@@ -228,21 +364,10 @@ class BrowserAutomation:
                 self.browser.add_cookies(cookies)
             self._seeded = True
 
-        self.page = self.browser.new_page()
-        self.page.set_default_navigation_timeout(60000)
-
-        # Set large viewport to show more content without scrolling
-        self.page.set_viewport_size({"width": 1920, "height": 1200})
-
-        # Hide automation indicators (defense in depth)
-        # Already handled by --disable-blink-features=AutomationControlled in args above
-        self.page.add_init_script(
-            """
-            Object.defineProperty(navigator, 'webdriver', {
-                get: () => undefined
-            });
-        """
-        )
+        # Create this session's tab in the freshly launched context (other sessions
+        # get their own tab lazily on first use). _ensure_page applies the viewport
+        # and anti-detection init script when it creates the tab.
+        self._ensure_page(_current_session_key())
 
         if force and had_previous_browser_state:
             return f"Previous browser closed by force. Browser opened with persistent profile: {profile_dir}"
@@ -1297,13 +1422,25 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         print(f"\n[browser] Screenshot saved to: {path}")
         print(f"[browser] Full page: {full_page}, Size: {len(screenshot_bytes)} bytes\n")
 
+        # Bound the payload. The screenshot is sent to the frontend as a base64 data URL
+        # in ONE relay WebSocket frame; base64 inflates bytes ~33% and the relay's default
+        # cap is 1 MB (websockets max_size), so a frame over it drops the relay connection
+        # (and reconnect replays it, so the agent flaps offline). A dense 1920-wide page is
+        # a ~800 KB PNG = >1 MB base64. Re-encode only oversized captures as JPEG
+        # (Playwright-native, no Pillow); keep PNG for the common case so text stays sharp.
+        mime = "image/png"
+        if len(screenshot_bytes) > 600_000:   # ~800 KB base64 + JSON, safely under 1 MB
+            screenshot_bytes = self.page.screenshot(full_page=full_page, type="jpeg", quality=85)
+            mime = "image/jpeg"
+            print(f"[browser] oversized PNG re-encoded as JPEG q85: {len(screenshot_bytes)} bytes\n")
+
         # Wait for page to stabilize after screenshot (especially for full_page which scrolls/resizes)
         # This prevents focus loss when typing after taking a screenshot
         self.page.wait_for_timeout(1000)
 
         screenshot_base64 = base64.b64encode(screenshot_bytes).decode('utf-8')
 
-        return f"data:image/png;base64,{screenshot_base64}"
+        return f"data:{mime};base64,{screenshot_base64}"
 
     def set_viewport(self, width: int, height: int) -> str:
         """Set the browser viewport size."""
@@ -1475,11 +1612,10 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         except Exception as exc:
             cleanup_errors.append(f"save context failed: {exc}")
 
-        try:
-            if self.page:
-                self.page.close()
-        except Exception as exc:
-            cleanup_errors.append(f"close page failed: {exc}")
+        for key in list(self._pages):     # close every session's tab
+            err = self._close_tab(key)
+            if err:
+                cleanup_errors.append(err)
         try:
             if self.browser:
                 self.browser.close()
@@ -1491,7 +1627,9 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         except Exception as exc:
             cleanup_errors.append(f"stop playwright failed: {exc}")
 
-        self.page = None
+        self._pages.clear()
+        self._page_used.clear()
+        self._page_url.clear()
         self.browser = None
         self.playwright = None
         if cleanup_errors:

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -3,7 +3,7 @@ Purpose: Natural language browser automation via Playwright with persistent prof
 LLM-Note:
   Dependencies: imports from [playwright.sync_api, connectonion Agent/llm_do, cli/browser_agent/element_finder, pydantic, pathlib, dotenv] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_agent.py]
   Data flow: BrowserAutomation() initializes Playwright → opens browser with persistent context → provides tools (navigate, find_element, click, type_text, screenshot, scroll, wait_for_login) → auto-saves cookies after each critical action → Agent uses these tools via natural language → element_finder.py uses vision LLM to locate elements | screenshots saved to .tmp/ directory
-  State/Effects: maintains browser/page/context state | persistent profile at ~/.co/browser_profile/ | auto-saves cookies after navigation and manual login | writes screenshots to .tmp/{timestamp}.png | modifies form_data dict for form fills | context manager ensures cleanup
+  State/Effects: maintains browser/page/context state | persistent profile at ~/.co/browser_profile/ | auto-saves cookies after navigation and manual login | writes screenshots to .tmp/{timestamp}.png | modifies form_data dict for form fills | context manager ensures cleanup | all public methods dispatch to one dedicated browser thread (Playwright sync API is thread-bound), so a shared instance is safe to call from any thread
   Integration: exposes BrowserAutomation(use_chrome_profile, headless) with methods: navigate(url), find_element(description), screenshot(viewport), scroll(direction, description), click(description), keyboard_type(text), keyboard_press(key), wait_for_login(seconds) | used by `co browser` CLI command
   Performance: headless by default (faster) | persistent context (instant profile load) | vision model for element finding (slower but accurate) | screenshots base64-encoded for LLM analysis | auto-save adds 500ms delay after critical actions
   Errors: returns error string if Playwright not installed | returns "Browser already open" if live browser exists | element not found returns descriptive error
@@ -23,8 +23,12 @@ Features:
 
 import os
 import base64
+import functools
+import inspect
 import json
 import platform
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, List, Dict, Any
@@ -48,6 +52,29 @@ except ImportError:
 # Path to the browser agent system prompt
 
 
+# Playwright's sync API binds to the thread that started it and raises
+# "Cannot switch to a different thread" from any other. Servers like host()
+# run each agent turn on an arbitrary threadpool thread, so consecutive turns
+# crash the shared browser. Route every public method through the instance's
+# dedicated worker thread: playwright starts there and every call lands there.
+def _runs_on_browser_thread(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if threading.current_thread() is self._executor_thread:
+            return method(self, *args, **kwargs)
+        return self._executor.submit(method, self, *args, **kwargs).result()
+
+    return wrapper
+
+
+def _public_methods_run_on_browser_thread(cls):
+    for name, method in vars(cls).copy().items():
+        if not name.startswith("_") and inspect.isfunction(method):
+            setattr(cls, name, _runs_on_browser_thread(method))
+    return cls
+
+
+@_public_methods_run_on_browser_thread
 class BrowserAutomation:
     """Browser automation with natural language support.
 
@@ -80,6 +107,9 @@ class BrowserAutomation:
         self._screenshots = []
         self._headless = headless
         self.screenshots_dir = str(SCREENSHOTS_DIR)
+        # All public methods run on this one thread (see _public_methods_run_on_browser_thread).
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="browser")
+        self._executor_thread = self._executor.submit(threading.current_thread).result()
 
     def _browser_is_usable(self) -> bool:
         """Return True when the current Playwright page can still be operated."""
@@ -1396,3 +1426,4 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
+

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -493,6 +493,59 @@ class BrowserAutomation:
             ensure_ascii=False,
         )
 
+    def click_in_frame(
+        self,
+        selector: str,
+        frame_url_contains: str = "",
+        frame_name: str = "",
+        index: int = 0,
+    ) -> str:
+        """Click an element inside a page frame with a real (trusted) mouse event.
+
+        Iterates page frames, so it reaches cross-origin iframes (e.g. a reCAPTCHA
+        "I'm not a robot" checkbox) that main-page DOM access and run_page_script
+        cannot. The click goes through Playwright's input layer, so the event is
+        isTrusted — unlike a JS `el.click()`, which bot checks reject. Narrow the
+        frame with frame_url_contains or frame_name; `selector` is resolved inside
+        each matching frame.
+        """
+        if not self.page:
+            return "Browser not open"
+
+        matches = []
+        for frame_index, frame in enumerate(self.page.frames):
+            url = getattr(frame, "url", "") or ""
+            raw_name = getattr(frame, "name", "") or ""
+            name = raw_name() if callable(raw_name) else raw_name
+            if frame_url_contains and frame_url_contains not in url:
+                continue
+            if frame_name and frame_name != name:
+                continue
+            locator = frame.locator(selector)
+            for locator_index in range(locator.count()):
+                matches.append((frame_index, name, url, locator.nth(locator_index)))
+
+        if not matches:
+            return f"No element found for selector: {selector} in matching frames"
+        if index < 0 or index >= len(matches):
+            return f"Selector matched {len(matches)} element(s); index {index} is out of range"
+
+        frame_index, name, url, target = matches[index]
+        target.click()
+        self._save_context()
+        self.page.wait_for_timeout(1000)
+        return json.dumps(
+            {
+                "ok": True,
+                "clicked": True,
+                "selector": selector,
+                "index": index,
+                "frame": {"index": frame_index, "name": name, "url": url},
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+
     def _load_script_args(self, script_path: str, args_json: str) -> tuple[Optional[str], Optional[dict], Optional[str]]:
         path = Path(script_path).expanduser()
         if not path.is_absolute():

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -30,6 +30,7 @@ import platform
 import random
 import threading
 import time
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
@@ -74,6 +75,27 @@ def _public_methods_run_on_browser_thread(cls):
         if not name.startswith("_") and inspect.isfunction(method):
             setattr(cls, name, _runs_on_browser_thread(method))
     return cls
+
+
+def _browser_proxy_from_env():
+    """Build Playwright's proxy config from the BROWSER_PROXY env var, or None if unset.
+
+    BROWSER_PROXY routes the browser's traffic through a proxy so the egress IP is e.g.
+    residential instead of the datacenter IP the agent runs on. Formats:
+        socks5://host:port              (no auth — e.g. a SOCKS relay; Chromium ignores SOCKS auth)
+        http://user:pass@host:port      (HTTP proxy with auth — e.g. a residential proxy service)
+    Unset => None => no proxy, current behaviour unchanged.
+    """
+    url = os.environ.get("BROWSER_PROXY", "").strip()
+    if not url:
+        return None
+    p = urllib.parse.urlparse(url)
+    proxy = {"server": f"{p.scheme}://{p.hostname}:{p.port}"}
+    if p.username:
+        proxy["username"] = urllib.parse.unquote(p.username)
+    if p.password:
+        proxy["password"] = urllib.parse.unquote(p.password)
+    return proxy
 
 
 def _human_mouse_move(page, x: float, y: float) -> None:
@@ -204,6 +226,7 @@ class BrowserAutomation:
             executable_path=chrome_path,
             args=CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
             ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
+            proxy=_browser_proxy_from_env(),  # route egress through BROWSER_PROXY if set, else None
             timeout=120000,
         )
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -132,13 +132,19 @@ class BrowserAutomation:
     This ensures session persistence even if the process crashes.
     """
 
-    def __init__(self, use_chrome_profile: bool = True, headless: bool = False):
+    def __init__(self, use_chrome_profile: bool = True, headless: bool = False, seed_state: Optional[str] = None):
         """Initialize browser automation.
 
         Args:
             use_chrome_profile: If True, uses your Chrome cookies/sessions.
                                Chrome must be closed before running.
             headless: If True, browser runs without visible window (default True).
+            seed_state: Optional path to a Playwright storage_state JSON (a {"cookies": [...]}
+                        file produced by save_state on another machine). When set, those cookies
+                        are injected into the context once, right after it is created and before
+                        any navigation, so a deployed agent starts already signed in. Cookies are
+                        applied with add_cookies because launch_persistent_context() cannot accept
+                        storage_state=. Unset => no injection, current behaviour unchanged.
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
@@ -148,6 +154,8 @@ class BrowserAutomation:
         self.use_chrome_profile = use_chrome_profile
         self._screenshots = []
         self._headless = headless
+        self._seed_state = seed_state
+        self._seeded = False
         self.screenshots_dir = str(SCREENSHOTS_DIR)
         # All public methods run on this one thread (see _public_methods_run_on_browser_thread).
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="browser")
@@ -230,6 +238,16 @@ class BrowserAutomation:
             timeout=120000,
         )
 
+        # Seed a portable login state into the fresh context once, before any navigation, so a
+        # deployed agent starts already signed in. launch_persistent_context() can't take
+        # storage_state=, so the exported cookies are applied with add_cookies. A missing file
+        # raises (fail loud): if a deploy declared a seed it must be packaged.
+        if self._seed_state and not self._seeded:
+            cookies = json.loads(Path(self._seed_state).read_text()).get("cookies", [])
+            if cookies:
+                self.browser.add_cookies(cookies)
+            self._seeded = True
+
         self.page = self.browser.new_page()
         self.page.set_default_navigation_timeout(60000)
 
@@ -251,6 +269,20 @@ class BrowserAutomation:
         if had_previous_browser_state:
             return f"Previous stale browser state closed. Browser opened with persistent profile: {profile_dir}"
         return f"Browser opened with persistent profile: {profile_dir}"
+
+    def save_state(self, path: str) -> str:
+        """Export the current login state to a portable Playwright storage_state JSON.
+
+        Writes {"cookies": [...], "origins": [...]} to `path`. Run this locally after logging
+        in by hand (headed) to capture a session, then ship the file and pass it back as
+        BrowserAutomation(seed_state=path) on the deployed agent. The JSON is plaintext and
+        portable across machines/OSes; a copied Chrome profile is not (its cookies are
+        encrypted per-OS).
+        """
+        if not self.browser:
+            return "Browser not open"
+        self.browser.storage_state(path=path)
+        return f"Saved login state to {path}"
 
     def go_to(self, url: str) -> str:
         """Navigate to a URL."""

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -27,7 +27,9 @@ import functools
 import inspect
 import json
 import platform
+import random
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
@@ -72,6 +74,24 @@ def _public_methods_run_on_browser_thread(cls):
         if not name.startswith("_") and inspect.isfunction(method):
             setattr(cls, name, _runs_on_browser_thread(method))
     return cls
+
+
+def _human_mouse_move(page, x: float, y: float) -> None:
+    """Move the cursor to (x, y) like a hand would — gradual, slightly bent, with a small
+    overshoot — instead of one teleport. (x, y) are absolute page-viewport coordinates.
+
+    Used before a real captcha click so the motion INTO the target looks human. Playwright
+    tracks the current cursor internally, so each mouse.move interpolates from wherever the
+    cursor is now through `steps` intermediate (trusted) mousemove events.
+    """
+    # approach a point near the target first, so the path bends instead of going dead straight
+    page.mouse.move(x + random.uniform(-60, 60), y + random.uniform(-45, 45),
+                    steps=random.randint(12, 22))
+    time.sleep(random.uniform(0.04, 0.12))
+    # small overshoot, then settle onto the target
+    page.mouse.move(x + random.uniform(-5, 5), y + random.uniform(-5, 5),
+                    steps=random.randint(6, 12))
+    page.mouse.move(x, y, steps=random.randint(3, 6))
 
 
 @_public_methods_run_on_browser_thread
@@ -531,7 +551,20 @@ class BrowserAutomation:
             return f"Selector matched {len(matches)} element(s); index {index} is out of range"
 
         frame_index, name, url, target = matches[index]
-        target.click()
+        # Human approach: move the cursor to the element like a hand (gradual, off-centre
+        # landing) then a real trusted click, instead of Playwright's instant move-and-click.
+        try:
+            target.scroll_into_view_if_needed(timeout=5000)
+            box = target.bounding_box()
+        except Exception:
+            box = None
+        if box:
+            tx = box["x"] + box["width"] * random.uniform(0.35, 0.65)
+            ty = box["y"] + box["height"] * random.uniform(0.35, 0.65)
+            _human_mouse_move(self.page, tx, ty)
+            self.page.mouse.click(tx, ty)
+        else:
+            target.click(force=True)
         self._save_context()
         self.page.wait_for_timeout(1000)
         return json.dumps(

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,8 +28,8 @@ Agent(
   - `None`: Uses default prompt
 - **api_key** (`Optional[str]`): OpenAI API key (if not using custom LLM)
 - **model** (`str`): Model to use (default: "co/gemini-2.5-pro")
-  - Managed keys: `co/gemini-2.5-pro`, `co/gpt-4o-mini`, `co/claude-3-5-sonnet`
-  - Your own key: `gpt-4o-mini`, `claude-3-5-sonnet`, `gemini-1.5-pro`
+  - Managed keys: `co/gemini-2.5-pro`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
+  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-2.5-pro`
 
 ### System Prompt Options
 
@@ -236,7 +236,7 @@ llm = create_llm("gpt-4o-mini")      # → OpenAILLM
 llm = create_llm("o4-mini")          # → OpenAILLM
 
 # Anthropic models
-llm = create_llm("claude-3-5-sonnet") # → AnthropicLLM
+llm = create_llm("claude-sonnet-4-5") # → AnthropicLLM
 
 # Google Gemini models
 llm = create_llm("gemini-2.5-flash")  # → GeminiLLM
@@ -294,7 +294,7 @@ from connectonion.llm import AnthropicLLM
 
 llm = AnthropicLLM(
     api_key="your-key",  # or ANTHROPIC_API_KEY env var
-    model="claude-3-5-sonnet-20241022"
+    model="claude-sonnet-4-5"
 )
 
 agent = Agent("bot", llm=llm)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -171,14 +171,14 @@ from connectonion import llm_do
 
 # Use co/ prefix
 response = llm_do("Hello", model="co/gpt-4o")
-response = llm_do("Hello", model="co/claude-3-5-sonnet")
-response = llm_do("Hello", model="co/gemini-1.5-pro")
+response = llm_do("Hello", model="co/claude-sonnet-4-5")
+response = llm_do("Hello", model="co/gemini-2.5-pro")
 ```
 
 **Available models:**
 - OpenAI: `co/gpt-4o`, `co/gpt-4o-mini`, `co/o4-mini`
-- Anthropic: `co/claude-3-5-sonnet`, `co/claude-3-5-haiku`
-- Google: `co/gemini-1.5-pro`, `co/gemini-1.5-flash`
+- Anthropic: `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
+- Google: `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - And more...
 
 **Benefits:**

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -35,8 +35,8 @@ response = llm_do("Hello", model="co/gpt-4o")
 
 Works across providers:
 - `co/gpt-4o`, `co/gpt-4o-mini`
-- `co/claude-3-5-sonnet`, `co/claude-3-5-haiku`
-- `co/gemini-1.5-pro`, `co/gemini-1.5-flash`
+- `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
+- `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 
 ## Troubleshooting
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -454,17 +454,17 @@ Default model is `co/gemini-2.5-pro`. You can use:
 # OpenAI models
 agent = Agent("bot", model="gpt-4o-mini")
 agent = Agent("bot", model="gpt-4o")
-agent = Agent("bot", model="o1-mini")
+agent = Agent("bot", model="o4-mini")
 agent = Agent("bot", model="o1")
 
 # Anthropic Claude
-agent = Agent("bot", model="claude-3-5-sonnet-20241022")
-agent = Agent("bot", model="claude-3-5-haiku-20241022")
+agent = Agent("bot", model="claude-sonnet-4-5")
+agent = Agent("bot", model="claude-haiku-4-5")
 agent = Agent("bot", model="claude-opus-4")
 
 # Google Gemini
-agent = Agent("bot", model="gemini-1.5-pro")
-agent = Agent("bot", model="gemini-1.5-flash")
+agent = Agent("bot", model="gemini-2.5-pro")
+agent = Agent("bot", model="gemini-2.5-flash")
 agent = Agent("bot", model="gemini-2.0-flash-exp")
 ```
 
@@ -473,7 +473,7 @@ agent = Agent("bot", model="gemini-2.0-flash-exp")
 ```python
 # Use managed keys instead of your own
 agent = Agent("bot", model="co/gpt-4o-mini")
-agent = Agent("bot", model="co/claude-3-5-sonnet")
+agent = Agent("bot", model="co/claude-sonnet-4-5")
 ```
 
 ### API Keys
@@ -494,7 +494,7 @@ agent = Agent("bot", api_key="sk-...", model="gpt-4o-mini")
 from connectonion.llm import AnthropicLLM
 
 custom_llm = AnthropicLLM(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-5",
     api_key="sk-ant-..."
 )
 
@@ -592,8 +592,8 @@ Token usage is automatically shown in console logs after each LLM call:
 
 Cost tracking works with all supported providers:
 - OpenAI (gpt-4o, gpt-4o-mini, o1, o3-mini, o4-mini)
-- Anthropic Claude (claude-3-5-sonnet, claude-3-5-haiku, claude-opus-4)
-- Google Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-1.5-pro)
+- Anthropic Claude (claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5)
+- Google Gemini (gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash)
 
 Unknown models use default pricing estimates.
 
@@ -790,7 +790,7 @@ def create_analyst(name: str, tools: list) -> Agent:
         name=name,
         tools=tools,
         system_prompt=Path("prompts/analyst.md"),
-        model="claude-3-5-sonnet-20241022",
+        model="claude-sonnet-4-5",
         max_iterations=15,
         log=f"logs/{name}.log"
     )

--- a/docs/concepts/llm_do.md
+++ b/docs/concepts/llm_do.md
@@ -15,7 +15,7 @@ print(answer)  # "4"
 answer = llm_do("What's 2+2?", model="gemini-2.5-flash")  
 
 # Anthropic Claude
-answer = llm_do("What's 2+2?", model="claude-3-5-haiku-20241022")
+answer = llm_do("What's 2+2?", model="claude-haiku-4-5")
 ```
 
 That's it! One function for any LLM task across multiple providers.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -440,7 +440,7 @@ agent = Agent("coder", model="claude-sonnet-4-5")
 ```python
 # Fastest options from each provider
 agent = Agent("quick", model="gpt-5-nano")       # OpenAI fastest
-agent = Agent("quick", model="gemini-1.5-flash") # Google fast
+agent = Agent("quick", model="gemini-2.5-flash") # Google fast
 agent = Agent("quick", model="claude-haiku-4-5") # Anthropic fast
 ```
 
@@ -448,14 +448,14 @@ agent = Agent("quick", model="claude-haiku-4-5") # Anthropic fast
 ```python
 # Most cost-efficient options
 agent = Agent("budget", model="gpt-5-nano")       # OpenAI cheapest
-agent = Agent("budget", model="gemini-1.5-flash-8b") # Google cheapest
+agent = Agent("budget", model="gemini-2.5-flash-lite") # Google cheapest
 ```
 
 **Long Context (>200K tokens)**
 ```python
 # Models with longest context windows
 agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
-agent = Agent("reader", model="gemini-1.5-pro")  # 2M tokens
+agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
 ```
 
 **Multimodal (Images, Audio, Video)**
@@ -515,8 +515,8 @@ def select_model(task_type: str, speed_priority: bool = False) -> str:
         return {
             "code": "gpt-5-mini",
             "chat": "gpt-5-nano",
-            "analysis": "gemini-1.5-flash",
-            "creative": "claude-3-5-haiku"
+            "analysis": "gemini-2.5-flash",
+            "creative": "claude-haiku-4-5"
         }.get(task_type, "gpt-5-nano")
     else:
         # Best quality models
@@ -632,7 +632,7 @@ def create_robust_agent(name: str, model: str, max_retries: int = 3):
                 # Try alternative model
                 alternatives = {
                     "gpt-5": "gpt-5-mini",
-                    "gemini-2.5-pro": "gemini-1.5-pro",
+                    "gemini-2.5-pro": "gemini-2.5-flash",
                     "claude-sonnet-4-5": "claude-sonnet-4"
                 }
                 alt_model = alternatives.get(model)

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -91,7 +91,7 @@ $ co logout
 ✅ Logged out successfully
 
 # Configure settings
-$ co config set default_model co/claude-3-5-sonnet
+$ co config set default_model co/claude-sonnet-4-5
 ✅ Default model updated
 ```
 
@@ -101,24 +101,24 @@ All models are available with the `co/` prefix:
 
 ### OpenAI Models
 ```python
+llm_do("Hello", model="co/gpt-5")
+llm_do("Hello", model="co/gpt-5-mini")
 llm_do("Hello", model="co/gpt-4o")
-llm_do("Hello", model="co/gpt-4o-mini")
-llm_do("Hello", model="co/o1-preview")
-llm_do("Hello", model="co/o1-mini")
+llm_do("Hello", model="co/o4-mini")
 ```
 
 ### Anthropic Models
 ```python
-llm_do("Hello", model="co/claude-3-5-sonnet")
-llm_do("Hello", model="co/claude-3-5-haiku")
-llm_do("Hello", model="co/claude-3-opus")
+llm_do("Hello", model="co/claude-opus-4-5")
+llm_do("Hello", model="co/claude-sonnet-4-5")
+llm_do("Hello", model="co/claude-haiku-4-5")
 ```
 
 ### Google Models
 ```python
-llm_do("Hello", model="co/gemini-1.5-pro")
-llm_do("Hello", model="co/gemini-1.5-flash")
-llm_do("Hello", model="co/gemini-2.0-flash-exp")
+llm_do("Hello", model="co/gemini-3-pro-preview")
+llm_do("Hello", model="co/gemini-3-flash-preview")
+llm_do("Hello", model="co/gemini-2.5-pro")
 ```
 
 ## Real-World Examples
@@ -141,7 +141,7 @@ class Summary(BaseModel):
 
 result = llm_do(
     "Summarize this article about AI...",
-    model="co/claude-3-5-sonnet",
+    model="co/claude-sonnet-4-5",
     output=Summary
 )
 print(result.key_points)
@@ -166,7 +166,7 @@ response = agent.input("Help me write a Python function")
 
 ```python
 # Compare responses from different models
-models = ["co/gpt-4o", "co/claude-3-5-sonnet", "co/gemini-1.5-pro"]
+models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-2.5-pro"]
 
 for model in models:
     response = llm_do("What's the meaning of life?", model=model)
@@ -218,8 +218,8 @@ def test_all_models(prompt):
     """Test prompt across all providers."""
     models = {
         "OpenAI": "co/gpt-4o",
-        "Anthropic": "co/claude-3-5-sonnet",
-        "Google": "co/gemini-1.5-pro"
+        "Anthropic": "co/claude-sonnet-4-5",
+        "Google": "co/gemini-2.5-pro"
     }
     
     results = {}

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -116,7 +116,12 @@ Variables from your `.env` file are securely passed to your agent container:
 OPENONION_API_KEY=eyJ...    # Required for co/ models
 OPENAI_API_KEY=sk-xxx       # Third-party API keys
 DATABASE_URL=postgres://...
+BROWSER_PROXY=http://user:pass@host:port  # Route the browser through a residential proxy
 ```
+
+`BROWSER_PROXY` is read by the browser tools and routes the agent's browser
+egress through a proxy — useful because deployed agents run on datacenter IPs
+that anti-bot systems distrust. See [Browser Tools › Proxy](../useful_tools/browser_tools.md#proxy-browser_proxy).
 
 ---
 
@@ -150,7 +155,7 @@ skill combinations of the same base template can run side by side:
 
 ```bash
 co deploy --template co-ai --name linkedin-agent \
-  --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+  --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
 ```
 
 ### Skills
@@ -165,13 +170,13 @@ The deployed agent loads skills from `.co/skills/` via the normal loader.
   co deploy
   ```
 - **External skills** — to bundle skills that live outside the project, pass
-  `--skills PATH [PATH...]`. A path that is itself a skill (contains
+  `--skills PATH` (repeatable). A path that is itself a skill (contains
   `SKILL.md`) lands at `.co/skills/<dirname>/`; a directory of skills has its
   contents copied into `.co/skills/`. Your working tree is untouched; on a
   name clash, later paths win:
   ```bash
   co deploy --skills /Users/changxing/project/OnCourse/platform/social-media-management-skills
-  co deploy --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+  co deploy --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
   ```
 
 > Your local `~/.claude/skills` are **not** auto-deployed. `co deploy` ships the
@@ -207,6 +212,22 @@ The landing page shows:
 - Tools and skills your agent has
 - `summary` and `examples` from `host.yaml` as suggested prompts
 - Chat input for conversation
+
+### Relay Directory Profile
+
+On its first connection to the relay, a hosted agent publishes a small display
+profile so it can appear in the public agent directory. The profile is
+deliberately limited to:
+
+- **alias** — the agent's name
+- **tools** — tool names
+- **model**
+- **skills** — **project-level skills only** (the ones under the project's `.co/skills/`)
+
+Kept **private**: the system-prompt summary, and your `~/.co/skills` (user) and
+built-in skills — the operator's personal toolbox never leaks into the public
+directory. The relay persists the profile, so the periodic ANNOUNCE heartbeats
+don't re-send it.
 
 ### Connect from Code
 

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -145,6 +145,14 @@ That creates `.tmp/connectonion-deploy/co-ai-agent`, deploys it, and cleans it u
 after success. Any template supported by `co create --template <name>` uses the
 same flow.
 
+`--name` sets the project name (and URL) for a template deploy, so different
+skill combinations of the same base template can run side by side:
+
+```bash
+co deploy --template co-ai --name linkedin-agent \
+  --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+```
+
 ### Skills
 
 The deployed agent loads skills from `.co/skills/` via the normal loader.
@@ -156,13 +164,14 @@ The deployed agent loads skills from `.co/skills/` via the normal loader.
   co skills copy <name>          # lands in .co/skills/<name>/
   co deploy
   ```
-- **External skills** — to bundle any skills folder that lives outside the
-  project, pass `--skills PATH`
-  (repeatable). The folder contents are copied into the container's
-  `.co/skills/` (your working tree is untouched); on a name clash, later paths
-  win:
+- **External skills** — to bundle skills that live outside the project, pass
+  `--skills PATH [PATH...]`. A path that is itself a skill (contains
+  `SKILL.md`) lands at `.co/skills/<dirname>/`; a directory of skills has its
+  contents copied into `.co/skills/`. Your working tree is untouched; on a
+  name clash, later paths win:
   ```bash
   co deploy --skills /Users/changxing/project/OnCourse/platform/social-media-management-skills
+  co deploy --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
   ```
 
 > Your local `~/.claude/skills` are **not** auto-deployed. `co deploy` ships the

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -493,6 +493,12 @@ Agent Thread (sync)              Async forwarder / router
 
 On reconnect, `ws_router.connect:handle_connect` calls `io.rewind_to(last_msg_id)` (also under the same lock) to reset the cursor — the new forward task replays everything after that id. If `last_msg_id` is omitted or unknown, cursor rewinds to 0 (full replay; client should dedup by id).
 
+### Bounded forwarder wait (idle sessions don't pin threads)
+
+`read_msgs_from_agent` runs its blocking wait on the event loop's **default executor** (`run_in_executor(None, …)`), whose pool is small — `min(32, cpu_count + 4)` threads. So the wait is bounded to **~1 s**: `_wait_for_msgs_from_agent` does `condition.wait(timeout=1.0)`, returns whatever is buffered (often nothing), and the caller loops.
+
+Why it matters: a session whose agent is blocked in `io.receive()` (e.g. an unanswered `ASK_USER`) emits no events. Without the bound, its forwarder would hold an executor thread **forever** — and on a 2-vCPU box the pool is only `2 + 4 = 6` threads, so ~6 idle sessions exhaust it and every new connection's forwarder queues behind them (new clients can't connect / hang). The 1 s cap lets each thread cycle back to the pool, so idle sessions stop starving new ones. New agent events still wake the waiter **immediately** via `condition.notify()` — the cap only governs the idle case, never message latency.
+
 ### mark_agent_done() and close()
 
 - **`io.mark_agent_done()`** — agent done emitting messages. Sets `_finished` flag and notifies all waiters. `read_msgs_from_agent` returns once it drains remaining buffered events.

--- a/docs/network/protocol.md
+++ b/docs/network/protocol.md
@@ -245,7 +245,9 @@ Client → ONBOARD_SUBMIT   {payload: {invite_code: "BETA2024"}}
 Server → ONBOARD_SUCCESS  {level: "contact"}    or    ERROR
 ```
 
-`handle_onboard_submit` verifies signature with "open" trust (strangers can't pass strict verification yet), checks blocked status, then validates the invite code or payment via `trust_agent`. On success the client is promoted and can re-CONNECT.
+`handle_onboard_submit` verifies signature with "open" trust (strangers can't pass strict verification yet), checks blocked status, then validates the invite code or payment via `trust_agent`. On success the client is promoted.
+
+The original CONNECT that the trust gate interrupted is **completed server-side** — `handle_connect` stashes it as `conn["pending_connect"]`, and after a verified onboard the session loop calls `establish_connection()` with the onboard-verified identity, ending in `CONNECTED`. The client does **not** re-send CONNECT (its signature could have aged past the 5-minute window while the user typed the code or paid); its pending `INPUT` resumes once `CONNECTED` lands.
 
 ---
 

--- a/docs/useful_plugins/README.md
+++ b/docs/useful_plugins/README.md
@@ -13,6 +13,7 @@ Pre-built plugins that extend agent behavior via event hooks.
 | [eval](eval.md) | Task evaluation/debugging | `from connectonion.useful_plugins import eval` |
 | [system_reminder](system_reminder.md) | Inject contextual guidance | `from connectonion.useful_plugins import system_reminder` |
 | [image_result_formatter](image_result_formatter.md) | Format images for vision | `from connectonion.useful_plugins import image_result_formatter` |
+| [human_jitter](human_jitter.md) | Human-like mouse motion before clicks | `from connectonion.useful_plugins import human_jitter` |
 | [shell_approval](shell_approval.md) | Shell command approval | `from connectonion.useful_plugins import shell_approval` |
 | [ui_stream](ui_stream.md) | Stream events to WebSocket clients | `from connectonion.useful_plugins import ui_stream` |
 | [auto_compact](auto_compact.md) | Compact conversation when context fills up | `from connectonion.useful_plugins import auto_compact` |

--- a/docs/useful_plugins/human_jitter.md
+++ b/docs/useful_plugins/human_jitter.md
@@ -1,0 +1,55 @@
+# human_jitter
+
+Make a browser agent's clicks look human: right before any `click*` tool runs, wander the mouse through a few random points on the page, so the click is preceded by organic motion instead of an instant teleport-and-click.
+
+## Quick Start
+
+```python
+from connectonion import Agent
+from connectonion.useful_tools.browser_tools import BrowserAutomation
+from connectonion.useful_plugins import human_jitter
+
+browser = BrowserAutomation()
+agent = Agent("web", tools=[browser], plugins=[human_jitter])
+
+agent.input("log into the site and click the verify checkbox")
+# before each click*, the cursor drifts through a few points first
+```
+
+## How It Works
+
+1. On `before_each_tool`, reads `agent.current_session['pending_tool']`.
+2. If the tool name starts with `click`, grabs the `BrowserAutomation` instance off the tool registry (`agent.tools.browserautomation`).
+3. Dispatches `jitter()` onto the browser's single worker thread (Playwright is not thread-safe): the cursor moves to a random point, then random-walks through 2–4 more, with short pauses.
+
+Jitter is **best-effort** — if the page is mid-navigation when it reads the viewport, the failure is caught and logged, never raised, so the click the agent asked for still proceeds.
+
+## Why `before_each_tool`
+
+It's the only hook that fires synchronously between "LLM picked a click tool" and "Playwright performs the click" — exactly where pre-click motion belongs. `after_tools` is too late (the click already happened).
+
+## Why a Plugin (not baked into `click`)
+
+Jitter is non-deterministic and opt-in. Forcing it on every browser user would make clicks non-reproducible for tests and agents that don't want it. Opt in with `plugins=[human_jitter]`.
+
+## Events
+
+| Handler | Event | Purpose |
+|---------|-------|---------|
+| `_jitter_before_click` | `before_each_tool` | Wander the mouse before any `click*` tool runs |
+
+## Notes
+
+- Only affects tools whose name starts with `click` (`click`, `click_element_by_selector`, …); other tools are untouched.
+- Cosmetic only — it raises a bot's trust score marginally, but egress IP reputation dominates anti-bot scoring. Pair with `BROWSER_PROXY` (see [Browser Tools](../useful_tools/browser_tools.md)) when that's the real bottleneck.
+
+## Customizing
+
+```bash
+co copy human_jitter
+```
+
+```python
+# from connectonion.useful_plugins import human_jitter  # Before
+from plugins.human_jitter import human_jitter            # After
+```

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -50,6 +50,28 @@ browser = BrowserAutomation()
 browser.go_to("https://x.com")           # Session restored automatically
 ```
 
+## Portable Login State (cross-machine)
+
+The persistent profile above lives at `~/.co/browser_profile/` and **can't be moved**: its cookies are encrypted per-OS, so copying the folder to another machine (or into a Linux deploy container) won't carry the login.
+
+To reuse a login across machines, export the session as a plaintext, portable `storage_state` JSON and inject it on the other side:
+
+```python
+# On your machine (headed): log in by hand, then export
+browser = BrowserAutomation(headless=False)
+browser.go_to("https://www.linkedin.com/login")
+input("Log in, then press Enter...")
+browser.save_state("linkedin_state.json")   # cookies + origins, plaintext, portable
+
+# On the deployed agent: inject at startup, before any navigation
+browser = BrowserAutomation(seed_state="linkedin_state.json")
+# the first open_browser() applies the cookies once → starts already signed in
+```
+
+Ship `linkedin_state.json` with the deploy (it's a small JSON, not the profile dir). `seed_state` injects via `add_cookies` because `launch_persistent_context()` can't accept a `storage_state` path. Unset `seed_state` → no injection, behaviour unchanged.
+
+> The cookies authenticate, but a different egress IP (e.g. a datacenter IP on a cloud deploy) can still trigger re-verification. Pair with `BROWSER_PROXY` (below) when the target is IP-sensitive.
+
 ## API
 
 ### Navigation
@@ -79,6 +101,26 @@ browser.click("email input field")       # Uses AI to find by description
 ```
 
 Element finding uses a vision LLM — describe what you see, not a CSS selector.
+
+When you have a stable CSS selector, click it directly (faster, deterministic):
+
+```python
+browser.click_element_by_selector('button[type="submit"]')
+browser.click_element_by_selector('button', text="Sign in")   # disambiguate by visible text
+browser.click_element_by_selector('.item', index=2)           # nth match (0-based)
+```
+
+To click inside an iframe — including a **cross-origin** one like a reCAPTCHA
+"I'm not a robot" checkbox that main-page selectors can't reach — pass
+`frame_url_contains` or `frame_name`:
+
+```python
+browser.click_element_by_selector('.recaptcha-checkbox-border', frame_url_contains="recaptcha")
+```
+
+The click goes through Playwright's input layer, so the event is trusted
+(`isTrusted`) — a JS `el.click()` is not, and bot checks reject it. (`text`
+matching stays main-frame only.)
 
 ### Hover and Advanced Mouse
 
@@ -195,6 +237,14 @@ agent.input("Navigate to github.com/trending and screenshot the page")
 agent.input("Fill in the contact form on example.com with test data")
 ```
 
+One `BrowserAutomation` instance is **safe to reuse across turns and across
+concurrent hosted sessions** — keep a single shared browser, don't create or
+close+reopen one per turn. Playwright's sync API binds to the thread that
+started it, and `host()` runs each turn on an arbitrary pool thread; every
+public method is serialized onto one dedicated internal worker thread, so calls
+from any thread land on the right one and the browser (and its login state)
+persists across turns.
+
 ## Common Patterns
 
 ### Login once, reuse session
@@ -228,6 +278,17 @@ browser.go_to("https://example.com/products")
 text = browser.get_text()
 links = browser.get_links_from_page("/product/")
 ```
+
+## Proxy (BROWSER_PROXY)
+
+Set the `BROWSER_PROXY` env var to route the browser's traffic through a proxy — e.g. so a cloud-deployed agent exits from a residential IP instead of the datacenter IP it runs on (which anti-bot systems distrust):
+
+```bash
+BROWSER_PROXY=http://user:pass@host:port   # HTTP proxy with auth (e.g. a residential proxy service)
+BROWSER_PROXY=socks5://host:port           # SOCKS5 relay (no auth — Chromium ignores SOCKS auth)
+```
+
+Read at `open_browser()`; unset → no proxy (behaviour unchanged). On a deploy, put it in `.env` so it's injected as a secret, never baked into the image.
 
 ## Notes
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     network: Tests that require network/relay server connection
     cli: CLI-specific tests
     asyncio: Async tests using pytest-asyncio
+    benchmark: Performance benchmark tests
 
 # Output options
 addopts =

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -363,11 +363,11 @@ class TestDeploySkillsPackaging:
             first.mkdir()
             (first / "SKILL.md").write_text("---\nname: real\n---\nhi\n")
 
-            # First path exists; the bare second path must also be collected
-            # as a skills path and fail validation by name.
+            # --skills is repeatable; the second (missing) path fails validation by name.
             result = runner.invoke(cli, [
                 'deploy',
-                '--skills', str(first), str(tmp_path / 'missing-skill'),
+                '--skills', str(first),
+                '--skills', str(tmp_path / 'missing-skill'),
             ])
             assert "missing-skill" in result.output
             assert "Skills path not found" in result.output

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -8,6 +8,10 @@ What it tests:
   - test_deploy_requires_git_repo: Verify git repo requirement
   - test_deploy_requires_co_project: Verify .co folder requirement
   - Git integration and deployment workflows
+- TestDeployPackaging / TestDeploySkillsPackaging: tarball contents
+  - --skills paths merge into .co/skills/; a path that is itself a skill
+    (contains SKILL.md) nests under its directory name
+  - --name is rejected without --template (project name comes from host.yaml)
 
 Components under test:
 - connectonion.cli.commands.deploy (deploy command)
@@ -317,6 +321,56 @@ class TestDeploySkillsPackaging:
         assert ".co/skills/hello/run.py" in names          # supporting files kept
         assert ".co/skills/world/SKILL.md" in names        # second --skills dir merged
         assert ".co/skills/.git/config" not in names       # dotfiles skipped
+
+    def test_single_skill_dir_nests_under_its_name(self, tmp_path):
+        import tarfile
+        from connectonion.cli.commands.deploy_commands import _build_tarball
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._make_repo(repo)
+
+        skill = tmp_path / "linkedin-login"
+        (skill / "scripts").mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: linkedin-login\n---\nlog in\n")
+        (skill / "scripts" / "fill.js").write_text("x\n")
+
+        tarball = _build_tarball(repo, [skill])
+        names = set(tarfile.open(tarball).getnames())
+
+        assert ".co/skills/linkedin-login/SKILL.md" in names
+        assert ".co/skills/linkedin-login/scripts/fill.js" in names
+        assert ".co/skills/SKILL.md" not in names          # not flattened
+
+    def test_name_without_template_errors_clearly(self):
+        runner = ArgparseCliRunner()
+        with runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+
+            result = runner.invoke(cli, ['deploy', '--name', 'other-name'])
+            assert "--name only applies to template deploys" in result.output
+
+    def test_skills_flag_takes_multiple_paths(self, tmp_path):
+        runner = ArgparseCliRunner()
+        with runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+            first = tmp_path / "real-skill"
+            first.mkdir()
+            (first / "SKILL.md").write_text("---\nname: real\n---\nhi\n")
+
+            # First path exists; the bare second path must also be collected
+            # as a skills path and fail validation by name.
+            result = runner.invoke(cli, [
+                'deploy',
+                '--skills', str(first), str(tmp_path / 'missing-skill'),
+            ])
+            assert "missing-skill" in result.output
+            assert "Skills path not found" in result.output
 
     def test_missing_skills_path_errors_clearly(self):
         runner = ArgparseCliRunner()

--- a/tests/unit/test_asgi_websocket_admin_onboard.py
+++ b/tests/unit/test_asgi_websocket_admin_onboard.py
@@ -454,3 +454,74 @@ class TestHandleAdminMessage:
         assert sent_messages[0]["type"] == "ERROR"
         assert "Unknown admin action" in sent_messages[0]["message"]
 
+
+
+@pytest.mark.asyncio
+class TestOnboardCompletesConnect:
+    async def test_input_after_onboard_runs_without_reconnect(self):
+        """The trust gate interrupts CONNECT before conn is populated. A successful
+        ONBOARD_SUBMIT must finish establishing the connection (CONNECTED sent,
+        conn authenticated) so the client's queued INPUT runs — the original bug
+        rejected it with 'authenticate first (send CONNECT)'."""
+        scope = {"path": "/ws", "type": "websocket"}
+        sent_messages = []
+        frames = [
+            {"type": "CONNECT", "session_id": "sess-1",
+             "payload": {"timestamp": 1234567890}, "from": "0xuser", "signature": "0xsig"},
+            {"type": "ONBOARD_SUBMIT", "payload": {"invite_code": "BETA", "timestamp": 1234567891},
+             "from": "0xuser", "signature": "0xsig2"},
+            {"type": "INPUT", "prompt": "hello", "input_id": "i1"},
+        ]
+        recv_count = [0]
+
+        async def receive():
+            recv_count[0] += 1
+            if recv_count[0] <= len(frames):
+                return {"type": "websocket.receive", "text": json.dumps(frames[recv_count[0] - 1])}
+            # The agent runs on a thread; let it consume the INPUT before closing.
+            import asyncio
+            for _ in range(200):
+                if ws_input.call_count:
+                    break
+                await asyncio.sleep(0.005)
+            return {"type": "websocket.disconnect"}
+
+        async def send(msg):
+            sent_messages.append(msg)
+
+        trust_agent = SimpleNamespace(
+            config={"onboard": {"invite_code": ["BETA"]}},
+            get_self_address=lambda: "0xagent123",
+            is_blocked=lambda identity: False,
+            verify_invite=lambda identity, code: code == "BETA",
+            get_level=lambda identity: "contact",
+        )
+
+        def auth(data, trust, **kw):
+            # CONNECT from a stranger is forbidden; the ONBOARD_SUBMIT signature
+            # check (trust="open") passes.
+            if trust == "open":
+                return None, "0xuser", True, None
+            return None, "0xuser", True, "forbidden: strangers"
+
+        ws_input = Mock(return_value={"result": "done", "duration_ms": 1, "session": {}})
+        storage = Mock()
+        storage.get.return_value = None
+
+        await handle_websocket(
+            scope, receive, send,
+            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            storage=storage,
+            registry=ActiveSessionRegistry(),
+            trust="careful",
+        )
+
+        events = _extract_ws_messages(sent_messages)
+        types = [e["type"] for e in events]
+
+        assert "ONBOARD_SUCCESS" in types
+        connected = [e for e in events if e["type"] == "CONNECTED"]
+        assert connected and connected[0]["session_id"] == "sess-1"
+        assert types.index("ONBOARD_SUCCESS") < types.index("CONNECTED")
+        assert not any("authenticate first" in str(e.get("message", "")) for e in events)
+        ws_input.assert_called_once()

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -1,5 +1,7 @@
 """Tests for BrowserAutomation lifecycle behavior."""
 
+import json
+
 import connectonion.useful_tools.browser_tools.browser as browser_mod
 
 
@@ -198,3 +200,90 @@ def test_close_reports_cleanup_warnings_and_clears_state():
     assert browser.page is None
     assert browser.browser is None
     assert browser.playwright is None
+
+
+class _RecordingContext(FakeContext):
+    """A context that records add_cookies / storage_state so seeding/export can be asserted."""
+
+    def __init__(self):
+        super().__init__()
+        self.added_cookies = None
+        self.saved_state_path = None
+
+    def add_cookies(self, cookies):
+        self.added_cookies = cookies
+
+    def storage_state(self, path=None):
+        self.saved_state_path = path
+
+
+def _recording_playwright(contexts):
+    """sync_playwright() stand-in whose contexts record add_cookies / storage_state calls."""
+
+    class FakeChromium:
+        def launch_persistent_context(self, user_data_dir, **kwargs):
+            context = _RecordingContext()
+            contexts.append(context)
+            return context
+
+    class FakePlaywright:
+        def __init__(self):
+            self.chromium = FakeChromium()
+
+        def stop(self):
+            pass
+
+    class FakeSyncPlaywright:
+        def start(self):
+            return FakePlaywright()
+
+    return FakeSyncPlaywright()
+
+
+def test_seed_state_injects_exported_cookies(monkeypatch, tmp_path):
+    cookies = [{"name": "li_at", "value": "secret", "domain": ".linkedin.com", "path": "/"}]
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"cookies": cookies}))
+
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True, seed_state=str(state))
+    browser.open_browser()
+
+    assert contexts[0].added_cookies == cookies
+
+
+def test_no_seed_state_injects_nothing(monkeypatch, tmp_path):
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.open_browser()
+
+    assert contexts[0].added_cookies is None
+
+
+def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.open_browser()
+    out = tmp_path / "exported.json"
+    result = browser.save_state(str(out))
+
+    assert contexts[0].saved_state_path == str(out)
+    assert "Saved login state" in result
+
+
+def test_save_state_without_browser_reports_not_open():
+    browser = browser_mod.BrowserAutomation(headless=True)
+
+    assert browser.save_state("/tmp/whatever.json") == "Browser not open"

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -1,0 +1,179 @@
+"""Unit tests for per-session browser tabs in BrowserAutomation.
+
+Each session (chat panel) gets its own tab in the shared context so concurrent
+sessions don't navigate over each other. Tabs are reclaimed by idle-TTL and a
+max-tabs backstop, and a reclaimed session transparently gets a fresh tab restored
+to its last URL (never a "target closed" crash).
+
+These tests fake the Playwright context/page, so they need no real browser.
+"""
+
+import time
+
+import pytest
+
+from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+
+
+class FakePage:
+    def __init__(self, idx):
+        self.idx = idx
+        self.url = f"about:blank#{idx}"
+        self.closed = False
+        self.goto_calls = []
+
+    def set_default_navigation_timeout(self, *a, **k):
+        pass
+
+    def set_viewport_size(self, *a, **k):
+        pass
+
+    def add_init_script(self, *a, **k):
+        pass
+
+    def goto(self, url, **k):
+        self.goto_calls.append(url)
+        self.url = url
+
+    def is_closed(self):
+        return self.closed
+
+    def close(self):
+        self.closed = True
+
+
+class FakeContext:
+    def __init__(self):
+        self.n = 0
+
+    def new_page(self):
+        self.n += 1
+        return FakePage(self.n)
+
+
+@pytest.fixture
+def browser():
+    b = BrowserAutomation()
+    b.browser = FakeContext()        # stand in for the launched persistent context
+    b._bind_session(None)            # reset this thread's binding between tests
+    yield b
+    b._executor.shutdown(wait=False)
+
+
+class TestPerSessionTabs:
+    def test_each_session_gets_its_own_tab(self, browser):
+        browser._bind_session("A")
+        browser._ensure_page("A")
+        page_a = browser.page
+
+        browser._bind_session("B")
+        browser._ensure_page("B")
+        page_b = browser.page
+
+        assert page_a is not page_b
+        assert {"A", "B"} <= set(browser._pages)
+
+    def test_page_property_routes_by_bound_session(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+
+        browser._bind_session("A")
+        assert browser.page is browser._pages["A"]
+        browser._bind_session("B")
+        assert browser.page is browser._pages["B"]
+
+    def test_navigating_one_session_does_not_touch_another(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+
+        browser._pages["A"].goto("https://linkedin.com")
+        # B's tab is a different page object, unaffected by A's navigation.
+        assert browser._pages["B"].url != "https://linkedin.com"
+
+    def test_no_session_uses_a_single_shared_tab(self, browser):
+        browser._bind_session(None)
+        browser._ensure_page(None)
+        browser._ensure_page(None)
+        assert list(browser._pages) == [None]
+        assert browser.page is browser._pages[None]
+
+
+class TestTabReclaim:
+    def test_idle_tab_is_reclaimed_and_active_is_kept(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+        page_a = browser._pages["A"]
+
+        browser._tab_idle_ttl = 3600
+        browser._page_used["A"] = time.monotonic() - 10_000  # A abandoned long ago
+
+        browser._bind_session("B")
+        browser._ensure_page("B")  # reclaim runs with active=B
+
+        assert "A" not in browser._pages          # idle tab closed
+        assert page_a.closed is True
+        assert "B" in browser._pages              # active tab kept
+        assert browser._page_url["A"]             # url remembered for restore
+
+    def test_reclaimed_session_recreates_and_restores_url(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._pages["A"].goto("https://example.com/feed")
+
+        browser._tab_idle_ttl = 0
+        browser._bind_session("B")
+        browser._ensure_page("B")  # active=B; A idle past ttl=0 -> reclaimed
+
+        assert "A" not in browser._pages
+
+        browser._bind_session("A")
+        browser._ensure_page("A")  # A returns -> fresh tab restored to its url
+        assert browser._pages["A"].goto_calls == ["https://example.com/feed"]
+
+    def test_max_tabs_backstop_evicts_lru_not_active(self, browser):
+        browser._max_tabs = 2
+        browser._tab_idle_ttl = 10_000  # disable idle path; test the hard cap only
+        for key in ("A", "B", "C"):
+            browser._bind_session(key)
+            browser._ensure_page(key)
+
+        assert len(browser._pages) == 2
+        assert "C" in browser._pages          # the active one is never evicted
+        assert "A" not in browser._pages      # least-recently-used evicted
+
+    def test_does_not_evict_when_under_cap_and_not_idle(self, browser):
+        browser._max_tabs = 10
+        browser._tab_idle_ttl = 10_000
+        for key in ("A", "B", "C"):
+            browser._bind_session(key)
+            browser._ensure_page(key)
+        assert set(browser._pages) == {"A", "B", "C"}
+
+
+class TestBindSessionPlugin:
+    def test_handler_binds_current_session_to_browser(self):
+        """The plugin reads the turn's session_id and hands it to the browser."""
+        from connectonion.useful_plugins.bind_browser_session import _bind_session
+
+        class FakeBrowser:
+            bound = "unset"
+            def _bind_session(self, sid):
+                self.bound = sid
+
+        class FakeAgent:
+            class tools:
+                browserautomation = FakeBrowser()
+            current_session = {"session_id": "sess-123"}
+
+        _bind_session(FakeAgent())
+        assert FakeAgent.tools.browserautomation.bound == "sess-123"
+
+    def test_handler_noop_without_browser(self):
+        """Agents with no browser tool are unaffected — the plugin does nothing."""
+        from connectonion.useful_plugins.bind_browser_session import _bind_session
+
+        class FakeAgent:
+            class tools:
+                pass
+            current_session = {"session_id": "sess-123"}
+
+        _bind_session(FakeAgent())  # must not raise

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -2,7 +2,8 @@
 LLM-Note: Tests for host relay
 
 What it tests:
-- Host Relay functionality
+- Host Relay functionality (ANNOUNCE/heartbeat protocol, including the
+  display profile published with the first ANNOUNCE of each connection)
 
 Components under test:
 - Module: host_relay
@@ -105,6 +106,44 @@ class TestHostRelayKeyManagement:
 
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
+
+    def test_profile_publishes_project_skills_only(self, tmp_path):
+        """Published profile carries display fields only: project-level skills,
+        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
+        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        profile = host_module._build_agent_profile({
+            "name": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "summary": "private prompt summary",
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
+                {"name": "linkedin-login", "description": "Operator skill",
+                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+            ],
+        }, tmp_path)
+
+        assert profile == {
+            "alias": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "skills": [{"name": "deploy-smoke", "description": "Smoke test"}],
+        }
+
+    def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
+        """Hosted agents publish their profile with the relay ANNOUNCE."""
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path):
+            with patch('connectonion.address.load', return_value=mock_addr):
+                with patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())) as mock_relay:
+                    with patch('uvicorn.run'):
+                        with patch.object(host_module, '_print_host_banner'):
+                            host_module.host(create_mock_agent, port=8080)
+
+        profile = mock_relay.call_args.kwargs["profile"]
+        assert profile["alias"]
+        assert "summary" not in profile
 
     def test_host_starts_relay_with_default_url(self, tmp_path, create_mock_agent):
         """Test that host() uses default relay URL (from config)."""

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -107,21 +107,21 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
-    def test_profile_publishes_project_skills_only(self, tmp_path):
+    def test_profile_publishes_project_skills_only(self):
         """Published profile carries display fields only: project-level skills,
-        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
-        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        no user/builtin skills (location is the discovery category, not a
+        path), no prompt summary."""
         profile = host_module._build_agent_profile({
             "name": "test_agent",
             "tools": ["search"],
             "model": "co/gemini-2.5-flash",
             "summary": "private prompt summary",
             "skills": [
-                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
-                {"name": "linkedin-login", "description": "Operator skill",
-                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+                {"name": "deploy-smoke", "description": "Smoke test", "location": "project"},
+                {"name": "linkedin-login", "description": "Operator skill", "location": "user"},
+                {"name": "commit", "description": "Built-in skill", "location": "builtin"},
             ],
-        }, tmp_path)
+        })
 
         assert profile == {
             "alias": "test_agent",

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -9,6 +9,7 @@ Tests cover:
 - Session merge logic
 - ActiveSessionRegistry for reconnection
 - Session to ChatItem conversion for UI
+- Screenshot images on trace entries re-emitted into replayed chat items
 """
 
 import json
@@ -734,6 +735,31 @@ class TestSessionToChatItems:
 
         ids = [item['id'] for item in items]
         assert len(ids) == len(set(ids))  # All unique
+
+    def test_emits_image_bubble_for_screenshot(self):
+        """A tool_result carrying an image (set by image_result_formatter) replays
+        as a tool_call item plus a standalone agent image bubble, so screenshots
+        survive a rebuild from server history instead of vanishing."""
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        session = {
+            'messages': [
+                {'role': 'user', 'content': 'screenshot'},
+                {'role': 'assistant', 'content': 'done'},
+            ],
+            'trace': [
+                {'type': 'user_input', 'turn': 1},
+                {'type': 'tool_result', 'tool_id': 't1', 'name': 'take_screenshot',
+                 'status': 'success', 'result': "Tool 'take_screenshot' returned image (image/png)",
+                 'image': data_url},
+            ],
+        }
+
+        items = session_to_chat_items(session)
+        types = [i['type'] for i in items]
+        assert types == ['user', 'tool_call', 'agent', 'agent']
+        img_item = items[2]
+        assert img_item['images'] == [data_url]
+        assert img_item['content'] == ''
 
 
 class TestReconnectionScenarios:

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -295,10 +295,13 @@ class TestFormatImageResult:
         _format_image_result(agent)
 
         # Trace result should be shortened
-        trace_result = agent.current_session['trace'][0]['result']
+        trace_entry = agent.current_session['trace'][0]
+        trace_result = trace_entry['result']
         assert 'screenshot' in trace_result
         assert 'image/png' in trace_result
         assert len(trace_result) < 100  # Much shorter than original
+        # Full data URL is retained out-of-band so session replay can re-emit it.
+        assert trace_entry['image'] == 'data:image/png;base64,' + 'A' * 1000
 
     def test_sends_image_to_io_when_available(self):
         """Image tool results are model-visible and sent to frontend IO."""

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -24,7 +24,6 @@ from connectonion.useful_plugins.image_result_formatter import (
     _is_image_message,
     _sanitize_image_urls,
     image_result_formatter,
-    KEEP_LAST_N_SCREENSHOTS,
 )
 from tests.utils.mock_helpers import MockLLM
 
@@ -387,13 +386,13 @@ class TestScreenshotSlidingWindow:
             self._take_screenshot(agent, n)
 
         image_msgs = [m for m in agent.current_session['messages'] if _is_image_message(m)]
-        assert len(image_msgs) == KEEP_LAST_N_SCREENSHOTS
+        assert len(image_msgs) == 3  # window keeps the last 3 of 5 screenshots
 
         placeholders = [
             m for m in agent.current_session['messages']
             if m.get('content') == "[earlier screenshot removed to bound context]"
         ]
-        assert len(placeholders) == 5 - KEEP_LAST_N_SCREENSHOTS
+        assert len(placeholders) == 2  # the 2 older ones are elided
 
     def test_context_payload_stays_flat_not_linear(self):
         """The byte size the LLM receives must stop growing once the window fills."""
@@ -411,7 +410,7 @@ class TestScreenshotSlidingWindow:
             sizes.append(image_bytes(agent))
 
         # Grows while filling the window, then plateaus (never linear in turn count).
-        assert sizes[-1] == sizes[KEEP_LAST_N_SCREENSHOTS - 1]
+        assert sizes[-1] == sizes[2]  # plateaus once the 3-screenshot window fills
         assert sizes[-1] == sizes[-2]
 
     def test_replay_trace_keeps_every_screenshot(self):

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -21,7 +21,9 @@ from unittest.mock import Mock
 from connectonion.useful_plugins.image_result_formatter import (
     _is_base64_image,
     _format_image_result,
+    _is_image_message,
     image_result_formatter,
+    KEEP_LAST_N_SCREENSHOTS,
 )
 from tests.utils.mock_helpers import MockLLM
 
@@ -355,6 +357,70 @@ class TestFormatImageResult:
 
         # Should not raise error even without io
         _format_image_result(agent)
+
+
+class TestScreenshotSlidingWindow:
+    """The LLM context keeps only the last N screenshots; older ones are elided."""
+
+    def _take_screenshot(self, agent, n):
+        """Simulate one turn: a screenshot tool result that gets formatted."""
+        b64 = "A" * 150
+        tool_id = f"call_{n}"
+        agent.current_session['messages'].append({
+            'role': 'tool',
+            'content': f"data:image/png;base64,{b64}",
+            'tool_call_id': tool_id,
+        })
+        agent.current_session['trace'].append({
+            'type': 'tool_result',
+            'name': 'take_screenshot',
+            'status': 'success',
+            'result': f"data:image/png;base64,{b64}",
+            'tool_id': tool_id,
+        })
+        _format_image_result(agent)
+
+    def test_keeps_only_last_n_screenshots(self):
+        agent = FakeAgent()
+        for n in range(5):
+            self._take_screenshot(agent, n)
+
+        image_msgs = [m for m in agent.current_session['messages'] if _is_image_message(m)]
+        assert len(image_msgs) == KEEP_LAST_N_SCREENSHOTS
+
+        placeholders = [
+            m for m in agent.current_session['messages']
+            if m.get('content') == "[earlier screenshot removed to bound context]"
+        ]
+        assert len(placeholders) == 5 - KEEP_LAST_N_SCREENSHOTS
+
+    def test_context_payload_stays_flat_not_linear(self):
+        """The byte size the LLM receives must stop growing once the window fills."""
+        def image_bytes(agent):
+            return sum(
+                len(part['image_url']['url'])
+                for m in agent.current_session['messages'] if _is_image_message(m)
+                for part in m['content'] if part.get('type') == 'image_url'
+            )
+
+        agent = FakeAgent()
+        sizes = []
+        for n in range(6):
+            self._take_screenshot(agent, n)
+            sizes.append(image_bytes(agent))
+
+        # Grows while filling the window, then plateaus (never linear in turn count).
+        assert sizes[-1] == sizes[KEEP_LAST_N_SCREENSHOTS - 1]
+        assert sizes[-1] == sizes[-2]
+
+    def test_replay_trace_keeps_every_screenshot(self):
+        """Eliding the LLM context must not touch the trace the frontend replays."""
+        agent = FakeAgent()
+        for n in range(5):
+            self._take_screenshot(agent, n)
+
+        # Every screenshot is still recoverable out-of-band for session replay.
+        assert all('image' in t for t in agent.current_session['trace'])
 
 
 class TestImageResultFormatterPlugin:

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -22,6 +22,7 @@ from connectonion.useful_plugins.image_result_formatter import (
     _is_base64_image,
     _format_image_result,
     _is_image_message,
+    _sanitize_image_urls,
     image_result_formatter,
     KEEP_LAST_N_SCREENSHOTS,
 )
@@ -421,6 +422,49 @@ class TestScreenshotSlidingWindow:
 
         # Every screenshot is still recoverable out-of-band for session replay.
         assert all('image' in t for t in agent.current_session['trace'])
+
+
+class TestSanitizeImageUrls:
+    """before_llm sanitizer: stale/invalid image_url parts must not reach the LLM."""
+
+    def _img_msg(self, url):
+        return {"role": "user", "content": [
+            {"type": "text", "text": "x"},
+            {"type": "image_url", "image_url": {"url": url}},
+        ]}
+
+    def test_placeholder_url_becomes_text(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("[image]")]
+        _sanitize_image_urls(agent)
+        part = agent.current_session['messages'][0]['content'][1]
+        assert part == {"type": "text", "text": "[image unavailable]"}
+
+    def test_empty_url_becomes_text(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("")]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'][1]['type'] == 'text'
+
+    def test_valid_data_url_kept(self):
+        agent = FakeAgent()
+        url = "data:image/png;base64,iVBORw0KGgo"
+        agent.current_session['messages'] = [self._img_msg(url)]
+        _sanitize_image_urls(agent)
+        part = agent.current_session['messages'][0]['content'][1]
+        assert part['type'] == 'image_url' and part['image_url']['url'] == url
+
+    def test_https_url_kept(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("https://x/y.png")]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'][1]['type'] == 'image_url'
+
+    def test_string_content_untouched(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [{"role": "user", "content": "hello"}]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'] == "hello"
 
 
 class TestImageResultFormatterPlugin:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -3,7 +3,8 @@
 LLM-Note: Tests for io
 
 What it tests:
-- Io functionality
+- Io functionality (channel coordination, replay cursor, and the bounded
+  forwarder wait that keeps idle sessions from pinning executor threads)
 
 Components under test:
 - Module: io
@@ -265,3 +266,46 @@ class TestHighLevelAPI:
 
         thread.join(timeout=1)
         assert result is False
+
+    def test_wait_for_msgs_returns_promptly_when_idle(self):
+        """_wait_for_msgs_from_agent runs on the event loop's shared default
+        executor; on an idle io (agent blocked in receive(), no new messages)
+        it must return within ~1s instead of looping forever, or each idle
+        session pins a pool thread until the pool starves every new connection."""
+        import time
+        io = WebSocketIO()
+
+        start = time.monotonic()
+        msgs, done = io._wait_for_msgs_from_agent(0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 3.0
+        assert msgs == []
+        assert done is False
+
+    def test_idle_forwarder_does_not_starve_other_io(self):
+        """One io stuck idle must not block another io's event delivery when
+        the executor has a single thread (worst-case pool contention)."""
+        import asyncio
+        from concurrent.futures import ThreadPoolExecutor
+
+        async def read_one(io):
+            async for event in io.read_msgs_from_agent():
+                return event
+
+        async def scenario():
+            asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=1))
+
+            idle_io = WebSocketIO()
+            busy_io = WebSocketIO()
+            busy_io.send({"type": "thinking"})
+
+            idle_task = asyncio.create_task(read_one(idle_io))
+            await asyncio.sleep(0.1)  # let the idle forwarder grab the only thread
+
+            event = await asyncio.wait_for(read_one(busy_io), timeout=5.0)
+            idle_task.cancel()
+            return event
+
+        event = asyncio.run(scenario())
+        assert event["type"] == "thinking"

--- a/tests/unit/test_no_progress_guard.py
+++ b/tests/unit/test_no_progress_guard.py
@@ -1,0 +1,109 @@
+"""Unit tests for connectonion/useful_plugins/no_progress_guard.py
+
+Tests cover:
+- _last_tool_signature: signature ignores call ids, reads the most recent call
+- no_progress_guard: stops on repeated identical calls, not on varying calls
+"""
+
+from unittest.mock import Mock
+
+from connectonion.useful_plugins.no_progress_guard import (
+    no_progress_guard,
+    _last_tool_signature,
+)
+
+
+class FakeAgent:
+    def __init__(self):
+        self.current_session = {'messages': []}
+        self.logger = Mock()
+
+
+def _assistant_call(name, arguments):
+    return {
+        'role': 'assistant',
+        'tool_calls': [
+            {'id': 'irrelevant', 'type': 'function',
+             'function': {'name': name, 'arguments': arguments}}
+        ],
+    }
+
+
+class TestLastToolSignature:
+    def test_ignores_call_id(self):
+        a = [{'role': 'assistant', 'tool_calls': [
+            {'id': '1', 'function': {'name': 'f', 'arguments': '{}'}}]}]
+        b = [{'role': 'assistant', 'tool_calls': [
+            {'id': '2', 'function': {'name': 'f', 'arguments': '{}'}}]}]
+        assert _last_tool_signature(a) == _last_tool_signature(b)
+
+    def test_reads_most_recent_call_past_tool_and_user_messages(self):
+        messages = [
+            _assistant_call('old', '{}'),
+            {'role': 'tool', 'content': 'x', 'tool_call_id': 'irrelevant'},
+            _assistant_call('new', '{}'),
+            {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'd'}}]},
+        ]
+        assert 'new' in _last_tool_signature(messages)
+        assert 'old' not in _last_tool_signature(messages)
+
+    def test_none_when_no_tool_calls(self):
+        assert _last_tool_signature([{'role': 'user', 'content': 'hi'}]) is None
+
+
+class TestNoProgressGuard:
+    def test_stops_after_repeated_identical_calls(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert agent.current_session.get('stop_signal') is True
+
+    def test_does_not_stop_when_calls_vary(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+        for selector in ['#a', '#b', '#c', '#d', '#e']:
+            agent.current_session['messages'].append(
+                _assistant_call('click_element_by_selector', f'{{"selector": "{selector}"}}'))
+            check(agent)
+            assert not agent.current_session.get('stop_signal')
+
+    def test_counter_resets_after_a_different_call(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+        # two identical, then a different one resets the streak, then two identical again
+        for name in ['scroll', 'scroll', 'screenshot', 'scroll', 'scroll']:
+            agent.current_session['messages'].append(_assistant_call(name, '{}'))
+            check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+    def test_threshold_is_configurable(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=2)[0]
+        agent.current_session['messages'].append(_assistant_call('f', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+        agent.current_session['messages'].append(_assistant_call('f', '{}'))
+        check(agent)
+        assert agent.current_session.get('stop_signal') is True
+
+    def test_plugin_registers_after_iteration(self):
+        from connectonion import Agent
+        from tests.utils.mock_helpers import MockLLM
+        from connectonion.core.llm import LLMResponse
+        from connectonion.core.usage import TokenUsage
+
+        mock_llm = MockLLM(responses=[
+            LLMResponse(content="done", tool_calls=[], raw_response=None, usage=TokenUsage())
+        ])
+        agent = Agent("test", llm=mock_llm, plugins=[no_progress_guard()], log=False)
+        assert 'after_iteration' in agent.events

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -411,3 +411,39 @@ class TestRelayIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestRelaySupervisorResilience:
+    """The relay supervisor (server._create_relay_lifespan) must keep reconnecting
+    across ANY transient failure, not die on the first non-ConnectionClosed error."""
+
+    @pytest.mark.asyncio
+    async def test_supervisor_reconnects_after_non_connectionclosed_error(self, monkeypatch):
+        # Regression: the old relay_loop had no try/except around connect()/serve_loop(),
+        # so a network blip surfacing as OSError escaped the loop and silently killed
+        # relay_task — the agent stopped announcing and went stale on the relay until
+        # restart. The supervisor must instead log, back off, and reconnect.
+        import asyncio
+        from connectonion.network import relay as relay_module
+        from connectonion.network.host.server import _create_relay_lifespan
+
+        calls = {"connect": 0}
+
+        async def boom(*args, **kwargs):
+            calls["connect"] += 1
+            raise OSError("simulated network blip")
+
+        monkeypatch.setattr(relay_module, "connect", boom)
+
+        addr_data = {"address": "0x" + "a" * 64}
+        on_startup, on_shutdown = _create_relay_lifespan(
+            "wss://relay.test", addr_data, "summary", 8000, lambda *a, **k: None,
+        )
+
+        await on_startup()
+        await asyncio.sleep(1.3)   # initial attempt + at least one retry after the 1s backoff
+        await on_shutdown()
+
+        assert calls["connect"] >= 2, (
+            "supervisor died after the first error instead of reconnecting"
+        )


### PR DESCRIPTION
Consolidates #151, #152, #153 into one PR (replaces all three).

**Relay profile (display metadata)**
- `host()` publishes a display profile (alias/tools/model + project-level skills only — user/builtin skills stay private) with the first ANNOUNCE of each connection; the relay persists it so heartbeats stay small. Pairs with openonion/oo-api#18 relay-side serving.
- Skill filter fix: `location` is a discovery category (project/user/builtin), not a path.

**Browser thread safety (hosted agents)**
- Playwright's sync API is thread-bound; `host()` runs turns on arbitrary pool threads. All public `BrowserAutomation` methods dispatch to the instance's dedicated worker thread (executor owned by `__init__`, wrapping applied by a class decorator).
- Bounded the idle-session forwarder wait (~1s) so idle sessions can't pin executor-pool threads and starve new connections.
- Screenshot data URLs stay on the trace (`entry['image']`) so session replay re-emits them; replays no longer lose screenshots.

**Onboard completes the gated CONNECT**
- The trust gate interrupts CONNECT before `conn` is populated; a successful ONBOARD_SUBMIT used to leave the connection in a dead end (`authenticate first (send CONNECT)` on the next INPUT, and a CONNECT replay can age past the 5-minute signature window during invite/payment entry). `handle_connect` now stashes the gated CONNECT; after a verified onboard the session loop runs `establish_connection()` with the onboard-verified identity, ending in CONNECTED so the client's pending input resumes. Pairs with the SDK-side retry removal in openonion/connectonion-ts#7.

**Template deploys with arbitrary skill combinations**
- `co deploy --template <t> --name <agent>` names the project (default `{template}-agent`), so different skill combos run side by side instead of overwriting each other.
- `--skills A B C` takes multiple paths after one flag (extra positionals are collected; misspellings fail loudly in path validation); repeated flags still work. A path that is itself a skill (contains `SKILL.md`) nests under `.co/skills/<dirname>/`.
- co-ai image gains `nodejs` (skills ship node scripts — the only difference vs the hand-written LinkedIn agent Dockerfile).
- Verified end to end: template deploy with three `--skills` paths → agent running with exactly those skills; the redeployed `linkedin-agent` runs this branch in production.

Every changed file's LLM-Note header updated. Tests: 2150 passed (unit + e2e/cli).