### PR TITLE
Stabilize hosted WebSocket and relay connections

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -26,6 +26,7 @@ don't interfere between concurrent requests.
 """
 
 import asyncio
+import random
 from functools import partial
 from pathlib import Path
 from typing import Callable, Union
@@ -262,6 +263,7 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
             # relay registration goes stale and it becomes unreachable via the relay until
             # the process is restarted.
             relay_console = Console()
+            failures = 0
             while True:
                 try:
                     ws = await relay.connect(relay_url)
@@ -270,12 +272,32 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
                         ws, announce_msg,
                         addr_data=addr_data, session_handler=relay_session_runner,
                     )
+                    failures = 0  # clean disconnect — next reconnect is immediate
                 except asyncio.CancelledError:
                     raise  # shutdown — propagate so on_shutdown can await it cleanly
                 except Exception as exc:
-                    relay_console.print(
-                        f"[magenta]\\[host][/magenta] [dim]relay connection error ({exc!r}); reconnecting in 1s[/dim]"
-                    )
+                    # Survive any transient fault, but don't HIDE a persistent one. Back off
+                    # (capped at 30s) so a dead relay isn't a 1/s reconnect+log storm, and add
+                    # jitter from the 2nd attempt on so a recovering relay doesn't get a
+                    # thundering herd. The first retry stays an exact 1s for fast single-blip
+                    # recovery. Escalate the log after several consecutive failures so a
+                    # permanent problem (revoked key, decommissioned relay, a real bug) is
+                    # surfaced loudly instead of buried in a dim 1s loop forever.
+                    failures += 1
+                    delay = min(2 ** min(failures - 1, 5), 30)
+                    if failures > 1:
+                        delay += random.uniform(0, 1.0)
+                    if failures >= 5:
+                        relay_console.print(
+                            f"[red]\\[host][/red] relay still unreachable after {failures} attempts "
+                            f"({exc!r}); retrying in {delay:.0f}s"
+                        )
+                    else:
+                        relay_console.print(
+                            f"[magenta]\\[host][/magenta] [dim]relay connection error ({exc!r}); reconnecting in {delay:.0f}s[/dim]"
+                        )
+                    await asyncio.sleep(delay)
+                    continue
                 await asyncio.sleep(1)
 
         relay_task = asyncio.create_task(relay_loop())

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -251,13 +251,31 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
         endpoints = announce.get_endpoints(port)
 
         async def relay_loop():
+            # Long-lived supervisor: keep the agent registered on the relay across ANY
+            # transient failure. serve_loop returns on a clean disconnect, but connect()
+            # or serve_loop can also RAISE — a network blip surfaces as OSError, the relay
+            # redeploys, DNS hiccups, a frame is malformed. For a connection meant to live
+            # for days those are normal operation, not bugs. So catch everything except
+            # cancellation, log, back off, and reconnect. Without this, the first
+            # non-ConnectionClosed error escapes the loop and silently kills relay_task:
+            # the agent keeps serving DIRECT connections but never announces again, so its
+            # relay registration goes stale and it becomes unreachable via the relay until
+            # the process is restarted.
+            relay_console = Console()
             while True:
-                ws = await relay.connect(relay_url)
-                announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
-                await relay.serve_loop(
-                    ws, announce_msg,
-                    addr_data=addr_data, session_handler=relay_session_runner,
-                )
+                try:
+                    ws = await relay.connect(relay_url)
+                    announce_msg = announce.create_announce_message(addr_data, summary, endpoints=endpoints, relay=relay_url)
+                    await relay.serve_loop(
+                        ws, announce_msg,
+                        addr_data=addr_data, session_handler=relay_session_runner,
+                    )
+                except asyncio.CancelledError:
+                    raise  # shutdown — propagate so on_shutdown can await it cleanly
+                except Exception as exc:
+                    relay_console.print(
+                        f"[magenta]\\[host][/magenta] [dim]relay connection error ({exc!r}); reconnecting in 1s[/dim]"
+                    )
                 await asyncio.sleep(1)
 
         relay_task = asyncio.create_task(relay_loop())
@@ -424,8 +442,13 @@ def host(
     if relay_url:
         # Pre-bind run_ws_session's host-wide deps so relay only needs to pass
         # (send_msg, recv_msg). Each call = one client session full lifecycle
-        # (auth → INPUT/OUTPUT cycles → disconnect). enable_ping=False because
-        # relay handles keep-alive via its own ANNOUNCE heartbeat.
+        # (auth → INPUT/OUTPUT cycles → disconnect). enable_ping=True: the 30s PING
+        # is the CLIENT-session keepalive — it's forwarded through the relay to the
+        # browser so the SDK's 60s-silence monitor doesn't declare the connection
+        # dead and reconnect. The relay's ANNOUNCE heartbeat is a different thing
+        # (it only keeps the agent↔relay link alive; it never reaches the client),
+        # so it can't substitute for the PING. Without this, idle relay sessions
+        # churn (silence → reconnect) every ~60s.
         relay_session_runner = partial(run_ws_session,
             route_handlers=route_handlers,
             storage=storage,
@@ -433,7 +456,7 @@ def host(
             trust=trust_agent,
             blacklist=blacklist,
             whitelist=whitelist,
-            enable_ping=False,
+            enable_ping=True,
         )
         on_startup, on_shutdown = _create_relay_lifespan(
             relay_url, addr_data, summary, port, relay_session_runner

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -2,7 +2,7 @@
 Purpose: Handle the CONNECT message — Ed25519 signature auth, session merge, status decision, optional reattach to a still-running agent
 LLM-Note:
   Dependencies: imports from [..session (merge_sessions, session_to_chat_items via lazy local import), ...trust.ws_admin (get_onboard_requirements), .agent_io (resume_forwarding), uuid, rich.console] | imported by [.session as part of CONNECT dispatch]
-  Data flow: route_handlers["auth"] verifies sig → if forbidden + onboard methods configured: send ONBOARD_REQUIRED | else if other err: send ERROR | else: populate conn (authenticated/identity/session_id/session) → merge_sessions if stored exists → registry status check (running/connected/new) → send CONNECTED → if running: io.rewind_to(last_msg_id) + resume_forwarding (returns (io, task))
+  Data flow: route_handlers["auth"] verifies sig → if forbidden + onboard methods configured: stash conn['pending_connect'] + send ONBOARD_REQUIRED | else if other err: send ERROR | else: establish_connection(): populate conn (authenticated/identity/session_id/session) → merge_sessions if stored exists → registry status check (running/connected/new) → send CONNECTED → if running: io.rewind_to(last_msg_id) + resume_forwarding (returns (io, task)) | establish_connection is also called by the session loop after a successful onboard, with the onboard-verified identity (no CONNECT replay — its signature may have aged past the 5-minute window)
   State/Effects: mutates conn dict in place (authenticated, identity, session_id, session) | calls registry.update_ping when reattaching to 'connected'
   Integration: handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist) → returns (io, forward_task) for reattach or None
   Performance: one storage.get + optional merge_sessions per CONNECT | one registry.get for status decision
@@ -27,6 +27,11 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         trust_agent = route_handlers["trust_agent"]
         onboard_info = get_onboard_requirements(trust_agent)
         if onboard_info:
+            # Stash the CONNECT so a successful onboard can finish establishing
+            # this connection (establish_connection) — the client must not need
+            # a second CONNECT, whose signature may have aged past the 5-minute
+            # window by the time an invite code or payment lands.
+            conn["pending_connect"] = data
             await send_msg({"type": "ONBOARD_REQUIRED", "identity": identity, **onboard_info})
             return
 
@@ -35,6 +40,15 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         await send_msg({"type": "ERROR", "message": err})
         return
 
+    return await establish_connection(data, identity, send_msg, conn, storage, registry)
+
+
+async def establish_connection(data, identity, send_msg, conn, storage, registry):
+    """Post-auth half of CONNECT: populate conn, merge sessions, send CONNECTED.
+
+    Called by handle_connect and, after a successful onboard, with the stashed
+    pending CONNECT — the identity is then the one verified on ONBOARD_SUBMIT.
+    """
     conn["authenticated"] = True
     conn["identity"] = identity
     session_id = data.get("session_id") or str(uuid.uuid4())

--- a/connectonion/network/host/ws_router/ping.py
+++ b/connectonion/network/host/ws_router/ping.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [asyncio] | imported by [.session as ping_loop coroutine wrapped in asyncio.create_task]
   Data flow: infinite loop — sleep 30s → send_msg({"type": "PING"})
   State/Effects: stateless | runs as an asyncio.Task spawned in run_ws_session, cancelled in run_ws_session's finally
-  Integration: ping_loop(send_msg) — coroutine factory; caller wraps in create_task | enable_ping=False for relay path (ANNOUNCE heartbeat covers it)
+  Integration: ping_loop(send_msg) — coroutine factory; caller wraps in create_task | enabled on both direct AND relay paths: the relay's ANNOUNCE heartbeat only keeps the agent↔relay link alive and never reaches the client, so the 30s client PING is still needed end-to-end (it also keeps the relay session's recv idle timer fresh via PONGs)
   Performance: trivial — one async sleep + one send per 30s
   Errors: send_msg failure propagates → task fails → run_ws_session finally still cancels it cleanly
 """

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -13,7 +13,7 @@ import uuid
 
 from rich.console import Console
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
-from .connect import handle_connect
+from .connect import handle_connect, establish_connection
 from .agent_io import start_agent
 from .ping import ping_loop
 
@@ -56,7 +56,16 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 await send_msg({"type": "SESSION_STATUS", "session_id": sid, "status": status})
 
             elif msg_type == "ONBOARD_SUBMIT":
-                await handle_onboard_submit(data, send_msg, route_handlers)
+                identity = await handle_onboard_submit(data, send_msg, route_handlers)
+                pending_connect = conn.pop("pending_connect", None)
+                if identity and pending_connect:
+                    # Finish the CONNECT the trust gate interrupted: the client
+                    # is a contact now and resumes its input once CONNECTED lands.
+                    result = await establish_connection(
+                        pending_connect, identity, send_msg, conn, storage, registry
+                    )
+                    if result:
+                        active_io, forward_task = result
             elif msg_type and msg_type.startswith("ADMIN_"):
                 await handle_admin_message(data, send_msg, route_handlers)
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -61,15 +61,27 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 # (e.g. wrong invite code) keeps it so a retry on the same socket can
                 # still complete the interrupted CONNECT.
                 if identity:
-                    pending_connect = conn.pop("pending_connect", None)
-                    if pending_connect:
-                        # Finish the CONNECT the trust gate interrupted: the client
-                        # is a contact now and resumes its input once CONNECTED lands.
-                        result = await establish_connection(
-                            pending_connect, identity, send_msg, conn, storage, registry
-                        )
-                        if result:
-                            active_io, forward_task = result
+                    # The onboard verified a fresh signature and promoted the identity, but
+                    # the host blacklist is an absolute deny, not a trust LEVEL, and onboarding
+                    # must not bypass it — a blacklisted client could otherwise pass the trust
+                    # gate by submitting a valid invite/payment (handle_onboard_submit checks
+                    # trust_agent.is_blocked, a different list from the host blacklist param).
+                    # Re-apply it (the signature is already verified) before finishing CONNECT.
+                    # whitelist is an allow-bypass (auth.py grants an instant allow on a match
+                    # but never denies non-members), so it is correctly absent here: a non-
+                    # whitelisted client that onboarded to "contact" should be admitted.
+                    if blacklist and identity in blacklist:
+                        await send_msg({"type": "ERROR", "message": "forbidden: blacklisted"})
+                    else:
+                        pending_connect = conn.pop("pending_connect", None)
+                        if pending_connect:
+                            # Finish the CONNECT the trust gate interrupted: the client
+                            # is a contact now and resumes its input once CONNECTED lands.
+                            result = await establish_connection(
+                                pending_connect, identity, send_msg, conn, storage, registry
+                            )
+                            if result:
+                                active_io, forward_task = result
             elif msg_type and msg_type.startswith("ADMIN_"):
                 await handle_admin_message(data, send_msg, route_handlers)
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [.connect (handle_connect), .agent_io (start_agent), .ping (ping_loop), ...trust.ws_admin (handle_admin_message, handle_onboard_submit), asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
   Data flow: recv_msg() → match data["type"] → dispatch | PONG → registry.update_ping | SESSION_STATUS → registry lookup + reply (inline) | CONNECT → handle_connect (auth + reattach) | INPUT → if running session: push_runtime_input + RUNTIME_INPUT_ACK (inline); else: start_agent | other types with active_io → active_io.send_to_agent | finally: cancel forward + ping tasks
   State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally
-  Integration: run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registry, trust, blacklist=None, whitelist=None, enable_ping=True) | enable_ping=False for relay path (ANNOUNCE heartbeat handles keepalive there)
+  Integration: run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registry, trust, blacklist=None, whitelist=None, enable_ping=True) | enable_ping=True on both direct and relay paths: the 30s client PING is forwarded through the relay to the client, since the relay's ANNOUNCE heartbeat only keeps the agent↔relay link alive and never reaches the client
   Performance: single-reader of recv_msg | O(1) per-message dispatch | bounded local state
   Errors: recv_msg returning None → exit loop normally | other exceptions propagate out (transport-level errors, programmer bugs)
 """
@@ -57,15 +57,19 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
 
             elif msg_type == "ONBOARD_SUBMIT":
                 identity = await handle_onboard_submit(data, send_msg, route_handlers)
-                pending_connect = conn.pop("pending_connect", None)
-                if identity and pending_connect:
-                    # Finish the CONNECT the trust gate interrupted: the client
-                    # is a contact now and resumes its input once CONNECTED lands.
-                    result = await establish_connection(
-                        pending_connect, identity, send_msg, conn, storage, registry
-                    )
-                    if result:
-                        active_io, forward_task = result
+                # Pop the stashed CONNECT only on a successful onboard: a failed one
+                # (e.g. wrong invite code) keeps it so a retry on the same socket can
+                # still complete the interrupted CONNECT.
+                if identity:
+                    pending_connect = conn.pop("pending_connect", None)
+                    if pending_connect:
+                        # Finish the CONNECT the trust gate interrupted: the client
+                        # is a contact now and resumes its input once CONNECTED lands.
+                        result = await establish_connection(
+                            pending_connect, identity, send_msg, conn, storage, registry
+                        )
+                        if result:
+                            active_io, forward_task = result
             elif msg_type and msg_type.startswith("ADMIN_"):
                 await handle_admin_message(data, send_msg, route_handlers)
 

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: agent calls io.send(event) → auto-stamps id (UUID) and ts if missing → enqueues for async forwarder | client message → enqueued for agent | read_msgs_from_agent() async-iterates outgoing for forwarding to client | send_to_agent() pushes incoming messages to agent
   State/Effects: maintains incoming + outgoing channels (async-safe) | finished flag prevents sends after close | unblocks agent's blocking receive on close
   Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs for mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
-  Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread
+  Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread | _wait_for_msgs_from_agent waits at most ~1s so idle-session forwarders don't pin executor-pool threads
   Errors: closed IO unblocks pending receive() so agent thread doesn't hang | no exceptions raised — channel coordination handled internally
 """
 
@@ -130,11 +130,15 @@ class WebSocketIO(IO):
             self._cursor = 0
 
     def _wait_for_msgs_from_agent(self, cursor, stop_event=None):
-        """Block until new agent messages available or finished. Returns (messages, done)."""
+        """Wait up to ~1s for new agent messages. Returns (messages, done).
+
+        Must return promptly even with no news: this runs on the event loop's
+        shared default executor, and a forwarder for an idle session (agent
+        blocked in receive()) would otherwise pin a pool thread forever —
+        enough idle sessions exhaust the pool and starve every new connection.
+        """
         with self._agent_condition:
-            while len(self._msgs_from_agent) <= cursor and not self._finished:
-                if stop_event and stop_event.is_set():
-                    return [], True
+            if len(self._msgs_from_agent) <= cursor and not self._finished:
                 self._agent_condition.wait(timeout=1.0)
             if stop_event and stop_event.is_set():
                 return [], True

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -1,6 +1,6 @@
 """WebSocket admin and onboard message handlers.
 
-Purpose: Verify signed websocket frames for ONBOARD_SUBMIT and ADMIN_* actions, then mutate trust state (verify invite/payment, promote/demote/block/unblock, super-admin add/remove) and stream back ONBOARD_SUCCESS / ADMIN_RESULT / ERROR responses.
+Purpose: Verify signed websocket frames for ONBOARD_SUBMIT and ADMIN_* actions, then mutate trust state (verify invite/payment, promote/demote/block/unblock, super-admin add/remove) and stream back ONBOARD_SUCCESS / ADMIN_RESULT / ERROR responses. handle_onboard_submit returns the verified identity so the session loop can finish the trust-gated CONNECT.
 LLM-Note:
   Dependencies: imports from [rich.console] | imported by [network/host/ws_router/session.py (handle_admin_message, handle_onboard_submit), network/host/ws_router/connect.py (get_onboard_requirements during CONNECT)] | tested by [tests/network/test_ws_admin.py, tests/integration/test_onboard_flow.py]
   Data flow:
@@ -39,7 +39,7 @@ def get_onboard_requirements(trust_agent) -> dict | None:
 
 
 async def handle_onboard_submit(data, send_msg, route_handlers):
-    """Handle ONBOARD_SUBMIT message from client."""
+    """Handle ONBOARD_SUBMIT message from client. Returns the verified identity on success."""
     trust_agent = route_handlers["trust_agent"]
 
     _, identity, sig_valid, err = route_handlers["auth"](data, "open")
@@ -65,7 +65,7 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
                 "level": actual_level,
                 "message": f"Invite code verified. You are now a {actual_level}."
             })
-            return
+            return identity
         else:
             console.print(f"[red]✗[/red] Invalid invite code [cyan]{invite_code}[/cyan] from {identity[:16]}...")
             await send_msg({"type": "ERROR", "message": "Invalid invite code"})
@@ -81,7 +81,7 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
                 "level": actual_level,
                 "message": f"Payment verified. You are now a {actual_level}."
             })
-            return
+            return identity
         else:
             console.print(f"[red]✗[/red] Insufficient payment [cyan]${payment}[/cyan] from {identity[:16]}...")
             await send_msg({"type": "ERROR", "message": "Insufficient payment"})

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -493,6 +493,12 @@ Agent Thread (sync)              Async forwarder / router
 
 On reconnect, `ws_router.connect:handle_connect` calls `io.rewind_to(last_msg_id)` (also under the same lock) to reset the cursor — the new forward task replays everything after that id. If `last_msg_id` is omitted or unknown, cursor rewinds to 0 (full replay; client should dedup by id).
 
+### Bounded forwarder wait
+
+`read_msgs_from_agent` runs its blocking wait on the event loop's default executor (`run_in_executor(None, ...)`), whose pool is small: `min(32, cpu_count + 4)` threads. The wait is bounded to about 1 second: `_wait_for_msgs_from_agent` calls `condition.wait(timeout=1.0)`, returns whatever is buffered, and the caller loops.
+
+This prevents idle sessions from pinning executor threads forever. A session whose agent is blocked in `io.receive()` emits no events; without the bound, enough idle forwarders can exhaust the default executor and make new connections wait behind them. New agent events still wake the waiter immediately via `condition.notify()`; the timeout only governs the idle case.
+
 ### mark_agent_done() and close()
 
 - **`io.mark_agent_done()`** — agent done emitting messages. Sets `_finished` flag and notifies all waiters. `read_msgs_from_agent` returns once it drains remaining buffered events.
@@ -573,4 +579,3 @@ if agent.io:
 
 - **[host.md](host.md)** - Host agents over HTTP/WebSocket
 - **[connect.md](connect.md)** - Connect to remote agents
-

--- a/docs/network/protocol.md
+++ b/docs/network/protocol.md
@@ -245,7 +245,9 @@ Client → ONBOARD_SUBMIT   {payload: {invite_code: "BETA2024"}}
 Server → ONBOARD_SUCCESS  {level: "contact"}    or    ERROR
 ```
 
-`handle_onboard_submit` verifies signature with "open" trust (strangers can't pass strict verification yet), checks blocked status, then validates the invite code or payment via `trust_agent`. On success the client is promoted and can re-CONNECT.
+`handle_onboard_submit` verifies signature with "open" trust (strangers can't pass strict verification yet), checks blocked status, then validates the invite code or payment via `trust_agent`. On success the client is promoted.
+
+The original CONNECT that the trust gate interrupted is completed server-side: `handle_connect` stashes it as `conn["pending_connect"]`, and after verified onboard the session loop calls `establish_connection()` with the onboard-verified identity, ending in `CONNECTED`. The client does not re-send CONNECT, so its pending `INPUT` can resume even if the original signature has aged while the user typed an invite code or completed payment.
 
 ---
 

--- a/tests/unit/test_asgi_websocket_admin_onboard.py
+++ b/tests/unit/test_asgi_websocket_admin_onboard.py
@@ -454,3 +454,74 @@ class TestHandleAdminMessage:
         assert sent_messages[0]["type"] == "ERROR"
         assert "Unknown admin action" in sent_messages[0]["message"]
 
+
+
+@pytest.mark.asyncio
+class TestOnboardCompletesConnect:
+    async def test_input_after_onboard_runs_without_reconnect(self):
+        """The trust gate interrupts CONNECT before conn is populated. A successful
+        ONBOARD_SUBMIT must finish establishing the connection (CONNECTED sent,
+        conn authenticated) so the client's queued INPUT runs — the original bug
+        rejected it with 'authenticate first (send CONNECT)'."""
+        scope = {"path": "/ws", "type": "websocket"}
+        sent_messages = []
+        frames = [
+            {"type": "CONNECT", "session_id": "sess-1",
+             "payload": {"timestamp": 1234567890}, "from": "0xuser", "signature": "0xsig"},
+            {"type": "ONBOARD_SUBMIT", "payload": {"invite_code": "BETA", "timestamp": 1234567891},
+             "from": "0xuser", "signature": "0xsig2"},
+            {"type": "INPUT", "prompt": "hello", "input_id": "i1"},
+        ]
+        recv_count = [0]
+
+        async def receive():
+            recv_count[0] += 1
+            if recv_count[0] <= len(frames):
+                return {"type": "websocket.receive", "text": json.dumps(frames[recv_count[0] - 1])}
+            # The agent runs on a thread; let it consume the INPUT before closing.
+            import asyncio
+            for _ in range(200):
+                if ws_input.call_count:
+                    break
+                await asyncio.sleep(0.005)
+            return {"type": "websocket.disconnect"}
+
+        async def send(msg):
+            sent_messages.append(msg)
+
+        trust_agent = SimpleNamespace(
+            config={"onboard": {"invite_code": ["BETA"]}},
+            get_self_address=lambda: "0xagent123",
+            is_blocked=lambda identity: False,
+            verify_invite=lambda identity, code: code == "BETA",
+            get_level=lambda identity: "contact",
+        )
+
+        def auth(data, trust, **kw):
+            # CONNECT from a stranger is forbidden; the ONBOARD_SUBMIT signature
+            # check (trust="open") passes.
+            if trust == "open":
+                return None, "0xuser", True, None
+            return None, "0xuser", True, "forbidden: strangers"
+
+        ws_input = Mock(return_value={"result": "done", "duration_ms": 1, "session": {}})
+        storage = Mock()
+        storage.get.return_value = None
+
+        await handle_websocket(
+            scope, receive, send,
+            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            storage=storage,
+            registry=ActiveSessionRegistry(),
+            trust="careful",
+        )
+
+        events = _extract_ws_messages(sent_messages)
+        types = [e["type"] for e in events]
+
+        assert "ONBOARD_SUCCESS" in types
+        connected = [e for e in events if e["type"] == "CONNECTED"]
+        assert connected and connected[0]["session_id"] == "sess-1"
+        assert types.index("ONBOARD_SUCCESS") < types.index("CONNECTED")
+        assert not any("authenticate first" in str(e.get("message", "")) for e in events)
+        ws_input.assert_called_once()

--- a/tests/unit/test_asgi_websocket_admin_onboard.py
+++ b/tests/unit/test_asgi_websocket_admin_onboard.py
@@ -525,3 +525,120 @@ class TestOnboardCompletesConnect:
         assert types.index("ONBOARD_SUCCESS") < types.index("CONNECTED")
         assert not any("authenticate first" in str(e.get("message", "")) for e in events)
         ws_input.assert_called_once()
+
+    async def test_onboard_does_not_bypass_blacklist(self):
+        """A blacklisted client must not pass the trust gate by onboarding: even with a
+        valid invite, after ONBOARD_SUCCESS the host re-applies the blacklist, so CONNECTED
+        is never sent and the queued INPUT never runs."""
+        scope = {"path": "/ws", "type": "websocket"}
+        sent_messages = []
+        frames = [
+            {"type": "CONNECT", "session_id": "sess-bl",
+             "payload": {"timestamp": 1234567890}, "from": "0xbad", "signature": "0xsig"},
+            {"type": "ONBOARD_SUBMIT", "payload": {"invite_code": "BETA", "timestamp": 1234567891},
+             "from": "0xbad", "signature": "0xsig2"},
+            {"type": "INPUT", "prompt": "hello", "input_id": "i1"},
+        ]
+        recv_count = [0]
+
+        async def receive():
+            recv_count[0] += 1
+            if recv_count[0] <= len(frames):
+                return {"type": "websocket.receive", "text": json.dumps(frames[recv_count[0] - 1])}
+            return {"type": "websocket.disconnect"}
+
+        async def send(msg):
+            sent_messages.append(msg)
+
+        trust_agent = SimpleNamespace(
+            config={"onboard": {"invite_code": ["BETA"]}},
+            get_self_address=lambda: "0xagent123",
+            is_blocked=lambda identity: False,    # not trust-blocked — only host-blacklisted
+            verify_invite=lambda identity, code: code == "BETA",
+            get_level=lambda identity: "contact",
+        )
+
+        def auth(data, trust, **kw):
+            # ONBOARD_SUBMIT signature (trust="open") passes; the CONNECT is forbidden
+            # because the identity is on the host blacklist.
+            if trust == "open":
+                return None, "0xbad", True, None
+            return None, "0xbad", True, "forbidden: blacklisted"
+
+        ws_input = Mock(return_value={"result": "done", "duration_ms": 1, "session": {}})
+        storage = Mock()
+        storage.get.return_value = None
+
+        await handle_websocket(
+            scope, receive, send,
+            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            storage=storage,
+            registry=ActiveSessionRegistry(),
+            trust="careful",
+            blacklist={"0xbad"},
+        )
+
+        events = _extract_ws_messages(sent_messages)
+        types = [e["type"] for e in events]
+
+        assert "ONBOARD_SUCCESS" in types                              # the invite itself was valid
+        assert "CONNECTED" not in types                               # but the blacklist still blocks
+        assert any(e["type"] == "ERROR" and "blacklisted" in str(e.get("message", ""))
+                   for e in events)
+        ws_input.assert_not_called()                                  # the queued INPUT never runs
+
+    async def test_onboard_completes_even_with_whitelist_configured(self):
+        """whitelist is an allow-bypass, not a restrict-to gate: a stranger who onboards to
+        a contact must still get CONNECTED even when the host has a whitelist set (they were
+        never on it — whitelisted identities don't need to onboard in the first place)."""
+        scope = {"path": "/ws", "type": "websocket"}
+        sent_messages = []
+        frames = [
+            {"type": "CONNECT", "session_id": "sess-wl",
+             "payload": {"timestamp": 1234567890}, "from": "0xuser", "signature": "0xsig"},
+            {"type": "ONBOARD_SUBMIT", "payload": {"invite_code": "BETA", "timestamp": 1234567891},
+             "from": "0xuser", "signature": "0xsig2"},
+        ]
+        recv_count = [0]
+
+        async def receive():
+            recv_count[0] += 1
+            if recv_count[0] <= len(frames):
+                return {"type": "websocket.receive", "text": json.dumps(frames[recv_count[0] - 1])}
+            return {"type": "websocket.disconnect"}
+
+        async def send(msg):
+            sent_messages.append(msg)
+
+        trust_agent = SimpleNamespace(
+            config={"onboard": {"invite_code": ["BETA"]}},
+            get_self_address=lambda: "0xagent123",
+            is_blocked=lambda identity: False,
+            verify_invite=lambda identity, code: code == "BETA",
+            get_level=lambda identity: "contact",
+        )
+
+        def auth(data, trust, **kw):
+            if trust == "open":
+                return None, "0xuser", True, None
+            return None, "0xuser", True, "forbidden: strangers"
+
+        ws_input = Mock(return_value={"result": "done", "duration_ms": 1, "session": {}})
+        storage = Mock()
+        storage.get.return_value = None
+
+        await handle_websocket(
+            scope, receive, send,
+            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            storage=storage,
+            registry=ActiveSessionRegistry(),
+            trust="careful",
+            whitelist={"0xsomeone-else"},   # the onboarding identity is NOT on the whitelist
+        )
+
+        events = _extract_ws_messages(sent_messages)
+        types = [e["type"] for e in events]
+
+        assert "ONBOARD_SUCCESS" in types
+        assert "CONNECTED" in types                                   # whitelist must not block an onboarded contact
+        assert not any("not whitelisted" in str(e.get("message", "")) for e in events)

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -3,7 +3,8 @@
 LLM-Note: Tests for io
 
 What it tests:
-- Io functionality
+- Io functionality (channel coordination, replay cursor, and the bounded
+  forwarder wait that keeps idle sessions from pinning executor threads)
 
 Components under test:
 - Module: io
@@ -265,3 +266,46 @@ class TestHighLevelAPI:
 
         thread.join(timeout=1)
         assert result is False
+
+    def test_wait_for_msgs_returns_promptly_when_idle(self):
+        """_wait_for_msgs_from_agent runs on the event loop's shared default
+        executor; on an idle io (agent blocked in receive(), no new messages)
+        it must return within ~1s instead of looping forever, or each idle
+        session pins a pool thread until the pool starves every new connection."""
+        import time
+        io = WebSocketIO()
+
+        start = time.monotonic()
+        msgs, done = io._wait_for_msgs_from_agent(0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 3.0
+        assert msgs == []
+        assert done is False
+
+    def test_idle_forwarder_does_not_starve_other_io(self):
+        """One io stuck idle must not block another io's event delivery when
+        the executor has a single thread (worst-case pool contention)."""
+        import asyncio
+        from concurrent.futures import ThreadPoolExecutor
+
+        async def read_one(io):
+            async for event in io.read_msgs_from_agent():
+                return event
+
+        async def scenario():
+            asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=1))
+
+            idle_io = WebSocketIO()
+            busy_io = WebSocketIO()
+            busy_io.send({"type": "thinking"})
+
+            idle_task = asyncio.create_task(read_one(idle_io))
+            await asyncio.sleep(0.1)  # let the idle forwarder grab the only thread
+
+            event = await asyncio.wait_for(read_one(busy_io), timeout=5.0)
+            idle_task.cancel()
+            return event
+
+        event = asyncio.run(scenario())
+        assert event["type"] == "thinking"

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -411,3 +411,39 @@ class TestRelayIntegration:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestRelaySupervisorResilience:
+    """The relay supervisor (server._create_relay_lifespan) must keep reconnecting
+    across ANY transient failure, not die on the first non-ConnectionClosed error."""
+
+    @pytest.mark.asyncio
+    async def test_supervisor_reconnects_after_non_connectionclosed_error(self, monkeypatch):
+        # Regression: the old relay_loop had no try/except around connect()/serve_loop(),
+        # so a network blip surfacing as OSError escaped the loop and silently killed
+        # relay_task — the agent stopped announcing and went stale on the relay until
+        # restart. The supervisor must instead log, back off, and reconnect.
+        import asyncio
+        from connectonion.network import relay as relay_module
+        from connectonion.network.host.server import _create_relay_lifespan
+
+        calls = {"connect": 0}
+
+        async def boom(*args, **kwargs):
+            calls["connect"] += 1
+            raise OSError("simulated network blip")
+
+        monkeypatch.setattr(relay_module, "connect", boom)
+
+        addr_data = {"address": "0x" + "a" * 64}
+        on_startup, on_shutdown = _create_relay_lifespan(
+            "wss://relay.test", addr_data, "summary", 8000, lambda *a, **k: None,
+        )
+
+        await on_startup()
+        await asyncio.sleep(1.3)   # initial attempt + at least one retry after the 1s backoff
+        await on_shutdown()
+
+        assert calls["connect"] >= 2, (
+            "supervisor died after the first error instead of reconnecting"
+        )

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -425,6 +425,7 @@ class TestRelaySupervisorResilience:
         # restart. The supervisor must instead log, back off, and reconnect.
         import asyncio
         from connectonion.network import relay as relay_module
+        from connectonion.network.host import server as server_module
         from connectonion.network.host.server import _create_relay_lifespan
 
         calls = {"connect": 0}
@@ -434,6 +435,7 @@ class TestRelaySupervisorResilience:
             raise OSError("simulated network blip")
 
         monkeypatch.setattr(relay_module, "connect", boom)
+        monkeypatch.setattr(server_module.announce, "get_endpoints", lambda port: [])
 
         addr_data = {"address": "0x" + "a" * 64}
         on_startup, on_shutdown = _create_relay_lifespan(


### PR DESCRIPTION
## Summary
- bound idle WebSocket forwarder waits so blocked sessions do not pin executor threads
- complete gated CONNECT server-side after onboard succeeds
- keep relay registration alive across transient supervisor failures and forward client PINGs through relay sessions
- document the connection lifecycle behavior

Conflict note: this branch intentionally does not include relay profile publication; ANNOUNCE shape stays on current main.

## Verification
- .venv/bin/python -m pytest tests/unit/test_io.py tests/unit/test_asgi_websocket_admin_onboard.py tests/unit/test_relay.py -q