### PR TITLE
Release v1.2.0

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -26,7 +26,7 @@ Example: `0.0.2`
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.1.0
+## Current Version: 1.2.0
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -35,6 +35,8 @@ Example: `0.0.2`
 - 0.2.0 → 0.2.9 (Documentation improvements, LLM refactoring, test coverage, CLI enhancements and fixes)
 - 0.3.0 → 0.3.8 (Enhanced debugger, CLI status/reset, Windows support, email refactoring, network features, pytest migration)
 - 0.4.0 → 0.4.1 (Automatic .env loading, event system, email API fixes, comprehensive CLI help)
+- 1.0.0 → 1.1.0 (Stable release; cancelable scheduled email, scheduled replies)
+- 1.2.0 (co browser multi-agent tab CLI: -t targeting, tab lifecycle, contention guard, exit-code contract, daemon race hardening; graceful interrupt; Patchright stealth pin)
 
 ## Files to Update When Versioning
 

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 # Auto-load .env files for the entire framework
 import sys as _sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.1.0"
+version = "1.2.0"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump 1.1.0 → 1.2.0 (MINOR: new features since last tag — co browser multi-agent tabs #195, graceful interrupt #188, hosted-session safety #186/#189, outlook rotation #187, daemon race fix #197).

🤖 Generated with [Claude Code](https://claude.com/claude-code)