### PR TITLE
Update remaining defaults to Gemini 3.5 Flash

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -312,7 +312,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         if "AGENT_CONFIG_PATH=" not in env_content:
             lines_to_add.append(f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n")
         if "# Default model:" not in env_content:
-            lines_to_add.append("# Default model: co/gemini-2.5-pro (managed keys with free credits)\n")
+            lines_to_add.append("# Default model: co/gemini-3.5-flash (managed keys with free credits)\n")
 
         if lines_to_add:
             # Add blank line after comments if we're adding any
@@ -322,7 +322,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         # Fallback - create minimal .env with detected keys
         env_lines = [
             f"AGENT_CONFIG_PATH={Path.home() / '.co'}",
-            "# Default model: co/gemini-2.5-pro (managed keys with free credits)",
+            "# Default model: co/gemini-3.5-flash (managed keys with free credits)",
             "",
         ]
 

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -213,7 +213,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     if not env_existed:
         if keys_to_add or global_keys:
             env_content = f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n"
-            env_content += "# Default model: co/gemini-2.5-pro (managed keys with free credits)\n\n"
+            env_content += "# Default model: co/gemini-3.5-flash (managed keys with free credits)\n\n"
             # Add all global keys + detected keys
             all_keys = list(global_keys.values()) + [k for k in keys_to_add if k not in global_keys.values()]
             env_content += '\n'.join(all_keys) + '\n'

--- a/connectonion/cli/templates/browser/agent.py
+++ b/connectonion/cli/templates/browser/agent.py
@@ -25,7 +25,7 @@ def create_agent():
     browser = BrowserAutomation(headless=True)
     return Agent(
         name="browser_agent",
-        model="co/gemini-2.5-pro",
+        model="co/gemini-3.5-flash",
         system_prompt=system_prompt_path,
         tools=[browser],
         plugins=[image_result_formatter, ui_stream],

--- a/connectonion/cli/templates/coder/agent.py
+++ b/connectonion/cli/templates/coder/agent.py
@@ -17,7 +17,7 @@ agent = Agent(
     name="coder",
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.5-flash",
     max_iterations=50,
 )
 

--- a/connectonion/cli/templates/minimal/agent.py
+++ b/connectonion/cli/templates/minimal/agent.py
@@ -20,7 +20,7 @@ agent = Agent(
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write, browser],
     plugins=[image_result_formatter, tool_approval],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.5-flash",
 )
 
 result = agent.input("what is your task?")

--- a/connectonion/cli/templates/web-research/agent.py
+++ b/connectonion/cli/templates/web-research/agent.py
@@ -108,7 +108,7 @@ def main():
     agent = Agent(
         name="web-research-agent",
         tools=[search_web, extract_data, analyze_data, save_research],
-        model=os.getenv("MODEL", "co/gemini-2.5-pro")
+        model=os.getenv("MODEL", "co/gemini-3.5-flash")
     )
     
     # Example research task

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -38,7 +38,7 @@ class Agent:
         tools: Optional[Union[List[Callable], Callable, Any]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-2.5-pro",
+        model: str = "co/gemini-3.5-flash",
         max_iterations: int = 100,
         log: Optional[Union[bool, str, Path]] = None,
         quiet: bool = False,

--- a/connectonion/llm_do.py
+++ b/connectonion/llm_do.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typing, pathlib, pydantic, dotenv, prompts.py, llm.py] | imported by [debug_explainer/explain_context.py, user code, examples] | tested by [tests/test_llm_do.py, tests/test_llm_do_comprehensive.py, tests/test_real_llm_do.py]
   Data flow: user calls llm_do(input, output, system_prompt, model, api_key, **kwargs) → validates input non-empty → loads system_prompt via load_system_prompt() → builds messages [system, user] → calls create_llm(model, api_key) factory → calls llm.complete(messages, **kwargs) OR llm.structured_complete(messages, output, **kwargs) → returns string OR Pydantic model instance
   State/Effects: loads .env via dotenv.load_dotenv() | reads system_prompt files if Path provided | makes one LLM API request | no caching or persistence | stateless
-  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-2.5-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
+  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-3.5-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
   Performance: minimal overhead (no agent loop, no tool calling, no conversation history) | one LLM call per invocation | no caching | synchronous blocking
   Errors: raises ValueError if input empty | provider errors from create_llm() and llm.complete() bubble up | Pydantic ValidationError if structured output doesn't match schema
 
@@ -43,7 +43,7 @@ Key Design Decisions
 -------------------
 - **Stateless**: No conversation history, each call is independent
 - **Simple API**: Minimal parameters, sensible defaults
-- **Default Model**: Uses "co/gemini-2.5-flash" (ConnectOnion managed keys) for zero-setup
+- **Default Model**: Uses "co/gemini-3.5-flash" (ConnectOnion managed keys) for zero-setup
 - **Structured Output**: Native Pydantic support via provider-specific APIs
 - **Flexible Parameters**: **kwargs pass through to underlying LLM (temperature, max_tokens, etc.)
 
@@ -134,7 +134,7 @@ Parameters
 - input (str): The text/question to send to the LLM
 - output (Type[BaseModel], optional): Pydantic model for structured output
 - system_prompt (str | Path, optional): System instructions (inline or file path)
-- model (str): Model name (default: "co/gemini-2.5-flash")
+- model (str): Model name (default: "co/gemini-3.5-flash")
 - temperature (float): Sampling temperature (default: 0.1 for consistency)
 - api_key (str, optional): Override API key (uses env vars by default)
 - **kwargs: Additional parameters passed to LLM (max_tokens, top_p, etc.)
@@ -231,7 +231,7 @@ def llm_do(
     input: str,
     output: Optional[Type[T]] = None,
     system_prompt: Optional[Union[str, Path]] = None,
-    model: str = "co/gemini-2.5-flash",
+    model: str = "co/gemini-3.5-flash",
     api_key: Optional[str] = None,
     **kwargs
 ) -> Union[str, T]:
@@ -248,7 +248,7 @@ def llm_do(
         input: The input text/question to send to the LLM
         output: Optional Pydantic model class for structured output
         system_prompt: Optional system prompt (string or file path)
-        model: Model name (default: "co/gemini-2.5-flash")
+        model: Model name (default: "co/gemini-3.5-flash")
         api_key: Optional API key (uses environment variable if not provided)
         **kwargs: Additional parameters (temperature, max_tokens, etc.)
 

--- a/connectonion/useful_events_handlers/reflect.py
+++ b/connectonion/useful_events_handlers/reflect.py
@@ -112,7 +112,7 @@ Error: {error}"""
 
     reasoning = llm_do(
         prompt,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.5-flash",
         temperature=0.2,
         system_prompt=REFLECT_PROMPT
     )

--- a/connectonion/useful_plugins/auto_compact.py
+++ b/connectonion/useful_plugins/auto_compact.py
@@ -2,10 +2,10 @@
 Purpose: Automatically compress conversation context when usage >= 90% to prevent overflow
 LLM-Note:
   Dependencies: imports from [typing, core.events, llm_do, pathlib, uuid] | imported by [useful_plugins/__init__.py, cli/co_ai/agent.py] | tested via after_llm event firing
-  Data flow: after_llm event fires → check_and_compact() checks context_percent → if >= 90% and len(messages) >= 8: _do_compact() → llm_do() with gemini-2.5-flash summarizes old messages → replaces old messages with summary → keeps system + summary + last 5 messages → returns "{old_count} → {new_count} messages"
+  Data flow: after_llm event fires → check_and_compact() checks context_percent → if >= 90% and len(messages) >= 8: _do_compact() → llm_do() with gemini-3.5-flash summarizes old messages → replaces old messages with summary → keeps system + summary + last 5 messages → returns "{old_count} → {new_count} messages"
   State/Effects: modifies agent.current_session['messages'] by replacing old messages with LLM-generated summary | sends compact events via agent.io if connected | logs to console via agent.logger | no file I/O except loading summarization.md prompt
   Integration: exposes auto_compact=[check_and_compact] plugin | fires on after_llm event | uses _do_compact(), _format_messages_for_summary() helper functions | COMPACT_THRESHOLD=90 constant | reads cli/co_ai/prompts/summarization.md for instructions
-  Performance: only fires when context >= 90% | minimum 8 messages required | keeps last 5 messages (recent_count) + system + summary | llm_do() call to gemini-2.5-flash (fast/cheap) | summary prompt limited to 800 words
+  Performance: only fires when context >= 90% | minimum 8 messages required | keeps last 5 messages (recent_count) + system + summary | llm_do() call to gemini-3.5-flash (fast/cheap) | summary prompt limited to 800 words
   Errors: catches all exceptions in _do_compact() and sends error event | prints red ✗ on failure | gracefully handles missing summarization.md (empty instructions)
 
 Auto-compact plugin - Automatically compresses context when running low.
@@ -137,7 +137,7 @@ Keep the summary under 800 words but preserve all critical technical details."""
 
     summary = llm_do(
         summary_prompt,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.5-flash",
         temperature=0,
     )
 

--- a/connectonion/useful_plugins/re_act.py
+++ b/connectonion/useful_plugins/re_act.py
@@ -134,7 +134,7 @@ Current user input: {user_prompt}
 
 Acknowledge this request (1-2 sentences):"""
 
-    model = "co/gemini-2.5-flash"
+    model = "co/gemini-3.5-flash"
     agent.logger.print(f"[dim]/understanding ({model})...[/dim]")
 
     ack = llm_do(

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -162,7 +162,7 @@ def task(agent, prompt: str, agent_type: str) -> str:
     # Extract configuration
     frontmatter = config['frontmatter']
     system_prompt = config['system_prompt']
-    model = frontmatter.get('model', 'co/gemini-2.5-pro')
+    model = frontmatter.get('model', 'co/gemini-3.5-flash')
     max_iterations = frontmatter.get('max_iterations', 10)
     tool_names = frontmatter.get('tools', [])
 

--- a/connectonion/useful_tools/browser_tools/element_finder.py
+++ b/connectonion/useful_tools/browser_tools/element_finder.py
@@ -208,7 +208,7 @@ def find_element(
     result = llm_do(
         prompt,
         output=ElementMatch,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.5-flash",
         temperature=0.1
     )
 

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -92,7 +92,7 @@ def _ai_scroll(page, times: int, description: str):
     strategy = llm_do(
         _PROMPT.format(description=description, scrollable_elements=scrollable, simplified_html=html),
         output=ScrollStrategy,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.5-flash",
         temperature=0.1
     )
     print(f"    AI: {strategy.explanation}")

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -288,7 +288,7 @@ class TestCliCreate:
             assert os.path.exists(env_file)
             with open(env_file) as f:
                 content = f.read()
-                assert "# Default model: co/gemini-2.5-pro" in content
+                assert "# Default model: co/gemini-3.5-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_create_adds_agent_address_explanation_to_global_keys(self):

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -347,7 +347,7 @@ class TestCliInit:
             assert os.path.exists(".env")
             with open(".env") as f:
                 content = f.read()
-                assert "# Default model: co/gemini-2.5-pro" in content
+                assert "# Default model: co/gemini-3.5-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_init_creates_agent_address_explanation_in_global_keys(self, tmp_path, monkeypatch):

--- a/tests/unit/test_default_models.py
+++ b/tests/unit/test_default_models.py
@@ -1,0 +1,17 @@
+"""Default managed models should stay aligned with the supported model list."""
+
+import inspect
+
+from connectonion import Agent, llm_do
+
+
+def test_agent_uses_latest_managed_default():
+    default = inspect.signature(Agent.__init__).parameters["model"].default
+
+    assert default == "co/gemini-3.5-flash"
+
+
+def test_llm_do_uses_latest_managed_default():
+    default = inspect.signature(llm_do).parameters["model"].default
+
+    assert default == "co/gemini-3.5-flash"

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -57,6 +57,7 @@ class TestMultiLLMSupport:
         # Test Google models
         assert MODEL_REGISTRY["gemini-3-pro-preview"] == "google"
         assert MODEL_REGISTRY["gemini-3-pro-image-preview"] == "google"
+        assert MODEL_REGISTRY["gemini-3.5-flash"] == "google"
         assert MODEL_REGISTRY["gemini-2.5-flash"] == "google"
 
     def test_create_llm_factory(self):

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -198,6 +198,7 @@ class TestModelPricing:
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in pricing."""
+        assert "gemini-3.5-flash" in MODEL_PRICING
         assert "gemini-3-pro-preview" in MODEL_PRICING
         assert "gemini-3-pro-image-preview" in MODEL_PRICING
         assert "gemini-2.5-pro" in MODEL_PRICING
@@ -219,6 +220,7 @@ class TestModelContextLimits:
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in context limits."""
+        assert MODEL_CONTEXT_LIMITS["gemini-3.5-flash"] == 1_000_000
         assert "gemini-3-pro-preview" in MODEL_CONTEXT_LIMITS
         assert MODEL_CONTEXT_LIMITS["gemini-3-pro-preview"] == 1_000_000
         assert "gemini-3-pro-image-preview" in MODEL_CONTEXT_LIMITS


### PR DESCRIPTION
## What changed

- Moves the core `Agent` and `llm_do` defaults from Gemini 2.5 to `co/gemini-3.5-flash`.
- Updates internal fast/default call sites and generated project templates.
- Adds regression coverage for the public defaults and the registered pricing/context metadata.

## Why this differs from the issue sketch

The issue proposed `co/gemini-3.5-pro` for `Agent`, but that model ID is not currently published by Google and is absent from the live OpenOnion `/v1/models` response. `co/gemini-3.5-flash` is the available 3.5 model, so this PR uses it consistently instead of shipping an invalid default. The reporter should confirm whether this is the intended tradeoff or whether `Agent` should stay on 2.5 Pro until a newer Pro model is available.

## Validation

```text
pytest tests/unit/test_default_models.py tests/unit/test_llm.py tests/unit/test_usage.py tests/e2e/cli/test_cli_create.py tests/e2e/cli/test_cli_init.py -q
80 passed
```

Fixes #196