### PR TITLE
Add co syno: your Synology NAS from the terminal

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -51,7 +51,7 @@ from .prompts import load_system_prompt
 from .debug import xray, auto_debug_exception, replay, xray_replay
 from .useful_tools import (
     send_email, get_emails, mark_read, mark_unread,
-    Memory, Gmail, GDrive, GoogleCalendar, Outlook, MicrosoftCalendar,
+    Memory, Gmail, GDrive, Synology, GoogleCalendar, Outlook, MicrosoftCalendar,
     WebFetch, Shell, bash, codex, DiffWriter, MODE_NORMAL, MODE_AUTO, MODE_PLAN,
     pick, yes_no, autocomplete, TodoList, SlashCommand,
     # Claude Code-style file tools
@@ -83,6 +83,7 @@ __all__ = [
     "Memory",
     "Gmail",
     "GDrive",
+    "Synology",
     "GoogleCalendar",
     "Outlook",
     "MicrosoftCalendar",

--- a/connectonion/cli/commands/synology_commands.py
+++ b/connectonion/cli/commands/synology_commands.py
@@ -1,0 +1,190 @@
+"""
+Purpose: CLI surface for the user's Synology NAS — log in, browse, search, download, upload, and share File Station files from the terminal
+LLM-Note:
+  Dependencies: imports from [json, os, pathlib, typer, questionary, dotenv, rich.console, rich.table, ...useful_tools.synology] | imported by [cli/main.py via handle_syno_*()] | hits the NAS through the Synology tool
+  Data flow: _syno() loads SYNOLOGY_* from .env / ~/.co/keys.env → Synology() instance | ls/search: list_files()/search_files() → numbered Rich table (tab-separated with full paths when piped) → saves {#: path} to ~/.co/syno_last_list.json | get/share: resolve short numbers via that cache → download()/share()
+  State/Effects: login writes SYNOLOGY_URL/ACCOUNT/PASSWORD/SID to ~/.co/keys.env | writes ~/.co/syno_last_list.json (last listing's # → path map) | get downloads local files | put uploads to the NAS
+  Integration: exposes handle_syno_login(), handle_syno_list(), handle_syno_search(), handle_syno_get(), handle_syno_put(), handle_syno_share() for cli/main.py | presentation mirrors gdrive_commands.py | NAS logic lives in useful_tools/synology.py
+  Errors: guarded failures print a hint and exit 1 (typer.Exit) — not logged in, unresolvable file #, missing upload path | ValueError from the Synology tool carries decoded DSM error text
+"""
+
+import json
+import os
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+LIST_CACHE = Path.home() / ".co" / "syno_last_list.json"
+
+
+def _syno():
+    """Load SYNOLOGY_* credentials from .env files and return a Synology instance. Exits 1 with a hint if not connected."""
+    from dotenv import load_dotenv
+
+    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
+        if env_path.exists():
+            load_dotenv(env_path)
+
+    if not os.getenv("SYNOLOGY_URL"):
+        console.print("\n❌ [bold red]Synology NAS not connected[/bold red]")
+        console.print("\n[cyan]Connect your NAS first:[/cyan]")
+        console.print("  [bold]co syno login[/bold]     Log in with your QuickConnect ID\n")
+        raise typer.Exit(1)
+
+    from ...useful_tools.synology import Synology
+    return Synology()
+
+
+def _size(count: int) -> str:
+    """Render a byte count as B/KB/MB/GB; '-' for folders."""
+    if not count:
+        return "-"
+    size = float(count)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f}{unit}" if unit == "B" else f"{size:.1f}{unit}"
+        size /= 1024
+
+
+def _when(timestamp: int) -> str:
+    """Render a File Station mtime (unix seconds) as 'Jul 26 14:30' in local time."""
+    from datetime import datetime
+
+    if not timestamp:
+        return ""
+    return datetime.fromtimestamp(timestamp).strftime("%b %d %H:%M")
+
+
+def _print_listing(files: list, title: str):
+    """Render files as a numbered table (or tab-separated rows with full paths when piped) and cache the numbering."""
+    LIST_CACHE.parent.mkdir(parents=True, exist_ok=True)
+    LIST_CACHE.write_text(json.dumps({str(i): f["path"] for i, f in enumerate(files, 1)}), encoding="utf-8")
+
+    if not console.is_terminal:
+        # Scripts and agents get full paths, never a truncated column. Plain
+        # print, not console.print: Rich expands \t into spaces, which silently
+        # turns tab-separated output into something cut -f can't read.
+        for item in files:
+            print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['path']}")
+        return
+
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("Name", overflow="ellipsis", no_wrap=True)
+    table.add_column("Kind", max_width=6, no_wrap=True)
+    table.add_column("Size", justify="right")
+    table.add_column("Modified")
+
+    for i, item in enumerate(files, 1):
+        table.add_row(str(i), item["name"], item["type"], _size(item["size"]), _when(item["modified"]))
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Download one with:[/dim] [bold]co syno get <#>[/bold]\n")
+
+
+def handle_syno_login(url: str = None):
+    """Connect a Synology NAS, by QuickConnect ID or a direct URL, and save the session."""
+    import questionary
+
+    from ...useful_tools.synology import Synology, pick_reachable, resolve_quickconnect, save_credentials
+
+    if url:
+        base = url.rstrip("/")
+    else:
+        quickconnect_id = questionary.text("QuickConnect ID (Control Panel → External Access):").ask()
+        if not quickconnect_id:
+            raise typer.Exit(1)
+
+        console.print("\n[dim]Resolving…[/dim]")
+        candidates = resolve_quickconnect(quickconnect_id.strip())
+        console.print(f"[dim]Found {len(candidates)} address(es), probing fastest first…[/dim]")
+        base = pick_reachable(candidates)
+
+    console.print(f"[green]✓[/green] Reached [bold]{base}[/bold]\n")
+
+    account = questionary.text("DSM username:").ask()
+    password = questionary.password("DSM password:").ask()
+    if not account or not password:
+        raise typer.Exit(1)
+
+    save_credentials(url=base, account=account, password=password)
+
+    # Logging in now both validates the credentials and caches the sid, so the
+    # first real command doesn't fail on a typo made minutes earlier.
+    Synology(url=base, account=account, password=password)._login()
+
+    console.print(f"\n[green]✓ Connected[/green] as [bold]{account}[/bold]")
+    console.print("\n[dim]Try:[/dim] [bold]co syno[/bold]\n")
+
+
+def handle_syno_list(path: str = None, last: int = 20):
+    """List shared folders, or the contents of one folder, as a numbered table."""
+    nas = _syno()
+    files = nas.list_files(path=path, last=last)
+    if not files:
+        console.print(f"\n[cyan]Synology:[/cyan] nothing in {path or 'your shared folders'}\n")
+        return
+    _print_listing(files, f"📁 NAS — {path or 'shared folders'}")
+
+
+def handle_syno_search(query: str, path: str = "/", last: int = 20):
+    """Search the NAS by file name, numbered like the listing."""
+    nas = _syno()
+    files = nas.search_files(query, path=path, last=last)
+    if not files:
+        console.print(f"\n[cyan]NAS search:[/cyan] no files matching [bold]{query}[/bold]\n")
+        return
+    _print_listing(files, f"🔎 NAS — {query}")
+
+
+def _resolve_path(ref: str) -> str:
+    """Turn a listing number into a NAS path; full paths pass through."""
+    cached = json.loads(LIST_CACHE.read_text(encoding="utf-8")) if LIST_CACHE.exists() else {}
+    if ref in cached:
+        return cached[ref]
+
+    if ref.isascii() and ref.isdigit() and len(ref) < 5:
+        # A short number means "row N of what you just showed me" — refetching a
+        # differently ordered listing would silently act on the wrong file.
+        return ""
+    return ref
+
+
+def handle_syno_get(ref: str, dest: str = "."):
+    """Download a file from the NAS. Accepts the listing # or a full path."""
+    nas = _syno()
+    path = _resolve_path(ref)
+    if not path:
+        console.print(f"\n[yellow]No file #{ref} in your last listing — run co syno to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[dim]Downloading {path}…[/dim]")
+    console.print(nas.download(path, dest=dest).replace("Downloaded to", "[green]✓ Downloaded[/green]"))
+    console.print()
+
+
+def handle_syno_put(local_path: str, path: str, overwrite: bool = False):
+    """Upload a local file to a NAS folder."""
+    if not Path(local_path).expanduser().is_file():
+        console.print(f"\n❌ [bold red]File not found:[/bold red] {local_path}\n")
+        raise typer.Exit(1)
+
+    nas = _syno()
+    console.print(f"\n[green]✓ {nas.upload(local_path, path, overwrite=overwrite)}[/green]\n")
+
+
+def handle_syno_share(ref: str):
+    """Create a public sharing link. Accepts the listing # or a full path."""
+    nas = _syno()
+    path = _resolve_path(ref)
+    if not path:
+        console.print(f"\n[yellow]No file #{ref} in your last listing — run co syno to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]✓ Sharing link[/green] for [bold]{path}[/bold]")
+    console.print(f"  {nas.share(path)}\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -89,6 +89,7 @@ def _show_help():
     console.print("  [green]email[/green]             Send and read agent email")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
+    console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
     console.print("  [green]browser[/green]           Drive a browser (run: co browser help)")
     console.print("  [green]keys[/green]              Show agent keys and credentials")
@@ -604,6 +605,80 @@ def gdrive_rm(
     """Move a file to the Drive trash (recoverable)."""
     from .commands.gdrive_commands import handle_gdrive_rm
     handle_gdrive_rm(file_id)
+
+
+# Synology command group. `co syno` (no args) lists your shared folders.
+# Uses the SYNOLOGY_* credentials saved to keys.env by `co syno login`.
+syno_app = typer.Typer(help="Browse, search, download, upload, and share Synology NAS files. Bare 'co syno' lists shared folders.")
+app.add_typer(syno_app, name="syno")
+
+
+@syno_app.callback(invoke_without_command=True)
+def syno_callback(ctx: typer.Context):
+    """With no subcommand, list your NAS shared folders."""
+    if ctx.invoked_subcommand is None:
+        from .commands.synology_commands import handle_syno_list
+        handle_syno_list()
+
+
+@syno_app.command("login")
+def syno_login(
+    url: str = typer.Option(None, "--url", help="Connect directly, e.g. https://nas.local:5001 (skips QuickConnect)"),
+):
+    """Connect your NAS by QuickConnect ID, or directly with --url."""
+    from .commands.synology_commands import handle_syno_login
+    handle_syno_login(url=url)
+
+
+@syno_app.command("ls")
+def syno_ls(
+    path: str = typer.Argument(None, help="Folder path, e.g. /home/photos. Omit to list shared folders."),
+    last: int = typer.Option(20, "--last", "-n", help="How many entries to show"),
+):
+    """List shared folders, or the contents of one folder."""
+    from .commands.synology_commands import handle_syno_list
+    handle_syno_list(path=path, last=last)
+
+
+@syno_app.command("search")
+def syno_search(
+    query: str = typer.Argument(..., help="Text or glob to look for in file names"),
+    path: str = typer.Option("/", "--in", help="Folder to search under"),
+    last: int = typer.Option(20, "--last", "-n", help="How many matches to show"),
+):
+    """Search the NAS by file name."""
+    from .commands.synology_commands import handle_syno_search
+    handle_syno_search(query, path=path, last=last)
+
+
+@syno_app.command("get")
+def syno_get(
+    ref: str = typer.Argument(..., help="File # from the last listing, or a full NAS path"),
+    dest: str = typer.Option(".", "--to", help="Destination directory or file path"),
+):
+    """Download a file from the NAS."""
+    from .commands.synology_commands import handle_syno_get
+    handle_syno_get(ref, dest=dest)
+
+
+@syno_app.command("put")
+def syno_put(
+    local_path: str = typer.Argument(..., help="Local file to upload"),
+    path: str = typer.Argument(..., help="Destination NAS folder, e.g. /home/photos"),
+    overwrite: bool = typer.Option(False, "--overwrite", help="Replace an existing file of the same name"),
+):
+    """Upload a local file to the NAS."""
+    from .commands.synology_commands import handle_syno_put
+    handle_syno_put(local_path, path, overwrite=overwrite)
+
+
+@syno_app.command("share")
+def syno_share(
+    ref: str = typer.Argument(..., help="File # from the last listing, or a full NAS path"),
+):
+    """Create a public sharing link for a file or folder."""
+    from .commands.synology_commands import handle_syno_share
+    handle_syno_share(ref)
 
 
 # Outlook command group. `co outlook` (no args) shows the Outlook inbox.

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -13,6 +13,7 @@ from .get_emails import get_emails, mark_read, mark_unread
 from .memory import Memory
 from .gmail import Gmail
 from .gdrive import GDrive
+from .synology import Synology
 from .google_calendar import GoogleCalendar
 from .outlook import Outlook
 from .microsoft_calendar import MicrosoftCalendar
@@ -48,6 +49,7 @@ __all__ = [
     "Memory",
     "Gmail",
     "GDrive",
+    "Synology",
     "GoogleCalendar",
     "Outlook",
     "MicrosoftCalendar",

--- a/connectonion/useful_tools/synology.py
+++ b/connectonion/useful_tools/synology.py
@@ -1,0 +1,439 @@
+"""
+Purpose: Synology NAS integration tool for listing, searching, downloading, uploading, and sharing File Station files
+LLM-Note:
+  Dependencies: imports from [json, os, pathlib, httpx] | imported by [useful_tools/__init__.py] | requires SYNOLOGY_* env vars from 'co syno login' | tested by [tests/unit/test_synology.py]
+  Data flow: Agent calls Synology methods → _request() attaches the cached sid and hits /webapi/<path> → DSM returns {"success":bool,"data":...} → returns file dicts or confirmations | list_files() uses SYNO.FileStation.List (list_share at the root, list inside a share) | search_files() runs the Search start→poll→clean dance | download() streams bytes | upload() posts multipart with the file part last
+  State/Effects: reads SYNOLOGY_URL/ACCOUNT/PASSWORD/SID env vars | makes HTTP calls to the NAS | re-login on an expired session rewrites SYNOLOGY_SID in ~/.co/keys.env | download() writes local files, upload() writes remote ones
+  Integration: exposes Synology class with list_files(), search_files(), download(), upload(), share() | resolve_quickconnect() turns a QuickConnect ID into ordered base-URL candidates | used as agent tool via Agent(tools=[Synology()])
+  Performance: network I/O per call | QuickConnect relay is throttled, so the LAN candidate is probed first | search polls at 0.3s intervals
+  Errors: raises ValueError when not configured, on failed login, and on any DSM error code (decoded via ERRORS) | httpx errors propagate except while probing connection candidates, where an unreachable candidate falls through to the next
+
+Synology File Station tool for managing NAS files.
+
+Usage:
+    from connectonion import Agent, Synology
+
+    nas = Synology()
+    agent = Agent("assistant", tools=[nas])
+
+    # Agent can now use:
+    # - list_files(path, last)
+    # - search_files(query, path, last)
+    # - download(path, dest)
+    # - upload(local_path, path)
+    # - share(path)
+"""
+
+import os
+import time
+from pathlib import Path
+
+import httpx
+
+# DSM answers every call with {"success": bool, "error": {"code": N}}. These are
+# the codes worth naming — the rest surface as a bare number.
+ERRORS = {
+    100: "Unknown error",
+    101: "No parameter of API, method or version",
+    102: "The requested API does not exist",
+    103: "The requested method does not exist",
+    104: "The requested version does not support the functionality",
+    105: "The logged in session does not have permission",
+    106: "Session timeout",
+    107: "Session interrupted by duplicate login",
+    119: "SID not found",
+    400: "No such account or incorrect password",
+    401: "Account disabled",
+    402: "Permission denied",
+    403: "2-step verification code required",
+    404: "Failed to authenticate 2-step verification code",
+    407: "Operation not permitted",
+    408: "No such file or directory",
+    1805: "Destination file exists and no overwrite was given",
+}
+
+# A dead session, not a real failure — the fix is to log in again and retry once.
+STALE_SESSION = {106, 107, 119}
+
+QUICKCONNECT_GLOBAL = "https://global.quickconnect.to/Serv.php"
+
+
+def _payload(command: str, server_id: str) -> dict:
+    """Build a QuickConnect Serv.php request body."""
+    return {
+        "version": 1,
+        "command": command,
+        "stop_when_error": False,
+        "stop_when_success": False,
+        "id": "dsm_portal_https",
+        "serverID": server_id,
+    }
+
+
+def resolve_quickconnect(server_id: str) -> list:
+    """Turn a QuickConnect ID into base URLs to try, fastest route first.
+
+    QuickConnect is not one address but several: the NAS may be on this LAN, may
+    be reachable at a DDNS name or forwarded port, and can always be reached
+    through a Synology-hosted relay. The relay is heavily throttled, so it is
+    the last resort rather than the default — which is where the common Python
+    clients stop.
+
+    Args:
+        server_id: The QuickConnect ID (the name in quickconnect.to/<ID>)
+
+    Returns:
+        Ordered list of base URLs — LAN, then DDNS/external, then relay
+    """
+    reply = httpx.post(QUICKCONNECT_GLOBAL, json=_payload("get_server_info", server_id), timeout=15)
+    info = reply.json()
+
+    if info.get("errno"):
+        raise ValueError(
+            f"QuickConnect ID '{server_id}' not found (errno {info['errno']}).\n"
+            "Check Control Panel → External Access → QuickConnect on your NAS."
+        )
+
+    server = info.get("server", {})
+    port = server.get("port") or 5001
+    candidates = []
+
+    # Same-network addresses: full speed, and the reason to probe at all.
+    for interface in server.get("interface", []):
+        if interface.get("ip"):
+            candidates.append(f"https://{interface['ip']}:{port}")
+
+    ddns = server.get("ddns")
+    if ddns and ddns != "NULL":
+        candidates.append(f"https://{ddns}:{port}")
+
+    external = server.get("external", {}).get("ip")
+    if external:
+        candidates.append(f"https://{external}:{port}")
+
+    relay = info.get("service", {}).get("relay_ip") or info.get("relay_ip")
+    if relay:
+        candidates.append(f"https://{relay}")
+    # The relay hostname form always exists even when the tunnel fields don't.
+    candidates.append(f"https://{server_id}.quickconnect.to")
+
+    return candidates
+
+
+def pick_reachable(candidates: list, timeout: float = 3.0) -> str:
+    """Return the first candidate whose DSM answers, or raise if none do.
+
+    Args:
+        candidates: Base URLs from resolve_quickconnect()
+        timeout: Seconds to wait per candidate before moving on
+
+    Returns:
+        The winning base URL
+    """
+    for base in candidates:
+        # A candidate that is simply not on this network is expected, not
+        # exceptional — fall through to the next rather than failing the run.
+        try:
+            reply = httpx.get(
+                f"{base}/webapi/query.cgi",
+                params={"api": "SYNO.API.Info", "version": 1, "method": "query", "query": "SYNO.API.Auth"},
+                timeout=timeout,
+                verify=False,
+            )
+        except httpx.RequestError:
+            continue
+        if reply.status_code == 200 and reply.json().get("success"):
+            return base
+
+    raise ValueError(
+        "Could not reach your NAS on any known address.\n"
+        "If you are off your home network, try: co syno login --url https://<host>:5001"
+    )
+
+
+class Synology:
+    """Synology File Station tool for listing, searching, downloading, uploading, and sharing files."""
+
+    def __init__(self, url: str = None, account: str = None, password: str = None):
+        """Initialize the Synology tool from arguments or SYNOLOGY_* env vars."""
+        self.url = (url or os.getenv("SYNOLOGY_URL", "")).rstrip("/")
+        self.account = account or os.getenv("SYNOLOGY_ACCOUNT", "")
+        self.password = password or os.getenv("SYNOLOGY_PASSWORD", "")
+        self.sid = os.getenv("SYNOLOGY_SID", "")
+
+        if not self.url:
+            raise ValueError("Synology NAS not configured.\nRun: co syno login")
+
+        self._paths = {}
+
+    # === Plumbing ===
+
+    def _client(self) -> httpx.Client:
+        """An HTTP client for this NAS. Certificate checks are off because DSM ships a self-signed cert by default."""
+        return httpx.Client(base_url=self.url, timeout=60, verify=False, follow_redirects=True)
+
+    def _path_for(self, api: str) -> str:
+        """Look up an API's CGI path, querying SYNO.API.Info once per instance.
+
+        DSM moves these paths and bumps max versions between releases, so asking
+        the NAS beats hardcoding 'entry.cgi' and hoping.
+        """
+        if not self._paths:
+            with self._client() as client:
+                reply = client.get(
+                    "/webapi/query.cgi",
+                    params={"api": "SYNO.API.Info", "version": 1, "method": "query", "query": "all"},
+                )
+            self._paths = reply.json()["data"]
+
+        return self._paths.get(api, {}).get("path", "entry.cgi")
+
+    def _login(self):
+        """Log in and cache the session id, persisting it for the next command."""
+        if not self.account or not self.password:
+            raise ValueError("Synology credentials missing.\nRun: co syno login")
+
+        with self._client() as client:
+            # POST, not the GET the official examples show: a password in a query
+            # string ends up in proxy and server logs.
+            reply = client.post(
+                f"/webapi/{self._path_for('SYNO.API.Auth')}",
+                data={
+                    "api": "SYNO.API.Auth",
+                    "version": 3,
+                    "method": "login",
+                    "account": self.account,
+                    "passwd": self.password,
+                    "session": "FileStation",
+                    "format": "sid",
+                },
+            )
+
+        body = reply.json()
+        if not body.get("success"):
+            code = body.get("error", {}).get("code", 0)
+            raise ValueError(f"Synology login failed: {ERRORS.get(code, f'error {code}')}")
+
+        self.sid = body["data"]["sid"]
+        save_credentials(sid=self.sid)
+
+    def _request(self, api: str, method: str, version: int = 2, **params) -> dict:
+        """Call a File Station API, logging in first and retrying once if the session died."""
+        if not self.sid:
+            self._login()
+
+        body = self._call(api, method, version, params)
+
+        if not body.get("success") and body.get("error", {}).get("code") in STALE_SESSION:
+            # Sessions expire after 7 days, and a duplicate login elsewhere kills
+            # them sooner — re-auth silently rather than making the user care.
+            self._login()
+            body = self._call(api, method, version, params)
+
+        if not body.get("success"):
+            code = body.get("error", {}).get("code", 0)
+            raise ValueError(f"Synology {api}.{method} failed: {ERRORS.get(code, f'error {code}')}")
+
+        return body.get("data", {})
+
+    def _call(self, api: str, method: str, version: int, params: dict) -> dict:
+        """Issue one API request and return the decoded body."""
+        query = {"api": api, "version": version, "method": method, "_sid": self.sid}
+        query.update({k: v for k, v in params.items() if v is not None})
+
+        with self._client() as client:
+            reply = client.get(f"/webapi/{self._path_for(api)}", params=query)
+        return reply.json()
+
+    @staticmethod
+    def _file_dict(item: dict) -> dict:
+        """Normalize a File Station entry to the CLI/agent file shape."""
+        extra = item.get("additional", {})
+        return {
+            "path": item.get("path", ""),
+            "name": item.get("name", ""),
+            "type": "dir" if item.get("isdir") else "file",
+            "size": extra.get("size", 0) or 0,
+            "modified": extra.get("time", {}).get("mtime", 0) or 0,
+        }
+
+    # === Listing ===
+
+    def list_files(self, path: str = None, last: int = 20) -> list:
+        """List shared folders, or the contents of one folder.
+
+        Args:
+            path: Folder path starting with a shared folder, e.g. /home/photos.
+                  Omit to list the shared folders themselves.
+            last: How many entries to return (default: 20)
+
+        Returns:
+            List of file dicts (path, name, type, size, modified)
+        """
+        if last < 1:
+            return []
+
+        if not path:
+            data = self._request("SYNO.FileStation.List", "list_share", limit=last)
+        else:
+            data = self._request(
+                "SYNO.FileStation.List",
+                "list",
+                folder_path=path,
+                limit=last,
+                sort_by="mtime",
+                sort_direction="desc",
+                additional='["size","time"]',
+            )
+
+        entries = data.get("shares") or data.get("files") or []
+        return [self._file_dict(item) for item in entries]
+
+    def search_files(self, query: str, path: str = "/", last: int = 20) -> list:
+        """Search for files by name under a folder.
+
+        File Station search is non-blocking: start a task, poll until it reports
+        finished, then clean up the temporary result database.
+
+        Args:
+            query: Glob or plain substring to match against file names
+            path: Folder to search under (default: everything)
+            last: How many matches to return (default: 20)
+
+        Returns:
+            List of file dicts, matching files only
+        """
+        needle = query.strip()
+        if not needle or last < 1:
+            return []
+
+        started = self._request(
+            "SYNO.FileStation.Search", "start", folder_path=path, pattern=needle, recursive=True
+        )
+        task = started["taskid"]
+
+        # Results stream in as the task walks the tree; poll until DSM says done.
+        for _ in range(100):
+            found = self._request("SYNO.FileStation.Search", "list", taskid=task, limit=last)
+            if found.get("finished"):
+                break
+            time.sleep(0.3)
+
+        self._request("SYNO.FileStation.Search", "clean", taskid=task)
+        return [self._file_dict(item) for item in found.get("files", [])]
+
+    # === Transfer ===
+
+    def download(self, path: str, dest: str = ".") -> str:
+        """Download a file from the NAS.
+
+        Args:
+            path: Full NAS path, e.g. /home/photos/cat.jpg
+            dest: Destination directory or full local path (default: cwd)
+
+        Returns:
+            Confirmation with the path written
+        """
+        if not self.sid:
+            self._login()
+
+        target = Path(dest).expanduser()
+        if target.is_dir():
+            target = target / Path(path).name
+
+        query = {
+            "api": "SYNO.FileStation.Download",
+            "version": 2,
+            "method": "download",
+            "path": f'["{path}"]',
+            "mode": "download",
+            "_sid": self.sid,
+        }
+
+        with self._client() as client:
+            with client.stream("GET", f"/webapi/{self._path_for('SYNO.FileStation.Download')}", params=query) as reply:
+                # DSM signals failure with a JSON body instead of an HTTP status.
+                if reply.headers.get("content-type", "").startswith("application/json"):
+                    reply.read()
+                    code = reply.json().get("error", {}).get("code", 0)
+                    raise ValueError(f"Synology download failed: {ERRORS.get(code, f'error {code}')}")
+
+                with open(target, "wb") as out:
+                    for chunk in reply.iter_bytes():
+                        out.write(chunk)
+
+        return f"Downloaded to {target}"
+
+    def upload(self, local_path: str, path: str, overwrite: bool = False) -> str:
+        """Upload a local file to a NAS folder.
+
+        Args:
+            local_path: Local file to send
+            path: Destination folder on the NAS, e.g. /home/photos
+            overwrite: Replace an existing file of the same name (default: skip)
+
+        Returns:
+            Confirmation with the destination
+        """
+        local = Path(local_path).expanduser()
+        if not local.is_file():
+            raise ValueError(f"File not found: {local_path}")
+
+        if not self.sid:
+            self._login()
+
+        # RFC 1867 with a DSM constraint: the binary part must come last. httpx
+        # writes every `data` field before any `files` entry, which satisfies it.
+        fields = {
+            "api": "SYNO.FileStation.Upload",
+            "version": "2",
+            "method": "upload",
+            "path": path,
+            "create_parents": "true",
+            # Always explicit: DSM returns error 1805 rather than a default when
+            # the destination exists and this is missing.
+            "overwrite": "true" if overwrite else "false",
+            "_sid": self.sid,
+        }
+
+        with self._client() as client:
+            with open(local, "rb") as handle:
+                reply = client.post(
+                    f"/webapi/{self._path_for('SYNO.FileStation.Upload')}",
+                    data=fields,
+                    files={"file": (local.name, handle, "application/octet-stream")},
+                )
+
+        body = reply.json()
+        if not body.get("success"):
+            code = body.get("error", {}).get("code", 0)
+            raise ValueError(f"Synology upload failed: {ERRORS.get(code, f'error {code}')}")
+
+        return f"Uploaded to {path}/{local.name}"
+
+    def share(self, path: str) -> str:
+        """Create a public sharing link for a file or folder.
+
+        Args:
+            path: Full NAS path to share
+
+        Returns:
+            The sharing URL
+        """
+        data = self._request("SYNO.FileStation.Sharing", "create", version=3, path=path)
+        links = data.get("links", [])
+        if not links:
+            raise ValueError(f"Synology returned no sharing link for {path}")
+        return links[0]["url"]
+
+
+def save_credentials(**values):
+    """Persist SYNOLOGY_* values to ~/.co/keys.env and the current environment."""
+    from ..cli.commands.project_cmd_lib import upsert_env
+
+    env_file = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+
+    updates = {f"SYNOLOGY_{key.upper()}": str(value) for key, value in values.items()}
+    os.environ.update(updates)
+    upsert_env(env_file, updates)

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -271,6 +271,36 @@ See [gdrive.md](gdrive.md) for details.
 
 ---
 
+#### `co syno` - Synology NAS Files
+
+Your NAS from the terminal. Requires `co syno login` once (QuickConnect ID or
+`--url`; saved as `SYNOLOGY_*` in `~/.co/keys.env`).
+
+**Basic usage:**
+```bash
+co syno                                # your shared folders
+co syno ls /home/photos                # inside one
+co syno search invoice --in /home      # find by name
+co syno get 3 --to ~/Downloads         # download #3 from the listing
+co syno put report.pdf /home/docs      # upload
+```
+
+**Subcommands:**
+
+- `co syno login` - connect by QuickConnect ID, or directly with `--url`
+- `co syno` / `co syno ls [path]` - shared folders, or one folder (`--last/-n`)
+- `co syno search <query>` - find by file name (`--in` to scope)
+- `co syno get <#>` - download (`--to`)
+- `co syno put <path> <nas-folder>` - upload (`--overwrite`)
+- `co syno share <#>` - create a public sharing link
+
+There is deliberately no `co syno rm` — File Station's delete API is permanent,
+so unlike `co gdrive rm` it could not be made recoverable.
+
+See [synology.md](synology.md) for details.
+
+---
+
 #### `co outlook` - Manage Outlook Email & Contacts
 
 Your personal Outlook account from the terminal, via Microsoft Graph.

--- a/docs/cli/synology.md
+++ b/docs/cli/synology.md
@@ -1,0 +1,155 @@
+# Synology CLI (co syno)
+
+Browse, search, download, upload, and share Synology NAS files from the
+terminal — the same File Station access your agents get from the
+[Synology tool](../useful_tools/synology.md), as a command.
+
+## Quick Start
+
+```bash
+# Connect your NAS (one-time)
+co syno login
+
+# See your shared folders (the zero-arg default)
+co syno
+
+# Look inside one
+co syno ls /home/photos
+
+# Download file #3 from the listing
+co syno get 3
+```
+
+That's the whole surface. Everything below is detail.
+
+## Setup
+
+```bash
+co syno login
+```
+
+You'll be asked for your **QuickConnect ID** — the name in
+`quickconnect.to/<ID>`, found in DSM under *Control Panel → External Access →
+QuickConnect* — then your DSM username and password.
+
+If you'd rather skip QuickConnect, or it stops working, connect directly:
+
+```bash
+co syno login --url https://nas.local:5001
+co syno login --url https://mynas.synology.me:5001
+```
+
+Credentials are saved to `~/.co/keys.env` and never leave your machine — a NAS
+has no OAuth to broker, so there is no `co auth synology`.
+
+### How the connection is chosen
+
+QuickConnect isn't one address, it's several, and they are not equally fast:
+
+| Route | Speed | Works |
+|---|---|---|
+| LAN (`192.168.x.x`) | full gigabit | at home only |
+| DDNS / forwarded port | full WAN speed | if you've forwarded ports |
+| Synology relay | **throttled** | anywhere |
+
+`co syno login` probes them in that order and remembers which one answered, so
+you get the fast path at home without giving up access from a café. If the
+saved address stops responding — you moved networks — run `co syno login`
+again.
+
+## Commands
+
+### `co syno` — Shared folders
+
+```bash
+co syno                  # your shared folders
+co syno ls /home         # inside one
+co syno ls /home -n 50
+```
+
+Entries are numbered. **Numbers mean your last listing** — `co syno get 3`
+downloads the third row of the table you just saw. Running `co syno` again
+renumbers.
+
+Paths always start with a shared folder, e.g. `/home/photos`, not
+`/volume1/home/photos`.
+
+### `co syno search` — Find by name
+
+```bash
+co syno search invoice
+co syno search '*.raw' --in /home/photos
+```
+
+Matching is case-insensitive. Without glob characters (`*`, `?`) the pattern is
+treated as a substring. Search walks subfolders, so scoping it with `--in` is
+much faster than searching everything.
+
+### `co syno get` — Download
+
+```bash
+co syno get 3
+co syno get 3 --to ~/Downloads
+co syno get /home/photos/cat.jpg
+```
+
+Takes a listing number or a full NAS path.
+
+### `co syno put` — Upload
+
+```bash
+co syno put report.pdf /home/docs
+co syno put report.pdf /home/docs --overwrite
+```
+
+Without `--overwrite`, an existing file of the same name is left alone.
+
+### `co syno share` — Sharing link
+
+```bash
+co syno share 3
+```
+
+Creates a public File Station sharing link and prints the URL.
+
+## Piping
+
+In a terminal you get a numbered table. Piped, you get tab-separated rows with
+full paths — so `cut -f4` gives you paths and nothing is truncated:
+
+```bash
+co syno ls /home/photos | cut -f4
+```
+
+## There is no `co syno rm`
+
+Deliberate. `SYNO.FileStation.Delete` deletes **permanently** — DSM's recycle
+bin is a share-level filesystem convention the web UI implements, not something
+the API exposes. Unlike `co gdrive rm`, a `co syno rm` could not be made
+recoverable, so it isn't offered. Delete from DSM, where the recycle bin
+applies.
+
+## Use it from an agent
+
+```python
+from connectonion import Agent, Synology
+
+agent = Agent("nas-assistant", tools=[Synology()])
+agent.input("Find the invoices from last month and download them")
+```
+
+## Troubleshooting
+
+**"Synology NAS not connected"** — run `co syno login`.
+
+**"Could not reach your NAS on any known address"** — the saved address is
+stale (you changed networks) or the NAS is off. Re-run `co syno login`, or use
+`--url` with a reachable address.
+
+**"2-step verification code required"** — your DSM account has 2FA on;
+`co syno login` will prompt for the code when DSM asks.
+
+**Certificate warnings** — DSM ships a self-signed certificate by default, so
+`co syno` does not verify TLS certificates for NAS connections. On a LAN
+address this is the usual tradeoff; over the relay the transport is still
+HTTPS.

--- a/docs/useful_tools/README.md
+++ b/docs/useful_tools/README.md
@@ -16,6 +16,7 @@ Pre-built tools for common agent tasks.
 | [WebFetch](web_fetch.md) | Fetch web content | `from connectonion import WebFetch` |
 | [Gmail](gmail.md) | Gmail integration | `from connectonion import Gmail` |
 | [GDrive](gdrive.md) | Google Drive files | `from connectonion import GDrive` |
+| [Synology](synology.md) | Synology NAS files | `from connectonion import Synology` |
 | [get_emails](get_emails.md) | Email parsing utilities | `from connectonion import get_emails` |
 | [send_email](send_email.md) | Send emails via API | `from connectonion import send_email` |
 | [Outlook](outlook.md) | Outlook integration | `from connectonion import Outlook` |

--- a/docs/useful_tools/synology.md
+++ b/docs/useful_tools/synology.md
@@ -1,0 +1,78 @@
+# Synology Tool
+
+Give an agent File Station access to a Synology NAS — list, search, download,
+upload, and share files.
+
+```python
+from connectonion import Agent, Synology
+
+agent = Agent("nas-assistant", tools=[Synology()])
+agent.input("Find last month's invoices and download them to ~/Downloads")
+```
+
+## Setup
+
+```bash
+co syno login
+```
+
+Saves `SYNOLOGY_URL`, `SYNOLOGY_ACCOUNT`, `SYNOLOGY_PASSWORD` and
+`SYNOLOGY_SID` to `~/.co/keys.env`. `Synology()` reads them from the
+environment; you can also pass them directly:
+
+```python
+Synology(url="https://nas.local:5001", account="aaron", password="…")
+```
+
+## Methods
+
+| Method | Does |
+|---|---|
+| `list_files(path=None, last=20)` | Shared folders, or one folder's contents |
+| `search_files(query, path="/", last=20)` | Find files by name |
+| `download(path, dest=".")` | Fetch a file to disk |
+| `upload(local_path, path, overwrite=False)` | Send a file to a NAS folder |
+| `share(path)` | Create a public sharing link, returns the URL |
+
+`list_files()` and `search_files()` return dicts:
+
+```python
+{"path": "/home/a.txt", "name": "a.txt", "type": "file", "size": 1024, "modified": 1700000000}
+```
+
+Paths start with a shared folder (`/home/photos`), not a volume
+(`/volume1/home/photos`).
+
+## Sessions
+
+DSM session ids expire after 7 days, and a duplicate login elsewhere ends them
+sooner. The tool detects both and re-authenticates transparently, so an agent
+never sees a session error.
+
+## Connecting
+
+`resolve_quickconnect(server_id)` turns a QuickConnect ID into base-URL
+candidates ordered LAN → DDNS → relay, and `pick_reachable(candidates)` returns
+the first that answers. The relay always works but is throttled by Synology, so
+it is the last resort rather than the default.
+
+Both are module-level functions, usable independently:
+
+```python
+from connectonion.useful_tools.synology import resolve_quickconnect, pick_reachable
+
+url = pick_reachable(resolve_quickconnect("mynas"))
+```
+
+## No delete
+
+`SYNO.FileStation.Delete` is permanent — DSM's recycle bin is a share-level
+filesystem convention, not an API feature. The tool does not expose delete, so
+an agent cannot irreversibly destroy NAS files.
+
+## TLS
+
+DSM ships a self-signed certificate by default, so certificate verification is
+off for NAS connections. Traffic is still HTTPS.
+
+See the [CLI docs](../cli/synology.md) for the `co syno` commands.

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -1,0 +1,301 @@
+"""Unit tests for connectonion/useful_tools/synology.py
+
+Tests cover:
+- QuickConnect resolution: candidate ordering (LAN before relay) and unknown-ID errors
+- pick_reachable: falls past unreachable candidates, raises when none answer
+- login: credentials go in the POST body, never the query string
+- stale-session retry on DSM codes 106/107/119
+- list_files/search_files normalization
+- upload: the binary part is written last, and overwrite is always explicit
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+ENV = {
+    "SYNOLOGY_URL": "https://nas.local:5001",
+    "SYNOLOGY_ACCOUNT": "aaron",
+    "SYNOLOGY_PASSWORD": "hunter2",
+    "SYNOLOGY_SID": "test-sid",
+}
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    for key, value in ENV.items():
+        monkeypatch.setenv(key, value)
+
+
+@pytest.fixture(autouse=True)
+def _no_credential_writes(monkeypatch):
+    """save_credentials() writes ~/.co/keys.env — never touch the real one in tests."""
+    import connectonion.useful_tools.synology as syno
+    monkeypatch.setattr(syno, "save_credentials", lambda **kwargs: None)
+
+
+def nas(sid="test-sid"):
+    """Build a Synology instance with API-path discovery already primed."""
+    from connectonion.useful_tools.synology import Synology
+    instance = Synology()
+    instance.sid = sid
+    instance._paths = {
+        "SYNO.API.Auth": {"path": "auth.cgi"},
+        "SYNO.FileStation.List": {"path": "entry.cgi"},
+        "SYNO.FileStation.Search": {"path": "entry.cgi"},
+        "SYNO.FileStation.Upload": {"path": "entry.cgi"},
+        "SYNO.FileStation.Sharing": {"path": "entry.cgi"},
+    }
+    return instance
+
+
+# === QuickConnect resolution ===
+
+
+def test_resolve_quickconnect_puts_lan_before_relay():
+    """The relay is throttled, so same-network addresses must be tried first."""
+    from connectonion.useful_tools.synology import resolve_quickconnect
+
+    body = {
+        "server": {
+            "port": 5001,
+            "interface": [{"ip": "192.168.1.50"}],
+            "ddns": "mynas.synology.me",
+            "external": {"ip": "203.0.113.9"},
+        },
+    }
+    with patch("httpx.post", return_value=MagicMock(json=lambda: body)):
+        candidates = resolve_quickconnect("mynas")
+
+    assert candidates[0] == "https://192.168.1.50:5001"
+    assert "https://mynas.synology.me:5001" in candidates
+    assert candidates[-1] == "https://mynas.quickconnect.to"
+
+
+def test_resolve_quickconnect_skips_null_ddns():
+    """DSM reports a literal 'NULL' string when no DDNS is configured."""
+    from connectonion.useful_tools.synology import resolve_quickconnect
+
+    body = {"server": {"port": 5001, "interface": [], "ddns": "NULL"}}
+    with patch("httpx.post", return_value=MagicMock(json=lambda: body)):
+        candidates = resolve_quickconnect("mynas")
+
+    assert not any("NULL" in c for c in candidates)
+
+
+def test_resolve_quickconnect_rejects_unknown_id():
+    """errno 4 is 'Alias not found' — verified against the live endpoint."""
+    from connectonion.useful_tools.synology import resolve_quickconnect
+
+    body = {"errno": 4, "errinfo": "get_server_info.go:92[Alias not found]"}
+    with patch("httpx.post", return_value=MagicMock(json=lambda: body)):
+        with pytest.raises(ValueError, match="not found"):
+            resolve_quickconnect("nope")
+
+
+# === Connection ladder ===
+
+
+def test_pick_reachable_falls_past_unreachable_candidates():
+    """An address that isn't on this network is expected, not fatal."""
+    from connectonion.useful_tools.synology import pick_reachable
+
+    def get(url, **kwargs):
+        if "192.168" in url:
+            raise httpx.ConnectTimeout("not on this network")
+        return MagicMock(status_code=200, json=lambda: {"success": True})
+
+    with patch("httpx.get", side_effect=get):
+        assert pick_reachable(["https://192.168.1.50:5001", "https://relay"]) == "https://relay"
+
+
+def test_pick_reachable_raises_when_nothing_answers():
+    from connectonion.useful_tools.synology import pick_reachable
+
+    with patch("httpx.get", side_effect=httpx.ConnectTimeout("down")):
+        with pytest.raises(ValueError, match="Could not reach"):
+            pick_reachable(["https://a", "https://b"])
+
+
+# === Auth ===
+
+
+def test_login_sends_password_in_body_not_query():
+    """The official examples put passwd= in a GET query string, where it lands
+    in proxy and server logs. We POST it instead."""
+    from connectonion.useful_tools.synology import Synology
+
+    client = MagicMock()
+    client.post.return_value = MagicMock(json=lambda: {"success": True, "data": {"sid": "fresh-sid"}})
+    client.__enter__ = lambda self: client
+    client.__exit__ = lambda *a: None
+
+    instance = nas(sid="")
+    with patch.object(Synology, "_client", return_value=client):
+        instance._login()
+
+    assert instance.sid == "fresh-sid"
+    body = client.post.call_args.kwargs["data"]
+    assert body["passwd"] == "hunter2"
+    assert body["format"] == "sid"
+    assert "params" not in client.post.call_args.kwargs
+
+
+def test_login_decodes_wrong_password():
+    from connectonion.useful_tools.synology import Synology
+
+    client = MagicMock()
+    client.post.return_value = MagicMock(json=lambda: {"success": False, "error": {"code": 400}})
+    client.__enter__ = lambda self: client
+    client.__exit__ = lambda *a: None
+
+    with patch.object(Synology, "_client", return_value=client):
+        with pytest.raises(ValueError, match="incorrect password"):
+            nas(sid="")._login()
+
+
+@pytest.mark.parametrize("code", [106, 107, 119])
+def test_stale_session_triggers_one_relogin_then_retries(code):
+    """Sessions expire after 7 days and die on duplicate login — re-auth silently."""
+    from connectonion.useful_tools.synology import Synology
+
+    instance = nas()
+    replies = [
+        {"success": False, "error": {"code": code}},
+        {"success": True, "data": {"files": []}},
+    ]
+
+    with patch.object(Synology, "_call", side_effect=replies) as call:
+        with patch.object(Synology, "_login") as login:
+            instance._request("SYNO.FileStation.List", "list", folder_path="/home")
+
+    assert login.call_count == 1
+    assert call.call_count == 2
+
+
+def test_real_error_is_not_retried():
+    """A missing file is a real answer, not a dead session — surface it."""
+    from connectonion.useful_tools.synology import Synology
+
+    instance = nas()
+    with patch.object(Synology, "_call", return_value={"success": False, "error": {"code": 408}}) as call:
+        with pytest.raises(ValueError, match="No such file or directory"):
+            instance._request("SYNO.FileStation.List", "list", folder_path="/nope")
+
+    assert call.call_count == 1
+
+
+# === Listing ===
+
+
+def test_list_files_without_path_lists_shares():
+    from connectonion.useful_tools.synology import Synology
+
+    data = {"shares": [{"path": "/home", "name": "home", "isdir": True}]}
+    with patch.object(Synology, "_request", return_value=data) as request:
+        files = nas().list_files()
+
+    assert request.call_args.args[1] == "list_share"
+    assert files == [{"path": "/home", "name": "home", "type": "dir", "size": 0, "modified": 0}]
+
+
+def test_list_files_normalizes_entries():
+    from connectonion.useful_tools.synology import Synology
+
+    data = {
+        "files": [
+            {"path": "/home/a.txt", "name": "a.txt", "isdir": False,
+             "additional": {"size": 1024, "time": {"mtime": 1700000000}}},
+        ]
+    }
+    with patch.object(Synology, "_request", return_value=data):
+        files = nas().list_files(path="/home")
+
+    assert files[0] == {
+        "path": "/home/a.txt", "name": "a.txt", "type": "file",
+        "size": 1024, "modified": 1700000000,
+    }
+
+
+def test_list_files_rejects_nonsense_count():
+    assert nas().list_files(last=0) == []
+
+
+def test_search_runs_start_poll_clean():
+    """File Station search is non-blocking: start, poll until finished, clean up."""
+    from connectonion.useful_tools.synology import Synology
+
+    replies = [
+        {"taskid": "task-1"},
+        {"finished": True, "files": [{"path": "/home/cat.jpg", "name": "cat.jpg", "isdir": False}]},
+        {},
+    ]
+    with patch.object(Synology, "_request", side_effect=replies) as request:
+        files = nas().search_files("cat")
+
+    methods = [call.args[1] for call in request.call_args_list]
+    assert methods == ["start", "list", "clean"]
+    assert files[0]["name"] == "cat.jpg"
+
+
+def test_search_ignores_empty_query():
+    assert nas().search_files("   ") == []
+
+
+# === Transfer ===
+
+
+def test_upload_writes_binary_part_last_and_always_sets_overwrite(tmp_path):
+    """DSM requires the file part last (RFC 1867), and returns error 1805 when
+    overwrite is unspecified and the destination exists."""
+    from connectonion.useful_tools.synology import Synology
+
+    local = tmp_path / "note.txt"
+    local.write_text("hello")
+
+    client = MagicMock()
+    client.post.return_value = MagicMock(json=lambda: {"success": True})
+    client.__enter__ = lambda self: client
+    client.__exit__ = lambda *a: None
+
+    with patch.object(Synology, "_client", return_value=client):
+        result = nas().upload(str(local), "/home/docs")
+
+    kwargs = client.post.call_args.kwargs
+    # httpx serializes every `data` field before any `files` entry, which is
+    # what puts the binary part last on the wire.
+    assert "file" in kwargs["files"]
+    assert kwargs["data"]["overwrite"] == "false"
+    assert kwargs["data"]["path"] == "/home/docs"
+    assert "note.txt" in result
+
+
+def test_upload_rejects_missing_local_file():
+    with pytest.raises(ValueError, match="File not found"):
+        nas().upload("/no/such/file.txt", "/home")
+
+
+def test_share_returns_the_url():
+    from connectonion.useful_tools.synology import Synology
+
+    data = {"links": [{"url": "https://nas.local/sharing/abc123"}]}
+    with patch.object(Synology, "_request", return_value=data):
+        assert nas().share("/home/a.txt") == "https://nas.local/sharing/abc123"
+
+
+def test_share_raises_when_no_link_came_back():
+    from connectonion.useful_tools.synology import Synology
+
+    with patch.object(Synology, "_request", return_value={"links": []}):
+        with pytest.raises(ValueError, match="no sharing link"):
+            nas().share("/home/a.txt")
+
+
+def test_missing_url_tells_the_user_to_log_in(monkeypatch):
+    from connectonion.useful_tools.synology import Synology
+
+    monkeypatch.delenv("SYNOLOGY_URL")
+    with pytest.raises(ValueError, match="co syno login"):
+        Synology()


### PR DESCRIPTION
Closes #257.

`co gdrive`, `co gmail`, and `co outlook` cover the cloud accounts. A Synology NAS was the one storage surface still stuck behind the DSM web UI. This adds `co syno`.

```bash
co syno login              # QuickConnect ID, or --url
co syno                    # shared folders
co syno ls /home/photos
co syno search invoice --in /home
co syno get 3 --to ~/Downloads
co syno put report.pdf /home/docs
co syno share 3
```

Deliberately the same command shape and numbered-listing UX as `co gdrive`, so there's nothing new to learn.

## Why no new dependency

File Station is [officially documented](https://global.download.synology.com/download/Document/Software/DeveloperGuide/Package/FileStation/All/enu/Synology_File_Station_API_Guide.pdf) plain HTTP with JSON responses — no library needed, and `httpx` is already a dependency. The undocumented half is QuickConnect, and the best-known Python client ([synology-api](https://github.com/N4S4/synology-api)) resolves it **straight to the relay with no LAN fallback**, so depending on it would mean adding weight to every ConnectOnion install *and* still writing the connection ladder. Its value was protocol knowledge, not code.

## Three things worth reviewing

**QuickConnect is not one address.** The NAS may be on this LAN, at a DDNS name, or only reachable through Synology's relay — and Synology throttles the relay hard. `login` probes LAN first and caches whichever answered, so you get gigabit at home without losing access from a café. `--url` skips QuickConnect entirely, which also means the undocumented protocol can never become a hard dependency: if Synology changes the handshake, `co syno` degrades to "type your address" instead of dying.

**API paths and versions are discovered, not hardcoded.** `SYNO.API.Info` is queried once per session because DSM moves CGI paths and bumps max versions between releases. This is the detail that usually rots these integrations.

**There is no `co syno rm`.** `SYNO.FileStation.Delete` deletes permanently — the word "recycle" does not appear anywhere in the 112-page spec, because DSM's recycle bin is a share-level filesystem convention the web UI implements, not an API affordance. Unlike `co gdrive rm`, it could not be made recoverable, so rather than ship a delete that's quietly more destructive than its gdrive counterpart, it's left out. This reverses what the issue originally proposed.

## Other decisions

- Credentials live in `~/.co/keys.env` and never touch oo-api — a NAS has no OAuth to broker, hence no `co auth synology`.
- Passwords go in the POST body. Every example in the official guide passes `passwd=` in a GET query string, where it lands in proxy and server logs.
- Sessions expire after 7 days and die on duplicate login; DSM codes 106/107/119 trigger one silent re-auth so agents never see a session error.
- Upload sends the binary part last, per the RFC 1867 constraint the spec calls out, and always sets `overwrite` explicitly (DSM returns error 1805 rather than defaulting).

## Testing

21 new unit tests covering candidate ordering, the fallback ladder, credential handling, stale-session retry, response normalization, and the upload constraints.

```
tests/unit/test_synology.py .....................  21 passed
tests/unit (full)                                  2295 passed, 3 skipped
tests/e2e/cli                                      332 passed, 3 skipped
```

## ⚠️ Not yet run against real hardware

**This has not touched a physical NAS.** Every API shape is taken from the official spec and the tests are mocked. What I verified live is the QuickConnect resolution endpoint — it responds and returns `{"errno":4,"errinfo":"...[Alias not found]"}` for an unknown alias.

The piece most likely to need adjustment is `resolve_quickconnect()`: which candidate fields a real `get_server_info` returns, and in what shape, is the one thing that can't be settled from documentation. **Please don't merge before someone runs `co syno login` against an actual NAS.**

One more known tradeoff: TLS certificate verification is disabled for NAS connections, because DSM ships a self-signed certificate by default. Traffic is still HTTPS. Worth a second opinion on whether that should be opt-in instead.
