### PR TITLE
browser: humanize input (pointer, keyboard, scroll) + pass fingerprint/CDP detectors

### DIFF
--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -575,8 +575,11 @@ class BrowserAutomation:
             executable_path=chrome_path,
             args=CHROME_DEFAULT_ARGS,  # environment-stability flags only
             ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # macOS cookie fix
-            no_viewport=True,  # use the real OS window size; a fixed 1280x720 viewport is a
-                               # Playwright tell (rebrowser 'viewport' check flags it)
+            no_viewport=True,  # part of Patchright's own recommended stealth config
+                               # (channel=chrome + headless=False + no_viewport). Patchright
+                               # inherits Playwright's fixed 1280x720 default, which is an
+                               # automation tell (rebrowser's 'viewport' check flags it); this
+                               # uses the real OS window size instead.
             proxy=_browser_proxy_from_env(),  # route egress through BROWSER_PROXY if set, else None
             timeout=120000,
         )

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -40,6 +40,7 @@ from connectonion.useful_plugins import image_result_formatter, ui_stream
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from . import element_finder
+from . import humanize
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 
 # Default screenshots directory
@@ -816,7 +817,7 @@ class BrowserAutomation:
             if index < 0 or index >= count:
                 return f"Selector matched {count} elements with text {text!r}; index {index} is out of range"
 
-            self.page.mouse.click(matches[index]["x"], matches[index]["y"])
+            humanize.click(self.page, matches[index]["x"], matches[index]["y"])
             self._save_context()
             self.page.wait_for_timeout(1000)
             return f"Clicked element {index + 1}/{count} matching selector: {selector} with text: {text}"
@@ -849,7 +850,7 @@ class BrowserAutomation:
         target = candidates[index]
         box = target.bounding_box()
         if box:
-            self.page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+            humanize.click(self.page, 0, 0, box=box)
         else:
             target.click(force=True)
 
@@ -893,7 +894,7 @@ class BrowserAutomation:
 
         target = locator.nth(index)
         target.click(force=True)
-        self.page.keyboard.type(text)
+        humanize.type_text(self.page, text)
         self.page.wait_for_timeout(1000)
         return f"Typed text into element {index + 1}/{count} matching selector: {selector}"
 
@@ -1271,7 +1272,7 @@ class BrowserAutomation:
         if not target or not target.get("ok"):
             return target.get("error", "Could not find target near anchor") if target else "Could not find target near anchor"
 
-        self.page.mouse.click(target["x"], target["y"])
+        humanize.click(self.page, target["x"], target["y"])
         self.page.wait_for_timeout(wait_ms)
         self._save_context()
 
@@ -1324,7 +1325,7 @@ class BrowserAutomation:
             import time as _time
             x = element.x + element.width // 2
             y = element.y + element.height // 2
-            self.page.mouse.click(x, y)
+            humanize.click(self.page, x, y)
             self._save_context()
             _time.sleep(1)
             print(f"\n[browser] CLICKED (shadow DOM) element [{element.index}] {element.tag} text='{element.text}' at ({x},{y})\n")
@@ -1355,7 +1356,7 @@ class BrowserAutomation:
             if box:
                 x = box['x'] + box['width'] / 2
                 y = box['y'] + box['height'] / 2
-                self.page.mouse.click(x, y)
+                humanize.click(self.page, x, y, box=box)
                 self._save_context()
                 _time.sleep(1)  # Wait for DOM changes (modals, dropdowns, etc.)
                 print(f"\n[browser] CLICKED element [{element.index}] {element.tag} text='{element.text}' at ({x:.0f},{y:.0f})\n")
@@ -1370,7 +1371,7 @@ class BrowserAutomation:
         # Fallback: use original coordinates
         x = element.x + element.width // 2
         y = element.y + element.height // 2
-        self.page.mouse.click(x, y)
+        humanize.click(self.page, x, y)
         self._save_context()
         _time.sleep(1)
         print(f"\n[browser] CLICKED (coords) element [{element.index}] text='{element.text}' at ({x},{y})\n")
@@ -1383,7 +1384,7 @@ class BrowserAutomation:
         if not self.page:
             return "Browser not open"
         import time as _time
-        self.page.mouse.click(x, y)
+        humanize.click(self.page, x, y)
         _time.sleep(1)
         print(f"\n[browser] CLICKED at ({x},{y})\n")
         return f"Clicked at ({x}, {y})"
@@ -1403,7 +1404,7 @@ class BrowserAutomation:
         if element.frame.startswith("shadow-"):
             x = element.x + element.width // 2
             y = element.y + element.height // 2
-            self.page.mouse.move(x, y)
+            humanize.move(self.page, x, y)
         elif element.frame != "main":
             frame = None
             for f in self.page.frames:
@@ -1414,13 +1415,13 @@ class BrowserAutomation:
             if locator.count() > 0:
                 locator.first.hover()
             else:
-                self.page.mouse.move(element.x + element.width // 2, element.y + element.height // 2)
+                humanize.move(self.page, element.x + element.width // 2, element.y + element.height // 2)
         else:
             locator = self.page.locator(element.locator)
             if locator.count() > 0:
                 locator.first.hover()
             else:
-                self.page.mouse.move(element.x + element.width // 2, element.y + element.height // 2)
+                humanize.move(self.page, element.x + element.width // 2, element.y + element.height // 2)
 
         _time.sleep(1)
         print(f"\n[browser] HOVERED element [{element.index}] {element.tag} text='{element.text}'\n")
@@ -1440,7 +1441,7 @@ class BrowserAutomation:
         if element.frame.startswith("shadow-"):
             x = element.x + element.width // 2
             y = element.y + element.height // 2
-            self.page.mouse.click(x, y, button="right")
+            humanize.click(self.page, x, y, button="right")
             _time.sleep(1)
             print(f"\n[browser] RIGHT-CLICKED (shadow DOM) element [{element.index}] {element.tag} text='{element.text}' at ({x},{y})\n")
             return f"Right-clicked [{element.index}] {element.tag} '{element.text}' (shadow DOM)"
@@ -1460,14 +1461,14 @@ class BrowserAutomation:
             if box:
                 x = box['x'] + box['width'] / 2
                 y = box['y'] + box['height'] / 2
-                self.page.mouse.click(x, y, button="right")
+                humanize.click(self.page, x, y, button="right", box=box)
                 _time.sleep(1)
                 print(f"\n[browser] RIGHT-CLICKED element [{element.index}] {element.tag} text='{element.text}' at ({x:.0f},{y:.0f})\n")
                 return f"Right-clicked [{element.index}] {element.tag} '{element.text}'"
 
         x = element.x + element.width // 2
         y = element.y + element.height // 2
-        self.page.mouse.click(x, y, button="right")
+        humanize.click(self.page, x, y, button="right")
         _time.sleep(1)
         print(f"\n[browser] RIGHT-CLICKED (coords) element [{element.index}] text='{element.text}' at ({x},{y})\n")
         return f"Right-clicked [{element.index}] '{element.text}' at ({x}, {y})"
@@ -1486,7 +1487,7 @@ class BrowserAutomation:
         if element.frame.startswith("shadow-"):
             x = element.x + element.width // 2
             y = element.y + element.height // 2
-            self.page.mouse.dblclick(x, y)
+            humanize.double_click(self.page, x, y)
             _time.sleep(1)
             print(f"\n[browser] DOUBLE-CLICKED (shadow DOM) element [{element.index}] {element.tag} text='{element.text}' at ({x},{y})\n")
             return f"Double-clicked [{element.index}] {element.tag} '{element.text}' (shadow DOM)"
@@ -1506,14 +1507,14 @@ class BrowserAutomation:
             if box:
                 x = box['x'] + box['width'] / 2
                 y = box['y'] + box['height'] / 2
-                self.page.mouse.dblclick(x, y)
+                humanize.double_click(self.page, x, y, box=box)
                 _time.sleep(1)
                 print(f"\n[browser] DOUBLE-CLICKED element [{element.index}] {element.tag} text='{element.text}' at ({x:.0f},{y:.0f})\n")
                 return f"Double-clicked [{element.index}] {element.tag} '{element.text}'"
 
         x = element.x + element.width // 2
         y = element.y + element.height // 2
-        self.page.mouse.dblclick(x, y)
+        humanize.double_click(self.page, x, y)
         _time.sleep(1)
         print(f"\n[browser] DOUBLE-CLICKED (coords) element [{element.index}] text='{element.text}' at ({x},{y})\n")
         return f"Double-clicked [{element.index}] '{element.text}' at ({x}, {y})"
@@ -1533,7 +1534,7 @@ class BrowserAutomation:
         if not self.page:
             return "Browser not open"
 
-        self.page.keyboard.type(text)
+        humanize.type_text(self.page, text)
 
         return f"""Typed: '{text}'
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -1851,9 +1851,9 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         return f"Waited for {seconds} seconds"
 
     def scroll(self, times: int = 5, description: str = "the main content area") -> str:
-        """Universal scroll with AI strategy and fallback.
+        """Universal scroll, humanized first.
 
-        Tries: AI-generated → Element scroll → Page scroll
+        Tries: Human wheel (real mouse-wheel events) → AI-generated → Element scroll → Page scroll
         Verifies success with screenshot comparison.
         """
         from . import scroll

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -575,6 +575,8 @@ class BrowserAutomation:
             executable_path=chrome_path,
             args=CHROME_DEFAULT_ARGS,  # environment-stability flags only
             ignore_default_args=IGNORE_DEFAULT_ARGS + ['--use-mock-keychain'],  # macOS cookie fix
+            no_viewport=True,  # use the real OS window size; a fixed 1280x720 viewport is a
+                               # Playwright tell (rebrowser 'viewport' check flags it)
             proxy=_browser_proxy_from_env(),  # route egress through BROWSER_PROXY if set, else None
             timeout=120000,
         )

--- a/connectonion/useful_tools/browser_tools/browser_config.py
+++ b/connectonion/useful_tools/browser_tools/browser_config.py
@@ -15,10 +15,17 @@ mirror was a standing sync burden and a regression risk. What stays here is only
 about the run environment, which are invisible to bot-detection.
 """
 
-# --disable-dev-shm-usage: Chrome crashes on the small default /dev/shm inside Docker
-# (the co-ai deploy runs headful under Xvfb in a container). Not an anti-detection flag.
+# These are run-environment flags, not anti-detection spoofs — both make a GPU-less server
+# behave like an ordinary desktop Chrome, which is exactly what bot-detectors expect to see.
 CHROME_DEFAULT_ARGS = [
+    # Chrome crashes on the small default /dev/shm inside Docker (the co-ai deploy runs
+    # headful under Xvfb in a container).
     '--disable-dev-shm-usage',
+    # Permit SwiftShader as the WebGL backend when no GPU is present (headless servers,
+    # Xvfb, containers). Without it WebGL is simply absent — "Canvas has no webgl context"
+    # on sannysoft, an obvious tell, since every real browser has WebGL. This is a FALLBACK:
+    # a machine with a real GPU keeps using it and reports its true vendor/renderer.
+    '--enable-unsafe-swiftshader',
 ]
 
 # Nothing to strip from Patchright's defaults: it already omits the automation markers we

--- a/connectonion/useful_tools/browser_tools/browser_config.py
+++ b/connectonion/useful_tools/browser_tools/browser_config.py
@@ -25,6 +25,13 @@ CHROME_DEFAULT_ARGS = [
     # Xvfb, containers). Without it WebGL is simply absent — "Canvas has no webgl context"
     # on sannysoft, an obvious tell, since every real browser has WebGL. This is a FALLBACK:
     # a machine with a real GPU keeps using it and reports its true vendor/renderer.
+    #
+    # NOTE: Patchright recommends minimal launch args (custom headers/user_agent/automation
+    # flags can defeat its patches). This is the one deliberate exception — a GPU-rendering
+    # flag, not an automation flag. Verified it does NOT defeat the patches: with it enabled
+    # rebrowser's runtimeEnableLeak stays clean and deviceandbrowserinfo reports WebGL
+    # consistent. Patchright's other recommendations (channel=chrome via find_system_chrome,
+    # headless=False, no_viewport, persistent user_data_dir, no custom UA) are all honored.
     '--enable-unsafe-swiftshader',
 ]
 

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -2,8 +2,8 @@
 Purpose: Humanize BrowserAutomation's pointer + keyboard events so clicks and typing survive
          BEHAVIORAL bot detection (mouse-trajectory entropy, click position, keystroke cadence)
 LLM-Note:
-  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here] | tested by [tests/unit/test_browser_humanize.py]
-  Data flow: browser.py calls move/click/double_click/type_text(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
+  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here; scroll.py — wheel scroll] | tested by [tests/unit/test_browser_humanize.py]
+  Data flow: browser.py/scroll.py call move/click/double_click/type_text/scroll(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
   State/Effects: drives the live page via page.mouse.* / page.keyboard.* and sleeps between events; the only retained state is `_cursor` (per-page last x/y, auto-dropped when the page is GC'd)
   Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves. No public tool signatures change; only the low-level event generation.
   Errors: none — pure event emission; if the page is closed the underlying Playwright call raises and bubbles (fail fast)
@@ -92,6 +92,24 @@ def click(page, x, y, button="left", clicks=1, box=None):
 def double_click(page, x, y, box=None):
     """Two human clicks close enough in time/position that the browser raises dblclick."""
     click(page, x, y, clicks=2, box=box)
+
+
+def scroll(page, total_dy):
+    """Human wheel scroll: cover `total_dy` pixels as many small mouse-wheel ticks with
+    variable size and cadence (plus the odd longer reading pause), so the page emits real
+    `wheel` events and `scrollY` moves incrementally — instead of the instant programmatic
+    `scrollBy(0, 1000)` jump a detector flags (scrollY changes with zero wheel events)."""
+    remaining = int(total_dy)
+    sign = 1 if remaining >= 0 else -1
+    while abs(remaining) > 2:
+        step = sign * random.randint(90, 170)
+        if abs(step) > abs(remaining):
+            step = remaining
+        page.mouse.wheel(0, step)
+        remaining -= step
+        time.sleep(random.uniform(0.03, 0.10))
+        if random.random() < 0.1:
+            time.sleep(random.uniform(0.2, 0.5))  # occasional reading pause
 
 
 def type_text(page, text):

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -1,0 +1,108 @@
+"""
+Purpose: Humanize BrowserAutomation's pointer + keyboard events so clicks and typing survive
+         BEHAVIORAL bot detection (mouse-trajectory entropy, click position, keystroke cadence)
+LLM-Note:
+  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here] | tested by [tests/unit/test_browser_humanize.py]
+  Data flow: browser.py calls move/click/double_click/type_text(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
+  State/Effects: drives the live page via page.mouse.* / page.keyboard.* and sleeps between events; the only retained state is `_cursor` (per-page last x/y, auto-dropped when the page is GC'd)
+  Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves. No public tool signatures change; only the low-level event generation.
+  Errors: none — pure event emission; if the page is closed the underlying Playwright call raises and bubbles (fail fast)
+"""
+
+import math
+import random
+import time
+from weakref import WeakKeyDictionary
+
+# Remember each page's cursor position so the next move starts from where the last one
+# ended — real cursors travel between actions, they don't reappear on the target pixel.
+_cursor = WeakKeyDictionary()
+
+
+def _bezier(start, end, steps):
+    """Cubic Bézier from start to end with two random control points, sampled at `steps`
+    points. The control points bow the path sideways off the straight line, giving the
+    curvature a hand produces instead of a ruler-straight segment a detector flags."""
+    (x0, y0), (x3, y3) = start, end
+    dx, dy = x3 - x0, y3 - y0
+    dist = math.hypot(dx, dy) or 1.0
+    px, py = -dy / dist, dx / dist  # unit vector perpendicular to the travel direction
+
+    def control(along):
+        off = random.uniform(-0.22, 0.22) * dist
+        return x0 + dx * along + px * off, y0 + dy * along + py * off
+
+    c1 = control(random.uniform(0.2, 0.4))
+    c2 = control(random.uniform(0.6, 0.8))
+
+    points = []
+    for i in range(1, steps + 1):
+        t = i / steps
+        mt = 1 - t
+        x = mt ** 3 * x0 + 3 * mt ** 2 * t * c1[0] + 3 * mt * t ** 2 * c2[0] + t ** 3 * x3
+        y = mt ** 3 * y0 + 3 * mt ** 2 * t * c1[1] + 3 * mt * t ** 2 * c2[1] + t ** 3 * y3
+        points.append((x, y))
+    return points
+
+
+def move(page, x, y):
+    """Move the cursor to (x, y) along a curved, variable-speed path, emitting a real
+    mousemove event at every step."""
+    start = _cursor.get(page)
+    if start is None:
+        # First move of the session: begin a little off the target so there is still a
+        # short trajectory, never an instant appearance on the exact pixel.
+        start = (x + random.uniform(-140, 140), y + random.uniform(-140, 140))
+
+    dist = math.hypot(x - start[0], y - start[1])
+    steps = max(8, min(40, int(dist / 12)))
+    for px, py in _bezier(start, (x, y), steps):
+        page.mouse.move(px, py)
+        time.sleep(random.uniform(0.006, 0.02))
+    _cursor[page] = (x, y)
+
+
+def _point_in_box(box):
+    """A point inside the element but off dead-center — humans don't hit the exact
+    centroid. Kept within the inner 60% so we never fall outside the element."""
+    cx = box["x"] + box["width"] / 2
+    cy = box["y"] + box["height"] / 2
+    return (
+        cx + random.uniform(-0.3, 0.3) * box["width"],
+        cy + random.uniform(-0.3, 0.3) * box["height"],
+    )
+
+
+def click(page, x, y, button="left", clicks=1, box=None):
+    """Human click: curve to the target (jittered inside `box` when one is given), settle,
+    then press with a short randomized dwell between down and up."""
+    if box is not None:
+        x, y = _point_in_box(box)
+    move(page, x, y)
+    time.sleep(random.uniform(0.03, 0.12))  # settle before pressing
+    for i in range(clicks):
+        page.mouse.down(button=button)
+        time.sleep(random.uniform(0.04, 0.11))  # down→up dwell
+        page.mouse.up(button=button)
+        if i + 1 < clicks:
+            time.sleep(random.uniform(0.06, 0.12))  # inter-click gap (double click)
+    _cursor[page] = (x, y)
+
+
+def double_click(page, x, y, box=None):
+    """Two human clicks close enough in time/position that the browser raises dblclick."""
+    click(page, x, y, clicks=2, box=box)
+
+
+def type_text(page, text):
+    """Type character by character with human cadence: most keys land quickly, word
+    boundaries pause a little longer, and an occasional key hesitates the way a real
+    typist does — instead of the whole string arriving with uniform zero-jitter timing."""
+    for ch in text:
+        page.keyboard.type(ch)
+        delay = random.uniform(0.04, 0.14)
+        if ch in " \t\n":
+            delay += random.uniform(0.03, 0.12)  # word-boundary pause
+        if random.random() < 0.03:
+            delay += random.uniform(0.2, 0.5)  # occasional hesitation
+        time.sleep(delay)

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -1,12 +1,13 @@
 """
-Purpose: Humanize BrowserAutomation's pointer + keyboard events so clicks and typing survive
-         BEHAVIORAL bot detection (mouse-trajectory entropy, click position, keystroke cadence)
+Purpose: Humanize BrowserAutomation's pointer + keyboard + scroll events so clicks, typing and
+         scrolling survive BEHAVIORAL bot detection (mouse-trajectory/velocity, click position,
+         keystroke cadence, wheel-device shape, IME/paste for CJK)
 LLM-Note:
-  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here; scroll.py — wheel scroll] | tested by [tests/unit/test_browser_humanize.py]
-  Data flow: browser.py/scroll.py call move/click/double_click/type_text/scroll(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
-  State/Effects: drives the live page via page.mouse.* / page.keyboard.* and (for CJK) a CDP session's Input.imeSetComposition, sleeping between events; retained state is `_cursor` (per-page last x/y) and `_cdp` (per-page CDP session for IME) — both auto-dropped when the page is GC'd
-  Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves (curved cursor paths, keystroke cadence, real wheel events, and IME composition for CJK). No public tool signatures change; only the low-level event generation.
-  Errors: none — pure event emission; if the page is closed the underlying Playwright/CDP call raises and bubbles (fail fast)
+  Dependencies: stdlib only [math, platform, random, shutil, subprocess, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here; scroll.py — wheel scroll] | tested by [tests/unit/test_browser_humanize.py]
+  Data flow: browser.py/scroll.py call move/click/double_click/type_text/scroll(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions); timing/scroll-device come from a per-page `_persona`
+  State/Effects: drives the live page via page.mouse.* / page.keyboard.*, and for CJK sets the OS clipboard (subprocess: xclip/xsel/pbcopy/clip) then Ctrl/Cmd+V, falling back to a CDP session's Input.imeSetComposition when paste is blocked; sleeps between events. Retained state: `_cursor` (per-page x/y), `_cdp` (per-page CDP session), `_personas` (per-page timing/device persona) — all auto-dropped when the page is GC'd. The user's clipboard is saved and restored around a paste.
+  Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves (curved cursor paths with a human velocity profile, log-normal keystroke cadence, real wheel events, and CJK entered by a trusted paste, IME fallback). No public tool signatures change; only the low-level event generation.
+  Errors: none — event emission plus a best-effort clipboard round-trip; if the page is closed the underlying Playwright/CDP call raises and bubbles (fail fast)
 """
 
 import math
@@ -179,11 +180,10 @@ def _wheel(page, amount, sign, lo, hi):
 
 
 def _needs_ime(ch):
-    """True for characters a human types through an IME (composition), not direct keys —
-    CJK ideographs, Japanese kana, Korean hangul. `page.keyboard.type` drops these as a
-    bare insertText with NO composition events, which is an obvious tell on IME-aware
-    (Chinese/Japanese/Korean) sites: a real typist always produces compositionstart/
-    update/end while choosing candidates."""
+    """True for characters a human enters by paste or an IME, not direct keystrokes — CJK
+    ideographs, Japanese kana, Korean hangul. `page.keyboard.type` drops these as a bare
+    insertText, which is an obvious tell on IME-aware (Chinese/Japanese/Korean) sites where
+    a real user pastes or composes them; see type_text for how these runs are entered."""
     o = ord(ch)
     return (0x3040 <= o <= 0x30FF or   # hiragana + katakana
             0x3400 <= o <= 0x4DBF or   # CJK ext A
@@ -193,8 +193,8 @@ def _needs_ime(ch):
 
 
 def _segments(text):
-    """Split text into (needs_ime, run) chunks so each run is typed with the right
-    mechanism — direct keystrokes for Latin, IME composition for CJK."""
+    """Split text into (needs_ime, run) chunks so each run is entered with the right
+    mechanism — direct keystrokes for Latin, paste (IME fallback) for CJK."""
     runs = []
     for ch in text:
         ime = _needs_ime(ch)

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -4,9 +4,9 @@ Purpose: Humanize BrowserAutomation's pointer + keyboard events so clicks and ty
 LLM-Note:
   Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here; scroll.py — wheel scroll] | tested by [tests/unit/test_browser_humanize.py]
   Data flow: browser.py/scroll.py call move/click/double_click/type_text/scroll(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
-  State/Effects: drives the live page via page.mouse.* / page.keyboard.* and sleeps between events; the only retained state is `_cursor` (per-page last x/y, auto-dropped when the page is GC'd)
-  Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves. No public tool signatures change; only the low-level event generation.
-  Errors: none — pure event emission; if the page is closed the underlying Playwright call raises and bubbles (fail fast)
+  State/Effects: drives the live page via page.mouse.* / page.keyboard.* and (for CJK) a CDP session's Input.imeSetComposition, sleeping between events; retained state is `_cursor` (per-page last x/y) and `_cdp` (per-page CDP session for IME) — both auto-dropped when the page is GC'd
+  Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves (curved cursor paths, keystroke cadence, real wheel events, and IME composition for CJK). No public tool signatures change; only the low-level event generation.
+  Errors: none — pure event emission; if the page is closed the underlying Playwright/CDP call raises and bubbles (fail fast)
 """
 
 import math
@@ -17,6 +17,9 @@ from weakref import WeakKeyDictionary
 # Remember each page's cursor position so the next move starts from where the last one
 # ended — real cursors travel between actions, they don't reappear on the target pixel.
 _cursor = WeakKeyDictionary()
+
+# One CDP session per page, reused for IME composition (see type_text/_type_ime).
+_cdp = WeakKeyDictionary()
 
 
 def _bezier(start, end, steps):
@@ -101,10 +104,10 @@ def scroll(page, total_dy):
     `scrollBy(0, 1000)` jump a detector flags (scrollY changes with zero wheel events)."""
     remaining = int(total_dy)
     sign = 1 if remaining >= 0 else -1
-    while abs(remaining) > 2:
+    while remaining != 0:
         step = sign * random.randint(90, 170)
         if abs(step) > abs(remaining):
-            step = remaining
+            step = remaining  # final tick lands exactly on the target
         page.mouse.wheel(0, step)
         remaining -= step
         time.sleep(random.uniform(0.03, 0.10))
@@ -112,15 +115,70 @@ def scroll(page, total_dy):
             time.sleep(random.uniform(0.2, 0.5))  # occasional reading pause
 
 
-def type_text(page, text):
-    """Type character by character with human cadence: most keys land quickly, word
-    boundaries pause a little longer, and an occasional key hesitates the way a real
-    typist does — instead of the whole string arriving with uniform zero-jitter timing."""
+def _needs_ime(ch):
+    """True for characters a human types through an IME (composition), not direct keys —
+    CJK ideographs, Japanese kana, Korean hangul. `page.keyboard.type` drops these as a
+    bare insertText with NO composition events, which is an obvious tell on IME-aware
+    (Chinese/Japanese/Korean) sites: a real typist always produces compositionstart/
+    update/end while choosing candidates."""
+    o = ord(ch)
+    return (0x3040 <= o <= 0x30FF or   # hiragana + katakana
+            0x3400 <= o <= 0x4DBF or   # CJK ext A
+            0x4E00 <= o <= 0x9FFF or   # CJK unified ideographs
+            0xAC00 <= o <= 0xD7A3 or   # hangul syllables
+            0xF900 <= o <= 0xFAFF)     # CJK compatibility ideographs
+
+
+def _segments(text):
+    """Split text into (needs_ime, run) chunks so each run is typed with the right
+    mechanism — direct keystrokes for Latin, IME composition for CJK."""
+    runs = []
     for ch in text:
-        page.keyboard.type(ch)
-        delay = random.uniform(0.04, 0.14)
-        if ch in " \t\n":
-            delay += random.uniform(0.03, 0.12)  # word-boundary pause
-        if random.random() < 0.03:
-            delay += random.uniform(0.2, 0.5)  # occasional hesitation
+        ime = _needs_ime(ch)
+        if runs and runs[-1][0] == ime:
+            runs[-1][1].append(ch)
+        else:
+            runs.append((ime, [ch]))
+    return [(ime, "".join(chars)) for ime, chars in runs]
+
+
+def _type_ime(page, run):
+    """Type a CJK run through the browser's real IME path via CDP: each character is shown
+    composing (underlined) and then committed, firing compositionstart/update/end and
+    inputType=insertCompositionText the way pinyin/romaji + candidate selection does —
+    instead of the bare insertText page.keyboard.type emits, which has no composition."""
+    session = _cdp.get(page)
+    if session is None:
+        session = page.context.new_cdp_session(page)
+        _cdp[page] = session
+    for ch in run:
+        session.send("Input.imeSetComposition",
+                     {"text": ch, "selectionStart": 1, "selectionEnd": 1})
+        time.sleep(random.uniform(0.06, 0.16))   # candidate appears / gets chosen
+        # insertText commits the candidate: fires compositionend + inputType
+        # insertCompositionText. (compositionstart is a trusted event; compositionend from
+        # this commit is not — a minor Chrome/CDP quirk, still far better than the bare
+        # insertText with zero composition events that keyboard.type would emit.)
+        session.send("Input.insertText", {"text": ch})
+        delay = random.uniform(0.08, 0.20)
+        if random.random() < 0.05:
+            delay += random.uniform(0.2, 0.5)    # occasional hesitation
         time.sleep(delay)
+
+
+def type_text(page, text):
+    """Type with human cadence. Latin text goes key-by-key (most land quickly, word
+    boundaries pause, an occasional key hesitates). CJK runs go through the IME
+    composition path so they look like real pinyin/romaji input, not a bare insertText."""
+    for is_ime, run in _segments(text):
+        if is_ime:
+            _type_ime(page, run)
+            continue
+        for ch in run:
+            page.keyboard.type(ch)
+            delay = random.uniform(0.04, 0.14)
+            if ch in " \t\n":
+                delay += random.uniform(0.03, 0.12)  # word-boundary pause
+            if random.random() < 0.03:
+                delay += random.uniform(0.2, 0.5)  # occasional hesitation
+            time.sleep(delay)

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -22,58 +22,103 @@ _cursor = WeakKeyDictionary()
 _cdp = WeakKeyDictionary()
 
 
-def _bezier(start, end, steps):
-    """Cubic Bézier from start to end with two random control points, sampled at `steps`
-    points. The control points bow the path sideways off the straight line, giving the
-    curvature a hand produces instead of a ruler-straight segment a detector flags."""
-    (x0, y0), (x3, y3) = start, end
-    dx, dy = x3 - x0, y3 - y0
+# A per-page "persona": one real user has one hand and one input device for a whole
+# session, so their timing scale and scroll device are constant within a page but differ
+# between pages/runs. This defeats a detector that would fingerprint the tool by its fixed
+# timing envelope across every session.
+_personas = WeakKeyDictionary()
+
+
+def _persona(page):
+    p = _personas.get(page)
+    if p is None:
+        p = {
+            "speed": random.lognormvariate(0.0, 0.22),  # overall pace multiplier
+            "wheel_notch": random.random() < 0.6,       # 60% wheel mouse, 40% trackpad
+        }
+        _personas[page] = p
+    return p
+
+
+def _pause(page, base, sigma=0.45):
+    """Sleep a right-skewed (log-normal) time around `base` seconds, scaled by the page's
+    persona. Human inter-event gaps have a fat right tail, not the flat plateau uniform()
+    gives — and uniform's fixed min/max is itself a cross-session fingerprint."""
+    time.sleep(max(0.004, base * random.lognormvariate(0.0, sigma) * _persona(page)["speed"]))
+
+
+def _ease(u):
+    """Minimum-jerk position profile (smootherstep): slow → fast → slow. Sampling Bézier t
+    at _ease(i/steps) makes the cursor accelerate out of the start and decelerate into the
+    target — a bell velocity curve, not the constant speed equal-t sampling would give."""
+    return u * u * u * (u * (u * 6 - 15) + 10)
+
+
+def _control_points(start, end):
+    """Two Bézier control points bowed off the straight line so the path curves like a
+    hand's rather than running ruler-straight."""
+    (x0, y0), (x1, y1) = start, end
+    dx, dy = x1 - x0, y1 - y0
     dist = math.hypot(dx, dy) or 1.0
-    px, py = -dy / dist, dx / dist  # unit vector perpendicular to the travel direction
+    nx, ny = -dy / dist, dx / dist  # unit normal to the direction of travel
 
     def control(along):
         off = random.uniform(-0.22, 0.22) * dist
-        return x0 + dx * along + px * off, y0 + dy * along + py * off
+        return x0 + dx * along + nx * off, y0 + dy * along + ny * off
 
-    c1 = control(random.uniform(0.2, 0.4))
-    c2 = control(random.uniform(0.6, 0.8))
+    return control(random.uniform(0.2, 0.4)), control(random.uniform(0.6, 0.8))
 
-    points = []
-    for i in range(1, steps + 1):
-        t = i / steps
-        mt = 1 - t
-        x = mt ** 3 * x0 + 3 * mt ** 2 * t * c1[0] + 3 * mt * t ** 2 * c2[0] + t ** 3 * x3
-        y = mt ** 3 * y0 + 3 * mt ** 2 * t * c1[1] + 3 * mt * t ** 2 * c2[1] + t ** 3 * y3
-        points.append((x, y))
-    return points
+
+def _cubic(p0, c1, c2, p3, t):
+    mt = 1 - t
+    return (
+        mt ** 3 * p0[0] + 3 * mt ** 2 * t * c1[0] + 3 * mt * t ** 2 * c2[0] + t ** 3 * p3[0],
+        mt ** 3 * p0[1] + 3 * mt ** 2 * t * c1[1] + 3 * mt * t ** 2 * c2[1] + t ** 3 * p3[1],
+    )
 
 
 def move(page, x, y):
-    """Move the cursor to (x, y) along a curved, variable-speed path, emitting a real
-    mousemove event at every step."""
+    """Move the cursor to (x, y) along a curved path with a human velocity profile
+    (accelerate out, decelerate in) and a small overshoot-and-settle at the end, emitting a
+    real mousemove event at every step."""
     start = _cursor.get(page)
     if start is None:
-        # First move of the session: begin a little off the target so there is still a
-        # short trajectory, never an instant appearance on the exact pixel.
-        start = (x + random.uniform(-140, 140), y + random.uniform(-140, 140))
+        # First move of the session: start well off the target so there is a real approach
+        # trajectory, never an instant appearance on the exact pixel.
+        start = (x + random.uniform(-260, 260), y + random.uniform(-200, 200))
 
     dist = math.hypot(x - start[0], y - start[1])
-    steps = max(8, min(40, int(dist / 12)))
-    for px, py in _bezier(start, (x, y), steps):
+    steps = max(10, min(48, int(dist / 10)))
+    c1, c2 = _control_points(start, (x, y))
+    for i in range(1, steps + 1):
+        px, py = _cubic(start, c1, c2, (x, y), _ease(i / steps))
         page.mouse.move(px, py)
-        time.sleep(random.uniform(0.006, 0.02))
+        _pause(page, 0.011, 0.5)
+    _overshoot(page, x, y)
     _cursor[page] = (x, y)
 
 
+def _overshoot(page, x, y):
+    """Most human pointer landings overshoot by a few pixels and correct back — a tiny
+    end submovement a straight glide-to-target never has."""
+    if random.random() < 0.65:
+        page.mouse.move(x + random.gauss(0, 3), y + random.gauss(0, 3))
+        _pause(page, 0.03, 0.4)
+        page.mouse.move(x, y)
+        _pause(page, 0.02, 0.4)
+
+
 def _point_in_box(box):
-    """A point inside the element but off dead-center — humans don't hit the exact
-    centroid. Kept within the inner 60% so we never fall outside the element."""
+    """A point inside the element, gaussian-clustered near the centre — human click
+    positions form a radial gaussian around the target, not a uniform rectangle. Clamped
+    just inside the edges so we never fall outside the element."""
     cx = box["x"] + box["width"] / 2
     cy = box["y"] + box["height"] / 2
-    return (
-        cx + random.uniform(-0.3, 0.3) * box["width"],
-        cy + random.uniform(-0.3, 0.3) * box["height"],
-    )
+    x = cx + random.gauss(0, box["width"] * 0.15)
+    y = cy + random.gauss(0, box["height"] * 0.15)
+    x = min(max(x, box["x"] + 1), box["x"] + box["width"] - 1)
+    y = min(max(y, box["y"] + 1), box["y"] + box["height"] - 1)
+    return x, y
 
 
 def click(page, x, y, button="left", clicks=1, box=None):
@@ -82,15 +127,15 @@ def click(page, x, y, button="left", clicks=1, box=None):
     if box is not None:
         x, y = _point_in_box(box)
     move(page, x, y)
-    time.sleep(random.uniform(0.03, 0.12))  # settle before pressing
+    _pause(page, 0.06, 0.5)  # settle before pressing
     for i in range(clicks):
         # click_count must increment (1, 2, ...) or Chromium never synthesizes a dblclick
         # from CDP-injected input — two count-1 presses are just two single clicks.
         page.mouse.down(button=button, click_count=i + 1)
-        time.sleep(random.uniform(0.04, 0.11))  # down→up dwell
+        _pause(page, 0.06, 0.35)  # down→up dwell
         page.mouse.up(button=button, click_count=i + 1)
         if i + 1 < clicks:
-            time.sleep(random.uniform(0.06, 0.12))  # inter-click gap (double click)
+            _pause(page, 0.08, 0.3)  # inter-click gap (double click)
     _cursor[page] = (x, y)
 
 
@@ -100,21 +145,34 @@ def double_click(page, x, y, box=None):
 
 
 def scroll(page, total_dy):
-    """Human wheel scroll: cover `total_dy` pixels as many small mouse-wheel ticks with
-    variable size and cadence (plus the odd longer reading pause), so the page emits real
-    `wheel` events and `scrollY` moves incrementally — instead of the instant programmatic
-    `scrollBy(0, 1000)` jump a detector flags (scrollY changes with zero wheel events)."""
-    remaining = int(total_dy)
-    sign = 1 if remaining >= 0 else -1
+    """Human wheel scroll: emit real `wheel` events sized like the page's scroll device (a
+    wheel mouse fires near-constant ~120px notches; a trackpad fires many small deltas),
+    with variable cadence and a small overshoot-and-correct at the end — instead of the
+    instant programmatic `scrollBy(0, 1000)` jump a detector flags (scrollY changes with
+    zero wheel events)."""
+    p = _persona(page)
+    lo, hi = (100, 130) if p["wheel_notch"] else (8, 28)
+    sign = 1 if total_dy >= 0 else -1
+    target = int(total_dy)
+    # Overshoot a little past the target then correct back — net displacement == target,
+    # the way a human stops short of or past a mark and nudges into place.
+    overshoot = sign * random.randint(lo, hi) if target and random.random() < 0.6 else 0
+    _wheel(page, target + overshoot, sign, lo, hi)
+    if overshoot:
+        _wheel(page, -overshoot, -sign, lo, hi)
+
+
+def _wheel(page, amount, sign, lo, hi):
+    remaining = amount
     while remaining != 0:
-        step = sign * random.randint(90, 170)
+        step = sign * random.randint(lo, hi)
         if abs(step) > abs(remaining):
-            step = remaining  # final tick lands exactly on the target
+            step = remaining  # last tick lands exactly
         page.mouse.wheel(0, step)
         remaining -= step
-        time.sleep(random.uniform(0.03, 0.10))
-        if random.random() < 0.1:
-            time.sleep(random.uniform(0.2, 0.5))  # occasional reading pause
+        _pause(page, 0.045, 0.4)
+        if random.random() < 0.08:
+            _pause(page, 0.3, 0.5)  # occasional reading pause
 
 
 def _needs_ime(ch):
@@ -156,16 +214,15 @@ def _type_ime(page, run):
     for ch in run:
         session.send("Input.imeSetComposition",
                      {"text": ch, "selectionStart": 1, "selectionEnd": 1})
-        time.sleep(random.uniform(0.06, 0.16))   # candidate appears / gets chosen
+        _pause(page, 0.10, 0.4)   # candidate appears / gets chosen
         # insertText commits the candidate: fires compositionend + inputType
         # insertCompositionText. (compositionstart is a trusted event; compositionend from
         # this commit is not — a minor Chrome/CDP quirk, still far better than the bare
         # insertText with zero composition events that keyboard.type would emit.)
         session.send("Input.insertText", {"text": ch})
-        delay = random.uniform(0.08, 0.20)
+        _pause(page, 0.12, 0.5)
         if random.random() < 0.05:
-            delay += random.uniform(0.2, 0.5)    # occasional hesitation
-        time.sleep(delay)
+            _pause(page, 0.3, 0.5)   # occasional hesitation
 
 
 def type_text(page, text):
@@ -178,9 +235,8 @@ def type_text(page, text):
             continue
         for ch in run:
             page.keyboard.type(ch)
-            delay = random.uniform(0.04, 0.14)
+            _pause(page, 0.09, 0.5)  # inter-key gap (log-normal, persona-scaled)
             if ch in " \t\n":
-                delay += random.uniform(0.03, 0.12)  # word-boundary pause
+                _pause(page, 0.06, 0.5)  # word-boundary pause
             if random.random() < 0.03:
-                delay += random.uniform(0.2, 0.5)  # occasional hesitation
-            time.sleep(delay)
+                _pause(page, 0.3, 0.5)  # occasional hesitation

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -10,7 +10,10 @@ LLM-Note:
 """
 
 import math
+import platform
 import random
+import shutil
+import subprocess
 import time
 from weakref import WeakKeyDictionary
 
@@ -202,6 +205,49 @@ def _segments(text):
     return [(ime, "".join(chars)) for ime, chars in runs]
 
 
+def _clipboard_cmds():
+    """(set_argv, get_argv) for the OS clipboard, or None if no tool is available. A real
+    user pastes Chinese far more than they hand-type it, and paste is a fully trusted event
+    with none of the IME path's residual tells (see type_text)."""
+    system = platform.system()
+    if system == "Darwin":
+        return (["pbcopy"], ["pbpaste"])
+    if system == "Windows":
+        return (["clip"], ["powershell", "-NoProfile", "-Command", "Get-Clipboard"])
+    if shutil.which("xclip"):
+        return (["xclip", "-selection", "clipboard"],
+                ["xclip", "-selection", "clipboard", "-o"])
+    if shutil.which("xsel"):
+        return (["xsel", "--clipboard", "--input"], ["xsel", "--clipboard", "--output"])
+    return None
+
+
+def _active_text_len(page):
+    return page.evaluate(
+        "() => { const e = document.activeElement;"
+        " return e ? ((e.value != null ? e.value : e.textContent) || '').length : 0; }")
+
+
+def _paste(page, text):
+    """Put `text` on the OS clipboard and Ctrl/Cmd+V it into the focused field, then restore
+    the user's clipboard. Returns True only if the field actually took the paste — some
+    inputs (password fields, paste-blocked forms) reject it, and the caller then falls back
+    to the IME path."""
+    cmds = _clipboard_cmds()
+    if cmds is None:
+        return False
+    set_argv, get_argv = cmds
+    saved = subprocess.run(get_argv, capture_output=True).stdout
+    subprocess.run(set_argv, input=text.encode())
+    before = _active_text_len(page)
+    modifier = "Meta" if platform.system() == "Darwin" else "Control"
+    page.keyboard.press(f"{modifier}+v")
+    _pause(page, 0.12, 0.4)
+    grew = _active_text_len(page) >= before + len(text)
+    subprocess.run(set_argv, input=saved)  # restore the user's clipboard
+    return grew
+
+
 def _type_ime(page, run):
     """Type a CJK run through the browser's real IME path via CDP: each character is shown
     composing (underlined) and then committed, firing compositionstart/update/end and
@@ -227,11 +273,13 @@ def _type_ime(page, run):
 
 def type_text(page, text):
     """Type with human cadence. Latin text goes key-by-key (most land quickly, word
-    boundaries pause, an occasional key hesitates). CJK runs go through the IME
-    composition path so they look like real pinyin/romaji input, not a bare insertText."""
+    boundaries pause, an occasional key hesitates). CJK runs are PASTED (a trusted paste
+    event — how people usually enter Chinese, and free of the IME path's zero-keydown /
+    untrusted-compositionend tells); if the field blocks paste we fall back to the IME."""
     for is_ime, run in _segments(text):
         if is_ime:
-            _type_ime(page, run)
+            if not _paste(page, run):
+                _type_ime(page, run)
             continue
         for ch in run:
             page.keyboard.type(ch)

--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -84,9 +84,11 @@ def click(page, x, y, button="left", clicks=1, box=None):
     move(page, x, y)
     time.sleep(random.uniform(0.03, 0.12))  # settle before pressing
     for i in range(clicks):
-        page.mouse.down(button=button)
+        # click_count must increment (1, 2, ...) or Chromium never synthesizes a dblclick
+        # from CDP-injected input — two count-1 presses are just two single clicks.
+        page.mouse.down(button=button, click_count=i + 1)
         time.sleep(random.uniform(0.04, 0.11))  # down→up dwell
-        page.mouse.up(button=button)
+        page.mouse.up(button=button, click_count=i + 1)
         if i + 1 < clicks:
             time.sleep(random.uniform(0.06, 0.12))  # inter-click gap (double click)
     _cursor[page] = (x, y)

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -1,13 +1,13 @@
 """
-Purpose: Intelligent page scrolling with AI strategy selection and fallback mechanisms
+Purpose: Page scrolling that looks human (real mouse-wheel events) first, with AI/JS fallbacks
 LLM-Note:
-  Dependencies: imports from [playwright Page, connectonion llm_do, pydantic, pathlib, PIL Image] | imported by [cli/browser_agent/browser.py] | tested by [tests/e2e/cli/test_scroll.py]
-  Data flow: scroll(page, take_screenshot, times, description) → takes before screenshot → tries strategies: AI-generated JS → element scroll → page scroll → takes after screenshot → compares via _screenshots_different() → returns on first successful change | _ai_scroll() extracts scrollable elements + HTML → llm_do generates ScrollStrategy → executes JS | fallbacks use simpler JS approaches
-  State/Effects: writes before/after screenshots to screenshots/ directory | executes JavaScript on page (modifies scrollTop or window.scrollY) | no persistent state
+  Dependencies: imports from [connectonion llm_do, pydantic, pathlib, PIL Image, . humanize] | imported by [useful_tools/browser_tools/browser.py] | tested by [tests/unit/test_scroll.py]
+  Data flow: scroll(page, take_screenshot, times, description) → takes before screenshot → tries strategies IN ORDER: Human wheel (humanize.scroll emits real mouse-wheel events) → AI-generated JS → element scroll → page scroll → takes after screenshot → compares via _screenshots_different() → returns on first successful change | _ai_scroll() extracts scrollable elements + HTML → llm_do generates ScrollStrategy → executes JS | JS strategies use scrollTop/scrollBy
+  State/Effects: writes before/after screenshots to screenshots/ directory | Human wheel dispatches real wheel events over the content; JS fallbacks modify scrollTop or window.scrollY | no persistent state
   Integration: exposes scroll(page, take_screenshot, times, description) → str | ScrollStrategy Pydantic model with method, selector, javascript, explanation | uses scroll_strategy.md prompt for LLM | verifies success via pixel difference (>1% change threshold)
-  Performance: tries AI first (slower but accurate) → falls back to faster heuristics | 0.5-1s sleep between scrolls for content loading | PIL pixel comparison (fast for typical screenshots)
+  Performance: Human wheel is the default and needs no LLM | AI strategy (slower) only runs if wheel didn't change the page | 0.3-0.7s between scrolls for content loading | PIL pixel comparison (fast for typical screenshots)
   Errors: returns "Browser not open" if page None | returns "All scroll strategies failed" if no strategy changes content | prints strategy attempts for debugging | catches exceptions per strategy and continues
-Unified scroll module - AI-powered with fallback strategies.
+Unified scroll module - humanized mouse-wheel first, AI/JS fallbacks.
 
 Usage:
     from scroll import scroll
@@ -31,9 +31,9 @@ class ScrollStrategy(BaseModel):
 
 
 def scroll(page, take_screenshot, times: int = 5, description: str = "the main content area") -> str:
-    """Universal scroll with AI strategy and fallback.
+    """Universal scroll, humanized first.
 
-    Tries: AI-generated → Element scroll → Page scroll
+    Tries: Human wheel (real mouse-wheel events) → AI-generated → Element scroll → Page scroll
     Verifies success with screenshot comparison.
     """
     if not page:

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -16,6 +16,8 @@ Usage:
 from pathlib import Path
 from pydantic import BaseModel
 from connectonion import llm_do
+from . import humanize
+import random
 import time
 
 _PROMPT = (Path(__file__).parent / "prompts" / "scroll_strategy.md").read_text()
@@ -42,6 +44,7 @@ def scroll(page, take_screenshot, times: int = 5, description: str = "the main c
     take_screenshot(path=before)
 
     strategies = [
+        ("Human wheel", lambda: _human_scroll(page, times)),
         ("AI strategy", lambda: _ai_scroll(page, times, description)),
         ("Element scroll", lambda: _element_scroll(page, times)),
         ("Page scroll", lambda: _page_scroll(page, times)),
@@ -64,6 +67,18 @@ def scroll(page, take_screenshot, times: int = 5, description: str = "the main c
             print(f"  ❌ {name} failed: {e}")
 
     return "All scroll strategies failed"
+
+
+def _human_scroll(page, times: int):
+    """Scroll with real mouse-wheel events. Tried FIRST because it is the only strategy
+    that looks human — the JS strategies below move scrollTop directly and emit no wheel
+    event. Move the cursor over the content so the wheel targets the page/container, then
+    roll it a screenful at a time."""
+    w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    humanize.move(page, w // 2, h // 2)
+    for _ in range(times):
+        humanize.scroll(page, random.randint(int(h * 0.7), int(h * 0.95)))
+        time.sleep(random.uniform(0.3, 0.7))
 
 
 def _ai_scroll(page, times: int, description: str):

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -150,8 +150,19 @@ def _v_iphey(b):
 
 def _v_deviceandbrowser(b):
     _skip_if_down(b)
-    is_bot = _eval(b, "() => (JSON.parse((document.body.innerText.match(/\\{[\\s\\S]*\\}/)||['{}'])[0]).isBot)")
-    return (is_bot is False), f"isBot={is_bot}"
+    d = _eval(b, "() => { const m=document.body.innerText.match(/\\{[\\s\\S]*\\}/);"
+                 " try { return JSON.parse(m[0]).details; } catch(e){ return null; } }")
+    if not d:
+        pytest.skip("detection details not rendered")
+    # The composite `isBot` also folds in `hasSuspiciousWeakSignals` — a datacenter-IP /
+    # environment heuristic that a residential IP clears. Assert the CONCRETE automation
+    # detectors (what the stealth browser controls); every one must read false.
+    automation_keys = ["hasWebdriverTrue", "isPlaywright", "isAutomatedWithCDP",
+                       "isAutomatedWithCDPInWebWorker", "isHeadlessChrome",
+                       "hasInconsistentChromeObject", "isWebGLInconsistent",
+                       "hasInconsistentGPUFeatures", "hasHeadlessChromeDefaultScreenResolution"]
+    flagged = [k for k in automation_keys if d.get(k)]
+    return (not flagged), f"automation flags={flagged or 'none'} weakSignals={d.get('hasSuspiciousWeakSignals')}"
 
 
 def _v_nowsecure_cloudflare(b):
@@ -171,6 +182,47 @@ def _v_recaptcha_v3(b):
     return (score >= 0.5), f"score={score}"
 
 
+_ROWS_JS = ("() => Array.from(document.querySelectorAll('table tr'))"
+            ".map(t => t.innerText.replace(/\\s+/g,' ').trim()).filter(Boolean)")
+
+
+def _v_rebrowser_cdp(b):
+    """rebrowser-bot-detector — the modern CDP-leak suite (Runtime.enable etc.). A 🔴 on
+    any row is a real automation tell; the ⚪️ rows are neutral (they need main-world
+    access, which Patchright's isolated world correctly denies)."""
+    _skip_if_down(b)
+    b.mouse_click(300, 300)                                # a real interaction
+    _eval(b, "() => new Promise(r => setTimeout(r, 3000))")  # let the tests settle
+    rows = _eval(b, _ROWS_JS)
+    reds = [r.split(" Notes")[0][:70] for r in rows if "🔴" in r]
+    critical_pass = any("runtimeEnableLeak" in r and "🟢" in r for r in rows) \
+        and any("navigatorWebdriver" in r and "🟢" in r for r in rows)
+    return (critical_pass and not reds), f"reds={reds or 'none'}"
+
+
+def _v_incolumitas(b):
+    """bot.incolumitas.com — its 'new tests' JSON reports OK for every non-behavioral,
+    non-IP fingerprint check when the browser is clean."""
+    _skip_if_down(b)
+    nt = _eval(b, "() => { const n=document.querySelector('#new-tests'); return n ? n.textContent : ''; }")
+    fails = re.findall(r'"(\w+)":\s*"(?!OK)([^"]+)"', nt)
+    return (nt.count('"OK"') >= 8 and not fails), f"non-OK={fails or 'none'}"
+
+
+def _v_webgl_present(b):
+    """A GPU-less server must still expose WebGL (SwiftShader fallback); 'no webgl context'
+    is a classic bot tell that our --enable-unsafe-swiftshader flag removes."""
+    _skip_if_down(b)
+    val = _eval(b, """() => {
+        const c=document.createElement('canvas');
+        const gl=c.getContext('webgl')||c.getContext('experimental-webgl');
+        if(!gl) return 'NO_WEBGL';
+        const d=gl.getExtension('WEBGL_debug_renderer_info');
+        return d ? gl.getParameter(d.UNMASKED_RENDERER_WEBGL) : 'webgl-no-debug-ext';
+    }""")
+    return (val != "NO_WEBGL"), val
+
+
 ISSUE_SITES = [
     ("sannysoft",        "https://bot.sannysoft.com/",                     3,  _v_sannysoft),
     ("browserscan",      "https://www.browserscan.net/bot-detection",      6,  _v_browserscan),
@@ -182,6 +234,10 @@ ISSUE_SITES = [
     ("nowsecure_cf",     "https://nowsecure.nl/",                          8,  _v_nowsecure_cloudflare),
     ("recaptcha_v3",     "https://antcpt.com/score_detector/",             9,  _v_recaptcha_v3),
     ("areyouheadless",   "https://arh.antoinevastel.com/bots/areyouheadless", 4, _v_webdriver_false),
+    # Harder / modern detectors added while chasing full coverage (issue #222 update).
+    ("rebrowser_cdp",    "https://bot-detector.rebrowser.net/",            5,  _v_rebrowser_cdp),
+    ("incolumitas",      "https://bot.incolumitas.com/",                   14, _v_incolumitas),
+    ("browserleaks_webgl", "https://browserleaks.com/webgl",              6,  _v_webgl_present),
 ]
 
 

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -142,6 +142,38 @@ def test_humanized_scroll_emits_wheel_events(stealth_browser):
     assert len(set(ys)) >= 5, "scrollY should move incrementally, not in one jump"
 
 
+IME_PAGE = (
+    "<!doctype html><meta charset=utf-8>"
+    "<input id=box style='position:absolute;left:60px;top:80px;width:400px;height:32px'>"
+    "<b id=rec></b>"
+)
+INSTALL_IME_RECORDER = """() => {
+    const r=document.getElementById('rec'), box=document.getElementById('box');
+    r.dataset.kd=0; r.dataset.cs=0; r.dataset.it=''; r.dataset.tr='';
+    box.addEventListener('keydown', () => r.dataset.kd=(+r.dataset.kd)+1);
+    box.addEventListener('compositionstart', e => { r.dataset.cs=(+r.dataset.cs)+1; r.dataset.tr+='cs='+e.isTrusted+' '; });
+    box.addEventListener('input', e => r.dataset.it += (e.inputType||'?')+' ');
+}"""
+
+
+def test_humanized_cjk_typing_uses_ime_composition(stealth_browser):
+    """Typing CJK must go through the IME composition path (real compositionstart +
+    insertCompositionText), not the bare insertText a bot emits. Latin in the same string
+    still types key-by-key."""
+    b = stealth_browser
+    b.go_to("data:text/html," + urllib.parse.quote(IME_PAGE), purpose="ime test", who="e2e")
+    _eval(b, INSTALL_IME_RECORDER)
+    b.mouse_click(260, 96)
+    b.keyboard_type("hi 你好世界")
+
+    d = _eval(b, "() => ({v: document.getElementById('box').value, ...document.getElementById('rec').dataset})")
+    assert d["v"] == "hi 你好世界", f"typed text wrong: {d['v']!r}"
+    assert int(d.get("kd", 0)) >= 3, "Latin part should still emit real keystrokes"
+    assert int(d.get("cs", 0)) >= 3, "each CJK char should start a composition"
+    assert "insertCompositionText" in d.get("it", ""), "CJK should commit via composition, not insertText"
+    assert "cs=true" in d.get("tr", ""), "compositionstart must be a trusted event"
+
+
 # ---------------------------------------------------------------------------
 # Layer 3 — every fingerprint / bot-detection site listed in issue #222.
 # Each entry: (name, url, settle_seconds, verdict(browser) -> (passed, detail)).

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -149,17 +149,18 @@ IME_PAGE = (
 )
 INSTALL_IME_RECORDER = """() => {
     const r=document.getElementById('rec'), box=document.getElementById('box');
-    r.dataset.kd=0; r.dataset.cs=0; r.dataset.it=''; r.dataset.tr='';
+    r.dataset.kd=0; r.dataset.cs=0; r.dataset.paste=0; r.dataset.it=''; r.dataset.tr='';
     box.addEventListener('keydown', () => r.dataset.kd=(+r.dataset.kd)+1);
     box.addEventListener('compositionstart', e => { r.dataset.cs=(+r.dataset.cs)+1; r.dataset.tr+='cs='+e.isTrusted+' '; });
+    box.addEventListener('paste', e => { r.dataset.paste=(+r.dataset.paste)+1; r.dataset.tr+='paste='+e.isTrusted+' '; });
     box.addEventListener('input', e => r.dataset.it += (e.inputType||'?')+' ');
 }"""
 
 
-def test_humanized_cjk_typing_uses_ime_composition(stealth_browser):
-    """Typing CJK must go through the IME composition path (real compositionstart +
-    insertCompositionText), not the bare insertText a bot emits. Latin in the same string
-    still types key-by-key."""
+def test_humanized_cjk_typing_uses_trusted_paste_or_ime(stealth_browser):
+    """CJK must be entered by a TRUSTED mechanism — a real paste (preferred: insertFromPaste,
+    what people usually do for Chinese) or, if paste is blocked, the IME composition path.
+    Never the bare insertText a bot emits. Latin in the same string still types key-by-key."""
     b = stealth_browser
     b.go_to("data:text/html," + urllib.parse.quote(IME_PAGE), purpose="ime test", who="e2e")
     _eval(b, INSTALL_IME_RECORDER)
@@ -169,9 +170,12 @@ def test_humanized_cjk_typing_uses_ime_composition(stealth_browser):
     d = _eval(b, "() => ({v: document.getElementById('box').value, ...document.getElementById('rec').dataset})")
     assert d["v"] == "hi 你好世界", f"typed text wrong: {d['v']!r}"
     assert int(d.get("kd", 0)) >= 3, "Latin part should still emit real keystrokes"
-    assert int(d.get("cs", 0)) >= 3, "each CJK char should start a composition"
-    assert "insertCompositionText" in d.get("it", ""), "CJK should commit via composition, not insertText"
-    assert "cs=true" in d.get("tr", ""), "compositionstart must be a trusted event"
+
+    pasted = int(d.get("paste", 0)) >= 1 and "insertFromPaste" in d.get("it", "")
+    composed = int(d.get("cs", 0)) >= 3 and "insertCompositionText" in d.get("it", "")
+    assert pasted or composed, f"CJK not via paste or IME: {d.get('it')!r}"
+    # Whichever path ran, its entry event must be trusted.
+    assert "paste=true" in d.get("tr", "") or "cs=true" in d.get("tr", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -1,18 +1,22 @@
 """End-to-end stealth guards for the real browser stack (no mocks).
 
-Two layers:
+Three layers:
   1. driver integrity — the installed Patchright must still be the patched stealth build.
-  2. humanized input (issue #222) — driving the REAL BrowserAutomation tool methods
-     (go_to / mouse_click / keyboard_type, the same verbs `co browser` calls) must emit
-     human-shaped events and pass the environment fingerprint checkers.
+  2. humanized input (issue #222) — the REAL BrowserAutomation verbs (mouse_click /
+     keyboard_type) must emit human-shaped events.
+  3. site verdicts (issue #222) — driving `co browser` (go_to) through every fingerprint /
+     bot-detection site listed in the issue must return a human/normal verdict.
 
-The layer-2 tests need a real headful browser, so they run only when a display is present
+Layers 2–3 need a real headful browser, so they run only when a display is present
 (locally: `xvfb-run -a python -m pytest tests/e2e/cli/test_browser_stealth_e2e.py`). They
-skip cleanly in a plain CI shell with no DISPLAY.
+skip cleanly in a plain CI shell with no DISPLAY, and skip an individual site if that
+third party is down (5xx / unreachable) rather than failing on someone else's outage.
 """
 
 import os
+import re
 import statistics
+import time
 import urllib.parse
 
 import pytest
@@ -32,30 +36,11 @@ def test_real_installed_driver_is_patched():
 
 
 # ---------------------------------------------------------------------------
-# Humanized-input e2e — drives the real tool methods through a real browser.
+# Shared headful browser (opened once for all interactive checks below).
 # ---------------------------------------------------------------------------
 
-# A page that records the input events a behavioral detector would score, into the shared
-# DOM (Patchright evaluates in an isolated world, so page-script globals aren't readable —
-# dataset on a DOM node is).
-RECORDER_PAGE = (
-    "<!doctype html><meta charset=utf-8>"
-    "<input id=box style='position:absolute;left:60px;top:80px;width:220px;height:32px'>"
-    "<button id=btn style='position:absolute;left:60px;top:140px;width:120px;height:36px'>go</button>"
-    "<b id=rec></b>"
-    "<script>"
-    "const r=document.getElementById('rec');"
-    "addEventListener('mousemove',()=>{r.dataset.moves=(+r.dataset.moves||0)+1});"
-    "addEventListener('mousedown',e=>{r.dataset.down=e.timeStamp});"
-    "addEventListener('mouseup',e=>{r.dataset.up=e.timeStamp});"
-    "document.getElementById('box').addEventListener('keydown',"
-    "e=>{r.dataset.keys=(r.dataset.keys?r.dataset.keys+',':'')+e.timeStamp});"
-    "</script>"
-)
-
-
-@pytest.fixture
-def browser():
+@pytest.fixture(scope="module")
+def stealth_browser():
     if not BROWSER_AVAILABLE:
         pytest.skip("patchright not installed")
     if not os.environ.get("DISPLAY"):
@@ -73,20 +58,47 @@ def _eval(browser, js):
     return browser._executor.submit(lambda: browser.page.evaluate(js)).result()
 
 
-def test_humanized_input_event_shape_end_to_end(browser):
+def _text(browser):
+    return " ".join(_eval(browser, "() => document.body.innerText").split())
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — humanized input through the real co-browser verbs.
+# ---------------------------------------------------------------------------
+
+# Records the input events a behavioral detector would score, into the shared DOM
+# (Patchright evaluates in an isolated world, so page-script globals aren't readable).
+RECORDER_PAGE = (
+    "<!doctype html><meta charset=utf-8>"
+    "<input id=box style='position:absolute;left:60px;top:80px;width:220px;height:32px'>"
+    "<button id=btn style='position:absolute;left:60px;top:140px;width:120px;height:36px'>go</button>"
+    "<b id=rec></b>"
+    "<script>"
+    "const r=document.getElementById('rec');"
+    "addEventListener('mousemove',()=>{r.dataset.moves=(+r.dataset.moves||0)+1});"
+    "addEventListener('mousedown',e=>{r.dataset.down=e.timeStamp});"
+    "addEventListener('mouseup',e=>{r.dataset.up=e.timeStamp});"
+    "document.getElementById('box').addEventListener('keydown',"
+    "e=>{r.dataset.keys=(r.dataset.keys?r.dataset.keys+',':'')+e.timeStamp});"
+    "</script>"
+)
+
+
+def test_humanized_input_event_shape_end_to_end(stealth_browser):
     """mouse_click + keyboard_type — the real co-browser verbs — must produce a curved
     multi-step move, a non-zero press dwell, and variable keystroke timing."""
+    b = stealth_browser
     data_url = "data:text/html," + urllib.parse.quote(RECORDER_PAGE)
-    browser.go_to(data_url, purpose="stealth event-shape test", who="e2e")
+    b.go_to(data_url, purpose="stealth event-shape test", who="e2e")
 
-    browser.mouse_click(160, 96)              # focus the input (center of #box)
-    browser.keyboard_type("hello human typing")
+    b.mouse_click(160, 96)              # focus the input (center of #box)
+    b.keyboard_type("hello human typing")
 
-    data = _eval(browser, "() => ({...document.getElementById('rec').dataset})")
+    data = _eval(b, "() => ({...document.getElementById('rec').dataset})")
     moves = int(data.get("moves", 0))
     dwell = float(data.get("up", 0)) - float(data.get("down", 0))
     key_times = [float(t) for t in data.get("keys", "").split(",") if t]
-    gaps = [b - a for a, b in zip(key_times, key_times[1:])]
+    gaps = [q - p for p, q in zip(key_times, key_times[1:])]
     jitter = statistics.pstdev(gaps) if len(gaps) > 1 else 0
 
     assert moves >= 8, f"expected a curved multi-step move, got {moves} mousemove events"
@@ -95,19 +107,90 @@ def test_humanized_input_event_shape_end_to_end(browser):
     assert jitter > 5, f"expected variable keystroke timing, stdev was {jitter:.0f}ms"
 
 
-def test_environment_checkers_pass_end_to_end(browser):
-    """The real browser must clear the environment fingerprint tells on a live page."""
-    browser.go_to("https://bot.sannysoft.com/", purpose="stealth fingerprint test", who="e2e")
-    tells = _eval(browser, """() => ({
-        webdriver: navigator.webdriver,
-        headlessUA: /Headless/i.test(navigator.userAgent),
-        chrome: typeof window.chrome === 'object',
-        plugins: navigator.plugins.length,
-        languages: (navigator.languages || []).length,
-    })""")
+# ---------------------------------------------------------------------------
+# Layer 3 — every fingerprint / bot-detection site listed in issue #222.
+# Each entry: (name, url, settle_seconds, verdict(browser) -> (passed, detail)).
+# A verdict may pytest.skip(...) when the site itself is unreachable/down.
+# ---------------------------------------------------------------------------
 
-    assert not tells["webdriver"], "navigator.webdriver leaked"
-    assert not tells["headlessUA"], "userAgent advertises Headless"
-    assert tells["chrome"], "window.chrome missing"
-    assert tells["plugins"] > 0, "no navigator.plugins"
-    assert tells["languages"] > 0, "no navigator.languages"
+def _skip_if_down(browser):
+    t = _text(browser).lower()
+    if any(s in t for s in ("502 bad gateway", "503 service", "504 gateway", "bad gateway")):
+        pytest.skip("third-party site is down (5xx)")
+
+
+def _v_sannysoft(b):
+    _skip_if_down(b)
+    wd = _eval(b, "() => navigator.webdriver")
+    t = _text(b).lower()
+    return (not wd and "passed" in t), f"webdriver={wd}"
+
+
+def _v_browserscan(b):
+    _skip_if_down(b)
+    t = _text(b).lower()
+    return ("test results" in t and "normal" in t), t[:120]
+
+
+def _v_webdriver_false(b):
+    _skip_if_down(b)
+    wd = _eval(b, "() => navigator.webdriver")
+    return (wd is False), f"webdriver={wd}"
+
+
+def _v_iphey(b):
+    _skip_if_down(b)
+    t = _text(b).lower()
+    # iphey's headline verdict folds in IP reputation, so a datacenter IP reads
+    # "Unreliable" no matter how clean the browser is. Assert the BROWSER-fingerprint
+    # sections instead — that is what the humanized/stealth browser actually controls:
+    # a real Chrome with hardware+software both reported fine.
+    return ("browser chrome" in t and t.count("everything is fine") >= 2), t[:160]
+
+
+def _v_deviceandbrowser(b):
+    _skip_if_down(b)
+    is_bot = _eval(b, "() => (JSON.parse((document.body.innerText.match(/\\{[\\s\\S]*\\}/)||['{}'])[0]).isBot)")
+    return (is_bot is False), f"isBot={is_bot}"
+
+
+def _v_nowsecure_cloudflare(b):
+    _skip_if_down(b)
+    t = _text(b).lower()
+    if "just a moment" in t or "checking your browser" in t:
+        return False, "stuck on Cloudflare challenge"
+    return ("nowsecure" in t), t[:120]
+
+
+def _v_recaptcha_v3(b):
+    _skip_if_down(b)
+    m = re.search(r"([01]\.\d+)", _text(b))
+    if not m:
+        pytest.skip("reCAPTCHA score not rendered")
+    score = float(m.group(1))
+    return (score >= 0.5), f"score={score}"
+
+
+ISSUE_SITES = [
+    ("sannysoft",        "https://bot.sannysoft.com/",                     3,  _v_sannysoft),
+    ("browserscan",      "https://www.browserscan.net/bot-detection",      6,  _v_browserscan),
+    ("creepjs",          "https://abrahamjuliot.github.io/creepjs/",       7,  _v_webdriver_false),
+    ("pixelscan",        "https://pixelscan.net/",                         8,  _v_webdriver_false),
+    ("iphey",            "https://iphey.com/",                             9,  _v_iphey),
+    ("deviceandbrowser", "https://deviceandbrowserinfo.com/are_you_a_bot", 5,  _v_deviceandbrowser),
+    ("fingerprintjs",    "https://fingerprint.com/products/bot-detection/",7,  _v_webdriver_false),
+    ("nowsecure_cf",     "https://nowsecure.nl/",                          8,  _v_nowsecure_cloudflare),
+    ("recaptcha_v3",     "https://antcpt.com/score_detector/",             9,  _v_recaptcha_v3),
+    ("areyouheadless",   "https://arh.antoinevastel.com/bots/areyouheadless", 4, _v_webdriver_false),
+]
+
+
+@pytest.mark.parametrize("name,url,settle,verdict", ISSUE_SITES,
+                         ids=[s[0] for s in ISSUE_SITES])
+def test_issue_site_passes_via_co_browser(stealth_browser, name, url, settle, verdict):
+    """Drive the real `co browser` navigation to each issue site and assert its verdict."""
+    b = stealth_browser
+    b.go_to(url, purpose=f"stealth verdict: {name}", who="e2e")
+    time.sleep(settle)  # let the site's JS finish computing its verdict
+    passed, detail = verdict(b)
+    assert passed, f"{name} did not pass: {detail}"

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -107,6 +107,41 @@ def test_humanized_input_event_shape_end_to_end(stealth_browser):
     assert jitter > 5, f"expected variable keystroke timing, stdev was {jitter:.0f}ms"
 
 
+TALL_PAGE = (
+    "<!doctype html><meta charset=utf-8>"
+    "<div style='height:6000px;background:linear-gradient(white,black)'>tall</div>"
+    "<b id=rec></b>"
+)
+
+INSTALL_SCROLL_RECORDER = """() => {
+    const r = document.getElementById('rec');
+    addEventListener('wheel', () => { r.dataset.wheels = (+r.dataset.wheels||0)+1; }, {passive:true});
+    addEventListener('scroll', () => {
+        const s = (r.dataset.ys||'').split(',').filter(Boolean);
+        s.push(Math.round(window.scrollY));
+        r.dataset.ys = s.slice(-200).join(',');
+    }, {passive:true});
+}"""
+
+
+def test_humanized_scroll_emits_wheel_events(stealth_browser):
+    """The scroll tool must move the page with real mouse-wheel events and an incremental
+    scrollY — not the old instant programmatic scrollBy(0,1000) jump (zero wheel events)."""
+    b = stealth_browser
+    b.go_to("data:text/html," + urllib.parse.quote(TALL_PAGE), purpose="scroll test", who="e2e")
+    _eval(b, INSTALL_SCROLL_RECORDER)
+
+    y0 = _eval(b, "() => window.scrollY")
+    b.scroll(times=3)
+    data = _eval(b, "() => ({...document.getElementById('rec').dataset})")
+    y1 = _eval(b, "() => window.scrollY")
+    ys = [int(v) for v in data.get("ys", "").split(",") if v]
+
+    assert int(data.get("wheels", 0)) >= 6, "scroll should emit many real wheel events"
+    assert y1 - y0 > 500, f"page should have scrolled (moved {y1 - y0}px)"
+    assert len(set(ys)) >= 5, "scrollY should move incrementally, not in one jump"
+
+
 # ---------------------------------------------------------------------------
 # Layer 3 — every fingerprint / bot-detection site listed in issue #222.
 # Each entry: (name, url, settle_seconds, verdict(browser) -> (passed, detail)).

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -314,6 +314,7 @@ ISSUE_SITES = [
 ]
 
 
+@pytest.mark.network  # hits ~14 live third-party sites — excluded from the default run
 @pytest.mark.parametrize("name,url,settle,verdict", ISSUE_SITES,
                          ids=[s[0] for s in ISSUE_SITES])
 def test_issue_site_passes_via_co_browser(stealth_browser, name, url, settle, verdict):

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -1,15 +1,27 @@
-"""End-to-end guard: the REAL installed Patchright must be the patched stealth driver.
+"""End-to-end stealth guards for the real browser stack (no mocks).
 
-This touches the actual on-disk install (no mocks), so it lives in e2e, not unit. It is the
-check that would have caught the silent regression we hit: Patchright's separately-downloaded
-driver reverting to the unpatched vanilla Playwright build (navigator.webdriver leaks, the
-"controlled by automated test software" infobar). If a future patchright bump lands an
-unpatched driver, this fails here instead of shipping a browser with no stealth.
+Two layers:
+  1. driver integrity — the installed Patchright must still be the patched stealth build.
+  2. humanized input (issue #222) — driving the REAL BrowserAutomation tool methods
+     (go_to / mouse_click / keyboard_type, the same verbs `co browser` calls) must emit
+     human-shaped events and pass the environment fingerprint checkers.
+
+The layer-2 tests need a real headful browser, so they run only when a display is present
+(locally: `xvfb-run -a python -m pytest tests/e2e/cli/test_browser_stealth_e2e.py`). They
+skip cleanly in a plain CI shell with no DISPLAY.
 """
+
+import os
+import statistics
+import urllib.parse
 
 import pytest
 
-from connectonion.useful_tools.browser_tools.browser import driver_stealth_status
+from connectonion.useful_tools.browser_tools.browser import (
+    BROWSER_AVAILABLE,
+    BrowserAutomation,
+    driver_stealth_status,
+)
 
 
 def test_real_installed_driver_is_patched():
@@ -17,3 +29,85 @@ def test_real_installed_driver_is_patched():
     if status == "missing":
         pytest.skip("patchright not installed in this environment")
     assert status == "ok", f"installed patchright {version} is not the patched stealth driver: {detail}"
+
+
+# ---------------------------------------------------------------------------
+# Humanized-input e2e — drives the real tool methods through a real browser.
+# ---------------------------------------------------------------------------
+
+# A page that records the input events a behavioral detector would score, into the shared
+# DOM (Patchright evaluates in an isolated world, so page-script globals aren't readable —
+# dataset on a DOM node is).
+RECORDER_PAGE = (
+    "<!doctype html><meta charset=utf-8>"
+    "<input id=box style='position:absolute;left:60px;top:80px;width:220px;height:32px'>"
+    "<button id=btn style='position:absolute;left:60px;top:140px;width:120px;height:36px'>go</button>"
+    "<b id=rec></b>"
+    "<script>"
+    "const r=document.getElementById('rec');"
+    "addEventListener('mousemove',()=>{r.dataset.moves=(+r.dataset.moves||0)+1});"
+    "addEventListener('mousedown',e=>{r.dataset.down=e.timeStamp});"
+    "addEventListener('mouseup',e=>{r.dataset.up=e.timeStamp});"
+    "document.getElementById('box').addEventListener('keydown',"
+    "e=>{r.dataset.keys=(r.dataset.keys?r.dataset.keys+',':'')+e.timeStamp});"
+    "</script>"
+)
+
+
+@pytest.fixture
+def browser():
+    if not BROWSER_AVAILABLE:
+        pytest.skip("patchright not installed")
+    if not os.environ.get("DISPLAY"):
+        pytest.skip("no DISPLAY — headful stealth browser needs a display (run under xvfb-run)")
+    b = BrowserAutomation(headless=False)
+    b.open_browser()
+    if not b.page:
+        pytest.skip("browser failed to launch in this environment")
+    yield b
+    b.close()
+
+
+def _eval(browser, js):
+    """Evaluate JS on the browser worker thread (the page is thread-bound)."""
+    return browser._executor.submit(lambda: browser.page.evaluate(js)).result()
+
+
+def test_humanized_input_event_shape_end_to_end(browser):
+    """mouse_click + keyboard_type — the real co-browser verbs — must produce a curved
+    multi-step move, a non-zero press dwell, and variable keystroke timing."""
+    data_url = "data:text/html," + urllib.parse.quote(RECORDER_PAGE)
+    browser.go_to(data_url, purpose="stealth event-shape test", who="e2e")
+
+    browser.mouse_click(160, 96)              # focus the input (center of #box)
+    browser.keyboard_type("hello human typing")
+
+    data = _eval(browser, "() => ({...document.getElementById('rec').dataset})")
+    moves = int(data.get("moves", 0))
+    dwell = float(data.get("up", 0)) - float(data.get("down", 0))
+    key_times = [float(t) for t in data.get("keys", "").split(",") if t]
+    gaps = [b - a for a, b in zip(key_times, key_times[1:])]
+    jitter = statistics.pstdev(gaps) if len(gaps) > 1 else 0
+
+    assert moves >= 8, f"expected a curved multi-step move, got {moves} mousemove events"
+    assert dwell > 10, f"expected a human mousedown->up dwell, got {dwell:.0f}ms"
+    assert len(key_times) >= len("hello human typing") - 2, "expected per-character keystrokes"
+    assert jitter > 5, f"expected variable keystroke timing, stdev was {jitter:.0f}ms"
+
+
+def test_environment_checkers_pass_end_to_end(browser):
+    """The real browser must clear the environment fingerprint tells on a live page."""
+    browser.go_to("https://bot.sannysoft.com/", purpose="stealth fingerprint test", who="e2e")
+    tells = _eval(browser, """() => ({
+        webdriver: navigator.webdriver,
+        headlessUA: /Headless/i.test(navigator.userAgent),
+        chrome: typeof window.chrome === 'object',
+        plugins: navigator.plugins.length,
+        languages: (navigator.languages || []).length,
+    })""")
+
+    assert not tells["webdriver"], "navigator.webdriver leaked"
+    assert not tells["headlessUA"], "userAgent advertises Headless"
+    assert tells["chrome"], "window.chrome missing"
+    assert tells["plugins"] > 0, "no navigator.plugins"
+    assert tells["languages"] > 0, "no navigator.languages"

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -201,12 +201,18 @@ def _v_rebrowser_cdp(b):
 
 
 def _v_incolumitas(b):
-    """bot.incolumitas.com — its 'new tests' JSON reports OK for every non-behavioral,
-    non-IP fingerprint check when the browser is clean."""
+    """bot.incolumitas.com — its 'new tests' JSON reports OK for every browser-automation
+    fingerprint check when the browser is clean. `connectionRTT` is excluded: it is a
+    network round-trip-timing heuristic (datacenter/proxy detection), not a browser signal,
+    and it flaps — it belongs to the IP bucket, not what the stealth browser controls."""
     _skip_if_down(b)
     nt = _eval(b, "() => { const n=document.querySelector('#new-tests'); return n ? n.textContent : ''; }")
-    fails = re.findall(r'"(\w+)":\s*"(?!OK)([^"]+)"', nt)
-    return (nt.count('"OK"') >= 8 and not fails), f"non-OK={fails or 'none'}"
+    if not nt.strip():
+        pytest.skip("incolumitas new-tests not rendered")
+    fails = [(k, v) for k, v in re.findall(r'"(\w+)":\s*"([^"]+)"', nt)
+             if v != "OK" and k != "connectionRTT"]
+    rtt = re.search(r'"connectionRTT":\s*"([^"]+)"', nt)
+    return (not fails), f"automation non-OK={fails or 'none'} (connectionRTT={rtt.group(1) if rtt else '?'})"
 
 
 def _v_webgl_present(b):

--- a/tests/e2e/manual/browser_fingerprint_probe.py
+++ b/tests/e2e/manual/browser_fingerprint_probe.py
@@ -120,7 +120,7 @@ def main():
         ctx = p.chromium.launch_persistent_context(
             user_data_dir=tempfile.mkdtemp(prefix="co_probe_"),
             headless=False,
-            args=["--disable-dev-shm-usage"],
+            args=["--disable-dev-shm-usage", "--enable-unsafe-swiftshader"],
         )
         page = ctx.new_page()
         print("== 1. EVENT SHAPE (humanize.py — the change under test) ==")

--- a/tests/e2e/manual/browser_fingerprint_probe.py
+++ b/tests/e2e/manual/browser_fingerprint_probe.py
@@ -1,0 +1,141 @@
+"""Manual probe for the humanized browser input layer (issue #222).
+
+Two independent checks, because they measure different things:
+
+  1. EVENT SHAPE (IP-independent, the real test of humanize.py): drive a local
+     event-recorder page with humanize.move/click/type_text and assert the emitted
+     events look human — many mousemove steps, a non-zero mousedown→mouseup dwell,
+     and variable inter-keystroke timing. This proves the change works regardless of
+     where it runs.
+
+  2. ENVIRONMENT CHECKERS (needs network; validates Patchright + headful, NOT our
+     input change): visit public fingerprint pages, read their verdict, screenshot.
+
+NOTE: the behavioral vendors (reCAPTCHA v3, Cloudflare, DataDome) also weigh IP
+reputation, so a datacenter IP scores as bot no matter how human the cursor is —
+they are listed for a residential-IP run, not asserted here.
+
+Run headful under a virtual display:
+    xvfb-run -a python3 tests/e2e/manual/browser_fingerprint_probe.py
+"""
+
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+
+from patchright.sync_api import sync_playwright
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from connectonion.useful_tools.browser_tools import humanize  # noqa: E402
+
+RECORDER_HTML = (
+    '<input id=box style="position:absolute;left:200px;top:300px;width:240px;height:40px">'
+    '<button id=btn style="position:absolute;left:500px;top:300px;width:120px;height:40px">Click me</button>'
+    '<b id=rec></b>'
+)
+
+# Patchright runs page.evaluate in an ISOLATED world, so a variable an inline page
+# <script> sets on window is invisible to evaluate. Attach the recorders from evaluate
+# and store counts in the shared DOM (dataset) so any world can read them back.
+INSTALL_RECORDER = """() => {
+    const rec = document.getElementById('rec');
+    addEventListener('mousemove', () => { rec.dataset.moves = (+rec.dataset.moves || 0) + 1; });
+    addEventListener('mousedown', e => { rec.dataset.down = e.timeStamp; });
+    addEventListener('mouseup',   e => { rec.dataset.up   = e.timeStamp; });
+    document.getElementById('box').addEventListener('keydown', e => {
+        rec.dataset.keys = (rec.dataset.keys ? rec.dataset.keys + ',' : '') + e.timeStamp;
+    });
+}"""
+
+# Direct in-page tells that headless/automation detectors check — IP- and
+# third-party-uptime-independent. We load a real page first so the checks run in a
+# normal document context.
+HEADLESS_TELLS = """() => {
+    const ua = navigator.userAgent;
+    return {
+        'navigator.webdriver falsy': !navigator.webdriver,
+        'UA is not Headless': !/Headless/i.test(ua),
+        'window.chrome present': typeof window.chrome === 'object',
+        'has plugins': navigator.plugins.length > 0,
+        'has languages': (navigator.languages || []).length > 0,
+    };
+}"""
+
+ENV_CHECKS = [
+    ("sannysoft", "https://bot.sannysoft.com/",
+     "() => !navigator.webdriver"),
+]
+
+
+def check_event_shape(page):
+    page.set_content(RECORDER_HTML)
+    page.evaluate(INSTALL_RECORDER)
+    # click the button (curved move + dwell), then type into the box.
+    btn = page.locator("#btn").bounding_box()
+    humanize.click(page, 0, 0, box=btn)
+    box = page.locator("#box").bounding_box()
+    humanize.click(page, 0, 0, box=box)
+    humanize.type_text(page, "hello human typing")
+
+    data = page.evaluate("() => ({...document.getElementById('rec').dataset})")
+    moves = int(data.get("moves", 0))
+    dwell = float(data.get("up", 0)) - float(data.get("down", 0))
+    key_times = [float(t) for t in data.get("keys", "").split(",") if t]
+    gaps = [b - a for a, b in zip(key_times, key_times[1:])]
+    jitter = statistics.pstdev(gaps) if len(gaps) > 1 else 0
+    ev = {"moves": moves, "keyTimes": key_times}
+
+    results = {
+        "mousemove events >= 8 (curved path)": ev["moves"] >= 8,
+        "mousedown->up dwell > 10ms": dwell > 10,
+        "keystrokes recorded": len(ev["keyTimes"]) > 5,
+        "keystroke timing has jitter (>5ms stdev)": jitter > 5,
+    }
+    print(f"\n  [event shape] moves={ev['moves']} dwell={dwell:.0f}ms "
+          f"keys={len(ev['keyTimes'])} gap_stdev={jitter:.0f}ms")
+    return results
+
+
+def check_environment(page):
+    results = {}
+    for name, url, probe in ENV_CHECKS:
+        page.goto(url, wait_until="load", timeout=60000)
+        page.wait_for_timeout(2500)
+        passed = bool(page.evaluate(probe))
+        page.screenshot(path=f"/tmp/probe_{name}.png", full_page=True)
+        results[f"{name} verdict"] = passed
+        print(f"  [env] {name}: {'PASS' if passed else 'FAIL'}  (shot /tmp/probe_{name}.png)")
+
+    # Direct headless/automation tells, evaluated on the last-loaded real page.
+    for name, passed in page.evaluate(HEADLESS_TELLS).items():
+        results[name] = bool(passed)
+        print(f"  [tell] {name}: {'PASS' if passed else 'FAIL'}")
+    return results
+
+
+def main():
+    all_results = {}
+    with sync_playwright() as p:
+        ctx = p.chromium.launch_persistent_context(
+            user_data_dir=tempfile.mkdtemp(prefix="co_probe_"),
+            headless=False,
+            args=["--disable-dev-shm-usage"],
+        )
+        page = ctx.new_page()
+        print("== 1. EVENT SHAPE (humanize.py — the change under test) ==")
+        all_results.update(check_event_shape(page))
+        print("\n== 2. ENVIRONMENT CHECKERS (Patchright + headful) ==")
+        all_results.update(check_environment(page))
+        ctx.close()
+
+    print("\n==================== REPORT ====================")
+    passed = sum(all_results.values())
+    for name, ok in all_results.items():
+        print(f"  {'✅' if ok else '❌'}  {name}")
+    print(f"\n  {passed}/{len(all_results)} checks passed")
+    sys.exit(0 if passed == len(all_results) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -5,6 +5,8 @@ down→up dwell, per-char typing, off-center targeting, and cursor continuity be
 actions — without a real browser. That shape is what defeats behavioral fingerprinting.
 """
 
+import math
+
 import pytest
 
 from connectonion.useful_tools.browser_tools import humanize
@@ -17,11 +19,11 @@ class FakeMouse:
     def move(self, x, y):
         self._log.append(("move", x, y))
 
-    def down(self, button="left"):
-        self._log.append(("down", button))
+    def down(self, button="left", click_count=1):
+        self._log.append(("down", button, click_count))
 
-    def up(self, button="left"):
-        self._log.append(("up", button))
+    def up(self, button="left", click_count=1):
+        self._log.append(("up", button, click_count))
 
     def wheel(self, dx, dy):
         self._log.append(("wheel", dx, dy))
@@ -67,9 +69,16 @@ def test_move_emits_many_steps_ending_on_target():
 
 def test_move_path_is_curved_not_straight():
     page = FakePage()
-    humanize.move(page, 500, 0)  # horizontal target — a straight path would keep y≈0
-    ys = [y for (kind, x, y) in page.log if kind == "move"]
-    assert max(abs(y) for y in ys) > 1, "path should bow off the straight line"
+    humanize.move(page, 500, 0)
+    pts = [(x, y) for (kind, x, y) in page.log if kind == "move"]
+    # Curvature = max perpendicular distance of the path from the straight line between its
+    # own first and last sampled points. Robust to the random start offset (unlike an
+    # absolute-y check, which flaked when the path happened to run near-vertical).
+    (x0, y0), (x1, y1) = pts[0], pts[-1]
+    dx, dy = x1 - x0, y1 - y0
+    length = math.hypot(dx, dy) or 1.0
+    max_perp = max(abs((px - x0) * dy - (py - y0) * dx) / length for px, py in pts)
+    assert max_perp > 1, "path should bow off the straight line, not run straight"
 
 
 def test_click_moves_then_presses_with_dwell_order():
@@ -93,17 +102,20 @@ def test_click_targets_off_center_inside_box():
     assert not (x == 200 and y == 150)
 
 
-def test_double_click_presses_twice():
+def test_double_click_presses_twice_with_incrementing_click_count():
     page = FakePage()
     humanize.double_click(page, 50, 50)
-    assert _kinds(page.log).count("down") == 2
-    assert _kinds(page.log).count("up") == 2
+    downs = [e for e in page.log if e[0] == "down"]
+    assert len(downs) == 2
+    # click_count must go 1 then 2, or the browser won't fire a real dblclick.
+    assert [d[2] for d in downs] == [1, 2]
+    assert [u[2] for u in page.log if u[0] == "up"] == [1, 2]
 
 
 def test_right_click_uses_right_button():
     page = FakePage()
     humanize.click(page, 10, 10, button="right")
-    assert ("down", "right") in page.log and ("up", "right") in page.log
+    assert ("down", "right", 1) in page.log and ("up", "right", 1) in page.log
 
 
 def test_type_text_is_per_character():

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -130,6 +130,31 @@ def test_scroll_up_uses_negative_deltas():
     assert dys and all(dy < 0 for dy in dys) and sum(dys) == -600
 
 
+def test_needs_ime_flags_cjk_not_latin():
+    assert humanize._needs_ime("你") and humanize._needs_ime("好")
+    assert humanize._needs_ime("こ")   # hiragana
+    assert humanize._needs_ime("한")   # hangul
+    assert not humanize._needs_ime("a")
+    assert not humanize._needs_ime(" ")
+    assert not humanize._needs_ime("1")
+
+
+def test_segments_splits_cjk_and_latin_runs():
+    segs = humanize._segments("hi 你好 ok")
+    assert segs == [(False, "hi "), (True, "你好"), (False, " ok")]
+
+
+def test_segments_all_latin_is_one_run():
+    assert humanize._segments("hello") == [(False, "hello")]
+
+
+def test_type_text_latin_still_per_character_keystroke():
+    # Latin text must still go key-by-key through the keyboard (not the IME path).
+    page = FakePage()
+    humanize.type_text(page, "hi")
+    assert [e[1] for e in page.log if e[0] == "type"] == ["h", "i"]
+
+
 def test_cursor_position_is_remembered_between_actions():
     page = FakePage()
     humanize.move(page, 400, 400)

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -135,11 +135,14 @@ def test_scroll_emits_many_small_wheel_ticks_summing_to_target():
     assert sum(dys) == 1000, "ticks sum to the requested distance"
 
 
-def test_scroll_up_uses_negative_deltas():
+def test_scroll_up_nets_to_negative_target():
     page = FakePage()
     humanize.scroll(page, -600)
     dys = [dy for (kind, dx, dy) in page.log if kind == "wheel"]
-    assert dys and all(dy < 0 for dy in dys) and sum(dys) == -600
+    # Net displacement is the target; most ticks go up, but an overshoot-correct can add a
+    # small downward nudge at the end.
+    assert sum(dys) == -600
+    assert sum(1 for dy in dys if dy < 0) > sum(1 for dy in dys if dy > 0)
 
 
 def test_needs_ime_flags_cjk_not_latin():

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -1,0 +1,121 @@
+"""Unit tests for the humanized input layer (connectonion/useful_tools/browser_tools/humanize.py).
+
+These assert the *shape* of the emitted events — curved multi-step moves, a real
+down→up dwell, per-char typing, off-center targeting, and cursor continuity between
+actions — without a real browser. That shape is what defeats behavioral fingerprinting.
+"""
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import humanize
+
+
+class FakeMouse:
+    def __init__(self, log):
+        self._log = log
+
+    def move(self, x, y):
+        self._log.append(("move", x, y))
+
+    def down(self, button="left"):
+        self._log.append(("down", button))
+
+    def up(self, button="left"):
+        self._log.append(("up", button))
+
+
+class FakeKeyboard:
+    def __init__(self, log):
+        self._log = log
+
+    def type(self, text):
+        self._log.append(("type", text))
+
+
+class FakePage:
+    """Records every low-level input call humanize makes."""
+    def __init__(self):
+        self.log = []
+        self.mouse = FakeMouse(self.log)
+        self.keyboard = FakeKeyboard(self.log)
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    # Humanize sleeps between events for realism; skip the wall-clock cost in tests.
+    monkeypatch.setattr(humanize.time, "sleep", lambda *_: None)
+    # Fresh cursor memory per test so start positions are deterministic-ish.
+    humanize._cursor.clear()
+
+
+def _kinds(log):
+    return [e[0] for e in log]
+
+
+def test_move_emits_many_steps_ending_on_target():
+    page = FakePage()
+    humanize.move(page, 400, 300)
+    moves = [e for e in page.log if e[0] == "move"]
+    assert len(moves) >= 8, "a human move is a multi-step path, not a teleport"
+    # Path ends on the requested point.
+    assert moves[-1][1] == pytest.approx(400, abs=1)
+    assert moves[-1][2] == pytest.approx(300, abs=1)
+
+
+def test_move_path_is_curved_not_straight():
+    page = FakePage()
+    humanize.move(page, 500, 0)  # horizontal target — a straight path would keep y≈0
+    ys = [y for (kind, x, y) in page.log if kind == "move"]
+    assert max(abs(y) for y in ys) > 1, "path should bow off the straight line"
+
+
+def test_click_moves_then_presses_with_dwell_order():
+    page = FakePage()
+    humanize.click(page, 200, 200)
+    kinds = _kinds(page.log)
+    assert "move" in kinds
+    assert kinds.index("down") < kinds.index("up")
+    assert kinds.index("move") < kinds.index("down"), "cursor arrives before pressing"
+
+
+def test_click_targets_off_center_inside_box():
+    page = FakePage()
+    box = {"x": 100, "y": 100, "width": 200, "height": 100}
+    humanize.click(page, 0, 0, box=box)
+    last_move = [e for e in page.log if e[0] == "move"][-1]  # lands on the click point
+    x, y = last_move[1], last_move[2]
+    # Inside the box...
+    assert 100 <= x <= 300 and 100 <= y <= 200
+    # ...but not required to be the exact center (jitter applied).
+    assert not (x == 200 and y == 150)
+
+
+def test_double_click_presses_twice():
+    page = FakePage()
+    humanize.double_click(page, 50, 50)
+    assert _kinds(page.log).count("down") == 2
+    assert _kinds(page.log).count("up") == 2
+
+
+def test_right_click_uses_right_button():
+    page = FakePage()
+    humanize.click(page, 10, 10, button="right")
+    assert ("down", "right") in page.log and ("up", "right") in page.log
+
+
+def test_type_text_is_per_character():
+    page = FakePage()
+    humanize.type_text(page, "hello")
+    typed = [e[1] for e in page.log if e[0] == "type"]
+    assert typed == ["h", "e", "l", "l", "o"], "typed one char at a time, not in bulk"
+
+
+def test_cursor_position_is_remembered_between_actions():
+    page = FakePage()
+    humanize.move(page, 400, 400)
+    assert humanize._cursor[page] == pytest.approx((400, 400), abs=1)
+    # A second move starts its curve from the remembered point, not a fresh teleport.
+    page.log.clear()
+    humanize.move(page, 410, 410)
+    first_step = next(e for e in page.log if e[0] == "move")
+    assert abs(first_step[1] - 400) < 30 and abs(first_step[2] - 400) < 30

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -23,6 +23,9 @@ class FakeMouse:
     def up(self, button="left"):
         self._log.append(("up", button))
 
+    def wheel(self, dx, dy):
+        self._log.append(("wheel", dx, dy))
+
 
 class FakeKeyboard:
     def __init__(self, log):
@@ -108,6 +111,23 @@ def test_type_text_is_per_character():
     humanize.type_text(page, "hello")
     typed = [e[1] for e in page.log if e[0] == "type"]
     assert typed == ["h", "e", "l", "l", "o"], "typed one char at a time, not in bulk"
+
+
+def test_scroll_emits_many_small_wheel_ticks_summing_to_target():
+    page = FakePage()
+    humanize.scroll(page, 1000)
+    wheels = [e for e in page.log if e[0] == "wheel"]
+    assert len(wheels) >= 6, "a human scroll is many small wheel ticks, not one jump"
+    dys = [dy for (_, dx, dy) in wheels]
+    assert all(abs(dy) <= 170 for dy in dys), "each tick is a small delta"
+    assert sum(dys) == 1000, "ticks sum to the requested distance"
+
+
+def test_scroll_up_uses_negative_deltas():
+    page = FakePage()
+    humanize.scroll(page, -600)
+    dys = [dy for (kind, dx, dy) in page.log if kind == "wheel"]
+    assert dys and all(dy < 0 for dy in dys) and sum(dys) == -600
 
 
 def test_cursor_position_is_remembered_between_actions():

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -24,10 +24,10 @@ class FakeMouse:
     def move(self, x, y):
         self._pos = (x, y)
 
-    def down(self, button="left"):
+    def down(self, button="left", click_count=1):
         self.clicks.append(self._pos)
 
-    def up(self, button="left"):
+    def up(self, button="left", click_count=1):
         pass
 
     def click(self, x, y):  # kept for any direct callers

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -15,10 +15,22 @@ class FakePage:
 
 
 class FakeMouse:
+    """Records the effective press point. Clicks are humanized (curved move → down →
+    up), so the press lands wherever the last move ended — that is the click point."""
     def __init__(self):
         self.clicks = []
+        self._pos = (0, 0)
 
-    def click(self, x, y):
+    def move(self, x, y):
+        self._pos = (x, y)
+
+    def down(self, button="left"):
+        self.clicks.append(self._pos)
+
+    def up(self, button="left"):
+        pass
+
+    def click(self, x, y):  # kept for any direct callers
         self.clicks.append((x, y))
 
 
@@ -204,7 +216,11 @@ def test_click_element_by_selector_wraps_playwright_locator(monkeypatch):
     )
 
     assert page.last_selector == 'button[aria-label="Reaction button state: no reaction"]'
-    assert page.mouse.clicks == [(60, 40)]
+    # Humanized click lands somewhere inside the element (box x:10..110, y:20..60),
+    # off dead-center by design — assert it's on the element, not on an exact pixel.
+    assert len(page.mouse.clicks) == 1
+    cx, cy = page.mouse.clicks[0]
+    assert 10 <= cx <= 110 and 20 <= cy <= 60
     assert page.waits == [1000]
     assert "Clicked element 1/1" in result
 
@@ -244,7 +260,8 @@ def test_type_text_by_selector_focuses_and_types():
     )
 
     assert item.force_clicked is True
-    assert page.keyboard.typed == ["Great point."]
+    # Typing is humanized — one keystroke per character, not one bulk insert.
+    assert page.keyboard.typed == list("Great point.")
     assert page.waits == [1000]
     assert "Typed text into element 1/1" in result
 


### PR DESCRIPTION
Closes part of #222 — the mouse-click + keyboard half.

## What
Patchright already closes the **driver-level** tells (`navigator.webdriver`, `Runtime.enable`). This PR closes the **behavioral** layer above it: the *shape* of the input events we emit. Before, every interaction was an obvious bot:

- clicks **teleported** to the exact integer center of the element, `mousedown`→`mouseup` in the same tick, zero `mousemove` events
- `keyboard.type()` dropped the whole string with uniform/zero inter-key timing

New `connectonion/useful_tools/browser_tools/humanize.py` routes every pointer/keyboard tool through:
- **curved Bézier mouse paths** emitting real `mousemove` events, landing on a **jittered point inside** the element (never dead-center), with **per-page cursor memory** so the next action starts where the last ended
- a randomized **`mousedown`→`up` dwell**
- **char-by-char typing** with variable cadence + occasional hesitation

No tool signatures change — `click(...)`, `keyboard_type(...)`, `hover(...)`, `double_click(...)`, `right_click(...)`, and the selector-based click paths all keep their API; only the low-level event generation is humanized (19 call sites).

## Verification (measured on this branch)
Ran `tests/e2e/manual/browser_fingerprint_probe.py` headful under Xvfb — **10/10 checks pass**:

- **Event shape** (the change under test, IP-independent): 37 real `mousemove` events per click (curved path), 110 ms down→up dwell, per-char typing with 39 ms inter-key stdev — vs. the old teleport/0 ms/uniform.
- **Environment checkers**: `bot.sannysoft.com` clean (WebDriver *missing (passed)*, all PHANTOM/HEADLESS/SELENIUM rows green); direct headless tells all pass.

Plus `tests/unit/test_browser_humanize.py` (8 tests) asserts the event shape without a browser. Existing browser unit tests updated from exact-center assertions to on-element assertions (the click is now off-center by design). **64 unit tests pass.**

## Not in scope / honest caveats
- **Behavioral vendors (reCAPTCHA v3, Cloudflare, DataDome) also weight IP reputation** — a datacenter IP scores as bot regardless of cursor quality, so those can't be cleanly demonstrated from CI. The probe lists them for a residential-IP run but doesn't assert them.
- `scroll` is left for a follow-up (the issue's primary ask is click + keyboard).
