### PR TITLE
release: 1.5.0 (+ document that a dashboard doesn't link out)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to ConnectOnion will be documented in this file.
 
+## [1.5.0] - 2026-07-28
+
+### ✨ Features
+- **Agent Home pages.** An agent can keep a `dashboard.html` in its project root; the host reads it and pushes it over the existing agent WebSocket, so a chat client can render it beside the conversation. Sent on connect and after any run that changed the file, with a per-connection `(mtime, size)` check so an untouched Home costs nothing per turn. `host()` writes a polished starter on day zero and never clobbers yours. Buttons carrying `data-ochat-skill` run a skill as a visible chat turn. See [docs/network/dashboard.md](docs/network/dashboard.md).
+- **`co syno`** — drive your Synology NAS from the terminal.
+- **`co ai` YOLO mode** — skip the approval prompts when you want it to just go.
+- **Agents can declare how long they need a browser tab**, so a long job isn't cut off by tab contention.
+
+### ♻️ Changed
+- **`co ai` and the project templates drive the browser through `co browser`** rather than 40 in-process tools — one browser story instead of two.
+- **Deploy polls the full build window** and validates the project name locally before uploading, so a typo fails fast instead of halfway through a build.
+
+### 🐛 Bug Fixes
+- The `[env]` diagnostic only prints when stderr is a terminal, so it no longer pollutes piped output.
+- A live daemon's socket is no longer unlinked on a non-refusal `OSError`.
+- Unit tests are hermetic, and `send_email` works without a `.env` file.
+
 ## [1.2.1] - 2026-07-17
 
 ### ✨ Features

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -26,7 +26,7 @@ Example: `0.0.2`
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.4.0
+## Current Version: 1.5.0
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -40,6 +40,8 @@ Example: `0.0.2`
 - 1.2.1 (native Windows co browser via named-pipe transport; zero-setup chromium auto-install without admin; offline first-run hardening; windows-e2e CI)
 - 1.3.0 (remote tool execution: remote.call / co call; codex tool via native app-server; agent balance in ANNOUNCE profile + /info; humanized browser input + stealth; Gemini 3.6 Flash; bash description optional; browser-workflow-skill-builder; security: tightened default remote-exec whitelist)
 - 1.4.0 (co gmail and co gdrive: your own Gmail and Google Drive from the terminal, plus the GDrive tool; co skills link publishes bundled skills to Claude Code and Codex; Outlook contacts; OAuth fixes: both .env and ~/.co/keys.env are loaded, rotated tokens persist, Gmail refreshes every session; credentials no longer printed in CLI tracebacks; Gemini 3.6 Flash everywhere)
+
+- 1.5.0 (agent Home pages: the host pushes `dashboard.html` over the agent WebSocket and chat clients render it beside the conversation, with a built-in dashboard skill; `co syno` for Synology NAS; `co ai` YOLO mode; `co ai` and the templates drive the browser through `co browser` instead of 40 in-process tools; agents can declare how long they need a tab; deploy polls the full build window and validates project names locally; hermetic unit tests)
 
 ## Files to Update When Versioning
 

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -35,3 +35,4 @@ A button that runs something MUST be a real, user-invocable skill, wired like th
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
 - Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting; only the `data-ochat-skill` button contract works.
 - Keep styles inline in the file (external URLs are blocked in the sandbox).
+- **No links out.** A Home page is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -47,10 +47,25 @@ sandbox rather than by convention:
   happen.
 - **No external URLs.** No CDN stylesheets, no remote images, no fonts from the
   network. Inline your styles and use `data:` URIs for images.
+- **No links out.** A Home page is one self-contained page. A client cancels clicks
+  on `<a href="https://…">`, so such a link renders as dead text — use a
+  `data-ochat-skill` button when you want the user to *do* something. Same-page
+  anchors (`href="#section"`) work normally.
 
 Keep it under **2MB**. The Host won't send a larger file, and the Home pane goes
 blank. Inline images are base64, which is ~33% larger than the source file — compress
 screenshots before embedding them.
+
+> **Why so locked down?** The client renders your `dashboard.html` in a sandboxed
+> iframe with a strict Content-Security-Policy, because from its side the file is
+> untrusted, agent-authored HTML. Everything above follows from that: nothing loads
+> from the network, nothing scripts, and nothing navigates away. A Home page is a
+> glanceable, self-contained page whose one action is running a skill.
+>
+> Supporting external links later is a deliberate change to that contract, not a
+> setting — it means deciding what a dashboard may navigate to and how (in-sandbox,
+> where the destination still can't be trusted, or handed to a real browser tab).
+> Until then, treat the page as a closed surface.
 
 ## Action buttons
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.4.0"
+version = "1.5.0"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Description

Cuts the 1.5.0 release, and documents one dashboard rule that #242 shipped without.

#242 is already merged, so this is follow-up work that needs its own PR. Nothing here changes runtime behavior — it's a version bump plus docs.

**PyPI is still on 1.4.0, same as `main`**, so nothing that landed since — including the dashboard — has shipped. This repo has no publish workflow (only `tests.yml`), so after merging, the release is manual:

```bash
git tag v1.5.0 && git push origin v1.5.0
python -m build && twine upload dist/*
```

## Related Issue

Follow-up to #242 / #237.

## Type of Change
- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes Made

**Release 1.5.0** — ten commits have landed since 1.4.0, several user-facing, so this is a MINOR bump. That matches how 1.3.0 and 1.4.0 were actually cut, rather than the patch-until-`.10` wording in `VERSIONING.md`, which the last few releases haven't followed. Flagging it in case you'd rather this were 1.4.1.

- `pyproject.toml` and `connectonion/__init__.py` → 1.5.0
- `VERSIONING.md` — current version and a history entry
- `CHANGELOG.md` — a 1.5.0 entry covering all ten commits: agent Home pages (#242), `co syno` (#275), `co ai` YOLO mode (#280), tab-duration declarations (#286), `co ai` and the templates moving onto `co browser` (#273, #279), deploy polling the full build window (#281), the `[env]` diagnostic only printing to a terminal (#284), hermetic unit tests (#278), and the daemon-socket fix (#271)

**A dashboard doesn't link out** — the Dashboard skill and `docs/network/dashboard.md` listed the sandbox constraints (no scripting, no external URLs) but never said a Home page can't link out. An agent could reasonably add an `<a href="https://…">` and end up with dead text, because the client cancels those clicks: neither CSP nor the sandbox stops a frame navigating *itself*, and the destination would run under its own policy. Both places now state the rule, point at `data-ochat-skill` buttons as the way to offer an action, and note that same-page anchors still work. Also records why the page is locked down at all, and that supporting external links later is a deliberate change to the contract rather than a setting to flip.

Client-side enforcement ships separately in openonion/oo-chat#34.

## Testing
- [x] I have tested this code locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality — no new functionality; docs and version metadata only

Unit suite: 2351 passed, 4 skipped. The 3 failures in `test_env_loading.py` are this container's system `httpx` missing `idna` — unrelated, and failing identically on `main`.

Wheel builds clean: `connectonion-1.5.0-py3-none-any.whl`.

## Example Usage

```python
from connectonion import Agent
from connectonion.network import host

# Writes a starter dashboard.html on first run; the agent's Home page from then on.
host(lambda: Agent("lisa", tools=[...]))
```

## Checklist
- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published — the SDK slice (openonion/connectonion-ts#17) is merged and published as `connectonion@0.1.9` on npm

## Additional Notes

The docs-site version badge is bumped alongside this in wu-changxing/connectonion-docs-site#19, per the `VERSIONING.md` checklist.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LG54YLHVimYKxqjLdm62wi)_