### PR TITLE
Implement Phase 1 backend hard stop for agent execution

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -473,9 +473,10 @@ class Agent:
             'status': 'running',
         })
 
+        messages = self.current_session['messages'].copy()
         start = time.time()
         response, interrupted = run_interruptible(
-            lambda: self.llm.complete(self.current_session['messages'], tools=tool_schemas),
+            lambda: self.llm.complete(messages, tools=tool_schemas),
             self.io,
         )
         duration = (time.time() - start) * 1000  # milliseconds

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -24,6 +24,7 @@ from ..debug.decorators import (
     _is_replay_enabled  # Only need this for replay check
 )
 from ..logger import Logger
+from .interrupt import AgentInterrupted, run_interruptible
 from .tool_executor import execute_and_record_tools, execute_single_tool
 from .events import EventHandler
 
@@ -422,7 +423,12 @@ class Agent:
             self._invoke_events('before_iteration')
 
             # Get LLM response
-            response = self._get_llm_decision()
+            try:
+                response = self._get_llm_decision()
+            except AgentInterrupted:
+                self.current_session.pop('stop_signal', None)
+                self._invoke_events('on_stop_signal')
+                return "What would you like me to do?"
 
             if not response.tool_calls:
                 content = response.content or ""
@@ -468,8 +474,26 @@ class Agent:
         })
 
         start = time.time()
-        response = self.llm.complete(self.current_session['messages'], tools=tool_schemas)
+        response, interrupted = run_interruptible(
+            lambda: self.llm.complete(self.current_session['messages'], tools=tool_schemas),
+            self.io,
+        )
         duration = (time.time() - start) * 1000  # milliseconds
+
+        if interrupted:
+            self._record_trace({
+                'type': 'llm_result',
+                'id': llm_id,
+                'model': self.llm.model,
+                'iteration': self.current_session['iteration'],
+                'duration_ms': duration,
+                'tool_calls_count': 0,
+                'usage': None,
+                'context_percent': self.context_percent,
+                'status': 'interrupted',
+            })
+            self.current_session['stop_signal'] = 'user_interrupt'
+            raise AgentInterrupted()
 
         # Track token usage
         if response.usage:

--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -17,15 +17,11 @@ def run_interruptible(
     poll_seconds: float = 0.2,
 ) -> tuple[T | None, bool]:
     """Return ``(result, False)`` or abandon the daemon worker on interrupt."""
-    receive_all = getattr(io, "receive_all", None) if io is not None else None
-    restore = getattr(io, "send_to_agent", None) if io is not None else None
-    declared_receive_all = getattr(type(io), "receive_all", None) if io is not None else None
-    if (
-        not callable(receive_all)
-        or not callable(declared_receive_all)
-        or not callable(restore)
-    ):
+    if io is None or getattr(io, "supports_interrupts", False) is not True:
         return fn(), False
+
+    receive_all = io.receive_all
+    requeue = io.requeue
 
     if receive_all("INTERRUPT"):
         return None, True
@@ -47,7 +43,7 @@ def run_interruptible(
         interrupts = receive_all("INTERRUPT")
         if interrupts and not worker.is_alive():
             for message in interrupts:
-                restore(message)
+                requeue(message)
             break
         if interrupts:
             return None, True

--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -1,0 +1,57 @@
+"""Run blocking agent steps without making user interrupts wait for them."""
+
+import threading
+from typing import Any, Callable, TypeVar
+
+
+T = TypeVar("T")
+
+
+class AgentInterrupted(Exception):
+    """Raised when a blocking interaction consumes a user INTERRUPT frame."""
+
+
+def run_interruptible(
+    fn: Callable[[], T],
+    io: Any,
+    poll_seconds: float = 0.2,
+) -> tuple[T | None, bool]:
+    """Return ``(result, False)`` or abandon the daemon worker on interrupt."""
+    receive_all = getattr(io, "receive_all", None) if io is not None else None
+    restore = getattr(io, "send_to_agent", None) if io is not None else None
+    declared_receive_all = getattr(type(io), "receive_all", None) if io is not None else None
+    if (
+        not callable(receive_all)
+        or not callable(declared_receive_all)
+        or not callable(restore)
+    ):
+        return fn(), False
+
+    if receive_all("INTERRUPT"):
+        return None, True
+
+    box: dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            box["result"] = fn()
+        except BaseException as exc:
+            box["error"] = exc
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    while worker.is_alive():
+        worker.join(timeout=poll_seconds)
+        if not worker.is_alive():
+            break
+        interrupts = receive_all("INTERRUPT")
+        if interrupts and not worker.is_alive():
+            for message in interrupts:
+                restore(message)
+            break
+        if interrupts:
+            return None, True
+
+    if "error" in box:
+        raise box["error"]
+    return box.get("result"), False

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -11,6 +11,7 @@ LLM-Note:
 
 import time
 import json
+import threading
 from typing import List, Dict, Any, Optional, Callable
 
 from ..debug.xray import (
@@ -18,6 +19,7 @@ from ..debug.xray import (
     clear_xray_context,
     is_xray_enabled
 )
+from .interrupt import AgentInterrupted, run_interruptible
 
 
 def execute_and_record_tools(
@@ -57,7 +59,8 @@ def execute_and_record_tools(
         # stop_signal: swap result with clean message, mark remaining as rejected
         rejection = agent.current_session.get('stop_signal')
         if rejection:
-            _add_tool_result_message(agent.current_session['messages'], tool_call.id, rejection)
+            current_result = trace_entry["result"] if trace_entry["status"] == "interrupted" else rejection
+            _add_tool_result_message(agent.current_session['messages'], tool_call.id, current_result)
             for remaining in tool_calls[i + 1:]:
                 _add_tool_result_message(agent.current_session['messages'], remaining.id, "Rejected by user")
             break
@@ -177,11 +180,12 @@ def execute_single_tool(
             'description': getattr(tool_func, 'description', '')
         }
 
-        # Invoke before_each_tool events
-        agent._invoke_events('before_each_tool')
-
-        # Clear pending_tool after event (it's only valid during before_tool)
-        agent.current_session.pop('pending_tool', None)
+        # Invoke before_each_tool events. pending_tool is valid only inside the
+        # event, including when an approval interrupt raises out of it.
+        try:
+            agent._invoke_events('before_each_tool')
+        finally:
+            agent.current_session.pop('pending_tool', None)
 
         # Execute the tool with timing (restart timer AFTER events for accurate tool timing)
         tool_start = time.time()
@@ -192,7 +196,27 @@ def execute_single_tool(
         if getattr(tool_func, '_needs_agent', False):
             tool_args['agent'] = agent
 
-        result = tool_func(**tool_args)
+        caller_thread = threading.get_ident()
+
+        def call_tool():
+            running_in_worker = threading.get_ident() != caller_thread
+            if running_in_worker:
+                inject_xray_context(
+                    agent=agent,
+                    user_prompt=agent.current_session.get('user_prompt', ''),
+                    messages=agent.current_session['messages'].copy(),
+                    iteration=agent.current_session['iteration'],
+                    previous_tools=previous_tools,
+                )
+            try:
+                return tool_func(**tool_args)
+            finally:
+                if running_in_worker:
+                    clear_xray_context()
+
+        result, interrupted = run_interruptible(call_tool, agent.io)
+        if interrupted:
+            raise AgentInterrupted()
         tool_duration = (time.time() - tool_start) * 1000  # milliseconds
 
         trace_entry["timing_ms"] = tool_duration
@@ -213,6 +237,17 @@ def execute_single_tool(
             )
 
         # Note: after_tool event will fire in execute_and_record_tools after result message added
+
+    except AgentInterrupted:
+        tool_duration = (time.time() - tool_start) * 1000
+        agent.current_session['stop_signal'] = 'user_interrupt'
+        trace_entry.update(
+            timing_ms=tool_duration,
+            result='Interrupted by user',
+            status='interrupted',
+        )
+        agent._record_trace(trace_entry)
+        logger.print(f"[yellow]Interrupted[/yellow] {tool_name}")
 
     except Exception as e:
         # Calculate timing from initial start (includes before_tool if it succeeded)

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -196,6 +196,9 @@ def execute_single_tool(
         if getattr(tool_func, '_needs_agent', False):
             tool_args['agent'] = agent
 
+        xray_user_prompt = agent.current_session.get('user_prompt', '')
+        xray_messages = agent.current_session['messages'].copy()
+        xray_iteration = agent.current_session['iteration']
         caller_thread = threading.get_ident()
 
         def call_tool():
@@ -203,9 +206,9 @@ def execute_single_tool(
             if running_in_worker:
                 inject_xray_context(
                     agent=agent,
-                    user_prompt=agent.current_session.get('user_prompt', ''),
-                    messages=agent.current_session['messages'].copy(),
-                    iteration=agent.current_session['iteration'],
+                    user_prompt=xray_user_prompt,
+                    messages=xray_messages,
+                    iteration=xray_iteration,
                     previous_tools=previous_tools,
                 )
             try:

--- a/connectonion/debug/xray.py
+++ b/connectonion/debug/xray.py
@@ -3,7 +3,7 @@ Purpose: Provide runtime debugging context and visual trace for AI agent tool ex
 LLM-Note:
   Dependencies: imports from [inspect, builtins, typing] | imported by [tool_executor.py, __init__.py] | tested by [tests/test_xray_class.py, tests/test_xray_without_decorator.py, tests/test_xray_auto_trace.py]
   Data flow: receives from tool_executor → inject_xray_context(agent, user_prompt, messages, iteration, previous_tools) → stores in builtins.xray global → tool accesses xray.agent, xray.task, etc. → tool calls xray.trace() to display formatted execution history → clear_xray_context() after execution
-  State/Effects: modifies builtins namespace by injecting global 'xray' object | stores thread-local context in XrayDecorator instance (_agent, _user_prompt, _messages, _iteration, _previous_tools) | clears context after tool execution | no file I/O or persistence
+  State/Effects: modifies builtins namespace by injecting global 'xray' object | stores agent, prompt, messages, iteration, and previous tools in threading.local() | clears context after tool execution | no file I/O or persistence
   Integration: exposes @xray decorator, xray global object with .agent, .task, .user_prompt, .messages, .iteration, .previous_tools properties, .trace() method | inject_xray_context(), clear_xray_context(), is_xray_enabled() helper functions | tool_executor checks __xray_enabled__ attribute to auto-print Rich tables
   Performance: lightweight context storage | trace() uses stack inspection to find agent instance | smart value formatting with truncation for strings (400 chars), lists, dicts, DataFrames, Images
   Errors: trace() handles missing agent gracefully with helpful messages | handles missing current_session | handles empty execution history
@@ -26,6 +26,7 @@ Usage:
 
 import inspect
 import builtins
+import threading
 from typing import Any, Callable, Optional
 
 
@@ -47,12 +48,7 @@ class XrayDecorator:
 
     def __init__(self):
         """Initialize with empty context."""
-        # Store context directly (no wrapper class needed)
-        self._agent = None
-        self._user_prompt = None
-        self._messages = []
-        self._iteration = None
-        self._previous_tools = []
+        self._context = threading.local()
 
         # Make available globally as 'xray' for easy access
         builtins.xray = self
@@ -97,67 +93,68 @@ class XrayDecorator:
     @property
     def agent(self):
         """The Agent instance that called this tool."""
-        return self._agent
+        return getattr(self._context, "agent", None)
 
     @property
     def task(self):
         """The original user prompt/task (alias for user_prompt)."""
-        return self._user_prompt
+        return getattr(self._context, "user_prompt", None)
 
     @property
     def user_prompt(self):
         """The original user prompt string from agent.input()."""
-        return self._user_prompt
+        return getattr(self._context, "user_prompt", None)
 
     @property
     def messages(self):
         """Complete conversation history (the prompt)."""
-        return self._messages
+        return getattr(self._context, "messages", [])
 
     @property
     def iteration(self):
         """Current iteration number in the agent loop."""
-        return self._iteration
+        return getattr(self._context, "iteration", None)
 
     @property
     def previous_tools(self):
         """List of tools called in previous iterations."""
-        return self._previous_tools
+        return getattr(self._context, "previous_tools", [])
 
     def _update(self, agent, user_prompt, messages, iteration, previous_tools):
         """Internal: Update context (called by tool_executor before tool runs)."""
-        self._agent = agent
-        self._user_prompt = user_prompt
-        self._messages = messages
-        self._iteration = iteration
-        self._previous_tools = previous_tools
+        self._context.agent = agent
+        self._context.user_prompt = user_prompt
+        self._context.messages = messages
+        self._context.iteration = iteration
+        self._context.previous_tools = previous_tools
 
     def _clear(self):
         """Internal: Clear context after tool execution."""
-        self._agent = None
-        self._user_prompt = None
-        self._messages = []
-        self._iteration = None
-        self._previous_tools = []
+        self._context.agent = None
+        self._context.user_prompt = None
+        self._context.messages = []
+        self._context.iteration = None
+        self._context.previous_tools = []
 
     def __repr__(self):
         """Provide helpful representation for debugging."""
-        if not self._agent:
+        if not self.agent:
             return "<xray (no active context)>"
 
-        agent_name = self._agent.name if self._agent else 'None'
-        prompt_preview = (self._user_prompt[:50] + '...') if self._user_prompt and len(self._user_prompt) > 50 else self._user_prompt
+        agent_name = self.agent.name if self.agent else 'None'
+        prompt = self.user_prompt
+        prompt_preview = (prompt[:50] + '...') if prompt and len(prompt) > 50 else prompt
 
         lines = [
             f"<xray active>",
             f"  agent: '{agent_name}'",
             f"  task: '{prompt_preview}'",
-            f"  iteration: {self._iteration}",
-            f"  messages: {len(self._messages)} items",
+            f"  iteration: {self.iteration}",
+            f"  messages: {len(self.messages)} items",
         ]
 
-        if self._previous_tools:
-            lines.append(f"  previous_tools: {self._previous_tools}")
+        if self.previous_tools:
+            lines.append(f"  previous_tools: {self.previous_tools}")
 
         return '\n'.join(lines)
 

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -518,7 +518,7 @@ class RemoteAgent:
             # Add new tool_call UI event with running status
             self._add_ui_event({
                 "type": "tool_call",
-                "id": event.get("id"),
+                "id": event.get("tool_id") or event.get("id"),
                 "name": event.get("name"),
                 "args": event.get("args"),
                 "status": "running"
@@ -526,10 +526,11 @@ class RemoteAgent:
 
         elif event_type == "tool_result":
             # Find and update existing tool_call by id
-            tool_id = event.get("id")
+            tool_id = event.get("tool_id") or event.get("id")
             for ui_event in self._ui_events:
                 if ui_event.get("type") == "tool_call" and ui_event.get("id") == tool_id:
-                    ui_event["status"] = "done" if event.get("status") == "success" else "error"
+                    raw_status = event.get("status")
+                    ui_event["status"] = "done" if raw_status in ("success", "interrupted") else "error"
                     ui_event["result"] = event.get("result")
                     break
 

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -25,6 +25,7 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
     except Exception as e:
         result_holder[0] = e
     finally:
+        io.close()
         io.mark_agent_done()
 
 

--- a/connectonion/network/io/base.py
+++ b/connectonion/network/io/base.py
@@ -13,6 +13,8 @@ IO interface for agent-client communication during hosted execution.
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
+from ...core.interrupt import AgentInterrupted
+
 
 class IO(ABC):
     """Base IO interface for agent-client communication.
@@ -102,12 +104,17 @@ class IO(ABC):
         Returns:
             True if approved, False if rejected
 
+        Raises:
+            AgentInterrupted: If the client stops the active run.
+
         Example:
             if not io.request_approval("delete_file", {"path": "/tmp/x"}):
                 raise ToolRejected()
         """
         self.send({"type": "approval_needed", "tool": tool, "arguments": arguments})
         response = self.receive()
+        if response.get("type") == "INTERRUPT":
+            raise AgentInterrupted()
         return response.get("approved", False)
 
     def send_image(self, image_data: str) -> None:

--- a/connectonion/network/io/base.py
+++ b/connectonion/network/io/base.py
@@ -38,6 +38,8 @@ class IO(ABC):
                         raise ToolRejected()
     """
 
+    supports_interrupts = False
+
     # ═══════════════════════════════════════════════════════
     # LOW-LEVEL API (Primitives)
     # ═══════════════════════════════════════════════════════
@@ -72,6 +74,14 @@ class IO(ABC):
             List of messages (empty if none).
         """
         pass
+
+    def requeue(self, message: Dict[str, Any]) -> None:
+        """Restore a selectively received message to the agent mailbox.
+
+        IO implementations that set ``supports_interrupts = True`` must
+        implement this operation so completed work can win an interrupt race.
+        """
+        raise NotImplementedError
 
     # ═══════════════════════════════════════════════════════
     # HIGH-LEVEL API (Patterns)

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -52,20 +52,23 @@ class WebSocketIO(IO):
 
         Auto-generates 'id' (UUID) and 'ts' (timestamp) if not present.
         """
-        if not self._closed:
+        with self._agent_condition:
+            if self._closed:
+                return
             if 'id' not in message:
                 message['id'] = str(uuid.uuid4())
             if 'ts' not in message:
                 message['ts'] = time.time()
-            with self._agent_condition:
-                self._msgs_from_agent.append(message)
-                self._agent_condition.notify_all()
+            self._msgs_from_agent.append(message)
+            self._agent_condition.notify_all()
 
     def receive(self) -> Dict[str, Any]:
         """Block until client message arrives."""
         with self._client_condition:
-            while not self._msgs_from_client:
+            while not self._msgs_from_client and not self._closed:
                 self._client_condition.wait()
+            if not self._msgs_from_client:
+                return {'type': 'io_closed'}
             return self._msgs_from_client.pop(0)
 
     def receive_all(self, msg_type: str = None) -> list[Dict[str, Any]]:
@@ -92,8 +95,12 @@ class WebSocketIO(IO):
             self._agent_condition.notify_all()
 
     def close(self):
-        """Mark IO as closed (prevents further sends)."""
-        self._closed = True
+        """Prevent further sends and unblock agent-side receive calls."""
+        with self._agent_condition:
+            self._closed = True
+            self._agent_condition.notify_all()
+        with self._client_condition:
+            self._client_condition.notify_all()
 
     # ═══════════════════════════════════════════════════════
     # Transport side (async)

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -26,6 +26,8 @@ class WebSocketIO(IO):
     - Client messages (client→agent): mailbox, selective receive, consumed on read
     """
 
+    supports_interrupts = True
+
     def __init__(self):
         # ── Agent messages (agent→client) ──
         self._msgs_from_agent: list[Dict[str, Any]] = []
@@ -88,6 +90,12 @@ class WebSocketIO(IO):
             self._msgs_from_client[:] = remaining
             return matched
 
+    def requeue(self, message: Dict[str, Any]) -> None:
+        """Restore a selectively received message to the agent mailbox."""
+        with self._client_condition:
+            self._msgs_from_client.append(message)
+            self._client_condition.notify_all()
+
     def mark_agent_done(self):
         """Signal that agent is done producing messages."""
         with self._agent_condition:
@@ -108,9 +116,7 @@ class WebSocketIO(IO):
 
     def send_to_agent(self, msg: Dict[str, Any]) -> None:
         """Deliver client message to agent mailbox."""
-        with self._client_condition:
-            self._msgs_from_client.append(msg)
-            self._client_condition.notify_all()
+        self.requeue(msg)
 
     def push_runtime_input(self, msg: Dict[str, Any]) -> None:
         """Queue a mid-execution user message; agent drains at next iteration."""

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -203,6 +203,7 @@ from typing import TYPE_CHECKING
 from pathlib import Path
 
 from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
+from ...core.interrupt import AgentInterrupted
 from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
 from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
 
@@ -550,6 +551,10 @@ def check_approval(agent: 'Agent') -> None:
 
     # Wait for client response (BLOCKS)
     response = agent.io.receive()
+
+    if response.get('type') == 'INTERRUPT':
+        agent.current_session['stop_signal'] = 'user_interrupt'
+        raise AgentInterrupted()
 
     # Handle connection closed
     if response.get('type') == 'io_closed':

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -725,13 +725,10 @@ def poll_mode_changes(agent: 'Agent') -> None:
 
 @after_iteration
 def poll_interrupt(agent: 'Agent') -> None:
-    """Stop the run at the iteration boundary when the client sent an INTERRUPT.
+    """Fallback for interrupts not consumed by a blocking-step wrapper.
 
-    Graceful stop: drains an INTERRUPT frame and sets the existing stop_signal,
-    which the iteration loop already honors right after after_iteration (halts and
-    returns a closing message). Runs after_iteration so the current step (LLM call
-    + tools) finishes first — not a mid-flight abort. Same primitive and placement
-    as no_progress_guard; no core changes.
+    Mid-flight LLM calls, tools, and interactive gates handle INTERRUPT directly.
+    This iteration-boundary poll preserves Stop behavior for any remaining frame.
     """
     if not agent.io:
         return

--- a/connectonion/useful_tools/ask_user.py
+++ b/connectonion/useful_tools/ask_user.py
@@ -9,6 +9,8 @@ LLM-Note:
 
 from typing import List
 
+from ..core.interrupt import AgentInterrupted
+
 
 def ask_user(
     agent,
@@ -43,4 +45,8 @@ def ask_user(
     if fields:
         event["fields"] = fields
     agent.io.send(event)
-    return agent.io.receive().get("answer", "")
+    response = agent.io.receive()
+    if response.get("type") == "INTERRUPT":
+        agent.current_session["stop_signal"] = "user_interrupt"
+        raise AgentInterrupted()
+    return response.get("answer", "")

--- a/connectonion/useful_tools/diff_writer.py
+++ b/connectonion/useful_tools/diff_writer.py
@@ -34,6 +34,8 @@ import difflib
 from pathlib import Path
 from typing import Optional, Tuple
 
+from ..core.interrupt import AgentInterrupted
+
 
 # Permission modes (like Claude Code's Shift+Tab cycle)
 MODE_NORMAL = "normal"      # Prompt for every edit
@@ -229,6 +231,9 @@ class DiffWriter:
 
         # Block waiting for response
         response = io.receive()
+
+        if response.get("type") == "INTERRUPT":
+            raise AgentInterrupted()
 
         # Handle connection closed
         if response.get("type") == "io_closed":

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -159,6 +159,24 @@ Description defaults to `"Execute the add tool."`
 
 ---
 
+## Interrupt behavior
+
+For hosted WebSocket and relay agents, clicking Stop abandons an in-flight tool
+within roughly 200–300ms. ConnectOnion records the tool as `interrupted`, supplies
+tool-result messages for every call in the batch, and ignores the abandoned
+function's eventual return value.
+
+Python threads cannot be killed safely. Treat interrupt as **abandon**, not
+**cancel**: filesystem writes, browser clicks, subprocesses, or network requests
+that already started may still finish in the background. Tool authors should keep
+side effects explicit and may add their own cooperative cancellation between
+operations when stronger semantics are required.
+
+Local agents and HTTP `POST /input` do not have an interrupt mailbox, so their
+tools continue to run synchronously.
+
+---
+
 ## Stateful Tools (class-based tools)
 
 **✅ RECOMMENDED: Pass the class instance directly to ConnectOnion!**

--- a/docs/design-decisions/019-agent-lifecycle-design.md
+++ b/docs/design-decisions/019-agent-lifecycle-design.md
@@ -474,8 +474,9 @@ side effects in the background, but its result and late IO events are discarded.
 The agent writes terminal `interrupted` trace entries and keeps every assistant
 tool call paired with a tool result so the next user turn has valid message history.
 
-This fast path is available to WebSocket and relay executions whose IO supports
-selective `receive_all`. Local agents and HTTP `POST /input` remain synchronous.
+This fast path is available to WebSocket and relay executions whose IO declares
+`supports_interrupts` and provides selective `receive_all` plus `requeue`. Local
+agents and HTTP `POST /input` remain synchronous.
 
 **Use cases:**
 - User rejects a tool execution (hard reject)

--- a/docs/design-decisions/019-agent-lifecycle-design.md
+++ b/docs/design-decisions/019-agent-lifecycle-design.md
@@ -462,11 +462,20 @@ Plugins can stop the iteration loop by setting `stop_signal` in the session:
 agent.current_session['stop_signal'] = "User rejected the tool"
 ```
 
-When `stop_signal` is set:
-1. The current iteration completes
-2. `@after_iteration` fires
-3. Agent checks `stop_signal` and returns immediately
-4. User must send a new message to continue
+When a plugin sets `stop_signal`, the current iteration completes, `@after_iteration`
+fires, and the agent returns immediately. A WebSocket `INTERRUPT` can also set the
+same signal while the agent is blocked in an LLM call, tool, approval, or
+`ask_user` wait. LLM calls and tool functions run on disposable daemon threads,
+so the agent can abandon their result within one 200ms poll. Interactive gates
+consume the interrupt directly and raise into the same stop path.
+
+An interrupt does not kill arbitrary Python. An abandoned tool may finish external
+side effects in the background, but its result and late IO events are discarded.
+The agent writes terminal `interrupted` trace entries and keeps every assistant
+tool call paired with a tool result so the next user turn has valid message history.
+
+This fast path is available to WebSocket and relay executions whose IO supports
+selective `receive_all`. Local agents and HTTP `POST /input` remain synchronous.
 
 **Use cases:**
 - User rejects a tool execution (hard reject)

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -93,8 +93,14 @@ class IO:
         """Two-way: request permission, wait for response."""
         self.send({"type": "approval_needed", "tool": tool, "arguments": arguments})
         response = self.receive()
+        if response.get("type") == "INTERRUPT":
+            raise AgentInterrupted()
         return response.get("approved", False)
 ```
+
+`INTERRUPT` is never treated as a rejection. The framework raises it into the
+agent loop, which records an interrupted tool result and follows the normal Stop
+path.
 
 ---
 

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -50,15 +50,18 @@ Same events. Same code. Just check `if agent.io:`.
 │  io.log(type, **data)          → one-way notify             │
 │  io.request_approval(tool, args) → bool (two-way)           │
 ├─────────────────────────────────────────────────────────────┤
-│  LOW-LEVEL API (2 methods)                                  │
-│  ─────────────────────────                                  │
+│  LOW-LEVEL API                                              │
+│  ─────────────                                              │
 │  io.send(event)                → send any event             │
 │  io.receive()                  → get response               │
+│  io.receive_all(type)          → selectively drain mailbox  │
+│  io.requeue(message)           → restore a drained message  │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 **High-level**: `log()` for notifications, `request_approval()` for permissions
-**Low-level**: `send()` / `receive()` for custom needs
+**Low-level**: `send()` / `receive()` for custom needs; interrupt-capable IO also
+uses selective `receive_all()` / `requeue()` mailbox operations
 
 ---
 
@@ -67,6 +70,8 @@ Same events. Same code. Just check `if agent.io:`.
 ```python
 class IO:
     """IO to client for real-time communication."""
+
+    supports_interrupts = False
 
     # ═══════════════════════════════════════════════════════
     # LOW-LEVEL API (Primitives)
@@ -77,6 +82,12 @@ class IO:
 
     def receive(self) -> dict:
         """Receive response from client."""
+
+    def receive_all(self, msg_type: str | None = None) -> list[dict]:
+        """Selectively drain pending client messages."""
+
+    def requeue(self, message: dict) -> None:
+        """Restore a selectively received message."""
 
     # ═══════════════════════════════════════════════════════
     # HIGH-LEVEL API (Patterns)
@@ -100,7 +111,9 @@ class IO:
 
 `INTERRUPT` is never treated as a rejection. The framework raises it into the
 agent loop, which records an interrupted tool result and follows the normal Stop
-path.
+path. IO implementations opt into mid-flight interruption with
+`supports_interrupts = True`; they must preserve nonmatching messages in
+`receive_all` and implement `requeue` for completion races.
 
 ---
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -216,6 +216,28 @@ Send a prompt. Only valid after CONNECTED. **No session data — just the prompt
 
 If sent while the session's agent is already running, this message is routed as runtime input: the prompt is appended to the running agent's message history (with framing telling the LLM to treat it as additional context, not a replacement) and the server replies `RUNTIME_INPUT_ACK` instead of starting a new OUTPUT cycle. No new `thinking` chat item is created — the existing one keeps streaming.
 
+#### INTERRUPT
+
+Stop the active agent run without waiting for its current LLM call or tool to
+finish:
+
+```json
+{
+  "type": "INTERRUPT"
+}
+```
+
+The server forwards the frame to the running agent's mailbox. Blocking LLM and
+tool steps are abandoned on the next 200ms poll; approval, `ask_user`, and
+`DiffWriter` waits recognize the frame directly. The run then follows the normal
+stop path and finishes with an `OUTPUT` whose result is
+`"What would you like me to do?"`.
+
+There is no interrupt acknowledgement frame. Stop means the agent discards the
+worker's eventual result; it does not kill arbitrary Python or guarantee that an
+already-started external side effect is cancelled. Late events from the abandoned
+worker are suppressed when the execution IO closes.
+
 #### PONG
 
 ```json

--- a/tests/e2e/test_host_ws.py
+++ b/tests/e2e/test_host_ws.py
@@ -260,7 +260,10 @@ class TestWebSocketHardInterrupt:
                     await incoming.put({"type": "websocket.disconnect"})
 
             async def interrupt_when_started():
-                await asyncio.get_running_loop().run_in_executor(None, started.wait, 1)
+                did_start = await asyncio.get_running_loop().run_in_executor(
+                    None, started.wait, 1
+                )
+                assert did_start, f"{blocked_step} did not start before interrupt"
                 interrupt_sent_at[0] = time.monotonic()
                 await incoming.put({
                     "type": "websocket.receive",

--- a/tests/e2e/test_host_ws.py
+++ b/tests/e2e/test_host_ws.py
@@ -32,6 +32,7 @@ Components under test:
 
 import asyncio
 import json
+import threading
 import time
 import pytest
 from nacl.signing import SigningKey
@@ -175,6 +176,143 @@ class TestWebSocket:
         sent = client.send_text("{not json}")
         errs = [json.loads(m["text"]) for m in sent if m.get("type") == "websocket.send"]
         assert any(e.get("type") == "ERROR" and "Invalid JSON" in e.get("message", "") for e in errs)
+
+
+class TestWebSocketHardInterrupt:
+    @pytest.mark.parametrize("blocked_step", ["llm", "tool"])
+    def test_interrupt_closes_trace_and_persists_while_step_is_still_blocked(
+        self, tmp_path, blocked_step
+    ):
+        from connectonion.core.llm import LLMResponse, ToolCall
+        from connectonion.core.usage import TokenUsage
+        from connectonion.network.host import SessionStorage, create_app
+
+        started = threading.Event()
+        release = threading.Event()
+
+        class BlockingLLM:
+            model = "blocking-test"
+
+            def complete(self, messages, tools=None):
+                if blocked_step == "llm":
+                    started.set()
+                    release.wait(timeout=2)
+                    return LLMResponse(
+                        content="late", tool_calls=[], raw_response={}, usage=TokenUsage()
+                    )
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(name="slow_tool", arguments={}, id="slow-call")],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+
+        def slow_tool() -> str:
+            started.set()
+            release.wait(timeout=2)
+            return "late"
+
+        def create_interrupt_agent():
+            tools = [slow_tool] if blocked_step == "tool" else None
+            return Agent(
+                "interrupt-agent",
+                llm=BlockingLLM(),
+                tools=tools,
+                log=False,
+                quiet=True,
+            )
+
+        storage = SessionStorage(str(tmp_path / "interrupt-sessions.jsonl"))
+        app = create_app(
+            create_interrupt_agent,
+            storage=storage,
+            trust="open",
+            result_ttl=3600,
+        )
+
+        async def scenario():
+            incoming = asyncio.Queue()
+            sent = []
+            output_received = asyncio.Event()
+            interrupt_sent_at = [None]
+            output_received_at = [None]
+            key = SigningKey.generate()
+            session_id = f"hard-interrupt-{blocked_step}"
+            connect = sign_init(key)
+            connect["session_id"] = session_id
+            await incoming.put({"type": "websocket.receive", "text": json.dumps(connect)})
+            await incoming.put({
+                "type": "websocket.receive",
+                "text": json.dumps({"type": "INPUT", "prompt": "slow"}),
+            })
+
+            async def receive():
+                return await incoming.get()
+
+            async def send(message):
+                sent.append(message)
+                if message.get("type") != "websocket.send":
+                    return
+                payload = json.loads(message["text"])
+                if payload.get("type") == "OUTPUT":
+                    output_received_at[0] = time.monotonic()
+                    output_received.set()
+                    await incoming.put({"type": "websocket.disconnect"})
+
+            async def interrupt_when_started():
+                await asyncio.get_running_loop().run_in_executor(None, started.wait, 1)
+                interrupt_sent_at[0] = time.monotonic()
+                await incoming.put({
+                    "type": "websocket.receive",
+                    "text": json.dumps({"type": "INTERRUPT"}),
+                })
+
+            feeder = asyncio.create_task(interrupt_when_started())
+            scope = {"type": "websocket", "path": "/ws", "query_string": b"", "headers": []}
+            await asyncio.wait_for(app(scope, receive, send), timeout=1.5)
+            await feeder
+            assert output_received.is_set()
+            payloads = [
+                json.loads(message["text"])
+                for message in sent
+                if message.get("type") == "websocket.send"
+            ]
+            output = next(payload for payload in payloads if payload.get("type") == "OUTPUT")
+            assert output["result"] == "What would you like me to do?"
+            assert output_received_at[0] - interrupt_sent_at[0] < 0.8
+
+            running_type = f"{blocked_step}_call"
+            terminal_type = f"{blocked_step}_result"
+            correlation_key = "id" if blocked_step == "llm" else "tool_id"
+            running = [payload for payload in payloads if payload.get("type") == running_type]
+            terminal = [payload for payload in payloads if payload.get("type") == terminal_type]
+            assert len(running) == len(terminal) == 1
+            assert terminal[0][correlation_key] == running[0][correlation_key]
+            assert terminal[0]["status"] == "interrupted"
+
+            session_trace = output["session"]["trace"]
+            session_terminal = [
+                entry for entry in session_trace if entry.get("type") == terminal_type
+            ]
+            assert session_terminal[-1][correlation_key] == running[0][correlation_key]
+            assert session_terminal[-1]["status"] == "interrupted"
+
+            if blocked_step == "tool":
+                tool_item = next(item for item in output["chat_items"] if item["type"] == "tool_call")
+                assert tool_item["id"] == "slow-call"
+                assert tool_item["status"] == "done"
+                assert tool_item["result"] == "Interrupted by user"
+
+            stored = storage.get(session_id)
+            assert stored is not None
+            assert stored.status == "done"
+            assert stored.result == "What would you like me to do?"
+            assert stored.session["trace"][-1]["status"] == "interrupted"
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            release.set()
 
 
 class TestWebSocketStrict:

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -736,13 +736,15 @@ class TestGracefulInterrupt:
             return "noted"
 
         class InterruptIO:
+            supports_interrupts = True
+
             def __init__(self):
                 self.sent = []
 
             def receive_all(self, msg_type=None):
                 return [{'type': 'INTERRUPT'}] if msg_type == 'INTERRUPT' else []
 
-            def send_to_agent(self, message):
+            def requeue(self, message):
                 pass
 
             def send(self, event):
@@ -800,8 +802,12 @@ class TestGracefulInterrupt:
         agent = Agent("hard-stop", llm=llm, on_events=[record_stop], log=False, quiet=True)
         agent.io = io
 
+        def interrupt_when_started():
+            assert started.wait(timeout=1)
+            io.send_to_agent({"type": "INTERRUPT"})
+
         sender = threading.Thread(
-            target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+            target=interrupt_when_started,
             daemon=True,
         )
         sender.start()
@@ -824,6 +830,41 @@ class TestGracefulInterrupt:
         release.set()
         time.sleep(0.02)
         assert all(message.get('content') != 'late' for message in agent.current_session['messages'])
+
+    def test_llm_call_snapshots_messages_before_worker_starts(self, monkeypatch):
+        received_messages = []
+
+        class CapturingLLM:
+            model = "snapshot-test"
+
+            def complete(self, messages, tools=None):
+                received_messages.extend(messages)
+                return LLMResponse(
+                    content="done",
+                    tool_calls=[],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+
+        agent = Agent("snapshot", llm=CapturingLLM(), log=False, quiet=True)
+
+        def start_after_session_changes(fn, io, poll_seconds=0.2):
+            agent.current_session['messages'].append({
+                'role': 'user',
+                'content': 'next turn',
+            })
+            return fn(), False
+
+        monkeypatch.setattr(
+            "connectonion.core.agent.run_interruptible",
+            start_after_session_changes,
+        )
+
+        assert agent.input("first turn") == "done"
+        assert received_messages == [
+            {'role': 'system', 'content': agent.system_prompt},
+            {'role': 'user', 'content': 'first turn'},
+        ]
 
     def test_none_llm_response_is_not_mistaken_for_user_interrupt(self):
         from connectonion import on_stop_signal
@@ -913,8 +954,13 @@ class TestGracefulInterrupt:
             quiet=True,
         )
         agent.io = io
+
+        def interrupt_when_started():
+            assert started.wait(timeout=1)
+            io.send_to_agent({"type": "INTERRUPT"})
+
         sender = threading.Thread(
-            target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+            target=interrupt_when_started,
             daemon=True,
         )
         sender.start()

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -9,6 +9,8 @@ Components under test:
 - Module: agent
 """
 
+import threading
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -723,25 +725,25 @@ def test_agent_input_file_path_traversal(tmp_path):
 
 
 class TestGracefulInterrupt:
-    """A client INTERRUPT stops the loop at the iteration boundary with a closing message."""
+    """A client INTERRUPT stops blocking work with a closing message."""
 
-    def test_interrupt_stops_after_current_step_with_message(self):
-        """The current step finishes, then poll_interrupt (after_iteration) halts the
-        loop via the existing stop_signal check — no silent cutoff, no extra LLM call."""
+    def test_pending_interrupt_prevents_step_from_starting(self):
+        """An already queued stop prevents the next LLM call from starting."""
         from connectonion.useful_plugins.tool_approval import poll_interrupt
 
         def note(text: str) -> str:
             """Record a note."""
             return "noted"
 
-        # INTERRUPT is queued; poll_interrupt drains it at iteration 1's after_iteration
-        # (after the LLM call + tools), and the loop's existing bottom check stops there.
         class InterruptIO:
             def __init__(self):
                 self.sent = []
 
             def receive_all(self, msg_type=None):
                 return [{'type': 'INTERRUPT'}] if msg_type == 'INTERRUPT' else []
+
+            def send_to_agent(self, message):
+                pass
 
             def send(self, event):
                 self.sent.append(event)
@@ -765,7 +767,188 @@ class TestGracefulInterrupt:
         result = agent.input("do work")
 
         assert result == "What would you like me to do?"  # existing stop_signal message
-        assert mock_llm.call_count == 1  # one step ran; stopped before a 2nd LLM call
+        assert mock_llm.call_count == 0
+
+    def test_interrupt_abandons_llm_and_next_turn_is_valid(self):
+        from connectonion import on_stop_signal
+        from connectonion.network.io import WebSocketIO
+
+        started = threading.Event()
+        release = threading.Event()
+        stop_events = []
+
+        class BlockingThenImmediateLLM:
+            model = "blocking-test"
+
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, messages, tools=None):
+                self.calls += 1
+                if self.calls == 1:
+                    started.set()
+                    release.wait(timeout=2)
+                    return LLMResponse(content="late", tool_calls=[], raw_response={}, usage=TokenUsage())
+                return LLMResponse(content="second turn", tool_calls=[], raw_response={}, usage=TokenUsage())
+
+        @on_stop_signal
+        def record_stop(agent):
+            stop_events.append(agent.current_session['iteration'])
+
+        io = WebSocketIO()
+        llm = BlockingThenImmediateLLM()
+        agent = Agent("hard-stop", llm=llm, on_events=[record_stop], log=False, quiet=True)
+        agent.io = io
+
+        sender = threading.Thread(
+            target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+            daemon=True,
+        )
+        sender.start()
+        began = time.monotonic()
+        first = agent.input("first turn")
+
+        assert first == "What would you like me to do?"
+        assert time.monotonic() - began < 0.8
+        assert stop_events == [1]
+        assert [m['role'] for m in agent.current_session['messages']] == ['system', 'user']
+        llm_results = [t for t in agent.current_session['trace'] if t['type'] == 'llm_result']
+        assert llm_results[-1]['status'] == 'interrupted'
+
+        second = agent.input("second turn")
+        assert second == "second turn"
+        assert [m['role'] for m in agent.current_session['messages']] == [
+            'system', 'user', 'user', 'assistant'
+        ]
+
+        release.set()
+        time.sleep(0.02)
+        assert all(message.get('content') != 'late' for message in agent.current_session['messages'])
+
+    def test_none_llm_response_is_not_mistaken_for_user_interrupt(self):
+        from connectonion import on_stop_signal
+
+        stop_events = []
+
+        class BrokenLLM:
+            model = "broken-test"
+
+            def complete(self, messages, tools=None):
+                return None
+
+        @on_stop_signal
+        def record_stop(agent):
+            stop_events.append(True)
+
+        agent = Agent(
+            "broken-llm",
+            llm=BrokenLLM(),
+            on_events=[record_stop],
+            log=False,
+            quiet=True,
+        )
+
+        with pytest.raises(AttributeError):
+            agent.input("fail normally")
+
+        assert stop_events == []
+
+    def test_interrupt_abandons_tool_and_next_turn_has_provider_valid_history(self):
+        from connectonion.core.llm import AnthropicLLM
+        from connectonion.network.io import WebSocketIO
+
+        started = threading.Event()
+        release = threading.Event()
+        later_called = False
+        second_call_messages = []
+
+        def slow_tool() -> str:
+            started.set()
+            release.wait(timeout=2)
+            return "late result"
+
+        def later_tool() -> str:
+            nonlocal later_called
+            later_called = True
+            return "must not run"
+
+        class ToolThenAnswerLLM:
+            model = "tool-interrupt-test"
+
+            def __init__(self):
+                self.calls = 0
+
+            def complete(self, messages, tools=None):
+                self.calls += 1
+                if self.calls == 1:
+                    return LLMResponse(
+                        content="",
+                        tool_calls=[
+                            ToolCall(
+                                name="slow_tool",
+                                arguments={},
+                                id="slow-call",
+                                extra_content={"google": {"thought_signature": "sig"}},
+                            ),
+                            ToolCall(name="later_tool", arguments={}, id="later-call"),
+                        ],
+                        raw_response={},
+                        usage=TokenUsage(),
+                    )
+                second_call_messages.extend(messages)
+                return LLMResponse(
+                    content="next turn is valid",
+                    tool_calls=[],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+
+        io = WebSocketIO()
+        llm = ToolThenAnswerLLM()
+        agent = Agent(
+            "tool-hard-stop",
+            llm=llm,
+            tools=[slow_tool, later_tool],
+            log=False,
+            quiet=True,
+        )
+        agent.io = io
+        sender = threading.Thread(
+            target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+            daemon=True,
+        )
+        sender.start()
+
+        assert agent.input("first turn") == "What would you like me to do?"
+        assert later_called is False
+        assert agent.input("second turn") == "next turn is valid"
+
+        assistant = next(message for message in second_call_messages if message["role"] == "assistant")
+        assert assistant["tool_calls"][0]["extra_content"] == {
+            "google": {"thought_signature": "sig"}
+        }
+        tool_results = [message for message in second_call_messages if message["role"] == "tool"]
+        assert [(message["tool_call_id"], message["content"]) for message in tool_results] == [
+            ("slow-call", "Interrupted by user"),
+            ("later-call", "Rejected by user"),
+        ]
+
+        anthropic_messages = AnthropicLLM.__new__(AnthropicLLM)._convert_messages(second_call_messages)
+        tool_use_ids = [
+            item["id"]
+            for message in anthropic_messages
+            for item in message["content"] if isinstance(message["content"], list)
+            if item["type"] == "tool_use"
+        ]
+        tool_result_ids = [
+            item["tool_use_id"]
+            for message in anthropic_messages
+            for item in message["content"] if isinstance(message["content"], list)
+            if item["type"] == "tool_result"
+        ]
+        assert tool_result_ids == tool_use_ids == ["slow-call", "later-call"]
+
+        release.set()
 
     def test_no_interrupt_runs_to_completion(self):
         """Without an INTERRUPT the loop is unaffected and finishes normally."""

--- a/tests/unit/test_ask_user.py
+++ b/tests/unit/test_ask_user.py
@@ -17,6 +17,7 @@ from connectonion.core.tool_factory import create_tool_from_function
 from connectonion.core.tool_executor import execute_single_tool
 from connectonion.core.tool_registry import ToolRegistry
 from connectonion.logger import Logger
+from connectonion.core.interrupt import AgentInterrupted
 
 
 class FakeAgent:
@@ -132,6 +133,16 @@ class TestAskUserTool:
 
         assert result == ""
 
+    def test_interrupt_is_not_treated_as_an_answer(self):
+        agent = FakeAgent()
+        agent.io = Mock()
+        agent.io.receive.return_value = {"type": "INTERRUPT"}
+
+        with pytest.raises(AgentInterrupted):
+            ask_user(agent, "Question?", options=["A", "B"])
+
+        assert agent.current_session['stop_signal'] == 'user_interrupt'
+
 
 class TestAskUserSchema:
     """Test that ask_user schema excludes agent parameter."""
@@ -192,6 +203,26 @@ class TestAskUserInjection:
         # Second call should be the ask_user event
         second_call = agent.io.send.call_args_list[1]
         assert second_call[0][0]["type"] == "ask_user"
+
+    def test_interrupt_closes_tool_trace(self):
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(ask_user))
+        agent = FakeAgent()
+        agent.io = Mock()
+        agent.io.receive.return_value = {"type": "INTERRUPT"}
+
+        trace = execute_single_tool(
+            tool_name="ask_user",
+            tool_args={"question": "Test?", "options": ["A", "B"]},
+            tool_id="call_interrupt",
+            tools=tools,
+            agent=agent,
+            logger=Logger("test", log=False),
+        )
+
+        assert trace["status"] == "interrupted"
+        assert trace["result"] == "Interrupted by user"
+        assert agent.current_session["stop_signal"] == "user_interrupt"
 
     def test_agent_not_injected_for_other_tools(self):
         """tool_executor does not inject agent for regular tools."""

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -231,6 +231,26 @@ class TestUIEventTransformation:
 
         assert agent.ui[0]["status"] == "error"
 
+    def test_handle_interrupted_tool_result_as_completed(self):
+        agent = RemoteAgent("0x123")
+        agent._handle_stream_event({
+            "type": "tool_call",
+            "id": "trace-start",
+            "tool_id": "tc1",
+            "name": "search",
+        })
+        agent._handle_stream_event({
+            "type": "tool_result",
+            "id": "trace-end",
+            "tool_id": "tc1",
+            "result": "Interrupted by user",
+            "status": "interrupted",
+        })
+
+        assert agent.ui[0]["id"] == "tc1"
+        assert agent.ui[0]["status"] == "done"
+        assert agent.ui[0]["result"] == "Interrupted by user"
+
     def test_handle_thinking_event(self):
         """Test thinking event adds thinking indicator."""
         agent = RemoteAgent("0x123")

--- a/tests/unit/test_diff_writer_tool.py
+++ b/tests/unit/test_diff_writer_tool.py
@@ -23,6 +23,7 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from connectonion.useful_tools.diff_writer import DiffWriter, MODE_NORMAL, MODE_AUTO, MODE_PLAN
+from connectonion.core.interrupt import AgentInterrupted
 
 
 class TestDiffWriterRead:
@@ -176,6 +177,18 @@ class TestDiffWriterWrite:
             assert not path.exists()
             assert "rejected" in result
             assert "different naming" in result
+
+    def test_interrupt_during_approval_does_not_write(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.txt"
+            io = Mock()
+            io.receive.return_value = {"type": "INTERRUPT"}
+            agent = Mock(io=io)
+
+            with pytest.raises(AgentInterrupted):
+                DiffWriter(mode=MODE_NORMAL).write(agent, str(path), "content")
+
+            assert not path.exists()
 
     def test_write_plan_mode_no_write(self):
         """Test plan mode doesn't write file."""

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -644,6 +644,7 @@ class TestSessionToChatItems:
                 {'type': 'tool_result', 'tool_id': 'b', 'name': 'write', 'status': 'running'},
                 {'type': 'tool_result', 'tool_id': 'c', 'name': 'edit', 'status': 'success'},
                 {'type': 'tool_result', 'tool_id': 'd', 'name': 'cmd', 'status': 'not_found'},
+                {'type': 'tool_result', 'tool_id': 'e', 'name': 'slow', 'status': 'interrupted'},
             ],
         }
 
@@ -653,6 +654,7 @@ class TestSessionToChatItems:
         assert items[1]['status'] == 'running'
         assert items[2]['status'] == 'done'
         assert items[3]['status'] == 'error'
+        assert items[4]['status'] == 'done'
 
     def test_skips_tool_call_placeholders(self):
         """Initial 'tool_call' trace entries (no result yet) are skipped — only 'tool_result' renders."""

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -1,0 +1,139 @@
+"""Tests for abandoning blocking agent steps on user interrupt."""
+
+import threading
+import time
+
+import pytest
+
+from connectonion.core.interrupt import run_interruptible
+
+
+class MailboxIO:
+    def __init__(self, messages=None):
+        self.messages = list(messages or [])
+        self.lock = threading.Lock()
+
+    def receive_all(self, msg_type=None):
+        with self.lock:
+            matched = [m for m in self.messages if msg_type is None or m.get("type") == msg_type]
+            self.messages = [m for m in self.messages if m not in matched]
+            return matched
+
+    def send_to_agent(self, message):
+        with self.lock:
+            self.messages.append(message)
+
+
+def test_without_interrupt_capable_io_runs_inline():
+    caller_thread = threading.get_ident()
+
+    result, interrupted = run_interruptible(threading.get_ident, io=None)
+
+    assert result == caller_thread
+    assert interrupted is False
+
+
+def test_selective_receive_without_requeue_runs_inline():
+    class ReceiveOnlyIO:
+        def receive_all(self, msg_type=None):
+            return []
+
+    caller_thread = threading.get_ident()
+
+    result, interrupted = run_interruptible(threading.get_ident, ReceiveOnlyIO())
+
+    assert result == caller_thread
+    assert interrupted is False
+
+
+def test_inline_exception_propagates():
+    def fail():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_interruptible(fail, io=None)
+
+
+def test_pending_interrupt_prevents_step_from_starting():
+    called = False
+    io = MailboxIO([{"type": "mode_change"}, {"type": "INTERRUPT"}])
+
+    def work():
+        nonlocal called
+        called = True
+
+    result, interrupted = run_interruptible(work, io)
+
+    assert result is None
+    assert interrupted is True
+    assert called is False
+    assert io.messages == [{"type": "mode_change"}]
+
+
+def test_interrupt_abandons_running_step_within_poll_bound():
+    io = MailboxIO()
+    started = threading.Event()
+    release = threading.Event()
+
+    def work():
+        started.set()
+        release.wait(timeout=2)
+        return "late"
+
+    timer = threading.Thread(
+        target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+        daemon=True,
+    )
+    timer.start()
+    began = time.monotonic()
+    result, interrupted = run_interruptible(work, io, poll_seconds=0.02)
+    elapsed = time.monotonic() - began
+    release.set()
+
+    assert result is None
+    assert interrupted is True
+    assert elapsed < 0.3
+
+
+def test_completed_step_wins_same_window_race():
+    class RaceIO:
+        def __init__(self):
+            self.calls = 0
+            self.release = threading.Event()
+            self.completed = threading.Event()
+            self.messages = []
+
+        def receive_all(self, msg_type=None):
+            self.calls += 1
+            if self.calls == 1:
+                return []
+            self.release.set()
+            assert self.completed.wait(timeout=1)
+            return [{"type": "INTERRUPT"}]
+
+        def send_to_agent(self, message):
+            self.messages.append(message)
+
+    io = RaceIO()
+
+    def work():
+        io.release.wait(timeout=1)
+        io.completed.set()
+        return "finished"
+
+    result, interrupted = run_interruptible(work, io, poll_seconds=0.05)
+
+    assert result == "finished"
+    assert interrupted is False
+    assert io.calls == 2
+    assert io.messages == [{"type": "INTERRUPT"}]
+
+
+def test_worker_exception_re_raises_on_caller_thread():
+    io = MailboxIO()
+
+    def fail():
+        raise ValueError("worker failed")
+
+    with pytest.raises(ValueError, match="worker failed"):
+        run_interruptible(fail, io)

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -9,6 +9,8 @@ from connectonion.core.interrupt import run_interruptible
 
 
 class MailboxIO:
+    supports_interrupts = True
+
     def __init__(self, messages=None):
         self.messages = list(messages or [])
         self.lock = threading.Lock()
@@ -19,9 +21,12 @@ class MailboxIO:
             self.messages = [m for m in self.messages if m not in matched]
             return matched
 
-    def send_to_agent(self, message):
+    def requeue(self, message):
         with self.lock:
             self.messages.append(message)
+
+    def send_to_agent(self, message):
+        self.requeue(message)
 
 
 def test_without_interrupt_capable_io_runs_inline():
@@ -33,7 +38,7 @@ def test_without_interrupt_capable_io_runs_inline():
     assert interrupted is False
 
 
-def test_selective_receive_without_requeue_runs_inline():
+def test_selective_receive_without_interrupt_capability_runs_inline():
     class ReceiveOnlyIO:
         def receive_all(self, msg_type=None):
             return []
@@ -80,8 +85,12 @@ def test_interrupt_abandons_running_step_within_poll_bound():
         release.wait(timeout=2)
         return "late"
 
+    def interrupt_when_started():
+        assert started.wait(timeout=1)
+        io.send_to_agent({"type": "INTERRUPT"})
+
     timer = threading.Thread(
-        target=lambda: (started.wait(timeout=1), io.send_to_agent({"type": "INTERRUPT"})),
+        target=interrupt_when_started,
         daemon=True,
     )
     timer.start()
@@ -97,6 +106,8 @@ def test_interrupt_abandons_running_step_within_poll_bound():
 
 def test_completed_step_wins_same_window_race():
     class RaceIO:
+        supports_interrupts = True
+
         def __init__(self):
             self.calls = 0
             self.release = threading.Event()
@@ -111,7 +122,7 @@ def test_completed_step_wins_same_window_race():
             assert self.completed.wait(timeout=1)
             return [{"type": "INTERRUPT"}]
 
-        def send_to_agent(self, message):
+        def requeue(self, message):
             self.messages.append(message)
 
     io = RaceIO()

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -14,6 +14,7 @@ Components under test:
 import threading
 import pytest
 
+from connectonion.core.interrupt import AgentInterrupted
 from connectonion.network.io import IO, WebSocketIO
 
 
@@ -70,6 +71,34 @@ class TestWebSocketIO:
 
         assert io._msgs_from_agent == []
 
+    def test_close_serializes_with_in_flight_send(self):
+        io = WebSocketIO()
+        send_entered = threading.Event()
+        release_send = threading.Event()
+        close_done = threading.Event()
+
+        class BlockingEvent(dict):
+            def __contains__(self, key):
+                send_entered.set()
+                release_send.wait(timeout=1)
+                return super().__contains__(key)
+
+        sender = threading.Thread(target=lambda: io.send(BlockingEvent(type="late")))
+        sender.start()
+        assert send_entered.wait(timeout=1)
+
+        closer = threading.Thread(target=lambda: (io.close(), close_done.set()))
+        closer.start()
+        assert not close_done.wait(timeout=0.05)
+
+        release_send.set()
+        sender.join(timeout=1)
+        closer.join(timeout=1)
+        io.send({"type": "after-close"})
+
+        assert close_done.is_set()
+        assert [message["type"] for message in io._msgs_from_agent] == ["late"]
+
     def test_receive_returns_from_inbox(self):
         """receive() returns item from incoming mailbox."""
         io = WebSocketIO()
@@ -100,6 +129,20 @@ class TestWebSocketIO:
 
         assert not thread.is_alive()
         assert result_holder[0] == {"approved": True}
+
+    def test_close_unblocks_receive_with_io_closed(self):
+        io = WebSocketIO()
+        result_holder = [None]
+        thread = threading.Thread(target=lambda: result_holder.__setitem__(0, io.receive()))
+        thread.start()
+        thread.join(timeout=0.05)
+        assert thread.is_alive()
+
+        io.close()
+        thread.join(timeout=0.1)
+
+        assert not thread.is_alive()
+        assert result_holder[0] == {"type": "io_closed"}
 
 
 class TestReceiveAll:
@@ -266,6 +309,13 @@ class TestHighLevelAPI:
 
         thread.join(timeout=1)
         assert result is False
+
+    def test_request_approval_interrupt_raises(self):
+        io = WebSocketIO()
+        io.send_to_agent({"type": "INTERRUPT"})
+
+        with pytest.raises(AgentInterrupted):
+            io.request_approval("delete_file", {"path": "/tmp/x"})
 
     def test_wait_for_msgs_returns_promptly_when_idle(self):
         """_wait_for_msgs_from_agent runs on the event loop's shared default

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -40,6 +40,15 @@ class TestWebSocketIO:
         assert io._closed is False
         assert io._finished is False
         assert io._cursor == 0
+        assert io.supports_interrupts is True
+
+    def test_requeue_restores_message_to_agent_mailbox(self):
+        io = WebSocketIO()
+        message = {"type": "INTERRUPT"}
+
+        io.requeue(message)
+
+        assert io.receive_all("INTERRUPT") == [message]
 
     def test_send_appends_event(self):
         """send() appends event to event log with auto-generated id and ts."""

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -43,6 +43,7 @@ from connectonion.useful_plugins.tool_approval.approval import (
     _get_approval_key,
     _resolve_display_name,
 )
+from connectonion.core.interrupt import AgentInterrupted
 
 
 class FakeIO:
@@ -169,6 +170,19 @@ class TestDangerousTools:
         assert io.sent[0]['tool'] == 'bash'  # Changed: no more :npm suffix
         assert io.sent[0]['arguments'] == {'command': 'npm install', 'description': 'Install dependencies'}
         assert io.sent[0]['description'] == 'Install dependencies'
+
+    def test_interrupt_during_approval_sets_stop_signal(self):
+        io = FakeIO(responses=[{'type': 'INTERRUPT'}])
+        agent = FakeAgent(io=io)
+        agent.current_session['pending_tool'] = {
+            'name': 'bash',
+            'arguments': {'command': 'sleep 30'},
+        }
+
+        with pytest.raises(AgentInterrupted):
+            check_approval(agent)
+
+        assert agent.current_session['stop_signal'] == 'user_interrupt'
 
     def test_approved_once_continues(self):
         """Approved with scope=once should continue without saving."""

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -12,7 +12,8 @@ Components under test:
 
 import pytest
 from unittest.mock import Mock, patch
-from connectonion.core.tool_executor import execute_single_tool, _add_assistant_message
+from connectonion.core.tool_executor import execute_and_record_tools, execute_single_tool, _add_assistant_message
+from connectonion.core.interrupt import AgentInterrupted
 from connectonion.core.tool_registry import ToolRegistry
 from connectonion.core.tool_factory import create_tool_from_function
 from connectonion.logger import Logger
@@ -81,6 +82,189 @@ class TestToolExecutor:
             logger=logger,
         )
         assert trace["status"] == "not_found"
+
+    def test_before_tool_interrupt_clears_pending_tool(self):
+        def sample_tool() -> str:
+            return "must not run"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(sample_tool))
+        agent = FakeAgent()
+
+        def interrupt(event_type):
+            if event_type == "before_each_tool":
+                raise AgentInterrupted()
+
+        agent._invoke_events = interrupt
+        trace = execute_single_tool(
+            tool_name="sample_tool",
+            tool_args={},
+            tool_id="call_interrupt",
+            tools=tools,
+            agent=agent,
+            logger=Logger("test-agent", log=False),
+        )
+
+        assert trace["status"] == "interrupted"
+        assert "pending_tool" not in agent.current_session
+
+    def test_interrupt_abandons_tool_and_completes_batch_messages(self):
+        import threading
+        import time
+
+        from connectonion.network.io import WebSocketIO
+
+        started = threading.Event()
+        release = threading.Event()
+        later_called = False
+
+        def slow_tool() -> str:
+            started.set()
+            release.wait(timeout=2)
+            return "late result"
+
+        def later_tool() -> str:
+            nonlocal later_called
+            later_called = True
+            return "should not run"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(slow_tool))
+        tools.add(create_tool_from_function(later_tool))
+        agent = FakeAgent()
+        agent.io = WebSocketIO()
+        logger = Logger("test-agent", log=False)
+        calls = [
+            ToolCall(
+                name="slow_tool",
+                arguments={},
+                id="call_1",
+                extra_content={"google": {"thought_signature": "sig"}},
+            ),
+            ToolCall(name="later_tool", arguments={}, id="call_2"),
+        ]
+        sender = threading.Thread(
+            target=lambda: (started.wait(timeout=1), agent.io.send_to_agent({"type": "INTERRUPT"})),
+            daemon=True,
+        )
+        sender.start()
+        began = time.monotonic()
+
+        execute_and_record_tools(calls, tools, agent, logger)
+
+        assert time.monotonic() - began < 0.8
+        assert later_called is False
+        assert agent.current_session['messages'][0]['tool_calls'][0]['extra_content'] == {
+            "google": {"thought_signature": "sig"}
+        }
+        results = agent.current_session['messages'][1:]
+        assert [(m['tool_call_id'], m['content']) for m in results] == [
+            ('call_1', 'Interrupted by user'),
+            ('call_2', 'Rejected by user'),
+        ]
+        terminal = [t for t in agent.current_session['trace'] if t['type'] == 'tool_result'][-1]
+        assert terminal['status'] == 'interrupted'
+        snapshot = list(agent.current_session['trace'])
+        release.set()
+        time.sleep(0.02)
+        assert agent.current_session['trace'] == snapshot
+
+    def test_interrupt_between_tools_prevents_next_tool_from_starting(self):
+        from connectonion.network.io import WebSocketIO
+
+        agent = FakeAgent()
+        agent.io = WebSocketIO()
+        second_called = False
+        third_called = False
+
+        def first_tool() -> str:
+            agent.io.send_to_agent({"type": "INTERRUPT"})
+            return "first done"
+
+        def second_tool() -> str:
+            nonlocal second_called
+            second_called = True
+            return "second done"
+
+        def third_tool() -> str:
+            nonlocal third_called
+            third_called = True
+            return "third done"
+
+        tools = ToolRegistry()
+        for tool in (first_tool, second_tool, third_tool):
+            tools.add(create_tool_from_function(tool))
+        calls = [
+            ToolCall(name="first_tool", arguments={}, id="call_1"),
+            ToolCall(name="second_tool", arguments={}, id="call_2"),
+            ToolCall(name="third_tool", arguments={}, id="call_3"),
+        ]
+
+        execute_and_record_tools(calls, tools, agent, Logger("test-agent", log=False))
+
+        assert second_called is False
+        assert third_called is False
+        results = agent.current_session['messages'][1:]
+        assert [(m['tool_call_id'], m['content']) for m in results] == [
+            ('call_1', 'first done'),
+            ('call_2', 'Interrupted by user'),
+            ('call_3', 'Rejected by user'),
+        ]
+
+    def test_abandoned_worker_keeps_its_xray_context_during_next_tool(self):
+        import builtins
+        import threading
+
+        from connectonion.network.io import WebSocketIO
+
+        started = threading.Event()
+        release = threading.Event()
+        abandoned_done = threading.Event()
+        observed = {}
+
+        def slow_tool() -> str:
+            observed["slow_before"] = builtins.xray.task
+            started.set()
+            release.wait(timeout=2)
+            observed["slow_after"] = builtins.xray.task
+            abandoned_done.set()
+            return "late"
+
+        def next_tool() -> str:
+            observed["next"] = builtins.xray.task
+            return "next"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(slow_tool))
+        tools.add(create_tool_from_function(next_tool))
+        agent = FakeAgent()
+        agent.io = WebSocketIO()
+        agent.current_session["user_prompt"] = "first turn"
+        sender = threading.Thread(
+            target=lambda: (started.wait(timeout=1), agent.io.send_to_agent({"type": "INTERRUPT"})),
+            daemon=True,
+        )
+        sender.start()
+
+        first = execute_single_tool(
+            "slow_tool", {}, "slow", tools, agent, Logger("test-agent", log=False)
+        )
+        assert first["status"] == "interrupted"
+
+        agent.current_session.pop("stop_signal", None)
+        agent.current_session["user_prompt"] = "second turn"
+        second = execute_single_tool(
+            "next_tool", {}, "next", tools, agent, Logger("test-agent", log=False)
+        )
+        assert second["status"] == "success"
+
+        release.set()
+        assert abandoned_done.wait(timeout=1)
+        assert observed == {
+            "slow_before": "first turn",
+            "next": "second turn",
+            "slow_after": "first turn",
+        }
 
 
 class TestAddAssistantMessage:

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -143,8 +143,13 @@ class TestToolExecutor:
             ),
             ToolCall(name="later_tool", arguments={}, id="call_2"),
         ]
+
+        def interrupt_when_started():
+            assert started.wait(timeout=1)
+            agent.io.send_to_agent({"type": "INTERRUPT"})
+
         sender = threading.Thread(
-            target=lambda: (started.wait(timeout=1), agent.io.send_to_agent({"type": "INTERRUPT"})),
+            target=interrupt_when_started,
             daemon=True,
         )
         sender.start()
@@ -240,8 +245,13 @@ class TestToolExecutor:
         agent = FakeAgent()
         agent.io = WebSocketIO()
         agent.current_session["user_prompt"] = "first turn"
+
+        def interrupt_when_started():
+            assert started.wait(timeout=1)
+            agent.io.send_to_agent({"type": "INTERRUPT"})
+
         sender = threading.Thread(
-            target=lambda: (started.wait(timeout=1), agent.io.send_to_agent({"type": "INTERRUPT"})),
+            target=interrupt_when_started,
             daemon=True,
         )
         sender.start()
@@ -264,6 +274,62 @@ class TestToolExecutor:
             "slow_before": "first turn",
             "next": "second turn",
             "slow_after": "first turn",
+        }
+
+    def test_tool_worker_uses_xray_snapshot_taken_before_start(self, monkeypatch):
+        import builtins
+        import threading
+
+        observed = {}
+
+        def inspect_context() -> str:
+            observed["task"] = builtins.xray.task
+            observed["messages"] = builtins.xray.messages
+            observed["iteration"] = builtins.xray.iteration
+            return "done"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(inspect_context))
+        agent = FakeAgent()
+        agent.current_session.update(
+            user_prompt="first turn",
+            messages=[{'role': 'user', 'content': 'first turn'}],
+            iteration=1,
+        )
+
+        def start_after_session_changes(fn, io, poll_seconds=0.2):
+            agent.current_session['user_prompt'] = 'second turn'
+            agent.current_session['messages'].append({
+                'role': 'user',
+                'content': 'second turn',
+            })
+            agent.current_session['iteration'] = 2
+            box = []
+            worker = threading.Thread(target=lambda: box.append(fn()))
+            worker.start()
+            worker.join(timeout=1)
+            assert not worker.is_alive()
+            return box[0], False
+
+        monkeypatch.setattr(
+            "connectonion.core.tool_executor.run_interruptible",
+            start_after_session_changes,
+        )
+
+        trace = execute_single_tool(
+            "inspect_context",
+            {},
+            "snapshot",
+            tools,
+            agent,
+            Logger("test-agent", log=False),
+        )
+
+        assert trace["status"] == "success"
+        assert observed == {
+            "task": "first turn",
+            "messages": [{'role': 'user', 'content': 'first turn'}],
+            "iteration": 1,
         }
 
 

--- a/tests/unit/test_xray.py
+++ b/tests/unit/test_xray.py
@@ -11,6 +11,7 @@ Components under test:
 
 
 import builtins
+import threading
 import pytest
 from unittest.mock import Mock, patch
 
@@ -34,11 +35,11 @@ class TestXrayDecoratorInit:
     def test_initial_context_is_empty(self):
         """Initial context values are empty/None."""
         decorator = XrayDecorator()
-        assert decorator._agent is None
-        assert decorator._user_prompt is None
-        assert decorator._messages == []
-        assert decorator._iteration is None
-        assert decorator._previous_tools == []
+        assert decorator.agent is None
+        assert decorator.user_prompt is None
+        assert decorator.messages == []
+        assert decorator.iteration is None
+        assert decorator.previous_tools == []
 
 
 class TestXrayDecoratorCall:
@@ -94,47 +95,47 @@ class TestXrayProperties:
     """Test XrayDecorator properties."""
 
     def test_agent_property(self):
-        """agent property returns _agent."""
+        """agent property returns the active agent."""
         decorator = XrayDecorator()
         mock_agent = Mock()
-        decorator._agent = mock_agent
+        decorator._update(mock_agent, "", [], None, [])
 
         assert decorator.agent is mock_agent
 
     def test_task_property(self):
         """task property returns user_prompt."""
         decorator = XrayDecorator()
-        decorator._user_prompt = "test prompt"
+        decorator._update(None, "test prompt", [], None, [])
 
         assert decorator.task == "test prompt"
 
     def test_user_prompt_property(self):
-        """user_prompt property returns _user_prompt."""
+        """user_prompt property returns the active prompt."""
         decorator = XrayDecorator()
-        decorator._user_prompt = "test prompt"
+        decorator._update(None, "test prompt", [], None, [])
 
         assert decorator.user_prompt == "test prompt"
 
     def test_messages_property(self):
-        """messages property returns _messages."""
+        """messages property returns active messages."""
         decorator = XrayDecorator()
         messages = [{"role": "user", "content": "hello"}]
-        decorator._messages = messages
+        decorator._update(None, "", messages, None, [])
 
         assert decorator.messages is messages
 
     def test_iteration_property(self):
-        """iteration property returns _iteration."""
+        """iteration property returns the active iteration."""
         decorator = XrayDecorator()
-        decorator._iteration = 3
+        decorator._update(None, "", [], 3, [])
 
         assert decorator.iteration == 3
 
     def test_previous_tools_property(self):
-        """previous_tools property returns _previous_tools."""
+        """previous_tools property returns active previous tools."""
         decorator = XrayDecorator()
         tools = ["search", "fetch"]
-        decorator._previous_tools = tools
+        decorator._update(None, "", [], None, tools)
 
         assert decorator.previous_tools is tools
 
@@ -151,11 +152,11 @@ class TestXrayUpdate:
 
         decorator._update(mock_agent, "prompt", messages, 5, previous)
 
-        assert decorator._agent is mock_agent
-        assert decorator._user_prompt == "prompt"
-        assert decorator._messages is messages
-        assert decorator._iteration == 5
-        assert decorator._previous_tools is previous
+        assert decorator.agent is mock_agent
+        assert decorator.user_prompt == "prompt"
+        assert decorator.messages is messages
+        assert decorator.iteration == 5
+        assert decorator.previous_tools is previous
 
 
 class TestXrayClear:
@@ -164,19 +165,40 @@ class TestXrayClear:
     def test_clear_resets_all_context(self):
         """_clear resets all context values."""
         decorator = XrayDecorator()
-        decorator._agent = Mock()
-        decorator._user_prompt = "prompt"
-        decorator._messages = [{"role": "user"}]
-        decorator._iteration = 5
-        decorator._previous_tools = ["tool1"]
+        decorator._update(Mock(), "prompt", [{"role": "user"}], 5, ["tool1"])
 
         decorator._clear()
 
-        assert decorator._agent is None
-        assert decorator._user_prompt is None
-        assert decorator._messages == []
-        assert decorator._iteration is None
-        assert decorator._previous_tools == []
+        assert decorator.agent is None
+        assert decorator.user_prompt is None
+        assert decorator.messages == []
+        assert decorator.iteration is None
+        assert decorator.previous_tools == []
+
+    def test_context_is_isolated_between_threads(self):
+        decorator = XrayDecorator()
+        barrier = threading.Barrier(3)
+        results = {}
+
+        def use_context(name):
+            agent = Mock(name=name)
+            decorator._update(agent, name, [{"content": name}], 1, [name])
+            barrier.wait(timeout=1)
+            results[name] = (decorator.agent, decorator.user_prompt, decorator.previous_tools)
+            decorator._clear()
+
+        first = threading.Thread(target=use_context, args=("first",))
+        second = threading.Thread(target=use_context, args=("second",))
+        first.start()
+        second.start()
+        barrier.wait(timeout=1)
+        first.join(timeout=1)
+        second.join(timeout=1)
+
+        assert results["first"][1:] == ("first", ["first"])
+        assert results["second"][1:] == ("second", ["second"])
+        assert results["first"][0] is not results["second"][0]
+        assert decorator.agent is None
 
 
 class TestXrayRepr:
@@ -196,10 +218,7 @@ class TestXrayRepr:
         decorator = XrayDecorator()
         mock_agent = Mock()
         mock_agent.name = "test_agent"
-        decorator._agent = mock_agent
-        decorator._user_prompt = "test prompt"
-        decorator._iteration = 2
-        decorator._messages = [{"role": "user"}]
+        decorator._update(mock_agent, "test prompt", [{"role": "user"}], 2, [])
 
         result = repr(decorator)
 
@@ -212,10 +231,7 @@ class TestXrayRepr:
         decorator = XrayDecorator()
         mock_agent = Mock()
         mock_agent.name = "agent"
-        decorator._agent = mock_agent
-        decorator._user_prompt = "A" * 100
-        decorator._iteration = 1
-        decorator._messages = []
+        decorator._update(mock_agent, "A" * 100, [], 1, [])
 
         result = repr(decorator)
 
@@ -233,30 +249,26 @@ class TestHelperFunctions:
 
         inject_xray_context(mock_agent, "prompt", messages, 3, previous)
 
-        assert xray._agent is mock_agent
-        assert xray._user_prompt == "prompt"
-        assert xray._messages is messages
-        assert xray._iteration == 3
-        assert xray._previous_tools is previous
+        assert xray.agent is mock_agent
+        assert xray.user_prompt == "prompt"
+        assert xray.messages is messages
+        assert xray.iteration == 3
+        assert xray.previous_tools is previous
 
         # Cleanup
         clear_xray_context()
 
     def test_clear_xray_context(self):
         """clear_xray_context resets global xray."""
-        xray._agent = Mock()
-        xray._user_prompt = "prompt"
-        xray._messages = [{}]
-        xray._iteration = 5
-        xray._previous_tools = ["tool"]
+        inject_xray_context(Mock(), "prompt", [{}], 5, ["tool"])
 
         clear_xray_context()
 
-        assert xray._agent is None
-        assert xray._user_prompt is None
-        assert xray._messages == []
-        assert xray._iteration is None
-        assert xray._previous_tools == []
+        assert xray.agent is None
+        assert xray.user_prompt is None
+        assert xray.messages == []
+        assert xray.iteration is None
+        assert xray.previous_tools == []
 
     def test_is_xray_enabled_true(self):
         """is_xray_enabled returns True for decorated functions."""


### PR DESCRIPTION
## Summary

Implements backend Phase 1 of #216: Stop now abandons in-flight LLM calls, tools, approvals, `ask_user`, and `DiffWriter` waits within the mailbox polling bound, without adding protocol frames or frontend behavior.

- adds a disposable daemon-thread `run_interruptible` primitive
- wraps the shared LLM and tool execution paths so all providers inherit the same behavior
- closes interrupted traces and preserves provider-valid tool-call history
- hardens blocking gates and hosted IO shutdown
- isolates xray context across abandoned and subsequent workers
- maps interrupted tools to a completed UI state
- documents that Stop abandons work but cannot kill arbitrary Python side effects

## Why

The existing INTERRUPT frame reaches the server mailbox immediately, but the synchronous agent thread only checked that mailbox at iteration boundaries. A long provider request or tool therefore delayed Stop for seconds or minutes, and approval/`ask_user` waits could misinterpret INTERRUPT as an ordinary response.

This change keeps the existing mailbox, `stop_signal`, persistence, reconnect, and OUTPUT contracts. The agent thread polls while a blocking step runs on a disposable worker; on Stop, the worker result is abandoned and existing stop handling completes the turn.

## Scope

This PR is backend-only Phase 1:

- no `INTERRUPT_ACK` frame
- no frontend "Stopping…" state
- no streaming cancellation
- no signals, asynchronous thread injection, subprocess isolation, or arbitrary Python termination

Local agents and HTTP `/input` remain synchronous. The hard-stop path is enabled only by IO implementations that explicitly declare `supports_interrupts` and provide selective `receive_all` plus `requeue`.

## Review history

The implementation was reviewed with the installed `aaron-review-my-code` skill, using ConnectOnion's "keep simple things simple" and state-ownership principles. The follow-up review identified five concrete issues, all addressed before this draft:

1. **Abandoned LLM request could read the next turn.** LLM messages are now snapshotted before worker startup.
2. **Delayed tool worker could read the next turn's xray context.** Prompt, messages, and iteration are now captured on the agent thread and injected from that snapshot.
3. **Interrupt support relied on transport-only introspection.** IO now exposes an explicit `supports_interrupts` / `requeue` capability contract.
4. **The WebSocket acceptance test did not prove the blocking step started.** It now asserts startup before sending INTERRUPT.
5. **`poll_interrupt` still described the old graceful-stop design.** Its documentation now describes the iteration-boundary fallback.

Deterministic regressions delay worker execution until after session mutation, proving abandoned workers retain their original inputs.

## Work and commit history

The history is intentionally separated for review:

### Implementation-only

- `4eddf4e` Add interruptible execution primitive
- `7902ceb` Interrupt in-flight LLM and tool calls
- `feb2ebd` Propagate interrupts through blocking gates
- `39d6dd3` Close hosted IO after agent execution
- `af98efd` Complete interrupted tools in remote UI

### Test-only

- `447343a` Test interruptible execution primitive
- `00d8ddc` Test interrupted LLM execution
- `1cb7ad0` Test interrupted tool execution
- `e71fef6` Test xray worker isolation
- `6dbfdd0` Test interrupt handling in blocking gates
- `2ffc29b` Test hosted IO shutdown behavior
- `8b1aa06` Test interrupted tool UI mapping
- `aec107b` Test WebSocket hard-stop flow

### Documentation-only

- `849731f` Document backend hard-stop semantics

### Aaron review follow-up

- `0e0d53e` Fix abandoned worker isolation
- `134d1dd` Test reviewed interrupt race conditions
- `8941726` Clarify interrupt-capable IO contract

The branch was fetched and explicitly rebased against `origin/main` at `130de2e`; it was already up to date.

## Validation

- Focused interrupt/agent/tool/IO/gate/WebSocket suite: **320 passed**
- Full `python -m pytest -m "not real_api"`: **2,469 passed, 5 skipped**
- One existing live relay multiturn assertion remains red: the external test model refuses to recall `7742`; it reproduces independently of this change.
- `git diff --check`: clean

## Behavioral limitation

Stop abandons the agent's wait; it does not kill arbitrary Python. An external request or tool side effect may finish in the background, but its result and late IO are discarded.

Refs #216