### PR TITLE
Preserve and bound session image replay

### DIFF
--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -91,6 +91,27 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
     return None
 
 
+def _is_replayed_screenshot(message: dict, screenshot_urls: set) -> bool:
+    """True if this user message is a formatter-inserted screenshot — its image is one
+    the image_result_formatter recorded on a trace entry (trace_entry['image']).
+
+    Those screenshots are replayed once as a standalone agent image bubble from the
+    trace, so the user-role message the plugin inserted only to feed the model must NOT
+    also be projected (it would double-render the image). A user-uploaded image is never
+    on the trace, so this returns False for it and it still renders as a user bubble.
+    """
+    content = message.get('content')
+    if not isinstance(content, list):
+        return False
+    for part in content:
+        if isinstance(part, dict) and part.get('type') == 'image_url':
+            image_url = part.get('image_url')
+            url = image_url.get('url') if isinstance(image_url, dict) else None
+            if url in screenshot_urls:
+                return True
+    return False
+
+
 def _append_trace_items(items_ui: list[dict], entry: dict, idx: int) -> None:
     """Append a trace entry's ChatItem(s): the item itself, plus a standalone
     image bubble when the entry carries an image (mirrors the live agent_image
@@ -112,6 +133,10 @@ def session_to_chat_items(session: dict) -> list[dict]:
     """
     messages = session.get('messages', [])
     trace = session.get('trace', [])
+    # Screenshots replay once, as agent image bubbles sourced from trace_entry['image'].
+    # The formatter also injects a user-role image message to feed the model; those are
+    # skipped below so they don't double-render. User uploads aren't on the trace.
+    screenshot_urls = {e['image'] for e in trace if e.get('image')}
 
     # Group trace entries by turn boundary (user_input markers).
     # turn_entries[k] = list of (idx, entry) tuples for trace entries belonging to turn k.
@@ -133,6 +158,11 @@ def session_to_chat_items(session: dict) -> list[dict]:
     for msg_idx, msg in enumerate(messages):
         role = msg.get('role', '')
         if role == 'user':
+            # Skip the formatter's injected screenshot messages: they're agent scaffolding
+            # for the model, replayed via the trace image bubble — not a user turn, so they
+            # must not project a bubble or advance the user/turn alignment.
+            if _is_replayed_screenshot(msg, screenshot_urls):
+                continue
             content = msg.get('content', '')
             if isinstance(content, str) and content.startswith(RUNTIME_INPUT_FRAME_PREFIX):
                 content = content[len(RUNTIME_INPUT_FRAME_PREFIX):]

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -2,7 +2,7 @@
 Purpose: Convert session storage format to ChatItems wire format for frontend rendering
 LLM-Note:
   Dependencies: imports from [useful_plugins/runtime_input.py for RUNTIME_INPUT_FRAME_PREFIX] | imported by [host/http_router.py, host/ws_router/agent_io.py, host/ws_router/connect.py, host/session/__init__.py] | tested by [tests/unit/test_host_session.py]
-  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking
+  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking | trace entries carrying an 'image' also emit a standalone agent image bubble, mirroring the live agent_image event so replays keep screenshots
   State/Effects: pure function, no side effects
   Integration: exposes session_to_chat_items(session) → list[dict] | used by http_router and ws_router when delivering server_newer state and OUTPUT
   Performance: O(n) where n = messages + trace entries
@@ -91,6 +91,18 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
     return None
 
 
+def _append_trace_items(items_ui: list[dict], entry: dict, idx: int) -> None:
+    """Append a trace entry's ChatItem(s): the item itself, plus a standalone
+    image bubble when the entry carries an image (mirrors the live agent_image
+    event so replayed history shows screenshots too)."""
+    item_ui = _trace_entry_to_item_ui(entry, idx)
+    if item_ui:
+        items_ui.append(item_ui)
+    image = entry.get('image')
+    if image:
+        items_ui.append({'id': f"img-{idx}", 'type': 'agent', 'content': '', 'images': [image]})
+
+
 def session_to_chat_items(session: dict) -> list[dict]:
     """Convert session → ChatItem[] for UI rendering, interleaved chronologically by turn.
 
@@ -128,9 +140,7 @@ def session_to_chat_items(session: dict) -> list[dict]:
             user_count += 1
             if user_count < len(turn_entries):
                 for trace_idx, entry in turn_entries[user_count]:
-                    item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-                    if item_ui:
-                        items_ui.append(item_ui)
+                    _append_trace_items(items_ui, entry, trace_idx)
         elif role == 'assistant' and msg.get('content'):
             items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': msg.get('content', '')})
 
@@ -138,8 +148,6 @@ def session_to_chat_items(session: dict) -> list[dict]:
     # entries at the end so the data isn't silently dropped (older sessions).
     if len(turn_entries) == 1 and turn_entries[0]:
         for trace_idx, entry in turn_entries[0]:
-            item_ui = _trace_entry_to_item_ui(entry, trace_idx)
-            if item_ui:
-                items_ui.append(item_ui)
+            _append_trace_items(items_ui, entry, trace_idx)
 
     return items_ui

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -8,7 +8,8 @@ frontend IO when available.
 Data flow: after_tools event -> scan successful tool_result trace entries ->
 detect image data URL or raw base64 -> replace the matching tool message with a
 short placeholder -> insert a user message containing image_url -> shorten the
-trace result.
+trace result, keeping the data URL on trace_entry['image'] so session replay
+(host/session/ui.py) can re-emit the screenshot into chat_items.
 
 State/Effects: mutates agent.current_session["messages"] and trace entries;
 optionally calls agent.io.send_image(data_url). Non-image tool results are ignored.
@@ -95,6 +96,11 @@ def _format_image_result(agent: 'Agent') -> None:
         if agent.io:
             agent.io.send_image(data_url)
 
+        # Keep the data URL on the trace (not sent to the LLM) so session replay
+        # can re-emit the image into chat_items. Without this, the shortened
+        # result below is the only trace record and screenshots vanish whenever
+        # the client rebuilds its UI from the server's canonical history.
+        trace_entry['image'] = data_url
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -55,37 +55,42 @@ def _is_base64_image(text: str) -> tuple[bool, str, str]:
     return False, "", ""
 
 
-# How many recent screenshots stay fully visible to the LLM. Older ones are stale
-# page state — useless to the model but they grow the context without bound over a
-# long browser task. Anthropic computer-use keeps the last few tool_result images
-# the same way (_maybe_filter_to_n_most_recent_images).
-KEEP_LAST_N_SCREENSHOTS = 3
+def _image_urls(message: dict) -> list:
+    """The image_url URLs carried in a message's content (empty if not multimodal)."""
+    content = message.get('content')
+    if not isinstance(content, list):
+        return []
+    urls = []
+    for part in content:
+        if isinstance(part, dict) and part.get('type') == 'image_url':
+            image_url = part.get('image_url')
+            urls.append(image_url.get('url') if isinstance(image_url, dict) else None)
+    return urls
 
 
 def _is_image_message(message: dict) -> bool:
-    """True if the message carries an image_url block (a screenshot we inserted)."""
-    content = message.get('content')
-    return isinstance(content, list) and any(
-        isinstance(part, dict) and part.get('type') == 'image_url'
-        for part in content
-    )
+    """True if the message carries an image_url block."""
+    return bool(_image_urls(message))
 
 
-def _elide_old_screenshots(messages: list, keep_last: int) -> None:
-    """Keep only the last `keep_last` screenshots in the LLM context; replace the
-    image_url block of older ones with a short text placeholder.
+def _elide_old_screenshots(messages: list, screenshot_urls: set, keep_last: int) -> None:
+    """Drop all but the last `keep_last` formatter-inserted screenshot messages from
+    the LLM context, so a long browser task doesn't grow the context without bound.
 
-    Only the LLM context (agent.current_session['messages']) is touched — each
-    trace_entry['image'] keeps the full data URL, so session replay still re-emits
-    every screenshot to the frontend. Idempotent: an already-elided message no
-    longer has an image_url block, so re-running skips it.
+    Only messages whose image is one the formatter recorded on the trace
+    (trace_entry['image'], passed in as `screenshot_urls`) are touched — a user-uploaded
+    image is never one of those, so user uploads stay intact in both the model context
+    and the replay. Old screenshots are removed outright rather than left as a placeholder,
+    so they don't surface as a stray bubble when the UI replays from `messages`; each
+    trace_entry['image'] keeps the full data URL, so replay still shows every screenshot.
     """
-    image_indices = [i for i, m in enumerate(messages) if _is_image_message(m)]
-    for i in image_indices[:-keep_last]:
-        messages[i] = {
-            "role": messages[i].get("role", "user"),
-            "content": "[earlier screenshot removed to bound context]",
-        }
+    indices = [
+        i for i, m in enumerate(messages)
+        if any(u in screenshot_urls for u in _image_urls(m))
+    ]
+    drop = set(indices[:-keep_last]) if keep_last else set(indices)
+    if drop:
+        messages[:] = [m for i, m in enumerate(messages) if i not in drop]
 
 
 def _format_image_result(agent: 'Agent') -> None:
@@ -137,9 +142,13 @@ def _format_image_result(agent: 'Agent') -> None:
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 
-    # Slide the window: at most KEEP_LAST_N_SCREENSHOTS screenshots stay visible to
-    # the LLM. Runs every turn so the context stays bounded over a long browser task.
-    _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
+    # Slide the window: keep at most the last 3 formatter-inserted screenshots visible
+    # to the LLM (older ones are stale page state — useless to the model but they grow
+    # context without bound; Anthropic computer-use bounds tool_result images the same
+    # way). Scoped to images we recorded on the trace, so a user's own uploaded image is
+    # never elided. Runs every turn to keep context bounded.
+    screenshot_urls = {t['image'] for t in trace if t.get('image')}
+    _elide_old_screenshots(messages, screenshot_urls, keep_last=3)
 
 
 def _sanitize_image_urls(agent: 'Agent') -> None:
@@ -157,7 +166,8 @@ def _sanitize_image_urls(agent: 'Agent') -> None:
             continue
         for i, part in enumerate(content):
             if isinstance(part, dict) and part.get('type') == 'image_url':
-                url = (part.get('image_url') or {}).get('url', '')
+                image_url = part.get('image_url')
+                url = image_url.get('url', '') if isinstance(image_url, dict) else ''
                 if not (isinstance(url, str) and url.startswith(('data:image/', 'http://', 'https://'))):
                     content[i] = {'type': 'text', 'text': '[image unavailable]'}
 

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -55,6 +55,39 @@ def _is_base64_image(text: str) -> tuple[bool, str, str]:
     return False, "", ""
 
 
+# How many recent screenshots stay fully visible to the LLM. Older ones are stale
+# page state — useless to the model but they grow the context without bound over a
+# long browser task. Anthropic computer-use keeps the last few tool_result images
+# the same way (_maybe_filter_to_n_most_recent_images).
+KEEP_LAST_N_SCREENSHOTS = 3
+
+
+def _is_image_message(message: dict) -> bool:
+    """True if the message carries an image_url block (a screenshot we inserted)."""
+    content = message.get('content')
+    return isinstance(content, list) and any(
+        isinstance(part, dict) and part.get('type') == 'image_url'
+        for part in content
+    )
+
+
+def _elide_old_screenshots(messages: list, keep_last: int) -> None:
+    """Keep only the last `keep_last` screenshots in the LLM context; replace the
+    image_url block of older ones with a short text placeholder.
+
+    Only the LLM context (agent.current_session['messages']) is touched — each
+    trace_entry['image'] keeps the full data URL, so session replay still re-emits
+    every screenshot to the frontend. Idempotent: an already-elided message no
+    longer has an image_url block, so re-running skips it.
+    """
+    image_indices = [i for i, m in enumerate(messages) if _is_image_message(m)]
+    for i in image_indices[:-keep_last]:
+        messages[i] = {
+            "role": messages[i].get("role", "user"),
+            "content": "[earlier screenshot removed to bound context]",
+        }
+
+
 def _format_image_result(agent: 'Agent') -> None:
     """Replace image tool result text with a multimodal image message."""
     trace = agent.current_session.get('trace', [])
@@ -103,6 +136,10 @@ def _format_image_result(agent: 'Agent') -> None:
         trace_entry['image'] = data_url
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
+
+    # Slide the window: at most KEEP_LAST_N_SCREENSHOTS screenshots stay visible to
+    # the LLM. Runs every turn so the context stays bounded over a long browser task.
+    _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
 
 
 # Plugin is an event list

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -20,7 +20,7 @@ tests/e2e/test_image_formatter_plugin.py.
 
 import re
 from typing import TYPE_CHECKING
-from ..core.events import after_tools
+from ..core.events import after_tools, before_llm
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -142,6 +142,29 @@ def _format_image_result(agent: 'Agent') -> None:
     _elide_old_screenshots(messages, KEEP_LAST_N_SCREENSHOTS)
 
 
-# Plugin is an event list
-# Uses after_tools because message modification can only happen after all tools finish
-image_result_formatter = [after_tools(_format_image_result)]
+def _sanitize_image_urls(agent: 'Agent') -> None:
+    """Before each LLM call, replace any image_url part whose URL isn't a real
+    data:/http(s) image with a short text note, in place.
+
+    A stale placeholder otherwise reaches the provider and 400s the whole turn:
+    oo-chat strips screenshots to '[image]' for localStorage, and an emptied URL can
+    survive a session round-trip — Gemini then rejects "Unsupported file URI type".
+    Validating here (the before_llm boundary) makes the agent immune to any source.
+    """
+    for msg in agent.current_session.get('messages', []):
+        content = msg.get('content')
+        if not isinstance(content, list):
+            continue
+        for i, part in enumerate(content):
+            if isinstance(part, dict) and part.get('type') == 'image_url':
+                url = (part.get('image_url') or {}).get('url', '')
+                if not (isinstance(url, str) and url.startswith(('data:image/', 'http://', 'https://'))):
+                    content[i] = {'type': 'text', 'text': '[image unavailable]'}
+
+
+# Plugin is an event list.
+# - after_tools: turn a screenshot tool result into a model-visible image message
+#   and slide the screenshot window (message modification must happen after tools).
+# - before_llm: drop stale/invalid image_url parts right before the LLM call, so a
+#   round-tripped placeholder never 400s the provider.
+image_result_formatter = [after_tools(_format_image_result), before_llm(_sanitize_image_urls)]

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -761,6 +761,48 @@ class TestSessionToChatItems:
         assert img_item['images'] == [data_url]
         assert img_item['content'] == ''
 
+    def test_skips_injected_screenshot_message_but_keeps_user_upload(self):
+        """The formatter injects a user-role screenshot message to feed the model; on
+        replay that must NOT double-render (the screenshot already replays as an agent
+        image bubble from the trace). A user-uploaded image is never on the trace, so it
+        still renders as a user bubble."""
+        shot_url = "data:image/png;base64,iVBORshot="
+        upload_url = "data:image/png;base64,iVBORupload="
+        session = {
+            'messages': [
+                {'role': 'user', 'content': [
+                    {'type': 'text', 'text': 'is this my product?'},
+                    {'type': 'image_url', 'image_url': {'url': upload_url}},
+                ]},
+                {'role': 'assistant', 'content': None, 'tool_calls': [{'id': 't1'}]},
+                {'role': 'tool', 'content': 'Tool returned an image (provided below)', 'tool_call_id': 't1'},
+                {'role': 'user', 'content': [
+                    {'type': 'text', 'text': "Here is the image from 'take_screenshot':"},
+                    {'type': 'image_url', 'image_url': {'url': shot_url}},
+                ]},
+                {'role': 'assistant', 'content': 'yes it matches'},
+            ],
+            'trace': [
+                {'type': 'user_input', 'turn': 1},
+                {'type': 'tool_result', 'tool_id': 't1', 'name': 'take_screenshot',
+                 'status': 'success', 'result': "Tool 'take_screenshot' returned image (image/png)",
+                 'image': shot_url},
+            ],
+        }
+
+        items = session_to_chat_items(session)
+
+        # The user upload renders as a user bubble (with its image), exactly once.
+        user_items = [i for i in items if i['type'] == 'user']
+        assert len(user_items) == 1
+        assert user_items[0]['content'][1]['image_url']['url'] == upload_url
+
+        # The screenshot renders exactly once — the trace-sourced agent image bubble —
+        # and the injected user-role screenshot message produces no second bubble.
+        image_bubbles = [i for i in items if i.get('images')]
+        assert image_bubbles == [{'id': 'img-1', 'type': 'agent', 'content': '', 'images': [shot_url]}]
+        assert all(shot_url not in str(i.get('content')) for i in user_items)
+
 
 class TestReconnectionScenarios:
     """End-to-end reconnection scenario tests."""

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -9,6 +9,7 @@ Tests cover:
 - Session merge logic
 - ActiveSessionRegistry for reconnection
 - Session to ChatItem conversion for UI
+- Screenshot images on trace entries re-emitted into replayed chat items
 """
 
 import json
@@ -734,6 +735,31 @@ class TestSessionToChatItems:
 
         ids = [item['id'] for item in items]
         assert len(ids) == len(set(ids))  # All unique
+
+    def test_emits_image_bubble_for_screenshot(self):
+        """A tool_result carrying an image (set by image_result_formatter) replays
+        as a tool_call item plus a standalone agent image bubble, so screenshots
+        survive a rebuild from server history instead of vanishing."""
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        session = {
+            'messages': [
+                {'role': 'user', 'content': 'screenshot'},
+                {'role': 'assistant', 'content': 'done'},
+            ],
+            'trace': [
+                {'type': 'user_input', 'turn': 1},
+                {'type': 'tool_result', 'tool_id': 't1', 'name': 'take_screenshot',
+                 'status': 'success', 'result': "Tool 'take_screenshot' returned image (image/png)",
+                 'image': data_url},
+            ],
+        }
+
+        items = session_to_chat_items(session)
+        types = [i['type'] for i in items]
+        assert types == ['user', 'tool_call', 'agent', 'agent']
+        img_item = items[2]
+        assert img_item['images'] == [data_url]
+        assert img_item['content'] == ''
 
 
 class TestReconnectionScenarios:

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -22,9 +22,9 @@ from connectonion.useful_plugins.image_result_formatter import (
     _is_base64_image,
     _format_image_result,
     _is_image_message,
+    _image_urls,
     _sanitize_image_urls,
     image_result_formatter,
-    KEEP_LAST_N_SCREENSHOTS,
 )
 from tests.utils.mock_helpers import MockLLM
 
@@ -365,7 +365,7 @@ class TestScreenshotSlidingWindow:
 
     def _take_screenshot(self, agent, n):
         """Simulate one turn: a screenshot tool result that gets formatted."""
-        b64 = "A" * 150
+        b64 = "A" * 149 + str(n)   # distinct same-length data URL per screenshot
         tool_id = f"call_{n}"
         agent.current_session['messages'].append({
             'role': 'tool',
@@ -387,13 +387,34 @@ class TestScreenshotSlidingWindow:
             self._take_screenshot(agent, n)
 
         image_msgs = [m for m in agent.current_session['messages'] if _is_image_message(m)]
-        assert len(image_msgs) == KEEP_LAST_N_SCREENSHOTS
+        assert len(image_msgs) == 3   # the window keeps the last 3 screenshots
 
-        placeholders = [
-            m for m in agent.current_session['messages']
-            if m.get('content') == "[earlier screenshot removed to bound context]"
-        ]
-        assert len(placeholders) == 5 - KEEP_LAST_N_SCREENSHOTS
+        # Old screenshots are removed outright, not left as a placeholder string, so they
+        # leave no stray bubble when the UI replays from messages.
+        assert not any(
+            isinstance(m.get('content'), str) and 'removed' in m['content']
+            for m in agent.current_session['messages']
+        )
+
+    def test_user_upload_is_not_elided(self):
+        """A user-uploaded image (never recorded on the trace) must survive the window —
+        the formatter elides only its own screenshots, never the user's reference image."""
+        agent = FakeAgent()
+        upload_url = "data:image/png;base64," + "U" * 200
+        agent.current_session['messages'].append({
+            'role': 'user',
+            'content': [
+                {'type': 'text', 'text': 'find this product'},
+                {'type': 'image_url', 'image_url': {'url': upload_url}},
+            ],
+        })
+        for n in range(5):
+            self._take_screenshot(agent, n)
+
+        uploads = [m for m in agent.current_session['messages']
+                   if m.get('role') == 'user' and upload_url in _image_urls(m)]
+        assert len(uploads) == 1                                       # image survived
+        assert {'type': 'text', 'text': 'find this product'} in uploads[0]['content']
 
     def test_context_payload_stays_flat_not_linear(self):
         """The byte size the LLM receives must stop growing once the window fills."""
@@ -410,8 +431,8 @@ class TestScreenshotSlidingWindow:
             self._take_screenshot(agent, n)
             sizes.append(image_bytes(agent))
 
-        # Grows while filling the window, then plateaus (never linear in turn count).
-        assert sizes[-1] == sizes[KEEP_LAST_N_SCREENSHOTS - 1]
+        # Grows while filling the window (3), then plateaus (never linear in turn count).
+        assert sizes[-1] == sizes[2]
         assert sizes[-1] == sizes[-2]
 
     def test_replay_trace_keeps_every_screenshot(self):

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -295,10 +295,13 @@ class TestFormatImageResult:
         _format_image_result(agent)
 
         # Trace result should be shortened
-        trace_result = agent.current_session['trace'][0]['result']
+        trace_entry = agent.current_session['trace'][0]
+        trace_result = trace_entry['result']
         assert 'screenshot' in trace_result
         assert 'image/png' in trace_result
         assert len(trace_result) < 100  # Much shorter than original
+        # Full data URL is retained out-of-band so session replay can re-emit it.
+        assert trace_entry['image'] == 'data:image/png;base64,' + 'A' * 1000
 
     def test_sends_image_to_io_when_available(self):
         """Image tool results are model-visible and sent to frontend IO."""

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -21,7 +21,9 @@ from unittest.mock import Mock
 from connectonion.useful_plugins.image_result_formatter import (
     _is_base64_image,
     _format_image_result,
+    _is_image_message,
     image_result_formatter,
+    KEEP_LAST_N_SCREENSHOTS,
 )
 from tests.utils.mock_helpers import MockLLM
 
@@ -355,6 +357,70 @@ class TestFormatImageResult:
 
         # Should not raise error even without io
         _format_image_result(agent)
+
+
+class TestScreenshotSlidingWindow:
+    """The LLM context keeps only the last N screenshots; older ones are elided."""
+
+    def _take_screenshot(self, agent, n):
+        """Simulate one turn: a screenshot tool result that gets formatted."""
+        b64 = "A" * 150
+        tool_id = f"call_{n}"
+        agent.current_session['messages'].append({
+            'role': 'tool',
+            'content': f"data:image/png;base64,{b64}",
+            'tool_call_id': tool_id,
+        })
+        agent.current_session['trace'].append({
+            'type': 'tool_result',
+            'name': 'take_screenshot',
+            'status': 'success',
+            'result': f"data:image/png;base64,{b64}",
+            'tool_id': tool_id,
+        })
+        _format_image_result(agent)
+
+    def test_keeps_only_last_n_screenshots(self):
+        agent = FakeAgent()
+        for n in range(5):
+            self._take_screenshot(agent, n)
+
+        image_msgs = [m for m in agent.current_session['messages'] if _is_image_message(m)]
+        assert len(image_msgs) == KEEP_LAST_N_SCREENSHOTS
+
+        placeholders = [
+            m for m in agent.current_session['messages']
+            if m.get('content') == "[earlier screenshot removed to bound context]"
+        ]
+        assert len(placeholders) == 5 - KEEP_LAST_N_SCREENSHOTS
+
+    def test_context_payload_stays_flat_not_linear(self):
+        """The byte size the LLM receives must stop growing once the window fills."""
+        def image_bytes(agent):
+            return sum(
+                len(part['image_url']['url'])
+                for m in agent.current_session['messages'] if _is_image_message(m)
+                for part in m['content'] if part.get('type') == 'image_url'
+            )
+
+        agent = FakeAgent()
+        sizes = []
+        for n in range(6):
+            self._take_screenshot(agent, n)
+            sizes.append(image_bytes(agent))
+
+        # Grows while filling the window, then plateaus (never linear in turn count).
+        assert sizes[-1] == sizes[KEEP_LAST_N_SCREENSHOTS - 1]
+        assert sizes[-1] == sizes[-2]
+
+    def test_replay_trace_keeps_every_screenshot(self):
+        """Eliding the LLM context must not touch the trace the frontend replays."""
+        agent = FakeAgent()
+        for n in range(5):
+            self._take_screenshot(agent, n)
+
+        # Every screenshot is still recoverable out-of-band for session replay.
+        assert all('image' in t for t in agent.current_session['trace'])
 
 
 class TestImageResultFormatterPlugin:

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -22,6 +22,7 @@ from connectonion.useful_plugins.image_result_formatter import (
     _is_base64_image,
     _format_image_result,
     _is_image_message,
+    _sanitize_image_urls,
     image_result_formatter,
     KEEP_LAST_N_SCREENSHOTS,
 )
@@ -421,6 +422,49 @@ class TestScreenshotSlidingWindow:
 
         # Every screenshot is still recoverable out-of-band for session replay.
         assert all('image' in t for t in agent.current_session['trace'])
+
+
+class TestSanitizeImageUrls:
+    """before_llm sanitizer: stale/invalid image_url parts must not reach the LLM."""
+
+    def _img_msg(self, url):
+        return {"role": "user", "content": [
+            {"type": "text", "text": "x"},
+            {"type": "image_url", "image_url": {"url": url}},
+        ]}
+
+    def test_placeholder_url_becomes_text(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("[image]")]
+        _sanitize_image_urls(agent)
+        part = agent.current_session['messages'][0]['content'][1]
+        assert part == {"type": "text", "text": "[image unavailable]"}
+
+    def test_empty_url_becomes_text(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("")]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'][1]['type'] == 'text'
+
+    def test_valid_data_url_kept(self):
+        agent = FakeAgent()
+        url = "data:image/png;base64,iVBORw0KGgo"
+        agent.current_session['messages'] = [self._img_msg(url)]
+        _sanitize_image_urls(agent)
+        part = agent.current_session['messages'][0]['content'][1]
+        assert part['type'] == 'image_url' and part['image_url']['url'] == url
+
+    def test_https_url_kept(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [self._img_msg("https://x/y.png")]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'][1]['type'] == 'image_url'
+
+    def test_string_content_untouched(self):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [{"role": "user", "content": "hello"}]
+        _sanitize_image_urls(agent)
+        assert agent.current_session['messages'][0]['content'] == "hello"
 
 
 class TestImageResultFormatterPlugin:


### PR DESCRIPTION
## Summary
- persist screenshot data URLs on trace entries so replayed sessions can rebuild image chat items
- keep only a small screenshot window in LLM context while preserving replay images
- sanitize stale or invalid image_url parts before provider calls

## Verification
- .venv/bin/python -m pytest tests/unit/test_host_session.py tests/unit/test_image_result_formatter.py -q