### PR TITLE
Pin patchright to 1.61.2 and add stealth-driver integrity check

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -128,6 +128,25 @@ def handle_doctor():
     console.print(Panel(config_table, title="[bold]Configuration[/bold]", border_style="green"))
     console.print()
 
+    # Browser checks (stealth driver integrity)
+    browser_table = Table(show_header=False, box=box.SIMPLE, padding=(0, 1))
+    browser_table.add_column("Check", style="cyan")
+    browser_table.add_column("Status")
+
+    from ...useful_tools.browser_tools.browser import driver_stealth_status
+    status, browser_version, detail = driver_stealth_status()
+    if status == "ok":
+        browser_table.add_row("Patchright", f"[green]✓[/green] {browser_version}")
+        browser_table.add_row("Stealth driver", f"[green]✓[/green] {detail}")
+    elif status == "broken":
+        browser_table.add_row("Patchright", f"[yellow]○[/yellow] {browser_version}")
+        browser_table.add_row("Stealth driver", f"[red]✗[/red] {detail}")
+    else:  # missing
+        browser_table.add_row("Patchright", f"[yellow]○[/yellow] {detail}")
+
+    console.print(Panel(browser_table, title="[bold]Browser[/bold]", border_style="cyan"))
+    console.print()
+
     # Connectivity checks (only if API key exists)
     if api_key:
         connectivity_table = Table(show_header=False, box=box.SIMPLE, padding=(0, 1))

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -135,6 +135,36 @@ def _browser_proxy_from_env():
     return proxy
 
 
+def driver_stealth_status():
+    """Report whether the installed Patchright driver still has its stealth patches.
+
+    Patchright ships its anti-detection patches in a separately-downloaded driver that has
+    silently regressed to the unpatched vanilla Playwright build across releases — leaving
+    navigator.webdriver=true and the "controlled by automated test software" infobar. The
+    patched driver always injects `--disable-blink-features=AutomationControlled`; the vanilla
+    one never does, so scanning the driver for that literal is a fast integrity check that
+    needs no browser launch. Surfaced by `co doctor`.
+
+    Returns (status, version, detail) where status is 'ok' | 'broken' | 'missing'.
+    """
+    import importlib.util
+    import importlib.metadata
+
+    if importlib.util.find_spec("patchright") is None:
+        return "missing", "", "patchright not installed — pip install patchright && patchright install chrome"
+
+    import patchright
+    version = importlib.metadata.version("patchright")
+    lib = Path(patchright.__file__).parent / "driver" / "package" / "lib"
+    marker = "disable-blink-features=AutomationControlled"
+    patched = any(marker in p.read_text(errors="ignore") for p in lib.rglob("*.js"))
+    if patched:
+        return "ok", version, "stealth patches present"
+    return ("broken", version,
+            "UNPATCHED driver — navigator.webdriver leaks. "
+            "Fix: pip install --force-reinstall --no-cache-dir patchright")
+
+
 @_public_methods_run_on_browser_thread
 class BrowserAutomation:
     """Browser automation with natural language support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,12 @@ dependencies = [
     "uvicorn>=0.20.0",
     "textual>=0.86.0",
     "textual-autocomplete>=3.0.0",
-    "patchright>=1.52.5",
+    # Pinned exact: Patchright ships its stealth patches inside a separately-downloaded
+    # driver, and that driver has silently regressed to the unpatched vanilla Playwright
+    # build across releases (1.57.x, 1.61.1 → navigator.webdriver leaks / automation infobar).
+    # 1.61.2 is verified-good. When bumping, re-verify with `co doctor`: the Browser panel
+    # must show the stealth patches present (navigator.webdriver false, no --enable-automation).
+    "patchright==1.61.2",
     "charset-normalizer>=3.0.0",
     "pypdf>=4.0.0",
     "python-pptx>=1.0.0",

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -1,0 +1,19 @@
+"""End-to-end guard: the REAL installed Patchright must be the patched stealth driver.
+
+This touches the actual on-disk install (no mocks), so it lives in e2e, not unit. It is the
+check that would have caught the silent regression we hit: Patchright's separately-downloaded
+driver reverting to the unpatched vanilla Playwright build (navigator.webdriver leaks, the
+"controlled by automated test software" infobar). If a future patchright bump lands an
+unpatched driver, this fails here instead of shipping a browser with no stealth.
+"""
+
+import pytest
+
+from connectonion.useful_tools.browser_tools.browser import driver_stealth_status
+
+
+def test_real_installed_driver_is_patched():
+    status, version, detail = driver_stealth_status()
+    if status == "missing":
+        pytest.skip("patchright not installed in this environment")
+    assert status == "ok", f"installed patchright {version} is not the patched stealth driver: {detail}"

--- a/tests/e2e/cli/test_cli_doctor.py
+++ b/tests/e2e/cli/test_cli_doctor.py
@@ -276,3 +276,39 @@ class TestHandleDoctorVirtualEnv:
             handle_doctor()
 
         assert mock_console.print.called
+
+
+class TestHandleDoctorBrowserChecks:
+    """The Browser panel surfaces Patchright stealth-driver integrity."""
+
+    def _run(self, monkeypatch, tmp_path, stealth):
+        import connectonion.cli.commands.doctor_commands as dc
+        monkeypatch.chdir(tmp_path)          # empty cwd → no local .env
+        monkeypatch.setenv("COLUMNS", "200")  # wide, so the detail isn't wrapped mid-word
+        monkeypatch.setattr(dc.shutil, "which", lambda x: "/usr/local/bin/co")
+        monkeypatch.setattr(dc.requests, "get", lambda *a, **k: Mock(status_code=200))
+        monkeypatch.setattr(dc.requests, "post", lambda *a, **k: Mock(status_code=200))
+        monkeypatch.setattr(
+            "connectonion.useful_tools.browser_tools.browser.driver_stealth_status",
+            lambda: stealth,
+        )
+        with patch.dict(os.environ, {"OPENONION_API_KEY": ""}):
+            dc.handle_doctor()
+
+    def test_doctor_shows_ok_stealth_driver(self, monkeypatch, tmp_path, capsys):
+        self._run(monkeypatch, tmp_path, ("ok", "1.61.2", "stealth patches present"))
+        out = capsys.readouterr().out
+        assert "Browser" in out
+        assert "1.61.2" in out
+        assert "stealth patches present" in out
+
+    def test_doctor_flags_broken_stealth_driver(self, monkeypatch, tmp_path, capsys):
+        self._run(monkeypatch, tmp_path,
+                  ("broken", "1.58.0", "UNPATCHED driver — navigator.webdriver leaks."))
+        out = capsys.readouterr().out
+        assert "UNPATCHED" in out
+
+    def test_doctor_notes_missing_patchright(self, monkeypatch, tmp_path, capsys):
+        self._run(monkeypatch, tmp_path, ("missing", "", "patchright not installed — pip install patchright"))
+        out = capsys.readouterr().out
+        assert "not installed" in out

--- a/tests/unit/test_browser_stealth.py
+++ b/tests/unit/test_browser_stealth.py
@@ -1,10 +1,9 @@
-"""Tests for the Patchright stealth-driver integrity check (driver_stealth_status).
+"""Unit tests for the Patchright stealth-driver integrity check (driver_stealth_status).
 
-Patchright ships its anti-detection patches in a separately-downloaded driver that has
-silently regressed to the unpatched vanilla Playwright build across releases. These tests
-lock the detection logic (patched vs vanilla vs not-installed) and guard that the pinned
-patchright actually IS the patched driver — so a bad bump fails CI instead of shipping a
-browser that leaks navigator.webdriver.
+Pure/isolated: the driver install is faked with a temp tree and monkeypatch, so these lock
+the detection logic (patched vs vanilla vs not-installed) with no dependency on the real
+install. The guard that the *real* pinned driver is patched is an e2e test (it touches the
+actual install): tests/e2e/cli/test_browser_stealth_e2e.py.
 """
 
 import importlib.util
@@ -52,12 +51,3 @@ def test_status_missing_when_not_installed(monkeypatch):
     assert status == "missing"
     assert version == ""
     assert "not installed" in detail
-
-
-def test_real_installed_driver_is_patched():
-    """Guard: the pinned patchright must actually be the patched stealth driver.
-
-    This is the check that would have caught the silent regression — if a future bump
-    lands an unpatched driver, this fails instead of shipping a webdriver leak."""
-    status, version, detail = browser_mod.driver_stealth_status()
-    assert status == "ok", f"installed patchright {version} is not the patched driver: {detail}"

--- a/tests/unit/test_browser_stealth.py
+++ b/tests/unit/test_browser_stealth.py
@@ -1,0 +1,63 @@
+"""Tests for the Patchright stealth-driver integrity check (driver_stealth_status).
+
+Patchright ships its anti-detection patches in a separately-downloaded driver that has
+silently regressed to the unpatched vanilla Playwright build across releases. These tests
+lock the detection logic (patched vs vanilla vs not-installed) and guard that the pinned
+patchright actually IS the patched driver — so a bad bump fails CI instead of shipping a
+browser that leaks navigator.webdriver.
+"""
+
+import importlib.util
+
+import connectonion.useful_tools.browser_tools.browser as browser_mod
+
+# The literal switch only the PATCHED driver injects; the vanilla driver never has it.
+PATCHED_MARKER = 'browser.launchOptions.args.push("--disable-blink-features=AutomationControlled")'
+# A snippet of the VANILLA driver (the exact form we observed on the broken 1.58 install).
+VANILLA_SNIPPET = 'assistantMode ? "" : "--enable-automation",'
+
+
+def _fake_patchright(tmp_path, js_content):
+    """Build a fake patchright install tree and return the __file__ to monkeypatch onto it."""
+    lib = tmp_path / "patchright" / "driver" / "package" / "lib" / "server" / "chromium"
+    lib.mkdir(parents=True)
+    (lib / "coreBundle.js").write_text(js_content)
+    return str(tmp_path / "patchright" / "__init__.py")
+
+
+def test_status_ok_when_driver_patched(tmp_path, monkeypatch):
+    import patchright
+    monkeypatch.setattr(patchright, "__file__", _fake_patchright(tmp_path, PATCHED_MARKER))
+
+    status, version, detail = browser_mod.driver_stealth_status()
+    assert status == "ok"
+    assert version  # importlib.metadata still reports the installed version
+    assert "present" in detail
+
+
+def test_status_broken_when_driver_vanilla(tmp_path, monkeypatch):
+    import patchright
+    monkeypatch.setattr(patchright, "__file__", _fake_patchright(tmp_path, VANILLA_SNIPPET))
+
+    status, version, detail = browser_mod.driver_stealth_status()
+    assert status == "broken"
+    assert "UNPATCHED" in detail
+    assert "force-reinstall" in detail  # tells the user how to fix it
+
+
+def test_status_missing_when_not_installed(monkeypatch):
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+    status, version, detail = browser_mod.driver_stealth_status()
+    assert status == "missing"
+    assert version == ""
+    assert "not installed" in detail
+
+
+def test_real_installed_driver_is_patched():
+    """Guard: the pinned patchright must actually be the patched stealth driver.
+
+    This is the check that would have caught the silent regression — if a future bump
+    lands an unpatched driver, this fails instead of shipping a webdriver leak."""
+    status, version, detail = browser_mod.driver_stealth_status()
+    assert status == "ok", f"installed patchright {version} is not the patched driver: {detail}"


### PR DESCRIPTION
## Problem

Patchright ships its anti-detection patches in a **separately-downloaded driver**, and that driver has silently regressed to the unpatched vanilla Playwright build across releases (1.57.x, 1.61.1). On the affected installs `co browser` was effectively running **plain Playwright with zero stealth** — `navigator.webdriver === true` and the "Chrome is being controlled by automated test software" infobar — with **no error**.

Verified locally: with the old floor (`patchright>=1.52.5`) the installed 1.58 driver's `chromiumSwitches.js` still had the vanilla `--enable-automation` ternary and no `--disable-blink-features=AutomationControlled`; `navigator.webdriver` was `true`. After pinning to 1.61.2 (patched driver): `--enable-automation` gone, `AutomationControlled` disabled, `navigator.webdriver` **false**, infobar gone.

## Changes

- **Pin `patchright==1.61.2`** (verified-good driver). Exact pin because the driver has regressed on both minor and patch bumps, and the failure is silent.
- **`driver_stealth_status()`** — scans the installed driver for the patched-only switch `--disable-blink-features=AutomationControlled`; fast, no browser launch.
- **`co doctor` Browser panel** surfaces it, so a future driver regression is visible instead of silent.

## Verify

```
co doctor   # Browser panel → Stealth driver ✓ stealth patches present
```

Scope: this PR is the patchright fix only. The `co browser` daemon-lifecycle fixes (self-heal, stale-lock, status integration) depend on the tab-sessions branch and are tracked separately.