### PR TITLE
Fix/ulw session restore

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -250,7 +250,11 @@ class Agent:
                 'session_id': session.get('session_id'),
                 'messages': list(session.get('messages', [])),
                 'trace': list(session.get('trace', [])),
-                'turn': session.get('turn', 0)
+                'turn': session.get('turn', 0),
+                'mode': session.get('mode'),
+                'skip_tool_approval': session.get('skip_tool_approval'),
+                'ulw_turns': session.get('ulw_turns'),
+                'ulw_turns_used': session.get('ulw_turns_used'),
             }
             # Start YAML session logging with session_id for thread safety
             self.logger.start_session(self.system_prompt, session_id=session.get('session_id'))

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -720,3 +720,47 @@ def test_agent_input_file_path_traversal(tmp_path):
     uploads_dir = tmp_path / ".co" / "uploads"
     assert len(list(uploads_dir.glob("*_passwd"))) == 1
     assert not (tmp_path / "etc").exists()
+
+
+def test_input_preserves_plugin_session_fields():
+    """Agent.input(session=…) should preserve plugin-owned fields (mode, ulw_turns, etc.)."""
+    agent = Agent(name="test", llm=MockLLM(), log=False)
+
+    session = {
+        "session_id": "test-123",
+        "mode": "ulw",
+        "skip_tool_approval": True,
+        "ulw_turns": 100,
+        "ulw_turns_used": 5,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    agent.input("hello", session=session)
+
+    assert agent.current_session.get("mode") == "ulw"
+    assert agent.current_session.get("skip_tool_approval") is True
+    assert agent.current_session.get("ulw_turns") == 100
+    assert agent.current_session.get("ulw_turns_used") == 5
+
+
+def test_input_does_not_leak_transient_keys():
+    """Agent.input(session=…) should not blindly restore server-internal keys."""
+    agent = Agent(name="test", llm=MockLLM(), log=False)
+
+    session = {
+        "session_id": "test-456",
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "permissions": {"admin": True},
+        "stop_signal": True,
+        "pending_tool": "bash",
+    }
+
+    agent.input("hello", session=session)
+
+    assert "permissions" not in agent.current_session
+    assert "stop_signal" not in agent.current_session
+    assert "pending_tool" not in agent.current_session


### PR DESCRIPTION
   ## Related Issue
   Fixes #191

   ## Type of Change
   - [x] Bug fix (non-breaking change which fixes an issue)
   - [ ] New feature (non-breaking change which adds functionality)
   - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - [ ] Documentation update

   ## Changes Made
   - Added `mode`, `skip_tool_approval`, `ulw_turns`, `ulw_turns_used` to the session reconstruction whitelist in `Agent.input()`
   - Uses the same whitelist pattern rather than `dict(session)`, so transient keys (`permissions`, `stop_signal`, `pending_tool`) remain blocked
   - Added `test_input_preserves_plugin_session_fields` and `test_input_does_not_leak_transient_keys`

   ## Testing
   - [x] I have tested this code locally
   - [x] All existing tests pass
   - [x] I have added tests for new functionality

   ## Checklist
   - [x] My code follows the project's code style
   - [x] I have performed a self-review of my own code
   - [ ] I have commented my code, particularly in hard-to-understand areas
   - [ ] I have made corresponding changes to the documentation
   - [x] My changes generate no new warnings
   - [x] New and existing unit tests pass locally
   - [ ] Any dependent changes have been merged and published