### PR TITLE
feat(tools): add read_file as a copyable multi-format tool

### DIFF
--- a/connectonion/cli/commands/copy_commands.py
+++ b/connectonion/cli/commands/copy_commands.py
@@ -26,6 +26,7 @@ TOOLS = {
     "memory": "memory.py",
     "microsoft_calendar": "microsoft_calendar.py",
     "outlook": "outlook.py",
+    "read_file": "read_file.py",
     "send_email": "send_email.py",
     "shell": "shell.py",
     "slash_command": "slash_command.py",

--- a/connectonion/useful_tools/read_file.py
+++ b/connectonion/useful_tools/read_file.py
@@ -1,0 +1,172 @@
+"""
+Purpose: One copyable tool that reads any file — text, images, PDF, LaTeX, PPTX, Word, audio, video — and returns the raw extracted content for the agent.
+LLM-Note:
+  Dependencies: imports from [base64, mimetypes, pathlib, shutil, subprocess, tempfile, charset_normalizer, docx, pypdf, pptx, connectonion.transcribe] | requires ffmpeg on PATH for video | imported by [copied into user projects via `co copy read_file`; not re-exported from useful_tools/__init__]
+  Data flow: read_file(path) → dispatch by extension → text/PDF/PPTX/DOCX return extracted text | images return a data:image/...;base64 URL (picked up by the image_result_formatter plugin so the vision model sees it) | audio transcribes via transcribe() | video extracts audio with ffmpeg then transcribes
+  State/Effects: reads the file from disk | audio/video make a transcription API call (transcribe) | video shells out to ffmpeg into a temp dir | no caching
+  Integration: exposes read_file(path) as an agent tool | supersedes the built-in text read_file — pass this one, not both (same tool name) | image results rely on the image_result_formatter plugin being enabled
+  Errors: returns "Error: ..." strings for the tool's own boundary checks (missing file, unsupported binary, legacy .ppt/.doc, ffmpeg missing) | lets transcribe()/pypdf/pptx/docx exceptions bubble to the tool executor
+
+Read any file and return its contents for the agent to use.
+
+Dispatches by extension:
+  - Text/code/markup (.txt .md .csv .json .tex .py …) → raw text
+  - Images (.png .jpg .jpeg .gif .webp)              → data URL for the vision model
+  - PDF (.pdf)                                       → extracted text, per page
+  - PowerPoint (.pptx)                               → extracted slide text
+  - Word (.docx)                                     → extracted document text
+  - Audio (.mp3 .wav .m4a …)                         → transcript
+  - Video (.mp4 .mov .mkv …)                         → audio transcript (via ffmpeg)
+
+This supersedes the built-in `read_file` (text + line numbers). When you copy it
+in, pass this one to your agent — not both (they share the tool name `read_file`).
+
+Usage:
+    from connectonion import Agent
+    from tools.read_file import read_file
+
+    agent = Agent("assistant", tools=[read_file])
+
+Video needs `ffmpeg` on PATH; the tool says so if it's missing.
+"""
+
+import base64
+import mimetypes
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from charset_normalizer import from_bytes
+from connectonion import transcribe
+from docx import Document
+from pypdf import PdfReader
+from pptx import Presentation
+
+# Extensions handled by a dedicated path; everything else is read as text.
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+AUDIO_EXTS = {".mp3", ".wav", ".aiff", ".aac", ".ogg", ".flac", ".m4a", ".webm"}
+VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".flv", ".wmv", ".m4v"}
+
+
+def read_file(path: str) -> str:
+    """Read any file and hand you its contents. Dispatches by extension:
+    - text / code / .md / .csv / .json / .tex  →  the file's text, as-is
+    - images (.png .jpg .jpeg .gif .webp)  →  the image enters your vision; after reading you can SEE and describe it
+    - PDF (.pdf)  →  the document's text, page by page
+    - PowerPoint (.pptx)  →  the text of each slide
+    - Word (.docx)  →  the document's text
+    - audio (.mp3 .wav …) / video (.mp4 …)  →  a transcript of the speech
+    Call this whenever you are given a file path — including images — before ever saying you cannot read or see it.
+
+    Args:
+        path: Path to the file to read.
+
+    Returns:
+        Extracted text for most types. Images return a `data:image/...;base64,...`
+        data URL that the image_result_formatter plugin turns into an image the
+        model can see. On a boundary problem (missing file, unsupported binary,
+        legacy .ppt/.doc, missing ffmpeg) returns an "Error: ..." message you can act on.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return f"Error: File '{path}' does not exist"
+    if not file_path.is_file():
+        return f"Error: '{path}' is not a file"
+
+    ext = file_path.suffix.lower()
+
+    if ext in IMAGE_EXTS:
+        return _read_image(file_path)
+    if ext == ".pdf":
+        return _read_pdf(file_path)
+    if ext in (".pptx", ".ppt"):
+        return _read_pptx(file_path, ext)
+    if ext in (".docx", ".doc"):
+        return _read_docx(file_path, ext)
+    if ext in AUDIO_EXTS:
+        return transcribe(str(file_path))
+    if ext in VIDEO_EXTS:
+        return _read_video(file_path)
+    return _read_text(file_path, ext)
+
+
+def _read_text(file_path: Path, ext: str) -> str:
+    """Read a text/code/markup file. Rejects binary files."""
+    data = file_path.read_bytes()
+    # NUL bytes almost never appear in text; their presence means binary.
+    if b"\x00" in data[:8192]:
+        return (
+            f"Error: '{file_path}' looks like a binary file with an unsupported "
+            f"extension ('{ext or 'none'}'), not text."
+        )
+    # Detect the encoding, limited to UTF-8 and Chinese GB18030 so short snippets
+    # aren't misdetected as some unrelated charset.
+    match = from_bytes(data, cp_isolation=["utf_8", "gb18030"]).best()
+    return str(match) if match is not None else data.decode("utf-8", errors="replace")
+
+
+def _read_image(file_path: Path) -> str:
+    """Return an image as a base64 data URL for the vision model."""
+    mime = mimetypes.guess_type(str(file_path))[0] or "image/png"
+    b64 = base64.b64encode(file_path.read_bytes()).decode("utf-8")
+    return f"data:{mime};base64,{b64}"
+
+
+def _read_pdf(file_path: Path) -> str:
+    """Extract text from a PDF, one section per page."""
+    texts = [(page.extract_text() or "").strip() for page in PdfReader(str(file_path)).pages]
+    if not any(texts):
+        return (
+            f"Error: no extractable text in '{file_path}'. "
+            "It may be a scanned PDF (images only)."
+        )
+    return "\n\n".join(f"--- Page {i} ---\n{t}" for i, t in enumerate(texts, 1))
+
+
+def _read_pptx(file_path: Path, ext: str) -> str:
+    """Extract slide text from a .pptx presentation."""
+    if ext == ".ppt":
+        return (
+            "Error: legacy .ppt is not supported. Convert it to .pptx "
+            "(e.g. with LibreOffice or PowerPoint) and try again."
+        )
+    slides = []
+    for i, slide in enumerate(Presentation(str(file_path)).slides, 1):
+        texts = [
+            shape.text_frame.text
+            for shape in slide.shapes
+            if shape.has_text_frame and shape.text_frame.text.strip()
+        ]
+        slides.append(f"--- Slide {i} ---\n" + "\n".join(texts))
+    return "\n\n".join(slides).strip()
+
+
+def _read_docx(file_path: Path, ext: str) -> str:
+    """Extract text from a .docx document, paragraph by paragraph."""
+    if ext == ".doc":
+        return (
+            "Error: legacy .doc is not supported. Convert it to .docx "
+            "(e.g. with LibreOffice or Word) and try again."
+        )
+    paras = [p.text for p in Document(str(file_path)).paragraphs if p.text.strip()]
+    return "\n".join(paras)
+
+
+def _read_video(file_path: Path) -> str:
+    """Extract the audio track with ffmpeg, then transcribe it."""
+    if shutil.which("ffmpeg") is None:
+        return (
+            "Error: reading video requires ffmpeg on PATH. "
+            "Install it (e.g. 'brew install ffmpeg' or 'apt install ffmpeg') and try again."
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        audio_path = Path(tmp) / "audio.mp3"
+        proc = subprocess.run(
+            ["ffmpeg", "-y", "-i", str(file_path),
+             "-vn", "-ac", "1", "-b:a", "64k", str(audio_path)],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0 or not audio_path.exists():
+            return f"Error: failed to extract audio from '{file_path}':\n{proc.stderr[-500:]}"
+        return transcribe(str(audio_path))

--- a/docs/useful_tools/README.md
+++ b/docs/useful_tools/README.md
@@ -9,6 +9,7 @@ Pre-built tools for common agent tasks.
 | [bash](bash.md) | Execute bash commands (Unix/Mac) | `from connectonion import bash` |
 | [Shell](shell.md) | Execute shell commands (cross-platform) | `from connectonion import Shell` |
 | [FileTools](file_tools.md) | Read/edit files with safety tracking | `from connectonion.useful_tools import FileTools` |
+| [read_file](read_file.md) | Read any file: text, images, PDF, PPTX, DOCX, audio, video | `co copy read_file` |
 | [BrowserAutomation](browser_tools.md) | Natural language browser automation | `from connectonion.useful_tools.browser_tools import BrowserAutomation` |
 | [DiffWriter](diff_writer.md) | Edit files with diffs | `from connectonion import DiffWriter` |
 | [TodoList](todo_list.md) | Track task progress | `from connectonion import TodoList` |
@@ -69,6 +70,7 @@ See [co copy](../cli/copy.md) for full details.
 - **bash** - Run bash commands, return output (Unix/Mac)
 - **Shell** - Run commands, scripts, git (cross-platform)
 - **FileTools** - Read/edit files with safety tracking (read-before-edit, stale-read detection)
+- **read_file** (copyable) - Read any file: text, images (→ vision model), PDF, PowerPoint, Word, audio/video (→ transcript)
 - **DiffWriter** - Edit files with visual diffs (legacy)
 
 ### Browser

--- a/docs/useful_tools/read_file.md
+++ b/docs/useful_tools/read_file.md
@@ -1,0 +1,74 @@
+# read_file
+
+One copyable tool that reads **any** file — text, code, images, PDF, LaTeX, PowerPoint, Word, audio, video — and hands the extracted content to the agent. It dispatches by file extension and returns the raw content; the agent decides what to do with it.
+
+This is a `co copy`-able tool (it is **not** imported from the package by default). It supersedes the lightweight built-in [`read_file`](file_tools.md) (text + line numbers) — copy this one in when you need the heavier formats. They share the tool name `read_file`, so pass one or the other, not both.
+
+## Quick Start
+
+```bash
+co copy read_file        # → ./tools/read_file.py
+```
+
+```python
+from connectonion import Agent
+from connectonion.useful_plugins import image_result_formatter
+from tools.read_file import read_file
+
+agent = Agent(
+    "assistant",
+    tools=[read_file],
+    plugins=[image_result_formatter],   # required so images reach the vision model
+)
+
+agent.input("What's in report.pdf?")
+agent.input("Describe diagram.png")     # the model actually sees the image
+```
+
+## Supported formats
+
+| Extension | Returns |
+|-----------|---------|
+| `.txt .md .csv .json .tex` + code | the file's text, as-is (UTF-8, or GB18030 for Chinese) |
+| `.png .jpg .jpeg .gif .webp` | a `data:image/…;base64,…` URL the vision model sees ([how](#how-images-reach-the-vision-model)) |
+| `.pdf` | extracted text, one section per page |
+| `.pptx` | the text of each slide |
+| `.docx` | the document's text |
+| `.mp3 .wav .m4a …` (audio) | a transcript (via `transcribe()`) |
+| `.mp4 .mov .mkv …` (video) | a transcript of the **audio** track (ffmpeg → `transcribe()`) |
+
+Legacy binary `.ppt` / `.doc`, scanned (text-less) PDFs, and a missing `ffmpeg` return an actionable `Error: …` string. Video reads the audio only — a silent video (screen recording, etc.) has nothing to transcribe.
+
+## How images reach the vision model
+
+Reading an image is **not** the tool doing OCR or captioning. `read_file` only produces the image *data*; a separate plugin turns that into something the model can actually see. The call chain:
+
+```
+read_file("diagram.png")
+      │  returns  "data:image/png;base64,iVBORw0KGgo…"      (raw image bytes, base64)
+      ▼
+tool result  →  a normal text tool-message in the conversation
+      ▼
+image_result_formatter plugin        (runs on the `after_tools` event)
+      │  1. detects the  data:image/…;base64,…  URL in the result
+      │  2. replaces the tool message with a short placeholder
+      │  3. inserts a user message: { "type": "image_url", "image_url": {...} }
+      ▼
+next LLM call  →  the model SEES the image (vision), not base64 text
+```
+
+**Why a plugin, and not `read_file` itself?** A tool's return value can only become a *text* tool-message. Putting an image into the conversation means mutating the message list, which is only safe on the `after_tools` event — so a plugin does it. This is the exact path browser screenshots use. Keeping `read_file` to "return the image data" and letting the plugin handle presentation keeps each piece single-purpose.
+
+**Consequence:** images only reach the model if the agent has the [`image_result_formatter`](../useful_plugins/image_result_formatter.md) plugin. The [`minimal`](../templates/minimal.md) template enables it by default; a bare `Agent(...)` does not — add `plugins=[image_result_formatter]`. Supported image types match the plugin: PNG, JPEG, GIF, WebP.
+
+## Dependencies
+
+Python packages (declared by connectonion, installed with it): `pypdf` (PDF), `python-pptx` (PPTX), `python-docx` (DOCX), `charset-normalizer` (text encoding detection). No lazy imports or "package missing" fallbacks — they're real dependencies.
+
+System tool: **ffmpeg** on `PATH`, for video only (it is not a pip package — `brew install ffmpeg` / `apt install ffmpeg`). Audio and video transcription use the Gemini-based `transcribe()`, which needs `co auth` (a managed key); audio needs no ffmpeg.
+
+## See Also
+
+- [image_result_formatter](../useful_plugins/image_result_formatter.md) — turns the image data URL into a real image the vision model sees
+- [FileTools](file_tools.md) — the built-in lightweight text `read_file` (line numbers, read-before-edit)
+- [co copy](../cli/copy.md) — copying tools into your project to customize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,10 @@ dependencies = [
     "textual>=0.86.0",
     "textual-autocomplete>=3.0.0",
     "playwright>=1.40.0",
+    "charset-normalizer>=3.0.0",
+    "pypdf>=4.0.0",
+    "python-pptx>=1.0.0",
+    "python-docx>=1.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/e2e/cli/test_cli_copy.py
+++ b/tests/e2e/cli/test_cli_copy.py
@@ -111,6 +111,16 @@ class TestCopyCommand:
         assert result1.exit_code == 0
         assert "Copied:" in result1.output
 
+    def test_copy_read_file_tool(self):
+        """Test copying the read_file multi-format tool creates tools/read_file.py."""
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(cli, ['copy', 'read_file'])
+
+        assert result.exit_code == 0
+        assert "Copied:" in result.output
+        assert (Path(self.test_dir) / "tools" / "read_file.py").exists()
+
     def test_copy_multiple_items(self):
         """Test copying multiple items at once."""
         from connectonion.cli.main import cli

--- a/tests/unit/test_read_file_tool.py
+++ b/tests/unit/test_read_file_tool.py
@@ -1,0 +1,213 @@
+"""Unit tests for connectonion/useful_tools/read_file.py (the `co copy read_file` tool).
+
+Covers the local dispatch paths and boundary errors. pypdf and python-pptx are
+real dependencies, so PDF/PPTX extraction is tested against real files. Audio/video
+transcription is exercised only through its dispatch + boundary branches (no
+network/API): audio dispatch calls transcribe(); video without ffmpeg and ffmpeg
+failure return actionable errors.
+"""
+
+import base64
+import shutil
+import pytest
+from pathlib import Path
+from unittest.mock import Mock
+from docx import Document
+from pptx import Presentation
+
+import connectonion.useful_tools.read_file as read_file_module
+from connectonion.useful_tools.read_file import read_file
+from connectonion.useful_plugins.image_result_formatter import _format_image_result
+
+
+# A minimal PDF whose single page contains the text "Hello PDF World".
+_MINIMAL_PDF = b"""%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 20 100 Td (Hello PDF World) Tj ET
+endstream endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f
+trailer<</Root 1 0 R/Size 6>>
+startxref
+0
+%%EOF"""
+
+
+class TestBoundaries:
+    def test_missing_file(self, tmp_path):
+        result = read_file(str(tmp_path / "nope.txt"))
+        assert result == f"Error: File '{tmp_path / 'nope.txt'}' does not exist"
+
+    def test_directory_is_not_a_file(self, tmp_path):
+        result = read_file(str(tmp_path))
+        assert "is not a file" in result
+
+
+class TestText:
+    def test_plain_text_returned_as_is(self, tmp_path):
+        f = tmp_path / "note.txt"
+        f.write_text("hello\nworld\n", encoding="utf-8")
+        # Raw content, no line numbers and no truncation (unlike the built-in read_file).
+        assert read_file(str(f)) == "hello\nworld\n"
+
+    def test_latex_source_is_read_as_text(self, tmp_path):
+        f = tmp_path / "paper.tex"
+        f.write_text(r"\documentclass{article}\begin{document}Hi\end{document}", encoding="utf-8")
+        assert r"\documentclass{article}" in read_file(str(f))
+
+    def test_json_and_code_read_as_text(self, tmp_path):
+        f = tmp_path / "data.json"
+        f.write_text('{"a": 1}', encoding="utf-8")
+        assert read_file(str(f)) == '{"a": 1}'
+
+    def test_non_utf8_chinese_is_decoded(self, tmp_path):
+        # GBK-encoded Chinese (common on Windows) must not come back as mojibake.
+        f = tmp_path / "gbk.txt"
+        f.write_bytes("你好，世界。这是一段中文。".encode("gbk"))
+        assert read_file(str(f)) == "你好，世界。这是一段中文。"
+
+    def test_large_text_returned_whole(self, tmp_path):
+        # Contract (#169): return raw content, no pre-formatting / truncation.
+        f = tmp_path / "big.txt"
+        body = "a" * 250_000
+        f.write_text(body, encoding="utf-8")
+        assert read_file(str(f)) == body
+
+    def test_unknown_binary_extension_rejected(self, tmp_path):
+        f = tmp_path / "blob.dat"
+        f.write_bytes(b"MZ\x00\x00\x90\x00binary\x00stuff")
+        result = read_file(str(f))
+        assert result.startswith("Error:")
+        assert "binary" in result
+
+
+class TestImage:
+    def test_png_returns_data_url(self, tmp_path):
+        f = tmp_path / "pic.png"
+        payload = b"\x89PNG\r\n\x1a\nfake-image-bytes"
+        f.write_bytes(payload)
+        result = read_file(str(f))
+        assert result.startswith("data:image/png;base64,")
+        # Round-trips to the original bytes so the vision model sees the real image.
+        b64 = result.split(",", 1)[1]
+        assert base64.b64decode(b64) == payload
+
+    def test_jpg_mime(self, tmp_path):
+        f = tmp_path / "pic.jpg"
+        f.write_bytes(b"\xff\xd8\xff\xe0jpeg")
+        assert read_file(str(f)).startswith("data:image/jpeg;base64,")
+
+
+class TestImageReachesVisionModel:
+    """read_file's image output must actually arrive at the model as an image.
+
+    The tool returns a data URL (data only); the image_result_formatter plugin
+    turns it into an image_url message the vision model can see — same path as
+    browser screenshots. This locks that end-to-end contract.
+    """
+
+    def test_image_output_becomes_image_url_message(self, tmp_path):
+        f = tmp_path / "shot.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-bytes")
+        data_url = read_file(str(f))
+        assert data_url.startswith("data:image/png;base64,")
+
+        # Simulate the tool result sitting in a session, then run the plugin.
+        agent = Mock()
+        agent.io = None
+        agent.current_session = {
+            "trace": [{
+                "type": "tool_result", "status": "success",
+                "name": "read_file", "tool_id": "call_1", "result": data_url,
+            }],
+            "messages": [{
+                "role": "tool", "tool_call_id": "call_1", "content": data_url,
+            }],
+        }
+
+        _format_image_result(agent)
+
+        messages = agent.current_session["messages"]
+        assert len(messages) == 2
+        image_msg = messages[1]
+        assert image_msg["role"] == "user"
+        image_part = next(p for p in image_msg["content"] if p["type"] == "image_url")
+        # The whole image reaches the model — not a truncated/altered blob.
+        assert image_part["image_url"]["url"] == data_url
+
+
+class TestPdfPptx:
+    def test_pdf_extracts_text(self, tmp_path):
+        f = tmp_path / "doc.pdf"
+        f.write_bytes(_MINIMAL_PDF)
+        result = read_file(str(f))
+        assert "Hello PDF World" in result
+        assert "--- Page 1 ---" in result
+
+    def test_pptx_extracts_slide_text(self, tmp_path):
+        prs = Presentation()
+        slide = prs.slides.add_slide(prs.slide_layouts[5])
+        slide.shapes.title.text = "Quarterly Results"
+        f = tmp_path / "deck.pptx"
+        prs.save(str(f))
+        result = read_file(str(f))
+        assert "--- Slide 1 ---" in result
+        assert "Quarterly Results" in result
+
+    def test_legacy_ppt_rejected(self, tmp_path):
+        f = tmp_path / "old.ppt"
+        f.write_bytes(b"\xd0\xcf\x11\xe0 legacy ppt")
+        result = read_file(str(f))
+        assert "legacy .ppt is not supported" in result
+
+    def test_docx_extracts_text(self, tmp_path):
+        doc = Document()
+        doc.add_paragraph("Contract Agreement")
+        doc.add_paragraph("Party A shall deliver the goods.")
+        f = tmp_path / "contract.docx"
+        doc.save(str(f))
+        result = read_file(str(f))
+        assert "Contract Agreement" in result
+        assert "Party A shall deliver the goods." in result
+
+    def test_legacy_doc_rejected(self, tmp_path):
+        f = tmp_path / "old.doc"
+        f.write_bytes(b"\xd0\xcf\x11\xe0 legacy doc")
+        result = read_file(str(f))
+        assert "legacy .doc is not supported" in result
+
+
+class TestAudioVideoDispatch:
+    def test_audio_dispatches_to_transcribe(self, tmp_path, monkeypatch):
+        calls = {}
+
+        def fake_transcribe(path):
+            calls["path"] = path
+            return "TRANSCRIPT"
+
+        monkeypatch.setattr(read_file_module, "transcribe", fake_transcribe)
+        f = tmp_path / "clip.mp3"
+        f.write_bytes(b"ID3 fake audio")
+        assert read_file(str(f)) == "TRANSCRIPT"
+        assert calls["path"] == str(f)
+
+    def test_video_without_ffmpeg(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(read_file_module.shutil, "which", lambda name: None)
+        f = tmp_path / "clip.mp4"
+        f.write_bytes(b"\x00\x00\x00\x18ftyp fake video")
+        result = read_file(str(f))
+        assert result.startswith("Error:")
+        assert "ffmpeg" in result
+
+    @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+    def test_video_ffmpeg_failure_reports_error(self, tmp_path):
+        # Real ffmpeg on non-video bytes exits non-zero -> actionable error, no transcription.
+        f = tmp_path / "clip.mp4"
+        f.write_bytes(b"not actually a video")
+        result = read_file(str(f))
+        assert result.startswith("Error: failed to extract audio")


### PR DESCRIPTION
Closes #169.

## What

One `co copy read_file`-able tool that reads any file and returns the raw extracted content for the agent, dispatching by extension. Sibling of the other `co copy`-able tools — keeps the core simple, users copy in the heavier capability when they need it.

| Type | Handling |
|------|----------|
| Text / code / `.md` / `.csv` / `.json` / `.tex` (LaTeX source) | returned as-is |
| Images `.png/.jpg/.gif/.webp` | `data:image/...;base64,...` URL for the vision model (same contract as browser screenshots + `image_result_formatter`) |
| PDF | per-page text (`pypdf`) |
| PowerPoint `.pptx` | slide text (`python-pptx`) |
| Audio | transcript via the existing `transcribe()` |
| Video | `ffmpeg` pulls the audio track → `transcribe()` |

The caller always just calls `read_file(path)`; the tool picks the path by extension. Return raw extracted content — no pre-formatting in code, the agent handles presentation.

## Design notes

- **Reuses existing primitives**: audio/video go through the existing `transcribe()`, not a reimplemented Gemini call.
- **Core stays light**: `pypdf` / `python-pptx` are imported lazily. Missing deps, legacy `.ppt` (python-pptx can't read the old binary format), scanned/text-less PDFs, and a missing `ffmpeg` all return actionable `Error: ...` messages.
- **No naming collision**: registered in the `co copy` `TOOLS` registry as `read_file` → `tools/read_file.py`, but intentionally **not** re-exported from `useful_tools/__init__`, so it doesn't shadow the built-in lightweight text `read_file`. Verified `connectonion.read_file` still resolves to the text reader.

## Tests

- `tests/unit/test_read_file_tool.py` — 15 tests: boundaries, text/LaTeX/JSON, binary rejection, truncation, image data URL, missing-dependency errors, legacy `.ppt`, audio dispatch to `transcribe`, video without ffmpeg / ffmpeg failure.
- `tests/e2e/cli/test_cli_copy.py` — `co copy read_file` creates `tools/read_file.py`.
- Real PDF / PPTX / LaTeX / image extraction verified manually.

## Not included (scope)

- PDF page-image rendering (needs poppler/pymupdf) — text-only with a scanned-PDF note.
- Video frame sampling (issue marked optional).