### PR TITLE
feat(keys): derive an SSH key from the same recovery phrase (#310)

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -307,3 +307,143 @@ def sign(address_data: Dict[str, Any], message: bytes) -> bytes:
         
     signed = address_data["signing_key"].sign(message)
     return signed.signature
+
+# ---------------------------------------------------------------------------
+# SSH access key
+#
+# The agent identity above uses only the first 32 of the seed's 64 bytes. The
+# same recovery phrase can therefore also back the operator's SSH key, so there
+# is still exactly one thing to write down.
+#
+# The agent key is deliberately left on its original derivation — bare
+# seed[:32]. Deriving it through HKDF instead would change every existing
+# agent's address and void every trust relationship keyed to it. Only the new
+# SSH key is derived with a label, so a third purpose can be added later
+# without disturbing either of the first two.
+#
+#     agent identity : SigningKey(seed[:32])                     (unchanged)
+#     ssh access     : HKDF(seed, info="connectonion:ssh:v1")
+#
+# Two keys, not one used twice: a signing oracle in the agent protocol must not
+# be usable against SSH login.
+# ---------------------------------------------------------------------------
+
+SSH_DERIVATION_INFO = b"connectonion:ssh:v1"
+
+
+def _hkdf_sha512(seed: bytes, info: bytes, length: int = 32) -> bytes:
+    """RFC 5869 HKDF with SHA-512, no salt. Enough for one 32-byte output."""
+    import hashlib
+    import hmac
+
+    prk = hmac.new(b"\x00" * hashlib.sha512().digest_size, seed, hashlib.sha512).digest()
+
+    out = b""
+    block = b""
+    counter = 1
+    while len(out) < length:
+        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha512).digest()
+        out += block
+        counter += 1
+    return out[:length]
+
+
+def derive_ssh_key(seed_phrase: str) -> Dict[str, str]:
+    """Derive an Ed25519 SSH keypair from a recovery phrase.
+
+    Ed25519 is a native OpenSSH type, so the public half is an ordinary
+    `ssh-ed25519 AAAA…` line that needs nothing custom on any server.
+
+    Args:
+        seed_phrase: The 12-word BIP39 recovery phrase
+
+    Returns:
+        {"public_line": "ssh-ed25519 AAAA… connectonion", "private_key": "-----BEGIN…"}
+
+    Example:
+        >>> keys = derive_ssh_key("legal winner thank year wave …")
+        >>> keys["public_line"].startswith("ssh-ed25519 ")
+        True
+    """
+    if Mnemonic is None or SigningKey is None:
+        raise ImportError(
+            "Missing dependencies. Install with:\n"
+            "  pip install pynacl mnemonic"
+        )
+
+    mnemo = Mnemonic("english")
+    if not mnemo.check(seed_phrase):
+        raise ValueError("Invalid recovery phrase")
+
+    seed = mnemo.to_seed(seed_phrase)
+    ssh_seed = _hkdf_sha512(seed, SSH_DERIVATION_INFO)
+    signing_key = SigningKey(ssh_seed)
+
+    return {
+        "public_line": _openssh_public_line(bytes(signing_key.verify_key)),
+        "private_key": _openssh_private_key(bytes(signing_key), bytes(signing_key.verify_key)),
+    }
+
+
+def _ssh_string(data: bytes) -> bytes:
+    """SSH wire format: 4-byte big-endian length, then the bytes."""
+    return len(data).to_bytes(4, "big") + data
+
+
+def _openssh_public_line(public_key: bytes, comment: str = "connectonion") -> str:
+    """Encode an Ed25519 public key as an authorized_keys line."""
+    import base64
+
+    blob = _ssh_string(b"ssh-ed25519") + _ssh_string(public_key)
+    return f"ssh-ed25519 {base64.b64encode(blob).decode()} {comment}"
+
+
+def _openssh_private_key(private_key: bytes, public_key: bytes,
+                         comment: str = "connectonion") -> str:
+    """Encode an Ed25519 keypair in the unencrypted OPENSSH private key format.
+
+    Written by hand rather than pulled from `cryptography`: the format is a
+    handful of length-prefixed strings, and this keeps the dependency list as it
+    is. Unencrypted because the recovery phrase is the thing being protected —
+    the file can always be re-derived from it.
+    """
+    import base64
+
+    # OpenSSH stores the private half as private||public (64 bytes)
+    key_pair = private_key + public_key
+
+    pub_blob = _ssh_string(b"ssh-ed25519") + _ssh_string(public_key)
+
+    # The checkint appears twice so a decrypting client can tell it got the
+    # passphrase right. With no passphrase any value works; zero is honest.
+    checkint = (0).to_bytes(4, "big")
+    private_blob = (
+        checkint + checkint
+        + _ssh_string(b"ssh-ed25519")
+        + _ssh_string(public_key)
+        + _ssh_string(key_pair)
+        + _ssh_string(comment.encode())
+    )
+    # Pad to the cipher block size (8 for "none") with 1,2,3…
+    pad = 0
+    while len(private_blob) % 8 != 0:
+        pad += 1
+        private_blob += bytes([pad])
+
+    body = (
+        b"openssh-key-v1\x00"
+        + _ssh_string(b"none")        # cipher
+        + _ssh_string(b"none")        # kdf
+        + _ssh_string(b"")            # kdf options
+        + (1).to_bytes(4, "big")      # number of keys
+        + _ssh_string(pub_blob)
+        + _ssh_string(private_blob)
+    )
+
+    b64 = base64.b64encode(body).decode()
+    lines = [b64[i:i + 70] for i in range(0, len(b64), 70)]
+    return (
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+        + "\n".join(lines)
+        + "\n-----END OPENSSH PRIVATE KEY-----\n"
+    )

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -81,11 +81,13 @@ def _source_label(co_dir: Path) -> str:
     return f"{co_dir} (project)"
 
 
-def handle_keys(reveal: bool = False):
+def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     """Show all agent keys and credentials.
 
     Args:
         reveal: If True, show full values instead of masked
+        ssh: If True, print the SSH public key derived from the recovery phrase
+        write: With ssh, also write the private half to ~/.ssh/
     """
     from ... import address
 
@@ -98,6 +100,10 @@ def handle_keys(reveal: bool = False):
     addr_data = address.load(co_dir)
     if not addr_data:
         console.print("\n[red]Failed to load keys.[/red]\n")
+        return
+
+    if ssh:
+        _show_ssh_key(addr_data, write=write)
         return
 
     env_vars = _load_env_vars()
@@ -187,3 +193,51 @@ def handle_keys(reveal: bool = False):
     else:
         console.print("[yellow]⚠ Secrets shown in full. Do not share these values.[/yellow]")
     console.print()
+
+
+def _show_ssh_key(addr_data: dict, write: bool = False) -> None:
+    """Print the SSH public key derived from the recovery phrase.
+
+    Same phrase as the agent identity, different derivation — so there is still
+    one thing to write down, and the operator can reach a provisioned server
+    without a second secret to manage.
+    """
+    from pathlib import Path
+    from ... import address
+
+    seed = addr_data.get("seed_phrase")
+    if not seed:
+        console.print("\n[red]No recovery phrase available.[/red]")
+        console.print("[dim]The SSH key is derived from it, so it cannot be rebuilt without it.[/dim]")
+        console.print("[cyan]It lives in .co/keys/recovery.txt — restore that file, or run 'co init' in a new project.[/cyan]\n")
+        return
+
+    keys = address.derive_ssh_key(seed)
+
+    console.print()
+    console.print(keys["public_line"])
+    console.print()
+
+    if not write:
+        console.print("[dim]Add that line to ~/.ssh/authorized_keys on any server you want to reach.[/dim]")
+        console.print("[dim]Use [bold]--write[/bold] to also write the private half to ~/.ssh/.[/dim]\n")
+        return
+
+    ssh_dir = Path.home() / ".ssh"
+    ssh_dir.mkdir(mode=0o700, exist_ok=True)
+    private_path = ssh_dir / "connectonion_ed25519"
+    public_path = ssh_dir / "connectonion_ed25519.pub"
+
+    if private_path.exists():
+        console.print(f"[yellow]{private_path} already exists — not overwriting.[/yellow]")
+        console.print("[dim]Delete it first if you want it rewritten; the key is derived, so nothing is lost.[/dim]\n")
+        return
+
+    private_path.write_text(keys["private_key"])
+    private_path.chmod(0o600)
+    public_path.write_text(keys["public_line"] + "\n")
+    public_path.chmod(0o644)
+
+    console.print(f"[green]✓[/green] wrote {private_path} [dim](0600)[/dim]")
+    console.print(f"[green]✓[/green] wrote {public_path}")
+    console.print(f"\n[dim]Use it with:[/dim] ssh -i {private_path} user@host\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -156,10 +156,12 @@ def auth(service: Optional[str] = typer.Argument(None, help="Service: google, mi
 @app.command()
 def keys(
     reveal: bool = typer.Option(False, "--reveal", "-r", help="Show full key values"),
+    ssh: bool = typer.Option(False, "--ssh", help="Print the SSH public key derived from your recovery phrase"),
+    write: bool = typer.Option(False, "--write", help="With --ssh, also write the private half to ~/.ssh/"),
 ):
     """Show agent keys and credentials."""
     from .commands.keys_commands import handle_keys
-    handle_keys(reveal=reveal)
+    handle_keys(reveal=reveal, ssh=ssh, write=write)
 
 
 @app.command()

--- a/tests/unit/test_address_ssh.py
+++ b/tests/unit/test_address_ssh.py
@@ -1,0 +1,132 @@
+"""Unit tests for the SSH key derived from the recovery phrase (address.py).
+
+The fixed vectors below are the point of this file. The agent address is the
+primary key for balances, trust relationships and the agent's email — if a
+future refactor moves the derivation, every existing agent loses its identity.
+A test with a hardcoded expectation is what stops that from happening quietly.
+"""
+
+import base64
+
+import pytest
+
+from connectonion import address
+
+
+# A BIP39 test-vector phrase. Any valid phrase would do; a fixed one lets the
+# expected outputs be hardcoded.
+PHRASE = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+
+EXPECTED_ADDRESS = "0xc6f2ac5598970c79633714d3eb5c34d7bfc3e92da58c7354b37996d9a4af3ab2"
+EXPECTED_SSH_LINE = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBs9N4V0K4pXPZNr5XPKmSJusfyalyjdi4xN36gqLt8U"
+    " connectonion"
+)
+
+
+class TestAgentAddressIsUnchanged:
+    """The agent identity must not move. This is the whole risk of the change."""
+
+    def test_known_phrase_produces_the_same_address(self):
+        assert address.recover(PHRASE)["address"] == EXPECTED_ADDRESS
+
+    def test_agent_key_still_uses_the_bare_first_half_of_the_seed(self):
+        """Explicitly pin the derivation, not just its output.
+
+        The SSH key uses HKDF; the agent key deliberately does not. If someone
+        "tidies up" by routing both through HKDF, this fails immediately instead
+        of silently reissuing every address.
+        """
+        from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
+
+        seed = Mnemonic("english").to_seed(PHRASE)
+        expected = "0x" + bytes(SigningKey(seed[:32]).verify_key).hex()
+
+        assert address.recover(PHRASE)["address"] == expected
+
+
+class TestDeriveSSHKey:
+    def test_known_phrase_produces_the_same_ssh_key(self):
+        assert address.derive_ssh_key(PHRASE)["public_line"] == EXPECTED_SSH_LINE
+
+    def test_derivation_is_deterministic(self):
+        assert address.derive_ssh_key(PHRASE) == address.derive_ssh_key(PHRASE)
+
+    def test_different_phrases_produce_different_keys(self):
+        other = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"
+        assert address.derive_ssh_key(other)["public_line"] != EXPECTED_SSH_LINE
+
+    def test_invalid_phrase_is_rejected(self):
+        with pytest.raises(ValueError, match="Invalid recovery phrase"):
+            address.derive_ssh_key("not actually a bip39 phrase at all")
+
+    def test_ssh_key_is_not_the_agent_key(self):
+        """Two keys, not one used twice.
+
+        A signing oracle in the agent protocol must not be usable against SSH
+        login, so neither key may be the other — and the SSH key must not be the
+        unused second half of the seed either, which would be a slice rather
+        than a derivation.
+        """
+        from mnemonic import Mnemonic
+
+        seed = Mnemonic("english").to_seed(PHRASE)
+        ssh_seed = address._hkdf_sha512(seed, address.SSH_DERIVATION_INFO)
+
+        assert ssh_seed != seed[:32]
+        assert ssh_seed != seed[32:]
+
+
+class TestOpenSSHEncoding:
+    """The output has to be usable verbatim by real ssh tooling."""
+
+    def test_public_line_has_the_three_authorized_keys_fields(self):
+        parts = address.derive_ssh_key(PHRASE)["public_line"].split()
+        assert len(parts) == 3
+        assert parts[0] == "ssh-ed25519"
+        assert parts[2] == "connectonion"
+
+    def test_public_blob_declares_its_own_type_and_carries_32_bytes(self):
+        """Decode the base64 the way sshd does: length-prefixed strings."""
+        blob = base64.b64decode(address.derive_ssh_key(PHRASE)["public_line"].split()[1])
+
+        type_len = int.from_bytes(blob[0:4], "big")
+        key_type = blob[4:4 + type_len]
+        key_len = int.from_bytes(blob[4 + type_len:8 + type_len], "big")
+
+        assert key_type == b"ssh-ed25519"
+        assert key_len == 32
+        assert len(blob) == 8 + type_len + key_len
+
+    def test_private_key_is_an_unencrypted_openssh_block(self):
+        private = address.derive_ssh_key(PHRASE)["private_key"]
+
+        assert private.startswith("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+        assert private.rstrip().endswith("-----END OPENSSH PRIVATE KEY-----")
+
+        body = base64.b64decode("".join(private.splitlines()[1:-1]))
+        assert body.startswith(b"openssh-key-v1\x00")
+        # cipher "none" and kdf "none" — the recovery phrase is the secret being
+        # protected, and the file can always be re-derived from it
+        assert b"none" in body[:40]
+
+    def test_private_blob_length_is_a_multiple_of_the_block_size(self):
+        """OpenSSH pads the private section to the cipher block size (8 for none).
+
+        Getting this wrong produces a file that looks right and that ssh-keygen
+        refuses to load.
+        """
+        private = address.derive_ssh_key(PHRASE)["private_key"]
+        body = base64.b64decode("".join(private.splitlines()[1:-1]))
+
+        offset = len(b"openssh-key-v1\x00")
+        for _ in range(3):  # cipher, kdf, kdf options
+            length = int.from_bytes(body[offset:offset + 4], "big")
+            offset += 4 + length
+        offset += 4  # number of keys
+        pub_len = int.from_bytes(body[offset:offset + 4], "big")
+        offset += 4 + pub_len
+        priv_len = int.from_bytes(body[offset:offset + 4], "big")
+
+        assert priv_len % 8 == 0


### PR DESCRIPTION
Closes #310. First link in the #309 chain — no dependencies, testable on its own.

## The choice #310 asked us to make and state

> Either keep that path for the agent key and use HKDF only for the new SSH key, or version the derivation and migrate deliberately.

**Kept the agent key exactly as it is: bare `SigningKey(seed[:32])`.** Only the SSH key is derived with a label. No migration, no risk to any existing address.

```
agent identity : SigningKey(seed[:32])                     unchanged
ssh access     : HKDF(seed, info="connectonion:ssh:v1")
```

Deriving the agent key through HKDF too would have been tidier, and would have silently reissued every existing agent's address — voiding every trust relationship keyed to it, which is the same failure as #306 but self-inflicted. The label on the SSH key means a third purpose can still be added later without moving either of the first two.

## What's here

- `address.derive_ssh_key(phrase)` → `{public_line, private_key}`. RFC 5869 HKDF-SHA512, then the OpenSSH wire encodings, written by hand — the format is a handful of length-prefixed strings and this adds no dependency.
- `co keys --ssh` prints the `ssh-ed25519 AAAA… connectonion` line, ready to paste into `authorized_keys`.
- `co keys --ssh --write` also writes `~/.ssh/connectonion_ed25519` at 0600 and the `.pub` at 0644. It **refuses to overwrite** an existing file — the key is derived, so nothing is ever lost by declining.

## Verification

**Cross-checked against real ssh tooling, not just the shape of the output.** `ssh-keygen -y` reads the hand-written private key and derives the identical public line:

```
$ ssh-keygen -y -f connectonion_ed25519
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBs9N4V0K4pXPZNr5XPKmSJusfyalyjdi4xN36gqLt8U connectonion
$ ssh-keygen -l -f connectonion_ed25519.pub
256 SHA256:PTVCk2h22ZuZeNJvG1aZpeTcHyuVWe8XM0vJQhmGPcg connectonion (ED25519)
```

`tests/unit/test_address_ssh.py` — 11 cases. The ones that matter:

- **Fixed vector on the agent address.** A known phrase must still produce `0xc6f2ac55…`, so a future refactor cannot move it quietly.
- **The agent derivation itself is pinned**, not just its output — recomputing `SigningKey(seed[:32])` independently and asserting equality. If someone routes both keys through HKDF, this fails immediately.
- **Fixed vector on the SSH public line.**
- The two keys differ, and the SSH key is not the unused second half of the seed either (a slice, not a derivation).
- The public blob is decoded the way sshd does it — length-prefixed `ssh-ed25519` + 32 bytes — and the private section's length is asserted to be a multiple of the cipher block size, which is the mistake that yields a file ssh-keygen silently refuses.

Full suite: **2375 passed, 3 skipped**.

## Not verified here

#310's definition of done includes logging in to a throwaway box with the key. I verified the format with `ssh-keygen` instead, which covers the encoding but not sshd's acceptance path. Worth doing once #311 lands, since that is when a real target exists.