### PR TITLE
Always persist Gmail/Outlook OAuth tokens to global ~/.co/keys.env

### DIFF
--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -257,11 +257,11 @@ def handle_google_auth():
     # Save credentials
     console.print("\n💾 Saving credentials...", style="cyan")
 
-    # Save to global ~/.co/keys.env
+    # Save to global ~/.co/keys.env (always, so every project can use the tokens)
     global_keys_env = Path.home() / ".co" / "keys.env"
-    if global_keys_env.exists():
-        _save_google_to_env(global_keys_env, credentials)
-        console.print(f"   ✓ Saved to {global_keys_env}", style="green")
+    global_keys_env.parent.mkdir(parents=True, exist_ok=True)
+    _save_google_to_env(global_keys_env, credentials)
+    console.print(f"   ✓ Saved to {global_keys_env}", style="green")
 
     # Save to local .env
     local_env = Path(".env")
@@ -350,11 +350,11 @@ def handle_microsoft_auth():
     # Save credentials
     console.print("\n💾 Saving credentials...", style="cyan")
 
-    # Save to global ~/.co/keys.env
+    # Save to global ~/.co/keys.env (always, so every project can use the tokens)
     global_keys_env = Path.home() / ".co" / "keys.env"
-    if global_keys_env.exists():
-        _save_microsoft_to_env(global_keys_env, credentials)
-        console.print(f"   ✓ Saved to {global_keys_env}", style="green")
+    global_keys_env.parent.mkdir(parents=True, exist_ok=True)
+    _save_microsoft_to_env(global_keys_env, credentials)
+    console.print(f"   ✓ Saved to {global_keys_env}", style="green")
 
     # Save to local .env
     local_env = Path(".env")

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1003,6 +1003,11 @@ def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> No
                     continue
             lines.append(line)
 
+    # A file whose last line has no newline would otherwise get the first
+    # appended key glued onto it (FOO=barBAZ=qux).
+    if lines and not lines[-1].endswith("\n"):
+        lines[-1] += "\n"
+
     for key, value in updates.items():
         if key not in found:
             lines.append(f"{key}={value}\n")

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -53,6 +53,7 @@ Example:
 """
 
 import os
+from pathlib import Path
 import base64
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
@@ -173,20 +174,16 @@ class Gmail:
         os.environ["GOOGLE_ACCESS_TOKEN"] = new_access_token
         os.environ["GOOGLE_TOKEN_EXPIRES_AT"] = expires_at
 
-        # Update .env file if it exists
-        env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
-        if os.path.exists(env_file):
-            with open(env_file, 'r', encoding="utf-8") as f:
-                lines = f.readlines()
-
-            with open(env_file, 'w', encoding="utf-8") as f:
-                for line in lines:
-                    if line.startswith("GOOGLE_ACCESS_TOKEN="):
-                        f.write(f"GOOGLE_ACCESS_TOKEN={new_access_token}\n")
-                    elif line.startswith("GOOGLE_TOKEN_EXPIRES_AT="):
-                        f.write(f"GOOGLE_TOKEN_EXPIRES_AT={expires_at}\n")
-                    else:
-                        f.write(line)
+        # Persist to global keys.env so the refreshed token survives this
+        # process. Google refresh tokens don't rotate, so the next process can
+        # always re-derive an access token — only keys.env needs updating.
+        from ..cli.commands.project_cmd_lib import upsert_env
+        env_file = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        upsert_env(env_file, {
+            "GOOGLE_ACCESS_TOKEN": new_access_token,
+            "GOOGLE_TOKEN_EXPIRES_AT": expires_at,
+        })
 
         return new_access_token
 

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -46,6 +46,7 @@ Example:
 
 import html
 import os
+from pathlib import Path
 
 import httpx
 
@@ -154,22 +155,22 @@ class Outlook:
         if new_refresh_token:
             os.environ["MICROSOFT_REFRESH_TOKEN"] = new_refresh_token
 
-        # Update .env file if it exists
-        env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
-        if os.path.exists(env_file):
-            with open(env_file, 'r', encoding="utf-8") as f:
-                lines = f.readlines()
+        # Persist so the rotated tokens survive this process. Both env files
+        # matter: load_dotenv reads .env first and does not override, so a
+        # stale project .env would shadow the fresh keys.env copy forever.
+        from ..cli.commands.project_cmd_lib import upsert_env
+        rotated = {
+            "MICROSOFT_ACCESS_TOKEN": new_access_token,
+            "MICROSOFT_TOKEN_EXPIRES_AT": expires_at,
+            "MICROSOFT_REFRESH_TOKEN": new_refresh_token,
+        }
+        keys_env = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
+        keys_env.parent.mkdir(parents=True, exist_ok=True)
+        upsert_env(keys_env, rotated)
 
-            with open(env_file, 'w', encoding="utf-8") as f:
-                for line in lines:
-                    if line.startswith("MICROSOFT_ACCESS_TOKEN="):
-                        f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")
-                    elif line.startswith("MICROSOFT_TOKEN_EXPIRES_AT="):
-                        f.write(f"MICROSOFT_TOKEN_EXPIRES_AT={expires_at}\n")
-                    elif line.startswith("MICROSOFT_REFRESH_TOKEN=") and new_refresh_token:
-                        f.write(f"MICROSOFT_REFRESH_TOKEN={new_refresh_token}\n")
-                    else:
-                        f.write(line)
+        local_env = Path(".env")
+        if local_env.exists() and "MICROSOFT_ACCESS_TOKEN=" in local_env.read_text(encoding="utf-8"):
+            upsert_env(local_env, rotated)
 
         return new_access_token
 

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -151,6 +151,70 @@ class TestOutlookTokenManagement:
 
         assert "MICROSOFT_REFRESH_TOKEN=old-refresh" in keys_env.read_text()
 
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_refresh_updates_project_env_holding_the_tokens(self, mock_httpx, tmp_path, monkeypatch):
+        """A project .env is loaded first and never overridden — it must rotate too."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text(
+            "MICROSOFT_ACCESS_TOKEN=old-access\n"
+            "MICROSOFT_REFRESH_TOKEN=old-refresh\n"
+        )
+        config_dir = tmp_path / "co"
+        config_dir.mkdir()
+
+        refresh_response = MagicMock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "access_token": "new-access",
+            "expires_at": "2099-12-31T23:59:59Z",
+            "refresh_token": "rotated-refresh",
+        }
+        mock_httpx.post.return_value = refresh_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-access",
+            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "OPENONION_API_KEY": "test-key",
+            "AGENT_CONFIG_PATH": str(config_dir),
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            assert Outlook()._get_access_token() == "new-access"
+
+        saved = (tmp_path / ".env").read_text()
+        assert "MICROSOFT_ACCESS_TOKEN=new-access" in saved
+        assert "MICROSOFT_REFRESH_TOKEN=rotated-refresh" in saved
+
+    @pytest.mark.real_refresh
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_refresh_leaves_unrelated_project_env_untouched(self, mock_httpx, tmp_path, monkeypatch):
+        """Don't scatter Microsoft keys into whatever .env the process sits next to."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("DATABASE_URL=postgres://local\n")
+        config_dir = tmp_path / "co"
+        config_dir.mkdir()
+
+        refresh_response = MagicMock()
+        refresh_response.status_code = 200
+        refresh_response.json.return_value = {
+            "access_token": "new-access",
+            "expires_at": "2099-12-31T23:59:59Z",
+        }
+        mock_httpx.post.return_value = refresh_response
+
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
+            "MICROSOFT_ACCESS_TOKEN": "old-access",
+            "MICROSOFT_REFRESH_TOKEN": "old-refresh",
+            "OPENONION_API_KEY": "test-key",
+            "AGENT_CONFIG_PATH": str(config_dir),
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            assert Outlook()._get_access_token() == "new-access"
+
+        assert (tmp_path / ".env").read_text() == "DATABASE_URL=postgres://local\n"
+
 
 class TestOutlookEmailFormatting:
     """Test Outlook email formatting."""

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -1,0 +1,54 @@
+"""Tests for CLI project helpers — upsert_env credential writing."""
+
+import sys
+
+from connectonion.cli.commands.project_cmd_lib import upsert_env
+
+
+class TestUpsertEnv:
+    """upsert_env replaces, appends, and creates .env files safely."""
+
+    def test_creates_file_with_new_keys(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        upsert_env(env_file, {"A": "1", "B": "2"})
+
+        assert env_file.read_text() == "A=1\nB=2\n"
+
+    def test_replaces_existing_key_and_keeps_the_rest(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        env_file.write_text("# comment\nA=old\nOTHER=keep\n")
+
+        upsert_env(env_file, {"A": "new"})
+
+        assert env_file.read_text() == "# comment\nA=new\nOTHER=keep\n"
+
+    def test_appends_to_file_without_trailing_newline(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        env_file.write_text("A=1")
+
+        upsert_env(env_file, {"B": "2"})
+
+        assert env_file.read_text() == "A=1\nB=2\n"
+
+    def test_skips_none_values(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        env_file.write_text("A=1\n")
+
+        upsert_env(env_file, {"A": None, "B": "2"})
+
+        assert env_file.read_text() == "A=1\nB=2\n"
+
+    def test_strip_prefix_drops_stale_credentials(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        env_file.write_text("MICROSOFT_OLD=x\nMICROSOFT_EMAIL=a@b.com\nKEEP=1\n")
+
+        upsert_env(env_file, {"MICROSOFT_EMAIL": "c@d.com"}, strip_prefix="MICROSOFT_")
+
+        assert env_file.read_text() == "KEEP=1\nMICROSOFT_EMAIL=c@d.com\n"
+
+    def test_written_file_is_owner_only(self, tmp_path):
+        env_file = tmp_path / "keys.env"
+        upsert_env(env_file, {"TOKEN": "secret"})
+
+        if sys.platform != "win32":
+            assert env_file.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Problem

`co auth google` and `co auth microsoft` only saved OAuth tokens to the global `~/.co/keys.env` **if the file already existed** — otherwise tokens landed only in the local project `.env`. On top of that, the token-refresh paths in `Gmail` and `Outlook` only rewrote lines that were already present in keys.env, so rotated tokens (Microsoft rotates the refresh token on every use) could be silently dropped.

Result: `~/.co/keys.env` was not guaranteed to hold the `co outlook` / `co gmail` tokens, and other projects/sessions lost access.

## Changes

- **`auth_commands.py`**: `handle_google_auth` and `handle_microsoft_auth` now always write credentials to `~/.co/keys.env` (creating `~/.co` if needed), in addition to the local `.env`.
- **`outlook.py` / `gmail.py`**: token refresh now uses `upsert_env` to persist refreshed/rotated tokens to global keys.env — missing keys are appended and the file is created if absent, instead of the old rewrite-only-existing-lines logic.

## Testing

- `pytest tests/unit/test_outlook.py tests/unit/test_gmail.py` — 63 passed
- Verified `upsert_env` creates a fresh keys.env, replaces existing keys, appends missing ones, and skips `None` (no rotated refresh token from older backends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)