### PR TITLE
Silence pytest-asyncio default-loop-scope deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,11 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 
+# pytest-asyncio: pin the default fixture loop scope explicitly. Silences the
+# "asyncio_default_fixture_loop_scope is unset" PytestDeprecationWarning; 'function'
+# keeps the historical default (a fresh event loop per test), so behavior is unchanged.
+asyncio_default_fixture_loop_scope = function
+
 # Markers
 markers =
     unit: Unit tests - fast, isolated tests with mocks


### PR DESCRIPTION
## What

pytest-asyncio prints a `PytestDeprecationWarning` on every run because `asyncio_default_fixture_loop_scope` is unset:

```
pytest_asyncio/plugin.py: PytestDeprecationWarning: The configuration option
"asyncio_default_fixture_loop_scope" is unset.
```

Set it explicitly to `function` in `pytest.ini`.

## Why `function`

`function` is pytest-asyncio's historical default (a fresh event loop per test), so this only makes the existing behavior explicit — no test behavior changes. It just stops the warning.

## Verify

```
pytest tests/unit/test_browser_stealth.py
# header now: asyncio: mode=strict, asyncio_default_fixture_loop_scope=function
# no PytestDeprecationWarning
```

`--strict-config` (already on) accepts the option, confirming it's valid. Repo-wide cleanup; unrelated to any feature.