### PR TITLE
Add Gemini 3.6 Flash model support

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -962,6 +962,7 @@ MODEL_REGISTRY = {
     "claude-3-7-sonnet-20250219": "anthropic",
     
     # Google Gemini models
+    "gemini-3.6-flash": "google",
     "gemini-3.5-flash": "google",
     "gemini-3-pro-preview": "google",
     "gemini-3-pro-image-preview": "google",

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -51,6 +51,7 @@ MODEL_PRICING = {
     "claude-opus-4-20250514": {"input": 15.00, "output": 75.00, "cached": 1.50, "cache_write": 18.75},
 
     # Google Gemini models - cached = 25% of input (75% discount)
+    "gemini-3.6-flash": {"input": 1.50, "output": 7.50, "cached": 0.15},
     "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cached": 0.375},
     "gemini-3-pro-preview": {"input": 2.00, "output": 12.00, "cached": 0.50},
     "gemini-3-pro-image-preview": {"input": 2.00, "output": 0.134},
@@ -85,6 +86,7 @@ MODEL_CONTEXT_LIMITS = {
     "claude-opus-4-20250514": 200000,
 
     # Gemini
+    "gemini-3.6-flash": 1000000,
     "gemini-3.5-flash": 1000000,
     "gemini-3-pro-preview": 1000000,
     "gemini-3-pro-image-preview": 65000,

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@ agent = Agent(name="bot", model="co/gemini-2.5-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-3-pro-preview`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
+- `co/gemini-3.6-flash`, `co/gemini-3-pro-preview`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`, `co/gemini-2.5-flash-lite`, `co/gemini-2.0-flash`
 - `co/claude-opus-4-5`, `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -83,6 +83,10 @@ agent = Agent("assistant", model="o4-mini")         # Your key
 agent = Agent("assistant", model="co/gemini-3-pro-preview")  # Managed
 agent = Agent("assistant", model="gemini-3-pro-preview")     # Your key
 
+# Newest Flash workhorse - frontier intelligence built for speed
+agent = Agent("assistant", model="co/gemini-3.6-flash")  # Managed
+agent = Agent("assistant", model="gemini-3.6-flash")     # Your key
+
 # Fastest Gemini 3 model
 agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
 agent = Agent("assistant", model="gemini-3.5-flash")     # Your key
@@ -190,6 +194,7 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | gpt-4o | 128K tokens |
 | o4-mini | 128K tokens |
 | **Google** | |
+| gemini-3.6-flash | 1M tokens |
 | gemini-3-pro-preview | 1M tokens |
 | gemini-3.5-flash | 1M tokens |
 | gemini-2.5-pro | 1M tokens |
@@ -218,8 +223,9 @@ All prices are **per 1M tokens** and match official provider pricing:
 
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
+| gemini-3.6-flash | $1.50 | $7.50 | Newest fast Gemini |
 | gemini-3-pro-preview | $2.00 | $12.00 | State-of-the-art reasoning |
-| gemini-3.5-flash | $1.50 | $9.00 | Latest fast Gemini |
+| gemini-3.5-flash | $1.50 | $9.00 | Previous fast Gemini |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |
 | gemini-2.5-pro | $1.25 | $10.00 | **Default model** - best for agents |
 | gemini-2.5-flash | $0.30 | $2.50 | Best price-performance |

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -55,6 +55,7 @@ class TestMultiLLMSupport:
         assert MODEL_REGISTRY["claude-opus-4.1"] == "anthropic"
 
         # Test Google models
+        assert MODEL_REGISTRY["gemini-3.6-flash"] == "google"
         assert MODEL_REGISTRY["gemini-3-pro-preview"] == "google"
         assert MODEL_REGISTRY["gemini-3-pro-image-preview"] == "google"
         assert MODEL_REGISTRY["gemini-2.5-flash"] == "google"

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -198,6 +198,7 @@ class TestModelPricing:
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in pricing."""
+        assert "gemini-3.6-flash" in MODEL_PRICING
         assert "gemini-3-pro-preview" in MODEL_PRICING
         assert "gemini-3-pro-image-preview" in MODEL_PRICING
         assert "gemini-2.5-pro" in MODEL_PRICING
@@ -219,6 +220,8 @@ class TestModelContextLimits:
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in context limits."""
+        assert "gemini-3.6-flash" in MODEL_CONTEXT_LIMITS
+        assert MODEL_CONTEXT_LIMITS["gemini-3.6-flash"] == 1_000_000
         assert "gemini-3-pro-preview" in MODEL_CONTEXT_LIMITS
         assert MODEL_CONTEXT_LIMITS["gemini-3-pro-preview"] == 1_000_000
         assert "gemini-3-pro-image-preview" in MODEL_CONTEXT_LIMITS


### PR DESCRIPTION
## Description
Adds support for Google's newest model, **Gemini 3.6 Flash** (`gemini-3.6-flash`): provider registry entry, pricing, context limit, docs, and tests.

## Related Issue
Fixes #219

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Changes Made
- `connectonion/core/llm.py`: register `gemini-3.6-flash` → `google` in the model registry (routing already works via the `gemini-*` prefix; this makes it explicit)
- `connectonion/core/usage.py`: pricing `$1.50/M` input, `$7.50/M` output, `$0.15/M` cached (per https://ai.google.dev/gemini-api/docs/pricing) and 1M-token context limit
- `docs/concepts/models.md`: usage examples, context-window row, pricing row
- `docs/api.md`: add `co/gemini-3.6-flash` to the managed-keys model list
- `tests/unit/test_usage.py`, `tests/unit/test_llm.py`: cover the new registry, pricing, and context-limit entries
- No new dependencies

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

Verified `MODEL_PRICING`, `MODEL_CONTEXT_LIMITS`, `get_pricing()`, and `get_context_limit()` return the new rates for `gemini-3.6-flash`.

## Example Usage
```python
from connectonion import Agent

agent = Agent("assistant", model="gemini-3.6-flash")     # Your key (GEMINI_API_KEY)
agent = Agent("assistant", model="co/gemini-3.6-flash")  # Managed keys
```

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)
N/A

## Additional Notes
Managed-keys (`co/gemini-3.6-flash`) also requires the server-side change in openonion/oo-api (companion PR adds the model to the proxy's pricing table and `/v1/models`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBMdzdkWVfXkA5UXU59k5T)_