### PR TITLE
Split screenshot capture from image reading

### DIFF
--- a/connectonion/cli/browser_agent/agent.py
+++ b/connectonion/cli/browser_agent/agent.py
@@ -16,6 +16,7 @@ from connectonion import Agent
 from connectonion.useful_plugins import image_result_formatter, ui_stream
 from dotenv import load_dotenv
 from connectonion.useful_tools.browser_tools import BrowserAutomation
+from connectonion.useful_tools import read_image
 
 # Prompt path for browser agent
 PROMPT_PATH = Path(__file__).parent / "prompts" / "agent.md"
@@ -39,7 +40,7 @@ def build_browser_agent(browser, api_key: str) -> Agent:
         model="co/gemini-3.6-flash",
         api_key=api_key,
         system_prompt=PROMPT_PATH,
-        tools=[browser],
+        tools=[browser, read_image],
         plugins=[image_result_formatter, ui_stream],
         max_iterations=200,
     )

--- a/connectonion/cli/browser_agent/prompts/agent.md
+++ b/connectonion/cli/browser_agent/prompts/agent.md
@@ -77,7 +77,7 @@ When something fails:
 1. Open browser if not already open
 2. Navigate to the target site
 3. Wait for page to load completely
-4. **Take a screenshot after navigation**
+4. **Take a screenshot after navigation, then call `read_image` with the returned path when you need to inspect it visually**
 
 ### Finding Elements
 - Use natural descriptions first
@@ -88,7 +88,7 @@ When something fails:
 - Use `click_element_near_selector(...)` when a skill provides an anchor selector and a nearby target selector.
 - Fall back to text matching if needed
 - Never expose CSS selectors to users
-- **Take a screenshot when you find important elements**
+- **Take a screenshot when you find important elements, then call `read_image` with its path to inspect it**
 
 ### Saving Page Context
 When a user wants to analyze a site's HTML/CSS, make a workflow more accurate, or debug why a click matched the wrong element, use `save_page_context(name)`.
@@ -100,12 +100,12 @@ It saves under `~/.co/browser_context/`:
 
 ### Form Filling
 1. Find all form fields first
-2. **Take a screenshot of the empty form**
+2. **Take a screenshot of the empty form and call `read_image` with its path**
 3. Generate appropriate values using user context
 4. Fill fields in logical order
-5. **Take a screenshot after filling**
+5. **Take a screenshot after filling and call `read_image` with its path**
 6. Validate before submission
-7. **Take a screenshot after submission**
+7. **Take a screenshot after submission and call `read_image` with its path**
 
 ### Completing Tasks
 - **Take screenshots at each major step**

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -27,6 +27,7 @@ from .terminal import yes_no, autocomplete
 from .todo_list import TodoList
 from .slash_command import SlashCommand
 from .ask_user import ask_user
+from .read_image import read_image
 
 # Claude Code-style file tools
 from .file_tools import (
@@ -69,6 +70,7 @@ __all__ = [
     "TodoList",
     "SlashCommand",
     "ask_user",
+    "read_image",
     # Claude Code-style file tools
     "FileTools",
     "read_file",

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -37,7 +37,6 @@ Features:
 """
 
 import os
-import base64
 import functools
 import inspect
 import json
@@ -1811,14 +1810,14 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         )
 
     def take_screenshot(self, path: str = None, full_page: bool = False) -> str:
-        """Take a screenshot of the current page and return base64 encoded image.
+        """Take a screenshot of the current page and return its saved path.
 
         Args:
             path: Optional path for the screenshot
             full_page: If True, captures entire page height (may lose details but shows overview)
 
         Returns:
-            Base64 encoded image data
+            Path to the saved screenshot. Call read_image(path) to inspect it.
         """
         if not BROWSER_AVAILABLE:
             return 'Browser tools not installed. Run: pip install patchright && patchright install chrome'
@@ -1842,25 +1841,11 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         print(f"\n[browser] Screenshot saved to: {path}")
         print(f"[browser] Full page: {full_page}, Size: {len(screenshot_bytes)} bytes\n")
 
-        # Bound the payload. The screenshot is sent to the frontend as a base64 data URL
-        # in ONE relay WebSocket frame; base64 inflates bytes ~33% and the relay's default
-        # cap is 1 MB (websockets max_size), so a frame over it drops the relay connection
-        # (and reconnect replays it, so the agent flaps offline). A dense 1920-wide page is
-        # a ~800 KB PNG = >1 MB base64. Re-encode only oversized captures as JPEG
-        # (Playwright-native, no Pillow); keep PNG for the common case so text stays sharp.
-        mime = "image/png"
-        if len(screenshot_bytes) > 600_000:   # ~800 KB base64 + JSON, safely under 1 MB
-            screenshot_bytes = self.page.screenshot(full_page=full_page, type="jpeg", quality=85)
-            mime = "image/jpeg"
-            print(f"[browser] oversized PNG re-encoded as JPEG q85: {len(screenshot_bytes)} bytes\n")
-
         # Wait for page to stabilize after screenshot (especially for full_page which scrolls/resizes)
         # This prevents focus loss when typing after taking a screenshot
         self.page.wait_for_timeout(1000)
 
-        screenshot_base64 = base64.b64encode(screenshot_bytes).decode('utf-8')
-
-        return f"data:{mime};base64,{screenshot_base64}"
+        return path
 
     def set_viewport(self, width: int, height: int) -> str:
         """Set the browser viewport size."""

--- a/connectonion/useful_tools/read_file.py
+++ b/connectonion/useful_tools/read_file.py
@@ -30,8 +30,6 @@ Usage:
 Video needs `ffmpeg` on PATH; the tool says so if it's missing.
 """
 
-import base64
-import mimetypes
 import shutil
 import subprocess
 import tempfile
@@ -42,6 +40,7 @@ from connectonion import transcribe
 from docx import Document
 from pypdf import PdfReader
 from pptx import Presentation
+from connectonion.useful_tools.read_image import read_image
 
 # Extensions handled by a dedicated path; everything else is read as text.
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
@@ -77,7 +76,7 @@ def read_file(path: str) -> str:
     ext = file_path.suffix.lower()
 
     if ext in IMAGE_EXTS:
-        return _read_image(file_path)
+        return read_image(str(file_path))
     if ext == ".pdf":
         return _read_pdf(file_path)
     if ext in (".pptx", ".ppt"):
@@ -104,13 +103,6 @@ def _read_text(file_path: Path, ext: str) -> str:
     # aren't misdetected as some unrelated charset.
     match = from_bytes(data, cp_isolation=["utf_8", "gb18030"]).best()
     return str(match) if match is not None else data.decode("utf-8", errors="replace")
-
-
-def _read_image(file_path: Path) -> str:
-    """Return an image as a base64 data URL for the vision model."""
-    mime = mimetypes.guess_type(str(file_path))[0] or "image/png"
-    b64 = base64.b64encode(file_path.read_bytes()).decode("utf-8")
-    return f"data:{mime};base64,{b64}"
 
 
 def _read_pdf(file_path: Path) -> str:

--- a/connectonion/useful_tools/read_image.py
+++ b/connectonion/useful_tools/read_image.py
@@ -1,0 +1,43 @@
+"""Read a local image into the multimodal data-URL format used by agents."""
+
+import base64
+import mimetypes
+from pathlib import Path
+
+
+IMAGE_MIME_TYPES = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+
+def read_image(path: str) -> str:
+    """Read an image so a vision-capable model can inspect it.
+
+    Args:
+        path: Path to a PNG, JPEG, GIF, or WebP image.
+
+    Returns:
+        A data URL consumed by the image_result_formatter plugin, or an
+        actionable error string when the path cannot be read as an image.
+    """
+    image_path = Path(path)
+    if not image_path.exists():
+        return f"Error: File '{path}' does not exist"
+    if not image_path.is_file():
+        return f"Error: '{path}' is not a file"
+
+    extension = image_path.suffix.lower()
+    if extension not in IMAGE_MIME_TYPES:
+        supported = ", ".join(sorted(IMAGE_MIME_TYPES))
+        return (
+            f"Error: unsupported image format '{extension or 'none'}'. "
+            f"Supported formats: {supported}"
+        )
+
+    mime = mimetypes.guess_type(str(image_path))[0] or IMAGE_MIME_TYPES[extension]
+    encoded = base64.b64encode(image_path.read_bytes()).decode("utf-8")
+    return f"data:{mime};base64,{encoded}"

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -110,7 +110,7 @@ Screenshot saved to: /Users/you/project/.tmp/step_20260630_142927.png
 
 Add `--full-page` to capture the entire scrollable height instead of just the viewport.
 
-> **Why a path, not the image?** The underlying `take_screenshot()` function returns a base64 data URL — that's what the AI agent "sees" when it drives the browser with `do`. A direct CLI call deliberately prints the **file path** instead, so `co browser take_screenshot` never floods your terminal with a screenful of base64. Open or pipe the saved file when you want the actual image.
+> **Why a path, not the image?** Screenshot capture and image inspection are separate operations. `take_screenshot()` returns the saved path without adding image data to model context. Agents call `read_image(path)` only when they need to inspect it visually.
 
 ## Scripting
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -82,7 +82,8 @@ browser.get_current_url()                # → "https://example.com"
 ### Screenshots
 
 ```python
-browser.take_screenshot()                # Returns base64 image (auto-saved to .tmp/)
+path = browser.take_screenshot()         # Returns saved path (auto-saved to .tmp/)
+read_image(path)                         # Inspect it with a vision-capable model
 browser.take_screenshot("my_step.png")  # Custom filename
 browser.take_screenshot(full_page=True) # Capture full page height
 ```

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -29,6 +29,10 @@ class FakePage:
             raise RuntimeError("page is closed")
         self.wait_timeout = timeout
 
+    def screenshot(self, path, full_page=False):
+        self.screenshot_args = {"path": path, "full_page": full_page}
+        return b"\x89PNG\r\n\x1a\n"
+
     def close(self):
         if self.closed:
             raise RuntimeError("page is closed")
@@ -36,6 +40,23 @@ class FakePage:
 
     def is_closed(self):
         return self.closed
+
+
+def test_take_screenshot_returns_saved_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(browser_mod, "BROWSER_AVAILABLE", True)
+    browser = browser_mod.BrowserAutomation(headless=True)
+    browser.screenshots_dir = str(tmp_path)
+    browser.page = FakePage()
+
+    result = browser_mod.BrowserAutomation.take_screenshot.__wrapped__(
+        browser, path="evidence.png", full_page=True
+    )
+
+    expected = str(tmp_path / "evidence.png")
+    assert result == expected
+    assert browser.last_screenshot_path == expected
+    assert browser.page.screenshot_args == {"path": expected, "full_page": True}
+    assert browser.page.wait_timeout == 1000
 
 
 class FakeContext:

--- a/tests/unit/test_read_image.py
+++ b/tests/unit/test_read_image.py
@@ -1,0 +1,33 @@
+import base64
+
+from connectonion.useful_tools.read_image import read_image
+
+
+def test_read_image_returns_data_url(tmp_path):
+    image = tmp_path / "shot.webp"
+    payload = b"RIFFfake-webp"
+    image.write_bytes(payload)
+
+    result = read_image(str(image))
+
+    assert result.startswith("data:image/webp;base64,")
+    assert base64.b64decode(result.split(",", 1)[1]) == payload
+
+
+def test_read_image_rejects_missing_file(tmp_path):
+    path = tmp_path / "missing.png"
+    assert read_image(str(path)) == f"Error: File '{path}' does not exist"
+
+
+def test_read_image_rejects_directory(tmp_path):
+    assert read_image(str(tmp_path)) == f"Error: '{tmp_path}' is not a file"
+
+
+def test_read_image_rejects_unsupported_format(tmp_path):
+    image = tmp_path / "shot.bmp"
+    image.write_bytes(b"BM")
+
+    result = read_image(str(image))
+
+    assert result.startswith("Error: unsupported image format '.bmp'")
+    assert ".png" in result


### PR DESCRIPTION
## What changed

- make `BrowserAutomation.take_screenshot()` save exactly one screenshot and return its path instead of a base64 data URL
- add a public `read_image(path)` tool for PNG, JPEG, GIF, and WebP files, with actionable path/format errors
- route image handling in the copyable `read_file` tool through `read_image`
- expose `read_image` to browser agents and update browser prompts/documentation for the explicit two-step workflow
- add separate unit coverage for screenshot capture and image reading

## Why

Screenshot capture and visual inspection were coupled, so every screenshot injected base64 image data into agent context even when the caller only needed saved evidence. Separating the operations keeps capture lightweight and makes the vision/context cost explicit.

## Impact

Callers that need visual inspection now use:

```python
path = browser.take_screenshot()
read_image(path)
```

Direct CLI screenshot calls continue to print the saved path.

## Validation

- `pytest -q tests/unit/test_read_image.py tests/unit/test_read_file_tool.py tests/unit/test_browser_automation.py tests/unit/test_cli_templates.py` — 41 passed
- `python -m compileall -q connectonion`
- `git diff --check`
- browser daemon non-socket coverage passed; socket-binding cases cannot run in the Codex workspace sandbox (`PermissionError: Operation not permitted`)