### PR TITLE
Add no-progress guard plugin

### DIFF
--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -25,5 +25,6 @@ from .ulw import ulw, handle_ulw_mode_change
 from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
+from .no_progress_guard import no_progress_guard
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'no_progress_guard']

--- a/connectonion/useful_plugins/no_progress_guard.py
+++ b/connectonion/useful_plugins/no_progress_guard.py
@@ -1,54 +1,72 @@
 """
 LLM-Note: No-progress guard plugin.
 
-Purpose: Stop the agent loop early when it makes the exact same tool call(s)
-several iterations in a row — a stuck loop doing the same thing (the classic
-browser-agent failure: screenshot -> same dead click -> screenshot -> ...).
-max_iterations is the slow-drift backstop; this catches tight loops before they
-burn the budget and pile screenshots into the context.
+Purpose: Stop the agent loop early when it emits the EXACT SAME tool call(s) in
+consecutive iterations — an agent hammering one identical call that gets it nowhere
+(e.g. retrying the same failing action with the same arguments, or an LLM stuck
+re-issuing a call it already made). max_iterations is the slow-drift backstop; this
+catches a tight byte-identical loop before it burns the budget.
 
-Data flow: after_iteration -> read the most recent assistant tool_calls ->
-build a signature (tool names + arguments, call ids stripped) -> compare to the
-previous iteration's signature stored in current_session -> if identical for
-`max_repeats` consecutive iterations, set stop_signal so the loop halts and asks
-the user what to do next.
+Scope: compares the WHOLE tool-call set of one iteration to the previous iteration's,
+and fires only on CONSECUTIVE byte-identical repetition. It deliberately does NOT
+catch a loop that alternates or cycles (e.g. screenshot -> click -> screenshot ->
+click, whose signature changes every step) or one that varies any argument — those
+are left to max_iterations. Detecting cycles would risk stopping legitimate periodic
+work (scroll -> screenshot -> scroll ...), so this stays narrow on purpose.
+
+Data flow: after_user_input -> clear the per-turn counter | after_iteration -> read
+the most recent assistant tool_calls -> build a signature (tool names + arguments,
+call ids stripped) -> compare to the previous iteration's signature stored in
+current_session -> if identical for `max_repeats` consecutive iterations, set
+stop_signal so the loop halts and asks the user what to do next.
 
 State/Effects: reads/writes current_session['_noprogress_sig'] and
-['_noprogress_count']; sets current_session['stop_signal'] when stuck. Touches
-nothing else.
+['_noprogress_count'], cleared at each turn boundary so a streak never crosses turns;
+sets current_session['stop_signal'] when stuck. Touches nothing else.
 
-Note: the signature compares the whole set of tool calls in an iteration, so a
-loop that varies any argument (e.g. a different selector each try) is treated as
-progress and not stopped — max_iterations covers that drift. This guard targets
-byte-identical repetition only, which keeps false positives near zero.
+Caveat: a tool that is legitimately called identically several times in a row (a
+fixed-interval poll, a same-args retry, paginating with an unchanged cursor) trips this
+at `max_repeats`. It is opt-in for exactly that reason — enable it only for agents where
+consecutive identical calls mean "stuck".
 """
 
 import json
-from ..core.events import after_iteration
+from ..core.events import after_user_input, after_iteration
 
 
 def _last_tool_signature(messages):
-    """Signature of the most recent assistant tool_calls, call ids stripped."""
+    """Signature of the most recent assistant tool_calls, call ids stripped.
+
+    `arguments` is compared as its raw serialized string, so detection relies on the
+    tool-call producer serializing it deterministically (it does — json.dumps in
+    tool_executor), which makes a repeated identical call serialize byte-for-byte.
+    """
     for message in reversed(messages):
         if message.get('role') == 'assistant' and message.get('tool_calls'):
             return json.dumps(
                 [
                     [tc['function']['name'], tc['function'].get('arguments', '')]
                     for tc in message['tool_calls']
-                ],
-                sort_keys=True,
+                ]
             )
     return None
 
 
 def no_progress_guard(max_repeats: int = 3):
-    """Plugin: halt the loop when the same tool call(s) repeat `max_repeats` times
-    in a row.
+    """Plugin: halt the loop when the same tool call(s) repeat `max_repeats` times in a
+    row within one turn.
 
     Args:
         max_repeats: consecutive identical iterations that trigger the stop
             (default 3 — the third identical call halts).
     """
+
+    def _reset(agent):
+        # The streak is per-turn: clear it when a new user message arrives, so a halt
+        # can be continued (the next turn's first identical call doesn't immediately
+        # re-halt) and identical calls across unrelated turns don't accumulate.
+        agent.current_session.pop('_noprogress_sig', None)
+        agent.current_session.pop('_noprogress_count', None)
 
     def _check(agent):
         session = agent.current_session
@@ -69,4 +87,6 @@ def no_progress_guard(max_repeats: int = 3):
             )
             session['stop_signal'] = True
 
-    return [after_iteration(_check)]
+    # List order is just a bundle — the agent registers each handler by its event type,
+    # so _check stays first for callers/tests that index [0].
+    return [after_iteration(_check), after_user_input(_reset)]

--- a/connectonion/useful_plugins/no_progress_guard.py
+++ b/connectonion/useful_plugins/no_progress_guard.py
@@ -1,0 +1,72 @@
+"""
+LLM-Note: No-progress guard plugin.
+
+Purpose: Stop the agent loop early when it makes the exact same tool call(s)
+several iterations in a row — a stuck loop doing the same thing (the classic
+browser-agent failure: screenshot -> same dead click -> screenshot -> ...).
+max_iterations is the slow-drift backstop; this catches tight loops before they
+burn the budget and pile screenshots into the context.
+
+Data flow: after_iteration -> read the most recent assistant tool_calls ->
+build a signature (tool names + arguments, call ids stripped) -> compare to the
+previous iteration's signature stored in current_session -> if identical for
+`max_repeats` consecutive iterations, set stop_signal so the loop halts and asks
+the user what to do next.
+
+State/Effects: reads/writes current_session['_noprogress_sig'] and
+['_noprogress_count']; sets current_session['stop_signal'] when stuck. Touches
+nothing else.
+
+Note: the signature compares the whole set of tool calls in an iteration, so a
+loop that varies any argument (e.g. a different selector each try) is treated as
+progress and not stopped — max_iterations covers that drift. This guard targets
+byte-identical repetition only, which keeps false positives near zero.
+"""
+
+import json
+from ..core.events import after_iteration
+
+
+def _last_tool_signature(messages):
+    """Signature of the most recent assistant tool_calls, call ids stripped."""
+    for message in reversed(messages):
+        if message.get('role') == 'assistant' and message.get('tool_calls'):
+            return json.dumps(
+                [
+                    [tc['function']['name'], tc['function'].get('arguments', '')]
+                    for tc in message['tool_calls']
+                ],
+                sort_keys=True,
+            )
+    return None
+
+
+def no_progress_guard(max_repeats: int = 3):
+    """Plugin: halt the loop when the same tool call(s) repeat `max_repeats` times
+    in a row.
+
+    Args:
+        max_repeats: consecutive identical iterations that trigger the stop
+            (default 3 — the third identical call halts).
+    """
+
+    def _check(agent):
+        session = agent.current_session
+        signature = _last_tool_signature(session['messages'])
+        if signature is None:
+            return
+
+        if signature == session.get('_noprogress_sig'):
+            session['_noprogress_count'] = session.get('_noprogress_count', 1) + 1
+        else:
+            session['_noprogress_sig'] = signature
+            session['_noprogress_count'] = 1
+
+        if session['_noprogress_count'] >= max_repeats:
+            agent.logger.print(
+                f"[yellow]No-progress guard: same tool call repeated "
+                f"{max_repeats}x — stopping the loop.[/yellow]"
+            )
+            session['stop_signal'] = True
+
+    return [after_iteration(_check)]

--- a/tests/unit/test_no_progress_guard.py
+++ b/tests/unit/test_no_progress_guard.py
@@ -96,6 +96,28 @@ class TestNoProgressGuard:
         check(agent)
         assert agent.current_session.get('stop_signal') is True
 
+    def test_counter_resets_at_turn_boundary(self):
+        """The streak is per-turn. After a halt, the next user turn (after_user_input)
+        clears the counter, so the turn's first identical call does not immediately
+        re-halt and unrelated turns don't accumulate into a false stop."""
+        agent = FakeAgent()
+        check, reset = no_progress_guard(max_repeats=3)
+
+        # Turn 1: three identical calls halt the loop.
+        for _ in range(3):
+            agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+            check(agent)
+        assert agent.current_session.get('stop_signal') is True
+
+        # New user turn: the loop popped stop_signal; after_user_input clears the streak.
+        agent.current_session.pop('stop_signal', None)
+        reset(agent)
+
+        # Turn 2: one more identical call must NOT immediately re-halt.
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+
     def test_plugin_registers_after_iteration(self):
         from connectonion import Agent
         from tests.utils.mock_helpers import MockLLM

--- a/tests/unit/test_no_progress_guard.py
+++ b/tests/unit/test_no_progress_guard.py
@@ -1,0 +1,109 @@
+"""Unit tests for connectonion/useful_plugins/no_progress_guard.py
+
+Tests cover:
+- _last_tool_signature: signature ignores call ids, reads the most recent call
+- no_progress_guard: stops on repeated identical calls, not on varying calls
+"""
+
+from unittest.mock import Mock
+
+from connectonion.useful_plugins.no_progress_guard import (
+    no_progress_guard,
+    _last_tool_signature,
+)
+
+
+class FakeAgent:
+    def __init__(self):
+        self.current_session = {'messages': []}
+        self.logger = Mock()
+
+
+def _assistant_call(name, arguments):
+    return {
+        'role': 'assistant',
+        'tool_calls': [
+            {'id': 'irrelevant', 'type': 'function',
+             'function': {'name': name, 'arguments': arguments}}
+        ],
+    }
+
+
+class TestLastToolSignature:
+    def test_ignores_call_id(self):
+        a = [{'role': 'assistant', 'tool_calls': [
+            {'id': '1', 'function': {'name': 'f', 'arguments': '{}'}}]}]
+        b = [{'role': 'assistant', 'tool_calls': [
+            {'id': '2', 'function': {'name': 'f', 'arguments': '{}'}}]}]
+        assert _last_tool_signature(a) == _last_tool_signature(b)
+
+    def test_reads_most_recent_call_past_tool_and_user_messages(self):
+        messages = [
+            _assistant_call('old', '{}'),
+            {'role': 'tool', 'content': 'x', 'tool_call_id': 'irrelevant'},
+            _assistant_call('new', '{}'),
+            {'role': 'user', 'content': [{'type': 'image_url', 'image_url': {'url': 'd'}}]},
+        ]
+        assert 'new' in _last_tool_signature(messages)
+        assert 'old' not in _last_tool_signature(messages)
+
+    def test_none_when_no_tool_calls(self):
+        assert _last_tool_signature([{'role': 'user', 'content': 'hi'}]) is None
+
+
+class TestNoProgressGuard:
+    def test_stops_after_repeated_identical_calls(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+        agent.current_session['messages'].append(_assistant_call('take_screenshot', '{}'))
+        check(agent)
+        assert agent.current_session.get('stop_signal') is True
+
+    def test_does_not_stop_when_calls_vary(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+        for selector in ['#a', '#b', '#c', '#d', '#e']:
+            agent.current_session['messages'].append(
+                _assistant_call('click_element_by_selector', f'{{"selector": "{selector}"}}'))
+            check(agent)
+            assert not agent.current_session.get('stop_signal')
+
+    def test_counter_resets_after_a_different_call(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=3)[0]
+        # two identical, then a different one resets the streak, then two identical again
+        for name in ['scroll', 'scroll', 'screenshot', 'scroll', 'scroll']:
+            agent.current_session['messages'].append(_assistant_call(name, '{}'))
+            check(agent)
+        assert not agent.current_session.get('stop_signal')
+
+    def test_threshold_is_configurable(self):
+        agent = FakeAgent()
+        check = no_progress_guard(max_repeats=2)[0]
+        agent.current_session['messages'].append(_assistant_call('f', '{}'))
+        check(agent)
+        assert not agent.current_session.get('stop_signal')
+        agent.current_session['messages'].append(_assistant_call('f', '{}'))
+        check(agent)
+        assert agent.current_session.get('stop_signal') is True
+
+    def test_plugin_registers_after_iteration(self):
+        from connectonion import Agent
+        from tests.utils.mock_helpers import MockLLM
+        from connectonion.core.llm import LLMResponse
+        from connectonion.core.usage import TokenUsage
+
+        mock_llm = MockLLM(responses=[
+            LLMResponse(content="done", tool_calls=[], raw_response=None, usage=TokenUsage())
+        ])
+        agent = Agent("test", llm=mock_llm, plugins=[no_progress_guard()], log=False)
+        assert 'after_iteration' in agent.events


### PR DESCRIPTION
## Summary
- add a generic `no_progress_guard` plugin that stops exact repeated tool-call loops
- compare tool-call names and arguments while ignoring transient call IDs
- export the plugin without adding Browser-specific plugins to this branch

## Verification
- .venv/bin/python -m pytest tests/unit/test_no_progress_guard.py -q