### PR TITLE
host: publish agent balance in ANNOUNCE profile and /info

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -128,6 +128,10 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
         },
     }
 
+    # Startup balance snapshot for co/* managed-key agents; omitted otherwise.
+    if agent_metadata.get("balance_usd") is not None:
+        result["balance_usd"] = agent_metadata["balance_usd"]
+
     if trust_config:
         onboard = trust_config.get("onboard", {})
         if onboard:

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -117,6 +117,17 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
         "skills": [{"name": s.name, "description": s.description, "location": s.location}
                    for s in raw_skills],
     }
+    # Managed-key (co/*) agents have an OpenOnion account balance; publish it so
+    # chat clients can show the agent's balance. Clients can't fetch it themselves
+    # — it's gated by the agent's private key — so the agent is the only party that
+    # can report it. This is a one-time startup snapshot; it refreshes on restart.
+    # Agents on their own provider keys have no such balance, so get_balance is
+    # absent and the field is simply omitted.
+    get_balance = getattr(sample.llm, "get_balance", None)
+    if callable(get_balance):
+        balance = get_balance()
+        if balance is not None:
+            metadata["balance_usd"] = balance
     return metadata, sample
 
 
@@ -136,6 +147,10 @@ def _build_agent_profile(agent_metadata: dict) -> dict:
         profile["tools"] = agent_metadata["tools"]
     if agent_metadata.get("model"):
         profile["model"] = agent_metadata["model"]
+    # Startup balance snapshot for co/* managed-key agents (see _extract_agent_metadata).
+    # Public for now — a later admin/subscriber tier can gate it.
+    if agent_metadata.get("balance_usd") is not None:
+        profile["balance_usd"] = agent_metadata["balance_usd"]
     # skill.location (useful_plugins/skills.py) is a 5-value discovery category. Publish
     # only the two that ship inside the project tree — project (.co/skills) and
     # claude-project (.claude/skills). user (~/.co/skills), claude-user (~/.claude/skills)

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -136,6 +136,29 @@ class TestHostRelayConnection:
             ],
         }
 
+    def test_profile_publishes_balance_when_present(self):
+        """Managed-key agents publish their balance so chat clients can show it
+        (clients can't fetch it themselves — it's gated by the agent's key)."""
+        profile = host_module._build_agent_profile({
+            "name": "test_agent",
+            "model": "co/gemini-2.5-flash",
+            "balance_usd": 4.22,
+            "skills": [],
+        })
+
+        assert profile["balance_usd"] == 4.22
+
+    def test_profile_omits_balance_when_absent(self):
+        """Agents on their own provider keys have no OpenOnion balance — the
+        field is simply left out rather than sent as null/zero."""
+        profile = host_module._build_agent_profile({
+            "name": "byo_key_agent",
+            "model": "gpt-4o",
+            "skills": [],
+        })
+
+        assert "balance_usd" not in profile
+
     def test_host_passes_profile_to_relay_lifespan(self, tmp_path, create_mock_agent):
         """Hosted agents publish their profile with the relay ANNOUNCE."""
         mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}

--- a/tests/unit/test_host_routes.py
+++ b/tests/unit/test_host_routes.py
@@ -270,6 +270,35 @@ class TestInfoHandler:
         assert result["trust"] == "careful"
         assert "version" in result
 
+    def test_includes_balance_when_present(self):
+        """A managed-key agent's balance snapshot is echoed on /info."""
+        metadata = {
+            "name": "my_agent",
+            "tools": [],
+            "address": "0x123",
+            "balance_usd": 4.22,
+        }
+        mock_trust = Mock()
+        mock_trust.trust = "careful"
+
+        result = info_handler(metadata, mock_trust)
+
+        assert result["balance_usd"] == 4.22
+
+    def test_omits_balance_when_absent(self):
+        """Agents without an OpenOnion balance don't get a null/zero field."""
+        metadata = {
+            "name": "agent",
+            "tools": [],
+            "address": "0x123",
+        }
+        mock_trust = Mock()
+        mock_trust.trust = "open"
+
+        result = info_handler(metadata, mock_trust)
+
+        assert "balance_usd" not in result
+
     def test_returns_onboard_info(self):
         """info_handler includes onboard info when trust_config provided."""
         metadata = {


### PR DESCRIPTION
## Description
Lets a hosted agent report its own OpenOnion balance so chat clients (OOCAT) can show the balance of the **agent that actually spends credits**, instead of the frontend's browser identity. Part 1 of 3 (backend → SDK → frontend).

## Related Issue
Part of openonion/oo-chat#31

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- `network/host/server.py`
  - `_extract_agent_metadata()`: for `co/*` managed-key agents, call `sample.llm.get_balance()` and store a `balance_usd` startup snapshot. Guarded by `hasattr` — agents on their own provider keys have no such method and the field is omitted.
  - `_build_agent_profile()`: include `balance_usd` in the published ANNOUNCE profile when present.
- `network/host/http_router.py`
  - `info_handler()`: echo `balance_usd` on `GET /info` when present.
- Rationale: balance is per-address and gated by that address's private key, so a chat client (which only holds its own key) can't query an agent's balance. The agent is the only party that can report it, and it already publishes a display profile — so balance rides that existing channel. Public for now; a later admin/subscriber tier can gate it.

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

`pytest tests/unit/test_host_relay.py tests/unit/test_host_routes.py` → **64 passed**. New tests: profile includes/omits `balance_usd`; `/info` includes/omits `balance_usd`.

## Additional Notes
- The balance is a **startup snapshot** (fetched once when the host starts), consistent with the agreed design in openonion/oo-chat#31 — it refreshes when the agent restarts, not live. Documented as a known tradeoff; a future live/periodic refresh can build on this.
- Dependent changes: `connectonion-ts` (adds `balance_usd` to `AgentInfo`) and `oo-chat` (displays it). This PR is safe to merge on its own — the field is additive.

---
_Generated by [Claude Code](https://claude.ai/code/session_014MCXF2XGjWhvRpiKS4KfcU)_