### PR TITLE
Say Apache-2.0 everywhere, matching the LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="center">
 
 [![Production Ready](https://img.shields.io/badge/Status-Production_Ready-success?style=flat-square)](https://connectonion.com)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10+-blue?style=flat-square&logo=python)](https://python.org)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/connectonion?period=total&units=international_system&left_color=black&right_color=green&left_text=downloads)](https://pepy.tech/projects/connectonion)
 [![GitHub stars](https://img.shields.io/github/stars/openonion/connectonion?style=flat-square)](https://github.com/openonion/connectonion)
@@ -887,7 +887,7 @@ See our [Contributing Guide](http://docs.connectonion.com/website-maintenance) f
 
 ## 📄 License
 
-MIT License - Use it anywhere, even commercially. See [LICENSE](LICENSE) file for details.
+Apache License 2.0 - Use it anywhere, even commercially. See [LICENSE](LICENSE) file for details.
 
 ---
 
@@ -974,7 +974,7 @@ Python 3.10+
 
 ### License
 
-MIT
+Apache-2.0
 
 ### Help Resources
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "connectonion"
 version = "1.5.0"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 authors = [
     { name = "ConnectOnion Team", email = "pypi@connectonion.com" }
@@ -27,7 +27,7 @@ keywords = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
The repo ships an **Apache License 2.0** (`LICENSE`, Copyright 2024 OpenOnion) while `pyproject.toml` declared MIT and the README carried an MIT badge.

PyPI publishes the `pyproject.toml` value, so the package page and the source tree have been telling people two different licences. Whichever a user believes, one of the two is wrong — and for anyone whose employer requires a licence review before adoption, that contradiction is the thing that stops the review.

Apache-2.0 is the one we intend, so the metadata moves to it:

- `license = {text = "Apache-2.0"}`
- `"License :: OSI Approved :: Apache Software License"` classifier
- README badge, the licence line at the bottom of the readme, and the one-word summary

`LICENSE` itself is unchanged — it was already correct.

This is metadata only; no code changes. The next PyPI release picks it up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjWtif58mkmvFB7EEPfVR3)_