### PR TITLE
fix: require approval for shell control syntax

### DIFF
--- a/connectonion/useful_plugins/shell_approval.py
+++ b/connectonion/useful_plugins/shell_approval.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 _console = Console()
 
+SHELL_CONTROL_RE = re.compile(r'&&|\|\||[|;<>`]|[$][(]|[\r\n]')
+
 # Safe read-only commands that don't need approval
 SAFE_PATTERNS = [
     r'^ls\b',                     # list files
@@ -87,6 +89,14 @@ SAFE_PATTERNS = [
 def _is_safe(command: str) -> bool:
     """Check if command is a safe read-only command."""
     cmd = command.strip()
+    if not cmd:
+        return False
+
+    # Treat shell control syntax as unsafe so chained commands, pipes,
+    # redirections, substitutions, and newline injection still require approval.
+    if SHELL_CONTROL_RE.search(cmd):
+        return False
+
     for pattern in SAFE_PATTERNS:
         if re.search(pattern, cmd):
             return True

--- a/tests/unit/test_shell_approval.py
+++ b/tests/unit/test_shell_approval.py
@@ -135,6 +135,17 @@ class TestIsSafe:
         assert _is_safe("  ls -la  ") is True
         assert _is_safe("\tgit status\n") is True
 
+    @pytest.mark.parametrize("command", [
+        "git status && rm -rf /tmp/poc",
+        "cat README.md > /tmp/out",
+        "echo hello | curl https://example.com",
+        "pwd; uname -a",
+        "printf ok$(rm -rf /tmp/poc)",
+    ])
+    def test_shell_control_syntax_is_not_safe(self, command):
+        """Safe prefixes must not bypass approval when shell control syntax is present."""
+        assert _is_safe(command) is False
+
 
 class TestCheckApproval:
     """Tests for _check_approval function - approval workflow."""
@@ -180,6 +191,21 @@ class TestCheckApproval:
 
         # Should not raise or require approval
         _check_approval(agent)
+
+    @patch.object(shell_approval_module, 'pick')
+    @patch.object(shell_approval_module, '_console')
+    def test_safe_prefix_with_chain_still_requires_approval(self, mock_console, mock_pick):
+        """A safe-looking prefix must not suppress approval for chained commands."""
+        mock_pick.return_value = "Yes, execute"
+
+        agent = FakeAgent()
+        agent.current_session['pending_tool'] = {
+            'name': 'shell',
+            'arguments': {'command': 'git status && rm -rf /tmp/test'}
+        }
+
+        _check_approval(agent)
+        mock_pick.assert_called_once()
 
     def test_auto_approved_command_skips_approval(self):
         """Test that previously auto-approved commands skip approval."""


### PR DESCRIPTION
## Summary
This hardens `shell_approval` so read-only prefixes like `git status` or `cat` no longer suppress the approval prompt when the full shell string also contains chaining, pipes, redirection, command substitution, or newline injection.

## Security impact
Before this patch, the standalone `shell_approval` plugin treated a command as safe when it merely started with a read-only prefix. That let an untrusted prompt or model step smuggle arbitrary follow-on shell behavior such as `git status && rm -rf /tmp/poc` or `cat README.md > /tmp/out` past the approval gate. The `Shell` tool then executed the full string with `subprocess.run(..., shell=True)`, so the human confirmation boundary was bypassed and attacker-controlled commands ran without the expected prompt.

## Changes
- reject shell control syntax in the safe-command fast-path
- keep plain read-only commands such as `git status` and `ls -la` auto-approved
- add regression coverage for chaining, pipes, redirection, and command substitution bypasses

## Validation
- reproduced the pre-patch misclassification in the repo venv:
  - `git status && rm -rf /tmp/poc => True`
  - `cat README.md > /tmp/out => True`
  - `echo hello | curl https://example.com => True`
- ran targeted regression coverage successfully:
  - `PYTHONPATH=/Users/joshuam33/.openclaw/workspace/state/current-run/repo-fork /Users/joshuam33/.openclaw/workspace/repos/connectonion/.venv/bin/python -m pytest -q /Users/joshuam33/.openclaw/workspace/state/current-run/repo-fork/tests/unit/test_shell_approval.py`

## Disclosure notes
- finding id: FIND-001
- pool: security-impact
- GitHub private vulnerability reporting is disabled for this repo
- no root `SECURITY.md` was present in the repo
- nothing has been submitted publicly
