### PR TITLE
co outlook contact list: emit real tabs when piped

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -250,12 +250,10 @@ def handle_outlook_search(query: str, last: int = 10):
 def _print_contacts(contacts: list, title: str):
     """Render contacts as a table, or stable tab-separated rows when piped."""
     if not console.is_terminal:
+        # Plain print, not console.print: Rich expands \t into spaces, which
+        # silently turns tab-separated output into something cut -f can't read.
         for contact in contacts:
-            console.print(
-                f"{contact['name']}\t{contact['email']}\t{contact['id']}",
-                markup=False,
-                highlight=False,
-            )
+            print(f"{contact['name']}\t{contact['email']}\t{contact['id']}")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -345,3 +345,19 @@ class TestHandleOutlookContacts:
             "yifei", max_results=25
         )
         assert "no contacts matching" in capsys.readouterr().out
+
+
+class TestContactPipedOutput:
+    """Piped contact rows must be machine-readable."""
+
+    def test_rows_are_really_tab_separated(self, monkeypatch, capsys):
+        """Rich expands \\t into spaces — the docs promise tabs, so `cut -f2` must work."""
+        monkeypatch.setattr(outlook_commands, "console", Console(force_terminal=False, width=120))
+
+        outlook_commands._print_contacts(
+            [{"id": "contact-1", "name": "Zhou Yifei", "email": "zhou@example.com"}],
+            "contacts",
+        )
+
+        row = capsys.readouterr().out.splitlines()[0]
+        assert row.split("\t") == ["Zhou Yifei", "zhou@example.com", "contact-1"]


### PR DESCRIPTION
## Problem

`docs/cli/outlook.md` promises:

> When output is piped, each contact is a tab-separated `name`, `email`, and full Microsoft Graph ID, so scripts do not receive truncated values.

It isn't tab-separated. `_print_contacts` builds the row with `\t` and hands it to `console.print`, and **Rich expands tabs into spaces**:

```python
>>> Console(force_terminal=False).print('a\tb\tc', markup=False, highlight=False)
'a       b       c\n'
```

So `co outlook contact list | cut -f2` returns the whole line instead of the email — the exact scripting case the piped branch exists to serve. Shipped in #243; found while building the same piped branch for `co gdrive` (#255), which avoids it.

## Fix

Plain `print()` for the machine-readable branch. There is no styling to lose there — that branch exists precisely because nothing should be styled or truncated.

Test asserts the row splits back into exactly three fields; it fails on main.