### PR TITLE
Add Outlook contact management to the CLI

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -1,11 +1,11 @@
 """
-Purpose: CLI surface for the user's Outlook mailbox — send, list (inbox/sent/scheduled), read, reply, and search from the terminal
+Purpose: CLI surface for Outlook email and contacts — send/read/search mail and add/list/search contacts from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env → Outlook() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/outlook_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin, attachments prechecked, --at validated to UTC ISO → send() | scheduled: get_scheduled() → read-only table (To/Subject/Sends at), plain full-id lines when piped; does NOT touch the numbering cache
-  State/Effects: writes ~/.co/outlook_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read marks emails read server-side | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
-  Integration: exposes handle_outlook_send(), handle_outlook_inbox(), handle_outlook_read(), handle_outlook_reply(), handle_outlook_sent(), handle_outlook_search(), handle_outlook_scheduled() for cli/main.py | presentation mirrors email_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
-  Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, missing/oversized attachments, invalid --at, unresolvable email # | Graph API errors propagate from the Outlook tool | scheduled sends can't be cancelled via API (Exchange 403) — the listing hints at Outlook's own Cancel Send
+  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env and checks the operation scope → Outlook() instance | mail commands use list/read/send methods and the numbered inbox cache | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
+  State/Effects: writes ~/.co/outlook_last_inbox.json for mail numbering | mutates Outlook mail/contact data through the library | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes handle_outlook_* functions for cli/main.py, including handle_outlook_contact_add/list/search | presentation mirrors existing mail tables | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
+  Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/Mail/Contacts.ReadWrite scopes, invalid files/times/ids | Graph API errors propagate from Outlook
 """
 
 import json
@@ -25,15 +25,28 @@ INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 ATTACHMENT_LIMIT = 3_000_000  # Graph sendMail rejects larger payloads
 
 
-def _outlook():
-    """Load MICROSOFT_* credentials from .env files and return an Outlook instance. Exits 1 with a hint if not connected."""
+def _outlook(required_scope: str = "Mail"):
+    """Load Microsoft credentials and require Mail or an exact Graph scope."""
     from dotenv import load_dotenv
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
         if env_path.exists():
             load_dotenv(env_path)
 
-    if not os.getenv("MICROSOFT_ACCESS_TOKEN") or "Mail" not in os.getenv("MICROSOFT_SCOPES", ""):
+    scopes = set(os.getenv("MICROSOFT_SCOPES", "").replace(",", " ").split())
+    has_scope = (
+        any(scope.startswith("Mail.") for scope in scopes)
+        if required_scope == "Mail"
+        else required_scope in scopes
+    )
+    if not os.getenv("MICROSOFT_ACCESS_TOKEN") or not has_scope:
+        if os.getenv("MICROSOFT_ACCESS_TOKEN") and required_scope != "Mail":
+            console.print(
+                f"\n❌ [bold red]Microsoft {required_scope} permission missing[/bold red]"
+            )
+            console.print("\n[cyan]Reconnect Microsoft to grant it:[/cyan]")
+            console.print("  [bold]co auth microsoft[/bold]\n")
+            raise typer.Exit(1)
         console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
         console.print("\n[cyan]Connect Outlook first:[/cyan]")
         console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")
@@ -237,6 +250,61 @@ def handle_outlook_search(query: str, last: int = 10):
         console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
         return
     _print_listing(outlook, emails, f"🔎 Outlook — {query}")
+
+
+def _print_contacts(contacts: list, title: str):
+    """Render contacts as a table, or stable tab-separated rows when piped."""
+    if not console.is_terminal:
+        for contact in contacts:
+            console.print(
+                f"{contact['name']}\t{contact['email']}\t{contact['id']}",
+                markup=False,
+                highlight=False,
+            )
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("Name", max_width=36, no_wrap=True)
+    table.add_column("Email", max_width=48, no_wrap=True)
+    for index, contact in enumerate(contacts, 1):
+        table.add_row(str(index), contact["name"], contact["email"])
+    console.print()
+    console.print(table)
+    console.print()
+
+
+def handle_outlook_contact_add(name: str, email: str):
+    """Create a contact in the connected Outlook account."""
+    outlook = _outlook(required_scope="Contacts.ReadWrite")
+    contact = outlook.add_contact(name, email)
+    console.print(
+        f"\n[green]✓ Saved contact[/green] "
+        f"[bold]{contact['name']}[/bold] <[cyan]{contact['email']}[/cyan]>\n"
+    )
+
+
+def handle_outlook_contact_list(last: int = 25):
+    """List contacts from the connected Outlook account."""
+    outlook = _outlook(required_scope="Contacts.ReadWrite")
+    contacts = outlook.list_contacts(max_results=last)
+    if not contacts:
+        console.print("\n[cyan]Outlook contacts:[/cyan] none saved\n")
+        return
+    _print_contacts(contacts, "👥 Outlook contacts")
+
+
+def handle_outlook_contact_search(query: str, last: int = 25):
+    """Search Outlook contacts by name or email."""
+    outlook = _outlook(required_scope="Contacts.ReadWrite")
+    contacts = outlook.search_contacts(query, max_results=last)
+    if not contacts:
+        console.print(
+            f"\n[cyan]Contact search:[/cyan] no contacts matching "
+            f"[bold]{query}[/bold]\n"
+        )
+        return
+    _print_contacts(contacts, f"🔎 Outlook contacts — {query}")
 
 
 def handle_outlook_scheduled():

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -26,30 +26,25 @@ ATTACHMENT_LIMIT = 3_000_000  # Graph sendMail rejects larger payloads
 
 
 def _outlook(required_scope: str = "Mail"):
-    """Load Microsoft credentials and require Mail or an exact Graph scope."""
+    """Load Microsoft credentials and require the Graph scope this command needs."""
     from dotenv import load_dotenv
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
         if env_path.exists():
             load_dotenv(env_path)
 
-    scopes = set(os.getenv("MICROSOFT_SCOPES", "").replace(",", " ").split())
-    has_scope = (
-        any(scope.startswith("Mail.") for scope in scopes)
-        if required_scope == "Mail"
-        else required_scope in scopes
-    )
-    if not os.getenv("MICROSOFT_ACCESS_TOKEN") or not has_scope:
-        if os.getenv("MICROSOFT_ACCESS_TOKEN") and required_scope != "Mail":
-            console.print(
-                f"\n❌ [bold red]Microsoft {required_scope} permission missing[/bold red]"
-            )
-            console.print("\n[cyan]Reconnect Microsoft to grant it:[/cyan]")
-            console.print("  [bold]co auth microsoft[/bold]\n")
-            raise typer.Exit(1)
+    if not os.getenv("MICROSOFT_ACCESS_TOKEN"):
         console.print("\n❌ [bold red]Microsoft account not connected[/bold red]")
         console.print("\n[cyan]Connect Outlook first:[/cyan]")
         console.print("  [bold]co auth microsoft[/bold]     Authorize Outlook access\n")
+        raise typer.Exit(1)
+
+    # "Mail" matches any Mail.* grant; "Contacts.ReadWrite" matches only itself.
+    scopes = os.getenv("MICROSOFT_SCOPES", "").replace(",", " ").split()
+    if not any(s == required_scope or s.startswith(f"{required_scope}.") for s in scopes):
+        console.print(f"\n❌ [bold red]Microsoft {required_scope} permission missing[/bold red]")
+        console.print("\n[cyan]Reconnect Microsoft to grant it:[/cyan]")
+        console.print("  [bold]co auth microsoft[/bold]     Re-authorize with the new scope\n")
         raise typer.Exit(1)
 
     from ...useful_tools.outlook import Outlook

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -74,7 +74,7 @@ def _show_help():
     console.print("  [green]deploy[/green]            Deploy to ConnectOnion Cloud")
     console.print("  [green]auth[/green]              Authenticate for managed keys")
     console.print("  [green]email[/green]             Send and read agent email")
-    console.print("  [green]outlook[/green]           Send and read Outlook email (co auth microsoft)")
+    console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
     console.print("  [green]status[/green]            Check account balance")
@@ -458,6 +458,42 @@ def outlook_callback(ctx: typer.Context):
     if ctx.invoked_subcommand is None:
         from .commands.outlook_commands import handle_outlook_inbox
         handle_outlook_inbox()
+
+
+outlook_contact_app = typer.Typer(
+    help="Add, list, and search Outlook contacts.",
+    no_args_is_help=True,
+)
+outlook_app.add_typer(outlook_contact_app, name="contact")
+
+
+@outlook_contact_app.command("add")
+def outlook_contact_add(
+    name: str = typer.Argument(..., help="Contact display name"),
+    email: str = typer.Argument(..., help="Contact email address"),
+):
+    """Save a contact with a name and email address."""
+    from .commands.outlook_commands import handle_outlook_contact_add
+    handle_outlook_contact_add(name, email)
+
+
+@outlook_contact_app.command("list")
+def outlook_contact_list(
+    last: int = typer.Option(25, "--last", "-n", help="How many contacts to show"),
+):
+    """List saved Outlook contacts."""
+    from .commands.outlook_commands import handle_outlook_contact_list
+    handle_outlook_contact_list(last=last)
+
+
+@outlook_contact_app.command("search")
+def outlook_contact_search(
+    query: str = typer.Argument(..., help="Name or email substring"),
+    last: int = typer.Option(25, "--last", "-n", help="How many matches to show"),
+):
+    """Search saved Outlook contacts by name or email."""
+    from .commands.outlook_commands import handle_outlook_contact_search
+    handle_outlook_contact_search(query, last=last)
 
 
 @outlook_app.command("send", epilog="Examples:  co outlook send a@b.com \"Hi\" \"Quick note\"  |  "

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -1,10 +1,10 @@
 """
-Purpose: Outlook integration tool for reading, sending, scheduling, and managing emails via Microsoft Graph API
+Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (email summaries, bodies, send confirmations) | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() pages the drafts folder (Graph rejects $filter on the property) and returns dicts (id, subject, to, send_at)
-  State/Effects: reads MICROSOFT_* env vars for OAuth tokens | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) | token refresh rewrites ~/.co/keys.env | no other local file persistence
-  Integration: exposes Outlook class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), send(), reply(), get_scheduled(), mark_read(), archive_email() | list_inbox()/list_search()/get_scheduled() return dicts for the CLI (cli/commands/outlook_commands.py) | used as agent tool via Agent(tools=[Outlook()])
+  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) and create contacts | token refresh rewrites ~/.co/keys.env | no other local file persistence
+  Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
 
@@ -24,6 +24,9 @@ Usage:
     # - send(to, subject, body, cc, bcc, attachments, send_at)
     # - reply(email_id, body, send_at)
     # - get_scheduled(max_results)
+    # - add_contact(name, email)
+    # - list_contacts(max_results)
+    # - search_contacts(query, max_results)
     # - mark_read(email_id)
     # - archive_email(email_id)
 
@@ -43,12 +46,12 @@ Example:
 
 import html
 import os
-from datetime import datetime, timedelta
+
 import httpx
 
 
 class Outlook:
-    """Outlook tool for reading and managing emails via Microsoft Graph API."""
+    """Outlook tool for managing email and contacts via Microsoft Graph API."""
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
 
@@ -59,15 +62,30 @@ class Outlook:
         Raises ValueError if credentials are missing.
         """
         scopes = os.getenv("MICROSOFT_SCOPES", "")
-        if not scopes or "Mail" not in scopes:
+        granted_scopes = set(scopes.replace(",", " ").split())
+        has_outlook_scope = any(
+            scope.startswith(("Mail.", "Contacts."))
+            for scope in granted_scopes
+        )
+        if not has_outlook_scope:
             raise ValueError(
-                "Missing Microsoft Mail scopes.\n"
+                "Missing Microsoft Mail scopes or Contacts scope.\n"
                 f"Current scopes: {scopes}\n"
                 "Please authorize Microsoft access:\n"
                 "  co auth microsoft"
             )
 
         self._access_token = None
+
+    def _require_scope(self, required_scope: str) -> None:
+        """Raise a re-consent hint when an operation's OAuth scope is absent."""
+        scopes = set(os.getenv("MICROSOFT_SCOPES", "").replace(",", " ").split())
+        if required_scope not in scopes:
+            raise ValueError(
+                f"Missing Microsoft {required_scope} scope.\n"
+                "Reconnect Microsoft access to grant it:\n"
+                "  co auth microsoft"
+            )
 
     def _get_access_token(self) -> str:
         """Get Microsoft access token, refreshing once per Outlook instance.
@@ -325,6 +343,77 @@ class Outlook:
             return f"No emails found matching query: {query}"
         return self._format_dicts(emails)
 
+    # === Contacts ===
+
+    @staticmethod
+    def _contact_dict(contact: dict) -> dict:
+        """Normalize a Graph contact to the CLI/agent contact shape."""
+        addresses = [
+            item.get("address", "")
+            for item in contact.get("emailAddresses", [])
+            if item.get("address")
+        ]
+        return {
+            "id": contact.get("id", ""),
+            "name": contact.get("displayName", ""),
+            "email": ", ".join(addresses),
+        }
+
+    def _iter_contacts(self):
+        """Yield normalized contacts from every Graph contacts page."""
+        endpoint = (
+            "/me/contacts"
+            "?$select=id,displayName,emailAddresses"
+            "&$orderby=displayName&$top=100"
+        )
+        while endpoint:
+            result = self._request("GET", endpoint)
+            for contact in result.get("value", []):
+                yield self._contact_dict(contact)
+            next_link = result.get("@odata.nextLink")
+            endpoint = next_link.replace(self.GRAPH_API_URL, "") if next_link else None
+
+    def add_contact(self, name: str, email: str) -> dict:
+        """Create an Outlook contact with a display name and email address."""
+        self._require_scope("Contacts.ReadWrite")
+        data = {
+            "displayName": name,
+            "emailAddresses": [{"name": name, "address": email}],
+        }
+        contact = self._contact_dict(
+            self._request("POST", "/me/contacts", json=data)
+        )
+        contact["name"] = contact["name"] or name
+        contact["email"] = contact["email"] or email
+        return contact
+
+    def list_contacts(self, max_results: int = 25) -> list:
+        """List Outlook contacts as dicts containing id, name, and email."""
+        self._require_scope("Contacts.ReadWrite")
+        if max_results < 1:
+            return []
+        contacts = []
+        for contact in self._iter_contacts():
+            contacts.append(contact)
+            if len(contacts) >= max_results:
+                break
+        return contacts
+
+    def search_contacts(self, query: str, max_results: int = 25) -> list:
+        """Find Outlook contacts by a case-insensitive name/email substring."""
+        self._require_scope("Contacts.ReadWrite")
+        needle = query.strip().casefold()
+        if not needle or max_results < 1:
+            return []
+        matches = []
+        for contact in self._iter_contacts():
+            searchable = f"{contact['name']} {contact['email']}".casefold()
+            if needle in searchable:
+                matches.append(contact)
+            if len(matches) >= max_results:
+                break
+        return matches
+
     # === Content ===
 
     def get_email_body(self, email_id: str) -> str:
@@ -493,7 +582,7 @@ class Outlook:
 
         if send_at:
             return f"Reply scheduled for {send_at}"
-        return f"Reply sent successfully"
+        return "Reply sent successfully"
 
     def get_scheduled(self, max_results: int = 25) -> list:
         """List emails waiting for scheduled delivery (deferred-send drafts).

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -1,7 +1,7 @@
 """
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
-  Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
+  Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
   Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) and create contacts | token refresh rewrites ~/.co/keys.env | no other local file persistence
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
@@ -380,12 +380,7 @@ class Outlook:
             "displayName": name,
             "emailAddresses": [{"name": name, "address": email}],
         }
-        contact = self._contact_dict(
-            self._request("POST", "/me/contacts", json=data)
-        )
-        contact["name"] = contact["name"] or name
-        contact["email"] = contact["email"] or email
-        return contact
+        return self._contact_dict(self._request("POST", "/me/contacts", json=data))
 
     def list_contacts(self, max_results: int = 25) -> list:
         """List Outlook contacts as dicts containing id, name, and email."""
@@ -400,7 +395,11 @@ class Outlook:
         return contacts
 
     def search_contacts(self, query: str, max_results: int = 25) -> list:
-        """Find Outlook contacts by a case-insensitive name/email substring."""
+        """Find Outlook contacts by a case-insensitive name/email substring.
+
+        Graph's $filter on contacts only does startswith on displayName, so
+        matching a substring of either name or email means paging client-side.
+        """
         self._require_scope("Contacts.ReadWrite")
         needle = query.strip().casefold()
         if not needle or max_results < 1:

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -224,10 +224,10 @@ details and current limitations.
 
 ---
 
-#### `co outlook` - Send & Read Outlook Email
+#### `co outlook` - Manage Outlook Email & Contacts
 
 Your personal Outlook account from the terminal, via Microsoft Graph.
-Requires `co auth microsoft` once (Mail scopes; saved as `MICROSOFT_*` in
+Requires `co auth microsoft` once (Mail/Contacts scopes; saved as `MICROSOFT_*` in
 `.env` / `~/.co/keys.env`).
 
 **Basic usage:**
@@ -237,6 +237,8 @@ co outlook inbox -n 25 -u                             # last 25, unread only
 co outlook read 3                                     # read #3 from the listing, mark read
 co outlook send bob@example.com "Hi" "Body text"      # send now
 co outlook send bob@example.com "Hi" - < body.txt     # body from stdin
+co outlook contact add "Zhou Yifei" zhou@example.com  # save contact
+co outlook contact search yifei                       # find by name/email
 ```
 
 **Subcommands:**
@@ -245,6 +247,9 @@ co outlook send bob@example.com "Hi" - < body.txt     # body from stdin
 - `co outlook send <to> <subject> <message>` - send, with `--cc`, `--bcc`, repeatable `--attach FILE` (~3MB Graph limit), and `--at` to schedule (`+30m`, `+2h`, or UTC ISO time — Exchange holds delivery)
 - `co outlook sent` - list recently sent emails
 - `co outlook search <query>` - search subject and body
+- `co outlook contact add <name> <email>` - save a contact
+- `co outlook contact list` - list saved contacts (`--last/-n`)
+- `co outlook contact search <query>` - find contacts by name or email
 
 The CLI wraps the same `Outlook` tool your agents use. See
 [outlook.md](outlook.md) for details.

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -1,8 +1,8 @@
 # Outlook CLI (co outlook)
 
-Send and read email from your Outlook account right in the terminal — the same
-Microsoft Graph access your agents get from the [Outlook tool](../useful_tools/outlook.md),
-as a command.
+Manage email and contacts from your Outlook account right in the terminal —
+the same Microsoft Graph access your agents get from the
+[Outlook tool](../useful_tools/outlook.md), as a command.
 
 ## Quick Start
 
@@ -18,13 +18,17 @@ co outlook read 3
 
 # Send a message
 co outlook send alice@example.com "Hello" "Thanks for the meeting today!"
+
+# Save and find contacts
+co outlook contact add "Zhou Yifei" zhouyifei0428@gmail.com
+co outlook contact search yifei
 ```
 
 That's the whole surface. Everything below is detail.
 
 ## Setup
 
-`co outlook` needs a connected Microsoft account with Mail scopes:
+`co outlook` needs a connected Microsoft account:
 
 ```bash
 co auth microsoft
@@ -32,11 +36,35 @@ co auth microsoft
 
 This opens the Microsoft OAuth flow and saves `MICROSOFT_*` credentials
 (access token, refresh token, scopes, email) to your project `.env` and
-`~/.co/keys.env`. Tokens auto-refresh. If credentials or Mail scopes are
-missing, any `co outlook` command tells you to run `co auth microsoft` first.
-See [Microsoft Integration](../integrations/microsoft.md) for scope details.
+`~/.co/keys.env`. Tokens auto-refresh.
+
+Contact commands require `Contacts.ReadWrite`. If you authenticated before
+contact support was added, run `co auth microsoft` once more to grant the new
+permission. See [Microsoft Integration](../integrations/microsoft.md) for all
+requested scopes.
 
 ## Commands
+
+### `co outlook contact` — Manage contacts
+
+Contacts start deliberately small: a display name and one email address.
+
+```bash
+# Create
+co outlook contact add "Zhou Yifei" zhouyifei0428@gmail.com
+
+# List (25 by default)
+co outlook contact list
+co outlook contact list -n 50
+
+# Find by a case-insensitive name or email substring
+co outlook contact search yifei
+co outlook contact search gmail.com -n 10
+```
+
+`list` and `search` print a Rich table in a terminal. When output is piped,
+each contact is a tab-separated `name`, `email`, and full Microsoft Graph ID,
+so scripts do not receive truncated values.
 
 ### `co outlook` — Show the inbox
 
@@ -183,6 +211,9 @@ Or call it directly:
 ```python
 outlook = Outlook()
 outlook.list_inbox(last=10, unread=True)
+outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.list_contacts(max_results=25)
+outlook.search_contacts("yifei")
 outlook.send(
     "alice@example.com", "Report", "See attached.",
     attachments=["report.pdf"],
@@ -194,6 +225,8 @@ outlook.send(
 
 - **"Microsoft account not connected"** → run `co auth microsoft`.
 - **Missing Mail scopes** → run `co auth microsoft` again to re-consent.
+- **Missing `Contacts.ReadWrite`** → run `co auth microsoft` again; an older
+  token cannot gain the new permission through refresh alone.
 - **Token expired** → tokens auto-refresh; if issues persist, re-run
   `co auth microsoft`.
 - **`No email #N in your inbox`** → the number is out of range; run

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -20,7 +20,7 @@ co outlook read 3
 co outlook send alice@example.com "Hello" "Thanks for the meeting today!"
 
 # Save and find contacts
-co outlook contact add "Zhou Yifei" zhouyifei0428@gmail.com
+co outlook contact add "Zhou Yifei" zhou@example.com
 co outlook contact search yifei
 ```
 
@@ -51,7 +51,7 @@ Contacts start deliberately small: a display name and one email address.
 
 ```bash
 # Create
-co outlook contact add "Zhou Yifei" zhouyifei0428@gmail.com
+co outlook contact add "Zhou Yifei" zhou@example.com
 
 # List (25 by default)
 co outlook contact list
@@ -211,7 +211,7 @@ Or call it directly:
 ```python
 outlook = Outlook()
 outlook.list_inbox(last=10, unread=True)
-outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.add_contact("Zhou Yifei", "zhou@example.com")
 outlook.list_contacts(max_results=25)
 outlook.search_contacts("yifei")
 outlook.send(

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -9,4 +9,4 @@ Connect ConnectOnion to external services.
 ## OAuth Integrations
 
 - [google.md](google.md) - Google OAuth (Gmail, Calendar)
-- [microsoft.md](microsoft.md) - Microsoft OAuth (Outlook, Calendar)
+- [microsoft.md](microsoft.md) - Microsoft OAuth (Outlook email, contacts, Calendar)

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -1,6 +1,6 @@
 # Microsoft Integration (co auth microsoft)
 
-> Send emails via Outlook and read calendar events from your AI agents. 30-second setup.
+> Manage Outlook email, contacts, and calendar events from your AI agents. 30-second setup.
 
 ---
 
@@ -13,11 +13,13 @@ co auth microsoft
 What happens:
 1. Clears any existing Microsoft connection (allows switching accounts)
 2. Opens browser to Microsoft OAuth consent screen
-3. You authorize Mail + Calendar permissions
+3. You authorize Mail + Contacts + Calendar permissions
 4. Credentials saved to `.env` (both local and global `~/.co/keys.env`)
 5. Ready to use Outlook and Microsoft Calendar tools immediately
 
-**That's it.** Your agents can now send emails via Outlook and read your Microsoft calendar. You can too, from the terminal — see [`co outlook`](../cli/outlook.md).
+**That's it.** Your agents can now manage Outlook email and contacts and read
+your Microsoft calendar. You can too, from the terminal — see
+[`co outlook`](../cli/outlook.md).
 
 **Switching accounts?** Just run `co auth microsoft` again - it will clear the old connection and let you pick a new Microsoft account.
 
@@ -44,7 +46,7 @@ After successful authentication, your `.env` file contains:
 MICROSOFT_ACCESS_TOKEN=eyJ0eXAi...
 MICROSOFT_REFRESH_TOKEN=0.ATcA...
 MICROSOFT_TOKEN_EXPIRES_AT=2025-12-31T23:59:59
-MICROSOFT_SCOPES=Mail.Read,Mail.Send,Calendars.Read,Calendars.ReadWrite
+MICROSOFT_SCOPES=Mail.ReadWrite,Mail.Send,Contacts.ReadWrite,Calendars.Read,Calendars.ReadWrite
 MICROSOFT_EMAIL=your.email@outlook.com
 ```
 
@@ -62,17 +64,19 @@ When you run `co auth microsoft`, we request these Microsoft Graph API scopes:
 
 | Scope | Purpose | What agents can do |
 |-------|---------|-------------------|
-| `Mail.Read` | Read user emails | Read inbox, search emails |
+| `Mail.ReadWrite` | Read and manage user emails | Read inbox, search, mark read, archive |
 | `Mail.Send` | Send emails on your behalf | Send emails via Outlook |
+| `Contacts.ReadWrite` | Manage personal Outlook contacts | Add, list, and search contacts |
 | `Calendars.Read` | Read calendar events | Read your calendar to check availability |
 | `Calendars.ReadWrite` | Create/modify calendar events | Create and update events |
 | `User.Read` | Get your profile | Identify which Microsoft account is connected |
 | `offline_access` | Refresh tokens | Keep credentials working without re-auth |
 
-**Privacy**: We only request the permissions needed. We cannot:
-- Delete your emails
-- Access your OneDrive or other services
-- Access your contacts beyond basic profile
+**Privacy**: We only request the permissions needed. The CLI does not expose
+email deletion and cannot access OneDrive or other unrelated services.
+
+The contact CLI currently exposes only add, list, and search. Microsoft grants
+`Contacts.ReadWrite` because Graph requires that scope to create a contact.
 
 ---
 
@@ -134,6 +138,11 @@ outlook.send(to="alice@example.com", subject="Report", body="See attached.",
              attachments=["report.pdf"],              # local files, ~3MB Graph limit
              send_at="2026-07-06T15:30:00Z")           # deferred send (UTC ISO)
 outlook.reply(email_id, body="Thanks for your message")
+
+# Contacts
+outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.list_contacts(max_results=25)
+outlook.search_contacts("yifei")
 
 # Actions
 outlook.mark_read(email_id)     # Mark email as read
@@ -319,7 +328,7 @@ The backend handles:
 | Email | Gmail | Outlook |
 | Calendar | Google Calendar | Microsoft Calendar |
 | API | Google APIs | Microsoft Graph API |
-| Scopes | gmail.send, calendar | Mail.Read, Mail.Send, Calendars.* |
+| Scopes | gmail.send, calendar | Mail.ReadWrite, Mail.Send, Contacts.ReadWrite, Calendars.* |
 | Token endpoint | oauth2.googleapis.com | login.microsoftonline.com |
 
 Both follow the same CLI pattern and save credentials in the same format.

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -140,7 +140,7 @@ outlook.send(to="alice@example.com", subject="Report", body="See attached.",
 outlook.reply(email_id, body="Thanks for your message")
 
 # Contacts
-outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.add_contact("Zhou Yifei", "zhou@example.com")
 outlook.list_contacts(max_results=25)
 outlook.search_contacts("yifei")
 

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -40,13 +40,13 @@ agent.input("Send an email to alice@example.com saying hello")
 co auth microsoft
 ```
 
-Your agent can now read and manage Outlook emails.
+Your agent can now read and manage Outlook emails and contacts.
 
 **Switch accounts?** Run `co auth microsoft` again to connect a different Microsoft account.
 
 **Prefer the terminal?** The same functions are available as
 [`co outlook`](../cli/outlook.md) commands (`inbox`, `read`, `send`, `reply`,
-`sent`, `search`, `scheduled`).
+`sent`, `search`, `scheduled`, and `contact add/list/search`).
 
 ## Agent Methods
 
@@ -73,6 +73,28 @@ Your agent can now read and manage Outlook emails.
 **`search_emails(query, max_results=10)`**
 - Search using Microsoft Graph search
 - Examples: `"quarterly report"`, `"meeting notes"`, `"invoice"`
+
+### Contacts
+
+**`add_contact(name, email)`**
+- Create a contact in the root Outlook Contacts folder
+- Returns a dict with `id`, `name`, and `email`
+- Requires the delegated `Contacts.ReadWrite` scope
+
+**`list_contacts(max_results=25)`**
+- List saved contacts as `id` / `name` / `email` dicts
+
+**`search_contacts(query, max_results=25)`**
+- Find contacts by a case-insensitive display-name or email substring
+
+```python
+outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.list_contacts()
+outlook.search_contacts("yifei")
+```
+
+If Microsoft was connected before contacts were enabled, run
+`co auth microsoft` again to consent to `Contacts.ReadWrite`.
 
 ### Sending
 
@@ -148,6 +170,7 @@ agent = Agent(
     system_prompt="You help manage Outlook emails and remember important info."
 )
 
+agent.input("Save Zhou Yifei <zhouyifei0428@gmail.com> as a contact")
 agent.input("Check unread emails and save important deadlines to memory")
 agent.input("Send an email to alice@example.com about the project update")
 agent.input("Find all emails about the quarterly report")
@@ -171,6 +194,9 @@ from tools.outlook import Outlook    # After - customize freely!
 ## Troubleshooting
 
 **Missing Microsoft Mail scopes**: Run `co auth microsoft`
+
+**Missing Microsoft Contacts.ReadWrite scope**: Run `co auth microsoft` again
+to grant the new contact permission.
 
 **Credentials not found**: Run `co auth microsoft`
 

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -88,7 +88,7 @@ Your agent can now read and manage Outlook emails and contacts.
 - Find contacts by a case-insensitive display-name or email substring
 
 ```python
-outlook.add_contact("Zhou Yifei", "zhouyifei0428@gmail.com")
+outlook.add_contact("Zhou Yifei", "zhou@example.com")
 outlook.list_contacts()
 outlook.search_contacts("yifei")
 ```
@@ -170,7 +170,7 @@ agent = Agent(
     system_prompt="You help manage Outlook emails and remember important info."
 )
 
-agent.input("Save Zhou Yifei <zhouyifei0428@gmail.com> as a contact")
+agent.input("Save Zhou Yifei <zhou@example.com> as a contact")
 agent.input("Check unread emails and save important deadlines to memory")
 agent.input("Send an email to alice@example.com about the project update")
 agent.input("Find all emails about the quarterly report")

--- a/tests/e2e/cli/test_cli_auth_microsoft.py
+++ b/tests/e2e/cli/test_cli_auth_microsoft.py
@@ -22,11 +22,10 @@ Components under test:
 - connectonion.cli.commands.auth_commands._save_microsoft_to_env
 """
 
-import os
 import tempfile
 from pathlib import Path
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 from .argparse_runner import ArgparseCliRunner
 
@@ -181,7 +180,7 @@ class TestAuthMicrosoftFlow:
                 'access_token': 'eyJ0eXAi.test',
                 'refresh_token': '0.ATcA.test',
                 'expires_at': '2025-12-31T23:59:59',
-                'scopes': 'Mail.Read,Mail.Send,Calendars.Read,Calendars.ReadWrite',
+                'scopes': 'Mail.ReadWrite,Mail.Send,Contacts.ReadWrite,Calendars.Read,Calendars.ReadWrite',
                 'microsoft_email': 'test@outlook.com'
             }
 
@@ -196,7 +195,7 @@ class TestAuthMicrosoftFlow:
 
             with patch('time.sleep', return_value=None):
                 from connectonion.cli.main import cli
-                result = self.runner.invoke(cli, ['auth', 'microsoft'])
+                self.runner.invoke(cli, ['auth', 'microsoft'])
 
             mock_requests.delete.assert_called_once()
             mock_webbrowser.open.assert_called_once()
@@ -204,6 +203,7 @@ class TestAuthMicrosoftFlow:
             env_content = Path('.env').read_text()
             assert 'MICROSOFT_ACCESS_TOKEN=eyJ0eXAi.test' in env_content
             assert 'MICROSOFT_REFRESH_TOKEN=0.ATcA.test' in env_content
+            assert 'Contacts.ReadWrite' in env_content
             assert 'MICROSOFT_EMAIL=test@outlook.com' in env_content
 
     @patch('connectonion.cli.commands.auth_commands.requests')
@@ -257,5 +257,3 @@ class TestAuthMicrosoftFlow:
             result = self.runner.invoke(cli, ['auth', 'microsoft'])
 
             assert 'timed out' in result.output.lower() or result.exit_code != 0
-
-

--- a/tests/e2e/cli/test_cli_outlook_contacts.py
+++ b/tests/e2e/cli/test_cli_outlook_contacts.py
@@ -1,0 +1,48 @@
+"""CLI routing tests for `co outlook contact`."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+runner = CliRunner()
+
+
+def test_outlook_contact_add_routes_arguments():
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_contact_add"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "contact", "add",
+            "Zhou Yifei", "zhouyifei0428@gmail.com",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "Zhou Yifei", "zhouyifei0428@gmail.com"
+    )
+
+
+def test_outlook_contact_list_routes_limit():
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_contact_list"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "contact", "list", "--last", "50",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=50)
+
+
+def test_outlook_contact_search_routes_query_and_limit():
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_contact_search"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "contact", "search", "yifei", "-n", "5",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("yifei", last=5)

--- a/tests/e2e/cli/test_cli_outlook_contacts.py
+++ b/tests/e2e/cli/test_cli_outlook_contacts.py
@@ -15,12 +15,12 @@ def test_outlook_contact_add_routes_arguments():
     ) as handler:
         result = runner.invoke(app, [
             "outlook", "contact", "add",
-            "Zhou Yifei", "zhouyifei0428@gmail.com",
+            "Zhou Yifei", "zhou@example.com",
         ])
 
     assert result.exit_code == 0
     handler.assert_called_once_with(
-        "Zhou Yifei", "zhouyifei0428@gmail.com"
+        "Zhou Yifei", "zhou@example.com"
     )
 
 

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -45,6 +45,17 @@ class TestOutlookInit:
             outlook = Outlook()
             assert outlook._access_token is None
 
+    def test_outlook_init_with_contacts_scope_only(self):
+        """Contact-only Graph credentials can use the contact methods."""
+        with patch.dict(
+            os.environ,
+            {"MICROSOFT_SCOPES": "User.Read,Contacts.ReadWrite"},
+            clear=False,
+        ):
+            from connectonion.useful_tools.outlook import Outlook
+
+            assert Outlook()._access_token is None
+
 
 class TestOutlookTokenManagement:
     """Test Outlook token management."""
@@ -638,3 +649,162 @@ class TestOutlookScheduled:
         assert url.endswith("/me/messages/sched-1")
 
 
+class TestOutlookContacts:
+    """Test minimal Outlook contact management through Microsoft Graph."""
+
+    ENV = {
+        "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send,Contacts.ReadWrite",
+        "MICROSOFT_ACCESS_TOKEN": "test-token",
+        "MICROSOFT_REFRESH_TOKEN": "test-refresh",
+    }
+
+    @patch("connectonion.useful_tools.outlook.httpx")
+    def test_add_contact_posts_name_and_email(self, mock_httpx):
+        response = MagicMock(status_code=201, text="ok")
+        response.json.return_value = {
+            "id": "contact-1",
+            "displayName": "Zhou Yifei",
+            "emailAddresses": [{
+                "name": "Zhou Yifei",
+                "address": "zhouyifei0428@gmail.com",
+            }],
+        }
+        mock_httpx.request.return_value = response
+
+        with patch.dict(os.environ, self.ENV, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._access_token = "test-token"
+            contact = outlook.add_contact(
+                "Zhou Yifei", "zhouyifei0428@gmail.com"
+            )
+
+        assert contact == {
+            "id": "contact-1",
+            "name": "Zhou Yifei",
+            "email": "zhouyifei0428@gmail.com",
+        }
+        method, url = mock_httpx.request.call_args.args[:2]
+        assert method == "POST"
+        assert url.endswith("/me/contacts")
+        assert mock_httpx.request.call_args.kwargs["json"] == {
+            "displayName": "Zhou Yifei",
+            "emailAddresses": [{
+                "name": "Zhou Yifei",
+                "address": "zhouyifei0428@gmail.com",
+            }],
+        }
+
+    @patch("connectonion.useful_tools.outlook.httpx")
+    def test_list_contacts_normalizes_graph_results(self, mock_httpx):
+        response = MagicMock(status_code=200, text="ok")
+        response.json.return_value = {"value": [
+            {
+                "id": "contact-1",
+                "displayName": "Zhou Yifei",
+                "emailAddresses": [{
+                    "name": "Zhou Yifei",
+                    "address": "zhouyifei0428@gmail.com",
+                }],
+            },
+            {
+                "id": "contact-2",
+                "displayName": "No Email",
+                "emailAddresses": [],
+            },
+        ]}
+        mock_httpx.request.return_value = response
+
+        with patch.dict(os.environ, self.ENV, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._access_token = "test-token"
+            contacts = outlook.list_contacts(max_results=25)
+
+        assert contacts == [
+            {
+                "id": "contact-1",
+                "name": "Zhou Yifei",
+                "email": "zhouyifei0428@gmail.com",
+            },
+            {"id": "contact-2", "name": "No Email", "email": ""},
+        ]
+        _, url = mock_httpx.request.call_args.args[:2]
+        assert "/me/contacts" in url
+        assert "$select=id,displayName,emailAddresses" in url
+
+    def test_search_contacts_matches_name_and_email_case_insensitively(self):
+        with patch.dict(os.environ, self.ENV, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            contacts = [
+                {
+                    "id": "contact-1",
+                    "name": "Zhou Yifei",
+                    "email": "zhouyifei0428@gmail.com",
+                },
+                {
+                    "id": "contact-2",
+                    "name": "Alice",
+                    "email": "alice@example.com",
+                },
+            ]
+            outlook._iter_contacts = MagicMock(side_effect=[
+                iter(contacts),
+                iter(contacts),
+            ])
+            assert outlook.search_contacts("YIFEI") == [{
+                "id": "contact-1",
+                "name": "Zhou Yifei",
+                "email": "zhouyifei0428@gmail.com",
+            }]
+            assert outlook.search_contacts("0428@gmail") == [{
+                "id": "contact-1",
+                "name": "Zhou Yifei",
+                "email": "zhouyifei0428@gmail.com",
+            }]
+
+    @patch("connectonion.useful_tools.outlook.httpx")
+    def test_search_contacts_follows_graph_pages(self, mock_httpx):
+        page1 = MagicMock(status_code=200, text="ok")
+        page1.json.return_value = {
+            "value": [{
+                "id": "contact-1",
+                "displayName": "Alice",
+                "emailAddresses": [{
+                    "name": "Alice",
+                    "address": "alice@example.com",
+                }],
+            }],
+            "@odata.nextLink": (
+                "https://graph.microsoft.com/v1.0/me/contacts?$skip=100"
+            ),
+        }
+        page2 = MagicMock(status_code=200, text="ok")
+        page2.json.return_value = {"value": [{
+            "id": "contact-2",
+            "displayName": "Zhou Yifei",
+            "emailAddresses": [{
+                "name": "Zhou Yifei",
+                "address": "zhouyifei0428@gmail.com",
+            }],
+        }]}
+        mock_httpx.request.side_effect = [page1, page2]
+
+        with patch.dict(os.environ, self.ENV, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            outlook._access_token = "test-token"
+            contacts = outlook.search_contacts("yifei")
+
+        assert [contact["id"] for contact in contacts] == ["contact-2"]
+        assert mock_httpx.request.call_count == 2
+
+    def test_contact_methods_require_contacts_readwrite(self):
+        with patch.dict(os.environ, {
+            "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send",
+        }, clear=False):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+            with pytest.raises(ValueError, match="Contacts.ReadWrite"):
+                outlook.list_contacts()

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -666,7 +666,7 @@ class TestOutlookContacts:
             "displayName": "Zhou Yifei",
             "emailAddresses": [{
                 "name": "Zhou Yifei",
-                "address": "zhouyifei0428@gmail.com",
+                "address": "zhou@example.com",
             }],
         }
         mock_httpx.request.return_value = response
@@ -676,13 +676,13 @@ class TestOutlookContacts:
             outlook = Outlook()
             outlook._access_token = "test-token"
             contact = outlook.add_contact(
-                "Zhou Yifei", "zhouyifei0428@gmail.com"
+                "Zhou Yifei", "zhou@example.com"
             )
 
         assert contact == {
             "id": "contact-1",
             "name": "Zhou Yifei",
-            "email": "zhouyifei0428@gmail.com",
+            "email": "zhou@example.com",
         }
         method, url = mock_httpx.request.call_args.args[:2]
         assert method == "POST"
@@ -691,7 +691,7 @@ class TestOutlookContacts:
             "displayName": "Zhou Yifei",
             "emailAddresses": [{
                 "name": "Zhou Yifei",
-                "address": "zhouyifei0428@gmail.com",
+                "address": "zhou@example.com",
             }],
         }
 
@@ -704,7 +704,7 @@ class TestOutlookContacts:
                 "displayName": "Zhou Yifei",
                 "emailAddresses": [{
                     "name": "Zhou Yifei",
-                    "address": "zhouyifei0428@gmail.com",
+                    "address": "zhou@example.com",
                 }],
             },
             {
@@ -725,7 +725,7 @@ class TestOutlookContacts:
             {
                 "id": "contact-1",
                 "name": "Zhou Yifei",
-                "email": "zhouyifei0428@gmail.com",
+                "email": "zhou@example.com",
             },
             {"id": "contact-2", "name": "No Email", "email": ""},
         ]
@@ -741,7 +741,7 @@ class TestOutlookContacts:
                 {
                     "id": "contact-1",
                     "name": "Zhou Yifei",
-                    "email": "zhouyifei0428@gmail.com",
+                    "email": "zhou@example.com",
                 },
                 {
                     "id": "contact-2",
@@ -756,12 +756,12 @@ class TestOutlookContacts:
             assert outlook.search_contacts("YIFEI") == [{
                 "id": "contact-1",
                 "name": "Zhou Yifei",
-                "email": "zhouyifei0428@gmail.com",
+                "email": "zhou@example.com",
             }]
-            assert outlook.search_contacts("0428@gmail") == [{
+            assert outlook.search_contacts("ou@example") == [{
                 "id": "contact-1",
                 "name": "Zhou Yifei",
-                "email": "zhouyifei0428@gmail.com",
+                "email": "zhou@example.com",
             }]
 
     @patch("connectonion.useful_tools.outlook.httpx")
@@ -786,7 +786,7 @@ class TestOutlookContacts:
             "displayName": "Zhou Yifei",
             "emailAddresses": [{
                 "name": "Zhou Yifei",
-                "address": "zhouyifei0428@gmail.com",
+                "address": "zhou@example.com",
             }],
         }]}
         mock_httpx.request.side_effect = [page1, page2]

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -30,6 +30,9 @@ from connectonion.cli.commands.outlook_commands import (
     _outlook,
     _parse_send_at,
     _resolve_email_id,
+    handle_outlook_contact_add,
+    handle_outlook_contact_list,
+    handle_outlook_contact_search,
     handle_outlook_inbox,
     handle_outlook_send,
 )
@@ -38,6 +41,11 @@ CONNECTED_ENV = {
     "MICROSOFT_ACCESS_TOKEN": "test-token",
     "MICROSOFT_SCOPES": "Mail.Read,Mail.Send",
     "MICROSOFT_EMAIL": "aaron@example.com",
+}
+
+CONNECTED_CONTACT_ENV = {
+    **CONNECTED_ENV,
+    "MICROSOFT_SCOPES": "Mail.ReadWrite,Mail.Send,Contacts.ReadWrite",
 }
 
 
@@ -80,6 +88,15 @@ class TestOutlookGuard:
 
         from connectonion.useful_tools.outlook import Outlook
         assert isinstance(result, Outlook)
+
+    def test_contacts_scope_missing_exits_with_reconnect_hint(self, capsys):
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with pytest.raises(typer.Exit):
+                _outlook(required_scope="Contacts.ReadWrite")
+
+        output = capsys.readouterr().out
+        assert "Contacts.ReadWrite" in output
+        assert "co auth microsoft" in output
 
 
 class TestParseSendAt:
@@ -258,3 +275,62 @@ class TestHandleOutlookSend:
                     handle_outlook_send(to="bob@example.com", subject="Hi", message="hello")
 
         mock_cls.assert_not_called()
+
+
+class TestHandleOutlookContacts:
+    """Contact handlers delegate Graph work to Outlook and format the result."""
+
+    def test_add_contact(self, capsys):
+        outlook = MagicMock()
+        outlook.add_contact.return_value = {
+            "id": "contact-1",
+            "name": "Zhou Yifei",
+            "email": "zhouyifei0428@gmail.com",
+        }
+
+        with patch.dict(os.environ, CONNECTED_CONTACT_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_contact_add(
+                    "Zhou Yifei", "zhouyifei0428@gmail.com"
+                )
+
+        outlook.add_contact.assert_called_once_with(
+            "Zhou Yifei", "zhouyifei0428@gmail.com"
+        )
+        output = capsys.readouterr().out
+        assert "Saved contact" in output
+        assert "Zhou Yifei" in output
+        assert "zhouyifei0428@gmail.com" in output
+
+    def test_list_contacts_terminal_table(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            outlook_commands, "console",
+            Console(force_terminal=True, width=120),
+        )
+        outlook = MagicMock()
+        outlook.list_contacts.return_value = [{
+            "id": "contact-1",
+            "name": "Zhou Yifei",
+            "email": "zhouyifei0428@gmail.com",
+        }]
+
+        with patch.object(outlook_commands, "_outlook", return_value=outlook):
+            handle_outlook_contact_list(last=25)
+
+        outlook.list_contacts.assert_called_once_with(max_results=25)
+        output = capsys.readouterr().out
+        assert "Outlook contacts" in output
+        assert "Zhou Yifei" in output
+        assert "zhouyifei0428@gmail.com" in output
+
+    def test_search_contacts_empty_result(self, capsys):
+        outlook = MagicMock()
+        outlook.search_contacts.return_value = []
+
+        with patch.object(outlook_commands, "_outlook", return_value=outlook):
+            handle_outlook_contact_search("yifei", last=25)
+
+        outlook.search_contacts.assert_called_once_with(
+            "yifei", max_results=25
+        )
+        assert "no contacts matching" in capsys.readouterr().out

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -79,8 +79,19 @@ class TestOutlookGuard:
                 _outlook()
 
         output = capsys.readouterr().out
-        assert "Microsoft account not connected" in output
+        assert "Mail permission missing" in output
         assert "co auth microsoft" in output
+
+    def test_mailbox_settings_scope_does_not_pass_as_mail(self, capsys):
+        with patch.dict(
+            os.environ,
+            {"MICROSOFT_ACCESS_TOKEN": "test-token", "MICROSOFT_SCOPES": "MailboxSettings.Read"},
+            clear=False,
+        ):
+            with pytest.raises(typer.Exit):
+                _outlook()
+
+        assert "Mail permission missing" in capsys.readouterr().out
 
     def test_connected_returns_outlook_instance(self):
         with patch.dict(os.environ, CONNECTED_ENV, clear=False):
@@ -285,22 +296,22 @@ class TestHandleOutlookContacts:
         outlook.add_contact.return_value = {
             "id": "contact-1",
             "name": "Zhou Yifei",
-            "email": "zhouyifei0428@gmail.com",
+            "email": "zhou@example.com",
         }
 
         with patch.dict(os.environ, CONNECTED_CONTACT_ENV, clear=False):
             with patch.object(outlook_commands, "_outlook", return_value=outlook):
                 handle_outlook_contact_add(
-                    "Zhou Yifei", "zhouyifei0428@gmail.com"
+                    "Zhou Yifei", "zhou@example.com"
                 )
 
         outlook.add_contact.assert_called_once_with(
-            "Zhou Yifei", "zhouyifei0428@gmail.com"
+            "Zhou Yifei", "zhou@example.com"
         )
         output = capsys.readouterr().out
         assert "Saved contact" in output
         assert "Zhou Yifei" in output
-        assert "zhouyifei0428@gmail.com" in output
+        assert "zhou@example.com" in output
 
     def test_list_contacts_terminal_table(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -311,7 +322,7 @@ class TestHandleOutlookContacts:
         outlook.list_contacts.return_value = [{
             "id": "contact-1",
             "name": "Zhou Yifei",
-            "email": "zhouyifei0428@gmail.com",
+            "email": "zhou@example.com",
         }]
 
         with patch.object(outlook_commands, "_outlook", return_value=outlook):
@@ -321,7 +332,7 @@ class TestHandleOutlookContacts:
         output = capsys.readouterr().out
         assert "Outlook contacts" in output
         assert "Zhou Yifei" in output
-        assert "zhouyifei0428@gmail.com" in output
+        assert "zhou@example.com" in output
 
     def test_search_contacts_empty_result(self, capsys):
         outlook = MagicMock()


### PR DESCRIPTION
## Summary

- add `co outlook contact add/list/search` for issue #221
- add `Outlook.add_contact()`, `list_contacts()`, and `search_contacts()` through Microsoft Graph
- require and explain the `Contacts.ReadWrite` permission, including the re-consent path for existing users
- document the CLI, tool API, OAuth permission, and script-friendly output
- cover Graph payloads, pagination, case-insensitive search, scope guards, formatting, and CLI routing

## Backend dependency

Requires openonion/oo-api#31 so new Microsoft authorizations, downloaded credentials, and token refreshes include `Contacts.ReadWrite`.

Existing Microsoft users should run `co auth microsoft` again after the backend change is deployed.

## Validation

- GitHub Actions: 8/8 jobs passed (Python 3.10–3.13, Windows browser matrix, Windows wheel E2E)
- targeted Outlook/contact suite: 66 passed
- complete CLI suite: 299 passed, 5 skipped, 13 deselected
- Python compilation: passed
- Ruff unused-code check on changed Python files: passed
- `git diff --check`: passed
- broader non-real-API attempt reached 375 passed; 3 live relay tests failed because this machine routes through SOCKS without the optional `python-socks` dependency

Closes #221