### PR TITLE
Switch defaults to Gemini 3.6 Flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ agent = Agent(name="test", api_key="your-api-key-here")
 
 ### Model Selection
 ```python
-agent = Agent(name="test", model="gpt-5")  # Default: co/gemini-2.5-pro
+agent = Agent(name="test", model="gpt-5")  # Default: co/gemini-3.6-flash
 ```
 
 ### Iteration Control

--- a/connectonion/cli/co_ai/agents/registry.py
+++ b/connectonion/cli/co_ai/agents/registry.py
@@ -33,7 +33,7 @@ SUBAGENTS: Dict[str, Dict[str, Any]] = {
     "plan": {
         "description": "Design implementation plans. Analyze architecture, identify files to change, plan steps.",
         "tools": [FileTools],
-        "model": "co/gemini-2.5-pro",  # Smarter model for planning
+        "model": "co/gemini-3.6-flash",  # Smarter model for planning
         "max_iterations": 10,
     },
 }

--- a/connectonion/cli/co_ai/prompts/connectonion/index.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/index.md
@@ -18,7 +18,7 @@ agent = Agent(
     name="my_bot",                        # Required: identifier
     tools=[func1, func2],                 # Functions or class instances
     system_prompt="You are helpful",      # String or file path
-    model="co/gemini-2.5-pro",            # Default model
+    model="co/gemini-3.6-flash",            # Default model
     max_iterations=10,                    # Tool call limit per task
     plugins=[plugin1, plugin2],           # Event handlers
 )

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -312,7 +312,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         if "AGENT_CONFIG_PATH=" not in env_content:
             lines_to_add.append(f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n")
         if "# Default model:" not in env_content:
-            lines_to_add.append("# Default model: co/gemini-2.5-pro (managed keys with free credits)\n")
+            lines_to_add.append("# Default model: co/gemini-3.6-flash (managed keys with free credits)\n")
 
         if lines_to_add:
             # Add blank line after comments if we're adding any
@@ -322,7 +322,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         # Fallback - create minimal .env with detected keys
         env_lines = [
             f"AGENT_CONFIG_PATH={Path.home() / '.co'}",
-            "# Default model: co/gemini-2.5-pro (managed keys with free credits)",
+            "# Default model: co/gemini-3.6-flash (managed keys with free credits)",
             "",
         ]
 

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -213,7 +213,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     if not env_existed:
         if keys_to_add or global_keys:
             env_content = f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n"
-            env_content += "# Default model: co/gemini-2.5-pro (managed keys with free credits)\n\n"
+            env_content += "# Default model: co/gemini-3.6-flash (managed keys with free credits)\n\n"
             # Add all global keys + detected keys
             all_keys = list(global_keys.values()) + [k for k in keys_to_add if k not in global_keys.values()]
             env_content += '\n'.join(all_keys) + '\n'

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -249,9 +249,9 @@ def api_key_setup_menu(temp_project_dir: Optional[Path] = None) -> Tuple[str, st
                             console.print("\n[green]✓ We verified your star. Thanks for supporting us![/green]")
                             console.print("[green]You now have 100k free tokens![/green]")
                             console.print("\n[cyan]You can use ConnectOnion models with the 'co/' prefix:[/cyan]")
-                            console.print("  • co/gemini-2.5-pro")
+                            console.print("  • co/gemini-3.6-flash")
                             console.print("  • co/gpt-4o")
-                            console.print("  • co/gemini-2.5-pro")
+                            console.print("  • co/gemini-3.6-flash")
                             console.print("  • co/gpt-5")
                             console.print("  • co/claude-3-haiku")
                             console.print("  • co/claude-3-sonnet")
@@ -332,9 +332,9 @@ def api_key_setup_menu(temp_project_dir: Optional[Path] = None) -> Tuple[str, st
                         console.print("\n[green]✓ We verified your star. Thanks for supporting us![/green]")
                         console.print("[green]You now have 100k free tokens![/green]")
                         console.print("\n[cyan]You can use ConnectOnion models with the 'co/' prefix:[/cyan]")
-                        console.print("  • co/gemini-2.5-pro")
+                        console.print("  • co/gemini-3.6-flash")
                         console.print("  • co/gpt-4o")
-                        console.print("  • co/gemini-2.5-pro")
+                        console.print("  • co/gemini-3.6-flash")
                         console.print("  • co/gpt-5")
                         console.print("  • co/claude-3-haiku")
                         console.print("  • co/claude-3-sonnet")
@@ -595,7 +595,7 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         },
         'connectonion': {
             'var': 'CONNECTONION_API_KEY',
-            'model': 'co/gemini-2.5-pro'  # Prefixed models for managed keys
+            'model': 'co/gemini-3.6-flash'  # Prefixed models for managed keys
         }
     }
 
@@ -610,8 +610,8 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
 # Same pricing as OpenAI/Anthropic
 
 # Model Configuration (use co/ prefix for managed models)
-MODEL=co/gemini-2.5-pro
-# Available models: co/gemini-2.5-pro, co/gpt-4o, co/claude-3-haiku, co/claude-3-sonnet
+MODEL=co/gemini-3.6-flash
+# Available models: co/gemini-3.6-flash, co/gpt-4o, co/claude-3-haiku, co/claude-3-sonnet
 
 # No API key needed - authentication handled via JWT token from 'co auth'
 
@@ -626,7 +626,7 @@ MODEL=co/gemini-2.5-pro
 # 3. Your GitHub star will be verified automatically
 
 # Model Configuration (use co/ prefix for managed models)
-MODEL=co/gemini-2.5-pro
+MODEL=co/gemini-3.6-flash
 
 # No API key needed - authentication handled via JWT token from 'co auth'
 
@@ -669,8 +669,8 @@ def generate_custom_template_with_name(description: str, api_key: str, model: st
         try:
             from ...core.llm import create_llm
 
-            # Use the model specified or default to co/gemini-2.5-pro
-            llm_model = model if model else "co/gemini-2.5-pro"
+            # Use the model specified or default to co/gemini-3.6-flash
+            llm_model = model if model else "co/gemini-3.6-flash"
 
             if loading_animation:
                 loading_animation.update(f"Connecting to {llm_model}...")
@@ -755,7 +755,7 @@ def process_request(query: str) -> str:
 # Create agent
 agent = Agent(
     name="{suggested_name.replace('-', '_')}",
-    model="{'co/gemini-2.5-pro' if model and model.startswith('co/') else 'co/gemini-2.5-pro'}",
+    model="{'co/gemini-3.6-flash' if model and model.startswith('co/') else 'co/gemini-3.6-flash'}",
     system_prompt=\"\"\"You are an AI agent designed to: {description}
 
     Provide helpful, accurate, and concise responses.\"\"\",

--- a/connectonion/cli/templates/browser/agent.py
+++ b/connectonion/cli/templates/browser/agent.py
@@ -25,7 +25,7 @@ def create_agent():
     browser = BrowserAutomation(headless=True)
     return Agent(
         name="browser_agent",
-        model="co/gemini-2.5-pro",
+        model="co/gemini-3.6-flash",
         system_prompt=system_prompt_path,
         tools=[browser],
         plugins=[image_result_formatter, ui_stream],

--- a/connectonion/cli/templates/coder/agent.py
+++ b/connectonion/cli/templates/coder/agent.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [connectonion (Agent, bash, read_file, edit, glob, grep, write)] | NOT imported by the connectonion package itself — copied verbatim into user projects by cli/commands/create.py | exercised by [tests/cli/test_create.py]
   Data flow: __main__ REPL → input() → agent.input(user_input) → Agent loops invoking bash/read_file/edit/glob/grep/write tools → prints response
   State/Effects: tools mutate user's filesystem (write/edit) and run shell commands (bash) | system_prompt loaded from ./prompt.md alongside this file
-  Integration: exposes module-level `agent` (model="co/gemini-2.5-pro", max_iterations=50)
+  Integration: exposes module-level `agent` (model="co/gemini-3.6-flash", max_iterations=50)
   Performance: max_iterations=50 caps coding loops
   Errors: errors bubble from tools/Agent — no try/except by design
 NOTE: Template ships as-is into user projects. Keep minimal.
@@ -17,7 +17,7 @@ agent = Agent(
     name="coder",
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
     max_iterations=50,
 )
 

--- a/connectonion/cli/templates/minimal/agent.py
+++ b/connectonion/cli/templates/minimal/agent.py
@@ -20,7 +20,7 @@ agent = Agent(
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write, browser],
     plugins=[image_result_formatter, tool_approval],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
 )
 
 result = agent.input("what is your task?")

--- a/connectonion/cli/templates/web-research/agent.py
+++ b/connectonion/cli/templates/web-research/agent.py
@@ -3,7 +3,7 @@ Purpose: Web research agent template for searching, extracting, and analyzing we
 LLM-Note:
   Dependencies: imports from [os, json, requests, connectonion.Agent, connectonion.llm_do] | template file copied by [cli/commands/init.py, cli/commands/create.py]
   Data flow: user query → Agent.input() → search_web (placeholder) | extract_data fetches URL → returns content preview | analyze_data uses llm_do | save_research writes JSON file
-  State/Effects: HTTP requests to external URLs | writes research JSON files | uses MODEL env var or co/gemini-2.5-pro
+  State/Effects: HTTP requests to external URLs | writes research JSON files | uses MODEL env var or co/gemini-3.6-flash
   Integration: template for 'co create --template web-research' | tools: search_web, extract_data, analyze_data, save_research | extensible for real search APIs
   Performance: HTTP timeout 10s | analysis truncates to 1000 chars for llm_do
   Errors: request exceptions caught and returned | ⚠️ TODO: search_web is placeholder, needs real API integration
@@ -108,7 +108,7 @@ def main():
     agent = Agent(
         name="web-research-agent",
         tools=[search_web, extract_data, analyze_data, save_research],
-        model=os.getenv("MODEL", "co/gemini-2.5-pro")
+        model=os.getenv("MODEL", "co/gemini-3.6-flash")
     )
     
     # Example research task

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -38,7 +38,7 @@ class Agent:
         tools: Optional[Union[List[Callable], Callable, Any]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-2.5-pro",
+        model: str = "co/gemini-3.6-flash",
         max_iterations: int = 100,
         log: Optional[Union[bool, str, Path]] = None,
         quiet: bool = False,

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -984,7 +984,7 @@ MODEL_REGISTRY = {
 class OpenOnionLLM(LLM):
     """OpenOnion managed keys LLM implementation using OpenAI-compatible API."""
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "co/o4-mini", **kwargs):
+    def __init__(self, api_key: Optional[str] = None, model: str = "co/gemini-3.6-flash", **kwargs):
         # For co/ models, api_key is actually the auth token
         # Framework auto-loads .env, so OPENONION_API_KEY will be in environment
         self.auth_token = api_key or os.getenv("OPENONION_API_KEY")

--- a/connectonion/llm_do.py
+++ b/connectonion/llm_do.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typing, pathlib, pydantic, dotenv, prompts.py, llm.py] | imported by [debug_explainer/explain_context.py, user code, examples] | tested by [tests/test_llm_do.py, tests/test_llm_do_comprehensive.py, tests/test_real_llm_do.py]
   Data flow: user calls llm_do(input, output, system_prompt, model, api_key, **kwargs) → validates input non-empty → loads system_prompt via load_system_prompt() → builds messages [system, user] → calls create_llm(model, api_key) factory → calls llm.complete(messages, **kwargs) OR llm.structured_complete(messages, output, **kwargs) → returns string OR Pydantic model instance
   State/Effects: loads .env via dotenv.load_dotenv() | reads system_prompt files if Path provided | makes one LLM API request | no caching or persistence | stateless
-  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-2.5-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
+  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-3.6-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
   Performance: minimal overhead (no agent loop, no tool calling, no conversation history) | one LLM call per invocation | no caching | synchronous blocking
   Errors: raises ValueError if input empty | provider errors from create_llm() and llm.complete() bubble up | Pydantic ValidationError if structured output doesn't match schema
 
@@ -43,7 +43,7 @@ Key Design Decisions
 -------------------
 - **Stateless**: No conversation history, each call is independent
 - **Simple API**: Minimal parameters, sensible defaults
-- **Default Model**: Uses "co/gemini-2.5-flash" (ConnectOnion managed keys) for zero-setup
+- **Default Model**: Uses "co/gemini-3.6-flash" (ConnectOnion managed keys) for zero-setup
 - **Structured Output**: Native Pydantic support via provider-specific APIs
 - **Flexible Parameters**: **kwargs pass through to underlying LLM (temperature, max_tokens, etc.)
 
@@ -95,7 +95,7 @@ All providers from llm.py module:
    - Structured output via response_schema
    - Good balance of speed and quality
 
-4. **ConnectOnion**: co/gpt-4o, co/o4-mini (DEFAULT)
+4. **ConnectOnion**: co/gpt-4o, co/gemini-3.6-flash (DEFAULT)
    - Managed API keys (no env vars needed!)
    - Proxies to OpenAI with usage tracking
    - Requires: run `co auth` first
@@ -134,7 +134,7 @@ Parameters
 - input (str): The text/question to send to the LLM
 - output (Type[BaseModel], optional): Pydantic model for structured output
 - system_prompt (str | Path, optional): System instructions (inline or file path)
-- model (str): Model name (default: "co/gemini-2.5-flash")
+- model (str): Model name (default: "co/gemini-3.6-flash")
 - temperature (float): Sampling temperature (default: 0.1 for consistency)
 - api_key (str, optional): Override API key (uses env vars by default)
 - **kwargs: Additional parameters passed to LLM (max_tokens, top_p, etc.)
@@ -231,7 +231,7 @@ def llm_do(
     input: str,
     output: Optional[Type[T]] = None,
     system_prompt: Optional[Union[str, Path]] = None,
-    model: str = "co/gemini-2.5-flash",
+    model: str = "co/gemini-3.6-flash",
     api_key: Optional[str] = None,
     **kwargs
 ) -> Union[str, T]:
@@ -242,13 +242,13 @@ def llm_do(
     - OpenAI: "gpt-4o", "o4-mini", "gpt-3.5-turbo"
     - Anthropic: "claude-3-5-sonnet", "claude-3-5-haiku-20241022"
     - Google: "gemini-2.5-pro", "gemini-2.5-flash"
-    - ConnectOnion Managed: "co/gpt-4o", "co/o4-mini" (no API keys needed!)
+    - ConnectOnion Managed: "co/gpt-4o", "co/gemini-3.6-flash" (no API keys needed!)
 
     Args:
         input: The input text/question to send to the LLM
         output: Optional Pydantic model class for structured output
         system_prompt: Optional system prompt (string or file path)
-        model: Model name (default: "co/gemini-2.5-flash")
+        model: Model name (default: "co/gemini-3.6-flash")
         api_key: Optional API key (uses environment variable if not provided)
         **kwargs: Additional parameters (temperature, max_tokens, etc.)
 
@@ -261,7 +261,7 @@ def llm_do(
         >>> print(answer)  # "4"
 
         >>> # With ConnectOnion managed keys (no API key needed!)
-        >>> answer = llm_do("What's 2+2?", model="co/o4-mini")
+        >>> answer = llm_do("What's 2+2?", model="co/gemini-3.6-flash")
 
         >>> # With Claude
         >>> answer = llm_do("Explain quantum physics", model="claude-3-5-haiku-20241022")

--- a/connectonion/useful_plugins/builtin_agents/explore/AGENT.md
+++ b/connectonion/useful_plugins/builtin_agents/explore/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast codebase exploration agent - find files, search code, answer questions
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - glob

--- a/connectonion/useful_plugins/builtin_agents/plan/AGENT.md
+++ b/connectonion/useful_plugins/builtin_agents/plan/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Implementation planning agent - analyze requirements and design actionable plans
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 10
 tools:
   - glob

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -162,7 +162,7 @@ def task(agent, prompt: str, agent_type: str) -> str:
     # Extract configuration
     frontmatter = config['frontmatter']
     system_prompt = config['system_prompt']
-    model = frontmatter.get('model', 'co/gemini-2.5-pro')
+    model = frontmatter.get('model', 'co/gemini-3.6-flash')
     max_iterations = frontmatter.get('max_iterations', 10)
     tool_names = frontmatter.get('tools', [])
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,7 +320,7 @@ class Agent:
         tools: Optional[List[Callable]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-2.5-pro",
+        model: str = "co/gemini-3.6-flash",
         max_iterations: int = 100
     )
     

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@ Agent(
     tools: Optional[List[Callable]] = None,
     system_prompt: Union[str, Path, None] = None,
     api_key: Optional[str] = None,
-    model: str = "co/gemini-2.5-pro"
+    model: str = "co/gemini-3.6-flash"
 )
 ```
 
@@ -27,8 +27,8 @@ Agent(
   - `Path`: Path object pointing to a prompt file
   - `None`: Uses default prompt
 - **api_key** (`Optional[str]`): OpenAI API key (if not using custom LLM)
-- **model** (`str`): Model to use (default: "co/gemini-2.5-pro")
-  - Managed keys: `co/gemini-2.5-pro`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
+- **model** (`str`): Model to use (default: "co/gemini-3.6-flash")
+  - Managed keys: `co/gemini-3.6-flash`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
   - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-2.5-pro`
 
 ### System Prompt Options

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -308,7 +308,7 @@ co auth
 
 ```python
 # After co auth, just use co/ prefix
-agent = Agent("bot", model="co/gemini-2.5-pro")
+agent = Agent("bot", model="co/gemini-3.6-flash")
 agent = Agent("bot", model="co/gpt-5")
 ```
 
@@ -501,7 +501,7 @@ print(result.sentiment)  # Type-safe!
 llm_do("Quick task")  # Uses co/gemini-2.5-flash
 
 # ✅ For complex reasoning
-llm_do("Complex analysis", model="co/gemini-2.5-pro")
+llm_do("Complex analysis", model="co/gemini-3.6-flash")
 
 # ✅ For structured output (Anthropic 4.5+ only)
 from pydantic import BaseModel

--- a/docs/co-directory-structure.md
+++ b/docs/co-directory-structure.md
@@ -122,7 +122,7 @@ Detailed per-session logs for eval and replay, one file per unique first input:
 ```yaml
 # evals/what_is_2_2.yaml
 agent: assistant
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 started_at: "2025-01-15T10:30:00Z"
 turns:
   - input: "What is 2+2?"

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -42,7 +42,7 @@ Agent(
     name="my_bot",                        # Required: agent identifier
     tools=[func1, func2],                 # Optional: functions agent can call
     system_prompt="You are helpful",      # Optional: personality/behavior
-    model="co/gemini-2.5-pro",            # Optional: LLM model (default: co/gemini-2.5-pro)
+    model="co/gemini-3.6-flash",            # Optional: LLM model (default: co/gemini-3.6-flash)
     max_iterations=100,                   # Optional: how many tool calls allowed (default: 100)
     api_key="sk-...",                     # Optional: override environment variable
     llm=custom_llm,                       # Optional: bring your own LLM instance
@@ -448,7 +448,7 @@ See [max_iterations.md](max_iterations.md) for detailed guide.
 
 ### Supported Providers
 
-Default model is `co/gemini-2.5-pro`. You can use:
+Default model is `co/gemini-3.6-flash`. You can use:
 
 ```python
 # OpenAI models

--- a/docs/concepts/llm_do.md
+++ b/docs/concepts/llm_do.md
@@ -7,7 +7,7 @@ Make direct LLM calls with optional structured output. Supports OpenAI, Google G
 ```python
 from connectonion import llm_do
 
-# Default: co/gemini-2.5-flash (managed key, no setup needed)
+# Default: co/gemini-3.6-flash (managed key, no setup needed)
 answer = llm_do("What's 2+2?")  
 print(answer)  # "4"
 
@@ -121,7 +121,7 @@ llm_do("Hello", model="co/o4-mini")
 
 # Google Gemini models (via managed keys)
 llm_do("Hello", model="co/gemini-2.5-pro")
-llm_do("Hello", model="co/gemini-2.5-flash")
+llm_do("Hello", model="co/gemini-3.6-flash")
 
 # Anthropic Claude models (via managed keys)
 llm_do("Hello", model="co/claude-sonnet-4-5")
@@ -146,7 +146,7 @@ class Answer(BaseModel):
 
 # Works with all providers
 llm_do("What is 2+2?", output=Answer, model="co/gpt-4o-mini")      # ✅
-llm_do("What is 2+2?", output=Answer, model="co/gemini-2.5-flash") # ✅
+llm_do("What is 2+2?", output=Answer, model="co/gemini-3.6-flash") # ✅
 llm_do("What is 2+2?", output=Answer, model="co/claude-sonnet-4-5") # ✅
 
 # Legacy Claude models do NOT support structured output
@@ -160,7 +160,7 @@ llm_do("What is 2+2?", output=Answer, model="co/claude-sonnet-4-5") # ✅
 | `input` | str | required | The input text/question |
 | `output` | BaseModel | None | Pydantic model for structured output |
 | `system_prompt` | str\|Path | None | System prompt (string or file path) |
-| `model` | str | "co/gemini-2.5-flash" | Model to use (supports OpenAI, Gemini, Claude) |
+| `model` | str | "co/gemini-3.6-flash" | Model to use (supports OpenAI, Gemini, Claude) |
 | `temperature` | float | 0.1 | Randomness (0=deterministic, 2=creative) |
 
 ## What You Get

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -178,7 +178,8 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | Model | Provider | Key Strengths | Multimodal |
 |-------|----------|---------------|------------|
 | gpt-5 | OpenAI | Best for coding and agentic tasks | ✅ |
-| gemini-2.5-pro | Google | Default model, best price-performance for agents | ✅ |
+| gemini-3.6-flash | Google | Default model, newest fast Gemini | ✅ |
+| gemini-2.5-pro | Google | Strong multimodal model for agents | ✅ |
 | gemini-3-pro-preview | Google | State-of-the-art reasoning | ✅ |
 | claude-sonnet-4-5 | Anthropic | Best balance of intelligence and speed | ✅ |
 | mistral-large-latest | Mistral | High performance European model | ✅ |
@@ -223,11 +224,11 @@ All prices are **per 1M tokens** and match official provider pricing:
 
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
-| gemini-3.6-flash | $1.50 | $7.50 | Newest fast Gemini |
+| gemini-3.6-flash | $1.50 | $7.50 | **Default model** - newest fast Gemini |
 | gemini-3-pro-preview | $2.00 | $12.00 | State-of-the-art reasoning |
 | gemini-3.5-flash | $1.50 | $9.00 | Previous fast Gemini |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |
-| gemini-2.5-pro | $1.25 | $10.00 | **Default model** - best for agents |
+| gemini-2.5-pro | $1.25 | $10.00 | Strong multimodal model for agents |
 | gemini-2.5-flash | $0.15 | $0.60 | Best price-performance |
 | gemini-2.5-flash-lite | $0.10 | $0.40 | Ultra fast, cheapest |
 | gemini-2.0-flash | $0.10 | $0.40 | Previous gen |

--- a/docs/connectonion.md
+++ b/docs/connectonion.md
@@ -290,7 +290,7 @@ class Agent:
         tools: Optional[List[Callable]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-2.5-pro",
+        model: str = "co/gemini-3.6-flash",
         max_iterations: int = 100
     )
     

--- a/docs/debug/auto_debug.md
+++ b/docs/debug/auto_debug.md
@@ -59,7 +59,7 @@ Type your message to the agent:
 ────────────────────────────────────────────────────
 
 Iteration 1/10
-→ LLM Request (co/gemini-2.5-pro)
+→ LLM Request (co/gemini-3.6-flash)
 ← LLM Response (234ms): 2 tool calls
 
 → Tool: search_emails({"query": "John"})
@@ -324,7 +324,7 @@ Conversation Messages:
 
 Agent State:
   Name: email_assistant
-  Model: co/gemini-2.5-pro
+  Model: co/gemini-3.6-flash
   Iteration: 1/10
   Tools available: [search_emails, send_email]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/debug/console.md
+++ b/docs/debug/console.md
@@ -19,7 +19,7 @@ When you run an agent, you'll see the onion stack banner and execution flow:
  ◎    my-assistant
 ●     ────────────────────
       connectonion v0.5.1
-      co/gemini-2.5-pro · 3 tools
+      co/gemini-3.6-flash · 3 tools
       .co/logs/ · .co/evals/
       ────────────────────
 

--- a/docs/debug/eval.md
+++ b/docs/debug/eval.md
@@ -124,7 +124,7 @@ from connectonion import Agent
 agent = Agent(
     name="my_agent",
     tools=[...],
-    model="co/gemini-2.5-pro"
+    model="co/gemini-3.6-flash"
 )
 
 if __name__ == "__main__":

--- a/docs/debug/log.md
+++ b/docs/debug/log.md
@@ -45,7 +45,7 @@ Session started: 2024-12-02 10:32:14
 ============================================================
 
 [10:32:14] INPUT: Generate a Python function...
-[10:32:14] -> LLM Request (co/gemini-2.5-pro) • 2 msgs • 3 tools
+[10:32:14] -> LLM Request (co/gemini-3.6-flash) • 2 msgs • 3 tools
 [10:32:15] <- LLM Response (1.1s) • 1 tools • 1.2k tokens • $0.0012
 [10:32:15] -> Tool: generate_code({"language": "python"})
 [10:32:15] <- Result (0.05s): def hello(): print("Hi")...
@@ -62,7 +62,7 @@ timestamp: 2024-12-02 10:32:14
 
 turns:
   - input: "Generate a Python function"
-    model: "co/gemini-2.5-pro"
+    model: "co/gemini-3.6-flash"
     duration_ms: 2300
     tokens: 1234
     cost: 0.0012

--- a/docs/templates/coder.md
+++ b/docs/templates/coder.md
@@ -41,7 +41,7 @@ agent = Agent(
     name="coder",
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
     max_iterations=50,
 )
 

--- a/docs/templates/minimal.md
+++ b/docs/templates/minimal.md
@@ -55,7 +55,7 @@ agent = Agent(
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write, browser],
     plugins=[image_result_formatter, tool_approval],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
 )
 
 result = agent.input("what is your task?")
@@ -101,7 +101,7 @@ agent = Agent(
     system_prompt="prompt.md",
     tools=[bash, read_file, edit, glob, grep, write, browser, my_tool],
     plugins=[image_result_formatter, tool_approval],
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
 )
 ```
 

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -288,7 +288,7 @@ class TestCliCreate:
             assert os.path.exists(env_file)
             with open(env_file) as f:
                 content = f.read()
-                assert "# Default model: co/gemini-2.5-pro" in content
+                assert "# Default model: co/gemini-3.6-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_create_adds_agent_address_explanation_to_global_keys(self):

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -347,7 +347,7 @@ class TestCliInit:
             assert os.path.exists(".env")
             with open(".env") as f:
                 content = f.read()
-                assert "# Default model: co/gemini-2.5-pro" in content
+                assert "# Default model: co/gemini-3.6-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_init_creates_agent_address_explanation_in_global_keys(self, tmp_path, monkeypatch):

--- a/tests/e2e/real_api/manual/manual_defaults.py
+++ b/tests/e2e/real_api/manual/manual_defaults.py
@@ -46,7 +46,7 @@ print(f"\nAgent default model: {agent_model_default}")
 print(f"llm_do default model: {llm_do_model_default}")
 
 # Expected values
-expected_agent = "co/o4-mini"
+expected_agent = "co/gemini-3.6-flash"
 expected_llm_do = "co/gpt-4o"
 
 if agent_model_default == expected_agent:
@@ -70,7 +70,7 @@ print("   ")
 print("   # Simple call - uses co/gpt-4o")
 print("   answer = llm_do('What is 2+2?')")
 print("   ")
-print("   # Agent - uses co/o4-mini")
+print("   # Agent - uses co/gemini-3.6-flash")
 print("   agent = Agent('assistant', tools=[...])")
 print("   result = agent.input('Analyze this data')")
 
@@ -81,7 +81,7 @@ print("   agent = Agent('name', model='claude-3-5-sonnet', api_key='sk-ant-...')
 
 print("\n3. Backend supported models:")
 print("   - co/gpt-4o ✓")
-print("   - co/o4-mini ✓")
+print("   - co/gemini-3.6-flash ✓")
 
 # Test 3: Try to use with override (if OpenAI key available)
 if has_openai:

--- a/tests/e2e/real_api/test_real_billing_error_agent.py
+++ b/tests/e2e/real_api/test_real_billing_error_agent.py
@@ -47,7 +47,7 @@ def test_beautiful_error_message():
 
     agent = Agent(
         name="billing_test",
-        model="co/gemini-2.5-pro",
+        model="co/gemini-3.6-flash",
         api_key=LOW_CREDIT_API_KEY,
         quiet=True,
         log=False
@@ -92,7 +92,7 @@ def test_exception_has_typed_attributes():
 
     agent = Agent(
         name="billing_test",
-        model="co/gemini-2.5-pro",
+        model="co/gemini-3.6-flash",
         api_key=LOW_CREDIT_API_KEY,
         quiet=True,
         log=False
@@ -133,7 +133,7 @@ def test_programmatic_error_handling():
 
     agent = Agent(
         name="billing_test",
-        model="co/gemini-2.5-pro",
+        model="co/gemini-3.6-flash",
         api_key=LOW_CREDIT_API_KEY,
         quiet=True,
         log=False

--- a/tests/e2e/real_api/test_responses_parse.py
+++ b/tests/e2e/real_api/test_responses_parse.py
@@ -41,13 +41,13 @@ OPENAI_MODELS = [
     "co/gpt-5",
     "co/gpt-5-mini",
     "co/gpt-5-nano",
-    "co/o4-mini",
+    "co/gemini-3.6-flash",
 ]
 
 GEMINI_MODELS = [
     "co/gemini-2.5-flash",
     "co/gemini-2.5-flash-lite",
-    "co/gemini-2.5-pro",
+    "co/gemini-3.6-flash",
     "co/gemini-2.0-flash",
     "co/gemini-2.0-flash-lite",
     "co/gemini-3.5-flash",

--- a/tests/unit/test_subagents.py
+++ b/tests/unit/test_subagents.py
@@ -61,7 +61,7 @@ class TestSubagentsPlugin:
         # Verify frontmatter
         fm = config['frontmatter']
         assert fm['name'] == 'explore'
-        assert fm['model'] == 'co/gemini-2.5-pro'
+        assert fm['model'] == 'co/gemini-3.6-flash'
         assert fm['max_iterations'] == 15
         assert 'glob' in fm['tools']
         assert 'grep' in fm['tools']
@@ -80,7 +80,7 @@ class TestSubagentsPlugin:
         # Verify frontmatter
         fm = config['frontmatter']
         assert fm['name'] == 'plan'
-        assert fm['model'] == 'co/gemini-2.5-pro'
+        assert fm['model'] == 'co/gemini-3.6-flash'
         assert fm['max_iterations'] == 10
         assert 'glob' in fm['tools']
         assert 'grep' in fm['tools']


### PR DESCRIPTION
### Motivation
- Bring the repository defaults up-to-date to use the newer Gemini 3.6 fast model as the zero‑setup managed model for agents and one-shot calls.
- Ensure managed-key fallbacks, CLI templates, generated project `.env` comments, examples, and built-in subagents consistently reference the new default.

### Description
- Updated the Agent default model to `co/gemini-3.6-flash` in `connectonion/core/agent.py` and related API docs and examples.
- Changed the OpenOnion managed-key LLM fallback default to `co/gemini-3.6-flash` in `connectonion/core/llm.py` and updated the `llm_do()` default to `co/gemini-3.6-flash` in `connectonion/llm_do.py`.
- Propagated the new default across CLI scaffolding, templates and `.env` generation in `connectonion/cli/...` and updated built-in subagent frontmatter and example agent files to use `co/gemini-3.6-flash`.
- Updated documentation and examples under `docs/` and test expectations in `tests/` to reflect the new default model.

### Testing
- Ran `git diff --check` with no whitespace or diff-check issues observed and compiled the package sources with `python -m compileall` which succeeded for the code paths exercised.
- Ran targeted compile checks for test modules (`tests/unit/test_llm.py`, `tests/unit/test_usage.py`, `tests/unit/test_subagents.py`, and selected e2e CLI tests) which compiled successfully.
- Attempted `pytest` for the same unit/e2e selection but the run was blocked by missing environment dependencies (`python-dotenv`) and by network failures when installing build dependencies, so full test execution could not complete.
- Notes: network access failures prevented installing packaging/build deps and some real-api tests, so CI should run a full `pytest` after dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63d72d8e248333a197c1812b93473c)