### PR TITLE
Stop printing local variables in CLI tracebacks

### DIFF
--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -38,7 +38,17 @@ for _env_file in (Path.home() / ".co" / "keys.env", Path.cwd() / ".env"):
         load_dotenv(_env_file)
 
 console = Console()
-app = typer.Typer(add_completion=False, no_args_is_help=False)
+# pretty_exceptions_show_locals defaults to True in Typer, which dumps every
+# local variable of every frame on an uncaught exception. The OAuth paths hold
+# OPENONION_API_KEY, refresh tokens and access tokens in locals, so a routine
+# "session expired" crash printed live credentials into the terminal — and from
+# there into scrollback, CI logs, and any error output a user pastes into a
+# chat or an issue.
+app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=False,
+    pretty_exceptions_show_locals=False,
+)
 
 
 def version_callback(value: bool):

--- a/tests/e2e/cli/test_cli_help.py
+++ b/tests/e2e/cli/test_cli_help.py
@@ -226,3 +226,12 @@ class TestHelpBestPractices:
 
         assert "co create" in result.output
         assert "python agent.py" in result.output
+
+
+def test_tracebacks_never_print_local_variables():
+    """Typer defaults show_locals=True, which dumps API keys and refresh
+    tokens from the OAuth frames straight into the terminal on any uncaught
+    exception — and from there into scrollback, CI logs, and pasted output."""
+    from connectonion.cli.main import app
+
+    assert app.pretty_exceptions_show_locals is False


### PR DESCRIPTION
## Problem

Typer's `pretty_exceptions_show_locals` **defaults to `True`**, and `cli/main.py` never overrode it. So any uncaught exception in any `co` command renders a locals panel for every frame.

On the OAuth paths those locals are credentials. Running `co outlook contact list` with an expired Microsoft token prints:

```
╭───────────────────────── locals ─────────────────────────╮
│       api_key = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9…'  │   ← OpenOnion JWT
│   backend_url = 'https://oo.openonion.ai'                │
│ refresh_token = '0.ATcA…'                                │   ← Microsoft refresh token
╰──────────────────────────────────────────────────────────╯
ValueError: Microsoft session expired and refresh failed (400).
```

A **session expiring is routine**, not exceptional — this is the error users hit most often, and it's exactly the output they screenshot, paste into Discord, or attach to an issue. The same panel appears for `_refresh_via_backend` in `gmail.py`, `gdrive.py`, `google_calendar.py`, and `microsoft_calendar.py`.

Credentials also land in terminal scrollback and in CI logs whenever a `co` command fails in a workflow.

## Fix

`pretty_exceptions_show_locals=False` on the Typer app. The traceback still shows the file, line, source, and exception message — everything needed to debug — minus the variable dump.

Verified against the same expired-token command: the actionable message survives, the credential panel is gone, and grepping the output for the JWT returns nothing.

## Test

`tests/e2e/cli/test_cli_help.py` asserts the flag stays off. It fails on main.

## Note

Not a fix for the underlying UX — an expired session should print a clean hint rather than any traceback at all, the way the scope guards already do. That's worth doing separately; this stops the credential disclosure now.