### PR TITLE
Make bash tool's `description` optional (prerequisite for remote exec)

### DIFF
--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [subprocess, platform] | imported by [useful_tools/__init__.py, useful_prompts/coding_agent/assembler.py] | tested by command execution
   Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() with shell=True → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
-  Integration: exposes bash(command, description, cwd, timeout) function | used as agent tool | description parameter for user clarity (not passed to shell) | Unix/Mac only (raises ValueError on Windows)
+  Integration: exposes bash(command, description="", cwd, timeout) function | used as agent tool | description is OPTIONAL (defaults "") — an LLM is prompted to fill it for the approval UI, but direct/programmatic callers (remote.call, co call, scripts) can pass command alone | not passed to shell | Unix/Mac only (raises ValueError on Windows)
   Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
   Errors: raises ValueError on Windows | returns formatted error on timeout | non-zero exit codes included in output | stderr merged with stdout
 
@@ -27,12 +27,14 @@ import subprocess
 import platform
 
 
-def bash(command: str, description: str, cwd: str = ".", timeout: int = 120) -> str:
+def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120) -> str:
     """Execute a bash command, returns output (Unix/Mac only).
 
     Args:
         command: Bash command to execute (e.g., "ls -la", "git status")
-        description: What this command does (e.g., "Install dependencies")
+        description: What this command does (e.g., "Install dependencies"). Optional
+            — an LLM should fill it in so the approval UI can show intent, but direct
+            callers (scripts, remote.call, co call) may pass just the command.
         cwd: Working directory (default: current directory)
         timeout: Seconds before timeout (default: 120, max: 600)
 

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -137,6 +137,24 @@ class TestBashBasic:
         result = bash("echo hello", "Echo test")
         assert "hello" in result
 
+    def test_bash_command_only_no_description(self):
+        """description is optional: a direct/programmatic caller (remote.call, co
+        call, a script) may pass just the command without a TypeError."""
+        result = bash("echo hi")
+        assert "hi" in result
+        # keyword form (exactly what remote.call('bash', command=...) does)
+        assert "hi" in bash(command="echo hi")
+
+    def test_bash_description_optional_in_schema(self):
+        """The LLM still sees description (docstring guides it) but it is not
+        required, so the tool is callable with command alone."""
+        from connectonion import create_tool_from_function
+        tool = create_tool_from_function(bash)
+        schema = tool.get_parameters_schema()
+        assert "description" in schema["properties"]
+        assert "command" in schema["required"]
+        assert "description" not in schema["required"]
+
     def test_bash_returns_stdout(self):
         """Test that stdout is captured."""
         result = bash("echo 'test output'", "Echo test output")


### PR DESCRIPTION
## Description
Make the `bash` tool's `description` parameter optional (default `""`) so it can be called with just a command. This is **PR A**, the prerequisite in a 3-PR split for remote browser control.

## Related Issue
Fixes #235

## Merge order (3-PR split)

This work is split into three PRs that must merge in order:

1. **A — this PR** (`#235`) — make `bash`'s `description` optional
2. **B — `#225`** — direct tool execution (`remote.call` / `co call` / whitelist)
3. **C — `#234`** — templates drive the browser via the `co browser` CLI

**A → B → C.** A lands first: B's documented `remote.call("bash", command=...)` path (and `co call <addr> co browser ...`) TypeErrors until `description` is optional. C then makes the shipped templates exercise B end to end.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- `connectonion/useful_tools/bash.py`: `description: str` → `description: str = ""`; docstring + LLM-Note updated to say it's optional (LLM should still fill it for the approval UI; direct callers may pass command alone).
- `tests/unit/test_shell_tool.py`: two regression tests — `bash(command=...)` works without a description, and the tool schema keeps `description` in `properties` but out of `required`.

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

`tests/unit/test_shell_tool.py` bash suite: 13 passed. Verified: `bash(command="echo hi")` returns output (previously `TypeError`), positional `bash("cmd", "desc")` unchanged, and the LLM schema lists `command` as required / `description` as optional.

## Example Usage
```python
from connectonion.useful_tools.bash import bash

bash(command="echo hi")          # now works — was: TypeError: missing 'description'
bash("ls -la", "list files")     # unchanged — LLM still supplies a description
```

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published

## Additional Notes
Why this was invisible until now: the LLM always fills `description`, so the agent path worked; only programmatic callers (`remote.call`, `co call`, scripts) hit the missing-arg error. The approval UI already read `description` defensively (`tool_args.get('description', '')`), so nothing downstream breaks when it's empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ec7tTubZigVqwNjb6qQ6T

---
_Generated by [Claude Code](https://claude.ai/code/session_014ec7tTubZigVqwNjb6qQ6T)_