### PR TITLE
Graceful stop: honor a client INTERRUPT at the iteration boundary

### DIFF
--- a/connectonion/useful_plugins/tool_approval/__init__.py
+++ b/connectonion/useful_plugins/tool_approval/__init__.py
@@ -1,10 +1,10 @@
 """
 Purpose: WebSocket-based tool approval plugin with mode system and unified permissions
 LLM-Note:
-  Dependencies: imports from [./approval.py (check_approval, load_config_permissions, poll_mode_changes, handle_mode_change, get_current_mode), ./constants.py (VALID_MODES, DEFAULT_MODE)] | imported by [../.__init__.py useful_plugins package, cli/co_ai/agent.py, cli/templates/minimal/agent.py, ulw.py, skills.py] | tested by [tests/unit/test_tool_approval.py, tests/integration/test_config_permissions.py, tests/integration/test_bash_chain_permissions.py]
-  Data flow: agent loads plugin → [load_config_permissions, poll_mode_changes, check_approval] registered as event handlers → after_user_input fires → load_config_permissions() loads .co/host.yaml → before_iteration fires → poll_mode_changes() checks WebSocket → before_each_tool fires → check_approval() validates tool → if dangerous: WebSocket approval protocol → if approved: tool executes | if rejected: ValueError raised
+  Dependencies: imports from [./approval.py (check_approval, load_config_permissions, poll_mode_changes, poll_interrupt, handle_mode_change, get_current_mode), ./constants.py (VALID_MODES, DEFAULT_MODE)] | imported by [../.__init__.py useful_plugins package, cli/co_ai/agent.py, cli/templates/minimal/agent.py, ulw.py, skills.py] | tested by [tests/unit/test_tool_approval.py, tests/integration/test_config_permissions.py, tests/integration/test_bash_chain_permissions.py]
+  Data flow: agent loads plugin → [load_config_permissions, poll_mode_changes, poll_interrupt, check_approval] registered as event handlers → after_user_input fires → load_config_permissions() loads .co/host.yaml → before_iteration fires → poll_mode_changes() checks WebSocket for mode_change → before_each_tool fires → check_approval() validates tool → if dangerous: WebSocket approval protocol → if approved: tool executes | if rejected: ValueError raised → after_iteration fires → poll_interrupt() checks WebSocket for INTERRUPT (sets stop_signal so the loop's existing check halts)
   State/Effects: exports tool_approval plugin list | exports utility functions handle_mode_change, get_current_mode | no module state
-  Integration: exposes tool_approval (list of 3 event handlers), handle_mode_change(agent, mode), get_current_mode(agent), VALID_MODES, DEFAULT_MODE | used by Agent(plugins=[tool_approval]) | integrates with co ai CLI for WebSocket-based coding agent
+  Integration: exposes tool_approval (list of 4 event handlers), handle_mode_change(agent, mode), get_current_mode(agent), VALID_MODES, DEFAULT_MODE | used by Agent(plugins=[tool_approval]) | integrates with co ai CLI for WebSocket-based coding agent
   Performance: plugin registration is O(1) | event handler overhead per tool call depends on approval.py check_approval()
   Errors: no errors at import time | errors from approval.py bubble up during agent execution
 
@@ -187,6 +187,7 @@ from .approval import (
     check_approval,
     load_config_permissions,
     poll_mode_changes,
+    poll_interrupt,
     handle_mode_change,
     get_current_mode,
 )
@@ -194,7 +195,7 @@ from .constants import VALID_MODES, DEFAULT_MODE
 
 # Export as plugin (list of event handlers)
 # Usage: Agent("name", plugins=[tool_approval])
-tool_approval = [load_config_permissions, poll_mode_changes, check_approval]
+tool_approval = [load_config_permissions, poll_mode_changes, poll_interrupt, check_approval]
 
 # Export mode functions for external use
 __all__ = [

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -202,7 +202,7 @@ File Relationships:
 from typing import TYPE_CHECKING
 from pathlib import Path
 
-from ...core.events import before_each_tool, before_iteration, after_user_input
+from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
 from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
 from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
 
@@ -716,6 +716,23 @@ def poll_mode_changes(agent: 'Agent') -> None:
         elif new_mode == 'ulw':
             from ..ulw import handle_ulw_mode_change
             handle_ulw_mode_change(agent, msg.get('turns'))
+
+
+@after_iteration
+def poll_interrupt(agent: 'Agent') -> None:
+    """Stop the run at the iteration boundary when the client sent an INTERRUPT.
+
+    Graceful stop: drains an INTERRUPT frame and sets the existing stop_signal,
+    which the iteration loop already honors right after after_iteration (halts and
+    returns a closing message). Runs after_iteration so the current step (LLM call
+    + tools) finishes first — not a mid-flight abort. Same primitive and placement
+    as no_progress_guard; no core changes.
+    """
+    if not agent.io:
+        return
+
+    if agent.io.receive_all('INTERRUPT'):
+        agent.current_session['stop_signal'] = 'user_interrupt'
 
 
 # =============================================================================

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -720,3 +720,73 @@ def test_agent_input_file_path_traversal(tmp_path):
     uploads_dir = tmp_path / ".co" / "uploads"
     assert len(list(uploads_dir.glob("*_passwd"))) == 1
     assert not (tmp_path / "etc").exists()
+
+
+class TestGracefulInterrupt:
+    """A client INTERRUPT stops the loop at the iteration boundary with a closing message."""
+
+    def test_interrupt_stops_after_current_step_with_message(self):
+        """The current step finishes, then poll_interrupt (after_iteration) halts the
+        loop via the existing stop_signal check — no silent cutoff, no extra LLM call."""
+        from connectonion.useful_plugins.tool_approval import poll_interrupt
+
+        def note(text: str) -> str:
+            """Record a note."""
+            return "noted"
+
+        # INTERRUPT is queued; poll_interrupt drains it at iteration 1's after_iteration
+        # (after the LLM call + tools), and the loop's existing bottom check stops there.
+        class InterruptIO:
+            def __init__(self):
+                self.sent = []
+
+            def receive_all(self, msg_type=None):
+                return [{'type': 'INTERRUPT'}] if msg_type == 'INTERRUPT' else []
+
+            def send(self, event):
+                self.sent.append(event)
+
+            def poll(self):
+                return None
+
+        mock_llm = MockLLM(responses=[
+            LLMResponse(
+                content="",
+                tool_calls=[ToolCall(name="note", arguments={"text": "x"}, id="c1")],
+                raw_response={},
+                usage=TokenUsage(),
+            ),
+            # Must never be reached — the run stops after the first iteration.
+            LLMResponse(content="should not be reached", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        ])
+        agent = Agent(name="stoppable", llm=mock_llm, tools=[note], on_events=[poll_interrupt], log=False, quiet=True)
+        agent.io = InterruptIO()
+
+        result = agent.input("do work")
+
+        assert result == "What would you like me to do?"  # existing stop_signal message
+        assert mock_llm.call_count == 1  # one step ran; stopped before a 2nd LLM call
+
+    def test_no_interrupt_runs_to_completion(self):
+        """Without an INTERRUPT the loop is unaffected and finishes normally."""
+        from connectonion.useful_plugins.tool_approval import poll_interrupt
+
+        class NeverInterruptIO:
+            def receive_all(self, msg_type=None):
+                return []
+
+            def send(self, event):
+                pass
+
+            def poll(self):
+                return None
+
+        mock_llm = MockLLM(responses=[
+            LLMResponse(content="all done", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        ])
+        agent = Agent(name="normal", llm=mock_llm, on_events=[poll_interrupt], log=False, quiet=True)
+        agent.io = NeverInterruptIO()
+
+        result = agent.input("do work")
+
+        assert result == "all done"

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -26,6 +26,7 @@ from unittest.mock import Mock
 from connectonion.useful_plugins.tool_approval import (
     check_approval,
     poll_mode_changes,
+    poll_interrupt,
     handle_mode_change,
     tool_approval,
     VALID_MODES,
@@ -765,3 +766,33 @@ class TestPluginExport:
 
         assert 'before_each_tool' in agent.events
         assert 'before_iteration' in agent.events
+
+
+class TestPollInterrupt:
+    """Test poll_interrupt before_iteration handler (stop button)."""
+
+    def test_poll_interrupt_no_io_skips(self):
+        """poll_interrupt should skip when no IO (local execution)."""
+        agent = FakeAgent(io=None)
+
+        poll_interrupt(agent)  # should not raise
+
+        assert 'stop_signal' not in agent.current_session
+
+    def test_poll_interrupt_sets_stop_signal(self):
+        """An INTERRUPT message sets stop_signal so the loop exits at the boundary."""
+        io = FakeIO(pending_signals=[{'type': 'INTERRUPT'}])
+        agent = FakeAgent(io=io)
+
+        poll_interrupt(agent)
+
+        assert agent.current_session['stop_signal'] == 'user_interrupt'
+
+    def test_poll_interrupt_no_message_leaves_signal_unset(self):
+        """Without an INTERRUPT, poll_interrupt must not stop the loop."""
+        io = FakeIO(pending_signals=[{'type': 'mode_change', 'mode': 'safe'}])
+        agent = FakeAgent(io=io)
+
+        poll_interrupt(agent)
+
+        assert 'stop_signal' not in agent.current_session


### PR DESCRIPTION
## Why

A "stop" button in a chat frontend needs the agent to actually stop, not just the UI to hide a spinner. This is the agent side of that feature.

## What

**`poll_interrupt`** — a new `after_iteration` handler in the `tool_approval` plugin (`approval.py`). It drains `agent.io.receive_all('INTERRUPT')` and sets the existing `stop_signal`. The iteration loop already halts on `stop_signal` right after `after_iteration` (`core/agent.py`, unchanged) and returns its closing message.

**No core change.** This reuses the exact primitive and placement that `no_progress_guard` (`after_iteration` → sets `stop_signal`) and `reject_hard` already use. Registered in the `tool_approval` list, so every agent that loads it (co ai + the minimal template) is stoppable. It rides the same `agent.io` client-message channel as `poll_mode_changes`; the relay forwards the frame verbatim, so no server change is needed.

## Graceful by design

Running `after_iteration` means the current step (LLM call + tool batch) finishes before the stop lands — nothing is aborted mid-flight. It does **not** kill an in-flight LLM generation or a long-running tool; the stop lands at the next iteration boundary. Because `after_iteration` runs immediately before the loop's `stop_signal` check, the signal is consumed the same iteration it is set — no wasted LLM call and no cross-turn leak.

The closing message is the loop's existing `"What would you like me to do?"` — a proper agent turn, not a silent cutoff.

## Tests

`tests/unit/test_tool_approval.py::TestPollInterrupt` and `tests/unit/test_agent.py::TestGracefulInterrupt`. Full affected suites (`test_tool_approval`, `test_agent`, `test_ulw`, `test_no_progress_guard`) — 105 passed.

## Coordination

Pairs with the oo-chat stop button (openonion/oo-chat#24, draft), which sends `{type:'INTERRUPT'}` over the existing WS. The button only actually stops once a deployed agent runs a connectonion build that includes this change.