### PR TITLE
Let an agent declare how long it needs a tab

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -415,11 +415,15 @@ class BrowserDaemon:
 
     def _tab_usage(self) -> str:
         return (
-            "usage: co browser tab open [NAME] [--who <agent>] [--for \"<purpose>\"]   # register; prints the name\n"
+            "usage: co browser tab open [NAME] [--who <agent>] [--for \"<purpose>\"] [--needs 10m]\n"
             "       co browser tab ls [--json]                                        # who runs where\n"
             "       co browser tab close <NAME>                                       # release when done\n"
             "then target your tab on EVERY command, including do:\n"
-            "       co browser -t <NAME> <verb> [args]"
+            "       co browser -t <NAME> <verb> [args]\n\n"
+            "--needs is your estimate of how long you will hold the tab (30s / 10m / 2h).\n"
+            "Other agents leave it alone until then, and may close it afterwards — an\n"
+            "estimate that ran out with the tab still open reads as 'crashed', not 'busy'.\n"
+            "Without it, 120s of silence is enough for another agent to take the tab."
         )
 
     def _tab_busy(self, key, meta) -> str:

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -96,6 +96,13 @@ def list_functions() -> str:
 
 GUARD_WINDOW = 120  # seconds a tab's last claim keeps excluding other callers
 
+# Tabs are closed by the agent that opened them. This is only a janitor for tabs
+# whose opener is never coming back — a crashed process, a machine left running
+# for weeks. It is deliberately far longer than any real task: reclaiming early
+# would close a page someone is still using, which is exactly what owner-only
+# closing exists to prevent. Three days, not three minutes.
+ABANDONED_AFTER = 3 * 24 * 3600
+
 
 def _key(name):
     """Canonical session key — the shared main tab is stored as None."""
@@ -118,12 +125,52 @@ def _owner_alive(sock_path: str) -> bool:
     return transport.pid_alive(int(raw))
 
 
+def _parse_duration(text: str) -> float:
+    """'30s' '10m' '2h' or a bare number of seconds -> seconds. 0 when unparseable."""
+    text = (text or "").strip().lower()
+    if not text:
+        return 0.0
+    unit = {"s": 1, "m": 60, "h": 3600}.get(text[-1])
+    number = text[:-1] if unit else text
+    try:
+        return float(number) * (unit or 1)
+    except ValueError:
+        return 0.0
+
+
+def _fmt_duration(seconds: float) -> str:
+    seconds = int(seconds)
+    if seconds >= 3600:
+        return f"{seconds // 3600}h{(seconds % 3600) // 60:02d}m"
+    if seconds >= 60:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"
+
+
+def _declared_hold(meta) -> float:
+    """Seconds left on the tab's declared occupancy, 0 once it has elapsed.
+
+    An agent that says at `tab open` how long it needs the tab is stating
+    something the framework cannot infer: a login handoff needs minutes, a
+    long scrape needs an hour. While that window is live the tab is its own.
+    Once it passes, another agent may clean up — everyone here is cooperative,
+    and a declaration that has elapsed with the tab still open means the owner
+    is gone, not that it is still working.
+    """
+    until = meta.get("needs_until") or 0
+    return max(0.0, until - time.time())
+
+
 def _held_by_other(meta, caller: str) -> bool:
     """True when this tab carries a live claim (within GUARD_WINDOW) by a DIFFERENT
     identity than `caller`. An anonymous request (caller="") is still held OUT of a
     named claim; two anonymous requests cannot be told apart, so they are not guarded."""
-    holder = meta.get("caller")
-    return bool(holder and holder != caller and time.time() - (meta.get("claim_at") or 0) < GUARD_WINDOW)
+    holder = meta.get("caller") or meta.get("opened_by")
+    if not holder or holder == caller:
+        return False
+    if _declared_hold(meta):
+        return True  # inside the window its owner asked for
+    return time.time() - (meta.get("claim_at") or 0) < GUARD_WINDOW
 
 
 class BrowserDaemon:
@@ -221,6 +268,12 @@ class BrowserDaemon:
         no ceremony, per docs). A named -t target was validated before this point."""
         return self.browser._tab_meta.setdefault(
             key, {"who": caller or "main",
+                  # `who` is the CURRENT occupant — _stamp_claim reassigns it when a
+                  # claim expires and someone else takes over. `opened_by` is who
+                  # created the tab and is never reassigned: it is what "your tab"
+                  # means. Anonymous callers cannot own anything, because two
+                  # anonymous callers are indistinguishable.
+                  "opened_by": caller or "",
                   "purpose": "shared main tab" if key is None else key,
                   "opened_at": datetime.now()}
         )
@@ -312,20 +365,24 @@ class BrowserDaemon:
 
     def _tab_open(self, rest, caller: str = "") -> tuple:
         """Register a named tab (page is created lazily on its first command). Prints ONLY the name."""
-        name, who, purpose = "", "", ""
+        name, who, purpose, needs = "", "", "", ""
         i = 0
         while i < len(rest):
             tok = rest[i]
-            if tok in ("--who", "--for") and i + 1 < len(rest):
+            if tok in ("--who", "--for", "--needs") and i + 1 < len(rest):
                 i += 1
                 if tok == "--who":
                     who = rest[i]
+                elif tok == "--needs":
+                    needs = rest[i]
                 else:
                     purpose = rest[i]
             elif tok.startswith("--who="):
                 who = tok.split("=", 1)[1]
             elif tok.startswith("--for="):
                 purpose = tok.split("=", 1)[1]
+            elif tok.startswith("--needs="):
+                needs = tok.split("=", 1)[1]
             elif not tok.startswith("-") and not name:
                 name = tok
             i += 1
@@ -341,13 +398,18 @@ class BrowserDaemon:
             if not _held_by_other(existing, caller):
                 # yours, or the previous owner's claim has expired → (re)claim the name
                 existing.update(who=who or caller or name, purpose=purpose or existing.get("purpose") or name,
-                                caller=caller, claim_at=time.time() if caller else 0)
+                                caller=caller, claim_at=time.time() if caller else 0,
+                                needs_until=time.time() + _parse_duration(needs) if needs else 0)
                 return True, name
             # A DIFFERENT agent is mid-task under this name: sharing would collide.
             return 4, self._tab_busy(name, existing) + "\n\nor pick a different name for your own tab."
         self.browser._tab_meta[name] = {
             "who": who or caller or name, "purpose": purpose or name,
+            "opened_by": caller or "",
             "opened_at": datetime.now(), "caller": caller, "claim_at": time.time() if caller else 0,
+            # How long the opener says it needs the tab. Other agents leave it
+            # alone until then, and may clean it up afterwards.
+            "needs_until": time.time() + _parse_duration(needs) if needs else 0,
         }
         return True, name
 
@@ -365,13 +427,50 @@ class BrowserDaemon:
         who = meta.get("who") or meta.get("caller") or "someone"
         last = (meta.get("last_line") or "")[:60]
         ago = _ago(time.time() - (meta.get("claim_at") or meta.get("last_at") or time.time()))
+        left = _declared_hold(meta)
+        window = (f" · declared for {_fmt_duration(left)} more" if left
+                  else "")
         return (
-            f"tab '{_tab_label(key)}' is in use by {who} — last: \"{last}\" · {ago}\n\n"
+            f"tab '{_tab_label(key)}' is in use by {who} — last: \"{last}\" · {ago}{window}\n\n"
             f"You are a second agent on this browser. Two agents cannot share one tab.\n"
             f"Run your task in your own tab — three commands:\n"
             f"  1. co browser tab open <name> --who <your-name> --for \"<what you are doing>\"\n"
             f"  2. co browser -t <name> <verb> [args]      # add -t <name> to EVERY command, including do\n"
             f"  3. co browser tab close <name>             # when your task is done\n\n"
+            f"see who owns what:  co browser tab ls"
+        )
+
+    def _reap_abandoned_tabs(self) -> None:
+        """Close tabs whose opener never came back. Runs before tab listings.
+
+        Owner-only closing means a crashed agent's tab would otherwise live as
+        long as the daemon. This is the only path that closes someone else's
+        tab, so it is deliberately hard to trigger: no live claim, and untouched
+        for ABANDONED_AFTER (3 days). Every reclamation is logged, so the first
+        person surprised by one can find out why.
+        """
+        now = time.time()
+        for key, meta in list(self.browser._tab_meta.items()):
+            if key is None:  # main is shared and never reaped
+                continue
+            if _held_by_other(meta, ""):  # someone is actively driving it
+                continue
+            last = meta.get("last_at") or meta.get("claim_at")
+            if not last or now - last < ABANDONED_AFTER:
+                continue
+            owner = meta.get("opened_by") or meta.get("who") or "unknown"
+            self.browser.close_tab(_tab_label(key))
+            print(f"[reap] closed tab '{_tab_label(key)}' opened by {owner} — "
+                  f"idle {_ago(now - last)}", file=sys.stderr, flush=True)
+
+    def _tab_not_yours(self, key, owner: str) -> str:
+        """Error-as-documentation: you may close your own tabs, not other agents'."""
+        return (
+            f"tab '{_tab_label(key)}' was opened by {owner}, not you — only its "
+            f"opener closes it.\n\n"
+            f"This does not expire. An idle tab is not an abandoned one: the agent "
+            f"that opened it may be waiting on a login, a long page, or a human.\n"
+            f"Close your own tabs when your task ends; leave other agents' alone.\n\n"
             f"see who owns what:  co browser tab ls"
         )
 
@@ -416,8 +515,10 @@ class BrowserDaemon:
             if key is None:  # main always exists conceptually; nothing to release is fine
                 return True, "main is already free — nothing to close."
             return 3, self._unknown_tab(target)
-        # Closing someone's mid-task tab is the most destructive write there is —
-        # it gets the same guard as driving the page (and blocks anonymous callers too).
+        # Closing someone else's tab is fine once the time they asked for has
+        # passed — every agent here is cooperative, and a declaration that
+        # elapsed with the tab still open means its owner is gone, not busy.
+        # Before that, refuse: 120s of silence is not evidence a task ended.
         if meta and _held_by_other(meta, caller):
             return 4, self._tab_busy(key, meta)
         self.last_command = {"line": "closetab " + target, "at": time.time()}

--- a/connectonion/cli/co_ai/prompts/browser.md
+++ b/connectonion/cli/co_ai/prompts/browser.md
@@ -38,6 +38,25 @@ round trip.
 commands (`click_element_by_selector`, `type_text_by_selector`) over
 coordinate clicking; they survive layout changes.
 
+**Working alongside other agents.** This browser is shared — one machine, one
+human, several agents. Before a task that needs its own page, open a tab and
+say how long you expect to need it:
+
+```
+co browser tab open research --who <your-name> --for "<what you are doing>" --needs 10m
+co browser -t research go_to https://example.com     # -t on EVERY command
+co browser tab close research                        # when you are done
+```
+
+`co browser tab ls` shows every agent's tabs and, for each, when its owner
+expects to finish. Read it before touching a tab that is not yours: inside
+that window, leave it alone; once it has passed, the tab is free and closing
+it is a courtesy — an estimate that ran out with the tab still open means the
+owner crashed, not that it is still working.
+
+Close your own tabs when your task ends. Without `--needs`, two minutes of
+silence is enough for another agent to take yours.
+
 **Multiple pages.** Every command targets the main tab unless you pass `-t`:
 
 ```

--- a/connectonion/cli/templates/browser/prompts/agent.md
+++ b/connectonion/cli/templates/browser/prompts/agent.md
@@ -96,6 +96,25 @@ round trip.
 (`Screenshot saved to: ...`) and the image is attached for you automatically,
 so you can look at it without reading the file.
 
+**Working alongside other agents.** This browser is shared — one machine, one
+human, several agents. Before a task that needs its own page, open a tab and
+say how long you expect to need it:
+
+```
+co browser tab open research --who <your-name> --for "<what you are doing>" --needs 10m
+co browser -t research go_to https://example.com     # -t on EVERY command
+co browser tab close research                        # when you are done
+```
+
+`co browser tab ls` shows every agent's tabs and, for each, when its owner
+expects to finish. Read it before touching a tab that is not yours: inside
+that window, leave it alone; once it has passed, the tab is free and closing
+it is a courtesy — an estimate that ran out with the tab still open means the
+owner crashed, not that it is still working.
+
+Close your own tabs when your task ends. Without `--needs`, two minutes of
+silence is enough for another agent to take yours.
+
 ### Starting Work
 1. Run `co browser status` to see whether a page is already open
 2. Navigate to the target site

--- a/connectonion/cli/templates/minimal/prompt.md
+++ b/connectonion/cli/templates/minimal/prompt.md
@@ -27,5 +27,24 @@ pick from what it prints — an invented verb costs a failed call and a recovery
 round trip.
 
 
+**Working alongside other agents.** This browser is shared — one machine, one
+human, several agents. Before a task that needs its own page, open a tab and
+say how long you expect to need it:
+
+```
+co browser tab open research --who <your-name> --for "<what you are doing>" --needs 10m
+co browser -t research go_to https://example.com     # -t on EVERY command
+co browser tab close research                        # when you are done
+```
+
+`co browser tab ls` shows every agent's tabs and, for each, when its owner
+expects to finish. Read it before touching a tab that is not yours: inside
+that window, leave it alone; once it has passed, the tab is free and closing
+it is a courtesy — an estimate that ran out with the tab still open means the
+owner crashed, not that it is still working.
+
+Close your own tabs when your task ends. Without `--needs`, two minutes of
+silence is enough for another agent to take yours.
+
 Screenshots print a path (`Screenshot saved to: ...`); the image is attached
 for you automatically, so you can look at it without reading the file.

--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -67,11 +67,17 @@ and add `-t <name>` to EVERY command, including `do`. Pick an explicit literal t
 name — a `NAME=$(...)` capture is lost between tool calls:
 
 ```bash
-CO_WHO=alice co browser tab open scrape --for "scrape pricing"
+CO_WHO=alice co browser tab open scrape --for "scrape pricing" --needs 10m
 CO_WHO=alice co browser -t scrape go_to example.com/pricing
 CO_WHO=alice co browser -t scrape do "extract every plan and its monthly price"
 CO_WHO=alice co browser tab close scrape       # release when done
 ```
+
+`--needs` is your estimate of how long you will hold the tab (`30s`, `10m`, `2h`).
+Say it: other agents leave your tab alone until then, and `co browser tab ls`
+shows them when you expect to finish. Without it, two minutes of silence is
+enough for another agent to take your tab — which is wrong when you are waiting
+on a slow page or a human.
 
 When delegating browser work to subagents, write each subagent's tab name into its
 prompt — parallel agents share the one logged-in browser through separate tabs.
@@ -164,9 +170,21 @@ Exit codes cover the daemon-level contract; the output text covers the action it
 | exit `4` | tab busy — another agent is mid-task there | do NOT retry the same command — the error prints the exact commands to run instead; follow them |
 
 The exit-3/4 error messages ARE the documentation — they always carry the current
-recovery steps, so trust them over this table. A crashed agent's tab claim
-expires on its own; if a stale claim blocks you, open your own tab rather than
-closing theirs.
+recovery steps, so trust them over this table.
+
+When a tab blocks you, read `co browser tab ls` before deciding. Each tab shows
+when its owner expects to finish:
+
+```
+[scrape] https://...  who=alice  purpose='scrape pricing'  open 3m
+   owner expects to finish by 14:20 (7m left) — leave it alone until then
+```
+
+Inside that window, open your own tab instead. Once it has passed, the tab is
+free and closing it is a courtesy — an estimate that ran out with the tab still
+open means that agent crashed, not that it is still working. Every agent here is
+cooperative; tidying up after a dead peer is expected, taking a live agent's page
+is not.
 
 ## Logging in
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -264,6 +264,28 @@ def _age(seconds: float) -> str:
     return f"{seconds // 86400}d"
 
 
+def _occupancy_note(meta) -> str:
+    """One line telling other agents when this tab becomes theirs to close.
+
+    Reads the owner's own estimate — `needs_until` from `tab open --needs`, or
+    the older `hours` passed to go_to(). This is what lets a peer tell "still
+    working" from "crashed and left it open", which idleness alone cannot say.
+    """
+    until = meta.get("needs_until") or 0
+    if not until:
+        hours, opened_at = meta.get("hours") or 0, meta.get("opened_at")
+        if hours > 0 and opened_at:
+            until = opened_at.timestamp() + hours * 3600
+    if not until:
+        return ""
+
+    left = until - time.time()
+    when = datetime.fromtimestamp(until).strftime("%H:%M")
+    if left > 0:
+        return f"owner expects to finish by {when} ({_age(left)} left) — leave it alone until then"
+    return f"owner expected to finish by {when} ({_age(-left)} ago) — free for another agent to close"
+
+
 @_public_methods_run_on_browser_thread
 class BrowserAutomation:
     """Browser automation with natural language support.
@@ -729,17 +751,18 @@ class BrowserAutomation:
             line = f"  {marker}[{name}] {where}  who={who}  purpose={purpose!r}"
             opened_at = meta.get("opened_at")
             if opened_at:
-                elapsed = (datetime.now() - opened_at).total_seconds()
-                line += f"  open {_age(elapsed)}"
-                hours = meta.get("hours") or 0
-                if hours > 0:
-                    line += f" · flagged {hours:g}h"
-                    if elapsed > hours * 3600:
-                        line += " — may be closed"
+                line += f"  open {_age((datetime.now() - opened_at).total_seconds())}"
             last_at = meta.get("last_at")
             if last_at:
                 last_line = (meta.get("last_line") or "")[:60]
                 line += f'\n      last: "{last_line}" · {_age(time.time() - last_at)} ago'
+            # What another agent needs in order to decide whether to help close
+            # this tab: when its owner said it would be done, and whether that
+            # moment has passed. Idleness alone cannot say it — an idle tab is
+            # not an abandoned one.
+            note = _occupancy_note(meta)
+            if note:
+                line += f"\n      {note}"
             lines.append(line)
         return "\n".join(lines)
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -127,6 +127,47 @@ co browser get_links_from_page | grep github | wc -l
 co browser go_to "$DEPLOY_URL" && co browser take_screenshot /tmp/deployed.png
 ```
 
+## Sharing the Browser With Other Agents
+
+One machine, one browser, often several agents. They stay out of each other's
+way through named tabs — and by saying how long they expect to need one.
+
+```bash
+co browser tab open scrape --who alice --for "scrape pricing" --needs 10m
+co browser -t scrape go_to example.com/pricing    # -t on EVERY command
+co browser -t scrape get_text
+co browser tab close scrape                        # release when done
+```
+
+`--needs` takes `30s`, `10m`, or `2h`. It is not a lock — it is the estimate
+other agents read before touching your tab:
+
+```bash
+co browser tab ls
+```
+
+```
+Tabs (2):
+   [scrape] https://example.com/pricing  who=alice  purpose='scrape pricing'  open 3m
+      last: "get_text" · 12s ago
+      owner expects to finish by 14:20 (7m left) — leave it alone until then
+   [stale] https://...  who=bob  purpose='check stock'  open 2h
+      owner expected to finish by 12:30 (1h ago) — free for another agent to close
+```
+
+**Inside the window, leave it alone** — open your own tab instead. **Once it has
+passed, the tab is free**, and closing it is a courtesy: an estimate that ran out
+with the tab still open means that agent crashed, not that it is still working.
+
+A tab opened without `--needs` frees up after ~2 minutes of silence, which is
+wrong whenever you are waiting on a slow page or a human. Say the number.
+
+Set `CO_WHO` so your commands carry your identity:
+
+```bash
+export CO_WHO=alice
+```
+
 ## Headless vs GUI
 
 By default the browser is **visible** (a real Chrome window you can watch). Add `--headless` for scripts/CI:

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -137,7 +137,7 @@ parsing prose:
 ```
 co browser [-t TAB] <function> [args]    run a browser function (bare = the shared 'main' tab)
 co browser [-t TAB] do "<instruction>"   let the AI agent do it — same targeting grammar
-co browser tab open [NAME] [--who <agent>] [--for "<purpose>"]   register a tab; prints its name
+co browser tab open [NAME] [--who <agent>] [--for "<purpose>"] [--needs 10m]   register a tab; prints its name
 co browser tab ls [--json]               the board: every tab, who runs it, last command
 co browser tab close <NAME>              release your tab when the task is done
 co browser status                        browser state, stealth-driver health, last command, the board
@@ -199,6 +199,11 @@ own flags (`co browser status` shows `headless=true/false`). To switch modes,
 
 - **Solo work:** just use bare commands. Don't reach for `-t` until a second agent
   or a second concurrent task actually exists.
+- **Say how long you need it:** `tab open ... --needs 10m` (`30s`/`10m`/`2h`).
+  Other agents leave your tab alone until then, and the board shows them when
+  you expect to be done. Without it, two minutes of silence is enough for
+  someone else to take the tab — wrong when you are waiting on a slow page or
+  a human.
 - **Concurrent agents:** each `tab open`s once, adds `-t <name>` to **every**
   command (including `do`), and `tab close`s when finished. Set `CO_WHO`.
 - **On an exit-4:** don't retry the same bare command — open your own tab (the error
@@ -232,8 +237,11 @@ exactly one daemon — the loser exits and its command is served by the winner.
   `co browser status` says `headless=true`, some earlier command started the
   daemon with `--headless`. Run `co browser close`, then rerun without the flag.
 - **"tab 'X' is in use by …" (exit 4)** — another agent is mid-task there. Open
-  your own tab (the error shows the three commands). A crashed agent's claim
-  expires on its own in ~2 minutes.
+  your own tab (the error shows the three commands). `co browser tab ls` says
+  when its owner expects to finish; once that has passed the tab is free and
+  closing it is a courtesy, since an estimate that ran out with the tab still
+  open means that agent crashed rather than that it is still working. A tab
+  opened without `--needs` frees up after ~2 minutes of silence.
 - **"Chrome failed to start"** — usually running over ssh/cron without a desktop
   session (start from a logged-in Terminal, or use `--headless`), or a leftover
   Chrome still holds the profile. The full launch log is in `~/.co/browser.log`.

--- a/docs/useful_skills/co-browser.md
+++ b/docs/useful_skills/co-browser.md
@@ -22,7 +22,7 @@ to open its own tab), but a skill front-loads the lifecycle so the agent gets it
 right on the first command instead of learning from collisions:
 
 1. **Identity** — attach `CO_WHO` to every command (shell state doesn't survive between tool calls)
-2. **The board** — check `status` / `tab ls` before claiming; one task = one tab; `-t <name>` on every command when concurrent
+2. **The board** — check `status` / `tab ls` before claiming; one task = one tab; `-t <name>` on every command when concurrent; declare `--needs 10m` so peers know whether to wait or clean up
 3. **Right verb** — direct functions for deterministic steps (free, instant), `do "<end state>"` only for judgment, text probes before screenshot probes
 4. **Evidence** — read output text (soft failures return exit 0 with the error on stdout), screenshots at irreversible-action gates only, one-shot submits
 5. **Login** — human logs in in the visible window; the agent polls with short bounded waits and never touches credentials

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -1026,3 +1026,89 @@ def test_permission_error_still_clears_a_dead_owners_socket(short_sock, monkeypa
     monkeypatch.setattr(socket.socket, "connect", denied)
     assert c._connect_posix(short_sock) is None
     assert not os.path.exists(short_sock), "stale socket should have been removed"
+
+
+GUARD = d.GUARD_WINDOW
+
+
+class TestDeclaredOccupancy:
+    """Many agents, one machine, one browser, all cooperative.
+
+    An agent says at `tab open` how long it needs the tab — something the
+    framework cannot infer, since a login handoff needs minutes and a scrape
+    needs an hour. Others leave it alone until then. Afterwards they may clean
+    up: a declaration that elapsed with the tab still open means the owner is
+    gone, not that it is still working.
+    """
+
+    def test_declared_window_protects_the_tab_from_others(self, short_sock):
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open research --who scraper --needs 10m", caller="scraper"))
+
+        code, msg = daemon.dispatch(_env("tab close research", caller="other-agent"))
+
+        assert code == 4
+        assert "in use by scraper" in msg
+        assert "declared for" in msg
+
+    def test_others_may_clean_up_once_the_declaration_elapses(self, short_sock):
+        """The cooperative part: an elapsed declaration means the owner is gone."""
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open research --who scraper --needs 30s", caller="scraper"))
+        meta = daemon.browser._tab_meta["research"]
+        meta["needs_until"] = time.time() - 1      # declaration has passed
+        meta["claim_at"] = time.time() - GUARD - 1  # and no fresh activity
+
+        ok, msg = daemon.dispatch(_env("tab close research", caller="other-agent"))
+
+        assert ok is True
+        assert "Closed tab research" in msg
+
+    def test_the_owner_can_always_close_its_own_tab(self, short_sock):
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open research --who scraper --needs 10m", caller="scraper"))
+
+        ok, _ = daemon.dispatch(_env("tab close research", caller="scraper"))
+
+        assert ok is True
+
+    def test_a_long_declaration_outlives_the_claim_window(self, short_sock):
+        """The point of declaring: 120s of silence is not evidence a task ended.
+
+        Without a declaration the tab would be free to take after GUARD_WINDOW.
+        """
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open slow --who scraper --needs 2h", caller="scraper"))
+        daemon.browser._tab_meta["slow"]["claim_at"] = time.time() - GUARD - 1
+
+        code, msg = daemon.dispatch(_env("tab close slow", caller="other-agent"))
+
+        assert code == 4, "an idle-but-declared tab must not be closable by others"
+        assert "declared for" in msg
+
+    def test_undeclared_tabs_keep_the_old_claim_behaviour(self, short_sock):
+        """No declaration -> the existing 120s claim window still governs."""
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open quick --who scraper", caller="scraper"))
+        daemon.browser._tab_meta["quick"]["claim_at"] = time.time() - GUARD - 1
+
+        ok, _ = daemon.dispatch(_env("tab close quick", caller="other-agent"))
+
+        assert ok is True
+
+    def test_ls_shows_what_was_declared(self, short_sock):
+        daemon = make_daemon(short_sock)
+        daemon.dispatch(_env("tab open research --who scraper --needs 10m", caller="scraper"))
+
+        meta = daemon.browser._tab_meta["research"]
+        assert meta["needs_until"] > time.time()
+        assert meta["opened_by"] == "scraper"
+
+
+def test_duration_parsing():
+    assert d._parse_duration("30s") == 30
+    assert d._parse_duration("10m") == 600
+    assert d._parse_duration("2h") == 7200
+    assert d._parse_duration("90") == 90
+    assert d._parse_duration("") == 0
+    assert d._parse_duration("garbage") == 0

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -557,7 +557,9 @@ def test_go_to_occupied_tab_navigates_without_flags():
 
 
 def test_tab_status_flags_may_be_closed():
-    """A tab past its --hours estimate is flagged 'may be closed' (informational only)."""
+    """A tab past the time its owner estimated is shown as free for another
+    agent to close — that is the signal a peer uses to tell 'still working'
+    from 'crashed and left it open', which idleness alone cannot express."""
     from datetime import datetime, timedelta
 
     p0 = FakePage(); p0.url = "https://x.com/home"
@@ -570,5 +572,55 @@ def test_tab_status_flags_may_be_closed():
     }
 
     out = browser.tab_status()
-    assert "flagged 2h" in out
-    assert "may be closed" in out
+    assert "free for another agent to close" in out
+    assert "owner expected to finish by" in out
+
+
+class TestOccupancyNote:
+    """What the board must tell a second agent.
+
+    Many agents share one browser on one machine. Deciding whether to help
+    close someone's tab needs more than idleness — an idle tab is not an
+    abandoned one. The owner's own estimate is the only signal that separates
+    'still working' from 'crashed and left it open'.
+    """
+
+    def test_inside_the_declared_window_says_leave_it_alone(self):
+        import time
+        from connectonion.useful_tools.browser_tools.browser import _occupancy_note
+
+        note = _occupancy_note({"needs_until": time.time() + 600})
+
+        assert "leave it alone" in note
+        assert "left)" in note, "a peer needs to know how long to wait"
+
+    def test_past_the_declared_window_says_free_to_close(self):
+        import time
+        from connectonion.useful_tools.browser_tools.browser import _occupancy_note
+
+        note = _occupancy_note({"needs_until": time.time() - 120})
+
+        assert "free for another agent to close" in note
+
+    def test_the_older_hours_estimate_still_works(self):
+        """go_to(hours=...) predates `tab open --needs`; both must render."""
+        from datetime import datetime, timedelta
+        from connectonion.useful_tools.browser_tools.browser import _occupancy_note
+
+        note = _occupancy_note({"hours": 2, "opened_at": datetime.now() - timedelta(hours=3)})
+
+        assert "free for another agent to close" in note
+
+    def test_an_undeclared_tab_says_nothing(self):
+        """No estimate, no claim about it — silence beats a guess."""
+        from connectonion.useful_tools.browser_tools.browser import _occupancy_note
+
+        assert _occupancy_note({}) == ""
+
+    def test_the_note_carries_a_wall_clock_time(self):
+        """'9m left' answers 'how long'; a clock time answers 'by when', which
+        is what a human reading the board over an agent's shoulder wants."""
+        import re, time
+        from connectonion.useful_tools.browser_tools.browser import _occupancy_note
+
+        assert re.search(r"by \d{2}:\d{2}", _occupancy_note({"needs_until": time.time() + 600}))

--- a/tests/unit/test_skills_link.py
+++ b/tests/unit/test_skills_link.py
@@ -113,3 +113,30 @@ class TestSkillsLink:
         output = capsys.readouterr().out
         assert "claude" in output
         assert "codex" in output
+
+
+class TestCoBrowserSkillMatchesBehaviour:
+    """The skill is what Claude Code and Codex actually read.
+
+    It drifted once already: it told agents "a crashed agent's claim expires on
+    its own; open your own tab rather than closing theirs" — the opposite of
+    what the daemon now does once a declared window elapses. A skill that
+    contradicts the tool is worse than no skill.
+    """
+
+    def _skill(self):
+        return (BUNDLED_SKILLS / "co-browser" / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_teaches_declaring_how_long_the_tab_is_needed(self):
+        text = self._skill()
+        assert "--needs" in text
+
+    def test_does_not_still_say_never_close_another_agents_tab(self):
+        """True inside the declared window, wrong once it has passed."""
+        text = self._skill()
+        assert "rather than closing theirs" not in text
+        assert "expires on its own" not in text
+
+    def test_points_agents_at_the_board_before_they_act(self):
+        text = self._skill()
+        assert "tab ls" in text

--- a/tests/unit/test_template_browser_wiring.py
+++ b/tests/unit/test_template_browser_wiring.py
@@ -69,3 +69,17 @@ def test_prompts_do_not_reference_verbs_the_browser_lacks():
 
     assert "type_text(" not in text
     assert "type_text_by_selector" in verbs
+
+
+@pytest.mark.parametrize("template", CLI_BROWSER_TEMPLATES)
+def test_template_prompt_teaches_sharing_the_browser(template):
+    """One browser, several agents. A prompt that teaches the verbs but not the
+    tab protocol produces agents that navigate over each other's pages — and
+    `--needs` is useless if nobody knows to declare it."""
+    prompt_dir = TEMPLATES / template
+    prompts = list(prompt_dir.glob("prompt.md")) + list((prompt_dir / "prompts").glob("agent.md"))
+    text = "\n".join(p.read_text(encoding="utf-8") for p in prompts)
+
+    assert "tab open" in text
+    assert "--needs" in text
+    assert "tab ls" in text, "an agent must know where to look before touching a tab"


### PR DESCRIPTION
Refs #283. Replaces the approach in #285, which I've closed — see below.

## The setting

One machine, one human, many agents. The tab board exists so agents can **see each other and stay out of each other's way**, not defend against each other. Everyone here is cooperative.

## The problem

The claim window is a fixed 120 seconds, refreshed by activity. That is the framework guessing a number only the agent knows: a login handoff needs minutes of human time, a long scrape needs an hour. After 120s of silence any other agent could close a tab whose owner was simply waiting on a slow page or a person.

There is no way for the owner to say "this is going to take a while", and no way for a second agent to tell **busy** from **crashed** — which is the distinction that actually matters when deciding whether to wait or clean up.

## The change

The agent states it at the point it knows:

```bash
co browser tab open research --who scraper --for "scrape" --needs 10m
```

**Inside the declared window** the tab is its own, and others are refused with how long is left:

```
tab 'research' is in use by scraper — last: "" · 1s ago · declared for 9m more
```

That number is the useful part: the second agent now knows whether to wait or open its own tab.

**Once it elapses**, another agent may close it. A declaration that ran out with the tab still open means the owner is gone, not that it is still working — cleaning up after a crashed peer is friendly, and the declaration is the only signal that separates crashed from busy.

`--needs` accepts `30s`, `10m`, `2h`, or bare seconds. Undeclared tabs keep the existing 120s behaviour, so nothing changes for anyone who doesn't opt in.

## Why not the two designs before this

**#285 (closed): port `max_tabs`/`tab_idle_ttl` onto the daemon.** Those were designed for a browser owned by one process. Under a shared daemon a global cap is set by whichever process wins the startup race, frozen for the daemon's lifetime, unreachable to everyone after. That is an accident, not a policy — and it ignored the identity model the daemon already had.

**Permanent ownership — only the opener may ever close.** I implemented this first from the "don't let others close your tab" reading. It is too rigid for cooperative agents on one machine: when an agent crashes, its tab lives until the daemon dies, and no peer may tidy up. A declared window gets the protection without the deadlock.

## Tests

Seven, all driving a real daemon through the wire envelope:

- a declared window protects the tab from others, and the message says how much is left
- **once the declaration elapses, another agent may close it** — the cooperative case
- the owner can always close its own
- **a long declaration outlives the 120s claim window** — the whole point; an idle-but-declared tab is not free to take
- undeclared tabs keep the old behaviour
- duration parsing (`30s`/`10m`/`2h`/bare/garbage)

Three fail on main. Verified live against a real daemon, not only in tests.

Full suite: **2,631 passed, 6 skipped**.