### PR TITLE
Support named template deploys and repeatable skills

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -295,7 +295,9 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     if skills_paths:
         console.print("  Skills:")
         for skills_path in skills_paths:
-            console.print(f"    {skills_path} -> .co/skills/")
+            # Mirror _build_tarball: a path that is itself a skill nests under its name.
+            dest = f".co/skills/{skills_path.name}/" if (skills_path / "SKILL.md").exists() else ".co/skills/"
+            console.print(f"    {skills_path} -> {dest}")
     console.print()
 
     deploy_data = {

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -2,9 +2,9 @@
 Purpose: Deploy agent projects to ConnectOnion Cloud with local packaging and env vars
 LLM-Note:
   Dependencies: imports from [fnmatch, json, os, re, shutil, subprocess, tarfile, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → optionally creates a temporary template project via co create → validates .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | template deploy creates/deletes a temporary project on success | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | normal deploy does not modify project files
-  Integration: exposes handle_deploy() for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | uses Bearer token auth | returns bool success
+  Integration: exposes handle_deploy(template, skills, name) for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | --name only valid with --template (otherwise the name comes from host.yaml) | uses Bearer token auth | returns bool success
   Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s up to 100 times (~5 min)
   Errors: fails if not ConnectOnion project (no host.yaml) | fails if no API key | prints backend error messages
 """
@@ -163,22 +163,26 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                     continue
                 tar.add(path, arcname=str(rel), recursive=False)
         for skills_path in skills_paths:
+            # A path is either one skill (has SKILL.md) or a directory of skills.
+            arc_prefix = Path(".co") / "skills"
+            if (skills_path / "SKILL.md").exists():
+                arc_prefix = arc_prefix / skills_path.name
             _add_directory_to_tarball(
                 tar,
                 skills_path,
-                Path(".co") / "skills",
+                arc_prefix,
                 _load_deploy_ignore_patterns(skills_path),
             )
     return tarball
 
 
-def _deploy_template_project(template: str, skills: list[str]) -> bool:
+def _deploy_template_project(template: str, skills: list[str], name: str | None = None) -> bool:
     """Create a temporary template project, deploy it, and clean up on success."""
     temp_root = Path.cwd() / ".tmp" / "connectonion-deploy"
     if temp_root.exists():
         shutil.rmtree(temp_root)
     temp_root.mkdir(parents=True)
-    project_name = f"{template}-agent"
+    project_name = name or f"{template}-agent"
     project_dir = temp_root / project_name
 
     console.print(f"[cyan]Creating temporary {template} project...[/cyan]")
@@ -403,10 +407,13 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     return deploy_success
 
 
-def handle_deploy(template: str | None = None, skills: list[str] | None = None):
+def handle_deploy(template: str | None = None, skills: list[str] | None = None, name: str | None = None):
     """Deploy agent to ConnectOnion Cloud."""
     skills = skills or []
     if template:
         absolute_skills = [str(Path(s).expanduser().resolve()) for s in skills]
-        return _deploy_template_project(template, absolute_skills)
+        return _deploy_template_project(template, absolute_skills, name)
+    if name:
+        console.print("[red]--name only applies to template deploys; project name comes from .co/host.yaml[/red]")
+        return False
     return _deploy_current_project(skills)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills with one or more paths, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills repeatable, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
   Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
@@ -97,19 +97,15 @@ def create(
     handle_create(name=name, ai=None, key=key, template=template, description=description, yes=yes)
 
 
-@app.command(context_settings={"allow_extra_args": True})
+@app.command()
 def deploy(
-    ctx: typer.Context,
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
-    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (accepts multiple paths)"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (repeatable: --skills a --skills b)"),
     name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    # Click options take one value each; the extra positionals collected by
-    # allow_extra_args are the rest of `--skills a b c`.
-    all_skills = (skills or []) + list(ctx.args)
-    handle_deploy(template=template, skills=all_skills, name=name)
+    handle_deploy(template=template, skills=skills, name=name)
 
 
 @app.command()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
   Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy, auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills with one or more paths, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
   Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
@@ -97,14 +97,19 @@ def create(
     handle_create(name=name, ai=None, key=key, template=template, description=description, yes=yes)
 
 
-@app.command()
+@app.command(context_settings={"allow_extra_args": True})
 def deploy(
+    ctx: typer.Context,
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
-    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skills directory to bundle into .co/skills/ (repeatable)"),
+    skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (accepts multiple paths)"),
+    name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
 ):
     """Deploy to ConnectOnion Cloud."""
     from .commands.deploy_commands import handle_deploy
-    handle_deploy(template=template, skills=skills)
+    # Click options take one value each; the extra positionals collected by
+    # allow_extra_args are the rest of `--skills a b c`.
+    all_skills = (skills or []) + list(ctx.args)
+    handle_deploy(template=template, skills=all_skills, name=name)
 
 
 @app.command()

--- a/connectonion/cli/templates/co-ai/Dockerfile
+++ b/connectonion/cli/templates/co-ai/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends git xvfb xauth nodejs && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN python -m playwright install --with-deps chrome

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -145,6 +145,14 @@ That creates `.tmp/connectonion-deploy/co-ai-agent`, deploys it, and cleans it u
 after success. Any template supported by `co create --template <name>` uses the
 same flow.
 
+`--name` sets the project name (and URL) for a template deploy, so different
+skill combinations of the same base template can run side by side:
+
+```bash
+co deploy --template co-ai --name linkedin-agent \
+  --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+```
+
 ### Skills
 
 The deployed agent loads skills from `.co/skills/` via the normal loader.
@@ -156,13 +164,14 @@ The deployed agent loads skills from `.co/skills/` via the normal loader.
   co skills copy <name>          # lands in .co/skills/<name>/
   co deploy
   ```
-- **External skills** — to bundle any skills folder that lives outside the
-  project, pass `--skills PATH`
-  (repeatable). The folder contents are copied into the container's
-  `.co/skills/` (your working tree is untouched); on a name clash, later paths
-  win:
+- **External skills** — to bundle skills that live outside the project, pass
+  `--skills PATH [PATH...]`. A path that is itself a skill (contains
+  `SKILL.md`) lands at `.co/skills/<dirname>/`; a directory of skills has its
+  contents copied into `.co/skills/`. Your working tree is untouched; on a
+  name clash, later paths win:
   ```bash
   co deploy --skills /Users/changxing/project/OnCourse/platform/social-media-management-skills
+  co deploy --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
   ```
 
 > Your local `~/.claude/skills` are **not** auto-deployed. `co deploy` ships the

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -150,7 +150,7 @@ skill combinations of the same base template can run side by side:
 
 ```bash
 co deploy --template co-ai --name linkedin-agent \
-  --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+  --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
 ```
 
 ### Skills
@@ -165,13 +165,13 @@ The deployed agent loads skills from `.co/skills/` via the normal loader.
   co deploy
   ```
 - **External skills** — to bundle skills that live outside the project, pass
-  `--skills PATH [PATH...]`. A path that is itself a skill (contains
+  `--skills PATH` (repeatable). A path that is itself a skill (contains
   `SKILL.md`) lands at `.co/skills/<dirname>/`; a directory of skills has its
   contents copied into `.co/skills/`. Your working tree is untouched; on a
   name clash, later paths win:
   ```bash
   co deploy --skills /Users/changxing/project/OnCourse/platform/social-media-management-skills
-  co deploy --skills ~/skills/linkedin-login ~/skills/linkedin-post-submit
+  co deploy --skills ~/skills/linkedin-login --skills ~/skills/linkedin-post-submit
   ```
 
 > Your local `~/.claude/skills` are **not** auto-deployed. `co deploy` ships the

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -363,11 +363,11 @@ class TestDeploySkillsPackaging:
             first.mkdir()
             (first / "SKILL.md").write_text("---\nname: real\n---\nhi\n")
 
-            # First path exists; the bare second path must also be collected
-            # as a skills path and fail validation by name.
+            # --skills is repeatable; the second (missing) path fails validation by name.
             result = runner.invoke(cli, [
                 'deploy',
-                '--skills', str(first), str(tmp_path / 'missing-skill'),
+                '--skills', str(first),
+                '--skills', str(tmp_path / 'missing-skill'),
             ])
             assert "missing-skill" in result.output
             assert "Skills path not found" in result.output

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -8,6 +8,10 @@ What it tests:
   - test_deploy_requires_git_repo: Verify git repo requirement
   - test_deploy_requires_co_project: Verify .co folder requirement
   - Git integration and deployment workflows
+- TestDeployPackaging / TestDeploySkillsPackaging: tarball contents
+  - --skills paths merge into .co/skills/; a path that is itself a skill
+    (contains SKILL.md) nests under its directory name
+  - --name is rejected without --template (project name comes from host.yaml)
 
 Components under test:
 - connectonion.cli.commands.deploy (deploy command)
@@ -317,6 +321,56 @@ class TestDeploySkillsPackaging:
         assert ".co/skills/hello/run.py" in names          # supporting files kept
         assert ".co/skills/world/SKILL.md" in names        # second --skills dir merged
         assert ".co/skills/.git/config" not in names       # dotfiles skipped
+
+    def test_single_skill_dir_nests_under_its_name(self, tmp_path):
+        import tarfile
+        from connectonion.cli.commands.deploy_commands import _build_tarball
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._make_repo(repo)
+
+        skill = tmp_path / "linkedin-login"
+        (skill / "scripts").mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: linkedin-login\n---\nlog in\n")
+        (skill / "scripts" / "fill.js").write_text("x\n")
+
+        tarball = _build_tarball(repo, [skill])
+        names = set(tarfile.open(tarball).getnames())
+
+        assert ".co/skills/linkedin-login/SKILL.md" in names
+        assert ".co/skills/linkedin-login/scripts/fill.js" in names
+        assert ".co/skills/SKILL.md" not in names          # not flattened
+
+    def test_name_without_template_errors_clearly(self):
+        runner = ArgparseCliRunner()
+        with runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+
+            result = runner.invoke(cli, ['deploy', '--name', 'other-name'])
+            assert "--name only applies to template deploys" in result.output
+
+    def test_skills_flag_takes_multiple_paths(self, tmp_path):
+        runner = ArgparseCliRunner()
+        with runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+            first = tmp_path / "real-skill"
+            first.mkdir()
+            (first / "SKILL.md").write_text("---\nname: real\n---\nhi\n")
+
+            # First path exists; the bare second path must also be collected
+            # as a skills path and fail validation by name.
+            result = runner.invoke(cli, [
+                'deploy',
+                '--skills', str(first), str(tmp_path / 'missing-skill'),
+            ])
+            assert "missing-skill" in result.output
+            assert "Skills path not found" in result.output
 
     def test_missing_skills_path_errors_clearly(self):
         runner = ArgparseCliRunner()


### PR DESCRIPTION
## Summary
- allow template deploys to set a project name with `--name`
- package each repeated `--skills PATH` into `.co/skills/` deterministically
- add Node.js to the `co-ai` template image
- update deploy docs for the repeatable `--skills` contract

## Verification
- .venv/bin/python -m pytest tests/e2e/cli/test_cli_deploy.py -q