### PR TITLE
Load both .env and ~/.co/keys.env, not one or the other

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -2,8 +2,8 @@
 Purpose: Main package entry point exposing public API for ConnectOnion framework
 LLM-Note:
   Dependencies: imports from [core/, logger.py, llm_do.py, transcribe.py, prompts.py, debug/, useful_tools/, network/, address.py] | imported by [user code, tests/, examples/] | no direct tests (integration tests import from here)
-  Data flow: loads .env from cwd via load_dotenv() → exports all public API symbols → user imports `from connectonion import Agent, llm_do, ...`
-  State/Effects: auto-loads .env file from current working directory (NOT module directory) at import time
+  Data flow: loads cwd .env then ~/.co/keys.env via load_dotenv() (first file to define a key wins) → exports all public API symbols → user imports `from connectonion import Agent, llm_do, ...`
+  State/Effects: auto-loads both the cwd .env (NOT module directory) and the global ~/.co/keys.env at import time
   Integration: exposes complete public API: Agent, LLM, Logger, create_tool_from_function, llm_do, transcribe, xray, event decorators, built-in tools, networking functions | __all__ defines explicit public exports
   Performance: .env loading happens once at first import (dotenv caches)
   Errors: none (import errors bubble from submodules)
@@ -17,20 +17,16 @@ import sys as _sys
 from dotenv import load_dotenv
 from pathlib import Path as _Path
 
-# Load .env with fallback: cwd .env -> global ~/.co/keys.env
+# Load BOTH the project .env and the global ~/.co/keys.env, in that order.
+# load_dotenv never overrides an already-set variable, so the first file to
+# define a key wins: the project .env overrides, keys.env fills in the rest.
+# Loading only one of them silently hid every credential that lives solely in
+# keys.env (OAuth tokens land there) from any project that had its own .env.
 # Diagnostics go to stderr so command output on stdout stays clean (scriptable).
-# Priority 1: Current directory .env (project-specific keys)
-_env_file = _Path.cwd() / ".env"
-if _env_file.exists():
-    load_dotenv(_env_file)
-    print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
-else:
-    # Priority 2: Global keys.env (shared API keys fallback)
-    _global_keys = _Path.home() / ".co" / "keys.env"
-    if _global_keys.exists():
-        load_dotenv(_global_keys)
-        print(f"[env] {_global_keys.resolve()}", file=_sys.stderr)
-    # No else - if neither exists, proceed without .env (API keys might be in shell env)
+for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
+    if _env_file.exists():
+        load_dotenv(_env_file)
+        print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
 
 from .core import Agent, LLM, create_tool_from_function
 from .core import (

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -29,10 +29,13 @@ from dotenv import load_dotenv
 
 from .. import __version__
 
-# Load global keys.env for all CLI commands
-_global_keys = Path.home() / ".co" / "keys.env"
-if _global_keys.exists():
-    load_dotenv(_global_keys)
+# Load both env files for all CLI commands. keys.env stays first — that is
+# already the CLI's effective precedence, since commands that load .env do so
+# after this import and load_dotenv never overrides. Adding .env here only
+# fills in keys it alone defines.
+for _env_file in (Path.home() / ".co" / "keys.env", Path.cwd() / ".env"):
+    if _env_file.exists():
+        load_dotenv(_env_file)
 
 console = Console()
 app = typer.Typer(add_completion=False, no_args_is_help=False)

--- a/tests/unit/test_env_loading.py
+++ b/tests/unit/test_env_loading.py
@@ -1,0 +1,75 @@
+"""Both env files must load — a project .env must never hide ~/.co/keys.env.
+
+Importing connectonion runs the env loading once per process, so these tests
+drive it in a subprocess with a controlled cwd and HOME.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_import(tmp_path, project_env: str, keys_env: str, probe: str) -> str:
+    """Import connectonion with a fake cwd/HOME and print one env var."""
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text(keys_env)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    if project_env is not None:
+        (project / ".env").write_text(project_env)
+
+    script = textwrap.dedent(f"""
+        import os, sys
+        sys.path.insert(0, {str(project.parent.parent)!r})
+        import connectonion  # noqa: F401
+        print(os.getenv({probe!r}, "<missing>"))
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project,
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin", "PYTHONPATH": _repo_root()},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _repo_root() -> str:
+    from pathlib import Path
+    return str(Path(__file__).resolve().parents[2])
+
+
+def test_keys_env_still_loads_when_project_env_exists(tmp_path):
+    """The regression: OAuth tokens live in keys.env and were invisible."""
+    value = _run_import(
+        tmp_path,
+        project_env="OPENAI_API_KEY=sk-project\n",
+        keys_env="GOOGLE_ACCESS_TOKEN=from-keys-env\n",
+        probe="GOOGLE_ACCESS_TOKEN",
+    )
+    assert value == "from-keys-env"
+
+
+def test_project_env_wins_over_keys_env(tmp_path):
+    """Project-specific values still override the global fallback."""
+    value = _run_import(
+        tmp_path,
+        project_env="OPENAI_API_KEY=sk-project\n",
+        keys_env="OPENAI_API_KEY=sk-global\n",
+        probe="OPENAI_API_KEY",
+    )
+    assert value == "sk-project"
+
+
+def test_keys_env_loads_when_no_project_env(tmp_path):
+    value = _run_import(
+        tmp_path,
+        project_env=None,
+        keys_env="OPENAI_API_KEY=sk-global\n",
+        probe="OPENAI_API_KEY",
+    )
+    assert value == "sk-global"


### PR DESCRIPTION
## Problem

This is why `co auth google` has to be re-run again and again.

`connectonion/__init__.py` loaded the project `.env` **or** the global `~/.co/keys.env` — an `else`, never both:

```python
_env_file = _Path.cwd() / ".env"
if _env_file.exists():
    load_dotenv(_env_file)
else:                                    # <-- only reached when .env is absent
    _global_keys = _Path.home() / ".co" / "keys.env"
    if _global_keys.exists():
        load_dotenv(_global_keys)
```

So any project directory with its own `.env` — even one containing nothing but `OPENAI_API_KEY` — made `~/.co/keys.env` invisible. Every credential that lives *only* there disappears.

OAuth tokens live exactly there. `co auth google` writes to both files, so it works in the directory you ran it from. Move to another project that has a `.env`, and `Gmail()` raises:

```
Google OAuth credentials not found.
Run: co auth google
```

which you do, and it works again — in *that* directory. Repeat per project. The refresh token was never the problem; it was never being read.

Same shape in `connectonion/cli/main.py`, which loaded `keys.env` and never the project `.env`.

## Fix

Load both, in a defined order. `load_dotenv` does not override an already-set variable, so the first file to define a key wins:

```python
for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
    if _env_file.exists():
        load_dotenv(_env_file)
        print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
```

Project `.env` keeps priority for keys it defines; `keys.env` fills in the rest. Both paths are still echoed to stderr, so `[env]` now prints one line per file actually loaded.

`cli/main.py` gets the same fallback with `keys.env` **first** — deliberately, because that is already the CLI's effective precedence: commands like `_outlook()` call `load_dotenv(".env")` *after* this module imports, and the earlier load wins. Keeping that order means this PR adds credentials and changes no existing resolution.

## Note on precedence

The two entry points therefore disagree: agents resolve `.env` first, the CLI resolves `keys.env` first. Both are strictly additive here, so nothing regresses, but the split is worth settling separately — it interacts with #206, which keeps the refreshed token written back to whichever file holds it.

## Testing

New `tests/unit/test_env_loading.py` drives the import in a subprocess with a controlled cwd and `HOME`:

- a project `.env` no longer hides a `GOOGLE_ACCESS_TOKEN` that lives in `keys.env` (this one **fails on main**, verified)
- a project `.env` still overrides `keys.env` for a key both define
- `keys.env` still loads when there is no project `.env`

Full unit suite: 2151 passed, 3 skipped.
