### PR TITLE
Update default agent model to gemini-3.5-flash

### DIFF
--- a/connectonion/cli/browser_agent/agent.py
+++ b/connectonion/cli/browser_agent/agent.py
@@ -3,7 +3,7 @@
 Purpose: Wrap BrowserAutomation with a ConnectOnion Agent so the `co browser` CLI can run natural-language browser commands end-to-end.
 LLM-Note:
   Dependencies: imports from [os, pathlib, dotenv, connectonion.Agent, connectonion.useful_plugins (image_result_formatter, ui_stream), connectonion.useful_tools.browser_tools.BrowserAutomation] | imported by [cli/browser_agent/__init__.py (re-exported), cli/commands/browser_commands.py (lazy import)] | tested by [tests/e2e/cli/test_cli_browser.py]
-  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → loads OPENONION_API_KEY (env or ~/.co/keys.env via dotenv) → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3-flash-preview", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
+  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → loads OPENONION_API_KEY (env or ~/.co/keys.env via dotenv) → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3.5-flash", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
   State/Effects: launches Playwright browser process via BrowserAutomation context manager (auto-closes on exit) | reads OPENONION_API_KEY from process env or ~/.co/keys.env | may create screenshots/files inside the BrowserAutomation tool calls | streams UI events via ui_stream plugin
   Integration: exposes execute_browser_command(command, headless=False) -> str | PROMPT_PATH points to ./prompts/agent.md (sibling to this file)
   Performance: synchronous, blocks for full agent loop (up to 200 iterations) | one browser session per call (no pooling)
@@ -36,7 +36,7 @@ def build_browser_agent(browser, api_key: str) -> Agent:
     """Build the natural-language browser Agent driving an existing BrowserAutomation."""
     return Agent(
         name="browser_cli",
-        model="co/gemini-3-flash-preview",
+        model="co/gemini-3.5-flash",
         api_key=api_key,
         system_prompt=PROMPT_PATH,
         tools=[browser],

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -56,7 +56,7 @@ GLOBAL_CO_DIR = Path.home() / ".co"
 
 
 def create_coding_agent(
-    model: str = "co/gemini-3-flash-preview",
+    model: str = "co/gemini-3.5-flash",
     max_iterations: int = 100,
     co_dir: Path = Path(".co"),
 ) -> Agent:

--- a/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
@@ -12,7 +12,7 @@ text = transcribe("meeting.mp3")
 print(text)
 
 # With your own Gemini API key
-text = transcribe("meeting.mp3", model="gemini-3-flash-preview")
+text = transcribe("meeting.mp3", model="gemini-3.5-flash")
 ```
 
 That's it! One function for audio-to-text.
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3-flash-preview" | Model to use |
+| `model` | str | "co/gemini-3.5-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,11 +110,11 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3-flash-preview")
+transcribe("audio.mp3", model="co/gemini-3.5-flash")
 transcribe("audio.mp3", model="co/gemini-2.5-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
-transcribe("audio.mp3", model="gemini-3-flash-preview")
+transcribe("audio.mp3", model="gemini-3.5-flash")
 transcribe("audio.mp3", model="gemini-2.5-flash")
 ```
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -169,7 +169,7 @@ def browser(
 def ai(
     prompt: Optional[str] = typer.Argument(None, help="One-shot prompt (runs and exits)"),
     port: int = typer.Option(8000, "--port", "-p", help="Port for web server"),
-    model: str = typer.Option("co/gemini-3-flash-preview", "--model", "-m", help="Model to use"),
+    model: str = typer.Option("co/gemini-3.5-flash", "--model", "-m", help="Model to use"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations"),
 ):
     """Start AI coding agent or run one-shot prompt."""

--- a/connectonion/cli/templates/hosted-browser/agent.py
+++ b/connectonion/cli/templates/hosted-browser/agent.py
@@ -89,7 +89,7 @@ def create_agent():
             bind_browser_session,     # each session gets its own tab in the shared browser
             reaper.stamp,             # any tool call resets the browser idle clock
         ],
-        model="co/gemini-3-flash-preview",
+        model="co/gemini-3.5-flash",
         max_iterations=200,           # a normal site flow is ~15-20 steps; backstop
     )
 

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -962,6 +962,7 @@ MODEL_REGISTRY = {
     "claude-3-7-sonnet-20250219": "anthropic",
     
     # Google Gemini models
+    "gemini-3.5-flash": "google",
     "gemini-3-pro-preview": "google",
     "gemini-3-pro-image-preview": "google",
     "gemini-2.5-pro": "google",

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -51,6 +51,7 @@ MODEL_PRICING = {
     "claude-opus-4-20250514": {"input": 15.00, "output": 75.00, "cached": 1.50, "cache_write": 18.75},
 
     # Google Gemini models - cached = 25% of input (75% discount)
+    "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cached": 0.375},
     "gemini-3-pro-preview": {"input": 2.00, "output": 12.00, "cached": 0.50},
     "gemini-3-pro-image-preview": {"input": 2.00, "output": 0.134},
     "gemini-2.5-pro": {"input": 1.25, "output": 10.00, "cached": 0.3125},
@@ -84,6 +85,7 @@ MODEL_CONTEXT_LIMITS = {
     "claude-opus-4-20250514": 200000,
 
     # Gemini
+    "gemini-3.5-flash": 1000000,
     "gemini-3-pro-preview": 1000000,
     "gemini-3-pro-image-preview": 65000,
     "gemini-2.5-pro": 1000000,

--- a/connectonion/transcribe.py
+++ b/connectonion/transcribe.py
@@ -87,7 +87,7 @@ def _get_api_key(model: str) -> str:
 def transcribe(
     audio: str,
     prompt: Optional[str] = None,
-    model: str = "co/gemini-3-flash-preview",
+    model: str = "co/gemini-3.5-flash",
     timestamps: bool = False,
 ) -> str:
     """
@@ -97,7 +97,7 @@ def transcribe(
         audio: Path to audio file (WAV, MP3, AIFF, AAC, OGG, FLAC)
         prompt: Optional context hints for better accuracy
                 (e.g., "Technical AI discussion, speakers: Aaron, Lisa")
-        model: Model to use (default: co/gemini-3-flash-preview)
+        model: Model to use (default: co/gemini-3.5-flash)
         timestamps: If True, include timestamps in output
 
     Returns:

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@ agent = Agent(name="bot", model="co/gemini-2.5-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-3-pro-preview`, `co/gemini-3-flash-preview`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
+- `co/gemini-3-pro-preview`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
 - `co/claude-opus-4-5`, `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -84,8 +84,8 @@ agent = Agent("assistant", model="co/gemini-3-pro-preview")  # Managed
 agent = Agent("assistant", model="gemini-3-pro-preview")     # Your key
 
 # Fastest Gemini 3 model
-agent = Agent("assistant", model="co/gemini-3-flash-preview")  # Managed
-agent = Agent("assistant", model="gemini-3-flash-preview")     # Your key
+agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
+agent = Agent("assistant", model="gemini-3.5-flash")     # Your key
 
 # Image generation model with grounded generation
 agent = Agent("assistant", model="co/gemini-3-pro-image-preview")  # Managed
@@ -191,7 +191,7 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | o4-mini | 128K tokens |
 | **Google** | |
 | gemini-3-pro-preview | 1M tokens |
-| gemini-3-flash-preview | 1M tokens |
+| gemini-3.5-flash | 1M tokens |
 | gemini-2.5-pro | 1M tokens |
 | gemini-2.5-flash | 1M tokens |
 | **Anthropic** | |
@@ -219,7 +219,7 @@ All prices are **per 1M tokens** and match official provider pricing:
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
 | gemini-3-pro-preview | $2.00 | $12.00 | State-of-the-art reasoning |
-| gemini-3-flash-preview | $0.50 | $3.00 | Fastest Gemini 3 |
+| gemini-3.5-flash | $1.50 | $9.00 | Latest fast Gemini |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |
 | gemini-2.5-pro | $1.25 | $10.00 | **Default model** - best for agents |
 | gemini-2.5-flash | $0.30 | $2.50 | Best price-performance |

--- a/docs/features/transcribe.md
+++ b/docs/features/transcribe.md
@@ -12,7 +12,7 @@ text = transcribe("meeting.mp3")
 print(text)
 
 # With your own Gemini API key
-text = transcribe("meeting.mp3", model="gemini-3-flash-preview")
+text = transcribe("meeting.mp3", model="gemini-3.5-flash")
 ```
 
 That's it! One function for audio-to-text.
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3-flash-preview" | Model to use |
+| `model` | str | "co/gemini-3.5-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,11 +110,11 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3-flash-preview")
+transcribe("audio.mp3", model="co/gemini-3.5-flash")
 transcribe("audio.mp3", model="co/gemini-2.5-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
-transcribe("audio.mp3", model="gemini-3-flash-preview")
+transcribe("audio.mp3", model="gemini-3.5-flash")
 transcribe("audio.mp3", model="gemini-2.5-flash")
 ```
 

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -129,7 +129,7 @@ llm_do("Hello", model="co/claude-haiku-4-5")
 ### Google Models
 ```python
 llm_do("Hello", model="co/gemini-3-pro-preview")
-llm_do("Hello", model="co/gemini-3-flash-preview")
+llm_do("Hello", model="co/gemini-3.5-flash")
 llm_do("Hello", model="co/gemini-2.5-pro")
 ```
 

--- a/examples/browser-agent/agent.py
+++ b/examples/browser-agent/agent.py
@@ -27,7 +27,7 @@ web = WebAutomation(use_chrome_profile=True)
 # ui_stream sends real-time activity events to connected UI clients via WebSocket
 agent = Agent(
     name="browser_agent",
-    model="co/gemini-3-flash-preview",
+    model="co/gemini-3.5-flash",
     system_prompt=Path(__file__).parent / "prompts" / "agent.md",
     tools=web,
     plugins=[image_result_formatter, ui_stream],  # Vision + real-time streaming

--- a/tests/e2e/real_api/test_real_transcribe.py
+++ b/tests/e2e/real_api/test_real_transcribe.py
@@ -43,7 +43,7 @@ def test_transcribe_gemini_direct(audio_file):
     """Test transcription using Gemini API directly."""
     from connectonion import transcribe
 
-    result = transcribe(audio_file, model="gemini-3-flash-preview")
+    result = transcribe(audio_file, model="gemini-3.5-flash")
 
     assert result is not None
     assert len(result) > 0
@@ -61,7 +61,7 @@ def test_transcribe_openonion_proxy(audio_file):
 
     from connectonion import transcribe
 
-    result = transcribe(audio_file, model="co/gemini-3-flash-preview")
+    result = transcribe(audio_file, model="co/gemini-3.5-flash")
 
     assert result is not None
     assert len(result) > 0
@@ -76,7 +76,7 @@ def test_transcribe_with_prompt(audio_file):
     result = transcribe(
         audio_file,
         prompt="A person at a zoo talking about animals",
-        model="gemini-3-flash-preview"
+        model="gemini-3.5-flash"
     )
 
     assert result is not None
@@ -91,7 +91,7 @@ def test_transcribe_with_timestamps(audio_file):
     result = transcribe(
         audio_file,
         timestamps=True,
-        model="gemini-3-flash-preview"
+        model="gemini-3.5-flash"
     )
 
     assert result is not None

--- a/tests/e2e/real_api/test_responses_parse.py
+++ b/tests/e2e/real_api/test_responses_parse.py
@@ -50,7 +50,7 @@ GEMINI_MODELS = [
     "co/gemini-2.5-pro",
     "co/gemini-2.0-flash",
     "co/gemini-2.0-flash-lite",
-    "co/gemini-3-flash-preview",
+    "co/gemini-3.5-flash",
     "co/gemini-3-pro-preview",
 ]
 

--- a/tests/unit/test_transcribe.py
+++ b/tests/unit/test_transcribe.py
@@ -57,7 +57,7 @@ class TestTranscribeUnit:
         # Clear all relevant env vars
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(ValueError, match="Gemini API key required"):
-                transcribe(str(TEST_AUDIO), model="gemini-3-flash-preview")
+                transcribe(str(TEST_AUDIO), model="gemini-3.5-flash")
 
     def test_transcribe_calls_gemini(self):
         """Test that transcribe calls Gemini API for non-co models."""
@@ -82,7 +82,7 @@ class TestTranscribeUnit:
             mock_openai.return_value = mock_client
 
             with patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}):
-                result = transcribe_mod.transcribe(str(TEST_AUDIO), model="gemini-3-flash-preview")
+                result = transcribe_mod.transcribe(str(TEST_AUDIO), model="gemini-3.5-flash")
 
             assert result == "Test transcription"
             mock_client.chat.completions.create.assert_called_once()
@@ -109,7 +109,7 @@ class TestTranscribeUnit:
             mock_post.return_value = mock_response
 
             with patch.dict("os.environ", {"OPENONION_API_KEY": "test-jwt"}):
-                result = transcribe_mod.transcribe(str(TEST_AUDIO), model="co/gemini-3-flash-preview")
+                result = transcribe_mod.transcribe(str(TEST_AUDIO), model="co/gemini-3.5-flash")
 
             assert result == "Test transcription via proxy"
             mock_post.assert_called_once()
@@ -123,7 +123,7 @@ class TestGetApiKey:
         monkeypatch.setenv("OPENONION_API_KEY", "env-token")
 
         from connectonion.transcribe import _get_api_key
-        assert _get_api_key("co/gemini-3-flash-preview") == "env-token"
+        assert _get_api_key("co/gemini-3.5-flash") == "env-token"
 
     def test_co_model_no_env_raises(self, monkeypatch):
         """Test that missing OPENONION_API_KEY raises ValueError."""
@@ -131,4 +131,4 @@ class TestGetApiKey:
 
         from connectonion.transcribe import _get_api_key
         with pytest.raises(ValueError, match="OpenOnion API key required"):
-            _get_api_key("co/gemini-3-flash-preview")
+            _get_api_key("co/gemini-3.5-flash")


### PR DESCRIPTION
## Summary

Replaces `gemini-3-flash-preview` with `gemini-3.5-flash` as the default model across the framework, matching oo-api which already advertises, routes, and prices `co/gemini-3.5-flash` (hardened in openonion/oo-api#27).

## Changes

- **Defaults switched to `co/gemini-3.5-flash`**: `co ai` agent, browser agent (`co browser`), CLI `--model` option, hosted-browser template, `transcribe()`, and the browser-agent example
- **Model registry** (`connectonion/core/llm.py`): added `gemini-3.5-flash` → google routing
- **Pricing/context tables** (`connectonion/core/usage.py`): added `gemini-3.5-flash` at $1.50/$9.00 per 1M tokens (cached $0.375), 1M context — matching oo-api billing
- **Docs**: `docs/concepts/models.md`, `docs/api.md`, `docs/features/transcribe.md`, `docs/integrations/auth.md`, and the co_ai transcribe prompt updated with the new model name and pricing
- **Tests**: unit and real-api tests updated to the new model name

The core `Agent` default (`co/gemini-2.5-pro`) is unchanged — this PR only replaces the flash-preview defaults.

## Validation

- `pytest tests/unit` — 2039 passed, 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)