### PR TITLE
Direct tool execution for remote agents (remote.call / co call)

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -61,7 +61,7 @@ from .useful_tools import (
     # Claude Code-style file tools
     read_file, edit, multi_edit, glob, grep, write,
 )
-from .network import connect, RemoteAgent, Response, host, create_app, IO
+from .network import connect, RemoteAgent, Response, ExecResult, host, create_app, IO
 from .network import relay, announce
 from . import address
 
@@ -114,6 +114,7 @@ __all__ = [
     "connect",
     "RemoteAgent",
     "Response",
+    "ExecResult",
     "host",
     "create_app",
     "IO",

--- a/connectonion/cli/commands/call_commands.py
+++ b/connectonion/cli/commands/call_commands.py
@@ -1,0 +1,135 @@
+"""
+Purpose: `co call <address> <command...>` — run ONE command on a remote agent and print the result, no LLM.
+LLM-Note:
+  Dependencies: imports from [sys, shlex, base64, pathlib, connectonion.connect (RemoteAgent), connectonion.address (load local signing keys)] | imported by [cli/main.py via call()] | tested by [tests/unit/test_cli_call.py]
+  Data flow: handle_call(args) → parse leading --out/--timeout/--relay options → first non-option token = address, everything after = the remote command VERBATIM → shlex.join → connect(address, keys).call("bash", command=...) → ExecResult → print text (or save an image result to --out / screenshot.png and print the path)
+  State/Effects: loads local identity from .co (project) then ~/.co to sign the request | opens a WebSocket to the remote agent (direct or via relay) | may write an image file | writes to stdout/stderr
+  Integration: exposes handle_call(args: list[str]) -> int (exit code) | mirrors handle_browser's thin-handler + exit-code contract (0 ok · 1 failure · 2 usage) | the remote symmetry of `co browser`: `co browser take_screenshot` locally == `co call <addr> co browser take_screenshot` remotely
+  Performance: one WebSocket round-trip per call | endpoint resolution cached inside RemoteAgent for the process
+  Errors: usage errors → stderr + exit 2 | connection/tool errors → stderr + exit 1 | the remote gates the command against ITS .co/host.yaml whitelist, so a non-whitelisted command comes back as an error result
+"""
+
+import sys
+import shlex
+from pathlib import Path
+
+USAGE = (
+    "co call — run one command on a remote agent, print the result (no LLM).\n"
+    "\n"
+    "  co call [options] <address> <command...>\n"
+    "\n"
+    "  co call 0x3d40... co status\n"
+    "  co call 0x3d40... co browser go_to https://example.com\n"
+    "  co call --out shot.png 0x3d40... co browser take_screenshot\n"
+    "\n"
+    "Options (before the address):\n"
+    "  --out PATH        save an image result (screenshot) to PATH; else ./screenshot.png\n"
+    "  --timeout SEC     seconds to wait for the result (default 60)\n"
+    "  --relay URL       relay server (default wss://oo.openonion.ai)\n"
+    "\n"
+    "Everything AFTER the address is the remote command, verbatim. It runs on the\n"
+    "remote agent, gated by ITS .co/host.yaml permission whitelist — `co ...`\n"
+    "(including `co browser <verb>`) is whitelisted by default.\n"
+    "\n"
+    "This is the remote twin of `co browser`: `co browser take_screenshot` here ==\n"
+    "`co call <address> co browser take_screenshot` there.\n"
+    "\n"
+    "stdout = result, stderr = errors; exit 0 ok · 1 failure · 2 usage."
+)
+
+
+def _load_keys():
+    """This machine's identity, to sign the request (required for strict-trust
+    remotes, harmless otherwise). Project .co first, then ~/.co; None if absent."""
+    from connectonion import address
+    co_dir = Path(".co")
+    if not (co_dir.exists() and (co_dir / "keys" / "agent.key").exists()):
+        co_dir = Path.home() / ".co"
+    return address.load(co_dir)
+
+
+def handle_call(args) -> int:
+    """Send one command to a remote agent's direct-exec path, print the result.
+
+    Returns the process exit code (0 ok · 1 failure · 2 usage). Everything after
+    the address is forwarded verbatim, so the remote command keeps its own flags.
+    """
+    args = list(args or [])
+    if not args:
+        print(USAGE, file=sys.stderr)
+        return 2
+    if args[0] in ("help", "--help", "-h"):
+        print(USAGE)
+        return 0
+
+    # Consume leading local options; stop at the first non-flag token (the address).
+    out, timeout, relay_url = None, 60.0, None
+    i = 0
+    while i < len(args) and args[i].startswith("-"):
+        opt = args[i]
+        val = args[i + 1] if i + 1 < len(args) else None
+        if opt in ("--out", "-o"):
+            if val is None:
+                print("usage: --out needs a path", file=sys.stderr)
+                return 2
+            out, i = val, i + 2
+        elif opt == "--timeout":
+            if val is None:
+                print("usage: --timeout needs seconds", file=sys.stderr)
+                return 2
+            try:
+                timeout = float(val)
+            except ValueError:
+                print("usage: --timeout needs a number", file=sys.stderr)
+                return 2
+            i += 2
+        elif opt == "--relay":
+            if val is None:
+                print("usage: --relay needs a url", file=sys.stderr)
+                return 2
+            relay_url, i = val, i + 2
+        else:
+            print(f"unknown option '{opt}' (options go before the address)", file=sys.stderr)
+            return 2
+
+    rest = args[i:]
+    if not rest:
+        print("usage: co call <address> <command...>", file=sys.stderr)
+        return 2
+    address = rest[0]
+    command_tokens = rest[1:]
+    if not command_tokens:
+        print("usage: co call <address> <command...>  e.g. co call 0x.. co browser take_screenshot",
+              file=sys.stderr)
+        return 2
+    command = shlex.join(command_tokens)
+
+    from connectonion import connect
+    kwargs = {"keys": _load_keys()}
+    if relay_url:
+        kwargs["relay_url"] = relay_url
+
+    try:
+        remote = connect(address, **kwargs)
+        result = remote.call("bash", command=command, timeout=timeout)
+    except Exception as e:
+        print(f"connection failed: {e}", file=sys.stderr)
+        return 1
+
+    if not result.ok:
+        print(result.error or "remote call failed", file=sys.stderr)
+        return 1
+
+    # An image result (a screenshot) is base64 — writing it to the terminal would
+    # flood it, so save to a file and print the path (script-friendly).
+    if result.images:
+        import base64
+        data = result.images[0]
+        payload = data.split(",", 1)[1] if "," in data else data
+        dest = out or "screenshot.png"
+        Path(dest).write_bytes(base64.b64decode(payload))
+        print(dest)
+        return 0
+
+    print(result.text)
+    return 0

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -177,6 +177,22 @@ def browser(
     raise typer.Exit(handle_browser(args or [], headless=headless))
 
 
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def call(
+    args: List[str] = typer.Argument(None, help="[--out F] [--timeout S] [--relay U] <address> <command...>"),
+):
+    """Run one command on a remote agent and print the result (no LLM).
+
+    The remote twin of `co browser` — everything after the address runs on the
+    remote agent, gated by its .co/host.yaml whitelist:
+
+        co call 0x3d40... co status
+        co call --out shot.png 0x3d40... co browser take_screenshot
+    """
+    from .commands.call_commands import handle_call
+    raise typer.Exit(handle_call(args or []))
+
+
 @app.command()
 def ai(
     prompt: Optional[str] = typer.Argument(None, help="One-shot prompt (runs and exits)"),

--- a/connectonion/cli/templates/hosted-browser/README.md
+++ b/connectonion/cli/templates/hosted-browser/README.md
@@ -54,16 +54,17 @@ commit it.
 ## Drive it directly (no LLM): `remote.call`
 
 Sometimes you don't want the agent to *think* — you just want to run a browser
-step and see the result, like a remote command line:
+step and see the result, like a remote command line. Drive it through the
+`co browser` CLI:
 
 ```python
 from connectonion import connect
 
 remote = connect("0x...", keys=my_keys)
 
-# Run one tool, get the raw result straight back — no reasoning, no history.
-remote.call("go_to", url="https://example.com")
-shot = remote.call("take_screenshot")
+# One command, raw result straight back — no reasoning, no history.
+remote.call("bash", command="co browser go_to https://example.com")
+shot = remote.call("bash", command="co browser take_screenshot")
 if shot.images:               # base64 data URLs extracted from the output
     open("page.png", "wb").write(base64.b64decode(shot.images[0].split(",")[1]))
 ```
@@ -74,11 +75,17 @@ of the output. It runs over the same authenticated WebSocket as `input()`, so
 relay discovery and trust still apply.
 
 What may run this way is the `.co/host.yaml` **permissions** whitelist — the very
-same list that lets the LLM auto-run a command without asking. The browser
-navigation/observation tools (`go_to`, `take_screenshot`, `click`, `scroll`, ...)
-and `co ...` CLI commands are whitelisted by default; add a line to `host.yaml`
-to expose more, e.g. `"Bash(git status)"`. Anything not on the list stays behind
-the agent's judgement via `input()`.
+same list that lets the LLM auto-run a command without asking. `co ...` commands
+(including `co browser <verb>`) are whitelisted by default; add a line to
+`host.yaml` to expose more, e.g. `"Bash(git status)"`.
+
+**Why `co browser` and not the browser tools directly?** This template's agent
+holds an *in-process* browser whose per-session tab routing lives in the
+`bind_browser_session` plugin — and `remote.call` runs a tool directly, with no
+plugin hooks, so that routing wouldn't fire. `co browser` instead talks to the
+persistent browser **daemon**, a separate process that handles tabs and lifecycle
+itself. It's the one clean path for direct browser control. See
+[docs/network/remote-call.md](https://github.com/openonion/connectonion/blob/main/docs/network/remote-call.md).
 
 ## Knobs that matter in production
 

--- a/connectonion/cli/templates/hosted-browser/README.md
+++ b/connectonion/cli/templates/hosted-browser/README.md
@@ -51,6 +51,31 @@ your local login with the browser's `save_state` tool and pass the file via
 `BrowserAutomation(seed_state=...)` from your deploy secret store — never
 commit it.
 
+## Drive it directly (no LLM): `remote.call`
+
+Sometimes you don't want the agent to *think* — you just want to run a browser
+step and see the result, like a remote command line. `host(..., exec_tools=[...])`
+(set in `agent.py`) exposes a curated set of tools for direct execution:
+
+```python
+from connectonion import connect
+
+remote = connect("0x...", keys=my_keys)
+
+# Run one tool, get the raw result straight back — no reasoning, no history.
+remote.call("go_to", url="https://example.com")
+shot = remote.call("take_screenshot")
+if shot.images:               # base64 data URLs extracted from the output
+    open("page.png", "wb").write(base64.b64decode(shot.images[0].split(",")[1]))
+```
+
+`remote.call(tool, **args)` returns an `ExecResult(text, status, duration_ms,
+error)`: `.ok` is True on success and `.images` pulls any base64 screenshots out
+of the output. This runs over the same authenticated WebSocket as `input()`, so
+relay discovery and trust still apply — only tools listed in `EXEC_TOOLS` are
+reachable this way; everything else stays behind the agent's judgement via
+`input()`.
+
 ## Knobs that matter in production
 
 - `BrowserAutomation(tab_idle_ttl=600, max_tabs=3)` — each chat session gets

--- a/connectonion/cli/templates/hosted-browser/README.md
+++ b/connectonion/cli/templates/hosted-browser/README.md
@@ -54,8 +54,7 @@ commit it.
 ## Drive it directly (no LLM): `remote.call`
 
 Sometimes you don't want the agent to *think* — you just want to run a browser
-step and see the result, like a remote command line. `host(..., exec_tools=[...])`
-(set in `agent.py`) exposes a curated set of tools for direct execution:
+step and see the result, like a remote command line:
 
 ```python
 from connectonion import connect
@@ -71,10 +70,15 @@ if shot.images:               # base64 data URLs extracted from the output
 
 `remote.call(tool, **args)` returns an `ExecResult(text, status, duration_ms,
 error)`: `.ok` is True on success and `.images` pulls any base64 screenshots out
-of the output. This runs over the same authenticated WebSocket as `input()`, so
-relay discovery and trust still apply — only tools listed in `EXEC_TOOLS` are
-reachable this way; everything else stays behind the agent's judgement via
-`input()`.
+of the output. It runs over the same authenticated WebSocket as `input()`, so
+relay discovery and trust still apply.
+
+What may run this way is the `.co/host.yaml` **permissions** whitelist — the very
+same list that lets the LLM auto-run a command without asking. The browser
+navigation/observation tools (`go_to`, `take_screenshot`, `click`, `scroll`, ...)
+and `co ...` CLI commands are whitelisted by default; add a line to `host.yaml`
+to expose more, e.g. `"Bash(git status)"`. Anything not on the list stays behind
+the agent's judgement via `input()`.
 
 ## Knobs that matter in production
 

--- a/connectonion/cli/templates/hosted-browser/agent.py
+++ b/connectonion/cli/templates/hosted-browser/agent.py
@@ -102,10 +102,20 @@ def create_hosted_agent():
     return agent
 
 
+# Tools a client may drive directly, bypassing the LLM (RemoteAgent.call). This
+# is the terminal-style fast path: `remote.call("take_screenshot")` runs the tool
+# and returns the raw result (a screenshot's base64 comes straight back) with no
+# thinking in between — good for a live "remote control" UI or scripted steps.
+# Only navigation/observation tools are exposed; anything destructive stays behind
+# the agent's judgement.
+EXEC_TOOLS = ["go_to", "take_screenshot", "click", "scroll",
+              "type_text_by_selector", "extract_items_by_selector", "wait_for_element"]
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         # Local one-shot run keeps wait_for_manual_login: with a headed browser
         # and a real terminal you can log in by hand once, and the profile keeps it.
         print(create_agent().input(" ".join(sys.argv[1:])))
     else:
-        host(create_hosted_agent)
+        host(create_hosted_agent, exec_tools=EXEC_TOOLS)

--- a/connectonion/cli/templates/hosted-browser/agent.py
+++ b/connectonion/cli/templates/hosted-browser/agent.py
@@ -102,20 +102,13 @@ def create_hosted_agent():
     return agent
 
 
-# Tools a client may drive directly, bypassing the LLM (RemoteAgent.call). This
-# is the terminal-style fast path: `remote.call("take_screenshot")` runs the tool
-# and returns the raw result (a screenshot's base64 comes straight back) with no
-# thinking in between — good for a live "remote control" UI or scripted steps.
-# Only navigation/observation tools are exposed; anything destructive stays behind
-# the agent's judgement.
-EXEC_TOOLS = ["go_to", "take_screenshot", "click", "scroll",
-              "type_text_by_selector", "extract_items_by_selector", "wait_for_element"]
-
-
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         # Local one-shot run keeps wait_for_manual_login: with a headed browser
         # and a real terminal you can log in by hand once, and the profile keeps it.
         print(create_agent().input(" ".join(sys.argv[1:])))
     else:
-        host(create_hosted_agent, exec_tools=EXEC_TOOLS)
+        # Clients can also drive tools directly (RemoteAgent.call) — that fast
+        # path is gated by the .co/host.yaml permissions whitelist, which already
+        # allows the browser navigation/observation tools. See README.
+        host(create_hosted_agent)

--- a/connectonion/network/__init__.py
+++ b/connectonion/network/__init__.py
@@ -21,7 +21,7 @@ This module contains:
 
 from .host import host, create_app, SessionStorage, Session
 from .io import IO, WebSocketIO
-from .connect import connect, RemoteAgent, Response
+from .connect import connect, RemoteAgent, Response, ExecResult
 from .relay import connect as relay_connect, serve_loop
 from .announce import create_announce_message
 from .trust import TrustAgent, Decision, get_default_trust_level, TRUST_LEVELS, parse_policy
@@ -37,6 +37,7 @@ __all__ = [
     "connect",
     "RemoteAgent",
     "Response",
+    "ExecResult",
     "relay_connect",
     "serve_loop",
     "create_announce_message",

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -114,6 +114,25 @@ class Response:
     done: bool      # True = complete, False = needs more input (agent asked a question)
 
 
+@dataclass
+class ExecResult:
+    """Result of a direct tool execution (RemoteAgent.call) — no LLM involved."""
+    text: str                     # Raw tool output (may contain base64 image data)
+    status: str                   # "success" | "error"
+    duration_ms: int = 0
+    error: Optional[str] = None   # Error message when status == "error"
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "success"
+
+    @property
+    def images(self) -> List[str]:
+        """Base64 data-URL images embedded in the output (e.g. screenshots)."""
+        import re
+        return re.findall(r'data:image/[a-z]+;base64,[A-Za-z0-9+/=]+', self.text)
+
+
 class RemoteAgent:
     """
     Interface to a remote agent with real-time UI updates.
@@ -229,6 +248,98 @@ class RemoteAgent:
     ) -> Response:
         """Async version of input()."""
         return await self._stream_input(prompt, timeout, on_onboard, images, files)
+
+    def call(self, tool: str, timeout: float = 60.0, **args) -> ExecResult:
+        """Run one of the remote agent's tools directly — no LLM, no thinking.
+
+        The terminal-style fast path: name a tool, pass its arguments, get the
+        raw output straight back. Like typing a command and reading stdout — the
+        result can be text or a base64 screenshot (see ExecResult.images).
+
+        The host must opt in with host(..., exec_tools=[...]); otherwise the
+        call returns an error ExecResult.
+
+        Args:
+            tool: Name of the remote tool to run (e.g. "bash", "take_screenshot")
+            timeout: Seconds to wait for the result
+            **args: Keyword arguments passed to the tool
+
+        Returns:
+            ExecResult(text, status, duration_ms, error) — .ok True on success,
+            .images extracts any base64 screenshots from the output.
+
+        Example:
+            >>> agent = connect("0x...", keys=keys)
+            >>> print(agent.call("bash", command="uptime").text)
+            >>> shot = agent.call("take_screenshot")
+            >>> if shot.images: save(shot.images[0])
+        """
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError(
+                "call() cannot be used inside async context. "
+                "Use 'await agent.call_async()' instead."
+            )
+        except RuntimeError as e:
+            if "call() cannot be used" in str(e):
+                raise
+        return asyncio.run(self.call_async(tool, timeout=timeout, **args))
+
+    async def call_async(self, tool: str, timeout: float = 60.0, **args) -> ExecResult:
+        """Async version of call()."""
+        import websockets
+
+        await self._try_resolve_endpoint()
+        if self._resolved_endpoint:
+            ws_url = self._resolved_endpoint
+            is_direct = True
+        else:
+            ws_url = f"{self._relay_url}/ws/input"
+            is_direct = False
+
+        exec_id = str(uuid.uuid4())
+        connect_msg = self._build_connect_message(is_direct)
+        exec_msg = {"type": "EXEC", "exec_id": exec_id, "tool": tool, "args": args}
+
+        try:
+            async with websockets.connect(ws_url) as ws:
+                await ws.send(json.dumps(connect_msg))
+
+                # Wait for CONNECTED (EXEC needs the same auth gate as INPUT).
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=30)
+                    event = json.loads(raw)
+                    etype = event.get("type")
+                    if etype == "CONNECTED":
+                        break
+                    if etype == "ONBOARD_REQUIRED":
+                        return ExecResult(text="", status="error",
+                                          error="agent requires onboarding — run input() once to onboard, then call() works")
+                    if etype == "ERROR":
+                        return ExecResult(text="", status="error",
+                                          error=event.get("message", "connect failed"))
+
+                await ws.send(json.dumps(exec_msg))
+
+                # Wait for our EXEC_RESULT; answer keepalive PINGs, skip other frames.
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                    event = json.loads(raw)
+                    etype = event.get("type")
+                    if etype == "EXEC_RESULT" and event.get("exec_id") == exec_id:
+                        return ExecResult(
+                            text=event.get("result", ""),
+                            status=event.get("status", "error"),
+                            duration_ms=event.get("duration_ms", 0),
+                            error=event.get("error"),
+                        )
+                    if etype == "PING":
+                        await ws.send(json.dumps({"type": "PONG"}))
+                    elif etype == "ERROR":
+                        return ExecResult(text="", status="error",
+                                          error=event.get("message", "exec failed"))
+        except asyncio.TimeoutError:
+            return ExecResult(text="", status="error", error=f"exec timed out after {timeout}s")
 
     def reset(self) -> None:
         """Clear conversation and start fresh."""

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -256,8 +256,9 @@ class RemoteAgent:
         raw output straight back. Like typing a command and reading stdout — the
         result can be text or a base64 screenshot (see ExecResult.images).
 
-        The host must opt in with host(..., exec_tools=[...]); otherwise the
-        call returns an error ExecResult.
+        The tool is gated by the host's .co/host.yaml permission whitelist — the
+        same list its LLM approval flow uses. A tool that isn't whitelisted comes
+        back as an error ExecResult.
 
         Args:
             tool: Name of the remote tool to run (e.g. "bash", "take_screenshot")

--- a/connectonion/network/host/host.yaml
+++ b/connectonion/network/host/host.yaml
@@ -301,6 +301,334 @@ permissions:
     expires:
       type: never
 
+  # File viewing & inspection (read-only, no side effects)
+  "Bash(cat *)":
+    allowed: true
+    source: config
+    reason: safe - view file contents
+    expires:
+      type: never
+
+  "Bash(head *)":
+    allowed: true
+    source: config
+    reason: safe - view start of file
+    expires:
+      type: never
+
+  "Bash(tail *)":
+    allowed: true
+    source: config
+    reason: safe - view end of file
+    expires:
+      type: never
+
+  "Bash(nl *)":
+    allowed: true
+    source: config
+    reason: safe - view file with line numbers
+    expires:
+      type: never
+
+  "Bash(wc *)":
+    allowed: true
+    source: config
+    reason: safe - count lines/words/bytes
+    expires:
+      type: never
+
+  "Bash(file *)":
+    allowed: true
+    source: config
+    reason: safe - identify file type
+    expires:
+      type: never
+
+  "Bash(stat *)":
+    allowed: true
+    source: config
+    reason: safe - file metadata
+    expires:
+      type: never
+
+  "Bash(diff *)":
+    allowed: true
+    source: config
+    reason: safe - compare files
+    expires:
+      type: never
+
+  "Bash(tree *)":
+    allowed: true
+    source: config
+    reason: safe - directory tree
+    expires:
+      type: never
+
+  "Bash(du *)":
+    allowed: true
+    source: config
+    reason: safe - disk usage of paths
+    expires:
+      type: never
+
+  "Bash(basename *)":
+    allowed: true
+    source: config
+    reason: safe - strip path
+    expires:
+      type: never
+
+  "Bash(dirname *)":
+    allowed: true
+    source: config
+    reason: safe - directory of path
+    expires:
+      type: never
+
+  "Bash(realpath *)":
+    allowed: true
+    source: config
+    reason: safe - resolve absolute path
+    expires:
+      type: never
+
+  "Bash(readlink *)":
+    allowed: true
+    source: config
+    reason: safe - resolve symlink
+    expires:
+      type: never
+
+  # Text processing (read-only — no in-place writes)
+  "Bash(echo *)":
+    allowed: true
+    source: config
+    reason: safe - print text
+    expires:
+      type: never
+
+  "Bash(sort *)":
+    allowed: true
+    source: config
+    reason: safe - sort lines
+    expires:
+      type: never
+
+  "Bash(uniq *)":
+    allowed: true
+    source: config
+    reason: safe - deduplicate lines
+    expires:
+      type: never
+
+  "Bash(cut *)":
+    allowed: true
+    source: config
+    reason: safe - extract columns
+    expires:
+      type: never
+
+  "Bash(tr *)":
+    allowed: true
+    source: config
+    reason: safe - translate characters
+    expires:
+      type: never
+
+  "Bash(column *)":
+    allowed: true
+    source: config
+    reason: safe - format into columns
+    expires:
+      type: never
+
+  "Bash(jq *)":
+    allowed: true
+    source: config
+    reason: safe - query JSON
+    expires:
+      type: never
+
+  # Checksums (read-only)
+  "Bash(md5sum *)":
+    allowed: true
+    source: config
+    reason: safe - md5 hash
+    expires:
+      type: never
+
+  "Bash(sha256sum *)":
+    allowed: true
+    source: config
+    reason: safe - sha256 hash
+    expires:
+      type: never
+
+  "Bash(shasum *)":
+    allowed: true
+    source: config
+    reason: safe - sha hash
+    expires:
+      type: never
+
+  "Bash(cksum *)":
+    allowed: true
+    source: config
+    reason: safe - checksum
+    expires:
+      type: never
+
+  # User & session identity (read-only)
+  "Bash(id *)":
+    allowed: true
+    source: config
+    reason: safe - user/group ids
+    expires:
+      type: never
+
+  "Bash(id)":
+    allowed: true
+    source: config
+    reason: safe - user/group ids
+    expires:
+      type: never
+
+  "Bash(groups *)":
+    allowed: true
+    source: config
+    reason: safe - group membership
+    expires:
+      type: never
+
+  "Bash(printenv *)":
+    allowed: true
+    source: config
+    reason: safe - environment variables
+    expires:
+      type: never
+
+  "Bash(locale)":
+    allowed: true
+    source: config
+    reason: safe - locale settings
+    expires:
+      type: never
+
+  "Bash(arch)":
+    allowed: true
+    source: config
+    reason: safe - machine architecture
+    expires:
+      type: never
+
+  "Bash(nproc *)":
+    allowed: true
+    source: config
+    reason: safe - cpu count
+    expires:
+      type: never
+
+  "Bash(lsb_release *)":
+    allowed: true
+    source: config
+    reason: safe - distro info
+    expires:
+      type: never
+
+  # Tool versions (exact — a wildcard here would run the interpreter itself)
+  "Bash(python --version)":
+    allowed: true
+    source: config
+    reason: safe - python version
+    expires:
+      type: never
+
+  "Bash(python3 --version)":
+    allowed: true
+    source: config
+    reason: safe - python version
+    expires:
+      type: never
+
+  "Bash(pip --version)":
+    allowed: true
+    source: config
+    reason: safe - pip version
+    expires:
+      type: never
+
+  "Bash(node --version)":
+    allowed: true
+    source: config
+    reason: safe - node version
+    expires:
+      type: never
+
+  "Bash(node -v)":
+    allowed: true
+    source: config
+    reason: safe - node version
+    expires:
+      type: never
+
+  "Bash(npm --version)":
+    allowed: true
+    source: config
+    reason: safe - npm version
+    expires:
+      type: never
+
+  "Bash(git --version)":
+    allowed: true
+    source: config
+    reason: safe - git version
+    expires:
+      type: never
+
+  "Bash(go version)":
+    allowed: true
+    source: config
+    reason: safe - go version
+    expires:
+      type: never
+
+  # Package inspection (read-only)
+  "Bash(pip list *)":
+    allowed: true
+    source: config
+    reason: safe - list installed packages
+    expires:
+      type: never
+
+  "Bash(pip freeze)":
+    allowed: true
+    source: config
+    reason: safe - list installed packages
+    expires:
+      type: never
+
+  "Bash(pip show *)":
+    allowed: true
+    source: config
+    reason: safe - package details
+    expires:
+      type: never
+
+  "Bash(npm list *)":
+    allowed: true
+    source: config
+    reason: safe - list npm packages
+    expires:
+      type: never
+
+  "Bash(npm ls *)":
+    allowed: true
+    source: config
+    reason: safe - list npm packages
+    expires:
+      type: never
+
   # Common command chains (exact matches)
   "Bash(pwd && ls -F)":
     allowed: true
@@ -349,6 +677,76 @@ permissions:
     allowed: true
     source: config
     reason: safe git branch info
+    expires:
+      type: never
+
+  "Bash(git show *)":
+    allowed: true
+    source: config
+    reason: safe git show
+    expires:
+      type: never
+
+  "Bash(git remote *)":
+    allowed: true
+    source: config
+    reason: safe git remote info
+    expires:
+      type: never
+
+  "Bash(git rev-parse *)":
+    allowed: true
+    source: config
+    reason: safe git rev-parse
+    expires:
+      type: never
+
+  "Bash(git describe *)":
+    allowed: true
+    source: config
+    reason: safe git describe
+    expires:
+      type: never
+
+  "Bash(git blame *)":
+    allowed: true
+    source: config
+    reason: safe git blame
+    expires:
+      type: never
+
+  "Bash(git shortlog *)":
+    allowed: true
+    source: config
+    reason: safe git shortlog
+    expires:
+      type: never
+
+  "Bash(git ls-files *)":
+    allowed: true
+    source: config
+    reason: safe git ls-files
+    expires:
+      type: never
+
+  "Bash(git stash list)":
+    allowed: true
+    source: config
+    reason: safe git stash list
+    expires:
+      type: never
+
+  "Bash(git config --get *)":
+    allowed: true
+    source: config
+    reason: safe git config read
+    expires:
+      type: never
+
+  "Bash(git config --list)":
+    allowed: true
+    source: config
+    reason: safe git config read
     expires:
       type: never
 

--- a/connectonion/network/host/host.yaml
+++ b/connectonion/network/host/host.yaml
@@ -98,6 +98,67 @@ permissions:
     expires:
       type: never
 
+  # Browser navigation & observation tools — safe to drive directly (no data
+  # loss), so a remote client can run them via RemoteAgent.call for a live
+  # "remote control" view. Inert for agents without a browser tool.
+  "go_to":
+    allowed: true
+    source: safe
+    reason: browser navigation
+    expires:
+      type: never
+
+  "take_screenshot":
+    allowed: true
+    source: safe
+    reason: read-only page capture
+    expires:
+      type: never
+
+  "click":
+    allowed: true
+    source: safe
+    reason: browser interaction
+    expires:
+      type: never
+
+  "scroll":
+    allowed: true
+    source: safe
+    reason: browser interaction
+    expires:
+      type: never
+
+  "type_text_by_selector":
+    allowed: true
+    source: safe
+    reason: browser interaction
+    expires:
+      type: never
+
+  "extract_items_by_selector":
+    allowed: true
+    source: safe
+    reason: read-only page extraction
+    expires:
+      type: never
+
+  "wait_for_element":
+    allowed: true
+    source: safe
+    reason: read-only wait
+    expires:
+      type: never
+
+  # co CLI — the framework's own commands (status, auth, browser, ...). Safe to
+  # run directly; they operate on this project's own .co config and identity.
+  "Bash(co *)":
+    allowed: true
+    source: config
+    reason: safe - connectonion CLI
+    expires:
+      type: never
+
   # System information commands (Linux/Unix)
   "Bash(pwd)":
     allowed: true

--- a/connectonion/network/host/host.yaml
+++ b/connectonion/network/host/host.yaml
@@ -98,60 +98,18 @@ permissions:
     expires:
       type: never
 
-  # Browser navigation & observation tools — safe to drive directly (no data
-  # loss), so a remote client can run them via RemoteAgent.call for a live
-  # "remote control" view. Inert for agents without a browser tool.
-  "go_to":
-    allowed: true
-    source: safe
-    reason: browser navigation
-    expires:
-      type: never
-
-  "take_screenshot":
-    allowed: true
-    source: safe
-    reason: read-only page capture
-    expires:
-      type: never
-
-  "click":
-    allowed: true
-    source: safe
-    reason: browser interaction
-    expires:
-      type: never
-
-  "scroll":
-    allowed: true
-    source: safe
-    reason: browser interaction
-    expires:
-      type: never
-
-  "type_text_by_selector":
-    allowed: true
-    source: safe
-    reason: browser interaction
-    expires:
-      type: never
-
-  "extract_items_by_selector":
-    allowed: true
-    source: safe
-    reason: read-only page extraction
-    expires:
-      type: never
-
-  "wait_for_element":
-    allowed: true
-    source: safe
-    reason: read-only wait
-    expires:
-      type: never
-
   # co CLI — the framework's own commands (status, auth, browser, ...). Safe to
   # run directly; they operate on this project's own .co config and identity.
+  #
+  # This is ALSO the browser remote-control entry point. `co browser <verb>`
+  # drives the persistent browser DAEMON (a separate process that arbitrates
+  # tabs, ownership, and lifecycle itself), so a remote client steers the
+  # browser with RemoteAgent.call("bash", command="co browser take_screenshot").
+  # Do NOT whitelist the in-process browser tool names (go_to, take_screenshot,
+  # ...) for direct exec: those bypass the daemon's tab arbitration and the
+  # per-session tab binding, and hit the purpose/who guard meant for the AI.
+  # The two stacks are different Chrome instances sharing one profile — see
+  # docs/network/remote-call.md ("Driving a browser").
   "Bash(co *)":
     allowed: true
     source: config

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -86,28 +86,28 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
     }
 
 
-def exec_handler(create_agent: Callable, exec_tools, tool_name: str, args: dict) -> dict:
+def exec_handler(create_agent: Callable, permissions: dict, tool_name: str, args: dict) -> dict:
     """Direct tool execution (WS EXEC) — run one registered tool by name, no LLM loop.
 
     The terminal-style fast path: the client names a tool and its arguments,
     the tool runs immediately, and the raw result (text, or base64 image for
     screenshot tools) goes straight back. No thinking, no session, no history.
 
-    Access is gated by exec_tools, set explicitly on host():
-      - None/False (default): EXEC disabled entirely
-      - True: every registered tool callable
-      - list[str]: only the named tools callable
+    Gated by the SAME permission whitelist the LLM approval flow uses — the
+    .co/host.yaml `permissions` block. Before running, the call is checked with
+    is_tool_permitted(); a command that isn't whitelisted is refused. So there is
+    one list to maintain, and "safe to run without a human" means the same thing
+    whether the LLM or a remote client initiates.
 
     Tool errors are returned as data, not raised — same contract as the LLM
     loop, where tool failures are reported back to the caller for retry.
     """
-    if not exec_tools:
-        return {"status": "error",
-                "error": "direct exec not enabled on this host — start it with host(..., exec_tools=[...])"}
+    from ...useful_plugins.tool_approval.approval import is_tool_permitted
 
-    if exec_tools is not True and tool_name not in exec_tools:
+    allowed, reason = is_tool_permitted(tool_name, args, permissions)
+    if not allowed:
         return {"status": "error",
-                "error": f"tool '{tool_name}' is not exec-enabled (allowed: {sorted(exec_tools)})"}
+                "error": f"blocked: {reason}. Allow it by adding a rule to .co/host.yaml permissions."}
 
     agent = create_agent()
     tool = agent.tools.get(tool_name)

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -86,6 +86,53 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
     }
 
 
+def exec_handler(create_agent: Callable, exec_tools, tool_name: str, args: dict) -> dict:
+    """Direct tool execution (WS EXEC) — run one registered tool by name, no LLM loop.
+
+    The terminal-style fast path: the client names a tool and its arguments,
+    the tool runs immediately, and the raw result (text, or base64 image for
+    screenshot tools) goes straight back. No thinking, no session, no history.
+
+    Access is gated by exec_tools, set explicitly on host():
+      - None/False (default): EXEC disabled entirely
+      - True: every registered tool callable
+      - list[str]: only the named tools callable
+
+    Tool errors are returned as data, not raised — same contract as the LLM
+    loop, where tool failures are reported back to the caller for retry.
+    """
+    if not exec_tools:
+        return {"status": "error",
+                "error": "direct exec not enabled on this host — start it with host(..., exec_tools=[...])"}
+
+    if exec_tools is not True and tool_name not in exec_tools:
+        return {"status": "error",
+                "error": f"tool '{tool_name}' is not exec-enabled (allowed: {sorted(exec_tools)})"}
+
+    agent = create_agent()
+    tool = agent.tools.get(tool_name)
+    if tool is None:
+        return {"status": "error",
+                "error": f"unknown tool '{tool_name}' (available: {agent.tools.names()})"}
+
+    # Same injection as tool_executor: tools that declare 'agent' get it at call
+    # time (never exposed to the caller's args).
+    if getattr(tool, '_needs_agent', False):
+        args = {**args, "agent": agent}
+
+    start = time.time()
+    try:
+        result = tool(**args)
+    except Exception as e:
+        return {"status": "error",
+                "error": f"{type(e).__name__}: {e}",
+                "duration_ms": int((time.time() - start) * 1000)}
+
+    return {"status": "success",
+            "result": str(result),
+            "duration_ms": int((time.time() - start) * 1000)}
+
+
 def session_handler(storage: SessionStorage, session_id: str) -> dict | None:
     """GET /sessions/{id}"""
     session = storage.get(session_id)

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -101,6 +101,16 @@ def exec_handler(create_agent: Callable, permissions: dict, tool_name: str, args
 
     Tool errors are returned as data, not raised — same contract as the LLM
     loop, where tool failures are reported back to the caller for retry.
+
+    NOTE — this runs the tool DIRECTLY: no LLM, and no event/plugin hooks
+    (before_each_tool etc.) fire. Anything a plugin does per tool call is skipped
+    here. That matters for the browser: the in-process BrowserAutomation relies
+    on the bind_browser_session plugin (a before_each_tool hook) to route each
+    session to its own tab, and that hook does NOT run for exec. So do NOT expose
+    the in-process browser tool names for direct exec. Browser remote-control
+    goes through the `co browser` CLI instead — `co browser <verb>` drives the
+    persistent browser DAEMON, a separate process that handles tab arbitration
+    and lifecycle on its own. See docs/network/remote-call.md.
     """
     from ...useful_plugins.tool_approval.approval import is_tool_permitted
 

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -150,7 +150,7 @@ def _build_agent_profile(agent_metadata: dict) -> dict:
     return profile
 
 
-def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict, exec_tools=None):
+def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict, exec_permissions: dict | None = None):
     """Create route handler dict for ASGI app.
 
     Args:
@@ -161,10 +161,12 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         result_ttl: How long to keep results on server in seconds
         trust_agent: TrustAgent instance for trust operations
         config: Host config dict (includes file upload limits)
-        exec_tools: Direct-exec gate for WS EXEC frames — None/False disables
-                    (default), True allows all tools, list[str] whitelists names.
+        exec_permissions: The .co/host.yaml permission whitelist that gates WS
+                          EXEC (direct tool execution). Same list the LLM
+                          approval flow uses; empty dict → nothing runs directly.
     """
     agent_name = agent_metadata["name"]
+    exec_permissions = exec_permissions or {}
 
     def handle_input(storage, prompt, session=None, connection=None, images=None, files=None):
         validate_files(files, config)
@@ -175,7 +177,7 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
 
     def handle_ws_exec(tool_name, args):
-        return exec_handler(create_agent, exec_tools, tool_name, args)
+        return exec_handler(create_agent, exec_permissions, tool_name, args)
 
     def handle_health(start_time):
         return health_handler(agent_name, start_time)
@@ -371,7 +373,6 @@ def host(
     co_dir: Path = None,
     summary: str = None,
     examples: list = None,
-    exec_tools: Union[bool, list, None] = None,
 ):
     """
     Host an agent over HTTP/WebSocket with P2P relay discovery (enabled by default).
@@ -412,11 +413,12 @@ def host(
         co_dir: Path to .co directory for agent identity (default: ~/.co/)
         summary: Agent description (default: from config or agent.system_prompt)
         examples: Example prompts (default: from config or auto-generated)
-        exec_tools: Enable direct tool execution (WS EXEC) — the terminal-style
-            fast path that bypasses the LLM. None/False (default) disables it,
-            True allows every registered tool, a list of names whitelists tools:
-            host(create_agent, exec_tools=["bash", "take_screenshot"]).
-            Clients use RemoteAgent.call("bash", command="ls -la").
+
+    Direct execution (WS EXEC):
+        Clients can run a tool directly, bypassing the LLM, via
+        RemoteAgent.call("bash", command="co status"). This is gated by the
+        SAME .co/host.yaml `permissions` whitelist the LLM approval flow uses —
+        only whitelisted commands run. Nothing to enable: edit the whitelist.
 
     Endpoints:
         POST /input          - Submit prompt, get result
@@ -500,7 +502,13 @@ def host(
     else:
         trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
 
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, config, exec_tools)
+    # Load the permission whitelist that gates direct execution (WS EXEC).
+    # Same list the LLM approval flow reads: template safe defaults + this
+    # project's .co/host.yaml permissions block.
+    from ...useful_plugins.tool_approval.approval import load_permission_patterns
+    exec_permissions = load_permission_patterns(co_dir)
+
+    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, config, exec_permissions)
 
     # Parse trust config for /info onboard info
     trust_config = _parse_trust_config(trust)
@@ -556,7 +564,7 @@ def host(
     uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, log_level="warning")
 
 
-def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None, exec_tools=None):
+def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None):
     """Create ASGI app for external uvicorn/gunicorn usage.
 
     Each request calls create_agent() to get a fresh Agent instance.
@@ -589,7 +597,8 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     else:
         trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
 
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, DEFAULT_FILE_LIMITS, exec_tools)
+    from ...useful_plugins.tool_approval.approval import load_permission_patterns
+    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, DEFAULT_FILE_LIMITS, load_permission_patterns())
     return asgi_create_app(
         route_handlers=route_handlers,
         storage=storage,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -46,6 +46,7 @@ from .config import load_host_config, load_list_file, validate_files, DEFAULT_FI
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
 from .http_router import (
     input_handler,
+    exec_handler,
     session_handler,
     sessions_handler,
     health_handler,
@@ -149,7 +150,7 @@ def _build_agent_profile(agent_metadata: dict) -> dict:
     return profile
 
 
-def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict):
+def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict, exec_tools=None):
     """Create route handler dict for ASGI app.
 
     Args:
@@ -160,6 +161,8 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         result_ttl: How long to keep results on server in seconds
         trust_agent: TrustAgent instance for trust operations
         config: Host config dict (includes file upload limits)
+        exec_tools: Direct-exec gate for WS EXEC frames — None/False disables
+                    (default), True allows all tools, list[str] whitelists names.
     """
     agent_name = agent_metadata["name"]
 
@@ -170,6 +173,9 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
     def handle_ws_input(storage, prompt, connection, session=None, images=None, files=None):
         validate_files(files, config)
         return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
+
+    def handle_ws_exec(tool_name, args):
+        return exec_handler(create_agent, exec_tools, tool_name, args)
 
     def handle_health(start_time):
         return health_handler(agent_name, start_time)
@@ -188,6 +194,7 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         "info": handle_info,
         "auth": extract_and_authenticate,
         "ws_input": handle_ws_input,
+        "ws_exec": handle_ws_exec,
         "admin_logs": handle_admin_logs,
         "admin_sessions": admin_sessions_handler,
         # TrustAgent instance for direct access in http.py/websocket.py
@@ -364,6 +371,7 @@ def host(
     co_dir: Path = None,
     summary: str = None,
     examples: list = None,
+    exec_tools: Union[bool, list, None] = None,
 ):
     """
     Host an agent over HTTP/WebSocket with P2P relay discovery (enabled by default).
@@ -404,6 +412,11 @@ def host(
         co_dir: Path to .co directory for agent identity (default: ~/.co/)
         summary: Agent description (default: from config or agent.system_prompt)
         examples: Example prompts (default: from config or auto-generated)
+        exec_tools: Enable direct tool execution (WS EXEC) — the terminal-style
+            fast path that bypasses the LLM. None/False (default) disables it,
+            True allows every registered tool, a list of names whitelists tools:
+            host(create_agent, exec_tools=["bash", "take_screenshot"]).
+            Clients use RemoteAgent.call("bash", command="ls -la").
 
     Endpoints:
         POST /input          - Submit prompt, get result
@@ -487,7 +500,7 @@ def host(
     else:
         trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
 
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, config)
+    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, config, exec_tools)
 
     # Parse trust config for /info onboard info
     trust_config = _parse_trust_config(trust)
@@ -543,7 +556,7 @@ def host(
     uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, log_level="warning")
 
 
-def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None):
+def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None, exec_tools=None):
     """Create ASGI app for external uvicorn/gunicorn usage.
 
     Each request calls create_agent() to get a fresh Agent instance.
@@ -576,7 +589,7 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     else:
         trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
 
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, DEFAULT_FILE_LIMITS)
+    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, DEFAULT_FILE_LIMITS, exec_tools)
     return asgi_create_app(
         route_handlers=route_handlers,
         storage=storage,

--- a/connectonion/network/host/ws_router/exec.py
+++ b/connectonion/network/host/ws_router/exec.py
@@ -1,0 +1,35 @@
+"""
+Purpose: Handle the EXEC message — direct tool execution bypassing the LLM loop
+LLM-Note:
+  Dependencies: imports from [asyncio, rich.console] | imported by [.session as part of EXEC dispatch] | tested by [tests/unit/test_ws_exec.py]
+  Data flow: run_exec(data, send_msg, route_handlers) → validate tool name → route_handlers["ws_exec"](tool, args) in a worker thread (blocking tools must not stall the WS read loop) → EXEC_RESULT frame {exec_id, tool, status, result|error, duration_ms}
+  State/Effects: no state | spawned as an asyncio Task per EXEC by session.py so pipelined EXECs run concurrently
+  Integration: run_exec(data, send_msg, route_handlers) — data is the raw EXEC frame {type, exec_id, tool, args} | session.py gates on conn["authenticated"] before dispatching here
+  Performance: one asyncio.to_thread per EXEC | no session storage, no registry — stateless request/response
+  Errors: missing tool name and handler exceptions both surface as EXEC_RESULT status=error (a background task's raise would be invisible to the client, which would hang until timeout)
+"""
+import asyncio
+
+from rich.console import Console
+
+console = Console()
+
+
+async def run_exec(data, send_msg, route_handlers):
+    """Run one EXEC request in a worker thread, reply with EXEC_RESULT."""
+    exec_id = data.get("exec_id")
+    tool_name = data.get("tool")
+    args = data.get("args") or {}
+
+    if not tool_name:
+        await send_msg({"type": "EXEC_RESULT", "exec_id": exec_id,
+                        "status": "error", "error": "tool required"})
+        return
+
+    console.print(f"[green]✓ EXEC[/green] tool={tool_name} args={str(args)[:80]}")
+    try:
+        result = await asyncio.to_thread(route_handlers["ws_exec"], tool_name, args)
+    except Exception as e:
+        result = {"status": "error", "error": f"{type(e).__name__}: {e}"}
+
+    await send_msg({"type": "EXEC_RESULT", "exec_id": exec_id, "tool": tool_name, **result})

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -2,7 +2,7 @@
 Purpose: Run one client session — read loop, per-type dispatch, lifecycle of forward + ping tasks
 LLM-Note:
   Dependencies: imports from [.connect (handle_connect), .agent_io (start_agent), .ping (ping_loop), ...trust.ws_admin (handle_admin_message, handle_onboard_submit), asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
-  Data flow: recv_msg() → match data["type"] → dispatch | PONG → registry.update_ping | SESSION_STATUS → registry lookup + reply (inline) | CONNECT → handle_connect (auth + reattach) | INPUT → if running session: push_runtime_input + RUNTIME_INPUT_ACK (inline); else: start_agent | other types with active_io → active_io.send_to_agent | finally: cancel forward + ping tasks
+  Data flow: recv_msg() → match data["type"] → dispatch | PONG → registry.update_ping | SESSION_STATUS → registry lookup + reply (inline) | CONNECT → handle_connect (auth + reattach) | INPUT → if running session: push_runtime_input + RUNTIME_INPUT_ACK (inline); else: start_agent | EXEC → run_exec as own task (direct tool call, no LLM; requires auth) | other types with active_io → active_io.send_to_agent | finally: cancel forward + ping + exec tasks
   State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally
   Integration: run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registry, trust, blacklist=None, whitelist=None, enable_ping=True) | enable_ping=True on both direct and relay paths: the 30s client PING is forwarded through the relay to the client, since the relay's ANNOUNCE heartbeat only keeps the agent↔relay link alive and never reaches the client
   Performance: single-reader of recv_msg | O(1) per-message dispatch | bounded local state
@@ -15,6 +15,7 @@ from rich.console import Console
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
 from .connect import handle_connect, establish_connection
 from .agent_io import start_agent
+from .exec import run_exec
 from .ping import ping_loop
 
 console = Console()
@@ -30,6 +31,7 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
     conn = {"authenticated": False, "agent_address": None, "session_id": None, "session": None}
     active_io = None
     forward_task = None
+    exec_tasks = set()
     ping_task = asyncio.create_task(ping_loop(send_msg)) if enable_ping else None
 
     try:
@@ -110,6 +112,17 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     if result:
                         active_io, forward_task = result
 
+            elif msg_type == "EXEC":
+                # Direct tool execution — no LLM, no session. Auth is the same
+                # gate as INPUT; each EXEC runs as its own task so a slow tool
+                # (long shell command) never blocks this read loop or other EXECs.
+                if not conn["authenticated"]:
+                    await send_msg({"type": "ERROR", "message": "authenticate first (send CONNECT)"})
+                else:
+                    task = asyncio.create_task(run_exec(data, send_msg, route_handlers))
+                    exec_tasks.add(task)
+                    task.add_done_callback(exec_tasks.discard)
+
             elif active_io:
                 # Anything else (ASK_USER_RESPONSE, APPROVAL_RESPONSE, mode_change, ...)
                 # → forward to the running agent's input mailbox.
@@ -118,7 +131,7 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
         # asyncio cancel idiom: cancel() only signals; await ensures the task
         # actually unwinds before we return. The CancelledError surfaced by
         # that await is the expected exit signal — not a bug, swallow it.
-        for task in (forward_task, ping_task):
+        for task in (forward_task, ping_task, *exec_tasks):
             if task and not task.done():
                 task.cancel()
                 try:

--- a/connectonion/useful_plugins/bind_browser_session.py
+++ b/connectonion/useful_plugins/bind_browser_session.py
@@ -23,6 +23,14 @@ browser uses a single shared tab (original behaviour).
 
 State/Effects: writes the per-thread binding on the browser instance; no agent or
 module state. Best-effort — no browser tool or no session_id => no-op.
+
+Scope note: this only runs during agent.input() — it's a before_each_tool event
+handler. Paths that call a browser tool WITHOUT the event loop (network EXEC /
+RemoteAgent.call, which invoke the tool directly) never trigger it, so the
+binding stays None and those calls land on the single shared 'main' tab. That's
+why browser remote-control goes through the `co browser` CLI (the daemon
+arbitrates tabs itself) rather than direct-exec on the in-process browser tools.
+See connectonion/network/host/http_router.py:exec_handler.
 """
 
 from typing import TYPE_CHECKING

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -622,6 +622,102 @@ def check_approval(agent: 'Agent') -> None:
     )
 
 
+def _convert_permission_patterns(raw: dict) -> dict:
+    """Normalize a raw host.yaml permissions dict.
+
+    A "Bash(cmd)" key keeps its form but gains when={command: cmd} so runtime
+    matching can fnmatch the actual command. Simple tool-name keys pass through.
+    """
+    converted = {}
+    for pattern, perm in raw.items():
+        if pattern.startswith('Bash(') and pattern.endswith(')'):
+            converted[pattern] = {**perm, 'when': {'command': pattern[5:-1]}}
+        else:
+            converted[pattern] = perm
+    return converted
+
+
+def load_permission_patterns(co_dir=None) -> dict:
+    """Load the merged permission whitelist: template safe defaults + project host.yaml.
+
+    Returns the same dict shape used in session['permissions']. This whitelist is
+    the single source of truth for "what may run without a human in the loop" —
+    honored both by the session approval flow (load_config_permissions) and by
+    direct tool execution (network EXEC), so there is only one list to maintain.
+
+    Args:
+        co_dir: Project .co directory (default: cwd/.co). The template defaults
+                always load; the project host.yaml merges on top.
+    """
+    import yaml
+
+    permissions = {}
+
+    template_path = Path(__file__).parent.parent.parent / 'network' / 'host' / 'host.yaml'
+    if template_path.exists():
+        with open(template_path, 'r', encoding='utf-8') as f:
+            template_config = yaml.safe_load(f) or {}
+        template_permissions = template_config.get('permissions')
+        if template_permissions and isinstance(template_permissions, dict):
+            permissions.update(_convert_permission_patterns(template_permissions))
+
+    co_dir = Path(co_dir) if co_dir else (Path.cwd() / '.co')
+    host_yaml = co_dir / 'host.yaml'
+    if host_yaml.exists():
+        with open(host_yaml, 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f) or {}
+        permissions_config = config.get('permissions')
+        if permissions_config and isinstance(permissions_config, dict):
+            for key, perm in _convert_permission_patterns(permissions_config).items():
+                # Project config overrides template, but never clobbers a
+                # user-granted approval.
+                if permissions.get(key, {}).get('source') != 'user':
+                    permissions[key] = perm
+
+    return permissions
+
+
+def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tuple[bool, str]:
+    """Check one tool call against a permission whitelist. Returns (allowed, reason).
+
+    Same matching the LLM approval flow uses in check_approval: bash command
+    chains require every subcommand permitted; other tools match by name (and
+    'when' parameter globs). Callers that run tools outside the LLM loop (network
+    EXEC) use this so direct execution honors exactly the host.yaml whitelist.
+    """
+    import fnmatch
+
+    if not permissions:
+        return False, "no permissions configured"
+
+    # Bash chains: every subcommand in "a && b | c" must be individually
+    # permitted. This is AUTHORITATIVE for bash — we never fall through to the
+    # generic loop below, because a pattern like "Bash(co *)" would otherwise
+    # prefix-match the whole chain string ("co status && rm -rf /") and wrongly
+    # permit the dangerous half. Per-subcommand matching is the only safe check.
+    if tool_name == 'bash' and 'command' in tool_args:
+        permitted, reason, _ = check_bash_chain_permitted(tool_args['command'], permissions)
+        return (True, reason or "permitted") if permitted else (False, "command not in the permission whitelist")
+
+    for pattern, perm in permissions.items():
+        if not perm.get('allowed'):
+            continue
+        if matches_permission_pattern(tool_name, tool_args, pattern):
+            when_config = perm.get('when')
+            if when_config:
+                all_match = True
+                for param_name, param_pattern in when_config.items():
+                    actual_value = tool_args.get(param_name, '')
+                    if not fnmatch.fnmatch(str(actual_value), str(param_pattern)):
+                        all_match = False
+                        break
+                if not all_match:
+                    continue
+            return True, perm.get('reason', 'allowed')
+
+    return False, f"'{tool_name}' is not in the permission whitelist"
+
+
 @after_user_input
 def load_config_permissions(agent: 'Agent') -> None:
     """Load permissions from host.yaml into session after user input.
@@ -634,68 +730,30 @@ def load_config_permissions(agent: 'Agent') -> None:
     Runs after user input so session is guaranteed to exist.
     Only loads once per session (first input).
     """
-    import yaml
-
     # Only load once per session
     if 'permissions' in agent.current_session and 'permissions_source' in agent.current_session:
         return
 
-    # Initialize permissions dict
-    if 'permissions' not in agent.current_session:
-        agent.current_session['permissions'] = {}
-
-    # Always load template permissions first (safe tools)
-    template_path = Path(__file__).parent.parent.parent / 'network' / 'host' / 'host.yaml'
-    if template_path.exists():
-        with open(template_path, 'r', encoding='utf-8') as f:
-            template_config = yaml.safe_load(f) or {}
-        template_permissions = template_config.get('permissions')
-        if template_permissions and isinstance(template_permissions, dict):
-            converted_template = {}
-            for pattern, perm in template_permissions.items():
-                if pattern.startswith('Bash(') and pattern.endswith(')'):
-                    # Keep Bash(X) as key (no collapse), add 'when' for runtime matching
-                    command_pattern = pattern[5:-1]
-                    converted_template[pattern] = {**perm, 'when': {'command': command_pattern}}
-                else:
-                    converted_template[pattern] = perm
-            agent.current_session['permissions'].update(converted_template)
-
-    # Then load project-specific config (if exists) and merge on top
+    # Reuse the shared loader — template safe defaults + project host.yaml —
+    # so the session flow and direct EXEC honor one whitelist.
     co_dir = Path.cwd() / '.co'
     host_yaml = co_dir / 'host.yaml'
+    loaded = load_permission_patterns(co_dir)
+
+    existing = agent.current_session.get('permissions', {})
+    # Preserve any user-granted approvals already in the session.
+    for key, perm in loaded.items():
+        if existing.get(key, {}).get('source') != 'user':
+            existing[key] = perm
+    agent.current_session['permissions'] = existing
 
     if host_yaml.exists():
-        with open(host_yaml, 'r', encoding='utf-8') as f:
-            config = yaml.safe_load(f) or {}
-
-        permissions_config = config.get('permissions')
-        if permissions_config and isinstance(permissions_config, dict):
-            converted_permissions = {}
-            for pattern, perm in permissions_config.items():
-                if pattern.startswith('Bash(') and pattern.endswith(')'):
-                    # Keep Bash(X) as key (avoids collapse), add 'when' for runtime fnmatch check
-                    command_pattern = pattern[5:-1]
-                    converted_permissions[pattern] = {**perm, 'when': {'command': command_pattern}}
-                else:
-                    converted_permissions[pattern] = perm
-
-            # Merge converted permissions (overrides template, but preserve user approvals)
-            for key, perm in converted_permissions.items():
-                # Don't overwrite user approvals
-                existing = agent.current_session['permissions'].get(key, {})
-                if existing.get('source') != 'user':
-                    agent.current_session['permissions'][key] = perm
-            agent.current_session['permissions_source'] = str(host_yaml.name)
-
-            # Log where permissions were loaded from (once, at startup)
-            if hasattr(agent, 'logger') and agent.logger and getattr(agent.logger, 'console', None):
-                count = len(permissions_config)
-                agent.logger.console.print(
-                    f"[dim]Loaded {count} permission(s) from {host_yaml.name}[/dim]"
-                )
+        agent.current_session['permissions_source'] = str(host_yaml.name)
+        if hasattr(agent, 'logger') and agent.logger and getattr(agent.logger, 'console', None):
+            agent.logger.console.print(
+                f"[dim]Loaded {len(loaded)} permission(s) from {host_yaml.name}[/dim]"
+            )
     else:
-        # No project config, using template only
         agent.current_session['permissions_source'] = 'template'
 
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -9,6 +9,21 @@ LLM-Note:
   Errors: an unoccupied tab's first go_to/newtab raises ValueError coaching the AGENT to re-call with purpose/who (_occupancy_help) | launch failure returns the first error line + a pointer to ~/.co/browser.log | context liveness is judged at the CONTEXT level (_context_is_alive), so one dead page never tears down other sessions' tabs
 Browser Agent for CLI - Natural language browser automation.
 
+Two stacks drive this class — same code, different process, DIFFERENT Chrome
+instance (both use ~/.co/browser_profile, so only one can run at a time):
+
+  1. In-process TOOL — an agent holds a BrowserAutomation instance in its own
+     process (e.g. the hosted-browser template). Tabs are routed per session by
+     the bind_browser_session plugin (a before_each_tool hook), so each chat
+     session drives its own tab. Driven by agent.input() (the LLM). A direct
+     call that skips the event loop (network EXEC) skips the plugin → lands on
+     the shared 'main' tab.
+  2. DAEMON — `co browser <verb>` talks to a persistent background daemon
+     (cli/browser_agent/daemon.py) that owns ONE BrowserAutomation and arbitrates
+     tabs/ownership/lifecycle itself (`-t <tab>` targets a tab; bare = 'main').
+     This is the path for remote control: RemoteAgent.call("bash",
+     command="co browser take_screenshot"). See docs/network/remote-call.md.
+
 This module provides a browser automation agent that understands natural language
 requests for browser operations via the ConnectOnion CLI.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 ├── README.md              # This file - complete reference for vibe coding
 ├── quickstart.md          # 60-second getting started guide
 ├── co-browser.md          # Drive one persistent browser from the shell (multi-agent tabs)
+│                          #   → remote: `co call <addr> co browser ...` (network/remote-call.md)
 ├── api.md                 # Full API reference
 ├── connectonion.md        # Framework architecture deep dive
 ├── examples.md            # Code examples and patterns

--- a/docs/api.md
+++ b/docs/api.md
@@ -456,3 +456,42 @@ agent = Agent(
 # Agent can use multiple tools in one request
 result = agent.input("Search for Python tutorials, calculate 42*17, and tell me the time")
 ```
+
+## Networking
+
+Host an agent and connect to it from anywhere. Full guides live in
+[`network/`](network/README.md); the core surface:
+
+### `host(create_agent, **kwargs)`
+
+Serve an agent over HTTP/WebSocket with relay discovery. `create_agent` is a
+factory called once per request (isolation). See [network/host.md](network/host.md).
+
+```python
+from connectonion import host
+host(lambda: Agent("assistant", tools=[...]))
+```
+
+### `connect(address, *, keys=None, relay_url=...) -> RemoteAgent`
+
+Client to a remote agent. See [network/connect.md](network/connect.md).
+
+```python
+from connectonion import connect
+remote = connect("0x3d40...")
+
+# LLM-driven task
+resp = remote.input("Book a flight")      # -> Response(text, done)
+
+# Direct tool execution — no LLM (see network/remote-call.md)
+res = remote.call("bash", command="co status")   # -> ExecResult
+```
+
+| Method | Returns | Purpose |
+|--------|---------|---------|
+| `remote.input(prompt, timeout=60)` | `Response(text, done)` | Hand the remote LLM a task |
+| `remote.call(tool, timeout=60, **args)` | `ExecResult(text, status, duration_ms, error)` | Run one tool directly, no LLM |
+
+`ExecResult`: `.ok` (bool), `.images` (base64 data URLs pulled from `.text`).
+Direct execution is gated by the host's `.co/host.yaml` permission whitelist.
+From the shell: `co call <address> <command...>` (see [cli/call.md](cli/call.md)).

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -575,6 +575,33 @@ co browser --headless go_to "$DEPLOY_URL"   # --headless for CI
 
 ---
 
+#### `co call <address> <command>` - Run a Command on a Remote Agent
+
+The **remote twin of `co browser`**: run one command on a remote agent and print
+the result — no LLM, no session. What `co browser take_screenshot` does locally,
+`co call <address> co browser take_screenshot` does on a remote agent. See
+[call.md](call.md).
+
+```bash
+co call 0x3d40... co status                                   # run co status remotely
+co call 0x3d40... co browser go_to https://example.com        # drive its browser
+co call --out shot.png 0x3d40... co browser take_screenshot   # save its screenshot
+co call 0x3d40... uptime                                      # any whitelisted command
+```
+
+Everything after the address runs on the remote, gated by **that agent's**
+`.co/host.yaml` whitelist (`co ...` and read-only commands allowed by default).
+Options (`--out`, `--timeout`, `--relay`) go before the address; clean stdout and
+standard exit codes (`0` ok · `1` failure · `2` usage) make it script- and
+agent-friendly.
+
+**When to use:**
+- An agent driving another agent with an exact command
+- Remote-control browser steps from the shell
+- Scripting remote actions (vs. `connect().input()` for LLM-driven tasks)
+
+---
+
 ## Global Configuration
 
 ### The `~/.co/` Directory
@@ -942,7 +969,8 @@ Agent URL: https://my-agent-abc123.agents.openonion.ai
 | `co deploy` | Deploy to cloud | No | ✅ Yes |
 | `co reset` | Reset account | Yes | ⚠️ Destructive |
 | `co doctor` | Diagnose issues | No | ✅ Yes |
-| `co browser` | Browser command | No | ✅ Yes |
+| `co browser` | Browser command (local) | No | ✅ Yes |
+| `co call` | Run a command on a remote agent | No | ✅ Yes |
 | `co outlook` | Send/read Outlook email | No | ✅ Yes |
 
 ---

--- a/docs/cli/call.md
+++ b/docs/cli/call.md
@@ -1,0 +1,103 @@
+# CLI Call
+
+Run one command on a **remote** agent from the shell, print the result. No LLM, no session — like a remote command line.
+
+## Quick Start (60 seconds)
+
+```bash
+co call 0x3d40... co status                              # run `co status` on the remote box
+co call 0x3d40... co browser go_to https://example.com   # drive its browser
+co call --out shot.png 0x3d40... co browser take_screenshot   # save its screenshot
+co call 0x3d40... uptime                                 # any whitelisted command
+```
+
+`co call` is the **remote twin of `co browser`**: what `co browser take_screenshot`
+does on *this* machine, `co call <address> co browser take_screenshot` does on a
+*remote* agent — same verbs, one extra `<address>` up front.
+
+## How it works
+
+```
+co call <address> <command...>
+        │           │
+        │           └── runs on the REMOTE agent, verbatim
+        └────────────── the agent's 0x address (or an announced alias)
+```
+
+The command is sent over the same authenticated WebSocket the Python `connect()`
+client uses (direct or via relay), executed on the remote through its
+direct-exec path, and the raw output comes straight back. Under the hood this is
+`connect(address).call("bash", command="<command...>")`.
+
+## Gated by the remote's whitelist
+
+The remote decides what may run: every `co call` is checked against **that
+agent's `.co/host.yaml` `permissions`** whitelist — the same list its own LLM
+uses to auto-run a command without asking. `co ...` commands (including
+`co browser <verb>`) are whitelisted by default; read-only shell commands too.
+Anything not on the list comes back as an error:
+
+```bash
+$ co call 0x3d40... rm -rf /
+blocked: command not in the permission whitelist. Allow it by adding a rule to .co/host.yaml permissions.
+$ echo $?
+1
+```
+
+To expose more, edit the whitelist **on the remote** (`.co/host.yaml`), e.g. add
+`"Bash(git status)"`. See [network/remote-call.md](../network/remote-call.md).
+
+## Driving a remote browser
+
+Browser control goes through `co browser`, which on the remote talks to its
+persistent browser **daemon** (a separate process that manages tabs and
+lifecycle itself):
+
+```bash
+co call 0x3d40... co browser go_to https://news.ycombinator.com
+co call 0x3d40... co browser click "text=login"
+co call --out home.png 0x3d40... co browser take_screenshot
+```
+
+A screenshot returns as base64; `co call` detects an image result and saves it —
+to `--out PATH` if given, else `./screenshot.png` — then prints the path.
+
+## Options
+
+Options go **before** the address; everything after the address is the remote
+command, verbatim (so it keeps its own flags — `co call 0x.. ls -la` works).
+
+- `--out PATH` — save an image result (screenshot) to `PATH` instead of `./screenshot.png`
+- `--timeout SEC` — seconds to wait for the result (default `60`)
+- `--relay URL` — relay server (default `wss://oo.openonion.ai`)
+
+## Scripting
+
+Clean stdout, standard exit codes — safe to pipe and branch on:
+
+```bash
+status=$(co call 0x3d40... co status)
+co call 0x3d40... co browser get_links_from_page | grep github
+co call --out /tmp/s.png 0x3d40... co browser take_screenshot && open /tmp/s.png
+```
+
+Exit codes: `0` ok · `1` failure (tool error / not whitelisted / connection) · `2` usage.
+
+## Identity
+
+`co call` signs the request with your local identity (`.co` in the project, else
+`~/.co`), which the remote needs if it runs at a strict trust level. For open /
+careful agents no keys are required — it works out of the box.
+
+## When to use
+
+- **`co call`** — you know the exact command and want the result now (scripting,
+  an agent driving another agent, remote-control steps).
+- **Python `connect().input(prompt)`** — hand the remote agent an open-ended
+  task and let its LLM decide the steps. See [network/connect.md](../network/connect.md).
+
+## See Also
+
+- [network/remote-call.md](../network/remote-call.md) — `remote.call` / EXEC internals and the whitelist
+- [browser.md](browser.md) — `co browser` (the local browser this mirrors)
+- [network/connect.md](../network/connect.md) — `connect()` and `input()` for LLM-driven tasks

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -250,8 +250,24 @@ exactly one daemon — the loser exits and its command is served by the winner.
   daemon log: `~/.co/browser.log` · socket: `$TMPDIR/co/browser.sock` (plus
   `.pid`/`.lock` beside it).
 
+## Remote control
+
+Everything here runs the browser on **this** machine. To drive the browser on a
+**remote** agent, prefix the same command with `co call <address>`:
+
+```bash
+co browser take_screenshot                          # local
+co call 0x3d40... co browser take_screenshot        # remote (same verb)
+```
+
+`co call` sends the command to the remote agent over an authenticated WebSocket;
+it runs there against the remote's own browser daemon and the result (text or a
+saved screenshot) comes back. Gated by the remote's `.co/host.yaml` whitelist —
+`co browser <verb>` is allowed by default. See [cli/call.md](cli/call.md).
+
 ## See Also
 
 - `co browser help` — the live list of every function you can call directly.
+- [cli/call.md](cli/call.md) — `co call`, the remote twin of this command.
 - The `browser` and `hosted-browser` project templates (`co create --template browser`)
   for building agents on top of the same browser automation.

--- a/docs/network/README.md
+++ b/docs/network/README.md
@@ -6,6 +6,7 @@ Connect and collaborate between agents with automatic reliability and recovery.
 
 - [host.md](host.md) - Make agents network-accessible with `host()`
 - [connect.md](connect.md) - Connect to remote agents with `connect()`
+- [remote-call.md](remote-call.md) - Run a remote agent's tools directly with `remote.call()`, gated by the host.yaml whitelist
 - [io.md](io.md) - Stream events and communicate with clients
 - [session-reconnect.md](session-reconnect.md) - WebSocket reconnection and session recovery
 

--- a/docs/network/connect.md
+++ b/docs/network/connect.md
@@ -115,6 +115,23 @@ agent.status    # 'idle' | 'working' | 'waiting'
 
 ---
 
+## Direct tool execution (`remote.call`)
+
+`input()` hands the remote **LLM** a task and waits for it to reason. When you
+already know the exact tool and arguments, `remote.call()` runs it directly — no
+LLM, no session — and returns the raw output (text or a base64 screenshot):
+
+```python
+remote = connect("0x3d40...")
+print(remote.call("bash", command="co status").text)
+shot = remote.call("bash", command="co browser take_screenshot")   # .images extracts base64
+```
+
+Gated by the host's `.co/host.yaml` whitelist. From the shell it's `co call
+<address> <command...>`. Full reference: [remote-call.md](remote-call.md).
+
+---
+
 ## Connection Modes
 
 ### Via Relay (Default)

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -581,7 +581,9 @@ ws.onmessage = (event) => {
 | ATTACH | Client → Server | Authenticate + resume existing session |
 | CONNECTED | Server → Client | Session info (session_id, status) |
 | INPUT | Client → Server | Send prompt (no auth needed) |
+| EXEC | Client → Server | Run one tool directly, no LLM |
 | OUTPUT | Server → Client | Final result + session data |
+| EXEC_RESULT | Server → Client | Result of an EXEC |
 | PING | Server → Client | Keep-alive (every 30s) |
 | PONG | Client → Server | Acknowledge keep-alive |
 | tool_call | Server → Client | Tool started |
@@ -590,6 +592,15 @@ ws.onmessage = (event) => {
 | ask_user | Server → Client | Agent needs input |
 | approval_needed | Server → Client | Tool approval required |
 | ERROR | Server → Client | Error message |
+
+### Direct tool execution (EXEC)
+
+Besides the LLM loop, a hosted agent exposes a **direct execution** fast path:
+clients can run one registered tool with no LLM via `EXEC` / `EXEC_RESULT`
+(`remote.call` in Python, `co call` from the shell). It's gated by the same
+`.co/host.yaml` `permissions` whitelist the LLM approval flow uses — nothing to
+enable, and only whitelisted commands run. See
+[remote-call.md](remote-call.md).
 
 ### Session Recovery
 

--- a/docs/network/remote-call.md
+++ b/docs/network/remote-call.md
@@ -61,6 +61,20 @@ if shot.images:
 relay discovery, Ed25519 auth, and trust all still apply. It's a fast path, not
 a back door.
 
+### From the shell: `co call`
+
+The same thing without writing Python — the remote twin of `co browser`:
+
+```bash
+co call 0x3d40... co status
+co call --out shot.png 0x3d40... co browser take_screenshot
+```
+
+`co call <address> <command...>` maps to `connect(address).call("bash",
+command="<command...>")`: everything after the address runs on the remote,
+gated by its whitelist, with clean stdout and exit codes for scripting. See
+[cli/call.md](../cli/call.md).
+
 ---
 
 ## The result: `ExecResult`

--- a/docs/network/remote-call.md
+++ b/docs/network/remote-call.md
@@ -43,17 +43,19 @@ remote = connect("0x3d4017c3...")           # add keys=... for strict-trust agen
 # Text out
 print(remote.call("bash", command="co status").text)
 
-# Image out — a screenshot tool returns base64; .images extracts it
-shot = remote.call("take_screenshot")
+# Drive the browser through the co CLI — text and screenshots come back as output
+remote.call("bash", command="co browser go_to https://example.com")
+shot = remote.call("bash", command="co browser take_screenshot")
+
+# Image out — the screenshot is base64 in the output; .images extracts it
 if shot.images:
     import base64
     png = base64.b64decode(shot.images[0].split(",", 1)[1])
     open("page.png", "wb").write(png)
-
-# Drive a browser step by step
-remote.call("go_to", url="https://example.com")
-remote.call("click", selector="text=Sign in")
 ```
+
+> Browser control goes through `co browser <verb>`, not the browser tools
+> directly — see [Driving a browser](#driving-a-browser) for why.
 
 `remote.call` runs over the **same authenticated WebSocket** as `input()`, so
 relay discovery, Ed25519 auth, and trust all still apply. It's a fast path, not
@@ -112,10 +114,10 @@ Entries are keyed either by **tool name** or by a **`Bash(...)` command pattern*
 ```yaml
 permissions:
   # Simple tool name — matches any call to that tool
-  "take_screenshot":
+  "read_file":
     allowed: true
     source: safe
-    reason: read-only page capture
+    reason: read-only operation
 
   # Exact command
   "Bash(git status)":
@@ -146,14 +148,12 @@ permissions:
 
 ## Allowed by default
 
-A fresh `host()` ships a whitelist of safe, read-only commands and the browser
-navigation/observation tools. Highlights:
+A fresh `host()` ships a whitelist of safe, read-only commands. Highlights:
 
 | Group | Entries |
 |---|---|
 | Read-only agent tools | `read`, `read_file`, `glob`, `grep`, `search`, `list_files`, `ask_user` |
-| Browser (navigation/observe) | `go_to`, `take_screenshot`, `click`, `scroll`, `type_text_by_selector`, `extract_items_by_selector`, `wait_for_element` |
-| ConnectOnion CLI | `Bash(co *)` |
+| ConnectOnion CLI (incl. browser) | `Bash(co *)` — includes `co browser <verb>` |
 | File viewing | `cat *`, `head *`, `tail *`, `nl *`, `wc *`, `file *`, `stat *`, `diff *`, `tree *`, `du *` |
 | Path helpers | `basename *`, `dirname *`, `realpath *`, `readlink *` |
 | Text (read-only) | `echo *`, `sort *`, `uniq *`, `cut *`, `tr *`, `column *`, `jq *` |
@@ -170,6 +170,41 @@ Deliberately **not** included: anything with side effects (`sed -i`,
 (bare `python`, `node`). Add those yourself only if you trust the caller.
 
 ---
+
+## Driving a browser
+
+Steer the remote browser through the **`co browser`** CLI, over `bash`:
+
+```python
+remote.call("bash", command="co browser go_to https://example.com")
+remote.call("bash", command="co browser click 'Sign in'")
+shot = remote.call("bash", command="co browser take_screenshot")   # base64 in .images
+```
+
+`co browser <verb>` talks to a persistent **browser daemon** — a separate
+background process that owns one Chrome and arbitrates tabs, ownership, and
+lifecycle on its own. A bare command uses the shared `main` tab; add `-t <name>`
+to drive an isolated tab (`co browser tab open mytask`, then `co browser -t
+mytask go_to …`). The daemon registers the tab before running, so navigation
+never trips the "who is this for?" guard, and the whole thing round-trips as
+ordinary command output.
+
+**Why not call the browser tools directly?** ConnectOnion has two browser stacks
+— same code, different process, different Chrome instance (both share
+`~/.co/browser_profile`, so only one runs at a time):
+
+| | In-process browser tool | `co browser` daemon |
+|---|---|---|
+| Where Chrome runs | inside the agent process | a separate daemon process |
+| Tab routing | `bind_browser_session` plugin, per chat session | the daemon, via `-t` / `main` |
+| Driven by | `agent.input()` (the LLM) | `co browser <verb>` commands |
+| Under `remote.call` | ⚠️ skips the plugin → shared tab + a purpose/who guard meant for the LLM | ✅ daemon handles everything |
+
+`remote.call` runs a tool **directly**, with no event/plugin hooks — so the
+in-process browser's per-session tab binding never fires. That's why the
+in-process browser tool names (`go_to`, `take_screenshot`, …) are **not**
+whitelisted for direct exec, and browser remote-control goes through the daemon
+instead. One clean path, no surprises.
 
 ## Adding your own commands
 
@@ -205,7 +240,7 @@ user granted interactively.
 Inside an event loop, use the async form:
 
 ```python
-result = await remote.call_async("take_screenshot", timeout=30)
+result = await remote.call_async("bash", command="co browser take_screenshot", timeout=30)
 ```
 
 `remote.call(...)` is the sync wrapper; calling it from within a running event
@@ -220,7 +255,7 @@ If the agent's trust level requires onboarding (invite code or payment), a raw
 then `call()` works on the same identity:
 
 ```python
-remote.call("take_screenshot")
+remote.call("bash", command="co status")
 # ExecResult(status="error", error="agent requires onboarding — run input() once to onboard, then call() works")
 ```
 

--- a/docs/network/remote-call.md
+++ b/docs/network/remote-call.md
@@ -1,0 +1,264 @@
+# Direct Tool Execution — `remote.call`
+
+> Run one of a remote agent's tools directly, bypassing the LLM. Input in, raw
+> output out — like a remote command line. Gated by the `.co/host.yaml`
+> permission whitelist.
+
+---
+
+## Why
+
+`connect().input(prompt)` sends a task to the agent's **LLM**: it reasons, picks
+tools, and comes back when the whole task is done. That's what you want for
+"check my notifications and reply to anything urgent."
+
+Sometimes you don't want the agent to *think* — you already know the exact tool
+and arguments, and you just want the result:
+
+- Take a screenshot of the remote browser *right now*
+- Run `co status` on the box and read the output
+- Click a selector, then grab the page
+
+`remote.call(tool, **args)` is that fast path. No reasoning, no session, no
+conversation history — the named tool runs and its raw result comes straight
+back. The result can be text **or** a base64 image (a screenshot), so it behaves
+like a terminal that can also draw.
+
+| | `remote.input(prompt)` | `remote.call(tool, **args)` |
+|---|---|---|
+| Who decides what runs | the LLM | you |
+| Latency | a full reasoning loop | one tool call |
+| Keeps history | yes (session) | no (stateless) |
+| Good for | open-ended tasks | known, scripted steps |
+
+---
+
+## Quick start
+
+```python
+from connectonion import connect
+
+remote = connect("0x3d4017c3...")           # add keys=... for strict-trust agents
+
+# Text out
+print(remote.call("bash", command="co status").text)
+
+# Image out — a screenshot tool returns base64; .images extracts it
+shot = remote.call("take_screenshot")
+if shot.images:
+    import base64
+    png = base64.b64decode(shot.images[0].split(",", 1)[1])
+    open("page.png", "wb").write(png)
+
+# Drive a browser step by step
+remote.call("go_to", url="https://example.com")
+remote.call("click", selector="text=Sign in")
+```
+
+`remote.call` runs over the **same authenticated WebSocket** as `input()`, so
+relay discovery, Ed25519 auth, and trust all still apply. It's a fast path, not
+a back door.
+
+---
+
+## The result: `ExecResult`
+
+```python
+result = remote.call("bash", command="uptime")
+
+result.text          # str  — raw tool output (may contain base64 image data)
+result.status        # "success" | "error"
+result.ok            # bool — True when status == "success"
+result.error         # str | None — message when status == "error"
+result.duration_ms   # int  — how long the tool ran on the server
+result.images        # list[str] — base64 data URLs pulled out of .text
+```
+
+`ExecResult` never raises for a *tool* failure — a crash inside the tool comes
+back as `status="error"` with the message in `.error`, exactly like the LLM loop
+reports tool errors for retry. (Transport problems like a timeout also return an
+error result rather than raising.)
+
+```python
+r = remote.call("bash", command="cat missing.txt")
+if not r.ok:
+    print("failed:", r.error)
+```
+
+---
+
+## The whitelist gates every call
+
+What may run via `remote.call` is **the same permission whitelist the LLM
+approval flow uses** — the `permissions:` block in `.co/host.yaml`. There is one
+list to maintain, and "safe to run without a human in the loop" means the same
+thing whether the LLM or a remote client initiates the tool.
+
+Before running, the server checks the request against the whitelist. Not on the
+list → refused:
+
+```python
+remote.call("bash", command="rm -rf /")
+# ExecResult(status="error", error="blocked: command not in the permission whitelist. ...")
+```
+
+Nothing to "enable" — it's on by default and bounded entirely by the whitelist.
+An empty whitelist means nothing runs directly.
+
+### How patterns match
+
+Entries are keyed either by **tool name** or by a **`Bash(...)` command pattern**:
+
+```yaml
+permissions:
+  # Simple tool name — matches any call to that tool
+  "take_screenshot":
+    allowed: true
+    source: safe
+    reason: read-only page capture
+
+  # Exact command
+  "Bash(git status)":
+    allowed: true
+    source: config
+    reason: safe git read
+
+  # Wildcard — trailing " *" means "this command with any args"
+  "Bash(ls *)":
+    allowed: true
+    source: config
+    reason: list directory contents
+```
+
+- `"Bash(ls *)"` matches `ls`, `ls -la`, `ls /tmp` — but not `lsof`.
+- `"Bash(git status)"` matches only the exact command.
+- Command **chains are checked per-subcommand**: `git status && ls -la` runs only
+  if *both* `git status` and `ls -la` are whitelisted. Sneaking a command in via
+  `&&`, `|`, or `;` doesn't work — `cat foo && rm bar` is rejected because `rm`
+  isn't allowed.
+
+> **Wildcards run the program, not a subcommand.** `"Bash(python *)"` would allow
+> `python evil.py` — running arbitrary code. That's why version checks are pinned
+> exact (`"Bash(python --version)"`), never `python *`. Keep wildcards to tools
+> that are safe with *any* arguments (`ls`, `cat`, `git log`).
+
+---
+
+## Allowed by default
+
+A fresh `host()` ships a whitelist of safe, read-only commands and the browser
+navigation/observation tools. Highlights:
+
+| Group | Entries |
+|---|---|
+| Read-only agent tools | `read`, `read_file`, `glob`, `grep`, `search`, `list_files`, `ask_user` |
+| Browser (navigation/observe) | `go_to`, `take_screenshot`, `click`, `scroll`, `type_text_by_selector`, `extract_items_by_selector`, `wait_for_element` |
+| ConnectOnion CLI | `Bash(co *)` |
+| File viewing | `cat *`, `head *`, `tail *`, `nl *`, `wc *`, `file *`, `stat *`, `diff *`, `tree *`, `du *` |
+| Path helpers | `basename *`, `dirname *`, `realpath *`, `readlink *` |
+| Text (read-only) | `echo *`, `sort *`, `uniq *`, `cut *`, `tr *`, `column *`, `jq *` |
+| Checksums | `md5sum *`, `sha256sum *`, `shasum *`, `cksum *` |
+| System info | `pwd`, `ls *`, `uname *`, `df *`, `free *`, `ps *`, `top *`, `uptime *`, `whoami`, `date *`, `which *`, `env *` |
+| Identity | `id`, `groups *`, `printenv *`, `locale`, `arch`, `nproc *`, `lsb_release *` |
+| Tool versions (exact) | `python --version`, `python3 --version`, `pip --version`, `node -v`, `npm --version`, `git --version`, `go version` |
+| Package inspection | `pip list *`, `pip freeze`, `pip show *`, `npm list *`, `npm ls *` |
+| Git (read-only) | `git status`, `git diff *`, `git log *`, `git branch *`, `git show *`, `git remote *`, `git blame *`, `git ls-files *`, `git config --get *` |
+| Testing | `pytest *`, `npm test` |
+
+Deliberately **not** included: anything with side effects (`sed -i`,
+`find -exec`/`-delete`, `tee`, `xargs`, `curl … | sh`) or interpreter execution
+(bare `python`, `node`). Add those yourself only if you trust the caller.
+
+---
+
+## Adding your own commands
+
+Edit `.co/host.yaml` — no code change, no restart of anything but the host:
+
+```yaml
+permissions:
+  "Bash(kubectl get *)":
+    allowed: true
+    source: config
+    reason: read k8s resources
+
+  "Bash(docker ps *)":
+    allowed: true
+    source: config
+    reason: list containers
+
+  # A whole tool, any args
+  "extract_data":
+    allowed: true
+    source: config
+    reason: safe read-only extraction
+```
+
+The project `.co/host.yaml` merges on top of the shipped defaults, so you only
+list what you add. Project entries override defaults, but never a permission a
+user granted interactively.
+
+---
+
+## Async
+
+Inside an event loop, use the async form:
+
+```python
+result = await remote.call_async("take_screenshot", timeout=30)
+```
+
+`remote.call(...)` is the sync wrapper; calling it from within a running event
+loop raises — use `call_async` there.
+
+---
+
+## Onboarding
+
+If the agent's trust level requires onboarding (invite code or payment), a raw
+`call()` can't complete the interactive handshake. Run `input()` once to onboard,
+then `call()` works on the same identity:
+
+```python
+remote.call("take_screenshot")
+# ExecResult(status="error", error="agent requires onboarding — run input() once to onboard, then call() works")
+```
+
+---
+
+## On the wire
+
+Direct execution adds two WebSocket frames (after the usual `CONNECT` →
+`CONNECTED` auth handshake):
+
+**Client → agent**
+
+```json
+{ "type": "EXEC", "exec_id": "uuid", "tool": "bash", "args": { "command": "co status" } }
+```
+
+**Agent → client**
+
+```json
+{
+  "type": "EXEC_RESULT",
+  "exec_id": "uuid",
+  "tool": "bash",
+  "status": "success",
+  "result": "…raw output…",
+  "duration_ms": 42
+}
+```
+
+Each `EXEC` runs as its own server-side task, so a slow tool (a long shell
+command) never blocks the connection's read loop or other in-flight `EXEC`s.
+`exec_id` correlates the reply, so you can pipeline several calls on one socket.
+
+---
+
+## Related
+
+- [connect.md](connect.md) — `connect()` and `input()` for LLM-driven tasks
+- [host.md](host.md) — hosting an agent with `host()`
+- [host-config.md](host-config.md) — the full `.co/host.yaml` reference
+- [websocket-protocol.md](websocket-protocol.md) — CONNECT/INPUT/OUTPUT frames

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -1,19 +1,22 @@
 # WebSocket Protocol
 
-> CONNECT to start or resume, INPUT to message. Session stays alive between executions.
+> CONNECT to start or resume, INPUT to message, EXEC to run one tool directly. Session stays alive between executions.
 
 ---
 
 ## Overview
 
-Two client message types, two intents:
+Three client message types, three intents:
 
 | Message | Intent | When |
 |---------|--------|------|
 | `CONNECT` | "Authenticate me, restore my session" | First message on every WebSocket |
 | `INPUT` | "Run this prompt" or runtime input mid-execution | After CONNECT |
+| `EXEC` | "Run this one tool directly, no LLM" | After CONNECT |
 
 If `INPUT` arrives while the session's agent is already running, the server treats it as **runtime input** (mid-execution user input) instead of starting a second agent. The new prompt is appended to the agent's message history at the next iteration, and the server replies with `RUNTIME_INPUT_ACK` instead of starting a new OUTPUT cycle.
+
+`EXEC` is the direct-execution fast path: it runs one named tool with no LLM, no session, and no history, replying with a single `EXEC_RESULT`. It requires the same CONNECT auth as INPUT, and the tool is gated by the host's `.co/host.yaml` permission whitelist. See [remote-call.md](remote-call.md).
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
@@ -216,6 +219,21 @@ Send a prompt. Only valid after CONNECTED. **No session data — just the prompt
 
 If sent while the session's agent is already running, this message is routed as runtime input: the prompt is appended to the running agent's message history (with framing telling the LLM to treat it as additional context, not a replacement) and the server replies `RUNTIME_INPUT_ACK` instead of starting a new OUTPUT cycle. No new `thinking` chat item is created — the existing one keeps streaming.
 
+#### EXEC
+
+Run one registered tool directly — no LLM, no session, no history. Only valid after CONNECTED. The server replies with a single `EXEC_RESULT`.
+
+```json
+{
+  "type": "EXEC",
+  "exec_id": "7c2a...",
+  "tool": "bash",
+  "args": { "command": "co status" }
+}
+```
+
+The tool is checked against the host's `.co/host.yaml` permission whitelist (the same list the LLM approval flow uses); a tool that isn't whitelisted comes back as an `EXEC_RESULT` with `status: "error"`. Each `EXEC` runs as its own server-side task, so a slow tool never blocks the connection, and `exec_id` correlates the reply — several `EXEC`s can be pipelined on one socket.
+
 #### PONG
 
 ```json
@@ -272,6 +290,23 @@ Execution completed. **Session stays alive for next INPUT.**
   "session": { "messages": [...], "trace": [...], "turn": 2 }
 }
 ```
+
+#### EXEC_RESULT
+
+Reply to an `EXEC`. `exec_id` echoes the request. `result` is the tool's raw output — text, or a base64 data URL for a screenshot tool.
+
+```json
+{
+  "type": "EXEC_RESULT",
+  "exec_id": "7c2a...",
+  "tool": "bash",
+  "status": "success",
+  "result": "...raw output...",
+  "duration_ms": 42
+}
+```
+
+On failure (tool raised, not whitelisted, unknown tool): `status: "error"` with an `error` field instead of `result`.
 
 #### PING
 

--- a/tests/unit/test_cli_call.py
+++ b/tests/unit/test_cli_call.py
@@ -1,0 +1,111 @@
+"""Unit tests for `co call` — remote one-shot command execution (cli/commands/call_commands.py).
+
+The network is mocked: connect() returns a fake RemoteAgent whose .call() yields a
+canned ExecResult, so these tests cover argument parsing, the exit-code contract,
+and image-vs-text output handling without touching a real agent.
+"""
+
+import base64
+import pytest
+
+from connectonion import ExecResult
+from connectonion.cli.commands import call_commands
+from connectonion.cli.commands.call_commands import handle_call
+
+
+class FakeRemote:
+    """Stand-in for RemoteAgent: records the last call and returns a canned result."""
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def call(self, tool, command=None, timeout=60.0, **kw):
+        self.calls.append({"tool": tool, "command": command, "timeout": timeout})
+        return self._result
+
+
+def install_fake(monkeypatch, result):
+    """Patch connect() (looked up as connectonion.connect inside handle_call) and
+    silence key loading so tests don't depend on a local .co."""
+    fake = FakeRemote(result)
+    monkeypatch.setattr("connectonion.connect", lambda address, **kw: fake, raising=False)
+    monkeypatch.setattr(call_commands, "_load_keys", lambda: None)
+    return fake
+
+
+# ─────────────────────────── usage / exit codes ───────────────────────────
+
+class TestUsage:
+    def test_no_args_is_usage_error(self, capsys):
+        assert handle_call([]) == 2
+        assert "co call" in capsys.readouterr().err
+
+    def test_help_is_success(self, capsys):
+        assert handle_call(["help"]) == 0
+        assert "remote agent" in capsys.readouterr().out
+
+    def test_address_without_command_is_usage_error(self, capsys):
+        assert handle_call(["0xabc"]) == 2
+        assert "usage" in capsys.readouterr().err.lower()
+
+    def test_unknown_option_is_usage_error(self, capsys):
+        assert handle_call(["--nope", "x", "0xabc", "co", "status"]) == 2
+        assert "unknown option" in capsys.readouterr().err
+
+    def test_out_without_value_is_usage_error(self, capsys):
+        assert handle_call(["--out"]) == 2
+
+
+# ─────────────────────────── text result ───────────────────────────
+
+class TestTextResult:
+    def test_prints_text_and_returns_zero(self, monkeypatch, capsys):
+        install_fake(monkeypatch, ExecResult(text="balance: $4.20", status="success"))
+        assert handle_call(["0xabc", "co", "status"]) == 0
+        assert capsys.readouterr().out.strip() == "balance: $4.20"
+
+    def test_command_is_forwarded_verbatim(self, monkeypatch):
+        fake = install_fake(monkeypatch, ExecResult(text="ok", status="success"))
+        handle_call(["0xabc", "co", "browser", "go_to", "https://x.com"])
+        # everything after the address is joined into one bash command
+        assert fake.calls[0]["tool"] == "bash"
+        assert fake.calls[0]["command"] == "co browser go_to https://x.com"
+
+    def test_remote_command_keeps_its_own_flags(self, monkeypatch):
+        fake = install_fake(monkeypatch, ExecResult(text="ok", status="success"))
+        handle_call(["0xabc", "ls", "-la"])
+        assert fake.calls[0]["command"] == "ls -la"
+
+
+# ─────────────────────────── error result ───────────────────────────
+
+class TestErrorResult:
+    def test_error_result_goes_to_stderr_exit_one(self, monkeypatch, capsys):
+        install_fake(monkeypatch, ExecResult(text="", status="error", error="blocked: not whitelisted"))
+        assert handle_call(["0xabc", "rm", "-rf", "/"]) == 1
+        assert "blocked" in capsys.readouterr().err
+
+    def test_connection_exception_is_exit_one(self, monkeypatch, capsys):
+        def boom(address, **kw):
+            raise ConnectionError("relay unreachable")
+        monkeypatch.setattr("connectonion.connect", boom, raising=False)
+        monkeypatch.setattr(call_commands, "_load_keys", lambda: None)
+        assert handle_call(["0xabc", "co", "status"]) == 1
+        assert "connection failed" in capsys.readouterr().err
+
+
+# ─────────────────────────── image result ───────────────────────────
+
+class TestImageResult:
+    def test_screenshot_saved_to_out_path(self, monkeypatch, capsys, tmp_path):
+        png = base64.b64encode(b"\x89PNG_fake").decode()
+        install_fake(monkeypatch, ExecResult(text=f"data:image/png;base64,{png}", status="success"))
+        dest = tmp_path / "shot.png"
+        assert handle_call(["--out", str(dest), "0xabc", "co", "browser", "take_screenshot"]) == 0
+        assert dest.read_bytes() == b"\x89PNG_fake"
+        assert capsys.readouterr().out.strip() == str(dest)
+
+    def test_timeout_option_parsed(self, monkeypatch):
+        fake = install_fake(monkeypatch, ExecResult(text="ok", status="success"))
+        handle_call(["--timeout", "5", "0xabc", "co", "status"])
+        assert fake.calls[0]["timeout"] == 5.0

--- a/tests/unit/test_ws_exec.py
+++ b/tests/unit/test_ws_exec.py
@@ -150,14 +150,18 @@ class TestPermissionWhitelist:
         # rm is not whitelisted → whole chain rejected
         assert is_tool_permitted("bash", {"command": "co status && rm -rf /"}, perms)[0] is False
 
-    def test_defaults_include_co_and_browser_tools(self):
-        """The shipped template whitelist grants co CLI + browser tools out of the box."""
+    def test_defaults_allow_co_cli_for_browser_control(self):
+        """Browser remote-control goes through `co browser` (the daemon), so the
+        shipped defaults whitelist the co CLI — NOT the in-process browser tool
+        names, which would bypass the daemon's tab arbitration."""
         from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns, is_tool_permitted
         # Point at a nonexistent .co so only the shipped template defaults load.
         perms = load_permission_patterns(co_dir="/nonexistent/.co")
-        assert is_tool_permitted("take_screenshot", {}, perms)[0] is True
-        assert is_tool_permitted("go_to", {"url": "https://x.com"}, perms)[0] is True
+        assert is_tool_permitted("bash", {"command": "co browser take_screenshot"}, perms)[0] is True
         assert is_tool_permitted("bash", {"command": "co status"}, perms)[0] is True
+        # In-process browser tool names are deliberately NOT whitelisted.
+        assert is_tool_permitted("take_screenshot", {}, perms)[0] is False
+        assert is_tool_permitted("go_to", {"url": "https://x.com"}, perms)[0] is False
         # Still blocks something dangerous by default.
         assert is_tool_permitted("bash", {"command": "rm -rf /"}, perms)[0] is False
 

--- a/tests/unit/test_ws_exec.py
+++ b/tests/unit/test_ws_exec.py
@@ -1,9 +1,12 @@
 """Unit tests for direct tool execution (WS EXEC) — the terminal-style fast path.
 
 Covers:
-- exec_handler (connectonion/network/host/http_router.py): the gate + dispatch
+- exec_handler (connectonion/network/host/http_router.py): whitelist gate + dispatch
 - run_exec (connectonion/network/host/ws_router/exec.py): the WS frame handler
 - ExecResult (connectonion/network/connect.py): the client-side result type
+
+EXEC is gated by the same .co/host.yaml permission whitelist the LLM approval
+flow uses (is_tool_permitted); tests build permission dicts in that shape.
 """
 
 import asyncio
@@ -36,61 +39,127 @@ def make_factory(*tools):
     return create_agent
 
 
+def allow(*tool_names):
+    """Build a permission whitelist granting the given simple tool names."""
+    return {name: {"allowed": True, "source": "config", "reason": "test"} for name in tool_names}
+
+
 # ─────────────────────────── exec_handler: the gate ───────────────────────────
 
 class TestExecHandlerGate:
-    def test_disabled_by_default(self):
-        """exec_tools=None → EXEC refused entirely."""
-        out = exec_handler(make_factory(_echo), None, "_echo", {"text": "hi"})
+    def test_empty_whitelist_blocks_everything(self):
+        """No permissions → EXEC refused."""
+        out = exec_handler(make_factory(_echo), {}, "_echo", {"text": "hi"})
         assert out["status"] == "error"
-        assert "not enabled" in out["error"]
-
-    def test_disabled_when_false(self):
-        out = exec_handler(make_factory(_echo), False, "_echo", {"text": "hi"})
-        assert out["status"] == "error"
+        assert "blocked" in out["error"]
 
     def test_tool_not_in_whitelist(self):
-        """A tool outside the allow-list is refused even though it exists."""
-        out = exec_handler(make_factory(_echo, _screenshot), ["_screenshot"], "_echo", {"text": "hi"})
+        """A tool outside the whitelist is refused even though it exists."""
+        out = exec_handler(make_factory(_echo, _screenshot), allow("_screenshot"), "_echo", {"text": "hi"})
         assert out["status"] == "error"
-        assert "not exec-enabled" in out["error"]
+        assert "not in the permission whitelist" in out["error"]
 
     def test_whitelisted_tool_runs(self):
-        out = exec_handler(make_factory(_echo, _screenshot), ["_echo"], "_echo", {"text": "hi"})
+        out = exec_handler(make_factory(_echo, _screenshot), allow("_echo"), "_echo", {"text": "hi"})
         assert out["status"] == "success"
         assert out["result"] == "echo: hi"
 
-    def test_true_allows_any_registered_tool(self):
-        out = exec_handler(make_factory(_echo), True, "_echo", {"text": "world"})
-        assert out["status"] == "success"
-        assert out["result"] == "echo: world"
+    def test_bash_command_gated_by_pattern(self):
+        """A Bash(...) whitelist entry gates the actual command, not just the tool."""
+        def bash(command: str) -> str:
+            """Fake bash — echoes the command instead of running it."""
+            return f"ran: {command}"
+
+        perms = {"Bash(echo *)": {"allowed": True, "source": "config",
+                                  "reason": "test", "when": {"command": "echo *"}}}
+        ok = exec_handler(make_factory(bash), perms, "bash", {"command": "echo hi"})
+        assert ok["status"] == "success"
+        assert ok["result"] == "ran: echo hi"
+
+        blocked = exec_handler(make_factory(bash), perms, "bash", {"command": "rm -rf /"})
+        assert blocked["status"] == "error"
+        assert "blocked" in blocked["error"]
 
 
 # ─────────────────────────── exec_handler: execution ──────────────────────────
 
 class TestExecHandlerExecution:
     def test_unknown_tool(self):
-        out = exec_handler(make_factory(_echo), True, "_nope", {})
+        """Whitelisted by name but not registered on the agent."""
+        out = exec_handler(make_factory(_echo), allow("_nope"), "_nope", {})
         assert out["status"] == "error"
         assert "unknown tool" in out["error"]
 
     def test_tool_error_returned_as_data(self):
         """Tool exceptions become error results, not raised — same as the LLM loop."""
-        out = exec_handler(make_factory(_boom), True, "_boom", {})
+        out = exec_handler(make_factory(_boom), allow("_boom"), "_boom", {})
         assert out["status"] == "error"
         assert "kaboom" in out["error"]
         assert "duration_ms" in out
 
     def test_success_carries_duration(self):
-        out = exec_handler(make_factory(_echo), True, "_echo", {"text": "x"})
+        out = exec_handler(make_factory(_echo), allow("_echo"), "_echo", {"text": "x"})
         assert out["status"] == "success"
         assert isinstance(out["duration_ms"], int)
 
     def test_screenshot_result_is_raw_base64(self):
         """Image tools flow through unchanged — the client extracts images."""
-        out = exec_handler(make_factory(_screenshot), True, "_screenshot", {})
+        out = exec_handler(make_factory(_screenshot), allow("_screenshot"), "_screenshot", {})
         assert out["status"] == "success"
         assert out["result"].startswith("data:image/png;base64,")
+
+
+# ────────────────────── the shared permission whitelist ───────────────────────
+
+class TestPermissionWhitelist:
+    """is_tool_permitted / load_permission_patterns — the single whitelist EXEC
+    and the LLM approval flow both honor."""
+
+    def test_simple_tool_name_allowed(self):
+        from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+        ok, _ = is_tool_permitted("take_screenshot", {}, allow("take_screenshot"))
+        assert ok is True
+
+    def test_unlisted_tool_blocked(self):
+        from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+        ok, reason = is_tool_permitted("delete", {}, allow("read"))
+        assert ok is False
+        assert "whitelist" in reason
+
+    def test_empty_permissions_blocks(self):
+        from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+        ok, reason = is_tool_permitted("read", {}, {})
+        assert ok is False
+
+    def test_co_command_allowed_by_wildcard(self):
+        from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+        perms = {"Bash(co *)": {"allowed": True, "source": "config",
+                                "reason": "co cli", "when": {"command": "co *"}}}
+        assert is_tool_permitted("bash", {"command": "co status"}, perms)[0] is True
+        assert is_tool_permitted("bash", {"command": "co auth login"}, perms)[0] is True
+        # A different command that merely starts with the same letters is rejected.
+        assert is_tool_permitted("bash", {"command": "cordump x"}, perms)[0] is False
+
+    def test_bash_chain_requires_all_permitted(self):
+        from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+        perms = {
+            "Bash(co *)": {"allowed": True, "source": "config", "reason": "", "when": {"command": "co *"}},
+            "Bash(ls *)": {"allowed": True, "source": "config", "reason": "", "when": {"command": "ls *"}},
+        }
+        assert is_tool_permitted("bash", {"command": "co status && ls -la"}, perms)[0] is True
+        # rm is not whitelisted → whole chain rejected
+        assert is_tool_permitted("bash", {"command": "co status && rm -rf /"}, perms)[0] is False
+
+    def test_defaults_include_co_and_browser_tools(self):
+        """The shipped template whitelist grants co CLI + browser tools out of the box."""
+        from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns, is_tool_permitted
+        # Point at a nonexistent .co so only the shipped template defaults load.
+        perms = load_permission_patterns(co_dir="/nonexistent/.co")
+        assert is_tool_permitted("take_screenshot", {}, perms)[0] is True
+        assert is_tool_permitted("go_to", {"url": "https://x.com"}, perms)[0] is True
+        assert is_tool_permitted("bash", {"command": "co status"}, perms)[0] is True
+        # Still blocks something dangerous by default.
+        assert is_tool_permitted("bash", {"command": "rm -rf /"}, perms)[0] is False
 
 
 # ─────────────────────────── run_exec: the WS frame ───────────────────────────

--- a/tests/unit/test_ws_exec.py
+++ b/tests/unit/test_ws_exec.py
@@ -1,0 +1,167 @@
+"""Unit tests for direct tool execution (WS EXEC) — the terminal-style fast path.
+
+Covers:
+- exec_handler (connectonion/network/host/http_router.py): the gate + dispatch
+- run_exec (connectonion/network/host/ws_router/exec.py): the WS frame handler
+- ExecResult (connectonion/network/connect.py): the client-side result type
+"""
+
+import asyncio
+import pytest
+
+from connectonion import Agent, ExecResult
+from connectonion.network.host.http_router import exec_handler
+from connectonion.network.host.ws_router.exec import run_exec
+
+
+def _echo(text: str) -> str:
+    """Echo the input back."""
+    return f"echo: {text}"
+
+
+def _boom() -> str:
+    """Always raises."""
+    raise ValueError("kaboom")
+
+
+def _screenshot() -> str:
+    """Return a base64 image data URL like a real screenshot tool."""
+    return "data:image/png;base64,iVBORw0KGgoAAAANS"
+
+
+def make_factory(*tools):
+    def create_agent():
+        # Direct exec never touches the LLM; a fake key is enough to construct.
+        return Agent("exec-test", tools=list(tools), api_key="fake_key", log=False)
+    return create_agent
+
+
+# ─────────────────────────── exec_handler: the gate ───────────────────────────
+
+class TestExecHandlerGate:
+    def test_disabled_by_default(self):
+        """exec_tools=None → EXEC refused entirely."""
+        out = exec_handler(make_factory(_echo), None, "_echo", {"text": "hi"})
+        assert out["status"] == "error"
+        assert "not enabled" in out["error"]
+
+    def test_disabled_when_false(self):
+        out = exec_handler(make_factory(_echo), False, "_echo", {"text": "hi"})
+        assert out["status"] == "error"
+
+    def test_tool_not_in_whitelist(self):
+        """A tool outside the allow-list is refused even though it exists."""
+        out = exec_handler(make_factory(_echo, _screenshot), ["_screenshot"], "_echo", {"text": "hi"})
+        assert out["status"] == "error"
+        assert "not exec-enabled" in out["error"]
+
+    def test_whitelisted_tool_runs(self):
+        out = exec_handler(make_factory(_echo, _screenshot), ["_echo"], "_echo", {"text": "hi"})
+        assert out["status"] == "success"
+        assert out["result"] == "echo: hi"
+
+    def test_true_allows_any_registered_tool(self):
+        out = exec_handler(make_factory(_echo), True, "_echo", {"text": "world"})
+        assert out["status"] == "success"
+        assert out["result"] == "echo: world"
+
+
+# ─────────────────────────── exec_handler: execution ──────────────────────────
+
+class TestExecHandlerExecution:
+    def test_unknown_tool(self):
+        out = exec_handler(make_factory(_echo), True, "_nope", {})
+        assert out["status"] == "error"
+        assert "unknown tool" in out["error"]
+
+    def test_tool_error_returned_as_data(self):
+        """Tool exceptions become error results, not raised — same as the LLM loop."""
+        out = exec_handler(make_factory(_boom), True, "_boom", {})
+        assert out["status"] == "error"
+        assert "kaboom" in out["error"]
+        assert "duration_ms" in out
+
+    def test_success_carries_duration(self):
+        out = exec_handler(make_factory(_echo), True, "_echo", {"text": "x"})
+        assert out["status"] == "success"
+        assert isinstance(out["duration_ms"], int)
+
+    def test_screenshot_result_is_raw_base64(self):
+        """Image tools flow through unchanged — the client extracts images."""
+        out = exec_handler(make_factory(_screenshot), True, "_screenshot", {})
+        assert out["status"] == "success"
+        assert out["result"].startswith("data:image/png;base64,")
+
+
+# ─────────────────────────── run_exec: the WS frame ───────────────────────────
+
+class TestRunExec:
+    @pytest.mark.asyncio
+    async def test_dispatches_and_replies(self):
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        def ws_exec(tool, args):
+            assert tool == "_echo"
+            return {"status": "success", "result": "echo: hey", "duration_ms": 1}
+
+        await run_exec({"type": "EXEC", "exec_id": "e1", "tool": "_echo", "args": {"text": "hey"}},
+                       send, {"ws_exec": ws_exec})
+
+        assert len(sent) == 1
+        assert sent[0]["type"] == "EXEC_RESULT"
+        assert sent[0]["exec_id"] == "e1"
+        assert sent[0]["tool"] == "_echo"
+        assert sent[0]["result"] == "echo: hey"
+
+    @pytest.mark.asyncio
+    async def test_missing_tool_name(self):
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        await run_exec({"type": "EXEC", "exec_id": "e2"}, send, {"ws_exec": lambda t, a: {}})
+        assert sent[0]["status"] == "error"
+        assert "tool required" in sent[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_handler_exception_becomes_error_frame(self):
+        """A raising handler must still produce an EXEC_RESULT — a background task's
+        raise would otherwise be invisible and hang the client until timeout."""
+        sent = []
+
+        async def send(msg):
+            sent.append(msg)
+
+        def ws_exec(tool, args):
+            raise RuntimeError("handler blew up")
+
+        await run_exec({"type": "EXEC", "exec_id": "e3", "tool": "_echo"},
+                       send, {"ws_exec": ws_exec})
+        assert sent[0]["type"] == "EXEC_RESULT"
+        assert sent[0]["status"] == "error"
+        assert "handler blew up" in sent[0]["error"]
+
+
+# ─────────────────────────── ExecResult: the client type ──────────────────────
+
+class TestExecResult:
+    def test_ok_true_on_success(self):
+        assert ExecResult(text="out", status="success").ok is True
+
+    def test_ok_false_on_error(self):
+        assert ExecResult(text="", status="error", error="boom").ok is False
+
+    def test_images_extracted_from_text(self):
+        r = ExecResult(text="prefix data:image/png;base64,ABC123 suffix", status="success")
+        assert r.images == ["data:image/png;base64,ABC123"]
+
+    def test_no_images_in_plain_text(self):
+        assert ExecResult(text="just text", status="success").images == []
+
+    def test_multiple_images(self):
+        r = ExecResult(text="data:image/png;base64,AA data:image/jpeg;base64,BB", status="success")
+        assert len(r.images) == 2


### PR DESCRIPTION
## Description
Adds a fast path to remote agents: run a single named tool directly, bypassing the LLM. Input in, raw output out — text or a base64 screenshot — like a remote command line. Exposed as a Python API (`remote.call`) and a CLI command (`co call`), so an agent (or a human) can drive a remote agent with one command.

This is the "remote control" companion to the existing `connect().input()`: `input()` hands the remote LLM a task and waits for it to reason; `call()` runs one known command and returns immediately.

## Merge order (3-PR split)

This is **PR B** in a 3-PR split. They must merge in order:

1. **A — #236** (`Fixes #235`) — make `bash`'s `description` optional
2. **B — this PR** — direct tool execution (`remote.call` / `co call` / whitelist)
3. **C — #234** — templates drive the browser via the `co browser` CLI (prompt + shell tool)

**A → B → C.** B **depends on A**: the documented `remote.call("bash", command=...)` and `co call <addr> co browser ...` paths TypeError until `bash`'s `description` is optional (A). And they only run end to end on an agent that has a `bash` tool — the shipped browser templates get that in C. On its own, B is the correct, general mechanism (run any whitelisted tool by name); A makes the bash path work, C makes the shipped templates exercise it.

## Related Issue
Part of the split above (A #236 · C #234). Separately, while testing I filed an unrelated pre-existing bug: #223 (`send_email` hard-requires a `.env` file) — not touched here.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Changes Made
- **EXEC transport** — new `EXEC` / `EXEC_RESULT` WebSocket frames, dispatched per-request in `ws_router` so a slow tool never blocks the connection; forwarded transparently by the relay (routes by `session_id`, frame-type agnostic).
- **Client API** — `RemoteAgent.call(tool, **args)` / `call_async` returning `ExecResult(text, status, duration_ms, error)` with `.ok` and `.images` (extracts base64 screenshots). Same authenticated socket as `input()` — relay discovery, Ed25519 auth, and trust still apply.
- **Whitelist gating (no new mechanism)** — direct exec is gated by the **same `.co/host.yaml` `permissions` whitelist the LLM approval flow already uses**. Extracted `load_permission_patterns()` / `is_tool_permitted()` in `tool_approval` and refactored `load_config_permissions()` to reuse them. For bash, the per-subcommand chain check is authoritative (fixes a latent prefix-match hole where `Bash(co *)` would wrongly permit `co status && rm -rf /`).
- **Default whitelist** — rounded out with common read-only commands (file viewing, text processing, checksums, identity, tool versions, git read-only, `Bash(co *)`). Deliberately excludes side-effecting / interpreter-executing commands.
- **`co call <address> <command...>`** — CLI remote twin of `co browser`; maps to `connect(address).call("bash", command=...)`. Everything after the address is verbatim; image results saved to `--out` / `./screenshot.png`; exit codes `0`/`1`/`2`.
- **Browser architecture docs** — comments + docs clarifying the two browser stacks (in-process `BrowserAutomation` tool vs. the `co browser` daemon) so remote browser control correctly goes through `co browser` (the daemon arbitrates tabs), not the in-process tools which bypass the `bind_browser_session` plugin.
- **Docs** — `docs/network/remote-call.md`, `docs/cli/call.md`, protocol/host/connect/api cross-links; hosted-browser template README/agent updated.
- No new dependencies.

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

New: `tests/unit/test_ws_exec.py` (22), `tests/unit/test_cli_call.py` (12). Full unit suite: **2082 passed**, 4 skipped (env-gated), the only failures being the pre-existing `test_email_functions.py` set from #223 (confirmed identical on `main`). Broad CLI/network/exec/permission sweep: 610 passed, 0 failures.

> Note: the exec/CLI tests use in-test tools. The real bash path is unblocked by A (#236) and exercised end to end by C (#234); a real-tool e2e test lands with C.

## Example Usage
```python
from connectonion import connect

remote = connect("0x3d40...")

# Text out (needs A #236 for the real bash tool)
print(remote.call("bash", command="co status").text)

# Screenshot out — base64 in the output, .images extracts it
shot = remote.call("bash", command="co browser take_screenshot")
if shot.images:
    import base64
    open("page.png", "wb").write(base64.b64decode(shot.images[0].split(",", 1)[1]))
```
```bash
# Same thing from the shell — the remote twin of `co browser`
co call 0x3d40... co status
co call --out shot.png 0x3d40... co browser take_screenshot
```
Host opt-in is just the whitelist it already ships: `co ...` (incl. `co browser <verb>`) and read-only commands are allowed by default; add a line to `.co/host.yaml` to expose more.

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published (depends on #236)

## Additional Notes
- **Security posture:** direct exec is bounded entirely by the host's whitelist — "safe to run without a human in the loop" now means the same thing whether the LLM or a remote client initiates. The default whitelist is read-only + `co *`.
- **Browser remote-control** is intentionally routed through `co browser` (the daemon) rather than direct exec on the in-process browser tools; the reasoning is documented in code and `remote-call.md`. Making the shipped templates actually run this path (shell tool + prompt) is C (#234).
- User-facing docs live in `docs/`; the separate wiki / docs-site repos still need a follow-up sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ec7tTubZigVqwNjb6qQ6T