### PR TITLE
Refresh the Gmail access token once per instance, like Outlook

### DIFF
--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -93,33 +93,28 @@ class Gmail:
         self.contacts_csv = contacts_csv
 
     def _get_service(self):
-        """Get Gmail API service (lazy load with auto-refresh)."""
-        access_token = os.getenv("GOOGLE_ACCESS_TOKEN")
-        refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
-        expires_at_str = os.getenv("GOOGLE_TOKEN_EXPIRES_AT")
+        """Get Gmail API service, refreshing the access token once per instance.
 
-        if not access_token or not refresh_token:
+        Mirrors Outlook: refresh unconditionally on first use rather than doing
+        expiry arithmetic. An access token lasts an hour, so a cached one is
+        nearly always stale by the next run anyway, and the old
+        "only refresh if GOOGLE_TOKEN_EXPIRES_AT says so" check silently did
+        nothing at all when that variable was absent — which the backend allows,
+        since /google/credentials returns expires_at: null when the stored row
+        has no expiry. That produced 401s that looked like broken auth.
+        """
+        if self._service:
+            return self._service
+
+        refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
+
+        if not os.getenv("GOOGLE_ACCESS_TOKEN") or not refresh_token:
             raise ValueError(
                 "Google OAuth credentials not found.\n"
                 "Run: co auth google"
             )
 
-        # Check if token is expired or about to expire (within 5 minutes)
-        # Always check before returning cached service
-        if expires_at_str:
-            from datetime import datetime, timedelta
-            expires_at = datetime.fromisoformat(expires_at_str.replace('Z', '+00:00'))
-            now = datetime.utcnow().replace(tzinfo=expires_at.tzinfo) if expires_at.tzinfo else datetime.utcnow()
-
-            if now >= expires_at - timedelta(minutes=5):
-                # Token expired or about to expire, refresh via backend
-                access_token = self._refresh_via_backend(refresh_token)
-                # Clear cached service to use new token
-                self._service = None
-
-        # Return cached service if available
-        if self._service:
-            return self._service
+        access_token = self._refresh_via_backend(refresh_token)
 
         # Create credentials without client_id/client_secret
         # Backend handles token refresh, so we don't need auto-refresh

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -36,6 +36,17 @@ from pathlib import Path
 FUTURE_EXPIRY = (datetime.utcnow() + timedelta(hours=1)).isoformat() + 'Z'
 
 
+@pytest.fixture(autouse=True)
+def _stub_token_refresh(request, monkeypatch):
+    """Gmail refreshes its access token once per instance; stub that network
+    call so API-operation tests stay isolated. Tests of the refresh flow
+    itself opt out with @pytest.mark.real_refresh."""
+    if "real_refresh" in request.keywords:
+        return
+    from connectonion.useful_tools.gmail import Gmail
+    monkeypatch.setattr(Gmail, "_refresh_via_backend", lambda self, rt: "test_token")
+
+
 class TestGmailInit:
     """Tests for Gmail initialization and scope validation."""
 
@@ -122,6 +133,44 @@ class TestGmailGetService:
 
         assert service1 == service2
         assert mock_build.call_count == 1  # Only built once
+
+    @pytest.mark.real_refresh
+    @patch.dict(os.environ, {
+        "GOOGLE_SCOPES": "gmail.readonly gmail.send",
+        "GOOGLE_ACCESS_TOKEN": "stale_token",
+        "GOOGLE_REFRESH_TOKEN": "test_refresh",
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+    })
+    @patch('connectonion.useful_tools.gmail.build')
+    def test_get_service_refreshes_even_when_expiry_looks_fresh(self, mock_build, monkeypatch):
+        """Refresh is unconditional — an hour-old token is stale by the next run."""
+        from connectonion.useful_tools.gmail import Gmail
+        calls = []
+        monkeypatch.setattr(
+            Gmail, "_refresh_via_backend",
+            lambda self, rt: calls.append(rt) or "fresh_token",
+        )
+
+        Gmail()._get_service()
+
+        assert calls == ["test_refresh"]
+        assert mock_build.call_args.kwargs["credentials"].token == "fresh_token"
+
+    @pytest.mark.real_refresh
+    @patch.dict(os.environ, {
+        "GOOGLE_SCOPES": "gmail.readonly gmail.send",
+        "GOOGLE_ACCESS_TOKEN": "stale_token",
+        "GOOGLE_REFRESH_TOKEN": "test_refresh",
+    }, clear=True)
+    @patch('connectonion.useful_tools.gmail.build')
+    def test_get_service_refreshes_without_expiry_variable(self, mock_build, monkeypatch):
+        """GOOGLE_TOKEN_EXPIRES_AT can be absent — that must not skip the refresh."""
+        from connectonion.useful_tools.gmail import Gmail
+        monkeypatch.setattr(Gmail, "_refresh_via_backend", lambda self, rt: "fresh_token")
+
+        Gmail()._get_service()
+
+        assert mock_build.call_args.kwargs["credentials"].token == "fresh_token"
 
     @patch.dict(os.environ, {"GOOGLE_SCOPES": "gmail.readonly gmail.send"}, clear=True)
     def test_get_service_missing_credentials(self):


### PR DESCRIPTION
## Problem

`Gmail._get_service()` refreshed the access token only when `GOOGLE_TOKEN_EXPIRES_AT` said it was within five minutes of expiry:

```python
if expires_at_str:                       # <-- no else
    expires_at = datetime.fromisoformat(...)
    if now >= expires_at - timedelta(minutes=5):
        access_token = self._refresh_via_backend(refresh_token)
```

When that variable is **absent, the whole block is skipped and no refresh ever happens** — the stale access token is handed straight to `build()`. And it can be absent: `/google/credentials` returns `"expires_at": None` when the stored OAuth row has no expiry, and `upsert_env` skips `None` values, so the key never reaches your env at all.

The symptom is a Gmail integration that works for one hour after `co auth google` and then 401s on every call — which reads as "auth broke, re-authorize" rather than "the token was never refreshed."

## Fix

Refresh unconditionally on first use, exactly as `Outlook._get_access_token()` already does:

```python
if self._service:
    return self._service
access_token = self._refresh_via_backend(refresh_token)
```

An access token lives an hour, so a cached one is nearly always stale by the next process anyway — the expiry arithmetic bought one saved round-trip in the rare same-hour rerun and in exchange hid a silent failure. Google refresh tokens do not rotate, so unlike Microsoft there is no spent-token hazard in refreshing every session.

Cost: one extra HTTPS round-trip per `Gmail()` instance, once, on first API call. Same as Outlook.

## Testing

- `test_get_service_refreshes_even_when_expiry_looks_fresh` — a far-future expiry no longer suppresses the refresh, and the built credentials carry the new token
- `test_get_service_refreshes_without_expiry_variable` — the regression: no `GOOGLE_TOKEN_EXPIRES_AT` at all still refreshes

Both **fail on main**, verified by reverting the source change and re-running.

Added an autouse `_stub_token_refresh` fixture mirroring `test_outlook.py`, so the rest of the Gmail suite stays offline; refresh-flow tests opt out with `@pytest.mark.real_refresh`.

Full unit suite: 2150 passed, 3 skipped.

## Related

Not the whole story for repeated `co auth google` — #252 fixes the larger cause, where a project `.env` made `~/.co/keys.env` unreadable so the credentials were never loaded in the first place.
