### PR TITLE
Add co-browser and install-connectonion skills to useful_skills

### DIFF
--- a/connectonion/cli/commands/copy_commands.py
+++ b/connectonion/cli/commands/copy_commands.py
@@ -97,6 +97,7 @@ TRUST = {
 
 # Registry of copyable skills (directories with SKILL.md, copied to .co/skills/)
 SKILLS = {
+    "co-browser": "co-browser",
     "ship-feature": "ship-feature",
 }
 

--- a/connectonion/cli/commands/copy_commands.py
+++ b/connectonion/cli/commands/copy_commands.py
@@ -98,6 +98,7 @@ TRUST = {
 # Registry of copyable skills (directories with SKILL.md, copied to .co/skills/)
 SKILLS = {
     "co-browser": "co-browser",
+    "install-connectonion": "install-connectonion",
     "ship-feature": "ship-feature",
 }
 

--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: co-browser
+description: Drive one persistent, logged-in browser from the shell with `co browser`. Use when the user asks to open a page, log into a site, scrape/extract page content, fill forms, upload files, take screenshots, or automate any browser task — solo or with multiple agents sharing the browser.
+tools:
+  - Bash(co browser *)
+  - Bash(export *)
+  - read_file
+  - write_file
+---
+
+# co browser Skill
+
+Drive **one real browser** from the shell. The browser stays open between commands —
+cookies and logins persist until `co browser close`. Every terminal on the machine
+talks to the same daemon: one browser, one board, no matter where you type.
+
+Output contract: **stdout = data, stderr = errors.** Exit code `0` = success.
+
+## Step 1: Identity — who are you?
+
+The daemon attributes every tab to a caller and uses that identity to stop two
+agents from silently driving the same page. Identity resolves in this order:
+
+1. `CO_WHO` environment variable — set it explicitly in scripts and subagents:
+
+   ```bash
+   export CO_WHO=alice     # once per shell — every command now carries it
+   ```
+
+2. Claude Code sessions are identified automatically (as `claude-<session>`).
+3. Anonymous — still works, but gets **no contention protection**.
+
+Concurrent agents must always have an identity. Solo interactive use can skip this step.
+
+## Step 2: Check the board, then claim a tab
+
+**One task = one tab.** Before touching the browser, see what's already happening:
+
+```bash
+co browser status      # daemon health, headless flag, last command, the board
+co browser tab ls      # every tab: who owns it, purpose, last command (--json for scripting)
+```
+
+**Solo (nobody else on the board)** — bare commands run on the shared `main` tab, no ceremony:
+
+```bash
+co browser go_to example.com     # runs on 'main'
+co browser get_text              # still 'main'
+```
+
+**Concurrent (another agent or a second parallel task exists)** — open your own tab
+with an owner and a purpose, then add `-t <name>` to EVERY command, including `do`:
+
+```bash
+NAME=$(co browser tab open --who "$CO_WHO" --for "scrape pricing")   # prints the tab name
+co browser -t "$NAME" go_to example.com/pricing
+co browser -t "$NAME" do "extract every plan and its monthly price"
+co browser tab close "$NAME"                                         # release when done
+```
+
+When delegating browser work to subagents, give each subagent its own tab name in
+its prompt — parallel agents share the one logged-in browser through separate tabs.
+
+## Step 3: Pick the right verb
+
+Two ways to drive the browser — pick per command, mix freely:
+
+**Direct functions** (deterministic, instant, free — no LLM). Use for every step you can spell out:
+
+```bash
+co browser go_to https://example.com/login        # https:// assumed if omitted
+co browser get_text                               # visible page text
+co browser get_links_from_page                    # every link, one per line
+co browser take_screenshot /tmp/page.png          # saves a PNG, prints its path
+co browser click_element_by_selector "button" --index=0 --text="Send message"
+co browser type_text_by_selector "#email" "user@example.com"
+co browser scroll --direction=down
+co browser get_current_url
+```
+
+`co browser help` prints the live list of every function with its arguments.
+Calling one with wrong arguments returns its usage line — self-correct from that.
+
+**`do "<instruction>"`** (natural language — an AI agent sees the page and works out
+the steps). Use for judgment, not for steps you already know:
+
+```bash
+co browser do "log in with the saved credentials and open my notifications"
+```
+
+Describe the **end state**, not the steps. `do` costs LLM calls and is slower;
+while it runs the daemon is busy and other commands queue behind it.
+
+A cheap trick for state checks — force a one-word answer:
+
+```bash
+co browser do "Look at the current page. Reply EXACTLY one of: STATE: feed | STATE: login | STATE: error"
+```
+
+## Step 4: Verify with evidence
+
+Screenshots are ground truth — never assume an action worked:
+
+- After a navigation or a click that matters: `co browser take_screenshot` and look
+  at the PNG, or read `get_text` / `get_current_url` output. Give the page a beat
+  to settle between navigating and screenshotting.
+- Before an irreversible action (submit, post, publish, pay): screenshot first,
+  act **exactly once**, screenshot after. Never click the same submit button twice —
+  if the result is ambiguous, report uncertain state instead of retrying.
+- To find stable selectors, save the DOM and grep it:
+
+  ```bash
+  co browser save_page_context li_composer
+  grep -o 'aria-label="[^"]*"' ~/.co/browser_context/*li_composer*/page.html | sort -u
+  ```
+
+- Site-specific DOM logic belongs in skill-local JS, not one-off shell parsing:
+
+  ```bash
+  co browser run_page_script .co/skills/<skill>/scripts/extract-items.js
+  ```
+
+## Step 5: React to exit codes
+
+Branch on the exit code — don't parse prose:
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| `0` | success | continue |
+| `1` | action failed (e.g. selector not found) | inspect the error, adjust selector or approach |
+| `2` | usage error (bad flags, empty `-t`, `tab` misuse) | fix the command syntax |
+| `3` | unknown tab | `tab open` the name first, then target it |
+| `4` | tab busy — another agent is mid-task there | do NOT retry the same command; open your own tab (the error shows the three commands) |
+
+A crashed agent's tab claim expires on its own in ~2 minutes.
+
+## Logging in
+
+The default is a **visible** window — exactly what you want for a first login.
+Never automate credentials: open the login page, let the human log in, poll until done:
+
+```bash
+co browser go_to https://site.com/login
+# human logs in in the visible window; poll until the URL leaves the login page
+for i in $(seq 1 30); do
+  sleep 20
+  co browser get_current_url | tail -1 | grep -q "/feed" && break
+done
+```
+
+Logins live in the profile (`~/.co/browser_profile/`), not the daemon — they survive
+`close` and daemon restarts. Log in once, stay logged in.
+
+Headless: `co browser --headless go_to ...` — the choice is made by whichever command
+**starts** the daemon and sticks for its lifetime. To switch: `close`, then relaunch.
+
+## Scripting hygiene
+
+- Wrap calls that might block in `timeout 60 co browser ...`; take the data line
+  with `tail -1` when the output includes env banners.
+- Read long pages in chunks: `co browser get_text | sed -n '1,200p'`.
+- Batch related commands in one turn; never spend a whole turn on a bare wait.
+- Don't screenshot while scanning — extracted text is the source of truth. Screenshot
+  only at evidence gates (before/after an irreversible action).
+- Uploads: try `upload_file_by_selector 'input[type="file"]' <path>` first; if the
+  input is hidden behind a button, `upload_file_after_click_by_selector '<button selector>' <path>`.
+
+## Troubleshooting
+
+- **"Where is my window?"** — `co browser status` says `headless=true`? An earlier
+  command started the daemon headless. `co browser close`, rerun without the flag.
+- **exit 4 ("tab in use by ...")** — another agent is mid-task. Open your own tab.
+- **"daemon is busy" after ~15s** — a long `do` holds the single-threaded daemon.
+  Wait, then check `co browser status`.
+- **"Opening in existing browser session" / profile in use (shows a PID)** — a
+  manually opened Chrome or stale daemon holds the profile; kill that PID, retry.
+- **`TargetClosedError` after a crash** — the page died under the daemon; run
+  `co browser open_browser` again before retrying the command.
+- **"Chrome failed to start"** — usually ssh/cron without a desktop session (run from
+  a logged-in Terminal, or use `--headless`), or a leftover Chrome holding the
+  profile. Full launch log: `~/.co/browser.log`.
+- **Nuclear option** — kill the daemon and let the next command start fresh
+  (logins survive — they live in the profile, not the daemon):
+
+  ```bash
+  pkill -f connectonion.cli.browser_agent.daemon
+  ```
+
+## Done checklist
+
+- [ ] Identity set (`CO_WHO`) if scripted or concurrent
+- [ ] Board checked (`status` / `tab ls`) before claiming a tab
+- [ ] Own tab used if any other agent/task shares the browser (`-t` on every command)
+- [ ] Irreversible actions performed exactly once, with before/after screenshots
+- [ ] Tab closed (`co browser tab close <name>`) when the task is done
+- [ ] Browser left open for the next task unless the user asked to `close`

--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -3,9 +3,16 @@ name: co-browser
 description: Drive one persistent, logged-in browser from the shell with `co browser`. Use when the user asks to open a page, log into a site, scrape/extract page content, fill forms, upload files, take screenshots, or automate any browser task — solo or with multiple agents sharing the browser.
 tools:
   - Bash(co browser *)
-  - Bash(export *)
+  - Bash(CO_WHO=*)
+  - Bash(export CO_WHO=*)
+  - Bash(timeout *)
+  - Bash(grep *)
+  - Bash(sed *)
+  - Bash(tail *)
+  - Bash(sort *)
+  - Bash(sleep *)
+  - Bash(pkill *)
   - read_file
-  - write_file
 ---
 
 # co browser Skill
@@ -14,30 +21,37 @@ Drive **one real browser** from the shell. The browser stays open between comman
 cookies and logins persist until `co browser close`. Every terminal on the machine
 talks to the same daemon: one browser, one board, no matter where you type.
 
-Output contract: **stdout = data, stderr = errors.** Exit code `0` = success.
+**Always read the output, not just the exit code.** A failed action (selector not
+found, browser not open) often returns exit `0` with the error text on stdout —
+never chain `co browser ... && next_step` as your only success check.
 
 ## Step 1: Identity — who are you?
 
 The daemon attributes every tab to a caller and uses that identity to stop two
-agents from silently driving the same page. Identity resolves in this order:
+agents from silently driving the same page. **Set `CO_WHO` explicitly** — shell
+state does not survive between your tool calls, so a lone `export` is lost.
+Either prefix every command:
 
-1. `CO_WHO` environment variable — set it explicitly in scripts and subagents:
+```bash
+CO_WHO=alice co browser go_to example.com
+```
 
-   ```bash
-   export CO_WHO=alice     # once per shell — every command now carries it
-   ```
+or keep the export and the commands in the SAME shell invocation:
 
-2. Claude Code sessions are identified automatically (as `claude-<session>`).
-3. Anonymous — still works, but gets **no contention protection**.
+```bash
+export CO_WHO=alice && co browser go_to example.com && co browser get_text
+```
 
-Concurrent agents must always have an identity. Solo interactive use can skip this step.
+(Some environments — e.g. Claude Code background jobs — are auto-identified,
+but setting `CO_WHO` is always safe and never worse.) An anonymous caller still
+works but gets **no contention protection**.
 
 ## Step 2: Check the board, then claim a tab
 
 **One task = one tab.** Before touching the browser, see what's already happening:
 
 ```bash
-co browser status      # daemon health, headless flag, last command, the board
+co browser status      # browser state, headless flag, last command, the board
 co browser tab ls      # every tab: who owns it, purpose, last command (--json for scripting)
 ```
 
@@ -49,17 +63,18 @@ co browser get_text              # still 'main'
 ```
 
 **Concurrent (another agent or a second parallel task exists)** — open your own tab
-with an owner and a purpose, then add `-t <name>` to EVERY command, including `do`:
+and add `-t <name>` to EVERY command, including `do`. Pick an explicit literal tab
+name — a `NAME=$(...)` capture is lost between tool calls:
 
 ```bash
-NAME=$(co browser tab open --who "$CO_WHO" --for "scrape pricing")   # prints the tab name
-co browser -t "$NAME" go_to example.com/pricing
-co browser -t "$NAME" do "extract every plan and its monthly price"
-co browser tab close "$NAME"                                         # release when done
+CO_WHO=alice co browser tab open scrape --for "scrape pricing"
+CO_WHO=alice co browser -t scrape go_to example.com/pricing
+CO_WHO=alice co browser -t scrape do "extract every plan and its monthly price"
+CO_WHO=alice co browser tab close scrape       # release when done
 ```
 
-When delegating browser work to subagents, give each subagent its own tab name in
-its prompt — parallel agents share the one logged-in browser through separate tabs.
+When delegating browser work to subagents, write each subagent's tab name into its
+prompt — parallel agents share the one logged-in browser through separate tabs.
 
 ## Step 3: Pick the right verb
 
@@ -74,12 +89,13 @@ co browser get_links_from_page                    # every link, one per line
 co browser take_screenshot /tmp/page.png          # saves a PNG, prints its path
 co browser click_element_by_selector "button" --index=0 --text="Send message"
 co browser type_text_by_selector "#email" "user@example.com"
-co browser scroll --direction=down
+co browser scroll                                 # scroll the page (scroll 3 = fewer steps)
 co browser get_current_url
 ```
 
-`co browser help` prints the live list of every function with its arguments.
-Calling one with wrong arguments returns its usage line — self-correct from that.
+`co browser help` prints the live list of every function with its arguments —
+trust it over any example here. Calling a function with wrong arguments returns
+its usage line: self-correct from that.
 
 **`do "<instruction>"`** (natural language — an AI agent sees the page and works out
 the steps). Use for judgment, not for steps you already know:
@@ -88,10 +104,18 @@ the steps). Use for judgment, not for steps you already know:
 co browser do "log in with the saved credentials and open my notifications"
 ```
 
-Describe the **end state**, not the steps. `do` costs LLM calls and is slower;
-while it runs the daemon is busy and other commands queue behind it.
+Describe the **end state**, not the steps. A `do` is a full agent run — many LLM
+calls, possibly minutes — and the daemon is busy for its whole duration, so other
+commands queue behind it. **Never wrap `do` in `timeout`**: killing the client
+does not stop the run, it only orphans it (you pay for an answer nobody reads).
 
-A cheap trick for state checks — force a one-word answer:
+For state checks, prefer the free text probes first (exit 0 = matched):
+
+```bash
+co browser get_current_url | grep "/feed"
+```
+
+Only when the state is visually ambiguous, fall back to a one-word `do` probe:
 
 ```bash
 co browser do "Look at the current page. Reply EXACTLY one of: STATE: feed | STATE: login | STATE: error"
@@ -99,14 +123,19 @@ co browser do "Look at the current page. Reply EXACTLY one of: STATE: feed | STA
 
 ## Step 4: Verify with evidence
 
-Screenshots are ground truth — never assume an action worked:
+- **Routine checks are text checks**: `get_current_url` / `get_text` after
+  navigation and clicks. Reserve screenshots for evidence gates.
+- **Irreversible actions (submit, post, publish, pay) get the full gate**:
+  screenshot before, act **exactly once**, screenshot after. Never click the same
+  submit button twice — if the result is ambiguous, report uncertain state
+  instead of retrying.
+- Long pages: dump once and read locally instead of re-extracting per chunk:
 
-- After a navigation or a click that matters: `co browser take_screenshot` and look
-  at the PNG, or read `get_text` / `get_current_url` output. Give the page a beat
-  to settle between navigating and screenshotting.
-- Before an irreversible action (submit, post, publish, pay): screenshot first,
-  act **exactly once**, screenshot after. Never click the same submit button twice —
-  if the result is ambiguous, report uncertain state instead of retrying.
+  ```bash
+  co browser get_text > /tmp/page.txt    # one daemon round-trip
+  sed -n '1,200p' /tmp/page.txt
+  ```
+
 - To find stable selectors, save the DOM and grep it:
 
   ```bash
@@ -114,54 +143,58 @@ Screenshots are ground truth — never assume an action worked:
   grep -o 'aria-label="[^"]*"' ~/.co/browser_context/*li_composer*/page.html | sort -u
   ```
 
-- Site-specific DOM logic belongs in skill-local JS, not one-off shell parsing:
+- Site-specific DOM logic belongs in skill-local JS run with an **absolute path**
+  (the daemon resolves relative paths against its own cwd, not yours):
 
   ```bash
-  co browser run_page_script .co/skills/<skill>/scripts/extract-items.js
+  co browser run_page_script /path/to/project/.co/skills/<skill>/scripts/extract-items.js
   ```
 
-## Step 5: React to exit codes
+## Step 5: React to failures
 
-Branch on the exit code — don't parse prose:
+Exit codes cover the daemon-level contract; the output text covers the action itself:
 
-| Code | Meaning | What to do |
-|------|---------|------------|
-| `0` | success | continue |
-| `1` | action failed (e.g. selector not found) | inspect the error, adjust selector or approach |
-| `2` | usage error (bad flags, empty `-t`, `tab` misuse) | fix the command syntax |
-| `3` | unknown tab | `tab open` the name first, then target it |
-| `4` | tab busy — another agent is mid-task there | do NOT retry the same command; open your own tab (the error shows the three commands) |
+| Signal | Meaning | What to do |
+|--------|---------|------------|
+| exit `0`, clean output | success | continue |
+| exit `0`, error text on stdout | the action failed softly (e.g. "No element found for selector") | read it, adjust selector or approach |
+| exit `1` | the command raised (bad arguments print the usage line) | self-correct from the message |
+| exit `2` | usage error (bad flags, empty `-t`, `tab` misuse) | fix the command syntax |
+| exit `3` | unknown tab | `tab open` the name first, then target it |
+| exit `4` | tab busy — another agent is mid-task there | do NOT retry the same command — the error prints the exact commands to run instead; follow them |
 
-A crashed agent's tab claim expires on its own in ~2 minutes.
+The exit-3/4 error messages ARE the documentation — they always carry the current
+recovery steps, so trust them over this table. A crashed agent's tab claim
+expires on its own; if a stale claim blocks you, open your own tab rather than
+closing theirs.
 
 ## Logging in
 
 The default is a **visible** window — exactly what you want for a first login.
-Never automate credentials: open the login page, let the human log in, poll until done:
+Never automate credentials: open the login page, tell the user, then check with
+short waits — one short check per tool call, not one long blocking loop (a long
+loop hits the tool timeout, and every poll refreshes your claim on the tab,
+locking other agents out for its whole duration):
 
 ```bash
 co browser go_to https://site.com/login
-# human logs in in the visible window; poll until the URL leaves the login page
-for i in $(seq 1 30); do
-  sleep 20
-  co browser get_current_url | tail -1 | grep -q "/feed" && break
-done
+# tell the user to log in in the visible window, then per check-in:
+sleep 15 && co browser get_current_url | tail -1
 ```
 
-Logins live in the profile (`~/.co/browser_profile/`), not the daemon — they survive
-`close` and daemon restarts. Log in once, stay logged in.
+Repeat the check a handful of times; if the URL is still the login page after
+that, stop and ask the user instead of looping forever. Logins live in the profile (`~/.co/browser_profile/`),
+not the daemon — they survive `close` and restarts. Log in once, stay logged in.
 
-Headless: `co browser --headless go_to ...` — the choice is made by whichever command
-**starts** the daemon and sticks for its lifetime. To switch: `close`, then relaunch.
+Headless: `co browser --headless go_to ...` — the mode is fixed by whichever
+command **starts** the daemon (`status` shows `headless=true/false`). To switch:
+`co browser close`, then relaunch.
 
 ## Scripting hygiene
 
-- Wrap calls that might block in `timeout 60 co browser ...`; take the data line
-  with `tail -1` when the output includes env banners.
-- Read long pages in chunks: `co browser get_text | sed -n '1,200p'`.
-- Batch related commands in one turn; never spend a whole turn on a bare wait.
-- Don't screenshot while scanning — extracted text is the source of truth. Screenshot
-  only at evidence gates (before/after an irreversible action).
+- Wrap **direct functions** that might block in `timeout 60 ...`; never `timeout` a `do`.
+- Take the data line with `tail -1` when output includes env banners.
+- Batch related commands in one tool call; never spend a whole call on a bare wait.
 - Uploads: try `upload_file_by_selector 'input[type="file"]' <path>` first; if the
   input is hidden behind a button, `upload_file_after_click_by_selector '<button selector>' <path>`.
 
@@ -169,18 +202,16 @@ Headless: `co browser --headless go_to ...` — the choice is made by whichever 
 
 - **"Where is my window?"** — `co browser status` says `headless=true`? An earlier
   command started the daemon headless. `co browser close`, rerun without the flag.
-- **exit 4 ("tab in use by ...")** — another agent is mid-task. Open your own tab.
-- **"daemon is busy" after ~15s** — a long `do` holds the single-threaded daemon.
-  Wait, then check `co browser status`.
+- **"daemon is busy"** — a long `do` is holding the single-threaded daemon. Wait
+  and retry; `co browser status` shows the last command once it frees up.
 - **"Opening in existing browser session" / profile in use (shows a PID)** — a
   manually opened Chrome or stale daemon holds the profile; kill that PID, retry.
 - **`TargetClosedError` after a crash** — the page died under the daemon; run
   `co browser open_browser` again before retrying the command.
-- **"Chrome failed to start"** — usually ssh/cron without a desktop session (run from
-  a logged-in Terminal, or use `--headless`), or a leftover Chrome holding the
-  profile. Full launch log: `~/.co/browser.log`.
+- **"Chrome failed to start"** — usually ssh/cron without a desktop session (run
+  from a logged-in Terminal, or use `--headless`). Full launch log: `~/.co/browser.log`.
 - **Nuclear option** — kill the daemon and let the next command start fresh
-  (logins survive — they live in the profile, not the daemon):
+  (logins survive in the profile):
 
   ```bash
   pkill -f connectonion.cli.browser_agent.daemon
@@ -188,9 +219,10 @@ Headless: `co browser --headless go_to ...` — the choice is made by whichever 
 
 ## Done checklist
 
-- [ ] Identity set (`CO_WHO`) if scripted or concurrent
+- [ ] Identity attached to every command (`CO_WHO=... co browser ...`)
 - [ ] Board checked (`status` / `tab ls`) before claiming a tab
 - [ ] Own tab used if any other agent/task shares the browser (`-t` on every command)
+- [ ] Output text read on every command, not just exit codes
 - [ ] Irreversible actions performed exactly once, with before/after screenshots
 - [ ] Tab closed (`co browser tab close <name>`) when the task is done
 - [ ] Browser left open for the next task unless the user asked to `close`

--- a/connectonion/useful_skills/install-connectonion/SKILL.md
+++ b/connectonion/useful_skills/install-connectonion/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: install-connectonion
-description: Install ConnectOnion and configure everything — Python check, package, project scaffold, API keys (managed or own), optional Google/Microsoft integrations — then verify with a real run and hand the user a plain-language account summary. Use when the user says "install connectonion", "set up connectonion", "get me started with co", or a co command fails because nothing is configured yet.
+description: Install ConnectOnion and configure everything on Windows, macOS, or Linux — find Python, install the package, scaffold a project, set up API keys (managed or own), install a browser if needed — then verify with a real run and hand the user a plain-language account summary. Use when the user says "install connectonion", "set up connectonion", "get me started with co", or a co command fails because nothing is configured yet.
 tools:
-  - Bash(pip *)
-  - Bash(pip3 *)
   - Bash(python *)
   - Bash(python3 *)
+  - Bash(py *)
+  - Bash(pip *)
+  - Bash(pip3 *)
   - Bash(co *)
-  - Bash(cat *)
-  - Bash(ls *)
-  - Bash(grep *)
+  - Bash(patchright *)
+  - shell
   - read_file
   - write
   - edit
@@ -17,118 +17,136 @@ tools:
 
 # Install ConnectOnion Skill
 
-Take a machine from nothing to a working, configured agent — then tell the person,
-in plain words, exactly what they have.
+Take a machine from nothing to a working, configured agent — on **whatever operating
+system the person is using** — then tell them, in plain words, exactly what they have.
 
 **Assume the person running this may not be technical.** They may not know what a
-"virtual environment", a "PATH", or an "API key" is, and that's fine — your job is
-to do the technical work *for* them and keep them informed in friendly, jargon-free
-language. Never dump a raw stack trace at them; translate every problem into "here's
-what happened and here's what I'm doing about it."
+"virtual environment", a "PATH", or an "API key" is, and that's fine — your job is to do
+the technical work *for* them and keep them informed in friendly, jargon-free language.
+Never dump a raw stack trace at them; translate every problem into "here's what happened
+and here's what I'm doing about it."
 
 ## How to run this skill
 
-1. **Verify every step before moving on.** Never assume a command worked — check its
-   output. Each step below has a check; run it.
-2. **Auto-correct instead of giving up.** When a step fails, do NOT stop and paste the
-   error. Diagnose the cause, apply the known fix (see the *Recovery* box under each
-   step and the reference table at the end), and retry. Give each fix **up to 2
-   attempts** before escalating.
-3. **Only ask the human for things only a human can do** — logging in through a browser,
-   adding money, choosing a project name. Ask in one plain sentence, never with a wall
-   of options.
-4. **Keep them in the loop.** A short friendly line before each phase ("Installing the
-   software now — about 30 seconds…") is worth more than silence.
-5. **Never print or store secrets.** Confirm a key is *present*, never show its value.
+1. **Work on the user's real OS.** Windows, macOS, and Linux differ in command names and
+   shells. Do Step 0 first and use the right commands for that platform — don't assume
+   `python3`, `grep`, or `bash` exist everywhere.
+2. **Verify every step before moving on.** Never assume a command worked — check its
+   output. Each step has a check; run it.
+3. **Auto-correct instead of giving up.** When a step fails, do NOT stop and paste the
+   error. Diagnose the cause, apply the known fix (the *Recovery* box under each step),
+   and retry. Give each fix **up to 2 attempts** before escalating.
+4. **Only ask the human for things only a human can do** — logging in through a browser,
+   adding money, choosing a project name. Ask in one plain sentence.
+5. **Keep them in the loop.** A short friendly line before each phase ("Installing now —
+   about 30 seconds…") beats silence.
+6. **Never print or store secrets.** Confirm a key is *present*, never show its value.
 
-## Step 1: Check Python
+## Step 0: Know the machine
 
-ConnectOnion needs **Python 3.10 or newer**. Check first — everything else depends on it.
+Figure out the platform and which commands to use. **Everything below writes `PY` for
+"the Python command that works on this machine"** — resolve it once here, then reuse it.
 
-```bash
-python3 --version        # must be 3.10+
-python3 -m pip --version
-```
+- **Detect the OS.** If you have a shell, `uname` (prints `Darwin`/`Linux`) vs. failing =
+  Windows is a quick tell; otherwise use whatever platform signal you have.
+- **Find Python (needs 3.10+).** Try these in order and keep the first that prints 3.10 or
+  newer — that is `PY`:
 
-A virtual environment keeps this install tidy and isolated (recommended, especially on
-a shared or fresh machine):
+  ```bash
+  python3 --version      # macOS / Linux usually
+  python --version       # Windows usually, sometimes macOS/Linux
+  py -3 --version        # Windows Python launcher
+  ```
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate      # Windows: .venv\Scripts\activate
-```
-
-After activating, `python` and `pip` point inside `.venv` — use them for the rest.
+- **Pick the right shell.** On macOS/Linux the `bash` tool is fine. **On Windows the
+  `bash` tool does not work** (it's Unix-only and returns an error) — use the
+  cross-platform `shell` tool instead, and don't rely on `grep`/`cat`/`ls`. Prefer
+  `co …` commands and `PY -c "…"` snippets, which behave the same everywhere.
 
 > **Recovery**
-> - `python3: command not found` or version < 3.10 → tell the person in plain words:
->   "This needs Python 3.10 or newer and I couldn't find it. You'll need to install it
->   from python.org (or your app store) first." Don't try to install system Python
->   yourself unless they ask.
-> - `venv` creation fails → skip the venv (it's optional) and continue; note it so they
->   know the install is global.
+> - None of `python3` / `python` / `py -3` is found, or all are < 3.10 → Python isn't
+>   installed (or is too old). Tell the person plainly and give the path for *their* OS:
+>   - **Windows:** install from python.org (tick "Add python.exe to PATH"), or
+>     `winget install Python.Python.3.12`. Afterward `py -3` works.
+>   - **macOS:** install from python.org, or `brew install python@3.12`.
+>   - **Linux:** use the distro package manager (e.g. `sudo apt install python3 python3-venv python3-pip`).
+>   Don't install system Python yourself unless they ask.
+
+## Step 1: Isolate with a virtual environment (recommended)
+
+Keeps this install tidy and avoids "externally-managed-environment" errors:
+
+```bash
+# macOS / Linux
+PY -m venv .venv && source .venv/bin/activate
+
+# Windows (PowerShell)
+py -3 -m venv .venv ; .venv\Scripts\Activate.ps1
+# Windows (cmd)
+py -3 -m venv .venv & .venv\Scripts\activate.bat
+```
+
+After activating, `python`/`pip` point inside `.venv` — from here `PY` can just be
+`python`. If venv creation fails, it's optional: skip it, continue globally, and note
+that to the user.
 
 ## Step 2: Install the package
 
+Use `PY -m pip` (works even when a bare `pip` isn't on PATH):
+
 ```bash
-pip install connectonion        # or: pip install -U connectonion to upgrade
+PY -m pip install connectonion       # add -U to upgrade an existing install
 ```
 
 Verify before continuing:
 
 ```bash
 co --version    # prints the installed version
-co doctor       # diagnoses the installation
+co doctor       # cross-platform health check: Python, config, keys, browser
 ```
 
 > **Recovery**
 > - `co: command not found` after a successful install → the scripts folder isn't on
->   PATH. Confirm the package itself works with
->   `python -m connectonion.cli.main --version`; if that prints a version, either use
->   `python -m connectonion.cli.main …` for the rest, or reinstall with
->   `pipx install connectonion` (which puts `co` on PATH). Retry the check.
-> - `pip: command not found` → use `python3 -m pip install connectonion`.
-> - Permission / "externally-managed-environment" error → go back and use the venv from
->   Step 1 (this is exactly what it prevents), then retry.
+>   PATH. Confirm the package works with `PY -m connectonion.cli.main --version`; if that
+>   prints a version, either use `PY -m connectonion.cli.main …` for the rest, or reinstall
+>   with `pipx install connectonion` (which puts `co` on PATH).
+> - "externally-managed-environment" / permission error → go back to Step 1 and use the
+>   venv (exactly what it prevents), then retry.
 
 ## Step 3: Create or initialize a project
 
 A project is just a folder with a `.env` (its keys) and a `.co/` folder (its config +
-identity). Pick based on what the person wants:
+identity). The CLI is cross-platform here — the same commands work on every OS.
 
 **New project** — **always pass `--yes`** so it doesn't stop to ask questions:
 
 ```bash
 co create my-agent --yes                            # minimal (default)
 co create my-coder --template coder --yes           # bash + file editing
-co create my-bot --template browser --yes           # browser automation
+co create my-bot --template browser --yes           # browser automation (see Step 6)
 co create my-researcher --template web-research --yes
 ```
 
 Other templates: `hosted-browser`, `co-ai`, `custom` (with `--description "..."`).
 
-**Existing directory** — add config in place:
+**Existing directory** — add config in place: `co init --yes` (config only) or
+`co init --template minimal --yes` (full starter). The first run on a machine also
+creates the global `~/.co/` config (keypair, agent address, agent email) automatically.
+
+Confirm it worked with a cross-platform check (don't use `ls` — it's not on Windows):
 
 ```bash
-co init --yes                     # adds the .co/ folder only
-co init --template minimal --yes  # adds the full starter template
-```
-
-The very first run on a machine also creates the global `~/.co/` config (a keypair, the
-agent's address, and its email) automatically — no separate step. Confirm the project
-was created:
-
-```bash
-ls -la .env .co/          # both should exist
+co doctor       # its Config/Keys lines show ✓ when .co/ and keys exist
+# or, portably:
+PY -c "import os; print('OK' if os.path.exists('.env') and os.path.isdir('.co') else 'MISSING')"
 ```
 
 > **Recovery**
-> - "Directory not empty" warning → the folder already has files. Only add `--force`
->   after confirming with the person that it's safe to write into this folder.
-> - The command hangs → it's waiting on an interactive prompt; you forgot `--yes`.
->   Re-run with `--yes`.
-> - `.env` or `.co/` missing afterward → re-run the command and read its output; don't
->   proceed to Step 4 until both exist.
+> - "Directory not empty" warning → the folder already has files. Add `--force` only after
+>   the person confirms it's safe to write here.
+> - The command hangs → it's waiting on an interactive prompt; you forgot `--yes`. Re-run
+>   with `--yes`.
+> - `.env` / `.co/` missing afterward → re-run and read the output before continuing.
 
 ## Step 4: Configure model access (pick ONE path)
 
@@ -140,13 +158,14 @@ An agent can't think without a model. Two paths — pick by what the person has.
 co auth
 ```
 
-This logs them in and saves `OPENONION_API_KEY` to `~/.co/keys.env` (and the project
-`.env`). Agents then use `co/*` models — `co/o4-mini`, `co/gpt-4o`,
-`co/claude-sonnet-4-5`, `co/gemini-2.5-pro` — with nothing else to configure.
-`co auth` opens a browser login, so this is a good moment to hand off: *"Please finish
-the login in the browser window that opened — I'll continue once you're back."*
+Logs them in and saves `OPENONION_API_KEY` to `~/.co/keys.env` (and the project `.env`).
+Agents then use `co/*` models — `co/o4-mini`, `co/gpt-4o`, `co/claude-sonnet-4-5`,
+`co/gemini-2.5-pro` — with nothing else to configure. `co auth` opens a browser login, so
+hand off: *"Please finish the login in the browser window that opened — I'll continue
+once you're back."*
 
-**Path B — their own provider key:** put it in the project `.env`:
+**Path B — their own provider key:** add it to the project `.env` with the `write`/`edit`
+tool (never echo the value back afterward):
 
 ```
 OPENAI_API_KEY=sk-...        # for gpt-* models
@@ -154,22 +173,20 @@ ANTHROPIC_API_KEY=sk-ant-... # for claude-* models
 GEMINI_API_KEY=...           # for gemini-* models
 ```
 
-The model name picks the provider: `gpt-*` → OpenAI, `claude-*` → Anthropic,
-`gemini-*` → Google, `co/*` → managed keys. Use the `write`/`edit` tool to add the key
-to `.env` — never echo the key back afterward.
+Model name picks the provider: `gpt-*` → OpenAI, `claude-*` → Anthropic, `gemini-*` →
+Google, `co/*` → managed keys.
 
-Verify whichever path you chose:
+Verify (cross-platform — `co doctor` reports where it found the key, no `grep` needed):
 
 ```bash
-co status                # Path A: shows the account, balance, and free credit
-grep -c "API_KEY" .env   # Path B: confirms the key landed in .env (count > 0)
+co status       # Path A: shows account, balance, and free credit
+co doctor       # either path: the "API Key" line shows ✓ Found in .env / keys.env
 ```
 
 > **Recovery**
-> - `co auth` browser login didn't complete → it's safe to re-run; `co auth` just
->   refreshes the token in place.
-> - `co status` says "No API key found" → the login didn't save. Re-run `co auth`
->   (Path A) or re-check the spelling of the variable name in `.env` (Path B).
+> - `co auth` login didn't complete → safe to re-run; it refreshes the token in place.
+> - "No API key found" → the key didn't land. Re-run `co auth` (Path A) or re-check the
+>   variable name spelling in `.env` (Path B).
 
 ## Step 5: Verify with a real run
 
@@ -179,42 +196,60 @@ provider's model:
 
 ```bash
 # Path A (managed keys — default model):
-python -c "
-from connectonion import Agent
-print(Agent('smoke-test', max_iterations=2).input('Reply with exactly: OK'))
-"
+PY -c "from connectonion import Agent; print(Agent('smoke-test', max_iterations=2).input('Reply with exactly: OK'))"
 
 # Path B (own key — name a model your key serves, e.g. OpenAI):
-python -c "
-from connectonion import Agent
-print(Agent('smoke-test', model='gpt-4o-mini', max_iterations=2).input('Reply with exactly: OK'))
-"
+PY -c "from connectonion import Agent; print(Agent('smoke-test', model='gpt-4o-mini', max_iterations=2).input('Reply with exactly: OK'))"
 ```
 
 Expected: a reply containing `OK`.
 
 > **Recovery — read the error and act, don't just report it**
-> - `InsufficientCreditsError` → the managed account is out of credit. This is a
->   *money* thing only the person can fix: show them the account address and balance
->   from `co status`, and point them to top up (https://o.openonion.ai/purchase) or ask
->   in Discord (https://discord.gg/4xfD9k8AUF). Not an install failure.
-> - Auth / `401` errors → the key from Step 4 didn't land. Re-run `co auth` (Path A) or
->   fix `.env` (Path B), then retry the run once.
-> - `ModuleNotFoundError: connectonion` → wrong Python/venv is active. Re-activate the
->   venv from Step 1 and retry.
-> - `co doctor` re-diagnoses the installation at any point if you're unsure what broke.
+> - `InsufficientCreditsError` → the managed account is out of credit. A *money* thing only
+>   the person can fix: show the address and balance from `co status`, point them to top up
+>   (https://o.openonion.ai/purchase) or Discord (https://discord.gg/4xfD9k8AUF). Not an
+>   install failure.
+> - Auth / `401` → the key from Step 4 didn't land. Re-run `co auth` (A) or fix `.env` (B),
+>   then retry once.
+> - `ModuleNotFoundError: connectonion` → wrong Python/venv is active. Re-activate the venv
+>   from Step 1 and retry.
 
-## Step 6: Hand the user a plain-language summary
+## Step 6: Browser setup — ONLY if they need web automation
 
-This is the payoff. Run `co status` one more time and turn its output into a short,
-friendly summary the person actually understands. **Do not just paste the raw panel** —
-translate it.
+Skip this entirely unless the person chose the `browser` / `hosted-browser` template or
+wants the agent to drive a web browser. **This is a real gotcha:** `pip install
+connectonion` installs the browser *library* (`patchright`) but **NOT a browser to
+drive**. Without one, browser commands fail.
+
+The agent looks for a **real Google Chrome** first (auto-detected on Windows, macOS, and
+Linux). If Chrome isn't installed, install Patchright's own browser:
+
+```bash
+PY -m patchright install chrome    # downloads a Chromium the agent can drive
+```
+
+Verify:
+
+```bash
+co doctor       # the Browser line reports ok / broken / missing
+```
+
+> **Recovery**
+> - `co doctor` browser line says **missing** → run `PY -m patchright install chrome`.
+> - Says **broken** (stealth driver) → `PY -m pip install --force-reinstall --no-cache-dir patchright`, then re-run `patchright install chrome`.
+> - Still failing → check `~/.co/browser.log`; the person may simply install desktop Google
+>   Chrome, which the agent will pick up automatically.
+
+## Step 7: Hand the user a plain-language summary
+
+The payoff. Run `co status` and turn it into a short, friendly summary — **don't paste the
+raw panel**, translate it.
 
 ```bash
 co status
 ```
 
-`co status` reports these fields — map them to plain language:
+Map the `co status` fields to plain language:
 
 | `co status` field | Say it like this |
 |--------------------|------------------|
@@ -233,30 +268,34 @@ Then present something like this (fill in the real values):
   💰  Money available to use now:          $X.XX
   📧  Your agent's email address:          you@mail.openonion.ai
   🤖  Model access:                        managed (co/* models) — nothing else needed
-  📦  Installed:                           connectonion vX.Y.Z
+  📦  Installed:                           connectonion vX.Y.Z  (Python 3.12 on Windows)
   📁  Your project:                        ./my-agent  (minimal template)
 
-  You can start using your agent now. If the balance ever runs low, you can
-  add more at https://o.openonion.ai/purchase — but the free credit is enough
-  to get going.
+  You can start using your agent now. If the balance ever runs low, you can add
+  more at https://o.openonion.ai/purchase — the free credit is enough to get going.
 ```
 
 Adjust for the situation:
-- **Balance is $0 / low** → say it gently and factually: "Your free credit is used up, so
-  you'll need to add a little to run the agent — here's where: …". No alarm, no jargon.
+- **Balance $0 / low** → say it gently: "Your free credit is used up, so you'll need to add
+  a little to keep running the agent — here's where: …". No alarm, no jargon.
 - **Path B (own keys)** → replace the money lines with "Model access: your own <provider>
-  key" and skip balance (their provider bills them directly).
-- **Integrations connected** → add a line: "📬 Connected: Gmail" etc.
+  key"; skip balance (their provider bills them directly).
+- **Browser installed** → add "🌐 Browser: ready".
+- **Integrations connected** → add "📬 Connected: Gmail" etc.
 
 Keep it to the handful of lines that matter to *this* person. Warmth over completeness.
 
 ## Notes
 
-- `--yes` on `co create` / `co init` is mandatory for unattended runs; without it the
-  command blocks on interactive prompts.
-- Never print, log, or commit API keys. The templates gitignore `.env` — keep it that way.
+- **Cross-platform:** the `co` CLI runs on Windows, macOS, and Linux. The gotchas are (1)
+  the `bash` *tool* is Unix-only — use `shell` on Windows; (2) `python3` may be `python`
+  or `py -3` on Windows (that's why Step 0 resolves `PY`); (3) the browser binary is never
+  auto-installed (Step 6).
+- `--yes` on `co create` / `co init` is mandatory for unattended runs, or the command
+  blocks on prompts.
+- Never print, log, or commit API keys. Templates gitignore `.env` — keep it that way.
 - `co auth` is safe to re-run; it refreshes the token in place.
 - A failing smoke test with a green `co doctor` / `co status` is a model-or-credit issue,
   not an install issue — say so plainly.
-- All state lives in two places: `~/.co/` (global identity + keys) and the project's
-  `.co/` + `.env` (per-project). Deleting one project never breaks another.
+- All state lives in `~/.co/` (global identity + keys) and the project's `.co/` + `.env`.
+  Deleting one project never breaks another.

--- a/connectonion/useful_skills/install-connectonion/SKILL.md
+++ b/connectonion/useful_skills/install-connectonion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: install-connectonion
-description: Install ConnectOnion and configure everything — package, project scaffold, API keys (managed or own), optional Google/Microsoft integrations — then verify with a real agent run. Use when the user says "install connectonion", "set up connectonion", "get me started with co", or a co command fails because nothing is configured yet.
+description: Install ConnectOnion and configure everything — Python check, package, project scaffold, API keys (managed or own), optional Google/Microsoft integrations — then verify with a real run and hand the user a plain-language account summary. Use when the user says "install connectonion", "set up connectonion", "get me started with co", or a co command fails because nothing is configured yet.
 tools:
   - Bash(pip *)
   - Bash(pip3 *)
@@ -8,17 +8,67 @@ tools:
   - Bash(python3 *)
   - Bash(co *)
   - Bash(cat *)
+  - Bash(ls *)
   - Bash(grep *)
   - read_file
   - write
+  - edit
 ---
 
 # Install ConnectOnion Skill
 
-Take a machine from nothing to a working, configured agent. Every step verifies
-itself before moving on — never assume a step worked.
+Take a machine from nothing to a working, configured agent — then tell the person,
+in plain words, exactly what they have.
 
-## Step 1: Install the package
+**Assume the person running this may not be technical.** They may not know what a
+"virtual environment", a "PATH", or an "API key" is, and that's fine — your job is
+to do the technical work *for* them and keep them informed in friendly, jargon-free
+language. Never dump a raw stack trace at them; translate every problem into "here's
+what happened and here's what I'm doing about it."
+
+## How to run this skill
+
+1. **Verify every step before moving on.** Never assume a command worked — check its
+   output. Each step below has a check; run it.
+2. **Auto-correct instead of giving up.** When a step fails, do NOT stop and paste the
+   error. Diagnose the cause, apply the known fix (see the *Recovery* box under each
+   step and the reference table at the end), and retry. Give each fix **up to 2
+   attempts** before escalating.
+3. **Only ask the human for things only a human can do** — logging in through a browser,
+   adding money, choosing a project name. Ask in one plain sentence, never with a wall
+   of options.
+4. **Keep them in the loop.** A short friendly line before each phase ("Installing the
+   software now — about 30 seconds…") is worth more than silence.
+5. **Never print or store secrets.** Confirm a key is *present*, never show its value.
+
+## Step 1: Check Python
+
+ConnectOnion needs **Python 3.10 or newer**. Check first — everything else depends on it.
+
+```bash
+python3 --version        # must be 3.10+
+python3 -m pip --version
+```
+
+A virtual environment keeps this install tidy and isolated (recommended, especially on
+a shared or fresh machine):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate      # Windows: .venv\Scripts\activate
+```
+
+After activating, `python` and `pip` point inside `.venv` — use them for the rest.
+
+> **Recovery**
+> - `python3: command not found` or version < 3.10 → tell the person in plain words:
+>   "This needs Python 3.10 or newer and I couldn't find it. You'll need to install it
+>   from python.org (or your app store) first." Don't try to install system Python
+>   yourself unless they ask.
+> - `venv` creation fails → skip the venv (it's optional) and continue; note it so they
+>   know the install is global.
+
+## Step 2: Install the package
 
 ```bash
 pip install connectonion        # or: pip install -U connectonion to upgrade
@@ -31,14 +81,22 @@ co --version    # prints the installed version
 co doctor       # diagnoses the installation
 ```
 
-If `co` is not found after install, the scripts directory isn't on PATH — run
-`python -m connectonion.cli.main --version` to confirm the package itself works,
-then fix PATH (or use `pipx install connectonion`).
+> **Recovery**
+> - `co: command not found` after a successful install → the scripts folder isn't on
+>   PATH. Confirm the package itself works with
+>   `python -m connectonion.cli.main --version`; if that prints a version, either use
+>   `python -m connectonion.cli.main …` for the rest, or reinstall with
+>   `pipx install connectonion` (which puts `co` on PATH). Retry the check.
+> - `pip: command not found` → use `python3 -m pip install connectonion`.
+> - Permission / "externally-managed-environment" error → go back and use the venv from
+>   Step 1 (this is exactly what it prevents), then retry.
 
-## Step 2: Create or initialize a project
+## Step 3: Create or initialize a project
 
-New project — **always pass `--yes`** (skips interactive prompts that would hang
-an unattended run) and pick the template that matches the goal:
+A project is just a folder with a `.env` (its keys) and a `.co/` folder (its config +
+identity). Pick based on what the person wants:
+
+**New project** — **always pass `--yes`** so it doesn't stop to ask questions:
 
 ```bash
 co create my-agent --yes                            # minimal (default)
@@ -49,29 +107,46 @@ co create my-researcher --template web-research --yes
 
 Other templates: `hosted-browser`, `co-ai`, `custom` (with `--description "..."`).
 
-Existing directory:
+**Existing directory** — add config in place:
 
 ```bash
-co init --yes                     # adds .co/ folder only
-co init --template minimal --yes  # adds the full template
+co init --yes                     # adds the .co/ folder only
+co init --template minimal --yes  # adds the full starter template
 ```
 
-First run ever on this machine also creates the global `~/.co/` config
-(keypair, agent address, agent email) automatically — no separate step.
+The very first run on a machine also creates the global `~/.co/` config (a keypair, the
+agent's address, and its email) automatically — no separate step. Confirm the project
+was created:
 
-## Step 3: Configure model access (pick ONE path)
+```bash
+ls -la .env .co/          # both should exist
+```
 
-**Path A — managed keys (recommended, no provider account needed):**
+> **Recovery**
+> - "Directory not empty" warning → the folder already has files. Only add `--force`
+>   after confirming with the person that it's safe to write into this folder.
+> - The command hangs → it's waiting on an interactive prompt; you forgot `--yes`.
+>   Re-run with `--yes`.
+> - `.env` or `.co/` missing afterward → re-run the command and read its output; don't
+>   proceed to Step 4 until both exist.
+
+## Step 4: Configure model access (pick ONE path)
+
+An agent can't think without a model. Two paths — pick by what the person has.
+
+**Path A — managed keys (recommended; no provider account, comes with free credit):**
 
 ```bash
 co auth
 ```
 
-This saves `OPENONION_API_KEY` to `~/.co/keys.env` (and the project `.env` if
-present). Agents then use `co/*` models — `co/o4-mini`, `co/gpt-4o`,
-`co/claude-sonnet-4-5`, `co/gemini-2.5-pro` — with no other keys.
+This logs them in and saves `OPENONION_API_KEY` to `~/.co/keys.env` (and the project
+`.env`). Agents then use `co/*` models — `co/o4-mini`, `co/gpt-4o`,
+`co/claude-sonnet-4-5`, `co/gemini-2.5-pro` — with nothing else to configure.
+`co auth` opens a browser login, so this is a good moment to hand off: *"Please finish
+the login in the browser window that opened — I'll continue once you're back."*
 
-**Path B — your own provider key:** put it in the project `.env`:
+**Path B — their own provider key:** put it in the project `.env`:
 
 ```
 OPENAI_API_KEY=sk-...        # for gpt-* models
@@ -79,30 +154,28 @@ ANTHROPIC_API_KEY=sk-ant-... # for claude-* models
 GEMINI_API_KEY=...           # for gemini-* models
 ```
 
-The model prefix picks the provider: `gpt-*` → OpenAI, `claude-*` → Anthropic,
-`gemini-*` → Google, `co/*` → managed keys.
+The model name picks the provider: `gpt-*` → OpenAI, `claude-*` → Anthropic,
+`gemini-*` → Google, `co/*` → managed keys. Use the `write`/`edit` tool to add the key
+to `.env` — never echo the key back afterward.
 
 Verify whichever path you chose:
 
 ```bash
-co status       # account/balance for managed keys
-grep -c "API_KEY" .env   # own keys: confirm the key landed in .env
+co status                # Path A: shows the account, balance, and free credit
+grep -c "API_KEY" .env   # Path B: confirms the key landed in .env (count > 0)
 ```
 
-## Step 4: Optional integrations
-
-Only if the user needs email/calendar tools:
-
-```bash
-co auth google      # Gmail + Google Calendar (opens browser OAuth)
-co auth microsoft   # Outlook + Microsoft Calendar
-```
+> **Recovery**
+> - `co auth` browser login didn't complete → it's safe to re-run; `co auth` just
+>   refreshes the token in place.
+> - `co status` says "No API key found" → the login didn't save. Re-run `co auth`
+>   (Path A) or re-check the spelling of the variable name in `.env` (Path B).
 
 ## Step 5: Verify with a real run
 
-Prove the whole chain works — a 2-line agent, end to end. **Match the model to
-the path chosen in Step 3** (the default model is a managed `co/*` one, so a
-Path-B setup must name its own provider's model):
+Prove the whole chain works with a tiny 2-line agent. **Match the model to the path from
+Step 4** — the default model is a managed `co/*` one, so a Path-B setup must name its own
+provider's model:
 
 ```bash
 # Path A (managed keys — default model):
@@ -118,29 +191,72 @@ print(Agent('smoke-test', model='gpt-4o-mini', max_iterations=2).input('Reply wi
 "
 ```
 
-Expected: a reply containing `OK`. Anything else, read the error:
+Expected: a reply containing `OK`.
 
-- `InsufficientCreditsError` — managed-key account needs credits: run
-  `co status` for the address/balance, top up or join Discord
-  (https://discord.gg/4xfD9k8AUF).
-- Auth/401 errors — the key path from Step 3 didn't land: rerun `co auth`
-  (Path A) or check `.env` spelling (Path B).
-- `co doctor` re-diagnoses the installation at any point.
+> **Recovery — read the error and act, don't just report it**
+> - `InsufficientCreditsError` → the managed account is out of credit. This is a
+>   *money* thing only the person can fix: show them the account address and balance
+>   from `co status`, and point them to top up (https://o.openonion.ai/purchase) or ask
+>   in Discord (https://discord.gg/4xfD9k8AUF). Not an install failure.
+> - Auth / `401` errors → the key from Step 4 didn't land. Re-run `co auth` (Path A) or
+>   fix `.env` (Path B), then retry the run once.
+> - `ModuleNotFoundError: connectonion` → wrong Python/venv is active. Re-activate the
+>   venv from Step 1 and retry.
+> - `co doctor` re-diagnoses the installation at any point if you're unsure what broke.
 
-## Step 6: Report
+## Step 6: Hand the user a plain-language summary
 
-Tell the user exactly what is now configured:
+This is the payoff. Run `co status` one more time and turn its output into a short,
+friendly summary the person actually understands. **Do not just paste the raw panel** —
+translate it.
 
-- installed version (`co --version` output)
-- project path and template
-- model access path (managed `co/*` or which provider keys)
-- integrations connected (google/microsoft/none)
-- the smoke-test reply
+```bash
+co status
+```
+
+`co status` reports these fields — map them to plain language:
+
+| `co status` field | Say it like this |
+|--------------------|------------------|
+| Credits            | 🎁 **Free credit from ConnectOnion** — money they gave you to start |
+| Balance            | 💰 **Money available right now** to run your agent |
+| Total Spent        | what's been used so far |
+| Email              | 📧 **Your agent's own email address** (it can send/receive mail) |
+| Agent ID / Address | your agent's unique ID |
+
+Then present something like this (fill in the real values):
+
+```
+✅ You're all set up! Here's your ConnectOnion account:
+
+  🎁  Free credit ConnectOnion gave you:  $X.XX
+  💰  Money available to use now:          $X.XX
+  📧  Your agent's email address:          you@mail.openonion.ai
+  🤖  Model access:                        managed (co/* models) — nothing else needed
+  📦  Installed:                           connectonion vX.Y.Z
+  📁  Your project:                        ./my-agent  (minimal template)
+
+  You can start using your agent now. If the balance ever runs low, you can
+  add more at https://o.openonion.ai/purchase — but the free credit is enough
+  to get going.
+```
+
+Adjust for the situation:
+- **Balance is $0 / low** → say it gently and factually: "Your free credit is used up, so
+  you'll need to add a little to run the agent — here's where: …". No alarm, no jargon.
+- **Path B (own keys)** → replace the money lines with "Model access: your own <provider>
+  key" and skip balance (their provider bills them directly).
+- **Integrations connected** → add a line: "📬 Connected: Gmail" etc.
+
+Keep it to the handful of lines that matter to *this* person. Warmth over completeness.
 
 ## Notes
 
-- Never print or commit API keys — `.env` is gitignored by the templates; keep it that way.
+- `--yes` on `co create` / `co init` is mandatory for unattended runs; without it the
+  command blocks on interactive prompts.
+- Never print, log, or commit API keys. The templates gitignore `.env` — keep it that way.
 - `co auth` is safe to re-run; it refreshes the token in place.
-- All state lives in two places: `~/.co/` (global identity + keys) and the
-  project's `.co/` + `.env` (per-project). Deleting a project never breaks
-  another one.
+- A failing smoke test with a green `co doctor` / `co status` is a model-or-credit issue,
+  not an install issue — say so plainly.
+- All state lives in two places: `~/.co/` (global identity + keys) and the project's
+  `.co/` + `.env` (per-project). Deleting one project never breaks another.

--- a/connectonion/useful_skills/install-connectonion/SKILL.md
+++ b/connectonion/useful_skills/install-connectonion/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: install-connectonion
+description: Install ConnectOnion and configure everything — package, project scaffold, API keys (managed or own), optional Google/Microsoft integrations — then verify with a real agent run. Use when the user says "install connectonion", "set up connectonion", "get me started with co", or a co command fails because nothing is configured yet.
+tools:
+  - Bash(pip *)
+  - Bash(pip3 *)
+  - Bash(python *)
+  - Bash(python3 *)
+  - Bash(co *)
+  - Bash(cat *)
+  - Bash(grep *)
+  - read_file
+  - write
+---
+
+# Install ConnectOnion Skill
+
+Take a machine from nothing to a working, configured agent. Every step verifies
+itself before moving on — never assume a step worked.
+
+## Step 1: Install the package
+
+```bash
+pip install connectonion        # or: pip install -U connectonion to upgrade
+```
+
+Verify before continuing:
+
+```bash
+co --version    # prints the installed version
+co doctor       # diagnoses the installation
+```
+
+If `co` is not found after install, the scripts directory isn't on PATH — run
+`python -m connectonion.cli.main --version` to confirm the package itself works,
+then fix PATH (or use `pipx install connectonion`).
+
+## Step 2: Create or initialize a project
+
+New project — **always pass `--yes`** (skips interactive prompts that would hang
+an unattended run) and pick the template that matches the goal:
+
+```bash
+co create my-agent --yes                            # minimal (default)
+co create my-coder --template coder --yes           # bash + file editing
+co create my-bot --template browser --yes           # browser automation
+co create my-researcher --template web-research --yes
+```
+
+Other templates: `hosted-browser`, `co-ai`, `custom` (with `--description "..."`).
+
+Existing directory:
+
+```bash
+co init --yes                     # adds .co/ folder only
+co init --template minimal --yes  # adds the full template
+```
+
+First run ever on this machine also creates the global `~/.co/` config
+(keypair, agent address, agent email) automatically — no separate step.
+
+## Step 3: Configure model access (pick ONE path)
+
+**Path A — managed keys (recommended, no provider account needed):**
+
+```bash
+co auth
+```
+
+This saves `OPENONION_API_KEY` to `~/.co/keys.env` (and the project `.env` if
+present). Agents then use `co/*` models — `co/o4-mini`, `co/gpt-4o`,
+`co/claude-sonnet-4-5`, `co/gemini-2.5-pro` — with no other keys.
+
+**Path B — your own provider key:** put it in the project `.env`:
+
+```
+OPENAI_API_KEY=sk-...        # for gpt-* models
+ANTHROPIC_API_KEY=sk-ant-... # for claude-* models
+GEMINI_API_KEY=...           # for gemini-* models
+```
+
+The model prefix picks the provider: `gpt-*` → OpenAI, `claude-*` → Anthropic,
+`gemini-*` → Google, `co/*` → managed keys.
+
+Verify whichever path you chose:
+
+```bash
+co status       # account/balance for managed keys
+grep -c "API_KEY" .env   # own keys: confirm the key landed in .env
+```
+
+## Step 4: Optional integrations
+
+Only if the user needs email/calendar tools:
+
+```bash
+co auth google      # Gmail + Google Calendar (opens browser OAuth)
+co auth microsoft   # Outlook + Microsoft Calendar
+```
+
+## Step 5: Verify with a real run
+
+Prove the whole chain works — a 2-line agent, end to end. **Match the model to
+the path chosen in Step 3** (the default model is a managed `co/*` one, so a
+Path-B setup must name its own provider's model):
+
+```bash
+# Path A (managed keys — default model):
+python -c "
+from connectonion import Agent
+print(Agent('smoke-test', max_iterations=2).input('Reply with exactly: OK'))
+"
+
+# Path B (own key — name a model your key serves, e.g. OpenAI):
+python -c "
+from connectonion import Agent
+print(Agent('smoke-test', model='gpt-4o-mini', max_iterations=2).input('Reply with exactly: OK'))
+"
+```
+
+Expected: a reply containing `OK`. Anything else, read the error:
+
+- `InsufficientCreditsError` — managed-key account needs credits: run
+  `co status` for the address/balance, top up or join Discord
+  (https://discord.gg/4xfD9k8AUF).
+- Auth/401 errors — the key path from Step 3 didn't land: rerun `co auth`
+  (Path A) or check `.env` spelling (Path B).
+- `co doctor` re-diagnoses the installation at any point.
+
+## Step 6: Report
+
+Tell the user exactly what is now configured:
+
+- installed version (`co --version` output)
+- project path and template
+- model access path (managed `co/*` or which provider keys)
+- integrations connected (google/microsoft/none)
+- the smoke-test reply
+
+## Notes
+
+- Never print or commit API keys — `.env` is gitignored by the templates; keep it that way.
+- `co auth` is safe to re-run; it refreshes the token in place.
+- All state lives in two places: `~/.co/` (global identity + keys) and the
+  project's `.co/` + `.env` (per-project). Deleting a project never breaks
+  another one.

--- a/docs/cli/copy.md
+++ b/docs/cli/copy.md
@@ -260,6 +260,8 @@ Skills are copied to `.co/skills/<name>/` and auto-discovered by the skills plug
 
 | Name | Description |
 |------|-------------|
+| co-browser | Drive one persistent, logged-in browser from the shell — solo or multi-agent |
+| install-connectonion | Install ConnectOnion and configure everything — package, project, keys, verified end to end |
 | ship-feature | Ship a feature end-to-end — update tests, docs, docs-site, then release to PyPI |
 
 ```bash

--- a/docs/cli/copy.md
+++ b/docs/cli/copy.md
@@ -261,7 +261,7 @@ Skills are copied to `.co/skills/<name>/` and auto-discovered by the skills plug
 | Name | Description |
 |------|-------------|
 | co-browser | Drive one persistent, logged-in browser from the shell — solo or multi-agent |
-| install-connectonion | Install ConnectOnion and configure everything — package, project, keys, verified end to end |
+| install-connectonion | Install & configure ConnectOnion for a (possibly non-technical) user — auto-corrects failures, ends with a plain-language account summary |
 | ship-feature | Ship a feature end-to-end — update tests, docs, docs-site, then release to PyPI |
 
 ```bash

--- a/docs/useful_skills/README.md
+++ b/docs/useful_skills/README.md
@@ -7,7 +7,7 @@ Pre-built skills you can copy into your project and invoke with `/skill-name`.
 | Skill | Purpose | Invoke |
 |-------|---------|--------|
 | [co-browser](co-browser.md) | Drive one persistent, logged-in browser from the shell — solo or multi-agent | `/co-browser` |
-| [install-connectonion](install-connectonion.md) | Install ConnectOnion and configure everything — package, project, keys, verified end to end | `/install-connectonion` |
+| [install-connectonion](install-connectonion.md) | Install & configure ConnectOnion for a (possibly non-technical) user — auto-corrects failures, ends with a plain-language account summary | `/install-connectonion` |
 | [ship-feature](ship-feature.md) | Ship a feature end-to-end: tests → docs → docs-site → release | `/ship-feature` |
 
 ## How to Use

--- a/docs/useful_skills/README.md
+++ b/docs/useful_skills/README.md
@@ -6,6 +6,7 @@ Pre-built skills you can copy into your project and invoke with `/skill-name`.
 
 | Skill | Purpose | Invoke |
 |-------|---------|--------|
+| [co-browser](co-browser.md) | Drive one persistent, logged-in browser from the shell — solo or multi-agent | `/co-browser` |
 | [ship-feature](ship-feature.md) | Ship a feature end-to-end: tests → docs → docs-site → release | `/ship-feature` |
 
 ## How to Use

--- a/docs/useful_skills/README.md
+++ b/docs/useful_skills/README.md
@@ -7,6 +7,7 @@ Pre-built skills you can copy into your project and invoke with `/skill-name`.
 | Skill | Purpose | Invoke |
 |-------|---------|--------|
 | [co-browser](co-browser.md) | Drive one persistent, logged-in browser from the shell — solo or multi-agent | `/co-browser` |
+| [install-connectonion](install-connectonion.md) | Install ConnectOnion and configure everything — package, project, keys, verified end to end | `/install-connectonion` |
 | [ship-feature](ship-feature.md) | Ship a feature end-to-end: tests → docs → docs-site → release | `/ship-feature` |
 
 ## How to Use

--- a/docs/useful_skills/co-browser.md
+++ b/docs/useful_skills/co-browser.md
@@ -15,38 +15,23 @@ co copy co-browser
 /co-browser open github and screenshot my notifications
 ```
 
-The skill teaches the agent the full `co browser` lifecycle:
+## What the Skill Teaches
 
-1. **Identity** — set `CO_WHO` so the daemon can attribute tabs
-2. **Solo vs concurrent** — bare commands on `main`, or `tab open` + `-t <name>` when a second agent exists
-3. **Direct functions vs `do`** — deterministic steps are free; natural language costs LLM calls
-4. **Evidence** — screenshot/`get_text` verification, one-shot rule for irreversible actions
-5. **Exit codes** — branch on `0/1/2/3/4` instead of parsing prose
+`co browser`'s errors are self-documenting (an exit-4 tells the agent exactly how
+to open its own tab), but a skill front-loads the lifecycle so the agent gets it
+right on the first command instead of learning from collisions:
 
-## Why a Skill
+1. **Identity** — attach `CO_WHO` to every command (shell state doesn't survive between tool calls)
+2. **The board** — check `status` / `tab ls` before claiming; one task = one tab; `-t <name>` on every command when concurrent
+3. **Right verb** — direct functions for deterministic steps (free, instant), `do "<end state>"` only for judgment, text probes before screenshot probes
+4. **Evidence** — read output text (soft failures return exit 0 with the error on stdout), screenshots at irreversible-action gates only, one-shot submits
+5. **Login** — human logs in in the visible window; the agent polls with short bounded waits and never touches credentials
 
-`co browser` errors are self-documenting (an exit-4 tells the agent exactly how to
-open its own tab), but a skill front-loads the lifecycle so the agent gets it right
-on the first command instead of learning from collisions:
-
-- Sets identity before touching the browser
-- Opens its own tab when the board shows another agent
-- Uses direct functions for deterministic steps, saving `do` for judgment
-- Screenshots before/after irreversible actions and never double-clicks submit
-
-## Key Commands
-
-```bash
-co browser go_to example.com          # navigate (daemon auto-starts, window visible)
-co browser get_text                   # page text
-co browser do "extract the pricing"   # AI agent drives the same live browser
-co browser tab ls                     # who is running what
-co browser status                     # daemon health, headless flag, the board
-co browser close                      # shut everything down
-```
+For the full command reference — tabs, contention, daemon lifecycle, exit codes —
+see [co browser](../co-browser.md); `co browser help` prints the live function list.
 
 ## See Also
 
-- [co browser](../co-browser.md) — full CLI reference (tabs, contention, daemon)
+- [co browser](../co-browser.md) — canonical CLI reference
 - [CLI Browser](../cli/browser.md) — dispatch rules and function discovery
 - [Built-in Skills](README.md) — all copyable skills

--- a/docs/useful_skills/co-browser.md
+++ b/docs/useful_skills/co-browser.md
@@ -1,0 +1,52 @@
+# co-browser
+
+Drive one persistent, logged-in browser from the shell with `co browser` — solo or with multiple agents sharing it.
+
+## Install
+
+```bash
+co copy co-browser
+# → .co/skills/co-browser/SKILL.md
+```
+
+## Usage
+
+```
+/co-browser open github and screenshot my notifications
+```
+
+The skill teaches the agent the full `co browser` lifecycle:
+
+1. **Identity** — set `CO_WHO` so the daemon can attribute tabs
+2. **Solo vs concurrent** — bare commands on `main`, or `tab open` + `-t <name>` when a second agent exists
+3. **Direct functions vs `do`** — deterministic steps are free; natural language costs LLM calls
+4. **Evidence** — screenshot/`get_text` verification, one-shot rule for irreversible actions
+5. **Exit codes** — branch on `0/1/2/3/4` instead of parsing prose
+
+## Why a Skill
+
+`co browser` errors are self-documenting (an exit-4 tells the agent exactly how to
+open its own tab), but a skill front-loads the lifecycle so the agent gets it right
+on the first command instead of learning from collisions:
+
+- Sets identity before touching the browser
+- Opens its own tab when the board shows another agent
+- Uses direct functions for deterministic steps, saving `do` for judgment
+- Screenshots before/after irreversible actions and never double-clicks submit
+
+## Key Commands
+
+```bash
+co browser go_to example.com          # navigate (daemon auto-starts, window visible)
+co browser get_text                   # page text
+co browser do "extract the pricing"   # AI agent drives the same live browser
+co browser tab ls                     # who is running what
+co browser status                     # daemon health, headless flag, the board
+co browser close                      # shut everything down
+```
+
+## See Also
+
+- [co browser](../co-browser.md) — full CLI reference (tabs, contention, daemon)
+- [CLI Browser](../cli/browser.md) — dispatch rules and function discovery
+- [Built-in Skills](README.md) — all copyable skills

--- a/docs/useful_skills/install-connectonion.md
+++ b/docs/useful_skills/install-connectonion.md
@@ -1,0 +1,36 @@
+# install-connectonion
+
+Install ConnectOnion and configure everything — package, project, keys, integrations — verified end to end.
+
+## Install
+
+```bash
+co copy install-connectonion
+# → .co/skills/install-connectonion/SKILL.md
+```
+
+(Chicken-and-egg note: this skill is for agents that set up ConnectOnion on
+*other* machines/projects — a coding agent that already has `co` can copy it,
+then walk a fresh environment through the whole setup.)
+
+## Usage
+
+```
+/install-connectonion
+```
+
+The skill walks 6 steps, each verified before the next:
+
+1. **Install** — `pip install connectonion`, verify with `co --version` + `co doctor`
+2. **Project** — `co create --yes` (minimal/coder/browser/web-research/...) or `co init --yes`
+3. **Model access** — managed keys via `co auth` (co/* models) OR own provider keys in `.env`
+4. **Integrations** — optional `co auth google` / `co auth microsoft`
+5. **Smoke test** — run a real 2-line agent and read the reply
+6. **Report** — tell the user exactly what is configured
+
+## See Also
+
+- [Quickstart](../quickstart.md) — the human-facing version of the same flow
+- [co auth](../cli/auth.md) — managed keys and OAuth integrations
+- [co create](../cli/create.md) — templates and first-time global setup
+- [Built-in Skills](README.md) — all copyable skills

--- a/docs/useful_skills/install-connectonion.md
+++ b/docs/useful_skills/install-connectonion.md
@@ -1,6 +1,8 @@
 # install-connectonion
 
-Install ConnectOnion and configure everything — package, project, keys, integrations — verified end to end.
+Install ConnectOnion and configure everything — Python check, package, project, keys —
+verified end to end, then hand the user a plain-language account summary. Built to be run
+**for a non-technical person**: it auto-corrects failures instead of dumping errors.
 
 ## Install
 
@@ -19,18 +21,45 @@ then walk a fresh environment through the whole setup.)
 /install-connectonion
 ```
 
-The skill walks 6 steps, each verified before the next:
+The skill walks 6 steps, each verified before the next, and self-corrects on failure:
 
-1. **Install** — `pip install connectonion`, verify with `co --version` + `co doctor`
-2. **Project** — `co create --yes` (minimal/coder/browser/web-research/...) or `co init --yes`
-3. **Model access** — managed keys via `co auth` (co/* models) OR own provider keys in `.env`
-4. **Integrations** — optional `co auth google` / `co auth microsoft`
-5. **Smoke test** — run a real 2-line agent and read the reply
-6. **Report** — tell the user exactly what is configured
+1. **Check Python** — requires 3.10+; sets up a virtualenv when it helps
+2. **Install** — `pip install connectonion`, verify with `co --version` + `co doctor`
+3. **Project** — `co create --yes` (minimal/coder/browser/web-research/...) or `co init --yes`
+4. **Model access** — managed keys via `co auth` (co/* models, comes with free credit) OR own provider keys in `.env`
+5. **Verify** — run a real 2-line agent and read the reply
+6. **Summary** — a friendly, plain-language account report: free credit, balance, agent email, what's installed
+
+## Built for non-technical users
+
+Two things make this skill different from a plain command list:
+
+- **Auto-correction.** Every step has a *Recovery* block. When something fails — `co` not
+  on PATH, a hung interactive prompt, a wrong virtualenv, an out-of-credit account — the
+  agent diagnoses it, applies the known fix, and retries (up to 2 attempts) instead of
+  stopping and pasting a stack trace. It only asks the human for things only a human can
+  do (browser login, adding credit).
+
+- **A real end-of-run UI.** Step 6 turns `co status` into a warm summary the person
+  actually understands:
+
+  ```
+  ✅ You're all set up! Here's your ConnectOnion account:
+
+    🎁  Free credit ConnectOnion gave you:  $X.XX
+    💰  Money available to use now:          $X.XX
+    📧  Your agent's email address:          you@mail.openonion.ai
+    🤖  Model access:                        managed (co/* models)
+    📦  Installed:                           connectonion vX.Y.Z
+    📁  Your project:                        ./my-agent  (minimal template)
+  ```
+
+  Low or `$0` balance is stated gently with the top-up link — never as an alarm.
 
 ## See Also
 
 - [Quickstart](../quickstart.md) — the human-facing version of the same flow
 - [co auth](../cli/auth.md) — managed keys and OAuth integrations
 - [co create](../cli/create.md) — templates and first-time global setup
+- [co status](../cli/status.md) — the account fields the summary is built from
 - [Built-in Skills](README.md) — all copyable skills

--- a/docs/useful_skills/install-connectonion.md
+++ b/docs/useful_skills/install-connectonion.md
@@ -21,24 +21,33 @@ then walk a fresh environment through the whole setup.)
 /install-connectonion
 ```
 
-The skill walks 6 steps, each verified before the next, and self-corrects on failure:
+The skill walks these steps on **Windows, macOS, or Linux**, each verified before the
+next, and self-corrects on failure:
 
-1. **Check Python** — requires 3.10+; sets up a virtualenv when it helps
+0. **Know the machine** — detect the OS and resolve the right Python command (`python3` /
+   `python` / `py -3`) and shell (the `bash` tool is Unix-only; use `shell` on Windows)
+1. **Virtualenv** — isolate the install (also dodges "externally-managed-environment")
 2. **Install** — `pip install connectonion`, verify with `co --version` + `co doctor`
 3. **Project** — `co create --yes` (minimal/coder/browser/web-research/...) or `co init --yes`
 4. **Model access** — managed keys via `co auth` (co/* models, comes with free credit) OR own provider keys in `.env`
 5. **Verify** — run a real 2-line agent and read the reply
-6. **Summary** — a friendly, plain-language account report: free credit, balance, agent email, what's installed
+6. **Browser (only if needed)** — `pip install` does NOT bring a browser; install one with `patchright install chrome` (or use system Chrome)
+7. **Summary** — a friendly, plain-language account report: free credit, balance, agent email, what's installed
 
-## Built for non-technical users
+## Built for non-technical users, on any OS
 
-Two things make this skill different from a plain command list:
+Three things make this skill different from a plain command list:
+
+- **Cross-platform.** Step 0 detects the OS and resolves the right Python command
+  (`python3` on macOS/Linux, `python` or `py -3` on Windows) and the right shell (the
+  `bash` tool is Unix-only, so it uses `shell` on Windows and avoids `grep`/`cat`/`ls`).
+  Verification leans on `co doctor` / `co status`, which behave identically everywhere.
 
 - **Auto-correction.** Every step has a *Recovery* block. When something fails — `co` not
-  on PATH, a hung interactive prompt, a wrong virtualenv, an out-of-credit account — the
-  agent diagnoses it, applies the known fix, and retries (up to 2 attempts) instead of
-  stopping and pasting a stack trace. It only asks the human for things only a human can
-  do (browser login, adding credit).
+  on PATH, a hung interactive prompt, a wrong virtualenv, a missing browser binary, an
+  out-of-credit account — the agent diagnoses it, applies the known fix, and retries (up
+  to 2 attempts) instead of stopping and pasting a stack trace. It only asks the human for
+  things only a human can do (browser login, adding credit, installing Python).
 
 - **A real end-of-run UI.** Step 6 turns `co status` into a warm summary the person
   actually understands:

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -237,7 +237,7 @@ ConnectOnion now supports ALL Unicode characters in usernames and file paths:
 
 ### Q: What if I'm using Python 2.7?
 
-**A:** Python 2.7 is not supported. ConnectOnion requires Python 3.7+.
+**A:** Python 2.7 is not supported. ConnectOnion requires Python 3.10+.
 
 ### Q: Does this work on Windows 7?
 

--- a/tests/e2e/cli/test_cli_copy.py
+++ b/tests/e2e/cli/test_cli_copy.py
@@ -192,28 +192,18 @@ class TestCopyCommand:
         assert len(list((cc_dir / "prompts" / "agents").glob("*.md"))) > 0
 
     def test_copy_skill_creates_co_skills_dir(self):
-        """Test copying a skill creates .co/skills/<name>/ directory."""
+        """Test copying every registered skill creates .co/skills/<name>/ with a SKILL.md."""
         from connectonion.cli.main import cli
+        from connectonion.cli.commands.copy_commands import SKILLS
 
-        result = self.runner.invoke(cli, ['copy', 'ship-feature'])
+        for skill_name in SKILLS:
+            result = self.runner.invoke(cli, ['copy', skill_name])
 
-        assert result.exit_code == 0
-        assert "Copied:" in result.output
-        skill_dir = Path(self.test_dir) / ".co" / "skills" / "ship-feature"
-        assert skill_dir.exists()
-        assert (skill_dir / "SKILL.md").exists()
-
-    def test_copy_co_browser_skill(self):
-        """Test copying the co-browser skill creates .co/skills/co-browser/."""
-        from connectonion.cli.main import cli
-
-        result = self.runner.invoke(cli, ['copy', 'co-browser'])
-
-        assert result.exit_code == 0
-        assert "Copied:" in result.output
-        skill_dir = Path(self.test_dir) / ".co" / "skills" / "co-browser"
-        assert skill_dir.exists()
-        assert (skill_dir / "SKILL.md").exists()
+            assert result.exit_code == 0
+            assert "Copied:" in result.output, f"Skill {skill_name} should copy"
+            skill_dir = Path(self.test_dir) / ".co" / "skills" / skill_name
+            assert skill_dir.exists()
+            assert (skill_dir / "SKILL.md").exists()
 
     def test_copy_unknown_item(self):
         """Test copy shows error for unknown item."""
@@ -266,13 +256,14 @@ class TestCopyListOutput:
         assert "prompt" in result.output
 
     def test_list_shows_skills(self):
-        """Test list shows available skills."""
+        """Test list shows every registered skill."""
         from connectonion.cli.main import cli
+        from connectonion.cli.commands.copy_commands import SKILLS
 
         result = self.runner.invoke(cli, ['copy', '--list'])
 
-        assert "ship-feature" in result.output
-        assert "co-browser" in result.output
+        for skill_name in SKILLS:
+            assert skill_name in result.output, f"Skill {skill_name} should be in list"
         assert "skill" in result.output
 
     def test_list_shows_usage_hint(self):

--- a/tests/e2e/cli/test_cli_copy.py
+++ b/tests/e2e/cli/test_cli_copy.py
@@ -203,6 +203,18 @@ class TestCopyCommand:
         assert skill_dir.exists()
         assert (skill_dir / "SKILL.md").exists()
 
+    def test_copy_co_browser_skill(self):
+        """Test copying the co-browser skill creates .co/skills/co-browser/."""
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(cli, ['copy', 'co-browser'])
+
+        assert result.exit_code == 0
+        assert "Copied:" in result.output
+        skill_dir = Path(self.test_dir) / ".co" / "skills" / "co-browser"
+        assert skill_dir.exists()
+        assert (skill_dir / "SKILL.md").exists()
+
     def test_copy_unknown_item(self):
         """Test copy shows error for unknown item."""
         from connectonion.cli.main import cli
@@ -260,6 +272,7 @@ class TestCopyListOutput:
         result = self.runner.invoke(cli, ['copy', '--list'])
 
         assert "ship-feature" in result.output
+        assert "co-browser" in result.output
         assert "skill" in result.output
 
     def test_list_shows_usage_hint(self):


### PR DESCRIPTION
## What

Two new copyable skills in `useful_skills/` (joining ship-feature):

```bash
co copy co-browser            # → .co/skills/co-browser/           → /co-browser
co copy install-connectonion  # → .co/skills/install-connectonion/ → /install-connectonion
```

## co-browser

Teaches an agent the full `co browser` lifecycle so the first command is already correct instead of learning from collisions. Grounded in `docs/co-browser.md` plus real usage patterns from recent working sessions, then **adversarially reviewed against the daemon/client source** — every command and claim in the skill was verified:

1. **Identity** — `CO_WHO=name co browser ...` prefix per command (shell state doesn't survive between tool calls; a lone `export` is silently lost)
2. **The board** — `status` / `tab ls` before claiming; one task = one tab; literal tab names (`NAME=$(...)` capture doesn't survive either); `-t` on every command including `do`
3. **Right verb** — direct functions for deterministic steps; `do ""` for judgment only; text probes (`get_current_url | grep`) before the LLM-costing `do` STATE probe; **never `timeout` a `do`** (killing the client orphans the run — the daemon keeps burning LLM calls on an answer nobody reads)
4. **Evidence** — soft action failures return **exit 0 with the error on stdout** (`_call_verb` wraps string returns in OK), so the skill teaches signal = exit code + output text, not `&&`-chaining; screenshots only at irreversible-action gates, one-shot submits
5. **Login** — human logs in in the visible window; short bounded checks per tool call (a 10-minute blocking loop would hold the tab claim against other agents the whole time)

Design choice per the CLI's own philosophy ("the error IS the documentation"): the skill does **not** freeze tunable internals (claim-expiry seconds, busy-wait deadline, exit-3/4 recovery prose) — it defers to the self-documenting errors, so copied skills in user repos don't go stale when constants change.

## install-connectonion

Zero → a setup where **every `co` command works** (not just `pip install`), **built to be run for a possibly non-technical person on Windows, macOS, or Linux**. It does the technical work for them, auto-corrects failures instead of dumping stack traces, and ends with a plain-language summary. Grounded in the actual CLI source (init/auth/email/browser), not guesses.

Steps, each verified before the next:

0. **Know the machine** — detect OS; resolve the working Python (`python3` / `python` / `py -3`, needs 3.10+) as `PY`; pick the shell (the `bash` **tool** is Unix-only → use `shell` on Windows, avoid `grep`/`cat`/`ls`)
1. **Virtualenv** — isolate; dodges "externally-managed-environment"
2. `PY -m pip install connectonion`, verify `co --version`
3. **`co init --yes`** — scaffolds the project **and authenticates in one step**, writing `~/.co/keys.env` (+ project `.env`): `OPENONION_API_KEY`, `AGENT_EMAIL`, `IS_EMAIL_ACTIVE=true`, `AGENT_ADDRESS`
4. **Confirm** — `co status` / `co doctor` prove the account + keys are wired
5. **Browser** (only if needed) — see the correctness notes below
6. **Integrations** (optional) — `co auth google` / `co auth microsoft` for *personal* Gmail/Outlook
7. **Verify the commands actually run** — `co status`, `co email inbox`, a real agent run, and (if browser set up) a real `co browser go_to`
8. **Plain-language summary** — account report + the exact commands the user can now run

### Correctness notes (why this rewrite matters — earlier drafts were wrong)

Verified against the code:

- **`co init` / `co create` already authenticate.** `init.py` calls `authenticate()` unconditionally, so after `co init --yes` the account is set up — `co auth` is the **repair** step (offline during init, expired token), not a mandatory second command.
- **`co email` is the built-in managed mailbox** (`…@mail.openonion.ai`), activated by that authentication; needs only `OPENONION_API_KEY` — **not** `co auth google`. Gmail/Outlook OAuth is separate and optional.
- **The browser binary is never auto-installed.** `pip install connectonion` brings the `patchright` *library* but no Chrome; `co browser` fails with *"Chrome failed to start"* until `PY -m patchright install chrome` (Linux: `--with-deps`) or desktop Chrome is present. **`co doctor` does NOT catch this** — it only checks the patchright stealth driver — so the skill proves the browser with a real `co browser go_to example.com`.
- **`co browser` is POSIX-only** (Unix-socket daemon): macOS/Linux, or **WSL on Windows**. The skill says so plainly instead of pretending it works in PowerShell.
- The signing private key lives in `~/.co/keys/agent.key`, never in keys.env and never printed.

### What makes it more than a command list

- **Cross-platform** — OS/Python detection, `shell` vs the Unix-only `bash` tool, per-OS guidance for a missing Python (python.org / winget / brew / apt).
- **Auto-correction** — every step has a *Recovery* block: diagnose → apply the known fix → retry (bounded to 2 attempts). Escalates to the human only for installing Python, adding credit, or an OAuth login.
- **A real end-of-run UI** — maps `co status` to plain language and lists what they can now do:

  ```
  ✅ You're all set up! Here's your ConnectOnion account:

    🎁  Free credit ConnectOnion gave you:  $X.XX
    💰  Money available to use now:          $X.XX
    📧  Your agent's email address:          you@mail.openonion.ai
    🤖  Model access:                        managed (co/* models)
    🌐  Browser (co browser):                ready
    📦  Installed:                           connectonion vX.Y.Z

    What you can do now: co status · co email · co browser do "…" · python agent.py
  ```

## Changes

- `connectonion/useful_skills/{co-browser,install-connectonion}/SKILL.md` (shipped via existing `connectonion/**/*.md` package-data glob)
- `copy_commands.py` — both registered in `SKILLS`
- `docs/useful_skills/` — two doc pages + README table; `docs/cli/copy.md` Available Skills table
- `docs/windows-support.md` — fix stale "Python 3.7+" → "Python 3.10+" (contradicted `pyproject.toml`'s `requires-python >=3.10`)
- `tests/e2e/cli/test_cli_copy.py` — registry-driven (loops over `SKILLS`), so every future skill is covered without a new test

## Review notes / follow-ups (not in this PR)

- `docs/cli/init.md` documents `--no-ai` / `--update-docs` flags that don't exist on the real `co init` (`--template/-t, --yes/-y, --key, --description, --force`); and `auth_commands.py`'s docstring cites the wrong auth URL. Out of scope here — flagging for a separate docs pass.
- `co ai` has a curated builtin skill set (`cli/co_ai/skills/builtin/`); if co-browser should be builtin there too, say the word.
- ship-feature's frontmatter has the same latent `write_file` → `write` tool-name mismatch this review caught; left untouched (out of scope).
- wiki/ and docs-site/ (nested repos) don't list copyable skills yet — separate push if wanted.
- Reaching users requires the usual PATCH release after merge.

## Test

```
python -m pytest tests/e2e/cli/test_cli_copy.py -q
19 passed
```

Also validated end to end: `co copy install-connectonion` lands the skill in `.co/skills/`, and its frontmatter YAML + tool names all parse/validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)