### PR TITLE
deploy: poll for the full build window and validate the project name locally

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -437,23 +437,23 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     if deploy_success:
         console.print(f"Dashboard: {DASHBOARD_URL}")
 
-    # Show the agent's startup logs (best-effort).
-    if deployment_id:
-        time.sleep(5)  # "running" fires when the container starts; wait for the app to print its banner or crash
-        try:
-            logs_resp = requests.get(
-                f"{API_BASE}/api/v1/deploy/{deployment_id}/logs?tail=20",
-                headers={"Authorization": f"Bearer {api_key}"},
-                timeout=10,
-            )
-        except requests.exceptions.RequestException:
-            logs_resp = None
-        if logs_resp is not None and logs_resp.status_code == 200:
-            logs = logs_resp.json().get("logs", "")
-            if logs:
-                console.print()
-                console.print("[dim]Container logs:[/dim]")
-                console.print(f"[dim]{logs}[/dim]")
+    # Show the agent's startup logs (best-effort). deployment_id is always set
+    # here — the missing-id case returned above.
+    time.sleep(5)  # "running" fires when the container starts; wait for the app to print its banner or crash
+    try:
+        logs_resp = requests.get(
+            f"{API_BASE}/api/v1/deploy/{deployment_id}/logs?tail=20",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=10,
+        )
+    except requests.exceptions.RequestException:
+        logs_resp = None
+    if logs_resp is not None and logs_resp.status_code == 200:
+        logs = logs_resp.json().get("logs", "")
+        if logs:
+            console.print()
+            console.print("[dim]Container logs:[/dim]")
+            console.print(f"[dim]{logs}[/dim]")
 
     console.print()
     return deploy_success

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -2,11 +2,11 @@
 Purpose: Deploy agent projects to ConnectOnion Cloud with local packaging and env vars
 LLM-Note:
   Dependencies: imports from [fnmatch, json, os, re, shutil, subprocess, tarfile, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → load_api_key() loads OPENONION_API_KEY → reads host.yaml for project name, entrypoint, env file path → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → reads host.yaml for project name, entrypoint, env file path → checks the name against PROJECT_NAME_PATTERN (same rule the backend enforces) and the entrypoint's host() export → load_api_key() loads OPENONION_API_KEY → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | template deploy creates/deletes a temporary project on success | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | normal deploy does not modify project files
   Integration: exposes handle_deploy(template, skills, name) for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | --name only valid with --template (otherwise the name comes from host.yaml) | uses Bearer token auth | returns bool success
-  Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s up to 100 times (~5 min)
-  Errors: fails if not ConnectOnion project (no host.yaml) | fails if no API key | prints backend error messages
+  Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s for up to 20 min, covering the backend's own build budget (rsync 120s + docker build 900s + run 60s)
+  Errors: fails if not ConnectOnion project (no host.yaml) | fails if project name is not a valid hostname label | fails if no API key | prints backend error messages
 """
 
 import fnmatch
@@ -30,6 +30,16 @@ console = Console()
 API_BASE = "https://oo.openonion.ai"
 DASHBOARD_URL = "https://o.openonion.ai/dashboard"
 
+# Poll until the backend's own build budget is exhausted (rsync 120s + docker
+# build 900s + run 60s), plus slack for queueing. Giving up at 5 minutes told
+# users a co-ai or browser deploy had failed while it was still building.
+DEPLOY_POLL_SECONDS = 3
+DEPLOY_TIMEOUT_SECONDS = 20 * 60
+
+# Mirrors the server's rule (oo-api deploy/service.py). Checked locally so a bad
+# name in host.yaml fails before packaging and uploading the whole project.
+PROJECT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,38}$")
+
 
 def _check_host_export(entrypoint: str) -> bool:
     """Check if entrypoint file exports an ASGI app via host().
@@ -45,11 +55,12 @@ def _check_host_export(entrypoint: str) -> bool:
 
     content = entrypoint_path.read_text(encoding="utf-8")
 
-    # Check for host() call pattern
-    # Matches: host(agent), host(my_agent), host( agent ), etc.
-    host_call_pattern = r'\bhost\s*\([^)]+\)'
+    # A host(...) call on a line of its own or bound to a name. `[^#\n]*` keeps
+    # commented-out calls from counting, and the lookbehind rules out attribute
+    # calls and names that merely end in "host" (client.host(...), ghost(...)).
+    host_call_pattern = r'^[^#\n]*(?<![\w.])host\s*\([^)]+\)'
 
-    if re.search(host_call_pattern, content):
+    if re.search(host_call_pattern, content, re.MULTILINE):
         return True
 
     return False
@@ -107,6 +118,17 @@ def _is_git_repo(project_dir: Path) -> bool:
         capture_output=True,
     )
     return result.returncode == 0 and Path(result.stdout.decode().strip()).resolve() == project_dir.resolve()
+
+
+def _error_text(response: requests.Response) -> str:
+    """Backend errors are {"detail": "..."}; fall back to the raw body."""
+    try:
+        detail = response.json().get("detail")
+    except ValueError:
+        return response.text
+    if isinstance(detail, str):
+        return detail
+    return response.text
 
 
 def _format_bytes(size: int) -> str:
@@ -236,18 +258,25 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
             console.print(f"[red]Skills path not found or not a directory: {sp}[/red]")
             return False
 
-    # Must have API key
-    api_key = load_api_key()
-    if not api_key:
-        console.print("[red]No API key. Run 'co auth' first.[/red]")
-        return False
-
-    # Load config from host.yaml
+    # Load config from host.yaml. The project is checked before credentials are:
+    # a broken host.yaml is worth reporting whether or not you happen to be
+    # logged in.
     with open(host_yaml_path, 'r', encoding="utf-8") as f:
         config = yaml.safe_load(f) or {}
     project_name = config.get("name", "unnamed-agent")
     env_file = config.get("env", ".env")
     entrypoint = config.get("entrypoint", "agent.py")
+
+    # The name becomes a hostname and a Docker tag, so the backend rejects
+    # anything outside this set. Fail here rather than after the upload.
+    if not PROJECT_NAME_PATTERN.match(project_name):
+        console.print(f"[red]Invalid project name: {project_name}[/red]")
+        console.print(
+            "[dim]Names may use 1-39 lowercase letters, digits, and hyphens, "
+            "and must start with a letter or digit.[/dim]"
+        )
+        console.print(f"[dim]Set 'name' in {host_yaml_path}[/dim]")
+        return False
 
     # Validate entrypoint exists
     entrypoint_path = project_dir / entrypoint
@@ -268,6 +297,12 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
         console.print("  [cyan]host(agent)  # Starts HTTP server[/cyan]")
         console.print()
         console.print("[dim]See: https://docs.connectonion.com/deploy[/dim]")
+        return False
+
+    # Must have API key
+    api_key = load_api_key()
+    if not api_key:
+        console.print("[red]No API key. Run 'co auth' first.[/red]")
         return False
 
     # Load env vars from .env as runtime secrets; .env itself stays out of the tarball.
@@ -317,7 +352,7 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
             )
 
     if response.status_code != 200:
-        console.print(f"[red]Deploy failed: {response.text}[/red]")
+        console.print(f"[red]Deploy failed: {_error_text(response)}[/red]")
         return False
 
     result = response.json()
@@ -329,8 +364,12 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
 
     deployment_id = result.get("id")
     url = result.get("url", "")
-    if deployment_id:
-        console.print(f"Deployment: {deployment_id}")
+    if not deployment_id:
+        # Without an id there is nothing to poll; don't spend five minutes
+        # requesting /deploy/None/status.
+        console.print("[red]Deploy failed: backend did not return a deployment id[/red]")
+        return False
+    console.print(f"Deployment: {deployment_id}")
 
     # Wait for deployment
     console.print("Building container on ConnectOnion Cloud...")
@@ -338,7 +377,9 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     final_status = "unknown"
     timeout_count = 0
 
-    for attempt in range(100):
+    deadline = time.monotonic() + DEPLOY_TIMEOUT_SECONDS
+
+    while time.monotonic() < deadline:
         try:
             status_resp = requests.get(
                 f"{API_BASE}/api/v1/deploy/{deployment_id}/status",
@@ -350,11 +391,11 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
             if timeout_count >= 3:
                 console.print("[yellow]Status checks timing out, but deploy may still succeed.[/yellow]")
                 break
-            time.sleep(3)
+            time.sleep(DEPLOY_POLL_SECONDS)
             continue
         except requests.exceptions.RequestException as e:
             console.print(f"[yellow]Network error: {e}[/yellow]")
-            time.sleep(3)
+            time.sleep(DEPLOY_POLL_SECONDS)
             continue
 
         if status_resp.status_code != 200:
@@ -363,7 +404,8 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
 
         result = status_resp.json()
         final_status = result.get("status", "unknown")
-        console.print(f"  [{attempt + 1}/100] status: {final_status}")
+        remaining = int(deadline - time.monotonic())
+        console.print(f"  [{remaining // 60}m{remaining % 60:02d}s left] status: {final_status}")
 
         if final_status == "running":
             deploy_success = True
@@ -373,7 +415,7 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
         if final_status in ("error", "failed"):
             console.print(f"[red]Deploy failed: {result.get('error_message') or 'Unknown error'}[/red]")
             return False
-        time.sleep(3)
+        time.sleep(DEPLOY_POLL_SECONDS)
 
     if deploy_success:
         console.print("[bold green]Deployed![/bold green]")

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -56,6 +56,14 @@ def _exports_asgi_app(entrypoint: str) -> bool:
 
     content = entrypoint_path.read_text(encoding="utf-8")
 
+    # Blank out single-line string literals first. The comment rule below is
+    # lexical, so without this a `#` inside a string would hide a real call
+    # later on the same line (`msg = "note: #1"; host(agent)`) and block a valid
+    # deploy. Triple-quoted strings are left alone — a `#` inside one followed
+    # by a host() call on the same physical line is not a real scenario, and a
+    # pre-flight check is not worth a tokenizer.
+    content = re.sub(r'"[^"\n]*"|\'[^\'\n]*\'', '""', content)
+
     # `[^#\n]*` keeps commented-out calls from counting. The lookbehind rules out
     # names that merely end in "host" (ghost(...), localhost(...)) but allows a
     # leading dot, so `connectonion.host(agent)` still counts — wrongly blocking
@@ -265,9 +273,13 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     # logged in.
     with open(host_yaml_path, 'r', encoding="utf-8") as f:
         config = yaml.safe_load(f) or {}
-    project_name = config.get("name", "unnamed-agent")
-    env_file = config.get("env", ".env")
-    entrypoint = config.get("entrypoint", "agent.py")
+    # host.yaml is hand-editable and YAML types values for you: an unquoted
+    # `name: 123` arrives as an int, and matching a regex against it raises
+    # TypeError — a traceback in place of the clear message below. Coerce to str
+    # so a hand-edited file fails cleanly, or works when the value is sensible.
+    project_name = str(config.get("name") or "unnamed-agent")
+    env_file = str(config.get("env") or ".env")
+    entrypoint = str(config.get("entrypoint") or "agent.py")
 
     # The name becomes a hostname and a Docker tag, so the backend rejects
     # anything outside this set. `co init` now normalizes it when writing
@@ -412,7 +424,10 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
 
         result = status_resp.json()
         final_status = result.get("status", "unknown")
-        remaining = int(deadline - time.monotonic())
+        # Clamp: a status call that returns near the deadline makes this
+        # negative, and -5 seconds formats as "-1m55s left" (// floors, % does
+        # not) rather than anything a reader can use.
+        remaining = max(0, int(deadline - time.monotonic()))
         console.print(f"  [{remaining // 60}m{remaining % 60:02d}s left] status: {final_status}")
 
         if final_status == "running":

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -55,10 +55,11 @@ def _check_host_export(entrypoint: str) -> bool:
 
     content = entrypoint_path.read_text(encoding="utf-8")
 
-    # A host(...) call on a line of its own or bound to a name. `[^#\n]*` keeps
-    # commented-out calls from counting, and the lookbehind rules out attribute
-    # calls and names that merely end in "host" (client.host(...), ghost(...)).
-    host_call_pattern = r'^[^#\n]*(?<![\w.])host\s*\([^)]+\)'
+    # `[^#\n]*` keeps commented-out calls from counting. The lookbehind rules out
+    # names that merely end in "host" (ghost(...), localhost(...)) but allows a
+    # leading dot, so `connectonion.host(agent)` still counts — wrongly blocking
+    # a valid deploy is worse than letting one through to a clear container error.
+    host_call_pattern = r'^[^#\n]*(?<![A-Za-z0-9_])host\s*\([^)]+\)'
 
     if re.search(host_call_pattern, content, re.MULTILINE):
         return True
@@ -118,6 +119,12 @@ def _is_git_repo(project_dir: Path) -> bool:
         capture_output=True,
     )
     return result.returncode == 0 and Path(result.stdout.decode().strip()).resolve() == project_dir.resolve()
+
+
+def _suggest_project_name(project_name: str) -> str | None:
+    """Nearest name that satisfies PROJECT_NAME_PATTERN, or None if there isn't one."""
+    candidate = re.sub(r"[^a-z0-9]+", "-", project_name.lower()).strip("-")[:39].rstrip("-")
+    return candidate if PROJECT_NAME_PATTERN.match(candidate) else None
 
 
 def _error_text(response: requests.Response) -> str:
@@ -275,6 +282,11 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
             "[dim]Names may use 1-39 lowercase letters, digits, and hyphens, "
             "and must start with a letter or digit.[/dim]"
         )
+        # `co create My_Agent` writes that name straight into host.yaml, so
+        # offer the corrected form rather than leaving the user to derive it.
+        suggestion = _suggest_project_name(project_name)
+        if suggestion:
+            console.print(f"[dim]Try:  name: {suggestion}[/dim]")
         console.print(f"[dim]Set 'name' in {host_yaml_path}[/dim]")
         return False
 

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -2,7 +2,7 @@
 Purpose: Deploy agent projects to ConnectOnion Cloud with local packaging and env vars
 LLM-Note:
   Dependencies: imports from [fnmatch, json, os, re, shutil, subprocess, tarfile, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → reads host.yaml for project name, entrypoint, env file path → checks the name against PROJECT_NAME_PATTERN (same rule the backend enforces) and the entrypoint's host() export → load_api_key() loads OPENONION_API_KEY → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → reads host.yaml for project name, entrypoint, env file path → checks the name against DEPLOY_NAME_PATTERN (same rule the backend enforces) and the entrypoint's host() export → load_api_key() loads OPENONION_API_KEY → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | template deploy creates/deletes a temporary project on success | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | normal deploy does not modify project files
   Integration: exposes handle_deploy(template, skills, name) for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | --name only valid with --template (otherwise the name comes from host.yaml) | uses Bearer token auth | returns bool success
   Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s for up to 20 min, covering the backend's own build budget (rsync 120s + docker build 900s + run 60s)
@@ -23,7 +23,12 @@ from pathlib import Path
 from rich.console import Console
 from dotenv import dotenv_values
 
-from .project_cmd_lib import GITIGNORE_CONTENT, load_api_key
+from .project_cmd_lib import (
+    GITIGNORE_CONTENT,
+    DEPLOY_NAME_PATTERN,
+    load_api_key,
+    normalize_deploy_name,
+)
 
 console = Console()
 
@@ -35,10 +40,6 @@ DASHBOARD_URL = "https://o.openonion.ai/dashboard"
 # users a co-ai or browser deploy had failed while it was still building.
 DEPLOY_POLL_SECONDS = 3
 DEPLOY_TIMEOUT_SECONDS = 20 * 60
-
-# Mirrors the server's rule (oo-api deploy/service.py). Checked locally so a bad
-# name in host.yaml fails before packaging and uploading the whole project.
-PROJECT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,38}$")
 
 
 def _check_host_export(entrypoint: str) -> bool:
@@ -119,12 +120,6 @@ def _is_git_repo(project_dir: Path) -> bool:
         capture_output=True,
     )
     return result.returncode == 0 and Path(result.stdout.decode().strip()).resolve() == project_dir.resolve()
-
-
-def _suggest_project_name(project_name: str) -> str | None:
-    """Nearest name that satisfies PROJECT_NAME_PATTERN, or None if there isn't one."""
-    candidate = re.sub(r"[^a-z0-9]+", "-", project_name.lower()).strip("-")[:39].rstrip("-")
-    return candidate if PROJECT_NAME_PATTERN.match(candidate) else None
 
 
 def _error_text(response: requests.Response) -> str:
@@ -275,16 +270,17 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     entrypoint = config.get("entrypoint", "agent.py")
 
     # The name becomes a hostname and a Docker tag, so the backend rejects
-    # anything outside this set. Fail here rather than after the upload.
-    if not PROJECT_NAME_PATTERN.match(project_name):
+    # anything outside this set. `co init` now normalizes it when writing
+    # host.yaml, but an older project or a hand-edited file can still carry a
+    # bad one — catch it here rather than after packaging and uploading.
+    if not DEPLOY_NAME_PATTERN.match(project_name):
         console.print(f"[red]Invalid project name: {project_name}[/red]")
         console.print(
             "[dim]Names may use 1-39 lowercase letters, digits, and hyphens, "
             "and must start with a letter or digit.[/dim]"
         )
-        # `co create My_Agent` writes that name straight into host.yaml, so
-        # offer the corrected form rather than leaving the user to derive it.
-        suggestion = _suggest_project_name(project_name)
+        # Offer the corrected form rather than leaving the user to derive it.
+        suggestion = normalize_deploy_name(project_name)
         if suggestion:
             console.print(f"[dim]Try:  name: {suggestion}[/dim]")
         console.print(f"[dim]Set 'name' in {host_yaml_path}[/dim]")

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -2,7 +2,7 @@
 Purpose: Deploy agent projects to ConnectOnion Cloud with local packaging and env vars
 LLM-Note:
   Dependencies: imports from [fnmatch, json, os, re, shutil, subprocess, tarfile, tempfile, time, yaml, requests, pathlib, rich.console, dotenv] | imported by [cli/main.py via handle_deploy()] | calls backend at [https://oo.openonion.ai/api/v1/deploy]
-  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → reads host.yaml for project name, entrypoint, env file path → checks the name against DEPLOY_NAME_PATTERN (same rule the backend enforces) and the entrypoint's host() export → load_api_key() loads OPENONION_API_KEY → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
+  Data flow: handle_deploy() → optionally creates a temporary template project via co create (named by --name, default {template}-agent) → validates .co/host.yaml → reads host.yaml for project name, entrypoint, env file path → checks the name against DEPLOY_NAME_PATTERN (same rule the backend enforces) and _exports_asgi_app() on the entrypoint → load_api_key() loads OPENONION_API_KEY → dotenv_values() loads env vars from .env → packages git-tracked files or initialized folder into tarball, merging each --skills path into .co/skills/ (a path that is itself a skill nests under its dirname) → POST to /api/v1/deploy with tarball + project_name + env_vars → polls /api/v1/deploy/{id}/status until running/error → displays agent URL
   State/Effects: creates temporary tarball file in tempdir | template deploy creates/deletes a temporary project on success | reads .co/host.yaml, .env files | makes network POST request | prints progress to stdout via rich.Console | normal deploy does not modify project files
   Integration: exposes handle_deploy(template, skills, name) for CLI | expects .co/host.yaml (name, entrypoint, env) unless --template is used | --name only valid with --template (otherwise the name comes from host.yaml) | uses Bearer token auth | returns bool success
   Performance: packaging is local file I/O | network timeout 600s for upload, 30s for status checks | polls every 3s for up to 20 min, covering the backend's own build budget (rsync 120s + docker build 900s + run 60s)
@@ -42,7 +42,7 @@ DEPLOY_POLL_SECONDS = 3
 DEPLOY_TIMEOUT_SECONDS = 20 * 60
 
 
-def _check_host_export(entrypoint: str) -> bool:
+def _exports_asgi_app(entrypoint: str) -> bool:
     """Check if entrypoint file exports an ASGI app via host().
 
     Looks for patterns like:
@@ -294,7 +294,7 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
         return False
 
     # Validate entrypoint exports ASGI app via host()
-    if not _check_host_export(str(entrypoint_path)):
+    if not _exports_asgi_app(str(entrypoint_path)):
         console.print(f"[red]Entrypoint '{entrypoint}' does not export an ASGI app.[/red]")
         console.print()
         console.print("[yellow]To deploy, your agent must call host():[/yellow]")

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -3,8 +3,8 @@ Purpose: Shared utility functions for CLI project commands including validation,
 LLM-Note:
   Dependencies: imports from [os, re, sys, time, shutil, rich.console, rich.prompt, rich.progress, rich.table, rich.panel, datetime, pathlib, __version__, address] | imported by [cli/commands/init.py, cli/commands/create.py] | calls LLM APIs for custom template generation | tested indirectly via test_cli_init.py and test_cli_create.py
   Data flow: provides utility functions called by init.py and create.py → validate_project_name() checks regex patterns → check_environment_for_api_keys() scans env vars for OpenAI/Anthropic/Google/Groq/Grok/OpenRouter keys → detect_api_provider() inspects key format to identify provider → api_key_setup_menu() displays interactive menu for key selection → generate_custom_template_with_name() calls LLM API with custom prompt to generate agent.py code → show_progress() displays Rich spinner → LoadingAnimation context manager for long operations → get_special_directory_warning() warns about home/root dirs
-  State/Effects: no persistent state | reads from environment variables | writes to stdout via rich.Console | calls LLM APIs (OpenAI/Anthropic/Google) when generating custom templates | creates Rich UI elements (tables, panels, progress bars, prompts) | does NOT write files (caller handles that)
-  Integration: exposes 16+ utility functions and 1 class (LoadingAnimation) | used by init.py and create.py for shared logic | validate_project_name() enforces naming conventions (starts with letter, no spaces, max 50 chars) | check_environment_for_api_keys() scans OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY | detect_api_provider() identifies provider by key prefix (sk- for OpenAI, sk-ant- for Anthropic, AIzaSy for Google, gsk- for Groq, xai- for Grok, sk-or- for OpenRouter) | generate_custom_template_with_name() uses LLM to create agent.py from natural language description
+  State/Effects: no persistent state | reads from environment variables | writes to stdout via rich.Console | calls LLM APIs (OpenAI/Anthropic/Google) when generating custom templates | creates Rich UI elements (tables, panels, progress bars, prompts) | writes no files except create_host_yaml() (.co/host.yaml)
+  Integration: exposes 16+ utility functions and 1 class (LoadingAnimation) | used by init.py and create.py for shared logic | validate_project_name() enforces naming conventions for the project/directory name (starts with letter, no spaces, max 50 chars) | normalize_deploy_name()/DEPLOY_NAME_PATTERN cover the separate, stricter rule for the deploy name written into host.yaml (a DNS label and Docker tag: lowercase, digits, hyphens), applied by create_host_yaml() and re-checked by deploy_commands.py | check_environment_for_api_keys() scans OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY | detect_api_provider() identifies provider by key prefix (sk- for OpenAI, sk-ant- for Anthropic, AIzaSy for Google, gsk- for Groq, xai- for Grok, sk-or- for OpenRouter) | generate_custom_template_with_name() uses LLM to create agent.py from natural language description
   Performance: environment scanning is O(n) env vars | regex validation is fast (<1ms) | LLM API calls for custom templates (5-15s) | Rich UI rendering is lightweight | LoadingAnimation runs in main thread (non-blocking spinner)
   Errors: validate_project_name() returns (False, error_msg) for invalid names | detect_api_provider() returns ("unknown", "unknown") for unrecognized keys | generate_custom_template_with_name() may fail if LLM API unreachable | api_key_setup_menu() catches KeyboardInterrupt and returns ("", "", None) | no try-except blocks (follows fail-fast principle)
 """
@@ -901,6 +901,20 @@ def copy_docs(co_dir: Path) -> bool:
         return False
 
 
+# The name in host.yaml becomes a DNS label and a Docker image tag when the
+# project is deployed, so `co deploy` and the backend both reject anything
+# outside this set. Kept here because host.yaml is written here.
+DEPLOY_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{0,38}$")
+
+
+def normalize_deploy_name(name: str) -> Optional[str]:
+    """Nearest deployable form of `name`, or None if nothing usable is left."""
+    if DEPLOY_NAME_PATTERN.match(name or ""):
+        return name
+    candidate = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")[:39].rstrip("-")
+    return candidate if DEPLOY_NAME_PATTERN.match(candidate) else None
+
+
 def create_host_yaml(co_dir: Path, project_name: str) -> bool:
     """Create .co/host.yaml from template. Returns True if created, False if already exists."""
     host_yaml_path = co_dir / "host.yaml"
@@ -911,7 +925,18 @@ def create_host_yaml(co_dir: Path, project_name: str) -> bool:
     with open(template_path, "r", encoding="utf-8") as f:
         template_content = f.read()
 
-    project_header = f"""name: {project_name}
+    # A directory name is chosen for people, not for DNS — `co init` inside
+    # "My_Agent" would otherwise write a name that can never deploy. Adjust it
+    # here rather than refusing to create the project, and say so, since the
+    # folder keeps its own name either way.
+    deploy_name = normalize_deploy_name(project_name) or "agent"
+    if deploy_name != project_name:
+        console.print(
+            f"  [yellow]Deployment name set to[/yellow] {deploy_name} "
+            f"[dim](from '{project_name}'; must be lowercase letters, digits, and hyphens)[/dim]"
+        )
+
+    project_header = f"""name: {deploy_name}
 entrypoint: agent.py
 """
     with open(host_yaml_path, "w", encoding='utf-8') as f:
@@ -1088,6 +1113,8 @@ __all__ = [
     'PROVIDER_TO_ENV',
     'copy_docs',
     'create_host_yaml',
+    'normalize_deploy_name',
+    'DEPLOY_NAME_PATTERN',
     'setup_gitignore',
     'print_resources',
     'load_api_key',

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -96,7 +96,7 @@ the same `co create` template logic, not by a separate deploy allowlist.
 
 ```yaml
 # .co/host.yaml
-name: my-agent          # Project name (used in URL)
+name: my-agent          # Project name (used in URL) — see the rule below
 entrypoint: agent.py    # Script to run in container
 trust: careful          # Trust level for incoming requests
 
@@ -106,6 +106,17 @@ examples:
   - "Example prompt 1"
   - "Example prompt 2"
 ```
+
+**Naming rule.** `name` becomes a hostname and a Docker image tag, so it must be
+1–39 characters of lowercase letters, digits, and hyphens, starting with a
+letter or digit. `co create` and `co init` write a conforming name for you — a
+project created in a folder called `My_Project` gets `name: my-project`, and the
+adjustment is printed — so this only matters if you edit `host.yaml` by hand.
+`co deploy` checks it before uploading and suggests the corrected form.
+
+Two projects whose names reduce to the same thing (`My_Agent` and `my-agent`)
+share one deployment URL, and deploying one replaces the other. Set `name`
+explicitly if you want them kept apart.
 
 ### Environment Variables
 

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -410,3 +410,24 @@ class TestCliCreate:
 
             # docs README should be in .co/docs/
             assert os.path.exists("readme-test-agent/.co/docs/README.md")
+
+    def test_create_writes_a_deployable_name_for_an_awkward_project_name(self):
+        """`co create My_Agent` keeps the folder name but must record a name
+        that can actually deploy — uppercase is not a legal Docker tag and an
+        underscore is not a legal DNS label."""
+        import yaml
+        from connectonion.cli.main import cli
+        from connectonion.cli.commands.project_cmd_lib import DEPLOY_NAME_PATTERN
+
+        with self.runner.isolated_filesystem():
+            result = self.runner.invoke(cli, ['create', 'My_Agent',
+                                              '--yes', '--template', 'minimal'])
+            assert result.exit_code == 0
+
+            # The directory keeps the name the user asked for.
+            assert os.path.isdir("My_Agent")
+
+            name = yaml.safe_load(Path("My_Agent/.co/host.yaml").read_text())["name"]
+            assert name == "my-agent"
+            assert DEPLOY_NAME_PATTERN.match(name)
+            assert "Deployment name set to" in result.output

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -92,8 +92,8 @@ class TestCliDeploy:
             mock_post.return_value = MagicMock(
                 status_code=200,
                 json=lambda: {
-                    "deployment_id": "abc123",
-                    "agent_url": "https://test-agent-abc123.agents.openonion.ai"
+                    "id": "abc123",
+                    "url": "https://test-agent-abc123.agents.openonion.ai"
                 }
             )
             mock_get.return_value = MagicMock(
@@ -277,6 +277,66 @@ class TestCliDeploy:
                 result = self.runner.invoke(cli, ['deploy'])
 
             assert "Deploy failed" in result.output
+
+
+class TestDeployValidation:
+    """Names and backend replies the CLI must reject before doing slow work."""
+
+    def setup_method(self):
+        self.runner = ArgparseCliRunner()
+
+    @pytest.mark.parametrize("project_name", [
+        "My-Agent",       # docker build rejects uppercase tags
+        "my_agent",       # not a legal DNS label
+        "x; rm -rf /",
+        "-leading-hyphen",
+    ])
+    def test_deploy_rejects_invalid_project_name(self, project_name):
+        """The name becomes a hostname and a Docker tag; fail before uploading."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text(f'name: {project_name!r}\nentrypoint: agent.py\n')
+            Path("agent.py").write_text("from connectonion import host\nhost(None)\n")
+
+            result = self.runner.invoke(cli, ['deploy'])
+            assert "Invalid project name" in result.output
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.get')
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_stops_when_backend_returns_no_id(self, mock_post, mock_get):
+        """Without an id there is nothing to poll — don't loop on /deploy/None/status."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.commands.deploy_commands import _deploy_current_project
+
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text('name: test-agent\nentrypoint: agent.py\n')
+            Path("agent.py").write_text("from connectonion import host\nhost(None)\n")
+
+            mock_post.return_value = MagicMock(status_code=200, json=lambda: {"url": "u"})
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                assert _deploy_current_project([]) is False
+
+            mock_get.assert_not_called()
+
+    def test_host_export_check_ignores_comments_and_attributes(self):
+        """Only a real host(...) call counts as exporting an ASGI app."""
+        from connectonion.cli.commands.deploy_commands import _check_host_export
+
+        with self.runner.isolated_filesystem():
+            Path("commented.py").write_text("# host(agent)\nprint('hi')\n")
+            assert _check_host_export("commented.py") is False
+
+            Path("attribute.py").write_text("client.host(agent)\n")
+            assert _check_host_export("attribute.py") is False
+
+            Path("real.py").write_text("from connectonion import host\nhost(agent)\n")
+            assert _check_host_export("real.py") is True
+
+            Path("assigned.py").write_text("app = host(agent)\n")
+            assert _check_host_export("assigned.py") is True
 
 
 @SKIP_NO_GIT

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -368,6 +368,47 @@ class TestDeployValidation:
                 Path(name).write_text(source)
                 assert _exports_asgi_app(name) is True, name
 
+    def test_host_export_check_ignores_a_hash_inside_a_string(self):
+        """The comment rule is lexical, so a `#` inside a string literal must
+        not hide a real host() call later on the same line — that would block a
+        valid deploy with an error the user cannot act on."""
+        from connectonion.cli.commands.deploy_commands import _exports_asgi_app
+
+        with self.runner.isolated_filesystem():
+            Path("hashy.py").write_text('msg = "note: #1"; host(agent)\n')
+            assert _exports_asgi_app("hashy.py") is True
+
+            Path("single.py").write_text("msg = 'issue #7'\nhost(agent)\n")
+            assert _exports_asgi_app("single.py") is True
+
+    @patch('connectonion.cli.commands.deploy_commands.requests.post')
+    def test_deploy_survives_a_yaml_typed_project_name(self, mock_post):
+        """`name: 123` unquoted parses as an int, and matching a regex against
+        an int raises TypeError — a traceback instead of a clean message.
+
+        The upload is mocked out: this is about surviving the config read, and
+        a real POST would make the test slow and dependent on the network.
+        """
+        from connectonion.cli.main import cli
+
+        mock_post.return_value = MagicMock(
+            status_code=400, text='{"detail": "nope"}',
+            json=lambda: {"detail": "nope"},
+        )
+
+        with self.runner.isolated_filesystem():
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: 123\nentrypoint: agent.py\n")
+            Path("agent.py").write_text("from connectonion import host\nhost(None)\n")
+
+            with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
+                result = self.runner.invoke(cli, ['deploy'])
+
+            assert "Traceback" not in result.output
+            # "123" is a legal deploy name, so it gets past validation instead
+            # of raising, and the run ends at the mocked backend error.
+            assert "Invalid project name" not in result.output
+            assert "Project: 123" in result.output
 
 @SKIP_NO_GIT
 class TestDeploySkillsPackaging:

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -304,8 +304,9 @@ class TestDeployValidation:
             assert "Invalid project name" in result.output
 
     def test_invalid_name_suggests_a_valid_one(self):
-        """`co create My_Agent` writes that name into host.yaml, so the deploy
-        error has to say what to change it to."""
+        """host.yaml can still carry a bad name — written before `co init`
+        normalized it, or edited by hand — so the error says what to change
+        it to rather than only what is wrong."""
         from connectonion.cli.main import cli
 
         with self.runner.isolated_filesystem():

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -303,6 +303,20 @@ class TestDeployValidation:
             result = self.runner.invoke(cli, ['deploy'])
             assert "Invalid project name" in result.output
 
+    def test_invalid_name_suggests_a_valid_one(self):
+        """`co create My_Agent` writes that name into host.yaml, so the deploy
+        error has to say what to change it to."""
+        from connectonion.cli.main import cli
+
+        with self.runner.isolated_filesystem():
+            os.makedirs(".co")
+            Path(".co/host.yaml").write_text("name: My_Agent\nentrypoint: agent.py\n")
+            Path("agent.py").write_text("from connectonion import host\nhost(None)\n")
+
+            result = self.runner.invoke(cli, ['deploy'])
+            assert "Invalid project name" in result.output
+            assert "my-agent" in result.output
+
     @patch('connectonion.cli.commands.deploy_commands.requests.get')
     @patch('connectonion.cli.commands.deploy_commands.requests.post')
     def test_deploy_stops_when_backend_returns_no_id(self, mock_post, mock_get):
@@ -321,22 +335,37 @@ class TestDeployValidation:
 
             mock_get.assert_not_called()
 
-    def test_host_export_check_ignores_comments_and_attributes(self):
-        """Only a real host(...) call counts as exporting an ASGI app."""
+    def test_host_export_check_ignores_commented_out_calls(self):
+        """A commented-out host() call must not pass the pre-flight check."""
         from connectonion.cli.commands.deploy_commands import _check_host_export
 
         with self.runner.isolated_filesystem():
             Path("commented.py").write_text("# host(agent)\nprint('hi')\n")
             assert _check_host_export("commented.py") is False
 
-            Path("attribute.py").write_text("client.host(agent)\n")
-            assert _check_host_export("attribute.py") is False
+            Path("trailing.py").write_text("x = 1  # host(agent) goes here later\n")
+            assert _check_host_export("trailing.py") is False
 
-            Path("real.py").write_text("from connectonion import host\nhost(agent)\n")
-            assert _check_host_export("real.py") is True
+            Path("similar.py").write_text("ghost(agent)\nurl = localhost(8000)\n")
+            assert _check_host_export("similar.py") is False
 
-            Path("assigned.py").write_text("app = host(agent)\n")
-            assert _check_host_export("assigned.py") is True
+    def test_host_export_check_accepts_every_way_of_calling_host(self):
+        """Blocking a valid deploy is worse than letting one reach a clear
+        container error, so any real host(...) call counts — including the
+        module-qualified form."""
+        from connectonion.cli.commands.deploy_commands import _check_host_export
+
+        with self.runner.isolated_filesystem():
+            for name, source in [
+                ("plain.py", "from connectonion import host\nhost(agent)\n"),
+                ("assigned.py", "app = host(agent)\n"),
+                ("kwargs.py", "host(agent, port=8000)\n"),
+                ("qualified.py", "import connectonion\nconnectonion.host(agent)\n"),
+                ("aliased.py", "import connectonion as co\nco.host(agent)\n"),
+                ("guarded.py", "if __name__ == '__main__': host(agent)\n"),
+            ]:
+                Path(name).write_text(source)
+                assert _check_host_export(name) is True, name
 
 
 @SKIP_NO_GIT

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -338,23 +338,23 @@ class TestDeployValidation:
 
     def test_host_export_check_ignores_commented_out_calls(self):
         """A commented-out host() call must not pass the pre-flight check."""
-        from connectonion.cli.commands.deploy_commands import _check_host_export
+        from connectonion.cli.commands.deploy_commands import _exports_asgi_app
 
         with self.runner.isolated_filesystem():
             Path("commented.py").write_text("# host(agent)\nprint('hi')\n")
-            assert _check_host_export("commented.py") is False
+            assert _exports_asgi_app("commented.py") is False
 
             Path("trailing.py").write_text("x = 1  # host(agent) goes here later\n")
-            assert _check_host_export("trailing.py") is False
+            assert _exports_asgi_app("trailing.py") is False
 
             Path("similar.py").write_text("ghost(agent)\nurl = localhost(8000)\n")
-            assert _check_host_export("similar.py") is False
+            assert _exports_asgi_app("similar.py") is False
 
     def test_host_export_check_accepts_every_way_of_calling_host(self):
         """Blocking a valid deploy is worse than letting one reach a clear
         container error, so any real host(...) call counts — including the
         module-qualified form."""
-        from connectonion.cli.commands.deploy_commands import _check_host_export
+        from connectonion.cli.commands.deploy_commands import _exports_asgi_app
 
         with self.runner.isolated_filesystem():
             for name, source in [
@@ -366,7 +366,7 @@ class TestDeployValidation:
                 ("guarded.py", "if __name__ == '__main__': host(agent)\n"),
             ]:
                 Path(name).write_text(source)
-                assert _check_host_export(name) is True, name
+                assert _exports_asgi_app(name) is True, name
 
 
 @SKIP_NO_GIT

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -528,3 +528,24 @@ class TestCliInit:
             name = yaml.safe_load(Path(".co/host.yaml").read_text())["name"]
             assert name == "my-project"
             assert "Deployment name set to" not in result.output
+
+    def test_init_falls_back_when_the_directory_name_has_nothing_reusable(self):
+        """A directory named entirely in non-ASCII leaves no usable deploy name.
+
+        It must still produce a project that can deploy — CI runs `co init` in a
+        CJK-named folder on Windows — rather than an empty or invalid name.
+        """
+        from connectonion.cli.main import cli
+        from connectonion.cli.commands.project_cmd_lib import DEPLOY_NAME_PATTERN
+
+        with self.runner.isolated_filesystem():
+            os.makedirs("我的 项目")
+            os.chdir("我的 项目")
+
+            result = self.runner.invoke(cli, ['init', '--template', 'minimal'])
+            assert result.exit_code == 0
+            assert "Traceback" not in result.output
+
+            name = yaml.safe_load(Path(".co/host.yaml").read_text())["name"]
+            assert name == "agent"
+            assert DEPLOY_NAME_PATTERN.match(name)

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -491,3 +491,40 @@ class TestCliInit:
 
             # docs README should only be in .co/docs/, not project root
             assert os.path.exists(".co/docs/README.md")
+
+    def test_init_writes_a_deployable_name_from_an_awkward_directory(self):
+        """A directory is named for people, not for DNS.
+
+        The name in host.yaml becomes a hostname and a Docker tag at deploy
+        time, so `co init` inside "My_Project" must not bake in a name that can
+        never deploy — and must say what it used instead.
+        """
+        from connectonion.cli.main import cli
+        from connectonion.cli.commands.project_cmd_lib import DEPLOY_NAME_PATTERN
+
+        with self.runner.isolated_filesystem():
+            os.makedirs("My_Project")
+            os.chdir("My_Project")
+
+            result = self.runner.invoke(cli, ['init', '--template', 'minimal'])
+            assert result.exit_code == 0
+
+            name = yaml.safe_load(Path(".co/host.yaml").read_text())["name"]
+            assert name == "my-project"
+            assert DEPLOY_NAME_PATTERN.match(name)
+            assert "Deployment name set to" in result.output
+
+    def test_init_keeps_an_already_valid_directory_name_untouched(self):
+        """No notice and no rewriting when the directory name is already fine."""
+        from connectonion.cli.main import cli
+
+        with self.runner.isolated_filesystem():
+            os.makedirs("my-project")
+            os.chdir("my-project")
+
+            result = self.runner.invoke(cli, ['init', '--template', 'minimal'])
+            assert result.exit_code == 0
+
+            name = yaml.safe_load(Path(".co/host.yaml").read_text())["name"]
+            assert name == "my-project"
+            assert "Deployment name set to" not in result.output


### PR DESCRIPTION
> **This PR has no security effect on its own.** It contains a client-side name check, and a client-side check is not a boundary — anyone can call `POST /api/v1/deploy` directly and bypass it entirely. The command injection on the agents VM is live today and is fixed by **openonion/oo-api#34**, which is open and unmerged. Treat this PR as a UX improvement; merge oo-api#34 for the actual fix.

## Description

Fixes found while reviewing the `co deploy` path. The main one: the CLI gave up polling after 100 attempts (~5 minutes) while the backend allows the Docker build alone 900s, precisely because co-ai and browser images take minutes to build. Those deploys printed `Deploy status: deploying` / `try again` on a deploy that was still building and would go on to succeed.

## Related Issue

None — found during a review of `co deploy`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Changes Made

**`co deploy` (`connectonion/cli/commands/deploy_commands.py`)**

- **Poll against a 20-minute deadline** covering the backend's own budget (rsync 120s + docker build 900s + run 60s) instead of a fixed 100 attempts. Progress shows time remaining rather than `[n/100]`, which was a misleading unit.
- **Reject an invalid deploy name locally**, before packaging and uploading the whole project, with the corrected name to paste back. Convenience only — see the banner above.
- **Check the project before the API key.** A broken `host.yaml` is worth reporting whether or not you happen to be logged in; previously `No API key` masked every project-level error.
- **Stop instead of polling `/deploy/None/status`.** If the response carries no `id`, the loop spent five minutes requesting a URL that could never resolve.
- **Print the backend's `detail`** on a failed POST instead of the raw JSON body.
- **`_exports_asgi_app` (was `_check_host_export`) no longer counts commented-out calls.** `\bhost\s*\(` matched `# host(agent)`, so a project that never calls `host()` could pass the pre-flight check and then fail at container start.

**`co create` / `co init` (`connectonion/cli/commands/project_cmd_lib.py`)**

The `name` in `host.yaml` becomes a DNS label and a Docker image tag at deploy time, but nothing produced it with that in mind — `co create My_Agent` wrote `My_Agent`, and `co init` wrote whatever the current directory happened to be called. Both produced projects that **could never deploy** (Docker rejects uppercase tags; `_` is not a legal DNS label) and only found out deep in the remote build.

`create_host_yaml` is the single point both paths funnel through, so the deploy name is normalized there and the adjustment is printed:

```
$ mkdir My_Project && cd My_Project && co init
  Deployment name set to my-project (from 'My_Project'; must be lowercase letters, digits, and hyphens)
```

Refusing to create the project would be the wrong trade — a directory is named for people, and the folder keeps its own name either way. Existing projects are untouched: `create_host_yaml` returns early when `host.yaml` already exists.

The rule has **one definition**, next to the code that writes `host.yaml`; `deploy_commands` imports it instead of carrying a copy. It is named for the deploy role (`DEPLOY_NAME_PATTERN` / `normalize_deploy_name`) so it is not confused with the existing `validate_project_name`, which governs the project/directory name and deliberately allows uppercase and underscores.

**Docs (`docs/network/deploy.md`)** — the naming rule governed a hostname and a Docker tag but was written down nowhere. Documented next to the `host.yaml` config it applies to, including the consequence below.

## Consequence worth knowing

Two folder names that reduce to the same deploy name (`My_Agent` and `my-agent`) now share one deployment URL, and deploying one replaces the other. Previously the first simply could not deploy at all, so nothing that used to work breaks — but it is a new way to collide, so it is called out in the docs with the fix (set `name` explicitly).

## Fixed after review

Four issues were raised in review; all four reproduced. ([full reply](https://github.com/openonion/connectonion/pull/281#issuecomment-5098563607))

- **A `#` inside a string literal hid a real `host()` call** later on the same line, because the comment rule is lexical — `msg = "note: #1"; host(agent)` was reported as "does not export an ASGI app", blocking a valid deploy. Single-line string literals are blanked before the rule runs.
- **An unquoted `name: 123`** parses as an `int`, and `re.match` on an int raises `TypeError` — a traceback in place of the clear message this code exists to print. The three `host.yaml` reads coerce to `str`.
- **The countdown could print `-1m55s left`** (`//` floors, `%` does not) when a status call returned near the deadline. Clamped to zero.
- **The security framing** was too soft; hence the banner at the top of this description.

## A bug this PR's own first draft introduced

The first version of `_exports_asgi_app` also excluded *attribute* calls, to skip things like `client.host(...)`. Testing the regex against real idioms showed that also excluded `connectonion.host(agent)` and `co.host(agent)` — legitimate ways to call it:

```
  True (want  True)  plain call
 False (want  True)  module-qualified call   <-- MISMATCH
 False (want  True)  fully qualified         <-- MISMATCH
```

That blocks a valid deploy with an error the user cannot act on. Letting a bad project through to a clear container error is the better failure, so the lookbehind now only rules out names *ending* in "host" (`ghost(`, `localhost(`) — which, checked against the original, `\b` already handled.

## Naming

Functions whose names would make a reader guess wrong were renamed (no behavior change): `_check_host_export` → `_exports_asgi_app`, which reads as the question the caller is asking rather than leaving "what does True mean" open.

## Testing

- [x] I have tested this code locally
- [x] All existing tests pass
- [x] I have added tests for new functionality

`pytest tests/e2e/cli/test_cli_deploy.py test_cli_init.py test_cli_create.py -q` → **89 passed**. Full suite: `pytest tests/ -m "not slow and not real_api and not network"` → 2691 passed.

New coverage:
- `TestDeployValidation`: invalid names (`My-Agent`, `my_agent`, `x; rm -rf /`, leading hyphen) rejected before upload; the suggestion (`My_Agent` → `my-agent`) in the error; a response with no `id` aborting without any status request; a YAML-typed `name: 123` surviving the config read; `_exports_asgi_app` accepting all six real ways to call `host()` and a `#` inside a string, while rejecting commented-out calls and `ghost`/`localhost`.
- `co init` inside `My_Project` writes `my-project` and says so; a CJK-named directory falls back to `agent`; an already-valid directory name is left alone with no notice.
- `co create My_Agent` keeps the `My_Agent` folder but records `my-agent`.

Also verified outside the test suite: `_exports_asgi_app` against **all 6 template `agent.py` files** — it detects exactly `co-ai` and `hosted-browser` (the two that call `host()`) and no others. And `co create` already rejects names with spaces itself, so the gap was only uppercase and underscores.

One existing mock returned `{"deployment_id", "agent_url"}` — key names the backend has never sent. Corrected to `{"id", "url"}`, the real response shape, which is what the new no-id guard made visible. One new test initially made a real network call and took 105s; it is mocked and hermetic now.

## Example Usage

```python
# New projects get a deployable name automatically, whatever the folder is called:
#
#   $ mkdir My_Project && cd My_Project && co init
#     Deployment name set to my-project (from 'My_Project'; must be lowercase...)
#
# An older project whose host.yaml predates that still fails early, with the fix:
#
#   $ co deploy
#   Invalid project name: My_Agent
#   Names may use 1-39 lowercase letters, digits, and hyphens, and must start
#   with a letter or digit.
#   Try:  name: my-agent
#   Set 'name' in /path/to/project/.co/host.yaml
#
# And a slow template deploy is followed to completion instead of being
# abandoned at five minutes:
#
#   $ co deploy --template co-ai
#   Building container on ConnectOnion Cloud...
#     [19m54s left] status: deploying
#     ...
#     [11m06s left] status: running
#   Deployed!
```

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published

## Additional Notes

The `LLM-Note` headers in both touched modules were updated for the new ordering, the new failure mode, the new poll budget, and the deploy-name rule.