### PR TITLE
network: agent discovery moves to /api/agents on oo-api

### DIFF
--- a/connectonion/cli/commands/sub_commands.py
+++ b/connectonion/cli/commands/sub_commands.py
@@ -3,7 +3,7 @@ Purpose: `co sub` — record a subscription relationship to a published agent, m
 LLM-Note:
   Dependencies: imports from [json, re, shutil, pathlib, httpx, rich.console, rich.table, .fanout] | imported by [cli/main.py via handle_sub_sync_one/sync_all/list/remove] | tested by [tests/unit/test_sub_commands.py, tests/cli/test_cli_sub.py]
   Data flow:
-    sync_one(target, relay?) → _resolve_target() validates 0x address or matches an alias already in subscriptions.txt → _fetch_profile() GET /api/relay/agents/<addr>/profile → _mirror_bundle() writes ~/.co/subs/<alias>/agent.json + for each skill GET /api/relay/agents/<addr>/skills/<name> → unwrap body (handles both JSON {body:...} and raw text/markdown content-types) → write SKILL.md → append `<address> <alias>` to ~/.co/subscriptions.txt (deduped) → fanout.install_all() symlinks/copies into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor, ~/.kiro
+    sync_one(target, relay?) → _resolve_target() validates 0x address or matches an alias already in subscriptions.txt → _fetch_profile() GET /api/agents/<addr>/profile → _mirror_bundle() writes ~/.co/subs/<alias>/agent.json + for each skill GET /api/agents/<addr>/skills/<name> → unwrap body (handles both JSON {body:...} and raw text/markdown content-types) → write SKILL.md → append `<address> <alias>` to ~/.co/subscriptions.txt (deduped) → fanout.install_all() symlinks/copies into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor, ~/.kiro
     sync_all(relay?) → walks ~/.co/subscriptions.txt, calls sync_one per entry, tolerates per-publisher failures, prints summary (ok/failed counts)
     list() → reads ~/.co/subscriptions.txt + ~/.co/subs/<alias>/agent.json → Rich table with alias, full address, version, skill count
     remove(target) → match by address or alias → fanout.uninstall_all() drops every per-tool install → rmtree ~/.co/subs/<alias>/ → rewrite subscriptions.txt without the line
@@ -17,8 +17,8 @@ Subscription persistence:
   Matches ~/.co/contacts.txt / whitelist.txt / blocklist.txt shape.
 
 Relay endpoints consumed (v1):
-  GET /api/relay/agents/{address}/profile       - {profile: {alias, bio, version, skills:[{name, description}, ...]}}
-  GET /api/relay/agents/{address}/skills/{name} - JSON {body: "..."} or raw markdown depending on Content-Type
+  GET /api/agents/{address}/profile       - {profile: {alias, bio, version, skills:[{name, description}, ...]}}
+  GET /api/agents/{address}/skills/{name} - JSON {body: "..."} or raw markdown depending on Content-Type
 
 ⚠️ v1 trusts the relay — no Ed25519 signature verification (relay strips signer/signature from profile responses).
 ⚠️ No alias→address resolver on relay — aliases are dangerous (mutable), so first-time subs require 0x address.
@@ -78,7 +78,7 @@ def _write_subs(subs: list[tuple[str, str]]) -> None:
 
 
 def _fetch_profile(address: str, relay: str) -> dict:
-    r = httpx.get(f"{relay}/api/relay/agents/{address}/profile", timeout=30)
+    r = httpx.get(f"{relay}/api/agents/{address}/profile", timeout=30)
     r.raise_for_status()
     data = r.json()
     # Relay wraps in {"profile": {...}} for this endpoint
@@ -86,7 +86,7 @@ def _fetch_profile(address: str, relay: str) -> dict:
 
 
 def _fetch_skill(address: str, name: str, relay: str) -> str:
-    r = httpx.get(f"{relay}/api/relay/agents/{address}/skills/{name}", timeout=30)
+    r = httpx.get(f"{relay}/api/agents/{address}/skills/{name}", timeout=30)
     r.raise_for_status()
     return r.json()["body"]
 

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -3,7 +3,7 @@ Purpose: Client SDK for talking to remote ConnectOnion agents over websockets �
 LLM-Note:
   Dependencies: imports from [asyncio, json, time, uuid, dataclasses, typing, httpx, websockets (lazy), .. address (sign)] | imported by [network/__init__.py (re-exports connect, RemoteAgent, Response), connectonion/__init__.py (top-level re-export)] | tested by [tests/network/test_connect.py, tests/integration/test_remote_agent.py]
   Data flow: connect(address, keys, relay_url) → RemoteAgent → .input(prompt) opens ws → CONNECT (signed payload {to, timestamp, optional session}) → CONNECTED {session_id} → INPUT {input_id, prompt, optional images/files} → streams (tool_call, tool_result, thinking, assistant, ask_user, ONBOARD_REQUIRED/SUCCESS) → OUTPUT {result, session} → returns Response(text, done)
-  State/Effects: mutates self._current_session, self._ui_events, self._status; opens outbound websocket connection; performs signed payloads via address.sign(keys, canonical_json) when keys provided; resolve_endpoint() makes httpx GETs to relay /api/relay/agents/{addr} and /info on each candidate to pick localhost/LAN/public WS endpoint (cached after first attempt)
+  State/Effects: mutates self._current_session, self._ui_events, self._status; opens outbound websocket connection; performs signed payloads via address.sign(keys, canonical_json) when keys provided; resolve_endpoint() makes httpx GETs to relay /api/agents/{addr} and /info on each candidate to pick localhost/LAN/public WS endpoint (cached after first attempt)
   Integration: exposes connect(address, keys=None, relay_url="wss://oo.openonion.ai") -> RemoteAgent | RemoteAgent.input/input_async/reset, .status, .current_session, .ui properties | Response dataclass(text, done) | resolve_endpoint(agent_address, relay_url, timeout=3.0) helper
   Performance: endpoint resolution attempted once per RemoteAgent (cached in _endpoint_resolved/_resolved_endpoint) | per-recv asyncio.wait_for to avoid hangs (default timeout=60s, 30s for CONNECTED) | sync .input() rejected inside running event loop (use input_async)
   Errors: raises ConnectionError on auth/agent ERROR frames | TimeoutError on ws recv timeout | RuntimeError if .input() called from async context | ValueError when interactive onboard prompt yields no credentials
@@ -70,7 +70,7 @@ async def resolve_endpoint(
     async with httpx.AsyncClient(timeout=timeout) as client:
         # Step 1: Query relay for agent info
         try:
-            response = await client.get(f"{https_relay}/api/relay/agents/{agent_address}")
+            response = await client.get(f"{https_relay}/api/agents/{agent_address}")
             if response.status_code != 200:
                 return None
             agent_info = response.json()

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -502,7 +502,7 @@ co sub remove changxing      # unsubscribe (by alias or address)
 ```
 
 **What `co sub sync <addr>` does:**
-1. `GET /api/relay/agents/<addr>/profile` → write `~/.co/subs/<alias>/agent.json`
+1. `GET /api/agents/<addr>/profile` → write `~/.co/subs/<alias>/agent.json`
 2. Pull each `SKILL.md` body → `~/.co/subs/<alias>/skills/<name>/`
 3. Append `<address> <alias>` to `~/.co/subscriptions.txt` (deduped)
 4. Symlink/copy into every detected `~/.<tool>/` directory

--- a/docs/network/connect.md
+++ b/docs/network/connect.md
@@ -150,7 +150,7 @@ The SDKs do **not** automatically probe endpoints yet; they use relay by default
 To implement smarter routing:
 1. **Lookup endpoints** for the agent via relay:
    - **WebSocket** `/ws/lookup` with `GET_AGENT`
-   - **HTTP** `/api/relay/agents/{address}`
+   - **HTTP** `/api/agents/{address}`
 2. **Try direct endpoints first** (if any):
    - Prefer `ws://`/`http://` endpoints that are reachable from your network.
    - If you are on the same LAN, a private IP (RFC1918) endpoint may be fastest.
@@ -185,7 +185,7 @@ so clients can automatically pick the best direct path.
 #### Lookup via HTTP
 
 ```bash
-curl https://oo.openonion.ai/api/relay/agents/0x3d4017c3...
+curl https://oo.openonion.ai/api/agents/0x3d4017c3...
 ```
 
 ```json


### PR DESCRIPTION
oo-api renamed its directory REST endpoints — they read the agent directory (registry + presence) and relay nothing, so they moved off the misleading `/api/relay` prefix (openonion/oo-api#22, which keeps the old paths as hidden aliases until published clients rotate).

This switches the SDK's callers to the canonical paths:

- `resolve_endpoint` (`connectonion/network/connect.py`): `GET /api/agents/{address}`
- `co sub` (`connectonion/cli/commands/sub_commands.py`): `GET /api/agents/{address}/profile`, `GET /api/agents/{address}/skills/{name}`
- docs updated to match

String-only change. Ordering: the public relay deploys oo-api#22 before this releases; against a stale server the endpoint lookup 404s and `resolve_endpoint` degrades to the relay path by existing contract (`co sub` fails visibly).