### PR TITLE
fix: require word boundary for Bash(cmd *) permission wildcard

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -373,10 +373,12 @@ def matches_permission_pattern(tool_name: str, tool_args: dict, pattern: str) ->
         if cmd_pattern == actual_cmd:
             return True
 
-        # Wildcard match: "git diff *" matches "git diff --staged"
+        # Wildcard match: "git diff *" matches "git diff --staged" (and bare
+        # "git diff"), but NOT "git difftool". Require a word boundary after the
+        # prefix so "git *" cannot match an unrelated binary like "gitleaks".
         if cmd_pattern.endswith(' *'):
             prefix = cmd_pattern[:-2]  # Remove " *"
-            if actual_cmd.startswith(prefix):
+            if actual_cmd == prefix or actual_cmd.startswith(prefix + ' '):
                 return True
 
         # Wildcard match: "git *" matches "git status"

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -186,6 +186,12 @@ class TestPatternMatching:
 
     def test_bash_command_prefix_wildcard(self):
         """Test bash command prefix wildcard (git *)."""
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'git'},
+            'Bash(git *)'
+        ) == True
+
         # "git *" should match any git command
         assert matches_permission_pattern(
             'bash',
@@ -205,11 +211,41 @@ class TestPatternMatching:
             'Bash(git *)'
         ) == True
 
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'git diff'},
+            'Bash(git diff *)'
+        ) == True
+
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'git diff --staged'},
+            'Bash(git diff *)'
+        ) == True
+
         # "git *" should NOT match non-git commands
         assert matches_permission_pattern(
             'bash',
             {'command': 'pytest'},
             'Bash(git *)'
+        ) == False
+
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'gitleaks detect'},
+            'Bash(git *)'
+        ) == False
+
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'lsof -i'},
+            'Bash(ls *)'
+        ) == False
+
+        assert matches_permission_pattern(
+            'bash',
+            {'command': 'git difftool'},
+            'Bash(git diff *)'
         ) == False
 
     def test_single_pattern_string(self):


### PR DESCRIPTION
## Problem
`matches_permission_pattern()` matches the `Bash(cmd *)` wildcard with `actual_cmd.startswith(prefix)` and no word boundary, so a permission scoped to one command family also authorizes unrelated commands sharing the prefix:

```
Bash(git *) -> matches 'gitleaks --dump-secrets'   (should not)
Bash(ls *)  -> matches 'lsof -i'                     (should not)
Bash(cat *) -> matches 'catnip /etc/passwd'          (should not)
```

This widens the auto-approved command set beyond operator intent (CWE-863). Severity is constrained by needing such a wildcard in config plus a useful prefix-sharing binary, so this is a hardening fix.

## Fix
Require an exact match or a trailing space after the prefix:
```python
if actual_cmd == prefix or actual_cmd.startswith(prefix + ' '):
    return True
```

## Test Plan
- [ ] Existing test suite passes (`pytest tests/unit/test_tool_approval.py`, Python >=3.10)
- [ ] `Bash(git *)` matches `git` and `git status`, but NOT `gitleaks --dump`
- [ ] `Bash(ls *)` does NOT match `lsof -i`

## Security Note
Low/hardening, CWE-863 (Incorrect Authorization). Reported by FailSafe Researcher (authorized security review).