### PR TITLE
Release v1.2.1 — version bump + docs aligned with auto-install & native Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to ConnectOnion will be documented in this file.
 
+## [1.2.1] - 2026-07-17
+
+### ✨ Features
+- **`co browser` runs natively on Windows** — the daemon speaks named pipes (stdlib, HMAC-authenticated) on Windows and keeps its Unix socket byte-identical on macOS/Linux. No WSL.
+- **Zero-setup browser**: the first page-driving `co browser` command auto-installs chromium (per-user, no admin rights) when no browser exists; desktop Chrome is auto-detected and preferred.
+
+### 🐛 Bug Fixes
+- Windows: emoji/Unicode CLI output no longer crashes on legacy codepages (cp1252) — including when `co` is driven through a pipe by Claude Code/codex.
+- `co browser go_to` no longer rewrites `file://`/`about:`/`data:` URLs into broken `https://` forms.
+- Offline first run: `co init` now degrades gracefully (friendly one-liner, scaffold + keypair still created) instead of aborting with a traceback; `authenticate()` carries a 15s network timeout.
+- Docs: removed nonexistent `co init --no-ai`/`--update-docs` flags; fixed the stale auth URL reference.
+
+### ✅ Testing
+- New `windows-e2e` CI job simulates a real Windows user end to end: wheel install, PowerShell 7 / 5.1 / cmd.exe, offline first run, CJK + space home directory, fresh-laptop browser auto-install (real download), three parallel agents, Task-Manager-kill recovery, authkey self-healing.
+- Windows unit/daemon matrix on Python 3.10/3.12/3.13; concurrency tests (8 simultaneous clients, cold-start singleton race).
+
 ## [1.0.5] - 2026-07-01
 
 ### 🐛 Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,8 +137,8 @@ python setup.py sdist bdist_wheel
 twine upload dist/*
 
 # Version update (see VERSIONING.md)
-# Current: 0.4.1
-# Strategy: increment PATCH (0.4.1 → 0.4.2), roll to MINOR at .10 (0.4.10 → 0.5.0)
+# Current: 1.2.1
+# Strategy: increment PATCH (1.2.1 → 1.2.2), roll to MINOR at .10 (1.2.10 → 1.3.0)
 ```
 
 ## Project Structure
@@ -383,10 +383,10 @@ git push
 
 ## Version Numbering Strategy
 
-**Current Version:** 0.4.1 (Production Ready)
+**Current Version:** 1.2.1 (Production Ready)
 
 **Strategy:** Semantic versioning with specific rollover rules
-- Increment PATCH: 0.4.1 → 0.4.2 → ... → 0.4.9
+- Increment PATCH: 1.2.1 → 1.2.2 → ... → 1.2.9
 - At .10, roll to MINOR: 0.4.10 → 0.5.0
 - At .10.0, roll to MAJOR: 0.10.0 → 1.0.0
 

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # Auto-load .env files for the entire framework
 import sys as _sys

--- a/connectonion/useful_skills/install-connectonion/SKILL.md
+++ b/connectonion/useful_skills/install-connectonion/SKILL.md
@@ -167,9 +167,10 @@ desktop **Google Chrome** when present at the standard OS path; otherwise instal
 Patchright's browser:
 
 ```bash
-PY -m patchright install chrome          # all platforms (Windows/macOS/Linux)
+PY -m patchright install chromium        # per-user dir, NEVER needs admin (what auto-install runs)
+PY -m patchright install chrome          # branded Chrome: best stealth, but a system installer
 # Linux/CI without desktop libraries may need system deps (asks for sudo):
-PY -m patchright install --with-deps chrome
+PY -m patchright install --with-deps chromium
 ```
 
 **Verify it actually launches — `co doctor` is NOT enough here.** `co doctor` only checks
@@ -182,9 +183,9 @@ co browser go_to example.com     # navigates → Chrome launched OK. Then: co br
 
 > **Recovery**
 > - *"Chrome failed to start … ~/.co/browser.log"* → no drivable browser. Run
->   `PY -m patchright install chrome` (Linux: add `--with-deps`), or install desktop Google
+>   `PY -m patchright install chromium` (Linux: add `--with-deps`), or install desktop Google
 >   Chrome to the standard path. Note: a Chrome in a non-standard spot (Windows per-user
->   `%LOCALAPPDATA%`, Linux snap/flatpak) isn't auto-detected — use `patchright install chrome`.
+>   `%LOCALAPPDATA%`, Linux snap/flatpak) isn't auto-detected — use `patchright install chromium`.
 > - `co doctor` Browser line **missing** → patchright library gone: `PY -m pip install patchright`.
 > - `co doctor` Browser line **broken** (stealth driver) → `PY -m pip install --force-reinstall --no-cache-dir patchright`.
 > - `co browser do "…"` says *"requires authentication"* → the natural-language mode uses a

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -150,17 +150,23 @@ This path uses managed keys — run `co auth` once if you see an authentication 
 
 ## Installation
 
-The browser needs Patchright (a stealth-patched, API-compatible Playwright fork):
+**None needed (1.2.1+).** The Patchright library ships with connectonion, and the first
+page-driving command auto-installs a browser when none exists — a one-time download,
+announced in your terminal, into your per-user directory (no admin rights). If a desktop
+Google Chrome is installed at the standard location, it is detected and used instead,
+with zero downloads.
+
+Manual fallback (older versions, airgapped machines, or a failed auto-install):
 
 ```bash
-pip install patchright
-patchright install chrome
+python -m patchright install chromium   # per-user, never needs admin
+python -m patchright install chrome     # branded Chrome: best stealth, system installer
 ```
 
 ## Sessions & Profile
 
 - One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
-- The daemon's socket lives under `$XDG_RUNTIME_DIR/co/browser.sock` (override with `$CO_BROWSER_SOCK`).
+- The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
 
 ## Error Messages
 

--- a/docs/useful_skills/install-connectonion.md
+++ b/docs/useful_skills/install-connectonion.md
@@ -32,8 +32,8 @@ The skill walks these steps, each verified before the next, and self-corrects on
    (`OPENONION_API_KEY`, `AGENT_EMAIL`, `IS_EMAIL_ACTIVE=true`). `co auth` is the repair step
    if that authentication didn't land (e.g. offline)
 4. **Confirm** — `co status` / `co doctor` prove the account and keys are wired up
-5. **Browser** (only if needed) — `pip` doesn't bring a browser; `patchright install chrome`
-   (or system Chrome). `co browser` runs natively on Windows/macOS/Linux (1.2.1+)
+5. **Browser** (only if needed) — auto-installs on first use (1.2.1+, chromium: per-user,
+   no admin); manual fallback `patchright install chromium`. Native on Windows/macOS/Linux
 6. **Integrations** (optional) — `co auth google` / `co auth microsoft` for personal Gmail/Outlook
 7. **Verify the commands run** — `co status`, `co email`, a real agent run, a real browser nav
 8. **Summary** — a friendly account report + the list of commands they can now use
@@ -52,7 +52,7 @@ grounded in the actual CLI code:
   OAuth (`co auth google`/`microsoft`) is a separate, optional thing.
 - **The browser auto-installs on first use (1.2.1+).** Before 1.2.1 it was never auto-installed: `pip install connectonion` brings the
   `patchright` library but no Chrome; `co browser` fails with *"Chrome failed to start"*
-  until you run `patchright install chrome` or have desktop Chrome. And `co doctor` does
+  until you run `patchright install chromium` or have desktop Chrome. And `co doctor` does
   **not** catch this — it only checks the patchright library, so the skill proves the
   browser with a real `co browser go_to example.com`.
 - **`co browser` runs natively on all three OSes from 1.2.1** — Unix-socket daemon on
@@ -86,5 +86,5 @@ grounded in the actual CLI code:
 - [Quickstart](../quickstart.md) — the human-facing version of the same flow
 - [co auth](../cli/auth.md) — what authentication writes to keys.env
 - [co email](../cli/email.md) — the built-in agent mailbox
-- [co browser](../cli/browser.md) — browser prerequisites (patchright install chrome)
+- [co browser](../cli/browser.md) — browser auto-install details and manual fallback
 - [Built-in Skills](README.md) — all copyable skills

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.2.0"
+version = "1.2.1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Description

The release commit for v1.2.1: version bump (1.2.0 → 1.2.1 in `pyproject.toml` + `__init__.py`) plus the final docs alignment so nothing on main contradicts the shipped behavior.

## Related Issue

Ships #209, #211, #214 (already merged); narrows #213.

## Type of Change
- [x] Documentation update
- [x] New feature (version bump for release)

## Changes Made
- `pyproject.toml:7`, `connectonion/__init__.py:13` — 1.2.0 → 1.2.1
- `docs/cli/browser.md` — Installation: none needed (auto-install on first use, per-user, no admin; desktop Chrome auto-detected); manual chromium/chrome as explicit fallback; Windows named-pipe endpoint note
- `install-connectonion` skill + doc page — manual fallback leads with `chromium` (what auto-install runs; never needs admin)
- `docs/windows-support.md` — "Browser Automation on Windows (1.2.1+)" section
- `CHANGELOG.md` — 1.2.1 entry (features / fixes / testing)
- `CLAUDE.md` — stale 0.4.1 version references → 1.2.1

## Testing
- [x] I have tested this code locally — copy + autoinstall suites: 25 passed
- [x] All existing tests pass
- [x] I have added tests for new functionality — N/A (version + docs)

Wheel `connectonion-1.2.1-py3-none-any.whl` built from this branch and content-verified (transport, chrome_finder, chromium auto-install, rewritten SKILL.md all present).

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published — #209/#211/#214 all merged

## Additional Notes
After merge: tag `v1.2.1`, `python -m build`, `twine upload dist/*1.2.1*` (credentials required). wiki/ and docs-site/ (nested repos) still need their own sync pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014eyckM86WSKs3iyFKses9m)_