### PR TITLE
Add co ai YOLO mode

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -18,7 +18,7 @@ Plugins included:
 - prefer_write_tool: Block bash file creation, soft-remind for file reading
 - tool_approval: Approval flow for dangerous operations
 - auto_compact: Context window management
-- ulw: Ultra work mode (autonomous N-turn sessions with continuation)
+- yolo: Approval-free autonomous N-turn sessions with continuation
 
 Architecture:
 - Uses prompt assembly from prompts/assembler.py
@@ -45,7 +45,17 @@ from .tools import (
 from .skills import skill
 from .plugins import system_reminder
 from connectonion import Agent, bash, TodoList
-from connectonion.useful_plugins import eval, tool_approval, auto_compact, prefer_write_tool, ulw, subagents, image_result_formatter, runtime_input
+from connectonion.useful_plugins import (
+    auto_compact,
+    enable_yolo,
+    eval,
+    image_result_formatter,
+    prefer_write_tool,
+    runtime_input,
+    subagents,
+    tool_approval,
+    yolo,
+)
 from connectonion.useful_plugins.skills import skills as skills_plugin
 
 
@@ -58,6 +68,7 @@ def create_coding_agent(
     model: str = "co/gemini-3.6-flash",
     max_iterations: int = 100,
     co_dir: Path = Path(".co"),
+    yolo_turns: int | None = None,
 ) -> Agent:
     todo = TodoList()
     file_tools = FileTools()
@@ -93,7 +104,18 @@ def create_coding_agent(
     # so panels no longer share a page and 40 tool schemas leave the request.
     # image_result_formatter stays — it turns the screenshot path the CLI prints
     # back into an image the model and the user can actually see.
-    plugins = [skills_plugin, subagents, eval, system_reminder, prefer_write_tool, tool_approval, auto_compact, ulw, image_result_formatter, runtime_input]
+    plugins = [
+        skills_plugin,
+        subagents,
+        eval,
+        system_reminder,
+        prefer_write_tool,
+        tool_approval,
+        auto_compact,
+        yolo,
+        image_result_formatter,
+        runtime_input,
+    ]
 
     agent = Agent(
         name="oo",
@@ -108,5 +130,8 @@ def create_coding_agent(
     # This browser helper blocks on stdin, which is wrong for co ai's websocket
     # chat runtime. Use browser tools plus frontend-mediated user handoffs.
     agent.tools.remove("wait_for_manual_login")
+
+    if yolo_turns is not None:
+        enable_yolo(agent, turns=yolo_turns)
 
     return agent

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -12,6 +12,8 @@ def handle_ai(
     port: int = 8000,
     model: str = "co/claude-opus-4-5",
     max_iterations: int = 100,
+    yolo: bool = False,
+    yolo_turns: int = 100,
 ):
     """Start AI coding agent or run one-shot prompt.
 
@@ -20,6 +22,8 @@ def handle_ai(
         port: Port for web server
         model: LLM model to use
         max_iterations: Max tool iterations
+        yolo: Skip tool approvals and keep working across turns
+        yolo_turns: Maximum autonomous turns before a checkpoint
 
     Examples:
         co ai                                    # Start web server
@@ -30,6 +34,7 @@ def handle_ai(
         model=model,
         max_iterations=max_iterations,
         co_dir=GLOBAL_CO_DIR,
+        yolo_turns=yolo_turns if yolo else None,
     )
 
     if prompt:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -214,10 +214,24 @@ def ai(
     port: int = typer.Option(8000, "--port", "-p", help="Port for web server"),
     model: str = typer.Option("co/gemini-3.6-flash", "--model", "-m", help="Model to use"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations"),
+    yolo: bool = typer.Option(False, "--yolo", help="Skip approvals and keep working autonomously"),
+    yolo_turns: int = typer.Option(
+        100,
+        "--yolo-turns",
+        min=1,
+        help="Autonomous turns before a checkpoint (requires --yolo)",
+    ),
 ):
     """Start AI coding agent or run one-shot prompt."""
     from .commands.ai_commands import handle_ai
-    handle_ai(prompt=prompt, port=port, model=model, max_iterations=max_iterations)
+    handle_ai(
+        prompt=prompt,
+        port=port,
+        model=model,
+        max_iterations=max_iterations,
+        yolo=yolo,
+        yolo_turns=yolo_turns,
+    )
 
 
 @app.command()

--- a/connectonion/useful_plugins/__init__.py
+++ b/connectonion/useful_plugins/__init__.py
@@ -21,7 +21,13 @@ from .system_reminder import system_reminder
 from .tool_approval import tool_approval, handle_mode_change
 from .auto_compact import auto_compact
 from .prefer_write_tool import prefer_write_tool
-from .ulw import ulw, handle_ulw_mode_change
+from .ulw import (
+    yolo,
+    enable_yolo,
+    handle_yolo_mode_change,
+    ulw,
+    handle_ulw_mode_change,
+)
 from .skills import skills, skill
 from .subagents import subagents, task
 from .runtime_input import runtime_input, RUNTIME_INPUT_FRAME_PREFIX
@@ -29,4 +35,4 @@ from .no_progress_guard import no_progress_guard
 from .human_jitter import human_jitter
 from .bind_browser_session import bind_browser_session
 
-__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'no_progress_guard', 'human_jitter', 'bind_browser_session']
+__all__ = ['re_act', 'eval', 'image_result_formatter', 'shell_approval', 'gmail_plugin', 'calendar_plugin', 'ui_stream', 'system_reminder', 'tool_approval', 'handle_mode_change', 'auto_compact', 'prefer_write_tool', 'yolo', 'enable_yolo', 'handle_yolo_mode_change', 'ulw', 'handle_ulw_mode_change', 'skills', 'skill', 'subagents', 'task', 'runtime_input', 'RUNTIME_INPUT_FRAME_PREFIX', 'no_progress_guard', 'human_jitter', 'bind_browser_session']

--- a/connectonion/useful_plugins/ulw.py
+++ b/connectonion/useful_plugins/ulw.py
@@ -23,13 +23,16 @@ Usage:
 
 from typing import TYPE_CHECKING
 
-from ..core.events import on_complete, before_iteration, before_llm
+from ..core.events import after_user_input, on_complete, before_iteration, before_llm
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
 
 
 ULW_DEFAULT_TURNS = 100
+# Public vocabulary. The ULW names remain the wire/session compatibility
+# contract used by existing frontends and persisted sessions.
+YOLO_DEFAULT_TURNS = ULW_DEFAULT_TURNS
 
 ULW_CONTINUE_PROMPT = """Review what you've done so far. Consider:
 - Are there edge cases not handled?
@@ -38,6 +41,7 @@ ULW_CONTINUE_PROMPT = """Review what you've done so far. Consider:
 - Any obvious improvements?
 
 Continue improving, or say "genuinely complete" if nothing meaningful left to do."""
+YOLO_CONTINUE_PROMPT = ULW_CONTINUE_PROMPT
 
 
 def _log(agent: 'Agent', message: str) -> None:
@@ -61,11 +65,19 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
         agent: Agent instance
         turns: Max turns before checkpoint (default: 100)
     """
+    turns = turns or ULW_DEFAULT_TURNS
+
+    # Preserve the documented pre-input activation path. The session does not
+    # exist until Agent.input(), so defer activation to after_user_input.
+    if agent.current_session is None:
+        agent._yolo_turns = turns
+        return
+
     old_mode = agent.current_session.get('mode', 'safe')
 
     # Set ULW state
     agent.current_session['mode'] = 'ulw'
-    agent.current_session['ulw_turns'] = turns or ULW_DEFAULT_TURNS
+    agent.current_session['ulw_turns'] = turns
     agent.current_session['ulw_turns_used'] = 0
     agent.current_session['skip_tool_approval'] = True
 
@@ -74,6 +86,31 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
         agent.io.send({'type': 'mode_changed', 'mode': 'ulw', 'triggered_by': 'user'})
 
     _log(agent, f"[cyan]Mode changed: {old_mode} → ulw ({agent.current_session['ulw_turns']} turns)[/cyan]")
+
+
+def handle_yolo_mode_change(agent: 'Agent', turns: int = None) -> None:
+    """Activate YOLO mode using ULW's stable session and wire contract."""
+    handle_ulw_mode_change(agent, turns)
+
+
+def enable_yolo(agent: 'Agent', turns: int = None) -> None:
+    """Configure approval-free autonomous mode before the agent's first input."""
+    turns = YOLO_DEFAULT_TURNS if turns is None else turns
+    if isinstance(turns, bool) or turns <= 0:
+        raise ValueError("YOLO turns must be a positive integer")
+
+    agent._yolo_turns = turns
+    if agent.current_session is not None:
+        handle_yolo_mode_change(agent, turns)
+
+
+@after_user_input
+def activate_configured_yolo(agent: 'Agent') -> None:
+    """Enter configured YOLO mode before the first LLM or tool call."""
+    turns = getattr(agent, '_yolo_turns', None)
+    if turns is None or agent.current_session.get('mode') == 'ulw':
+        return
+    handle_yolo_mode_change(agent, turns)
 
 
 def _exit_ulw_mode(agent: 'Agent', new_mode: str = 'safe') -> None:
@@ -159,8 +196,24 @@ def inject_ulw_prompt(agent: 'Agent') -> None:
         messages[0]['content'] = f"{base}\n\n[Prompt]\n{prompt}"
 
 
-# Export as plugin
-ulw = [ulw_keep_working, poll_prompt_update, inject_ulw_prompt]
+# Export the new public name while retaining ULW as an exact plugin alias.
+ulw = [
+    activate_configured_yolo,
+    ulw_keep_working,
+    poll_prompt_update,
+    inject_ulw_prompt,
+]
+yolo = ulw
 
-# Export mode handler for external use
-__all__ = ['ulw', 'handle_ulw_mode_change', 'ULW_DEFAULT_TURNS']
+# Export mode handlers for external use.
+__all__ = [
+    'yolo',
+    'enable_yolo',
+    'handle_yolo_mode_change',
+    'YOLO_DEFAULT_TURNS',
+    'YOLO_CONTINUE_PROMPT',
+    'ulw',
+    'handle_ulw_mode_change',
+    'ULW_DEFAULT_TURNS',
+    'ULW_CONTINUE_PROMPT',
+]

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -40,12 +40,40 @@ Runs the prompt, prints the result, and exits. No server started.
 | `--port` | `-p` | `8000` | Port for web server |
 | `--model` | `-m` | `co/gemini-3.6-flash` | LLM model to use |
 | `--max-iterations` | `-i` | `100` | Max tool iterations per turn |
+| `--yolo` | | off | Skip tool approvals and keep working across turns |
+| `--yolo-turns` | | `100` | Autonomous turns before a checkpoint; must be positive |
 
 ```bash
 co ai --port 9000
 co ai --model co/gemini-3.6-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
+co ai --yolo "Fix the failing suite" --yolo-turns 20
 ```
+
+## YOLO mode
+
+Use `--yolo` for a trusted task that should run without tool-approval prompts.
+It works in both one-shot and web-server modes:
+
+```bash
+# Run one task autonomously, then exit at the 20-turn bound
+co ai --yolo "Implement issue #123" --yolo-turns 20
+
+# Start web chat with autonomous mode enabled for each session
+co ai --yolo --yolo-turns 20
+```
+
+Slash skills are expanded before the first model call. Project skills can live
+under either `.co/skills/` or `.claude/skills/`, so a project workflow can run
+directly:
+
+```bash
+co ai --yolo "/deploy-oo-chat" --yolo-turns 10
+```
+
+YOLO deliberately reuses the existing ULW session and frontend protocol.
+Persisted fields such as `mode: ulw`, `ulw_turns`, and
+`skip_tool_approval` remain unchanged for compatibility.
 
 ## What the Agent Can Do
 

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -61,7 +61,8 @@ agent = Agent("a", plugins=[re_act, logger])
 | `system_reminder` | Inject contextual reminders into tool results | [system_reminder.md](../useful_plugins/system_reminder.md) |
 | `auto_compact` | Compact conversation when context gets large | [auto_compact.md](../useful_plugins/auto_compact.md) |
 | `prefer_write_tool` | Guide agent to prefer write over edit for new files | [prefer_write_tool.md](../useful_plugins/prefer_write_tool.md) |
-| `ulw` | Ultra-light workflow: pause loop for user input | [ulw.md](../useful_plugins/ulw.md) |
+| `yolo` | Approval-free autonomous work with bounded checkpoints | [yolo.md](../useful_plugins/yolo.md) |
+| `ulw` | Compatibility alias and frontend wire protocol for YOLO | [ulw.md](../useful_plugins/ulw.md) |
 | `gmail_plugin` | Gmail OAuth flow | [gmail_plugin.md](../useful_plugins/gmail_plugin.md) |
 | `calendar_plugin` | Google Calendar OAuth flow | [calendar_plugin.md](../useful_plugins/calendar_plugin.md) |
 

--- a/docs/useful_plugins/README.md
+++ b/docs/useful_plugins/README.md
@@ -18,7 +18,8 @@ Pre-built plugins that extend agent behavior via event hooks.
 | [ui_stream](ui_stream.md) | Stream events to WebSocket clients | `from connectonion.useful_plugins import ui_stream` |
 | [auto_compact](auto_compact.md) | Compact conversation when context fills up | `from connectonion.useful_plugins import auto_compact` |
 | [prefer_write_tool](prefer_write_tool.md) | Guide agent to prefer write for new files | `from connectonion.useful_plugins import prefer_write_tool` |
-| [ulw](ulw.md) | Ultra-light workflow: pause for user input | `from connectonion.useful_plugins import ulw` |
+| [yolo](yolo.md) | Approval-free autonomous work with a turn bound | `from connectonion.useful_plugins import yolo` |
+| [ulw](ulw.md) | Compatibility alias and frontend wire protocol for YOLO | `from connectonion.useful_plugins import ulw` |
 | [gmail_plugin](gmail_plugin.md) | Gmail OAuth flow | `from connectonion.useful_plugins import gmail_plugin` |
 | [calendar_plugin](calendar_plugin.md) | Calendar OAuth flow | `from connectonion.useful_plugins import calendar_plugin` |
 
@@ -86,7 +87,8 @@ See [co copy](../cli/copy.md) for full details.
 - **auto_compact** - Compact conversation when context window fills up
 
 ### User Interaction
-- **ulw** - Ultra-light workflow: pause loop and wait for user input
+- **yolo** - Approval-free autonomous loop with bounded checkpoints
+- **ulw** - Compatibility alias and existing frontend wire protocol
 
 ### Streaming
 - **ui_stream** - Stream agent trace events to WebSocket clients

--- a/docs/useful_plugins/ulw.md
+++ b/docs/useful_plugins/ulw.md
@@ -1,6 +1,8 @@
-# ulw (Ultra Light Work)
+# ulw (compatibility name)
 
-Autonomous agent mode: the agent keeps working turn after turn without asking for approval, until it reaches a checkpoint or declares itself "genuinely complete".
+ULW is the original name for the autonomous engine now exposed publicly as
+[YOLO](yolo.md). Existing imports, frontend messages, session fields, and
+checkpoint events remain supported.
 
 ## Usage
 
@@ -12,6 +14,16 @@ agent = Agent("worker", plugins=[tool_approval, ulw])
 ```
 
 Requires `tool_approval` — ULW mode works by setting a flag that tells `tool_approval` to skip all checks.
+
+New code can use `yolo` and configure it before the first input:
+
+```python
+from connectonion.useful_plugins import enable_yolo, tool_approval, yolo
+
+agent = Agent("worker", plugins=[tool_approval, yolo])
+enable_yolo(agent, turns=10)
+agent.input("Refactor the codebase")
+```
 
 ## What it does
 

--- a/docs/useful_plugins/yolo.md
+++ b/docs/useful_plugins/yolo.md
@@ -1,0 +1,47 @@
+# yolo
+
+Approval-free, bounded autonomous work backed by the existing ULW engine.
+
+## Usage
+
+```python
+from connectonion import Agent
+from connectonion.useful_plugins import enable_yolo, tool_approval, yolo
+
+agent = Agent("worker", plugins=[tool_approval, yolo])
+enable_yolo(agent, turns=10)
+agent.input("Fix the failing tests")
+```
+
+`enable_yolo()` can be called before the first input. The plugin activates after
+the session is initialized and before the first model or tool call.
+
+For the built-in coding agent:
+
+```bash
+co ai --yolo "Fix the failing tests" --yolo-turns 10
+co ai --yolo "/deploy-oo-chat" --yolo-turns 10
+```
+
+## Compatibility
+
+YOLO is the public name for the existing ULW behavior. The old imports remain
+valid:
+
+```python
+from connectonion.useful_plugins import handle_ulw_mode_change, ulw
+```
+
+The frontend wire mode and persisted session fields also remain unchanged:
+
+```json
+{
+  "mode": "ulw",
+  "ulw_turns": 10,
+  "ulw_turns_used": 0,
+  "skip_tool_approval": true
+}
+```
+
+Existing `mode_change` messages and `ulw_turns_reached` checkpoint events keep
+working. See [ulw](ulw.md) for the compatibility protocol.

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import patch
 
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from connectonion.cli.main import app
@@ -35,5 +36,6 @@ def test_ai_rejects_non_positive_yolo_turns():
     )
 
     assert result.exit_code != 0
-    assert "--yolo-turns" in result.output
-    assert "1" in result.output
+    output = strip_ansi(result.output)
+    assert "--yolo-turns" in output
+    assert "1" in output

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -1,0 +1,39 @@
+"""CLI routing tests for `co ai` YOLO mode."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_ai_forwards_yolo_options():
+    with patch("connectonion.cli.commands.ai_commands.handle_ai") as handler:
+        result = runner.invoke(
+            app,
+            ["ai", "task", "--yolo", "--yolo-turns", "4"],
+        )
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        prompt="task",
+        port=8000,
+        model="co/gemini-3.6-flash",
+        max_iterations=100,
+        yolo=True,
+        yolo_turns=4,
+    )
+
+
+def test_ai_rejects_non_positive_yolo_turns():
+    result = runner.invoke(
+        app,
+        ["ai", "task", "--yolo", "--yolo-turns", "0"],
+    )
+
+    assert result.exit_code != 0
+    assert "--yolo-turns" in result.output
+    assert "1" in result.output

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -32,13 +32,44 @@ def test_handle_ai_calls_start_server(monkeypatch):
     monkeypatch.setattr("connectonion.cli.co_ai.agent.create_coding_agent", fake_create_coding_agent)
     monkeypatch.setattr("connectonion.cli.co_ai.main.start_server", fake_start_server)
 
-    ai_mod.handle_ai(port=1111, model="m", max_iterations=3)
+    ai_mod.handle_ai(
+        port=1111,
+        model="m",
+        max_iterations=3,
+        yolo=True,
+        yolo_turns=7,
+    )
 
     assert called["port"] == 1111
     assert called["agent"] is created["agent"]
     assert created["model"] == "m"
     assert created["max_iterations"] == 3
     assert created["co_dir"] == GLOBAL_CO_DIR
+    assert created["yolo_turns"] == 7
+
+
+def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
+    created = {}
+
+    class FakeAgent:
+        def input(self, prompt):
+            created["prompt"] = prompt
+            return "done"
+
+    def fake_create_coding_agent(**kwargs):
+        created.update(kwargs)
+        return FakeAgent()
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_coding_agent",
+        fake_create_coding_agent,
+    )
+
+    ai_mod.handle_ai(prompt="task", yolo=False, yolo_turns=9)
+
+    assert created["prompt"] == "task"
+    assert created["yolo_turns"] is None
+    assert capsys.readouterr().out.endswith("done\n")
 
 
 def test_trust_commands_list_and_actions(tmp_path, monkeypatch):

--- a/tests/unit/test_ulw.py
+++ b/tests/unit/test_ulw.py
@@ -2,14 +2,23 @@
 
 from unittest.mock import Mock
 
+from connectonion import Agent
+from connectonion.core.llm import LLMResponse
+from connectonion.core.usage import TokenUsage
+from connectonion.useful_plugins.skills import skills
 from connectonion.useful_plugins.ulw import (
     ULW_CONTINUE_PROMPT,
     ULW_DEFAULT_TURNS,
+    YOLO_DEFAULT_TURNS,
+    enable_yolo,
     handle_ulw_mode_change,
+    handle_yolo_mode_change,
     inject_ulw_prompt,
     poll_prompt_update,
+    yolo,
     ulw_keep_working,
 )
+from tests.utils.mock_helpers import MockLLM
 
 
 class FakeAgent:
@@ -58,6 +67,123 @@ def test_mode_change_notifies_io_when_present():
 def test_mode_change_skips_notify_without_io():
     agent = FakeAgent(io=None)
     handle_ulw_mode_change(agent)  # should not raise
+
+
+def test_yolo_public_api_uses_ulw_compatibility_state():
+    agent = FakeAgent()
+
+    handle_yolo_mode_change(agent, turns=4)
+
+    assert YOLO_DEFAULT_TURNS == ULW_DEFAULT_TURNS
+    assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['ulw_turns'] == 4
+    assert agent.current_session['skip_tool_approval'] is True
+    assert yolo
+
+
+def test_enable_yolo_before_first_input_activates_on_the_first_turn(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    skill_dir = tmp_path / '.claude' / 'skills' / 'deploy-oo-chat'
+    skill_dir.mkdir(parents=True)
+    (skill_dir / 'SKILL.md').write_text(
+        '---\n'
+        'name: deploy-oo-chat\n'
+        'description: Deploy oo-chat\n'
+        'tools:\n'
+        '  - Bash(pytest *)\n'
+        '---\n'
+        'Run the deployment checks without deploying.',
+        encoding='utf-8',
+    )
+    llm = MockLLM(responses=[
+        LLMResponse(
+            content='done',
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        )
+    ])
+    agent = Agent(
+        name='yolo-skill',
+        llm=llm,
+        plugins=[skills, yolo],
+        log=False,
+        quiet=True,
+    )
+
+    enable_yolo(agent, turns=1)
+    result = agent.input('/deploy-oo-chat')
+
+    assert result == 'done'
+    user_message = next(
+        message
+        for message in llm.last_call['messages']
+        if message['role'] == 'user'
+    )
+    assert user_message['content'] == (
+        'Run the deployment checks without deploying.'
+    )
+    assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['skip_tool_approval'] is True
+    assert agent.current_session['ulw_turns'] == 1
+    assert agent.current_session['ulw_turns_used'] == 1
+
+
+def test_plain_ulw_plugin_does_not_enable_yolo_implicitly():
+    llm = MockLLM(responses=[
+        LLMResponse(
+            content='done',
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        )
+    ])
+    agent = Agent(
+        name='safe-by-default',
+        llm=llm,
+        plugins=[yolo],
+        log=False,
+        quiet=True,
+    )
+
+    agent.input('hello')
+
+    assert 'mode' not in agent.current_session
+    assert 'skip_tool_approval' not in agent.current_session
+
+
+def test_configured_yolo_activates_after_hosted_session_restore():
+    llm = MockLLM(responses=[
+        LLMResponse(
+            content='done',
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        )
+    ])
+    agent = Agent(
+        name='hosted-yolo',
+        llm=llm,
+        plugins=[yolo],
+        log=False,
+        quiet=True,
+    )
+    enable_yolo(agent, turns=1)
+
+    agent.input(
+        'continue',
+        session={
+            'session_id': 'session-1',
+            'messages': [{'role': 'system', 'content': 'system'}],
+            'trace': [],
+            'turn': 0,
+        },
+    )
+
+    assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['skip_tool_approval'] is True
+    assert agent.current_session['ulw_turns'] == 1
+    assert agent.current_session['ulw_turns_used'] == 1
 
 
 # ---------- ulw_keep_working ----------
@@ -173,5 +299,3 @@ def test_inject_prompt_replaces_existing_prompt_section():
     agent.current_session['ulw_prompt'] = 'new goal'
     inject_ulw_prompt(agent)
     assert agent.current_session['messages'][0]['content'] == 'base\n\n[Prompt]\nnew goal'
-
-


### PR DESCRIPTION
## Summary

- expose `yolo` as the public name for the existing ULW autonomous engine
- add `enable_yolo()` for activation before the first input
- add `co ai --yolo` and positive `--yolo-turns` options for one-shot and hosted use
- preserve the existing `ulw` import, frontend mode, checkpoint events, and persisted session fields
- verify that `/deploy-oo-chat` expands from `.claude/skills/` before the first model call
- document the CLI and plugin APIs

## Implementation

Previously ULW could only be activated after a session existed, normally through a frontend `mode_change`. The CLI had no public activation path. The new configuration is stored on the agent, then an `after_user_input` handler enters the existing `mode: ulw` state after session initialization and before LLM/tool execution.

The branch is rebased onto the current `co browser` coding-agent architecture from #273; YOLO only changes plugin selection and activation state.

## Companion skill PR

- openonion/connectonion-claude-plugin#1

## Validation

- `python -m pytest tests/ -q --tb=short -m 'not slow and not real_api and not network'` — 2,691 passed, 8 skipped, 156 deselected
- forced-color CLI regression test — 2 passed
- focused YOLO/ULW and CLI suite — 23 passed
- `git diff --check`

The prior Linux CI failure was test-only: ANSI styling split the rendered option name. The assertion now strips ANSI before checking the message. No production deployment was performed.

Closes #272