### PR TITLE
Publish hosted agent relay profile

### DIFF
--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -66,9 +66,12 @@ def create_announce_message(
         summary: agent capability description (max 1000 chars)
         endpoints: direct connection URLs (http://host:port, ws://host:port/ws)
         relay: relay fallback URL (e.g. "wss://oo.openonion.ai")
-        profile: optional publishable profile {alias, bio, version, skills: [{name, description, body}]}.
-                 When present, the signature covers it atomically so the relay
-                 can trust the metadata + inlined SKILL.md bodies.
+        profile: optional publishable display profile. Shape varies by producer —
+                 host() sends {alias, tools, model, skills: [{name, description}]} and
+                 never inlines skill bodies; `co announce` sends {alias, bio, version,
+                 skills: [{name, description, body?}]}, inlining a SKILL.md body per skill
+                 gated by `publish: true`. When present, the signature covers it atomically
+                 so the relay can trust the metadata (and any inlined bodies).
 
     Returns:
         Signed ANNOUNCE message ready to send to /ws/announce.

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -120,22 +120,30 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
 
 
 def _build_agent_profile(agent_metadata: dict) -> dict:
-    """Build the publishable profile sent with the first ANNOUNCE of a connection.
+    """Build the publishable display profile sent with the first ANNOUNCE of a connection.
 
-    Only project-level skills are published (skill.location is the discovery
-    category: project/user/builtin): discovery also picks up ~/.co/skills —
-    the operator's personal toolbox, which must not leak into the public
-    directory. The prompt summary stays private for the same reason.
+    Carries display fields only — alias, tool names, model, and the names+descriptions
+    of project-scoped skills. The operator's personal skills and builtin skills are
+    filtered out. Skill bodies are never inlined here; subscribers fetch them by name
+    from the relay.
+
+    (The agent's prompt summary is broadcast separately via the top-level ANNOUNCE
+    `summary` field — it is not part of this profile and not made private by it.)
     """
     profile = {"alias": agent_metadata["name"]}
     if agent_metadata.get("tools"):
         profile["tools"] = agent_metadata["tools"]
     if agent_metadata.get("model"):
         profile["model"] = agent_metadata["model"]
+    # skill.location (useful_plugins/skills.py) is a 5-value discovery category. Publish
+    # only the two that ship inside the project tree — project (.co/skills) and
+    # claude-project (.claude/skills). user (~/.co/skills), claude-user (~/.claude/skills)
+    # are the operator's personal toolboxes and builtin is framework noise; none may leak
+    # into the public directory. Allowlist, so an unknown future category stays private.
     profile["skills"] = [
         {"name": s["name"], "description": s.get("description", "")}
         for s in agent_metadata.get("skills", [])
-        if s.get("location") == "project"
+        if s.get("location") in ("project", "claude-project")
     ]
     return profile
 

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -3,7 +3,7 @@ Purpose: Host agent as HTTP/WebSocket server with trust-based access control
 LLM-Note:
   Dependencies: imports from [network/asgi/, network/host/ws_router/ (run_ws_session), network/trust/, network/host/session/, network/host/auth.py, network/host/http_router.py, network/announce.py, network/relay.py] | imported by [network/__init__.py as host()] | tested by [tests/network/test_host.py]
   Data flow: host(create_agent, port, trust) → _create_route_handlers() wraps all routes → asgi_create_app() creates FastAPI/Starlette app → uvicorn.run() starts server → each request calls create_agent() for fresh instance → executes via input_handler()/ws_input() → returns result + session | trust enforcement via extract_and_authenticate() at request boundary
-  State/Effects: starts HTTP server on specified port | creates .co/logs/ directory | stores sessions in SessionStorage (in-memory with TTL) | optionally announces to relay server | each request gets fresh agent instance (no state bleeding)
+  State/Effects: starts HTTP server on specified port | creates .co/logs/ directory | stores sessions in SessionStorage (in-memory with TTL) | optionally announces to relay server, publishing a display profile (alias/tools/model + project-level skills only — user/builtin skills stay private) with the first ANNOUNCE of each connection | each request gets fresh agent instance (no state bleeding)
   Integration: exposes host(create_agent, port=8000, trust=None, result_ttl=3600, relay_url="wss://oo.openonion.ai") | creates ASGI app with routes: POST /input, GET /sessions, GET /sessions/{id}, GET /health, GET /info, WebSocket /ws, admin endpoints | trust accepts: "open"/"careful"/"strict" (level), markdown string (policy), or Agent (custom verifier)
   Performance: factory pattern creates fresh agent per request (thread-safe) | SessionStorage auto-expires old results via TTL | WebSocket supports real-time bidirectional I/O | relay connection runs in background thread
   Errors: trust errors return 401/403 via extract_and_authenticate() | missing sessions return None (404) | raises if port already in use
@@ -119,6 +119,28 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
+def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+    """Build the publishable profile sent with the first ANNOUNCE of a connection.
+
+    Only project-level skills are published: skill discovery also picks up
+    ~/.co/skills (the operator's personal toolbox), which must not leak into
+    the public directory. Locations are filesystem paths and stay private,
+    same as the prompt summary.
+    """
+    profile = {"alias": agent_metadata["name"]}
+    if agent_metadata.get("tools"):
+        profile["tools"] = agent_metadata["tools"]
+    if agent_metadata.get("model"):
+        profile["model"] = agent_metadata["model"]
+    project_root = str(project_dir.resolve())
+    profile["skills"] = [
+        {"name": s["name"], "description": s.get("description", "")}
+        for s in agent_metadata.get("skills", [])
+        if str(Path(s["location"]).resolve()).startswith(project_root)
+    ]
+    return profile
+
+
 def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
     """Create route handler dict for ASGI app.
 
@@ -231,7 +253,7 @@ def _print_host_banner(
     console.print()
 
 
-def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner):
+def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner, *, profile: dict | None = None):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
     Args:
@@ -240,6 +262,8 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         summary: Summary text for relay announcement
         port: HTTP port for endpoint discovery
         relay_session_runner: async (send_msg, recv_msg) -> None, runs protocol for one relay session
+        profile: publishable display info, sent with the first ANNOUNCE of each
+                 connection; the relay persists it, so heartbeats don't carry it
 
     Returns:
         Tuple of (on_startup, on_shutdown) async callbacks
@@ -253,7 +277,9 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         async def relay_loop():
             while True:
                 ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                announce_msg = announce.create_announce_message(
+                    addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
+                )
                 await relay.serve_loop(
                     ws, announce_msg,
                     addr_data=addr_data, session_handler=relay_session_runner,
@@ -436,7 +462,8 @@ def host(
             enable_ping=False,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
-            relay_url, addr_data, summary, port, relay_session_runner
+            relay_url, addr_data, summary, port, relay_session_runner,
+            profile=_build_agent_profile(agent_metadata, Path.cwd()),
         )
 
     app = asgi_create_app(

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -119,24 +119,23 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     return metadata, sample
 
 
-def _build_agent_profile(agent_metadata: dict, project_dir: Path) -> dict:
+def _build_agent_profile(agent_metadata: dict) -> dict:
     """Build the publishable profile sent with the first ANNOUNCE of a connection.
 
-    Only project-level skills are published: skill discovery also picks up
-    ~/.co/skills (the operator's personal toolbox), which must not leak into
-    the public directory. Locations are filesystem paths and stay private,
-    same as the prompt summary.
+    Only project-level skills are published (skill.location is the discovery
+    category: project/user/builtin): discovery also picks up ~/.co/skills —
+    the operator's personal toolbox, which must not leak into the public
+    directory. The prompt summary stays private for the same reason.
     """
     profile = {"alias": agent_metadata["name"]}
     if agent_metadata.get("tools"):
         profile["tools"] = agent_metadata["tools"]
     if agent_metadata.get("model"):
         profile["model"] = agent_metadata["model"]
-    project_root = str(project_dir.resolve())
     profile["skills"] = [
         {"name": s["name"], "description": s.get("description", "")}
         for s in agent_metadata.get("skills", [])
-        if str(Path(s["location"]).resolve()).startswith(project_root)
+        if s.get("location") == "project"
     ]
     return profile
 
@@ -463,7 +462,7 @@ def host(
         )
         on_startup, on_shutdown = _create_relay_lifespan(
             relay_url, addr_data, summary, port, relay_session_runner,
-            profile=_build_agent_profile(agent_metadata, Path.cwd()),
+            profile=_build_agent_profile(agent_metadata),
         )
 
     app = asgi_create_app(

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -2,7 +2,8 @@
 LLM-Note: Tests for host relay
 
 What it tests:
-- Host Relay functionality
+- Host Relay functionality (ANNOUNCE/heartbeat protocol, including the
+  display profile published with the first ANNOUNCE of each connection)
 
 Components under test:
 - Module: host_relay
@@ -105,6 +106,44 @@ class TestHostRelayKeyManagement:
 
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
+
+    def test_profile_publishes_project_skills_only(self, tmp_path):
+        """Published profile carries display fields only: project-level skills,
+        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
+        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        profile = host_module._build_agent_profile({
+            "name": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "summary": "private prompt summary",
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
+                {"name": "linkedin-login", "description": "Operator skill",
+                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+            ],
+        }, tmp_path)
+
+        assert profile == {
+            "alias": "test_agent",
+            "tools": ["search"],
+            "model": "co/gemini-2.5-flash",
+            "skills": [{"name": "deploy-smoke", "description": "Smoke test"}],
+        }
+
+    def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
+        """Hosted agents publish their profile with the relay ANNOUNCE."""
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path):
+            with patch('connectonion.address.load', return_value=mock_addr):
+                with patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())) as mock_relay:
+                    with patch('uvicorn.run'):
+                        with patch.object(host_module, '_print_host_banner'):
+                            host_module.host(create_mock_agent, port=8080)
+
+        profile = mock_relay.call_args.kwargs["profile"]
+        assert profile["alias"]
+        assert "summary" not in profile
 
     def test_host_starts_relay_with_default_url(self, tmp_path, create_mock_agent):
         """Test that host() uses default relay URL (from config)."""

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -107,10 +107,11 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
-    def test_profile_publishes_project_skills_only(self):
-        """Published profile carries display fields only: project-level skills,
-        no user/builtin skills (location is the discovery category, not a
-        path), no prompt summary."""
+    def test_profile_publishes_project_scoped_skills_only(self):
+        """Published profile carries display fields only. Both project-tree skill
+        categories are advertised (project = .co/skills, claude-project = .claude/skills);
+        the operator's personal toolboxes (user = ~/.co/skills, claude-user = ~/.claude/skills)
+        and builtin skills stay private. location is the discovery category, not a path."""
         profile = host_module._build_agent_profile({
             "name": "test_agent",
             "tools": ["search"],
@@ -118,7 +119,9 @@ class TestHostRelayConnection:
             "summary": "private prompt summary",
             "skills": [
                 {"name": "deploy-smoke", "description": "Smoke test", "location": "project"},
+                {"name": "repo-helper", "description": "Repo skill", "location": "claude-project"},
                 {"name": "linkedin-login", "description": "Operator skill", "location": "user"},
+                {"name": "personal-notes", "description": "Personal skill", "location": "claude-user"},
                 {"name": "commit", "description": "Built-in skill", "location": "builtin"},
             ],
         })
@@ -127,7 +130,10 @@ class TestHostRelayConnection:
             "alias": "test_agent",
             "tools": ["search"],
             "model": "co/gemini-2.5-flash",
-            "skills": [{"name": "deploy-smoke", "description": "Smoke test"}],
+            "skills": [
+                {"name": "deploy-smoke", "description": "Smoke test"},
+                {"name": "repo-helper", "description": "Repo skill"},
+            ],
         }
 
     def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -107,21 +107,21 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
-    def test_profile_publishes_project_skills_only(self, tmp_path):
+    def test_profile_publishes_project_skills_only(self):
         """Published profile carries display fields only: project-level skills,
-        no ~/.co user-level skills, no filesystem locations, no prompt summary."""
-        project_skill = tmp_path / ".co" / "skills" / "deploy-smoke" / "SKILL.md"
+        no user/builtin skills (location is the discovery category, not a
+        path), no prompt summary."""
         profile = host_module._build_agent_profile({
             "name": "test_agent",
             "tools": ["search"],
             "model": "co/gemini-2.5-flash",
             "summary": "private prompt summary",
             "skills": [
-                {"name": "deploy-smoke", "description": "Smoke test", "location": str(project_skill)},
-                {"name": "linkedin-login", "description": "Operator skill",
-                 "location": "/Users/me/.co/skills/linkedin-login/SKILL.md"},
+                {"name": "deploy-smoke", "description": "Smoke test", "location": "project"},
+                {"name": "linkedin-login", "description": "Operator skill", "location": "user"},
+                {"name": "commit", "description": "Built-in skill", "location": "builtin"},
             ],
-        }, tmp_path)
+        })
 
         assert profile == {
             "alias": "test_agent",


### PR DESCRIPTION
## Summary
- publish a limited hosted-agent profile on the first relay ANNOUNCE
- keep personal and built-in skills private by filtering for project skills only
- cover the relay profile payload and skill filtering behavior

## Verification
- .venv/bin/python -m pytest tests/unit/test_host_relay.py -q