### PR TITLE
Don't unlink a live daemon's socket on a non-refusal OSError

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -48,8 +48,14 @@ def _connect_posix(sock_path: str):
             time.sleep(0.1)
         except OSError:
             conn.close()
-            if os.path.exists(sock_path):
-                os.unlink(sock_path)  # stale socket: nothing is listening on it
+            # ConnectionRefused (handled above) is the only error that means
+            # "nobody is listening". Any other OSError — EACCES from a process
+            # sandbox, EMFILE, ENOBUFS — says nothing about whether the daemon
+            # is alive, and unlinking on those took a live, idle daemon
+            # permanently offline: it kept accept()ing on an unlinked inode
+            # while every later client reported "daemon is busy".
+            if not _owner_alive(sock_path) and os.path.exists(sock_path):
+                os.unlink(sock_path)
             return None
     return None  # still refusing after the window — let the caller spawn a fresh daemon
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -980,3 +980,49 @@ def test_second_daemon_yields_at_the_singleton_lock(short_sock, monkeypatch):
     code = c.send("go_to survivor.com", headless=True)
     assert code == 0
     assert ("go_to", "survivor.com") in winner.browser.calls
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX socket path")
+def test_permission_error_never_unlinks_a_live_socket(short_sock, monkeypatch):
+    """A sandbox that denies connect() must not take a healthy daemon offline.
+
+    _connect_posix used to treat every non-ConnectionRefused OSError as proof of
+    a stale socket. An EACCES from a restricted process therefore unlinked the
+    socket of a live, idle daemon, which kept accept()ing on the now-unlinked
+    inode while every later client reported "daemon is busy".
+    """
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    daemon = make_daemon(short_sock)
+    thread = threading.Thread(target=daemon.serve, daemon=True)
+    thread.start()
+    _wait_until_listening(short_sock)
+
+    real_connect = socket.socket.connect
+
+    def denied(self, addr):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    assert c._connect_posix(short_sock) is None
+    monkeypatch.setattr(socket.socket, "connect", real_connect)
+
+    # The live daemon keeps its socket, and a normal client still reaches it.
+    assert os.path.exists(short_sock), "live daemon's socket was unlinked"
+    assert c.send("go_to survivor.com", headless=True) == 0
+    assert ("go_to", "survivor.com") in daemon.browser.calls
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX socket path")
+def test_permission_error_still_clears_a_dead_owners_socket(short_sock, monkeypatch):
+    """The cleanup this guard replaced must still happen when nobody is home."""
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.bind(short_sock)  # a socket file with no live owner recorded
+    sock.close()
+
+    def denied(self, addr):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    assert c._connect_posix(short_sock) is None
+    assert not os.path.exists(short_sock), "stale socket should have been removed"


### PR DESCRIPTION
Closes #245.

## The bug

`_connect_posix` treated **every** `OSError` except `ConnectionRefusedError` as proof that the socket was stale:

```python
except OSError:
    conn.close()
    if os.path.exists(sock_path):
        os.unlink(sock_path)  # stale socket: nothing is listening on it
    return None
```

Only `ConnectionRefusedError` actually means "nobody is listening". `EACCES` from a process sandbox, `EMFILE`, `ENOBUFS` — none of them say anything about whether a daemon is alive, and each one deleted its socket.

## Why the symptom was so confusing

The daemon **survives** having its socket unlinked. It keeps `accept()`ing on the now-unlinked inode, still owning the browser and `~/.co/browser_profile`. Every later client then finds no socket, checks the recorded owner, sees a live pid, correctly declines to replace it, waits out the window, and reports:

```
browser daemon is busy (a long command is holding it) — try again
```

Nothing is holding it. The diagnosis in #245 confirms it: daemon idle at negligible CPU, main thread parked in `accept()`, `lsof` showing it still owned the listening FD, `browser.sock` gone while `.pid` and `.lock` remained.

## The fix

The `ConnectionRefusedError` branch immediately above already answers "is anyone home?" with `_owner_alive()`. The unlink now uses the same answer:

```python
if not _owner_alive(sock_path) and os.path.exists(sock_path):
    os.unlink(sock_path)
```

A live daemon keeps its socket. A genuinely orphaned socket is still cleaned up, so the recovery path this code existed for is unchanged.

## Tests

Two, both driving a real daemon over a real `AF_UNIX` socket with `connect()` monkeypatched to raise `PermissionError`:

- **a live daemon keeps its socket** and still serves a normal client afterwards — this one **fails on main**
- **a dead owner's socket is still removed** — passes both before and after, pinning that the guard didn't over-correct

`tests/e2e/cli/test_browser_daemon.py`: 71 passed.

## Why now

#270 and #234 both move callers onto this daemon — `co ai` and every `co create` template would drive the browser through it. A failure mode that takes the daemon permanently offline and then misreports why is worth closing before that traffic arrives.