### PR TITLE
Add YOLO mode to co ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,20 @@ Inject logic at any point in the agent execution cycle:
 
 ```python
 from connectonion import Agent, after_tools, llm_do
-from connectonion.useful_plugins import re_act, eval, auto_compact, subagents, ulw
+from connectonion.useful_plugins import re_act, eval, auto_compact, subagents, yolo
 
 # Built-in plugins — same capabilities as Claude Code, open to any agent
 agent = Agent("researcher", tools=[search], plugins=[
     re_act,         # Reflect + plan after each tool call
     auto_compact,   # Auto-compress context at 90% capacity
     subagents,      # Spawn sub-agents with independent tools and prompts
-    ulw,            # Ultra Light Work — fully autonomous mode
+    yolo(turns=25), # Bounded approval-free autonomous mode
 ])
 ```
 
-These plugins mirror Claude Code's internal capabilities — `auto_compact`, `subagents`, `ulw` directly correspond to Claude Code's context compression, sub-agent spawning, and autonomous work mode. ConnectOnion makes these capabilities available to any agent you build.
+These plugins mirror coding-agent capabilities such as context compression,
+sub-agent spawning, and autonomous work. Existing `ulw` imports and frontend
+messages remain supported as compatibility aliases for `yolo`.
 
 Hooks: `after_user_input`, `before_iteration`, `before_llm`, `after_llm`, `before_tools`, `before_each_tool`, `after_each_tool`, `after_tools`, `on_error`, `after_iteration`, `on_stop_signal`, `on_complete`
 
@@ -759,7 +761,7 @@ Plugins are lists of lifecycle hooks that inject logic at any point in the agent
 - `re_act`: Reflect + plan after each tool call
 - `auto_compact`: Auto-compress context at 90% capacity
 - `subagents`: Spawn sub-agents with independent tools
-- `ulw`: Ultra Light Work — fully autonomous mode
+- `yolo`: Bounded approval-free autonomous mode (`ulw` remains compatible)
 
 ```python
 from connectonion.useful_plugins import re_act, subagents
@@ -915,7 +917,7 @@ ConnectOnion is a simple, elegant framework for production-ready AI agents. Phil
 | Approval System | Dangerous ops auto-trigger approval |
 | Skills System | Claude Code compatible, auto-discovery |
 | 12 Lifecycle Hooks | Inject logic at any point |
-| Plugin System | re_act, auto_compact, subagents, ulw |
+| Plugin System | re_act, auto_compact, subagents, yolo |
 | Multi-Agent Trust | Fast rules, zero token cost |
 
 ### Quick Start
@@ -941,7 +943,7 @@ co copy Gmail  # Copy tool source for modification
 | re_act | Reflect + plan after each tool | - |
 | auto_compact | Auto-compress context at 90% | Context compression |
 | subagents | Spawn sub-agents | Sub-agent spawning |
-| ulw | Ultra Light Work autonomous | Autonomous mode |
+| yolo / ulw | Bounded autonomous work | Autonomous mode |
 
 ### Skills Auto-Discovery
 

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -18,7 +18,7 @@ Plugins included:
 - prefer_write_tool: Block bash file creation, soft-remind for file reading
 - tool_approval: Approval flow for dangerous operations
 - auto_compact: Context window management
-- ulw: Ultra work mode (autonomous N-turn sessions with continuation)
+- yolo/ulw: Bounded autonomous work with approval bypass and continuation
 
 Architecture:
 - Uses prompt assembly from prompts/assembler.py
@@ -46,7 +46,7 @@ from .skills import skill
 from .plugins import system_reminder
 from connectonion import Agent, bash, TodoList
 from connectonion.useful_tools.browser_tools import BrowserAutomation
-from connectonion.useful_plugins import eval, tool_approval, auto_compact, prefer_write_tool, ulw, subagents, image_result_formatter, runtime_input, bind_browser_session
+from connectonion.useful_plugins import eval, tool_approval, auto_compact, prefer_write_tool, ulw, yolo, subagents, image_result_formatter, runtime_input, bind_browser_session
 from connectonion.useful_plugins.skills import skills as skills_plugin
 
 
@@ -59,6 +59,7 @@ def create_coding_agent(
     model: str = "co/gemini-3.6-flash",
     max_iterations: int = 100,
     co_dir: Path = Path(".co"),
+    yolo_turns: int | None = None,
 ) -> Agent:
     todo = TodoList()
     file_tools = FileTools()
@@ -95,7 +96,8 @@ def create_coding_agent(
     # bind_browser_session routes each chat panel to its own browser tab: co ai is
     # served via host(), which runs every session's turns on the shared BrowserAutomation,
     # so without it concurrent panels navigate over one shared page.
-    plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, ulw, image_result_formatter, runtime_input, bind_browser_session]
+    autonomous_work = yolo(yolo_turns) if yolo_turns is not None else ulw
+    plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, autonomous_work, image_result_formatter, runtime_input, bind_browser_session]
 
     agent = Agent(
         name="oo",

--- a/connectonion/cli/co_ai/prompts/connectonion/index.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/index.md
@@ -96,7 +96,7 @@ Use `load_guide(path)` to load detailed documentation.
 | `useful_plugins/auto_compact` | Context window management |
 | `useful_plugins/image_result_formatter` | Format base64 images for vision models |
 | `useful_plugins/prefer_write_tool` | Block bash file creation, soft-remind for file reading |
-| `useful_plugins/ulw` | Ultra work mode — autonomous multi-turn sessions |
+| `useful_plugins/yolo` | Bounded approval-free autonomous work (`ulw` compatible) |
 | `useful_plugins/gmail_plugin` | Email approval and CRM sync |
 | `useful_plugins/calendar_plugin` | Calendar operation approval |
 

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -12,6 +12,8 @@ def handle_ai(
     port: int = 8000,
     model: str = "co/claude-opus-4-5",
     max_iterations: int = 100,
+    yolo: bool = False,
+    yolo_turns: int = 100,
 ):
     """Start AI coding agent or run one-shot prompt.
 
@@ -20,6 +22,8 @@ def handle_ai(
         port: Port for web server
         model: LLM model to use
         max_iterations: Max tool iterations
+        yolo: Run in bounded approval-free autonomous mode
+        yolo_turns: Completed turns before the YOLO checkpoint
 
     Examples:
         co ai                                    # Start web server
@@ -30,6 +34,7 @@ def handle_ai(
         model=model,
         max_iterations=max_iterations,
         co_dir=GLOBAL_CO_DIR,
+        yolo_turns=yolo_turns if yolo else None,
     )
 
     if prompt:

--- a/connectonion/cli/commands/copy_commands.py
+++ b/connectonion/cli/commands/copy_commands.py
@@ -56,6 +56,7 @@ PLUGINS = {
     "system_reminder": "system_reminder.py",
     "ui_stream": "ui_stream.py",
     "ulw": "ulw.py",
+    "yolo": "ulw.py",
 }
 
 # Registry of copyable plugin directories

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -214,10 +214,19 @@ def ai(
     port: int = typer.Option(8000, "--port", "-p", help="Port for web server"),
     model: str = typer.Option("co/gemini-3.6-flash", "--model", "-m", help="Model to use"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations"),
+    yolo: bool = typer.Option(False, "--yolo", help="Skip approvals and keep working autonomously"),
+    yolo_turns: int = typer.Option(100, "--yolo-turns", min=1, help="Completed turns before a YOLO checkpoint"),
 ):
     """Start AI coding agent or run one-shot prompt."""
     from .commands.ai_commands import handle_ai
-    handle_ai(prompt=prompt, port=port, model=model, max_iterations=max_iterations)
+    handle_ai(
+        prompt=prompt,
+        port=port,
+        model=model,
+        max_iterations=max_iterations,
+        yolo=yolo,
+        yolo_turns=yolo_turns,
+    )
 
 
 @app.command()

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -60,6 +60,11 @@ class Agent:
         # Session storage (None locally, injected by host() for persistence)
         self.storage = None
 
+        # Runtime-only continuation queue. Plugins can enqueue another user turn
+        # without recursively calling input(); it is never restored or synced as
+        # part of current_session.
+        self._pending_inputs: List[str] = []
+
         # Token usage tracking
         self.total_cost: float = 0.0  # Cumulative cost in USD
         self.last_usage: Optional[TokenUsage] = None  # From most recent LLM call
@@ -240,10 +245,6 @@ class Agent:
         Returns:
             The agent's response after processing the input
         """
-        start_time = time.time()
-        if self.logger.console:
-            self.logger.console.print_task(prompt)
-
         # Session restoration: if session passed, restore it (stateless API continuation)
         if session is not None:
             self.current_session = {
@@ -292,6 +293,50 @@ class Agent:
             file_list = "\n".join(f"- {p}" for p in saved_files)
             prompt += f"\n\n<system-reminder>The user uploaded the following files:\n{file_list}\nUse your read_file tool or other available tools to read the file contents before responding. Do not assume or guess the contents.</system-reminder>"
 
+        self._pending_inputs.clear()
+        try:
+            result = self._run_input_turn(
+                prompt,
+                max_iterations=max_iterations or self.max_iterations,
+                images=images,
+                saved_files=saved_files,
+            )
+
+            # Drain plugin-requested continuations iteratively. Recursive
+            # agent.input() calls used to return the first result, reverse log
+            # ordering, and eventually hit Python's recursion limit.
+            while self._pending_inputs:
+                next_prompt = self._pending_inputs.pop(0)
+                result = self._run_input_turn(
+                    next_prompt,
+                    max_iterations=self.max_iterations,
+                    images=None,
+                    saved_files=[],
+                )
+
+            return result
+        finally:
+            # Never leak continuations into a later user request after an error.
+            self._pending_inputs.clear()
+
+    def _queue_input(self, prompt: str) -> None:
+        """Queue a runtime-only continuation for the active input call."""
+        if not isinstance(prompt, str) or not prompt:
+            raise ValueError("queued input must be a non-empty string")
+        self._pending_inputs.append(prompt)
+
+    def _run_input_turn(
+        self,
+        prompt: str,
+        *,
+        max_iterations: int,
+        images: list[str] | None,
+        saved_files: list[str],
+    ) -> str:
+        """Run one input turn, including its complete event and turn log."""
+        if self.logger.console:
+            self.logger.console.print_task(prompt)
+
         # Add user message to conversation (multimodal if images provided)
         if images:
             content = [{"type": "text", "text": prompt}]
@@ -327,9 +372,7 @@ class Agent:
 
         # Process
         self.current_session['iteration'] = 0  # Reset iteration for this turn
-        result = self._run_iteration_loop(
-            max_iterations or self.max_iterations
-        )
+        result = self._run_iteration_loop(max_iterations)
 
         # Calculate duration
         duration = time.time() - turn_start
@@ -427,6 +470,12 @@ class Agent:
             if not response.tool_calls:
                 content = response.content or ""
                 self.current_session['messages'].append({"role": "assistant", "content": content})
+                # after_llm handlers can detect a text-only graceful interrupt.
+                # Honor it here without firing after_iteration, whose existing
+                # contract is the completed tool-call boundary.
+                if self.current_session.pop('stop_signal', None):
+                    self._invoke_events('on_stop_signal')
+                    return "What would you like me to do?"
                 return content
 
             # Process tool calls

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -21,7 +21,7 @@ from .system_reminder import system_reminder
 from .tool_approval import tool_approval, handle_mode_change
 from .auto_compact import auto_compact
 from .prefer_write_tool import prefer_write_tool
-from .ulw import ulw, handle_ulw_mode_change
+from .ulw import ulw, yolo, handle_ulw_mode_change, handle_yolo_mode_change
 from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
@@ -29,4 +29,4 @@ from .no_progress_guard import no_progress_guard
 from .human_jitter import human_jitter
 from .bind_browser_session import bind_browser_session
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'no_progress_guard', 'human_jitter', 'bind_browser_session']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'yolo', 'handle_ulw_mode_change', 'handle_yolo_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'no_progress_guard', 'human_jitter', 'bind_browser_session']

--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -117,12 +117,12 @@ def evaluate_completion(agent: 'Agent') -> None:
     Generates expected outcome (if not set) and evaluates AFTER task completes.
     This avoids blocking the main workflow.
 
-    Skips evaluation in ULW mode since the agent is still working autonomously.
+    Skips evaluation in YOLO/ULW mode since the agent is still working autonomously.
     """
     import uuid
 
-    # Skip eval in ULW mode - agent is still working, not done yet
-    if agent.current_session.get('mode') == 'ulw':
+    # Skip eval in autonomous mode - agent is still working, not done yet
+    if agent.current_session.get('mode') in {'yolo', 'ulw'}:
         return
 
     user_prompt = agent.current_session.get('user_prompt', '')

--- a/connectonion/useful_plugins/tool_approval/__init__.py
+++ b/connectonion/useful_plugins/tool_approval/__init__.py
@@ -30,7 +30,8 @@ Mode System:
 - "safe" (default): Dangerous tools need approval
 - "plan": Read-only only, exit_plan_and_implement uses its own io.send/receive
 - "accept_edits": File edits auto-approved, other dangerous tools need approval
-- "ulw": Handled by ulw plugin - bypasses all approvals
+- "yolo": Public autonomous mode - bypasses all approvals
+- "ulw": Backward-compatible autonomous mode - bypasses all approvals
 
 Session Memory:
 - scope="once": Approve for this call only
@@ -166,7 +167,7 @@ Architecture - Unified Permission System Lifecycle:
 
 Integration with other plugins:
     - skills plugin: grants turn-scoped permissions, snapshots/restores
-    - ulw plugin: sets skip_tool_approval=True to bypass all checks
+    - yolo/ulw plugin: sets skip_tool_approval=True to bypass all checks
     - tool_approval: owns matches_permission_pattern() for validation
     - co_ai CLI: includes tool_approval by default for WebSocket agent
 
@@ -188,6 +189,7 @@ from .approval import (
     load_config_permissions,
     poll_mode_changes,
     poll_interrupt,
+    poll_interrupt_after_text,
     handle_mode_change,
     get_current_mode,
 )
@@ -195,7 +197,13 @@ from .constants import VALID_MODES, DEFAULT_MODE
 
 # Export as plugin (list of event handlers)
 # Usage: Agent("name", plugins=[tool_approval])
-tool_approval = [load_config_permissions, poll_mode_changes, poll_interrupt, check_approval]
+tool_approval = [
+    load_config_permissions,
+    poll_mode_changes,
+    poll_interrupt,
+    poll_interrupt_after_text,
+    check_approval,
+]
 
 # Export mode functions for external use
 __all__ = [

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -43,7 +43,7 @@ Mode System (session['mode']):
         - Other dangerous tools: need approval (bash, send_email)
         - Used for: rapid editing with approval only for risky ops
 
-    ulw (handled by ulw plugin):
+    yolo / ulw (handled by the autonomous-work plugin):
         - Sets skip_tool_approval=True → bypasses all checks
         - Used for: unlimited write access (trusted scenarios)
 
@@ -202,7 +202,13 @@ File Relationships:
 from typing import TYPE_CHECKING
 from pathlib import Path
 
-from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
+from ...core.events import (
+    after_iteration,
+    after_llm,
+    after_user_input,
+    before_each_tool,
+    before_iteration,
+)
 from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
 from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
 
@@ -431,7 +437,7 @@ def check_approval(agent: 'Agent') -> None:
                 # Check if ALL commands in chain are permitted
                 permitted, reason, source = check_bash_chain_permitted(tool_args['command'], permissions)
                 if permitted:
-                    if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+                    if getattr(getattr(agent, 'logger', None), 'console', None):
                         agent.logger.console.log_permission_granted('bash', tool_args, source, reason)
                     return
 
@@ -460,19 +466,25 @@ def check_approval(agent: 'Agent') -> None:
                     # Pattern matched (and params matched if 'when' field exists)
                     reason = perm.get('reason', 'unknown')
                     source = perm.get('source', 'config')
-                    if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+                    if getattr(getattr(agent, 'logger', None), 'console', None):
                         agent.logger.console.log_permission_granted(tool_name, tool_args, source, reason)
                     return
 
     # =================================================================
-    # Check if another plugin requested to skip approvals (e.g., ulw)
+    # Check if the bounded autonomous-work plugin requested to skip approvals.
     # =================================================================
-    if agent.current_session.get('mode') == 'ulw':
+    autonomous_mode = agent.current_session.get('mode')
+    if autonomous_mode in {'yolo', 'ulw'}:
         pending = agent.current_session.get('pending_tool')
         tool_name = pending['name'] if pending else 'unknown'
         tool_args = pending.get('arguments', {}) if pending else {}
-        if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
-            agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'ulw mode')
+        if getattr(getattr(agent, 'logger', None), 'console', None):
+            agent.logger.console.log_permission_granted(
+                tool_name,
+                tool_args,
+                'mode',
+                f'{autonomous_mode} mode',
+            )
         return
 
     # reject_hard was set by a previous tool in this batch — reject remaining
@@ -497,7 +509,7 @@ def check_approval(agent: 'Agent') -> None:
     # =================================================================
     if mode == 'accept_edits':
         if tool_name in FILE_EDIT_TOOLS:
-            if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+            if getattr(getattr(agent, 'logger', None), 'console', None):
                 agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'accept_edits mode')
             return
         # Other dangerous tools fall through to approval logic
@@ -762,7 +774,7 @@ def poll_mode_changes(agent: 'Agent') -> None:
     """Poll for mode_change signals at iteration start.
 
     Checks if client sent mode_change while agent was working.
-    Handles all modes: safe, plan, accept_edits, ulw.
+    Handles all modes: safe, plan, accept_edits, yolo, ulw.
     """
     if not agent.io:
         return
@@ -771,26 +783,37 @@ def poll_mode_changes(agent: 'Agent') -> None:
         new_mode = msg.get('mode')
         if new_mode in VALID_MODES:
             handle_mode_change(agent, new_mode)
-        elif new_mode == 'ulw':
-            from ..ulw import handle_ulw_mode_change
-            handle_ulw_mode_change(agent, msg.get('turns'))
+        elif new_mode in {'yolo', 'ulw'}:
+            from ..ulw import handle_ulw_mode_change, handle_yolo_mode_change
+            handler = handle_yolo_mode_change if new_mode == 'yolo' else handle_ulw_mode_change
+            handler(agent, msg.get('turns'))
+
+
+def _poll_interrupt(agent: 'Agent') -> None:
+    """Drain one pending interrupt into the Agent's standard stop signal."""
+    if agent.io and agent.io.receive_all('INTERRUPT'):
+        agent.current_session['stop_signal'] = 'user_interrupt'
 
 
 @after_iteration
 def poll_interrupt(agent: 'Agent') -> None:
-    """Stop the run at the iteration boundary when the client sent an INTERRUPT.
+    """Poll after a tool-call iteration so its current batch finishes first."""
+    _poll_interrupt(agent)
 
-    Graceful stop: drains an INTERRUPT frame and sets the existing stop_signal,
-    which the iteration loop already honors right after after_iteration (halts and
-    returns a closing message). Runs after_iteration so the current step (LLM call
-    + tools) finishes first — not a mid-flight abort. Same primitive and placement
-    as no_progress_guard; no core changes.
-    """
-    if not agent.io:
-        return
 
-    if agent.io.receive_all('INTERRUPT'):
-        agent.current_session['stop_signal'] = 'user_interrupt'
+@after_llm
+def poll_interrupt_after_text(agent: 'Agent') -> None:
+    """Poll after a terminal text response, which has no after_iteration event."""
+    llm_result = next(
+        (
+            entry
+            for entry in reversed(agent.current_session.get('trace', []))
+            if entry.get('type') == 'llm_result'
+        ),
+        None,
+    )
+    if llm_result and llm_result.get('tool_calls_count') == 0:
+        _poll_interrupt(agent)
 
 
 # =============================================================================
@@ -802,14 +825,14 @@ def handle_mode_change(agent: 'Agent', mode: str) -> None:
 
     Called when frontend sends { type: 'mode_change', mode: '...' }
     Only handles modes known to this plugin (safe, plan, accept_edits).
-    Other modes (e.g., ulw) should be handled by their respective plugins.
+    Other modes (for example yolo/ulw) are handled by their respective plugin.
 
     Args:
         agent: Agent instance
         mode: New mode ('safe', 'plan', 'accept_edits')
     """
     if mode not in VALID_MODES:
-        # Unknown mode - might be handled by another plugin (e.g., ulw)
+        # Unknown mode - might be handled by another plugin (for example yolo/ulw)
         return
 
     old_mode = _get_mode(agent)

--- a/connectonion/useful_plugins/tool_approval/constants.py
+++ b/connectonion/useful_plugins/tool_approval/constants.py
@@ -33,8 +33,9 @@ Tool Classification:
 #   - 'plan': Read-only tools only, exit_plan_and_implement shows plan for approval
 #   - 'accept_edits': File edit tools auto-approved, other dangerous tools need approval
 #
-# Other modes (handled by separate plugins via skip_tool_approval flag):
-#   - 'ulw': Handled by ulw plugin - sets skip_tool_approval=True
+# Other modes (handled by the autonomous-work plugin):
+#   - 'yolo': Public CLI mode - sets skip_tool_approval=True
+#   - 'ulw': Backward-compatible frontend alias for yolo
 #
 # Mode can be changed by:
 #   - User: via WebSocket { type: 'mode_change', mode: '...' }

--- a/connectonion/useful_plugins/ulw.py
+++ b/connectonion/useful_plugins/ulw.py
@@ -1,35 +1,44 @@
 """
-Purpose: ULW (Ultra Light Work) plugin - autonomous agent mode with turn-based checkpoints
+Purpose: YOLO/ULW autonomous agent mode with turn-based checkpoints
 LLM-Note:
   Dependencies: imports from [core/events.py] | imported by [useful_plugins/__init__.py]
-  Data flow: mode_change to 'ulw' → set skip_tool_approval=True → on_complete fires → continue until max turns
+  Data flow: --yolo or mode_change to 'yolo'/'ulw' → skip approvals → on_complete continues until max turns
   State/Effects: sets mode, ulw_turns, ulw_turns_used, skip_tool_approval in session
   Integration: communicates with tool_approval via skip_tool_approval flag in session
-  Errors: no explicit error handling, agent.input() failures propagate
+  Errors: continuation failures propagate; a stop signal exits autonomous mode
 
-ULW Mode - Ultra Light Work.
+YOLO mode is the public name for approval-free autonomous work. ULW remains a
+backward-compatible plugin and wire-protocol name for existing clients.
 
-When in ULW mode:
+When in YOLO/ULW mode:
 1. All tool approvals are skipped (via skip_tool_approval flag)
 2. Agent keeps working until max turns reached
 3. At checkpoint, user can continue, switch mode, or stop
 
 Usage:
     from connectonion import Agent
-    from connectonion.useful_plugins import tool_approval, ulw
+    from connectonion.useful_plugins import tool_approval, yolo
 
-    agent = Agent("worker", plugins=[tool_approval, ulw])
+    agent = Agent("worker", plugins=[tool_approval, yolo(turns=25)])
 """
 
 from typing import TYPE_CHECKING
 
-from ..core.events import on_complete, before_iteration, before_llm
+from ..core.events import (
+    after_user_input,
+    before_iteration,
+    before_llm,
+    on_complete,
+    on_stop_signal,
+)
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
 
 
 ULW_DEFAULT_TURNS = 100
+YOLO_DEFAULT_TURNS = ULW_DEFAULT_TURNS
+AUTONOMOUS_MODES = frozenset({"yolo", "ulw"})
 
 ULW_CONTINUE_PROMPT = """Review what you've done so far. Consider:
 - Are there edge cases not handled?
@@ -38,6 +47,7 @@ ULW_CONTINUE_PROMPT = """Review what you've done so far. Consider:
 - Any obvious improvements?
 
 Continue improving, or say "genuinely complete" if nothing meaningful left to do."""
+YOLO_CONTINUE_PROMPT = ULW_CONTINUE_PROMPT
 
 
 def _log(agent: 'Agent', message: str) -> None:
@@ -46,8 +56,50 @@ def _log(agent: 'Agent', message: str) -> None:
         agent.logger.print(message)
 
 
+def _validate_turns(turns: int | None) -> int:
+    """Return a positive turn budget, using the default when omitted."""
+    if turns is None:
+        return YOLO_DEFAULT_TURNS
+    if isinstance(turns, bool) or not isinstance(turns, int) or turns <= 0:
+        raise ValueError("turns must be a positive integer")
+    return turns
+
+
+def _activate_autonomous_mode(
+    agent: 'Agent',
+    mode: str,
+    turns: int | None,
+    *,
+    label: str | None = None,
+) -> None:
+    """Activate a named autonomous mode while retaining ULW state keys."""
+    turn_budget = _validate_turns(turns)
+    old_mode = agent.current_session.get('mode', 'safe')
+    display_name = label or mode
+
+    # Keep the ulw_* keys and events stable for existing SDK and oo-chat clients.
+    agent.current_session['mode'] = mode
+    agent.current_session['ulw_turns'] = turn_budget
+    agent.current_session['ulw_turns_used'] = 0
+    agent.current_session['skip_tool_approval'] = True
+
+    if agent.io:
+        agent.io.send({'type': 'mode_changed', 'mode': mode, 'triggered_by': 'user'})
+
+    _log(agent, f"[cyan]Mode changed: {old_mode} → {display_name} ({turn_budget} turns)[/cyan]")
+
+
+def handle_yolo_mode_change(agent: 'Agent', turns: int = None) -> None:
+    """Activate public YOLO mode.
+
+    CLI callers use this public name. Runtime state and frontend messages remain
+    ``ulw`` so currently deployed SDK and oo-chat clients stay compatible.
+    """
+    _activate_autonomous_mode(agent, 'ulw', turns, label='yolo')
+
+
 def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
-    """Handle mode change to ULW.
+    """Handle the legacy ULW mode change.
 
     Called when frontend sends { type: 'mode_change', mode: 'ulw', turns: N }
 
@@ -61,42 +113,44 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
         agent: Agent instance
         turns: Max turns before checkpoint (default: 100)
     """
-    old_mode = agent.current_session.get('mode', 'safe')
-
-    # Set ULW state
-    agent.current_session['mode'] = 'ulw'
-    agent.current_session['ulw_turns'] = turns or ULW_DEFAULT_TURNS
-    agent.current_session['ulw_turns_used'] = 0
-    agent.current_session['skip_tool_approval'] = True
-
-    # Notify frontend
-    if agent.io:
-        agent.io.send({'type': 'mode_changed', 'mode': 'ulw', 'triggered_by': 'user'})
-
-    _log(agent, f"[cyan]Mode changed: {old_mode} → ulw ({agent.current_session['ulw_turns']} turns)[/cyan]")
+    # Older clients used zero as the "use the default" sentinel. Keep that
+    # wire behavior while the public YOLO API and CLI reject non-positive input.
+    if turns == 0 and not isinstance(turns, bool):
+        turns = None
+    _activate_autonomous_mode(agent, 'ulw', turns)
 
 
-def _exit_ulw_mode(agent: 'Agent', new_mode: str = 'safe') -> None:
-    """Exit ULW mode and switch to another mode.
+def _exit_autonomous_mode(
+    agent: 'Agent',
+    new_mode: str = 'safe',
+    *,
+    triggered_by: str | None = None,
+) -> None:
+    """Exit YOLO/ULW mode and switch to another mode.
 
     Cleans up ULW state and clears skip_tool_approval flag.
     """
+    old_mode = agent.current_session.get('mode', 'yolo')
     agent.current_session.pop('skip_tool_approval', None)
     agent.current_session.pop('ulw_turns', None)
     agent.current_session.pop('ulw_turns_used', None)
     agent.current_session['mode'] = new_mode
 
     if agent.io:
-        agent.io.send({'type': 'mode_changed', 'mode': new_mode, 'triggered_by': 'ulw_checkpoint'})
+        agent.io.send({
+            'type': 'mode_changed',
+            'mode': new_mode,
+            'triggered_by': triggered_by or f'{old_mode}_checkpoint',
+        })
 
-    _log(agent, f"[cyan]Exited ULW mode → {new_mode}[/cyan]")
+    _log(agent, f"[cyan]Exited {old_mode} mode → {new_mode}[/cyan]")
 
 
 @on_complete
 def ulw_keep_working(agent: 'Agent') -> None:
-    """If ULW mode and turns remaining, start another turn."""
+    """If YOLO/ULW mode and turns remain, start another turn."""
     mode = agent.current_session.get('mode')
-    if mode != 'ulw':
+    if mode not in AUTONOMOUS_MODES:
         return
 
     # Track turns
@@ -117,25 +171,33 @@ def ulw_keep_working(agent: 'Agent') -> None:
             action = response.get('action')
             if action == 'continue':
                 # Extend turns and continue
-                extend = response.get('turns', ULW_DEFAULT_TURNS)
+                extend = _validate_turns(response.get('turns'))
                 agent.current_session['ulw_turns'] += extend
-                _log(agent, f"[cyan]ULW extended: +{extend} turns[/cyan]")
+                _log(agent, f"[cyan]{mode.upper()} extended: +{extend} turns[/cyan]")
                 # Fall through to continue working
             elif action == 'switch_mode':
                 # Switch to another mode
                 new_mode = response.get('mode', 'safe')
-                _exit_ulw_mode(agent, new_mode)
+                _exit_autonomous_mode(agent, new_mode)
                 return  # Stop working
             else:
                 # Unknown action or stop - exit to safe mode
-                _exit_ulw_mode(agent, 'safe')
+                _exit_autonomous_mode(agent, 'safe')
                 return
         else:
             # No IO, truly complete
             return
 
-    # Continue working - start another turn
-    agent.input(ULW_CONTINUE_PROMPT)
+    # Continue working without recursively entering Agent.input().
+    agent._queue_input(ULW_CONTINUE_PROMPT)
+
+
+@on_stop_signal
+def stop_autonomous_mode(agent: 'Agent') -> None:
+    """An interrupt or hard stop must not start another autonomous turn."""
+    if agent.current_session.get('mode') in AUTONOMOUS_MODES:
+        agent._pending_inputs.clear()
+        _exit_autonomous_mode(agent, 'safe', triggered_by='stop_signal')
 
 
 @before_iteration
@@ -160,7 +222,40 @@ def inject_ulw_prompt(agent: 'Agent') -> None:
 
 
 # Export as plugin
-ulw = [ulw_keep_working, poll_prompt_update, inject_ulw_prompt]
+ulw = [
+    ulw_keep_working,
+    stop_autonomous_mode,
+    poll_prompt_update,
+    inject_ulw_prompt,
+]
 
-# Export mode handler for external use
-__all__ = ['ulw', 'handle_ulw_mode_change', 'ULW_DEFAULT_TURNS']
+
+def yolo(turns: int = YOLO_DEFAULT_TURNS):
+    """Create an auto-activating YOLO plugin with a bounded turn budget.
+
+    Unlike the legacy ``ulw`` bundle, this plugin activates itself on the first
+    user input. That makes it suitable for ``co ai --yolo`` in both one-shot and
+    hosted modes without requiring a frontend mode-change message.
+    """
+    turn_budget = _validate_turns(turns)
+
+    @after_user_input
+    def activate_yolo(agent: 'Agent') -> None:
+        if agent.current_session.get('mode') not in AUTONOMOUS_MODES:
+            handle_yolo_mode_change(agent, turn_budget)
+
+    return [activate_yolo, *ulw]
+
+
+__all__ = [
+    'AUTONOMOUS_MODES',
+    'ULW_CONTINUE_PROMPT',
+    'ULW_DEFAULT_TURNS',
+    'YOLO_CONTINUE_PROMPT',
+    'YOLO_DEFAULT_TURNS',
+    'handle_ulw_mode_change',
+    'handle_yolo_mode_change',
+    'stop_autonomous_mode',
+    'ulw',
+    'yolo',
+]

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -29,6 +29,7 @@ co ai
 co ai "Create a calculator tool"
 co ai "Fix the failing test in tests/unit/test_agent.py"
 co ai "Refactor agent.py to use the new event system"
+co ai --yolo "/deploy-oo-chat"
 ```
 
 Runs the prompt, prints the result, and exits. No server started.
@@ -40,12 +41,38 @@ Runs the prompt, prints the result, and exits. No server started.
 | `--port` | `-p` | `8000` | Port for web server |
 | `--model` | `-m` | `co/gemini-3.6-flash` | LLM model to use |
 | `--max-iterations` | `-i` | `100` | Max tool iterations per turn |
+| `--yolo` | | off | Skip tool approvals and keep starting improvement turns |
+| `--yolo-turns` | | `100` | Completed turns before the autonomous checkpoint |
 
 ```bash
 co ai --port 9000
 co ai --model co/gemini-3.6-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
+co ai --yolo --yolo-turns 25 "Finish the refactor and tests"
 ```
+
+## YOLO Mode
+
+YOLO mode is an explicit, bounded autonomous mode. It bypasses tool-approval
+prompts, reviews the result after each completed turn, and keeps working until
+the configured turn checkpoint.
+
+Use it only for work you have already authorized:
+
+```bash
+# Autonomous one-shot task
+co ai --yolo "Fix the failing tests and open a draft PR"
+
+# Invoke a project skill from .co/skills/ or .claude/skills/
+co ai --yolo --yolo-turns 20 "/deploy-oo-chat"
+
+# Start web chat with YOLO enabled for its agent turns
+co ai --yolo
+```
+
+The default `co ai` behavior is unchanged. YOLO uses the existing `ulw` wire
+mode, session keys, and events so currently deployed web clients remain
+compatible.
 
 ## What the Agent Can Do
 
@@ -116,6 +143,9 @@ co ai "The test test_agent_loop is failing, investigate and fix it"
 
 # Use a different model
 co ai --model co/gemini-3.6-flash
+
+# Run an authorized skill without approval prompts
+co ai --yolo "/deploy-oo-chat"
 
 # Run on a different port
 co ai --port 9000

--- a/docs/cli/copy.md
+++ b/docs/cli/copy.md
@@ -146,7 +146,8 @@ co copy Gmail --force
 | subagents | subagents.py | Sub-agent task delegation |
 | system_reminder | system_reminder.py | Inject contextual reminders into tool results |
 | ui_stream | ui_stream.py | Stream agent output to UI |
-| ulw | ulw.py | Ultra Light Work - autonomous continuous execution |
+| ulw | ulw.py | Legacy name for bounded autonomous work |
+| yolo | ulw.py | Bounded approval-free autonomous execution |
 
 ### Plugins with Prompts
 

--- a/docs/useful_plugins/README.md
+++ b/docs/useful_plugins/README.md
@@ -18,7 +18,7 @@ Pre-built plugins that extend agent behavior via event hooks.
 | [ui_stream](ui_stream.md) | Stream events to WebSocket clients | `from connectonion.useful_plugins import ui_stream` |
 | [auto_compact](auto_compact.md) | Compact conversation when context fills up | `from connectonion.useful_plugins import auto_compact` |
 | [prefer_write_tool](prefer_write_tool.md) | Guide agent to prefer write for new files | `from connectonion.useful_plugins import prefer_write_tool` |
-| [ulw](ulw.md) | Ultra-light workflow: pause for user input | `from connectonion.useful_plugins import ulw` |
+| [yolo / ulw](ulw.md) | Bounded autonomous work; ULW-compatible | `from connectonion.useful_plugins import yolo` |
 | [gmail_plugin](gmail_plugin.md) | Gmail OAuth flow | `from connectonion.useful_plugins import gmail_plugin` |
 | [calendar_plugin](calendar_plugin.md) | Calendar OAuth flow | `from connectonion.useful_plugins import calendar_plugin` |
 
@@ -86,7 +86,8 @@ See [co copy](../cli/copy.md) for full details.
 - **auto_compact** - Compact conversation when context window fills up
 
 ### User Interaction
-- **ulw** - Ultra-light workflow: pause loop and wait for user input
+- **yolo** - Explicit approval-free autonomous work with a turn checkpoint
+- **ulw** - Backward-compatible frontend-controlled alias
 
 ### Streaming
 - **ui_stream** - Stream agent trace events to WebSocket clients

--- a/docs/useful_plugins/ulw.md
+++ b/docs/useful_plugins/ulw.md
@@ -1,46 +1,75 @@
-# ulw (Ultra Light Work)
+# yolo (with ULW compatibility)
 
-Autonomous agent mode: the agent keeps working turn after turn without asking for approval, until it reaches a checkpoint or declares itself "genuinely complete".
+YOLO is the public autonomous mode: the agent keeps working turn after turn
+without asking for approval until it reaches a bounded checkpoint. The original
+`ulw` plugin and frontend protocol remain available as compatibility aliases.
 
 ## Usage
 
 ```python
 from connectonion import Agent
+from connectonion.useful_plugins import tool_approval, yolo
+
+agent = Agent("worker", plugins=[tool_approval, yolo(turns=25)])
+```
+
+`yolo(turns=N)` activates itself on the first user input. It works with
+`tool_approval` by setting a bounded autonomous mode that bypasses approval
+checks.
+
+Existing frontend-controlled agents can continue using:
+
+```python
 from connectonion.useful_plugins import tool_approval, ulw
 
 agent = Agent("worker", plugins=[tool_approval, ulw])
 ```
 
-Requires `tool_approval` — ULW mode works by setting a flag that tells `tool_approval` to skip all checks.
-
 ## What it does
 
-When activated (via a `mode_change` event from the frontend):
+When activated:
 1. Skips all tool approval prompts (`skip_tool_approval = True`)
 2. After each turn completes, automatically starts another turn
 3. At the turn limit (default: 100), pauses for user input
 4. User can continue, extend turns, or switch back to safe mode
 
-## How to trigger ULW mode
+## How to trigger YOLO mode
 
-ULW is triggered from the web chat UI by sending a mode change message:
+From the `co ai` CLI:
+
+```bash
+co ai --yolo --yolo-turns 25 "Complete the task"
+co ai --yolo "/project-skill"
+```
+
+From a frontend:
+
+```json
+{ "type": "mode_change", "mode": "yolo", "turns": 10 }
+```
+
+The runtime normalizes that public alias to the existing `ulw` wire mode. The
+legacy ULW message remains supported:
 
 ```json
 { "type": "mode_change", "mode": "ulw", "turns": 10 }
 ```
 
-In code (programmatic use):
+In code, use the auto-activating plugin:
 
 ```python
-from connectonion.useful_plugins.ulw import handle_ulw_mode_change
+from connectonion import Agent
+from connectonion.useful_plugins import tool_approval, yolo
 
-handle_ulw_mode_change(agent, turns=10)
+agent = Agent("worker", plugins=[tool_approval, yolo(turns=10)])
 agent.input("Refactor the entire codebase to use async functions")
 ```
 
 ## Turn-based checkpoints
 
-After reaching `ulw_turns`, the agent pauses and the frontend receives:
+The legacy `ulw_turns` session keys and checkpoint event stay stable so current
+SDK and oo-chat clients do not break. After reaching the budget, the frontend
+receives:
 
 ```json
 { "type": "ulw_turns_reached", "turns_used": 10, "max_turns": 10 }
@@ -68,11 +97,16 @@ This is injected into the system prompt before each LLM call, keeping the agent 
 - Extended research and writing sessions
 - Any autonomous work where you don't want to approve every tool call
 
+YOLO bypasses approval prompts. Invoke it only after the user has explicitly
+authorized the full task and production targets.
+
 ## Events used
 
 | Event | Handler | Purpose |
 |-------|---------|---------|
+| `after_user_input` | `activate_yolo` | Activate YOLO for `yolo(turns=N)` |
 | `on_complete` | `ulw_keep_working` | Start next turn if turns remain |
+| `on_stop_signal` | `stop_autonomous_mode` | Stop immediately on interrupt or hard rejection |
 | `before_iteration` | `poll_prompt_update` | Check for goal updates from frontend |
 | `before_llm` | `inject_ulw_prompt` | Inject current goal into system prompt |
 

--- a/tests/e2e/cli/test_cli_help.py
+++ b/tests/e2e/cli/test_cli_help.py
@@ -126,6 +126,53 @@ class TestCliHelp:
         assert result.exit_code == 0
         assert "Usage:" in result.output
 
+    def test_ai_help_shows_yolo_options(self):
+        """The autonomous mode is discoverable from command help."""
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(cli, ['ai', '--help'])
+
+        assert result.exit_code == 0
+        assert "--yolo" in result.output
+        assert "--yolo-turns" in result.output
+
+    @pytest.mark.parametrize("turns", ["0", "-1"])
+    def test_ai_rejects_non_positive_yolo_turns(self, turns):
+        """Typer validates the bounded YOLO turn budget before agent startup."""
+        from connectonion.cli.main import cli
+
+        result = self.runner.invoke(
+            cli,
+            ['ai', '--yolo', '--yolo-turns', turns, 'task'],
+        )
+
+        assert result.exit_code != 0
+        assert result.exception is not None
+
+    def test_ai_cli_forwards_yolo_options(self, monkeypatch):
+        """The real Typer command forwards the parsed YOLO flag and budget."""
+        from connectonion.cli.main import cli
+
+        captured = {}
+
+        def fake_handle_ai(**kwargs):
+            captured.update(kwargs)
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.ai_commands.handle_ai",
+            fake_handle_ai,
+        )
+
+        result = self.runner.invoke(
+            cli,
+            ['ai', '--yolo', '--yolo-turns', '17', '/deploy-oo-chat'],
+        )
+
+        assert result.exit_code == 0
+        assert captured["prompt"] == "/deploy-oo-chat"
+        assert captured["yolo"] is True
+        assert captured["yolo_turns"] == 17
+
     def test_copy_help(self):
         """Test 'co copy --help' shows command-specific help."""
         from connectonion.cli.main import cli

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -39,6 +39,28 @@ def test_handle_ai_calls_start_server(monkeypatch):
     assert created["model"] == "m"
     assert created["max_iterations"] == 3
     assert created["co_dir"] == GLOBAL_CO_DIR
+    assert created["yolo_turns"] is None
+
+
+def test_handle_ai_forwards_yolo_turn_budget_to_one_shot_agent(monkeypatch, capsys):
+    created = {}
+
+    class FakeAgent:
+        def input(self, prompt):
+            created["prompt"] = prompt
+            return "done"
+
+    def fake_create_coding_agent(**kwargs):
+        created.update(kwargs)
+        return FakeAgent()
+
+    monkeypatch.setattr("connectonion.cli.co_ai.agent.create_coding_agent", fake_create_coding_agent)
+
+    ai_mod.handle_ai(prompt="/deploy-oo-chat", yolo=True, yolo_turns=17)
+
+    assert created["yolo_turns"] == 17
+    assert created["prompt"] == "/deploy-oo-chat"
+    assert "done" in capsys.readouterr().out
 
 
 def test_trust_commands_list_and_actions(tmp_path, monkeypatch):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -45,6 +45,33 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     assert _bind_browser_session in agent.events["before_each_tool"]
 
 
+def test_create_coding_agent_configures_yolo_activation(monkeypatch):
+    class FakeLLM:
+        model = "fake-model"
+
+    monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr(agent_mod, "assemble_prompt", lambda *a, **k: "BASE")
+    monkeypatch.setattr(agent_mod, "load_project_context", lambda *a, **k: "")
+
+    agent = agent_mod.create_coding_agent(model="fake", yolo_turns=9)
+    agent.current_session = {
+        "messages": [{"role": "user", "content": "task"}],
+        "trace": [],
+        "turn": 1,
+    }
+
+    activators = [
+        handler
+        for handler in agent.events["after_user_input"]
+        if handler.__name__ == "activate_yolo"
+    ]
+    assert len(activators) == 1
+
+    activators[0](agent)
+    assert agent.current_session["mode"] == "ulw"
+    assert agent.current_session["ulw_turns"] == 9
+
+
 def test_start_server_hosts_provided_agent(monkeypatch):
     agent = SimpleNamespace(name="agent")
     called = {}

--- a/tests/unit/test_host_routes.py
+++ b/tests/unit/test_host_routes.py
@@ -25,6 +25,9 @@ import pytest
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 
+from connectonion import Agent
+from connectonion.core.llm import LLMResponse
+from connectonion.core.usage import TokenUsage
 from connectonion.network.host.http_router import (
     input_handler,
     session_handler,
@@ -42,6 +45,8 @@ from connectonion.network.host.http_router import (
     admin_admins_remove_handler,
 )
 from connectonion.network.host.session import Session, SessionStorage
+from connectonion.useful_plugins import yolo
+from tests.utils.mock_helpers import MockLLM
 
 
 class TestInputHandler:
@@ -167,6 +172,55 @@ class TestInputHandler:
                       session={"session_id": "test-123"})
 
         assert mock_agent.storage == storage
+
+    def test_yolo_host_result_session_and_storage_use_terminal_turn(self, tmp_path):
+        """Hosted YOLO returns and stores the same final result and checkpoint."""
+        storage = SessionStorage(str(tmp_path / "sessions.jsonl"))
+        checkpoint_events = []
+
+        class CheckpointIO:
+            def send(self, event):
+                checkpoint_events.append(event)
+
+            def receive_all(self, msg_type=None):
+                return []
+
+            def receive(self):
+                return {'action': 'stop'}
+
+        def create_agent():
+            llm = MockLLM(responses=[
+                LLMResponse(content="turn-1", tool_calls=[], raw_response={}, usage=TokenUsage()),
+                LLMResponse(content="turn-2", tool_calls=[], raw_response={}, usage=TokenUsage()),
+                LLMResponse(content="turn-3", tool_calls=[], raw_response={}, usage=TokenUsage()),
+            ])
+            return Agent(
+                "hosted-yolo",
+                llm=llm,
+                plugins=[yolo(turns=3)],
+                log=False,
+                quiet=True,
+            )
+
+        result = input_handler(
+            create_agent,
+            storage,
+            "start",
+            result_ttl=3600,
+            session={"session_id": "yolo-123"},
+            connection=CheckpointIO(),
+        )
+        stored = storage.get("yolo-123")
+
+        assert result["result"] == "turn-3"
+        assert result["session"]["result"] == "turn-3"
+        assert stored.result == "turn-3"
+        assert stored.session["result"] == "turn-3"
+        assert {
+            'type': 'ulw_turns_reached',
+            'turns_used': 3,
+            'max_turns': 3,
+        } in checkpoint_events
 
 
 class TestSessionHandler:

--- a/tests/unit/test_no_progress_guard.py
+++ b/tests/unit/test_no_progress_guard.py
@@ -129,3 +129,49 @@ class TestNoProgressGuard:
         ])
         agent = Agent("test", llm=mock_llm, plugins=[no_progress_guard()], log=False)
         assert 'after_iteration' in agent.events
+
+    def test_terminal_text_does_not_recount_the_previous_tool_call(self):
+        """A successful text response is not another tool-call iteration."""
+        from connectonion import Agent
+        from connectonion.core.llm import LLMResponse, ToolCall
+        from connectonion.core.usage import TokenUsage
+        from tests.utils.mock_helpers import MockLLM
+
+        def check_status() -> str:
+            """Return a stable status."""
+            return "pending"
+
+        def repeated_call(call_id):
+            return LLMResponse(
+                content="",
+                tool_calls=[ToolCall(
+                    name="check_status",
+                    arguments={},
+                    id=call_id,
+                )],
+                raw_response={},
+                usage=TokenUsage(),
+            )
+        llm = MockLLM(responses=[
+            repeated_call("call-1"),
+            repeated_call("call-2"),
+            LLMResponse(
+                content="genuinely done",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            ),
+        ])
+        agent = Agent(
+            "progress-final",
+            llm=llm,
+            tools=[check_status],
+            plugins=[no_progress_guard(max_repeats=3)],
+            log=False,
+            quiet=True,
+        )
+
+        result = agent.input("finish")
+
+        assert result == "genuinely done"
+        assert agent.current_session['_noprogress_count'] == 2

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -305,6 +305,116 @@ class TestSkillInvocation:
         # Message should not be replaced
         assert agent.current_session['messages'][-1]['content'] == '/nonexistent'
 
+    def test_claude_project_skill_composes_with_yolo(self, tmp_path, monkeypatch):
+        """co ai --yolo can invoke a project skill from .claude/skills."""
+        from connectonion.useful_plugins.ulw import yolo
+
+        skill_dir = tmp_path / ".claude" / "skills" / "deploy-oo-chat"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: deploy-oo-chat\n"
+            "description: Deploy oo-chat\n"
+            "---\n\n"
+            "Run the production release workflow.",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        agent = FakeAgent()
+        agent.io = None
+        agent.current_session['messages'] = [
+            {'role': 'user', 'content': '/deploy-oo-chat'}
+        ]
+
+        handle_skill_invocation(agent)
+        yolo(turns=7)[0](agent)
+
+        assert agent.current_session['messages'][-1]['content'] == (
+            "Run the production release workflow."
+        )
+        assert agent.current_session['mode'] == 'ulw'
+        assert agent.current_session['ulw_turns'] == 7
+
+    def test_real_agent_runs_claude_skill_and_bypasses_first_approval_in_yolo(
+        self, tmp_path, monkeypatch
+    ):
+        """The real plugin order loads /skill before YOLO's first tool call."""
+        from connectonion import Agent
+        from connectonion.core.llm import LLMResponse, ToolCall
+        from connectonion.core.usage import TokenUsage
+        from connectonion.useful_plugins import tool_approval, yolo
+        from tests.utils.mock_helpers import MockLLM
+
+        skill_dir = tmp_path / ".claude" / "skills" / "deploy-oo-chat"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: deploy-oo-chat\n"
+            "description: Deploy oo-chat\n"
+            "---\n\n"
+            "Run the production release workflow.",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+        executed = []
+
+        def bash(command: str) -> str:
+            """Record a harmless stand-in for a dangerous shell call."""
+            executed.append(command)
+            return "ok"
+
+        class CheckpointIO:
+            def __init__(self):
+                self.sent = []
+
+            def receive_all(self, msg_type=None):
+                return []
+
+            def send(self, event):
+                self.sent.append(event)
+
+            def receive(self):
+                assert self.sent[-1]['type'] == 'ulw_turns_reached'
+                return {'action': 'stop'}
+
+        llm = MockLLM(responses=[
+            LLMResponse(
+                content="",
+                tool_calls=[ToolCall(
+                    name="bash",
+                    arguments={"command": "printf safe"},
+                    id="shell-1",
+                )],
+                raw_response={},
+                usage=TokenUsage(),
+            ),
+            LLMResponse(
+                content="deployed",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            ),
+        ])
+        agent = Agent(
+            "skill-yolo",
+            llm=llm,
+            tools=[bash],
+            plugins=[skills, tool_approval, yolo(turns=1)],
+            log=False,
+            quiet=True,
+        )
+        agent.io = CheckpointIO()
+
+        result = agent.input("/deploy-oo-chat")
+
+        assert result == "deployed"
+        assert executed == ["printf safe"]
+        assert llm.calls[0]["messages"][1]["content"] == (
+            "Run the production release workflow."
+        )
+        assert not any(event.get('type') == 'approval_needed' for event in agent.io.sent)
+
 
 class TestCleanup:
     """Tests for cleanup on turn end."""

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -130,6 +130,24 @@ class TestNoIO:
         check_approval(agent)
 
 
+class TestAutonomousModes:
+    """YOLO and legacy ULW bypass approval without changing safe mode."""
+
+    @pytest.mark.parametrize("mode", ["yolo", "ulw"])
+    def test_autonomous_mode_skips_dangerous_tool_approval(self, mode):
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = mode
+        agent.current_session['pending_tool'] = {
+            'name': 'bash',
+            'arguments': {'command': 'npm publish'},
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+
+
 class TestSafeTools:
     """Test safe tools skip approval."""
 
@@ -694,6 +712,18 @@ class TestPollModeChanges:
 
         assert agent.current_session['mode'] == 'ulw'
         assert agent.current_session['ulw_turns'] == 50
+        assert agent.current_session['skip_tool_approval'] is True
+
+    def test_poll_mode_changes_handles_yolo_mode(self):
+        """poll_mode_changes should handle the public yolo mode."""
+        io = FakeIO(pending_signals=[{'type': 'mode_change', 'mode': 'yolo', 'turns': 12}])
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = 'safe'
+
+        poll_mode_changes(agent)
+
+        assert agent.current_session['mode'] == 'ulw'
+        assert agent.current_session['ulw_turns'] == 12
         assert agent.current_session['skip_tool_approval'] is True
 
     def test_poll_mode_changes_handles_multiple_signals(self):

--- a/tests/unit/test_ulw.py
+++ b/tests/unit/test_ulw.py
@@ -1,15 +1,25 @@
 """Unit tests for connectonion/useful_plugins/ulw.py"""
 
+import pytest
 from unittest.mock import Mock
 
+from connectonion import Agent
+from connectonion.core.events import after_user_input, on_complete
+from connectonion.core.llm import LLMResponse, ToolCall
+from connectonion.core.usage import TokenUsage
 from connectonion.useful_plugins.ulw import (
     ULW_CONTINUE_PROMPT,
     ULW_DEFAULT_TURNS,
+    YOLO_DEFAULT_TURNS,
     handle_ulw_mode_change,
+    handle_yolo_mode_change,
     inject_ulw_prompt,
     poll_prompt_update,
+    stop_autonomous_mode,
     ulw_keep_working,
+    yolo,
 )
+from tests.utils.mock_helpers import MockLLM
 
 
 class FakeAgent:
@@ -24,8 +34,12 @@ class FakeAgent:
         if mode is not None:
             self.current_session['mode'] = mode
         self.input_calls = []
+        self._pending_inputs = []
 
     def input(self, text):
+        self.input_calls.append(text)
+
+    def _queue_input(self, text):
         self.input_calls.append(text)
 
 
@@ -46,6 +60,12 @@ def test_mode_change_uses_explicit_turns():
     assert agent.current_session['ulw_turns'] == 5
 
 
+def test_legacy_zero_turn_sentinel_uses_default():
+    agent = FakeAgent()
+    handle_ulw_mode_change(agent, turns=0)
+    assert agent.current_session['ulw_turns'] == ULW_DEFAULT_TURNS
+
+
 def test_mode_change_notifies_io_when_present():
     io = Mock()
     agent = FakeAgent(io=io)
@@ -58,6 +78,42 @@ def test_mode_change_notifies_io_when_present():
 def test_mode_change_skips_notify_without_io():
     agent = FakeAgent(io=None)
     handle_ulw_mode_change(agent)  # should not raise
+
+
+def test_yolo_mode_uses_legacy_wire_mode_and_state_keys():
+    io = Mock()
+    agent = FakeAgent(io=io)
+
+    handle_yolo_mode_change(agent, turns=8)
+
+    assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['ulw_turns'] == 8
+    assert agent.current_session['ulw_turns_used'] == 0
+    assert agent.current_session['skip_tool_approval'] is True
+    io.send.assert_called_once_with(
+        {'type': 'mode_changed', 'mode': 'ulw', 'triggered_by': 'user'}
+    )
+
+
+@pytest.mark.parametrize("turns", [0, -1, True, 1.5, "10"])
+def test_autonomous_mode_rejects_invalid_turn_budget(turns):
+    with pytest.raises(ValueError, match="positive integer"):
+        handle_yolo_mode_change(FakeAgent(), turns=turns)
+
+
+def test_yolo_plugin_auto_activates_on_first_user_input():
+    agent = FakeAgent(mode='safe')
+
+    plugin = yolo(turns=6)
+    plugin[0](agent)
+
+    assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['ulw_turns'] == 6
+
+
+def test_yolo_plugin_rejects_invalid_turn_budget_at_configuration_time():
+    with pytest.raises(ValueError, match="positive integer"):
+        yolo(turns=0)
 
 
 # ---------- ulw_keep_working ----------
@@ -75,6 +131,17 @@ def test_keep_working_increments_turns_and_calls_input_below_max():
     agent.current_session['ulw_turns_used'] = 1
     ulw_keep_working(agent)
     assert agent.current_session['ulw_turns_used'] == 2
+    assert agent.input_calls == [ULW_CONTINUE_PROMPT]
+
+
+def test_keep_working_supports_yolo_mode():
+    agent = FakeAgent(mode='yolo')
+    agent.current_session['ulw_turns'] = YOLO_DEFAULT_TURNS
+    agent.current_session['ulw_turns_used'] = 0
+
+    ulw_keep_working(agent)
+
+    assert agent.current_session['ulw_turns_used'] == 1
     assert agent.input_calls == [ULW_CONTINUE_PROMPT]
 
 
@@ -120,6 +187,190 @@ def test_keep_working_at_max_without_io_returns_silently():
     ulw_keep_working(agent)
     assert agent.input_calls == []
     assert agent.current_session['mode'] == 'ulw'  # state untouched
+
+
+def test_stop_signal_exits_autonomous_mode():
+    io = Mock()
+    agent = FakeAgent(io=io, mode='ulw')
+    agent.current_session['ulw_turns'] = 5
+    agent.current_session['ulw_turns_used'] = 2
+    agent.current_session['skip_tool_approval'] = True
+
+    stop_autonomous_mode(agent)
+
+    assert agent.current_session['mode'] == 'safe'
+    assert 'ulw_turns' not in agent.current_session
+    assert 'ulw_turns_used' not in agent.current_session
+    assert 'skip_tool_approval' not in agent.current_session
+    io.send.assert_called_once_with(
+        {'type': 'mode_changed', 'mode': 'safe', 'triggered_by': 'stop_signal'}
+    )
+
+
+def test_yolo_returns_and_persists_the_terminal_turn_result():
+    llm = MockLLM(responses=[
+        LLMResponse(content="turn-1", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        LLMResponse(content="turn-2", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        LLMResponse(content="turn-3", tool_calls=[], raw_response={}, usage=TokenUsage()),
+    ])
+    agent = Agent("yolo-result", llm=llm, plugins=[yolo(turns=3)], log=False, quiet=True)
+
+    result = agent.input("start")
+
+    assert result == "turn-3"
+    assert agent.current_session['result'] == "turn-3"
+    assert agent.current_session['turn'] == 3
+    assert llm.call_count == 3
+
+
+def test_yolo_continuations_are_iterative_beyond_python_recursion_depth():
+    turn_budget = 400
+    llm = MockLLM(on_complete=lambda messages, tools: LLMResponse(
+        content=f"turn-{llm.call_count}",
+        tool_calls=[],
+        raw_response={},
+        usage=TokenUsage(),
+    ))
+    agent = Agent(
+        "yolo-iterative",
+        llm=llm,
+        plugins=[yolo(turns=turn_budget)],
+        log=False,
+        quiet=True,
+    )
+
+    result = agent.input("start")
+
+    assert result == f"turn-{turn_budget}"
+    assert agent.current_session['result'] == result
+    assert llm.call_count == turn_budget
+
+
+def test_yolo_preserves_chronological_turn_lifecycle():
+    lifecycle = []
+
+    @after_user_input
+    def record_input(agent):
+        lifecycle.append(f"input-{agent.current_session['turn']}")
+
+    @on_complete
+    def record_complete(agent):
+        lifecycle.append(f"complete-{agent.current_session['turn']}")
+
+    llm = MockLLM(responses=[
+        LLMResponse(content="one", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        LLMResponse(content="two", tool_calls=[], raw_response={}, usage=TokenUsage()),
+    ])
+    agent = Agent(
+        "yolo-lifecycle",
+        llm=llm,
+        plugins=[yolo(turns=2)],
+        on_events=[record_input, record_complete],
+        log=False,
+        quiet=True,
+    )
+
+    agent.input("start")
+
+    assert lifecycle == ["input-1", "complete-1", "input-2", "complete-2"]
+
+
+def test_interrupt_exits_yolo_without_starting_another_turn():
+    from connectonion.useful_plugins.tool_approval import poll_interrupt
+
+    def note(text: str) -> str:
+        """Record a note."""
+        return "noted"
+
+    class InterruptIO:
+        def __init__(self):
+            self.sent = []
+
+        def receive_all(self, msg_type=None):
+            return [{'type': 'INTERRUPT'}] if msg_type == 'INTERRUPT' else []
+
+        def send(self, event):
+            self.sent.append(event)
+
+    llm = MockLLM(responses=[
+        LLMResponse(
+            content="",
+            tool_calls=[ToolCall(name="note", arguments={"text": "x"}, id="c1")],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+        LLMResponse(
+            content="continued-after-interrupt",
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+    ])
+    agent = Agent(
+        "yolo-interrupt",
+        llm=llm,
+        tools=[note],
+        plugins=[yolo(turns=2)],
+        on_events=[poll_interrupt],
+        log=False,
+        quiet=True,
+    )
+    agent.io = InterruptIO()
+
+    result = agent.input("start")
+
+    assert result == "What would you like me to do?"
+    assert agent.current_session['result'] == result
+    assert agent.current_session['mode'] == 'safe'
+    assert llm.call_count == 1
+
+
+def test_interrupt_exits_yolo_after_a_text_only_turn():
+    from connectonion.useful_plugins.tool_approval import (
+        poll_interrupt,
+        poll_interrupt_after_text,
+    )
+
+    class InterruptIO:
+        def __init__(self):
+            self.sent = []
+
+        def receive_all(self, msg_type=None):
+            return [{'type': 'INTERRUPT'}] if msg_type == 'INTERRUPT' else []
+
+        def send(self, event):
+            self.sent.append(event)
+
+    llm = MockLLM(responses=[
+        LLMResponse(
+            content="first-final",
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+        LLMResponse(
+            content="second-final",
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+    ])
+    agent = Agent(
+        "yolo-text-interrupt",
+        llm=llm,
+        plugins=[yolo(turns=2)],
+        on_events=[poll_interrupt, poll_interrupt_after_text],
+        log=False,
+        quiet=True,
+    )
+    agent.io = InterruptIO()
+
+    result = agent.input("start")
+
+    assert result == "What would you like me to do?"
+    assert agent.current_session['result'] == result
+    assert agent.current_session['mode'] == 'safe'
+    assert llm.call_count == 1
 
 
 # ---------- poll_prompt_update ----------
@@ -173,5 +424,3 @@ def test_inject_prompt_replaces_existing_prompt_section():
     agent.current_session['ulw_prompt'] = 'new goal'
     inject_ulw_prompt(agent)
     assert agent.current_session['messages'][0]['content'] == 'base\n\n[Prompt]\nnew goal'
-
-


### PR DESCRIPTION
Addresses #272

## Summary

- expose a bounded public YOLO mode through the yolo plugin and co ai --yolo/--yolo-turns while retaining ULW wire compatibility
- run autonomous continuations iteratively, preserve the terminal result, and honor both tool-call and text-only interrupts
- enable project slash skills in co ai and bypass interactive tool approval only while YOLO mode is active
- document the CLI/plugin behavior and retain legacy ULW events and state

## Testing

- python -m pytest tests/unit -q (2299 passed, 3 skipped)
- python -m pytest tests/e2e/cli/test_cli_help.py -q (23 passed)
- git diff --check
- independent forward review: merge-ready, no blockers