### PR TITLE
image_result_formatter: upload screenshots to oo-api (URL instead of base64)

### DIFF
--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -3,14 +3,14 @@ LLM-Note: Image result formatter plugin.
 
 Purpose: Remove raw base64 image payloads from the tool message, add a
 multimodal image message so the LLM can see the image, and send image results to
-frontend IO when available. For managed (co/) agents the image bytes are uploaded
-to oo-api (content-addressed GCS) and referenced by URL, so screenshots never bloat
-the replayed message history; non-managed agents keep the inline data URL.
+frontend IO when available. Image bytes are uploaded to oo-api (content-addressed
+GCS) and referenced by URL, so screenshots never bloat the replayed message
+history. Requires OPENONION_API_KEY (set up by `co init`).
 
 Data flow: after_tools event -> scan successful tool_result trace entries ->
-detect image data URL or raw base64 -> upload to oo-api (managed) or keep data URL
--> replace the matching tool message with a short placeholder -> insert a user
-message containing image_url -> shorten the trace result.
+detect image data URL or raw base64 -> upload to oo-api -> replace the matching
+tool message with a short placeholder -> insert a user message containing
+image_url -> shorten the trace result.
 
 State/Effects: mutates agent.current_session["messages"] and trace entries;
 optionally calls agent.io.send_image(image_url). Non-image tool results are ignored.
@@ -19,6 +19,7 @@ Test coverage: tests/unit/test_image_result_formatter.py and
 tests/e2e/test_image_formatter_plugin.py.
 """
 
+import os
 import re
 import base64
 import requests
@@ -75,13 +76,7 @@ def _format_image_result(agent: 'Agent') -> None:
         if not is_image:
             continue
 
-        # Managed (co/) agents offload the bytes to oo-api and keep only a short URL
-        # in the replayed history; other LLMs have no oo-api, so keep the data URL.
-        # OpenOnionLLM is checked by name to avoid importing the llm module here.
-        if type(agent.llm).__name__ == "OpenOnionLLM":
-            image_url = _upload_to_oo_api(agent.llm, base64_data, mime_type)
-        else:
-            image_url = f"data:{mime_type};base64,{base64_data}"
+        image_url = _upload_to_oo_api(base64_data, mime_type)
         tool_message_index = next(
             i for i, msg in enumerate(messages)
             if msg.get('role') == 'tool' and msg.get('tool_call_id') == tool_call_id
@@ -109,20 +104,21 @@ def _format_image_result(agent: 'Agent') -> None:
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 
 
-def _upload_to_oo_api(llm, base64_data: str, mime_type: str) -> str:
+def _upload_to_oo_api(base64_data: str, mime_type: str) -> str:
     """Upload image bytes to oo-api and return the stable /img URL.
 
     oo-api stores the image in content-addressed GCS and materializes it per
     provider at call time (e.g. inlines it for Gemini, which can't fetch URLs).
+    Keeping only a ~70-byte URL in the message history stops screenshots from
+    bloating the replayed context.
 
-    Fails loudly on upload error: a managed agent already depends on oo-api for its
-    LLM calls, and silently reverting to base64 would hide a broken image pipeline
-    while re-inflating the context.
+    Fails loudly on upload error: silently reverting to base64 would hide a
+    broken image pipeline while re-inflating the context.
     """
-    base = llm.base_url.rsplit("/v1", 1)[0]  # "https://oo.openonion.ai/v1" -> base
+    base = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
     resp = requests.post(
         f"{base}/api/v1/images",
-        headers={"Authorization": f"Bearer {llm.auth_token}"},
+        headers={"Authorization": f"Bearer {os.environ['OPENONION_API_KEY']}"},
         files={"file": ("screenshot", base64.b64decode(base64_data), mime_type)},
         timeout=30,
     )

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -75,11 +75,13 @@ def _format_image_result(agent: 'Agent') -> None:
         if not is_image:
             continue
 
-        # Keep the raw bytes out of the message history (which is replayed to the LLM
-        # every turn). Managed (co/) agents upload to oo-api -> content-addressed GCS
-        # and reference the image by URL; oo-api materializes it per provider at call
-        # time. Non-managed agents have no oo-api, so keep the inline data URL.
-        image_url = _upload_image(agent, base64_data, mime_type)
+        # Managed (co/) agents offload the bytes to oo-api and keep only a short URL
+        # in the replayed history; other LLMs have no oo-api, so keep the data URL.
+        # OpenOnionLLM is checked by name to avoid importing the llm module here.
+        if type(agent.llm).__name__ == "OpenOnionLLM":
+            image_url = _upload_to_oo_api(agent.llm, base64_data, mime_type)
+        else:
+            image_url = f"data:{mime_type};base64,{base64_data}"
         tool_message_index = next(
             i for i, msg in enumerate(messages)
             if msg.get('role') == 'tool' and msg.get('tool_call_id') == tool_call_id
@@ -107,23 +109,16 @@ def _format_image_result(agent: 'Agent') -> None:
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
 
 
-def _upload_image(agent: 'Agent', base64_data: str, mime_type: str) -> str:
-    """Upload the image to oo-api (managed agents) and return its stable URL.
+def _upload_to_oo_api(llm, base64_data: str, mime_type: str) -> str:
+    """Upload image bytes to oo-api and return the stable /img URL.
 
-    Only managed (co/) agents route through oo-api, which owns the /img endpoint and
-    materializes the image per provider. For any other LLM there is no oo-api to
-    offload to, so keep the inline data URL (previous behavior).
+    oo-api stores the image in content-addressed GCS and materializes it per
+    provider at call time (e.g. inlines it for Gemini, which can't fetch URLs).
 
     Fails loudly on upload error: a managed agent already depends on oo-api for its
     LLM calls, and silently reverting to base64 would hide a broken image pipeline
     while re-inflating the context.
     """
-    llm = getattr(agent, "llm", None)
-    # OpenOnionLLM == managed keys == requests go through oo-api (checked by name to
-    # avoid importing the llm module into this plugin).
-    if type(llm).__name__ != "OpenOnionLLM":
-        return f"data:{mime_type};base64,{base64_data}"
-
     base = llm.base_url.rsplit("/v1", 1)[0]  # "https://oo.openonion.ai/v1" -> base
     resp = requests.post(
         f"{base}/api/v1/images",

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -3,21 +3,25 @@ LLM-Note: Image result formatter plugin.
 
 Purpose: Remove raw base64 image payloads from the tool message, add a
 multimodal image message so the LLM can see the image, and send image results to
-frontend IO when available.
+frontend IO when available. For managed (co/) agents the image bytes are uploaded
+to oo-api (content-addressed GCS) and referenced by URL, so screenshots never bloat
+the replayed message history; non-managed agents keep the inline data URL.
 
 Data flow: after_tools event -> scan successful tool_result trace entries ->
-detect image data URL or raw base64 -> replace the matching tool message with a
-short placeholder -> insert a user message containing image_url -> shorten the
-trace result.
+detect image data URL or raw base64 -> upload to oo-api (managed) or keep data URL
+-> replace the matching tool message with a short placeholder -> insert a user
+message containing image_url -> shorten the trace result.
 
 State/Effects: mutates agent.current_session["messages"] and trace entries;
-optionally calls agent.io.send_image(data_url). Non-image tool results are ignored.
+optionally calls agent.io.send_image(image_url). Non-image tool results are ignored.
 
 Test coverage: tests/unit/test_image_result_formatter.py and
 tests/e2e/test_image_formatter_plugin.py.
 """
 
 import re
+import base64
+import requests
 from typing import TYPE_CHECKING
 from ..core.events import after_tools
 
@@ -71,7 +75,11 @@ def _format_image_result(agent: 'Agent') -> None:
         if not is_image:
             continue
 
-        data_url = f"data:{mime_type};base64,{base64_data}"
+        # Keep the raw bytes out of the message history (which is replayed to the LLM
+        # every turn). Managed (co/) agents upload to oo-api -> content-addressed GCS
+        # and reference the image by URL; oo-api materializes it per provider at call
+        # time. Non-managed agents have no oo-api, so keep the inline data URL.
+        image_url = _upload_image(agent, base64_data, mime_type)
         tool_message_index = next(
             i for i, msg in enumerate(messages)
             if msg.get('role') == 'tool' and msg.get('tool_call_id') == tool_call_id
@@ -87,16 +95,44 @@ def _format_image_result(agent: 'Agent') -> None:
                 },
                 {
                     "type": "image_url",
-                    "image_url": {"url": data_url}
+                    "image_url": {"url": image_url}
                 }
             ]
         })
 
         if agent.io:
-            agent.io.send_image(data_url)
+            agent.io.send_image(image_url)
 
         trace_entry['result'] = f"Tool '{tool_name}' returned image ({mime_type})"
         agent.logger.print(f"[dim]Formatted '{tool_name}' result as image[/dim]")
+
+
+def _upload_image(agent: 'Agent', base64_data: str, mime_type: str) -> str:
+    """Upload the image to oo-api (managed agents) and return its stable URL.
+
+    Only managed (co/) agents route through oo-api, which owns the /img endpoint and
+    materializes the image per provider. For any other LLM there is no oo-api to
+    offload to, so keep the inline data URL (previous behavior).
+
+    Fails loudly on upload error: a managed agent already depends on oo-api for its
+    LLM calls, and silently reverting to base64 would hide a broken image pipeline
+    while re-inflating the context.
+    """
+    llm = getattr(agent, "llm", None)
+    # OpenOnionLLM == managed keys == requests go through oo-api (checked by name to
+    # avoid importing the llm module into this plugin).
+    if type(llm).__name__ != "OpenOnionLLM":
+        return f"data:{mime_type};base64,{base64_data}"
+
+    base = llm.base_url.rsplit("/v1", 1)[0]  # "https://oo.openonion.ai/v1" -> base
+    resp = requests.post(
+        f"{base}/api/v1/images",
+        headers={"Authorization": f"Bearer {llm.auth_token}"},
+        files={"file": ("screenshot", base64.b64decode(base64_data), mime_type)},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["url"]
 
 
 # Plugin is an event list

--- a/docs/useful_plugins/image_result_formatter.md
+++ b/docs/useful_plugins/image_result_formatter.md
@@ -20,9 +20,10 @@ agent.input("Take a screenshot and describe what you see")
 When a tool returns base64 encoded image data:
 
 1. Detects base64 image in tool result
-2. Converts to OpenAI vision format for LLM consumption
-3. Sends image to frontend via WebSocket (if hosted with `agent.io`)
-4. Allows LLM to see image visually (not as text)
+2. Managed (`co/`) agents: uploads the bytes to oo-api and keeps only a short `/img` URL in the message history, so screenshots never bloat the replayed context. Other agents keep the inline data URL
+3. Converts to OpenAI vision format for LLM consumption
+4. Sends the image URL to frontend via WebSocket (if hosted with `agent.io`)
+5. Allows LLM to see image visually (not as text)
 
 ## Supported Formats
 
@@ -77,7 +78,7 @@ def create_agent():
 host(create_agent, port=8000, trust="open")
 ```
 
-The plugin detects `agent.io` and sends images via WebSocket for real-time display.
+The plugin detects `agent.io` and sends the image via WebSocket for real-time display — a hosted `/img` URL for managed (`co/`) agents, a data URL otherwise. Frontends should handle both forms.
 
 ### Manual (Direct Send)
 

--- a/docs/useful_plugins/image_result_formatter.md
+++ b/docs/useful_plugins/image_result_formatter.md
@@ -20,7 +20,7 @@ agent.input("Take a screenshot and describe what you see")
 When a tool returns base64 encoded image data:
 
 1. Detects base64 image in tool result
-2. Managed (`co/`) agents: uploads the bytes to oo-api and keeps only a short `/img` URL in the message history, so screenshots never bloat the replayed context. Other agents keep the inline data URL
+2. Uploads the bytes to oo-api and keeps only a short `/img` URL in the message history, so screenshots never bloat the replayed context (requires `OPENONION_API_KEY`, set up by `co init`)
 3. Converts to OpenAI vision format for LLM consumption
 4. Sends the image URL to frontend via WebSocket (if hosted with `agent.io`)
 5. Allows LLM to see image visually (not as text)
@@ -78,7 +78,7 @@ def create_agent():
 host(create_agent, port=8000, trust="open")
 ```
 
-The plugin detects `agent.io` and sends the image via WebSocket for real-time display — a hosted `/img` URL for managed (`co/`) agents, a data URL otherwise. Frontends should handle both forms.
+The plugin detects `agent.io` and sends the hosted `/img` URL via WebSocket for real-time display.
 
 ### Manual (Direct Send)
 

--- a/tests/e2e/test_image_formatter_plugin.py
+++ b/tests/e2e/test_image_formatter_plugin.py
@@ -25,6 +25,18 @@ Components under test:
 import pytest
 from unittest.mock import Mock
 
+UPLOADED_URL = "https://oo.openonion.ai/img/test"
+
+
+@pytest.fixture(autouse=True)
+def fake_upload(monkeypatch):
+    """The formatter uploads every image to oo-api; stub the network call."""
+    monkeypatch.setenv("OPENONION_API_KEY", "test-token")
+    resp = Mock()
+    resp.json.return_value = {"url": UPLOADED_URL}
+    monkeypatch.setattr('requests.post', Mock(return_value=resp))
+
+
 from connectonion import Agent
 from connectonion.core.llm import LLMResponse, ToolCall
 from connectonion.core.usage import TokenUsage
@@ -105,7 +117,7 @@ class TestImageFormatterPluginE2E:
         assert response is not None
         assert "screenshot" in response.lower() or "see" in response.lower()
 
-        mock_io.send_image.assert_called_once_with(take_screenshot("https://example.com"))
+        mock_io.send_image.assert_called_once_with(UPLOADED_URL)
 
         # Verify messages were properly formatted
         messages = agent.current_session['messages']
@@ -137,8 +149,7 @@ class TestImageFormatterPluginE2E:
 
         assert 'image' in text_part['text'].lower()
         assert 'take_screenshot' in text_part['text'].lower()
-        assert 'data:image/png;base64,' in image_part['image_url']['url']
-        assert 'iVBORw0KGgo' in image_part['image_url']['url']
+        assert image_part['image_url']['url'] == UPLOADED_URL
 
     def test_image_workflow_without_io(self):
         """
@@ -199,7 +210,7 @@ class TestImageFormatterPluginE2E:
         # Verify image is in the message
         content = user_image_msg['content']
         image_part = next(item for item in content if item['type'] == 'image_url')
-        assert 'data:image/png;base64,' in image_part['image_url']['url']
+        assert image_part['image_url']['url'] == UPLOADED_URL
 
     def test_multiple_images_workflow(self):
         """

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -36,6 +36,7 @@ class FakeAgent:
         }
         self.logger = Mock()
         self.io = Mock() if with_io else None
+        self.llm = MockLLM()  # not OpenOnionLLM -> keeps the inline data URL path
 
 
 class TestIsBase64Image:
@@ -381,3 +382,52 @@ class TestImageResultFormatterPlugin:
         )
 
         assert 'after_tools' in agent.events
+
+
+class OpenOnionLLM:
+    """Name matters: the plugin routes managed agents by class name."""
+    base_url = "https://oo.openonion.ai/v1"
+    auth_token = "test-token"
+
+
+class TestManagedUpload:
+    """Managed (co/) agents upload image bytes to oo-api and keep only the URL."""
+
+    def test_uploads_and_uses_returned_url(self, monkeypatch):
+        agent = FakeAgent(with_io=True)
+        agent.llm = OpenOnionLLM()
+        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        data_url = f"data:image/png;base64,{base64_data}"
+        agent.current_session['trace'] = [
+            {
+                'type': 'tool_result',
+                'name': 'screenshot',
+                'status': 'success',
+                'result': data_url,
+                'tool_id': 'call_789'
+            }
+        ]
+        agent.current_session['messages'] = [
+            {'role': 'tool', 'content': data_url, 'tool_call_id': 'call_789'}
+        ]
+
+        captured = {}
+
+        def fake_post(url, headers=None, files=None, timeout=None):
+            captured['url'] = url
+            captured['auth'] = headers['Authorization']
+            resp = Mock()
+            resp.json.return_value = {"url": "https://oo.openonion.ai/img/abc123"}
+            return resp
+
+        monkeypatch.setattr('requests.post', fake_post)  # plugin uses the shared requests module
+
+        _format_image_result(agent)
+
+        assert captured['url'] == "https://oo.openonion.ai/api/v1/images"
+        assert captured['auth'] == "Bearer test-token"
+        image_msg = agent.current_session['messages'][1]
+        image_part = next(p for p in image_msg['content'] if p['type'] == 'image_url')
+        assert image_part['image_url']['url'] == "https://oo.openonion.ai/img/abc123"
+        agent.io.send_image.assert_called_once_with("https://oo.openonion.ai/img/abc123")
+        assert base64_data not in str(agent.current_session['messages'])

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -26,6 +26,18 @@ from connectonion.useful_plugins.image_result_formatter import (
 from tests.utils.mock_helpers import MockLLM
 
 
+UPLOADED_URL = "https://oo.openonion.ai/img/test"
+
+
+@pytest.fixture(autouse=True)
+def fake_upload(monkeypatch):
+    """The formatter uploads every image to oo-api; stub the network call."""
+    monkeypatch.setenv("OPENONION_API_KEY", "test-token")
+    resp = Mock()
+    resp.json.return_value = {"url": UPLOADED_URL}
+    monkeypatch.setattr('requests.post', Mock(return_value=resp))
+
+
 class FakeAgent:
     """Fake agent for testing plugins."""
 
@@ -36,7 +48,6 @@ class FakeAgent:
         }
         self.logger = Mock()
         self.io = Mock() if with_io else None
-        self.llm = MockLLM()  # not OpenOnionLLM -> keeps the inline data URL path
 
 
 class TestIsBase64Image:
@@ -122,7 +133,7 @@ class TestFormatImageResult:
     def test_formats_image_result_correctly(self):
         """Test that image results are formatted as multimodal content."""
         agent = FakeAgent()
-        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAE"
+        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         agent.current_session['trace'] = [
             {
                 'type': 'tool_result',
@@ -155,12 +166,12 @@ class TestFormatImageResult:
         content = image_msg['content']
         assert content[0]['type'] == 'text'
         assert content[1]['type'] == 'image_url'
-        assert 'data:image/png;base64' in content[1]['image_url']['url']
+        assert content[1]['image_url']['url'] == UPLOADED_URL
 
     def test_drops_raw_base64_from_text_context(self):
         """Raw base64 image results should not be copied into text context."""
         agent = FakeAgent()
-        base64_data = "A" * 150
+        base64_data = "A" * 152  # valid base64: length divisible by 4
         agent.current_session['trace'] = [
             {
                 'type': 'tool_result',
@@ -188,7 +199,7 @@ class TestFormatImageResult:
         assert base64_data not in image_text
         assert tool_msg == "Tool returned an image (provided below)"
         assert image_text == "Here is the image from 'take_screenshot':"
-        assert image_msg['content'][1]['image_url']['url'].endswith(base64_data)
+        assert image_msg['content'][1]['image_url']['url'] == UPLOADED_URL
 
     def test_prints_formatting_message(self):
         """Test that formatting message is printed."""
@@ -198,14 +209,14 @@ class TestFormatImageResult:
                 'type': 'tool_result',
                 'name': 'capture',
                 'status': 'success',
-                'result': 'data:image/png;base64,iVBORw0KGgo',
+                'result': 'data:image/png;base64,iVBORw0KGgo=',
                 'tool_id': 'call_456'
             }
         ]
         agent.current_session['messages'] = [
             {
                 'role': 'tool',
-                'content': 'data:image/png;base64,iVBORw0KGgo',
+                'content': 'data:image/png;base64,iVBORw0KGgo=',
                 'tool_call_id': 'call_456'
             }
         ]
@@ -304,7 +315,7 @@ class TestFormatImageResult:
     def test_sends_image_to_io_when_available(self):
         """Image tool results are model-visible and sent to frontend IO."""
         agent = FakeAgent(with_io=True)
-        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAE"
+        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         data_url = f"data:image/png;base64,{base64_data}"
         agent.current_session['trace'] = [
             {
@@ -325,15 +336,15 @@ class TestFormatImageResult:
 
         _format_image_result(agent)
 
-        agent.io.send_image.assert_called_once_with(data_url)
+        agent.io.send_image.assert_called_once_with(UPLOADED_URL)
         image_msg = agent.current_session['messages'][1]
         image_part = next(item for item in image_msg['content'] if item['type'] == 'image_url')
-        assert image_part['image_url']['url'] == data_url
+        assert image_part['image_url']['url'] == UPLOADED_URL
 
     def test_skips_sending_to_io_when_not_available(self):
         """Test that no error occurs when io is None."""
         agent = FakeAgent(with_io=False)
-        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAE"
+        base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         agent.current_session['trace'] = [
             {
                 'type': 'tool_result',
@@ -384,18 +395,11 @@ class TestImageResultFormatterPlugin:
         assert 'after_tools' in agent.events
 
 
-class OpenOnionLLM:
-    """Name matters: the plugin routes managed agents by class name."""
-    base_url = "https://oo.openonion.ai/v1"
-    auth_token = "test-token"
-
-
-class TestManagedUpload:
-    """Managed (co/) agents upload image bytes to oo-api and keep only the URL."""
+class TestUploadToOoApi:
+    """Every image is uploaded to oo-api and referenced by URL."""
 
     def test_uploads_and_uses_returned_url(self, monkeypatch):
         agent = FakeAgent(with_io=True)
-        agent.llm = OpenOnionLLM()
         base64_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
         data_url = f"data:image/png;base64,{base64_data}"
         agent.current_session['trace'] = [
@@ -417,10 +421,10 @@ class TestManagedUpload:
             captured['url'] = url
             captured['auth'] = headers['Authorization']
             resp = Mock()
-            resp.json.return_value = {"url": "https://oo.openonion.ai/img/abc123"}
+            resp.json.return_value = {"url": UPLOADED_URL}
             return resp
 
-        monkeypatch.setattr('requests.post', fake_post)  # plugin uses the shared requests module
+        monkeypatch.setattr('requests.post', fake_post)
 
         _format_image_result(agent)
 
@@ -428,6 +432,6 @@ class TestManagedUpload:
         assert captured['auth'] == "Bearer test-token"
         image_msg = agent.current_session['messages'][1]
         image_part = next(p for p in image_msg['content'] if p['type'] == 'image_url')
-        assert image_part['image_url']['url'] == "https://oo.openonion.ai/img/abc123"
-        agent.io.send_image.assert_called_once_with("https://oo.openonion.ai/img/abc123")
+        assert image_part['image_url']['url'] == UPLOADED_URL
+        agent.io.send_image.assert_called_once_with(UPLOADED_URL)
         assert base64_data not in str(agent.current_session['messages'])

--- a/tests/unit/test_read_file_tool.py
+++ b/tests/unit/test_read_file_tool.py
@@ -111,11 +111,18 @@ class TestImageReachesVisionModel:
     browser screenshots. This locks that end-to-end contract.
     """
 
-    def test_image_output_becomes_image_url_message(self, tmp_path):
+    def test_image_output_becomes_image_url_message(self, tmp_path, monkeypatch):
         f = tmp_path / "shot.png"
         f.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-bytes")
         data_url = read_file(str(f))
         assert data_url.startswith("data:image/png;base64,")
+
+        # The formatter uploads image bytes to oo-api; stub the network call.
+        monkeypatch.setenv("OPENONION_API_KEY", "test-token")
+        uploaded_url = "https://oo.openonion.ai/img/test"
+        resp = Mock()
+        resp.json.return_value = {"url": uploaded_url}
+        monkeypatch.setattr("requests.post", Mock(return_value=resp))
 
         # Simulate the tool result sitting in a session, then run the plugin.
         agent = Mock()
@@ -137,8 +144,8 @@ class TestImageReachesVisionModel:
         image_msg = messages[1]
         assert image_msg["role"] == "user"
         image_part = next(p for p in image_msg["content"] if p["type"] == "image_url")
-        # The whole image reaches the model — not a truncated/altered blob.
-        assert image_part["image_url"]["url"] == data_url
+        # The image reaches the model via the uploaded oo-api URL.
+        assert image_part["image_url"]["url"] == uploaded_url
 
 
 class TestPdfPptx:


### PR DESCRIPTION
## What
Managed (`co/`) agents upload screenshot bytes to oo-api's `/api/v1/images` (content-addressed GCS) and reference the image by a stable `/img` URL in the message, instead of embedding the base64 data URL.

## Why
The base64 payload sits in `current_session["messages"]`, which is replayed to the LLM every turn and persisted in session logs / stateless continuation. A multi-step browser agent (many screenshots) blows up context size, memory, and transfer. Uploading the bytes to GCS keeps history at a ~70-byte URL. Non-managed agents (no oo-api) keep the inline data URL, so their behavior is unchanged.

## Pairs with
oo-api images routes (`POST /api/v1/images`, `GET /img/{sha}`) + per-provider materialization (`forward_to_gemini` inlines the URL for Gemini, which can't fetch remote URLs). The oo-api side is already deployed.

## Notes
- Upload-only; the 3-screenshot sliding window (hosted-agents) is a separate concern, not included here.
- Fails loudly on upload error (managed agents already depend on oo-api for LLM calls).

## Test
Verified end-to-end locally: `co/gemini` agent → screenshot → upload → GCS → oo-api inline → real Gemini correctly read the image; the session held the `/img` URL, not base64.

## Follow-up (77baaef, review by Aaron)
- Hoisted the managed/non-managed branch into `_format_image_result` — the two paths are visible at the call site; helper renamed `_upload_to_oo_api` (it only uploads now; the old `_upload_image` name lied on the non-managed path)
- Removed defensive `getattr(agent, "llm", None)`; the test `FakeAgent` now has an `llm` like real Agents
- Added a unit test for the managed upload path (endpoint, Bearer auth, URL in message + io, no base64 left in history)
- Updated `docs/useful_plugins/image_result_formatter.md`: How It Works covers the oo-api upload; `send_image` documented as URL-or-data-URL
