### PR TITLE
oauth: keep Microsoft refresh tokens server-side

### DIFF
--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -12,6 +12,7 @@ LLM-Note:
 import sys
 import time
 import requests
+from requests import RequestException
 import json
 import webbrowser
 import os
@@ -197,7 +198,8 @@ def handle_google_auth():
         console.print("  [bold]co auth[/bold]     Get your OpenOnion API key\n")
         return
 
-    api_url = "https://oo.openonion.ai/api/v1/oauth"
+    backend_url = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
+    api_url = f"{backend_url.rstrip('/')}/api/v1/oauth"
     headers = {"Authorization": f"Bearer {api_key}"}
 
     # Clear any existing connection first - this ensures we wait for NEW OAuth to complete
@@ -269,15 +271,15 @@ def handle_google_auth():
     console.print(f"   [dim]agent = Agent('assistant', tools=[gmail_send])[/dim]\n")
 
 
-def _save_microsoft_to_env(env_file: Path, credentials: dict) -> None:
-    """Save Microsoft OAuth credentials to .env file."""
-    upsert_env(env_file, {
-        "MICROSOFT_ACCESS_TOKEN": credentials['access_token'],
-        "MICROSOFT_REFRESH_TOKEN": credentials['refresh_token'],
-        "MICROSOFT_TOKEN_EXPIRES_AT": credentials['expires_at'],
-        "MICROSOFT_SCOPES": credentials['scopes'],
-        "MICROSOFT_EMAIL": credentials['microsoft_email'],
-    }, strip_prefix="MICROSOFT_")
+def _save_microsoft_to_env(env_file: Path, connection: dict) -> None:
+    """Save non-secret Microsoft connection metadata to an env file."""
+    values = {
+        "MICROSOFT_CONNECTED": "true",
+        "MICROSOFT_SCOPES": connection['scopes'],
+    }
+    if connection.get("email"):
+        values["MICROSOFT_EMAIL"] = connection["email"]
+    upsert_env(env_file, values, strip_prefix="MICROSOFT_")
 
 
 def handle_microsoft_auth():
@@ -291,24 +293,36 @@ def handle_microsoft_auth():
         console.print("  [bold]co auth[/bold]     Get your OpenOnion API key\n")
         return
 
-    api_url = "https://oo.openonion.ai/api/v1/oauth"
+    backend_url = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
+    api_url = f"{backend_url.rstrip('/')}/api/v1/oauth"
     headers = {"Authorization": f"Bearer {api_key}"}
-
-    # Clear any existing connection first
-    requests.delete(f"{api_url}/microsoft/revoke", headers=headers)
 
     # Get OAuth URL
     console.print("🔑 Initializing Microsoft OAuth...", style="cyan")
 
-    response = requests.get(f"{api_url}/microsoft/init", headers=headers)
+    try:
+        response = requests.get(
+            f"{api_url}/microsoft/init", headers=headers, timeout=15
+        )
+    except RequestException:
+        console.print("\n❌ Microsoft OAuth service is unavailable", style="red")
+        return
     if response.status_code != 200:
         console.print(f"\n❌ Failed to initialize OAuth: {response.text}", style="red")
         return
 
-    auth_url = response.json()['auth_url']
+    try:
+        init = response.json()
+    except ValueError:
+        init = {}
+    auth_url = init.get('auth_url')
+    authorization_id = init.get('authorization_id')
+    if not auth_url or not authorization_id:
+        console.print("\n❌ Microsoft OAuth initialization response is invalid", style="red")
+        return
 
     # Open browser
-    console.print(f"\n🌐 Opening browser for Microsoft authentication...")
+    console.print("\n🌐 Opening browser for Microsoft authentication...")
     console.print(f"    URL: {auth_url}\n", style="dim")
 
     webbrowser.open(auth_url)
@@ -318,13 +332,26 @@ def handle_microsoft_auth():
     console.print("   (Complete the authorization in your browser)\n", style="dim")
 
     max_attempts = 60  # 5 minutes (5 second intervals)
-    for attempt in range(max_attempts):
+    connection = None
+    for _ in range(max_attempts):
         time.sleep(5)
 
-        status_response = requests.get(f"{api_url}/microsoft/status", headers=headers)
+        try:
+            status_response = requests.get(
+                f"{api_url}/microsoft/status",
+                headers=headers,
+                params={"authorization_id": authorization_id},
+                timeout=15,
+            )
+        except RequestException:
+            continue
         if status_response.status_code == 200:
-            status = status_response.json()
+            try:
+                status = status_response.json()
+            except ValueError:
+                continue
             if status.get('connected'):
+                connection = status
                 console.print("✓ Authorization successful!", style="green")
                 break
     else:
@@ -332,32 +359,38 @@ def handle_microsoft_auth():
         console.print("Please try again with: [bold]co auth microsoft[/bold]\n")
         return
 
-    # Get credentials
-    creds_response = requests.get(f"{api_url}/microsoft/credentials", headers=headers)
-    if creds_response.status_code != 200:
-        console.print(f"\n❌ Failed to get credentials: {creds_response.text}", style="red")
+    if not connection.get("scopes"):
+        console.print("\n❌ Microsoft connection metadata is incomplete", style="red")
         return
 
-    credentials = creds_response.json()
-
-    # Save credentials
-    console.print("\n💾 Saving credentials...", style="cyan")
-
-    # Save to global ~/.co/keys.env
-    global_keys_env = Path.home() / ".co" / "keys.env"
-    if global_keys_env.exists():
-        _save_microsoft_to_env(global_keys_env, credentials)
-        console.print(f"   ✓ Saved to {global_keys_env}", style="green")
+    console.print("\n💾 Saving connection...", style="cyan")
 
     # Save to local .env
     local_env = Path(".env")
-    _save_microsoft_to_env(local_env, credentials)
+    try:
+        _save_microsoft_to_env(local_env, connection)
+    except OSError:
+        console.print("\n❌ Could not save Microsoft connection metadata", style="red")
+        return
     console.print(f"   ✓ Saved to {local_env.absolute()}", style="green")
+
+    # Global metadata is useful across projects, but a read-only home config
+    # should not discard the successful connection or local save.
+    global_keys_env = Path.home() / ".co" / "keys.env"
+    if global_keys_env.exists():
+        try:
+            _save_microsoft_to_env(global_keys_env, connection)
+        except OSError:
+            console.print(
+                f"   ⚠ Could not update {global_keys_env}", style="yellow"
+            )
+        else:
+            console.print(f"   ✓ Saved to {global_keys_env}", style="green")
 
     # Success message
     console.print(f"\n✅ [bold green]Microsoft account connected![/bold green]")
-    console.print(f"   Email: {credentials['microsoft_email']}", style="green")
+    if connection.get("email"):
+        console.print(f"   Email: {connection['email']}", style="green")
     console.print(f"\n📧 You can now use Microsoft tools in your agents:")
     console.print(f"   [dim]from connectonion import Outlook, MicrosoftCalendar[/dim]")
     console.print(f"   [dim]agent = Agent('assistant', tools=[Outlook()])[/dim]\n")
-

--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -1,28 +1,35 @@
 """
 Purpose: Authenticate with OpenOnion backend using Ed25519 signature-based authentication to obtain JWT for managed keys
 LLM-Note:
-  Dependencies: imports from [sys, time, yaml, requests, pathlib, rich.console, rich.progress, rich.panel, address] | imported by [cli/main.py via handle_auth(), cli/commands/init.py, cli/commands/create.py] | calls backend at [https://api.openonion.ai/api/auth/login] | tested by [tests/e2e/cli/test_cli_auth.py]
-  Data flow: receives co_dir: Path from caller → address.load(co_dir) reads Ed25519 keypair from .co/keys/ → creates auth message with timestamp → address.sign() creates signature → POST to /api/auth/login with {public_key, message, signature, timestamp} → backend verifies signature → receives JWT token → saves to ~/.co/keys.env as OPENONION_API_KEY → optionally saves to project .env if save_to_project=True → displays balance and email status → returns success bool
+  Dependencies: imports from [sys, time, requests, webbrowser, pathlib, rich, address, cli.oauth_loopback] | imported by [cli/main.py via handle_auth(), cli/commands/init.py, cli/commands/create.py] | tested by [tests/e2e/cli/test_cli_auth.py, tests/e2e/cli/test_cli_auth_microsoft.py, tests/unit/test_oauth_loopback.py]
+  Data flow: OpenOnion auth signs a challenge and stores its API key | Microsoft auth binds 127.0.0.1 before POST /microsoft/init → browser code returns through the local listener → authenticated POST /microsoft/complete → only connected/scopes/email metadata is persisted
   State/Effects: modifies ~/.co/keys.env (adds/updates OPENONION_API_KEY and AGENT_EMAIL) | optionally modifies project .env if save_to_project=True | makes network POST request to api.openonion.ai | chmod 0o600 on .env files (Unix/Mac) | writes to stdout via rich.Console with progress spinner | updates ~/.co/keys.env with IS_EMAIL_ACTIVE
   Integration: exposes handle_auth() for CLI and authenticate(co_dir, save_to_project) for programmatic use | called by init.py and create.py during project setup | relies on address module for Ed25519 keypair operations | uses requests for HTTP calls | displays Rich progress spinner during network call | backend creates account on first auth (no separate registration)
-  Performance: network call to backend (2-5s) | signature generation is fast (<10ms) | file I/O for .env and keys.env | retries on network errors (up to 3 attempts with exponential backoff)
+  Performance: network calls to backend (2-5s) | Microsoft listener waits up to five minutes and uses correlated status only to recover a lost completion response | signature generation and local file I/O are small
   Errors: fails if ~/.co/keys/ missing (no keypair) | fails if backend unreachable (network error) | fails if signature invalid (backend 401) | fails if timestamp expired (5min window) | prints error messages to console and returns False | backend 500 errors bubble up with error details
 """
 
+import json
+import os
 import sys
 import time
-import requests
-from requests import RequestException
-import json
 import webbrowser
-import os
 from pathlib import Path
-from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich.panel import Panel
+from urllib.parse import urlsplit
+
+import requests
 from dotenv import load_dotenv
+from requests import RequestException
+from rich.console import Console
+from rich.panel import Panel
+from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from ... import address
+from ..oauth_loopback import (
+    MicrosoftOAuthLoopback,
+    OAuthLoopbackTimeout,
+    is_valid_microsoft_authorization_id,
+)
 from .project_cmd_lib import load_api_key, upsert_env
 
 console = Console()
@@ -282,6 +289,48 @@ def _save_microsoft_to_env(env_file: Path, connection: dict) -> None:
     upsert_env(env_file, values, strip_prefix="MICROSOFT_")
 
 
+def _is_valid_microsoft_connection(value: object) -> bool:
+    """Validate metadata returned after a Microsoft authorization."""
+    if not isinstance(value, dict):
+        return False
+    scopes = value.get("scopes")
+    email = value.get("email")
+    return (
+        value.get("connected") is True
+        and isinstance(scopes, str)
+        and bool(scopes.strip())
+        and (email is None or isinstance(email, str))
+    )
+
+
+def _recover_microsoft_connection(
+    api_url: str,
+    headers: dict,
+    authorization_id: str,
+) -> dict | None:
+    """Recover a completion whose HTTP response may have been lost."""
+    for attempt in range(5):
+        try:
+            response = requests.get(
+                f"{api_url}/microsoft/status",
+                headers=headers,
+                params={"authorization_id": authorization_id},
+                timeout=5,
+            )
+        except RequestException:
+            response = None
+        if response is not None and response.status_code == 200:
+            try:
+                status = response.json()
+            except ValueError:
+                status = None
+            if _is_valid_microsoft_connection(status):
+                return status
+        if attempt < 4:
+            time.sleep(0.5)
+    return None
+
+
 def handle_microsoft_auth():
     """Authenticate with Microsoft OAuth for Outlook/Calendar access."""
 
@@ -297,71 +346,139 @@ def handle_microsoft_auth():
     api_url = f"{backend_url.rstrip('/')}/api/v1/oauth"
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    # Get OAuth URL
     console.print("🔑 Initializing Microsoft OAuth...", style="cyan")
 
     try:
-        response = requests.get(
-            f"{api_url}/microsoft/init", headers=headers, timeout=15
-        )
-    except RequestException:
-        console.print("\n❌ Microsoft OAuth service is unavailable", style="red")
-        return
-    if response.status_code != 200:
-        console.print(f"\n❌ Failed to initialize OAuth: {response.text}", style="red")
-        return
-
-    try:
-        init = response.json()
-    except ValueError:
-        init = {}
-    auth_url = init.get('auth_url')
-    authorization_id = init.get('authorization_id')
-    if not auth_url or not authorization_id:
-        console.print("\n❌ Microsoft OAuth initialization response is invalid", style="red")
-        return
-
-    # Open browser
-    console.print("\n🌐 Opening browser for Microsoft authentication...")
-    console.print(f"    URL: {auth_url}\n", style="dim")
-
-    webbrowser.open(auth_url)
-
-    # Poll for completion
-    console.print("⏳ Waiting for authorization...", style="yellow")
-    console.print("   (Complete the authorization in your browser)\n", style="dim")
-
-    max_attempts = 60  # 5 minutes (5 second intervals)
-    connection = None
-    for _ in range(max_attempts):
-        time.sleep(5)
-
-        try:
-            status_response = requests.get(
-                f"{api_url}/microsoft/status",
-                headers=headers,
-                params={"authorization_id": authorization_id},
-                timeout=15,
-            )
-        except RequestException:
-            continue
-        if status_response.status_code == 200:
+        with MicrosoftOAuthLoopback() as loopback:
             try:
-                status = status_response.json()
+                response = requests.post(
+                    f"{api_url}/microsoft/init",
+                    headers=headers,
+                    json={"completion_redirect_uri": loopback.callback_uri},
+                    timeout=15,
+                )
+            except RequestException:
+                console.print(
+                    "\n❌ Microsoft OAuth service is unavailable",
+                    style="red",
+                )
+                return
+            if response.status_code != 200:
+                console.print(
+                    f"\n❌ Failed to initialize OAuth: {response.text}",
+                    style="red",
+                )
+                return
+
+            try:
+                init = response.json()
             except ValueError:
-                continue
-            if status.get('connected'):
-                connection = status
-                console.print("✓ Authorization successful!", style="green")
-                break
-    else:
+                init = {}
+            auth_url = init.get("auth_url")
+            authorization_id = init.get("authorization_id")
+            try:
+                parsed_auth_url = (
+                    urlsplit(auth_url) if isinstance(auth_url, str) else None
+                )
+            except ValueError:
+                parsed_auth_url = None
+            if (
+                parsed_auth_url is None
+                or parsed_auth_url.scheme != "https"
+                or parsed_auth_url.netloc != "login.microsoftonline.com"
+                or not parsed_auth_url.path.endswith("/oauth2/v2.0/authorize")
+                or not is_valid_microsoft_authorization_id(authorization_id)
+            ):
+                console.print(
+                    "\n❌ Microsoft OAuth initialization response is invalid",
+                    style="red",
+                )
+                return
+
+            console.print("\n🌐 Opening browser for Microsoft authentication...")
+            try:
+                browser_opened = webbrowser.open(auth_url)
+            except (webbrowser.Error, OSError):
+                browser_opened = False
+            if not browser_opened:
+                console.print(
+                    "   Open this URL in a browser on this same computer:",
+                    style="yellow",
+                )
+                console.print(f"   {auth_url}\n", style="dim")
+
+            console.print("⏳ Waiting for authorization...", style="yellow")
+            console.print(
+                "   (Complete the authorization in your browser)\n",
+                style="dim",
+            )
+            result = loopback.wait_for_result(authorization_id)
+            if result.error or not result.code:
+                console.print(
+                    "\n❌ Microsoft authorization was cancelled or denied",
+                    style="red",
+                )
+                return
+
+            completion_response = None
+            try:
+                completion_response = requests.post(
+                    f"{api_url}/microsoft/complete",
+                    headers=headers,
+                    json={
+                        "authorization_id": authorization_id,
+                        "code": result.code,
+                    },
+                    timeout=15,
+                )
+            except RequestException:
+                # The API may have committed the connection before the response
+                # was lost. The correlated status endpoint is safe recovery.
+                pass
+
+            connection = None
+            should_recover = completion_response is None
+            if (
+                completion_response is not None
+                and completion_response.status_code == 200
+            ):
+                try:
+                    candidate = completion_response.json()
+                except ValueError:
+                    candidate = None
+                if _is_valid_microsoft_connection(candidate):
+                    connection = candidate
+                else:
+                    should_recover = True
+
+            if connection is None and should_recover:
+                connection = _recover_microsoft_connection(
+                    api_url,
+                    headers,
+                    authorization_id,
+                )
+            if connection is None:
+                console.print(
+                    "\n❌ Microsoft authorization could not be completed",
+                    style="red",
+                )
+                console.print(
+                    "Your existing connection was not changed. "
+                    "Please try again with: [bold]co auth microsoft[/bold]\n"
+                )
+                return
+    except OAuthLoopbackTimeout:
         console.print("\n❌ Authorization timed out", style="red")
         console.print("Please try again with: [bold]co auth microsoft[/bold]\n")
         return
-
-    if not connection.get("scopes"):
-        console.print("\n❌ Microsoft connection metadata is incomplete", style="red")
+    except OSError:
+        console.print(
+            "\n❌ Could not start the local Microsoft authorization listener",
+            style="red",
+        )
         return
+
+    console.print("✓ Authorization successful!", style="green")
 
     console.print("\n💾 Saving connection...", style="cyan")
 

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -2,9 +2,9 @@
 Purpose: Display and manage agent keys, credentials, and OAuth connections with masked/revealed output
 LLM-Note:
   Dependencies: imports from [os, pathlib, rich.console, rich.panel, rich.table, dotenv.load_dotenv, address] | imported by [cli/main.py via handle_keys()] | tested by [tests/e2e/cli/test_cli_keys.py]
-  Data flow: receives reveal flag (bool) → _find_co_dir() searches for .co/keys/ (local first, then ~/.co) → address.load() reads Ed25519 keypair → _load_env_vars() loads from local .env and global ~/.co/keys.env → _mask() obscures secrets unless --reveal → displays Identity table (address, short ID, email, source, key file) → displays Secrets table (recovery phrase, API key) → displays OAuth table (Google/Microsoft email and tokens if connected) → displays Env Files table (global and local paths with ✓/✗ status)
+  Data flow: receives reveal flag (bool) → _find_co_dir() searches for .co/keys/ (local first, then ~/.co) → address.load() reads Ed25519 keypair → _load_env_vars() loads from local .env and global ~/.co/keys.env → _mask() obscures secrets unless --reveal → displays Identity table (address, short ID, email, source, key file) → displays Secrets table (recovery phrase, API key) → displays OAuth table (Google credentials when revealed; Microsoft email only because its tokens stay server-side) → displays Env Files table (global and local paths with ✓/✗ status)
   State/Effects: no state modifications | reads from .co/keys/agent.key, recovery.txt, .env, ~/.co/keys.env | writes to stdout via rich.Console | does NOT modify any files
-  Integration: exposes handle_keys() for CLI | similar to status command but focuses on credentials | relies on address module for keypair loading | uses Rich for formatted panel output | checks env vars in priority order: OPENONION_API_KEY, GOOGLE_EMAIL/tokens, MICROSOFT_EMAIL/tokens | recovery phrase shown if recovery.txt exists
+  Integration: exposes handle_keys() for CLI | similar to status command but focuses on credentials | relies on address module for keypair loading | uses Rich for formatted panel output | checks env vars in priority order: OPENONION_API_KEY, GOOGLE_EMAIL/tokens, MICROSOFT_EMAIL | recovery phrase shown if recovery.txt exists
   Performance: file I/O for key loading and env vars (<50ms) | Rich table rendering is fast | no network calls
   Errors: prints message if no .co directory found (run 'co init' or 'co create') | prints message if keys fail to load | gracefully handles missing recovery.txt (shows "missing" message) | gracefully handles missing OAuth tokens (not shown in table) | gracefully handles missing env files (shows red ✗)
 """
@@ -50,9 +50,8 @@ def _load_env_vars() -> dict:
         "GOOGLE_EMAIL": os.getenv("GOOGLE_EMAIL"),
         "GOOGLE_ACCESS_TOKEN": os.getenv("GOOGLE_ACCESS_TOKEN"),
         "GOOGLE_REFRESH_TOKEN": os.getenv("GOOGLE_REFRESH_TOKEN"),
+        "MICROSOFT_CONNECTED": os.getenv("MICROSOFT_CONNECTED"),
         "MICROSOFT_EMAIL": os.getenv("MICROSOFT_EMAIL"),
-        "MICROSOFT_ACCESS_TOKEN": os.getenv("MICROSOFT_ACCESS_TOKEN"),
-        "MICROSOFT_REFRESH_TOKEN": os.getenv("MICROSOFT_REFRESH_TOKEN"),
     }
 
 
@@ -139,9 +138,10 @@ def handle_keys(reveal: bool = False):
 
     # --- OAuth Connections ---
     google_email = env_vars.get("GOOGLE_EMAIL")
+    microsoft_connected = env_vars.get("MICROSOFT_CONNECTED") == "true"
     microsoft_email = env_vars.get("MICROSOFT_EMAIL")
 
-    if google_email or microsoft_email:
+    if google_email or microsoft_connected:
         oauth_table = Table(show_header=False, box=None, padding=(0, 2))
         oauth_table.add_column("key", style="cyan", min_width=14)
         oauth_table.add_column("value", overflow="fold", no_wrap=False)
@@ -156,15 +156,11 @@ def handle_keys(reveal: bool = False):
                 if refresh:
                     oauth_table.add_row("  Refresh Token", refresh)
 
-        if microsoft_email:
-            oauth_table.add_row("Microsoft", f"[green]✓[/green] {microsoft_email}")
-            if reveal:
-                token = env_vars.get("MICROSOFT_ACCESS_TOKEN")
-                if token:
-                    oauth_table.add_row("  Access Token", token)
-                refresh = env_vars.get("MICROSOFT_REFRESH_TOKEN")
-                if refresh:
-                    oauth_table.add_row("  Refresh Token", refresh)
+        if microsoft_connected:
+            oauth_table.add_row(
+                "Microsoft",
+                f"[green]✓[/green] {microsoft_email or 'connected'}",
+            )
 
         console.print(Panel(oauth_table, title="[bold]OAuth[/bold]", border_style="green"))
 

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -2,8 +2,8 @@
 Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent/scheduled), read, reply, and search from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin, attachments prechecked, --at validated to UTC ISO → send() | scheduled: get_scheduled() → read-only table (To/Subject/Sends at), plain full-id lines when piped; does NOT touch the numbering cache
-  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Data flow: _outlook() loads Microsoft connection metadata + OpenOnion API key from .env / ~/.co/keys.env → Outlook() instance | Outlook asks oo-api for short-lived access tokens | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin, attachments prechecked, --at validated to UTC ISO → send() | scheduled: get_scheduled() → read-only table (To/Subject/Sends at), plain full-id lines when piped; does NOT touch the numbering cache
+  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read marks emails read server-side | no Microsoft tokens are persisted locally
   Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_reply(), handle_outlook_sent(), handle_outlook_search(), handle_outlook_scheduled() for cli/main.py | presentation mirrors email_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
   Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, missing/oversized attachments, invalid --at, unresolvable email # | Graph API errors propagate from the Outlook tool | scheduled sends can't be cancelled via API (Exchange 403) — the listing hints at Outlook's own Cancel Send
 """
@@ -26,14 +26,18 @@ ATTACHMENT_LIMIT = 3_000_000  # Graph sendMail rejects larger payloads
 
 
 def _outlook():
-    """Load MICROSOFT_* credentials from .env files and return an Outlook instance. Exits 1 with a hint if not connected."""
+    """Load connection metadata and return Outlook, or exit with a hint."""
     from dotenv import load_dotenv
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
         if env_path.exists():
             load_dotenv(env_path)
 
-    if not os.getenv("MICROSOFT_ACCESS_TOKEN") or "Mail" not in os.getenv("MICROSOFT_SCOPES", ""):
+    if (
+        not os.getenv("OPENONION_API_KEY")
+        or os.getenv("MICROSOFT_CONNECTED", "").lower() != "true"
+        or "Mail" not in os.getenv("MICROSOFT_SCOPES", "")
+    ):
         console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
         console.print("\n[cyan]Connect Outlook first:[/cyan]")
         console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -419,7 +419,7 @@ def email_upgrade(
 
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.
-# Uses the MICROSOFT_* OAuth tokens saved to .env by `co auth microsoft`.
+# Microsoft tokens stay in oo-api; the client stores only email and scopes.
 outlook_app = typer.Typer(help="Send and read email from your Outlook account. Bare 'co outlook' shows the inbox.")
 app.add_typer(outlook_app, name="outlook")
 

--- a/connectonion/cli/oauth_loopback.py
+++ b/connectonion/cli/oauth_loopback.py
@@ -1,0 +1,207 @@
+"""Small, single-use loopback receiver for browser OAuth completion."""
+
+from __future__ import annotations
+
+import hmac
+import time
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional
+from urllib.parse import parse_qs, urlsplit
+
+
+MICROSOFT_CALLBACK_PATH = "/oauth/microsoft/callback"
+_MIN_AUTHORIZATION_ID_LENGTH = 32
+_MAX_AUTHORIZATION_ID_LENGTH = 128
+_MAX_AUTHORIZATION_CODE_LENGTH = 8192
+_REQUEST_TIMEOUT_SECONDS = 1.0
+
+
+class OAuthLoopbackTimeout(TimeoutError):
+    """Raised when the browser does not return before the local deadline."""
+
+
+@dataclass(frozen=True)
+class OAuthLoopbackResult:
+    """A terminal result received from the browser on loopback."""
+
+    code: Optional[str] = None
+    error: Optional[str] = None
+
+
+def is_valid_microsoft_authorization_id(value: object) -> bool:
+    """Return whether a value has the shape of the server-generated state."""
+    return (
+        isinstance(value, str)
+        and _MIN_AUTHORIZATION_ID_LENGTH <= len(value) <= _MAX_AUTHORIZATION_ID_LENGTH
+        and value.isascii()
+        and all(character.isalnum() or character in "-_" for character in value)
+    )
+
+
+class _LoopbackHTTPServer(HTTPServer):
+    """Bound only to IPv4 loopback, with a timeout for accepted sockets."""
+
+    def get_request(self):
+        request, client_address = super().get_request()
+        request.settimeout(_REQUEST_TIMEOUT_SECONDS)
+        return request, client_address
+
+
+class MicrosoftOAuthLoopback:
+    """Receive exactly one correlated Microsoft OAuth result on 127.0.0.1."""
+
+    def __init__(self) -> None:
+        self._authorization_id: Optional[str] = None
+        self._result: Optional[OAuthLoopbackResult] = None
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            server_version = "ConnectOnion"
+            sys_version = ""
+
+            def do_GET(self) -> None:  # noqa: N802 - stdlib callback name
+                owner._handle_get(self)
+
+            def log_message(self, _format: str, *args) -> None:
+                # Never copy the callback query (which contains a one-use code)
+                # into terminal or application logs.
+                return
+
+        self._server = _LoopbackHTTPServer(("127.0.0.1", 0), Handler)
+        self._server.timeout = 0.5
+
+    @property
+    def callback_uri(self) -> str:
+        """Canonical URI accepted by oo-api's strict redirect allowlist."""
+        return (
+            f"http://127.0.0.1:{self._server.server_port}"
+            f"{MICROSOFT_CALLBACK_PATH}"
+        )
+
+    @property
+    def port(self) -> int:
+        return self._server.server_port
+
+    def wait_for_result(
+        self,
+        authorization_id: str,
+        timeout: float = 5 * 60,
+    ) -> OAuthLoopbackResult:
+        """Serve loopback until the matching result arrives or time expires."""
+        if not is_valid_microsoft_authorization_id(authorization_id):
+            raise ValueError("authorization_id is invalid")
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
+
+        self._authorization_id = authorization_id
+        deadline = time.monotonic() + timeout
+        while self._result is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise OAuthLoopbackTimeout("Microsoft authorization timed out")
+            self._server.timeout = min(0.5, remaining)
+            self._server.handle_request()
+        return self._result
+
+    def close(self) -> None:
+        self._server.server_close()
+
+    def __enter__(self) -> "MicrosoftOAuthLoopback":
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> None:
+        self.close()
+
+    def _handle_get(self, handler: BaseHTTPRequestHandler) -> None:
+        try:
+            parsed = urlsplit(handler.path)
+            params = parse_qs(
+                parsed.query,
+                keep_blank_values=True,
+                max_num_fields=8,
+            )
+        except ValueError:
+            self._send_page(handler, 400, _INVALID_PAGE)
+            return
+
+        expected_host = f"127.0.0.1:{self._server.server_port}"
+        host_headers = handler.headers.get_all("Host", [])
+        allowed_keys = {"authorization_id", "code", "error"}
+        authorization_ids = params.get("authorization_id", [])
+        codes = params.get("code", [])
+        errors = params.get("error", [])
+
+        valid_envelope = (
+            self._authorization_id is not None
+            and parsed.scheme == ""
+            and parsed.netloc == ""
+            and parsed.path == MICROSOFT_CALLBACK_PATH
+            and parsed.fragment == ""
+            and len(host_headers) == 1
+            and host_headers[0] == expected_host
+            and set(params).issubset(allowed_keys)
+            and len(authorization_ids) == 1
+            and is_valid_microsoft_authorization_id(authorization_ids[0])
+            and hmac.compare_digest(
+                authorization_ids[0].encode("ascii"),
+                (self._authorization_id or "").encode("ascii"),
+            )
+            and (
+                (
+                    len(codes) == 1
+                    and 0 < len(codes[0]) <= _MAX_AUTHORIZATION_CODE_LENGTH
+                    and not errors
+                )
+                or (
+                    not codes
+                    and errors == ["authorization_failed"]
+                )
+            )
+        )
+        if not valid_envelope:
+            self._send_page(handler, 400, _INVALID_PAGE)
+            return
+
+        if codes:
+            self._result = OAuthLoopbackResult(code=codes[0])
+            self._send_page(handler, 200, _SUCCESS_PAGE)
+        else:
+            self._result = OAuthLoopbackResult(error="authorization_failed")
+            self._send_page(handler, 200, _CANCELLED_PAGE)
+
+    @staticmethod
+    def _send_page(
+        handler: BaseHTTPRequestHandler,
+        status_code: int,
+        body: bytes,
+    ) -> None:
+        handler.send_response(status_code)
+        handler.send_header("Cache-Control", "no-store")
+        handler.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; frame-ancestors 'none'; base-uri 'none'",
+        )
+        handler.send_header("Referrer-Policy", "no-referrer")
+        handler.send_header("X-Content-Type-Options", "nosniff")
+        handler.send_header("Content-Type", "text/html; charset=utf-8")
+        handler.send_header("Content-Length", str(len(body)))
+        handler.send_header("Connection", "close")
+        handler.end_headers()
+        handler.wfile.write(body)
+
+
+_SUCCESS_PAGE = (
+    b"<!doctype html><html><head><title>Microsoft connected</title></head>"
+    b"<body><h1>Microsoft connected</h1>"
+    b"<p>You can close this window and return to the terminal.</p></body></html>"
+)
+_CANCELLED_PAGE = (
+    b"<!doctype html><html><head><title>Authorization cancelled</title></head>"
+    b"<body><h1>Authorization was not completed</h1>"
+    b"<p>You can close this window and return to the terminal.</p></body></html>"
+)
+_INVALID_PAGE = (
+    b"<!doctype html><html><head><title>Invalid callback</title></head>"
+    b"<body><h1>Invalid authorization callback</h1></body></html>"
+)

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -1,9 +1,9 @@
 """
 Purpose: Microsoft Calendar integration tool for managing events via Microsoft Graph API
 LLM-Note:
-  Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_microsoft_calendar.py]
-  Data flow: Agent calls MicrosoftCalendar methods → _get_headers() loads MICROSOFT_ACCESS_TOKEN from env → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (event lists, confirmations, free slots)
-  State/Effects: reads MICROSOFT_* env vars for OAuth tokens | makes HTTP calls to Microsoft Graph API | can create/update/delete events, create Teams meetings | no local file persistence
+  Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires 'co auth' + 'co auth microsoft' | tested by [tests/unit/test_microsoft_calendar.py]
+  Data flow: Agent calls MicrosoftCalendar methods → _get_access_token() asks oo-api for a usable short-lived token → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (event lists, confirmations, free slots)
+  State/Effects: keeps one access token in instance memory | makes HTTP calls to oo-api and Microsoft Graph API | can create/update/delete events, create Teams meetings | no local token persistence
   Integration: exposes MicrosoftCalendar class with list_events(), get_today_events(), get_event(), create_event(), update_event(), delete_event(), create_teams_meeting(), get_upcoming_meetings(), find_free_slots(), check_availability() | used as agent tool via Agent(tools=[MicrosoftCalendar()])
   Performance: network I/O per API call | batch fetching for list operations | date parsing for queries
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | returns error strings for display
@@ -44,13 +44,19 @@ Example:
 
 import os
 from datetime import datetime, timedelta
+from hashlib import sha256
+import time
+from typing import Optional
 import httpx
+from httpx import RequestError
 
 
 class MicrosoftCalendar:
     """Microsoft Calendar tool for managing events via Microsoft Graph API."""
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
+    ACCESS_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60
 
     def __init__(self):
         """Initialize Microsoft Calendar tool.
@@ -68,78 +74,87 @@ class MicrosoftCalendar:
             )
 
         self._access_token = None
+        self._access_token_refresh_at = None
 
     def _get_access_token(self) -> str:
-        """Get Microsoft access token (with auto-refresh)."""
-        access_token = os.getenv("MICROSOFT_ACCESS_TOKEN")
-        refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
-        expires_at_str = os.getenv("MICROSOFT_TOKEN_EXPIRES_AT")
-
-        if not access_token or not refresh_token:
-            raise ValueError(
-                "Microsoft OAuth credentials not found.\n"
-                "Run: co auth microsoft"
+        """Return the instance token, asking oo-api on first use."""
+        if (
+            not self._access_token
+            or (
+                self._access_token_refresh_at is not None
+                and time.monotonic() >= self._access_token_refresh_at
             )
-
-        # Check if token is expired or about to expire (within 5 minutes)
-        if expires_at_str:
-            expires_at = datetime.fromisoformat(expires_at_str.replace('Z', '+00:00'))
-            now = datetime.utcnow().replace(tzinfo=expires_at.tzinfo) if expires_at.tzinfo else datetime.utcnow()
-
-            if now >= expires_at - timedelta(minutes=5):
-                access_token = self._refresh_via_backend(refresh_token)
-                self._access_token = None
-
-        if self._access_token:
-            return self._access_token
-
-        self._access_token = access_token
+        ):
+            self._access_token = self._fetch_access_token()
         return self._access_token
 
-    def _refresh_via_backend(self, refresh_token: str) -> str:
-        """Refresh access token via backend API."""
-        backend_url = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
+    def _fetch_access_token(
+        self,
+        rejected_access_token: Optional[str] = None,
+    ) -> str:
+        """Ask oo-api for a usable access token; refresh tokens stay server-side."""
+        backend_url = os.getenv(
+            "OPENONION_API_URL", "https://oo.openonion.ai"
+        ).rstrip("/")
         api_key = os.getenv("OPENONION_API_KEY")
 
         if not api_key:
             raise ValueError(
                 "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
+                "Authenticate with OpenOnion first: co auth"
             )
 
-        response = httpx.post(
-            f"{backend_url}/api/v1/oauth/microsoft/refresh",
-            headers={"Authorization": f"Bearer {api_key}"},
-            json={"refresh_token": refresh_token}
-        )
+        request = {
+            "headers": {"Authorization": f"Bearer {api_key}"},
+        }
+        if rejected_access_token:
+            request["json"] = {
+                "rejected_access_token_hash": sha256(
+                    rejected_access_token.encode()
+                ).hexdigest()
+            }
+        try:
+            response = httpx.post(
+                f"{backend_url}/api/v1/oauth/microsoft/refresh", **request
+            )
+        except RequestError as exc:
+            raise ValueError(
+                "Microsoft token service unavailable. Please try again."
+            ) from exc
 
+        if response.status_code in {404, 409}:
+            raise ValueError(
+                "Microsoft authorization expired.\n"
+                "Reconnect with: co auth microsoft"
+            )
+        if response.status_code in {401, 403}:
+            raise ValueError("OpenOnion authentication expired.\nRun: co auth")
         if response.status_code != 200:
             raise ValueError(
-                f"Failed to refresh Microsoft token via backend: {response.text}"
+                f"Microsoft token service unavailable ({response.status_code}). "
+                "Please try again."
             )
 
-        data = response.json()
-        new_access_token = data["access_token"]
-        expires_at = data["expires_at"]
-
-        os.environ["MICROSOFT_ACCESS_TOKEN"] = new_access_token
-        os.environ["MICROSOFT_TOKEN_EXPIRES_AT"] = expires_at
-
-        env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
-        if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
-                lines = f.readlines()
-
-            with open(env_file, 'w') as f:
-                for line in lines:
-                    if line.startswith("MICROSOFT_ACCESS_TOKEN="):
-                        f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")
-                    elif line.startswith("MICROSOFT_TOKEN_EXPIRES_AT="):
-                        f.write(f"MICROSOFT_TOKEN_EXPIRES_AT={expires_at}\n")
-                    else:
-                        f.write(line)
-
-        return new_access_token
+        try:
+            payload = response.json()
+            access_token = payload["access_token"]
+            expires_in = payload["expires_in"]
+        except (ValueError, KeyError, TypeError) as exc:
+            raise ValueError("oo-api returned an invalid Microsoft token response") from exc
+        if (
+            not isinstance(access_token, str)
+            or not access_token
+            or isinstance(expires_in, bool)
+            or not isinstance(expires_in, int)
+            or expires_in <= 0
+            or expires_in > self.MAX_ACCESS_TOKEN_LIFETIME_SECONDS
+        ):
+            raise ValueError("oo-api returned an invalid Microsoft token response")
+        self._access_token_refresh_at = time.monotonic() + max(
+            0,
+            expires_in - self.ACCESS_TOKEN_REFRESH_BUFFER_SECONDS,
+        )
+        return access_token
 
     def _request(self, method: str, endpoint: str, **kwargs) -> dict:
         """Make authenticated request to Microsoft Graph API."""
@@ -153,12 +168,12 @@ class MicrosoftCalendar:
         response = httpx.request(method, url, headers=headers, **kwargs)
 
         if response.status_code == 401:
-            refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
-            if refresh_token:
-                self._access_token = None
-                token = self._refresh_via_backend(refresh_token)
-                headers["Authorization"] = f"Bearer {token}"
-                response = httpx.request(method, url, headers=headers, **kwargs)
+            self._access_token = None
+            self._access_token_refresh_at = None
+            token = self._fetch_access_token(rejected_access_token=token)
+            self._access_token = token
+            headers["Authorization"] = f"Bearer {token}"
+            response = httpx.request(method, url, headers=headers, **kwargs)
 
         if response.status_code not in [200, 201, 202, 204]:
             raise ValueError(f"Microsoft Graph API error: {response.status_code} - {response.text}")

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -56,7 +56,8 @@ class MicrosoftCalendar:
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
     ACCESS_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
-    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60
+    # Microsoft CAE access tokens can legitimately last 20-28 hours.
+    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 48 * 60 * 60
 
     def __init__(self):
         """Initialize Microsoft Calendar tool.

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -55,7 +55,8 @@ class Outlook:
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
     ACCESS_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
-    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60
+    # Microsoft CAE access tokens can legitimately last 20-28 hours.
+    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 48 * 60 * 60
 
     def __init__(self):
         """Initialize Outlook tool.

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -1,9 +1,9 @@
 """
 Purpose: Outlook integration tool for reading, sending, scheduling, and managing emails via Microsoft Graph API
 LLM-Note:
-  Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (email summaries, bodies, send confirmations) | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() pages the drafts folder (Graph rejects $filter on the property) and returns dicts (id, subject, to, send_at)
-  State/Effects: reads MICROSOFT_* env vars for OAuth tokens | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) | token refresh rewrites ~/.co/keys.env | no other local file persistence
+  Dependencies: imports from [os, httpx] | imported by [useful_tools/__init__.py] | requires 'co auth' + 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
+  Data flow: Agent calls Outlook methods → _get_access_token() asks oo-api for a usable short-lived token → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (email summaries, bodies, send confirmations) | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() pages the drafts folder (Graph rejects $filter on the property) and returns dicts (id, subject, to, send_at)
+  State/Effects: keeps one access token in instance memory | makes HTTP calls to oo-api and Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) | no local token persistence
   Integration: exposes Outlook class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), send(), reply(), get_scheduled(), mark_read(), archive_email() | list_inbox()/list_search()/get_scheduled() return dicts for the CLI (cli/commands/outlook_commands.py) | used as agent tool via Agent(tools=[Outlook()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
@@ -42,15 +42,20 @@ Example:
 """
 
 import html
+from hashlib import sha256
 import os
-from datetime import datetime, timedelta
+import time
+from typing import Optional
 import httpx
+from httpx import RequestError
 
 
 class Outlook:
     """Outlook tool for reading and managing emails via Microsoft Graph API."""
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
+    ACCESS_TOKEN_REFRESH_BUFFER_SECONDS = 5 * 60
+    MAX_ACCESS_TOKEN_LIFETIME_SECONDS = 24 * 60 * 60
 
     def __init__(self):
         """Initialize Outlook tool.
@@ -68,92 +73,87 @@ class Outlook:
             )
 
         self._access_token = None
+        self._access_token_refresh_at = None
 
     def _get_access_token(self) -> str:
-        """Get Microsoft access token, refreshing once per Outlook instance.
-
-        Microsoft refresh tokens live 90 days and replace themselves on
-        every use — refreshing at the start of each session (and persisting
-        the rotated token) keeps that window sliding forever, so re-auth is
-        only ever needed after a password change or revocation.
-        """
-        if self._access_token:
-            return self._access_token
-
-        access_token = os.getenv("MICROSOFT_ACCESS_TOKEN")
-        refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
-
-        if not access_token or not refresh_token:
-            raise ValueError(
-                "Microsoft OAuth credentials not found.\n"
-                "Run: co auth microsoft"
+        """Return the instance token, asking oo-api on first use."""
+        if (
+            not self._access_token
+            or (
+                self._access_token_refresh_at is not None
+                and time.monotonic() >= self._access_token_refresh_at
             )
-
-        self._access_token = self._refresh_via_backend(refresh_token)
+        ):
+            self._access_token = self._fetch_access_token()
         return self._access_token
 
-    def _refresh_via_backend(self, refresh_token: str) -> str:
-        """Refresh tokens via backend API and persist the rotated pair.
-
-        Args:
-            refresh_token: The refresh token
-
-        Returns:
-            New access token
-        """
-        backend_url = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
+    def _fetch_access_token(
+        self,
+        rejected_access_token: Optional[str] = None,
+    ) -> str:
+        """Ask oo-api for a usable access token; refresh tokens stay server-side."""
+        backend_url = os.getenv(
+            "OPENONION_API_URL", "https://oo.openonion.ai"
+        ).rstrip("/")
         api_key = os.getenv("OPENONION_API_KEY")
 
         if not api_key:
             raise ValueError(
                 "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
+                "Authenticate with OpenOnion first: co auth"
             )
 
-        response = httpx.post(
-            f"{backend_url}/api/v1/oauth/microsoft/refresh",
-            headers={"Authorization": f"Bearer {api_key}"},
-            json={"refresh_token": refresh_token}
-        )
-
-        if response.status_code != 200:
+        request = {
+            "headers": {"Authorization": f"Bearer {api_key}"},
+        }
+        if rejected_access_token:
+            request["json"] = {
+                "rejected_access_token_hash": sha256(
+                    rejected_access_token.encode()
+                ).hexdigest()
+            }
+        try:
+            response = httpx.post(
+                f"{backend_url}/api/v1/oauth/microsoft/refresh", **request
+            )
+        except RequestError as exc:
             raise ValueError(
-                f"Microsoft session expired and refresh failed ({response.status_code}).\n"
+                "Microsoft token service unavailable. Please try again."
+            ) from exc
+
+        if response.status_code in {404, 409}:
+            raise ValueError(
+                "Microsoft authorization expired.\n"
                 "Reconnect with: co auth microsoft"
             )
+        if response.status_code in {401, 403}:
+            raise ValueError("OpenOnion authentication expired.\nRun: co auth")
+        if response.status_code != 200:
+            raise ValueError(
+                f"Microsoft token service unavailable ({response.status_code}). "
+                "Please try again."
+            )
 
-        data = response.json()
-        new_access_token = data["access_token"]
-        expires_at = data["expires_at"]
-        # Microsoft rotates refresh tokens on every use — persist the new one
-        # or the connection dies when the original expires at 90 days.
-        # (Older backends don't return it; keep the current one then.)
-        new_refresh_token = data.get("refresh_token")
-
-        # Update environment variables for this session
-        os.environ["MICROSOFT_ACCESS_TOKEN"] = new_access_token
-        os.environ["MICROSOFT_TOKEN_EXPIRES_AT"] = expires_at
-        if new_refresh_token:
-            os.environ["MICROSOFT_REFRESH_TOKEN"] = new_refresh_token
-
-        # Update .env file if it exists
-        env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
-        if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
-                lines = f.readlines()
-
-            with open(env_file, 'w') as f:
-                for line in lines:
-                    if line.startswith("MICROSOFT_ACCESS_TOKEN="):
-                        f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")
-                    elif line.startswith("MICROSOFT_TOKEN_EXPIRES_AT="):
-                        f.write(f"MICROSOFT_TOKEN_EXPIRES_AT={expires_at}\n")
-                    elif line.startswith("MICROSOFT_REFRESH_TOKEN=") and new_refresh_token:
-                        f.write(f"MICROSOFT_REFRESH_TOKEN={new_refresh_token}\n")
-                    else:
-                        f.write(line)
-
-        return new_access_token
+        try:
+            payload = response.json()
+            access_token = payload["access_token"]
+            expires_in = payload["expires_in"]
+        except (ValueError, KeyError, TypeError) as exc:
+            raise ValueError("oo-api returned an invalid Microsoft token response") from exc
+        if (
+            not isinstance(access_token, str)
+            or not access_token
+            or isinstance(expires_in, bool)
+            or not isinstance(expires_in, int)
+            or expires_in <= 0
+            or expires_in > self.MAX_ACCESS_TOKEN_LIFETIME_SECONDS
+        ):
+            raise ValueError("oo-api returned an invalid Microsoft token response")
+        self._access_token_refresh_at = time.monotonic() + max(
+            0,
+            expires_in - self.ACCESS_TOKEN_REFRESH_BUFFER_SECONDS,
+        )
+        return access_token
 
     def _request(self, method: str, endpoint: str, **kwargs) -> dict:
         """Make authenticated request to Microsoft Graph API."""
@@ -167,13 +167,12 @@ class Outlook:
         response = httpx.request(method, url, headers=headers, **kwargs)
 
         if response.status_code == 401:
-            # Token might have expired, try refreshing
-            refresh_token = os.getenv("MICROSOFT_REFRESH_TOKEN")
-            if refresh_token:
-                self._access_token = None
-                token = self._refresh_via_backend(refresh_token)
-                headers["Authorization"] = f"Bearer {token}"
-                response = httpx.request(method, url, headers=headers, **kwargs)
+            self._access_token = None
+            self._access_token_refresh_at = None
+            token = self._fetch_access_token(rejected_access_token=token)
+            self._access_token = token
+            headers["Authorization"] = f"Bearer {token}"
+            response = httpx.request(method, url, headers=headers, **kwargs)
 
         if response.status_code not in [200, 201, 202, 204]:
             raise ValueError(f"Microsoft Graph API error: {response.status_code} - {response.text}")

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -228,8 +228,8 @@ details and current limitations.
 #### `co outlook` - Send & Read Outlook Email
 
 Your personal Outlook account from the terminal, via Microsoft Graph.
-Requires `co auth microsoft` once (Mail scopes; saved as `MICROSOFT_*` in
-`.env` / `~/.co/keys.env`).
+Requires `co auth microsoft` once. Microsoft refresh tokens stay encrypted in
+oo-api; `.env` / `~/.co/keys.env` contain only connection metadata.
 
 **Basic usage:**
 ```bash

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -30,9 +30,10 @@ That's the whole surface. Everything below is detail.
 co auth microsoft
 ```
 
-This opens the Microsoft OAuth flow and saves `MICROSOFT_*` credentials
-(access token, refresh token, scopes, email) to your project `.env` and
-`~/.co/keys.env`. Tokens auto-refresh. If credentials or Mail scopes are
+This opens the Microsoft OAuth flow. Refresh tokens stay encrypted in oo-api;
+the client saves only connection metadata (`MICROSOFT_CONNECTED`, scopes, and
+optional email) in the project `.env` and `~/.co/keys.env`. oo-api renews the
+short-lived access token on demand. If the connection or Mail scopes are
 missing, any `co outlook` command tells you to run `co auth microsoft` first.
 See [Microsoft Integration](../integrations/microsoft.md) for scope details.
 

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -1,373 +1,153 @@
-# Microsoft Integration (co auth microsoft)
+# Microsoft Integration (`co auth microsoft`)
 
-> Send emails via Outlook and read calendar events from your AI agents. 30-second setup.
-
----
-
-## Quick Start
-
-```bash
-co auth microsoft
-```
-
-What happens:
-1. Clears any existing Microsoft connection (allows switching accounts)
-2. Opens browser to Microsoft OAuth consent screen
-3. You authorize Mail + Calendar permissions
-4. Credentials saved to `.env` (both local and global `~/.co/keys.env`)
-5. Ready to use Outlook and Microsoft Calendar tools immediately
-
-**That's it.** Your agents can now send emails via Outlook and read your Microsoft calendar. You can too, from the terminal — see [`co outlook`](../cli/outlook.md).
-
-**Switching accounts?** Just run `co auth microsoft` again - it will clear the old connection and let you pick a new Microsoft account.
-
----
-
-## Prerequisites
-
-Before running `co auth microsoft`, you must authenticate with OpenOnion:
+Connect Outlook Mail and Microsoft Calendar to ConnectOnion:
 
 ```bash
 co auth
+co auth microsoft
 ```
 
-This creates your `OPENONION_API_KEY` which is required for Microsoft OAuth to work.
+The second command opens Microsoft's consent page. After consent, oo-api keeps
+the Microsoft refresh token encrypted on the server. The client stores only
+non-secret connection metadata and asks oo-api for a short-lived access token
+when an Outlook or Calendar tool needs one.
 
----
+## What is stored locally
 
-## What Gets Saved
-
-After successful authentication, your `.env` file contains:
+The project `.env` contains metadata, not Microsoft bearer tokens:
 
 ```bash
-# Microsoft OAuth Credentials
-MICROSOFT_ACCESS_TOKEN=eyJ0eXAi...
-MICROSOFT_REFRESH_TOKEN=0.ATcA...
-MICROSOFT_TOKEN_EXPIRES_AT=2025-12-31T23:59:59
-MICROSOFT_SCOPES=Mail.Read,Mail.Send,Calendars.Read,Calendars.ReadWrite
-MICROSOFT_EMAIL=your.email@outlook.com
+MICROSOFT_CONNECTED=true
+MICROSOFT_SCOPES=Mail.ReadWrite,Mail.Send,Calendars.Read,Calendars.ReadWrite
+MICROSOFT_EMAIL=you@example.com
 ```
 
-**Security notes:**
-- Credentials are saved to both local `.env` and `~/.co/keys.env`
-- File permissions set to `0600` (read/write for owner only) on Unix systems
-- Access tokens expire, but refresh tokens allow automatic renewal
-- You can revoke access anytime via Microsoft Account settings
+The same metadata is updated in `~/.co/keys.env` when that file exists. An
+existing `MICROSOFT_ACCESS_TOKEN`, `MICROSOFT_REFRESH_TOKEN`, or
+`MICROSOFT_TOKEN_EXPIRES_AT` entry is removed during authentication.
 
----
+Do not put a Microsoft refresh token in an application `.env` file. It is a
+long-lived credential and is managed by oo-api.
 
-## Permissions Requested
+## Token refresh behavior
 
-When you run `co auth microsoft`, we request these Microsoft Graph API scopes:
+- Microsoft controls the access-token lifetime and reports it in the token
+  response. It is commonly around 60–90 minutes, but the client does not assume
+  a fixed one-hour lifetime.
+- oo-api returns the cached access token while it has more than five minutes
+  remaining.
+- At five minutes or less, oo-api uses its encrypted refresh token and stores
+  Microsoft's rotated refresh token atomically.
+- If Microsoft Graph rejects an apparently valid access token with `401`, the
+  client asks oo-api to refresh it and retries that Graph request once.
+- If Microsoft requires interaction, the command reports that you must run
+  `co auth microsoft` again.
 
-| Scope | Purpose | What agents can do |
-|-------|---------|-------------------|
-| `Mail.Read` | Read user emails | Read inbox, search emails |
-| `Mail.Send` | Send emails on your behalf | Send emails via Outlook |
-| `Calendars.Read` | Read calendar events | Read your calendar to check availability |
-| `Calendars.ReadWrite` | Create/modify calendar events | Create and update events |
-| `User.Read` | Get your profile | Identify which Microsoft account is connected |
-| `offline_access` | Refresh tokens | Keep credentials working without re-auth |
+There is no periodic “refresh the refresh token” timer. The refresh token is
+used only when a new access token is required.
 
-**Privacy**: We only request the permissions needed. We cannot:
-- Delete your emails
-- Access your OneDrive or other services
-- Access your contacts beyond basic profile
+## Permissions
 
----
+The integration requests delegated Microsoft Graph permissions:
 
-## Using Microsoft OAuth in Agents
+| Scope | Purpose |
+| --- | --- |
+| `Mail.ReadWrite` | Read, update, move, and archive mailbox messages |
+| `Mail.Send` | Send messages |
+| `Calendars.Read` | Read calendar events |
+| `Calendars.ReadWrite` | Create, update, and delete events |
+| `User.Read` | Show which Microsoft account is connected |
+| `offline_access` | Let oo-api renew access without repeated sign-in |
 
-Once authenticated, your agents can use Microsoft-powered tools:
+Only approve these permissions for a Microsoft account whose mailbox and
+calendar you intend the agent to use.
 
-### Send Email via Outlook
+## Use Outlook
 
 ```python
 from connectonion import Agent, Outlook
 
 outlook = Outlook()
+agent = Agent("outlook-assistant", tools=[outlook])
 
-agent = Agent(
-    "Outlook Assistant",
-    tools=[outlook]
-)
-
-agent.input("Send an email to alice@example.com saying hello")
+agent.input("Show my unread email")
+agent.input("Send alice@example.com a short project update")
 ```
 
-### Read Calendar Events
+Useful methods include `read_inbox`, `get_sent_emails`, `search_emails`,
+`get_email_body`, `send`, `reply`, `mark_read`, `mark_unread`, and
+`archive_email`.
+
+The terminal interface is documented in [`co outlook`](../cli/outlook.md).
+
+## Use Microsoft Calendar
 
 ```python
 from connectonion import Agent, MicrosoftCalendar
 
 calendar = MicrosoftCalendar()
+agent = Agent("calendar-assistant", tools=[calendar])
 
-agent = Agent(
-    "Calendar Assistant",
-    tools=[calendar]
-)
-
-agent.input("What's on my calendar this week?")
+agent.input("What is on my calendar this week?")
+agent.input("Find a free one-hour slot tomorrow afternoon")
 ```
 
----
+Useful methods include `list_events`, `get_today_events`, `get_event`,
+`create_event`, `update_event`, `delete_event`, `create_teams_meeting`, and
+`find_free_slots`.
 
-## Outlook Tool Methods
+## How the authorization flow works
 
-The `Outlook` tool provides these capabilities:
+1. The CLI authenticates to oo-api with `OPENONION_API_KEY` and requests a new
+   authorization transaction.
+2. oo-api creates a random, short-lived state value and PKCE verifier.
+3. The CLI opens Microsoft's authorization page and polls the matching status
+   endpoint.
+4. Microsoft's callback is exchanged by oo-api. The access and refresh tokens
+   are encrypted and associated with the OpenOnion account.
+5. The CLI saves only `MICROSOFT_CONNECTED`, scopes, and optional email.
 
-```python
-from connectonion import Outlook
-
-outlook = Outlook()
-
-# Reading emails
-outlook.read_inbox(last=10, unread=False)  # Get recent inbox emails
-outlook.get_sent_emails(max_results=10)    # Get sent emails
-outlook.search_emails("quarterly report")   # Search all emails
-outlook.get_email_body(email_id)           # Get full email content
-
-# Sending emails
-outlook.send(to="alice@example.com", subject="Hello", body="Hi there!")
-outlook.send(to="alice@example.com", subject="Hello", body="Hi!", cc="bob@example.com")
-outlook.send(to="alice@example.com", subject="Report", body="See attached.",
-             attachments=["report.pdf"],              # local files, ~3MB Graph limit
-             send_at="2026-07-06T15:30:00Z")           # deferred send (UTC ISO)
-outlook.reply(email_id, body="Thanks for your message")
-
-# Actions
-outlook.mark_read(email_id)     # Mark email as read
-outlook.mark_unread(email_id)   # Mark email as unread
-outlook.archive_email(email_id) # Move to archive folder
-
-# Stats
-outlook.count_unread()          # Count unread emails in inbox
-outlook.get_my_email()          # Get connected Microsoft email address
-```
-
----
-
-## Microsoft Calendar Tool Methods
-
-The `MicrosoftCalendar` tool provides:
-
-```python
-from connectonion import MicrosoftCalendar
-
-calendar = MicrosoftCalendar()
-
-# Reading events
-calendar.list_events(days_ahead=7, max_results=20)  # Get upcoming events
-calendar.get_today_events()                          # Get today's events
-calendar.get_event(event_id)                         # Get event details
-
-# Creating events
-calendar.create_event(
-    title="Team Meeting",
-    start_time="2025-01-15 14:00",
-    end_time="2025-01-15 15:00",
-    description="Weekly sync",
-    attendees="alice@example.com,bob@example.com",
-    location="Conference Room A"
-)
-
-# Create Teams meeting (with auto-generated meeting link)
-calendar.create_teams_meeting(
-    title="Project Sync",
-    start_time="2025-01-15 14:00",
-    end_time="2025-01-15 15:00",
-    attendees="alice@example.com,bob@example.com"
-)
-
-# Updating & deleting
-calendar.update_event(event_id, title="Updated Title")
-calendar.delete_event(event_id)
-
-# Meetings & availability
-calendar.get_upcoming_meetings(days_ahead=7)   # Get events with attendees
-calendar.find_free_slots("2025-01-15", duration_minutes=60)  # Find free time
-calendar.check_availability("2025-01-15 14:00")  # Check if specific time is free
-```
-
----
+Starting another flow does not delete a working connection. The connection is
+replaced only after a new authorization succeeds.
 
 ## Troubleshooting
 
-### "Not authenticated with OpenOnion"
-
-You need to run `co auth` first to get your `OPENONION_API_KEY`:
+If ConnectOnion authentication is missing or expired:
 
 ```bash
 co auth
-co auth microsoft
 ```
 
-### Authorization Timeout
-
-If the browser window doesn't complete authorization within 5 minutes:
-
-```bash
-# Try again
-co auth microsoft
-```
-
-### Access Denied / User Cancelled
-
-If you click "Cancel" on the Microsoft consent screen:
-
-```bash
-# Just run it again when ready
-co auth microsoft
-```
-
-### Credentials Not Working
-
-Check if credentials are properly saved:
-
-```bash
-# Check local .env
-cat .env | grep MICROSOFT_
-
-# Check global keys
-cat ~/.co/keys.env | grep MICROSOFT_
-```
-
-If credentials exist but don't work, re-authenticate:
+If Microsoft authorization was cancelled, timed out, revoked, or requires
+interaction:
 
 ```bash
 co auth microsoft
 ```
 
-### Switch Microsoft Account
-
-To use a different Microsoft account:
+To inspect local connection metadata without revealing any Microsoft token:
 
 ```bash
-co auth microsoft
+co keys
 ```
 
-This automatically clears the old connection before starting a new OAuth flow.
+Removing `MICROSOFT_*` metadata locally only hides the connection from that
+client; it does not revoke the server-held Microsoft authorization. To revoke
+the Microsoft grant, remove OpenOnion from the Microsoft account's consent/app
+permissions page. A first-class `co auth microsoft --disconnect` command is not
+yet available.
 
-### Revoke Access
+## Security notes
 
-To disconnect your Microsoft account:
-
-1. Via Microsoft Account Settings:
-   - Go to https://account.live.com/consent/Manage
-   - Find "OpenOnion" and click "Remove"
-
-2. Manually remove credentials:
-   ```bash
-   # Remove from local .env
-   sed -i '' '/^MICROSOFT_/d' .env
-
-   # Remove from global keys
-   sed -i '' '/^MICROSOFT_/d' ~/.co/keys.env
-   ```
-
----
-
-## Environment Variables Reference
-
-After running `co auth microsoft`, these variables are available:
-
-```bash
-MICROSOFT_ACCESS_TOKEN      # Short-lived token for API calls (expires in 1 hour)
-MICROSOFT_REFRESH_TOKEN     # Long-lived token for getting new access tokens
-MICROSOFT_TOKEN_EXPIRES_AT  # ISO timestamp when access token expires
-MICROSOFT_SCOPES            # Comma-separated list of granted scopes
-MICROSOFT_EMAIL             # Your Microsoft account email address
-```
-
-**Usage in code:**
-
-```python
-import os
-
-# Check if Microsoft OAuth is configured
-if os.getenv("MICROSOFT_ACCESS_TOKEN"):
-    print(f"Connected as: {os.getenv('MICROSOFT_EMAIL')}")
-else:
-    print("Not connected. Run: co auth microsoft")
-```
-
----
-
-## How It Works
-
-Behind the scenes, `co auth microsoft`:
-
-1. **Clears existing connection**: Calls `/api/v1/oauth/microsoft/revoke` to remove old credentials
-2. **Initiates OAuth flow**: Calls `/api/v1/oauth/microsoft/init` with your `OPENONION_API_KEY`
-3. **Opens browser**: Launches Microsoft's OAuth consent screen with required scopes
-4. **Polls for completion**: Checks `/api/v1/oauth/microsoft/status` every 5 seconds
-5. **Retrieves credentials**: Gets tokens from `/api/v1/oauth/microsoft/credentials`
-6. **Saves locally**: Writes credentials to `.env` files with secure permissions
-
-The backend handles:
-- OAuth 2.0 authorization code flow
-- Token refresh logic via Microsoft Graph API
-- Secure storage of credentials
-- Association with your OpenOnion account
-
----
-
-## Comparison: Google vs Microsoft
-
-| Feature | Google (`co auth google`) | Microsoft (`co auth microsoft`) |
-|---------|--------------------------|--------------------------------|
-| Email | Gmail | Outlook |
-| Calendar | Google Calendar | Microsoft Calendar |
-| API | Google APIs | Microsoft Graph API |
-| Scopes | gmail.send, calendar | Mail.Read, Mail.Send, Calendars.* |
-| Token endpoint | oauth2.googleapis.com | login.microsoftonline.com |
-
-Both follow the same CLI pattern and save credentials in the same format.
-
----
-
-## Security Best Practices
-
-1. **Never commit `.env` files**: Add to `.gitignore`
-   ```bash
-   echo ".env" >> .gitignore
-   ```
-
-2. **Use environment-specific credentials**:
-   - Development: Use test Microsoft account
-   - Production: Use production account
-
-3. **Regularly rotate credentials**:
-   ```bash
-   # Re-authenticate every few months
-   co auth microsoft
-   ```
-
-4. **Monitor usage**: Check your Microsoft Account activity regularly
-
-5. **Revoke when done**: If you stop using a project, revoke access
-
----
+- Protect `OPENONION_API_KEY`: it authorizes oo-api to obtain short-lived
+  Microsoft access tokens for the connected account.
+- Never commit `.env`, `~/.co/keys.env`, or bearer tokens.
+- Reauthenticate only when prompted; periodic manual refresh-token rotation is
+  unnecessary.
+- Revoke the Microsoft grant when the integration is no longer needed.
 
 ## Related
 
-- [Google Integration](google.md) - Gmail and Google Calendar integration
-- [CLI Auth](../cli/auth.md) - Authenticate with OpenOnion first
-- [Global .co Directory](../co-directory-structure.md) - Where credentials are stored
-
----
-
-## Privacy Policy & Terms
-
-By using `co auth microsoft`, you agree to:
-- [OpenOnion Privacy Policy](https://o.openonion.ai/privacy)
-- [OpenOnion Terms of Service](https://o.openonion.ai/terms)
-- [Microsoft APIs Terms of Use](https://docs.microsoft.com/en-us/legal/microsoft-apis/terms-of-use)
-
-We only use your Microsoft data for the purposes you authorize. We never:
-- Sell your data
-- Share with third parties (except Microsoft)
-- Store more than necessary
-- Access data beyond requested scopes
-
-You can revoke access at any time.
+- [Outlook CLI](../cli/outlook.md)
+- [CLI authentication](../cli/auth.md)
+- [Google integration](google.md)

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -18,7 +18,7 @@ The project `.env` contains metadata, not Microsoft bearer tokens:
 
 ```bash
 MICROSOFT_CONNECTED=true
-MICROSOFT_SCOPES=Mail.ReadWrite,Mail.Send,Calendars.Read,Calendars.ReadWrite
+MICROSOFT_SCOPES=Mail.ReadWrite,Mail.Send,Calendars.ReadWrite
 MICROSOFT_EMAIL=you@example.com
 ```
 
@@ -32,8 +32,8 @@ long-lived credential and is managed by oo-api.
 ## Token refresh behavior
 
 - Microsoft controls the access-token lifetime and reports it in the token
-  response. It is commonly around 60–90 minutes, but the client does not assume
-  a fixed one-hour lifetime.
+  response. It is commonly around 60–90 minutes; CAE tokens can last 20–28
+  hours. The client does not assume a fixed lifetime.
 - oo-api returns the cached access token while it has more than five minutes
   remaining.
 - At five minutes or less, oo-api uses its encrypted refresh token and stores
@@ -46,6 +46,11 @@ long-lived credential and is managed by oo-api.
 There is no periodic “refresh the refresh token” timer. The refresh token is
 used only when a new access token is required.
 
+Microsoft documents a 90-day default refresh-token lifetime for this web flow,
+but the token can be revoked earlier. Active use normally rotates it whenever a
+new access token is needed; after extended inactivity or a policy/revocation
+event, run `co auth microsoft` again.
+
 ## Permissions
 
 The integration requests delegated Microsoft Graph permissions:
@@ -54,8 +59,7 @@ The integration requests delegated Microsoft Graph permissions:
 | --- | --- |
 | `Mail.ReadWrite` | Read, update, move, and archive mailbox messages |
 | `Mail.Send` | Send messages |
-| `Calendars.Read` | Read calendar events |
-| `Calendars.ReadWrite` | Create, update, and delete events |
+| `Calendars.ReadWrite` | Read, create, update, and delete events |
 | `User.Read` | Show which Microsoft account is connected |
 | `offline_access` | Let oo-api renew access without repeated sign-in |
 
@@ -98,17 +102,26 @@ Useful methods include `list_events`, `get_today_events`, `get_event`,
 
 ## How the authorization flow works
 
-1. The CLI authenticates to oo-api with `OPENONION_API_KEY` and requests a new
-   authorization transaction.
-2. oo-api creates a random, short-lived state value and PKCE verifier.
-3. The CLI opens Microsoft's authorization page and polls the matching status
-   endpoint.
-4. Microsoft's callback is exchanged by oo-api. The access and refresh tokens
-   are encrypted and associated with the OpenOnion account.
-5. The CLI saves only `MICROSOFT_CONNECTED`, scopes, and optional email.
+1. The CLI first binds a random local port on `127.0.0.1`, then authenticates to
+   oo-api and starts a short-lived authorization transaction.
+2. oo-api creates random state and PKCE values. Microsoft still returns to the
+   registered HTTPS oo-api callback; the local URI is never registered with
+   Microsoft and never receives a token.
+3. After consent, the HTTPS callback validates state, stores only a hash of the
+   one-use authorization code, and redirects that code to the initiating CLI's
+   loopback listener. It does not exchange or activate Microsoft tokens.
+4. The CLI constant-time checks the returned authorization ID and submits the
+   code to oo-api with `OPENONION_API_KEY`.
+5. oo-api exchanges the code, encrypts the access/refresh pair, and replaces the
+   existing connection atomically. The CLI saves only connected status, scopes,
+   and optional email.
 
 Starting another flow does not delete a working connection. The connection is
 replaced only after a new authorization succeeds.
+
+The browser must run on the same computer as the CLI. A browser on another
+machine cannot reach the CLI's `127.0.0.1` listener; this is intentional account
+binding, not a network configuration to bypass.
 
 ## Troubleshooting
 
@@ -145,6 +158,12 @@ yet available.
 - Reauthenticate only when prompted; periodic manual refresh-token rotation is
   unnecessary.
 - Revoke the Microsoft grant when the integration is no longer needed.
+
+Microsoft references:
+
+- [Access-token lifetime](https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#token-lifetime)
+- [Refresh-token lifetime and rotation](https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens)
+- [Cache-first token acquisition](https://learn.microsoft.com/en-us/entra/identity-platform/msal-acquire-cache-tokens)
 
 ## Related
 

--- a/docs/useful_tools/microsoft_calendar.md
+++ b/docs/useful_tools/microsoft_calendar.md
@@ -41,6 +41,9 @@ Requires Microsoft OAuth authorization:
 co auth microsoft
 ```
 
+Microsoft refresh tokens stay encrypted in oo-api; the local client keeps only
+connection metadata and obtains short-lived access tokens on demand.
+
 ## Methods
 
 ### Reading Events

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -40,6 +40,9 @@ agent.input("Send an email to alice@example.com saying hello")
 co auth microsoft
 ```
 
+Microsoft refresh tokens stay encrypted in oo-api; the local client keeps only
+connection metadata and obtains short-lived access tokens on demand.
+
 Your agent can now read and manage Outlook emails.
 
 **Switch accounts?** Run `co auth microsoft` again to connect a different Microsoft account.
@@ -172,6 +175,7 @@ from tools.outlook import Outlook    # After - customize freely!
 
 **Missing Microsoft Mail scopes**: Run `co auth microsoft`
 
-**Credentials not found**: Run `co auth microsoft`
+**Connection not found**: Run `co auth microsoft`
 
-**Token expired**: Tokens auto-refresh. If issues persist, run `co auth microsoft` again.
+**Authorization expired**: oo-api refreshes access tokens automatically. If it
+asks for interaction, run `co auth microsoft` again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ markers = [
     "real_api: Tests requiring real API keys",
     "slow: Tests that take >10 seconds",
     "network: Tests requiring network/relay",
+    "token_fetch: Tests of the real oo-api token-fetch handshake",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,7 +24,7 @@ markers =
     cli: CLI-specific tests
     asyncio: Async tests using pytest-asyncio
     benchmark: Performance/benchmark tests
-    real_refresh: Outlook token-refresh flow tests (bypass the refresh stub)
+    token_fetch: Tests of the real oo-api token-fetch handshake
 
 # Output options
 addopts =

--- a/tests/e2e/cli/test_cli_auth_microsoft.py
+++ b/tests/e2e/cli/test_cli_auth_microsoft.py
@@ -22,12 +22,14 @@ Components under test:
 - connectonion.cli.commands.auth_commands._save_microsoft_to_env
 """
 
-import os
 import tempfile
 from pathlib import Path
-import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
+import pytest
+from requests import RequestException
+
+from connectonion.cli.oauth_loopback import OAuthLoopbackTimeout
 from .argparse_runner import ArgparseCliRunner
 
 
@@ -72,6 +74,28 @@ class TestAuthMicrosoftHelp:
 class TestSaveMicrosoftToEnv:
     """Test the _save_microsoft_to_env helper function."""
 
+    def test_connection_metadata_requires_strict_contract(self):
+        from connectonion.cli.commands.auth_commands import (
+            _is_valid_microsoft_connection,
+        )
+
+        assert _is_valid_microsoft_connection(
+            {
+                'connected': True,
+                'scopes': 'Mail.ReadWrite,Mail.Send,Calendars.ReadWrite',
+                'email': 'test@outlook.com',
+            }
+        )
+        assert not _is_valid_microsoft_connection(
+            {'connected': 'true', 'scopes': 'Mail.ReadWrite'}
+        )
+        assert not _is_valid_microsoft_connection(
+            {'connected': True, 'scopes': ''}
+        )
+        assert not _is_valid_microsoft_connection(
+            {'connected': True, 'scopes': ['Mail.ReadWrite']}
+        )
+
     def test_save_microsoft_connection_to_new_env(self):
         """Save only connection metadata, never Microsoft bearer tokens."""
         from connectonion.cli.commands.auth_commands import _save_microsoft_to_env
@@ -80,7 +104,7 @@ class TestSaveMicrosoftToEnv:
             env_file = Path(tmpdir) / '.env'
 
             connection = {
-                'scopes': 'Mail.Read,Mail.Send,Calendars.Read',
+                'scopes': 'Mail.ReadWrite,Mail.Send,Calendars.ReadWrite',
                 'email': 'test@outlook.com',
             }
 
@@ -90,7 +114,10 @@ class TestSaveMicrosoftToEnv:
 
             content = env_file.read_text()
             assert 'MICROSOFT_CONNECTED=true' in content
-            assert 'MICROSOFT_SCOPES=Mail.Read,Mail.Send,Calendars.Read' in content
+            assert (
+                'MICROSOFT_SCOPES=Mail.ReadWrite,Mail.Send,Calendars.ReadWrite'
+                in content
+            )
             assert 'MICROSOFT_EMAIL=test@outlook.com' in content
             assert 'TOKEN' not in content
 
@@ -156,101 +183,297 @@ class TestAuthMicrosoftFlow:
         """Setup test environment."""
         self.runner = ArgparseCliRunner()
 
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
     @patch('connectonion.cli.commands.auth_commands.webbrowser')
     @patch('connectonion.cli.commands.auth_commands.requests')
     def test_auth_microsoft_success_flow(
-        self, mock_requests, mock_webbrowser, isolated_home
+        self, mock_requests, mock_webbrowser, mock_loopback, isolated_home
     ):
-        """Test successful Microsoft OAuth flow."""
+        """Bind loopback, initialize, complete, and persist metadata only."""
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
+
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            listener.wait_for_result.return_value = Mock(
+                code='one-use-code',
+                error=None,
+            )
 
             mock_init_response = Mock()
             mock_init_response.status_code = 200
             mock_init_response.json.return_value = {
                 'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...',
-                'authorization_id': 'authorization-id',
+                'authorization_id': 'a' * 43,
             }
 
-            mock_status_response = Mock()
-            mock_status_response.status_code = 200
-            mock_status_response.json.return_value = {
+            mock_complete_response = Mock()
+            mock_complete_response.status_code = 200
+            mock_complete_response.json.return_value = {
                 'connected': True,
-                'scopes': 'Mail.Read,Mail.Send,Calendars.Read,Calendars.ReadWrite',
+                'scopes': 'Mail.ReadWrite,Mail.Send,Calendars.ReadWrite',
                 'email': 'test@outlook.com',
             }
-
-            mock_requests.get.side_effect = [
+            mock_requests.post.side_effect = [
                 mock_init_response,
-                mock_status_response,
+                mock_complete_response,
             ]
-
             mock_webbrowser.open.return_value = True
 
-            with patch('time.sleep', return_value=None):
-                from connectonion.cli.main import cli
-                result = self.runner.invoke(cli, ['auth', 'microsoft'])
+            from connectonion.cli.main import cli
+            result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
             mock_requests.delete.assert_not_called()
             mock_webbrowser.open.assert_called_once()
-            status_call = mock_requests.get.call_args_list[1]
-            assert status_call.kwargs["params"] == {
-                "authorization_id": "authorization-id"
+            listener.wait_for_result.assert_called_once_with('a' * 43)
+            init_call, complete_call = mock_requests.post.call_args_list
+            assert init_call.args[0].endswith('/microsoft/init')
+            assert init_call.kwargs['json'] == {
+                'completion_redirect_uri': listener.callback_uri
             }
+            assert complete_call.args[0].endswith('/microsoft/complete')
+            assert complete_call.kwargs['json'] == {
+                'authorization_id': 'a' * 43,
+                'code': 'one-use-code',
+            }
+            mock_requests.get.assert_not_called()
 
             env_content = Path('.env').read_text()
             assert 'MICROSOFT_CONNECTED=true' in env_content
             assert 'MICROSOFT_EMAIL=test@outlook.com' in env_content
             assert 'MICROSOFT_ACCESS_TOKEN' not in env_content
             assert 'MICROSOFT_REFRESH_TOKEN' not in env_content
-            assert all('/credentials' not in call.args[0] for call in mock_requests.get.call_args_list)
+            assert '/credentials' not in str(mock_requests.mock_calls)
+            assert 'one-use-code' not in result.output
 
             global_content = (isolated_home / '.co' / 'keys.env').read_text()
             assert 'MICROSOFT_CONNECTED=true' in global_content
             assert 'MICROSOFT_ACCESS_TOKEN' not in global_content
             assert 'MICROSOFT_REFRESH_TOKEN' not in global_content
 
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
     @patch('connectonion.cli.commands.auth_commands.requests')
-    def test_auth_microsoft_init_failure(self, mock_requests):
+    def test_auth_microsoft_init_failure(self, mock_requests, mock_loopback):
         """Test handling of OAuth init failure."""
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+
             mock_response = Mock()
             mock_response.status_code = 500
             mock_response.text = 'Internal Server Error'
-            mock_requests.get.return_value = mock_response
+            mock_requests.post.return_value = mock_response
 
             from connectonion.cli.main import cli
             result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
             assert 'Failed to initialize OAuth' in result.output or result.exit_code != 0
+            mock_requests.get.assert_not_called()
 
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
     @patch('connectonion.cli.commands.auth_commands.webbrowser')
     @patch('connectonion.cli.commands.auth_commands.requests')
-    @patch('time.sleep')
-    def test_auth_microsoft_timeout(self, mock_sleep, mock_requests, mock_webbrowser):
+    def test_auth_microsoft_rejects_non_microsoft_authorization_url(
+        self,
+        mock_requests,
+        mock_webbrowser,
+        mock_loopback,
+    ):
+        with self.runner.isolated_filesystem():
+            Path('.env').write_text('OPENONION_API_KEY=test-key\n')
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            response = Mock(status_code=200)
+            response.json.return_value = {
+                'auth_url': 'https://login.microsoftonline.com.evil/authorize',
+                'authorization_id': 'a' * 43,
+            }
+            mock_requests.post.return_value = response
+
+            from connectonion.cli.main import cli
+            result = self.runner.invoke(cli, ['auth', 'microsoft'])
+
+            assert 'initialization response is invalid' in result.output
+            mock_webbrowser.open.assert_not_called()
+            listener.wait_for_result.assert_not_called()
+
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
+    @patch('connectonion.cli.commands.auth_commands.webbrowser')
+    @patch('connectonion.cli.commands.auth_commands.requests')
+    def test_auth_microsoft_timeout(
+        self,
+        mock_requests,
+        mock_webbrowser,
+        mock_loopback,
+    ):
         """Test handling of authorization timeout."""
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
+
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            listener.wait_for_result.side_effect = OAuthLoopbackTimeout()
 
             mock_init_response = Mock()
             mock_init_response.status_code = 200
             mock_init_response.json.return_value = {
                 'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...',
-                'authorization_id': 'authorization-id',
+                'authorization_id': 'a' * 43,
             }
-
-            mock_status_response = Mock()
-            mock_status_response.status_code = 200
-            mock_status_response.json.return_value = {'connected': False}
-
-            mock_requests.get.side_effect = [
-                mock_init_response,
-                *[mock_status_response] * 60
-            ]
+            mock_requests.post.return_value = mock_init_response
+            mock_webbrowser.open.return_value = True
 
             from connectonion.cli.main import cli
             result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
             assert 'timed out' in result.output.lower() or result.exit_code != 0
+            assert mock_requests.post.call_count == 1
+            mock_requests.get.assert_not_called()
+
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
+    @patch('connectonion.cli.commands.auth_commands.webbrowser')
+    @patch('connectonion.cli.commands.auth_commands.requests')
+    def test_auth_microsoft_definitive_completion_failure_does_not_poll(
+        self,
+        mock_requests,
+        mock_webbrowser,
+        mock_loopback,
+    ):
+        """A definitive API failure is not treated as a lost response."""
+        with self.runner.isolated_filesystem():
+            Path('.env').write_text(
+                'OPENONION_API_KEY=test-key\n'
+                'MICROSOFT_CONNECTED=true\n'
+                'MICROSOFT_EMAIL=existing@outlook.com\n'
+            )
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            listener.wait_for_result.return_value = Mock(
+                code='one-use-code',
+                error=None,
+            )
+
+            init_response = Mock(status_code=200)
+            init_response.json.return_value = {
+                'auth_url': (
+                    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+                ),
+                'authorization_id': 'a' * 43,
+            }
+            completion_response = Mock(status_code=409)
+            mock_requests.post.side_effect = [
+                init_response,
+                completion_response,
+            ]
+            mock_webbrowser.open.return_value = True
+
+            from connectonion.cli.main import cli
+            result = self.runner.invoke(cli, ['auth', 'microsoft'])
+
+            assert 'could not be completed' in result.output
+            mock_requests.get.assert_not_called()
+            assert 'MICROSOFT_EMAIL=existing@outlook.com' in Path('.env').read_text()
+
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
+    @patch('connectonion.cli.commands.auth_commands.webbrowser')
+    @patch('connectonion.cli.commands.auth_commands.requests')
+    def test_auth_microsoft_recovers_lost_completion_response(
+        self,
+        mock_requests,
+        mock_webbrowser,
+        mock_loopback,
+    ):
+        """A correlated status read recovers a committed but lost response."""
+        with self.runner.isolated_filesystem():
+            Path('.env').write_text('OPENONION_API_KEY=test-key\n')
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            listener.wait_for_result.return_value = Mock(
+                code='one-use-code',
+                error=None,
+            )
+
+            init_response = Mock(status_code=200)
+            init_response.json.return_value = {
+                'auth_url': (
+                    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+                ),
+                'authorization_id': 'a' * 43,
+            }
+            mock_requests.post.side_effect = [
+                init_response,
+                RequestException('response lost'),
+            ]
+            status_response = Mock(status_code=200)
+            status_response.json.return_value = {
+                'connected': True,
+                'scopes': 'Mail.ReadWrite,Mail.Send,Calendars.ReadWrite',
+                'email': 'recovered@outlook.com',
+            }
+            mock_requests.get.return_value = status_response
+            mock_webbrowser.open.return_value = True
+
+            from connectonion.cli.main import cli
+            result = self.runner.invoke(cli, ['auth', 'microsoft'])
+
+            assert 'Microsoft account connected' in result.output
+            status_call = mock_requests.get.call_args
+            assert status_call.kwargs['params'] == {
+                'authorization_id': 'a' * 43
+            }
+            assert 'MICROSOFT_EMAIL=recovered@outlook.com' in Path('.env').read_text()
+
+    @patch('connectonion.cli.commands.auth_commands.MicrosoftOAuthLoopback')
+    @patch('connectonion.cli.commands.auth_commands.webbrowser')
+    @patch('connectonion.cli.commands.auth_commands.requests')
+    def test_auth_microsoft_cancel_keeps_existing_metadata(
+        self,
+        mock_requests,
+        mock_webbrowser,
+        mock_loopback,
+    ):
+        """A denied consent never completes or erases the working connection."""
+        with self.runner.isolated_filesystem():
+            Path('.env').write_text(
+                'OPENONION_API_KEY=test-key\n'
+                'MICROSOFT_CONNECTED=true\n'
+                'MICROSOFT_EMAIL=existing@outlook.com\n'
+            )
+            listener = mock_loopback.return_value.__enter__.return_value
+            listener.callback_uri = (
+                'http://127.0.0.1:49152/oauth/microsoft/callback'
+            )
+            listener.wait_for_result.return_value = Mock(
+                code=None,
+                error='authorization_failed',
+            )
+            init_response = Mock(status_code=200)
+            init_response.json.return_value = {
+                'auth_url': (
+                    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+                ),
+                'authorization_id': 'a' * 43,
+            }
+            mock_requests.post.return_value = init_response
+            mock_webbrowser.open.return_value = True
+
+            from connectonion.cli.main import cli
+            result = self.runner.invoke(cli, ['auth', 'microsoft'])
+
+            assert 'cancelled or denied' in result.output
+            assert mock_requests.post.call_count == 1
+            assert 'MICROSOFT_EMAIL=existing@outlook.com' in Path('.env').read_text()

--- a/tests/e2e/cli/test_cli_auth_microsoft.py
+++ b/tests/e2e/cli/test_cli_auth_microsoft.py
@@ -8,8 +8,8 @@ What it tests:
   - test_auth_help_shows_microsoft_option: Verify microsoft appears in help
   - test_auth_microsoft_requires_openonion_auth: Verify OpenOnion auth required first
 - TestSaveMicrosoftToEnv: Credential persistence
-  - test_save_microsoft_credentials_to_new_env: Create new .env with credentials
-  - test_save_microsoft_credentials_updates_existing_env: Update existing .env preserving other vars
+  - test_save_microsoft_connection_to_new_env: Save non-secret metadata only
+  - test_save_microsoft_connection_removes_legacy_tokens: Purge old local tokens
   - test_save_microsoft_credentials_file_permissions: Verify 0600 permissions on Unix
 - TestAuthMicrosoftFlow: OAuth flow with mocked backend
   - test_auth_microsoft_success_flow: Complete successful OAuth flow
@@ -29,6 +29,17 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 
 from .argparse_runner import ArgparseCliRunner
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(tmp_path):
+    """Never let CLI auth tests read or modify the developer's real config."""
+    home = tmp_path / "home"
+    config_dir = home / ".co"
+    config_dir.mkdir(parents=True)
+    (config_dir / "keys.env").write_text("OPENONION_API_KEY=global-key\n")
+    with patch.object(Path, "home", return_value=home):
+        yield home
 
 
 class TestAuthMicrosoftHelp:
@@ -61,34 +72,30 @@ class TestAuthMicrosoftHelp:
 class TestSaveMicrosoftToEnv:
     """Test the _save_microsoft_to_env helper function."""
 
-    def test_save_microsoft_credentials_to_new_env(self):
-        """Test saving Microsoft credentials to a new .env file."""
+    def test_save_microsoft_connection_to_new_env(self):
+        """Save only connection metadata, never Microsoft bearer tokens."""
         from connectonion.cli.commands.auth_commands import _save_microsoft_to_env
 
         with tempfile.TemporaryDirectory() as tmpdir:
             env_file = Path(tmpdir) / '.env'
 
-            credentials = {
-                'access_token': 'eyJ0eXAi.test123',
-                'refresh_token': '0.ATcA.test456',
-                'expires_at': '2025-12-31T23:59:59',
+            connection = {
                 'scopes': 'Mail.Read,Mail.Send,Calendars.Read',
-                'microsoft_email': 'test@outlook.com'
+                'email': 'test@outlook.com',
             }
 
-            _save_microsoft_to_env(env_file, credentials)
+            _save_microsoft_to_env(env_file, connection)
 
             assert env_file.exists()
 
             content = env_file.read_text()
-            assert 'MICROSOFT_ACCESS_TOKEN=eyJ0eXAi.test123' in content
-            assert 'MICROSOFT_REFRESH_TOKEN=0.ATcA.test456' in content
-            assert 'MICROSOFT_TOKEN_EXPIRES_AT=2025-12-31T23:59:59' in content
+            assert 'MICROSOFT_CONNECTED=true' in content
             assert 'MICROSOFT_SCOPES=Mail.Read,Mail.Send,Calendars.Read' in content
             assert 'MICROSOFT_EMAIL=test@outlook.com' in content
+            assert 'TOKEN' not in content
 
-    def test_save_microsoft_credentials_updates_existing_env(self):
-        """Test that saving Microsoft credentials updates existing .env."""
+    def test_save_microsoft_connection_removes_legacy_tokens(self):
+        """A new authorization removes tokens left by older SDK releases."""
         from connectonion.cli.commands.auth_commands import _save_microsoft_to_env
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -97,31 +104,28 @@ class TestSaveMicrosoftToEnv:
             env_file.write_text('''OPENONION_API_KEY=existing-key
 MICROSOFT_ACCESS_TOKEN=old-token
 MICROSOFT_REFRESH_TOKEN=old-refresh
+MICROSOFT_TOKEN_EXPIRES_AT=old-expiry
 MICROSOFT_EMAIL=old@outlook.com
 OTHER_VAR=keep-this
 ''')
 
-            credentials = {
-                'access_token': 'new-token',
-                'refresh_token': 'new-refresh',
-                'expires_at': '2025-12-31T23:59:59',
+            connection = {
                 'scopes': 'Mail.Read',
-                'microsoft_email': 'new@outlook.com'
+                'email': 'new@outlook.com',
             }
 
-            _save_microsoft_to_env(env_file, credentials)
+            _save_microsoft_to_env(env_file, connection)
 
             content = env_file.read_text()
 
             assert 'OPENONION_API_KEY=existing-key' in content
             assert 'OTHER_VAR=keep-this' in content
 
-            assert 'MICROSOFT_ACCESS_TOKEN=new-token' in content
-            assert 'MICROSOFT_REFRESH_TOKEN=new-refresh' in content
+            assert 'MICROSOFT_CONNECTED=true' in content
             assert 'MICROSOFT_EMAIL=new@outlook.com' in content
-
-            assert 'old-token' not in content
-            assert 'old-refresh' not in content
+            assert 'MICROSOFT_ACCESS_TOKEN' not in content
+            assert 'MICROSOFT_REFRESH_TOKEN' not in content
+            assert 'MICROSOFT_TOKEN_EXPIRES_AT' not in content
 
     def test_save_microsoft_credentials_file_permissions(self):
         """Test that .env file has restrictive permissions on Unix."""
@@ -134,15 +138,12 @@ OTHER_VAR=keep-this
         with tempfile.TemporaryDirectory() as tmpdir:
             env_file = Path(tmpdir) / '.env'
 
-            credentials = {
-                'access_token': 'test',
-                'refresh_token': 'test',
-                'expires_at': '2025-12-31T23:59:59',
+            connection = {
                 'scopes': 'Mail.Read',
-                'microsoft_email': 'test@outlook.com'
+                'email': 'test@outlook.com',
             }
 
-            _save_microsoft_to_env(env_file, credentials)
+            _save_microsoft_to_env(env_file, connection)
 
             stat = env_file.stat()
             assert oct(stat.st_mode)[-3:] == '600'
@@ -157,39 +158,31 @@ class TestAuthMicrosoftFlow:
 
     @patch('connectonion.cli.commands.auth_commands.webbrowser')
     @patch('connectonion.cli.commands.auth_commands.requests')
-    def test_auth_microsoft_success_flow(self, mock_requests, mock_webbrowser):
+    def test_auth_microsoft_success_flow(
+        self, mock_requests, mock_webbrowser, isolated_home
+    ):
         """Test successful Microsoft OAuth flow."""
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404
-
             mock_init_response = Mock()
             mock_init_response.status_code = 200
             mock_init_response.json.return_value = {
-                'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...'
+                'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...',
+                'authorization_id': 'authorization-id',
             }
 
             mock_status_response = Mock()
             mock_status_response.status_code = 200
-            mock_status_response.json.return_value = {'connected': True}
-
-            mock_creds_response = Mock()
-            mock_creds_response.status_code = 200
-            mock_creds_response.json.return_value = {
-                'access_token': 'eyJ0eXAi.test',
-                'refresh_token': '0.ATcA.test',
-                'expires_at': '2025-12-31T23:59:59',
+            mock_status_response.json.return_value = {
+                'connected': True,
                 'scopes': 'Mail.Read,Mail.Send,Calendars.Read,Calendars.ReadWrite',
-                'microsoft_email': 'test@outlook.com'
+                'email': 'test@outlook.com',
             }
 
-            mock_requests.delete.return_value = mock_revoke_response
             mock_requests.get.side_effect = [
                 mock_init_response,
                 mock_status_response,
-                mock_creds_response
             ]
 
             mock_webbrowser.open.return_value = True
@@ -198,23 +191,30 @@ class TestAuthMicrosoftFlow:
                 from connectonion.cli.main import cli
                 result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
-            mock_requests.delete.assert_called_once()
+            mock_requests.delete.assert_not_called()
             mock_webbrowser.open.assert_called_once()
+            status_call = mock_requests.get.call_args_list[1]
+            assert status_call.kwargs["params"] == {
+                "authorization_id": "authorization-id"
+            }
 
             env_content = Path('.env').read_text()
-            assert 'MICROSOFT_ACCESS_TOKEN=eyJ0eXAi.test' in env_content
-            assert 'MICROSOFT_REFRESH_TOKEN=0.ATcA.test' in env_content
+            assert 'MICROSOFT_CONNECTED=true' in env_content
             assert 'MICROSOFT_EMAIL=test@outlook.com' in env_content
+            assert 'MICROSOFT_ACCESS_TOKEN' not in env_content
+            assert 'MICROSOFT_REFRESH_TOKEN' not in env_content
+            assert all('/credentials' not in call.args[0] for call in mock_requests.get.call_args_list)
+
+            global_content = (isolated_home / '.co' / 'keys.env').read_text()
+            assert 'MICROSOFT_CONNECTED=true' in global_content
+            assert 'MICROSOFT_ACCESS_TOKEN' not in global_content
+            assert 'MICROSOFT_REFRESH_TOKEN' not in global_content
 
     @patch('connectonion.cli.commands.auth_commands.requests')
     def test_auth_microsoft_init_failure(self, mock_requests):
         """Test handling of OAuth init failure."""
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
-
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404
-            mock_requests.delete.return_value = mock_revoke_response
 
             mock_response = Mock()
             mock_response.status_code = 500
@@ -234,14 +234,11 @@ class TestAuthMicrosoftFlow:
         with self.runner.isolated_filesystem():
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404
-            mock_requests.delete.return_value = mock_revoke_response
-
             mock_init_response = Mock()
             mock_init_response.status_code = 200
             mock_init_response.json.return_value = {
-                'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...'
+                'auth_url': 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?...',
+                'authorization_id': 'authorization-id',
             }
 
             mock_status_response = Mock()
@@ -257,5 +254,3 @@ class TestAuthMicrosoftFlow:
             result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
             assert 'timed out' in result.output.lower() or result.exit_code != 0
-
-

--- a/tests/e2e/cli/test_cli_keys.py
+++ b/tests/e2e/cli/test_cli_keys.py
@@ -198,6 +198,22 @@ class TestLoadEnvVars:
             finally:
                 os.chdir(original_cwd)
 
+    def test_never_loads_legacy_microsoft_tokens(self):
+        """Even --reveal has no code path to read Microsoft bearer tokens."""
+        from connectonion.cli.commands.keys_commands import _load_env_vars
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_CONNECTED": "true",
+            "MICROSOFT_EMAIL": "user@outlook.com",
+            "MICROSOFT_ACCESS_TOKEN": "legacy-access",
+            "MICROSOFT_REFRESH_TOKEN": "legacy-refresh",
+        }, clear=True):
+            result = _load_env_vars()
+
+        assert result["MICROSOFT_CONNECTED"] == "true"
+        assert "MICROSOFT_ACCESS_TOKEN" not in result
+        assert "MICROSOFT_REFRESH_TOKEN" not in result
+
 
 class TestHandleKeysNoKeys:
     """Tests for handle_keys when no keys exist."""
@@ -353,7 +369,7 @@ class TestHandleKeysOAuth:
     def test_shows_microsoft_oauth(self, mock_load, mock_env, mock_find, mock_console):
         mock_find.return_value = Path(".co")
         mock_load.return_value = self.MOCK_ADDR
-        mock_env.return_value = {"OPENONION_API_KEY": "key", "AGENT_ADDRESS": None, "AGENT_EMAIL": None, "GOOGLE_EMAIL": None, "GOOGLE_ACCESS_TOKEN": None, "GOOGLE_REFRESH_TOKEN": None, "MICROSOFT_EMAIL": "user@outlook.com", "MICROSOFT_ACCESS_TOKEN": "ms_token", "MICROSOFT_REFRESH_TOKEN": "ms_refresh"}
+        mock_env.return_value = {"OPENONION_API_KEY": "key", "AGENT_ADDRESS": None, "AGENT_EMAIL": None, "GOOGLE_EMAIL": None, "GOOGLE_ACCESS_TOKEN": None, "GOOGLE_REFRESH_TOKEN": None, "MICROSOFT_CONNECTED": "true", "MICROSOFT_EMAIL": "user@outlook.com"}
 
         from connectonion.cli.commands.keys_commands import handle_keys
         handle_keys()

--- a/tests/unit/test_microsoft_calendar.py
+++ b/tests/unit/test_microsoft_calendar.py
@@ -11,8 +11,23 @@ Components under test:
 
 
 import os
+from hashlib import sha256
+import httpx
 import pytest
 from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture(autouse=True)
+def _stub_token_fetch(request, monkeypatch):
+    """Keep Graph-operation tests isolated from the oo-api token endpoint."""
+    if "token_fetch" in request.keywords:
+        return
+    from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+    monkeypatch.setattr(
+        MicrosoftCalendar,
+        "_fetch_access_token",
+        lambda self, rejected_access_token=None: "test-token",
+    )
 
 
 class TestMicrosoftCalendarInit:
@@ -38,31 +53,149 @@ class TestMicrosoftCalendarInit:
 class TestMicrosoftCalendarTokenManagement:
     """Test MicrosoftCalendar token management."""
 
-    def test_get_access_token_requires_credentials(self):
-        """Test that getting token requires credentials."""
+    @pytest.mark.token_fetch
+    def test_get_access_token_requires_openonion_auth(self):
+        """The client needs only an OpenOnion API key, not Microsoft tokens."""
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Calendars.Read,Calendars.ReadWrite",
-            "MICROSOFT_ACCESS_TOKEN": "",
-            "MICROSOFT_REFRESH_TOKEN": ""
+            "OPENONION_API_KEY": "",
         }, clear=False):
             from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
             calendar = MicrosoftCalendar()
             with pytest.raises(ValueError) as exc_info:
                 calendar._get_access_token()
-            assert "credentials not found" in str(exc_info.value)
+            assert "co auth" in str(exc_info.value)
 
-    def test_get_access_token_returns_valid_token(self):
-        """Test that valid token is returned."""
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_first_use_fetches_once_without_a_request_body(self, mock_httpx):
+        """First use asks oo-api once; later uses reuse only instance memory."""
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "server-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = response
+
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Calendars.Read,Calendars.ReadWrite",
-            "MICROSOFT_ACCESS_TOKEN": "test-token",
-            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
-            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+            "OPENONION_API_KEY": "api-key",
+            "OPENONION_API_URL": "https://oo.example",
         }, clear=False):
             from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
             calendar = MicrosoftCalendar()
-            token = calendar._get_access_token()
-            assert token == "test-token"
+            assert calendar._get_access_token() == "server-access"
+            assert calendar._get_access_token() == "server-access"
+
+        mock_httpx.post.assert_called_once_with(
+            "https://oo.example/api/v1/oauth/microsoft/refresh",
+            headers={"Authorization": "Bearer api-key"},
+        )
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_access_token_is_refetched_five_minutes_before_expiry(self, mock_httpx):
+        first = MagicMock(status_code=200)
+        first.json.return_value = {
+            "access_token": "first-access",
+            "expires_in": 3600,
+        }
+        second = MagicMock(status_code=200)
+        second.json.return_value = {
+            "access_token": "second-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.side_effect = [first, second]
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.Read,Calendars.ReadWrite",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False), patch(
+            "connectonion.useful_tools.microsoft_calendar.time.monotonic",
+            side_effect=[1000, 4299, 4300, 4300],
+        ):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            calendar = MicrosoftCalendar()
+            assert calendar._get_access_token() == "first-access"
+            assert calendar._get_access_token() == "first-access"
+            assert calendar._get_access_token() == "second-access"
+
+        assert mock_httpx.post.call_count == 2
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_graph_401_reports_rejected_token_and_retries_once(self, mock_httpx):
+        """A Graph 401 triggers one server refresh tied to the rejected token."""
+        first_graph = MagicMock(status_code=401, text="expired")
+        second_graph = MagicMock(status_code=200, text='{"value": []}')
+        second_graph.json.return_value = {"value": []}
+        mock_httpx.request.side_effect = [first_graph, second_graph]
+        token_response = MagicMock(status_code=200)
+        token_response.json.return_value = {
+            "access_token": "fresh-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = token_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.Read,Calendars.ReadWrite",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            calendar = MicrosoftCalendar()
+            calendar._access_token = "rejected-access"
+            assert calendar._request("GET", "/me/events") == {"value": []}
+
+        assert mock_httpx.request.call_count == 2
+        mock_httpx.post.assert_called_once_with(
+            "https://oo.openonion.ai/api/v1/oauth/microsoft/refresh",
+            headers={"Authorization": "Bearer api-key"},
+            json={
+                "rejected_access_token_hash": sha256(
+                    b"rejected-access"
+                ).hexdigest()
+            },
+        )
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_second_graph_401_is_not_retried(self, mock_httpx):
+        """The retry budget is exactly one Graph request."""
+        graph_401 = MagicMock(status_code=401, text="expired")
+        mock_httpx.request.side_effect = [graph_401, graph_401]
+        token_response = MagicMock(status_code=200)
+        token_response.json.return_value = {
+            "access_token": "fresh-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = token_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.Read,Calendars.ReadWrite",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            calendar = MicrosoftCalendar()
+            calendar._access_token = "rejected-access"
+            with pytest.raises(ValueError, match="Microsoft Graph API error: 401"):
+                calendar._request("GET", "/me/events")
+
+        assert mock_httpx.request.call_count == 2
+        assert mock_httpx.post.call_count == 1
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx.post')
+    def test_token_service_network_failure_is_sanitized(self, post):
+        request = httpx.Request("POST", "https://oo.example/refresh")
+        post.side_effect = httpx.ConnectError("offline", request=request)
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            with pytest.raises(ValueError, match="token service unavailable"):
+                MicrosoftCalendar()._get_access_token()
 
 
 class TestMicrosoftCalendarDateTimeParsing:

--- a/tests/unit/test_microsoft_calendar.py
+++ b/tests/unit/test_microsoft_calendar.py
@@ -94,6 +94,47 @@ class TestMicrosoftCalendarTokenManagement:
 
     @pytest.mark.token_fetch
     @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_cae_28_hour_access_token_is_accepted(self, mock_httpx):
+        """Microsoft documents 20-28 hour CAE access-token lifetimes."""
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "cae-access",
+            "expires_in": 28 * 60 * 60,
+        }
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.ReadWrite",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False), patch(
+            "connectonion.useful_tools.microsoft_calendar.time.monotonic",
+            return_value=1000,
+        ):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            calendar = MicrosoftCalendar()
+            assert calendar._get_access_token() == "cae-access"
+            assert calendar._access_token_refresh_at == 1000 + 28 * 60 * 60 - 300
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
+    def test_implausible_access_token_lifetime_is_rejected(self, mock_httpx):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "bad-access",
+            "expires_in": 48 * 60 * 60 + 1,
+        }
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Calendars.ReadWrite",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.microsoft_calendar import MicrosoftCalendar
+            with pytest.raises(ValueError, match="invalid Microsoft token response"):
+                MicrosoftCalendar()._get_access_token()
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.microsoft_calendar.httpx')
     def test_access_token_is_refetched_five_minutes_before_expiry(self, mock_httpx):
         first = MagicMock(status_code=200)
         first.json.return_value = {

--- a/tests/unit/test_oauth_loopback.py
+++ b/tests/unit/test_oauth_loopback.py
@@ -1,0 +1,156 @@
+"""Socket-level tests for the single-use Microsoft OAuth loopback receiver."""
+
+from __future__ import annotations
+
+import socket
+from threading import Thread
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pytest
+
+from connectonion.cli.oauth_loopback import (
+    MicrosoftOAuthLoopback,
+    OAuthLoopbackTimeout,
+)
+
+
+AUTHORIZATION_ID = "a" * 43
+
+
+def _wait_in_thread(listener: MicrosoftOAuthLoopback, timeout: float = 3):
+    result = {}
+
+    def wait() -> None:
+        try:
+            result["value"] = listener.wait_for_result(
+                AUTHORIZATION_ID,
+                timeout=timeout,
+            )
+        except BaseException as exc:  # make thread failures visible to pytest
+            result["error"] = exc
+
+    thread = Thread(target=wait)
+    thread.start()
+    return thread, result
+
+
+def _get(url: str, host: str | None = None):
+    request = Request(url, headers={"Host": host} if host else {})
+    return urlopen(request, timeout=2)
+
+
+def test_loopback_rejects_probes_then_accepts_exact_correlated_code(capsys):
+    code = "one-use-code+/=?"
+    with MicrosoftOAuthLoopback() as listener:
+        thread, outcome = _wait_in_thread(listener)
+
+        bad_urls = [
+            listener.callback_uri.replace(
+                "/oauth/microsoft/callback",
+                "/wrong-path",
+            )
+            + "?"
+            + urlencode({"authorization_id": AUTHORIZATION_ID, "code": code}),
+            listener.callback_uri
+            + "?"
+            + urlencode({"authorization_id": "wrong-state", "code": code}),
+            listener.callback_uri
+            + "?authorization_id="
+            + AUTHORIZATION_ID
+            + "&authorization_id=duplicate&code=secret",
+            listener.callback_uri
+            + "?"
+            + urlencode({"authorization_id": "é" * 43, "code": code}),
+        ]
+        for url in bad_urls:
+            with pytest.raises(HTTPError) as exc_info:
+                _get(url)
+            assert exc_info.value.code == 400
+
+        with pytest.raises(HTTPError) as exc_info:
+            _get(
+                listener.callback_uri
+                + "?"
+                + urlencode({"authorization_id": AUTHORIZATION_ID, "code": code}),
+                host="evil.example",
+            )
+        assert exc_info.value.code == 400
+
+        response = _get(
+            listener.callback_uri
+            + "?"
+            + urlencode({"authorization_id": AUTHORIZATION_ID, "code": code})
+        )
+        page = response.read().decode()
+        assert response.status == 200
+        assert response.headers["Cache-Control"] == "no-store"
+        assert response.headers["Referrer-Policy"] == "no-referrer"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert "default-src 'none'" in response.headers["Content-Security-Policy"]
+        assert code not in page
+        assert AUTHORIZATION_ID not in page
+
+        thread.join(3)
+        assert not thread.is_alive()
+        assert "error" not in outcome
+        assert outcome["value"].code == code
+        assert outcome["value"].error is None
+        captured = capsys.readouterr()
+        assert code not in captured.out
+        assert "Traceback" not in captured.err
+
+
+def test_loopback_returns_sanitized_authorization_error():
+    with MicrosoftOAuthLoopback() as listener:
+        thread, outcome = _wait_in_thread(listener)
+        response = _get(
+            listener.callback_uri
+            + "?"
+            + urlencode(
+                {
+                    "authorization_id": AUTHORIZATION_ID,
+                    "error": "authorization_failed",
+                }
+            )
+        )
+        assert response.status == 200
+        assert "not completed" in response.read().decode()
+
+        thread.join(3)
+        assert "error" not in outcome
+        assert outcome["value"].code is None
+        assert outcome["value"].error == "authorization_failed"
+
+
+def test_loopback_timeout_and_context_close_the_port():
+    listener = MicrosoftOAuthLoopback()
+    port = listener.port
+    with pytest.raises(OAuthLoopbackTimeout):
+        listener.wait_for_result(AUTHORIZATION_ID, timeout=0.05)
+    listener.close()
+
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.settimeout(0.5)
+        assert probe.connect_ex(("127.0.0.1", port)) != 0
+    finally:
+        probe.close()
+
+
+@pytest.mark.parametrize("timeout", [0, -1])
+def test_loopback_rejects_nonpositive_timeout(timeout):
+    with MicrosoftOAuthLoopback() as listener:
+        with pytest.raises(ValueError, match="timeout must be positive"):
+            listener.wait_for_result(AUTHORIZATION_ID, timeout=timeout)
+
+
+@pytest.mark.parametrize(
+    "authorization_id",
+    ["", "a" * 31, "é" * 43, "a" * 42 + "!"],
+)
+def test_loopback_rejects_invalid_authorization_id(authorization_id):
+    with MicrosoftOAuthLoopback() as listener:
+        with pytest.raises(ValueError, match="authorization_id is invalid"):
+            listener.wait_for_result(authorization_id, timeout=0.05)

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -94,6 +94,47 @@ class TestOutlookTokenManagement:
 
     @pytest.mark.token_fetch
     @patch('connectonion.useful_tools.outlook.httpx')
+    def test_cae_28_hour_access_token_is_accepted(self, mock_httpx):
+        """Microsoft documents 20-28 hour CAE access-token lifetimes."""
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "cae-access",
+            "expires_in": 28 * 60 * 60,
+        }
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False), patch(
+            "connectonion.useful_tools.outlook.time.monotonic",
+            return_value=1000,
+        ):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            assert outlook._get_access_token() == "cae-access"
+            assert outlook._access_token_refresh_at == 1000 + 28 * 60 * 60 - 300
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_implausible_access_token_lifetime_is_rejected(self, mock_httpx):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "bad-access",
+            "expires_in": 48 * 60 * 60 + 1,
+        }
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError, match="invalid Microsoft token response"):
+                Outlook()._get_access_token()
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
     def test_access_token_is_refetched_five_minutes_before_expiry(self, mock_httpx):
         first = MagicMock(status_code=200)
         first.json.return_value = {

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -11,19 +11,23 @@ Components under test:
 
 
 import os
+from hashlib import sha256
+import httpx
 import pytest
 from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture(autouse=True)
-def _stub_token_refresh(request, monkeypatch):
-    """Outlook refreshes tokens once per instance; stub that network call so
-    Graph-operation tests stay isolated. Tests of the refresh flow itself
-    opt out with @pytest.mark.real_refresh."""
-    if "real_refresh" in request.keywords:
+def _stub_token_fetch(request, monkeypatch):
+    """Keep Graph-operation tests isolated from the oo-api token endpoint."""
+    if "token_fetch" in request.keywords:
         return
     from connectonion.useful_tools.outlook import Outlook
-    monkeypatch.setattr(Outlook, "_refresh_via_backend", lambda self, rt: "test-token")
+    monkeypatch.setattr(
+        Outlook,
+        "_fetch_access_token",
+        lambda self, rejected_access_token=None: "test-token",
+    )
 
 
 class TestOutlookInit:
@@ -49,96 +53,189 @@ class TestOutlookInit:
 class TestOutlookTokenManagement:
     """Test Outlook token management."""
 
-    def test_get_access_token_requires_credentials(self):
-        """Test that getting token requires credentials."""
+    @pytest.mark.token_fetch
+    def test_get_access_token_requires_openonion_auth(self):
+        """The client needs only an OpenOnion API key, not Microsoft tokens."""
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
-            "MICROSOFT_ACCESS_TOKEN": "",
-            "MICROSOFT_REFRESH_TOKEN": ""
+            "OPENONION_API_KEY": "",
         }, clear=False):
             from connectonion.useful_tools.outlook import Outlook
             outlook = Outlook()
             with pytest.raises(ValueError) as exc_info:
                 outlook._get_access_token()
-            assert "credentials not found" in str(exc_info.value)
+            assert "co auth" in str(exc_info.value)
 
-    def test_get_access_token_returns_valid_token(self):
-        """Test that valid token is returned."""
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_first_use_fetches_once_without_a_request_body(self, mock_httpx):
+        """First use asks oo-api once; later uses reuse only instance memory."""
+        response = MagicMock(status_code=200)
+        response.json.return_value = {
+            "access_token": "server-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = response
+
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
-            "MICROSOFT_ACCESS_TOKEN": "test-token",
-            "MICROSOFT_REFRESH_TOKEN": "test-refresh",
-            "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
+            "OPENONION_API_KEY": "api-key",
+            "OPENONION_API_URL": "https://oo.example",
         }, clear=False):
             from connectonion.useful_tools.outlook import Outlook
             outlook = Outlook()
-            token = outlook._get_access_token()
-            assert token == "test-token"
+            assert outlook._get_access_token() == "server-access"
+            assert outlook._get_access_token() == "server-access"
 
-    @pytest.mark.real_refresh
-    @patch('connectonion.useful_tools.outlook.httpx')
-    def test_refresh_persists_rotated_refresh_token(self, mock_httpx, tmp_path):
-        """Every use refreshes and saves the rotated refresh token to keys.env."""
-        keys_env = tmp_path / "keys.env"
-        keys_env.write_text(
-            "MICROSOFT_ACCESS_TOKEN=old-access\n"
-            "MICROSOFT_REFRESH_TOKEN=old-refresh\n"
-            "MICROSOFT_TOKEN_EXPIRES_AT=2026-01-01T00:00:00Z\n"
+        mock_httpx.post.assert_called_once_with(
+            "https://oo.example/api/v1/oauth/microsoft/refresh",
+            headers={"Authorization": "Bearer api-key"},
         )
 
-        refresh_response = MagicMock()
-        refresh_response.status_code = 200
-        refresh_response.json.return_value = {
-            "access_token": "new-access",
-            "expires_at": "2099-12-31T23:59:59Z",
-            "refresh_token": "rotated-refresh",
-        }
-        mock_httpx.post.return_value = refresh_response
-
-        with patch.dict(os.environ, {
-            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
-            "MICROSOFT_ACCESS_TOKEN": "old-access",
-            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
-            "OPENONION_API_KEY": "test-key",
-            "AGENT_CONFIG_PATH": str(tmp_path),
-        }, clear=False):
-            from connectonion.useful_tools.outlook import Outlook
-            token = Outlook()._get_access_token()
-
-            assert token == "new-access"
-            assert os.environ["MICROSOFT_REFRESH_TOKEN"] == "rotated-refresh"
-
-        saved = keys_env.read_text()
-        assert "MICROSOFT_REFRESH_TOKEN=rotated-refresh" in saved
-        assert "MICROSOFT_ACCESS_TOKEN=new-access" in saved
-
-    @pytest.mark.real_refresh
+    @pytest.mark.token_fetch
     @patch('connectonion.useful_tools.outlook.httpx')
-    def test_refresh_without_rotated_token_keeps_current(self, mock_httpx, tmp_path):
-        """Older backends omit refresh_token — the current one must survive."""
-        keys_env = tmp_path / "keys.env"
-        keys_env.write_text("MICROSOFT_REFRESH_TOKEN=old-refresh\n")
-
-        refresh_response = MagicMock()
-        refresh_response.status_code = 200
-        refresh_response.json.return_value = {
-            "access_token": "new-access",
-            "expires_at": "2099-12-31T23:59:59Z",
+    def test_access_token_is_refetched_five_minutes_before_expiry(self, mock_httpx):
+        first = MagicMock(status_code=200)
+        first.json.return_value = {
+            "access_token": "first-access",
+            "expires_in": 3600,
         }
-        mock_httpx.post.return_value = refresh_response
+        second = MagicMock(status_code=200)
+        second.json.return_value = {
+            "access_token": "second-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.side_effect = [first, second]
 
         with patch.dict(os.environ, {
             "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
-            "MICROSOFT_ACCESS_TOKEN": "old-access",
-            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
-            "OPENONION_API_KEY": "test-key",
-            "AGENT_CONFIG_PATH": str(tmp_path),
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False), patch(
+            "connectonion.useful_tools.outlook.time.monotonic",
+            side_effect=[1000, 4299, 4300, 4300],
+        ):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            assert outlook._get_access_token() == "first-access"
+            assert outlook._get_access_token() == "first-access"
+            assert outlook._get_access_token() == "second-access"
+
+        assert mock_httpx.post.call_count == 2
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_graph_401_reports_rejected_token_and_retries_once(self, mock_httpx):
+        """A Graph 401 triggers one server refresh tied to the rejected token."""
+        first_graph = MagicMock(status_code=401, text="expired")
+        second_graph = MagicMock(status_code=200, text='{"value": []}')
+        second_graph.json.return_value = {"value": []}
+        mock_httpx.request.side_effect = [first_graph, second_graph]
+
+        token_response = MagicMock(status_code=200)
+        token_response.json.return_value = {
+            "access_token": "fresh-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = token_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "api-key",
         }, clear=False):
             from connectonion.useful_tools.outlook import Outlook
-            assert Outlook()._get_access_token() == "new-access"
-            assert os.environ["MICROSOFT_REFRESH_TOKEN"] == "old-refresh"
+            outlook = Outlook()
+            outlook._access_token = "rejected-access"
+            assert outlook._request("GET", "/me/messages") == {"value": []}
 
-        assert "MICROSOFT_REFRESH_TOKEN=old-refresh" in keys_env.read_text()
+        assert mock_httpx.request.call_count == 2
+        mock_httpx.post.assert_called_once_with(
+            "https://oo.openonion.ai/api/v1/oauth/microsoft/refresh",
+            headers={"Authorization": "Bearer api-key"},
+            json={
+                "rejected_access_token_hash": sha256(
+                    b"rejected-access"
+                ).hexdigest()
+            },
+        )
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_second_graph_401_is_not_retried(self, mock_httpx):
+        """The retry budget is exactly one Graph request."""
+        graph_401 = MagicMock(status_code=401, text="expired")
+        mock_httpx.request.side_effect = [graph_401, graph_401]
+        token_response = MagicMock(status_code=200)
+        token_response.json.return_value = {
+            "access_token": "fresh-access",
+            "expires_in": 3600,
+        }
+        mock_httpx.post.return_value = token_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._access_token = "rejected-access"
+            with pytest.raises(ValueError, match="Microsoft Graph API error: 401"):
+                outlook._request("GET", "/me/messages")
+
+        assert mock_httpx.request.call_count == 2
+        assert mock_httpx.post.call_count == 1
+
+    @pytest.mark.token_fetch
+    @pytest.mark.parametrize(
+        ("status_code", "message"),
+        [
+            (404, "Reconnect with: co auth microsoft"),
+            (409, "Reconnect with: co auth microsoft"),
+            (401, "Run: co auth"),
+            (403, "Run: co auth"),
+            (503, "token service unavailable"),
+        ],
+    )
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_token_service_error_mapping(self, mock_httpx, status_code, message):
+        response = MagicMock(status_code=status_code)
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError, match=message):
+                Outlook()._get_access_token()
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx.post')
+    def test_token_service_network_failure_is_sanitized(self, post):
+        request = httpx.Request("POST", "https://oo.example/refresh")
+        post.side_effect = httpx.ConnectError("offline", request=request)
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError, match="token service unavailable"):
+                Outlook()._get_access_token()
+
+    @pytest.mark.token_fetch
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_malformed_token_response_is_rejected(self, mock_httpx):
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"expires_in": 3600}
+        mock_httpx.post.return_value = response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read",
+            "OPENONION_API_KEY": "api-key",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            with pytest.raises(ValueError, match="invalid Microsoft token response"):
+                Outlook()._get_access_token()
 
 
 class TestOutlookEmailFormatting:
@@ -636,5 +733,3 @@ class TestOutlookScheduled:
         method, url = mock_httpx.request.call_args.args[:2]
         assert method == "DELETE"
         assert url.endswith("/me/messages/sched-1")
-
-

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -35,7 +35,8 @@ from connectonion.cli.commands.outlook_commands import (
 )
 
 CONNECTED_ENV = {
-    "MICROSOFT_ACCESS_TOKEN": "test-token",
+    "OPENONION_API_KEY": "api-key",
+    "MICROSOFT_CONNECTED": "true",
     "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
     "MICROSOFT_EMAIL": "aaron@example.com",
 }
@@ -56,8 +57,8 @@ def sample_emails(n):
 class TestOutlookGuard:
     """_outlook() returns None with a hint when not connected."""
 
-    def test_missing_access_token_exits_with_hint(self, capsys):
-        with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "", "MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
+    def test_missing_connection_metadata_exits_with_hint(self, capsys):
+        with patch.dict(os.environ, {"MICROSOFT_CONNECTED": "", "MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
             with pytest.raises(typer.Exit):
                 _outlook()
 
@@ -66,7 +67,7 @@ class TestOutlookGuard:
         assert "co auth microsoft" in output
 
     def test_scopes_without_mail_exits_with_hint(self, capsys):
-        with patch.dict(os.environ, {"MICROSOFT_ACCESS_TOKEN": "test-token", "MICROSOFT_SCOPES": "User.Read"}, clear=False):
+        with patch.dict(os.environ, {"MICROSOFT_CONNECTED": "true", "MICROSOFT_SCOPES": "User.Read"}, clear=False):
             with pytest.raises(typer.Exit):
                 _outlook()
 


### PR DESCRIPTION
## Summary

Keep Microsoft refresh tokens in oo-api and make the ConnectOnion client a small, expiry-aware consumer of short-lived access tokens.

Depends on https://github.com/openonion/oo-api/pull/25 and must be released with that API contract.

## Refresh behavior

- Microsoft controls access-token lifetime and reports it in `expires_in`: ordinarily 60–90 minutes, while CAE tokens can last 20–28 hours.
- The client caches the access token only in instance memory until five minutes before reported expiry.
- On demand, it asks oo-api for a usable token; oo-api owns refresh-token rotation.
- A Graph `401` sends only the rejected token's SHA-256 digest, obtains a usable token, and retries exactly once.
- There is no periodic refresh-token timer. Inactive clients do nothing.

For this confidential web flow, Microsoft documents a 90-day default refresh-token lifetime. It rotates on use and can be revoked earlier, so reconnect remains a normal recovery path.

Official references:

- https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens#token-lifetime
- https://learn.microsoft.com/en-us/entra/identity-platform/refresh-tokens
- https://learn.microsoft.com/en-us/entra/identity-platform/msal-acquire-cache-tokens

## What changed

- `co auth microsoft` binds an ephemeral `127.0.0.1` listener before initializing authorization.
- The hosted callback bounces the one-use code to that listener; the authenticated CLI submits it to oo-api for exchange. A copied authorization URL cannot attach another browser user's mailbox to the sender's account.
- Strictly validate the Microsoft authorization URL, URL-safe authorization ID, loopback path/host/query, callback metadata, and one-use result.
- Poll correlated status only when the completion HTTP result is genuinely ambiguous; definitive failures return immediately.
- Store only `MICROSOFT_CONNECTED`, scopes, and optional email. Successful reconnect removes legacy local Microsoft access/refresh tokens and expiry fields.
- Outlook and Microsoft Calendar fetch access tokens from oo-api, accept legitimate CAE lifetimes up to 48 hours, and never receive a refresh token.
- Keep existing connection metadata unchanged on timeout, denial, malformed callbacks, or failed replacement authorization.
- Isolate CLI auth tests from the developer's real home directory.

The browser must run on the same computer as the CLI. Remote/headless authorization needs an explicit device-flow design rather than weakening loopback validation.

## Validation

- Microsoft CLI/loopback/Outlook/Calendar focused suite: 77 passed.
- Full offline client suite: 2,437 passed, 5 skipped, 139 deselected.
- GitHub Actions matrix on Python 3.10, 3.11, 3.12, and 3.13: passed.
- Compile checks, `git diff --check`, and live-secret pattern scan: passed.
- Independent correctness, security, and simplicity reviews: no remaining implementation blocker.

The full suite still emits pre-existing browser-daemon thread shutdown tracebacks after pytest exits successfully; no tests fail.

## Deployment and compatibility

1. Complete the oo-api migration and deploy openonion/oo-api#25.
2. Release this SDK/CLI change in the same coordinated rollout.
3. Users with legacy local Microsoft token entries run `co auth microsoft` once to replace them with metadata-only entries.

## Merge gates — keep draft

- Credentials previously committed to oo-api history must be rotated/revoked externally.
- The existing long-lived, non-revocable OpenOnion API credential needs explicit risk acceptance or redesign because it can request delegated Microsoft access tokens.

No merge is requested until the API dependency and operational security gates are resolved.
