### PR TITLE
Add 'co outlook' CLI command for Outlook email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to ConnectOnion will be documented in this file.
 
 ### 🎉 Major Features
 
+#### `co outlook` - Outlook Email from the Terminal
+- **NEW**: `co outlook` command group — send and read your Outlook account via Microsoft Graph (requires `co auth microsoft` with Mail scopes; `MICROSOFT_*` in `.env` / `~/.co/keys.env`)
+- **`co outlook` / `co outlook inbox -n 10 -u`**: numbered inbox table; numbering is cached so `co outlook read 3` works later (full Graph message IDs also accepted)
+- **`co outlook read <#>`**: prints the full body and marks the email read
+- **`co outlook send <to> <subject> <message>`**: with `--cc`, `--bcc`, repeatable `--attach FILE` (screenshots, PDFs — ~3MB Graph limit), and `--at` for scheduling (`+30m`, `+2h`, or UTC ISO like `2026-07-06T15:30:00Z`); a message of `-` reads the body from stdin (`co outlook send a@b.com "Subject" - < body.txt`)
+- **`co outlook sent`** / **`co outlook search <query>`**: list sent mail and search subject/body
+- **Outlook tool**: `send()` gains `attachments=[...]` and `send_at="..."` (deferred send — Exchange holds delivery, works with just `Mail.Send`); new `list_inbox()` returns email dicts for programmatic use
+
 #### FileTools Refactor - Claude Code-style File Operations
 - **NEW**: `FileTools` class with read-before-edit tracking and permission control
 - **Read-Before-Edit Validation**: Prevents edits without prior file reads

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -34,12 +34,13 @@ def _outlook():
     return Outlook()
 
 
-def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None):
+def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None,
+                        attachments: list = None):
     """Send an email from the connected Outlook account."""
     outlook = _outlook()
     if not outlook:
         return
-    result = outlook.send(to, subject, message, cc=cc, bcc=bcc)
+    result = outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments)
     console.print(f"\n[green]✓[/green] {result}")
     console.print(f"  From: {os.getenv('MICROSOFT_EMAIL', '')}\n")
 

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -1,19 +1,24 @@
 """
 Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent), read, and search email from the terminal
 LLM-Note:
-  Dependencies: imports from [os, pathlib, dotenv, rich.console, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance → each handler calls one Outlook method → prints the tool's formatted string
-  State/Effects: no local state | network calls happen inside the Outlook tool | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
-  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_sent(), handle_outlook_search() for cli/main.py | thin presentation layer — all Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
-  Errors: prints a 'run co auth microsoft' hint when MICROSOFT_* credentials are missing | Graph API errors propagate from the Outlook tool
+  Dependencies: imports from [os, sys, json, pathlib, dotenv, rich.console, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
+  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance | inbox: list_inbox() → Rich table numbered 1..N → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read: resolves short numbers via that cache (falls back to a fresh list_inbox) → get_email_body() → mark_read() | send: '-' body reads stdin → send() → '✓ Sent' confirmation
+  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map) | network calls happen inside the Outlook tool | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_sent(), handle_outlook_search() for cli/main.py | presentation mirrors email_commands.py (same table shape, ● unread mark, '✓ Sent' wording) | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
+  Errors: prints a 'run co auth microsoft' hint when MICROSOFT_* credentials or Mail scopes are missing | Graph API errors propagate from the Outlook tool
 """
 
+import json
 import os
+import sys
 from pathlib import Path
 
 from rich.console import Console
+from rich.table import Table
 
 console = Console()
+
+INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 
 
 def _outlook():
@@ -24,7 +29,7 @@ def _outlook():
         if env_path.exists():
             load_dotenv(env_path)
 
-    if not os.getenv("MICROSOFT_ACCESS_TOKEN"):
+    if not os.getenv("MICROSOFT_ACCESS_TOKEN") or "Mail" not in os.getenv("MICROSOFT_SCOPES", ""):
         console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
         console.print("\n[cyan]Connect Outlook first:[/cyan]")
         console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")
@@ -36,34 +41,84 @@ def _outlook():
 
 def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None,
                         attachments: list = None):
-    """Send an email from the connected Outlook account."""
+    """Send an email from the connected Outlook account. A message of '-' reads the body from stdin."""
+    if message == "-":
+        message = sys.stdin.read()
+
     outlook = _outlook()
     if not outlook:
         return
-    result = outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments)
-    console.print(f"\n[green]✓[/green] {result}")
-    console.print(f"  From: {os.getenv('MICROSOFT_EMAIL', '')}\n")
+    outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments)
+
+    console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
+    console.print(f"  From: {os.getenv('MICROSOFT_EMAIL', '')}")
+    if attachments:
+        names = ", ".join(Path(p).name for p in attachments)
+        console.print(f"  Attached: {names}")
+    console.print()
 
 
 def handle_outlook_inbox(last: int = 10, unread: bool = False):
-    """List recent emails in the Outlook inbox."""
+    """List recent Outlook inbox emails as a numbered table, and remember the numbering for 'read'."""
     outlook = _outlook()
     if not outlook:
         return
-    console.print(f"\n📬 [bold cyan]Outlook inbox[/bold cyan] [dim]({os.getenv('MICROSOFT_EMAIL', '')})[/dim]\n")
-    console.print(outlook.read_inbox(last=last, unread=unread))
-    console.print("\n[dim]Read one with:[/dim] [bold]co outlook read <ID>[/bold]\n")
+
+    emails = outlook.list_inbox(last=last, unread=unread)
+    if not emails:
+        scope = "unread " if unread else ""
+        console.print(f"\n[cyan]Outlook inbox:[/cyan] no {scope}emails\n")
+        return
+
+    table = Table(title=f"📬 Outlook — {os.getenv('MICROSOFT_EMAIL', '')}", show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("From")
+    table.add_column("Subject")
+    table.add_column("Received")
+
+    for i, email in enumerate(emails, 1):
+        unread_mark = "[bold green]●[/bold green] " if email["unread"] else ""
+        table.add_row(str(i), email["from"], f"{unread_mark}{email['subject']}", str(email["date"])[:19])
+
+    INBOX_CACHE.parent.mkdir(exist_ok=True)
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Read one with:[/dim] [bold]co outlook read <#>[/bold]\n")
+
+
+def _resolve_email_id(outlook, email_id: str) -> str:
+    """Turn a short inbox number into a Graph message id; full ids pass through."""
+    if not (email_id.isdigit() and len(email_id) < 5):
+        return email_id
+
+    if INBOX_CACHE.exists():
+        cached = json.loads(INBOX_CACHE.read_text()).get(email_id)
+        if cached:
+            return cached
+
+    emails = outlook.list_inbox(last=int(email_id))
+    if len(emails) < int(email_id):
+        return ""
+    return emails[int(email_id) - 1]["id"]
 
 
 def handle_outlook_read(email_id: str):
-    """Show one Outlook email's full body and mark it read."""
+    """Show one Outlook email's full body and mark it read. Accepts the inbox # or a full message id."""
     outlook = _outlook()
     if not outlook:
         return
+
+    resolved = _resolve_email_id(outlook, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your inbox.[/yellow]\n")
+        return
+
     console.print()
-    console.print(outlook.get_email_body(email_id))
+    console.print(outlook.get_email_body(resolved))
     console.print()
-    outlook.mark_read(email_id)
+    outlook.mark_read(resolved)
 
 
 def handle_outlook_sent(last: int = 10):

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -1,11 +1,11 @@
 """
-Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent), read, and search email from the terminal
+Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent), read, reply, and search email from the terminal
 LLM-Note:
-  Dependencies: imports from [os, sys, json, pathlib, dotenv, rich.console, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance | inbox: list_inbox() → Rich table numbered 1..N → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read: resolves short numbers via that cache (falls back to a fresh list_inbox) → get_email_body() → mark_read() | send: '-' body reads stdin → send() → '✓ Sent' confirmation
-  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map) | network calls happen inside the Outlook tool | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
-  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_sent(), handle_outlook_search() for cli/main.py | presentation mirrors email_commands.py (same table shape, ● unread mark, '✓ Sent' wording) | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
-  Errors: prints a 'run co auth microsoft' hint when MICROSOFT_* credentials or Mail scopes are missing | Graph API errors propagate from the Outlook tool
+  Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
+  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin, attachments prechecked, --at validated to UTC ISO → send()
+  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map; "numbers mean your last listing") | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_reply(), handle_outlook_sent(), handle_outlook_search() for cli/main.py | presentation mirrors email_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
+  Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, missing/oversized attachments, invalid --at, unresolvable email # | Graph API errors propagate from the Outlook tool
 """
 
 import json
@@ -13,16 +13,20 @@ import os
 import sys
 from pathlib import Path
 
+import typer
 from rich.console import Console
+from rich.panel import Panel
 from rich.table import Table
 
 console = Console()
 
 INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 
+ATTACHMENT_LIMIT = 3_000_000  # Graph sendMail rejects larger payloads
+
 
 def _outlook():
-    """Load MICROSOFT_* credentials from .env files and return an Outlook instance, or None with a hint."""
+    """Load MICROSOFT_* credentials from .env files and return an Outlook instance. Exits 1 with a hint if not connected."""
     from dotenv import load_dotenv
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
@@ -33,24 +37,82 @@ def _outlook():
         console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
         console.print("\n[cyan]Connect Outlook first:[/cyan]")
         console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")
-        return None
+        raise typer.Exit(1)
 
     from ...useful_tools.outlook import Outlook
     return Outlook()
 
 
-def _parse_send_at(at: str) -> str:
-    """Turn '+30m' / '+2h' into a UTC ISO timestamp; ISO strings pass through."""
-    if not at.startswith("+"):
-        return at
+def _when(iso: str) -> str:
+    """Render a Graph UTC timestamp as short local time, e.g. 'Jul 06 15:23'."""
+    from datetime import datetime
 
+    return datetime.fromisoformat(str(iso).replace("Z", "+00:00")).astimezone().strftime("%b %d %H:%M")
+
+
+def _print_listing(outlook, emails: list, title: str):
+    """Render emails as a numbered table (or plain ID-bearing text when piped) and cache the numbering for read/reply."""
+    INBOX_CACHE.parent.mkdir(exist_ok=True)
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}))
+
+    if not console.is_terminal:
+        # Scripts and agents get the untruncated format with full message ids.
+        console.print(outlook._format_dicts(emails), markup=False, highlight=False)
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("From", max_width=28, no_wrap=True)
+    table.add_column("Subject", overflow="ellipsis", no_wrap=True)
+    table.add_column("Received")
+
+    for i, email in enumerate(emails, 1):
+        unread_mark = "[bold green]●[/bold green] " if email["unread"] else ""
+        sender = email.get("from_name") or email["from"]
+        table.add_row(str(i), sender, f"{unread_mark}{email['subject']}", _when(email["date"]))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Read one with:[/dim] [bold]co outlook read <#>[/bold]\n")
+
+
+def _parse_send_at(at: str) -> str:
+    """Turn '+30m' / '+2h' into a UTC ISO timestamp; validate ISO strings. Exits 1 on bad input."""
     from datetime import datetime, timedelta, timezone
 
-    unit = at[-1]
-    if unit not in ("m", "h") or not at[1:-1].isdigit():
-        raise ValueError(f"Invalid --at value: {at} (use +30m, +2h, or a UTC ISO time)")
-    delta = timedelta(**{{"m": "minutes", "h": "hours"}[unit]: int(at[1:-1])})
-    return (datetime.now(timezone.utc) + delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+    def bad():
+        console.print(f"\n❌ [bold red]Invalid --at value:[/bold red] {at}")
+        console.print("   Use [bold]+30m[/bold], [bold]+2h[/bold], or UTC ISO like [bold]2026-07-06T15:30:00Z[/bold]\n")
+        raise typer.Exit(1)
+
+    if at.startswith("+"):
+        n, unit = at[1:-1], at[-1]
+        if unit not in ("m", "h") or not (n.isascii() and n.isdigit()):
+            bad()
+        delta = timedelta(**{{"m": "minutes", "h": "hours"}[unit]: int(n)})
+        return (datetime.now(timezone.utc) + delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    try:
+        parsed = datetime.fromisoformat(at.replace("Z", "+00:00"))
+    except ValueError:
+        bad()
+    if parsed.tzinfo is None:
+        # Exchange reads the deferred-send time as UTC; a naive local time
+        # would silently go out hours off target.
+        bad()
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _check_attachments(attachments: list):
+    """Precheck attachment paths before base64-encoding megabytes. Exits 1 on bad input."""
+    paths = [Path(p).expanduser() for p in attachments]
+    for given, path in zip(attachments, paths):
+        if not path.is_file():
+            console.print(f"\n❌ [bold red]Attachment not found:[/bold red] {given}\n")
+            raise typer.Exit(1)
+    if sum(p.stat().st_size for p in paths) > ATTACHMENT_LIMIT:
+        console.print("\n❌ [bold red]Attachments exceed Outlook's 3MB send limit.[/bold red]\n")
+        raise typer.Exit(1)
 
 
 def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None,
@@ -59,10 +121,10 @@ def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc
     if message == "-":
         message = sys.stdin.read()
     send_at = _parse_send_at(at) if at else None
+    if attachments:
+        _check_attachments(attachments)
 
     outlook = _outlook()
-    if not outlook:
-        return
     outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments, send_at=send_at)
 
     if send_at:
@@ -79,42 +141,28 @@ def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc
 def handle_outlook_inbox(last: int = 10, unread: bool = False):
     """List recent Outlook inbox emails as a numbered table, and remember the numbering for 'read'."""
     outlook = _outlook()
-    if not outlook:
-        return
-
     emails = outlook.list_inbox(last=last, unread=unread)
     if not emails:
         scope = "unread " if unread else ""
         console.print(f"\n[cyan]Outlook inbox:[/cyan] no {scope}emails\n")
         return
-
-    table = Table(title=f"📬 Outlook — {os.getenv('MICROSOFT_EMAIL', '')}", show_header=True, header_style="bold cyan")
-    table.add_column("#", justify="right")
-    table.add_column("From")
-    table.add_column("Subject")
-    table.add_column("Received")
-
-    for i, email in enumerate(emails, 1):
-        unread_mark = "[bold green]●[/bold green] " if email["unread"] else ""
-        table.add_row(str(i), email["from"], f"{unread_mark}{email['subject']}", str(email["date"])[:19])
-
-    INBOX_CACHE.parent.mkdir(exist_ok=True)
-    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}))
-
-    console.print()
-    console.print(table)
-    console.print("\n[dim]Read one with:[/dim] [bold]co outlook read <#>[/bold]\n")
+    _print_listing(outlook, emails, f"📬 Outlook — {os.getenv('MICROSOFT_EMAIL', '')}")
 
 
 def _resolve_email_id(outlook, email_id: str) -> str:
-    """Turn a short inbox number into a Graph message id; full ids pass through."""
-    if not (email_id.isdigit() and len(email_id) < 5):
-        return email_id
+    """Turn a listing number into a Graph message id; full ids pass through. Numbers mean the last listing shown."""
+    cached = json.loads(INBOX_CACHE.read_text()) if INBOX_CACHE.exists() else {}
+    if email_id in cached:
+        return cached[email_id]
 
-    if INBOX_CACHE.exists():
-        cached = json.loads(INBOX_CACHE.read_text()).get(email_id)
-        if cached:
-            return cached
+    if not (email_id.isascii() and email_id.isdigit() and len(email_id) < 5):
+        return email_id  # full Graph message id
+
+    if cached or int(email_id) < 1:
+        # The user is pointing at their last listing and that number wasn't in
+        # it — fetching a fresh (differently numbered) list would silently open
+        # the wrong email.
+        return ""
 
     emails = outlook.list_inbox(last=int(email_id))
     if len(emails) < int(email_id):
@@ -123,37 +171,61 @@ def _resolve_email_id(outlook, email_id: str) -> str:
 
 
 def handle_outlook_read(email_id: str):
-    """Show one Outlook email's full body and mark it read. Accepts the inbox # or a full message id."""
+    """Show one Outlook email's full body and mark it read. Accepts the listing # or a full message id."""
     outlook = _outlook()
-    if not outlook:
-        return
-
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your inbox.[/yellow]\n")
-        return
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        raise typer.Exit(1)
 
+    body = outlook.get_email_body(resolved)
+    header, _, content = body.partition("\n--- Email Body ---\n")
     console.print()
-    console.print(outlook.get_email_body(resolved))
+    console.print(Panel.fit(header.replace("From:", "[cyan]From:[/cyan]")
+                            .replace("To:", "[cyan]To:[/cyan]", 1)
+                            .replace("Subject:", "[cyan]Subject:[/cyan]")
+                            .replace("Date:", "[cyan]Date:[/cyan]"),
+                            title=f"✉️  Email {email_id}", border_style="cyan"))
     console.print()
-    outlook.mark_read(resolved)
+    console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
+
+    marked = ""
+    if "Mail.ReadWrite" in os.getenv("MICROSOFT_SCOPES", ""):
+        # Marking read is a mailbox write — Graph rejects it with 403 on
+        # tokens that only carry Mail.Read + Mail.Send.
+        outlook.mark_read(resolved)
+        marked = "Marked read. "
+    console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
+
+
+def handle_outlook_reply(email_id: str, message: str):
+    """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin."""
+    if message == "-":
+        message = sys.stdin.read()
+
+    outlook = _outlook()
+    resolved = _resolve_email_id(outlook, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    outlook.reply(resolved, message)
+    console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
 
 
 def handle_outlook_sent(last: int = 10):
     """List recently sent Outlook emails."""
     outlook = _outlook()
-    if not outlook:
-        return
     console.print(f"\n📤 [bold cyan]Outlook sent[/bold cyan] [dim]({os.getenv('MICROSOFT_EMAIL', '')})[/dim]\n")
-    console.print(outlook.get_sent_emails(max_results=last))
+    console.print(outlook.get_sent_emails(max_results=last), markup=False, highlight=False)
     console.print()
 
 
 def handle_outlook_search(query: str, last: int = 10):
-    """Search Outlook emails by subject and body."""
+    """Search Outlook emails and list matches with the same numbering contract as the inbox."""
     outlook = _outlook()
-    if not outlook:
+    emails = outlook.list_search(query, max_results=last)
+    if not emails:
+        console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
         return
-    console.print()
-    console.print(outlook.search_emails(query, max_results=last))
-    console.print()
+    _print_listing(outlook, emails, f"🔎 Outlook — {query}")

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -1,0 +1,85 @@
+"""
+Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent), read, and search email from the terminal
+LLM-Note:
+  Dependencies: imports from [os, pathlib, dotenv, rich.console, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
+  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance → each handler calls one Outlook method → prints the tool's formatted string
+  State/Effects: no local state | network calls happen inside the Outlook tool | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_sent(), handle_outlook_search() for cli/main.py | thin presentation layer — all Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
+  Errors: prints a 'run co auth microsoft' hint when MICROSOFT_* credentials are missing | Graph API errors propagate from the Outlook tool
+"""
+
+import os
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+
+def _outlook():
+    """Load MICROSOFT_* credentials from .env files and return an Outlook instance, or None with a hint."""
+    from dotenv import load_dotenv
+
+    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
+        if env_path.exists():
+            load_dotenv(env_path)
+
+    if not os.getenv("MICROSOFT_ACCESS_TOKEN"):
+        console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
+        console.print("\n[cyan]Connect Outlook first:[/cyan]")
+        console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")
+        return None
+
+    from ...useful_tools.outlook import Outlook
+    return Outlook()
+
+
+def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None):
+    """Send an email from the connected Outlook account."""
+    outlook = _outlook()
+    if not outlook:
+        return
+    result = outlook.send(to, subject, message, cc=cc, bcc=bcc)
+    console.print(f"\n[green]✓[/green] {result}")
+    console.print(f"  From: {os.getenv('MICROSOFT_EMAIL', '')}\n")
+
+
+def handle_outlook_inbox(last: int = 10, unread: bool = False):
+    """List recent emails in the Outlook inbox."""
+    outlook = _outlook()
+    if not outlook:
+        return
+    console.print(f"\n📬 [bold cyan]Outlook inbox[/bold cyan] [dim]({os.getenv('MICROSOFT_EMAIL', '')})[/dim]\n")
+    console.print(outlook.read_inbox(last=last, unread=unread))
+    console.print("\n[dim]Read one with:[/dim] [bold]co outlook read <ID>[/bold]\n")
+
+
+def handle_outlook_read(email_id: str):
+    """Show one Outlook email's full body and mark it read."""
+    outlook = _outlook()
+    if not outlook:
+        return
+    console.print()
+    console.print(outlook.get_email_body(email_id))
+    console.print()
+    outlook.mark_read(email_id)
+
+
+def handle_outlook_sent(last: int = 10):
+    """List recently sent Outlook emails."""
+    outlook = _outlook()
+    if not outlook:
+        return
+    console.print(f"\n📤 [bold cyan]Outlook sent[/bold cyan] [dim]({os.getenv('MICROSOFT_EMAIL', '')})[/dim]\n")
+    console.print(outlook.get_sent_emails(max_results=last))
+    console.print()
+
+
+def handle_outlook_search(query: str, last: int = 10):
+    """Search Outlook emails by subject and body."""
+    outlook = _outlook()
+    if not outlook:
+        return
+    console.print()
+    console.print(outlook.search_emails(query, max_results=last))
+    console.print()

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -39,18 +39,36 @@ def _outlook():
     return Outlook()
 
 
+def _parse_send_at(at: str) -> str:
+    """Turn '+30m' / '+2h' into a UTC ISO timestamp; ISO strings pass through."""
+    if not at.startswith("+"):
+        return at
+
+    from datetime import datetime, timedelta, timezone
+
+    unit = at[-1]
+    if unit not in ("m", "h") or not at[1:-1].isdigit():
+        raise ValueError(f"Invalid --at value: {at} (use +30m, +2h, or a UTC ISO time)")
+    delta = timedelta(**{{"m": "minutes", "h": "hours"}[unit]: int(at[1:-1])})
+    return (datetime.now(timezone.utc) + delta).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def handle_outlook_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None,
-                        attachments: list = None):
+                        attachments: list = None, at: str = None):
     """Send an email from the connected Outlook account. A message of '-' reads the body from stdin."""
     if message == "-":
         message = sys.stdin.read()
+    send_at = _parse_send_at(at) if at else None
 
     outlook = _outlook()
     if not outlook:
         return
-    outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments)
+    outlook.send(to, subject, message, cc=cc, bcc=bcc, attachments=attachments, send_at=send_at)
 
-    console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
+    if send_at:
+        console.print(f"\n[green]✓ Scheduled[/green] for [bold]{send_at}[/bold] to [cyan]{to}[/cyan]")
+    else:
+        console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
     console.print(f"  From: {os.getenv('MICROSOFT_EMAIL', '')}")
     if attachments:
         names = ", ".join(Path(p).name for p in attachments)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -62,6 +62,7 @@ def _show_help():
     console.print("  [green]deploy[/green]            Deploy to ConnectOnion Cloud")
     console.print("  [green]auth[/green]              Authenticate for managed keys")
     console.print("  [green]email[/green]             Send and read agent email")
+    console.print("  [green]outlook[/green]           Send and read Outlook email (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
     console.print("  [green]status[/green]            Check account balance")
@@ -415,6 +416,67 @@ def email_upgrade(
     """Upgrade email tier — deducts the monthly price from your credits."""
     from .commands.email_commands import handle_email_upgrade
     handle_email_upgrade(tier, domain=domain, alias=alias)
+
+
+# Outlook command group. `co outlook` (no args) shows the Outlook inbox.
+# Uses the MICROSOFT_* OAuth tokens saved to .env by `co auth microsoft`.
+outlook_app = typer.Typer(help="Send and read email from your Outlook account")
+app.add_typer(outlook_app, name="outlook")
+
+
+@outlook_app.callback(invoke_without_command=True)
+def outlook_callback(ctx: typer.Context):
+    """With no subcommand, show the Outlook inbox."""
+    if ctx.invoked_subcommand is None:
+        from .commands.outlook_commands import handle_outlook_inbox
+        handle_outlook_inbox()
+
+
+@outlook_app.command("send")
+def outlook_send(
+    to: str = typer.Argument(..., help="Recipient email address (comma-separated for multiple)"),
+    subject: str = typer.Argument(..., help="Subject line"),
+    message: str = typer.Argument(..., help="Body (plain text)"),
+    cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
+    bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
+):
+    """Send an email from your Outlook account."""
+    from .commands.outlook_commands import handle_outlook_send
+    handle_outlook_send(to, subject, message, cc=cc, bcc=bcc)
+
+
+@outlook_app.command("inbox")
+def outlook_inbox(
+    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
+):
+    """List recent emails in your Outlook inbox."""
+    from .commands.outlook_commands import handle_outlook_inbox
+    handle_outlook_inbox(last=last, unread=unread)
+
+
+@outlook_app.command("read")
+def outlook_read(email_id: str = typer.Argument(..., help="Email ID from the inbox list")):
+    """Show one email's body and mark it read."""
+    from .commands.outlook_commands import handle_outlook_read
+    handle_outlook_read(email_id)
+
+
+@outlook_app.command("sent")
+def outlook_sent(last: int = typer.Option(10, "--last", "-n", help="How many emails to show")):
+    """List recently sent Outlook emails."""
+    from .commands.outlook_commands import handle_outlook_sent
+    handle_outlook_sent(last=last)
+
+
+@outlook_app.command("search")
+def outlook_search(
+    query: str = typer.Argument(..., help="Search query (matches subject and body)"),
+    last: int = typer.Option(10, "--last", "-n", help="How many results to show"),
+):
+    """Search your Outlook emails."""
+    from .commands.outlook_commands import handle_outlook_search
+    handle_outlook_search(query, last=last)
 
 
 # Subscription command group. `co sub` (no args) syncs every subscription.

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -436,7 +436,7 @@ def outlook_callback(ctx: typer.Context):
 def outlook_send(
     to: str = typer.Argument(..., help="Recipient email address (comma-separated for multiple)"),
     subject: str = typer.Argument(..., help="Subject line"),
-    message: str = typer.Argument(..., help="Body (plain text)"),
+    message: str = typer.Argument(..., help="Body (plain text, or '-' to read from stdin)"),
     cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
     bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
     attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
@@ -457,7 +457,7 @@ def outlook_inbox(
 
 
 @outlook_app.command("read")
-def outlook_read(email_id: str = typer.Argument(..., help="Email ID from the inbox list")):
+def outlook_read(email_id: str = typer.Argument(..., help="Email # from the inbox list (or a full message ID)")):
     """Show one email's body and mark it read."""
     from .commands.outlook_commands import handle_outlook_read
     handle_outlook_read(email_id)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -420,7 +420,7 @@ def email_upgrade(
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.
 # Uses the MICROSOFT_* OAuth tokens saved to .env by `co auth microsoft`.
-outlook_app = typer.Typer(help="Send and read email from your Outlook account")
+outlook_app = typer.Typer(help="Send and read email from your Outlook account. Bare 'co outlook' shows the inbox.")
 app.add_typer(outlook_app, name="outlook")
 
 
@@ -432,7 +432,9 @@ def outlook_callback(ctx: typer.Context):
         handle_outlook_inbox()
 
 
-@outlook_app.command("send")
+@outlook_app.command("send", epilog="Examples:  co outlook send a@b.com \"Hi\" \"Quick note\"  |  "
+                                    "cat body.txt | co outlook send a@b.com \"Report\" -  |  "
+                                    "co outlook send a@b.com \"Invoice\" \"Attached\" --attach invoice.pdf --at +2h")
 def outlook_send(
     to: str = typer.Argument(..., help="Recipient email address (comma-separated for multiple)"),
     subject: str = typer.Argument(..., help="Subject line"),
@@ -458,10 +460,20 @@ def outlook_inbox(
 
 
 @outlook_app.command("read")
-def outlook_read(email_id: str = typer.Argument(..., help="Email # from the inbox list (or a full message ID)")):
+def outlook_read(email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing (re-run to refresh numbers)")):
     """Show one email's body and mark it read."""
     from .commands.outlook_commands import handle_outlook_read
     handle_outlook_read(email_id)
+
+
+@outlook_app.command("reply")
+def outlook_reply(
+    email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
+    message: str = typer.Argument(..., help="Reply body (plain text, or '-' to read from stdin)"),
+):
+    """Reply to an email (threaded)."""
+    from .commands.outlook_commands import handle_outlook_reply
+    handle_outlook_reply(email_id, message)
 
 
 @outlook_app.command("sent")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -440,10 +440,11 @@ def outlook_send(
     cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
     bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
     attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
+    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z)"),
 ):
-    """Send an email from your Outlook account."""
+    """Send an email from your Outlook account, now or scheduled with --at."""
     from .commands.outlook_commands import handle_outlook_send
-    handle_outlook_send(to, subject, message, cc=cc, bcc=bcc, attachments=attach)
+    handle_outlook_send(to, subject, message, cc=cc, bcc=bcc, attachments=attach, at=at)
 
 
 @outlook_app.command("inbox")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -439,10 +439,11 @@ def outlook_send(
     message: str = typer.Argument(..., help="Body (plain text)"),
     cc: Optional[str] = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
     bcc: Optional[str] = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
+    attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
 ):
     """Send an email from your Outlook account."""
     from .commands.outlook_commands import handle_outlook_send
-    handle_outlook_send(to, subject, message, cc=cc, bcc=bcc)
+    handle_outlook_send(to, subject, message, cc=cc, bcc=bcc, attachments=attach)
 
 
 @outlook_app.command("inbox")

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -176,22 +176,22 @@ class Outlook:
             return {}
         return response.json()
 
-    def _format_emails(self, messages: list, max_results: int = 10) -> str:
-        """Helper to format email list."""
-        if not messages:
-            return "No emails found."
+    def _email_dicts(self, messages: list) -> list:
+        """Convert raw Graph messages into plain email dicts."""
+        return [{
+            'id': msg['id'],
+            'from': msg.get('from', {}).get('emailAddress', {}).get('address', 'Unknown'),
+            'from_name': msg.get('from', {}).get('emailAddress', {}).get('name', ''),
+            'subject': msg.get('subject', 'No Subject'),
+            'date': msg.get('receivedDateTime', 'Unknown'),
+            'snippet': msg.get('bodyPreview', '')[:100],
+            'unread': not msg.get('isRead', True)
+        } for msg in messages]
 
-        emails = []
-        for msg in messages[:max_results]:
-            emails.append({
-                'id': msg['id'],
-                'from': msg.get('from', {}).get('emailAddress', {}).get('address', 'Unknown'),
-                'from_name': msg.get('from', {}).get('emailAddress', {}).get('name', ''),
-                'subject': msg.get('subject', 'No Subject'),
-                'date': msg.get('receivedDateTime', 'Unknown'),
-                'snippet': msg.get('bodyPreview', '')[:100],
-                'unread': not msg.get('isRead', True)
-            })
+    def _format_dicts(self, emails: list) -> str:
+        """Format email dicts (from _email_dicts) into a readable list."""
+        if not emails:
+            return "No emails found."
 
         output = [f"Found {len(emails)} email(s):\n"]
         for i, email in enumerate(emails, 1):
@@ -205,17 +205,25 @@ class Outlook:
 
         return "\n".join(output)
 
+    def _format_emails(self, messages: list, max_results: int = 10) -> str:
+        """Helper to format raw Graph messages as a readable list."""
+        if not messages:
+            return "No emails found."
+        return self._format_dicts(self._email_dicts(messages[:max_results]))
+
     # === Reading ===
 
-    def read_inbox(self, last: int = 10, unread: bool = False) -> str:
-        """Read emails from inbox.
+    def list_inbox(self, last: int = 10, unread: bool = False) -> list:
+        """Fetch inbox emails as dicts (id, from, from_name, subject, date, snippet, unread).
+
+        Programmatic counterpart of read_inbox() — used by the CLI.
 
         Args:
             last: Number of emails to retrieve (default: 10)
             unread: Only get unread emails (default: False)
 
         Returns:
-            Formatted string with email list
+            List of email dicts, newest first
         """
         endpoint = "/me/mailFolders/inbox/messages"
         params = {
@@ -228,8 +236,19 @@ class Outlook:
             params["$filter"] = "isRead eq false"
 
         result = self._request("GET", endpoint, params=params)
-        messages = result.get('value', [])
-        return self._format_emails(messages, last)
+        return self._email_dicts(result.get('value', []))
+
+    def read_inbox(self, last: int = 10, unread: bool = False) -> str:
+        """Read emails from inbox.
+
+        Args:
+            last: Number of emails to retrieve (default: 10)
+            unread: Only get unread emails (default: False)
+
+        Returns:
+            Formatted string with email list
+        """
+        return self._format_dicts(self.list_inbox(last=last, unread=unread))
 
     def get_sent_emails(self, max_results: int = 10) -> str:
         """Get emails you sent.

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -340,7 +340,28 @@ class Outlook:
 
     # === Sending ===
 
-    def send(self, to: str, subject: str, body: str, cc: str = None, bcc: str = None) -> str:
+    def _file_attachment(self, file_path: str) -> dict:
+        """Read a local file into a Graph fileAttachment object (base64 contentBytes)."""
+        import base64
+        import mimetypes
+
+        path = os.path.expanduser(file_path)
+        if not os.path.isfile(path):
+            raise ValueError(f"Attachment not found: {file_path}")
+
+        content_type = mimetypes.guess_type(path)[0] or "application/octet-stream"
+        with open(path, "rb") as f:
+            content = base64.b64encode(f.read()).decode()
+
+        return {
+            "@odata.type": "#microsoft.graph.fileAttachment",
+            "name": os.path.basename(path),
+            "contentType": content_type,
+            "contentBytes": content,
+        }
+
+    def send(self, to: str, subject: str, body: str, cc: str = None, bcc: str = None,
+             attachments: list = None) -> str:
         """Send email via Microsoft Graph API.
 
         Args:
@@ -349,6 +370,8 @@ class Outlook:
             body: Email body (plain text)
             cc: Optional CC recipients (comma-separated)
             bcc: Optional BCC recipients (comma-separated)
+            attachments: Optional list of local file paths to attach (images,
+                screenshots, PDFs, etc. — Graph sendMail limit is ~3MB total)
 
         Returns:
             Confirmation message
@@ -379,8 +402,16 @@ class Outlook:
                 for addr in bcc.split(',')
             ]
 
+        if attachments:
+            message["message"]["attachments"] = [
+                self._file_attachment(path) for path in attachments
+            ]
+
         self._request("POST", "/me/sendMail", json=message)
 
+        if attachments:
+            names = ", ".join(os.path.basename(os.path.expanduser(p)) for p in attachments)
+            return f"Email sent successfully to {to} with attachment(s): {names}"
         return f"Email sent successfully to {to}"
 
     def reply(self, email_id: str, body: str) -> str:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -172,7 +172,8 @@ class Outlook:
         if response.status_code not in [200, 201, 202, 204]:
             raise ValueError(f"Microsoft Graph API error: {response.status_code} - {response.text}")
 
-        if response.status_code == 204:
+        # 202 (sendMail) and 204 come back with an empty body
+        if response.status_code == 204 or not response.text:
             return {}
         return response.json()
 

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -381,8 +381,8 @@ class Outlook:
         }
 
     def send(self, to: str, subject: str, body: str, cc: str = None, bcc: str = None,
-             attachments: list = None) -> str:
-        """Send email via Microsoft Graph API.
+             attachments: list = None, send_at: str = None) -> str:
+        """Send email via Microsoft Graph API, immediately or at a scheduled time.
 
         Args:
             to: Recipient email address
@@ -392,47 +392,58 @@ class Outlook:
             bcc: Optional BCC recipients (comma-separated)
             attachments: Optional list of local file paths to attach (images,
                 screenshots, PDFs, etc. — Graph sendMail limit is ~3MB total)
+            send_at: Optional UTC ISO time (e.g. "2026-07-06T15:30:00Z") to
+                schedule delivery — Exchange holds the email until then
 
         Returns:
             Confirmation message
         """
         message = {
-            "message": {
-                "subject": subject,
-                "body": {
-                    "contentType": "Text",
-                    "content": body
-                },
-                "toRecipients": [
-                    {"emailAddress": {"address": addr.strip()}}
-                    for addr in to.split(',')
-                ]
-            }
+            "subject": subject,
+            "body": {
+                "contentType": "Text",
+                "content": body
+            },
+            "toRecipients": [
+                {"emailAddress": {"address": addr.strip()}}
+                for addr in to.split(',')
+            ]
         }
 
         if cc:
-            message["message"]["ccRecipients"] = [
+            message["ccRecipients"] = [
                 {"emailAddress": {"address": addr.strip()}}
                 for addr in cc.split(',')
             ]
 
         if bcc:
-            message["message"]["bccRecipients"] = [
+            message["bccRecipients"] = [
                 {"emailAddress": {"address": addr.strip()}}
                 for addr in bcc.split(',')
             ]
 
         if attachments:
-            message["message"]["attachments"] = [
+            message["attachments"] = [
                 self._file_attachment(path) for path in attachments
             ]
 
-        self._request("POST", "/me/sendMail", json=message)
-
+        suffix = ""
         if attachments:
             names = ", ".join(os.path.basename(os.path.expanduser(p)) for p in attachments)
-            return f"Email sent successfully to {to} with attachment(s): {names}"
-        return f"Email sent successfully to {to}"
+            suffix = f" with attachment(s): {names}"
+
+        if send_at:
+            # PidTagDeferredSendTime — Exchange holds delivery until this time.
+            # Works through sendMail with only the Mail.Send scope.
+            message["singleValueExtendedProperties"] = [
+                {"id": "SystemTime 0x3FEF", "value": send_at}
+            ]
+
+        self._request("POST", "/me/sendMail", json={"message": message})
+
+        if send_at:
+            return f"Email scheduled for {send_at} to {to}{suffix}"
+        return f"Email sent successfully to {to}{suffix}"
 
     def reply(self, email_id: str, body: str) -> str:
         """Reply to an email.

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -121,7 +121,8 @@ class Outlook:
 
         if response.status_code != 200:
             raise ValueError(
-                f"Failed to refresh Microsoft token via backend: {response.text}"
+                f"Microsoft session expired and refresh failed ({response.status_code}).\n"
+                "Reconnect with: co auth microsoft"
             )
 
         data = response.json()
@@ -234,7 +235,10 @@ class Outlook:
         }
 
         if unread:
-            params["$filter"] = "isRead eq false"
+            # Graph requires $orderby properties to also appear in $filter,
+            # first and in the same order (else 400 InefficientFilter on
+            # Exchange work/school tenants).
+            params["$filter"] = "receivedDateTime ge 1970-01-01T00:00:00Z and isRead eq false"
 
         result = self._request("GET", endpoint, params=params)
         return self._email_dicts(result.get('value', []))
@@ -286,6 +290,21 @@ class Outlook:
 
     # === Search ===
 
+    def list_search(self, query: str, max_results: int = 10) -> list:
+        """Search emails and return them as dicts (same shape as list_inbox).
+
+        Programmatic counterpart of search_emails() — used by the CLI.
+        """
+        endpoint = "/me/messages"
+        params = {
+            "$top": max_results,
+            "$search": f'"{query}"',
+            "$select": "id,from,subject,receivedDateTime,bodyPreview,isRead"
+        }
+
+        result = self._request("GET", endpoint, params=params)
+        return self._email_dicts(result.get('value', []))
+
     def search_emails(self, query: str, max_results: int = 10) -> str:
         """Search emails.
 
@@ -296,20 +315,10 @@ class Outlook:
         Returns:
             Formatted string with matching emails
         """
-        endpoint = "/me/messages"
-        params = {
-            "$top": max_results,
-            "$search": f'"{query}"',
-            "$select": "id,from,subject,receivedDateTime,bodyPreview,isRead"
-        }
-
-        result = self._request("GET", endpoint, params=params)
-        messages = result.get('value', [])
-
-        if not messages:
+        emails = self.list_search(query, max_results)
+        if not emails:
             return f"No emails found matching query: {query}"
-
-        return self._format_emails(messages, max_results)
+        return self._format_dicts(emails)
 
     # === Content ===
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -225,6 +225,33 @@ details and current limitations.
 
 ---
 
+#### `co outlook` - Send & Read Outlook Email
+
+Your personal Outlook account from the terminal, via Microsoft Graph.
+Requires `co auth microsoft` once (Mail scopes; saved as `MICROSOFT_*` in
+`.env` / `~/.co/keys.env`).
+
+**Basic usage:**
+```bash
+co outlook                                            # show inbox (default)
+co outlook inbox -n 25 -u                             # last 25, unread only
+co outlook read 3                                     # read #3 from the listing, mark read
+co outlook send bob@example.com "Hi" "Body text"      # send now
+co outlook send bob@example.com "Hi" - < body.txt     # body from stdin
+```
+
+**Subcommands:**
+- `co outlook` / `co outlook inbox` - numbered inbox table (`--last/-n`, `--unread/-u`)
+- `co outlook read <#>` - print one message's body and mark it read (inbox # or full Graph ID)
+- `co outlook send <to> <subject> <message>` - send, with `--cc`, `--bcc`, repeatable `--attach FILE` (~3MB Graph limit), and `--at` to schedule (`+30m`, `+2h`, or UTC ISO time — Exchange holds delivery)
+- `co outlook sent` - list recently sent emails
+- `co outlook search <query>` - search subject and body
+
+The CLI wraps the same `Outlook` tool your agents use. See
+[outlook.md](outlook.md) for details.
+
+---
+
 #### `co status` - Check Account and Deployments
 
 Shows your managed keys balance, usage, and deployed agents.
@@ -917,6 +944,7 @@ Agent URL: https://my-agent-abc123.agents.openonion.ai
 | `co reset` | Reset account | Yes | ⚠️ Destructive |
 | `co doctor` | Diagnose issues | No | ✅ Yes |
 | `co browser` | Browser command | No | ✅ Yes |
+| `co outlook` | Send/read Outlook email | No | ✅ Yes |
 
 ---
 

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -69,8 +69,19 @@ in a later shell session.
 co outlook read 3
 ```
 
-Prints the full body (sender, subject, date, content), then marks the message
-read. Accepts the `#` from the last inbox listing or a full Graph message ID.
+Prints the full body (sender, subject, date, content). Accepts the `#` from
+your last listing (inbox or search) or a full Graph message ID. If your
+Microsoft auth includes the `Mail.ReadWrite` scope, the message is also
+marked read.
+
+### `co outlook reply <#> <message>` — Reply
+
+```bash
+co outlook reply 3 "Sounds good, see you then."
+```
+
+Sends a threaded reply to an email from your last listing. Use `-` as the
+message to read the reply body from stdin.
 
 ### `co outlook send <to> <subject> <message>` — Send
 

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -1,0 +1,164 @@
+# Outlook CLI (co outlook)
+
+Send and read email from your Outlook account right in the terminal — the same
+Microsoft Graph access your agents get from the [Outlook tool](../useful_tools/outlook.md),
+as a command.
+
+## Quick Start
+
+```bash
+# Connect your Microsoft account (one-time)
+co auth microsoft
+
+# Check your inbox (the zero-arg default)
+co outlook
+
+# Read message #3 from the inbox list
+co outlook read 3
+
+# Send a message
+co outlook send alice@example.com "Hello" "Thanks for the meeting today!"
+```
+
+That's the whole surface. Everything below is detail.
+
+## Setup
+
+`co outlook` needs a connected Microsoft account with Mail scopes:
+
+```bash
+co auth microsoft
+```
+
+This opens the Microsoft OAuth flow and saves `MICROSOFT_*` credentials
+(access token, refresh token, scopes, email) to your project `.env` and
+`~/.co/keys.env`. Tokens auto-refresh. If credentials or Mail scopes are
+missing, any `co outlook` command tells you to run `co auth microsoft` first.
+See [Microsoft Integration](../integrations/microsoft.md) for scope details.
+
+## Commands
+
+### `co outlook` — Show the inbox
+
+With no subcommand, prints your most recent emails. Same as `co outlook inbox`.
+
+```bash
+co outlook
+```
+
+### `co outlook inbox` — List received email
+
+```bash
+co outlook inbox                 # last 10
+co outlook inbox -n 25           # last 25  (alias: --last)
+co outlook inbox -u              # only unread  (alias: --unread)
+```
+
+Unread messages are marked with a green `●`. The leftmost `#` is the email's
+number — pass it to `co outlook read`. The numbering is cached (in
+`~/.co/outlook_last_inbox.json`), so `read 3` still finds the right message
+in a later shell session.
+
+**Options**
+- `--last, -n` — how many to show (default: 10)
+- `--unread, -u` — only unread messages
+
+### `co outlook read <#>` — Read one message
+
+```bash
+co outlook read 3
+```
+
+Prints the full body (sender, subject, date, content), then marks the message
+read. Accepts the `#` from the last inbox listing or a full Graph message ID.
+
+### `co outlook send <to> <subject> <message>` — Send
+
+```bash
+co outlook send bob@example.com "Subject line" "Body text"
+```
+
+All three arguments are positional and required. `to`, `--cc`, and `--bcc`
+take comma-separated addresses for multiple recipients.
+
+**Options**
+- `--cc` — CC recipients (comma-separated)
+- `--bcc` — BCC recipients (comma-separated)
+- `--attach, -a FILE` — attach a local file; repeat for multiple
+- `--at` — schedule delivery: `+30m`, `+2h`, or a UTC ISO time
+
+**Attachments** — screenshots, PDFs, images, anything:
+
+```bash
+co outlook send bob@example.com "Report" "See attached." \
+    --attach report.pdf --attach screenshot.png
+```
+
+> Graph's `sendMail` limit is ~3MB total across attachments.
+
+**Scheduling** — Exchange holds delivery until the time you give (deferred
+send), so it works with just the `Mail.Send` scope and no extra setup:
+
+```bash
+co outlook send bob@example.com "Reminder" "Standup in 30." --at +30m
+co outlook send bob@example.com "Launch" "We're live!" --at 2026-07-06T15:30:00Z
+```
+
+`+30m` / `+2h` are relative to now; anything else is taken as a UTC ISO time.
+
+**Long bodies** — pass `-` as the message to read the body from stdin:
+
+```bash
+co outlook send alice@example.com "Weekly update" - < body.txt
+```
+
+### `co outlook sent` — List sent email
+
+```bash
+co outlook sent            # last 10
+co outlook sent -n 25      # last 25
+```
+
+### `co outlook search <query>` — Search
+
+```bash
+co outlook search "quarterly report"
+co outlook search invoice -n 25
+```
+
+Matches subject and body via Microsoft Graph search.
+
+## Same functions, in your agent
+
+The CLI is a thin wrapper over the [Outlook tool](../useful_tools/outlook.md),
+so anything `co outlook` does, your agent can do too:
+
+```python
+from connectonion import Agent, Outlook
+
+outlook = Outlook()
+agent = Agent("assistant", tools=[outlook])
+
+agent.input("Check my inbox and send the report to alice@example.com")
+```
+
+Or call it directly:
+
+```python
+outlook = Outlook()
+outlook.list_inbox(last=10, unread=True)
+outlook.send(
+    "alice@example.com", "Report", "See attached.",
+    attachments=["report.pdf"],
+    send_at="2026-07-06T15:30:00Z",
+)
+```
+
+## Troubleshooting
+
+- **"Microsoft account not connected"** → run `co auth microsoft`.
+- **Missing Mail scopes** → run `co auth microsoft` again to re-consent.
+- **Token expired** → tokens auto-refresh; if issues persist, re-run
+  `co auth microsoft`.
+- **`No email #N in your inbox`** → the number is out of range; run
+  `co outlook inbox` to refresh the listing.

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -17,7 +17,7 @@ What happens:
 4. Credentials saved to `.env` (both local and global `~/.co/keys.env`)
 5. Ready to use Outlook and Microsoft Calendar tools immediately
 
-**That's it.** Your agents can now send emails via Outlook and read your Microsoft calendar.
+**That's it.** Your agents can now send emails via Outlook and read your Microsoft calendar. You can too, from the terminal — see [`co outlook`](../cli/outlook.md).
 
 **Switching accounts?** Just run `co auth microsoft` again - it will clear the old connection and let you pick a new Microsoft account.
 
@@ -130,6 +130,9 @@ outlook.get_email_body(email_id)           # Get full email content
 # Sending emails
 outlook.send(to="alice@example.com", subject="Hello", body="Hi there!")
 outlook.send(to="alice@example.com", subject="Hello", body="Hi!", cc="bob@example.com")
+outlook.send(to="alice@example.com", subject="Report", body="See attached.",
+             attachments=["report.pdf"],              # local files, ~3MB Graph limit
+             send_at="2026-07-06T15:30:00Z")           # deferred send (UTC ISO)
 outlook.reply(email_id, body="Thanks for your message")
 
 # Actions

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -44,6 +44,10 @@ Your agent can now read and manage Outlook emails.
 
 **Switch accounts?** Run `co auth microsoft` again to connect a different Microsoft account.
 
+**Prefer the terminal?** The same functions are available as
+[`co outlook`](../cli/outlook.md) commands (`inbox`, `read`, `send`, `sent`,
+`search`).
+
 ## Agent Methods
 
 ### Reading
@@ -52,6 +56,11 @@ Your agent can now read and manage Outlook emails.
 - Read emails from inbox
 - `last`: Number of emails (default: 10)
 - `unread`: Only unread emails (default: False)
+
+**`list_inbox(last=10, unread=False)`**
+- Programmatic counterpart of `read_inbox()` — returns a list of dicts
+  (`id`, `from`, `from_name`, `subject`, `date`, `snippet`, `unread`)
+  instead of a formatted string. Used by the `co outlook` CLI.
 
 **`get_sent_emails(max_results=10)`**
 - Get emails you sent
@@ -67,13 +76,26 @@ Your agent can now read and manage Outlook emails.
 
 ### Sending
 
-**`send(to, subject, body, cc=None, bcc=None)`**
-- Send email via Microsoft Graph API
+**`send(to, subject, body, cc=None, bcc=None, attachments=None, send_at=None)`**
+- Send email via Microsoft Graph API, now or scheduled
 - `to`: Recipient email (comma-separated for multiple)
 - `subject`: Email subject
 - `body`: Email body (plain text)
 - `cc`: Optional CC recipients
 - `bcc`: Optional BCC recipients
+- `attachments`: Optional list of local file paths (images, screenshots,
+  PDFs, etc. — Graph sendMail limit is ~3MB total)
+- `send_at`: Optional UTC ISO time (e.g. `"2026-07-06T15:30:00Z"`) —
+  Exchange holds delivery until then (deferred send, works with just the
+  `Mail.Send` scope)
+
+```python
+outlook.send(
+    "alice@example.com", "Report", "See attached.",
+    attachments=["report.pdf", "screenshot.png"],
+    send_at="2026-07-06T15:30:00Z",
+)
+```
 
 **`reply(email_id, body)`**
 - Reply to an existing email

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -219,7 +219,7 @@ class TestOutlookSendOperations:
         """Test sending email."""
         mock_response = MagicMock()
         mock_response.status_code = 202
-        mock_response.json.return_value = {}
+        mock_response.text = ""  # Graph sendMail returns 202 with an empty body
         mock_httpx.request.return_value = mock_response
 
         with patch.dict(os.environ, {
@@ -244,7 +244,7 @@ class TestOutlookSendOperations:
         """Test sending email with a file attachment."""
         mock_response = MagicMock()
         mock_response.status_code = 202
-        mock_response.json.return_value = {}
+        mock_response.text = ""  # Graph sendMail returns 202 with an empty body
         mock_httpx.request.return_value = mock_response
 
         screenshot = tmp_path / "screenshot.png"

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -276,6 +276,42 @@ class TestOutlookSendOperations:
             assert attachment["contentBytes"]
 
     @patch('connectonion.useful_tools.outlook.httpx')
+    def test_send_email_scheduled(self, mock_httpx):
+        """Test scheduled send sets the deferred-send extended property."""
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.text = ""  # Graph sendMail returns 202 with an empty body
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            result = outlook.send(
+                to="recipient@example.com",
+                subject="Test Subject",
+                body="Test Body",
+                send_at="2026-07-06T15:30:00Z"
+            )
+
+            assert "scheduled" in result.lower()
+            assert "2026-07-06T15:30:00Z" in result
+            assert "recipient@example.com" in result
+
+            method, url = mock_httpx.request.call_args.args[:2]
+            assert method == "POST"
+            assert url.endswith("/me/sendMail")
+
+            sent_message = mock_httpx.request.call_args.kwargs["json"]["message"]
+            assert sent_message["singleValueExtendedProperties"] == [
+                {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+            ]
+
+    @patch('connectonion.useful_tools.outlook.httpx')
     def test_send_email_missing_attachment(self, mock_httpx):
         """Test sending with a nonexistent attachment path raises."""
         with patch.dict(os.environ, {

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -196,6 +196,62 @@ class TestOutlookSendOperations:
             assert "sent successfully" in result
             assert "recipient@example.com" in result
 
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_send_email_with_attachment(self, mock_httpx, tmp_path):
+        """Test sending email with a file attachment."""
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.json.return_value = {}
+        mock_httpx.request.return_value = mock_response
+
+        screenshot = tmp_path / "screenshot.png"
+        screenshot.write_bytes(b"\x89PNG fake image data")
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            result = outlook.send(
+                to="recipient@example.com",
+                subject="Test Subject",
+                body="Test Body",
+                attachments=[str(screenshot)]
+            )
+
+            assert "sent successfully" in result
+            assert "screenshot.png" in result
+
+            sent_message = mock_httpx.request.call_args.kwargs["json"]["message"]
+            attachment = sent_message["attachments"][0]
+            assert attachment["@odata.type"] == "#microsoft.graph.fileAttachment"
+            assert attachment["name"] == "screenshot.png"
+            assert attachment["contentType"] == "image/png"
+            assert attachment["contentBytes"]
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_send_email_missing_attachment(self, mock_httpx):
+        """Test sending with a nonexistent attachment path raises."""
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            import pytest
+            outlook = Outlook()
+            with pytest.raises(ValueError, match="Attachment not found"):
+                outlook.send(
+                    to="recipient@example.com",
+                    subject="Test",
+                    body="Test",
+                    attachments=["/no/such/file.png"]
+                )
+
 
 class TestOutlookActions:
     """Test Outlook action operations with mocked API."""

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -168,6 +168,49 @@ class TestOutlookReadOperations:
             assert "Search Result" in result
 
 
+class TestOutlookListInbox:
+    """Test structured inbox listing (used by the CLI)."""
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_list_inbox_returns_dicts(self, mock_httpx):
+        """Test list_inbox returns plain email dicts."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'value': [
+                {
+                    'id': 'msg-1',
+                    'from': {'emailAddress': {'address': 'test@example.com', 'name': 'Test'}},
+                    'subject': 'Hello',
+                    'receivedDateTime': '2024-01-15T10:00:00Z',
+                    'bodyPreview': 'Preview text',
+                    'isRead': False
+                }
+            ]
+        }
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            emails = outlook.list_inbox(last=5)
+
+            assert emails == [{
+                'id': 'msg-1',
+                'from': 'test@example.com',
+                'from_name': 'Test',
+                'subject': 'Hello',
+                'date': '2024-01-15T10:00:00Z',
+                'snippet': 'Preview text',
+                'unread': True
+            }]
+
+
 class TestOutlookSendOperations:
     """Test Outlook send operations with mocked API."""
 

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -1,0 +1,226 @@
+"""Tests for the `co outlook` CLI command layer."""
+"""
+LLM-Note: Tests for cli/commands/outlook_commands
+
+What it tests:
+- _outlook() credential/scope guard (prints 'co auth microsoft' hint, returns None)
+- _parse_send_at relative (+30m/+2h) and ISO pass-through parsing
+- _resolve_email_id short-number resolution via cache file and list_inbox fallback
+- handle_outlook_inbox writes the {#: message_id} cache
+- handle_outlook_send reads the body from stdin when message is '-'
+
+Components under test:
+- Module: connectonion.cli.commands.outlook_commands
+"""
+
+import io
+import json
+import os
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from connectonion.cli.commands import outlook_commands
+from connectonion.cli.commands.outlook_commands import (
+    _outlook,
+    _parse_send_at,
+    _resolve_email_id,
+    handle_outlook_inbox,
+    handle_outlook_send,
+)
+
+CONNECTED_ENV = {
+    "MICROSOFT_ACCESS_TOKEN": "test-token",
+    "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+    "MICROSOFT_EMAIL": "aaron@example.com",
+}
+
+
+def sample_emails(n):
+    return [{
+        "id": f"msg-{i}",
+        "from": f"sender{i}@example.com",
+        "from_name": f"Sender {i}",
+        "subject": f"Subject {i}",
+        "date": "2026-07-06T10:00:00Z",
+        "snippet": "Preview",
+        "unread": i == 1,
+    } for i in range(1, n + 1)]
+
+
+class TestOutlookGuard:
+    """_outlook() returns None with a hint when not connected."""
+
+    def test_missing_access_token_returns_none_with_hint(self, capsys):
+        with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "", "MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
+            result = _outlook()
+
+        assert result is None
+        output = capsys.readouterr().out
+        assert "Microsoft account not connected" in output
+        assert "co auth microsoft" in output
+
+    def test_scopes_without_mail_returns_none_with_hint(self, capsys):
+        with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "test-token", "MICROSOFT_SCOPES": "User.Read"}, clear=False):
+            result = _outlook()
+
+        assert result is None
+        output = capsys.readouterr().out
+        assert "Microsoft account not connected" in output
+        assert "co auth microsoft" in output
+
+    def test_connected_returns_outlook_instance(self):
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            result = _outlook()
+
+        from connectonion.useful_tools.outlook import Outlook
+        assert isinstance(result, Outlook)
+
+
+class TestParseSendAt:
+    """_parse_send_at turns relative offsets into UTC ISO timestamps."""
+
+    def test_plus_minutes(self):
+        before = datetime.now(timezone.utc)
+        result = _parse_send_at("+30m")
+        after = datetime.now(timezone.utc)
+
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        assert before + timedelta(minutes=30) - timedelta(seconds=2) <= parsed
+        assert parsed <= after + timedelta(minutes=30) + timedelta(seconds=2)
+
+    def test_plus_hours(self):
+        before = datetime.now(timezone.utc)
+        result = _parse_send_at("+2h")
+        after = datetime.now(timezone.utc)
+
+        parsed = datetime.strptime(result, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        assert before + timedelta(hours=2) - timedelta(seconds=2) <= parsed
+        assert parsed <= after + timedelta(hours=2) + timedelta(seconds=2)
+
+    def test_iso_string_passes_through(self):
+        assert _parse_send_at("2026-07-06T15:30:00Z") == "2026-07-06T15:30:00Z"
+
+    def test_invalid_unit_raises(self):
+        with pytest.raises(ValueError, match=r"\+5x"):
+            _parse_send_at("+5x")
+
+    def test_missing_number_raises(self):
+        with pytest.raises(ValueError, match=r"\+m"):
+            _parse_send_at("+m")
+
+
+class TestResolveEmailId:
+    """_resolve_email_id maps short inbox numbers to Graph message ids."""
+
+    def test_short_number_resolves_from_cache(self, tmp_path, monkeypatch):
+        cache = tmp_path / "outlook_last_inbox.json"
+        cache.write_text(json.dumps({"1": "msg-cached-1", "2": "msg-cached-2"}))
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", cache)
+
+        outlook = MagicMock()
+        assert _resolve_email_id(outlook, "2") == "msg-cached-2"
+        outlook.list_inbox.assert_not_called()
+
+    def test_short_number_falls_back_to_list_inbox(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", tmp_path / "missing.json")
+
+        outlook = MagicMock()
+        outlook.list_inbox.return_value = sample_emails(3)
+        assert _resolve_email_id(outlook, "2") == "msg-2"
+
+    def test_short_number_beyond_inbox_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", tmp_path / "missing.json")
+
+        outlook = MagicMock()
+        outlook.list_inbox.return_value = sample_emails(1)
+        assert _resolve_email_id(outlook, "5") == ""
+
+    def test_long_numeric_id_passes_through(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", tmp_path / "missing.json")
+
+        outlook = MagicMock()
+        assert _resolve_email_id(outlook, "12345") == "12345"
+        outlook.list_inbox.assert_not_called()
+
+    def test_graph_message_id_passes_through(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", tmp_path / "missing.json")
+
+        outlook = MagicMock()
+        assert _resolve_email_id(outlook, "AAMkAGI2NGVhZTVlLTI=") == "AAMkAGI2NGVhZTVlLTI="
+        outlook.list_inbox.assert_not_called()
+
+
+class TestHandleOutlookInbox:
+    """handle_outlook_inbox lists emails and remembers the numbering."""
+
+    def test_writes_cache_mapping(self, tmp_path, monkeypatch, capsys):
+        cache = tmp_path / ".co" / "outlook_last_inbox.json"
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", cache)
+
+        outlook = MagicMock()
+        outlook.list_inbox.return_value = sample_emails(2)
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_inbox(last=2)
+
+        assert json.loads(cache.read_text()) == {"1": "msg-1", "2": "msg-2"}
+        output = capsys.readouterr().out
+        assert "Subject 1" in output
+        assert "co outlook read" in output
+
+    def test_empty_inbox_prints_message_without_cache(self, tmp_path, monkeypatch, capsys):
+        cache = tmp_path / ".co" / "outlook_last_inbox.json"
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", cache)
+
+        outlook = MagicMock()
+        outlook.list_inbox.return_value = []
+
+        with patch.object(outlook_commands, "_outlook", return_value=outlook):
+            handle_outlook_inbox(last=10, unread=True)
+
+        assert not cache.exists()
+        assert "no unread emails" in capsys.readouterr().out
+
+
+class TestHandleOutlookSend:
+    """handle_outlook_send sends via the Outlook tool."""
+
+    def test_message_dash_reads_stdin(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("Body from stdin\nline two\n"))
+
+        outlook = MagicMock()
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_send(to="bob@example.com", subject="Hi", message="-")
+
+        outlook.send.assert_called_once_with(
+            "bob@example.com", "Hi", "Body from stdin\nline two\n",
+            cc=None, bcc=None, attachments=None, send_at=None,
+        )
+        assert "Sent" in capsys.readouterr().out
+
+    def test_scheduled_send_prints_scheduled(self, capsys):
+        outlook = MagicMock()
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_send(to="bob@example.com", subject="Hi", message="Later",
+                                    at="2026-07-06T15:30:00Z")
+
+        assert outlook.send.call_args.kwargs["send_at"] == "2026-07-06T15:30:00Z"
+        output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+        assert "Scheduled" in output
+        assert "2026-07-06T15:30:00Z" in output
+
+    def test_not_connected_does_not_send(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("unused"))
+
+        with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "", "MICROSOFT_SCOPES": ""}, clear=False):
+            with patch("connectonion.useful_tools.outlook.Outlook") as mock_cls:
+                handle_outlook_send(to="bob@example.com", subject="Hi", message="hello")
+
+        mock_cls.assert_not_called()

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -23,6 +23,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 import typer
+from rich.console import Console
 
 from connectonion.cli.commands import outlook_commands
 from connectonion.cli.commands.outlook_commands import (
@@ -173,6 +174,8 @@ class TestHandleOutlookInbox:
     def test_writes_cache_mapping(self, tmp_path, monkeypatch, capsys):
         cache = tmp_path / ".co" / "outlook_last_inbox.json"
         monkeypatch.setattr(outlook_commands, "INBOX_CACHE", cache)
+        # Pin the interactive branch — CI has no tty, dev shells may force color.
+        monkeypatch.setattr(outlook_commands, "console", Console(force_terminal=True, width=120))
 
         outlook = MagicMock()
         outlook.list_inbox.return_value = sample_emails(2)
@@ -185,6 +188,23 @@ class TestHandleOutlookInbox:
         output = capsys.readouterr().out
         assert "Subject 1" in output
         assert "co outlook read" in output
+
+    def test_piped_output_prints_plain_listing_with_cache(self, tmp_path, monkeypatch, capsys):
+        cache = tmp_path / ".co" / "outlook_last_inbox.json"
+        monkeypatch.setattr(outlook_commands, "INBOX_CACHE", cache)
+        # Pin the non-tty branch: scripts get the untruncated tool format.
+        monkeypatch.setattr(outlook_commands, "console", Console(force_terminal=False))
+
+        outlook = MagicMock()
+        outlook.list_inbox.return_value = sample_emails(2)
+        outlook._format_dicts.return_value = "Found 2 email(s) with full ids"
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_inbox(last=2)
+
+        assert json.loads(cache.read_text()) == {"1": "msg-1", "2": "msg-2"}
+        assert "Found 2 email(s) with full ids" in capsys.readouterr().out
 
     def test_empty_inbox_prints_message_without_cache(self, tmp_path, monkeypatch, capsys):
         cache = tmp_path / ".co" / "outlook_last_inbox.json"

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
+import typer
 
 from connectonion.cli.commands import outlook_commands
 from connectonion.cli.commands.outlook_commands import (
@@ -54,20 +55,20 @@ def sample_emails(n):
 class TestOutlookGuard:
     """_outlook() returns None with a hint when not connected."""
 
-    def test_missing_access_token_returns_none_with_hint(self, capsys):
+    def test_missing_access_token_exits_with_hint(self, capsys):
         with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "", "MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
-            result = _outlook()
+            with pytest.raises(typer.Exit):
+                _outlook()
 
-        assert result is None
         output = capsys.readouterr().out
         assert "Microsoft account not connected" in output
         assert "co auth microsoft" in output
 
-    def test_scopes_without_mail_returns_none_with_hint(self, capsys):
+    def test_scopes_without_mail_exits_with_hint(self, capsys):
         with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "test-token", "MICROSOFT_SCOPES": "User.Read"}, clear=False):
-            result = _outlook()
+            with pytest.raises(typer.Exit):
+                _outlook()
 
-        assert result is None
         output = capsys.readouterr().out
         assert "Microsoft account not connected" in output
         assert "co auth microsoft" in output
@@ -104,13 +105,25 @@ class TestParseSendAt:
     def test_iso_string_passes_through(self):
         assert _parse_send_at("2026-07-06T15:30:00Z") == "2026-07-06T15:30:00Z"
 
-    def test_invalid_unit_raises(self):
-        with pytest.raises(ValueError, match=r"\+5x"):
+    def test_invalid_unit_exits(self, capsys):
+        with pytest.raises(typer.Exit):
             _parse_send_at("+5x")
+        assert "Invalid --at value" in capsys.readouterr().out
 
-    def test_missing_number_raises(self):
-        with pytest.raises(ValueError, match=r"\+m"):
+    def test_missing_number_exits(self, capsys):
+        with pytest.raises(typer.Exit):
             _parse_send_at("+m")
+        assert "Invalid --at value" in capsys.readouterr().out
+
+    def test_naive_iso_time_exits(self, capsys):
+        with pytest.raises(typer.Exit):
+            _parse_send_at("2026-07-06T15:30:00")
+        assert "Invalid --at value" in capsys.readouterr().out
+
+    def test_garbage_string_exits(self, capsys):
+        with pytest.raises(typer.Exit):
+            _parse_send_at("tomorrow")
+        assert "Invalid --at value" in capsys.readouterr().out
 
 
 class TestResolveEmailId:
@@ -221,6 +234,7 @@ class TestHandleOutlookSend:
 
         with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "", "MICROSOFT_SCOPES": ""}, clear=False):
             with patch("connectonion.useful_tools.outlook.Outlook") as mock_cls:
-                handle_outlook_send(to="bob@example.com", subject="Hi", message="hello")
+                with pytest.raises(typer.Exit):
+                    handle_outlook_send(to="bob@example.com", subject="Hi", message="hello")
 
         mock_cls.assert_not_called()


### PR DESCRIPTION
## What

Adds a `co outlook` command group so the CLI can send/receive Outlook email using the `MICROSOFT_*` OAuth tokens that `co auth microsoft` already saves to `.env` / `~/.co/keys.env`.

```
co outlook                                  # inbox
co outlook inbox -n 10 -u                   # unread only
co outlook send <to> <subject> <message>    # --cc / --bcc supported
co outlook read <id>                        # full body + mark read
co outlook sent
co outlook search <query>
```

## How

- New `cli/commands/outlook_commands.py` — thin presentation layer over the existing `useful_tools/outlook.py` Graph tool (token refresh via oo-api already lives there).
- Wired `outlook_app` typer group into `cli/main.py` and added it to the `co` help listing.
- Missing credentials print a `co auth microsoft` hint; Graph errors propagate.

## Testing

- Live-tested `inbox`, `sent`, and the no-auth hint against a real connected Outlook account.
- `pytest tests/unit`: 1960 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)