### PR TITLE
Show credential sources and optional values in co status

### DIFF
--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -1,17 +1,20 @@
 """
-Purpose: Display account status including balance, usage, and email configuration without re-authenticating
+Purpose: Display account status, deployments, and redacted credential-source diagnostics without re-authenticating
 LLM-Note:
-  Dependencies: imports from [os, yaml, requests, pathlib, rich.console, rich.panel, dotenv.load_dotenv, jwt, address] | imported by [cli/main.py via handle_status()] | calls backend at [https://oo.openonion.ai/api/v1/auth] | tested by [tests/e2e/cli/test_cli_status.py]
-  Data flow: receives no args → load_api_key() checks OPENONION_API_KEY from env/local .env/global ~/.co/keys.env → address.load() reads Ed25519 keypair → creates fresh auth message with timestamp → address.sign() creates signature → POST to /api/v1/auth to get current user data → displays balance, credits, total spent, email, agent ID → warns if balance <= 0
-  State/Effects: no state modifications | makes network GET request to oo.openonion.ai | reads from env vars, .env, ~/.co/keys.env | writes to stdout via rich.Console and rich.Panel | does NOT update any files
-  Integration: exposes handle_status() for CLI | similar to authenticate() but read-only | relies on address module for signature generation | uses requests for HTTP calls | displays Rich panel with account info | checks OPENONION_API_KEY in 3 locations (priority: env var > local .env > global ~/.co/keys.env)
+  Dependencies: imports from [os, requests, pathlib, dotenv.dotenv_values, rich.console, rich.panel, rich.table, address] | imported by [cli/main.py via handle_status()] | calls backend at [https://oo.openonion.ai/api/v1/auth] | tested by [tests/e2e/cli/test_cli_status.py]
+  Data flow: receives no args → inspects supported provider variable names in process env/local .env/global ~/.co/keys.env without loading values → displays redacted name/status/source table → load_api_key() resolves OPENONION_API_KEY → address.load() reads Ed25519 keypair → creates fresh auth message with timestamp → address.sign() creates signature → POST to /api/v1/auth → displays account and deployments
+  State/Effects: no state modifications | makes network requests to oo.openonion.ai after local diagnostics | reads env vars, .env, ~/.co/keys.env without exporting them | writes only credential names/status/source paths, never values or fingerprints | does NOT update any files
+  Integration: exposes handle_status() for CLI | credential discovery supports every provider in core/llm.py | OpenOnion auth still uses load_api_key() priority | source paths are privacy-safe (<project>/.env and ~/.co/keys.env)
   Performance: network call to backend (1-2s) | signature generation is fast (<10ms) | file I/O for .env files
-  Errors: fails gracefully if OPENONION_API_KEY not found (prints message to run 'co auth') | fails if keys missing in .co/keys/ | fails if backend unreachable (prints HTTP error) | handles response errors with status code display
+  Errors: credential parse/read failures are treated as no discovered keys | account status fails gracefully if OPENONION_API_KEY or identity keys are missing | backend errors do not expose credential values
 """
 
 import os
-import requests
 from pathlib import Path
+from typing import Mapping
+
+import requests
+from dotenv import dotenv_values
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -21,6 +24,148 @@ from .project_cmd_lib import load_api_key
 console = Console()
 
 API_BASE = "https://oo.openonion.ai"
+
+CREDENTIAL_ENV_VARS = (
+    ("OPENONION_API_KEY", "OpenOnion"),
+    ("OPENAI_API_KEY", "OpenAI"),
+    ("ANTHROPIC_API_KEY", "Anthropic"),
+    ("GEMINI_API_KEY", "Gemini"),
+    ("GOOGLE_API_KEY", "Gemini alias"),
+    ("GROQ_API_KEY", "Groq"),
+    ("XAI_API_KEY", "xAI"),
+    ("OPENROUTER_API_KEY", "OpenRouter"),
+    ("MISTRAL_API_KEY", "Mistral"),
+)
+
+_PLACEHOLDER_VALUES = {
+    "changeme",
+    "replace-me",
+    "replace_me",
+    "your-api-key-here",
+    "your_api_key_here",
+}
+
+
+def _is_configured(value: object) -> bool:
+    """Return whether *value* looks like a real configured secret.
+
+    Values are inspected only in memory. They are never included in returned
+    rows, terminal output, logs, or errors.
+    """
+    if value is None:
+        return False
+    normalized = str(value).strip().strip("\"'")
+    if not normalized:
+        return False
+    lowered = normalized.lower()
+    return not (
+        lowered in _PLACEHOLDER_VALUES
+        or lowered.startswith(("sk-your", "your-", "your_", "<"))
+        or (lowered.startswith("${") and lowered.endswith("}"))
+    )
+
+
+def _read_credential_file(path: Path) -> dict[str, str]:
+    """Read supported key entries without mutating ``os.environ``."""
+    if not path.is_file():
+        return {}
+    try:
+        values = dotenv_values(path, interpolate=False)
+    except (OSError, UnicodeError):
+        return {}
+    supported = {name for name, _provider in CREDENTIAL_ENV_VARS}
+    return {
+        name: str(value)
+        for name, value in values.items()
+        if name in supported and _is_configured(value)
+    }
+
+
+def _credential_rows(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> list[dict[str, str]]:
+    """Return redacted credential metadata suitable for display or JSON.
+
+    The returned dictionaries intentionally cannot contain secret values.
+    """
+    project_dir = (project_dir or Path.cwd()).resolve()
+    home = (home or Path.home()).resolve()
+    environ = os.environ if environ is None else environ
+
+    local_values = _read_credential_file(project_dir / ".env")
+    global_values = _read_credential_file(home / ".co" / "keys.env")
+    sources = (
+        ("process environment", environ),
+        ("<project>/.env", local_values),
+        ("~/.co/keys.env", global_values),
+    )
+
+    rows: list[dict[str, str]] = []
+    for name, provider in CREDENTIAL_ENV_VARS:
+        found = [
+            (source, str(values.get(name)))
+            for source, values in sources
+            if _is_configured(values.get(name))
+        ]
+        source_names = [source for source, _value in found]
+        unique_values = {value for _source, value in found}
+
+        if not found:
+            status = "missing"
+            source = "—"
+        elif len(unique_values) > 1:
+            status = "conflict"
+            source = " + ".join(source_names)
+        elif source_names[0] == "process environment":
+            status = "configured"
+            source = " + ".join(source_names)
+        else:
+            status = "discovered · not loaded"
+            source = " + ".join(source_names)
+
+        rows.append(
+            {
+                "provider": provider,
+                "credential": name,
+                "status": status,
+                "source": source,
+            }
+        )
+    return rows
+
+
+def _show_credentials() -> None:
+    """Print provider credential availability without any secret material."""
+    status_style = {
+        "configured": "green",
+        "discovered · not loaded": "yellow",
+        "conflict": "red",
+        "missing": "dim",
+    }
+    table = Table(
+        title="Credential Sources",
+        show_header=True,
+        header_style="bold cyan",
+    )
+    table.add_column("Provider")
+    table.add_column("Credential")
+    table.add_column("Status")
+    table.add_column("Source")
+
+    for row in _credential_rows():
+        style = status_style[row["status"]]
+        table.add_row(
+            row["provider"],
+            row["credential"],
+            f"[{style}]{row['status']}[/{style}]",
+            row["source"],
+        )
+
+    console.print()
+    console.print(table)
 
 
 def _fetch_deployments(api_key: str):
@@ -75,6 +220,8 @@ def handle_status():
     - Last seen
     - Warnings if balance is low
     """
+    _show_credentials()
+
     # Load API key
     api_key = load_api_key()
     if not api_key:
@@ -84,6 +231,7 @@ def handle_status():
         return
 
     import time
+
     from ... import address
 
     # Load keys to re-sign
@@ -121,9 +269,6 @@ def handle_status():
     user = data.get("user", {})
     email_info = user.get("email") or {}
 
-    # Build info display
-    api_key_display = f"{api_key[:20]}..." if len(api_key) > 20 else api_key
-
     # Compute short address from full address (first 6 chars + ... + last 4 chars)
     short_address = f"{public_key[:6]}...{public_key[-4:]}"
 
@@ -131,7 +276,6 @@ def handle_status():
         f"[cyan]Agent Address:[/cyan] {public_key}",
         f"[cyan]Agent ID:[/cyan] {short_address}",
         f"[cyan]Email:[/cyan] {email_info.get('address') or os.getenv('AGENT_EMAIL', 'Not configured')}",
-        f"[cyan]API Key:[/cyan] {api_key_display}",
         f"[cyan]Balance:[/cyan] ${user.get('balance_usd', 0.0):.4f}",
         f"[cyan]Total Spent:[/cyan] ${user.get('total_cost_usd', 0.0):.4f}",
         f"[cyan]Credits:[/cyan] ${user.get('credits_usd', 0.0):.4f}",

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -1,12 +1,12 @@
 """
-Purpose: Display account status, deployments, and redacted credential-source diagnostics without re-authenticating
+Purpose: Display account status, deployments, and credential-source diagnostics without re-authenticating
 LLM-Note:
-  Dependencies: imports from [os, requests, pathlib, dotenv.dotenv_values, rich.console, rich.panel, rich.table, address] | imported by [cli/main.py via handle_status()] | calls backend at [https://oo.openonion.ai/api/v1/auth] | tested by [tests/e2e/cli/test_cli_status.py]
-  Data flow: receives no args → inspects supported provider variable names in process env/local .env/global ~/.co/keys.env without loading values → displays redacted name/status/source table → load_api_key() resolves OPENONION_API_KEY → address.load() reads Ed25519 keypair → creates fresh auth message with timestamp → address.sign() creates signature → POST to /api/v1/auth → displays account and deployments
-  State/Effects: no state modifications | makes network requests to oo.openonion.ai after local diagnostics | reads env vars, .env, ~/.co/keys.env without exporting them | writes only credential names/status/source paths, never values or fingerprints | does NOT update any files
-  Integration: exposes handle_status() for CLI | credential discovery supports every provider in core/llm.py | OpenOnion auth still uses load_api_key() priority | source paths are privacy-safe (<project>/.env and ~/.co/keys.env)
+  Dependencies: imports from [os, requests, pathlib, dotenv.dotenv_values, rich.console, rich.panel, rich.table, rich.text, address] | imported by [cli/main.py via handle_status()] | calls backend at [https://oo.openonion.ai/api/v1/auth] | tested by [tests/e2e/cli/test_cli_status.py]
+  Data flow: receives reveal=False by default → inspects supported provider variable names in process env/local .env/global ~/.co/keys.env without loading values → displays redacted name/status/source table → if reveal=True, displays full values in a separate warning-marked table → load_api_key() resolves OPENONION_API_KEY → address.load() reads Ed25519 keypair → creates fresh auth message with timestamp → address.sign() creates signature → POST to /api/v1/auth → displays account and deployments
+  State/Effects: no state modifications | makes network requests to oo.openonion.ai after local diagnostics | reads env vars, .env, ~/.co/keys.env without exporting them | default output contains no secret material; explicit --reveal writes full values to the terminal | does NOT update any files
+  Integration: exposes handle_status(reveal=False) for CLI | credential discovery supports every provider in core/llm.py | OpenOnion auth still uses load_api_key() priority | source paths are privacy-safe (<project>/.env and ~/.co/keys.env)
   Performance: network call to backend (1-2s) | signature generation is fast (<10ms) | file I/O for .env files
-  Errors: credential parse/read failures are treated as no discovered keys | account status fails gracefully if OPENONION_API_KEY or identity keys are missing | backend errors do not expose credential values
+  Errors: credential parse/read failures are treated as no discovered keys | account status fails gracefully if OPENONION_API_KEY or identity keys are missing | backend errors do not expose credential values; only explicit --reveal prints them
 """
 
 import os
@@ -18,6 +18,7 @@ from dotenv import dotenv_values
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from .project_cmd_lib import load_api_key
 
@@ -49,8 +50,8 @@ _PLACEHOLDER_VALUES = {
 def _is_configured(value: object) -> bool:
     """Return whether *value* looks like a real configured secret.
 
-    Values are inspected only in memory. They are never included in returned
-    rows, terminal output, logs, or errors.
+    Values are inspected only in memory unless the caller explicitly selects
+    the ``--reveal`` display path.
     """
     if value is None:
         return False
@@ -81,6 +82,24 @@ def _read_credential_file(path: Path) -> dict[str, str]:
     }
 
 
+def _credential_sources(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> tuple[tuple[str, Mapping[str, str]], ...]:
+    """Return supported credential values grouped by privacy-safe source."""
+    project_dir = (project_dir or Path.cwd()).resolve()
+    home = (home or Path.home()).resolve()
+    environ = os.environ if environ is None else environ
+
+    return (
+        ("process environment", environ),
+        ("<project>/.env", _read_credential_file(project_dir / ".env")),
+        ("~/.co/keys.env", _read_credential_file(home / ".co" / "keys.env")),
+    )
+
+
 def _credential_rows(
     *,
     project_dir: Path | None = None,
@@ -91,16 +110,10 @@ def _credential_rows(
 
     The returned dictionaries intentionally cannot contain secret values.
     """
-    project_dir = (project_dir or Path.cwd()).resolve()
-    home = (home or Path.home()).resolve()
-    environ = os.environ if environ is None else environ
-
-    local_values = _read_credential_file(project_dir / ".env")
-    global_values = _read_credential_file(home / ".co" / "keys.env")
-    sources = (
-        ("process environment", environ),
-        ("<project>/.env", local_values),
-        ("~/.co/keys.env", global_values),
+    sources = _credential_sources(
+        project_dir=project_dir,
+        home=home,
+        environ=environ,
     )
 
     rows: list[dict[str, str]] = []
@@ -137,8 +150,36 @@ def _credential_rows(
     return rows
 
 
-def _show_credentials() -> None:
-    """Print provider credential availability without any secret material."""
+def _revealed_credential_rows(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> list[dict[str, str]]:
+    """Return full credential values for the explicit ``--reveal`` path."""
+    sources = _credential_sources(
+        project_dir=project_dir,
+        home=home,
+        environ=environ,
+    )
+    rows: list[dict[str, str]] = []
+    for name, provider in CREDENTIAL_ENV_VARS:
+        for source, values in sources:
+            value = values.get(name)
+            if _is_configured(value):
+                rows.append(
+                    {
+                        "provider": provider,
+                        "credential": name,
+                        "source": source,
+                        "value": str(value),
+                    }
+                )
+    return rows
+
+
+def _show_credentials(reveal: bool = False) -> None:
+    """Print provider credential availability and optionally full values."""
     status_style = {
         "configured": "green",
         "discovered · not loaded": "yellow",
@@ -166,6 +207,42 @@ def _show_credentials() -> None:
 
     console.print()
     console.print(table)
+
+    if not reveal:
+        console.print(
+            "[dim]Values hidden. Use [bold]co status --reveal[/bold] "
+            "only when you intentionally need full credentials.[/dim]"
+        )
+        return
+
+    revealed_rows = _revealed_credential_rows()
+    if not revealed_rows:
+        console.print("[dim]No credential values are available to reveal.[/dim]")
+        return
+
+    console.print(
+        "\n[bold yellow]⚠ Secrets shown in full. "
+        "Do not share this output or paste it into logs.[/bold yellow]"
+    )
+    revealed_table = Table(
+        title="Revealed Credential Values",
+        show_header=True,
+        header_style="bold yellow",
+    )
+    revealed_table.add_column("Provider")
+    revealed_table.add_column("Credential")
+    revealed_table.add_column("Source")
+    revealed_table.add_column("Value", overflow="fold", no_wrap=False)
+
+    for row in revealed_rows:
+        revealed_table.add_row(
+            row["provider"],
+            row["credential"],
+            row["source"],
+            Text(row["value"]),
+        )
+
+    console.print(revealed_table)
 
 
 def _fetch_deployments(api_key: str):
@@ -209,8 +286,11 @@ def _show_deployments(deployments):
     console.print(table)
 
 
-def handle_status():
+def handle_status(reveal: bool = False):
     """Check account status without re-authenticating.
+
+    Args:
+        reveal: If True, print full provider credential values.
 
     Shows:
     - Agent ID
@@ -220,7 +300,7 @@ def handle_status():
     - Last seen
     - Warnings if balance is low
     """
-    _show_credentials()
+    _show_credentials(reveal=reveal)
 
     # Load API key
     api_key = load_api_key()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -21,11 +21,12 @@ if sys.platform == "win32":
         if hasattr(_stream, "reconfigure"):
             _stream.reconfigure(encoding="utf-8", errors="replace")
 
-import typer
 from pathlib import Path
-from rich.console import Console
-from typing import Optional, List
+from typing import List, Optional
+
+import typer
 from dotenv import load_dotenv
+from rich.console import Console
 
 from .. import __version__
 
@@ -77,7 +78,7 @@ def _show_help():
     console.print("  [green]outlook[/green]           Send and read Outlook email (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
-    console.print("  [green]status[/green]            Check account balance")
+    console.print("  [green]status[/green]            Check credentials, account, and deployments")
     console.print("  [green]doctor[/green]            Diagnose installation")
     console.print()
     console.print("[bold]Docs:[/bold] https://docs.connectonion.com")
@@ -147,7 +148,7 @@ def keys(
 
 @app.command()
 def status():
-    """Check account status."""
+    """Check credential sources, account status, and deployments."""
     from .commands.status_commands import handle_status
     handle_status()
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -2,9 +2,9 @@
 Purpose: Entry point for ConnectOnion CLI application using Typer framework with Rich formatting
 LLM-Note:
   Dependencies: imports from [typer, rich.console, typing, __version__] | imported by [setup.py entry_points, __main__.py] | loads commands from [cli/commands/{init, create, deploy, auth, status, reset, doctor, browser}_commands.py] | tested by [tests/e2e/cli/test_cli_help.py]
-  Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
+  Data flow: cli() entry point → creates Typer app → registers command callbacks (init, create, deploy, auth, status, reset, doctor, browser) → Typer parses args (including status --reveal/-r) → invokes corresponding handle_*() function from commands module → command outputs via rich.Console
   State/Effects: no persistent state | writes to stdout via rich.Console | lazy imports command handlers on invocation | registers typer.Option and typer.Argument decorators | uses typer.Exit() for early termination
-  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills repeatable, --name for template deploys), auth [google|microsoft], status, reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
+  Integration: exposes cli() entry point registered in setup.py as 'co' command | app() is the Typer instance | commands: init, create, deploy (-t/--template, --skills repeatable, --name for template deploys), auth [google|microsoft], status (--reveal/-r), reset, doctor, browser | --version flag shows version | -b/--browser flag shortcuts browser command | no args shows custom help via _show_help()
   Performance: fast startup (lazy imports) | Typer arg parsing is O(n) args | Rich console initialization is lightweight
   Errors: typer.Exit() on --version or --browser | invalid commands show Typer error with suggestions | command-specific errors handled in respective handlers
 """
@@ -147,10 +147,17 @@ def keys(
 
 
 @app.command()
-def status():
+def status(
+    reveal: bool = typer.Option(
+        False,
+        "--reveal",
+        "-r",
+        help="Show full provider credential values",
+    ),
+):
     """Check credential sources, account status, and deployments."""
     from .commands.status_commands import handle_status
-    handle_status()
+    handle_status(reveal=reveal)
 
 
 @app.command()

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -251,9 +251,10 @@ The CLI wraps the same `Outlook` tool your agents use. See
 
 ---
 
-#### `co status` - Check Account and Deployments
+#### `co status` - Check Credentials, Account, and Deployments
 
-Shows your managed keys balance, usage, and deployed agents.
+Shows redacted provider credential availability and source paths, followed by your
+managed-keys balance, usage, and deployed agents. Credential values are never shown.
 
 **Basic usage:**
 ```bash
@@ -263,6 +264,14 @@ co status
 **Example output:**
 ```bash
 $ co status
+
+Credential Sources
+┏━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
+┃ Provider   ┃ Credential        ┃ Status                  ┃ Source              ┃
+┡━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
+│ Gemini     │ GEMINI_API_KEY    │ discovered · not loaded │ <project>/.env      │
+│ OpenAI     │ OPENAI_API_KEY    │ configured              │ process environment │
+└────────────┴───────────────────┴─────────────────────────┴─────────────────────┘
 
 ConnectOnion Account Status
 ============================
@@ -280,6 +289,9 @@ Deployed Agents
 ```
 
 **When to use:**
+- See which supported provider credentials are configured or discovered
+- Find a credential's privacy-safe source path without exposing its value
+- Diagnose credentials that exist in `.env` but are not loaded
 - Check remaining credits
 - Verify authentication
 - See account details

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -254,11 +254,13 @@ The CLI wraps the same `Outlook` tool your agents use. See
 #### `co status` - Check Credentials, Account, and Deployments
 
 Shows redacted provider credential availability and source paths, followed by your
-managed-keys balance, usage, and deployed agents. Credential values are never shown.
+managed-keys balance, usage, and deployed agents. Credential values are hidden by
+default and shown in full only when you explicitly pass `--reveal`.
 
 **Basic usage:**
 ```bash
 co status
+co status --reveal  # intentionally print full provider credential values
 ```
 
 **Example output:**
@@ -292,6 +294,8 @@ Deployed Agents
 - See which supported provider credentials are configured or discovered
 - Find a credential's privacy-safe source path without exposing its value
 - Diagnose credentials that exist in `.env` but are not loaded
+- Intentionally inspect full values with `co status --reveal` (avoid shared terminals,
+  logs, recordings, and screenshots)
 - Check remaining credits
 - Verify authentication
 - See account details

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -85,12 +85,17 @@ What it does:
 
 ```bash
 co status
+co status --reveal  # intentionally print full provider credential values
 ```
 
 The default output lists supported credential variable names, whether each one is
 configured, discovered-but-not-loaded, conflicting, or missing, and its privacy-safe
 source such as `process environment`, `<project>/.env`, or `~/.co/keys.env`. It never
-prints any raw, partial, hashed, or fingerprinted secret material.
+prints any raw, partial, hashed, or fingerprinted secret material by default.
+
+Pass `--reveal` (or `-r`) only when you deliberately need the full provider values.
+This prints every discovered value and its source, including conflicts. Avoid using
+it in shared terminals, logs, recordings, screenshots, or support messages.
 
 Use this after `co auth` to confirm the CLI can load your API key and reach the backend,
 or to diagnose why a provider key in `.env` is not visible to the current process.

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -81,13 +81,19 @@ What it does:
 4. Calls the OpenOnion auth API.
 5. Saves `OPENONION_API_KEY`, `AGENT_EMAIL`, and `AGENT_ADDRESS` to the appropriate env files.
 
-### `co status` — check account and deployment status
+### `co status` — check credentials, account, and deployments
 
 ```bash
 co status
 ```
 
-Use this after `co auth` to confirm the CLI can load your API key and reach the backend.
+The default output lists supported credential variable names, whether each one is
+configured, discovered-but-not-loaded, conflicting, or missing, and its privacy-safe
+source such as `process environment`, `<project>/.env`, or `~/.co/keys.env`. It never
+prints any raw, partial, hashed, or fingerprinted secret material.
+
+Use this after `co auth` to confirm the CLI can load your API key and reach the backend,
+or to diagnose why a provider key in `.env` is not visible to the current process.
 
 ### `co keys` — inspect local credentials
 

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -22,9 +22,11 @@ from unittest.mock import Mock, patch
 
 from rich.console import Console
 
+from .argparse_runner import ArgparseCliRunner
+
 
 class TestCredentialStatus:
-    """Credential diagnostics expose metadata, never secret material."""
+    """Credential diagnostics are redacted unless explicitly revealed."""
 
     @staticmethod
     def _row(rows, credential):
@@ -184,6 +186,46 @@ class TestCredentialStatus:
         assert secret not in rendered
         assert secret[:20] not in rendered
 
+    def test_explicit_reveal_prints_full_values_and_sources(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from connectonion.cli.commands import status_commands
+
+        project = tmp_path / "project"
+        fake_home = tmp_path / "home"
+        project.mkdir()
+        fake_home.mkdir()
+        process_secret = "gemini-process-secret"
+        local_secret = "gemini-project-secret"
+        (project / ".env").write_text(f"GEMINI_API_KEY={local_secret}\n")
+        monkeypatch.chdir(project)
+
+        output = StringIO()
+        test_console = Console(
+            file=output,
+            force_terminal=False,
+            color_system=None,
+            width=160,
+        )
+        with patch.dict(
+            os.environ,
+            {"GEMINI_API_KEY": process_secret},
+            clear=True,
+        ):
+            with patch.object(Path, "home", return_value=fake_home):
+                with patch.object(status_commands, "console", test_console):
+                    status_commands._show_credentials(reveal=True)
+
+        rendered = output.getvalue()
+        assert "Revealed Credential Values" in rendered
+        assert "Secrets shown in full" in rendered
+        assert "process environment" in rendered
+        assert "<project>/.env" in rendered
+        assert process_secret in rendered
+        assert local_secret in rendered
+
 
 class TestLoadApiKey:
     """Tests for _load_api_key function."""
@@ -270,6 +312,37 @@ class TestHandleStatusNoApiKey:
 
         # Should print error message
         assert mock_console.print.called
+
+    @patch('connectonion.cli.commands.status_commands._show_credentials')
+    @patch('connectonion.cli.commands.status_commands.load_api_key')
+    def test_status_forwards_explicit_reveal(
+        self,
+        mock_load_key,
+        mock_show_credentials,
+    ):
+        mock_load_key.return_value = None
+
+        from connectonion.cli.commands.status_commands import handle_status
+
+        handle_status(reveal=True)
+
+        mock_show_credentials.assert_called_once_with(reveal=True)
+
+
+class TestStatusCli:
+    """Tests for the status command's Typer options."""
+
+    def setup_method(self):
+        self.runner = ArgparseCliRunner()
+
+    @patch('connectonion.cli.commands.status_commands.handle_status')
+    def test_status_reveal_flag(self, mock_handle_status):
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(cli, ["status", "--reveal"])
+
+        assert result.exit_code == 0
+        mock_handle_status.assert_called_once_with(reveal=True)
 
 
 class TestHandleStatusNoKeys:

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -1,12 +1,4 @@
-"""Unit tests for connectonion/cli/commands/status_commands.py
-
-Tests cover:
-- load_api_key: Load API key from env var, .env, ~/.co/keys.env
-- handle_status: Display account status without re-authenticating
-"""
-
-"""
-LLM-Note: Tests for CLI status command (co status)
+"""Tests for the CLI status command (``co status``).
 
 What it tests:
 - TestLoadApiKey: API key loading from multiple sources
@@ -18,15 +10,179 @@ What it tests:
 
 Components under test:
 - connectonion.cli.commands.project_cmd_lib.load_api_key
-- connectonion.cli.commands.status_commands._load_config
+- connectonion.cli.commands.status_commands._credential_rows
 - connectonion.cli.commands.status_commands.handle_status
 """
 
-import pytest
 import os
 import tempfile
+from io import StringIO
 from pathlib import Path
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import Mock, patch
+
+from rich.console import Console
+
+
+class TestCredentialStatus:
+    """Credential diagnostics expose metadata, never secret material."""
+
+    @staticmethod
+    def _row(rows, credential):
+        return next(row for row in rows if row["credential"] == credential)
+
+    def test_reports_configured_key_and_all_matching_sources(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        home.mkdir()
+        secret = "gemini-super-secret-value"
+        (project / ".env").write_text(f"GEMINI_API_KEY={secret}\n")
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ={"GEMINI_API_KEY": secret},
+        )
+        gemini = self._row(rows, "GEMINI_API_KEY")
+
+        assert gemini == {
+            "provider": "Gemini",
+            "credential": "GEMINI_API_KEY",
+            "status": "configured",
+            "source": "process environment + <project>/.env",
+        }
+        assert secret not in repr(rows)
+
+    def test_reports_discovered_key_without_loading_environment(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        home.mkdir()
+        (project / ".env").write_text("OPENAI_API_KEY=local-secret\n")
+        environment = {}
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ=environment,
+        )
+        openai = self._row(rows, "OPENAI_API_KEY")
+
+        assert openai["status"] == "discovered · not loaded"
+        assert openai["source"] == "<project>/.env"
+        assert environment == {}
+        assert "local-secret" not in repr(rows)
+
+    def test_reports_conflicting_sources_without_values(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        (home / ".co").mkdir(parents=True)
+        (project / ".env").write_text("ANTHROPIC_API_KEY=local-secret\n")
+        (home / ".co" / "keys.env").write_text(
+            "ANTHROPIC_API_KEY=global-secret\n"
+        )
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ={},
+        )
+        anthropic = self._row(rows, "ANTHROPIC_API_KEY")
+
+        assert anthropic["status"] == "conflict"
+        assert anthropic["source"] == "<project>/.env + ~/.co/keys.env"
+        assert "local-secret" not in repr(rows)
+        assert "global-secret" not in repr(rows)
+        assert str(tmp_path) not in repr(rows)
+
+    def test_ignores_placeholders_and_empty_values(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        home.mkdir()
+        (project / ".env").write_text(
+            "GROQ_API_KEY=your-api-key-here\n"
+            "XAI_API_KEY=\n"
+            "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}\n"
+        )
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ={},
+        )
+
+        for credential in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"):
+            assert self._row(rows, credential)["status"] == "missing"
+
+    @patch('connectonion.address.load')
+    @patch('connectonion.address.sign')
+    @patch('connectonion.cli.commands.status_commands.requests.get')
+    @patch('connectonion.cli.commands.status_commands.requests.post')
+    def test_default_status_never_prints_api_key_material(
+        self,
+        mock_post,
+        mock_get,
+        mock_sign,
+        mock_load,
+        tmp_path,
+        monkeypatch,
+    ):
+        from connectonion.cli.commands import status_commands
+
+        secret = "openonion-secret-that-must-never-appear"
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OPENONION_API_KEY", secret)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        co_dir = tmp_path / ".co" / "keys"
+        co_dir.mkdir(parents=True)
+        (co_dir / "agent.key").write_text("dummy")
+
+        mock_load.return_value = {"address": "0x1234567890abcdef"}
+        mock_sign.return_value = b'\x00' * 64
+        mock_post.return_value = Mock(
+            status_code=200,
+            json=lambda: {
+                "user": {
+                    "balance_usd": 1.0,
+                    "total_cost_usd": 0.0,
+                    "credits_usd": 1.0,
+                    "email": {"address": "test@mail.openonion.ai"},
+                }
+            },
+        )
+        mock_get.return_value = Mock(
+            status_code=200,
+            json=lambda: {"deployments": []},
+        )
+
+        output = StringIO()
+        test_console = Console(
+            file=output,
+            force_terminal=False,
+            color_system=None,
+            width=140,
+        )
+        with patch.object(Path, "home", return_value=fake_home):
+            with patch.object(status_commands, "console", test_console):
+                status_commands.handle_status()
+
+        rendered = output.getvalue()
+        assert "Credential Sources" in rendered
+        assert "OPENONION_API_KEY" in rendered
+        assert "process environment" in rendered
+        assert secret not in rendered
+        assert secret[:20] not in rendered
 
 
 class TestLoadApiKey:
@@ -53,16 +209,18 @@ class TestLoadApiKey:
             try:
                 # Clear env var
                 with patch.dict(os.environ, {}, clear=True):
-                    # Need to reimport after patching env
                     from connectonion.cli.commands.project_cmd_lib import load_api_key
+
                     result = load_api_key()
-                    # Result depends on dotenv loading
+                    assert result == "local-env-key"
             finally:
                 os.chdir(original_cwd)
 
     def test_load_api_key_from_global_keys_env(self):
         """Test loading API key from ~/.co/keys.env."""
         with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            os.chdir(tmpdir)
             fake_home = Path(tmpdir) / "fake_home"
             fake_home.mkdir()
             co_dir = fake_home / ".co"
@@ -70,10 +228,14 @@ class TestLoadApiKey:
             keys_env = co_dir / "keys.env"
             keys_env.write_text("OPENONION_API_KEY=global-keys-env-key\n")
 
-            with patch.object(Path, 'home', return_value=fake_home):
-                with patch.dict(os.environ, {}, clear=True):
-                    from connectonion.cli.commands.project_cmd_lib import load_api_key
-                    # Result depends on dotenv loading and env state
+            try:
+                with patch.object(Path, 'home', return_value=fake_home):
+                    with patch.dict(os.environ, {}, clear=True):
+                        from connectonion.cli.commands.project_cmd_lib import load_api_key
+
+                        assert load_api_key() == "global-keys-env-key"
+            finally:
+                os.chdir(original_cwd)
 
     def test_load_api_key_returns_none_when_not_found(self):
         """Test _load_api_key returns None when key not found anywhere."""
@@ -87,8 +249,9 @@ class TestLoadApiKey:
                 with patch.object(Path, 'home', return_value=fake_home):
                     with patch.dict(os.environ, {}, clear=True):
                         from connectonion.cli.commands.project_cmd_lib import load_api_key
+
                         result = load_api_key()
-                        # Should be None or empty when not found
+                        assert not result
             finally:
                 os.chdir(original_cwd)
 


### PR DESCRIPTION
## What changed

- Show a redacted credential inventory by default in `co status`.
- Report provider, environment-variable name, status, and privacy-safe source labels.
- Distinguish `configured`, `discovered · not loaded`, `missing`, and `conflict`.
- Add explicit `co status --reveal` / `-r` support for full provider values.
- In reveal mode, list each source separately so conflicting keys can be diagnosed.
- Cover all provider credential variables currently supported by the LLM layer.
- Remove the previous partial OpenOnion key preview from default status output.
- Add CLI documentation and regression tests.

## Why

A credential can exist in a dotenv file while the command that needs it cannot see it. Agents and users need a safe default view of which credentials exist and where they were discovered, plus an intentional local escape hatch when comparing the actual values is necessary.

## Security properties

- Default `co status` never returns a value, prefix, suffix, hash, or fingerprint.
- Full values appear only after an explicit `--reveal` or `-r` flag and a prominent do-not-share/log warning.
- Secret values are rendered as literal terminal text rather than Rich markup.
- Reads dotenv files without exporting their contents to `os.environ`.
- Displays only safe source labels: `process environment`, `<project>/.env`, and `~/.co/keys.env`.
- Does not create, move, or modify credential files.

## Validation

- `67 passed` across focused status/help/keys CLI tests.
- Regression coverage verifies default output contains no full or partial key material.
- Reveal coverage verifies full fake values and each source appear only when requested.
- Ruff checks passed for changed Python files.
- Python compile check passed.
- `git diff --check` passed.
- Earlier wider CLI run: `280 passed, 3 skipped`; 23 unrelated failures required browser sockets, network access, or writes outside the sandbox.

Closes #247