### PR TITLE
Make browser tools safe for hosted sessions

### DIFF
--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -26,5 +26,6 @@ from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
 from .human_jitter import human_jitter
+from .bind_browser_session import bind_browser_session
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter', 'bind_browser_session']

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -25,5 +25,6 @@ from .ulw import ulw, handle_ulw_mode_change
 from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
+from .human_jitter import human_jitter
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'human_jitter']

--- a/connectonion/useful_plugins/bind_browser_session.py
+++ b/connectonion/useful_plugins/bind_browser_session.py
@@ -1,0 +1,44 @@
+"""
+LLM-Note: Bind-browser-session plugin.
+
+Purpose: tell the shared BrowserAutomation which session (chat panel) the current
+agent turn belongs to, so each session drives its own browser tab instead of all
+sessions fighting over one page (A navigates and B's page jumps / closes).
+
+Data flow: before_each_tool -> read agent.current_session['session_id'] -> hand it
+to the BrowserAutomation instance via agent.tools.browserautomation._bind_session(),
+which stashes it in a thread-local that the browser's dispatch decorator reads to
+route the call to that session's tab (creating it on first use).
+
+Why before_each_tool: it fires on the agent's own thread right before each tool
+runs — the same thread the browser dispatch decorator later reads the binding from.
+Per-tool is cheap and keeps the binding correct across multi-turn sessions.
+
+Why a plugin (not connectonion core): session routing stays opt-in and out of core —
+an agent enables multi-tab isolation by adding this to plugins, exactly like
+human_jitter. Agents without it (or with no browser) are unaffected: the key stays
+None and the browser uses a single shared tab (original behaviour).
+
+State/Effects: writes a thread-local on the agent thread; no agent state. Best-effort
+— if there is no browser tool or no session_id, it does nothing.
+"""
+
+from typing import TYPE_CHECKING
+
+from ..core.events import before_each_tool
+
+if TYPE_CHECKING:
+    from ..core.agent import Agent
+
+
+def _bind_session(agent: "Agent") -> None:
+    browser = getattr(agent.tools, "browserautomation", None)
+    if browser is None:
+        return
+    session_id = (agent.current_session or {}).get("session_id")
+    browser._bind_session(session_id)
+
+
+# Plugin is an event list. before_each_tool runs on the agent thread just before a
+# tool executes, which is where the browser dispatch decorator reads the binding.
+bind_browser_session = [before_each_tool(_bind_session)]

--- a/connectonion/useful_plugins/human_jitter.py
+++ b/connectonion/useful_plugins/human_jitter.py
@@ -1,0 +1,69 @@
+"""
+LLM-Note: Human mouse-jitter plugin.
+
+Purpose: Make a browser agent's clicks look human. Right before any click* tool
+runs, wander the mouse through a few random points on the page, so the click is
+preceded by organic motion instead of an instant teleport-and-click.
+
+Data flow: before_each_tool event -> read agent.current_session['pending_tool'] ->
+if its name starts with 'click', grab the BrowserAutomation instance off the tool
+registry (agent.tools.browserautomation) and dispatch jitter() onto the browser's
+single worker thread (Playwright is not thread-safe).
+
+Why before_each_tool (not after_tools): this is the only hook that fires
+synchronously between "LLM picked a click tool" and "Playwright performs the click",
+which is exactly where pre-click motion belongs.
+
+Why a plugin (not baked into BrowserAutomation.click): jitter is non-deterministic
+and opt-in. Forcing it on every browser user would make clicks non-reproducible for
+tests and agents that don't want it. Agents opt in with plugins=[human_jitter].
+
+State/Effects: moves the mouse cursor via Playwright; no agent state. Best-effort —
+if the page is mid-navigation when jitter reads the viewport, the click must still
+proceed, so that transient failure is caught and logged, never raised.
+"""
+
+import random
+import time
+from typing import TYPE_CHECKING
+
+from ..core.events import before_each_tool
+
+if TYPE_CHECKING:
+    from ..core.agent import Agent
+
+
+def jitter(page):
+    """Wander the mouse through a few random points on the page.
+
+    Must run on the browser's worker thread (Playwright is single-threaded).
+    """
+    w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    x = random.uniform(w * 0.2, w * 0.8)
+    y = random.uniform(h * 0.2, h * 0.8)
+    page.mouse.move(x, y, steps=random.randint(8, 16))
+    for _ in range(random.randint(2, 4)):
+        x = min(max(x + random.uniform(-120, 120), 1), w - 1)
+        y = min(max(y + random.uniform(-90, 90), 1), h - 1)
+        page.mouse.move(x, y, steps=random.randint(6, 14))
+        time.sleep(random.uniform(0.03, 0.12))
+
+
+def _jitter_before_click(agent: "Agent"):
+    pending = agent.current_session.get("pending_tool") or {}
+    if not pending.get("name", "").startswith("click"):
+        return
+    browser = getattr(agent.tools, "browserautomation", None)
+    if browser is None or getattr(browser, "page", None) is None:
+        return
+    try:
+        browser._executor.submit(jitter, browser.page).result()
+    except Exception as e:
+        # Jitter is cosmetic; a mid-navigation page (viewport read throws) must not
+        # block the click the agent actually asked for.
+        agent.logger.print(f"[dim]human_jitter skipped: {e}[/dim]")
+
+
+# Plugin is an event list. before_each_tool is the only hook between tool selection
+# and tool execution, so it's where pre-click motion has to go.
+human_jitter = [before_each_tool(_jitter_before_click)]

--- a/connectonion/useful_plugins/human_jitter.py
+++ b/connectonion/useful_plugins/human_jitter.py
@@ -1,9 +1,11 @@
 """
-LLM-Note: Human mouse-jitter plugin.
+LLM-Note: Mouse-movement plugin.
 
-Purpose: Make a browser agent's clicks look human. Right before any click* tool
-runs, wander the mouse through a few random points on the page, so the click is
-preceded by organic motion instead of an instant teleport-and-click.
+Purpose: Move the cursor along an organic path before a click instead of teleporting
+straight to the target. Some interfaces only reveal or enable a control after real
+pointer movement (hover menus, lazy-loaded widgets, drag affordances), so a single
+teleport-click can land on nothing; a short wander first makes the interaction land.
+Use it on sites whose terms permit automation.
 
 Data flow: before_each_tool event -> read agent.current_session['pending_tool'] ->
 if its name starts with 'click', grab the BrowserAutomation instance off the tool

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -28,6 +28,7 @@ import inspect
 import json
 import platform
 import threading
+import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -53,17 +54,46 @@ except ImportError:
 # Path to the browser agent system prompt
 
 
+# Carries "which session is the current call for" from the agent thread (set by the
+# bind_browser_session plugin via _bind_session) to the browser worker thread. A
+# threading.local so concurrent agent threads never clobber each other's key; when
+# no plugin sets it the key is None and every call shares one tab (current behaviour).
+_session_binding = threading.local()
+
+
+def _current_session_key():
+    return getattr(_session_binding, "key", None)
+
+
+# Context-level methods that must NOT auto-create a tab before they run:
+# open_browser creates the tab itself after launching the context; close/save_state
+# operate on the whole context, and a fresh tab right before teardown is wrong.
+_NO_TAB_METHODS = {"open_browser", "close", "save_state"}
+
+
 # Playwright's sync API binds to the thread that started it and raises
 # "Cannot switch to a different thread" from any other. Servers like host()
 # run each agent turn on an arbitrary threadpool thread, so consecutive turns
 # crash the shared browser. Route every public method through the instance's
 # dedicated worker thread: playwright starts there and every call lands there.
+#
+# The wrapper also routes per session: it reads the caller thread's session key,
+# propagates it onto the worker thread, and ensures that session's own tab exists
+# before the method runs (so self.page resolves to the right tab).
 def _runs_on_browser_thread(method):
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        if threading.current_thread() is self._executor_thread:
+        key = _current_session_key()  # read on the caller (agent) thread
+
+        def run():
+            _session_binding.key = key      # propagate onto the worker thread
+            if method.__name__ not in _NO_TAB_METHODS:
+                self._ensure_page(key)      # this session gets / keeps its own tab
             return method(self, *args, **kwargs)
-        return self._executor.submit(method, self, *args, **kwargs).result()
+
+        if threading.current_thread() is self._executor_thread:
+            return run()
+        return self._executor.submit(run).result()
 
     return wrapper
 
@@ -73,6 +103,7 @@ def _public_methods_run_on_browser_thread(cls):
         if not name.startswith("_") and inspect.isfunction(method):
             setattr(cls, name, _runs_on_browser_thread(method))
     return cls
+
 
 def _browser_proxy_from_env():
     """Build Playwright's proxy config from the BROWSER_PROXY env var, or None if unset.
@@ -93,6 +124,7 @@ def _browser_proxy_from_env():
     if p.password:
         proxy["password"] = urllib.parse.unquote(p.password)
     return proxy
+
 
 @_public_methods_run_on_browser_thread
 class BrowserAutomation:
@@ -126,7 +158,14 @@ class BrowserAutomation:
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
-        self.page: Optional[Page] = None
+        # One tab per session (chat panel) in the shared context, so concurrent
+        # sessions don't navigate over each other. Key = session_id (None = no
+        # session bound = single shared tab, the original single-page behaviour).
+        self._pages: Dict[Optional[str], "Page"] = {}
+        self._page_used: Dict[Optional[str], float] = {}   # key -> last-use monotonic ts (LRU/TTL)
+        self._page_url: Dict[Optional[str], str] = {}      # key -> last url (restore a reclaimed tab)
+        self._tab_idle_ttl = 3600.0   # reclaim a tab after 60 min idle (a panel left untouched)
+        self._max_tabs = 10           # backstop cap; a few real panels never hit it
         self.current_url: str = ""
         self.form_data: Dict[str, Any] = {}
         self.use_chrome_profile = use_chrome_profile
@@ -141,6 +180,18 @@ class BrowserAutomation:
 
     def _browser_is_usable(self) -> bool:
         """Return True when the current Playwright page can still be operated."""
+        key = _current_session_key()
+
+        def run():
+            _session_binding.key = key
+            return self._browser_is_usable_on_browser_thread()
+
+        if threading.current_thread() is self._executor_thread:
+            return run()
+        return self._executor.submit(run).result()
+
+    def _browser_is_usable_on_browser_thread(self) -> bool:
+        """Check browser usability on Playwright's owning thread."""
         if not self.browser or not self.page:
             return False
 
@@ -152,6 +203,105 @@ class BrowserAutomation:
             return True
         except Exception:
             return False
+
+    @property
+    def page(self):
+        """The Playwright tab for the session this call belongs to.
+
+        Each session (chat panel) gets its own tab in the shared, single-login
+        context, so concurrent sessions don't navigate over each other. The session
+        key is set by the bind_browser_session plugin on the agent thread and
+        propagated onto the worker thread by the dispatch decorator; both threads
+        read it from the same threading.local. Returns None until the tab is created
+        (so the existing `if not self.page: ...` guards still read "browser not open").
+        """
+        return self._pages.get(_current_session_key())
+
+    @page.setter
+    def page(self, value):
+        """Set the current session's tab. Internal flows create tabs via
+        _ensure_page; this setter keeps `self.page = <page>` working for callers
+        and tests that inject a page directly (it writes the current session's slot)."""
+        key = _current_session_key()
+        self._pages[key] = value
+        self._page_used[key] = time.monotonic()
+
+    def _bind_session(self, session_id) -> None:
+        """Record, on the CALLER (agent) thread, which session the next browser
+        calls on this thread belong to. Underscore-prefixed so it is neither
+        dispatched to the worker thread nor exposed to the LLM as a tool; the
+        bind_browser_session plugin calls it before each tool, and the dispatch
+        decorator reads the binding to route to the right tab."""
+        _session_binding.key = session_id
+
+    def _ensure_page(self, key) -> None:
+        """Make sure session `key` has a live tab, then reclaim abandoned ones.
+
+        Reused by two callers, always on the worker thread: the dispatch decorator
+        (before every tab-using tool, so self.page resolves to this session's tab)
+        and open_browser (to create the first tab after launching the context).
+
+        Creates the tab in the shared context (restored to its last URL), stamps its
+        last-use time, then reclaims. No-op until the context is open; harmless if the
+        tab already exists.
+
+        Reclaim bounds memory but never closes the active `key`: first tabs idle past
+        _tab_idle_ttl (a panel untouched for an hour), then — only if still over
+        _max_tabs — the least-recently-used ones as a runaway backstop. A reclaimed
+        session transparently gets a fresh restored tab next call (no "target closed").
+        """
+        if not self.browser:
+            return
+
+        page = self._pages.get(key)
+        if page is None or (callable(getattr(page, "is_closed", None)) and page.is_closed()):
+            page = self.browser.new_page()
+            page.set_default_navigation_timeout(60000)
+            page.set_viewport_size({"width": 1920, "height": 1200})
+            # Hide automation indicators (defense in depth; also set via launch args).
+            page.add_init_script(
+                "Object.defineProperty(navigator, 'webdriver', {get: () => undefined});"
+            )
+            restore_url = self._page_url.get(key)
+            if restore_url:  # a reclaimed session comes back to where it was
+                try:
+                    page.goto(restore_url, wait_until="domcontentloaded", timeout=30000)
+                except Exception:
+                    pass
+            self._pages[key] = page
+        self._page_used[key] = time.monotonic()
+
+        now = time.monotonic()
+        for k in [k for k, t in list(self._page_used.items())
+                  if k != key and now - t > self._tab_idle_ttl]:
+            self._close_tab(k)
+        if len(self._pages) > self._max_tabs:
+            lru_first = sorted(
+                (k for k in self._pages if k != key),
+                key=lambda k: self._page_used.get(k, 0.0),
+            )
+            for k in lru_first[: len(self._pages) - self._max_tabs]:
+                self._close_tab(k)
+
+    def _close_tab(self, key) -> Optional[str]:
+        """Close one session's tab, remembering its URL so the session can resume.
+
+        Reused by two callers: _ensure_page's reclaim (best-effort, ignores the
+        return) and close() (surfaces the return as a cleanup warning). Returns an
+        error string if the page would not close, else None."""
+        page = self._pages.pop(key, None)
+        self._page_used.pop(key, None)
+        if page is None:
+            return None
+        try:
+            self._page_url[key] = page.url
+        except Exception:
+            pass
+        try:
+            page.close()
+        except Exception as exc:
+            return f"close page failed: {exc}"
+        return None
 
     def open_browser(self, headless: bool = None, force: bool = False) -> str:
         """Open a new browser window.
@@ -226,21 +376,10 @@ class BrowserAutomation:
                 self.browser.add_cookies(cookies)
             self._seeded = True
 
-        self.page = self.browser.new_page()
-        self.page.set_default_navigation_timeout(60000)
-
-        # Set large viewport to show more content without scrolling
-        self.page.set_viewport_size({"width": 1920, "height": 1200})
-
-        # Hide automation indicators (defense in depth)
-        # Already handled by --disable-blink-features=AutomationControlled in args above
-        self.page.add_init_script(
-            """
-            Object.defineProperty(navigator, 'webdriver', {
-                get: () => undefined
-            });
-        """
-        )
+        # Create this session's tab in the freshly launched context (other sessions
+        # get their own tab lazily on first use). _ensure_page applies the viewport
+        # and anti-detection init script when it creates the tab.
+        self._ensure_page(_current_session_key())
 
         if force and had_previous_browser_state:
             return f"Previous browser closed by force. Browser opened with persistent profile: {profile_dir}"
@@ -1295,13 +1434,25 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         print(f"\n[browser] Screenshot saved to: {path}")
         print(f"[browser] Full page: {full_page}, Size: {len(screenshot_bytes)} bytes\n")
 
+        # Bound the payload. The screenshot is sent to the frontend as a base64 data URL
+        # in ONE relay WebSocket frame; base64 inflates bytes ~33% and the relay's default
+        # cap is 1 MB (websockets max_size), so a frame over it drops the relay connection
+        # (and reconnect replays it, so the agent flaps offline). A dense 1920-wide page is
+        # a ~800 KB PNG = >1 MB base64. Re-encode only oversized captures as JPEG
+        # (Playwright-native, no Pillow); keep PNG for the common case so text stays sharp.
+        mime = "image/png"
+        if len(screenshot_bytes) > 600_000:   # ~800 KB base64 + JSON, safely under 1 MB
+            screenshot_bytes = self.page.screenshot(full_page=full_page, type="jpeg", quality=85)
+            mime = "image/jpeg"
+            print(f"[browser] oversized PNG re-encoded as JPEG q85: {len(screenshot_bytes)} bytes\n")
+
         # Wait for page to stabilize after screenshot (especially for full_page which scrolls/resizes)
         # This prevents focus loss when typing after taking a screenshot
         self.page.wait_for_timeout(1000)
 
         screenshot_base64 = base64.b64encode(screenshot_bytes).decode('utf-8')
 
-        return f"data:image/png;base64,{screenshot_base64}"
+        return f"data:{mime};base64,{screenshot_base64}"
 
     def set_viewport(self, width: int, height: int) -> str:
         """Set the browser viewport size."""
@@ -1473,11 +1624,10 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         except Exception as exc:
             cleanup_errors.append(f"save context failed: {exc}")
 
-        try:
-            if self.page:
-                self.page.close()
-        except Exception as exc:
-            cleanup_errors.append(f"close page failed: {exc}")
+        for key in list(self._pages):     # close every session's tab
+            err = self._close_tab(key)
+            if err:
+                cleanup_errors.append(err)
         try:
             if self.browser:
                 self.browser.close()
@@ -1489,7 +1639,9 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         except Exception as exc:
             cleanup_errors.append(f"stop playwright failed: {exc}")
 
-        self.page = None
+        self._pages.clear()
+        self._page_used.clear()
+        self._page_url.clear()
         self.browser = None
         self.playwright = None
         if cleanup_errors:

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -28,6 +28,8 @@ import inspect
 import json
 import platform
 import threading
+import time
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
@@ -73,6 +75,25 @@ def _public_methods_run_on_browser_thread(cls):
             setattr(cls, name, _runs_on_browser_thread(method))
     return cls
 
+def _browser_proxy_from_env():
+    """Build Playwright's proxy config from the BROWSER_PROXY env var, or None if unset.
+
+    BROWSER_PROXY routes the browser's traffic through a proxy so the egress IP is e.g.
+    residential instead of the datacenter IP the agent runs on. Formats:
+        socks5://host:port              (no auth — e.g. a SOCKS relay; Chromium ignores SOCKS auth)
+        http://user:pass@host:port      (HTTP proxy with auth — e.g. a residential proxy service)
+    Unset => None => no proxy, current behaviour unchanged.
+    """
+    url = os.environ.get("BROWSER_PROXY", "").strip()
+    if not url:
+        return None
+    p = urllib.parse.urlparse(url)
+    proxy = {"server": f"{p.scheme}://{p.hostname}:{p.port}"}
+    if p.username:
+        proxy["username"] = urllib.parse.unquote(p.username)
+    if p.password:
+        proxy["password"] = urllib.parse.unquote(p.password)
+    return proxy
 
 @_public_methods_run_on_browser_thread
 class BrowserAutomation:
@@ -184,6 +205,7 @@ class BrowserAutomation:
             executable_path=chrome_path,
             args=CHROME_DEFAULT_ARGS,  # 53 args + 30 disabled features from browser-use
             ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # + macOS cookie fix
+            proxy=_browser_proxy_from_env(),  # route egress through BROWSER_PROXY if set, else None
             timeout=120000,
         )
 
@@ -1479,4 +1501,3 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
-

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -111,13 +111,19 @@ class BrowserAutomation:
     This ensures session persistence even if the process crashes.
     """
 
-    def __init__(self, use_chrome_profile: bool = True, headless: bool = False):
+    def __init__(self, use_chrome_profile: bool = True, headless: bool = False, seed_state: Optional[str] = None):
         """Initialize browser automation.
 
         Args:
             use_chrome_profile: If True, uses your Chrome cookies/sessions.
                                Chrome must be closed before running.
             headless: If True, browser runs without visible window (default True).
+            seed_state: Optional path to a Playwright storage_state JSON (a {"cookies": [...]}
+                        file produced by save_state on another machine). When set, those cookies
+                        are injected into the context once, right after it is created and before
+                        any navigation, so a deployed agent starts already signed in. Cookies are
+                        applied with add_cookies because launch_persistent_context() cannot accept
+                        storage_state=. Unset => no injection, current behaviour unchanged.
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
@@ -127,6 +133,8 @@ class BrowserAutomation:
         self.use_chrome_profile = use_chrome_profile
         self._screenshots = []
         self._headless = headless
+        self._seed_state = seed_state
+        self._seeded = False
         self.screenshots_dir = str(SCREENSHOTS_DIR)
         # All public methods run on this one thread (see _public_methods_run_on_browser_thread).
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="browser")
@@ -209,6 +217,16 @@ class BrowserAutomation:
             timeout=120000,
         )
 
+        # Seed a portable login state into the fresh context once, before any navigation, so a
+        # deployed agent starts already signed in. launch_persistent_context() can't take
+        # storage_state=, so the exported cookies are applied with add_cookies. A missing file
+        # raises (fail loud): if a deploy declared a seed it must be packaged.
+        if self._seed_state and not self._seeded:
+            cookies = json.loads(Path(self._seed_state).read_text()).get("cookies", [])
+            if cookies:
+                self.browser.add_cookies(cookies)
+            self._seeded = True
+
         self.page = self.browser.new_page()
         self.page.set_default_navigation_timeout(60000)
 
@@ -230,6 +248,20 @@ class BrowserAutomation:
         if had_previous_browser_state:
             return f"Previous stale browser state closed. Browser opened with persistent profile: {profile_dir}"
         return f"Browser opened with persistent profile: {profile_dir}"
+
+    def save_state(self, path: str) -> str:
+        """Export the current login state to a portable Playwright storage_state JSON.
+
+        Writes {"cookies": [...], "origins": [...]} to `path`. Run this locally after logging
+        in by hand (headed) to capture a session, then ship the file and pass it back as
+        BrowserAutomation(seed_state=path) on the deployed agent. The JSON is plaintext and
+        portable across machines/OSes; a copied Chrome profile is not (its cookies are
+        encrypted per-OS).
+        """
+        if not self.browser:
+            return "Browser not open"
+        self.browser.storage_state(path=path)
+        return f"Saved login state to {path}"
 
     def go_to(self, url: str) -> str:
         """Navigate to a URL."""

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -3,7 +3,7 @@ Purpose: Natural language browser automation via Playwright with persistent prof
 LLM-Note:
   Dependencies: imports from [playwright.sync_api, connectonion Agent/llm_do, cli/browser_agent/element_finder, pydantic, pathlib, dotenv] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_agent.py]
   Data flow: BrowserAutomation() initializes Playwright → opens browser with persistent context → provides tools (navigate, find_element, click, type_text, screenshot, scroll, wait_for_login) → auto-saves cookies after each critical action → Agent uses these tools via natural language → element_finder.py uses vision LLM to locate elements | screenshots saved to .tmp/ directory
-  State/Effects: maintains browser/page/context state | persistent profile at ~/.co/browser_profile/ | auto-saves cookies after navigation and manual login | writes screenshots to .tmp/{timestamp}.png | modifies form_data dict for form fills | context manager ensures cleanup
+  State/Effects: maintains browser/page/context state | persistent profile at ~/.co/browser_profile/ | auto-saves cookies after navigation and manual login | writes screenshots to .tmp/{timestamp}.png | modifies form_data dict for form fills | context manager ensures cleanup | all public methods dispatch to one dedicated browser thread (Playwright sync API is thread-bound), so a shared instance is safe to call from any thread
   Integration: exposes BrowserAutomation(use_chrome_profile, headless) with methods: navigate(url), find_element(description), screenshot(viewport), scroll(direction, description), click(description), keyboard_type(text), keyboard_press(key), wait_for_login(seconds) | used by `co browser` CLI command
   Performance: headless by default (faster) | persistent context (instant profile load) | vision model for element finding (slower but accurate) | screenshots base64-encoded for LLM analysis | auto-save adds 500ms delay after critical actions
   Errors: returns error string if Playwright not installed | returns "Browser already open" if live browser exists | element not found returns descriptive error
@@ -23,8 +23,12 @@ Features:
 
 import os
 import base64
+import functools
+import inspect
 import json
 import platform
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, List, Dict, Any
@@ -48,6 +52,29 @@ except ImportError:
 # Path to the browser agent system prompt
 
 
+# Playwright's sync API binds to the thread that started it and raises
+# "Cannot switch to a different thread" from any other. Servers like host()
+# run each agent turn on an arbitrary threadpool thread, so consecutive turns
+# crash the shared browser. Route every public method through the instance's
+# dedicated worker thread: playwright starts there and every call lands there.
+def _runs_on_browser_thread(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        if threading.current_thread() is self._executor_thread:
+            return method(self, *args, **kwargs)
+        return self._executor.submit(method, self, *args, **kwargs).result()
+
+    return wrapper
+
+
+def _public_methods_run_on_browser_thread(cls):
+    for name, method in vars(cls).copy().items():
+        if not name.startswith("_") and inspect.isfunction(method):
+            setattr(cls, name, _runs_on_browser_thread(method))
+    return cls
+
+
+@_public_methods_run_on_browser_thread
 class BrowserAutomation:
     """Browser automation with natural language support.
 
@@ -80,6 +107,9 @@ class BrowserAutomation:
         self._screenshots = []
         self._headless = headless
         self.screenshots_dir = str(SCREENSHOTS_DIR)
+        # All public methods run on this one thread (see _public_methods_run_on_browser_thread).
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="browser")
+        self._executor_thread = self._executor.submit(threading.current_thread).result()
 
     def _browser_is_usable(self) -> bool:
         """Return True when the current Playwright page can still be operated."""
@@ -1396,3 +1426,4 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
+

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -493,6 +493,59 @@ class BrowserAutomation:
             ensure_ascii=False,
         )
 
+    def click_in_frame(
+        self,
+        selector: str,
+        frame_url_contains: str = "",
+        frame_name: str = "",
+        index: int = 0,
+    ) -> str:
+        """Click an element inside a page frame with a real (trusted) mouse event.
+
+        Iterates page frames, so it reaches cross-origin iframes (e.g. a reCAPTCHA
+        "I'm not a robot" checkbox) that main-page DOM access and run_page_script
+        cannot. The click goes through Playwright's input layer, so the event is
+        isTrusted — unlike a JS `el.click()`, which bot checks reject. Narrow the
+        frame with frame_url_contains or frame_name; `selector` is resolved inside
+        each matching frame.
+        """
+        if not self.page:
+            return "Browser not open"
+
+        matches = []
+        for frame_index, frame in enumerate(self.page.frames):
+            url = getattr(frame, "url", "") or ""
+            raw_name = getattr(frame, "name", "") or ""
+            name = raw_name() if callable(raw_name) else raw_name
+            if frame_url_contains and frame_url_contains not in url:
+                continue
+            if frame_name and frame_name != name:
+                continue
+            locator = frame.locator(selector)
+            for locator_index in range(locator.count()):
+                matches.append((frame_index, name, url, locator.nth(locator_index)))
+
+        if not matches:
+            return f"No element found for selector: {selector} in matching frames"
+        if index < 0 or index >= len(matches):
+            return f"Selector matched {len(matches)} element(s); index {index} is out of range"
+
+        frame_index, name, url, target = matches[index]
+        target.click()
+        self._save_context()
+        self.page.wait_for_timeout(1000)
+        return json.dumps(
+            {
+                "ok": True,
+                "clicked": True,
+                "selector": selector,
+                "index": index,
+                "frame": {"index": frame_index, "name": name, "url": url},
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+
     def _load_script_args(self, script_path: str, args_json: str) -> tuple[Optional[str], Optional[dict], Optional[str]]:
         path = Path(script_path).expanduser()
         if not path.is_absolute():

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -332,15 +332,35 @@ class BrowserAutomation:
         if not PLAYWRIGHT_AVAILABLE:
             return "Browser tools not installed. Run: pip install playwright && playwright install chromium"
 
+        # If a shared context is already running, a brand-new session has no tab in it yet.
+        # Give this session its tab BEFORE judging usability, so a new session never reads
+        # the shared context as "unusable" (its own page is None) and tears it down — that
+        # would close the tabs other sessions are actively using. If the context is really
+        # dead, _ensure_page can't make a tab and the check below falls through to relaunch.
+        if self.browser is not None:
+            try:
+                self._ensure_page(_current_session_key())
+            except Exception:
+                pass
+
         if self._browser_is_usable():
             if not force:
                 return "<system-reminder>Browser already open and usable. Continue using the current browser page.</system-reminder>"
-            self.close()
+            # force=True: caller wants a fresh start. A bound session (hosted multi-session)
+            # recycles only its OWN tab — a full teardown would kill every other session's
+            # tabs. An unbound caller (single-session CLI) tears the whole context down.
+            key = _current_session_key()
+            if key is not None:
+                self._close_tab(key)
+                self._page_url.pop(key, None)   # fresh = a blank tab, not the old url restored
+                self._ensure_page(key)
+                return "Opened a fresh tab for this session."
+            self._teardown()
             had_previous_browser_state = True
         else:
             had_previous_browser_state = bool(self.browser or self.page or self.playwright)
             if had_previous_browser_state:
-                self.close()
+                self._teardown()   # context is dead/unusable — full cleanup before relaunch
 
         self.playwright = sync_playwright().start()
 
@@ -1650,7 +1670,20 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         self.page.wait_for_timeout(500)
 
     def close(self) -> str:
-        """Close the browser and save persistent context."""
+        """Close the browser. A bound session (hosted multi-session) closes only its OWN tab;
+        an unbound caller (single-session CLI / context-manager exit) tears the whole context
+        down. Closing the shared context for one session would kill every other session's tab,
+        so per-session callers must never reach the full teardown."""
+        key = _current_session_key()
+        if key is not None:
+            err = self._close_tab(key)
+            return f"close tab failed: {err}" if err else "Closed this session's browser tab."
+        return self._teardown()
+
+    def _teardown(self) -> str:
+        """Tear the whole shared browser/context down and clear state. Underscore-prefixed so
+        it is never exposed as a per-session LLM tool; called only from close() (unbound) and
+        open_browser, both already on the browser worker thread."""
         cleanup_errors = []
         try:
             self._save_context()

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -28,7 +28,6 @@ import inspect
 import json
 import platform
 import threading
-import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -296,13 +295,20 @@ class BrowserAutomation:
             return element.locator
         return f"Could not find element matching: {description}"
 
-    def click_element_by_selector(self, selector: str, index: int = 0, text: str = "") -> str:
+    def click_element_by_selector(self, selector: str, index: int = 0, text: str = "", frame_url_contains: str = "", frame_name: str = "") -> str:
         """Click an element using a CSS selector via Playwright locator().
 
         Use when a workflow has a stable selector such as an aria-label,
         role-compatible attribute, or data-testid. `index` is zero-based.
         If `text` is provided, only visible elements with exactly that text are
         considered.
+
+        Set frame_url_contains or frame_name to resolve the selector inside a page
+        frame, including cross-origin iframes (e.g. a reCAPTCHA checkbox) that
+        main-page selectors can't reach. The click goes through Playwright's input
+        layer either way, so the event is trusted (isTrusted) — a JS el.click()
+        is not. Frame targeting applies to the selector path; `text` matching is
+        main-frame only.
         """
         if not self.page:
             return "Browser not open"
@@ -350,14 +356,32 @@ class BrowserAutomation:
             self.page.wait_for_timeout(1000)
             return f"Clicked element {index + 1}/{count} matching selector: {selector} with text: {text}"
 
-        locator = self.page.locator(selector)
-        count = locator.count()
-        if count == 0:
-            return f"No element found for selector: {selector}"
-        if index < 0 or index >= count:
-            return f"Selector matched {count} elements; index {index} is out of range"
+        if frame_url_contains or frame_name:
+            # Resolve inside matching page frames so cross-origin iframes (e.g. a
+            # reCAPTCHA checkbox) the main-page DOM can't reach are clickable.
+            candidates = []
+            for frame in self.page.frames:
+                url = getattr(frame, "url", "") or ""
+                name = getattr(frame, "name", "") or ""
+                if frame_url_contains and frame_url_contains not in url:
+                    continue
+                if frame_name and frame_name != name:
+                    continue
+                loc = frame.locator(selector)
+                candidates.extend(loc.nth(i) for i in range(loc.count()))
+            where = f" in frames matching {(frame_url_contains or frame_name)!r}"
+        else:
+            loc = self.page.locator(selector)
+            candidates = [loc.nth(i) for i in range(loc.count())]
+            where = ""
 
-        target = locator.nth(index)
+        count = len(candidates)
+        if count == 0:
+            return f"No element found for selector: {selector}{where}"
+        if index < 0 or index >= count:
+            return f"Selector matched {count} elements{where}; index {index} is out of range"
+
+        target = candidates[index]
         box = target.bounding_box()
         if box:
             self.page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
@@ -366,7 +390,7 @@ class BrowserAutomation:
 
         self._save_context()
         self.page.wait_for_timeout(1000)
-        return f"Clicked element {index + 1}/{count} matching selector: {selector}"
+        return f"Clicked element {index + 1}/{count} matching selector: {selector}{where}"
 
     def count_elements_by_selector(self, selector: str) -> str:
         """Count elements matching a CSS selector via Playwright locator()."""
@@ -540,59 +564,6 @@ class BrowserAutomation:
                 "file": str(path),
                 "click_selector": click_selector,
                 "text": text,
-                "index": index,
-                "frame": {"index": frame_index, "name": name, "url": url},
-            },
-            indent=2,
-            ensure_ascii=False,
-        )
-
-    def click_in_frame(
-        self,
-        selector: str,
-        frame_url_contains: str = "",
-        frame_name: str = "",
-        index: int = 0,
-    ) -> str:
-        """Click an element inside a page frame with a real (trusted) mouse event.
-
-        Iterates page frames, so it reaches cross-origin iframes (e.g. a reCAPTCHA
-        "I'm not a robot" checkbox) that main-page DOM access and run_page_script
-        cannot. The click goes through Playwright's input layer, so the event is
-        isTrusted — unlike a JS `el.click()`, which bot checks reject. Narrow the
-        frame with frame_url_contains or frame_name; `selector` is resolved inside
-        each matching frame.
-        """
-        if not self.page:
-            return "Browser not open"
-
-        matches = []
-        for frame_index, frame in enumerate(self.page.frames):
-            url = getattr(frame, "url", "") or ""
-            raw_name = getattr(frame, "name", "") or ""
-            name = raw_name() if callable(raw_name) else raw_name
-            if frame_url_contains and frame_url_contains not in url:
-                continue
-            if frame_name and frame_name != name:
-                continue
-            locator = frame.locator(selector)
-            for locator_index in range(locator.count()):
-                matches.append((frame_index, name, url, locator.nth(locator_index)))
-
-        if not matches:
-            return f"No element found for selector: {selector} in matching frames"
-        if index < 0 or index >= len(matches):
-            return f"Selector matched {len(matches)} element(s); index {index} is out of range"
-
-        frame_index, name, url, target = matches[index]
-        target.click()
-        self._save_context()
-        self.page.wait_for_timeout(1000)
-        return json.dumps(
-            {
-                "ok": True,
-                "clicked": True,
-                "selector": selector,
                 "index": index,
                 "frame": {"index": frame_index, "name": name, "url": url},
             },

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -27,6 +27,7 @@ import functools
 import inspect
 import json
 import platform
+import sys
 import threading
 import time
 import urllib.parse
@@ -108,17 +109,20 @@ def _public_methods_run_on_browser_thread(cls):
 def _browser_proxy_from_env():
     """Build Playwright's proxy config from the BROWSER_PROXY env var, or None if unset.
 
-    BROWSER_PROXY routes the browser's traffic through a proxy so the egress IP is e.g.
-    residential instead of the datacenter IP the agent runs on. Formats:
-        socks5://host:port              (no auth — e.g. a SOCKS relay; Chromium ignores SOCKS auth)
-        http://user:pass@host:port      (HTTP proxy with auth — e.g. a residential proxy service)
-    Unset => None => no proxy, current behaviour unchanged.
+    BROWSER_PROXY routes the browser's traffic through an HTTP or SOCKS proxy — e.g. to
+    control the egress IP, test geo-specific behaviour, or comply with a corporate
+    network policy. Formats:
+        socks5://host:port              (no auth; Chromium ignores SOCKS auth)
+        http://user:pass@host:port      (HTTP proxy with auth)
+    Use only against sites whose terms permit it. Unset => None => no proxy, current
+    behaviour unchanged.
     """
     url = os.environ.get("BROWSER_PROXY", "").strip()
     if not url:
         return None
     p = urllib.parse.urlparse(url)
-    proxy = {"server": f"{p.scheme}://{p.hostname}:{p.port}"}
+    server = f"{p.scheme}://{p.hostname}" + (f":{p.port}" if p.port else "")
+    proxy = {"server": server}
     if p.username:
         proxy["username"] = urllib.parse.unquote(p.username)
     if p.password:
@@ -154,7 +158,9 @@ class BrowserAutomation:
                         are injected into the context once, right after it is created and before
                         any navigation, so a deployed agent starts already signed in. Cookies are
                         applied with add_cookies because launch_persistent_context() cannot accept
-                        storage_state=. Unset => no injection, current behaviour unchanged.
+                        storage_state=. The file holds live session cookies — inject it from the
+                        deploy secret store and never commit it. Unset => no injection, current
+                        behaviour unchanged.
         """
         self.playwright: Optional[Playwright] = None
         self.browser: Optional[Browser] = None
@@ -166,6 +172,7 @@ class BrowserAutomation:
         self._page_url: Dict[Optional[str], str] = {}      # key -> last url (restore a reclaimed tab)
         self._tab_idle_ttl = 3600.0   # reclaim a tab after 60 min idle (a panel left untouched)
         self._max_tabs = 10           # backstop cap; a few real panels never hit it
+        self._max_url_memory = 200    # bound the restore-url map; session ids are unique per panel
         self.current_url: str = ""
         self.form_data: Dict[str, Any] = {}
         self.use_chrome_profile = use_chrome_profile
@@ -294,9 +301,17 @@ class BrowserAutomation:
         if page is None:
             return None
         try:
-            self._page_url[key] = page.url
+            url = page.url
         except Exception:
-            pass
+            url = None
+        if url:
+            # Remember where the session was so it resumes there, but bound the map:
+            # session ids are unique per panel, so without a cap it grows forever on a
+            # long-lived shared host. Re-insert (LRU) then trim the oldest keys.
+            self._page_url.pop(key, None)
+            self._page_url[key] = url
+            while len(self._page_url) > self._max_url_memory:
+                self._page_url.pop(next(iter(self._page_url)))
         try:
             page.close()
         except Exception as exc:
@@ -395,11 +410,18 @@ class BrowserAutomation:
         BrowserAutomation(seed_state=path) on the deployed agent. The JSON is plaintext and
         portable across machines/OSes; a copied Chrome profile is not (its cookies are
         encrypted per-OS).
+
+        SECURITY: the file holds live session cookies — anyone with it can act as the
+        logged-in user. Treat it as a secret: never commit it (add to .gitignore), don't
+        bake it into a Docker image, and prefer injecting it via the deploy secret store.
         """
         if not self.browser:
             return "Browser not open"
         self.browser.storage_state(path=path)
-        return f"Saved login state to {path}"
+        return (
+            f"Saved login state to {path}. This file contains live session cookies — "
+            f"keep it secret, add it to .gitignore, and never commit or bake it into an image."
+        )
 
     def go_to(self, url: str) -> str:
         """Navigate to a URL."""
@@ -443,11 +465,11 @@ class BrowserAutomation:
         considered.
 
         Set frame_url_contains or frame_name to resolve the selector inside a page
-        frame, including cross-origin iframes (e.g. a reCAPTCHA checkbox) that
-        main-page selectors can't reach. The click goes through Playwright's input
-        layer either way, so the event is trusted (isTrusted) — a JS el.click()
-        is not. Frame targeting applies to the selector path; `text` matching is
-        main-frame only.
+        frame, including cross-origin iframes (e.g. an embedded widget or payment
+        form) that main-page selectors can't reach. The click is dispatched through
+        Playwright's input layer as a real pointer event at the element's
+        coordinates. Frame targeting applies to the selector path; `text` matching
+        is main-frame only.
         """
         if not self.page:
             return "Browser not open"
@@ -496,8 +518,8 @@ class BrowserAutomation:
             return f"Clicked element {index + 1}/{count} matching selector: {selector} with text: {text}"
 
         if frame_url_contains or frame_name:
-            # Resolve inside matching page frames so cross-origin iframes (e.g. a
-            # reCAPTCHA checkbox) the main-page DOM can't reach are clickable.
+            # Resolve inside matching page frames so cross-origin iframes (e.g. an
+            # embedded widget) the main-page DOM can't reach are clickable.
             candidates = []
             for frame in self.page.frames:
                 url = getattr(frame, "url", "") or ""
@@ -1531,7 +1553,7 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
     def wait_for_manual_login(self, site_name: str = "the website") -> str:
         """Pause automation for user to login manually.
 
-        Useful for sites with 2FA or CAPTCHA.
+        Useful for sites with 2FA or other interactive sign-in steps.
 
         Args:
             site_name: Name of the site (e.g., "Gmail")
@@ -1541,6 +1563,17 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """
         if not self.page:
             return "Browser not open"
+
+        # Manual login needs an interactive terminal. A hosted deploy has no stdin,
+        # and every public method runs on the one shared browser worker thread —
+        # blocking on input() there would freeze every other session's browser
+        # indefinitely. Refuse fast; hosted agents sign in via save_state/seed_state.
+        if not sys.stdin or not sys.stdin.isatty():
+            return (
+                "Manual login needs an interactive terminal, which a hosted deploy "
+                "doesn't have. Capture the login locally with save_state(path) and "
+                "start the deployed browser with seed_state=<path>."
+            )
 
         print(f"\n{'='*60}")
         print(f"  MANUAL LOGIN REQUIRED")

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -116,7 +116,10 @@ Variables from your `.env` file are securely passed to your agent container:
 OPENONION_API_KEY=eyJ...    # Required for co/ models
 OPENAI_API_KEY=sk-xxx       # Third-party API keys
 DATABASE_URL=postgres://...
+BROWSER_PROXY=http://user:pass@host:port  # Optional browser proxy
 ```
+
+`BROWSER_PROXY` is read by browser tools and routes browser egress through a proxy. See [Browser Tools › Proxy](../useful_tools/browser_tools.md#proxy).
 
 ---
 

--- a/docs/useful_plugins/README.md
+++ b/docs/useful_plugins/README.md
@@ -13,6 +13,7 @@ Pre-built plugins that extend agent behavior via event hooks.
 | [eval](eval.md) | Task evaluation/debugging | `from connectonion.useful_plugins import eval` |
 | [system_reminder](system_reminder.md) | Inject contextual guidance | `from connectonion.useful_plugins import system_reminder` |
 | [image_result_formatter](image_result_formatter.md) | Format images for vision | `from connectonion.useful_plugins import image_result_formatter` |
+| [human_jitter](human_jitter.md) | Human-like mouse motion before clicks | `from connectonion.useful_plugins import human_jitter` |
 | [shell_approval](shell_approval.md) | Shell command approval | `from connectonion.useful_plugins import shell_approval` |
 | [ui_stream](ui_stream.md) | Stream events to WebSocket clients | `from connectonion.useful_plugins import ui_stream` |
 | [auto_compact](auto_compact.md) | Compact conversation when context fills up | `from connectonion.useful_plugins import auto_compact` |

--- a/docs/useful_plugins/README.md
+++ b/docs/useful_plugins/README.md
@@ -13,7 +13,7 @@ Pre-built plugins that extend agent behavior via event hooks.
 | [eval](eval.md) | Task evaluation/debugging | `from connectonion.useful_plugins import eval` |
 | [system_reminder](system_reminder.md) | Inject contextual guidance | `from connectonion.useful_plugins import system_reminder` |
 | [image_result_formatter](image_result_formatter.md) | Format images for vision | `from connectonion.useful_plugins import image_result_formatter` |
-| [human_jitter](human_jitter.md) | Human-like mouse motion before clicks | `from connectonion.useful_plugins import human_jitter` |
+| [human_jitter](human_jitter.md) | Organic cursor motion before clicks | `from connectonion.useful_plugins import human_jitter` |
 | [shell_approval](shell_approval.md) | Shell command approval | `from connectonion.useful_plugins import shell_approval` |
 | [ui_stream](ui_stream.md) | Stream events to WebSocket clients | `from connectonion.useful_plugins import ui_stream` |
 | [auto_compact](auto_compact.md) | Compact conversation when context fills up | `from connectonion.useful_plugins import auto_compact` |

--- a/docs/useful_plugins/human_jitter.md
+++ b/docs/useful_plugins/human_jitter.md
@@ -1,0 +1,34 @@
+# human_jitter
+
+Make a browser agent's clicks look human: right before any `click*` tool runs, wander the mouse through a few random points on the page, so the click is preceded by organic motion instead of an instant teleport-and-click.
+
+## Quick Start
+
+```python
+from connectonion import Agent
+from connectonion.useful_tools.browser_tools import BrowserAutomation
+from connectonion.useful_plugins import human_jitter
+
+browser = BrowserAutomation()
+agent = Agent("web", tools=[browser], plugins=[human_jitter])
+
+agent.input("log into the site and click the verify checkbox")
+# before each click*, the cursor drifts through a few points first
+```
+
+## How It Works
+
+1. On `before_each_tool`, reads `agent.current_session['pending_tool']`.
+2. If its name starts with `click`, grabs the `BrowserAutomation` instance off the tool registry (`agent.tools.browserautomation`).
+3. Dispatches `jitter()` onto the browser's single worker thread: the cursor moves to a random point, then random-walks through a few more, with short pauses.
+
+Jitter is best-effort. If the page is mid-navigation when it reads the viewport, the failure is caught and logged so the click the agent asked for can still proceed.
+
+## Why a Plugin
+
+Jitter is non-deterministic and opt-in. Forcing it on every browser user would make clicks non-reproducible for tests and agents that do not want it. Opt in with `plugins=[human_jitter]`.
+
+## Notes
+
+- Only affects tools whose name starts with `click` (`click`, `click_element_by_selector`, and similar browser tools).
+- Pair with `BROWSER_PROXY` when egress IP reputation is the real bottleneck.

--- a/docs/useful_plugins/human_jitter.md
+++ b/docs/useful_plugins/human_jitter.md
@@ -1,6 +1,6 @@
 # human_jitter
 
-Make a browser agent's clicks look human: right before any `click*` tool runs, wander the mouse through a few random points on the page, so the click is preceded by organic motion instead of an instant teleport-and-click.
+Move the cursor along an organic path before a click instead of teleporting straight to the target. Some interfaces only reveal or enable a control after real pointer movement (hover menus, lazy-loaded widgets, drag affordances), so a single teleport-click can land on nothing — a short wander first makes the interaction land. Use it on sites whose terms permit automation.
 
 ## Quick Start
 
@@ -12,7 +12,7 @@ from connectonion.useful_plugins import human_jitter
 browser = BrowserAutomation()
 agent = Agent("web", tools=[browser], plugins=[human_jitter])
 
-agent.input("log into the site and click the verify checkbox")
+agent.input("open the menu and click Settings")
 # before each click*, the cursor drifts through a few points first
 ```
 
@@ -31,4 +31,4 @@ Jitter is non-deterministic and opt-in. Forcing it on every browser user would m
 ## Notes
 
 - Only affects tools whose name starts with `click` (`click`, `click_element_by_selector`, and similar browser tools).
-- Pair with `BROWSER_PROXY` when egress IP reputation is the real bottleneck.
+- Respect each site's terms of service and `robots`/automation policy when enabling it.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -67,6 +67,8 @@ browser = BrowserAutomation(seed_state="linkedin_state.json")
 
 `seed_state` injects cookies with `add_cookies()` after the persistent context opens. Unset `seed_state` keeps the current behavior.
 
+> **Treat the state file as a secret.** It holds live session cookies — anyone with it can act as the logged-in user. Add it to `.gitignore`, never commit it or bake it into a Docker image, and inject it on deploy through the secret store rather than shipping it in the project tarball.
+
 ## API
 
 ### Navigation
@@ -105,16 +107,16 @@ browser.click_element_by_selector('button', text="Sign in")
 browser.click_element_by_selector('.item', index=2)
 ```
 
-To click inside an iframe, including a cross-origin one like a reCAPTCHA checkbox that main-page selectors cannot reach, pass `frame_url_contains` or `frame_name`:
+To click inside an iframe, including a cross-origin one (an embedded widget, payment form, or editor) that main-page selectors cannot reach, pass `frame_url_contains` or `frame_name`:
 
 ```python
 browser.click_element_by_selector(
-    '.recaptcha-checkbox-border',
-    frame_url_contains="recaptcha",
+    '#subscribe',
+    frame_url_contains="checkout",
 )
 ```
 
-The click goes through Playwright's input layer, so the event is trusted. Text matching remains main-frame only.
+The click is dispatched through Playwright's input layer as a real pointer event at the element's coordinates. Text matching remains main-frame only.
 
 ### Hover and Advanced Mouse
 
@@ -269,14 +271,14 @@ links = browser.get_links_from_page("/product/")
 
 ## Proxy
 
-Set `BROWSER_PROXY` to route browser traffic through a proxy, for example when a cloud-deployed agent should exit through a residential proxy instead of a datacenter IP:
+Set `BROWSER_PROXY` to route browser traffic through an HTTP or SOCKS proxy — for example to control the egress IP, test geo-specific behavior, or comply with a corporate network policy:
 
 ```bash
 BROWSER_PROXY=http://user:pass@host:port
 BROWSER_PROXY=socks5://host:port
 ```
 
-`BROWSER_PROXY` is read when `open_browser()` launches the context. Leave it unset for direct egress.
+`BROWSER_PROXY` is read when `open_browser()` launches the context. Leave it unset for direct egress. Use a proxy only against sites whose terms permit it.
 
 ## Notes
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -50,6 +50,23 @@ browser = BrowserAutomation()
 browser.go_to("https://x.com")           # Session restored automatically
 ```
 
+## Portable Login State
+
+The persistent profile above lives at `~/.co/browser_profile/` and cannot be moved safely across operating systems because its cookies are encrypted per machine. To reuse a login on another machine or inside a Linux deploy container, export a Playwright storage state JSON and inject it when constructing the browser:
+
+```python
+# On your machine, headed: log in by hand, then export
+browser = BrowserAutomation(headless=False)
+browser.go_to("https://www.linkedin.com/login")
+input("Log in, then press Enter...")
+browser.save_state("linkedin_state.json")
+
+# On the deployed agent: inject before the first navigation
+browser = BrowserAutomation(seed_state="linkedin_state.json")
+```
+
+`seed_state` injects cookies with `add_cookies()` after the persistent context opens. Unset `seed_state` keeps the current behavior.
+
 ## API
 
 ### Navigation
@@ -79,6 +96,25 @@ browser.click("email input field")       # Uses AI to find by description
 ```
 
 Element finding uses a vision LLM — describe what you see, not a CSS selector.
+
+When you have a stable CSS selector, click it directly:
+
+```python
+browser.click_element_by_selector('button[type="submit"]')
+browser.click_element_by_selector('button', text="Sign in")
+browser.click_element_by_selector('.item', index=2)
+```
+
+To click inside an iframe, including a cross-origin one like a reCAPTCHA checkbox that main-page selectors cannot reach, pass `frame_url_contains` or `frame_name`:
+
+```python
+browser.click_element_by_selector(
+    '.recaptcha-checkbox-border',
+    frame_url_contains="recaptcha",
+)
+```
+
+The click goes through Playwright's input layer, so the event is trusted. Text matching remains main-frame only.
 
 ### Hover and Advanced Mouse
 
@@ -195,6 +231,8 @@ agent.input("Navigate to github.com/trending and screenshot the page")
 agent.input("Fill in the contact form on example.com with test data")
 ```
 
+One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
+
 ## Common Patterns
 
 ### Login once, reuse session
@@ -228,6 +266,17 @@ browser.go_to("https://example.com/products")
 text = browser.get_text()
 links = browser.get_links_from_page("/product/")
 ```
+
+## Proxy
+
+Set `BROWSER_PROXY` to route browser traffic through a proxy, for example when a cloud-deployed agent should exit through a residential proxy instead of a datacenter IP:
+
+```bash
+BROWSER_PROXY=http://user:pass@host:port
+BROWSER_PROXY=socks5://host:port
+```
+
+`BROWSER_PROXY` is read when `open_browser()` launches the context. Leave it unset for direct egress.
 
 ## Notes
 

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -287,3 +287,24 @@ def test_save_state_without_browser_reports_not_open():
     browser = browser_mod.BrowserAutomation(headless=True)
 
     assert browser.save_state("/tmp/whatever.json") == "Browser not open"
+
+
+def test_wait_for_manual_login_refuses_without_tty(monkeypatch):
+    """On a host (no interactive stdin) manual login must return immediately rather than
+    block input() on the single shared browser worker thread — that thread serializes
+    every session's browser ops, so blocking it would freeze them all indefinitely."""
+    class _NoTTY:
+        def isatty(self):
+            return False
+
+    monkeypatch.setattr(browser_mod.sys, "stdin", _NoTTY())
+
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.browser = FakeContext()
+    try:
+        result = browser.wait_for_manual_login("Example")
+    finally:
+        browser._executor.shutdown(wait=False)
+
+    assert "interactive terminal" in result
+    assert "seed_state" in result

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -2,7 +2,19 @@
 
 import json
 
+import pytest
+
 import connectonion.useful_tools.browser_tools.browser as browser_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_session_binding():
+    """The browser session key lives in a module-level threading.local; reset it around every
+    test so one test's bound session can't leak into the next (open_browser/close now branch on
+    whether a session is bound)."""
+    browser_mod._session_binding.key = None
+    yield
+    browser_mod._session_binding.key = None
 
 
 class FakePage:

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -1,5 +1,7 @@
 """Tests for BrowserAutomation lifecycle behavior."""
 
+import json
+
 import connectonion.useful_tools.browser_tools.browser as browser_mod
 
 
@@ -198,3 +200,90 @@ def test_close_reports_cleanup_warnings_and_clears_state():
     assert browser.page is None
     assert browser.browser is None
     assert browser.playwright is None
+
+
+class _RecordingContext(FakeContext):
+    """A context that records add_cookies / storage_state so seeding/export can be asserted."""
+
+    def __init__(self):
+        super().__init__()
+        self.added_cookies = None
+        self.saved_state_path = None
+
+    def add_cookies(self, cookies):
+        self.added_cookies = cookies
+
+    def storage_state(self, path=None):
+        self.saved_state_path = path
+
+
+def _recording_playwright(contexts):
+    """sync_playwright() stand-in whose contexts record add_cookies / storage_state calls."""
+
+    class FakeChromium:
+        def launch_persistent_context(self, user_data_dir, **kwargs):
+            context = _RecordingContext()
+            contexts.append(context)
+            return context
+
+    class FakePlaywright:
+        def __init__(self):
+            self.chromium = FakeChromium()
+
+        def stop(self):
+            pass
+
+    class FakeSyncPlaywright:
+        def start(self):
+            return FakePlaywright()
+
+    return FakeSyncPlaywright()
+
+
+def test_seed_state_injects_exported_cookies(monkeypatch, tmp_path):
+    cookies = [{"name": "li_at", "value": "secret", "domain": ".linkedin.com", "path": "/"}]
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"cookies": cookies}))
+
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True, seed_state=str(state))
+    browser.open_browser()
+
+    assert contexts[0].added_cookies == cookies
+
+
+def test_no_seed_state_injects_nothing(monkeypatch, tmp_path):
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.open_browser()
+
+    assert contexts[0].added_cookies is None
+
+
+def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
+    contexts = []
+    monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+    monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.open_browser()
+    out = tmp_path / "exported.json"
+    result = browser.save_state(str(out))
+
+    assert contexts[0].saved_state_path == str(out)
+    assert "Saved login state" in result
+
+
+def test_save_state_without_browser_reports_not_open():
+    browser = browser_mod.BrowserAutomation(headless=True)
+
+    assert browser.save_state("/tmp/whatever.json") == "Browser not open"

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -14,6 +14,16 @@ import threading
 import pytest
 
 from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+import connectonion.useful_tools.browser_tools.browser as browser_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_session_binding():
+    """The browser session key lives in a module-level threading.local; reset it around every
+    test so one test's bound session can't leak into the next (open_browser/close branch on it)."""
+    browser_mod._session_binding.key = None
+    yield
+    browser_mod._session_binding.key = None
 
 
 class FakePage:
@@ -218,3 +228,99 @@ class TestBindSessionPlugin:
             current_session = {"session_id": "sess-123"}
 
         _bind_session(FakeAgent())  # must not raise
+
+
+class TestOpenBrowserSharedContext:
+    """A shared BrowserAutomation must not let one session's open_browser/close tear down the
+    context other sessions are using. Full teardown is only for an unbound (CLI) caller."""
+
+    @staticmethod
+    def _install_mock_playwright(monkeypatch, tmp_path):
+        """Patch sync_playwright with a fake; return the list of launched contexts so a test
+        can assert how many times the shared context was (re)launched."""
+        import connectonion.useful_tools.browser_tools.browser as browser_mod
+        launched = []
+
+        class _RecordingContext:
+            def __init__(self):
+                self.closed = False
+                self.n = 0
+
+            def new_page(self):
+                self.n += 1
+                return FakePage(self.n)
+
+            def add_cookies(self, cookies):
+                pass
+
+            def close(self):
+                self.closed = True
+
+        class _Chromium:
+            def launch_persistent_context(self, *a, **k):
+                launched.append(_RecordingContext())
+                return launched[-1]
+
+        class _Playwright:
+            def __init__(self):
+                self.chromium = _Chromium()
+
+            def stop(self):
+                pass
+
+        monkeypatch.setattr(browser_mod, "PLAYWRIGHT_AVAILABLE", True)
+        monkeypatch.setattr(browser_mod, "sync_playwright",
+                            lambda: type("S", (), {"start": lambda self: _Playwright()})())
+        monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+        return launched
+
+    def test_second_session_open_browser_reuses_context(self, monkeypatch, tmp_path):
+        """A second session calling open_browser must REUSE the live shared context, not
+        tear it down — otherwise the first session's tabs vanish mid-task."""
+        launched = self._install_mock_playwright(monkeypatch, tmp_path)
+        b = BrowserAutomation()
+        try:
+            b._bind_session("A"); b.open_browser()  # session A launches the context + its tab
+            b._bind_session("B"); b.open_browser()  # session B must reuse it, not relaunch
+
+            assert len(launched) == 1              # launched once, never relaunched
+            assert launched[0].closed is False     # and never torn down
+            assert {"A", "B"} <= set(b._pages)     # both sessions have their own tab in it
+        finally:
+            b._executor.shutdown(wait=False)
+
+    def test_force_from_bound_session_recycles_only_its_tab(self, monkeypatch, tmp_path):
+        """open_browser(force=True) from a bound session must recycle only THAT session's tab,
+        not tear down the shared context (which would kill every other session)."""
+        launched = self._install_mock_playwright(monkeypatch, tmp_path)
+        b = BrowserAutomation()
+        try:
+            b._bind_session("A"); b.open_browser()
+            page_a = b._pages["A"]
+            b._bind_session("B"); b.open_browser()
+            b.open_browser(force=True)             # B forces a fresh start for itself
+
+            assert len(launched) == 1              # shared context never relaunched
+            assert launched[0].closed is False
+            assert b._pages["A"] is page_a         # A's tab untouched
+            assert page_a.closed is False
+            assert "B" in b._pages                 # B has a (fresh) tab
+        finally:
+            b._executor.shutdown(wait=False)
+
+    def test_close_from_bound_session_closes_only_its_tab(self, browser):
+        """close() from a bound session closes only that session's tab — the shared context and
+        every other session's tab stay intact (full teardown is for an unbound caller)."""
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+        page_a = browser._pages["A"]
+        context = browser.browser
+
+        browser._bind_session("B")
+        result = browser.close()
+
+        assert "B" not in browser._pages           # B's own tab closed
+        assert browser._pages["A"] is page_a       # A's tab untouched
+        assert page_a.closed is False
+        assert browser.browser is context          # shared context NOT torn down
+        assert "tab" in result.lower()

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -1,0 +1,205 @@
+"""Unit tests for per-session browser tabs in BrowserAutomation.
+
+Each session (chat panel) gets its own tab in the shared context so concurrent
+sessions don't navigate over each other. Tabs are reclaimed by idle-TTL and a
+max-tabs backstop, and a reclaimed session transparently gets a fresh tab restored
+to its last URL (never a "target closed" crash).
+
+These tests fake the Playwright context/page, so they need no real browser.
+"""
+
+import time
+import threading
+
+import pytest
+
+from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+
+
+class FakePage:
+    def __init__(self, idx):
+        self.idx = idx
+        self.url = f"about:blank#{idx}"
+        self.closed = False
+        self.goto_calls = []
+
+    def set_default_navigation_timeout(self, *a, **k):
+        pass
+
+    def set_viewport_size(self, *a, **k):
+        pass
+
+    def add_init_script(self, *a, **k):
+        pass
+
+    def goto(self, url, **k):
+        self.goto_calls.append(url)
+        self.url = url
+
+    def is_closed(self):
+        return self.closed
+
+    def close(self):
+        self.closed = True
+
+
+class ThreadCheckingPage(FakePage):
+    def __init__(self, idx):
+        self.url_thread = None
+        self._url = ""
+        super().__init__(idx)
+
+    @property
+    def url(self):
+        self.url_thread = threading.current_thread()
+        return self._url
+
+    @url.setter
+    def url(self, value):
+        self._url = value
+
+
+class FakeContext:
+    def __init__(self):
+        self.n = 0
+
+    def new_page(self):
+        self.n += 1
+        return FakePage(self.n)
+
+
+@pytest.fixture
+def browser():
+    b = BrowserAutomation()
+    b.browser = FakeContext()        # stand in for the launched persistent context
+    b._bind_session(None)            # reset this thread's binding between tests
+    yield b
+    b._executor.shutdown(wait=False)
+
+
+class TestPerSessionTabs:
+    def test_each_session_gets_its_own_tab(self, browser):
+        browser._bind_session("A")
+        browser._ensure_page("A")
+        page_a = browser.page
+
+        browser._bind_session("B")
+        browser._ensure_page("B")
+        page_b = browser.page
+
+        assert page_a is not page_b
+        assert {"A", "B"} <= set(browser._pages)
+
+    def test_page_property_routes_by_bound_session(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+
+        browser._bind_session("A")
+        assert browser.page is browser._pages["A"]
+        browser._bind_session("B")
+        assert browser.page is browser._pages["B"]
+
+    def test_navigating_one_session_does_not_touch_another(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+
+        browser._pages["A"].goto("https://linkedin.com")
+        # B's tab is a different page object, unaffected by A's navigation.
+        assert browser._pages["B"].url != "https://linkedin.com"
+
+    def test_no_session_uses_a_single_shared_tab(self, browser):
+        browser._bind_session(None)
+        browser._ensure_page(None)
+        browser._ensure_page(None)
+        assert list(browser._pages) == [None]
+        assert browser.page is browser._pages[None]
+
+    def test_browser_is_usable_dispatches_to_browser_thread(self, browser):
+        page = ThreadCheckingPage(1)
+        browser._pages[None] = page
+        browser._page_used[None] = time.monotonic()
+
+        assert threading.current_thread() is not browser._executor_thread
+        assert browser._browser_is_usable() is True
+        assert page.url_thread is browser._executor_thread
+
+
+class TestTabReclaim:
+    def test_idle_tab_is_reclaimed_and_active_is_kept(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._bind_session("B"); browser._ensure_page("B")
+        page_a = browser._pages["A"]
+
+        browser._tab_idle_ttl = 3600
+        browser._page_used["A"] = time.monotonic() - 10_000  # A abandoned long ago
+
+        browser._bind_session("B")
+        browser._ensure_page("B")  # reclaim runs with active=B
+
+        assert "A" not in browser._pages          # idle tab closed
+        assert page_a.closed is True
+        assert "B" in browser._pages              # active tab kept
+        assert browser._page_url["A"]             # url remembered for restore
+
+    def test_reclaimed_session_recreates_and_restores_url(self, browser):
+        browser._bind_session("A"); browser._ensure_page("A")
+        browser._pages["A"].goto("https://example.com/feed")
+
+        browser._tab_idle_ttl = 0
+        browser._bind_session("B")
+        browser._ensure_page("B")  # active=B; A idle past ttl=0 -> reclaimed
+
+        assert "A" not in browser._pages
+
+        browser._bind_session("A")
+        browser._ensure_page("A")  # A returns -> fresh tab restored to its url
+        assert browser._pages["A"].goto_calls == ["https://example.com/feed"]
+
+    def test_max_tabs_backstop_evicts_lru_not_active(self, browser):
+        browser._max_tabs = 2
+        browser._tab_idle_ttl = 10_000  # disable idle path; test the hard cap only
+        for key in ("A", "B", "C"):
+            browser._bind_session(key)
+            browser._ensure_page(key)
+
+        assert len(browser._pages) == 2
+        assert "C" in browser._pages          # the active one is never evicted
+        assert "A" not in browser._pages      # least-recently-used evicted
+
+    def test_does_not_evict_when_under_cap_and_not_idle(self, browser):
+        browser._max_tabs = 10
+        browser._tab_idle_ttl = 10_000
+        for key in ("A", "B", "C"):
+            browser._bind_session(key)
+            browser._ensure_page(key)
+        assert set(browser._pages) == {"A", "B", "C"}
+
+
+class TestBindSessionPlugin:
+    def test_handler_binds_current_session_to_browser(self):
+        """The plugin reads the turn's session_id and hands it to the browser."""
+        from connectonion.useful_plugins.bind_browser_session import _bind_session
+
+        class FakeBrowser:
+            bound = "unset"
+            def _bind_session(self, sid):
+                self.bound = sid
+
+        class FakeAgent:
+            class tools:
+                browserautomation = FakeBrowser()
+            current_session = {"session_id": "sess-123"}
+
+        _bind_session(FakeAgent())
+        assert FakeAgent.tools.browserautomation.bound == "sess-123"
+
+    def test_handler_noop_without_browser(self):
+        """Agents with no browser tool are unaffected — the plugin does nothing."""
+        from connectonion.useful_plugins.bind_browser_session import _bind_session
+
+        class FakeAgent:
+            class tools:
+                pass
+            current_session = {"session_id": "sess-123"}
+
+        _bind_session(FakeAgent())  # must not raise

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -174,6 +174,21 @@ class TestTabReclaim:
             browser._ensure_page(key)
         assert set(browser._pages) == {"A", "B", "C"}
 
+    def test_close_tab_bounds_url_memory(self, browser):
+        """_page_url must stay bounded: session ids are unique per panel, so an
+        unbounded restore map leaks one url per session forever on a shared host."""
+        browser._max_url_memory = 5
+        for i in range(20):
+            key = f"s{i}"
+            page = FakePage(i)
+            page.url = f"https://example.com/{i}"
+            browser._pages[key] = page
+            browser._page_used[key] = time.monotonic()
+            browser._close_tab(key)
+        assert len(browser._page_url) == 5
+        assert "s19" in browser._page_url        # most recently closed kept
+        assert "s0" not in browser._page_url     # oldest evicted
+
 
 class TestBindSessionPlugin:
     def test_handler_binds_current_session_to_browser(self):


### PR DESCRIPTION
## Summary
- keep the current daemon/client `co browser` CLI mode intact
- serialize BrowserAutomation public calls through one Playwright-owning worker thread
- make `_browser_is_usable()` safe for daemon-side liveness checks from non-browser threads
- add per-session tabs through `bind_browser_session` so hosted sessions do not fight over one page
- add portable login state import/export, BROWSER_PROXY support, iframe-aware selector clicks, bounded screenshot payloads, and `human_jitter`
- document the Browser tool changes

## Verification
- .venv/bin/python -m pytest tests/unit/test_browser_automation.py tests/unit/test_browser_session_pages.py tests/e2e/cli/test_browser_daemon.py -q
- .venv/bin/python -m py_compile connectonion/useful_tools/browser_tools/browser.py connectonion/useful_plugins/human_jitter.py connectonion/useful_plugins/bind_browser_session.py connectonion/useful_plugins/__init__.py

Note: the daemon tests require AF_UNIX socket bind permissions and were run outside the sandbox.