### PR TITLE
co outlook: list and cancel scheduled emails

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -217,6 +217,43 @@ def handle_outlook_reply(email_id: str, message: str, at: str = None):
         console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
 
 
+def handle_outlook_scheduled(last: int = 10):
+    """List scheduled emails that haven't gone out yet, numbered for cancel."""
+    outlook = _outlook()
+    emails = outlook.list_scheduled(last=last)
+    if not emails:
+        console.print("\n[cyan]Scheduled:[/cyan] no pending scheduled emails\n")
+        return
+
+    INBOX_CACHE.parent.mkdir(exist_ok=True)
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}))
+
+    table = Table(title="⏰ Scheduled — waiting to send", show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("To", max_width=32, no_wrap=True)
+    table.add_column("Subject", overflow="ellipsis", no_wrap=True)
+    table.add_column("Sends at")
+
+    for i, email in enumerate(emails, 1):
+        table.add_row(str(i), email["to"], email["subject"], _when(email["send_at"]))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Cancel one with:[/dim] [bold]co outlook cancel <#>[/bold]\n")
+
+
+def handle_outlook_cancel(email_id: str):
+    """Cancel a scheduled email before Exchange sends it."""
+    outlook = _outlook()
+    resolved = _resolve_email_id(outlook, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook scheduled first.[/yellow]\n")
+        raise typer.Exit(1)
+
+    outlook.cancel_scheduled(resolved)
+    console.print(f"\n[green]✓ Canceled[/green] scheduled email {email_id}\n")
+
+
 def handle_outlook_sent(last: int = 10):
     """List recently sent Outlook emails."""
     outlook = _outlook()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -477,6 +477,20 @@ def outlook_reply(
     handle_outlook_reply(email_id, message, at=at)
 
 
+@outlook_app.command("scheduled")
+def outlook_scheduled(last: int = typer.Option(10, "--last", "-n", help="How many to show")):
+    """List scheduled emails that haven't been sent yet."""
+    from .commands.outlook_commands import handle_outlook_scheduled
+    handle_outlook_scheduled(last=last)
+
+
+@outlook_app.command("cancel")
+def outlook_cancel(email_id: str = typer.Argument(..., help="Email # from 'co outlook scheduled' (or a full message ID)")):
+    """Cancel a scheduled email before it goes out."""
+    from .commands.outlook_commands import handle_outlook_cancel
+    handle_outlook_cancel(email_id)
+
+
 @outlook_app.command("sent")
 def outlook_sent(last: int = typer.Option(10, "--last", "-n", help="How many emails to show")):
     """List recently sent Outlook emails."""

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -243,6 +243,46 @@ class Outlook:
         result = self._request("GET", endpoint, params=params)
         return self._email_dicts(result.get('value', []))
 
+    def list_scheduled(self, last: int = 10) -> list:
+        """List scheduled (deferred-send) emails that haven't gone out yet.
+
+        Scheduled messages wait in Drafts carrying the deferred-send
+        property until Exchange delivers them.
+
+        Returns:
+            List of dicts: id, to, subject, send_at
+        """
+        result = self._request("GET", "/me/mailFolders/drafts/messages", params={
+            "$top": max(last * 5, 25),  # drafts folder mixes in ordinary drafts
+            "$select": "id,subject,toRecipients",
+            "$expand": "singleValueExtendedProperties($filter=id eq 'SystemTime 0x3FEF')",
+        })
+        scheduled = []
+        for msg in result.get('value', []):
+            props = msg.get('singleValueExtendedProperties')
+            if not props:
+                continue
+            to = ", ".join(r.get('emailAddress', {}).get('address', '') for r in msg.get('toRecipients', []))
+            scheduled.append({
+                'id': msg['id'],
+                'to': to,
+                'subject': msg.get('subject', 'No Subject'),
+                'send_at': props[0]['value'],
+            })
+        return scheduled[:last]
+
+    def cancel_scheduled(self, email_id: str) -> str:
+        """Cancel a scheduled email by deleting it before Exchange sends it.
+
+        Args:
+            email_id: Message ID from list_scheduled()
+
+        Returns:
+            Confirmation message
+        """
+        self._request("DELETE", f"/me/messages/{email_id}")
+        return f"Canceled scheduled email: {email_id}"
+
     def read_inbox(self, last: int = 10, unread: bool = False) -> str:
         """Read emails from inbox.
 

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -84,6 +84,16 @@ Sends a threaded reply to an email from your last listing. Use `-` as the
 message to read the reply body from stdin, and `--at +2h` (or a UTC ISO
 time) to schedule the reply like a scheduled send.
 
+### `co outlook scheduled` / `co outlook cancel <#>` — Manage scheduled email
+
+```bash
+co outlook scheduled      # what's waiting to send, and when
+co outlook cancel 1       # cancel it before Exchange sends it
+```
+
+Scheduled emails wait in Drafts until their `--at` time; cancel deletes the
+pending message so it never goes out.
+
 ### `co outlook send <to> <subject> <message>` — Send
 
 ```bash

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -422,6 +422,74 @@ class TestOutlookReply:
             assert mock_httpx.request.call_args.kwargs["json"]["comment"] == "<p>Already HTML</p>"
 
 
+class TestOutlookScheduled:
+    """Test scheduled-email listing and cancel."""
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_list_scheduled_filters_to_deferred_drafts(self, mock_httpx):
+        """Test list_scheduled keeps only drafts with the deferred-send property."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'value': [
+                {
+                    'id': 'draft-plain',
+                    'subject': 'Ordinary draft',
+                    'toRecipients': [],
+                },
+                {
+                    'id': 'draft-scheduled',
+                    'subject': 'Scheduled one',
+                    'toRecipients': [{'emailAddress': {'address': 'bob@example.com'}}],
+                    'singleValueExtendedProperties': [
+                        {'id': 'SystemTime 0x3FEF', 'value': '2026-07-06T15:30:00Z'}
+                    ],
+                },
+            ]
+        }
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            scheduled = outlook.list_scheduled()
+
+            assert scheduled == [{
+                'id': 'draft-scheduled',
+                'to': 'bob@example.com',
+                'subject': 'Scheduled one',
+                'send_at': '2026-07-06T15:30:00Z',
+            }]
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_cancel_scheduled_deletes_message(self, mock_httpx):
+        """Test cancel_scheduled issues a DELETE for the message."""
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.text = ""
+        mock_httpx.request.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "test-token",
+            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            result = outlook.cancel_scheduled("draft-scheduled")
+
+            assert "Canceled" in result
+            method, url = mock_httpx.request.call_args.args[:2]
+            assert method == "DELETE"
+            assert url.endswith("/me/messages/draft-scheduled")
+
+
 class TestOutlookActions:
     """Test Outlook action operations with mocked API."""
 


### PR DESCRIPTION
Scheduled emails wait in Drafts carrying the deferred-send property until Exchange sends them — so they can be listed and canceled before delivery.

- `co outlook scheduled` — numbered queue (to, subject, sends-at), same numbering contract as inbox/search
- `co outlook cancel <#>` — deletes the pending message; exit 1 if the number isn't in the last listing
- `Outlook.list_scheduled()` / `Outlook.cancel_scheduled(id)` for agents
- Verified live: scheduled test email listed, canceled, and confirmed never delivered; works with existing Mail.Read/Mail.Send scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)