### PR TITLE
Only print the [env] diagnostic when stderr is a terminal

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -13,6 +13,7 @@ ConnectOnion - A simple agent framework with behavior tracking.
 __version__ = "1.4.0"
 
 # Auto-load .env files for the entire framework
+import os as _os
 import sys as _sys
 from dotenv import load_dotenv
 from pathlib import Path as _Path
@@ -22,11 +23,18 @@ from pathlib import Path as _Path
 # define a key wins: the project .env overrides, keys.env fills in the rest.
 # Loading only one of them silently hid every credential that lives solely in
 # keys.env (OAuth tokens land there) from any project that had its own .env.
-# Diagnostics go to stderr so command output on stdout stays clean (scriptable).
+# The [env] diagnostic answers "which file won?" for a human at a terminal.
+# It is written to stderr only when stderr IS a terminal: agents drive `co`
+# through bash, which appends any stderr to the tool result as "STDERR:" no
+# matter what the exit code was, so an unconditional print made every
+# successful command look like it had failed. CO_DEBUG_ENV=1 forces it on for
+# piped or redirected debugging.
+_show_env = _sys.stderr.isatty() or _os.getenv("CO_DEBUG_ENV") == "1"
 for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
     if _env_file.exists():
         load_dotenv(_env_file)
-        print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
+        if _show_env:
+            print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
 
 from .core import Agent, LLM, create_tool_from_function
 from .core import (

--- a/tests/unit/test_env_diagnostic.py
+++ b/tests/unit/test_env_diagnostic.py
@@ -6,13 +6,26 @@ bash("co browser <verb>"), an unconditional [env] print made every
 successful command look to the agent like it had failed.
 """
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 
-def _run(env_extra=None, tty=False):
-    """Import connectonion in a subprocess and return what it wrote to stderr."""
-    env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": "/tmp"}
+def _run(tmp_path, env_extra=None, tty=False):
+    """Import connectonion in a subprocess and return what it wrote to stderr.
+
+    A .env is created in the working directory on purpose: the diagnostic only
+    prints for env files that exist, so without one these tests would pass
+    vacuously anywhere the developer happens to lack a local .env — which is
+    exactly how they first failed in CI while passing on my machine.
+    """
+    (tmp_path / ".env").write_text("EXAMPLE_KEY=value\n", encoding="utf-8")
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(tmp_path),
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+    }
     env.update(env_extra or {})
     if tty:
         # A pty makes stderr a terminal, which is the human case.
@@ -30,23 +43,24 @@ def _run(env_extra=None, tty=False):
             "except OSError: pass\n"
             "sys.stdout.write(out.decode(errors='replace'))\n"
         )
-        r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+        r = subprocess.run([sys.executable, "-c", code], capture_output=True,
+                           text=True, env=env, cwd=tmp_path)
         return r.stdout
     r = subprocess.run([sys.executable, "-c", "import connectonion"],
-                       capture_output=True, text=True, env=env)
+                       capture_output=True, text=True, env=env, cwd=tmp_path)
     return r.stderr
 
 
-def test_piped_output_carries_no_env_diagnostic():
+def test_piped_output_carries_no_env_diagnostic(tmp_path):
     """The agent's case: stderr is a pipe, so nothing should be written."""
-    assert "[env]" not in _run()
+    assert "[env]" not in _run(tmp_path)
 
 
-def test_a_terminal_still_gets_the_diagnostic():
+def test_a_terminal_still_gets_the_diagnostic(tmp_path):
     """The human's case: it answers 'which env file won?'."""
-    assert "[env]" in _run(tty=True)
+    assert "[env]" in _run(tmp_path, tty=True)
 
 
-def test_co_debug_env_forces_it_back_on():
+def test_co_debug_env_forces_it_back_on(tmp_path):
     """Escape hatch for debugging a piped or redirected run."""
-    assert "[env]" in _run({"CO_DEBUG_ENV": "1"})
+    assert "[env]" in _run(tmp_path, {"CO_DEBUG_ENV": "1"})

--- a/tests/unit/test_env_diagnostic.py
+++ b/tests/unit/test_env_diagnostic.py
@@ -1,0 +1,52 @@
+"""The [env] diagnostic must not reach agents through tool output.
+
+`bash` appends any non-empty stderr to the tool result as "STDERR:",
+regardless of exit code. Since agents drive the browser as
+bash("co browser <verb>"), an unconditional [env] print made every
+successful command look to the agent like it had failed.
+"""
+
+import subprocess
+import sys
+
+
+def _run(env_extra=None, tty=False):
+    """Import connectonion in a subprocess and return what it wrote to stderr."""
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "HOME": "/tmp"}
+    env.update(env_extra or {})
+    if tty:
+        # A pty makes stderr a terminal, which is the human case.
+        code = (
+            "import pty, os, sys\n"
+            "pid, fd = pty.fork()\n"
+            "if pid == 0:\n"
+            "    os.execvpe(sys.executable, [sys.executable, '-c', 'import connectonion'], os.environ)\n"
+            "out = b''\n"
+            "try:\n"
+            "    while True:\n"
+            "        d = os.read(fd, 1024)\n"
+            "        if not d: break\n"
+            "        out += d\n"
+            "except OSError: pass\n"
+            "sys.stdout.write(out.decode(errors='replace'))\n"
+        )
+        r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+        return r.stdout
+    r = subprocess.run([sys.executable, "-c", "import connectonion"],
+                       capture_output=True, text=True, env=env)
+    return r.stderr
+
+
+def test_piped_output_carries_no_env_diagnostic():
+    """The agent's case: stderr is a pipe, so nothing should be written."""
+    assert "[env]" not in _run()
+
+
+def test_a_terminal_still_gets_the_diagnostic():
+    """The human's case: it answers 'which env file won?'."""
+    assert "[env]" in _run(tty=True)
+
+
+def test_co_debug_env_forces_it_back_on():
+    """Escape hatch for debugging a piped or redirected run."""
+    assert "[env]" in _run({"CO_DEBUG_ENV": "1"})


### PR DESCRIPTION
Closes #282.

## The problem

`bash` appends any non-empty stderr to the tool result as `STDERR:` — **regardless of exit code** (`bash.py:71`). Since #273 and #279 the agent drives the browser as `bash("co browser <verb>")`, which spawns a fresh `co` process per action, and each one reprinted the `[env]` lines from `connectonion/__init__.py`.

So a completely successful command reached the agent looking like this:

```
Example Domain

This domain is for use in documentation examples without needing permission.

Learn more
STDERR:
[env] /Users/you/.co/keys.env
```

The token cost was minor — 35–70 characters, 8–17 tokens, though 20% of a short `get_text` payload. **The misleading shape was the problem.** Nothing in that output says the exit code was 0. An agent reasonably reads `STDERR:` as a warning worth reacting to: retrying, or reporting a failure that never happened. We were handing the model a false signal on every single browser action.

## The fix

The diagnostic exists so a **human at a terminal** can see which env file won. It now prints only when stderr is one:

```python
_show_env = _sys.stderr.isatty() or _os.getenv("CO_DEBUG_ENV") == "1"
```

`CO_DEBUG_ENV=1` forces it back on for a piped or redirected debugging run, so the case the escape hatch exists for isn't lost.

## Verified

```python
>>> from connectonion import bash
>>> bash(command="co browser get_text")
'Example Domain\n\nThis domain is for use in documentation examples...\n\nLearn more'
```

No `STDERR`, no `[env]`. Before this change the same call carried both.

## Tests

Three, each running the import in a real subprocess rather than mocking `isatty`:

- **piped** stderr writes nothing — the agent's case; **fails on main**
- **a pty** still gets it — the human's case, so the diagnostic isn't quietly killed for everyone
- **`CO_DEBUG_ENV=1`** forces it on through a pipe

Full suite: **2,627 passed, 6 skipped**.

## Considered, not done here

`bash` labelling stderr by outcome — `NOTE (exit 0):` versus `STDERR (exit 1):` — would fix this class for *every* command rather than just `co`. Much broader blast radius, so it deserves its own decision rather than riding along here.