### PR TITLE
browser: humanize scrolling with real mouse-wheel events

### DIFF
--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -2,8 +2,8 @@
 Purpose: Humanize BrowserAutomation's pointer + keyboard events so clicks and typing survive
          BEHAVIORAL bot detection (mouse-trajectory entropy, click position, keystroke cadence)
 LLM-Note:
-  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here] | tested by [tests/unit/test_browser_humanize.py]
-  Data flow: browser.py calls move/click/double_click/type_text(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
+  Dependencies: stdlib only [math, random, time, weakref] | imported by [useful_tools/browser_tools/browser.py — every click/hover/type path routes through here; scroll.py — wheel scroll] | tested by [tests/unit/test_browser_humanize.py]
+  Data flow: browser.py/scroll.py call move/click/double_click/type_text/scroll(page, ...) on the browser worker thread → each remembers the page's last cursor position in the module-level WeakKeyDictionary `_cursor`, so the NEXT action starts its curve from where the last one ended (a real cursor never teleports between actions)
   State/Effects: drives the live page via page.mouse.* / page.keyboard.* and sleeps between events; the only retained state is `_cursor` (per-page last x/y, auto-dropped when the page is GC'd)
   Integration: Patchright already fixes the DRIVER-level tells (navigator.webdriver, Runtime.enable); this module fixes the layer above it — the shape of the events themselves. No public tool signatures change; only the low-level event generation.
   Errors: none — pure event emission; if the page is closed the underlying Playwright call raises and bubbles (fail fast)
@@ -92,6 +92,24 @@ def click(page, x, y, button="left", clicks=1, box=None):
 def double_click(page, x, y, box=None):
     """Two human clicks close enough in time/position that the browser raises dblclick."""
     click(page, x, y, clicks=2, box=box)
+
+
+def scroll(page, total_dy):
+    """Human wheel scroll: cover `total_dy` pixels as many small mouse-wheel ticks with
+    variable size and cadence (plus the odd longer reading pause), so the page emits real
+    `wheel` events and `scrollY` moves incrementally — instead of the instant programmatic
+    `scrollBy(0, 1000)` jump a detector flags (scrollY changes with zero wheel events)."""
+    remaining = int(total_dy)
+    sign = 1 if remaining >= 0 else -1
+    while abs(remaining) > 2:
+        step = sign * random.randint(90, 170)
+        if abs(step) > abs(remaining):
+            step = remaining
+        page.mouse.wheel(0, step)
+        remaining -= step
+        time.sleep(random.uniform(0.03, 0.10))
+        if random.random() < 0.1:
+            time.sleep(random.uniform(0.2, 0.5))  # occasional reading pause
 
 
 def type_text(page, text):

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -16,6 +16,8 @@ Usage:
 from pathlib import Path
 from pydantic import BaseModel
 from connectonion import llm_do
+from . import humanize
+import random
 import time
 
 _PROMPT = (Path(__file__).parent / "prompts" / "scroll_strategy.md").read_text()
@@ -42,6 +44,7 @@ def scroll(page, take_screenshot, times: int = 5, description: str = "the main c
     take_screenshot(path=before)
 
     strategies = [
+        ("Human wheel", lambda: _human_scroll(page, times)),
         ("AI strategy", lambda: _ai_scroll(page, times, description)),
         ("Element scroll", lambda: _element_scroll(page, times)),
         ("Page scroll", lambda: _page_scroll(page, times)),
@@ -64,6 +67,18 @@ def scroll(page, take_screenshot, times: int = 5, description: str = "the main c
             print(f"  ❌ {name} failed: {e}")
 
     return "All scroll strategies failed"
+
+
+def _human_scroll(page, times: int):
+    """Scroll with real mouse-wheel events. Tried FIRST because it is the only strategy
+    that looks human — the JS strategies below move scrollTop directly and emit no wheel
+    event. Move the cursor over the content so the wheel targets the page/container, then
+    roll it a screenful at a time."""
+    w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    humanize.move(page, w // 2, h // 2)
+    for _ in range(times):
+        humanize.scroll(page, random.randint(int(h * 0.7), int(h * 0.95)))
+        time.sleep(random.uniform(0.3, 0.7))
 
 
 def _ai_scroll(page, times: int, description: str):

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -107,6 +107,41 @@ def test_humanized_input_event_shape_end_to_end(stealth_browser):
     assert jitter > 5, f"expected variable keystroke timing, stdev was {jitter:.0f}ms"
 
 
+TALL_PAGE = (
+    "<!doctype html><meta charset=utf-8>"
+    "<div style='height:6000px;background:linear-gradient(white,black)'>tall</div>"
+    "<b id=rec></b>"
+)
+
+INSTALL_SCROLL_RECORDER = """() => {
+    const r = document.getElementById('rec');
+    addEventListener('wheel', () => { r.dataset.wheels = (+r.dataset.wheels||0)+1; }, {passive:true});
+    addEventListener('scroll', () => {
+        const s = (r.dataset.ys||'').split(',').filter(Boolean);
+        s.push(Math.round(window.scrollY));
+        r.dataset.ys = s.slice(-200).join(',');
+    }, {passive:true});
+}"""
+
+
+def test_humanized_scroll_emits_wheel_events(stealth_browser):
+    """The scroll tool must move the page with real mouse-wheel events and an incremental
+    scrollY — not the old instant programmatic scrollBy(0,1000) jump (zero wheel events)."""
+    b = stealth_browser
+    b.go_to("data:text/html," + urllib.parse.quote(TALL_PAGE), purpose="scroll test", who="e2e")
+    _eval(b, INSTALL_SCROLL_RECORDER)
+
+    y0 = _eval(b, "() => window.scrollY")
+    b.scroll(times=3)
+    data = _eval(b, "() => ({...document.getElementById('rec').dataset})")
+    y1 = _eval(b, "() => window.scrollY")
+    ys = [int(v) for v in data.get("ys", "").split(",") if v]
+
+    assert int(data.get("wheels", 0)) >= 6, "scroll should emit many real wheel events"
+    assert y1 - y0 > 500, f"page should have scrolled (moved {y1 - y0}px)"
+    assert len(set(ys)) >= 5, "scrollY should move incrementally, not in one jump"
+
+
 # ---------------------------------------------------------------------------
 # Layer 3 — every fingerprint / bot-detection site listed in issue #222.
 # Each entry: (name, url, settle_seconds, verdict(browser) -> (passed, detail)).

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -23,6 +23,9 @@ class FakeMouse:
     def up(self, button="left"):
         self._log.append(("up", button))
 
+    def wheel(self, dx, dy):
+        self._log.append(("wheel", dx, dy))
+
 
 class FakeKeyboard:
     def __init__(self, log):
@@ -108,6 +111,23 @@ def test_type_text_is_per_character():
     humanize.type_text(page, "hello")
     typed = [e[1] for e in page.log if e[0] == "type"]
     assert typed == ["h", "e", "l", "l", "o"], "typed one char at a time, not in bulk"
+
+
+def test_scroll_emits_many_small_wheel_ticks_summing_to_target():
+    page = FakePage()
+    humanize.scroll(page, 1000)
+    wheels = [e for e in page.log if e[0] == "wheel"]
+    assert len(wheels) >= 6, "a human scroll is many small wheel ticks, not one jump"
+    dys = [dy for (_, dx, dy) in wheels]
+    assert all(abs(dy) <= 170 for dy in dys), "each tick is a small delta"
+    assert sum(dys) == 1000, "ticks sum to the requested distance"
+
+
+def test_scroll_up_uses_negative_deltas():
+    page = FakePage()
+    humanize.scroll(page, -600)
+    dys = [dy for (kind, dx, dy) in page.log if kind == "wheel"]
+    assert dys and all(dy < 0 for dy in dys) and sum(dys) == -600
 
 
 def test_cursor_position_is_remembered_between_actions():


### PR DESCRIPTION
Closes #228. Stacked on #224 (uses `humanize.py`) — **base branch is `browser/humanize-input`**, so review/merge that first.

## What
Scrolling was the last robotic input. All three `scroll.py` strategies were **programmatic JS jumps** (`window.scrollBy(0,1000)`, `el.scrollTop += 1000`, LLM-generated JS) — instant 1000px steps with **zero `wheel` events**. Behavioral detectors flag exactly that: `scrollY` changes with no wheel event, in impossible jumps.

New `humanize.scroll(page, total_dy)` covers the distance as many small **mouse-wheel ticks** (~90–170px) with variable cadence and the odd reading pause, so the page emits real `wheel` events and `scrollY` moves incrementally. `scroll.py` now tries a **"Human wheel"** strategy first (cursor moved over the content, then wheels a screenful at a time); the JS strategies remain as fallbacks for overflow/virtualized containers that only move via `scrollTop`.

No tool signature change — `scroll(times, description)` is identical.

## Verified (real `BrowserAutomation.scroll`, headful)
- **24 real `wheel` events** (was 0), `scrollY` 0→2894 in **24 incremental steps** (was one instant jump)
- New e2e `test_humanized_scroll_emits_wheel_events` ✅
- Unit: `humanize.scroll` (2 tests) ✅ · existing `test_scroll.py` fallback chain still green (Human wheel degrades gracefully when there's no real mouse) ✅

## Scope
- `humanize.py` — add `scroll`
- `scroll.py` — wheel-first strategy
