### PR TITLE
fix: preserve system prompts in provider requests

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -325,7 +325,7 @@ class AnthropicLLM(LLM):
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
         """Complete a conversation with optional tool support."""
         # Convert messages to Anthropic format
-        anthropic_messages = self._convert_messages(messages)
+        anthropic_messages, system = self._convert_messages(messages)
 
         api_kwargs = {
             "model": self.model,
@@ -333,6 +333,9 @@ class AnthropicLLM(LLM):
             "max_tokens": self.max_tokens,  # Required by Anthropic
             **kwargs  # User can override max_tokens via kwargs
         }
+
+        if system:
+            api_kwargs["system"] = system
 
         # Add tools if provided
         if tools:
@@ -381,7 +384,7 @@ class AnthropicLLM(LLM):
         workaround: create a dummy tool with the Pydantic schema and force its use.
         """
         # Convert messages to Anthropic format
-        anthropic_messages = self._convert_messages(messages)
+        anthropic_messages, system = self._convert_messages(messages)
 
         # Create a tool with the Pydantic schema as input_schema
         tool = {
@@ -400,6 +403,9 @@ class AnthropicLLM(LLM):
             **kwargs  # User can override max_tokens, temperature, etc.
         }
 
+        if system:
+            api_kwargs["system"] = system
+
         # Force the model to use this tool
         response = self.client.messages.create(**api_kwargs)
 
@@ -411,16 +417,19 @@ class AnthropicLLM(LLM):
 
         raise ValueError("No structured output received from Claude")
 
-    def _convert_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _convert_messages(self, messages: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], Optional[str]]:
         """Convert OpenAI-style messages to Anthropic format."""
         anthropic_messages = []
+        system_parts = []
         i = 0
         
         while i < len(messages):
             msg = messages[i]
             
-            # Skip system messages (will be handled separately)
+            # Anthropic accepts system instructions as a top-level request parameter.
             if msg["role"] == "system":
+                if msg.get("content"):
+                    system_parts.append(msg["content"])
                 i += 1
                 continue
             
@@ -513,7 +522,8 @@ class AnthropicLLM(LLM):
             else:
                 i += 1
         
-        return anthropic_messages
+        system = "\n\n".join(system_parts)
+        return anthropic_messages, system or None
     
     def _convert_tools(self, tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert OpenAI-style tools to Anthropic format."""

--- a/tests/unit/test_anthropic_llm.py
+++ b/tests/unit/test_anthropic_llm.py
@@ -1,0 +1,76 @@
+"""Unit tests for Anthropic request conversion."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from pydantic import BaseModel
+
+from connectonion.core.llm import AnthropicLLM
+
+
+class Answer(BaseModel):
+    value: str
+
+
+def make_llm(response):
+    llm = AnthropicLLM(api_key="test-key")
+    llm.client.messages.create = Mock(return_value=response)
+    return llm
+
+
+def test_complete_passes_combined_system_prompt():
+    response = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="ok")],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+    )
+    llm = make_llm(response)
+
+    llm.complete(
+        [
+            {"role": "system", "content": "Follow the rules."},
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "Hello"},
+        ]
+    )
+
+    request = llm.client.messages.create.call_args.kwargs
+    assert request["system"] == "Follow the rules.\n\nBe concise."
+    assert request["messages"] == [{"role": "user", "content": "Hello"}]
+
+
+def test_complete_omits_system_parameter_when_absent():
+    response = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="ok")],
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1),
+    )
+    llm = make_llm(response)
+
+    llm.complete([{"role": "user", "content": "Hello"}])
+
+    assert "system" not in llm.client.messages.create.call_args.kwargs
+
+
+def test_structured_complete_passes_system_prompt():
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                type="tool_use",
+                name="return_structured_output",
+                input={"value": "ok"},
+            )
+        ]
+    )
+    llm = make_llm(response)
+
+    result = llm.structured_complete(
+        [
+            {"role": "system", "content": "Return a short answer."},
+            {"role": "user", "content": "Hello"},
+        ],
+        Answer,
+    )
+
+    assert result == Answer(value="ok")
+    request = llm.client.messages.create.call_args.kwargs
+    assert request["system"] == "Return a short answer."
+    assert request["messages"] == [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## Description

Preserves system instructions when converting messages for provider requests.

## Related Issue

Fixes #289

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Collects multiple system messages without placing them in the conversation message list.
- Sends combined system instructions for standard and structured completions.
- Adds regression coverage for combined, absent, and structured system instructions.

## Testing

- [x] `.venv/bin/python -m pytest tests/ -q --tb=short -m 'not slow and not real_api and not network'`
- [x] `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass
