### PR TITLE
Finish the Gemini 3.6 rollout that #246 started

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,7 @@ git push
 - Example:
   ```python
   try:
-      agent = Agent("my_agent", model="co/gemini-2.5-pro")
+      agent = Agent("my_agent", model="co/gemini-3.6-flash")
       response = agent.input("Hello")
   except InsufficientCreditsError as e:
       print(f"Need ${e.shortfall:.4f} more credits")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ connectonion/
 - Session persists across turns for multi-turn conversations
 - `tools`: ToolRegistry with O(1) lookup via `.get()` or attribute access (`agent.tools.tool_name`)
 - Class instances accessible via `agent.tools.instance_name` (e.g., `agent.tools.gmail`)
-- Default model: `co/gemini-2.5-pro` (managed keys via OpenOnion proxy)
+- Default model: `co/gemini-3.6-flash` (managed keys via OpenOnion proxy)
 
 ### LLM Provider Routing (`connectonion/core/llm.py:create_llm()`)
 - Model prefix determines provider:
@@ -441,7 +441,7 @@ git push
 - Example:
   ```python
   try:
-      agent = Agent("my_agent", model="co/gemini-2.5-pro")
+      agent = Agent("my_agent", model="co/gemini-3.6-flash")
       response = agent.input("Hello")
   except InsufficientCreditsError as e:
       print(f"Need ${e.shortfall:.4f} more credits")
@@ -476,7 +476,7 @@ git push
 
 ### Code Organization Preferences
 - Avoid `utils.py` - keep helper functions with their features
-- Default model for agents: `co/gemini-2.5-pro` (managed keys)
+- Default model for agents: `co/gemini-3.6-flash` (managed keys)
 - No Co-Authored-By lines in commit messages (no Claude, Happy, or other brand attribution)
 - Function-based tools over class-based tools
 - Events/plugins over subclassing Agent

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -56,7 +56,7 @@ GLOBAL_CO_DIR = Path.home() / ".co"
 
 
 def create_coding_agent(
-    model: str = "co/gemini-3.5-flash",
+    model: str = "co/gemini-3.6-flash",
     max_iterations: int = 100,
     co_dir: Path = Path(".co"),
 ) -> Agent:

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -755,7 +755,7 @@ def process_request(query: str) -> str:
 # Create agent
 agent = Agent(
     name="{suggested_name.replace('-', '_')}",
-    model="{'co/gemini-3.6-flash' if model and model.startswith('co/') else 'co/gemini-3.6-flash'}",
+    model="{model if model and model.startswith('co/') else 'co/gemini-3.6-flash'}",
     system_prompt=\"\"\"You are an AI agent designed to: {description}
 
     Provide helpful, accurate, and concise responses.\"\"\",

--- a/connectonion/transcribe.py
+++ b/connectonion/transcribe.py
@@ -23,7 +23,7 @@ Usage:
     >>> text = transcribe("meeting.mp3", prompt="Technical AI discussion, speakers: Aaron, Lisa")
 
     # Different model
-    >>> text = transcribe("meeting.mp3", model="co/gemini-2.5-flash")
+    >>> text = transcribe("meeting.mp3", model="co/gemini-3.6-flash")
 
 Supported formats: WAV, MP3, AIFF, AAC, OGG, FLAC
 Token cost: 32 tokens per second of audio (1 minute = 1,920 tokens)
@@ -87,7 +87,7 @@ def _get_api_key(model: str) -> str:
 def transcribe(
     audio: str,
     prompt: Optional[str] = None,
-    model: str = "co/gemini-3.5-flash",
+    model: str = "co/gemini-3.6-flash",
     timestamps: bool = False,
 ) -> str:
     """
@@ -97,7 +97,7 @@ def transcribe(
         audio: Path to audio file (WAV, MP3, AIFF, AAC, OGG, FLAC)
         prompt: Optional context hints for better accuracy
                 (e.g., "Technical AI discussion, speakers: Aaron, Lisa")
-        model: Model to use (default: co/gemini-3.5-flash)
+        model: Model to use (default: co/gemini-3.6-flash)
         timestamps: If True, include timestamps in output
 
     Returns:

--- a/connectonion/useful_events_handlers/reflect.py
+++ b/connectonion/useful_events_handlers/reflect.py
@@ -112,7 +112,7 @@ Error: {error}"""
 
     reasoning = llm_do(
         prompt,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0.2,
         system_prompt=REFLECT_PROMPT
     )

--- a/connectonion/useful_plugins/auto_compact.py
+++ b/connectonion/useful_plugins/auto_compact.py
@@ -137,7 +137,7 @@ Keep the summary under 800 words but preserve all critical technical details."""
 
     summary = llm_do(
         summary_prompt,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0,
     )
 

--- a/connectonion/useful_plugins/re_act.py
+++ b/connectonion/useful_plugins/re_act.py
@@ -134,7 +134,7 @@ Current user input: {user_prompt}
 
 Acknowledge this request (1-2 sentences):"""
 
-    model = "co/gemini-2.5-flash"
+    model = "co/gemini-3.6-flash"
     agent.logger.print(f"[dim]/understanding ({model})...[/dim]")
 
     ack = llm_do(

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -18,7 +18,7 @@ AGENT.md Format:
 ---
 name: explore
 description: Fast codebase exploration agent
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - glob

--- a/connectonion/useful_tools/browser_tools/element_finder.py
+++ b/connectonion/useful_tools/browser_tools/element_finder.py
@@ -208,7 +208,7 @@ def find_element(
     result = llm_do(
         prompt,
         output=ElementMatch,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0.1
     )
 

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -107,7 +107,7 @@ def _ai_scroll(page, times: int, description: str):
     strategy = llm_do(
         _PROMPT.format(description=description, scrollable_elements=scrollable, simplified_html=html),
         output=ScrollStrategy,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0.1
     )
     print(f"    AI: {strategy.explanation}")

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ Agent(
 - **api_key** (`Optional[str]`): OpenAI API key (if not using custom LLM)
 - **model** (`str`): Model to use (default: "co/gemini-3.6-flash")
   - Managed keys: `co/gemini-3.6-flash`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
-  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-2.5-pro`
+  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-3.6-flash`
 
 ### System Prompt Options
 
@@ -239,11 +239,11 @@ llm = create_llm("o4-mini")          # → OpenAILLM
 llm = create_llm("claude-sonnet-4-5") # → AnthropicLLM
 
 # Google Gemini models
-llm = create_llm("gemini-2.5-flash")  # → GeminiLLM
+llm = create_llm("gemini-3.6-flash")  # → GeminiLLM
 
 # ConnectOnion managed keys (co/ prefix)
 llm = create_llm("co/gpt-4o-mini")    # → OpenOnionLLM
-llm = create_llm("co/gemini-2.5-flash") # → OpenOnionLLM
+llm = create_llm("co/gemini-3.6-flash") # → OpenOnionLLM
 ```
 
 ### co/ Models (Managed Keys)
@@ -254,7 +254,7 @@ Models prefixed with `co/` use ConnectOnion's managed API keys through the OpenO
 from connectonion import Agent
 
 # Uses OpenOnion managed keys - no API key needed
-agent = Agent(name="bot", model="co/gemini-2.5-flash")
+agent = Agent(name="bot", model="co/gemini-3.6-flash")
 ```
 
 **How it works:**
@@ -310,7 +310,7 @@ from connectonion.core.llm import GeminiLLM
 
 llm = GeminiLLM(
     api_key="your-key",  # or GEMINI_API_KEY env var
-    model="gemini-2.5-flash"
+    model="gemini-3.6-flash"
 )
 
 agent = Agent("bot", llm=llm)
@@ -325,7 +325,7 @@ from connectonion.core.llm import OpenOnionLLM
 
 llm = OpenOnionLLM(
     api_key="your-token",  # or OPENONION_API_KEY env var
-    model="co/gemini-2.5-flash"
+    model="co/gemini-3.6-flash"
 )
 
 agent = Agent("bot", llm=llm)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -498,7 +498,7 @@ print(result.sentiment)  # Type-safe!
 
 ```python
 # ✅ Default: Fast and cheap
-llm_do("Quick task")  # Uses co/gemini-2.5-flash
+llm_do("Quick task")  # Uses co/gemini-3.6-flash
 
 # ✅ For complex reasoning
 llm_do("Complex analysis", model="co/gemini-3.6-flash")

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -171,13 +171,13 @@ from connectonion import llm_do
 # Use co/ prefix
 response = llm_do("Hello", model="co/gpt-4o")
 response = llm_do("Hello", model="co/claude-sonnet-4-5")
-response = llm_do("Hello", model="co/gemini-2.5-pro")
+response = llm_do("Hello", model="co/gemini-3.6-flash")
 ```
 
 **Available models:**
 - OpenAI: `co/gpt-4o`, `co/gpt-4o-mini`, `co/o4-mini`
 - Anthropic: `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- Google: `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- Google: `co/gemini-3.6-flash` (default), `co/gemini-3-pro-preview`, `co/gemini-2.5-flash`
 - And more...
 
 **Benefits:**

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -38,12 +38,12 @@ Runs the prompt, prints the result, and exits. No server started.
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--port` | `-p` | `8000` | Port for web server |
-| `--model` | `-m` | `co/gemini-3.5-flash` | LLM model to use |
+| `--model` | `-m` | `co/gemini-3.6-flash` | LLM model to use |
 | `--max-iterations` | `-i` | `100` | Max tool iterations per turn |
 
 ```bash
 co ai --port 9000
-co ai --model co/gemini-2.5-pro
+co ai --model co/gemini-3.6-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 ```
 
@@ -115,7 +115,7 @@ co ai "Add rate limiting to the API endpoint in oo-api/routes/llm.py"
 co ai "The test test_agent_loop is failing, investigate and fix it"
 
 # Use a different model
-co ai --model co/gemini-2.5-pro
+co ai --model co/gemini-3.6-flash
 
 # Run on a different port
 co ai --port 9000

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -36,7 +36,7 @@ response = llm_do("Hello", model="co/gpt-4o")
 Works across providers:
 - `co/gpt-4o`, `co/gpt-4o-mini`
 - `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- `co/gemini-3.6-flash` (default), `co/gemini-3-pro-preview`, `co/gemini-2.5-flash`
 
 ## Troubleshooting
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -463,8 +463,8 @@ agent = Agent("bot", model="claude-haiku-4-5")
 agent = Agent("bot", model="claude-opus-4")
 
 # Google Gemini
-agent = Agent("bot", model="gemini-2.5-pro")
-agent = Agent("bot", model="gemini-2.5-flash")
+agent = Agent("bot", model="gemini-3.6-flash")
+agent = Agent("bot", model="gemini-3.6-flash")
 agent = Agent("bot", model="gemini-2.0-flash-exp")
 ```
 
@@ -895,7 +895,7 @@ import pytest
 @pytest.mark.real_api
 def test_real_agent():
     """Requires OPENONION_API_KEY or GEMINI_API_KEY in environment."""
-    agent = Agent("test", tools=[search], model="co/gemini-2.5-flash")
+    agent = Agent("test", tools=[search], model="co/gemini-3.6-flash")
     result = agent.input("Search for Python")
     assert "Python" in result
 

--- a/docs/concepts/llm_do.md
+++ b/docs/concepts/llm_do.md
@@ -12,7 +12,7 @@ answer = llm_do("What's 2+2?")
 print(answer)  # "4"
 
 # Google Gemini (your own key)
-answer = llm_do("What's 2+2?", model="gemini-2.5-flash")  
+answer = llm_do("What's 2+2?", model="gemini-3.6-flash")  
 
 # Anthropic Claude
 answer = llm_do("What's 2+2?", model="claude-haiku-4-5")
@@ -120,7 +120,7 @@ llm_do("Hello", model="co/gpt-4o-mini")
 llm_do("Hello", model="co/o4-mini")
 
 # Google Gemini models (via managed keys)
-llm_do("Hello", model="co/gemini-2.5-pro")
+llm_do("Hello", model="co/gemini-3.6-flash")
 llm_do("Hello", model="co/gemini-3.6-flash")
 
 # Anthropic Claude models (via managed keys)

--- a/docs/debug/console.md
+++ b/docs/debug/console.md
@@ -25,8 +25,8 @@ When you run an agent, you'll see the onion stack banner and execution flow:
 
 [co] > "Generate a Python function"
 
-[co] ○ gemini-2.5-pro                                    1/100
-[co] ● gemini-2.5-pro · 1 tool · 150 tok · $0.0012       ⚡ 1.2s
+[co] ○ gemini-3.6-flash                                    1/100
+[co] ● gemini-3.6-flash · 1 tool · 150 tok · $0.0012       ⚡ 1.2s
 [co]   ▸ generate_code(language="python")         ✓ 0.12s
 
 [co] ═══════════════════════════════════════════════

--- a/docs/debug/eval-format.md
+++ b/docs/debug/eval-format.md
@@ -22,7 +22,7 @@ name: say_hello_to_alice
 created: '2025-12-25 11:56:26'
 updated: '2025-12-25 11:56:56'
 runs: 2
-model: gemini-2.5-flash
+model: gemini-3.6-flash
 turns:
 - input: Say hello to Alice
   run: 2

--- a/docs/features/transcribe.md
+++ b/docs/features/transcribe.md
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3.5-flash" | Model to use |
+| `model` | str | "co/gemini-3.6-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,12 +110,12 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3.5-flash")
-transcribe("audio.mp3", model="co/gemini-2.5-flash")
+transcribe("audio.mp3", model="co/gemini-3.6-flash")
+transcribe("audio.mp3", model="co/gemini-3.6-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
 transcribe("audio.mp3", model="gemini-3.5-flash")
-transcribe("audio.mp3", model="gemini-2.5-flash")
+transcribe("audio.mp3", model="gemini-3.6-flash")
 ```
 
 ## Error Handling

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -129,8 +129,8 @@ llm_do("Hello", model="co/claude-haiku-4-5")
 ### Google Models
 ```python
 llm_do("Hello", model="co/gemini-3-pro-preview")
-llm_do("Hello", model="co/gemini-3.5-flash")
-llm_do("Hello", model="co/gemini-2.5-pro")
+llm_do("Hello", model="co/gemini-3.6-flash")
+llm_do("Hello", model="co/gemini-3.6-flash")
 ```
 
 ## Real-World Examples
@@ -178,7 +178,7 @@ response = agent.input("Help me write a Python function")
 
 ```python
 # Compare responses from different models
-models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-2.5-pro"]
+models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-3.6-flash"]
 
 for model in models:
     response = llm_do("What's the meaning of life?", model=model)
@@ -231,7 +231,7 @@ def test_all_models(prompt):
     models = {
         "OpenAI": "co/gpt-4o",
         "Anthropic": "co/claude-sonnet-4-5",
-        "Google": "co/gemini-2.5-pro"
+        "Google": "co/gemini-3.6-flash"
     }
     
     results = {}

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -26,7 +26,7 @@ INFO: Loaded global keys: /Users/you/.co/keys.env
 
 [agent] ─────────────────────────────────────
         translator
-        co/gemini-2.5-pro • 12 tools
+        co/gemini-3.6-flash • 12 tools
 
 [host]  ─────────────────────────────────────
         http://localhost:8000
@@ -434,7 +434,7 @@ curl http://localhost:8000/info
   "name": "translator",
   "address": "0x3d4017c3...",
   "tools": ["translate", "detect_language"],
-  "model": "co/gemini-2.5-pro",
+  "model": "co/gemini-3.6-flash",
   "trust": "careful",
   "version": "0.4.1",
   "accepted_inputs": {

--- a/docs/network/session-websocket-lifecycle.md
+++ b/docs/network/session-websocket-lifecycle.md
@@ -98,7 +98,7 @@ def _record_trace(self, entry: dict):
 {
   type: "llm_call",
   id: "uuid-1",
-  model: "gemini-2.5-pro",
+  model: "gemini-3.6-flash",
   iteration: 1,
   status: "running",
   ts: 1234567890
@@ -119,7 +119,7 @@ def _record_trace(self, entry: dict):
 {
   type: "llm_result",
   id: "uuid-1",
-  model: "gemini-2.5-pro",
+  model: "gemini-3.6-flash",
   duration_ms: 1500,
   tool_calls_count: 1,
   iteration: 1,

--- a/docs/subagent-definition-format.md
+++ b/docs/subagent-definition-format.md
@@ -28,7 +28,7 @@ Each file has:
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - glob
@@ -166,7 +166,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
         ---
         name: explore
         description: Fast codebase exploration
-        model: co/gemini-2.5-flash
+        model: co/gemini-3.6-flash
         max_iterations: 15
         tools: [glob, grep, read_file]
         plugins: []
@@ -210,7 +210,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
     return SubAgentDefinition(
         name=config.get('name', file_path.stem),
         description=config.get('description', ''),
-        model=config.get('model', 'co/gemini-2.5-flash'),
+        model=config.get('model', 'co/gemini-3.6-flash'),
         max_iterations=config.get('max_iterations', 15),
         tools=config.get('tools', []),
         plugins=config.get('plugins', []),
@@ -376,7 +376,7 @@ __all__ = ["task", "load_subagents", "get_available_agent_types"]
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools: [glob, grep, read_file]
 plugins: []
@@ -396,7 +396,7 @@ You are a read-only exploration agent specialized in quickly understanding codeb
 ---
 name: plan
 description: Design implementation plans and architecture strategies
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 10
 tools: [glob, grep, read_file]
 plugins: []
@@ -416,7 +416,7 @@ You are a planning agent specialized in designing implementation strategies.
 ---
 name: debug
 description: Analyze errors and suggest fixes
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tools: [glob, grep, read_file, bash]
 plugins: []
@@ -471,7 +471,7 @@ How to verify the fix works
 ---
 name: research
 description: Research topics using web search and documentation
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tools: [WebFetch]
 plugins: []
@@ -591,7 +591,7 @@ class SubAgentSchema(BaseModel):
 
     name: str = Field(..., description="Unique agent identifier")
     description: str = Field(..., description="One-line description")
-    model: str = Field(default="co/gemini-2.5-flash", description="LLM model")
+    model: str = Field(default="co/gemini-3.6-flash", description="LLM model")
     max_iterations: int = Field(default=15, ge=1, le=100)
     tools: List[str] = Field(default_factory=list)
     plugins: List[str] = Field(default_factory=list)

--- a/docs/subagent-function-assembly.md
+++ b/docs/subagent-function-assembly.md
@@ -84,7 +84,7 @@ Agent(
     tools=[FileTools(permission="read")],  # ← Class instance
     plugins=[],
     system_prompt="# Explore Agent...",
-    model="co/gemini-2.5-flash",
+    model="co/gemini-3.6-flash",
     max_iterations=15
 )
                 ↓

--- a/docs/subagent-mechanism.md
+++ b/docs/subagent-mechanism.md
@@ -41,13 +41,13 @@
 │  │   "explore": {                                                │  │
 │  │     "description": "Fast codebase exploration",               │  │
 │  │     "tools": [FileTools],  # glob, grep, read_file only      │  │
-│  │     "model": "co/gemini-2.5-flash",  # Fast & cheap          │  │
+│  │     "model": "co/gemini-3.6-flash",  # Fast & cheap          │  │
 │  │     "max_iterations": 15,                                     │  │
 │  │   },                                                          │  │
 │  │   "plan": {                                                   │  │
 │  │     "description": "Design implementation plans",             │  │
 │  │     "tools": [FileTools],  # Read-only                       │  │
-│  │     "model": "co/gemini-2.5-pro",  # Smart                   │  │
+│  │     "model": "co/gemini-3.6-flash",  # Smart                   │  │
 │  │     "max_iterations": 10,                                     │  │
 │  │   },                                                          │  │
 │  │ }                                                             │  │
@@ -84,7 +84,7 @@
 │  │   └────────────────────────────────────────────────────────┘  │  │
 │  │                                                               │  │
 │  │ Tools: [glob, grep, read_file]  # Read-only                  │  │
-│  │ Model: co/gemini-2.5-flash                                    │  │
+│  │ Model: co/gemini-3.6-flash                                    │  │
 │  │ Plugins: []  # None                                           │  │
 │  │ Max Iterations: 15                                            │  │
 │  │ Session: FRESH - no memory of parent conversation            │  │
@@ -299,14 +299,14 @@ Main Agent (co/claude-opus-4-5)
 ├─ Context: 200k tokens
 └─ Use case: Complex reasoning, code generation
 
-Explore Sub-Agent (co/gemini-2.5-flash)
+Explore Sub-Agent (co/gemini-3.6-flash)
 ├─ Input cost: $0.15 / 1M tokens  (100x cheaper!)
 ├─ Output cost: $0.60 / 1M tokens  (125x cheaper!)
 ├─ Speed: ~2000 tokens/sec  (4x faster!)
 ├─ Context: 1M tokens
 └─ Use case: Fast file finding, simple searches
 
-Plan Sub-Agent (co/gemini-2.5-pro)
+Plan Sub-Agent (co/gemini-3.6-flash)
 ├─ Input cost: $2.50 / 1M tokens  (6x cheaper)
 ├─ Output cost: $10 / 1M tokens   (7.5x cheaper)
 ├─ Speed: ~1000 tokens/sec  (2x faster)

--- a/docs/subagent-tool-naming.md
+++ b/docs/subagent-tool-naming.md
@@ -79,7 +79,7 @@ email
 ---
 name: explore
 description: Fast codebase exploration
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - file_read      # ← Clear: only reading files
@@ -91,7 +91,7 @@ tools:
 ---
 name: plan
 description: Design implementation plans
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 10
 tools:
   - file_read      # ← Same: only reading
@@ -103,7 +103,7 @@ tools:
 ---
 name: debug
 description: Analyze errors and suggest fixes
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tools:
   - file_read      # Read files
@@ -129,7 +129,7 @@ tools:
 ---
 name: scraper
 description: Web scraping with browser automation
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 25
 tools:
   - browser        # Navigate, click, screenshot
@@ -143,7 +143,7 @@ tools:
 ---
 name: research
 description: Research topics and save findings
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tools:
   - web            # Fetch documentation
@@ -156,7 +156,7 @@ tools:
 ---
 name: email_assistant
 description: Manage emails and drafts
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - email          # Send, read, organize

--- a/docs/subagent-tool-resolution.md
+++ b/docs/subagent-tool-resolution.md
@@ -164,7 +164,7 @@ agent.tools = {
 ---
 name: browser
 description: Web scraping and browser automation
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tools:
   - browser_navigate
@@ -224,7 +224,7 @@ Instead of listing individual tools, use **tool groups**:
 ---
 name: scraper
 description: Web scraping agent
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 20
 tool_groups:
   - file_read      # FileTools(permission="read")
@@ -329,7 +329,7 @@ def _resolve_tools(tool_names: List[str]) -> List:
 ---
 name: scraper
 description: Web scraping with browser automation and file storage
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 25
 tools:
   - browser        # BrowserAutomation (navigate, click, screenshot)

--- a/docs/tui/status_bar.md
+++ b/docs/tui/status_bar.md
@@ -11,7 +11,7 @@ from rich.console import Console
 console = Console()
 
 status = StatusBar([
-    ("🤖", "co/gemini-2.5-pro", "magenta"),
+    ("🤖", "co/gemini-3.6-flash", "magenta"),
     ("📊", "50%", "green"),
     ("", "main", "blue"),
 ])
@@ -63,5 +63,5 @@ ProgressSegment(
 ## Example Output
 
 ```
-🤖 co/gemini-2.5-pro  📊 50%   main
+🤖 co/gemini-3.6-flash  📊 50%   main
 ```

--- a/docs/useful_plugins/auto_compact.md
+++ b/docs/useful_plugins/auto_compact.md
@@ -14,7 +14,7 @@ agent = Agent("assistant", plugins=[auto_compact])
 ## What it does
 
 When the context window hits 90% full:
-1. Summarizes old messages into a single compact message using `co/gemini-2.5-flash`
+1. Summarizes old messages into a single compact message using `co/gemini-3.6-flash`
 2. Replaces old messages with the summary (keeps system prompt + summary + last 5 messages)
 3. Continues the session without interruption
 
@@ -32,7 +32,7 @@ A long research session that would normally hit token limits:
 from connectonion import Agent
 from connectonion.useful_plugins import auto_compact
 
-agent = Agent("researcher", plugins=[auto_compact], model="co/gemini-2.5-pro")
+agent = Agent("researcher", plugins=[auto_compact], model="co/gemini-3.6-flash")
 
 # Works even on very long sessions
 for topic in topics:

--- a/docs/useful_plugins/subagents.md
+++ b/docs/useful_plugins/subagents.md
@@ -38,7 +38,7 @@ builtin/{name}/AGENT.md         # Built-in agents
 ---
 name: explore
 description: Fast codebase exploration agent
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - glob

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -226,7 +226,7 @@ from connectonion import Agent
 from connectonion.useful_tools.browser_tools import BrowserAutomation
 
 browser = BrowserAutomation(headless=False)  # Visible for debugging
-agent = Agent("scraper", tools=[browser], model="co/gemini-2.5-pro")
+agent = Agent("scraper", tools=[browser], model="co/gemini-3.6-flash")
 
 agent.input("Go to news.ycombinator.com, get the top 5 story titles")
 agent.input("Navigate to github.com/trending and screenshot the page")

--- a/docs/useful_tools/file_tools.md
+++ b/docs/useful_tools/file_tools.md
@@ -141,7 +141,7 @@ from connectonion.useful_tools import FileTools
 
 agent = Agent(
     "code-reviewer",
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
     tools=[FileTools()],
     instructions="Review and fix code. Always read files before editing."
 )

--- a/subagents/README.md
+++ b/subagents/README.md
@@ -12,7 +12,7 @@ Create a `.md` file in `subagents/`:
 ---
 name: explore
 description: Fast agent for exploring codebases
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - glob
@@ -43,7 +43,7 @@ result = task("Find all API endpoints", "explore")
 ---
 name: explore                          # Required: unique identifier
 description: Fast codebase exploration  # Required: one-line description
-model: co/gemini-2.5-flash             # Required: LLM model
+model: co/gemini-3.6-flash             # Required: LLM model
 max_iterations: 15                      # Required: max iteration limit
 tools:                                  # Required: list of tool names
   - glob
@@ -70,7 +70,7 @@ Everything after `---` is the system prompt sent to the agent.
 class SubAgentDefinition:
     name: str               # "explore"
     description: str        # "Fast codebase exploration"
-    model: str             # "co/gemini-2.5-flash"
+    model: str             # "co/gemini-3.6-flash"
     max_iterations: int    # 15
     tools: List[str]       # ["glob", "grep", "read_file"]
     system_prompt: str     # Full markdown body
@@ -126,7 +126,7 @@ Fast, cheap exploration agent using Flash model:
 ```yaml
 ---
 name: explore
-model: co/gemini-2.5-flash  # 100x cheaper than Opus
+model: co/gemini-3.6-flash  # 100x cheaper than Opus
 max_iterations: 15
 tools: [glob, grep, read_file]
 read_only: true
@@ -140,7 +140,7 @@ Smart planning agent using Pro model:
 ```yaml
 ---
 name: plan
-model: co/gemini-2.5-pro    # Smart but still 6x cheaper than Opus
+model: co/gemini-3.6-flash    # Smart but still 6x cheaper than Opus
 max_iterations: 10
 tools: [glob, grep, read_file]
 read_only: true

--- a/subagents/explore.md
+++ b/subagents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-2.5-flash
+model: co/gemini-3.6-flash
 max_iterations: 15
 tools:
   - file_read

--- a/subagents/loader.py
+++ b/subagents/loader.py
@@ -7,7 +7,7 @@ File format:
     ---
     name: explore
     description: Fast codebase exploration
-    model: co/gemini-2.5-flash
+    model: co/gemini-3.6-flash
     max_iterations: 15
     tools:
       - glob
@@ -146,7 +146,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
     return SubAgentDefinition(
         name=config.get('name', file_path.stem),
         description=config.get('description', ''),
-        model=config.get('model', 'co/gemini-2.5-flash'),
+        model=config.get('model', 'co/gemini-3.6-flash'),
         max_iterations=config.get('max_iterations', 15),
         tools=config.get('tools', []),
         system_prompt=system_prompt,

--- a/subagents/plan.md
+++ b/subagents/plan.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Design implementation plans and architecture strategies
-model: co/gemini-2.5-pro
+model: co/gemini-3.6-flash
 max_iterations: 10
 tools:
   - file_read


### PR DESCRIPTION
## Problem

#246 switched the default to `co/gemini-3.6-flash` in `Agent`, `llm_do`, and `OpenOnionLLM` — the three obvious places — and left **fourteen** others behind. The result: what the default actually was depended on which entry point you came through.

Still running an older model until this PR:

| Where | Was |
|---|---|
| **`co ai`** (`cli/co_ai/agent.py`) | 3.5-flash |
| `transcribe()` | 3.5-flash |
| **`subagents/loader.py`** fallback | 2.5-flash |
| `re_act`, `auto_compact`, `reflect` plugins | 2.5-flash |
| browser `element_finder`, `scroll` | 2.5-flash |
| `subagents/plan.md` | 2.5-**pro** |
| `subagents/explore.md` | 2.5-flash |
| `CLAUDE.md` (3×), `AGENTS.md`, `subagents/README.md` (5×) | 2.5-pro / 2.5-flash |

Two of these are worse than cosmetic:

**`co ai` is the most visible agent in the product** and was two generations behind the documented default.

**`subagents/loader.py:149`** is a  fallback, so **every subagent definition without an explicit `model:` field silently ran 2.5-flash** — the default was invisible unless you read the loader.

And `CLAUDE.md`/`AGENTS.md` are loaded at the start of every session in this repo, so each agent was handed "default model: `co/gemini-2.5-pro`" as fact while the code already said otherwise.

## Change

Everything to `co/gemini-3.6-flash`, including `subagents/plan.md`, which was deliberately on a *pro* tier — flagged and confirmed as intended.

Test fixtures that merely pass a model string (`test_subagents.py`, `test_host_relay.py`, `test_deploy.py`) are left alone: they assert plumbing, not defaults, and pinning them to a real model name would make them re-break on the next bump.

## Verification

`grep -rn 'co/gemini-2\.5\|co/gemini-3\.5'` over source and docs returns nothing outside test fixtures, CHANGELOG, and design-decision records.

Full unit suite: **2274 passed, 3 skipped**.