### PR TITLE
Fix Windows GBK/cp936 encoding errors once and for all (file I/O, subprocess, console)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,7 +313,7 @@ jobs:
           from connectonion.useful_tools.shell import Shell
           from connectonion.cli.co_ai.tools import background as bg
 
-          cps = [20013, 25991, 27979, 35797, 128640]   # 中文测试 + rocket emoji
+          cps = [20013, 25991, 27979, 35797, 128640]   # CJK chars + a rocket emoji
           want = "".join(chr(c) for c in cps)
           # Build the child from codepoints so the command line stays pure ASCII;
           # the child generates the Unicode itself and prints it (UTF-8 thanks to the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,6 +294,49 @@ jobs:
           co browser close
           if ($LASTEXITCODE -ne 0) { exit 1 }
 
+      # The GBK/cp936 minefield (issue #230): a Chinese Windows console runs in the
+      # legacy GBK codepage. Before the fix, the co_ai/shell subprocess layer used
+      # text=True with NO explicit encoding, so a child that emitted UTF-8/emoji
+      # crashed the reader thread (UnicodeDecodeError) or the child itself
+      # (UnicodeEncodeError). Force the console into GBK and turn OFF Python's UTF-8
+      # mode so the legacy codepage is actually in effect, then drive the *shipped*
+      # Shell + background runner through a child that prints CJK + an emoji and
+      # assert it round-trips cleanly.
+      - name: Subprocess tools survive the Chinese (GBK/cp936) console codepage
+        shell: pwsh
+        env:
+          PYTHONUTF8: "0"
+        run: |
+          chcp 936
+          @'
+          import sys, time
+          from connectonion.useful_tools.shell import Shell
+          from connectonion.cli.co_ai.tools import background as bg
+
+          cps = [20013, 25991, 27979, 35797, 128640]   # 中文测试 + rocket emoji
+          want = "".join(chr(c) for c in cps)
+          # Build the child from codepoints so the command line stays pure ASCII;
+          # the child generates the Unicode itself and prints it (UTF-8 thanks to the
+          # env the Shell/background runner inject).
+          inner = "print(''.join(chr(c) for c in %s))" % cps
+          child = '"%s" -c "%s"' % (sys.executable, inner)
+
+          out = Shell().run(child)
+          assert want in out, "Shell lost unicode under GBK console: %r" % out
+
+          bg.run_background(child)
+          for _ in range(100):
+              t = bg._tasks.get("bg_1")
+              if t and t.status != bg.TaskStatus.RUNNING:
+                  break
+              time.sleep(0.1)
+          o2 = bg.task_output("bg_1")
+          assert want in o2, "background lost unicode under GBK console: %r" % o2
+          print("OK: GBK/cp936 console subprocess round-trip clean")
+          '@ | Set-Content -Path gbk_check.py -Encoding ascii
+          python gbk_check.py
+          if ($LASTEXITCODE -ne 0) { Write-Error "GBK/cp936 subprocess round-trip failed"; exit 1 }
+
       # Task-Manager-kill recovery: a stale pid file whose pid now belongs to a
       # LIVE unrelated process must never block a fresh daemon (the pre-fix
       # behavior was a permanent 'daemon is busy' denial of service).

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -88,7 +88,7 @@ def _spawn_daemon(sock_path: str, headless: bool):
     cmd = [sys.executable, "-m", "connectonion.cli.browser_agent.daemon", sock_path]
     if headless:
         cmd.append("--headless")
-    with open(log_path, "a") as log:  # the child dups the handle; ours closes right away
+    with open(log_path, "a", encoding="utf-8") as log:  # the child dups the handle; ours closes right away
         transport.spawn_detached(cmd, log)  # POSIX: new session · Windows: DETACHED_PROCESS
 
     # Wall-clock deadline, not an attempt count: against a busy daemon each _connect

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -112,7 +112,7 @@ def _owner_alive(sock_path: str) -> bool:
     pid_file = Path(transport.pid_path(sock_path))
     if not pid_file.exists():
         return False
-    raw = pid_file.read_text().strip()
+    raw = pid_file.read_text(encoding="utf-8").strip()
     if not raw.isdigit():
         return False
     return transport.pid_alive(int(raw))
@@ -532,7 +532,7 @@ class BrowserDaemon:
                 os.unlink(self.sock_path)  # stale socket
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(self.sock_path)
-        Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()))
+        Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()), encoding="utf-8")
         self._srv.listen(8)
 
     def _bind_windows(self):
@@ -557,7 +557,7 @@ class BrowserDaemon:
             # First-instance pipe creation refused: another daemon owns the name after
             # all (probe raced its accept loop). Yield, exactly like the POSIX loser.
             sys.exit(0)
-        Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()))
+        Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()), encoding="utf-8")
 
     # ---- transport seam: POSIX raw AF_UNIX socket vs Windows named-pipe Connection ----
 
@@ -606,7 +606,7 @@ class BrowserDaemon:
         # daemon may already own the path — a late-exiting zombie deleting the live
         # socket or pid file would re-arm the very bug the pid file exists to prevent.
         pid_file = Path(transport.pid_path(self.sock_path))
-        if pid_file.exists() and pid_file.read_text().strip() == str(os.getpid()):
+        if pid_file.exists() and pid_file.read_text(encoding="utf-8").strip() == str(os.getpid()):
             if not transport.IS_WINDOWS and os.path.exists(self.sock_path):
                 os.unlink(self.sock_path)  # POSIX: remove our socket file (mpc did it on Win)
             pid_file.unlink()

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -205,7 +205,7 @@ def acquire_singleton_lock(path: str):
 
     POSIX: fcntl.flock. Windows: msvcrt.locking on the first byte.
     """
-    handle = open(path, "a+")
+    handle = open(path, "a+", encoding="utf-8")
     try:
         if IS_WINDOWS:
             import msvcrt

--- a/connectonion/cli/co_ai/commands/undo.py
+++ b/connectonion/cli/co_ai/commands/undo.py
@@ -40,20 +40,20 @@ def _is_git_repo() -> bool:
 def _git_stash_push(message: str) -> bool:
     result = subprocess.run(
         ["git", "stash", "push", "-m", message, "--include-untracked"],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     return result.returncode == 0
 
 
 def _git_stash_pop() -> bool:
-    result = subprocess.run(["git", "stash", "pop"], capture_output=True, text=True)
+    result = subprocess.run(["git", "stash", "pop"], capture_output=True, text=True, encoding="utf-8", errors="replace")
     return result.returncode == 0
 
 
 def _git_stash_apply(index: int = 0) -> bool:
     result = subprocess.run(
         ["git", "stash", "apply", f"stash@{{{index}}}"],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     return result.returncode == 0
 
@@ -61,7 +61,7 @@ def _git_stash_apply(index: int = 0) -> bool:
 def _git_stash_drop(index: int = 0) -> bool:
     result = subprocess.run(
         ["git", "stash", "drop", f"stash@{{{index}}}"],
-        capture_output=True, text=True
+        capture_output=True, text=True, encoding="utf-8", errors="replace"
     )
     return result.returncode == 0
 

--- a/connectonion/cli/co_ai/context.py
+++ b/connectonion/cli/co_ai/context.py
@@ -109,6 +109,8 @@ def _get_git_info(base: Path) -> Optional[str]:
             ["git", "branch", "--show-current"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=base,
             timeout=5,
         )
@@ -119,6 +121,8 @@ def _get_git_info(base: Path) -> Optional[str]:
             ["git", "status", "--short"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=base,
             timeout=5,
         )
@@ -129,6 +133,8 @@ def _get_git_info(base: Path) -> Optional[str]:
             ["git", "log", "--oneline", "-3"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=base,
             timeout=5,
         )

--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -87,7 +87,7 @@ def _load_reminders(reminders_dir):
         return {}
     reminders = {}
     for f in reminders_dir.glob("*.md"):
-        meta, body = _parse_frontmatter(f.read_text())
+        meta, body = _parse_frontmatter(f.read_text(encoding="utf-8"))
         if meta.get('name'):
             reminders[meta['name']] = {
                 'content': body,
@@ -141,18 +141,18 @@ def _load_build_context():
     # Workflow (agent creation workflow)
     workflow_file = PROMPTS_DIR / "workflow.md"
     if workflow_file.exists():
-        parts.append(workflow_file.read_text())
+        parts.append(workflow_file.read_text(encoding="utf-8"))
 
     # ConnectOnion framework index (API reference + guides table)
     co_index = PROMPTS_DIR / "connectonion" / "index.md"
     if co_index.exists():
-        parts.append(co_index.read_text())
+        parts.append(co_index.read_text(encoding="utf-8"))
 
     # ConnectOnion examples
     examples_dir = PROMPTS_DIR / "connectonion" / "examples"
     if examples_dir.exists():
         for example_file in sorted(examples_dir.glob("*.md")):
-            parts.append(example_file.read_text())
+            parts.append(example_file.read_text(encoding="utf-8"))
 
     return "\n\n---\n\n".join(parts)
 

--- a/connectonion/cli/co_ai/prompts/assembler.py
+++ b/connectonion/cli/co_ai/prompts/assembler.py
@@ -199,7 +199,7 @@ def assemble_prompt(
     # 1. Main prompt (required)
     main_file = prompts_path / "main.md"
     if main_file.exists():
-        content = main_file.read_text()
+        content = main_file.read_text(encoding="utf-8")
         parts.append(interpolate(content, ctx_dict))
 
     # 2. Workflow, ConnectOnion index, and examples are loaded on-demand
@@ -212,7 +212,7 @@ def assemble_prompt(
             tool_name = _get_tool_name(tool).lower()
             tool_file = tools_dir / f"{tool_name}.md"
             if tool_file.exists():
-                content = tool_file.read_text()
+                content = tool_file.read_text(encoding="utf-8")
                 parts.append(interpolate(content, ctx_dict))
     
     return "\n\n---\n\n".join(parts)
@@ -245,7 +245,7 @@ def load_reminder(
     if not reminder_file.exists():
         return None
     
-    content = reminder_file.read_text()
+    content = reminder_file.read_text(encoding="utf-8")
     
     # Build interpolation context
     ctx_dict = {}
@@ -284,7 +284,7 @@ def load_agent_prompt(
     if not agent_file.exists():
         return None
 
-    content = agent_file.read_text()
+    content = agent_file.read_text(encoding="utf-8")
 
     # Build interpolation context
     ctx_dict = {}

--- a/connectonion/cli/co_ai/tools/background.py
+++ b/connectonion/cli/co_ai/tools/background.py
@@ -15,6 +15,7 @@ Architecture:
 - Used by co_ai for builds, tests, servers, and other long operations
 """
 
+import os
 import subprocess
 import threading
 import time
@@ -100,7 +101,12 @@ def run_background(command: str, description: str = "") -> str:
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        encoding="utf-8",
+        errors="replace",  # a stray non-UTF-8 byte must never kill the reader thread
         bufsize=1,
+        # Force UTF-8 in child processes regardless of the Windows console codepage
+        # (Chinese GBK/cp936, etc.), so their output round-trips through the pipe above.
+        env={**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"},
     )
 
     task = BackgroundTask(

--- a/connectonion/cli/commands/announce_commands.py
+++ b/connectonion/cli/commands/announce_commands.py
@@ -35,7 +35,7 @@ def _load_profile() -> dict:
     if not AGENT_JSON.exists():
         console.print(f"[red]No {AGENT_JSON}. Run `co setup` first.[/red]")
         raise SystemExit(1)
-    return json.loads(AGENT_JSON.read_text())
+    return json.loads(AGENT_JSON.read_text(encoding="utf-8"))
 
 
 def _build_listed_skills(profile: dict) -> list:

--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -97,7 +97,7 @@ def authenticate(co_dir: Path, save_to_project: bool = True, quiet: bool = False
             })
             # Ensure AGENT_ADDRESS and AGENT_CONFIG_PATH exist (append-only, don't overwrite)
             if global_keys_env.exists():
-                existing = global_keys_env.read_text()
+                existing = global_keys_env.read_text(encoding="utf-8")
                 append_lines = []
                 if 'AGENT_ADDRESS=' not in existing:
                     append_lines.append(f"AGENT_ADDRESS={public_key}\n")

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -55,10 +55,10 @@ def _next_tip():
     """Rotate through TIPS so each run teaches something new; index persists in ~/.co.
     A garbled state file (e.g. two commands racing the write) resets to the first tip."""
     state = Path.home() / ".co" / ".browser_tip"
-    raw = state.read_text().strip() if state.exists() else ""
+    raw = state.read_text(encoding="utf-8").strip() if state.exists() else ""
     idx = int(raw) if raw.isdigit() else 0
     state.parent.mkdir(parents=True, exist_ok=True)
-    state.write_text(str((idx + 1) % len(TIPS)))
+    state.write_text(str((idx + 1) % len(TIPS)), encoding="utf-8")
     return TIPS[idx % len(TIPS)]
 
 

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -71,7 +71,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     # Authenticate only if OPENONION_API_KEY not already in global keys.env
     global_dir = Path.home() / ".co"
     global_keys_env = global_dir / "keys.env"
-    already_authed = global_keys_env.exists() and "OPENONION_API_KEY=" in global_keys_env.read_text()
+    already_authed = global_keys_env.exists() and "OPENONION_API_KEY=" in global_keys_env.read_text(encoding="utf-8")
 
     if not already_authed:
         if not yes:

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -43,7 +43,7 @@ def _check_host_export(entrypoint: str) -> bool:
     if not entrypoint_path.exists():
         return False
 
-    content = entrypoint_path.read_text()
+    content = entrypoint_path.read_text(encoding="utf-8")
 
     # Check for host() call pattern
     # Matches: host(agent), host(my_agent), host( agent ), etc.
@@ -60,7 +60,7 @@ def _load_deploy_ignore_patterns(project_dir: Path) -> list[str]:
     lines = GITIGNORE_CONTENT.splitlines()
     gitignore = project_dir / ".gitignore"
     if gitignore.exists():
-        lines.extend(gitignore.read_text().splitlines())
+        lines.extend(gitignore.read_text(encoding="utf-8").splitlines())
     return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
 
 
@@ -243,7 +243,7 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
         return False
 
     # Load config from host.yaml
-    with open(host_yaml_path, 'r') as f:
+    with open(host_yaml_path, 'r', encoding="utf-8") as f:
         config = yaml.safe_load(f) or {}
     project_name = config.get("name", "unnamed-agent")
     env_file = config.get("env", ".env")

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -80,7 +80,7 @@ def handle_doctor():
     if local_config.exists():
         config_table.add_row("Config", f"[green]✓[/green] {local_config}")
         import yaml
-        with open(local_config, 'r') as f:
+        with open(local_config, 'r', encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
         agent_name = config.get("name", "Not set")
         config_table.add_row("Agent Name", f"[dim]{agent_name}[/dim]")

--- a/connectonion/cli/commands/eval_commands.py
+++ b/connectonion/cli/commands/eval_commands.py
@@ -105,7 +105,7 @@ def _run_evals(eval_files: list, agent_override: Optional[str] = None):
     agents_cache = {}  # Cache agents by file path
 
     for eval_file in eval_files:
-        with open(eval_file) as f:
+        with open(eval_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         # Get agent file: CLI override > YAML > error
@@ -201,7 +201,7 @@ def _run_evals(eval_files: list, agent_override: Optional[str] = None):
             # Update runs count and save
             data['runs'] = data.get('runs', 0) + 1
             data['updated'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            with open(eval_file, 'w') as f:
+            with open(eval_file, 'w', encoding="utf-8") as f:
                 yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
 
         console.print(f"[green]✓[/green] {eval_file.stem} completed")
@@ -241,7 +241,7 @@ def _show_eval_status(eval_files: list):
     no_expected = 0
 
     for eval_file in sorted(eval_files):
-        with open(eval_file) as f:
+        with open(eval_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
 
         for turn in data.get('turns', []):

--- a/connectonion/cli/commands/fanout.py
+++ b/connectonion/cli/commands/fanout.py
@@ -63,7 +63,7 @@ def install_cursor(bundle: Path, alias: str) -> int:
         md = skill / "SKILL.md"
         if not md.exists():
             continue
-        m = FRONTMATTER_RE.match(md.read_text())
+        m = FRONTMATTER_RE.match(md.read_text(encoding="utf-8"))
         if not m:
             continue
         fm, body = m.groups()
@@ -72,7 +72,8 @@ def install_cursor(bundle: Path, alias: str) -> int:
             "",
         )
         (rules / f"{alias}-{skill.name}.mdc").write_text(
-            f"---\ndescription: {desc}\nalwaysApply: false\n---\n{body}"
+            f"---\ndescription: {desc}\nalwaysApply: false\n---\n{body}",
+            encoding="utf-8",
         )
         n += 1
     return n

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -57,7 +57,7 @@ def _when(iso: str) -> str:
 def _print_listing(outlook, emails: list, title: str):
     """Render emails as a numbered table (or plain ID-bearing text when piped) and cache the numbering for read/reply."""
     INBOX_CACHE.parent.mkdir(exist_ok=True)
-    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}))
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}), encoding="utf-8")
 
     if not console.is_terminal:
         # Scripts and agents get the untruncated format with full message ids.
@@ -155,7 +155,7 @@ def handle_outlook_inbox(last: int = 10, unread: bool = False):
 
 def _resolve_email_id(outlook, email_id: str) -> str:
     """Turn a listing number into a Graph message id; full ids pass through. Numbers mean the last listing shown."""
-    cached = json.loads(INBOX_CACHE.read_text()) if INBOX_CACHE.exists() else {}
+    cached = json.loads(INBOX_CACHE.read_text(encoding="utf-8")) if INBOX_CACHE.exists() else {}
     if email_id in cached:
         return cached[email_id]
 
@@ -248,7 +248,7 @@ def handle_outlook_scheduled():
         return
 
     INBOX_CACHE.parent.mkdir(exist_ok=True)
-    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(scheduled, 1)}))
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(scheduled, 1)}), encoding="utf-8")
 
     if not console.is_terminal:
         # Scripts and agents get one plain line per email with the full id.

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -991,7 +991,7 @@ def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> No
     found = set()
 
     if env_path.exists():
-        for line in env_path.read_text().splitlines(keepends=True):
+        for line in env_path.read_text(encoding="utf-8").splitlines(keepends=True):
             stripped = line.strip()
             if strip_prefix and stripped.startswith(strip_prefix):
                 continue
@@ -1007,7 +1007,7 @@ def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> No
         if key not in found:
             lines.append(f"{key}={value}\n")
 
-    env_path.write_text(''.join(lines))
+    env_path.write_text(''.join(lines), encoding="utf-8")
     if sys.platform != 'win32':
         env_path.chmod(0o600)
 
@@ -1058,7 +1058,7 @@ def ensure_global_config() -> None:
         lines = []
         config_path_found = False
         address_updated = False
-        for line in keys_env.read_text().splitlines(keepends=True):
+        for line in keys_env.read_text(encoding="utf-8").splitlines(keepends=True):
             if line.strip().startswith('AGENT_ADDRESS='):
                 lines.append(f"AGENT_ADDRESS={addr_data['address']}\n")
                 address_updated = True
@@ -1071,7 +1071,7 @@ def ensure_global_config() -> None:
             lines.insert(0, f"AGENT_CONFIG_PATH={global_dir}\n")
         if not address_updated:
             lines.append(f"AGENT_ADDRESS={addr_data['address']}\n")
-        keys_env.write_text(''.join(lines))
+        keys_env.write_text(''.join(lines), encoding="utf-8")
         if sys.platform != 'win32':
             os.chmod(keys_env, 0o600)
     console.print(f"  ✓ Created ~/.co/keys.env")

--- a/connectonion/cli/commands/setup_commands.py
+++ b/connectonion/cli/commands/setup_commands.py
@@ -51,7 +51,7 @@ def _write_agent_json(name: str, bio: str, addr: str):
         "skills":  [],
         "version": "v0.1.0",
     }
-    AGENT_JSON.write_text(json.dumps(profile, indent=2))
+    AGENT_JSON.write_text(json.dumps(profile, indent=2), encoding="utf-8")
 
 
 def handle_setup(
@@ -69,7 +69,7 @@ def handle_setup(
 
     # Phase 2: agent.json
     if AGENT_JSON.exists() and not force:
-        existing = json.loads(AGENT_JSON.read_text())
+        existing = json.loads(AGENT_JSON.read_text(encoding="utf-8"))
         console.print(f"[dim]✓ {AGENT_JSON} exists (alias={existing.get('alias')}, skip — pass --force to overwrite)[/dim]")
     else:
         if AGENT_JSON.exists() and force:
@@ -92,7 +92,7 @@ def handle_setup(
         handle_skills_manifest()
 
     # Auth check
-    auth_ok = KEYS_ENV.exists() and "OPENONION_API_KEY=" in KEYS_ENV.read_text()
+    auth_ok = KEYS_ENV.exists() and "OPENONION_API_KEY=" in KEYS_ENV.read_text(encoding="utf-8")
     console.print()
     if auth_ok:
         console.print("[green]✓ Auth:[/green] OPENONION_API_KEY present")

--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -118,7 +118,7 @@ def handle_skills_discover(save: bool = True, json_out: bool = False, include_na
 
     if save:
         SKILLS_DIR.mkdir(parents=True, exist_ok=True)
-        INDEX_FILE.write_text(json.dumps(index, indent=2))
+        INDEX_FILE.write_text(json.dumps(index, indent=2), encoding="utf-8")
 
     if json_out:
         console.print_json(data=index)
@@ -141,7 +141,7 @@ def handle_skills_discover(save: bool = True, json_out: bool = False, include_na
 def _load_index() -> Optional[dict]:
     if not INDEX_FILE.exists():
         return None
-    return json.loads(INDEX_FILE.read_text())
+    return json.loads(INDEX_FILE.read_text(encoding="utf-8"))
 
 
 SOURCE_PRIORITY = {src: i for i, (src, _, _) in enumerate(SOURCES)}
@@ -277,7 +277,7 @@ def handle_skills_manifest(
         if not out_path.exists():
             console.print(f"[red]Not found: {out_path}. Run `co setup` first or pass --out to write standalone JSON.[/red]")
             raise SystemExit(1)
-        profile = json.loads(out_path.read_text())
+        profile = json.loads(out_path.read_text(encoding="utf-8"))
         existing_by_name = {
             s.get("name"): s
             for s in profile.get("skills", [])
@@ -290,11 +290,11 @@ def handle_skills_manifest(
         profile["skills"] = manifest
         profile.pop("signature", None)
         profile.pop("signer", None)
-        out_path.write_text(json.dumps(profile, indent=2))
+        out_path.write_text(json.dumps(profile, indent=2), encoding="utf-8")
         console.print(f"[green]✓ Merged {len(manifest)} skill(s) into {out_path}[/green]")
         console.print("[dim]Note: removed prior signature — re-sign before publishing.[/dim]")
     else:
-        out_path.write_text(json.dumps(manifest, indent=2))
+        out_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
         console.print(f"[green]✓ Wrote {len(manifest)} skill(s) → {out_path}[/green]")
 
 

--- a/connectonion/cli/templates/web-research/agent.py
+++ b/connectonion/cli/templates/web-research/agent.py
@@ -96,7 +96,7 @@ def save_research(topic: str, findings: List[str], filename: str = None) -> str:
         "timestamp": __import__('datetime').datetime.now().isoformat()
     }
     
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding="utf-8") as f:
         json.dump(research_data, f, indent=2)
     
     return f"Research saved to {filename}"

--- a/connectonion/debug/runtime_inspector/runtime_inspector.py
+++ b/connectonion/debug/runtime_inspector/runtime_inspector.py
@@ -349,7 +349,7 @@ class RuntimeInspector:
             if not path.exists():
                 return f"File not found: {filename}"
 
-            with open(path, 'r') as f:
+            with open(path, 'r', encoding="utf-8") as f:
                 lines = f.readlines()
 
             start = max(0, line_number - context_lines - 1)

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -195,7 +195,7 @@ class Logger:
 
         # Load existing or create new
         if self.eval_file.exists():
-            with open(self.eval_file, 'r') as f:
+            with open(self.eval_file, 'r', encoding="utf-8") as f:
                 self.eval_data = yaml.safe_load(f) or {}
 
             # Check if this is the same conversation (same first input)
@@ -469,5 +469,5 @@ class Logger:
         """Load eval data from file."""
         if not self.eval_file or not self.eval_file.exists():
             return {'turns': [], 'runs': 0}
-        with open(self.eval_file, 'r') as f:
+        with open(self.eval_file, 'r', encoding="utf-8") as f:
             return yaml.safe_load(f) or {'turns': [], 'runs': 0}

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -143,7 +143,7 @@ def admin_logs_handler(agent_name: str) -> dict:
     """GET /admin/logs"""
     log_path = Path(f".co/logs/{agent_name}.log")
     if log_path.exists():
-        return {"content": log_path.read_text()}
+        return {"content": log_path.read_text(encoding="utf-8")}
     return {"error": "No logs found"}
 
 
@@ -156,7 +156,7 @@ def admin_sessions_handler() -> dict:
 
     sessions = []
     for session_file in sessions_dir.glob("*.yaml"):
-        with open(session_file) as f:
+        with open(session_file, encoding="utf-8") as f:
             session_data = yaml.safe_load(f)
             if session_data:
                 sessions.append(session_data)

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -37,14 +37,14 @@ class SessionStorage:
         self.path.parent.mkdir(exist_ok=True)
 
     def save(self, session: Session):
-        with open(self.path, "a") as f:
+        with open(self.path, "a", encoding="utf-8") as f:
             f.write(session.model_dump_json() + "\n")
 
     def get(self, session_id: str) -> Session | None:
         if not self.path.exists():
             return None
         now = time.time()
-        with open(self.path) as f:
+        with open(self.path, encoding="utf-8") as f:
             lines = f.readlines()
         for line in reversed(lines):
             data = json.loads(line)
@@ -60,7 +60,7 @@ class SessionStorage:
             return []
         sessions = {}
         now = time.time()
-        with open(self.path) as f:
+        with open(self.path, encoding="utf-8") as f:
             for line in f:
                 data = json.loads(line)
                 sessions[data["session_id"]] = Session(**data)

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -136,7 +136,7 @@ def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
     """
     for path in _get_skill_paths(skill_name):
         if path.exists():
-            content = path.read_text()
+            content = path.read_text(encoding="utf-8")
             frontmatter, instructions = _parse_skill_content(content)
             return {
                 'path': str(path),
@@ -219,7 +219,7 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
 
             seen.add(name)
 
-            content = skill_file.read_text()
+            content = skill_file.read_text(encoding="utf-8")
             frontmatter, _ = _parse_skill_content(content)
             description = frontmatter.get('description', 'No description')
 

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -65,7 +65,7 @@ def _load_agent(agent_name: str) -> Optional[Dict[str, Any]]:
     """Load agent configuration from filesystem."""
     for path in _get_agent_paths(agent_name):
         if path.exists():
-            content = path.read_text()
+            content = path.read_text(encoding="utf-8")
             frontmatter, system_prompt = _parse_agent_content(content)
             return {
                 'path': str(path),
@@ -121,7 +121,7 @@ def _discover_all_agents() -> List[Dict[str, str]]:
 
             seen_names.add(agent_name)
 
-            content = agent_file.read_text()
+            content = agent_file.read_text(encoding="utf-8")
             frontmatter, _ = _parse_agent_content(content)
             description = frontmatter.get('description', 'No description')
 

--- a/connectonion/useful_plugins/system_reminder.py
+++ b/connectonion/useful_plugins/system_reminder.py
@@ -50,7 +50,7 @@ def _load_reminders(reminders_dir):
         return {}
     reminders = {}
     for f in reminders_dir.glob("*.md"):
-        meta, body = _parse_frontmatter(f.read_text())
+        meta, body = _parse_frontmatter(f.read_text(encoding="utf-8"))
         if meta.get('name'):
             reminders[meta['name']] = {'content': body, 'triggers': meta.get('triggers', [])}
     return reminders

--- a/connectonion/useful_prompts/coding_agent/assembler.py
+++ b/connectonion/useful_prompts/coding_agent/assembler.py
@@ -60,7 +60,7 @@ def assemble_prompt(
     # 1. Main prompt (required)
     main_file = prompts_path / "main.md"
     if main_file.exists():
-        parts.append(main_file.read_text())
+        parts.append(main_file.read_text(encoding="utf-8"))
 
     # 2. Tool descriptions (for each available tool)
     tools_dir = prompts_path / "tools"
@@ -69,13 +69,13 @@ def assemble_prompt(
             tool_name = _get_tool_name(tool).lower()
             tool_file = tools_dir / f"{tool_name}.md"
             if tool_file.exists():
-                parts.append(tool_file.read_text())
+                parts.append(tool_file.read_text(encoding="utf-8"))
 
     # 3. Project context (optional)
     if context_file:
         context_path = Path(context_file)
         if context_path.exists():
-            parts.append(f"# Project Context\n\n{context_path.read_text()}")
+            parts.append(f"# Project Context\n\n{context_path.read_text(encoding='utf-8')}")
 
     return "\n\n---\n\n".join(parts)
 
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     # Define tools
     def read_file(path: str) -> str:
         """Read file contents."""
-        return Path(path).read_text()
+        return Path(path).read_text(encoding="utf-8")
 
     writer = DiffWriter()
     todo = TodoList()

--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -53,6 +53,8 @@ def bash(command: str, description: str, cwd: str = ".", timeout: int = 120) -> 
             executable="/bin/bash",
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=cwd,
             timeout=timeout
         )

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -194,7 +194,7 @@ def driver_stealth_status():
     version = importlib.metadata.version("patchright")
     lib = Path(patchright.__file__).parent / "driver" / "package" / "lib"
     marker = "disable-blink-features=AutomationControlled"
-    patched = any(marker in p.read_text(errors="ignore") for p in lib.rglob("*.js"))
+    patched = any(marker in p.read_text(errors="ignore", encoding="utf-8") for p in lib.rglob("*.js"))
     if patched:
         return "ok", version, "stealth patches present"
     return ("broken", version,
@@ -583,7 +583,7 @@ class BrowserAutomation:
         # storage_state=, so the exported cookies are applied with add_cookies. A missing file
         # raises (fail loud): if a deploy declared a seed it must be packaged.
         if self._seed_state and not self._seeded:
-            cookies = json.loads(Path(self._seed_state).read_text()).get("cookies", [])
+            cookies = json.loads(Path(self._seed_state).read_text(encoding="utf-8")).get("cookies", [])
             if cookies:
                 self.browser.add_cookies(cookies)
             self._seeded = True

--- a/connectonion/useful_tools/browser_tools/element_finder.py
+++ b/connectonion/useful_tools/browser_tools/element_finder.py
@@ -41,11 +41,11 @@ _BASE_DIR = Path(__file__).parent
 # Reload prompts on each use (so changes are picked up without restart)
 def _get_extract_js():
     """Load extract_elements.js fresh each time (no caching for development)."""
-    return (_BASE_DIR / "scripts" / "extract_elements.js").read_text()
+    return (_BASE_DIR / "scripts" / "extract_elements.js").read_text(encoding="utf-8")
 
 def _get_element_matcher_prompt():
     """Load element_matcher.md fresh each time (no caching for development)."""
-    return (_BASE_DIR / "prompts" / "element_matcher.md").read_text()
+    return (_BASE_DIR / "prompts" / "element_matcher.md").read_text(encoding="utf-8")
 
 
 class InteractiveElement(BaseModel):
@@ -102,7 +102,7 @@ def extract_elements(page) -> List[InteractiveElement]:
     debug_dir.mkdir(parents=True, exist_ok=True)
     debug_file = debug_dir / "elements.json"
 
-    with open(debug_file, 'w') as f:
+    with open(debug_file, 'w', encoding="utf-8") as f:
         json.dump(raw, f, indent=2)
 
     # Count elements by frame context

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from connectonion import llm_do
 import time
 
-_PROMPT = (Path(__file__).parent / "prompts" / "scroll_strategy.md").read_text()
+_PROMPT = (Path(__file__).parent / "prompts" / "scroll_strategy.md").read_text(encoding="utf-8")
 
 
 class ScrollStrategy(BaseModel):

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -181,10 +181,10 @@ class Gmail:
         # Update .env file if it exists
         env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
         if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
+            with open(env_file, 'r', encoding="utf-8") as f:
                 lines = f.readlines()
 
-            with open(env_file, 'w') as f:
+            with open(env_file, 'w', encoding="utf-8") as f:
                 for line in lines:
                     if line.startswith("GOOGLE_ACCESS_TOKEN="):
                         f.write(f"GOOGLE_ACCESS_TOKEN={new_access_token}\n")
@@ -1035,7 +1035,7 @@ class Gmail:
 
         # Write emails CSV
         if self.emails_csv:
-            with open(self.emails_csv, 'w', newline='') as f:
+            with open(self.emails_csv, 'w', newline='', encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=['id', 'thread_id', 'from_email', 'to_email', 'subject', 'date', 'snippet'])
                 writer.writeheader()
                 writer.writerows(email_records)
@@ -1043,7 +1043,7 @@ class Gmail:
         # Write contacts CSV (OVERWRITES - use sync_contacts to preserve CRM data)
         if self.contacts_csv:
             fieldnames = ['email', 'name', 'frequency', 'last_contact', 'type', 'company', 'relationship', 'priority', 'deal', 'next_contact_date', 'tags', 'notes']
-            with open(self.contacts_csv, 'w', newline='') as f:
+            with open(self.contacts_csv, 'w', newline='', encoding="utf-8") as f:
                 writer = csv.DictWriter(f, fieldnames=fieldnames)
                 writer.writeheader()
                 writer.writerows(sorted_contacts)
@@ -1301,7 +1301,7 @@ Emails:
         # Get existing email IDs from cache
         existing_ids = set()
         if os.path.exists(self.emails_csv):
-            with open(self.emails_csv, 'r') as f:
+            with open(self.emails_csv, 'r', encoding="utf-8") as f:
                 reader = csv.DictReader(f)
                 for row in reader:
                     existing_ids.add(row['id'])
@@ -1369,7 +1369,7 @@ Emails:
         # Append new emails to CSV
         fieldnames = ['id', 'thread_id', 'from_email', 'to_email', 'subject', 'date', 'body', 'snippet']
         file_exists = os.path.exists(self.emails_csv) and os.path.getsize(self.emails_csv) > 0
-        with open(self.emails_csv, 'a', newline='') as f:
+        with open(self.emails_csv, 'a', newline='', encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             if not file_exists:
                 writer.writeheader()
@@ -1403,7 +1403,7 @@ Emails:
         # Step 1: Load existing contacts with ALL data
         existing = {}
         if os.path.exists(self.contacts_csv):
-            with open(self.contacts_csv, 'r') as f:
+            with open(self.contacts_csv, 'r', encoding="utf-8") as f:
                 for row in csv.DictReader(f):
                     existing[row['email'].lower()] = dict(row)
 
@@ -1434,7 +1434,7 @@ Emails:
                       'relationship', 'priority', 'deal', 'next_contact_date', 'tags', 'notes']
         sorted_contacts = sorted(existing.values(), key=lambda x: int(x.get('frequency', 0)), reverse=True)
 
-        with open(self.contacts_csv, 'w', newline='') as f:
+        with open(self.contacts_csv, 'w', newline='', encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(sorted_contacts)
@@ -1453,7 +1453,7 @@ Emails:
         import csv
 
         contacts = []
-        with open(self.contacts_csv, 'r') as f:
+        with open(self.contacts_csv, 'r', encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 contacts.append(row)
@@ -1496,7 +1496,7 @@ Emails:
         # Read existing contacts
         contacts = []
         found = False
-        with open(self.contacts_csv, 'r') as f:
+        with open(self.contacts_csv, 'r', encoding="utf-8") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames
             for row in reader:
@@ -1526,7 +1526,7 @@ Emails:
             return f"Contact {email} not found in contacts.csv"
 
         # Write back
-        with open(self.contacts_csv, 'w', newline='') as f:
+        with open(self.contacts_csv, 'w', newline='', encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(contacts)
@@ -1575,7 +1575,7 @@ Emails:
         # Read all contacts
         contacts = []
         fieldnames = None
-        with open(self.contacts_csv, 'r') as f:
+        with open(self.contacts_csv, 'r', encoding="utf-8") as f:
             reader = csv.DictReader(f)
             fieldnames = reader.fieldnames
             for row in reader:
@@ -1588,7 +1588,7 @@ Emails:
                 contacts.append(row)
 
         # Write back
-        with open(self.contacts_csv, 'w', newline='') as f:
+        with open(self.contacts_csv, 'w', newline='', encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(contacts)

--- a/connectonion/useful_tools/google_calendar.py
+++ b/connectonion/useful_tools/google_calendar.py
@@ -153,10 +153,10 @@ class GoogleCalendar:
         # Update .env file if it exists
         env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
         if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
+            with open(env_file, 'r', encoding="utf-8") as f:
                 lines = f.readlines()
 
-            with open(env_file, 'w') as f:
+            with open(env_file, 'w', encoding="utf-8") as f:
                 for line in lines:
                     if line.startswith("GOOGLE_ACCESS_TOKEN="):
                         f.write(f"GOOGLE_ACCESS_TOKEN={new_access_token}\n")

--- a/connectonion/useful_tools/memory.py
+++ b/connectonion/useful_tools/memory.py
@@ -144,12 +144,12 @@ class Memory:
         """Write to single memory file."""
         if not os.path.exists(self.memory_file):
             # Create new file
-            with open(self.memory_file, 'w') as f:
+            with open(self.memory_file, 'w', encoding="utf-8") as f:
                 f.write(f"## {key}\n\n{content}\n\n")
             return f"Memory saved: {key}"
 
         # Read and parse existing file
-        with open(self.memory_file, 'r') as f:
+        with open(self.memory_file, 'r', encoding="utf-8") as f:
             file_content = f.read()
 
         sections = self._parse_sections(file_content)
@@ -157,7 +157,7 @@ class Memory:
 
         # Write back
         new_content = self._serialize_sections(sections)
-        with open(self.memory_file, 'w') as f:
+        with open(self.memory_file, 'w', encoding="utf-8") as f:
             f.write(new_content)
 
         # Check if we need to split
@@ -173,7 +173,7 @@ class Memory:
         if not os.path.exists(self.memory_file):
             return f"Memory not found: {key}\nNo memories stored yet"
 
-        with open(self.memory_file, 'r') as f:
+        with open(self.memory_file, 'r', encoding="utf-8") as f:
             file_content = f.read()
 
         sections = self._parse_sections(file_content)
@@ -189,7 +189,7 @@ class Memory:
         if not os.path.exists(self.memory_file):
             return "No memories stored yet"
 
-        with open(self.memory_file, 'r') as f:
+        with open(self.memory_file, 'r', encoding="utf-8") as f:
             file_content = f.read()
 
         sections = self._parse_sections(file_content)
@@ -209,7 +209,7 @@ class Memory:
         if not os.path.exists(self.memory_file):
             return "No memories to search"
 
-        with open(self.memory_file, 'r') as f:
+        with open(self.memory_file, 'r', encoding="utf-8") as f:
             file_content = f.read()
 
         sections = self._parse_sections(file_content)
@@ -283,7 +283,7 @@ class Memory:
         # Write each section to its own file
         for key, content in sections.items():
             filepath = os.path.join(self.memory_dir, f"{key}.md")
-            with open(filepath, 'w') as f:
+            with open(filepath, 'w', encoding="utf-8") as f:
                 f.write(content)
 
         # Remove single file
@@ -297,7 +297,7 @@ class Memory:
         """Write to directory structure."""
         os.makedirs(self.memory_dir, exist_ok=True)
         filepath = os.path.join(self.memory_dir, f"{key}.md")
-        with open(filepath, 'w') as f:
+        with open(filepath, 'w', encoding="utf-8") as f:
             f.write(content)
         return f"Memory saved: {key}"
 
@@ -313,7 +313,7 @@ class Memory:
             available = ", ".join(sorted(files)) if files else "none"
             return f"Memory not found: {key}\nAvailable memories: {available}"
 
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding="utf-8") as f:
             content = f.read()
 
         return f"Memory: {key}\n\n{content}"
@@ -356,7 +356,7 @@ class Memory:
             key = filename.replace('.md', '')
             filepath = os.path.join(self.memory_dir, filename)
 
-            with open(filepath, 'r') as f:
+            with open(filepath, 'r', encoding="utf-8") as f:
                 content = f.read()
                 lines = content.split('\n')
 

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -127,10 +127,10 @@ class MicrosoftCalendar:
 
         env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
         if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
+            with open(env_file, 'r', encoding="utf-8") as f:
                 lines = f.readlines()
 
-            with open(env_file, 'w') as f:
+            with open(env_file, 'w', encoding="utf-8") as f:
                 for line in lines:
                     if line.startswith("MICROSOFT_ACCESS_TOKEN="):
                         f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -139,10 +139,10 @@ class Outlook:
         # Update .env file if it exists
         env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
         if os.path.exists(env_file):
-            with open(env_file, 'r') as f:
+            with open(env_file, 'r', encoding="utf-8") as f:
                 lines = f.readlines()
 
-            with open(env_file, 'w') as f:
+            with open(env_file, 'w', encoding="utf-8") as f:
                 for line in lines:
                     if line.startswith("MICROSOFT_ACCESS_TOKEN="):
                         f.write(f"MICROSOFT_ACCESS_TOKEN={new_access_token}\n")

--- a/connectonion/useful_tools/read_file.py
+++ b/connectonion/useful_tools/read_file.py
@@ -165,7 +165,7 @@ def _read_video(file_path: Path) -> str:
         proc = subprocess.run(
             ["ffmpeg", "-y", "-i", str(file_path),
              "-vn", "-ac", "1", "-b:a", "64k", str(audio_path)],
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
         )
         if proc.returncode != 0 or not audio_path.exists():
             return f"Error: failed to extract audio from '{file_path}':\n{proc.stderr[-500:]}"

--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -166,7 +166,7 @@ def get_agent_email() -> Optional[str]:
         return None
 
     try:
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
         agent_config = config.get("agent", {})
 

--- a/connectonion/useful_tools/shell.py
+++ b/connectonion/useful_tools/shell.py
@@ -24,7 +24,19 @@ Note: Uses system default shell (bash/sh on Unix, cmd on Windows).
 For Unix-specific bash, use the `bash` function from bash.py instead.
 """
 
+import os
 import subprocess
+
+
+def _utf8_env() -> dict:
+    """Child env that forces UTF-8 I/O regardless of the console codepage.
+
+    On non-UTF-8 Windows locales (Chinese GBK/cp936, Japanese cp932, ...) a child
+    Python process would otherwise encode its stdout with the legacy codepage and
+    crash on emoji/non-local characters. PYTHONUTF8/PYTHONIOENCODING make it emit
+    UTF-8, which pairs with our UTF-8 decoding of the pipe below.
+    """
+    return {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
 
 
 class Shell:
@@ -56,8 +68,11 @@ class Shell:
                 shell=True,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=self.cwd,
-                timeout=timeout
+                timeout=timeout,
+                env=_utf8_env(),
             )
         except subprocess.TimeoutExpired:
             return f"Error: Command timed out after {timeout} seconds"
@@ -83,8 +98,11 @@ class Shell:
                 shell=True,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 cwd=directory,
-                timeout=timeout
+                timeout=timeout,
+                env=_utf8_env(),
             )
         except subprocess.TimeoutExpired:
             return f"Error: Command timed out after {timeout} seconds"

--- a/connectonion/useful_tools/slash_command.py
+++ b/connectonion/useful_tools/slash_command.py
@@ -96,7 +96,7 @@ class SlashCommand:
             yaml.YAMLError: If frontmatter is invalid
             ValueError: If required fields missing
         """
-        content = filepath.read_text()
+        content = filepath.read_text(encoding="utf-8")
 
         # Split frontmatter and prompt
         if not content.startswith("---"):

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -82,6 +82,34 @@ is_global = co_dir.resolve() == (Path.home() / ".co").resolve()  # ✅ Works!
 # Both normalize to same canonical path
 ```
 
+### Problem 4: Subprocess Encoding (GBK/cp936)
+
+**Before:**
+```
+UnicodeDecodeError: 'gbk' codec can't decode byte 0x?? in position ...:
+illegal multibyte sequence
+```
+
+**Why it failed:**
+- Chinese/Japanese/Korean Windows uses a legacy locale codepage (GBK/cp936, cp932) as the default text encoding — **not UTF-8**
+- `subprocess` with `text=True` but no explicit `encoding` decodes a child process's stdout/stderr with that codepage
+- When `co ai` (or the `Shell`/background tools) ran a command that emitted UTF-8/emoji output, the reader crashed with `UnicodeDecodeError` — and a child printing emoji to a GBK console raised `UnicodeEncodeError`
+- Note: v0.3.5 fixed **file** I/O; this was the remaining **subprocess pipe** gap (see issue #230)
+
+**After:**
+```python
+# All subprocess calls pin UTF-8 and never crash on a stray byte
+subprocess.run(cmd, text=True, encoding="utf-8", errors="replace", ...)
+
+# Command runners also force child processes to emit UTF-8 regardless of codepage
+env = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
+```
+
+**Fixed in:**
+- `useful_tools/shell.py`, `useful_tools/bash.py`, `useful_tools/read_file.py`
+- `cli/co_ai/tools/background.py` (the `co ai` background runner)
+- `cli/co_ai/context.py`, `cli/co_ai/commands/undo.py` (git subprocess calls)
+
 ## User Journey: Windows with Chinese Username
 
 ### Scenario: User "王小明" installing ConnectOnion
@@ -205,6 +233,11 @@ New tests in `tests/unit/test_windows_compat.py`:
 - ✅ chmod skipped on Windows, applied on Unix
 - ✅ Path comparison with `.resolve()`
 - ✅ Round-trip encoding (write → read → same content)
+- ✅ Subprocess pipe decodes UTF-8/emoji even when the locale reports GBK/cp936
+- ✅ Subprocess survives non-UTF-8 bytes (`errors="replace"`, no crash)
+
+A real Windows E2E job (`.github/workflows/tests.yml` → `windows-e2e`) also runs the
+shipped `Shell` + background runner under an actual `chcp 936` (GBK) console.
 
 ## Supported Characters
 

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -110,6 +110,37 @@ env = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
 - `cli/co_ai/tools/background.py` (the `co ai` background runner)
 - `cli/co_ai/context.py`, `cli/co_ai/commands/undo.py` (git subprocess calls)
 
+### Problem 5: Console Output Codepage
+
+**Before:**
+```
+UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f680' ...
+```
+
+**Why it failed:**
+- The `co` CLI prints emoji and box-drawing characters (Rich output). On a GBK/cp1252 console, `sys.stdout` uses that codepage, so any non-encodable character crashes the command — including when `co`/`co ai` is driven through a pipe by another tool.
+
+**After:**
+```python
+# connectonion/cli/main.py — reconfigure the CLI's own streams before anything prints
+if sys.platform == "win32":
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+```
+
+`co ai` is a subcommand of the `co` app, so it inherits this reconfigure automatically.
+
+### Comprehensive UTF-8 coverage
+
+Beyond the specific traceback fixes above, a full audit now pins **every** text-mode
+file read/write in the package to `encoding="utf-8"` (`open()`, `Path.read_text()`,
+`Path.write_text()`) — CSV contact/email exports, `.env`/keys files, session storage,
+memory JSON, eval YAML, skills manifests, prompt assembly, and browser-daemon
+pid/lock files. Binary I/O (images, tarballs, raw fds) is intentionally left alone.
+The three encoding directions — **file I/O**, **subprocess pipes**, and **console
+output** — are now all UTF-8 regardless of the Windows locale codepage.
+
 ## User Journey: Windows with Chinese Username
 
 ### Scenario: User "王小明" installing ConnectOnion

--- a/tests/unit/test_windows_compat.py
+++ b/tests/unit/test_windows_compat.py
@@ -19,12 +19,26 @@ Components under test:
 
 import tempfile
 import sys
+import time
 import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 from connectonion import address
 from connectonion.console import Console
+
+
+# Codepoints for "中文测试🚀" (CJK + an emoji outside the BMP). We build the string
+# from codepoints so the *command line* stays pure ASCII — the child process
+# generates the Unicode itself and writes it to stdout. This isolates the pipe
+# decoding path (the actual bug) from Windows command-line argument encoding.
+_CJK_CODEPOINTS = [20013, 25991, 27979, 35797, 128640]
+_CJK_TEXT = "".join(chr(c) for c in _CJK_CODEPOINTS)
+
+
+def _py(code: str) -> str:
+    """A shell command that runs `code` in this interpreter (path safely quoted)."""
+    return f'"{sys.executable}" -c "{code}"'
 
 
 class TestUTF8Encoding:
@@ -109,6 +123,68 @@ class TestUTF8Encoding:
             # Read back with UTF-8 (critical test!)
             content = log_file.read_text(encoding='utf-8')
             assert "Test message with emoji 🚀" in content
+
+
+class TestSubprocessUTF8:
+    """Subprocess pipe I/O must decode as UTF-8 regardless of the console codepage.
+
+    On Chinese/Japanese/etc. Windows the default text encoding is a legacy codepage
+    (GBK/cp936, cp932). With `text=True` but no explicit `encoding`, subprocess would
+    decode child output with that codepage and raise UnicodeDecodeError on UTF-8/emoji
+    bytes — which is what broke `co ai` (see issue #230). These tests pin the encoding
+    to UTF-8 and prove it no longer depends on the ambient locale.
+    """
+
+    def test_shell_decodes_utf8_output_even_when_locale_claims_gbk(self, monkeypatch):
+        """Shell.run() returns CJK+emoji intact even if the locale says cp936."""
+        # Simulate a Chinese Windows box: locale reports GBK. Our explicit
+        # encoding="utf-8" must win over this.
+        monkeypatch.setattr("locale.getpreferredencoding", lambda *a, **k: "cp936")
+
+        from connectonion.useful_tools.shell import Shell
+
+        shell = Shell()
+        code = f"print(''.join(chr(c) for c in {_CJK_CODEPOINTS}))"
+        out = shell.run(_py(code))
+
+        assert _CJK_TEXT in out
+
+    def test_shell_survives_non_utf8_bytes(self, monkeypatch):
+        """A stray non-UTF-8 byte is replaced, not fatal (errors='replace')."""
+        monkeypatch.setattr("locale.getpreferredencoding", lambda *a, **k: "cp936")
+
+        from connectonion.useful_tools.shell import Shell
+
+        shell = Shell()
+        # Write a lone 0xFF byte (invalid UTF-8) between valid text.
+        code = r"import sys; sys.stdout.buffer.write(b'ok\xff done')"
+        out = shell.run(_py(code))
+
+        # Must not raise; surrounding text is preserved.
+        assert "ok" in out and "done" in out
+
+    def test_background_task_decodes_utf8_output(self, monkeypatch):
+        """run_background()'s reader thread must not die on UTF-8/emoji output."""
+        monkeypatch.setattr("locale.getpreferredencoding", lambda *a, **k: "cp936")
+
+        from connectonion.cli.co_ai.tools import background as bg
+
+        bg._reset_for_testing()
+        code = f"print(''.join(chr(c) for c in {_CJK_CODEPOINTS}))"
+        bg.run_background(_py(code))
+
+        # Wait for the reader thread + process to finish.
+        deadline = time.time() + 15
+        task = None
+        while time.time() < deadline:
+            task = bg._tasks.get("bg_1")
+            if task and task.status != bg.TaskStatus.RUNNING:
+                break
+            time.sleep(0.05)
+
+        assert task is not None
+        assert task.status == bg.TaskStatus.COMPLETED, f"reader thread failed: {task.status}"
+        assert _CJK_TEXT in bg.task_output("bg_1")
 
 
 class TestChmodPlatformCheck:


### PR DESCRIPTION
## Description
On Chinese/Japanese/etc. Windows the default text encoding is a legacy codepage (GBK/cp936, cp932), not UTF-8. Any code path that relied on that default would crash with `UnicodeDecodeError` / `UnicodeEncodeError` on non-ASCII/emoji content. This PR makes all **three** encoding directions UTF-8 regardless of the Windows locale:

1. **Subprocess pipes** — `text=True` with no explicit encoding decoded child output with the locale codepage, crashing `co ai` and the shell/background tools.
2. **File I/O** — many `open()`/`read_text()`/`write_text()` calls had no explicit encoding, so reads/writes of CSVs, `.env`/keys, session storage, memory JSON, etc. used the locale codepage.
3. **Console output** — printing emoji/box-drawing to a GBK/cp1252 console. (Already handled by `cli/main.py` reconfiguring its streams; `co ai` inherits it as a subcommand — documented here for completeness.)

## Related Issue
Fixes #230

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made
**Subprocess pipe I/O** — added `encoding="utf-8", errors="replace"` (a stray byte never crashes a run) to every subprocess that reads child output; command runners also inject `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` so children *emit* UTF-8:
- `useful_tools/shell.py`, `useful_tools/bash.py`, `useful_tools/read_file.py`
- `cli/co_ai/tools/background.py` (the `co ai` background runner)
- `cli/co_ai/context.py`, `cli/co_ai/commands/undo.py` (git calls)

**File I/O sweep** — an AST audit found every text-mode file read/write missing an explicit encoding; all now pinned to `encoding="utf-8"` (94 sites across 34 files): Gmail CSV contact/email exports, `.env`/keys files, memory JSON, calendar/outlook, session storage, eval YAML, skills manifests, co_ai prompt assembly, browser-daemon pid/lock files, and more. Binary I/O (PIL `Image.open`, `tarfile`, `os.open`) and non-file calls (`webbrowser.open`) were deliberately left unchanged.

**Tests** — new `TestSubprocessUTF8` in `tests/unit/test_windows_compat.py`: monkeypatches `locale.getpreferredencoding` → `cp936` and proves CJK/emoji round-trips, that non-UTF-8 bytes are replaced (no crash), and that the background reader thread survives.

**CI** — new `windows-e2e` step runs the shipped `Shell` + background runner under a real `chcp 936` (GBK) console with `PYTHONUTF8=0`.

**Docs** — `docs/windows-support.md` gains Problem 4 (subprocess), Problem 5 (console), and a "Comprehensive UTF-8 coverage" summary.

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

Targeted tests for every touched area pass (91 passed across memory/gmail/windows_compat/read_file/co_ai). The full unit suite shows **35 pre-existing failures unchanged** (no new failures from this PR) — they need `OPENONION_API_KEY`/`.env` and are filed separately as #232 and #223. Whole package compiles; audit confirms only legitimate binary/non-file calls remain without encoding.

## Additional Notes
`errors="replace"` is used only on the subprocess *pipe* reads (a long command's output must degrade gracefully, not die on one bad byte). File I/O uses plain `encoding="utf-8"` to match the existing v0.3.5 convention. Bytes-only calls (e.g. `git rev-parse` checking a return code, `os.open` fds) were intentionally left unchanged.
