### PR TITLE
Add `co gdrive` and the GDrive tool

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -51,7 +51,7 @@ from .prompts import load_system_prompt
 from .debug import xray, auto_debug_exception, replay, xray_replay
 from .useful_tools import (
     send_email, get_emails, mark_read, mark_unread,
-    Memory, Gmail, GoogleCalendar, Outlook, MicrosoftCalendar,
+    Memory, Gmail, GDrive, GoogleCalendar, Outlook, MicrosoftCalendar,
     WebFetch, Shell, bash, codex, DiffWriter, MODE_NORMAL, MODE_AUTO, MODE_PLAN,
     pick, yes_no, autocomplete, TodoList, SlashCommand,
     # Claude Code-style file tools
@@ -82,6 +82,7 @@ __all__ = [
     # Class-based tools
     "Memory",
     "Gmail",
+    "GDrive",
     "GoogleCalendar",
     "Outlook",
     "MicrosoftCalendar",

--- a/connectonion/cli/commands/gdrive_commands.py
+++ b/connectonion/cli/commands/gdrive_commands.py
@@ -1,0 +1,181 @@
+"""
+Purpose: CLI surface for the user's Google Drive — list, search, download, upload, and trash files from the terminal
+LLM-Note:
+  Dependencies: imports from [json, os, pathlib, typer, dotenv, rich.console, rich.table, ...useful_tools.gdrive.GDrive] | imported by [cli/main.py via handle_gdrive_*()] | hits the Drive API through the GDrive tool
+  Data flow: _gdrive() loads GOOGLE_* from .env / ~/.co/keys.env and checks the drive scope → GDrive() instance | list/search: list_files()/search_files() → numbered Rich table (tab-separated with full ids when piped) → saves {#: file_id} to ~/.co/gdrive_last_list.json | get/rm: resolve short numbers via that cache → download()/delete()
+  State/Effects: writes ~/.co/gdrive_last_list.json (last listing's # → file id map; "numbers mean your last listing") | downloads write local files | put uploads to Drive | rm trashes (recoverable) rather than deleting
+  Integration: exposes handle_gdrive_list(), handle_gdrive_search(), handle_gdrive_get(), handle_gdrive_put(), handle_gdrive_rm() for cli/main.py | presentation mirrors gmail_commands.py / outlook_commands.py | Drive logic lives in useful_tools/gdrive.py | requires prior 'co auth google'
+  Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/drive scope, unresolvable file #, missing upload path | Drive API errors propagate from the GDrive tool
+"""
+
+import json
+import os
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+LIST_CACHE = Path.home() / ".co" / "gdrive_last_list.json"
+
+
+def _gdrive():
+    """Load GOOGLE_* credentials from .env files and return a GDrive instance. Exits 1 with a hint if not connected."""
+    from dotenv import load_dotenv
+
+    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
+        if env_path.exists():
+            load_dotenv(env_path)
+
+    if not os.getenv("GOOGLE_ACCESS_TOKEN"):
+        console.print("\n❌ [bold red]Google account not connected[/bold red]")
+        console.print("\n[cyan]Connect Google Drive first:[/cyan]")
+        console.print("  [bold]co auth google[/bold]     Authorize Drive access\n")
+        raise typer.Exit(1)
+
+    if "drive" not in os.getenv("GOOGLE_SCOPES", ""):
+        # Drive was added to the OAuth scopes after Gmail and Calendar — a token
+        # from before that grants everything else but not this.
+        console.print("\n❌ [bold red]Google Drive permission missing[/bold red]")
+        console.print("\n[cyan]Reconnect Google to grant it:[/cyan]")
+        console.print("  [bold]co auth google[/bold]     Re-authorize with Drive access\n")
+        raise typer.Exit(1)
+
+    from ...useful_tools.gdrive import GDrive
+    return GDrive()
+
+
+def _size(count: int) -> str:
+    """Render a byte count as B/KB/MB/GB; '-' for the sizeless (folders, native docs)."""
+    if not count:
+        return "-"
+    size = float(count)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f}{unit}" if unit == "B" else f"{size:.1f}{unit}"
+        size /= 1024
+
+
+def _kind(mime: str) -> str:
+    """Render a mimeType as a short human label."""
+    from ...useful_tools.gdrive import NATIVE_PREFIX
+
+    if mime.startswith(NATIVE_PREFIX):
+        return mime[len(NATIVE_PREFIX):]
+    return mime.rsplit("/", 1)[-1]
+
+
+def _when(timestamp: str) -> str:
+    """Render Drive's RFC 3339 modifiedTime as 'Jul 26 14:30' in local time."""
+    from datetime import datetime
+
+    if not timestamp:
+        return ""
+    # Drive sends fractional seconds ('2026-07-26T14:30:00.123Z'), which
+    # fromisoformat() rejects on Python 3.10 — display is minute-granular.
+    cleaned = timestamp.replace("Z", "+00:00").split(".")[0]
+    if "+" in timestamp and "." in timestamp:
+        cleaned = f"{cleaned}+00:00"
+    return datetime.fromisoformat(cleaned).astimezone().strftime("%b %d %H:%M")
+
+
+def _print_listing(files: list, title: str):
+    """Render files as a numbered table (or tab-separated rows with full ids when piped) and cache the numbering."""
+    LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    LIST_CACHE.write_text(json.dumps({str(i): f["id"] for i, f in enumerate(files, 1)}), encoding="utf-8")
+
+    if not console.is_terminal:
+        # Scripts and agents get full file ids, never a truncated column.
+        # Plain print, not console.print: Rich expands \t into spaces, which
+        # silently turns tab-separated output into something cut -f can't read.
+        for item in files:
+            print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['id']}")
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("Name", overflow="ellipsis", no_wrap=True)
+    table.add_column("Kind", max_width=14, no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Modified")
+
+    for i, item in enumerate(files, 1):
+        table.add_row(str(i), item["name"], _kind(item["type"]), _size(item["size"]), _when(item["modified"]))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Download one with:[/dim] [bold]co gdrive get <#>[/bold]\n")
+
+
+def handle_gdrive_list(last: int = 20):
+    """List recently modified Drive files as a numbered table."""
+    drive = _gdrive()
+    files = drive.list_files(last=last)
+    if not files:
+        console.print("\n[cyan]Google Drive:[/cyan] no files\n")
+        return
+    _print_listing(files, f"📁 Drive — {os.getenv('GOOGLE_EMAIL', '')}")
+
+
+def handle_gdrive_search(query: str, last: int = 20):
+    """Search Drive by file name, numbered like the listing."""
+    drive = _gdrive()
+    files = drive.search_files(query, last=last)
+    if not files:
+        console.print(f"\n[cyan]Drive search:[/cyan] no files matching [bold]{query}[/bold]")
+        console.print("[dim]Drive matches word prefixes, not any substring.[/dim]\n")
+        return
+    _print_listing(files, f"🔎 Drive — {query}")
+
+
+def _resolve_file_id(file_id: str) -> str:
+    """Turn a listing number into a Drive file id; full ids pass through."""
+    cached = json.loads(LIST_CACHE.read_text(encoding="utf-8")) if LIST_CACHE.exists() else {}
+    if file_id in cached:
+        return cached[file_id]
+
+    if file_id.isascii() and file_id.isdigit() and len(file_id) < 5:
+        # A short number means "row N of what you just showed me" — refetching a
+        # differently ordered listing would silently act on the wrong file.
+        return ""
+    return file_id
+
+
+def handle_gdrive_get(file_id: str, dest: str = "."):
+    """Download a Drive file. Accepts the listing # or a full file id."""
+    drive = _gdrive()
+    resolved = _resolve_file_id(file_id)
+    if not resolved:
+        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    console.print(drive.download(resolved, dest=dest).replace("Downloaded to", "\n[green]✓ Downloaded[/green]"))
+    console.print()
+
+
+def handle_gdrive_put(path: str, name: str = None):
+    """Upload a local file to Drive."""
+    if not Path(path).expanduser().is_file():
+        console.print(f"\n❌ [bold red]File not found:[/bold red] {path}\n")
+        raise typer.Exit(1)
+
+    drive = _gdrive()
+    uploaded = drive.upload(path, name=name)
+    console.print(f"\n[green]✓ Uploaded[/green] [bold]{uploaded['name']}[/bold]")
+    if uploaded["link"]:
+        console.print(f"  {uploaded['link']}")
+    console.print()
+
+
+def handle_gdrive_rm(file_id: str):
+    """Move a Drive file to the trash. Accepts the listing # or a full file id."""
+    drive = _gdrive()
+    resolved = _resolve_file_id(file_id)
+    if not resolved:
+        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    drive.delete(resolved)
+    console.print(f"\n[green]✓ Moved to trash[/green] — restore it from drive.google.com if that was wrong\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -78,6 +78,7 @@ def _show_help():
     console.print("  [green]auth[/green]              Authenticate for managed keys")
     console.print("  [green]email[/green]             Send and read agent email")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
+    console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
@@ -524,6 +525,66 @@ def gmail_search(
     """Search your mail with Gmail query syntax."""
     from .commands.gmail_commands import handle_gmail_search
     handle_gmail_search(query, last=last)
+# Google Drive command group. `co gdrive` (no args) lists recent files.
+# Uses the GOOGLE_* OAuth tokens saved to .env by `co auth google`.
+gdrive_app = typer.Typer(help="List, search, download, and upload Google Drive files. Bare 'co gdrive' lists recent files.")
+app.add_typer(gdrive_app, name="gdrive")
+
+
+@gdrive_app.callback(invoke_without_command=True)
+def gdrive_callback(ctx: typer.Context):
+    """With no subcommand, list recent Drive files."""
+    if ctx.invoked_subcommand is None:
+        from .commands.gdrive_commands import handle_gdrive_list
+        handle_gdrive_list()
+
+
+@gdrive_app.command("list")
+def gdrive_list(
+    last: int = typer.Option(20, "--last", "-n", help="How many files to show"),
+):
+    """List recently modified files, numbered for get/rm."""
+    from .commands.gdrive_commands import handle_gdrive_list
+    handle_gdrive_list(last=last)
+
+
+@gdrive_app.command("search")
+def gdrive_search(
+    query: str = typer.Argument(..., help="Text to look for in file names"),
+    last: int = typer.Option(20, "--last", "-n", help="How many matches to show"),
+):
+    """Search Drive by file name."""
+    from .commands.gdrive_commands import handle_gdrive_search
+    handle_gdrive_search(query, last=last)
+
+
+@gdrive_app.command("get")
+def gdrive_get(
+    file_id: str = typer.Argument(..., help="File # from the last listing, or a full file id"),
+    dest: str = typer.Option(".", "--to", help="Destination directory or file path"),
+):
+    """Download a file (Google Docs/Sheets/Slides are exported)."""
+    from .commands.gdrive_commands import handle_gdrive_get
+    handle_gdrive_get(file_id, dest=dest)
+
+
+@gdrive_app.command("put")
+def gdrive_put(
+    path: str = typer.Argument(..., help="Local file to upload"),
+    name: str = typer.Option(None, "--name", help="Name to give it in Drive"),
+):
+    """Upload a local file to Drive."""
+    from .commands.gdrive_commands import handle_gdrive_put
+    handle_gdrive_put(path, name=name)
+
+
+@gdrive_app.command("rm")
+def gdrive_rm(
+    file_id: str = typer.Argument(..., help="File # from the last listing, or a full file id"),
+):
+    """Move a file to the Drive trash (recoverable)."""
+    from .commands.gdrive_commands import handle_gdrive_rm
+    handle_gdrive_rm(file_id)
 
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [send_email, get_emails, memory, gmail, google_calendar, outlook, microsoft_calendar, web_fetch, shell, diff_writer, tui.pick, terminal, todo_list, slash_command, read_file, edit, multi_edit, glob_files, grep_files, write_file] | imported by [__init__.py main package] | re-exports tools for agent consumption
   Data flow: agent imports from useful_tools → accesses tool functions/classes directly
   State/Effects: no state | pure re-exports | lazy loading for heavy dependencies
-  Integration: exposes send_email, get_emails, mark_read, mark_unread (email functions) | Memory, Gmail, GoogleCalendar, Outlook, MicrosoftCalendar, WebFetch, Shell, DiffWriter, TodoList (tool classes) | pick, yes_no, autocomplete (TUI helpers) | SlashCommand (extension point) | read_file, edit, multi_edit, glob, grep, write, Write (Claude Code-style tools)
+  Integration: exposes send_email, get_emails, mark_read, mark_unread (email functions) | Memory, Gmail, GDrive, GoogleCalendar, Outlook, MicrosoftCalendar, WebFetch, Shell, DiffWriter, TodoList (tool classes) | pick, yes_no, autocomplete (TUI helpers) | SlashCommand (extension point) | read_file, edit, multi_edit, glob, grep, write, Write (Claude Code-style tools)
   Errors: ImportError if dependency not installed (e.g., google-auth for GoogleCalendar, httpx for Outlook/MicrosoftCalendar)
 """
 
@@ -12,6 +12,7 @@ from .send_email import send_email
 from .get_emails import get_emails, mark_read, mark_unread
 from .memory import Memory
 from .gmail import Gmail
+from .gdrive import GDrive
 from .google_calendar import GoogleCalendar
 from .outlook import Outlook
 from .microsoft_calendar import MicrosoftCalendar
@@ -46,6 +47,7 @@ __all__ = [
     # Class-based tools
     "Memory",
     "Gmail",
+    "GDrive",
     "GoogleCalendar",
     "Outlook",
     "MicrosoftCalendar",

--- a/connectonion/useful_tools/gdrive.py
+++ b/connectonion/useful_tools/gdrive.py
@@ -1,0 +1,366 @@
+"""
+Purpose: Google Drive integration tool for listing, searching, downloading, and uploading files via the Drive API
+LLM-Note:
+  Dependencies: imports from [io, mimetypes, os, pathlib, googleapiclient.discovery, googleapiclient.http, google.oauth2.credentials] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gdrive.py]
+  Data flow: Agent calls GDrive methods → _get_service() refreshes the access token via oo-api once per instance → Drive v3 API → returns file dicts or confirmations | list_files()/search_files() page through files().list() with 'trashed = false' | download() picks get_media() for binary files and export_media() for Google-native docs | upload() sends a MediaFileUpload
+  State/Effects: reads GOOGLE_* env vars for OAuth tokens | makes HTTP calls to the Drive API | creates/overwrites local files on download and remote files on upload | token refresh rewrites ~/.co/keys.env
+  Integration: exposes GDrive class with list_files(), search_files(), download(), upload(), delete() | list_files()/search_files() return dicts for the CLI (cli/commands/gdrive_commands.py) | used as agent tool via Agent(tools=[GDrive()])
+  Performance: network I/O per API call | listings page at 100/request | downloads stream in chunks
+  Errors: raises ValueError if OAuth not configured, if the Drive scope is missing, on unknown file ids, and on Google-native types with no export format | HttpError from the Drive API propagates
+
+Google Drive tool for managing files.
+
+Usage:
+    from connectonion import Agent, GDrive
+
+    drive = GDrive()
+    agent = Agent("assistant", tools=[drive])
+
+    # Agent can now use:
+    # - list_files(last)
+    # - search_files(query, last)
+    # - download(file_id, dest)
+    # - upload(path, name)
+    # - delete(file_id)
+
+Example:
+    from connectonion import Agent, GDrive
+
+    agent = Agent(
+        name="drive-assistant",
+        system_prompt="You are a Google Drive assistant.",
+        tools=[GDrive()]
+    )
+
+    agent.input("What did I change in Drive this week?")
+"""
+
+import io
+import mimetypes
+import os
+from pathlib import Path
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
+
+# Everything under this prefix is a Google-native doc: it has no bytes of its
+# own, so it must be exported to a real format rather than downloaded.
+NATIVE_PREFIX = "application/vnd.google-apps."
+
+# What each native type becomes on download, and the extension to give it.
+EXPORT_FORMATS = {
+    "application/vnd.google-apps.document": ("text/markdown", ".md"),
+    "application/vnd.google-apps.spreadsheet": ("text/csv", ".csv"),
+    "application/vnd.google-apps.presentation": ("application/pdf", ".pdf"),
+    "application/vnd.google-apps.drawing": ("application/pdf", ".pdf"),
+}
+
+# Drive returns only id/name/mimeType/kind unless asked; and in a list request
+# the file fields have to be nested under files(...).
+FILE_FIELDS = "id, name, mimeType, modifiedTime, size, webViewLink"
+LIST_FIELDS = f"nextPageToken, files({FILE_FIELDS})"
+
+
+class GDrive:
+    """Google Drive tool for listing, searching, downloading, and uploading files."""
+
+    def __init__(self):
+        """Initialize the Drive tool.
+
+        Validates that Google OAuth is configured with the Drive scope.
+        Raises ValueError if it is missing.
+        """
+        scopes = os.getenv("GOOGLE_SCOPES", "")
+        if "drive" not in scopes:
+            raise ValueError(
+                "Missing 'drive' scope.\n"
+                f"Current scopes: {scopes}\n"
+                "Please authorize Google Drive access:\n"
+                "  co auth google"
+            )
+
+        self._service = None
+
+    def _get_service(self):
+        """Get the Drive API service, refreshing the access token once per instance.
+
+        Same contract as the Gmail tool: an access token lives an hour, so a
+        cached one is almost always stale by the next run — refresh up front
+        rather than doing expiry arithmetic that can silently skip.
+        """
+        if self._service:
+            return self._service
+
+        refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
+
+        if not os.getenv("GOOGLE_ACCESS_TOKEN") or not refresh_token:
+            raise ValueError(
+                "Google OAuth credentials not found.\n"
+                "Run: co auth google"
+            )
+
+        access_token = self._refresh_via_backend(refresh_token)
+
+        creds = Credentials(
+            token=access_token,
+            refresh_token=refresh_token,
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=None,
+            client_secret=None,
+            scopes=["https://www.googleapis.com/auth/drive"]
+        )
+
+        self._service = build('drive', 'v3', credentials=creds)
+        return self._service
+
+    def _refresh_via_backend(self, refresh_token: str) -> str:
+        """Refresh the access token via the backend and persist it.
+
+        Args:
+            refresh_token: The refresh token
+
+        Returns:
+            New access token
+        """
+        import httpx
+
+        backend_url = os.getenv("OPENONION_API_URL", "https://oo.openonion.ai")
+        api_key = os.getenv("OPENONION_API_KEY")
+
+        if not api_key:
+            raise ValueError(
+                "OPENONION_API_KEY not found.\n"
+                "This is needed to refresh tokens via backend."
+            )
+
+        response = httpx.post(
+            f"{backend_url}/api/v1/oauth/google/refresh",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"refresh_token": refresh_token}
+        )
+
+        if response.status_code != 200:
+            raise ValueError(
+                f"Failed to refresh token via backend: {response.text}"
+            )
+
+        data = response.json()
+        new_access_token = data["access_token"]
+        expires_at = data["expires_at"]
+
+        os.environ["GOOGLE_ACCESS_TOKEN"] = new_access_token
+        os.environ["GOOGLE_TOKEN_EXPIRES_AT"] = expires_at
+
+        from ..cli.commands.project_cmd_lib import upsert_env
+        env_file = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        upsert_env(env_file, {
+            "GOOGLE_ACCESS_TOKEN": new_access_token,
+            "GOOGLE_TOKEN_EXPIRES_AT": expires_at,
+        })
+
+        return new_access_token
+
+    @staticmethod
+    def _file_dict(item: dict) -> dict:
+        """Normalize a Drive file resource to the CLI/agent file shape."""
+        return {
+            "id": item.get("id", ""),
+            "name": item.get("name", ""),
+            "type": item.get("mimeType", ""),
+            "modified": item.get("modifiedTime", ""),
+            # Folders, shortcuts and native docs report no size.
+            "size": int(item["size"]) if item.get("size") else 0,
+            "link": item.get("webViewLink", ""),
+        }
+
+    def _list(self, query: str, last: int) -> list:
+        """Page through files().list() until `last` files are collected."""
+        service = self._get_service()
+        files = []
+        page_token = None
+
+        while len(files) < last:
+            result = service.files().list(
+                q=query,
+                orderBy="modifiedTime desc",
+                pageSize=min(last - len(files), 100),
+                fields=LIST_FIELDS,
+                pageToken=page_token,
+                includeItemsFromAllDrives=True,
+                supportsAllDrives=True,
+            ).execute()
+
+            files.extend(self._file_dict(item) for item in result.get("files", []))
+            page_token = result.get("nextPageToken")
+            if not page_token:
+                break
+
+        return files[:last]
+
+    # === Listing ===
+
+    def list_files(self, last: int = 20) -> list:
+        """List recently modified Drive files as dicts (id, name, type, modified, size, link).
+
+        Args:
+            last: Number of files to retrieve (default: 20)
+
+        Returns:
+            List of file dicts, most recently modified first
+        """
+        if last < 1:
+            return []
+        return self._list("trashed = false", last)
+
+    def search_files(self, query: str, last: int = 20) -> list:
+        """Find Drive files by name.
+
+        Drive matches `name contains` on token prefixes, not arbitrary
+        substrings: on "HelloWorld", 'Hello' matches and 'World' does not.
+
+        Args:
+            query: Text to look for in file names
+            last: Number of matches to return (default: 20)
+
+        Returns:
+            List of file dicts, most recently modified first
+        """
+        needle = query.strip()
+        if not needle or last < 1:
+            return []
+
+        # A quote or backslash in the name would otherwise break out of the
+        # query literal and make Drive reject the whole request.
+        escaped = needle.replace("\\", "\\\\").replace("'", "\\'")
+        return self._list(f"name contains '{escaped}' and trashed = false", last)
+
+    def format_files(self, files: list) -> str:
+        """Format file dicts into a readable list."""
+        if not files:
+            return "No files found."
+
+        output = [f"Found {len(files)} file(s):\n"]
+        for i, item in enumerate(files, 1):
+            output.append(f"{i}. {item['name']}")
+            output.append(f"   Type: {item['type']}")
+            output.append(f"   Modified: {item['modified']}")
+            output.append(f"   ID: {item['id']}\n")
+
+        return "\n".join(output)
+
+    def list_recent(self, last: int = 20) -> str:
+        """List recent Drive files as readable text (agent-facing counterpart of list_files)."""
+        return self.format_files(self.list_files(last=last))
+
+    def search(self, query: str, last: int = 20) -> str:
+        """Search Drive by file name and return readable text."""
+        files = self.search_files(query, last=last)
+        if not files:
+            return f"No files found matching: {query}"
+        return self.format_files(files)
+
+    # === Transfer ===
+
+    def _get_meta(self, file_id: str) -> dict:
+        """Fetch one file's metadata, resolving shortcuts to their target."""
+        service = self._get_service()
+        item = service.files().get(
+            fileId=file_id,
+            fields=f"{FILE_FIELDS}, shortcutDetails",
+            supportsAllDrives=True,
+        ).execute()
+
+        shortcut = item.get("shortcutDetails")
+        if shortcut:
+            return self._get_meta(shortcut["targetId"])
+        return item
+
+    def download(self, file_id: str, dest: str = ".") -> str:
+        """Download a Drive file, exporting Google-native docs to a real format.
+
+        Args:
+            file_id: Drive file id
+            dest: Destination directory, or a full file path (default: cwd)
+
+        Returns:
+            Confirmation with the path written
+        """
+        item = self._get_meta(file_id)
+        name, mime = item["name"], item["mimeType"]
+        service = self._get_service()
+
+        if mime.startswith(NATIVE_PREFIX):
+            if mime not in EXPORT_FORMATS:
+                raise ValueError(
+                    f"'{name}' is a {mime.replace(NATIVE_PREFIX, '')} — Drive has "
+                    "no export format for it, so it cannot be downloaded."
+                )
+            export_mime, suffix = EXPORT_FORMATS[mime]
+            request = service.files().export_media(fileId=item["id"], mimeType=export_mime)
+            name = f"{name}{suffix}"
+        else:
+            request = service.files().get_media(fileId=item["id"], supportsAllDrives=True)
+
+        path = Path(dest).expanduser()
+        if path.is_dir():
+            path = path / name
+
+        buffer = io.BytesIO()
+        downloader = MediaIoBaseDownload(buffer, request)
+        done = False
+        while not done:
+            _, done = downloader.next_chunk()
+
+        path.write_bytes(buffer.getvalue())
+        return f"Downloaded to {path}"
+
+    def upload(self, path: str, name: str = None) -> dict:
+        """Upload a local file to Drive.
+
+        Args:
+            path: Local file path
+            name: Name to give it in Drive (default: the file's own name)
+
+        Returns:
+            File dict for the created file
+        """
+        local = Path(path).expanduser()
+        if not local.is_file():
+            raise ValueError(f"File not found: {path}")
+
+        service = self._get_service()
+        media = MediaFileUpload(
+            str(local),
+            mimetype=mimetypes.guess_type(local.name)[0] or "application/octet-stream",
+            resumable=True,
+        )
+        created = service.files().create(
+            body={"name": name or local.name},
+            media_body=media,
+            fields=FILE_FIELDS,
+            supportsAllDrives=True,
+        ).execute()
+
+        return self._file_dict(created)
+
+    def delete(self, file_id: str) -> str:
+        """Move a Drive file to the trash.
+
+        Trashing rather than deleting outright — an agent calling this by
+        mistake should be recoverable from the Drive UI.
+
+        Args:
+            file_id: Drive file id
+
+        Returns:
+            Confirmation message
+        """
+        service = self._get_service()
+        service.files().update(
+            fileId=file_id,
+            body={"trashed": True},
+            supportsAllDrives=True,
+        ).execute()
+        return f"Moved to trash: {file_id}"

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -237,6 +237,17 @@ co gmail inbox -n 25 -u                             # last 25, unread only
 co gmail read 3                                     # read #3 from the listing, mark read
 co gmail send bob@example.com "Hi" "Body text"      # send now
 co gmail search "from:alice@example.com is:unread"  # full Gmail query syntax
+#### `co gdrive` - Google Drive Files
+
+Your Drive from the terminal. Requires `co auth google` once (Drive scope;
+saved as `GOOGLE_*` in `.env` / `~/.co/keys.env`).
+
+**Basic usage:**
+```bash
+co gdrive                             # 20 most recently modified files
+co gdrive search report                # find by name (word prefixes)
+co gdrive get 3 --to ~/Downloads       # download #3 from the listing
+co gdrive put report.pdf               # upload
 ```
 
 **Subcommands:**
@@ -250,6 +261,13 @@ co gmail search "from:alice@example.com is:unread"  # full Gmail query syntax
 
 The CLI wraps the same `Gmail` tool your agents use. See
 [gmail.md](gmail.md) for details.
+- `co gdrive` / `co gdrive list` - recent files (`--last/-n`)
+- `co gdrive search <query>` - find by file name
+- `co gdrive get <#>` - download (`--to`); Docs/Sheets/Slides are exported to md/csv/pdf
+- `co gdrive put <path>` - upload (`--name`)
+- `co gdrive rm <#>` - move to trash (recoverable)
+
+See [gdrive.md](gdrive.md) for details.
 
 ---
 

--- a/docs/cli/gdrive.md
+++ b/docs/cli/gdrive.md
@@ -1,0 +1,148 @@
+# Google Drive CLI (co gdrive)
+
+List, search, download, and upload Drive files from the terminal — the same
+Drive access your agents get from the [GDrive tool](../useful_tools/gdrive.md),
+as a command.
+
+## Quick Start
+
+```bash
+# Connect your Google account (one-time)
+co auth google
+
+# See what changed recently (the zero-arg default)
+co gdrive
+
+# Download file #3 from the listing
+co gdrive get 3
+
+# Upload something
+co gdrive put report.pdf
+```
+
+That's the whole surface. Everything below is detail.
+
+## Setup
+
+`co gdrive` needs a connected Google account with the Drive scope:
+
+```bash
+co auth google
+```
+
+Drive was added to the requested scopes **after** Gmail and Calendar. If you
+authorized before that, run `co auth google` once more — a token refresh
+cannot widen scopes, so an older token has everything except Drive. The
+command tells you exactly that if it happens.
+
+## Commands
+
+### `co gdrive` — Recent files
+
+```bash
+co gdrive                # 20 most recently modified
+co gdrive list -n 50
+```
+
+Files are numbered. **Numbers mean your last listing** — `co gdrive get 3`
+downloads the third row of the table you just saw. Running `co gdrive` again
+renumbers.
+
+Trashed files are excluded.
+
+### `co gdrive search <query>` — Find by name
+
+```bash
+co gdrive search report
+co gdrive search "Q3 budget" -n 5
+```
+
+One caveat worth knowing: Drive matches **word prefixes, not any substring**.
+On a file named `HelloWorld`, searching `Hello` matches and `World` does not.
+That is the API's behavior, not ours.
+
+### `co gdrive get <#>` — Download
+
+```bash
+co gdrive get 3                       # into the current directory
+co gdrive get 3 --to ~/Downloads      # into a directory
+co gdrive get 3 --to notes.md         # to an exact path
+co gdrive get 1A2b3C4d5E6f7G8h        # by full file id
+```
+
+Google Docs, Sheets, and Slides have no file bytes of their own, so they are
+**exported** on the way down and get the matching extension:
+
+| In Drive | Downloads as |
+|---|---|
+| Google Doc | Markdown (`.md`) |
+| Google Sheet | CSV (`.csv`, first sheet) |
+| Google Slides | PDF (`.pdf`) |
+| Google Drawing | PDF (`.pdf`) |
+
+Everything else downloads byte-for-byte. Folders and Forms have no export
+format at all — the command says so rather than writing a broken file.
+Shortcuts resolve to whatever they point at.
+
+### `co gdrive put <path>` — Upload
+
+```bash
+co gdrive put report.pdf
+co gdrive put ./out/report.pdf --name "Q3 Report.pdf"
+```
+
+Uploads to the root of your Drive and prints the link.
+
+### `co gdrive rm <#>` — Trash
+
+```bash
+co gdrive rm 3
+```
+
+Moves the file to the Drive trash. It is **not** permanently deleted — restore
+it from drive.google.com if that was a mistake.
+
+## Piping
+
+In a terminal you get a Rich table with truncated columns. When output is
+piped, each file is one tab-separated row of `name`, `type`, `size`, and the
+**full file id**, so scripts never receive a truncated value:
+
+```bash
+co gdrive list -n 100 | cut -f4      # just the ids
+co gdrive search report | cut -f1    # just the names
+```
+
+## Using it from an agent
+
+```python
+from connectonion import Agent, GDrive
+
+agent = Agent("assistant", tools=[GDrive()])
+agent.input("What did I change in Drive this week?")
+```
+
+Or call it directly:
+
+```python
+drive = GDrive()
+drive.list_files(last=20)
+drive.search_files("report")
+drive.download("1A2b3C4d5E6f7G8h", dest="~/Downloads")
+drive.upload("report.pdf")
+```
+
+## Troubleshooting
+
+- **"Google account not connected"** → run `co auth google`.
+- **"Google Drive permission missing"** → your token predates Drive support;
+  run `co auth google` again to re-consent.
+- **`No file #N in your last listing`** → the number is out of range or the
+  listing changed; run `co gdrive` to refresh the numbering.
+- **A search finds nothing you can see in Drive** → Drive matches word
+  prefixes, not substrings. Try the beginning of a word in the name.
+
+## See also
+
+- [`co gmail`](gmail.md) — the same shape for your Gmail mailbox
+- [Google Integration](../integrations/google.md) — the OAuth scopes requested

--- a/tests/e2e/cli/test_cli_gdrive.py
+++ b/tests/e2e/cli/test_cli_gdrive.py
@@ -1,0 +1,102 @@
+"""CLI routing tests for `co gdrive`."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+runner = CliRunner()
+
+
+def test_bare_gdrive_lists_files():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_list") as handler:
+        result = runner.invoke(app, ["gdrive"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with()
+
+
+def test_gdrive_list_routes_limit():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_list") as handler:
+        result = runner.invoke(app, ["gdrive", "list", "--last", "50"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=50)
+
+
+def test_gdrive_list_defaults():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_list") as handler:
+        result = runner.invoke(app, ["gdrive", "list"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(last=20)
+
+
+def test_gdrive_search_routes_query_and_limit():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_search") as handler:
+        result = runner.invoke(app, ["gdrive", "search", "report", "-n", "5"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("report", last=5)
+
+
+def test_gdrive_get_routes_id_and_destination():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_get") as handler:
+        result = runner.invoke(app, ["gdrive", "get", "3", "--to", "/tmp"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("3", dest="/tmp")
+
+
+def test_gdrive_get_defaults_to_cwd():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_get") as handler:
+        result = runner.invoke(app, ["gdrive", "get", "3"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("3", dest=".")
+
+
+def test_gdrive_put_routes_path_and_name():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_put") as handler:
+        result = runner.invoke(app, ["gdrive", "put", "report.pdf", "--name", "Q3.pdf"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("report.pdf", name="Q3.pdf")
+
+
+def test_gdrive_rm_routes_id():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_rm") as handler:
+        result = runner.invoke(app, ["gdrive", "rm", "2"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("2")
+
+
+def test_gdrive_requires_an_id_to_get():
+    with patch("connectonion.cli.commands.gdrive_commands.handle_gdrive_get") as handler:
+        result = runner.invoke(app, ["gdrive", "get"])
+
+    assert result.exit_code != 0
+    handler.assert_not_called()
+
+
+def test_gdrive_appears_in_help():
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "gdrive" in result.output
+
+
+def test_gdrive_help_lists_every_subcommand():
+    result = runner.invoke(app, ["gdrive", "--help"])
+
+    assert result.exit_code == 0
+    for command in ["list", "search", "get", "put", "rm"]:
+        assert command in result.output
+
+
+def test_unknown_gdrive_subcommand_fails():
+    result = runner.invoke(app, ["gdrive", "sync"])
+
+    assert result.exit_code != 0

--- a/tests/unit/test_gdrive.py
+++ b/tests/unit/test_gdrive.py
@@ -1,0 +1,365 @@
+"""Unit tests for connectonion/useful_tools/gdrive.py
+
+Tests cover:
+- scope validation at construction
+- token refresh once per instance (mirrors the Gmail contract)
+- list_files/search_files normalization, paging, and query escaping
+- download: binary via get_media, Google-native via export_media, shortcut resolution
+- upload and delete (trash, not permanent)
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ENV = {
+    "GOOGLE_SCOPES": "gmail.send,gmail.readonly,gmail.modify,calendar,drive",
+    "GOOGLE_ACCESS_TOKEN": "test-token",
+    "GOOGLE_REFRESH_TOKEN": "test-refresh",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stub_token_refresh(request, monkeypatch):
+    """Drive refreshes its access token once per instance; stub that network
+    call so API-operation tests stay isolated. Tests of the refresh flow
+    itself opt out with @pytest.mark.real_refresh."""
+    if "real_refresh" in request.keywords:
+        return
+    from connectonion.useful_tools.gdrive import GDrive
+    monkeypatch.setattr(GDrive, "_refresh_via_backend", lambda self, rt: "test-token")
+
+
+def drive_with_service(service):
+    """Build a GDrive whose _get_service() returns the given mock."""
+    from connectonion.useful_tools.gdrive import GDrive
+    drive = GDrive()
+    drive._service = service
+    return drive
+
+
+def file_resource(**overrides):
+    resource = {
+        "id": "file-1",
+        "name": "Report.pdf",
+        "mimeType": "application/pdf",
+        "modifiedTime": "2026-07-26T14:30:00.000Z",
+        "size": "2048",
+        "webViewLink": "https://drive.google.com/file/d/file-1/view",
+    }
+    resource.update(overrides)
+    return resource
+
+
+class TestGDriveInit:
+
+    def test_requires_drive_scope(self):
+        with patch.dict(os.environ, {"GOOGLE_SCOPES": "gmail.send,calendar"}, clear=False):
+            from connectonion.useful_tools.gdrive import GDrive
+            with pytest.raises(ValueError) as exc:
+                GDrive()
+            assert "drive" in str(exc.value)
+            assert "co auth google" in str(exc.value)
+
+    def test_initializes_with_drive_scope(self):
+        with patch.dict(os.environ, ENV, clear=False):
+            from connectonion.useful_tools.gdrive import GDrive
+            assert GDrive()._service is None
+
+    @pytest.mark.real_refresh
+    def test_missing_credentials_raise(self):
+        with patch.dict(os.environ, {**ENV, "GOOGLE_ACCESS_TOKEN": "", "GOOGLE_REFRESH_TOKEN": ""}, clear=False):
+            from connectonion.useful_tools.gdrive import GDrive
+            with pytest.raises(ValueError) as exc:
+                GDrive()._get_service()
+            assert "credentials not found" in str(exc.value)
+
+    @pytest.mark.real_refresh
+    @patch("connectonion.useful_tools.gdrive.build")
+    def test_refreshes_token_before_building_service(self, mock_build, monkeypatch):
+        """Same contract as Gmail: refresh up front, never trust a cached token."""
+        from connectonion.useful_tools.gdrive import GDrive
+        calls = []
+        monkeypatch.setattr(GDrive, "_refresh_via_backend", lambda self, rt: calls.append(rt) or "fresh")
+
+        with patch.dict(os.environ, ENV, clear=False):
+            GDrive()._get_service()
+
+        assert calls == ["test-refresh"]
+        assert mock_build.call_args.kwargs["credentials"].token == "fresh"
+
+
+class TestListFiles:
+
+    def test_normalizes_and_excludes_trash(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {
+            "files": [file_resource(), file_resource(id="file-2", name="Notes", size=None)]
+        }
+
+        with patch.dict(os.environ, ENV, clear=False):
+            files = drive_with_service(service).list_files(last=20)
+
+        assert files[0] == {
+            "id": "file-1",
+            "name": "Report.pdf",
+            "type": "application/pdf",
+            "modified": "2026-07-26T14:30:00.000Z",
+            "size": 2048,
+            "link": "https://drive.google.com/file/d/file-1/view",
+        }
+        # Folders and native docs report no size at all.
+        assert files[1]["size"] == 0
+        assert service.files.return_value.list.call_args.kwargs["q"] == "trashed = false"
+
+    def test_orders_by_most_recently_modified(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": []}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).list_files()
+
+        assert service.files.return_value.list.call_args.kwargs["orderBy"] == "modifiedTime desc"
+
+    def test_requests_the_fields_it_reads(self):
+        """Without an explicit nested fields string Drive omits size/modifiedTime."""
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": []}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).list_files()
+
+        fields = service.files.return_value.list.call_args.kwargs["fields"]
+        assert fields.startswith("nextPageToken, files(")
+        for name in ("id", "name", "mimeType", "modifiedTime", "size", "webViewLink"):
+            assert name in fields
+
+    def test_pages_until_enough_files(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.side_effect = [
+            {"files": [file_resource(id=f"a{i}") for i in range(100)], "nextPageToken": "page2"},
+            {"files": [file_resource(id="b1"), file_resource(id="b2")]},
+        ]
+
+        with patch.dict(os.environ, ENV, clear=False):
+            files = drive_with_service(service).list_files(last=101)
+
+        assert len(files) == 101
+        assert files[-1]["id"] == "b1"
+
+    def test_stops_when_drive_runs_out(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": [file_resource()]}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            files = drive_with_service(service).list_files(last=50)
+
+        assert len(files) == 1
+
+    def test_zero_returns_empty_without_calling_drive(self):
+        service = MagicMock()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            assert drive_with_service(service).list_files(last=0) == []
+
+        service.files.assert_not_called()
+
+
+class TestSearchFiles:
+
+    def test_builds_name_query_and_excludes_trash(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": [file_resource()]}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).search_files("report")
+
+        assert service.files.return_value.list.call_args.kwargs["q"] == (
+            "name contains 'report' and trashed = false"
+        )
+
+    def test_escapes_quotes_so_the_query_cannot_break_out(self):
+        """An apostrophe in a filename would otherwise make Drive reject the request."""
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": []}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).search_files("Bob's plan")
+
+        assert service.files.return_value.list.call_args.kwargs["q"] == (
+            "name contains 'Bob\\'s plan' and trashed = false"
+        )
+
+    def test_escapes_backslashes(self):
+        service = MagicMock()
+        service.files.return_value.list.return_value.execute.return_value = {"files": []}
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).search_files("a\\b")
+
+        assert "a\\\\b" in service.files.return_value.list.call_args.kwargs["q"]
+
+    def test_blank_query_returns_empty_without_calling_drive(self):
+        service = MagicMock()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            assert drive_with_service(service).search_files("   ") == []
+
+        service.files.assert_not_called()
+
+
+class TestDownload:
+
+    def _stub_download(self, monkeypatch, payload=b"filebytes"):
+        """Make MediaIoBaseDownload write payload into the buffer in one chunk."""
+        def fake_downloader(buffer, request):
+            downloader = MagicMock()
+
+            def next_chunk():
+                buffer.write(payload)
+                return (None, True)
+
+            downloader.next_chunk.side_effect = next_chunk
+            return downloader
+
+        monkeypatch.setattr("connectonion.useful_tools.gdrive.MediaIoBaseDownload", fake_downloader)
+
+    def test_binary_file_uses_get_media(self, tmp_path, monkeypatch):
+        self._stub_download(monkeypatch)
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            result = drive_with_service(service).download("file-1", dest=str(tmp_path))
+
+        service.files.return_value.get_media.assert_called_once()
+        service.files.return_value.export_media.assert_not_called()
+        assert (tmp_path / "Report.pdf").read_bytes() == b"filebytes"
+        assert "Report.pdf" in result
+
+    def test_google_doc_is_exported_with_an_extension(self, tmp_path, monkeypatch):
+        """A Doc has no bytes of its own — downloading it must export instead."""
+        self._stub_download(monkeypatch, b"# Title")
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(
+            name="Design Notes",
+            mimeType="application/vnd.google-apps.document",
+            size=None,
+        )
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).download("file-1", dest=str(tmp_path))
+
+        service.files.return_value.export_media.assert_called_once()
+        assert service.files.return_value.export_media.call_args.kwargs["mimeType"] == "text/markdown"
+        assert (tmp_path / "Design Notes.md").read_bytes() == b"# Title"
+
+    def test_sheet_exports_to_csv(self, tmp_path, monkeypatch):
+        self._stub_download(monkeypatch, b"a,b\n1,2\n")
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(
+            name="Budget", mimeType="application/vnd.google-apps.spreadsheet", size=None,
+        )
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).download("file-1", dest=str(tmp_path))
+
+        assert service.files.return_value.export_media.call_args.kwargs["mimeType"] == "text/csv"
+        assert (tmp_path / "Budget.csv").exists()
+
+    def test_folder_download_is_refused_with_a_clear_message(self, tmp_path):
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource(
+            name="Projects", mimeType="application/vnd.google-apps.folder", size=None,
+        )
+
+        with patch.dict(os.environ, ENV, clear=False):
+            with pytest.raises(ValueError) as exc:
+                drive_with_service(service).download("file-1", dest=str(tmp_path))
+
+        assert "folder" in str(exc.value)
+        assert "Projects" in str(exc.value)
+
+    def test_shortcut_resolves_to_its_target(self, tmp_path, monkeypatch):
+        self._stub_download(monkeypatch)
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.side_effect = [
+            file_resource(
+                id="shortcut-1",
+                name="Link to Report",
+                mimeType="application/vnd.google-apps.shortcut",
+                size=None,
+                shortcutDetails={"targetId": "file-1"},
+            ),
+            file_resource(),
+        ]
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).download("shortcut-1", dest=str(tmp_path))
+
+        assert (tmp_path / "Report.pdf").exists()
+
+    def test_explicit_destination_path_is_honoured(self, tmp_path, monkeypatch):
+        self._stub_download(monkeypatch)
+        service = MagicMock()
+        service.files.return_value.get.return_value.execute.return_value = file_resource()
+        target = tmp_path / "renamed.pdf"
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).download("file-1", dest=str(target))
+
+        assert target.read_bytes() == b"filebytes"
+
+
+class TestUploadAndDelete:
+
+    def test_upload_sends_the_file_and_returns_its_dict(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "connectonion.useful_tools.gdrive.MediaFileUpload",
+            lambda path, mimetype=None, resumable=False: MagicMock(),
+        )
+        local = tmp_path / "report.pdf"
+        local.write_bytes(b"data")
+        service = MagicMock()
+        service.files.return_value.create.return_value.execute.return_value = file_resource()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            result = drive_with_service(service).upload(str(local))
+
+        assert service.files.return_value.create.call_args.kwargs["body"] == {"name": "report.pdf"}
+        assert result["id"] == "file-1"
+
+    def test_upload_honours_an_explicit_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "connectonion.useful_tools.gdrive.MediaFileUpload",
+            lambda path, mimetype=None, resumable=False: MagicMock(),
+        )
+        local = tmp_path / "report.pdf"
+        local.write_bytes(b"data")
+        service = MagicMock()
+        service.files.return_value.create.return_value.execute.return_value = file_resource()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).upload(str(local), name="Q3 Report.pdf")
+
+        assert service.files.return_value.create.call_args.kwargs["body"]["name"] == "Q3 Report.pdf"
+
+    def test_upload_missing_file_raises(self, tmp_path):
+        service = MagicMock()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            with pytest.raises(ValueError) as exc:
+                drive_with_service(service).upload(str(tmp_path / "nope.pdf"))
+
+        assert "not found" in str(exc.value)
+
+    def test_delete_trashes_rather_than_destroying(self):
+        """An agent calling this by mistake must be recoverable from the Drive UI."""
+        service = MagicMock()
+
+        with patch.dict(os.environ, ENV, clear=False):
+            drive_with_service(service).delete("file-1")
+
+        service.files.return_value.delete.assert_not_called()
+        assert service.files.return_value.update.call_args.kwargs["body"] == {"trashed": True}

--- a/tests/unit/test_gdrive_commands.py
+++ b/tests/unit/test_gdrive_commands.py
@@ -1,0 +1,276 @@
+"""Unit tests for connectonion/cli/commands/gdrive_commands.py
+
+Tests cover:
+- _gdrive() credential/scope guard (prints 'co auth google' hint, exits 1)
+- _size/_kind/_when column rendering
+- listing: table in a terminal, tab-separated full ids when piped, numbering cache
+- _resolve_file_id() short-number resolution
+- get/put/rm handlers
+"""
+
+import json
+import os
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from rich.console import Console
+
+from connectonion.cli.commands import gdrive_commands
+from connectonion.cli.commands.gdrive_commands import (
+    _gdrive,
+    _kind,
+    _resolve_file_id,
+    _size,
+    _when,
+    handle_gdrive_get,
+    handle_gdrive_list,
+    handle_gdrive_put,
+    handle_gdrive_rm,
+    handle_gdrive_search,
+)
+
+CONNECTED_ENV = {
+    "GOOGLE_SCOPES": "gmail.send,gmail.readonly,gmail.modify,calendar,drive",
+    "GOOGLE_ACCESS_TOKEN": "test-token",
+    "GOOGLE_REFRESH_TOKEN": "test-refresh",
+    "GOOGLE_EMAIL": "aaron@example.com",
+}
+
+# A token issued before Drive was added to the OAuth scopes.
+PRE_DRIVE_ENV = {**CONNECTED_ENV, "GOOGLE_SCOPES": "gmail.send,gmail.readonly,gmail.modify,calendar"}
+
+
+def plain(text):
+    """Strip ANSI colour codes so assertions match what a user reads."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def sample_files(n):
+    return [{
+        "id": f"file-{i}",
+        "name": f"Document {i}.pdf",
+        "type": "application/pdf",
+        "modified": "2026-07-26T14:30:00.000Z",
+        "size": 2048 * i,
+        "link": f"https://drive.google.com/file/d/file-{i}/view",
+    } for i in range(1, n + 1)]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path, monkeypatch):
+    """Never touch the real ~/.co/gdrive_last_list.json."""
+    monkeypatch.setattr(gdrive_commands, "LIST_CACHE", tmp_path / ".co" / "gdrive_last_list.json")
+
+
+class TestGDriveGuard:
+
+    def test_missing_access_token_exits_with_hint(self, capsys):
+        with patch.dict(os.environ, {"GOOGLE_ACCESS_TOKEN": "", "GOOGLE_SCOPES": "drive"}, clear=False):
+            with pytest.raises(typer.Exit):
+                _gdrive()
+
+        output = capsys.readouterr().out
+        assert "Google account not connected" in output
+        assert "co auth google" in output
+
+    def test_pre_drive_token_gets_reconnect_hint(self, capsys):
+        """Drive was added after Gmail/Calendar — old tokens lack it."""
+        with patch.dict(os.environ, PRE_DRIVE_ENV, clear=False):
+            with pytest.raises(typer.Exit):
+                _gdrive()
+
+        output = capsys.readouterr().out
+        assert "Drive permission missing" in output
+        assert "co auth google" in output
+
+    def test_connected_returns_gdrive_instance(self):
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            result = _gdrive()
+
+        from connectonion.useful_tools.gdrive import GDrive
+        assert isinstance(result, GDrive)
+
+
+class TestColumns:
+
+    def test_size_renders_units(self):
+        assert _size(512) == "512B"
+        assert _size(2048) == "2.0KB"
+        assert _size(5 * 1024 * 1024) == "5.0MB"
+
+    def test_sizeless_files_show_a_dash(self):
+        """Folders, shortcuts and Google-native docs report no size."""
+        assert _size(0) == "-"
+
+    def test_kind_shortens_native_types(self):
+        assert _kind("application/vnd.google-apps.spreadsheet") == "spreadsheet"
+
+    def test_kind_shortens_binary_types(self):
+        assert _kind("application/pdf") == "pdf"
+
+    def test_when_renders_rfc3339_with_fractional_seconds(self):
+        assert re.fullmatch(r"[A-Z][a-z]{2} \d{2} \d{2}:\d{2}", _when("2026-07-26T14:30:00.000Z"))
+
+    def test_when_renders_rfc3339_without_fractional_seconds(self):
+        assert re.fullmatch(r"[A-Z][a-z]{2} \d{2} \d{2}:\d{2}", _when("2026-07-26T14:30:00Z"))
+
+    def test_when_handles_empty(self):
+        assert _when("") == ""
+
+
+class TestHandleList:
+
+    def test_empty_listing_message(self, capsys):
+        drive = MagicMock()
+        drive.list_files.return_value = []
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_list()
+
+        assert "no files" in capsys.readouterr().out
+
+    def test_empty_listing_writes_no_cache(self):
+        """An empty listing must not clobber the numbering from the last one."""
+        drive = MagicMock()
+        drive.list_files.return_value = []
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_list()
+
+        assert not gdrive_commands.LIST_CACHE.exists()
+
+    def test_table_and_cache(self, monkeypatch, capsys):
+        monkeypatch.setattr(gdrive_commands, "console", Console(force_terminal=True, width=120))
+        drive = MagicMock()
+        drive.list_files.return_value = sample_files(3)
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_list(last=3)
+
+        output = plain(capsys.readouterr().out)
+        assert "Document 1.pdf" in output
+        assert "co gdrive get" in output
+        assert json.loads(gdrive_commands.LIST_CACHE.read_text()) == {
+            "1": "file-1", "2": "file-2", "3": "file-3",
+        }
+
+    def test_piped_output_carries_full_ids(self, monkeypatch, capsys):
+        monkeypatch.setattr(gdrive_commands, "console", Console(force_terminal=False, width=120))
+        drive = MagicMock()
+        drive.list_files.return_value = sample_files(2)
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_list(last=2)
+
+        output = capsys.readouterr().out
+        assert "file-1" in output and "file-2" in output
+        # Real tabs, not Rich's space-expanded ones — `cut -f4` must work.
+        assert output.splitlines()[0].split("\t") == [
+            "Document 1.pdf", "application/pdf", "2048", "file-1",
+        ]
+
+    def test_limit_reaches_the_tool(self):
+        drive = MagicMock()
+        drive.list_files.return_value = []
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_list(last=50)
+
+        drive.list_files.assert_called_once_with(last=50)
+
+
+class TestHandleSearch:
+
+    def test_no_matches_explains_prefix_matching(self, capsys):
+        """Drive matches word prefixes, so a 'no results' needs that caveat."""
+        drive = MagicMock()
+        drive.search_files.return_value = []
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_search("report", last=5)
+
+        output = capsys.readouterr().out
+        assert "no files matching" in output
+        assert "prefix" in output
+        drive.search_files.assert_called_once_with("report", last=5)
+
+
+class TestResolveFileId:
+
+    def test_number_resolves_through_cache(self):
+        gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a", "2": "file-b"}))
+
+        assert _resolve_file_id("2") == "file-b"
+
+    def test_full_id_passes_through(self):
+        assert _resolve_file_id("1A2b3C4d5E6f7G8h") == "1A2b3C4d5E6f7G8h"
+
+    def test_number_missing_from_cache_returns_empty(self):
+        gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
+
+        assert _resolve_file_id("7") == ""
+
+
+class TestGetPutRm:
+
+    def test_get_downloads_resolved_id(self, capsys):
+        gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
+        drive = MagicMock()
+        drive.download.return_value = "Downloaded to /tmp/Report.pdf"
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_get("1", dest="/tmp")
+
+        drive.download.assert_called_once_with("file-a", dest="/tmp")
+        assert "Report.pdf" in plain(capsys.readouterr().out)
+
+    def test_get_unknown_number_exits(self, capsys):
+        drive = MagicMock()
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            with pytest.raises(typer.Exit):
+                handle_gdrive_get("9")
+
+        drive.download.assert_not_called()
+        assert "No file #9" in capsys.readouterr().out
+
+    def test_put_uploads_and_shows_the_link(self, tmp_path, capsys):
+        local = tmp_path / "report.pdf"
+        local.write_bytes(b"data")
+        drive = MagicMock()
+        drive.upload.return_value = {
+            "id": "file-1", "name": "report.pdf", "type": "application/pdf",
+            "modified": "", "size": 4, "link": "https://drive.google.com/file/d/file-1/view",
+        }
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_put(str(local))
+
+        drive.upload.assert_called_once_with(str(local), name=None)
+        output = plain(capsys.readouterr().out)
+        assert "Uploaded" in output
+        assert "drive.google.com" in output
+
+    def test_put_missing_file_exits_before_touching_drive(self, tmp_path, capsys):
+        with patch.object(gdrive_commands, "_gdrive") as guard:
+            with pytest.raises(typer.Exit):
+                handle_gdrive_put(str(tmp_path / "nope.pdf"))
+
+        guard.assert_not_called()
+        assert "File not found" in capsys.readouterr().out
+
+    def test_rm_trashes_resolved_id(self, capsys):
+        gdrive_commands.LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        gdrive_commands.LIST_CACHE.write_text(json.dumps({"1": "file-a"}))
+        drive = MagicMock()
+
+        with patch.object(gdrive_commands, "_gdrive", return_value=drive):
+            handle_gdrive_rm("1")
+
+        drive.delete.assert_called_once_with("file-a")
+        assert "trash" in plain(capsys.readouterr().out)


### PR DESCRIPTION
Closes #251. Client half — the Drive OAuth scope is openonion/oo-api#32.

## Why

Drive was the one Google service with no ConnectOnion surface at all: no tool, no CLI, nothing. Gmail and Calendar both had tools; Drive had neither.

```bash
co gdrive                             # 20 most recently modified (zero-arg default)
co gdrive list -n 50
co gdrive search report
co gdrive get 3 --to ~/Downloads
co gdrive put report.pdf --name "Q3 Report.pdf"
co gdrive rm 3
```

Shaped like `co gmail` and `co outlook` — numbered listings, "numbers mean your last listing", a Rich table that degrades to full-id rows when piped — so all three read as one command with different backends.

## Scope: full `drive`, and why not `drive.file`

`drive.file` grants access **only to files the app itself created**, plus files handed over through the Google Picker. A CLI has no Picker, so `co gdrive list` under `drive.file` would show an essentially empty Drive — it cannot see anything you made in the Drive web UI. `drive.readonly` covers list/download but not upload. So: full `drive`, matching how `calendar` is already requested.

## Two Drive-specific things the shape had to absorb

**Google Docs, Sheets, and Slides have no bytes of their own.** `files().get_media()` on a Doc fails — they must be *exported*. `download()` picks the right path off the mimeType and gives the file the matching extension:

| In Drive | Downloads as |
|---|---|
| Doc | Markdown `.md` |
| Sheet | CSV `.csv` (first sheet) |
| Slides | PDF `.pdf` |
| Drawing | PDF `.pdf` |

Native types with no export format at all — folders, Forms — are refused by name rather than half-writing something unopenable. Shortcuts resolve to their target before downloading.

**Rich expands `\t` into spaces.** The piped rows use plain `print()`, not `console.print()`, because `console.print("a\tb")` emits `a       b` — which silently turns "tab-separated output" into something `cut -f` cannot read. A test asserts real tabs.

> Worth flagging: **this same bug is live on `main`** in `co outlook contact list`, whose docs promise tab-separated piped output but which goes through `console.print`. Separate one-line fix incoming — I didn't want to mix it into this branch.

## Other deliberate choices

- `rm` **trashes** rather than deletes. An agent calling it by mistake stays recoverable from the Drive UI.
- Listings pass `trashed = false` — Drive includes trashed files by default, which would otherwise show deleted work as current.
- Search escapes `'` and `\` before interpolating into the Drive query, or a filename with an apostrophe makes the API reject the whole request.
- `search` warns on empty results that Drive matches **word prefixes, not substrings** (on `HelloWorld`, `Hello` matches, `World` does not) — otherwise "no results" looks like a bug.
- `fields` is requested explicitly and nested as `files(...)`; without it Drive silently omits `modifiedTime`, `size`, and `webViewLink`.
- Token refresh follows #253's contract — once per instance, no expiry arithmetic.

## Tests

**60 passing**, and the full unit suite is 2201 passed / 3 skipped.

- `tests/unit/test_gdrive.py` (24) — scope validation, refresh-once contract, listing normalization and paging, query escaping, binary vs export download, shortcut resolution, folder refusal, upload, trash-not-delete
- `tests/unit/test_gdrive_commands.py` (24) — guards including the pre-Drive-token case, size/kind/time column rendering, numbering cache, real-tab piped output, get/put/rm
- `tests/e2e/cli/test_cli_gdrive.py` (12) — routing, defaults, missing args, unknown subcommand

## Rollout

Needs oo-api#32 merged **and deployed**, then existing users must re-run `co auth google` — a refresh cannot widen scopes. Until then `co gdrive` prints "Google Drive permission missing" with the re-auth hint rather than failing at the API.
