### PR TITLE
feat(events): add before_user_input hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ builtin/skill-name/SKILL.md         # Built-in
 
 Automatically loads Claude Code skills from `.claude/skills/` — no conversion needed.
 
-### 12 Lifecycle Hooks + Plugin System
+### 13 Lifecycle Hooks + Plugin System
 
 Inject logic at any point in the agent execution cycle:
 
@@ -164,7 +164,7 @@ agent = Agent("researcher", tools=[search], plugins=[
 
 These plugins mirror Claude Code's internal capabilities — `auto_compact`, `subagents`, `ulw` directly correspond to Claude Code's context compression, sub-agent spawning, and autonomous work mode. ConnectOnion makes these capabilities available to any agent you build.
 
-Hooks: `after_user_input`, `before_iteration`, `before_llm`, `after_llm`, `before_tools`, `before_each_tool`, `after_each_tool`, `after_tools`, `on_error`, `after_iteration`, `on_stop_signal`, `on_complete`
+Hooks: `before_user_input`, `after_user_input`, `before_iteration`, `before_llm`, `after_llm`, `before_tools`, `before_each_tool`, `after_each_tool`, `after_tools`, `on_error`, `after_iteration`, `on_stop_signal`, `on_complete`
 
 Plugins are just lists of event handlers — visible, modifiable, `co copy`-able.
 
@@ -898,7 +898,7 @@ ConnectOnion is a simple, elegant framework for production-ready AI agents. Phil
 | Ready-to-Use Tools | Import without schema writing |
 | Approval System | Dangerous ops auto-trigger approval |
 | Skills System | Claude Code compatible, auto-discovery |
-| 12 Lifecycle Hooks | Inject logic at any point |
+| 13 Lifecycle Hooks | Inject logic at any point |
 | Plugin System | re_act, auto_compact, subagents, ulw |
 | Multi-Agent Trust | Fast rules, zero token cost |
 
@@ -933,7 +933,7 @@ Project → User → Built-in levels. Automatically loads Claude Code skills fro
 
 ### Lifecycle Hooks
 
-after_user_input, before_iteration, before_llm, after_llm, before_tools, after_tools, on_error, after_iteration, on_stop_signal, on_complete
+before_user_input, after_user_input, before_iteration, before_llm, after_llm, before_tools, before_each_tool, after_each_tool, after_tools, on_error, after_iteration, on_stop_signal, on_complete
 
 ### Trust System Presets
 

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -35,6 +35,7 @@ else:
 from .core import Agent, LLM, create_tool_from_function
 from .core import (
     on_agent_ready,
+    before_user_input,
     after_user_input,
     before_iteration,
     after_iteration,
@@ -122,6 +123,7 @@ __all__ = [
     "address",
     # Event decorators
     "on_agent_ready",
+    "before_user_input",
     "after_user_input",
     "before_iteration",
     "after_iteration",

--- a/connectonion/core/__init__.py
+++ b/connectonion/core/__init__.py
@@ -22,6 +22,7 @@ from .llm import LLM, create_llm, TokenUsage
 from .events import (
     EventHandler,
     on_agent_ready,
+    before_user_input,
     after_user_input,
     before_iteration,
     after_iteration,
@@ -47,6 +48,7 @@ __all__ = [
     "TokenUsage",
     "EventHandler",
     "on_agent_ready",
+    "before_user_input",
     "after_user_input",
     "before_iteration",
     "after_iteration",

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -77,6 +77,7 @@ class Agent:
         # before_tools/after_tools fire ONCE per batch (safe for adding messages)
         self.events = {
             'on_agent_ready': [],      # Fires once during initialization when agent is ready
+            'before_user_input': [],
             'after_user_input': [],
             'before_iteration': [],    # Start of each iteration (poll IO, mode changes)
             'after_iteration': [],     # End of each iteration (metrics, checkpoints)
@@ -292,6 +293,12 @@ class Agent:
             file_list = "\n".join(f"- {p}" for p in saved_files)
             prompt += f"\n\n<system-reminder>The user uploaded the following files:\n{file_list}\nUse your read_file tool or other available tools to read the file contents before responding. Do not assume or guess the contents.</system-reminder>"
 
+        self.current_session['user_prompt'] = prompt  # Store user prompt for xray/debugging
+
+        # Invoke before_user_input events before appending the user message.
+        # Exceptions propagate so invalid input fails fast without mutating messages.
+        self._invoke_events('before_user_input')
+
         # Add user message to conversation (multimodal if images provided)
         if images:
             content = [{"type": "text", "text": prompt}]
@@ -303,7 +310,6 @@ class Agent:
 
         # Track this turn
         self.current_session['turn'] += 1
-        self.current_session['user_prompt'] = prompt  # Store user prompt for xray/debugging
         turn_start = time.time()
 
         # Record trace entry (also streams to io if connected)

--- a/connectonion/core/events.py
+++ b/connectonion/core/events.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: None (standalone module) | imported by [agent.py, __init__.py] | tested by [tests/test_events.py]
   Data flow: Wrapper functions tag event handlers with _event_type attribute → Agent organizes handlers by type → Agent invokes handlers at specific lifecycle points passing agent instance
   State/Effects: Event handlers receive agent instance and can modify agent.current_session (messages, trace, etc.)
-  Integration: exposes on_agent_ready(), after_user_input(), before_iteration(), after_iteration(), before_llm(), after_llm(), before_each_tool(), before_tools(), after_each_tool(), after_tools(), on_error(), on_complete(), on_stop_signal()
+  Integration: exposes on_agent_ready(), before_user_input(), after_user_input(), before_iteration(), after_iteration(), before_llm(), after_llm(), before_each_tool(), before_tools(), after_each_tool(), after_tools(), on_error(), on_complete(), on_stop_signal()
   Performance: Minimal overhead - just function attribute checking and iteration over handler lists
   Errors: Event handler exceptions propagate and stop agent execution (fail fast)
 """
@@ -16,6 +16,27 @@ if TYPE_CHECKING:
 
 # Event handler type: function that takes Agent and returns None
 EventHandler = Callable[['Agent'], None]
+
+
+def before_user_input(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]:
+    """
+    Mark function(s) as before_user_input event handlers.
+
+    Fires once per turn, after user_prompt is set and before user input is added to session.
+    Use for: input validation, turn setup, rejecting invalid input.
+
+    Supports both decorator and wrapper syntax:
+        # As decorator
+        @before_user_input
+        def validate_input(agent):
+            ...
+
+        # As wrapper (single or multiple)
+        on_events=[before_user_input(handler1, handler2)]
+    """
+    for fn in funcs:
+        fn._event_type = 'before_user_input'  # type: ignore
+    return funcs[0] if len(funcs) == 1 else list(funcs)
 
 
 def after_user_input(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]:

--- a/docs/concepts/events.md
+++ b/docs/concepts/events.md
@@ -63,6 +63,7 @@ agent = Agent(
 
 | Event              | When It Runs                   | Fires              | Use For                                                |
 | ------------------ | ------------------------------ | ------------------ | ------------------------------------------------------ |
+| `before_user_input` | Before user input is appended  | Once per turn      | Validate, reject, or prepare state before message add  |
 | `after_user_input` | After user provides input      | Once per turn      | Add context, timestamps, initialize turn state         |
 | `before_iteration` | Before each iteration starts   | Once per iteration | Poll IO, check mode changes, setup                     |
 | `before_llm`       | Before each LLM call           | Multiple per turn  | Modify messages for each LLM call                      |
@@ -90,6 +91,8 @@ agent = Agent(
 
 ```
 TURN START
+│
+├─ before_user_input
 │
 ├─ after_user_input
 │
@@ -236,7 +239,7 @@ agent = Agent(
 
 ### Add Context Once Per Turn
 
-Use `after_user_input` to add context that should only be set once per turn:
+Use `before_user_input` to validate or prepare state before the user message is appended. Use `after_user_input` to add context that should only be set once per turn:
 
 ```python
 from connectonion import Agent, after_user_input

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -1061,6 +1061,7 @@ host(agent)
 ```
 
 Available events:
+- `before_user_input` - Before user input is added to the session
 - `after_user_input` - After receiving input
 - `before_llm` - Before each LLM call
 - `after_llm` - After each LLM call

--- a/tests/unit/test_additional_modules.py
+++ b/tests/unit/test_additional_modules.py
@@ -13,6 +13,7 @@ Components under test:
 from pathlib import Path
 
 import connectonion.core.events as events
+import connectonion
 import importlib
 
 host_server = importlib.import_module("connectonion.network.host.server")
@@ -31,6 +32,9 @@ def test_event_decorators_tag_function():
 
     events.after_user_input(fn)
     assert getattr(fn, "_event_type", None) == "after_user_input"
+    events.before_user_input(fn)
+    assert getattr(fn, "_event_type", None) == "before_user_input"
+    assert connectonion.before_user_input is events.before_user_input
 
 
 def test_parse_trust_config_inline():

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -13,7 +13,7 @@ Components under test:
 
 import pytest
 from unittest.mock import Mock
-from connectonion import Agent, after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete, on_stop_signal
+from connectonion import Agent, before_user_input, after_user_input, before_llm, after_llm, before_each_tool, before_tools, after_each_tool, after_tools, on_error, on_complete, on_stop_signal
 from connectonion.core.llm import LLMResponse, ToolCall
 from connectonion.core.usage import TokenUsage
 
@@ -73,6 +73,35 @@ def failing_tool(query: str) -> str:
 class TestEventSystem:
     """Test event system functionality"""
 
+    def test_before_user_input_fires_before_after_user_input(self):
+        """Test before_user_input fires before the user message is appended."""
+        calls = []
+
+        def track_before(agent):
+            calls.append('before_user_input')
+            assert agent.current_session['user_prompt'] == "test prompt"
+            assert [m["role"] for m in agent.current_session['messages']] == ["system"]
+
+        def track_after(agent):
+            calls.append('after_user_input')
+            assert agent.current_session['messages'][-1] == {
+                "role": "user",
+                "content": "test prompt",
+            }
+
+        agent = Agent(
+            "test",
+            model="gpt-4o-mini",
+            on_events=[
+                before_user_input(track_before),
+                after_user_input(track_after),
+            ]
+        )
+
+        agent.input("test prompt")
+
+        assert calls == ['before_user_input', 'after_user_input']
+
     def test_after_user_input_fires_once(self):
         """Test after_user_input fires once per turn"""
         calls = []
@@ -92,6 +121,27 @@ class TestEventSystem:
 
         # Should fire exactly once per turn
         assert calls == ['after_user_input']
+
+    def test_before_user_input_exception_prevents_user_message_append(self):
+        """Test before_user_input fails fast before appending user message."""
+
+        def reject_input(agent):
+            assert agent.current_session['user_prompt'] == "blocked"
+            raise RuntimeError("blocked input")
+
+        agent = Agent(
+            "test",
+            model="gpt-4o-mini",
+            on_events=[before_user_input(reject_input)]
+        )
+
+        with pytest.raises(RuntimeError, match="blocked input"):
+            agent.input("blocked")
+
+        assert agent.current_session['messages'] == [
+            {"role": "system", "content": agent.system_prompt}
+        ]
+
 
     def test_before_llm_fires_multiple_times(self):
         """Test before_llm fires before each LLM call"""
@@ -367,6 +417,7 @@ class TestEventSystem:
         def handler(agent):
             pass
 
+        assert before_user_input(handler)._event_type == 'before_user_input'
         assert after_user_input(handler)._event_type == 'after_user_input'
         assert before_llm(handler)._event_type == 'before_llm'
         assert after_llm(handler)._event_type == 'after_llm'
@@ -551,6 +602,10 @@ class TestNewEventSyntax:
     def test_decorator_syntax_all_event_types(self):
         """Test decorator syntax works for all event types"""
 
+        @before_user_input
+        def handler0(agent):
+            pass
+
         @after_user_input
         def handler1(agent):
             pass
@@ -589,6 +644,7 @@ class TestNewEventSyntax:
         assert callable(handler7)
 
         # All should have correct _event_type
+        assert handler0._event_type == 'before_user_input'
         assert handler1._event_type == 'after_user_input'
         assert handler2._event_type == 'before_llm'
         assert handler3._event_type == 'after_llm'


### PR DESCRIPTION
## Description
  Add a `before_user_input` lifecycle hook that runs after `user_prompt` is set and before the user message is appended to the session. This lets validation handlers fail fast without mutating session messages.

  ## Related Issue
  Closes #104

  ## Type of Change
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update

  ## Changes Made
  - Added the `before_user_input` lifecycle hook and event registration.
  - Exported `before_user_input` from core and top-level package APIs.
  - Added tests for hook ordering, fail-fast behavior, and public exports.
  - Updated lifecycle hook documentation.

  ## Testing
  - [x] I have tested this code locally
  - [x] All existing tests pass
  - [x] I have added tests for new functionality

  ```bash
  .venv/bin/python -m pytest tests/unit/test_agent.py tests/unit/test_events.py tests/unit/test_additional_modules.py tests/unit/test_docs.py -q
  .venv/bin/python -m py_compile connectonion/core/events.py connectonion/core/agent.py connectonion/core/__init__.py connectonion/__init__.py tests/unit/test_events.py tests/unit/test_additional_modules.py

  ## Example Usage

  from connectonion import Agent, before_user_input

  def validate_input(agent):
      if not agent.current_session["user_prompt"].strip():
          raise ValueError("User input cannot be empty")

  agent = Agent("assistant", on_events=[before_user_input(validate_input)])

  ## Checklist

  - [x] My code follows the project's code style
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [x] New and existing unit tests pass locally
  - [x] Any dependent changes have been merged and published

  ## Screenshots (if applicable)

  N/A

  ## Additional Notes

  N/A