### PR TITLE
Catch the Gemini 3.6 sites #263 and I both missed

### DIFF
--- a/connectonion/cli/browser_agent/agent.py
+++ b/connectonion/cli/browser_agent/agent.py
@@ -3,7 +3,7 @@
 Purpose: Wrap BrowserAutomation with a ConnectOnion Agent so the `co browser` CLI can run natural-language browser commands end-to-end.
 LLM-Note:
   Dependencies: imports from [os, pathlib, dotenv, connectonion.Agent, connectonion.useful_plugins (image_result_formatter, ui_stream), connectonion.useful_tools.browser_tools.BrowserAutomation] | imported by [cli/browser_agent/__init__.py (re-exported), cli/commands/browser_commands.py (lazy import)] | tested by [tests/e2e/cli/test_cli_browser.py]
-  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → loads OPENONION_API_KEY (env or ~/.co/keys.env via dotenv) → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3.5-flash", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
+  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → loads OPENONION_API_KEY (env or ~/.co/keys.env via dotenv) → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3.6-flash", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
   State/Effects: launches Playwright browser process via BrowserAutomation context manager (auto-closes on exit) | reads OPENONION_API_KEY from process env or ~/.co/keys.env | may create screenshots/files inside the BrowserAutomation tool calls | streams UI events via ui_stream plugin
   Integration: exposes execute_browser_command(command, headless=False) -> str | PROMPT_PATH points to ./prompts/agent.md (sibling to this file)
   Performance: synchronous, blocks for full agent loop (up to 200 iterations) | one browser session per call (no pooling)
@@ -36,7 +36,7 @@ def build_browser_agent(browser, api_key: str) -> Agent:
     """Build the natural-language browser Agent driving an existing BrowserAutomation."""
     return Agent(
         name="browser_cli",
-        model="co/gemini-3.5-flash",
+        model="co/gemini-3.6-flash",
         api_key=api_key,
         system_prompt=PROMPT_PATH,
         tools=[browser],

--- a/connectonion/cli/co_ai/agents/registry.py
+++ b/connectonion/cli/co_ai/agents/registry.py
@@ -27,7 +27,7 @@ SUBAGENTS: Dict[str, Dict[str, Any]] = {
     "explore": {
         "description": "Fast agent for exploring codebases. Find files, search code, answer questions about structure.",
         "tools": [FileTools],
-        "model": "co/gemini-2.5-flash",  # Fast model for exploration
+        "model": "co/gemini-3.6-flash",  # Fast model for exploration
         "max_iterations": 15,
     },
     "plan": {

--- a/connectonion/cli/co_ai/commands/compact.py
+++ b/connectonion/cli/co_ai/commands/compact.py
@@ -15,7 +15,7 @@ Compaction strategy:
 - Replaces old messages with single summary message
 
 Summarization:
-- Uses fast model: co/gemini-2.5-flash
+- Uses fast model: co/gemini-3.6-flash
 - Prompt asks for concise summary preserving key decisions/facts
 - Summary becomes new "assistant" message in conversation
 - Reduces token count while maintaining continuity
@@ -164,7 +164,7 @@ Keep the summary under 1000 words but preserve all critical technical details.""
 
     summary = llm_do(
         summary_prompt,
-        model="co/gemini-2.5-flash",  # Fast model for summarization
+        model="co/gemini-3.6-flash",  # Fast model for summarization
     )
 
     # Create compacted messages

--- a/connectonion/cli/co_ai/commands/export.py
+++ b/connectonion/cli/co_ai/commands/export.py
@@ -11,7 +11,7 @@ Key function:
 Export format:
 - Markdown file with conversation metadata header
 - Date and timestamp
-- Model name (e.g., co/gemini-2.5-pro)
+- Model name (e.g., co/gemini-3.6-flash)
 - Formatted message history (user/assistant/tool)
 - Tool calls displayed with formatting
 - Tool results in code blocks

--- a/connectonion/cli/co_ai/commands/help.py
+++ b/connectonion/cli/co_ai/commands/help.py
@@ -57,7 +57,7 @@ oo "fix the bug in auth.py"
 oo
 
 # With options
-oo -m co/gemini-2.5-pro "task"   # Use different model
+oo -m co/gemini-3.6-flash "task"   # Use different model
 oo -y "task"                      # Auto-approve file changes
 ```
 

--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -188,7 +188,7 @@ def detect_intent(agent: 'Agent') -> None:
     # Use llm_do with structured output
     analysis = llm_do(
         INTENT_PROMPT.format(user_prompt=user_prompt),
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         output=IntentAnalysis,
         temperature=0,
     )

--- a/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3.5-flash" | Model to use |
+| `model` | str | "co/gemini-3.6-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,8 +110,8 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3.5-flash")
-transcribe("audio.mp3", model="co/gemini-2.5-flash")
+transcribe("audio.mp3", model="co/gemini-3.6-flash")
+transcribe("audio.mp3", model="co/gemini-3.6-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
 transcribe("audio.mp3", model="gemini-3.5-flash")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -212,7 +212,7 @@ def call(
 def ai(
     prompt: Optional[str] = typer.Argument(None, help="One-shot prompt (runs and exits)"),
     port: int = typer.Option(8000, "--port", "-p", help="Port for web server"),
-    model: str = typer.Option("co/gemini-3.5-flash", "--model", "-m", help="Model to use"),
+    model: str = typer.Option("co/gemini-3.6-flash", "--model", "-m", help="Model to use"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations"),
 ):
     """Start AI coding agent or run one-shot prompt."""

--- a/connectonion/cli/templates/hosted-browser/agent.py
+++ b/connectonion/cli/templates/hosted-browser/agent.py
@@ -89,7 +89,7 @@ def create_agent():
             bind_browser_session,     # each session gets its own tab in the shared browser
             reaper.stamp,             # any tool call resets the browser idle clock
         ],
-        model="co/gemini-3.5-flash",
+        model="co/gemini-3.6-flash",
         max_iterations=200,           # a normal site flow is ~15-20 steps; backstop
     )
 

--- a/connectonion/tui/__init__.py
+++ b/connectonion/tui/__init__.py
@@ -15,7 +15,7 @@ Usage:
 
     # Status bar with model/context/git info
     status = StatusBar([
-        ("🤖", "co/gemini-2.5-pro", "magenta"),
+        ("🤖", "co/gemini-3.6-flash", "magenta"),
         ("📊", "50%", "green"),
         ("", "main", "blue"),
     ])

--- a/connectonion/tui/status_bar.py
+++ b/connectonion/tui/status_bar.py
@@ -38,7 +38,7 @@ class ProgressSegment:
         from connectonion.tui import StatusBar, ProgressSegment
 
         status = StatusBar([
-            ("🤖", "co/gemini-2.5-pro", "magenta"),
+            ("🤖", "co/gemini-3.6-flash", "magenta"),
             ProgressSegment(percent=78, bg_color="green"),
         ])
     """
@@ -68,19 +68,19 @@ class StatusBar:
 
         # Text segments only
         bar = StatusBar([
-            ("🤖", "co/gemini-2.5-pro", "magenta"),
+            ("🤖", "co/gemini-3.6-flash", "magenta"),
             ("", "main", "blue"),
         ])
 
         # With progress bar for context window
         bar = StatusBar([
-            ("🤖", "co/gemini-2.5-pro", "magenta"),
+            ("🤖", "co/gemini-3.6-flash", "magenta"),
             ProgressSegment(percent=78, bg_color="green"),
         ])
         console.print(bar.render())
 
     Output (with powerline font):
-        🤖 co/gemini-2.5-pro  ███████░░░ 78%
+        🤖 co/gemini-3.6-flash  ███████░░░ 78%
     """
 
     def __init__(
@@ -144,13 +144,13 @@ class SimpleStatusBar:
 
     Usage:
         bar = SimpleStatusBar([
-            ("🤖", "co/gemini-2.5-pro", "magenta"),
+            ("🤖", "co/gemini-3.6-flash", "magenta"),
             ("📊", "50%", "green"),
         ])
         console.print(bar.render())
 
     Output:
-        [🤖 co/gemini-2.5-pro] [📊 50%]
+        [🤖 co/gemini-3.6-flash] [📊 50%]
     """
 
     def __init__(self, segments: list[tuple[str, str, str]]):

--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -72,7 +72,7 @@ What should happen to complete this task? (1-2 sentences)"""
 
     return llm_do(
         prompt,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0.2,
         system_prompt=EXPECTED_PROMPT
     )
@@ -187,7 +187,7 @@ Is this task truly complete? What was achieved or what's missing?"""
     eval_result = llm_do(
         prompt,
         output=EvalResult,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.6-flash",
         temperature=0,
         system_prompt=EVALUATE_PROMPT_TEXT
     )

--- a/connectonion/useful_tools/file_tools/README.md
+++ b/connectonion/useful_tools/file_tools/README.md
@@ -195,7 +195,7 @@ from connectonion.useful_tools import FileTools
 
 agent = Agent(
     "code-reviewer",
-    model="co/gemini-2.5-pro",
+    model="co/gemini-3.6-flash",
     tools=[FileTools()],
     instructions="Review and fix code. Always read files before editing."
 )


### PR DESCRIPTION
## What happened

I claimed in #263 that the rollout was complete. It wasn't, and the verification was the problem: I grepped with `head -20` and read "no more results" off a truncated list. A complete scan finds **twelve more sites**, three of them user-facing agents.

| Where | Was |
|---|---|
| **`co browser`** (`cli/browser_agent/agent.py`) | 3.5-flash |
| **`co ai --model` flag default** (`cli/main.py`) | 3.5-flash |
| `co ai` explore subagent (`co_ai/agents/registry.py`) | 2.5-flash |
| `co ai` compact summarizer | 2.5-flash |
| `co ai` system_reminder plugin | 2.5-flash |
| eval plugin, two `llm_do` calls | 2.5-flash |
| hosted-browser template | 3.5-flash |
| TUI status bar samples, help/export text | 2.5-pro |

`cli/main.py` is the sharp one: the `--model` flag defaulted to a **different model than the agent it configures**, so `co ai` and `co ai -m <default>` behaved differently.

## A trap worth recording

Most files under `cli/co_ai/prompts/connectonion/` are **symlinks into `docs/`**:

```
prompts/connectonion/api.md -> ../../../../../docs/api.md
```

So a sweep over `connectonion/` writes straight through them. Mine re-flattened the model catalogs in `docs/concepts/models.md` and `docs/api.md` and edited `design-decisions/019` — precisely the files #263 went out of its way to protect. Caught by diffing before commit and reverted.

Only `prompts/connectonion/concepts/transcribe.md` is a real file there (`docs/` keeps transcribe under `features/`, so there is nothing to link to); that one change is kept.

Anyone scripting a bulk edit under `connectonion/` should assume that directory aliases `docs/`.

## Verification, done properly this time

```
grep -rn 'co/gemini-2\.5|co/gemini-3\.5' connectonion/ subagents/   →  0
```

No `head`, no filters, every file type — not just `.py`.

Full unit suite: **2274 passed, 3 skipped**.