### PR TITLE
Make unit tests hermetic and send_email work without a .env file (#232, #223)

### DIFF
--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -15,6 +15,7 @@ import yaml
 import requests
 from pathlib import Path
 from typing import Dict, Optional
+from dotenv import load_dotenv
 
 
 def send_email(to: str, subject: str, message: str) -> Dict:
@@ -32,11 +33,14 @@ def send_email(to: str, subject: str, message: str) -> Dict:
             - from (str): Sender email address
             - error (str): Error message if failed
     """
-    # Find .env file by searching up the directory tree
+    # Credentials come from the environment. A .env file is a convenience fallback,
+    # NOT a precondition: env vars set directly (container / CI / systemd, or already
+    # loaded by the `co` CLI) are equally valid. Load a .env if we can find one to
+    # populate any missing vars, but never require the file to exist on disk.
     env_file = None
     current_dir = Path.cwd()
 
-    # Search up to 5 levels for .env
+    # Search up to 5 levels for a local .env
     for _ in range(5):
         potential_env = current_dir / ".env"
         if potential_env.exists():
@@ -46,32 +50,30 @@ def send_email(to: str, subject: str, message: str) -> Dict:
             break
         current_dir = current_dir.parent
 
-    # If no local .env found, try global keys.env
+    # Fall back to the global keys.env
     if not env_file:
         global_keys_env = Path.home() / ".co" / "keys.env"
         if global_keys_env.exists():
             env_file = global_keys_env
 
-    if not env_file:
-        return {
-            "success": False,
-            "error": "No .env file found. Run 'co init' or 'co auth' first."
-        }
+    # Load it if present (does not override vars already set in the environment)
+    if env_file:
+        load_dotenv(env_file)
 
-    # Get authentication token and agent email from environment
+    # Get authentication token and agent email from the environment
     token = os.getenv("OPENONION_API_KEY")
     from_email = os.getenv("AGENT_EMAIL")
 
     if not token:
         return {
             "success": False,
-            "error": "OPENONION_API_KEY not found in .env. Run 'co auth' to authenticate."
+            "error": "OPENONION_API_KEY not set. Run 'co auth' to authenticate."
         }
 
     if not from_email:
         return {
             "success": False,
-            "error": "AGENT_EMAIL not found in .env. Run 'co auth' to set up email."
+            "error": "AGENT_EMAIL not set. Run 'co auth' to set up email."
         }
     
     # Validate recipient email

--- a/tests/unit/test_config_permissions.py
+++ b/tests/unit/test_config_permissions.py
@@ -126,7 +126,7 @@ def test_simple_tool_name_pattern_matching(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     # Create agent
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
 
     # Initialize session
     agent.current_session = {
@@ -177,7 +177,7 @@ def test_bash_exact_command_pattern(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.current_session = {
         'messages': [],
         'trace': [],
@@ -225,7 +225,7 @@ def test_bash_wildcard_pattern(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.current_session = {
         'messages': [],
         'trace': [],
@@ -276,7 +276,7 @@ def test_parameter_matching_with_match_field(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.current_session = {
         'messages': [],
         'trace': [],
@@ -330,7 +330,7 @@ def test_parameter_matching_rejects_non_matching(tmp_path, monkeypatch):
     mock_io.send = Mock()
     mock_io.receive = Mock(return_value={'approved': False, 'mode': 'reject_hard'})
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.io = mock_io
     agent.current_session = {
         'messages': [],
@@ -376,7 +376,7 @@ def test_glob_pattern_matching_in_match_field(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.current_session = {
         'messages': [],
         'trace': [],
@@ -422,7 +422,7 @@ def test_priority_config_permissions_with_safe_tools(tmp_path, monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    agent = Agent("test", plugins=[tool_approval])
+    agent = Agent("test", plugins=[tool_approval], llm=MockLLM())
     agent.current_session = {
         'messages': [],
         'trace': [],
@@ -470,7 +470,7 @@ def _make_agent_with_permissions(tmp_path, monkeypatch, bash_patterns):
     }}
     (co_dir / 'host.yaml').write_text(yaml.dump(config))
     monkeypatch.chdir(tmp_path)
-    agent = Agent("test", plugins=[tool_approval], quiet=True)
+    agent = Agent("test", plugins=[tool_approval], quiet=True, llm=MockLLM())
     agent.current_session = {'messages': [], 'trace': [], 'turn': 0}
     load_config_permissions(agent)
     return agent

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -71,6 +71,9 @@ def test_send_email_not_activated(mock_post):
     assert "Email not activated" in result["error"]
 
 
+# Neutralize .env discovery so a stray ~/.co/keys.env on the dev machine can't
+# re-inject real credentials into the cleared environment (keeps this hermetic).
+@patch('connectonion.useful_tools.send_email.load_dotenv', lambda *a, **k: None)
 @patch.dict('os.environ', {}, clear=True)
 def test_send_email_no_project():
     """Test email sending when missing OPENONION_API_KEY."""

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -20,6 +20,11 @@ import sys
 import requests
 import pytest
 
+import importlib
+# The `send_email` function is re-exported in the connectonion.useful_tools package
+# namespace, which shadows the submodule for attribute-based lookups. Resolve the
+# actual module object via importlib so patch.object targets the module, not the fn.
+send_email_module = importlib.import_module("connectonion.useful_tools.send_email")
 from connectonion.useful_tools.send_email import send_email, get_agent_email, is_email_active
 from connectonion.useful_tools.get_emails import get_emails, mark_read, mark_unread
 
@@ -73,7 +78,9 @@ def test_send_email_not_activated(mock_post):
 
 # Neutralize .env discovery so a stray ~/.co/keys.env on the dev machine can't
 # re-inject real credentials into the cleared environment (keeps this hermetic).
-@patch('connectonion.useful_tools.send_email.load_dotenv', lambda *a, **k: None)
+# patch.object on the module object avoids the send_email module-vs-function name
+# collision that string-target patching resolves inconsistently across Python versions.
+@patch.object(send_email_module, 'load_dotenv', lambda *a, **k: None)
 @patch.dict('os.environ', {}, clear=True)
 def test_send_email_no_project():
     """Test email sending when missing OPENONION_API_KEY."""

--- a/tests/unit/test_memory_integration.py
+++ b/tests/unit/test_memory_integration.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import pytest
 from connectonion import Agent, Memory
+from tests.utils.mock_helpers import MockLLM
 from unittest.mock import Mock, MagicMock
 
 
@@ -37,7 +38,7 @@ def memory_instance():
 
 def test_memory_as_agent_tool(memory_instance):
     """Test that Memory can be used as an agent tool."""
-    agent = Agent("test-agent", tools=[memory_instance])
+    agent = Agent("test-agent", tools=[memory_instance], llm=MockLLM())
 
     # Check that all memory methods are registered as tools
     tool_names = [tool.name for tool in agent.tools]
@@ -50,7 +51,7 @@ def test_memory_as_agent_tool(memory_instance):
 
 def test_memory_tool_schemas(memory_instance):
     """Test that Memory methods have correct tool schemas."""
-    agent = Agent("test-agent", tools=[memory_instance])
+    agent = Agent("test-agent", tools=[memory_instance], llm=MockLLM())
 
     # Check write_memory schema
     write_tool = agent.tools.get("write_memory")
@@ -68,7 +69,7 @@ def test_memory_tool_schemas(memory_instance):
 
 def test_memory_methods_callable_from_agent(memory_instance):
     """Test that memory methods work when called via agent's tools."""
-    agent = Agent("test-agent", tools=[memory_instance])
+    agent = Agent("test-agent", tools=[memory_instance], llm=MockLLM())
 
     # Write via tools
     write_result = agent.tools.write_memory.run("test-key", "test content")
@@ -87,8 +88,8 @@ def test_multiple_agents_same_memory():
 
     memory = Memory(memory_dir=shared_dir)
 
-    agent1 = Agent("agent1", tools=[memory])
-    agent2 = Agent("agent2", tools=[memory])
+    agent1 = Agent("agent1", tools=[memory], llm=MockLLM())
+    agent2 = Agent("agent2", tools=[memory], llm=MockLLM())
 
     # Agent1 writes
     agent1.tools.write_memory.run("shared-key", "Shared content")
@@ -107,7 +108,7 @@ def test_memory_with_other_tools(memory_instance):
         """Calculate a math expression."""
         return str(eval(expression))
 
-    agent = Agent("multi-tool-agent", tools=[memory_instance, calculate])
+    agent = Agent("multi-tool-agent", tools=[memory_instance, calculate], llm=MockLLM())
 
     tool_names = [tool.name for tool in agent.tools]
     assert "write_memory" in tool_names

--- a/tests/unit/test_prefer_write_tool.py
+++ b/tests/unit/test_prefer_write_tool.py
@@ -2,6 +2,7 @@
 
 import pytest
 from connectonion import Agent
+from tests.utils.mock_helpers import MockLLM
 from connectonion.useful_plugins import prefer_write_tool
 from connectonion.useful_plugins.prefer_write_tool import (
     _is_file_creation_command,
@@ -94,7 +95,7 @@ class TestFileReadingDetection:
 class TestFileCreationBlocking:
 
     def _make_agent(self, command):
-        agent = Agent("test", plugins=[prefer_write_tool])
+        agent = Agent("test", plugins=[prefer_write_tool], llm=MockLLM())
         agent.current_session = {
             'messages': [],
             'trace': [],
@@ -129,7 +130,7 @@ class TestFileCreationBlocking:
         block_bash_file_creation(agent)  # Should not raise
 
     def test_allows_non_bash_tools(self):
-        agent = Agent("test", plugins=[prefer_write_tool])
+        agent = Agent("test", plugins=[prefer_write_tool], llm=MockLLM())
         agent.current_session = {
             'messages': [],
             'trace': [],
@@ -147,7 +148,7 @@ class TestFileCreationBlocking:
 class TestFileReadingSoftReminder:
 
     def _make_agent(self, command):
-        agent = Agent("test", plugins=[prefer_write_tool])
+        agent = Agent("test", plugins=[prefer_write_tool], llm=MockLLM())
         agent.current_session = {
             'messages': [],
             'trace': [],
@@ -224,7 +225,7 @@ class TestFileReadingSoftReminder:
 class TestEdgeCases:
 
     def test_no_pending_tool(self):
-        agent = Agent("test", plugins=[prefer_write_tool])
+        agent = Agent("test", plugins=[prefer_write_tool], llm=MockLLM())
         agent.current_session = {
             'messages': [],
             'trace': [],
@@ -233,7 +234,7 @@ class TestEdgeCases:
         block_bash_file_creation(agent)  # Should not raise
 
     def test_empty_command(self):
-        agent = Agent("test", plugins=[prefer_write_tool])
+        agent = Agent("test", plugins=[prefer_write_tool], llm=MockLLM())
         agent.current_session = {
             'messages': [],
             'trace': [],

--- a/tests/unit/test_subagents.py
+++ b/tests/unit/test_subagents.py
@@ -5,6 +5,7 @@ Unit tests for subagents plugin
 import pytest
 from pathlib import Path
 from connectonion import Agent
+from tests.utils.mock_helpers import MockLLM
 from connectonion.useful_plugins import subagents, task
 from connectonion.useful_plugins.subagents import (
     _discover_all_agents,
@@ -23,7 +24,7 @@ class TestSubagentsPlugin:
             name="test-agent",
             tools=[],
             plugins=[subagents],
-            model="co/gemini-2.5-flash",
+            llm=MockLLM(),
             quiet=True
         )
 
@@ -144,7 +145,7 @@ With multiple lines.
             name="test-agent",
             tools=[],
             plugins=[subagents],
-            model="co/gemini-2.5-flash",
+            llm=MockLLM(),
             quiet=True
         )
 


### PR DESCRIPTION
## Description
Two failures that only show up in a **clean checkout / CI** (no credentials, no `.env`), discovered while running the full unit suite. Both are fixed here.

## Related Issue
Fixes #232
Fixes #223

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
**#232 — unit tests required `OPENONION_API_KEY`.** 31 tests constructed `Agent(...)` with the default managed model (`co/*`), which builds `OpenOnionLLM` and requires a key at construction — so they failed on any machine without credentials (and only "passed" locally when a stray `~/.co/keys.env` existed). Fix: give those constructions an explicit `llm=MockLLM()`, the same pattern already used elsewhere in `test_config_permissions.py`. The unit tier is now offline and credential-free.
- `tests/unit/test_config_permissions.py`, `tests/unit/test_prefer_write_tool.py`, `tests/unit/test_memory_integration.py`, `tests/unit/test_subagents.py`

**#223 — `send_email()` hard-required a physical `.env` file.** It searched for a `.env` and returned `"No .env file found"` *before* reading the environment, so a container/CI/systemd deployment that sets `OPENONION_API_KEY`/`AGENT_EMAIL` directly (no file) failed even with valid creds. Fix: load a `.env` only as a *fallback* to populate missing vars, then read from the environment and fail only when the credentials are genuinely absent.
- `connectonion/useful_tools/send_email.py` — `.env` is now a fallback, not a precondition (`load_dotenv` imported at module level; does not override vars already set)
- `tests/unit/test_email_functions.py` — `test_send_email_no_project` neutralizes `load_dotenv` so a stray `~/.co/keys.env` can't re-inject creds into the cleared environment (keeps it hermetic)
- `get_emails.py` already reads the environment directly — no change needed

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality (existing tests now pass hermetically)

Under a clean-checkout condition (hid `~/.co/keys.env`, no key in env, ran from a dir with no `.env`): the previously-failing tests now pass — **78 passed**. Full unit suite: **2270 passed**, with 3 unrelated `test_env_loading.py` failures that are pre-existing and environmental (they spawn a subprocess whose isolated env can't import `idna` in this sandbox; confirmed identical with these changes stashed, and they pass on CI where `idna` is installed system-wide).

## Additional Notes
`MockLLM` (from `tests/utils/mock_helpers.py`) needs no args and was already the in-repo way to build a credential-free agent — this just applies it consistently. The `send_email` change is also a real product fix, not only a test fix: it makes the tool usable in credential-injected deployments.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NN1aAFvAVq1GWgMEy4v3KS)_