### PR TITLE
co browser: direct verb dispatch via a persistent browser daemon

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -13,21 +13,23 @@ ConnectOnion - A simple agent framework with behavior tracking.
 __version__ = "1.0.1"
 
 # Auto-load .env files for the entire framework
+import sys as _sys
 from dotenv import load_dotenv
 from pathlib import Path as _Path
 
 # Load .env with fallback: cwd .env -> global ~/.co/keys.env
+# Diagnostics go to stderr so command output on stdout stays clean (scriptable).
 # Priority 1: Current directory .env (project-specific keys)
 _env_file = _Path.cwd() / ".env"
 if _env_file.exists():
     load_dotenv(_env_file)
-    print(f"[env] {_env_file.resolve()}")
+    print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
 else:
     # Priority 2: Global keys.env (shared API keys fallback)
     _global_keys = _Path.home() / ".co" / "keys.env"
     if _global_keys.exists():
         load_dotenv(_global_keys)
-        print(f"[env] {_global_keys.resolve()}")
+        print(f"[env] {_global_keys.resolve()}", file=_sys.stderr)
     # No else - if neither exists, proceed without .env (API keys might be in shell env)
 
 from .core import Agent, LLM, create_tool_from_function

--- a/connectonion/cli/browser_agent/agent.py
+++ b/connectonion/cli/browser_agent/agent.py
@@ -21,30 +21,38 @@ from connectonion.useful_tools.browser_tools import BrowserAutomation
 PROMPT_PATH = Path(__file__).parent / "prompts" / "agent.md"
 
 
-def execute_browser_command(command: str, headless: bool = False) -> str:
-    """Execute a browser command using natural language.
-
-    Returns the agent's natural language response directly.
-    """
+def resolve_api_key() -> str:
+    """Return the OpenOnion API key from env or ~/.co/keys.env (empty string if absent)."""
     api_key = os.getenv('OPENONION_API_KEY')
-
     if not api_key:
         global_env = Path.home() / ".co" / "keys.env"
         if global_env.exists():
             load_dotenv(global_env)
             api_key = os.getenv('OPENONION_API_KEY')
+    return api_key or ""
 
+
+def build_browser_agent(browser, api_key: str) -> Agent:
+    """Build the natural-language browser Agent driving an existing BrowserAutomation."""
+    return Agent(
+        name="browser_cli",
+        model="co/gemini-3-flash-preview",
+        api_key=api_key,
+        system_prompt=PROMPT_PATH,
+        tools=[browser],
+        plugins=[image_result_formatter, ui_stream],
+        max_iterations=200,
+    )
+
+
+def execute_browser_command(command: str, headless: bool = False) -> str:
+    """Execute a browser command using natural language.
+
+    Returns the agent's natural language response directly.
+    """
+    api_key = resolve_api_key()
     if not api_key:
         return 'Browser agent requires authentication. Run: co auth'
 
     with BrowserAutomation(headless=headless) as browser:
-        agent = Agent(
-            name="browser_cli",
-            model="co/gemini-3-flash-preview",
-            api_key=api_key,
-            system_prompt=PROMPT_PATH,
-            tools=[browser],
-            plugins=[image_result_formatter, ui_stream],
-            max_iterations=200
-        )
-        return agent.input(command)
+        return build_browser_agent(browser, api_key).input(command)

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -1,0 +1,76 @@
+"""
+Purpose: Thin client for the browser daemon — sends one request line over the Unix socket and maps the reply to stdout/stderr/exit code.
+LLM-Note:
+  Dependencies: imports from [socket, os, sys, time, subprocess, pathlib, browser_agent.daemon.default_sock_path] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_cli_browser.py]
+  Data flow: send(line, headless) → connect to default_sock_path() (spawning the daemon detached if absent / unlinking a stale socket) → send line, half-close → read reply to EOF → first line "OK"/"ERR" sets exit code, rest is payload → OK prints to stdout, ERR prints to stderr → returns exit code int
+  State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` with start_new_session=True, logging to ~/.co/browser.log | writes to stdout/stderr
+  Integration: exposes send(line, headless=False) -> int
+  Performance: one connect + request/response | daemon spawn adds browser launch latency on first call
+  Errors: connection refused / missing socket → spawn daemon and retry until ready or timeout
+"""
+
+import os
+import sys
+import time
+import socket
+import subprocess
+from pathlib import Path
+
+from .daemon import default_sock_path
+
+
+def _connect(sock_path: str):
+    """Connect to the daemon socket, or None if nothing is listening."""
+    if not os.path.exists(sock_path):
+        return None
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        conn.connect(sock_path)
+        return conn
+    except OSError:
+        conn.close()
+        os.unlink(sock_path)  # stale socket
+        return None
+
+
+def _spawn_daemon(sock_path: str, headless: bool):
+    """Launch the daemon detached and wait until its socket accepts connections."""
+    log_path = Path.home() / ".co" / "browser.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log = open(log_path, "a")
+    cmd = [sys.executable, "-m", "connectonion.cli.browser_agent.daemon", sock_path]
+    if headless:
+        cmd.append("--headless")
+    subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+
+    for _ in range(100):  # up to ~10s for the browser to launch
+        conn = _connect(sock_path)
+        if conn:
+            return conn
+        time.sleep(0.1)
+    raise RuntimeError(f"browser daemon did not start (see {log_path})")
+
+
+def send(line: str, headless: bool = False) -> int:
+    """Send one request line; print the reply; return the process exit code."""
+    sock_path = default_sock_path()
+    conn = _connect(sock_path) or _spawn_daemon(sock_path, headless)
+
+    conn.sendall(line.encode())
+    conn.shutdown(socket.SHUT_WR)
+
+    chunks = []
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    conn.close()
+
+    header, _, payload = b"".join(chunks).decode().partition("\n")
+    if header == "OK":
+        if payload:
+            print(payload)
+        return 0
+    print(payload, file=sys.stderr)
+    return 1

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -1,0 +1,187 @@
+"""
+Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI verbs to it over a Unix socket.
+LLM-Note:
+  Dependencies: imports from [socket, os, sys, shlex, inspect, signal, atexit, pathlib, useful_tools.browser_tools.BrowserAutomation, browser_agent.agent (resolve_api_key, build_browser_agent)] | imported by [browser_agent/client.py (spawns via python -m), cli/commands/browser_commands.py (indirectly)] | tested by [tests/e2e/cli/test_cli_browser.py]
+  Data flow: client sends one request line over AF_UNIX socket → shlex.split → first token compared against BrowserAutomation method names → match: coerce args via signature type hints + getattr(browser, verb)(*args) → no match: whole line handed to NL Agent on the same live browser → response "OK\n<payload>" or "ERR\n<message>" written back, connection closed
+  State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | binds AF_UNIX socket at default_sock_path() | daemon exits once an opened browser becomes unusable (close / crash / window shut) | unlinks socket on exit
+  Integration: exposes default_sock_path(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]`
+  Performance: one request at a time | browser launch overhead on first verb (1-3s) | NL verb builds a fresh Agent per call
+  Errors: method exceptions are caught at the dispatch boundary and returned as "ERR\n<message>" (the protocol's purpose) | bind race with a second daemon → loser exits
+"""
+
+import os
+import sys
+import socket
+import shlex
+import inspect
+import signal
+import atexit
+import tempfile
+import threading
+from pathlib import Path
+
+from connectonion.useful_tools.browser_tools import BrowserAutomation
+from .agent import resolve_api_key, build_browser_agent
+
+
+def default_sock_path() -> str:
+    """Runtime socket path: $CO_BROWSER_SOCK, else $XDG_RUNTIME_DIR/co, else $TMPDIR/co."""
+    override = os.environ.get("CO_BROWSER_SOCK")
+    if override:
+        return override
+    runtime = os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir()
+    base = Path(runtime) / "co"
+    base.mkdir(parents=True, exist_ok=True)
+    os.chmod(base, 0o700)
+    return str(base / "browser.sock")
+
+
+def _coerce(value: str, annotation):
+    """Coerce a shell string token to the parameter's annotated type."""
+    if annotation is bool:
+        return value.lower() in ("1", "true", "yes", "on")
+    if annotation is int:
+        return int(value)
+    if annotation is float:
+        return float(value)
+    return value
+
+
+def _split_tokens(tokens):
+    """Split shell tokens into positional args and --key[=value] kwargs."""
+    positional, kwargs = [], {}
+    for tok in tokens:
+        if tok.startswith("--"):
+            key, eq, val = tok[2:].partition("=")
+            kwargs[key.replace("-", "_")] = val if eq else True
+        else:
+            positional.append(tok)
+    return positional, kwargs
+
+
+def _is_verb(browser, name: str) -> bool:
+    """True when `name` is a public, callable method on the browser instance."""
+    if name.startswith("_"):
+        return False
+    attr = getattr(browser, name, None)
+    return callable(attr)
+
+
+class BrowserDaemon:
+    """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
+
+    def __init__(self, sock_path: str, headless: bool = False):
+        self.sock_path = sock_path
+        self.browser = BrowserAutomation(headless=headless)
+        self._srv = None
+        self._had_browser = False
+
+    def dispatch(self, line: str) -> tuple:
+        """Run one request. Returns (ok: bool, payload: str)."""
+        tokens = shlex.split(line)
+        if not tokens:
+            return False, "empty request"
+
+        verb = tokens[0]
+        if verb == "do":  # explicit natural-language agent
+            command = line.split(None, 1)[1] if len(tokens) > 1 else ""
+            return self._run_nl(command)
+        if _is_verb(self.browser, verb):
+            return self._call_verb(verb, tokens[1:])
+        return False, f"unknown command: {verb}"
+
+    def _call_verb(self, verb: str, raw_args) -> tuple:
+        """Match the verb to a browser method and execute it with coerced args."""
+        method = getattr(self.browser, verb)
+        positional, kwargs = _split_tokens(raw_args)
+
+        params = list(inspect.signature(method).parameters.values())
+        args = [_coerce(v, params[i].annotation if i < len(params) else str)
+                for i, v in enumerate(positional)]
+        kw = {}
+        param_by_name = {p.name: p for p in params}
+        for k, v in kwargs.items():
+            ann = param_by_name[k].annotation if k in param_by_name else str
+            kw[k] = v if v is True else _coerce(v, ann)
+
+        try:
+            result = method(*args, **kw)
+        except Exception as exc:  # dispatch boundary: report to client as ERR
+            return False, f"{type(exc).__name__}: {exc}"
+        return True, _stringify(result)
+
+    def _run_nl(self, command: str) -> tuple:
+        """Hand the command to the NL agent driving the same live browser."""
+        api_key = resolve_api_key()
+        if not api_key:
+            return False, "Browser agent requires authentication. Run: co auth"
+        try:
+            result = build_browser_agent(self.browser, api_key).input(command)
+        except Exception as exc:
+            return False, f"{type(exc).__name__}: {exc}"
+        return True, _stringify(result)
+
+    def serve(self):
+        self._bind()
+        atexit.register(self._cleanup)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
+        while True:
+            conn, _ = self._srv.accept()
+            request = _recv_all(conn).decode().strip()
+            ok, payload = self.dispatch(request)
+            conn.sendall((("OK" if ok else "ERR") + "\n" + payload).encode())
+            conn.close()
+
+            self._had_browser = self._had_browser or self.browser._browser_is_usable()
+            if self._had_browser and not self.browser._browser_is_usable():
+                break  # browser closed / crashed → daemon's job is done
+
+    def _bind(self):
+        """Bind the socket, yielding to any daemon that already owns it."""
+        if os.path.exists(self.sock_path):
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                probe.connect(self.sock_path)
+                probe.close()
+                sys.exit(0)  # another daemon already serving
+            except OSError:
+                os.unlink(self.sock_path)  # stale socket
+        self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._srv.bind(self.sock_path)
+        self._srv.listen(8)
+
+    def _cleanup(self):
+        self.browser.close()
+        if self._srv:
+            self._srv.close()
+        if os.path.exists(self.sock_path):
+            os.unlink(self.sock_path)
+
+
+def _recv_all(conn) -> bytes:
+    """Read until the client half-closes (EOF)."""
+    chunks = []
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+
+
+def _stringify(result) -> str:
+    """Methods return str or list[str]; lists print one item per line for piping."""
+    if isinstance(result, list):
+        return "\n".join(str(x) for x in result)
+    return "" if result is None else str(result)
+
+
+def main():
+    sock_path = sys.argv[1] if len(sys.argv) > 1 else default_sock_path()
+    headless = "--headless" in sys.argv[2:]
+    BrowserDaemon(sock_path, headless=headless).serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -67,6 +67,32 @@ def _is_verb(browser, name: str) -> bool:
     return callable(attr)
 
 
+def signature_str(method) -> str:
+    """Render a method's call signature without `self`, e.g. '(url)' or '(path=None, full_page=False)'."""
+    parts = []
+    for p in inspect.signature(method).parameters.values():
+        if p.name == "self":
+            continue
+        parts.append(p.name if p.default is inspect.Parameter.empty else f"{p.name}={p.default!r}")
+    return "(" + ", ".join(parts) + ")"
+
+
+def list_functions() -> str:
+    """One line per public browser function: `name(args) — first docstring line`.
+
+    Introspects the BrowserAutomation class (no browser launched) so the CLI is
+    self-describing — an agent can run `co browser help` to discover what it can call.
+    """
+    lines = []
+    for name, method in inspect.getmembers(BrowserAutomation, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        doc = (inspect.getdoc(method) or "").splitlines()
+        summary = doc[0] if doc else ""
+        lines.append(f"  {name}{signature_str(method)}" + (f" — {summary}" if summary else ""))
+    return "\n".join(lines)
+
+
 class BrowserDaemon:
     """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
 
@@ -88,7 +114,11 @@ class BrowserDaemon:
             return self._run_nl(command)
         if _is_verb(self.browser, verb):
             return self._call_verb(verb, tokens[1:])
-        return False, f"unknown command: {verb}"
+        return False, (
+            f"unknown command: {verb}\n"
+            f"Run 'co browser help' to list functions, or "
+            f"'co browser do \"<instruction>\"' for natural language."
+        )
 
     def _call_verb(self, verb: str, raw_args) -> tuple:
         """Match the verb to a browser method and execute it with coerced args."""
@@ -107,7 +137,9 @@ class BrowserDaemon:
         try:
             result = method(*args, **kw)
         except Exception as exc:  # dispatch boundary: report to client as ERR
-            return False, f"{type(exc).__name__}: {exc}"
+            # On wrong arguments, show the expected signature so an agent can self-correct.
+            hint = f"\nusage: {verb}{signature_str(method)}" if isinstance(exc, TypeError) else ""
+            return False, f"{type(exc).__name__}: {exc}{hint}"
         return True, _stringify(result)
 
     def _run_nl(self, command: str) -> tuple:

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -1,28 +1,31 @@
 """
-Purpose: Execute browser automation commands using Playwright-based browser agent
+Purpose: Thin CLI handler for `co browser` — forwards verbs to the persistent browser daemon.
 LLM-Note:
-  Dependencies: imports from [rich.console, cli/browser_agent/browser.execute_browser_command] | imported by [cli/main.py via handle_browser()] | requires Playwright installation | tested by [tests/e2e/cli/test_cli_browser.py]
-  Data flow: receives command: str from CLI parser (e.g., "screenshot localhost:3000") → calls execute_browser_command(command) → browser agent parses command and executes via Playwright → returns result string → prints to console via rich.Console
-  State/Effects: no persistent state | launches headless browser via Playwright | may create screenshot files in current directory | writes to stdout via rich.Console | browser process lifecycle managed by browser_agent module
-  Integration: exposes handle_browser(command) | called from main.py via --browser flag or 'browser' subcommand | delegates to browser_agent/browser.execute_browser_command() | supports commands like "screenshot URL", "navigate URL", "click selector"
-  Performance: browser launch overhead (1-3s) | Playwright operations vary by command | screenshot generation is fast (<1s)
-  Errors: fails if Playwright not installed | fails if browser launch fails | fails if invalid command syntax | prints error to console but doesn't raise exception
+  Dependencies: imports from [shlex, browser_agent.client.send] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_cli_browser.py]
+  Data flow: receives args: list[str] (+ headless: bool) from CLI → shlex.join → client.send() → connects to daemon (spawns if absent) → daemon matches the first word to a BrowserAutomation method and executes it (or runs the NL agent for the `do` verb) → result printed to stdout/stderr by client, exit code returned
+  State/Effects: no local state | delegates browser/process lifecycle to the daemon | prints usage to stderr when called with no args
+  Integration: exposes handle_browser(args, headless=False) -> int (exit code) | called from main.py browser command
+  Performance: one socket round-trip per call | first call spawns the daemon (browser launch latency)
+  Errors: daemon-side errors come back as ERR → stderr + exit 1
 """
 
-from rich.console import Console
+import sys
+import shlex
 
-console = Console()
+from ..browser_agent.client import send
+
+USAGE = (
+    "Usage: co browser <command> [args]\n"
+    "  co browser go_to x.com           run a browser function directly\n"
+    "  co browser take_screenshot       (any BrowserAutomation method works)\n"
+    "  co browser do \"<instruction>\"    run the natural-language agent\n"
+    "  co browser close                 close the browser (stops the daemon)"
+)
 
 
-def handle_browser(command: str, headless: bool = False):
-    """Execute browser automation commands - guide browser to do something.
-
-    This is an alternative to the -b flag. Both 'co -b' and 'co browser' are supported.
-
-    Args:
-        command: The browser command to execute
-        headless: Run browser without visible window (default True)
-    """
-    from ..browser_agent.agent import execute_browser_command
-    result = execute_browser_command(command, headless=headless)
-    console.print(result)
+def handle_browser(args, headless: bool = False) -> int:
+    """Forward a browser command to the daemon. Returns the process exit code."""
+    if not args:
+        print(USAGE, file=sys.stderr)
+        return 1
+    return send(shlex.join(args), headless=headless)

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -1,31 +1,40 @@
 """
-Purpose: Thin CLI handler for `co browser` — forwards verbs to the persistent browser daemon.
+Purpose: Thin CLI handler for `co browser` — forwards verbs to the persistent browser daemon, and serves self-describing help.
 LLM-Note:
-  Dependencies: imports from [shlex, browser_agent.client.send] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_cli_browser.py]
-  Data flow: receives args: list[str] (+ headless: bool) from CLI → shlex.join → client.send() → connects to daemon (spawns if absent) → daemon matches the first word to a BrowserAutomation method and executes it (or runs the NL agent for the `do` verb) → result printed to stdout/stderr by client, exit code returned
-  State/Effects: no local state | delegates browser/process lifecycle to the daemon | prints usage to stderr when called with no args
+  Dependencies: imports from [sys, shlex, browser_agent.client.send, browser_agent.daemon.list_functions] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_cli_browser.py, tests/e2e/cli/test_browser_daemon.py]
+  Data flow: receives args: list[str] (+ headless: bool) from CLI → `help`/`--list` printed locally by introspecting BrowserAutomation (no browser launched) → otherwise shlex.join → client.send() → daemon matches the first word to a BrowserAutomation method and executes it (or runs the NL agent for the `do` verb) → result printed to stdout/stderr by client, exit code returned
+  State/Effects: no local state | `help` introspects the class only | other verbs delegate browser/process lifecycle to the daemon | prints usage to stderr when called with no args
   Integration: exposes handle_browser(args, headless=False) -> int (exit code) | called from main.py browser command
-  Performance: one socket round-trip per call | first call spawns the daemon (browser launch latency)
-  Errors: daemon-side errors come back as ERR → stderr + exit 1
+  Performance: `help` is import-only (no socket, no Chrome) | other verbs: one socket round-trip, first call spawns the daemon
+  Errors: daemon-side errors come back as ERR → stderr + exit 1; unknown verbs and wrong-argument errors include a next-step hint
 """
 
 import sys
 import shlex
 
 from ..browser_agent.client import send
+from ..browser_agent.daemon import list_functions
 
 USAGE = (
-    "Usage: co browser <command> [args]\n"
-    "  co browser go_to x.com           run a browser function directly\n"
-    "  co browser take_screenshot       (any BrowserAutomation method works)\n"
-    "  co browser do \"<instruction>\"    run the natural-language agent\n"
-    "  co browser close                 close the browser (stops the daemon)"
+    "co browser — drive one persistent browser from the shell\n"
+    "\n"
+    "  co browser <function> [args]     run a browser function directly (deterministic)\n"
+    '  co browser do "<instruction>"    let the AI agent do it (natural language)\n'
+    "  co browser close                 close the browser and stop the daemon\n"
+    "  co browser help                  list every browser function\n"
+    "\n"
+    "The browser stays open between commands (one shared session) until `close`.\n"
+    "Add --headless before the function to run without a visible window.\n"
+    "Output goes to stdout, errors to stderr; exit code is 0 on success, 1 on failure."
 )
 
 
 def handle_browser(args, headless: bool = False) -> int:
-    """Forward a browser command to the daemon. Returns the process exit code."""
+    """Forward a browser command to the daemon, or print help. Returns the process exit code."""
     if not args:
         print(USAGE, file=sys.stderr)
         return 1
+    if args[0] in ("help", "--list", "list"):
+        print(USAGE + "\n\nFunctions:\n" + list_functions())
+        return 0
     return send(shlex.join(args), headless=headless)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -150,14 +150,14 @@ def doctor():
     handle_doctor()
 
 
-@app.command()
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def browser(
     headless: bool = typer.Option(False, "--headless/--no-headless", help="Run browser headless"),
-    command: str = typer.Argument(..., help="Browser command"),
+    args: List[str] = typer.Argument(None, help="Browser function + args, or: do \"<instruction>\""),
 ):
-    """Browser automation."""
+    """Browser automation: run a browser function directly, or `do` for the NL agent."""
     from .commands.browser_commands import handle_browser
-    handle_browser(command, headless=headless)
+    raise typer.Exit(handle_browser(args or [], headless=headless))
 
 
 @app.command()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -61,6 +61,7 @@ def _show_help():
     console.print("  [green]trust[/green]             Manage trust lists")
     console.print("  [green]deploy[/green]            Deploy to ConnectOnion Cloud")
     console.print("  [green]auth[/green]              Authenticate for managed keys")
+    console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
     console.print("  [green]status[/green]            Check account balance")
     console.print("  [green]doctor[/green]            Diagnose installation")
@@ -155,7 +156,8 @@ def browser(
     headless: bool = typer.Option(False, "--headless/--no-headless", help="Run browser headless"),
     args: List[str] = typer.Argument(None, help="Browser function + args, or: do \"<instruction>\""),
 ):
-    """Browser automation: run a browser function directly, or `do` for the NL agent."""
+    """Drive one persistent browser. Run a function directly (co browser go_to x.com),
+    use `do` for the AI agent (co browser do "..."), or `co browser help` to list functions."""
     from .commands.browser_commands import handle_browser
     raise typer.Exit(handle_browser(args or [], headless=headless))
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -493,37 +493,33 @@ See [sub documentation](sub.md) for the full fan-out behavior and v1 limitations
 
 #### `co browser <command>` - Browser Automation
 
-Execute browser commands quickly.
+Drive one persistent browser from the shell. Call a browser function directly, or use `do` for the AI agent. State persists between commands until you `close`. See [browser.md](browser.md).
 
-**Basic usage:**
+**Direct function calls:**
 ```bash
-co browser "screenshot localhost:3000"
-co browser "click on login button"
-
-# Shortcut
-co -b "screenshot localhost:3000"
+co browser go_to localhost:3000       # navigate
+co browser take_screenshot shot.png   # screenshot
+co browser get_current_url            # print current URL
+co browser get_links_from_page        # one link per line (pipeable)
+co browser close                      # close browser, stop daemon
 ```
 
-**Common commands:**
+**Natural language (AI agent on the same browser):**
 ```bash
-# Screenshots
-co -b "screenshot https://example.com"
+co browser do "click the login button and open the dashboard"
+```
 
-# Page interaction
-co -b "click on submit button"
-co -b "fill form with test data"
-co -b "navigate to /dashboard"
-
-# Data extraction
-co -b "get text from .price"
-co -b "extract all links"
+**Scripting (clean stdout, exit codes):**
+```bash
+url=$(co browser get_current_url)
+co browser get_links_from_page | grep github
+co browser --headless go_to "$DEPLOY_URL"   # --headless for CI
 ```
 
 **When to use:**
-- Quick testing
-- Visual verification
-- Ad-hoc automation
-- Debugging browser tools
+- Scripting exact browser steps (direct calls)
+- Letting the agent handle a task (`do`)
+- Visual verification and debugging
 
 ---
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -1,235 +1,143 @@
-# CLI Browser Feature
+# CLI Browser
 
-Quick browser screenshots with one command.
+Drive one real browser from the shell — call browser functions directly, or hand a task to the AI agent.
 
-## Overview
-
-The `-b` flag (or `co browser`) takes instant screenshots without writing code. Perfect for debugging, testing, and sharing visual proof.
-
-## Basic Usage
+## Quick Start (60 seconds)
 
 ```bash
-co -b "screenshot localhost:3000"
+co browser go_to news.ycombinator.com    # opens a browser, navigates
+co browser get_current_url               # → https://news.ycombinator.com/
+co browser take_screenshot /tmp/shot.png # saves a PNG
+co browser close                         # done
 ```
 
-Saves to `.tmp/screenshot_YYYYMMDD_HHMMSS.png` by default.
+The browser stays open **between commands**. Each `co browser ...` call drives the *same* window — your navigation, cookies, and logged-in session persist until you `close`.
 
-## Command Format
+## Why Use This
+
+Two ways to use a browser from the CLI, and you pick per command:
+
+- **Direct function call** — `co browser go_to x.com`. Deterministic, instant, free (no LLM). Great for scripting and exact steps you already know.
+- **Natural language** — `co browser do "find the cheapest flight"`. The AI agent figures out the steps. Great when you don't want to spell them out.
+
+Both drive the **same live browser**, so you can mix them: script the boring parts, let the agent handle the hard part.
 
 ```bash
-co -b "screenshot [URL] [save to PATH] [size SIZE]"
+co browser go_to myapp.com/login
+co browser do "log me in and open the billing page"   # agent takes over the same window
+co browser take_screenshot billing.png                # back to a direct call
 ```
 
-All parts except URL are optional.
+## How It Works
 
-## Examples
+The first `co browser` command starts a small background **daemon** that owns one browser. Every later command connects to it over a local socket and drives that same browser. The daemon lives exactly as long as the browser:
 
-### Basic Screenshot
+```
+co browser go_to x.com   ──► starts daemon ──► opens browser ─┐
+co browser click "Login" ──────────────────► same browser    │  state persists
+co browser screenshot    ──────────────────► same browser    │
+co browser close         ──► browser closes ──► daemon exits ─┘
+```
+
+You never manage the daemon directly — the **first command starts it**, and `close` (or closing the window) stops it. There is no separate "start" step.
+
+### How a command is dispatched
+
+The first word is compared against the browser's function names:
+
+| You type | What happens |
+|----------|--------------|
+| `co browser go_to x.com` | `go_to` **is** a function → runs it directly |
+| `co browser do "..."` | `do` → hands the instruction to the AI agent |
+| `co browser frobnicate` | matches nothing → `unknown command: frobnicate` (exit 1) |
+
+> Quote natural-language instructions: `co browser do "click the blue button"`. A bare word that happens to be a function name (like `click`) is treated as a direct call, not language.
+
+## Common Functions
+
+Any method on the browser is callable. The ones you'll reach for most:
 
 ```bash
-# Screenshot local development
-co -b "screenshot localhost:3000"
-
-# With specific port
-co -b "screenshot localhost:8080"
-
-# External site
-co -b "screenshot example.com"
+co browser go_to <url>                     # navigate
+co browser get_current_url                 # print the current URL
+co browser get_text                        # print visible page text
+co browser take_screenshot /tmp/shot.png [--full-page]
+co browser click "<description or selector>"
+co browser type_text_by_selector <css> "<text>"
+co browser get_links_from_page             # one link per line
+co browser scroll                          # scroll the main content
+co browser close                           # close browser, stop daemon
 ```
 
-### Save to Specific Path
+Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters.
+
+> **Use absolute paths for files.** The daemon resolves relative paths against *its own* working directory (where it was first started), not the directory you run each command from. `take_screenshot /tmp/shot.png` is predictable; a bare `shot.png` lands in the daemon's `.tmp/` folder.
+
+## Scripting
+
+Output is clean stdout, errors go to stderr, and the exit code is `0` on success / `1` on failure — so commands compose like any Unix tool:
 
 ```bash
-# Save to temp directory
-co -b "screenshot localhost:3000 save to /tmp/debug.png"
+# Capture a value
+url=$(co browser get_current_url)
 
-# Save to current directory with name
-co -b "screenshot localhost:3000 save to homepage.png"
+# Pipe list output (one item per line)
+co browser get_links_from_page | grep github | wc -l
 
-# Save to subdirectory
-co -b "screenshot localhost:3000 save to screenshots/test.png"
+# Fail-fast in a script
+co browser go_to "$DEPLOY_URL" && co browser take_screenshot deployed.png
 ```
 
-### Device Sizes
+## Headless vs GUI
+
+By default the browser is **visible** (a real Chrome window you can watch). Add `--headless` for scripts/CI:
 
 ```bash
-# iPhone viewport
-co -b "screenshot localhost:3000 size iphone"
-
-# Custom dimensions
-co -b "screenshot localhost:3000 size 390x844"
-
-# Common presets
-co -b "screenshot localhost:3000 size ipad"
-co -b "screenshot localhost:3000 size desktop"
+co browser --headless go_to example.com    # no window
+co browser go_to example.com               # visible window (default)
 ```
 
-### Complete Examples
+The mode is fixed when the daemon starts (the first command). To switch modes, `co browser close` first, then start again with the mode you want.
+
+## Natural Language Agent
+
+`do` runs the full AI browser agent on the live browser and prints its final answer:
 
 ```bash
-# Debug mobile checkout flow
-co -b "screenshot localhost:3000/checkout save to /tmp/checkout-mobile.png size iphone"
-
-# Document bug on specific page
-co -b "screenshot localhost:3000/xray save to bug-report.png size 1920x1080"
-
-# Test responsive design
-co -b "screenshot localhost:3000 save to mobile.png size 390x844"
-co -b "screenshot localhost:3000 save to tablet.png size 768x1024"
-co -b "screenshot localhost:3000 save to desktop.png size 1920x1080"
+co browser do "search for wireless headphones and list the top 3 prices"
 ```
 
-## Device Presets
-
-| Preset | Dimensions | Device |
-|--------|------------|--------|
-| `iphone` | 390x844 | iPhone 14/15 |
-| `android` | 360x800 | Common Android |
-| `ipad` | 768x1024 | iPad |
-| `desktop` | 1920x1080 | Full HD Desktop |
-
-## URL Handling
-
-The command intelligently handles URLs:
-
-- `localhost` → `http://localhost`
-- `localhost:3000` → `http://localhost:3000`
-- `example.com` → `https://example.com`
-- `http://example.com` → `http://example.com` (unchanged)
-
-## Output Files
-
-If no path specified:
-- Saves under `.tmp/`
-- Named `screenshot_YYYYMMDD_HHMMSS.png`
-- Example: `.tmp/screenshot_20240115_143022.png`
+This path uses managed keys — run `co auth` once if you see an authentication message.
 
 ## Installation
 
-Browser features require Playwright:
+The browser needs Playwright:
 
 ```bash
 pip install playwright
 playwright install chromium
 ```
 
-Or install ConnectOnion with browser support:
+## Sessions & Profile
+
+- One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
+- The daemon's socket lives under `$XDG_RUNTIME_DIR/co/browser.sock` (override with `$CO_BROWSER_SOCK`).
+
+## Troubleshooting
 
 ```bash
-pip install connectonion[browser]
+# Nothing happens / stuck browser → close and start fresh
+co browser close
+
+# See what the agent/daemon is doing
+cat ~/.co/browser.log
+
+# Authentication needed (only for `do`)
+co auth
 ```
 
-## Use Cases
+## See Also
 
-### 1. Debug Local Development
-
-```bash
-# Quick check of homepage
-co -b "screenshot localhost:3000"
-
-# Debug specific route
-co -b "screenshot localhost:3000/api/status"
-```
-
-### 2. Document Bugs
-
-```bash
-# Capture error state
-co -b "screenshot localhost:3000/error save to bug.png"
-
-# Mobile-specific issue
-co -b "screenshot localhost:3000/mobile-bug save to mobile-issue.png size iphone"
-```
-
-### 3. Test Responsive Design
-
-```bash
-# Test different viewports
-for size in iphone android ipad desktop; do
-  co -b "screenshot localhost:3000 save to view-$size.png size $size"
-done
-```
-
-### 4. CI/CD Integration
-
-```bash
-# In GitHub Actions or similar
-co -b "screenshot $DEPLOY_URL save to artifacts/deployed.png"
-```
-
-## Error Messages
-
-```bash
-# Missing URL
-co -b "screenshot"
-❌ Usage: co -b "screenshot [URL] [save to PATH] [size SIZE]"
-
-# Playwright not installed  
-co -b "screenshot localhost:3000"
-❌ Browser tools not installed
-   Run: pip install playwright && playwright install chromium
-
-# Missing OPENAI_API_KEY
-co -b "screenshot localhost:3000"
-❌ Natural language browser agent unavailable. Set OPENAI_API_KEY and try again.
-
-# Cannot reach URL
-co -b "screenshot localhost:3000"
-❌ Cannot reach http://localhost:3000
-   Is your server running?
-
-# Permission denied
-co -b "screenshot localhost:3000 save to /root/test.png"
-❌ Cannot save to /root/test.png (permission denied)
-```
-
-## Tips
-
-1. **Quick Debug**: Just `co -b "screenshot localhost:3000"` for instant feedback
-2. **Organize Screenshots**: Use descriptive paths like `save to bugs/issue-123.png`
-3. **Test Viewports**: Use device names (`iphone`, `ipad`) for common sizes
-4. **Timestamps**: Default filenames include timestamp for versioning
-
-## Limitations
-
-- Screenshots only (no interaction, clicking, forms)
-- Single page at a time
-- Headless browser only
-- PNG format only
-
-For complex browser automation, use the full ConnectOnion browser agent or Playwright directly.
-
-## Requirements
-
-- `OPENAI_API_KEY` must be set (managed keys are not used here)
-- Playwright installed and set up
-
-## Examples for Common Frameworks
-
-### Next.js
-```bash
-co -b "screenshot localhost:3000"
-co -b "screenshot localhost:3000/_error save to error.png"
-```
-
-### FastAPI
-```bash
-co -b "screenshot localhost:8000"
-co -b "screenshot localhost:8000/docs save to api-docs.png"
-```
-
-### Django
-```bash
-co -b "screenshot localhost:8000"
-co -b "screenshot localhost:8000/admin save to admin.png"
-```
-
-### React Dev Server
-```bash
-co -b "screenshot localhost:3000"
-co -b "screenshot localhost:3000 size iphone"
-```
-
-## Summary
-
-The `-b` flag provides dead-simple browser screenshots. No setup, no complexity - just describe what screenshot you want and where to save it. Perfect for debugging during development.
+- [`co auth`](auth.md) — managed keys for the `do` agent
+- [Browser tools library](../useful_tools/browser_tools.md) — `BrowserAutomation` used in your own agents
+- [`browser` template](../templates/browser.md) — scaffold a browser agent project

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -53,9 +53,28 @@ The first word is compared against the browser's function names:
 
 > Quote natural-language instructions: `co browser do "click the blue button"`. A bare word that happens to be a function name (like `click`) is treated as a direct call, not language.
 
+## Discovering Functions
+
+The CLI describes itself — run `help` to list every callable function with its arguments and a one-line summary (no browser is launched):
+
+```bash
+co browser help
+```
+
+```
+Functions:
+  go_to(url) — Navigate to a URL.
+  take_screenshot(path=None, full_page=False) — Take a screenshot of the current page...
+  click(description) — Click on an element using natural language description.
+  get_links_from_page(domain_filter='') — Extract all unique links from the current page...
+  ...
+```
+
+This is the fastest way — for a person or an AI agent — to find the exact function name and arguments before calling it.
+
 ## Common Functions
 
-Any method on the browser is callable. The ones you'll reach for most:
+Any function listed by `co browser help` is callable. The ones you'll reach for most:
 
 ```bash
 co browser go_to <url>                     # navigate
@@ -122,6 +141,38 @@ playwright install chromium
 
 - One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
 - The daemon's socket lives under `$XDG_RUNTIME_DIR/co/browser.sock` (override with `$CO_BROWSER_SOCK`).
+
+## Error Messages
+
+Errors print to **stderr** and exit with code `1`. Each one tells you the next step — handy when an AI agent is driving the CLI and needs to self-correct.
+
+**Unknown function**
+```bash
+$ co browser frobnicate
+unknown command: frobnicate
+Run 'co browser help' to list functions, or 'co browser do "<instruction>"' for natural language.
+```
+The first word didn't match any browser function. List them with `co browser help`, or use `do` to describe the task in plain English.
+
+**Wrong arguments**
+```bash
+$ co browser go_to
+TypeError: BrowserAutomation.go_to() missing 1 required positional argument: 'url'
+usage: go_to(url)
+```
+The function exists but the arguments don't fit. The `usage:` line shows the exact signature — pass the missing argument: `co browser go_to example.com`.
+
+**Authentication required** (only for `do`)
+```bash
+$ co browser do "find the price"
+Browser agent requires authentication. Run: co auth
+```
+The natural-language agent uses managed keys. Run `co auth` once. Direct function calls don't need this.
+
+**Playwright not installed**
+```bash
+Browser tools not installed. Run: pip install playwright && playwright install chromium
+```
 
 ## Troubleshooting
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -25,7 +25,7 @@ Both drive the **same live browser**, so you can mix them: script the boring par
 ```bash
 co browser go_to myapp.com/login
 co browser do "log me in and open the billing page"   # agent takes over the same window
-co browser take_screenshot billing.png                # back to a direct call
+co browser take_screenshot /tmp/billing.png           # back to a direct call
 ```
 
 ## How It Works
@@ -104,7 +104,7 @@ url=$(co browser get_current_url)
 co browser get_links_from_page | grep github | wc -l
 
 # Fail-fast in a script
-co browser go_to "$DEPLOY_URL" && co browser take_screenshot deployed.png
+co browser go_to "$DEPLOY_URL" && co browser take_screenshot /tmp/deployed.png
 ```
 
 ## Headless vs GUI

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
     network: Tests that require network/relay server connection
     cli: CLI-specific tests
     asyncio: Async tests using pytest-asyncio
+    benchmark: Performance/benchmark tests
 
 # Output options
 addopts =

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -123,7 +123,19 @@ def test_dispatch_unknown_command(tmp_path):
     daemon = make_daemon(str(tmp_path / "s.sock"))
     ok, payload = daemon.dispatch("frobnicate now")
     assert ok is False
-    assert payload == "unknown command: frobnicate"
+    assert payload.startswith("unknown command: frobnicate")
+    # agent-friendly next steps
+    assert "co browser help" in payload
+    assert 'do "<instruction>"' in payload
+
+
+def test_dispatch_wrong_args_shows_signature(tmp_path):
+    """A TypeError from wrong args must include the function's usage so an agent can fix it."""
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("go_to")  # missing required `url`
+    assert ok is False
+    assert "TypeError" in payload
+    assert "usage: go_to(url)" in payload
 
 
 def test_dispatch_empty(tmp_path):
@@ -149,6 +161,40 @@ def test_dispatch_do_routes_to_nl(tmp_path, monkeypatch):
     assert ok is True
     assert payload == "agent says hi"
     assert captured["command"] == "find the cheapest flight"
+
+
+# ---- self-describing help (no browser launched) -------------------------
+
+def test_signature_str():
+    assert d.signature_str(StubBrowser.go_to) == "(url)"
+    assert d.signature_str(StubBrowser.take_screenshot) == "(path=None, full_page=False)"
+
+
+def test_list_functions_describes_real_methods():
+    """`co browser help` introspects BrowserAutomation: name + signature + summary."""
+    text = d.list_functions()
+    assert "go_to(url)" in text
+    assert "— Navigate to a URL." in text
+    # private methods are hidden
+    assert "_browser_is_usable" not in text
+
+
+def test_handle_browser_help_needs_no_browser(capsys):
+    """`co browser help` prints functions and exits 0 without spawning a daemon."""
+    from connectonion.cli.commands.browser_commands import handle_browser
+    code = handle_browser(["help"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Functions:" in out
+    assert "go_to(url)" in out
+
+
+def test_handle_browser_no_args_is_usage_error(capsys):
+    from connectonion.cli.commands.browser_commands import handle_browser
+    code = handle_browser([])
+    err = capsys.readouterr().err
+    assert code == 1
+    assert "co browser <function>" in err
 
 
 # ---- full socket round-trip: client.send() ↔ daemon ----------------------

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -1,0 +1,184 @@
+"""
+LLM-Note: Browser daemon dispatch + socket round-trip tests
+
+What it tests:
+- Pure helpers: _coerce, _split_tokens, _is_verb, _stringify
+- dispatch(): verb matches a BrowserAutomation method → executes it; `do` → NL agent; unknown → error
+- Full socket round-trip: client.send() ↔ a running BrowserDaemon over a real AF_UNIX socket
+
+Components under test:
+- connectonion.cli.browser_agent.daemon (BrowserDaemon, helpers)
+- connectonion.cli.browser_agent.client (send)
+
+Strategy: a StubBrowser stands in for BrowserAutomation so no real Chrome/Playwright
+or network is needed. The daemon's lazy BrowserAutomation is swapped for the stub.
+"""
+
+import os
+import threading
+import time
+
+import pytest
+
+from connectonion.cli.browser_agent import daemon as d
+from connectonion.cli.browser_agent import client as c
+
+
+@pytest.fixture
+def short_sock():
+    """A short AF_UNIX path (macOS caps socket paths at 104 chars; tmp_path is too long)."""
+    path = f"/tmp/co_test_{os.getpid()}_{time.time_ns()}.sock"
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+class StubBrowser:
+    """Stand-in for BrowserAutomation: same method shapes, no real browser."""
+
+    def __init__(self):
+        self.calls = []
+
+    def go_to(self, url: str) -> str:
+        self.calls.append(("go_to", url))
+        return f"Navigated to {url}"
+
+    def take_screenshot(self, path: str = None, full_page: bool = False) -> str:
+        return f"shot path={path} full={full_page}"
+
+    def get_links_from_page(self, domain_filter: str = "") -> list:
+        return ["https://a.com", "https://b.com"]
+
+    def _browser_is_usable(self) -> bool:
+        return True
+
+    def close(self) -> str:
+        return "Browser closed"
+
+
+def _wait_until_listening(sock_path, timeout=5.0):
+    """Wait until the daemon has bound its socket (file appears), without leaking a connection."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(sock_path):
+            return
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not bind socket in time")
+
+
+def make_daemon(sock_path, stub=None):
+    """Build a daemon whose lazy BrowserAutomation is replaced by a stub."""
+    daemon = d.BrowserDaemon(sock_path, headless=True)
+    daemon.browser = stub or StubBrowser()
+    return daemon
+
+
+# ---- pure helpers --------------------------------------------------------
+
+def test_coerce_types():
+    assert d._coerce("true", bool) is True
+    assert d._coerce("0", bool) is False
+    assert d._coerce("7", int) == 7
+    assert d._coerce("1.5", float) == 1.5
+    assert d._coerce("x.com", str) == "x.com"
+
+
+def test_split_tokens():
+    pos, kw = d._split_tokens(["x.com", "--full-page", "--index=2"])
+    assert pos == ["x.com"]
+    assert kw == {"full_page": True, "index": "2"}
+
+
+def test_stringify_list_is_one_per_line():
+    assert d._stringify(["a", "b"]) == "a\nb"
+    assert d._stringify(None) == ""
+    assert d._stringify("hi") == "hi"
+
+
+# ---- dispatch (the core: match function name → execute) ------------------
+
+def test_dispatch_matched_verb_executes(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("go_to x.com")
+    assert ok is True
+    assert payload == "Navigated to x.com"
+    assert daemon.browser.calls == [("go_to", "x.com")]
+
+
+def test_dispatch_coerces_bool_flag(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("take_screenshot --full-page")
+    assert ok is True
+    assert payload == "shot path=None full=True"
+
+
+def test_dispatch_list_result(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("get_links_from_page")
+    assert ok is True
+    assert payload == "https://a.com\nhttps://b.com"
+
+
+def test_dispatch_unknown_command(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("frobnicate now")
+    assert ok is False
+    assert payload == "unknown command: frobnicate"
+
+
+def test_dispatch_empty(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch("")
+    assert ok is False
+
+
+def test_dispatch_do_routes_to_nl(tmp_path, monkeypatch):
+    """`do` must go to the NL agent, not function dispatch."""
+    captured = {}
+
+    class FakeAgent:
+        def input(self, command):
+            captured["command"] = command
+            return "agent says hi"
+
+    monkeypatch.setattr(d, "resolve_api_key", lambda: "key")
+    monkeypatch.setattr(d, "build_browser_agent", lambda browser, key: FakeAgent())
+
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    ok, payload = daemon.dispatch('do find the cheapest flight')
+    assert ok is True
+    assert payload == "agent says hi"
+    assert captured["command"] == "find the cheapest flight"
+
+
+# ---- full socket round-trip: client.send() ↔ daemon ----------------------
+
+def test_socket_round_trip(short_sock, monkeypatch, capsys):
+    sock_path = short_sock
+    monkeypatch.setenv("CO_BROWSER_SOCK", sock_path)
+
+    daemon = make_daemon(sock_path)
+    t = threading.Thread(target=daemon.serve, daemon=True)
+    t.start()
+
+    _wait_until_listening(sock_path)
+
+    code = c.send("go_to example.com", headless=True)
+    out = capsys.readouterr().out.strip()
+    assert code == 0
+    assert out == "Navigated to example.com"
+    assert daemon.browser.calls == [("go_to", "example.com")]
+
+
+def test_socket_round_trip_error_to_stderr(short_sock, monkeypatch, capsys):
+    sock_path = short_sock
+    monkeypatch.setenv("CO_BROWSER_SOCK", sock_path)
+
+    daemon = make_daemon(sock_path)
+    threading.Thread(target=daemon.serve, daemon=True).start()
+    _wait_until_listening(sock_path)
+
+    code = c.send("frobnicate", headless=True)
+    err = capsys.readouterr().err.strip()
+    assert code == 1
+    assert "unknown command: frobnicate" in err


### PR DESCRIPTION
Closes #157.

## What

`co browser <verb>` now matches the word against `BrowserAutomation`'s methods and **executes that function directly** over a Unix socket — deterministic, no LLM, scriptable. Natural language is explicit via `co browser do "..."`.

```bash
co browser go_to x.com          # matches go_to() → runs it directly
co browser get_current_url      # reuses the SAME browser across processes
co browser get_links_from_page  # list result, one per line (pipeable)
co browser do "find cheapest"   # explicit NL agent on the live browser
co browser close                # close browser, stop daemon, remove socket
```

## How (one daemon, one session — the tmux/ssh-agent pattern)

A single daemon owns one live browser; thin CLI clients talk to it over a runtime Unix socket. Chosen over CDP re-attach (sites fingerprint CDP) and forced by the profile lock (`~/.co/browser_profile` is single-owner).

- **`daemon.py`** — single-threaded (sync Playwright) socket server; pure `getattr(browser, verb)` dispatch with type-coerced args; `do` → NL agent; daemon lifetime bound to the browser (close/crash → exit, socket unlinked).
- **`client.py`** — thin: connect, spawn daemon on first use, send line, map `OK`→stdout/exit 0, `ERR`→stderr/exit 1.
- **`browser_commands.py` / `main.py`** — thin handler, multi-arg passthrough, exit-code propagation.
- **`agent.py`** — extract `build_browser_agent()` so the `do` path reuses the *live* browser instead of opening a second Chrome.
- **`__init__.py`** — route the `[env]` diagnostic line to **stderr** so stdout stays clean for `url=$(co browser get_current_url)`.

## Constraints honored

- **No CDP re-attach** — Chrome launches normally once (existing anti-detection args); IPC is a Unix socket, invisible to sites.
- **Sync Playwright** — daemon is single-threaded, serial.
- **Profile lock** — single daemon = sole owner; collision impossible.

## Tests

`tests/e2e/cli/test_browser_daemon.py` — 11 passing: pure helpers, `dispatch()` matching (verb→method, `do`→NL, unknown→error), and full socket round-trip via a `StubBrowser` (no Chrome/network needed).

Verified live on the real CLI in **both headless and GUI** modes: session persists across separate `co browser` invocations, list output pipes, `close` stops the daemon and cleans the socket.

## Not built (YAGNI)

Named multi-sessions (hook left via `\$CO_BROWSER_SOCK`), NL streaming, `--json` output.