### PR TITLE
co outlook reply: scheduled replies with --at

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -198,10 +198,11 @@ def handle_outlook_read(email_id: str):
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 
-def handle_outlook_reply(email_id: str, message: str):
+def handle_outlook_reply(email_id: str, message: str, at: str = None):
     """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin."""
     if message == "-":
         message = sys.stdin.read()
+    send_at = _parse_send_at(at) if at else None
 
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
@@ -209,8 +210,11 @@ def handle_outlook_reply(email_id: str, message: str):
         console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
         raise typer.Exit(1)
 
-    outlook.reply(resolved, message)
-    console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
+    outlook.reply(resolved, message, send_at=send_at)
+    if send_at:
+        console.print(f"\n[green]✓ Reply scheduled[/green] for [bold]{send_at}[/bold] to email {email_id}\n")
+    else:
+        console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
 
 
 def handle_outlook_sent(last: int = 10):

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -470,10 +470,11 @@ def outlook_read(email_id: str = typer.Argument(..., help="Email # from your las
 def outlook_reply(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     message: str = typer.Argument(..., help="Reply body (plain text, or '-' to read from stdin)"),
+    at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z)"),
 ):
-    """Reply to an email (threaded)."""
+    """Reply to an email (threaded), now or scheduled with --at."""
     from .commands.outlook_commands import handle_outlook_reply
-    handle_outlook_reply(email_id, message)
+    handle_outlook_reply(email_id, message, at=at)
 
 
 @outlook_app.command("sent")

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -454,12 +454,14 @@ class Outlook:
             return f"Email scheduled for {send_at} to {to}{suffix}"
         return f"Email sent successfully to {to}{suffix}"
 
-    def reply(self, email_id: str, body: str) -> str:
-        """Reply to an email.
+    def reply(self, email_id: str, body: str, send_at: str = None) -> str:
+        """Reply to an email, immediately or at a scheduled time.
 
         Args:
             email_id: Outlook message ID to reply to
             body: Reply message body (plain text)
+            send_at: Optional UTC ISO time (e.g. "2026-07-06T15:30:00Z") to
+                schedule delivery — Exchange holds the reply until then
 
         Returns:
             Confirmation message
@@ -468,9 +470,19 @@ class Outlook:
         data = {
             "comment": body
         }
+        if send_at:
+            # Same deferred-send property as send(); the reply action accepts
+            # message properties alongside the comment.
+            data["message"] = {
+                "singleValueExtendedProperties": [
+                    {"id": "SystemTime 0x3FEF", "value": send_at}
+                ]
+            }
 
         self._request("POST", endpoint, json=data)
 
+        if send_at:
+            return f"Reply scheduled for {send_at}"
         return f"Reply sent successfully"
 
     # === Actions ===

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -81,7 +81,8 @@ co outlook reply 3 "Sounds good, see you then."
 ```
 
 Sends a threaded reply to an email from your last listing. Use `-` as the
-message to read the reply body from stdin.
+message to read the reply body from stdin, and `--at +2h` (or a UTC ISO
+time) to schedule the reply like a scheduled send.
 
 ### `co outlook send <to> <subject> <message>` — Send
 

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -332,6 +332,55 @@ class TestOutlookSendOperations:
                 )
 
 
+class TestOutlookReply:
+    """Test reply operations with mocked API."""
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_scheduled(self, mock_httpx):
+        """Test scheduled reply carries the deferred-send property."""
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.text = ""
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            result = outlook.reply("msg-1", "See you then", send_at="2026-07-06T15:30:00Z")
+
+            assert "scheduled" in result.lower()
+            payload = mock_httpx.request.call_args.kwargs["json"]
+            assert payload["comment"] == "See you then"
+            prop = payload["message"]["singleValueExtendedProperties"][0]
+            assert prop == {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_immediate_has_no_message_block(self, mock_httpx):
+        """Test immediate reply payload stays a bare comment."""
+        mock_response = MagicMock()
+        mock_response.status_code = 202
+        mock_response.text = ""
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            result = outlook.reply("msg-1", "Thanks!")
+
+            assert "sent" in result.lower()
+            assert mock_httpx.request.call_args.kwargs["json"] == {"comment": "Thanks!"}
+
+
 class TestOutlookActions:
     """Test Outlook action operations with mocked API."""
 


### PR DESCRIPTION
Graph's reply action accepts message properties alongside the comment, so the same `PidTagDeferredSendTime` deferred-send used by `send --at` works for threaded replies.

- `Outlook.reply(email_id, body, send_at=)`
- `co outlook reply <#> <message> --at +30m|+2h|<UTC ISO>`
- Verified live: deferred reply accepted and held by Exchange; unit tests assert the payload shape for scheduled and immediate replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)