### PR TITLE
Align model examples with supported proxy models

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,8 +28,8 @@ Agent(
   - `None`: Uses default prompt
 - **api_key** (`Optional[str]`): OpenAI API key (if not using custom LLM)
 - **model** (`str`): Model to use (default: "co/gemini-2.5-pro")
-  - Managed keys: `co/gemini-2.5-pro`, `co/gpt-4o-mini`, `co/claude-3-5-sonnet`
-  - Your own key: `gpt-4o-mini`, `claude-3-5-sonnet`, `gemini-1.5-pro`
+  - Managed keys: `co/gemini-2.5-pro`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
+  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-2.5-pro`
 
 ### System Prompt Options
 
@@ -236,7 +236,7 @@ llm = create_llm("gpt-4o-mini")      # → OpenAILLM
 llm = create_llm("o4-mini")          # → OpenAILLM
 
 # Anthropic models
-llm = create_llm("claude-3-5-sonnet") # → AnthropicLLM
+llm = create_llm("claude-sonnet-4-5") # → AnthropicLLM
 
 # Google Gemini models
 llm = create_llm("gemini-2.5-flash")  # → GeminiLLM
@@ -294,7 +294,7 @@ from connectonion.llm import AnthropicLLM
 
 llm = AnthropicLLM(
     api_key="your-key",  # or ANTHROPIC_API_KEY env var
-    model="claude-3-5-sonnet-20241022"
+    model="claude-sonnet-4-5"
 )
 
 agent = Agent("bot", llm=llm)

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,8 @@ agent = Agent(name="bot", model="co/gemini-2.5-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
+- `co/gemini-3-pro-preview`, `co/gemini-3-flash-preview`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
+- `co/claude-opus-4-5`, `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -171,14 +171,14 @@ from connectonion import llm_do
 
 # Use co/ prefix
 response = llm_do("Hello", model="co/gpt-4o")
-response = llm_do("Hello", model="co/claude-3-5-sonnet")
-response = llm_do("Hello", model="co/gemini-1.5-pro")
+response = llm_do("Hello", model="co/claude-sonnet-4-5")
+response = llm_do("Hello", model="co/gemini-2.5-pro")
 ```
 
 **Available models:**
 - OpenAI: `co/gpt-4o`, `co/gpt-4o-mini`, `co/o4-mini`
-- Anthropic: `co/claude-3-5-sonnet`, `co/claude-3-5-haiku`
-- Google: `co/gemini-1.5-pro`, `co/gemini-1.5-flash`
+- Anthropic: `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
+- Google: `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - And more...
 
 **Benefits:**

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -35,8 +35,8 @@ response = llm_do("Hello", model="co/gpt-4o")
 
 Works across providers:
 - `co/gpt-4o`, `co/gpt-4o-mini`
-- `co/claude-3-5-sonnet`, `co/claude-3-5-haiku`
-- `co/gemini-1.5-pro`, `co/gemini-1.5-flash`
+- `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
+- `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 
 ## Troubleshooting
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -454,17 +454,17 @@ Default model is `co/gemini-2.5-pro`. You can use:
 # OpenAI models
 agent = Agent("bot", model="gpt-4o-mini")
 agent = Agent("bot", model="gpt-4o")
-agent = Agent("bot", model="o1-mini")
+agent = Agent("bot", model="o4-mini")
 agent = Agent("bot", model="o1")
 
 # Anthropic Claude
-agent = Agent("bot", model="claude-3-5-sonnet-20241022")
-agent = Agent("bot", model="claude-3-5-haiku-20241022")
+agent = Agent("bot", model="claude-sonnet-4-5")
+agent = Agent("bot", model="claude-haiku-4-5")
 agent = Agent("bot", model="claude-opus-4")
 
 # Google Gemini
-agent = Agent("bot", model="gemini-1.5-pro")
-agent = Agent("bot", model="gemini-1.5-flash")
+agent = Agent("bot", model="gemini-2.5-pro")
+agent = Agent("bot", model="gemini-2.5-flash")
 agent = Agent("bot", model="gemini-2.0-flash-exp")
 ```
 
@@ -473,7 +473,7 @@ agent = Agent("bot", model="gemini-2.0-flash-exp")
 ```python
 # Use managed keys instead of your own
 agent = Agent("bot", model="co/gpt-4o-mini")
-agent = Agent("bot", model="co/claude-3-5-sonnet")
+agent = Agent("bot", model="co/claude-sonnet-4-5")
 ```
 
 ### API Keys
@@ -494,7 +494,7 @@ agent = Agent("bot", api_key="sk-...", model="gpt-4o-mini")
 from connectonion.llm import AnthropicLLM
 
 custom_llm = AnthropicLLM(
-    model="claude-3-5-sonnet-20241022",
+    model="claude-sonnet-4-5",
     api_key="sk-ant-..."
 )
 
@@ -592,8 +592,8 @@ Token usage is automatically shown in console logs after each LLM call:
 
 Cost tracking works with all supported providers:
 - OpenAI (gpt-4o, gpt-4o-mini, o1, o3-mini, o4-mini)
-- Anthropic Claude (claude-3-5-sonnet, claude-3-5-haiku, claude-opus-4)
-- Google Gemini (gemini-2.5-pro, gemini-2.5-flash, gemini-1.5-pro)
+- Anthropic Claude (claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5)
+- Google Gemini (gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash)
 
 Unknown models use default pricing estimates.
 
@@ -790,7 +790,7 @@ def create_analyst(name: str, tools: list) -> Agent:
         name=name,
         tools=tools,
         system_prompt=Path("prompts/analyst.md"),
-        model="claude-3-5-sonnet-20241022",
+        model="claude-sonnet-4-5",
         max_iterations=15,
         log=f"logs/{name}.log"
     )

--- a/docs/concepts/llm_do.md
+++ b/docs/concepts/llm_do.md
@@ -15,7 +15,7 @@ print(answer)  # "4"
 answer = llm_do("What's 2+2?", model="gemini-2.5-flash")  
 
 # Anthropic Claude
-answer = llm_do("What's 2+2?", model="claude-3-5-haiku-20241022")
+answer = llm_do("What's 2+2?", model="claude-haiku-4-5")
 ```
 
 That's it! One function for any LLM task across multiple providers.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -79,10 +79,6 @@ agent = Agent("assistant", model="o4-mini")         # Your key
 
 #### Gemini 3 (Newest - State-of-the-Art Reasoning)
 ```python
-# Latest Gemini 3.5 Flash
-agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
-agent = Agent("assistant", model="gemini-3.5-flash")     # Your key
-
 # Most intelligent model family with state-of-the-art reasoning
 agent = Agent("assistant", model="co/gemini-3-pro-preview")  # Managed
 agent = Agent("assistant", model="gemini-3-pro-preview")     # Your key
@@ -194,10 +190,9 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | gpt-4o | 128K tokens |
 | o4-mini | 128K tokens |
 | **Google** | |
-| gemini-3.5-flash | 1M tokens |
 | gemini-3-pro-preview | 1M tokens |
 | gemini-3-flash-preview | 1M tokens |
-| gemini-2.5-pro | 2M tokens |
+| gemini-2.5-pro | 1M tokens |
 | gemini-2.5-flash | 1M tokens |
 | **Anthropic** | |
 | claude-opus-4-5 | 200K tokens |
@@ -223,7 +218,6 @@ All prices are **per 1M tokens** and match official provider pricing:
 
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
-| gemini-3.5-flash | $1.50 | $9.00 | Latest Gemini 3.5 Flash |
 | gemini-3-pro-preview | $2.00 | $12.00 | State-of-the-art reasoning |
 | gemini-3-flash-preview | $0.50 | $3.00 | Fastest Gemini 3 |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |
@@ -454,8 +448,8 @@ agent = Agent("budget", model="gemini-2.5-flash-lite") # Google cheapest
 **Long Context (>200K tokens)**
 ```python
 # Models with longest context windows
-agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
-agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
+agent = Agent("reader", model="gemini-2.5-pro")        # 1M tokens
+agent = Agent("reader", model="gemini-3-pro-preview")  # 1M tokens
 ```
 
 **Multimodal (Images, Audio, Video)**

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -440,7 +440,7 @@ agent = Agent("coder", model="claude-sonnet-4-5")
 ```python
 # Fastest options from each provider
 agent = Agent("quick", model="gpt-5-nano")       # OpenAI fastest
-agent = Agent("quick", model="gemini-1.5-flash") # Google fast
+agent = Agent("quick", model="gemini-2.5-flash") # Google fast
 agent = Agent("quick", model="claude-haiku-4-5") # Anthropic fast
 ```
 
@@ -448,14 +448,14 @@ agent = Agent("quick", model="claude-haiku-4-5") # Anthropic fast
 ```python
 # Most cost-efficient options
 agent = Agent("budget", model="gpt-5-nano")       # OpenAI cheapest
-agent = Agent("budget", model="gemini-1.5-flash-8b") # Google cheapest
+agent = Agent("budget", model="gemini-2.5-flash-lite") # Google cheapest
 ```
 
 **Long Context (>200K tokens)**
 ```python
 # Models with longest context windows
 agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
-agent = Agent("reader", model="gemini-1.5-pro")  # 2M tokens
+agent = Agent("reader", model="gemini-2.5-pro")  # 2M tokens
 ```
 
 **Multimodal (Images, Audio, Video)**
@@ -515,8 +515,8 @@ def select_model(task_type: str, speed_priority: bool = False) -> str:
         return {
             "code": "gpt-5-mini",
             "chat": "gpt-5-nano",
-            "analysis": "gemini-1.5-flash",
-            "creative": "claude-3-5-haiku"
+            "analysis": "gemini-2.5-flash",
+            "creative": "claude-haiku-4-5"
         }.get(task_type, "gpt-5-nano")
     else:
         # Best quality models
@@ -632,7 +632,7 @@ def create_robust_agent(name: str, model: str, max_retries: int = 3):
                 # Try alternative model
                 alternatives = {
                     "gpt-5": "gpt-5-mini",
-                    "gemini-2.5-pro": "gemini-1.5-pro",
+                    "gemini-2.5-pro": "gemini-2.5-flash",
                     "claude-sonnet-4-5": "claude-sonnet-4"
                 }
                 alt_model = alternatives.get(model)

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -91,7 +91,7 @@ $ co logout
 ✅ Logged out successfully
 
 # Configure settings
-$ co config set default_model co/claude-3-5-sonnet
+$ co config set default_model co/claude-sonnet-4-5
 ✅ Default model updated
 ```
 
@@ -101,24 +101,24 @@ All models are available with the `co/` prefix:
 
 ### OpenAI Models
 ```python
+llm_do("Hello", model="co/gpt-5")
+llm_do("Hello", model="co/gpt-5-mini")
 llm_do("Hello", model="co/gpt-4o")
-llm_do("Hello", model="co/gpt-4o-mini")
-llm_do("Hello", model="co/o1-preview")
-llm_do("Hello", model="co/o1-mini")
+llm_do("Hello", model="co/o4-mini")
 ```
 
 ### Anthropic Models
 ```python
-llm_do("Hello", model="co/claude-3-5-sonnet")
-llm_do("Hello", model="co/claude-3-5-haiku")
-llm_do("Hello", model="co/claude-3-opus")
+llm_do("Hello", model="co/claude-opus-4-5")
+llm_do("Hello", model="co/claude-sonnet-4-5")
+llm_do("Hello", model="co/claude-haiku-4-5")
 ```
 
 ### Google Models
 ```python
-llm_do("Hello", model="co/gemini-1.5-pro")
-llm_do("Hello", model="co/gemini-1.5-flash")
-llm_do("Hello", model="co/gemini-2.0-flash-exp")
+llm_do("Hello", model="co/gemini-3-pro-preview")
+llm_do("Hello", model="co/gemini-3-flash-preview")
+llm_do("Hello", model="co/gemini-2.5-pro")
 ```
 
 ## Real-World Examples
@@ -141,7 +141,7 @@ class Summary(BaseModel):
 
 result = llm_do(
     "Summarize this article about AI...",
-    model="co/claude-3-5-sonnet",
+    model="co/claude-sonnet-4-5",
     output=Summary
 )
 print(result.key_points)
@@ -166,7 +166,7 @@ response = agent.input("Help me write a Python function")
 
 ```python
 # Compare responses from different models
-models = ["co/gpt-4o", "co/claude-3-5-sonnet", "co/gemini-1.5-pro"]
+models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-2.5-pro"]
 
 for model in models:
     response = llm_do("What's the meaning of life?", model=model)
@@ -218,8 +218,8 @@ def test_all_models(prompt):
     """Test prompt across all providers."""
     models = {
         "OpenAI": "co/gpt-4o",
-        "Anthropic": "co/claude-3-5-sonnet",
-        "Google": "co/gemini-1.5-pro"
+        "Anthropic": "co/claude-sonnet-4-5",
+        "Google": "co/gemini-2.5-pro"
     }
     
     results = {}


### PR DESCRIPTION
## Summary
- update documentation examples to use currently supported managed model names
- keep direct-provider examples aligned with the supported model list

Note: PR #154 also included a benchmark marker registration commit, but current `main` already contains the `benchmark` marker, so there is no marker diff in this branch.

## Verification
- .venv/bin/python -m pytest --collect-only tests/e2e/real_api/test_real_multi_llm.py -q -m "real_api or benchmark"