### PR TITLE
Add `co gmail`

### DIFF
--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -1,0 +1,197 @@
+"""
+Purpose: CLI surface for the user's Gmail mailbox — send, list (inbox/sent), read, reply, and search from the terminal
+LLM-Note:
+  Dependencies: imports from [os, sys, json, pathlib, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.gmail.Gmail] | imported by [cli/main.py via handle_gmail_*()] | hits the Gmail API through the Gmail tool
+  Data flow: _gmail() loads GOOGLE_* from .env / ~/.co/keys.env → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin
+  State/Effects: writes ~/.co/gmail_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read marks emails read server-side | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  Integration: exposes handle_gmail_send(), handle_gmail_inbox(), handle_gmail_read(), handle_gmail_reply(), handle_gmail_sent(), handle_gmail_search() for cli/main.py | presentation mirrors outlook_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Gmail API logic lives in useful_tools/gmail.py | requires prior 'co auth google'
+  Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, unresolvable email # | Gmail API errors propagate from the Gmail tool
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+
+INBOX_CACHE = Path.home() / ".co" / "gmail_last_inbox.json"
+
+
+def _gmail():
+    """Load GOOGLE_* credentials from .env files and return a Gmail instance. Exits 1 with a hint if not connected."""
+    from dotenv import load_dotenv
+
+    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
+        if env_path.exists():
+            load_dotenv(env_path)
+
+    if not os.getenv("GOOGLE_ACCESS_TOKEN"):
+        console.print("\n❌ [bold red]Google account not connected[/bold red]")
+        console.print("\n[cyan]Connect Gmail first:[/cyan]")
+        console.print("  [bold]co auth google[/bold]     Authorize Gmail access\n")
+        raise typer.Exit(1)
+
+    # Gmail() itself requires both scopes — check them here so a partially
+    # authorized token gets the hint instead of a raw ValueError traceback.
+    scopes = os.getenv("GOOGLE_SCOPES", "")
+    if "gmail.readonly" not in scopes or "gmail.send" not in scopes:
+        console.print("\n❌ [bold red]Gmail permission missing[/bold red]")
+        console.print("\n[cyan]Reconnect Google to grant it:[/cyan]")
+        console.print("  [bold]co auth google[/bold]     Re-authorize with Gmail access\n")
+        raise typer.Exit(1)
+
+    from ...useful_tools.gmail import Gmail
+    return Gmail()
+
+
+def _when(date: str) -> str:
+    """Render a Gmail RFC 2822 Date header as 'Jul 26 14:30' in local time.
+
+    Messages without a Date header arrive here as 'Unknown', and spam carries
+    outright malformed ones; parsedate_to_datetime() raises ValueError on both,
+    which would take down the whole listing. Show the raw value instead.
+    """
+    from email.utils import parsedate_to_datetime
+
+    try:
+        parsed = parsedate_to_datetime(date)
+    except ValueError:
+        return date
+    return parsed.astimezone().strftime("%b %d %H:%M")
+
+
+def _print_listing(gmail, emails: list, title: str):
+    """Render emails as a numbered table (or plain ID-bearing text when piped) and cache the numbering for read/reply."""
+    INBOX_CACHE.parent.mkdir(exist_ok=True)
+    INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}), encoding="utf-8")
+
+    if not console.is_terminal:
+        # Scripts and agents get the untruncated format with full message ids.
+        console.print(gmail._format_dicts(emails), markup=False, highlight=False)
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("From", max_width=28, no_wrap=True)
+    table.add_column("Subject", overflow="ellipsis", no_wrap=True)
+    table.add_column("Received")
+
+    for i, email in enumerate(emails, 1):
+        unread_mark = "[bold green]●[/bold green] " if email["unread"] else ""
+        table.add_row(str(i), email["from"], f"{unread_mark}{email['subject']}", _when(email["date"]))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Read one with:[/dim] [bold]co gmail read <#>[/bold]\n")
+
+
+def handle_gmail_inbox(last: int = 10, unread: bool = False):
+    """List recent Gmail inbox emails as a numbered table, and remember the numbering for 'read'."""
+    gmail = _gmail()
+    emails = gmail.list_inbox(last=last, unread=unread)
+    if not emails:
+        scope = "unread " if unread else ""
+        console.print(f"\n[cyan]Gmail inbox:[/cyan] no {scope}emails\n")
+        return
+    _print_listing(gmail, emails, f"📬 Gmail — {os.getenv('GOOGLE_EMAIL', '')}")
+
+
+def _resolve_email_id(gmail, email_id: str) -> str:
+    """Turn a listing number into a Gmail message id; full ids pass through. Numbers mean the last listing shown."""
+    cached = json.loads(INBOX_CACHE.read_text(encoding="utf-8")) if INBOX_CACHE.exists() else {}
+    if email_id in cached:
+        return cached[email_id]
+
+    if not (email_id.isascii() and email_id.isdigit() and len(email_id) < 5):
+        return email_id  # full Gmail message id
+
+    if cached or int(email_id) < 1:
+        # The user is pointing at their last listing and that number wasn't in
+        # it — fetching a fresh (differently numbered) list would silently open
+        # the wrong email.
+        return ""
+
+    emails = gmail.list_inbox(last=int(email_id))
+    if len(emails) < int(email_id):
+        return ""
+    return emails[int(email_id) - 1]["id"]
+
+
+def handle_gmail_read(email_id: str):
+    """Show one Gmail email's full body and mark it read. Accepts the listing # or a full message id."""
+    gmail = _gmail()
+    resolved = _resolve_email_id(gmail, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    body = gmail.get_email_body(resolved)
+    header, _, content = body.partition("\n--- Email Body ---\n")
+    console.print()
+    console.print(Panel.fit(header.replace("From:", "[cyan]From:[/cyan]")
+                            .replace("To:", "[cyan]To:[/cyan]", 1)
+                            .replace("Subject:", "[cyan]Subject:[/cyan]")
+                            .replace("Date:", "[cyan]Date:[/cyan]"),
+                            title=f"✉️  Email {email_id}", border_style="cyan"))
+    console.print()
+    console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
+
+    marked = ""
+    if "gmail.modify" in os.getenv("GOOGLE_SCOPES", ""):
+        # Marking read is a mailbox write — the API rejects it on tokens that
+        # only carry gmail.readonly + gmail.send.
+        gmail.mark_read(resolved)
+        marked = "Marked read. "
+    console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co gmail reply <#> <message>[/bold]\n")
+
+
+def handle_gmail_reply(email_id: str, message: str):
+    """Reply to an email from the last listing (threaded). A message of '-' reads stdin."""
+    if message == "-":
+        message = sys.stdin.read()
+
+    gmail = _gmail()
+    resolved = _resolve_email_id(gmail, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    gmail.reply(resolved, message)
+    console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
+
+
+def handle_gmail_send(to: str, subject: str, message: str, cc: str = None, bcc: str = None):
+    """Send an email from the connected Gmail account. A message of '-' reads the body from stdin."""
+    if message == "-":
+        message = sys.stdin.read()
+
+    gmail = _gmail()
+    gmail.send(to, subject, message, cc=cc, bcc=bcc)
+
+    console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
+    console.print(f"  From: {os.getenv('GOOGLE_EMAIL', '')}")
+    console.print()
+
+
+def handle_gmail_sent(last: int = 10):
+    """List recently sent Gmail emails."""
+    gmail = _gmail()
+    console.print(f"\n📤 [bold cyan]Gmail sent[/bold cyan] [dim]({os.getenv('GOOGLE_EMAIL', '')})[/dim]\n")
+    console.print(gmail.get_sent_emails(max_results=last), markup=False, highlight=False)
+    console.print()
+
+
+def handle_gmail_search(query: str, last: int = 10):
+    """Search Gmail and list matches with the same numbering contract as the inbox."""
+    gmail = _gmail()
+    emails = gmail.list_search(query, max_results=last)
+    if not emails:
+        console.print(f"\n[cyan]Search:[/cyan] no emails matching [bold]{query}[/bold]\n")
+        return
+    _print_listing(gmail, emails, f"🔎 Gmail — {query}")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -77,6 +77,7 @@ def _show_help():
     console.print("  [green]deploy[/green]            Deploy to ConnectOnion Cloud")
     console.print("  [green]auth[/green]              Authenticate for managed keys")
     console.print("  [green]email[/green]             Send and read agent email")
+    console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
@@ -447,6 +448,82 @@ def email_upgrade(
     """Upgrade email tier — deducts the monthly price from your credits."""
     from .commands.email_commands import handle_email_upgrade
     handle_email_upgrade(tier, domain=domain, alias=alias)
+
+
+# Gmail command group. `co gmail` (no args) shows the Gmail inbox.
+# Uses the GOOGLE_* OAuth tokens saved to .env by `co auth google`.
+gmail_app = typer.Typer(help="Send and read email from your Gmail account. Bare 'co gmail' shows the inbox.")
+app.add_typer(gmail_app, name="gmail")
+
+
+@gmail_app.callback(invoke_without_command=True)
+def gmail_callback(ctx: typer.Context):
+    """With no subcommand, show the Gmail inbox."""
+    if ctx.invoked_subcommand is None:
+        from .commands.gmail_commands import handle_gmail_inbox
+        handle_gmail_inbox()
+
+
+@gmail_app.command("inbox")
+def gmail_inbox(
+    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
+):
+    """List recent inbox emails, numbered for read/reply."""
+    from .commands.gmail_commands import handle_gmail_inbox
+    handle_gmail_inbox(last=last, unread=unread)
+
+
+@gmail_app.command("read")
+def gmail_read(
+    email_id: str = typer.Argument(..., help="Email # from the last listing, or a full message id"),
+):
+    """Show one email's full body and mark it read."""
+    from .commands.gmail_commands import handle_gmail_read
+    handle_gmail_read(email_id)
+
+
+@gmail_app.command("reply")
+def gmail_reply(
+    email_id: str = typer.Argument(..., help="Email # from the last listing, or a full message id"),
+    message: str = typer.Argument(..., help="Reply body, or '-' to read stdin"),
+):
+    """Reply to an email from the last listing."""
+    from .commands.gmail_commands import handle_gmail_reply
+    handle_gmail_reply(email_id, message)
+
+
+@gmail_app.command("send", epilog="Examples:  co gmail send a@b.com \"Hi\" \"Quick note\"  |  "
+                                  "cat body.txt | co gmail send a@b.com \"Report\" -")
+def gmail_send(
+    to: str = typer.Argument(..., help="Recipient address (comma-separated for several)"),
+    subject: str = typer.Argument(..., help="Email subject"),
+    message: str = typer.Argument(..., help="Email body, or '-' to read stdin"),
+    cc: str = typer.Option(None, "--cc", help="CC recipients (comma-separated)"),
+    bcc: str = typer.Option(None, "--bcc", help="BCC recipients (comma-separated)"),
+):
+    """Send an email from your Gmail account."""
+    from .commands.gmail_commands import handle_gmail_send
+    handle_gmail_send(to, subject, message, cc=cc, bcc=bcc)
+
+
+@gmail_app.command("sent")
+def gmail_sent(
+    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+):
+    """List recently sent emails."""
+    from .commands.gmail_commands import handle_gmail_sent
+    handle_gmail_sent(last=last)
+
+
+@gmail_app.command("search")
+def gmail_search(
+    query: str = typer.Argument(..., help="Gmail search query, e.g. 'from:alice@example.com'"),
+    last: int = typer.Option(10, "--last", "-n", help="How many matches to show"),
+):
+    """Search your mail with Gmail query syntax."""
+    from .commands.gmail_commands import handle_gmail_search
+    handle_gmail_search(query, last=last)
 
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -190,11 +190,8 @@ class Gmail:
 
         return new_access_token
 
-    def _format_emails(self, messages, max_results=10):
-        """Helper to format email list."""
-        if not messages:
-            return "No emails found."
-
+    def _email_dicts(self, messages, max_results=10):
+        """Fetch metadata for message stubs and return plain email dicts."""
         service = self._get_service()
         emails = []
 
@@ -211,19 +208,22 @@ class Gmail:
             from_email = next((h['value'] for h in headers if h['name'] == 'From'), 'Unknown')
             date = next((h['value'] for h in headers if h['name'] == 'Date'), 'Unknown')
 
-            snippet = message.get('snippet', '')
-            is_unread = 'UNREAD' in message.get('labelIds', [])
-
             emails.append({
                 'id': msg['id'],
                 'from': from_email,
                 'subject': subject,
                 'date': date,
-                'snippet': snippet,
-                'unread': is_unread
+                'snippet': message.get('snippet', ''),
+                'unread': 'UNREAD' in message.get('labelIds', [])
             })
 
-        # Format output
+        return emails
+
+    def _format_dicts(self, emails):
+        """Format email dicts (from _email_dicts) into a readable list."""
+        if not emails:
+            return "No emails found."
+
         output = [f"Found {len(emails)} email(s):\n"]
         for i, email in enumerate(emails, 1):
             status = "[UNREAD]" if email['unread'] else ""
@@ -235,7 +235,50 @@ class Gmail:
 
         return "\n".join(output)
 
+    def _format_emails(self, messages, max_results=10):
+        """Helper to format raw message stubs as a readable list."""
+        if not messages:
+            return "No emails found."
+        return self._format_dicts(self._email_dicts(messages, max_results))
+
     # === Reading ===
+
+    def list_inbox(self, last: int = 10, unread: bool = False) -> list:
+        """Fetch inbox emails as dicts (id, from, subject, date, snippet, unread).
+
+        Programmatic counterpart of read_inbox() — used by the CLI.
+
+        Args:
+            last: Number of emails to retrieve (default: 10)
+            unread: Only get unread emails (default: False)
+
+        Returns:
+            List of email dicts, newest first
+        """
+        service = self._get_service()
+
+        results = service.users().messages().list(
+            userId='me',
+            q="is:unread in:inbox" if unread else "in:inbox",
+            maxResults=last
+        ).execute()
+
+        return self._email_dicts(results.get('messages', []), last)
+
+    def list_search(self, query: str, max_results: int = 10) -> list:
+        """Search emails and return them as dicts (same shape as list_inbox).
+
+        Programmatic counterpart of search_emails() — used by the CLI.
+        """
+        service = self._get_service()
+
+        results = service.users().messages().list(
+            userId='me',
+            q=query,
+            maxResults=max_results
+        ).execute()
+
+        return self._email_dicts(results.get('messages', []), max_results)
 
     def read_inbox(self, last: int = 10, unread: bool = False) -> str:
         """Read emails from inbox.
@@ -247,18 +290,7 @@ class Gmail:
         Returns:
             Formatted string with email list
         """
-        service = self._get_service()
-
-        query = "is:unread in:inbox" if unread else "in:inbox"
-
-        results = service.users().messages().list(
-            userId='me',
-            q=query,
-            maxResults=last
-        ).execute()
-
-        messages = results.get('messages', [])
-        return self._format_emails(messages, last)
+        return self._format_dicts(self.list_inbox(last=last, unread=unread))
 
     def get_sent_emails(self, max_results: int = 10) -> str:
         """Get emails you sent.
@@ -311,20 +343,10 @@ class Gmail:
         Returns:
             Formatted string with matching emails
         """
-        service = self._get_service()
-
-        results = service.users().messages().list(
-            userId='me',
-            q=query,
-            maxResults=max_results
-        ).execute()
-
-        messages = results.get('messages', [])
-
-        if not messages:
+        emails = self.list_search(query, max_results)
+        if not emails:
             return f"No emails found matching query: {query}"
-
-        return self._format_emails(messages, max_results)
+        return self._format_dicts(emails)
 
     # === Content ===
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -224,6 +224,35 @@ details and current limitations.
 
 ---
 
+#### `co gmail` - Send & Read Gmail
+
+Your personal Gmail account from the terminal, via the Gmail API. Requires
+`co auth google` once (Gmail scopes; saved as `GOOGLE_*` in `.env` /
+`~/.co/keys.env`).
+
+**Basic usage:**
+```bash
+co gmail                                            # inbox (10 most recent)
+co gmail inbox -n 25 -u                             # last 25, unread only
+co gmail read 3                                     # read #3 from the listing, mark read
+co gmail send bob@example.com "Hi" "Body text"      # send now
+co gmail search "from:alice@example.com is:unread"  # full Gmail query syntax
+```
+
+**Subcommands:**
+
+- `co gmail` / `co gmail inbox` - list recent emails (`--last/-n`, `--unread/-u`)
+- `co gmail read <#>` - show one email and mark it read
+- `co gmail reply <#> <message>` - threaded reply (`-` reads stdin)
+- `co gmail send <to> <subject> <message>` - send, with `--cc` and `--bcc`
+- `co gmail sent` - list recently sent emails
+- `co gmail search <query>` - search with Gmail query syntax
+
+The CLI wraps the same `Gmail` tool your agents use. See
+[gmail.md](gmail.md) for details.
+
+---
+
 #### `co outlook` - Manage Outlook Email & Contacts
 
 Your personal Outlook account from the terminal, via Microsoft Graph.

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -1,0 +1,155 @@
+# Gmail CLI (co gmail)
+
+Send and read email from your Gmail account right in the terminal — the same
+Gmail API access your agents get from the [Gmail tool](../useful_tools/gmail.md),
+as a command.
+
+## Quick Start
+
+```bash
+# Connect your Google account (one-time)
+co auth google
+
+# Check your inbox (the zero-arg default)
+co gmail
+
+# Read message #3 from the inbox list
+co gmail read 3
+
+# Send a message
+co gmail send alice@example.com "Hello" "Thanks for the meeting today!"
+```
+
+That's the whole surface. Everything below is detail.
+
+## Setup
+
+`co gmail` needs a connected Google account:
+
+```bash
+co auth google
+```
+
+This opens the Google OAuth flow and saves `GOOGLE_*` credentials (access
+token, refresh token, scopes, email) to your project `.env` and
+`~/.co/keys.env`. Tokens auto-refresh — the access token is renewed at the
+start of every command, so you authorize once.
+
+See [Google Integration](../integrations/google.md) for the requested scopes.
+
+## Commands
+
+### `co gmail` — Show the inbox
+
+With no subcommand, prints your most recent emails. Same as `co gmail inbox`.
+
+```bash
+co gmail                 # 10 most recent
+co gmail inbox -n 25     # last 25
+co gmail inbox -u        # unread only
+```
+
+Emails are numbered. **Numbers mean your last listing** — `co gmail read 3`
+opens the third row of the table you just saw. Running `co gmail` again
+renumbers.
+
+A green ● marks unread.
+
+### `co gmail read <#>` — Read one email
+
+```bash
+co gmail read 3                    # by listing number
+co gmail read 18f2c9d0a1b2c3d4     # by full message id
+```
+
+Prints headers in a panel and the body below it, then marks the email read
+(only when your token carries `gmail.modify` — a read-only token skips it).
+
+### `co gmail reply <#> <message>` — Reply
+
+```bash
+co gmail reply 3 "Sounds good, see you then."
+cat reply.txt | co gmail reply 3 -
+```
+
+Threaded — the reply goes back on the original conversation. A message of `-`
+reads the body from stdin.
+
+### `co gmail send <to> <subject> <message>` — Send
+
+```bash
+co gmail send alice@example.com "Report" "See notes below."
+co gmail send alice@example.com "Report" - < body.txt
+co gmail send a@x.com,b@y.com "Update" "Shipping today" --cc lead@x.com
+```
+
+Recipients are comma-separated. `--cc` and `--bcc` take the same form. A
+message of `-` reads the body from stdin.
+
+### `co gmail sent` — Recently sent
+
+```bash
+co gmail sent
+co gmail sent -n 25
+```
+
+Read-only listing; it does **not** touch the read/reply numbering.
+
+### `co gmail search <query>` — Search
+
+Takes full Gmail query syntax, not just plain words:
+
+```bash
+co gmail search "invoice"
+co gmail search "from:alice@example.com is:unread"
+co gmail search "subject:meeting after:2026/07/01" -n 25
+```
+
+Matches are numbered exactly like the inbox, so `co gmail read <#>` works on
+search results too.
+
+## Piping
+
+In a terminal you get a Rich table with truncated columns. When output is
+piped, you get the plain listing with **full message ids** instead, so scripts
+and agents never receive a truncated value:
+
+```bash
+co gmail inbox -n 50 | grep "ID:"
+```
+
+## Using it from an agent
+
+The CLI wraps the same `Gmail` tool your agents use:
+
+```python
+from connectonion import Agent, Gmail
+
+agent = Agent("assistant", tools=[Gmail()])
+agent.input("Any unread mail from Alice?")
+```
+
+Or call it directly:
+
+```python
+gmail = Gmail()
+gmail.list_inbox(last=10, unread=True)
+gmail.list_search("from:alice@example.com")
+gmail.send("alice@example.com", "Report", "See attached.")
+```
+
+## Troubleshooting
+
+- **"Google account not connected"** → run `co auth google`.
+- **Missing Gmail scopes** → run `co auth google` again to re-consent.
+- **`No email #N in your last listing`** → the number is out of range or the
+  listing changed; run `co gmail` to refresh the numbering.
+- **Credentials found in one project but not another** → fixed in 1.3.1;
+  older versions read either the project `.env` or `~/.co/keys.env`, never
+  both, so a project with its own `.env` hid the Google tokens.
+
+## See also
+
+- [`co outlook`](outlook.md) — same surface for an Outlook mailbox
+- [`co email`](email.md) — your agent's own address, no OAuth needed
+- [Gmail tool](../useful_tools/gmail.md) — the full method list for agents

--- a/tests/e2e/cli/test_cli_gmail.py
+++ b/tests/e2e/cli/test_cli_gmail.py
@@ -1,0 +1,132 @@
+"""CLI routing tests for `co gmail`."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+runner = CliRunner()
+
+
+def test_bare_gmail_shows_inbox():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_inbox") as handler:
+        result = runner.invoke(app, ["gmail"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with()
+
+
+def test_gmail_inbox_routes_flags():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_inbox") as handler:
+        result = runner.invoke(app, ["gmail", "inbox", "--last", "25", "--unread"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=25, unread=True)
+
+
+def test_gmail_inbox_defaults():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_inbox") as handler:
+        result = runner.invoke(app, ["gmail", "inbox"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=10, unread=False)
+
+
+def test_gmail_inbox_short_flags():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_inbox") as handler:
+        result = runner.invoke(app, ["gmail", "inbox", "-n", "3", "-u"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=3, unread=True)
+
+
+def test_gmail_read_routes_id():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_read") as handler:
+        result = runner.invoke(app, ["gmail", "read", "3"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("3")
+
+
+def test_gmail_send_routes_arguments():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_send") as handler:
+        result = runner.invoke(app, [
+            "gmail", "send", "bob@example.com", "Hi", "Body", "--cc", "carol@example.com",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "bob@example.com", "Hi", "Body", cc="carol@example.com", bcc=None
+    )
+
+
+def test_gmail_read_requires_an_id():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_read") as handler:
+        result = runner.invoke(app, ["gmail", "read"])
+
+    assert result.exit_code != 0
+    handler.assert_not_called()
+
+
+def test_gmail_reply_routes_id_and_message():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_reply") as handler:
+        result = runner.invoke(app, ["gmail", "reply", "2", "Sounds good"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2", "Sounds good")
+
+
+def test_gmail_reply_routes_stdin_marker():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_reply") as handler:
+        result = runner.invoke(app, ["gmail", "reply", "2", "-"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2", "-")
+
+
+def test_gmail_send_routes_bcc():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_send") as handler:
+        result = runner.invoke(app, [
+            "gmail", "send", "bob@example.com", "Hi", "-", "--bcc", "dan@example.com",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("bob@example.com", "Hi", "-", cc=None, bcc="dan@example.com")
+
+
+def test_gmail_sent_routes_limit():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_sent") as handler:
+        result = runner.invoke(app, ["gmail", "sent", "--last", "7"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=7)
+
+
+def test_gmail_search_routes_query_and_limit():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_search") as handler:
+        result = runner.invoke(app, ["gmail", "search", "from:alice@example.com", "-n", "5"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("from:alice@example.com", last=5)
+
+
+def test_gmail_appears_in_help():
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "gmail" in result.output
+
+
+def test_gmail_help_lists_every_subcommand():
+    result = runner.invoke(app, ["gmail", "--help"])
+
+    assert result.exit_code == 0
+    for command in ["inbox", "read", "reply", "send", "sent", "search"]:
+        assert command in result.output
+
+
+def test_unknown_gmail_subcommand_fails():
+    result = runner.invoke(app, ["gmail", "archive", "3"])
+
+    assert result.exit_code != 0

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -330,6 +330,162 @@ class TestReadEmails:
         assert "No emails found matching query" in result
 
 
+class TestListingFormat:
+    """Pins the exact text of every listing method.
+
+    read_inbox/search_emails/get_sent_emails/get_all_emails are agent-facing
+    tool output, so their wording and layout are the contract. These goldens
+    were captured from the pre-refactor implementation.
+    """
+
+    @pytest.fixture
+    def gmail_with_mock(self):
+        with patch.dict(os.environ, {
+            "GOOGLE_SCOPES": "gmail.readonly gmail.send",
+            "GOOGLE_ACCESS_TOKEN": "test_token",
+            "GOOGLE_REFRESH_TOKEN": "test_refresh"
+        }):
+            from connectonion.useful_tools.gmail import Gmail
+            gmail = Gmail()
+            mock_service = Mock()
+            gmail._get_service = Mock(return_value=mock_service)
+            return gmail, mock_service
+
+    def load(self, mock_service, messages):
+        """Serve `messages` (keyed by id) from the mocked Gmail API."""
+        mock_service.users().messages().list().execute.return_value = {
+            'messages': [{'id': mid} for mid in messages]
+        }
+        mock_service.users().messages().get.side_effect = lambda **kw: Mock(
+            execute=Mock(return_value=messages[kw['id']])
+        )
+
+    def two_emails(self):
+        return {
+            'msg1': {
+                'payload': {'headers': [
+                    {'name': 'From', 'value': 'alice@example.com'},
+                    {'name': 'Subject', 'value': 'Meeting Notes'},
+                    {'name': 'Date', 'value': 'Sun, 26 Jul 2026 14:30:00 +0000'},
+                ]},
+                'snippet': 'Hello there',
+                'labelIds': ['UNREAD', 'INBOX'],
+            },
+            # No headers at all, and a snippet past the 80-char preview cut.
+            'msg2': {'payload': {'headers': []}, 'snippet': 'b' * 100, 'labelIds': []},
+        }
+
+    GOLDEN = (
+        "Found 2 email(s):\n"
+        "\n"
+        "1. [UNREAD] From: alice@example.com\n"
+        "   Subject: Meeting Notes\n"
+        "   Date: Sun, 26 Jul 2026 14:30:00 +0000\n"
+        "   Preview: Hello there...\n"
+        "   ID: msg1\n"
+        "\n"
+        "2.  From: Unknown\n"
+        "   Subject: No Subject\n"
+        "   Date: Unknown\n"
+        "   Preview: " + "b" * 80 + "...\n"
+        "   ID: msg2\n"
+    )
+
+    def test_read_inbox_exact_output(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        assert gmail.read_inbox(last=10) == self.GOLDEN
+
+    def test_search_emails_exact_output(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        assert gmail.search_emails("from:alice@example.com") == self.GOLDEN
+
+    def test_get_sent_emails_exact_output(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        assert gmail.get_sent_emails() == self.GOLDEN
+
+    def test_get_all_emails_exact_output(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        assert gmail.get_all_emails() == self.GOLDEN
+
+    def test_message_without_snippet_key(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, {'msg1': {'payload': {'headers': []}, 'labelIds': []}})
+
+        assert gmail.read_inbox() == (
+            "Found 1 email(s):\n"
+            "\n"
+            "1.  From: Unknown\n"
+            "   Subject: No Subject\n"
+            "   Date: Unknown\n"
+            "   Preview: ...\n"
+            "   ID: msg1\n"
+        )
+
+    def test_limit_truncates_to_requested_count(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        result = gmail.read_inbox(last=1)
+
+        assert result.startswith("Found 1 email(s):")
+        assert "msg2" not in result
+
+    def test_list_inbox_returns_the_same_emails_it_formats(self, gmail_with_mock):
+        """The CLI reads dicts, the agent reads text — they must agree."""
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        assert gmail.list_inbox(last=10) == [
+            {'id': 'msg1', 'from': 'alice@example.com', 'subject': 'Meeting Notes',
+             'date': 'Sun, 26 Jul 2026 14:30:00 +0000', 'snippet': 'Hello there', 'unread': True},
+            {'id': 'msg2', 'from': 'Unknown', 'subject': 'No Subject',
+             'date': 'Unknown', 'snippet': 'b' * 100, 'unread': False},
+        ]
+
+    def test_list_search_returns_dicts_for_the_query(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        self.load(mock_service, self.two_emails())
+
+        emails = gmail.list_search("from:alice@example.com", max_results=5)
+
+        assert [e['id'] for e in emails] == ['msg1', 'msg2']
+        call_kwargs = mock_service.users().messages().list.call_args[1]
+        assert call_kwargs['q'] == "from:alice@example.com"
+        assert call_kwargs['maxResults'] == 5
+
+    def test_list_inbox_unread_filter(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        mock_service.users().messages().list().execute.return_value = {'messages': []}
+
+        assert gmail.list_inbox(last=10, unread=True) == []
+        assert mock_service.users().messages().list.call_args[1]['q'] == "is:unread in:inbox"
+
+    def test_list_inbox_default_scopes_to_inbox(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        mock_service.users().messages().list().execute.return_value = {'messages': []}
+
+        gmail.list_inbox(last=10)
+
+        assert mock_service.users().messages().list.call_args[1]['q'] == "in:inbox"
+
+    def test_empty_listings_say_no_emails_found(self, gmail_with_mock):
+        gmail, mock_service = gmail_with_mock
+        mock_service.users().messages().list().execute.return_value = {'messages': []}
+
+        assert gmail.read_inbox() == "No emails found."
+        assert gmail.get_sent_emails() == "No emails found."
+        assert gmail.get_all_emails() == "No emails found."
+        assert gmail.search_emails("nope") == "No emails found matching query: nope"
+
+
 class TestEmailContent:
     """Tests for email body and attachment methods."""
 

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -1,0 +1,494 @@
+"""Unit tests for connectonion/cli/commands/gmail_commands.py
+
+Tests cover:
+- _gmail() credential/scope guard (prints 'co auth google' hint, exits 1)
+- _when() rendering of RFC 2822 Date headers, including missing/malformed ones
+- inbox listing: table in a terminal, full-id text when piped, numbering cache
+- _resolve_email_id() short-number resolution against the cache and the fallback
+- read/reply/send/sent/search handlers
+"""
+
+import io
+import json
+import os
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from connectonion.cli.commands import gmail_commands
+from connectonion.cli.commands.gmail_commands import (
+    _gmail,
+    _resolve_email_id,
+    _when,
+    handle_gmail_inbox,
+    handle_gmail_read,
+    handle_gmail_reply,
+    handle_gmail_search,
+    handle_gmail_send,
+    handle_gmail_sent,
+)
+
+CONNECTED_ENV = {
+    "GOOGLE_SCOPES": "gmail.send,gmail.readonly,gmail.modify,calendar",
+    "GOOGLE_ACCESS_TOKEN": "test-token",
+    "GOOGLE_REFRESH_TOKEN": "test-refresh",
+    "GOOGLE_EMAIL": "aaron@example.com",
+}
+
+READONLY_ENV = {**CONNECTED_ENV, "GOOGLE_SCOPES": "gmail.send,gmail.readonly,calendar"}
+
+
+def sample_emails(n):
+    return [{
+        "id": f"msg-{i}",
+        "from": f"Sender {i} <sender{i}@example.com>",
+        "subject": f"Subject {i}",
+        "date": "Sun, 26 Jul 2026 14:30:00 +0000",
+        "snippet": f"Preview {i}",
+        "unread": i == 1,
+    } for i in range(1, n + 1)]
+
+
+def plain(text):
+    """Strip ANSI colour codes so assertions match what a user reads."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    """Never touch the real ~/.co/gmail_last_inbox.json."""
+    monkeypatch.setattr(gmail_commands, "INBOX_CACHE", tmp_path / ".co" / "gmail_last_inbox.json")
+
+
+class TestGmailGuard:
+    """_gmail() exits with a hint when Google is not connected."""
+
+    def test_missing_access_token_exits_with_hint(self, capsys):
+        with patch.dict(os.environ, {"GOOGLE_ACCESS_TOKEN": "", "GOOGLE_SCOPES": "gmail.send"}, clear=False):
+            with pytest.raises(typer.Exit):
+                _gmail()
+
+        output = capsys.readouterr().out
+        assert "Google account not connected" in output
+        assert "co auth google" in output
+
+    def test_scopes_without_gmail_exits_with_hint(self, capsys):
+        with patch.dict(os.environ, {"GOOGLE_ACCESS_TOKEN": "test-token", "GOOGLE_SCOPES": "calendar"}, clear=False):
+            with pytest.raises(typer.Exit):
+                _gmail()
+
+        output = capsys.readouterr().out
+        assert "Gmail permission missing" in output
+        assert "co auth google" in output
+
+    def test_readonly_without_send_exits_with_hint(self, capsys):
+        """Gmail() needs gmail.send too — the guard must catch it, not traceback."""
+        with patch.dict(
+            os.environ,
+            {"GOOGLE_ACCESS_TOKEN": "test-token", "GOOGLE_SCOPES": "gmail.readonly"},
+            clear=False,
+        ):
+            with pytest.raises(typer.Exit):
+                _gmail()
+
+        assert "Gmail permission missing" in capsys.readouterr().out
+
+    def test_send_without_readonly_exits_with_hint(self, capsys):
+        with patch.dict(
+            os.environ,
+            {"GOOGLE_ACCESS_TOKEN": "test-token", "GOOGLE_SCOPES": "gmail.send"},
+            clear=False,
+        ):
+            with pytest.raises(typer.Exit):
+                _gmail()
+
+        assert "Gmail permission missing" in capsys.readouterr().out
+
+    def test_connected_returns_gmail_instance(self):
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            result = _gmail()
+
+        from connectonion.useful_tools.gmail import Gmail
+        assert isinstance(result, Gmail)
+
+    def test_full_scope_urls_are_accepted(self):
+        """`co auth google` may store scopes as full Google URLs."""
+        urls = ("https://www.googleapis.com/auth/gmail.readonly "
+                "https://www.googleapis.com/auth/gmail.send")
+        with patch.dict(os.environ, {**CONNECTED_ENV, "GOOGLE_SCOPES": urls}, clear=False):
+            from connectonion.useful_tools.gmail import Gmail
+            assert isinstance(_gmail(), Gmail)
+
+
+class TestWhen:
+    """_when() renders Gmail's RFC 2822 Date header."""
+
+    def test_formats_rfc2822_header(self):
+        assert re.fullmatch(r"[A-Z][a-z]{2} \d{2} \d{2}:\d{2}", _when("Sun, 26 Jul 2026 14:30:00 +0000"))
+
+    def test_keeps_month_and_day(self):
+        assert _when("Sun, 26 Jul 2026 14:30:00 +0000").startswith("Jul")
+
+    def test_missing_date_header_shows_raw_value(self):
+        """_email_dicts() fills 'Unknown' when a message has no Date header."""
+        assert _when("Unknown") == "Unknown"
+
+    def test_malformed_date_shows_raw_value(self):
+        assert _when("15 Jannuary 2024") == "15 Jannuary 2024"
+
+    def test_empty_date_shows_raw_value(self):
+        assert _when("") == ""
+
+    def test_date_without_offset_still_renders(self):
+        assert re.fullmatch(r"[A-Z][a-z]{2} \d{2} \d{2}:\d{2}", _when("Sun, 26 Jul 2026 14:30:00"))
+
+
+class TestHandleGmailInbox:
+    """Inbox listing renders a table and caches the numbering."""
+
+    def test_empty_inbox_message(self, capsys):
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox()
+
+        assert "no emails" in capsys.readouterr().out
+
+    def test_empty_inbox_writes_no_cache(self, capsys):
+        """An empty listing must not clobber the numbering from the last one."""
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=10, unread=True)
+
+        assert not gmail_commands.INBOX_CACHE.exists()
+        assert "no unread emails" in capsys.readouterr().out
+
+    def test_table_and_cache(self, monkeypatch, capsys):
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = sample_emails(3)
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=3)
+
+        output = capsys.readouterr().out
+        assert "Subject 1" in output
+        assert "co gmail read" in output
+        cached = json.loads(gmail_commands.INBOX_CACHE.read_text())
+        assert cached == {"1": "msg-1", "2": "msg-2", "3": "msg-3"}
+
+    def test_flags_reach_the_tool(self):
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=25, unread=True)
+
+        gmail.list_inbox.assert_called_once_with(last=25, unread=True)
+
+    def test_email_without_date_header_still_lists(self, monkeypatch, capsys):
+        """A missing Date header must not take down the whole listing."""
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
+        emails = sample_emails(2)
+        emails[0]["date"] = "Unknown"
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = emails
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=2)
+
+        output = capsys.readouterr().out
+        assert "Subject 1" in output
+        assert "Subject 2" in output
+
+    def test_piped_output_carries_full_ids(self, monkeypatch, capsys):
+        """Scripts and agents must get untruncated ids, not a numbered table."""
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = sample_emails(2)
+        gmail._format_dicts.return_value = "ID: msg-1\nID: msg-2"
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=2)
+
+        assert "msg-1" in capsys.readouterr().out
+        gmail._format_dicts.assert_called_once()
+
+    def test_piped_output_still_caches_numbering(self, monkeypatch, capsys):
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=False, width=120))
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = sample_emails(2)
+        gmail._format_dicts.return_value = "listing"
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_inbox(last=2)
+
+        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-1", "2": "msg-2"}
+
+
+class TestResolveEmailId:
+    """Short numbers mean the last listing shown."""
+
+    def write_cache(self, mapping):
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps(mapping))
+
+    def test_number_resolves_through_cache(self):
+        self.write_cache({"1": "msg-a", "2": "msg-b"})
+
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "2") == "msg-b"
+        gmail.list_inbox.assert_not_called()
+
+    def test_full_id_passes_through(self):
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "18f2c9d0a1b2c3d4") == "18f2c9d0a1b2c3d4"
+        gmail.list_inbox.assert_not_called()
+
+    def test_long_numeric_id_passes_through(self):
+        """Gmail ids can be all digits — 5+ digits is an id, not a listing number."""
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "12345") == "12345"
+        gmail.list_inbox.assert_not_called()
+
+    def test_number_missing_from_cache_returns_empty(self):
+        """Refetching a differently numbered list would open the wrong email."""
+        self.write_cache({"1": "msg-a"})
+
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "7") == ""
+        gmail.list_inbox.assert_not_called()
+
+    def test_number_falls_back_to_list_inbox_without_cache(self):
+        """First run of the session: no listing yet, so fetch one."""
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = sample_emails(3)
+
+        assert _resolve_email_id(gmail, "2") == "msg-2"
+
+    def test_number_beyond_inbox_returns_empty(self):
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = sample_emails(1)
+
+        assert _resolve_email_id(gmail, "5") == ""
+
+    def test_zero_returns_empty_without_fetching(self):
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "0") == ""
+        gmail.list_inbox.assert_not_called()
+
+    def test_non_ascii_digits_are_not_listing_numbers(self):
+        """Full-width digits can't index a listing; treat them as an id."""
+        gmail = MagicMock()
+        assert _resolve_email_id(gmail, "２") == "２"
+        gmail.list_inbox.assert_not_called()
+
+
+class TestHandleGmailRead:
+    """Read shows the body and only marks read when the scope allows it."""
+
+    def _gmail_mock(self):
+        gmail = MagicMock()
+        gmail.get_email_body.return_value = (
+            "From: alice@example.com\nSubject: Hello\n--- Email Body ---\nThe body text"
+        )
+        return gmail
+
+    def test_unresolvable_number_exits_with_hint(self, capsys):
+        gmail = MagicMock()
+        gmail.list_inbox.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with pytest.raises(typer.Exit):
+                handle_gmail_read("4")
+
+        assert "No email #4" in plain(capsys.readouterr().out)
+        gmail.get_email_body.assert_not_called()
+
+    def test_prints_header_and_body(self, capsys):
+        gmail = self._gmail_mock()
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_read("18f2c9d0a1b2c3d4")
+
+        gmail.get_email_body.assert_called_once_with("18f2c9d0a1b2c3d4")
+        output = plain(capsys.readouterr().out)
+        assert "alice@example.com" in output
+        assert "The body text" in output
+
+    def test_marks_read_with_modify_scope(self, capsys):
+        gmail = self._gmail_mock()
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_read("18f2c9d0a1b2c3d4")
+
+        gmail.mark_read.assert_called_once_with("18f2c9d0a1b2c3d4")
+        assert "Marked read" in plain(capsys.readouterr().out)
+
+    def test_does_not_mark_read_without_modify_scope(self, capsys):
+        """The API rejects the write on readonly+send tokens."""
+        gmail = self._gmail_mock()
+
+        with patch.dict(os.environ, READONLY_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_read("18f2c9d0a1b2c3d4")
+
+        gmail.mark_read.assert_not_called()
+        assert "Marked read" not in plain(capsys.readouterr().out)
+
+    def test_resolves_listing_number_through_cache(self, capsys):
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a", "2": "msg-b"}))
+        gmail = self._gmail_mock()
+
+        with patch.dict(os.environ, READONLY_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_read("2")
+
+        gmail.get_email_body.assert_called_once_with("msg-b")
+
+
+class TestHandleGmailReply:
+
+    def test_replies_to_cached_number(self, capsys):
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
+        gmail = MagicMock()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_reply("1", "Sounds good")
+
+        gmail.reply.assert_called_once_with("msg-a", "Sounds good")
+        assert "Replied" in plain(capsys.readouterr().out)
+
+    def test_message_dash_reads_stdin(self, monkeypatch):
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
+        monkeypatch.setattr(sys, "stdin", io.StringIO("Body from stdin\nline two\n"))
+        gmail = MagicMock()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_reply("1", "-")
+
+        gmail.reply.assert_called_once_with("msg-a", "Body from stdin\nline two\n")
+
+    def test_unresolvable_number_does_not_reply(self, capsys):
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
+        gmail = MagicMock()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            with pytest.raises(typer.Exit):
+                handle_gmail_reply("9", "Sounds good")
+
+        gmail.reply.assert_not_called()
+        assert "No email #9" in plain(capsys.readouterr().out)
+
+
+class TestHandleGmailSendAndSearch:
+
+    def test_send_reports_recipient(self, capsys):
+        gmail = MagicMock()
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_send("bob@example.com", "Hi", "hello")
+
+        gmail.send.assert_called_once_with("bob@example.com", "Hi", "hello", cc=None, bcc=None)
+        output = plain(capsys.readouterr().out)
+        assert "bob@example.com" in output
+        assert "Sent" in output
+
+    def test_send_passes_cc_and_bcc(self):
+        gmail = MagicMock()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_send("bob@example.com", "Hi", "hello",
+                              cc="carol@example.com", bcc="dan@example.com")
+
+        assert gmail.send.call_args.kwargs == {"cc": "carol@example.com", "bcc": "dan@example.com"}
+
+    def test_send_reads_stdin_body(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("piped body"))
+        gmail = MagicMock()
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_send("bob@example.com", "Hi", "-")
+
+        assert gmail.send.call_args.args[2] == "piped body"
+
+    def test_not_connected_does_not_send(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdin", io.StringIO("unused"))
+
+        with patch.dict(os.environ, {"GOOGLE_ACCESS_TOKEN": "", "GOOGLE_SCOPES": ""}, clear=False):
+            with patch("connectonion.useful_tools.gmail.Gmail") as mock_cls:
+                with pytest.raises(typer.Exit):
+                    handle_gmail_send("bob@example.com", "Hi", "hello")
+
+        mock_cls.assert_not_called()
+
+    def test_search_empty_result(self, capsys):
+        gmail = MagicMock()
+        gmail.list_search.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_search("invoice", last=5)
+
+        gmail.list_search.assert_called_once_with("invoice", max_results=5)
+        assert "no emails matching" in capsys.readouterr().out
+
+    def test_search_empty_result_writes_no_cache(self):
+        gmail = MagicMock()
+        gmail.list_search.return_value = []
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_search("invoice", last=5)
+
+        assert not gmail_commands.INBOX_CACHE.exists()
+
+    def test_search_results_share_the_inbox_numbering_contract(self, monkeypatch, capsys):
+        """`co gmail read <#>` after a search must open the search hit."""
+        monkeypatch.setattr(gmail_commands, "console", Console(force_terminal=True, width=120))
+        gmail = MagicMock()
+        gmail.list_search.return_value = sample_emails(2)
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_search("invoice", last=2)
+
+        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-1", "2": "msg-2"}
+        assert "Subject 1" in capsys.readouterr().out
+
+
+class TestHandleGmailSent:
+
+    def test_prints_sent_listing(self, capsys):
+        gmail = MagicMock()
+        gmail.get_sent_emails.return_value = "Found 1 email(s):\n\n1.  From: me@example.com"
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_sent(last=5)
+
+        gmail.get_sent_emails.assert_called_once_with(max_results=5)
+        assert "me@example.com" in capsys.readouterr().out
+
+    def test_sent_does_not_disturb_the_read_numbering(self, capsys):
+        """Only inbox and search define what `read <#>` means."""
+        gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gmail_commands.INBOX_CACHE.write_text(json.dumps({"1": "msg-a"}))
+        gmail = MagicMock()
+        gmail.get_sent_emails.return_value = "Found 0 email(s):"
+
+        with patch.object(gmail_commands, "_gmail", return_value=gmail):
+            handle_gmail_sent(last=5)
+
+        assert json.loads(gmail_commands.INBOX_CACHE.read_text()) == {"1": "msg-a"}


### PR DESCRIPTION
Closes #250.

## Why

Gmail was the asymmetry. It is the **richer** of the two mail tools — 18+ methods against Outlook's — and the only one with no way to reach it from a terminal:

| | tool | CLI |
|---|---|---|
| agent's own address | `send_email`/`get_emails` | `co email` |
| Outlook | `Outlook` | `co outlook` |
| Gmail | `Gmail` | **nothing** |

`co auth google` already grants `gmail.send`, `gmail.readonly`, and `gmail.modify`, so no OAuth or backend work was needed — the credentials were sitting there unused.

```bash
co gmail                                            # inbox (the zero-arg default)
co gmail inbox -n 25 -u
co gmail read 3
co gmail reply 3 "Sounds good"
co gmail send bob@example.com "Hi" "Body"
co gmail send bob@example.com "Hi" - < body.txt
co gmail sent
co gmail search "from:alice@example.com is:unread"
```

Deliberately shaped identically to `co outlook` — same numbered listings, same "numbers mean your last listing" contract, same `●` unread mark, same table that degrades to full-id text when piped — so the two are one command with different mailboxes rather than two things to learn. Labels, stars, and attachments are left out of this first cut; they can follow when someone asks.

## The actual work was in the tool

Gmail's methods returned pre-formatted display strings, which a CLI cannot render into a table. Split `_format_emails` into `_email_dicts` (data) + `_format_dicts` (display) and added `list_inbox()` / `list_search()` — the structure `Outlook` already has.

That refactor is verified, not assumed: I extracted `origin/main`'s `gmail.py` and ran both versions side by side over 4 message shapes × 3 limits × 4 methods. `read_inbox` / `search_emails` / `get_sent_emails` / `get_all_emails` are **byte-identical** in every realistic case. One degenerate divergence: `max_results=0` used to return `"Found 0 email(s):\n"` and now returns `"No emails found."` — strictly better, and now pinned. The captured pre-refactor output is checked in as goldens.

## Two real bugs, found by writing the tests

**`_when()` took down the entire listing on a message with no `Date` header.** `_email_dicts()` fills that field with the literal `'Unknown'`, and on Python 3.10 `email.utils.parsedate_to_datetime("Unknown")` **raises** rather than returning `None` — so the existing `if parsed is None` fallback was dead code and one dateless or spam-malformed message crashed all of `co gmail inbox`. Fixed with a narrow `except ValueError` returning the raw header. (One of the few places try/except is genuinely required — the stdlib offers no non-raising parse.)

**The scope guard let partially-authorized tokens through to a traceback.** It checked for the substring `"gmail"`, but `Gmail.__init__` requires **both** `gmail.readonly` and `gmail.send`. A token carrying only `gmail.readonly` passed the friendly guard and then died on a raw `ValueError`. Now a two-branch check matching Outlook's: missing token → "Google account not connected", missing scopes → "Gmail permission missing". Full Google scope URLs still match.

Both were red-checked — reverting the source makes exactly 7 of the new tests fail with the real errors.

## Tests

**111 passing** across the three files:

- `tests/unit/test_gmail.py` 41 → **52** (refactor goldens, `list_*` dict shape and query args)
- `tests/unit/test_gmail_commands.py` → **44** (scope-guard variants, numbering-cache hit/miss/fallback, read/reply/send/sent/search handlers, `mark_read` only under `gmail.modify`, `_when` edge cases)
- `tests/e2e/cli/test_cli_gmail.py` → **16** (routing, defaults, short flags, missing args, unknown subcommand)

Full unit + CLI suite: 2474 passed, 6 skipped.

## Docs

`docs/cli/gmail.md` mirroring `docs/cli/outlook.md`, plus the `co gmail` section in `docs/cli/README.md` and the entry in `co` help.
