### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -512,6 +512,7 @@ def check_environment_for_api_keys() -> Optional[Tuple[str, str]]:
         ('GROQ_API_KEY', 'groq'),
         ('XAI_API_KEY', 'grok'),
         ('OPENROUTER_API_KEY', 'openrouter'),
+        ('ATLASCLOUD_API_KEY', 'atlascloud'),
     ]
 
     for env_var, provider in checks:
@@ -554,6 +555,10 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     if api_key.startswith('sk-or-'):
         return 'openrouter', 'openrouter'
 
+    # Atlas Cloud
+    if api_key.startswith('apikey-'):
+        return 'atlascloud', 'atlascloud'
+
     # Default to OpenAI if unsure
     return 'openai', 'unknown'
 
@@ -592,6 +597,10 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         'openrouter': {
             'var': 'OPENROUTER_API_KEY',
             'model': 'openrouter/openai/gpt-4o-mini'
+        },
+        'atlascloud': {
+            'var': 'ATLASCLOUD_API_KEY',
+            'model': 'atlascloud/qwen/qwen3.5-flash'
         },
         'connectonion': {
             'var': 'CONNECTONION_API_KEY',
@@ -873,6 +882,7 @@ PROVIDER_TO_ENV = {
     "groq": "GROQ_API_KEY",
     "grok": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "atlascloud": "ATLASCLOUD_API_KEY",
     "openonion": "OPENONION_API_KEY",
 }
 

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1,17 +1,17 @@
 """
-Purpose: Unified LLM provider abstraction with factory pattern for OpenAI, Anthropic, Gemini, Groq, Grok, Mistral, OpenRouter, and OpenOnion
+Purpose: Unified LLM provider abstraction with factory pattern for OpenAI, Anthropic, Gemini, Groq, Grok, Mistral, OpenRouter, Atlas Cloud, and OpenOnion
 LLM-Note:
   Dependencies: imports from [abc, typing, dataclasses, json, os, base64, openai, anthropic, requests, pathlib, yaml, pydantic, .usage, .exceptions] | imported by [agent.py, llm_do.py, conftest.py] | tested by [tests/test_llm.py, tests/test_llm_do.py, tests/test_real_*.py, tests/test_billing_error_agent.py]
   Data flow: Agent/llm_do calls create_llm(model, api_key) → factory routes to provider class → Provider.__init__() validates API key → Agent calls complete(messages, tools) OR structured_complete(messages, output_schema) → provider converts to native format → calls API → parses response → returns LLMResponse(content, tool_calls, raw_response) OR Pydantic model instance
-  State/Effects: reads environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, OPENONION_API_KEY) | reads OPENONION_API_KEY from env / .env / ~/.co/keys.env | makes HTTP requests to LLM APIs | no caching or persistence
-  Integration: exposes create_llm(model, api_key), LLM abstract base class, OpenAILLM, AnthropicLLM, GeminiLLM, GroqLLM, GrokLLM, OpenRouterLLM, OpenOnionLLM, LLMResponse, ToolCall dataclasses | providers implement complete() and structured_complete() | OpenAI message format is lingua franca | tool calling uses OpenAI schema converted per-provider
+  State/Effects: reads environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, ATLASCLOUD_API_KEY, OPENONION_API_KEY) | reads OPENONION_API_KEY from env / .env / ~/.co/keys.env | makes HTTP requests to LLM APIs | no caching or persistence
+  Integration: exposes create_llm(model, api_key), LLM abstract base class, OpenAILLM, AnthropicLLM, GeminiLLM, GroqLLM, GrokLLM, OpenRouterLLM, AtlasCloudLLM, OpenOnionLLM, LLMResponse, ToolCall dataclasses | providers implement complete() and structured_complete() | OpenAI message format is lingua franca | tool calling uses OpenAI schema converted per-provider
   Performance: stateless (no caching) | synchronous (no streaming) | default max_tokens=8192 for Anthropic (required) | each call hits API
   Errors: raises ValueError for missing API keys, unknown models, invalid parameters | provider-specific errors bubble up (openai.APIError, anthropic.APIError, etc.) | OpenOnionLLM transforms 402 errors to InsufficientCreditsError with formatted message and typed attributes | Pydantic ValidationError for invalid structured output
 
 Unified LLM provider abstraction layer for ConnectOnion framework.
 
 This module provides a consistent interface for interacting with multiple LLM providers
-(OpenAI, Anthropic, Google Gemini, Groq, Grok, Mistral, OpenRouter, and ConnectOnion managed keys)
+(OpenAI, Anthropic, Google Gemini, Groq, Grok, Mistral, OpenRouter, Atlas Cloud, and ConnectOnion managed keys)
 through a common API.
 
 Architecture Overview
@@ -31,6 +31,7 @@ The module follows a factory pattern with provider-specific implementations:
    - GrokLLM: xAI Grok via OpenAI-compatible endpoint
    - MistralLLM: Mistral AI via OpenAI-compatible endpoint
    - OpenRouterLLM: OpenRouter via OpenAI-compatible endpoint
+   - AtlasCloudLLM: Atlas Cloud via OpenAI-compatible endpoint
    - OpenOnionLLM: Managed keys using OpenAI-compatible proxy endpoint
 
 3. **Factory Function (create_llm)**:
@@ -924,6 +925,80 @@ class MistralLLM(LLM):
         return output_schema.model_validate_json(content)
 
 
+class AtlasCloudLLM(LLM):
+    """Atlas Cloud LLM implementation using OpenAI-compatible endpoint."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "atlascloud/qwen/qwen3.5-flash", **kwargs):
+        self.api_key = api_key or os.getenv("ATLASCLOUD_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Atlas Cloud API key required. Set ATLASCLOUD_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+        self.model = model.removeprefix("atlascloud/")
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url="https://api.atlascloud.ai/v1",
+        )
+
+    def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
+        """Complete a conversation using Atlas Cloud's OpenAI-compatible endpoint."""
+        api_kwargs = {
+            "model": self.model,
+            "messages": messages,
+            **kwargs,
+        }
+
+        if tools:
+            api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
+            api_kwargs["tool_choice"] = "auto"
+
+        response = self.client.chat.completions.create(**api_kwargs)
+        message = response.choices[0].message
+
+        tool_calls = []
+        if hasattr(message, 'tool_calls') and message.tool_calls:
+            for tc in message.tool_calls:
+                tool_calls.append(ToolCall(
+                    name=tc.function.name,
+                    arguments=json.loads(tc.function.arguments) if isinstance(tc.function.arguments, str) else tc.function.arguments,
+                    id=tc.id
+                ))
+
+        usage = None
+        if hasattr(response, 'usage') and response.usage:
+            input_tokens = response.usage.prompt_tokens
+            output_tokens = response.usage.completion_tokens
+            cost = calculate_cost(self.model, input_tokens, output_tokens)
+            usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost=cost,
+            )
+
+        return LLMResponse(content=message.content, tool_calls=tool_calls, raw_response=response, usage=usage)
+
+    def structured_complete(self, messages: List[Dict], output_schema: Type[BaseModel], **kwargs) -> BaseModel:
+        """Get structured Pydantic output using JSON-mode + schema validation."""
+        schema_json = json.dumps(output_schema.model_json_schema(), indent=2)
+        schema_instruction = (
+            "Return ONLY valid JSON (no markdown) that matches this JSON Schema:\n"
+            f"{schema_json}"
+        )
+
+        structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
+
+        completion = self.client.chat.completions.create(
+            model=self.model,
+            messages=structured_messages,
+            response_format={"type": "json_object"},
+            **kwargs,
+        )
+        content = completion.choices[0].message.content or "{}"
+        return output_schema.model_validate_json(content)
+
+
 # Model registry mapping model names to providers
 MODEL_REGISTRY = {
     # OpenAI models
@@ -977,6 +1052,10 @@ MODEL_REGISTRY = {
     "gemini-1.5-flash-001": "google",
     "gemini-1.5-flash-8b": "google",
     "gemini-1.0-pro": "google",
+
+    # Atlas Cloud OpenAI-compatible models
+    "atlascloud/qwen/qwen3.5-flash": "atlascloud",
+    "atlascloud/deepseek-ai/deepseek-v4-pro": "atlascloud",
 }
 
 
@@ -1160,6 +1239,8 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
         return GrokLLM(api_key=api_key, model=model, **kwargs)
     if model.startswith("mistral/"):
         return MistralLLM(api_key=api_key, model=model, **kwargs)
+    if model.startswith("atlascloud/"):
+        return AtlasCloudLLM(api_key=api_key, model=model, **kwargs)
     
     # Get provider from registry
     provider = MODEL_REGISTRY.get(model)
@@ -1182,5 +1263,7 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
         return AnthropicLLM(api_key=api_key, model=model, **kwargs)
     elif provider == "google":
         return GeminiLLM(api_key=api_key, model=model, **kwargs)
+    elif provider == "atlascloud":
+        return AtlasCloudLLM(api_key=api_key, model=model, **kwargs)
     else:
         raise ValueError(f"Provider '{provider}' not implemented")

--- a/tests/unit/test_atlascloud_provider.py
+++ b/tests/unit/test_atlascloud_provider.py
@@ -1,0 +1,41 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands.project_cmd_lib import (
+    PROVIDER_TO_ENV,
+    check_environment_for_api_keys,
+    configure_env_for_provider,
+    detect_api_provider,
+)
+from connectonion.core.llm import AtlasCloudLLM, MODEL_REGISTRY, create_llm
+
+
+def test_atlascloud_model_registry_and_factory_route():
+    assert MODEL_REGISTRY["atlascloud/qwen/qwen3.5-flash"] == "atlascloud"
+    assert MODEL_REGISTRY["atlascloud/deepseek-ai/deepseek-v4-pro"] == "atlascloud"
+
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+        llm = create_llm("atlascloud/deepseek-ai/deepseek-v4-pro")
+
+    assert isinstance(llm, AtlasCloudLLM)
+    assert llm.model == "deepseek-ai/deepseek-v4-pro"
+
+
+def test_atlascloud_requires_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="ATLASCLOUD_API_KEY"):
+            AtlasCloudLLM(model="atlascloud/qwen/qwen3.5-flash")
+
+
+def test_atlascloud_cli_provider_mapping():
+    assert PROVIDER_TO_ENV["atlascloud"] == "ATLASCLOUD_API_KEY"
+    assert detect_api_provider("apikey-test") == ("atlascloud", "atlascloud")
+
+    with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "apikey-test"}, clear=True):
+        assert check_environment_for_api_keys() == ("atlascloud", "apikey-test")
+
+    env_content = configure_env_for_provider("atlascloud", "apikey-test")
+    assert "ATLASCLOUD_API_KEY=apikey-test" in env_content
+    assert "MODEL=atlascloud/qwen/qwen3.5-flash" in env_content

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -38,6 +38,7 @@ from connectonion.core.llm import (
     GroqLLM,
     GrokLLM,
     OpenRouterLLM,
+    AtlasCloudLLM,
     OpenOnionLLM,
     LLMResponse,
     ToolCall
@@ -414,6 +415,40 @@ class TestOpenAICompatibleProviders:
             called = llm.client.chat.completions.create.call_args.kwargs
             assert called["response_format"] == {"type": "json_object"}
 
+    def test_atlascloud_uses_openai_compatible_endpoint(self):
+        """Atlas Cloud should configure the OpenAI client with its API base URL."""
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+            with patch("connectonion.core.llm.openai.OpenAI") as mock_openai:
+                llm = AtlasCloudLLM(model="atlascloud/qwen/qwen3.5-flash")
+
+                _, kwargs = mock_openai.call_args
+                assert kwargs["api_key"] == "test-key"
+                assert kwargs["base_url"] == "https://api.atlascloud.ai/v1"
+                assert llm.model == "qwen/qwen3.5-flash"
+
+    def test_atlascloud_structured_complete_json_mode(self):
+        """Atlas Cloud structured output should use JSON mode and validate with Pydantic."""
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+            llm = AtlasCloudLLM(model="atlascloud/qwen/qwen3.5-flash")
+
+            mock_message = Mock()
+            mock_message.content = '{"value": 13, "message": "atlas"}'
+            mock_response = Mock()
+            mock_response.choices = [Mock(message=mock_message)]
+            llm.client.chat.completions.create = Mock(return_value=mock_response)
+
+            result = llm.structured_complete(
+                [{"role": "user", "content": "Return test payload"}],
+                StructuredOutputSchema
+            )
+
+            assert result.value == 13
+            assert result.message == "atlas"
+            llm.client.chat.completions.create.assert_called_once()
+            called = llm.client.chat.completions.create.call_args.kwargs
+            assert called["model"] == "qwen/qwen3.5-flash"
+            assert called["response_format"] == {"type": "json_object"}
+
 
 class TestModelInference:
     """Test model provider inference from model names."""
@@ -430,6 +465,12 @@ class TestModelInference:
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             llm = create_llm("openrouter/openai/gpt-4o-mini")
             assert isinstance(llm, OpenRouterLLM)
+
+    def test_infer_atlascloud_from_prefix(self):
+        """Test that atlascloud/* models are routed to AtlasCloudLLM."""
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+            llm = create_llm("atlascloud/qwen/qwen3.5-flash")
+            assert isinstance(llm, AtlasCloudLLM)
 
     def test_infer_grok_from_prefix(self):
         """Test that grok/* models are routed to GrokLLM."""


### PR DESCRIPTION
## Summary
- add an Atlas Cloud OpenAI-compatible LLM provider routed by `atlascloud/...` model prefixes
- wire `ATLASCLOUD_API_KEY` into CLI provider detection and generated `.env` config
- add focused tests for provider routing, endpoint setup, structured JSON mode, and CLI mapping

## Validation
- `uv run --extra dev pytest -q tests/unit/test_atlascloud_provider.py tests/unit/test_llm_errors.py::TestOpenAICompatibleProviders tests/unit/test_llm_errors.py::TestModelInference` (17 passed)
- `python3 -m compileall connectonion/core/llm.py connectonion/cli/commands/project_cmd_lib.py tests/unit/test_atlascloud_provider.py tests/unit/test_llm_errors.py`
- `git diff --check`
- live Atlas model catalog check confirmed `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro`

No README, sponsor, logo, credits, or partner promotion changes.
