### PR TITLE
fix(anthropic): send the system prompt to Claude (#289)

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -334,6 +334,10 @@ class AnthropicLLM(LLM):
             **kwargs  # User can override max_tokens via kwargs
         }
 
+        system = self._extract_system(messages)
+        if system:
+            api_kwargs["system"] = system
+
         # Add tools if provided
         if tools:
             api_kwargs["tools"] = self._convert_tools(tools)
@@ -400,6 +404,10 @@ class AnthropicLLM(LLM):
             **kwargs  # User can override max_tokens, temperature, etc.
         }
 
+        system = self._extract_system(messages)
+        if system:
+            api_kwargs["system"] = system
+
         # Force the model to use this tool
         response = self.client.messages.create(**api_kwargs)
 
@@ -411,15 +419,31 @@ class AnthropicLLM(LLM):
 
         raise ValueError("No structured output received from Claude")
 
+    def _extract_system(self, messages: List[Dict[str, Any]]) -> Optional[str]:
+        """Pull the system prompt out for Anthropic's top-level `system` parameter.
+
+        Anthropic takes the system prompt as its own argument, not as a message in
+        the list — which is why _convert_messages drops system messages. Whoever
+        builds api_kwargs has to put it back, or the agent runs with no system
+        prompt at all and nothing reports it.
+        """
+        parts = [msg["content"] for msg in messages
+                 if msg.get("role") == "system" and msg.get("content")]
+        return "\n\n".join(parts) if parts else None
+
     def _convert_messages(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Convert OpenAI-style messages to Anthropic format."""
+        """Convert OpenAI-style messages to Anthropic format.
+
+        System messages are dropped here on purpose — they travel as the top-level
+        `system` argument instead. Use _extract_system() to get them.
+        """
         anthropic_messages = []
         i = 0
-        
+
         while i < len(messages):
             msg = messages[i]
-            
-            # Skip system messages (will be handled separately)
+
+            # Dropped here, carried by _extract_system() into api_kwargs["system"]
             if msg["role"] == "system":
                 i += 1
                 continue

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -330,6 +330,96 @@ class TestProviderErrorBubbling:
                 llm.complete([{"role": "user", "content": "test"}])
 
 
+class TestAnthropicSystemPrompt:
+    """The system prompt must reach Claude as the top-level `system` argument.
+
+    Anthropic does not accept a system message inside `messages`, so
+    _convert_messages drops it. If the caller does not put it back into
+    api_kwargs["system"], the agent runs with no system prompt and nothing
+    reports it — no error, no warning, just an agent with no instructions.
+    """
+
+    def _mock_response(self):
+        response = Mock()
+        block = Mock()
+        block.type = "text"
+        block.text = "ok"
+        response.content = [block]
+        response.usage.input_tokens = 1
+        response.usage.output_tokens = 1
+        response.usage.cache_read_input_tokens = 0
+        response.usage.cache_creation_input_tokens = 0
+        return response
+
+    def test_complete_sends_system_prompt(self):
+        """complete() passes the system message as the `system` argument."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            llm.client.messages.create = Mock(return_value=self._mock_response())
+
+            llm.complete([
+                {"role": "system", "content": "You are a helpful pirate."},
+                {"role": "user", "content": "hi"},
+            ])
+
+            kwargs = llm.client.messages.create.call_args.kwargs
+            assert kwargs.get("system") == "You are a helpful pirate."
+            # and it must not leak into messages, which Anthropic would reject
+            assert all(m["role"] != "system" for m in kwargs["messages"])
+
+    def test_structured_complete_sends_system_prompt(self):
+        """structured_complete() passes it too — same bug, second call site."""
+        from pydantic import BaseModel
+
+        class Out(BaseModel):
+            answer: str
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            response = Mock()
+            block = Mock()
+            block.type = "tool_use"
+            block.name = "return_structured_output"
+            block.input = {"answer": "yes"}
+            response.content = [block]
+            llm.client.messages.create = Mock(return_value=response)
+
+            llm.structured_complete(
+                [
+                    {"role": "system", "content": "Answer in one word."},
+                    {"role": "user", "content": "ok?"},
+                ],
+                Out,
+            )
+
+            kwargs = llm.client.messages.create.call_args.kwargs
+            assert kwargs.get("system") == "Answer in one word."
+
+    def test_multiple_system_messages_are_joined(self):
+        """Several system messages arrive as one block, in order."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            llm.client.messages.create = Mock(return_value=self._mock_response())
+
+            llm.complete([
+                {"role": "system", "content": "First."},
+                {"role": "system", "content": "Second."},
+                {"role": "user", "content": "hi"},
+            ])
+
+            assert llm.client.messages.create.call_args.kwargs["system"] == "First.\n\nSecond."
+
+    def test_no_system_message_sends_no_system_key(self):
+        """Without a system message, `system` is absent — not None, not empty."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
+            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            llm.client.messages.create = Mock(return_value=self._mock_response())
+
+            llm.complete([{"role": "user", "content": "hi"}])
+
+            assert "system" not in llm.client.messages.create.call_args.kwargs
+
+
 class TestOpenAICompatibleProviders:
     """Test Groq/OpenRouter OpenAI-compatible behavior."""
 


### PR DESCRIPTION
Fixes #289.

## The bug

`_convert_messages` skips system messages with the comment "will be handled separately":

```python
# connectonion/core/llm.py
if msg["role"] == "system":
    i += 1
    continue
```

That is correct on its own — Anthropic takes the system prompt as a top-level `system` argument, not as a message. But **"separately" was never implemented.** Neither `complete()` nor `structured_complete()` ever set `api_kwargs["system"]`.

So every call to a `claude-*` model went out with **no system prompt at all**. No persona, no instructions, no constraints — and no error, no warning. Silent.

## The fix

`_extract_system()` collects the system messages; both call sites put the result into `api_kwargs["system"]` when non-empty. Multiple system messages join with a blank line, in order. When there is no system message the key is absent entirely rather than `None`.

Also documented on `_convert_messages` *why* it drops them, so the next reader doesn't restore the bug by "fixing" the skip.

## Tests

`TestAnthropicSystemPrompt` — 4 cases: `complete()`, `structured_complete()` (the second call site had the same bug), multiple system messages joined in order, and no-system-message sending no key.

Verified red before the fix: 3 of the 4 fail on the parent commit. (The fourth asserts `system` is *absent*, which trivially holds when it is never set — kept because it locks the behaviour going forward.)

`tests/unit` is 2365 passed / 3 skipped.