### PR TITLE
outlook: refresh tokens on every use and persist the rotation

### DIFF
--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -70,10 +70,18 @@ class Outlook:
         self._access_token = None
 
     def _get_access_token(self) -> str:
-        """Get Microsoft access token (with auto-refresh)."""
+        """Get Microsoft access token, refreshing once per Outlook instance.
+
+        Microsoft refresh tokens live 90 days and replace themselves on
+        every use — refreshing at the start of each session (and persisting
+        the rotated token) keeps that window sliding forever, so re-auth is
+        only ever needed after a password change or revocation.
+        """
+        if self._access_token:
+            return self._access_token
+
         access_token = os.getenv("MICROSOFT_ACCESS_TOKEN")
         refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
-        expires_at_str = os.getenv("MICROSOFT_TOKEN_EXPIRES_AT")
 
         if not access_token or not refresh_token:
             raise ValueError(
@@ -81,24 +89,11 @@ class Outlook:
                 "Run: co auth microsoft"
             )
 
-        # Check if token is expired or about to expire (within 5 minutes)
-        if expires_at_str:
-            expires_at = datetime.fromisoformat(expires_at_str.replace('Z', '+00:00'))
-            now = datetime.utcnow().replace(tzinfo=expires_at.tzinfo) if expires_at.tzinfo else datetime.utcnow()
-
-            if now >= expires_at - timedelta(minutes=5):
-                # Token expired or about to expire, refresh via backend
-                access_token = self._refresh_via_backend(refresh_token)
-                self._access_token = None
-
-        if self._access_token:
-            return self._access_token
-
-        self._access_token = access_token
+        self._access_token = self._refresh_via_backend(refresh_token)
         return self._access_token
 
     def _refresh_via_backend(self, refresh_token: str) -> str:
-        """Refresh access token via backend API.
+        """Refresh tokens via backend API and persist the rotated pair.
 
         Args:
             refresh_token: The refresh token
@@ -130,10 +125,16 @@ class Outlook:
         data = response.json()
         new_access_token = data["access_token"]
         expires_at = data["expires_at"]
+        # Microsoft rotates refresh tokens on every use — persist the new one
+        # or the connection dies when the original expires at 90 days.
+        # (Older backends don't return it; keep the current one then.)
+        new_refresh_token = data.get("refresh_token")
 
         # Update environment variables for this session
         os.environ["MICROSOFT_ACCESS_TOKEN"] = new_access_token
         os.environ["MICROSOFT_TOKEN_EXPIRES_AT"] = expires_at
+        if new_refresh_token:
+            os.environ["MICROSOFT_REFRESH_TOKEN"] = new_refresh_token
 
         # Update .env file if it exists
         env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
@@ -147,6 +148,8 @@ class Outlook:
                         f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")
                     elif line.startswith("MICROSOFT_TOKEN_EXPIRES_AT="):
                         f.write(f"MICROSOFT_TOKEN_EXPIRES_AT={expires_at}\n")
+                    elif line.startswith("MICROSOFT_REFRESH_TOKEN=") and new_refresh_token:
+                        f.write(f"MICROSOFT_REFRESH_TOKEN={new_refresh_token}\n")
                     else:
                         f.write(line)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,7 @@ markers =
     cli: CLI-specific tests
     asyncio: Async tests using pytest-asyncio
     benchmark: Performance/benchmark tests
+    real_refresh: Outlook token-refresh flow tests (bypass the refresh stub)
 
 # Output options
 addopts =

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -15,6 +15,17 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+@pytest.fixture(autouse=True)
+def _stub_token_refresh(request, monkeypatch):
+    """Outlook refreshes tokens once per instance; stub that network call so
+    Graph-operation tests stay isolated. Tests of the refresh flow itself
+    opt out with @pytest.mark.real_refresh."""
+    if "real_refresh" in request.keywords:
+        return
+    from connectonion.useful_tools.outlook import Outlook
+    monkeypatch.setattr(Outlook, "_refresh_via_backend", lambda self, rt: "test-token")
+
+
 class TestOutlookInit:
     """Test Outlook initialization."""
 
@@ -63,6 +74,71 @@ class TestOutlookTokenManagement:
             outlook = Outlook()
             token = outlook._get_access_token()
             assert token == "test-token"
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_refresh_persists_rotated_refresh_token(self, mock_httpx, tmp_path):
+        """Every use refreshes and saves the rotated refresh token to keys.env."""
+        keys_env = tmp_path / "keys.env"
+        keys_env.write_text(
+            "MICROSOFT_ACCESS_TOKEN=old-access\n"
+            "MICROSOFT_REFRESH_TOKEN=old-refresh\n"
+            "MICROSOFT_TOKEN_EXPIRES_AT=2026-01-01T00:00:00Z\n"
+        )
+
+        refresh_response = MagicMock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "access_token": "new-access",
+            "expires_at": "2099-12-31T23:59:59Z",
+            "refresh_token": "rotated-refresh",
+        }
+        mock_httpx.post.return_value = refresh_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-access",
+            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "OPENONION_API_KEY": "test-key",
+            "AGENT_CONFIG_PATH": str(tmp_path),
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            token = Outlook()._get_access_token()
+
+            assert token == "new-access"
+            assert os.environ["MICROSOFT_REFRESH_TOKEN"] == "rotated-refresh"
+
+        saved = keys_env.read_text()
+        assert "MICROSOFT_REFRESH_TOKEN=rotated-refresh" in saved
+        assert "MICROSOFT_ACCESS_TOKEN=new-access" in saved
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_refresh_without_rotated_token_keeps_current(self, mock_httpx, tmp_path):
+        """Older backends omit refresh_token — the current one must survive."""
+        keys_env = tmp_path / "keys.env"
+        keys_env.write_text("MICROSOFT_REFRESH_TOKEN=old-refresh\n")
+
+        refresh_response = MagicMock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "access_token": "new-access",
+            "expires_at": "2099-12-31T23:59:59Z",
+        }
+        mock_httpx.post.return_value = refresh_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-access",
+            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "OPENONION_API_KEY": "test-key",
+            "AGENT_CONFIG_PATH": str(tmp_path),
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            assert Outlook()._get_access_token() == "new-access"
+            assert os.environ["MICROSOFT_REFRESH_TOKEN"] == "old-refresh"
+
+        assert "MICROSOFT_REFRESH_TOKEN=old-refresh" in keys_env.read_text()
 
 
 class TestOutlookEmailFormatting:


### PR DESCRIPTION
Fixes the recurring forced re-auth (`co auth microsoft`) that hits every ~90 days.

**Root cause**: Microsoft rotates refresh tokens on every use and expects clients to store the replacement ([docs](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)). We refreshed lazily and never persisted the rotated token, so the original refresh token from initial auth aged out at its 90-day lifetime.

**Change**:
- `Outlook._get_access_token()` refreshes once per instance (every `co outlook` run starts with a fresh token pair — the industry-standard rotate-on-use pattern)
- `_refresh_via_backend()` persists the rotated `refresh_token` to env and `~/.co/keys.env` when the backend returns one (openonion/oo-api#25); falls back to keeping the current token with older backends
- Tests: autouse refresh stub for Graph-operation tests; `real_refresh`-marked tests cover rotation persistence and the older-backend fallback

**Verified live**: `co outlook inbox` works through the always-refresh path against the currently deployed backend (no rotation returned yet → current token preserved). Full unit suite: 1994 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)