### PR TITLE
Give the `co browser` daemon the tab bounds BrowserAutomation already had

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -129,9 +129,18 @@ def _held_by_other(meta, caller: str) -> bool:
 class BrowserDaemon:
     """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
 
-    def __init__(self, sock_path: str, headless: bool = False):
+    def __init__(self, sock_path: str, headless: bool = False,
+                 tab_idle_ttl: float = None, max_tabs: int = None):
         self.sock_path = sock_path
-        self.browser = BrowserAutomation(headless=headless)
+        # One daemon owns the browser for every caller on the box, so these
+        # bounds are the box's, not one caller's. Left as BrowserAutomation's
+        # defaults unless set, so nothing changes for anyone who doesn't ask.
+        limits = {}
+        if tab_idle_ttl is not None:
+            limits["tab_idle_ttl"] = tab_idle_ttl
+        if max_tabs is not None:
+            limits["max_tabs"] = max_tabs
+        self.browser = BrowserAutomation(headless=headless, **limits)
         self._srv = None
         self._had_browser = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
@@ -277,7 +286,16 @@ class BrowserDaemon:
         """Report browser state, the last command, and the tab board."""
         open_state = "open" if self.browser._context_is_alive() else "not open"
         headless = str(getattr(self.browser, "_headless", False)).lower()
-        lines = [f"Browser: {open_state} · headless={headless} · targeting is per-command (-t <tab>; bare = main)"]
+        # Show the limits actually in force: one daemon serves every caller, so
+        # "which numbers am I bound by?" is not answerable from any one launch
+        # command.
+        ttl = int(getattr(self.browser, "_tab_idle_ttl", 0))
+        cap = getattr(self.browser, "_max_tabs", 0)
+        lines = [
+            f"Browser: {open_state} · headless={headless} · "
+            f"max_tabs={cap} · tab_idle_ttl={ttl}s · "
+            "targeting is per-command (-t <tab>; bare = main)"
+        ]
         # Surface stealth-driver health here so a misconfigured driver (webdriver leak) is
         # visible where users look for browser state, not only in `co doctor`.
         stealth, version, detail = driver_stealth_status()
@@ -655,8 +673,28 @@ def main():
             if hasattr(stream, "reconfigure"):
                 stream.reconfigure(encoding="utf-8", errors="replace")
     sock_path = sys.argv[1] if len(sys.argv) > 1 else default_sock_path()
-    headless = "--headless" in sys.argv[2:]
-    BrowserDaemon(sock_path, headless=headless).serve()
+    args = sys.argv[2:]
+    headless = "--headless" in args
+
+    def _opt(flag: str, env: str):
+        """Flag wins over env; both absent means BrowserAutomation's default.
+
+        The env vars matter because the daemon is usually started implicitly by
+        the first client, not by a hand-written command line."""
+        if flag in args:
+            i = args.index(flag)
+            if i + 1 < len(args):
+                return args[i + 1]
+        return os.environ.get(env)
+
+    ttl = _opt("--tab-idle-ttl", "CO_BROWSER_TAB_IDLE_TTL")
+    cap = _opt("--max-tabs", "CO_BROWSER_MAX_TABS")
+    BrowserDaemon(
+        sock_path,
+        headless=headless,
+        tab_idle_ttl=float(ttl) if ttl else None,
+        max_tabs=int(cap) if cap else None,
+    ).serve()
 
 
 if __name__ == "__main__":

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -16,6 +16,7 @@ or network is needed. The daemon's lazy BrowserAutomation is swapped for the stu
 
 import contextlib
 import os
+import sys
 import socket
 import subprocess
 import threading
@@ -1026,3 +1027,60 @@ def test_permission_error_still_clears_a_dead_owners_socket(short_sock, monkeypa
     monkeypatch.setattr(socket.socket, "connect", denied)
     assert c._connect_posix(short_sock) is None
     assert not os.path.exists(short_sock), "stale socket should have been removed"
+
+
+class TestTabLimits:
+    """One daemon owns the browser for every caller on the box, so tab bounds
+    are the box's. Before these knobs existed, hosted-browser could not move
+    to the CLI without silently losing tab reclamation and its tab cap."""
+
+    def test_defaults_are_unchanged_when_nothing_is_asked_for(self, short_sock):
+        # Real BrowserAutomation, not the stub — the point is its own defaults.
+        # Construction is lazy, so no browser actually launches.
+        daemon = d.BrowserDaemon(short_sock)
+        assert daemon.browser._max_tabs == 10
+        assert daemon.browser._tab_idle_ttl == 3600.0
+
+    def test_explicit_limits_reach_the_browser(self, short_sock):
+        daemon = d.BrowserDaemon(short_sock, tab_idle_ttl=600, max_tabs=3)
+        assert daemon.browser._max_tabs == 3
+        assert daemon.browser._tab_idle_ttl == 600
+
+    def test_status_reports_the_limits_in_force(self, short_sock):
+        """A caller cannot read them off a launch command it never wrote."""
+        daemon = d.BrowserDaemon(short_sock, tab_idle_ttl=600, max_tabs=3)
+        daemon.browser = StubBrowser()
+        daemon.browser._max_tabs = 3  # StubBrowser mirrors the real attribute names
+        daemon.browser._tab_idle_ttl = 600
+        daemon.browser._headless = False
+
+        ok, text = daemon.dispatch("status")
+
+        assert ok is True
+        assert "max_tabs=3" in text
+        assert "tab_idle_ttl=600s" in text
+
+    def test_flags_and_env_both_work_and_flag_wins(self, monkeypatch, short_sock):
+        """The daemon is usually started implicitly by the first client, so the
+        env vars are the only reachable knob in that path."""
+        seen = {}
+
+        class Recorder(d.BrowserDaemon):
+            def __init__(self, sock, headless=False, tab_idle_ttl=None, max_tabs=None):
+                seen["ttl"] = tab_idle_ttl
+                seen["cap"] = max_tabs
+
+            def serve(self):
+                pass
+
+        monkeypatch.setattr(d, "BrowserDaemon", Recorder)
+
+        monkeypatch.setattr(sys, "argv", ["daemon", short_sock])
+        monkeypatch.setenv("CO_BROWSER_MAX_TABS", "5")
+        monkeypatch.setenv("CO_BROWSER_TAB_IDLE_TTL", "900")
+        d.main()
+        assert (seen["cap"], seen["ttl"]) == (5, 900.0)
+
+        monkeypatch.setattr(sys, "argv", ["daemon", short_sock, "--max-tabs", "2"])
+        d.main()
+        assert seen["cap"] == 2, "an explicit flag must beat the environment"


### PR DESCRIPTION
Closes #283. Unblocks the last template in #234.

## The gap

`BrowserAutomation` takes two resource guards; the daemon exposed **neither** and silently took the defaults:

```
BrowserAutomation(tab_idle_ttl=3600.0, max_tabs=10)
grep -c 'tab_idle_ttl\|max_tabs' daemon.py  →  0
```

That is precisely why `hosted-browser` could not follow #273 and #279 onto the CLI. It runs with `tab_idle_ttl=600, max_tabs=3`, and its own README lists those under *"Knobs that matter in production"* — one browser serves every chat session, and those two numbers are what stop tabs accumulating until a small box runs out of memory. Converting it would have looked like consistency and behaved like a downgrade.

## The change

```bash
co browser status
# Browser: not open · headless=false · max_tabs=3 · tab_idle_ttl=600s · targeting is per-command

CO_BROWSER_MAX_TABS=3 CO_BROWSER_TAB_IDLE_TTL=600 co browser status
python -m connectonion.cli.browser_agent.daemon <sock> --max-tabs 3 --tab-idle-ttl 600
```

**The env vars are not a convenience.** The daemon is usually started *implicitly by the first client*, so a hand-written command line is the one path nobody takes — without them the flags would be unreachable in normal use.

**`status` reporting the effective values matters for the same reason.** With one daemon per box there is one browser and one set of limits for every caller. Nobody can read their limits off a launch command they never wrote. "First client wins" is a defensible rule, but only debuggable if the winner is visible — so this PR makes it visible rather than leaving it implicit.

Defaults are untouched when nothing is asked for: `max_tabs=10`, `tab_idle_ttl=3600`, exactly as before.

## Tests

Four in `TestTabLimits`:

- defaults unchanged when nothing is asked for — constructed against the **real** `BrowserAutomation` rather than the stub, since its own defaults are the thing under test
- explicit limits reach the browser
- `status` reports what is in force
- flags and env both work, **and an explicit flag beats the environment**

Verified live against a fresh daemon, not only in tests:

```
$ CO_BROWSER_MAX_TABS=3 CO_BROWSER_TAB_IDLE_TTL=600 co browser status
Browser: not open · headless=false · max_tabs=3 · tab_idle_ttl=600s · ...
```

Full suite: **2,628 passed, 6 skipped**.

## Next

`hosted-browser` can now move to the CLI like the other two, which closes #234.