### PR TITLE
image_result_formatter: upload screenshots to oo-api (URL instead of base64)

### DIFF
--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -3,21 +3,25 @@ LLM-Note: Image result formatter plugin.
 
 Purpose: Remove raw base64 image payloads from the tool message, add a
 multimodal image message so the LLM can see the image, and send image results to
-frontend IO when available.
+frontend IO when available. For managed (co/) agents the image bytes are uploaded
+to oo-api (content-addressed GCS) and referenced by URL, so screenshots never bloat
+the replayed message history; non-managed agents keep the inline data URL.
 
 Data flow: after_tools event -> scan successful tool_result trace entries ->
-detect image data URL or raw base64 -> replace the matching tool message with a
-short placeholder -> insert a user message containing image_url -> shorten the
-trace result.
+detect image data URL or raw base64 -> upload to oo-api (managed) or keep data URL
+-> replace the matching tool message with a short placeholder -> insert a user
+message containing image_url -> shorten the trace result.
 
 State/Effects: mutates agent.current_session["messages"] and trace entries;
-optionally calls agent.io.send_image(data_url). Non-image tool results are ignored.
+optionally calls agent.io.send_image(image_url). Non-image tool results are ignored.
 
 Test coverage: tests/unit/test_image_result_formatter.py and
 tests/e2e/test_image_formatter_plugin.py.
 """
 
 import re
+import base64
+import requests
 from typing import TYPE_CHECKING
 from ..core.events import after_tools
 
@@ -71,7 +75,11 @@ def _format_image_result(agent: 'Agent') -> None:
         if not is_image:
             continue
 
-        data_url = f"data:{mime_type};base64,{base64_data}"
+        # Keep the raw bytes out of the message history (which is replayed to the LLM
+        # every turn). Managed (co/) agents upload to oo-api -> content-addressed GCS
+        # and reference the image by URL; oo-api materializes it per provider at call
+        # time. Non-managed agents have no oo-api, so keep the inline data URL.
+        image_url = _upload_image(agent, base64_data, mime_type)
         tool_message_index = next(
             i for i, msg in enumerate(messages)
             if msg.get('role') == 'tool' and msg.get('tool_call_id') == tool_call_id
@@ -87,16 +95,44 @@ def _format_image_result(agent: 'Agent') -> None:
                 },
                 {
                     "type": "image_url",
-                    "image_url": {"url": data_url}
+                    "image_url": {"url": image_url}
                 }
             ]
         })
 
         if agent.io:
-            agent.io.send_image(data_url)
+            agent.io.send_image(image_url)
 
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
+
+
+def _upload_image(agent: 'Agent', base64_data: str, mime_type: str) -> str:
+    """Upload the image to oo-api (managed agents) and return its stable URL.
+
+    Only managed (co/) agents route through oo-api, which owns the /img endpoint and
+    materializes the image per provider. For any other LLM there is no oo-api to
+    offload to, so keep the inline data URL (previous behavior).
+
+    Fails loudly on upload error: a managed agent already depends on oo-api for its
+    LLM calls, and silently reverting to base64 would hide a broken image pipeline
+    while re-inflating the context.
+    """
+    llm = getattr(agent, "llm", None)
+    # OpenOnionLLM == managed keys == requests go through oo-api (checked by name to
+    # avoid importing the llm module into this plugin).
+    if type(llm).__name__ != "OpenOnionLLM":
+        return f"data:{mime_type};base64,{base64_data}"
+
+    base = llm.base_url.rsplit("/v1", 1)[0]  # "https://oo.openonion.ai/v1" -> base
+    resp = requests.post(
+        f"{base}/api/v1/images",
+        headers={"Authorization": f"Bearer {llm.auth_token}"},
+        files={"file": ("screenshot", base64.b64decode(base64_data), mime_type)},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["url"]
 
 
 # Plugin is an event list


### PR DESCRIPTION
## What
Managed (`co/`) agents upload screenshot bytes to oo-api's `/api/v1/images` (content-addressed GCS) and reference the image by a stable `/img` URL in the message, instead of embedding the base64 data URL.

## Why
The base64 payload sits in `current_session["messages"]`, which is replayed to the LLM every turn and persisted in session logs / stateless continuation. A multi-step browser agent (many screenshots) blows up context size, memory, and transfer. Uploading the bytes to GCS keeps history at a ~70-byte URL. Non-managed agents (no oo-api) keep the inline data URL, so their behavior is unchanged.

## Pairs with
oo-api images routes (`POST /api/v1/images`, `GET /img/{sha}`) + per-provider materialization (`forward_to_gemini` inlines the URL for Gemini, which can't fetch remote URLs). The oo-api side is already deployed.

## Notes
- Upload-only; the 3-screenshot sliding window (hosted-agents) is a separate concern, not included here.
- Fails loudly on upload error (managed agents already depend on oo-api for LLM calls).

## Test
Verified end-to-end locally: `co/gemini` agent → screenshot → upload → GCS → oo-api inline → real Gemini correctly read the image; the session held the `/img` URL, not base64.
