### PR TITLE
feat(server): register, list and preflight a deploy target (#311)

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -1,0 +1,244 @@
+"""
+Purpose: Register, list and preflight the machines `co deploy --to` can target
+LLM-Note:
+  Dependencies: imports from [subprocess, shutil, pathlib, yaml, rich] | imported by [cli/main.py via handle_server_*] | tested by [tests/unit/test_server_commands.py]
+  Data flow: handle_server_add(name, ssh_target) → _load()/_save() ~/.co/servers.yaml → handle_server_list() renders the table | handle_server_check(name) → _ssh(target, probe script) → parses one KEY=value line per requirement → prints the first failure by name
+  State/Effects: reads and writes ~/.co/servers.yaml (name → ssh target, last check result) | shells out to the system ssh binary | never stores a credential
+  Integration: exposes handle_server_add(), handle_server_list(), handle_server_check(), load_server() for deploy | requirement list is Ubuntu 24.04, python 3.11+, systemd the user may manage, free disk
+  Performance: one ssh round trip per check; the probe is a single command, not one per requirement
+  Errors: an unreachable host fails with ssh's own message and a short timeout, never a hang | a missing requirement is named
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+SERVERS_FILE = Path.home() / ".co" / "servers.yaml"
+
+# Deliberately short. "It doesn't work on my box" is only answerable if we
+# stated a narrow promise and `co server check` says which item is missing.
+MIN_PYTHON = (3, 11)
+MIN_FREE_DISK_GB = 5
+SUPPORTED_UBUNTU = "24.04"
+
+# ssh must fail fast rather than hang: an unreachable host is the common case
+# when a name is typed wrong, and a hang looks like a bug in us.
+SSH_TIMEOUT_SECONDS = 10
+
+
+def _load() -> Dict[str, dict]:
+    if not SERVERS_FILE.exists():
+        return {}
+    data = yaml.safe_load(SERVERS_FILE.read_text()) or {}
+    return data.get("servers", {})
+
+
+def _save(servers: Dict[str, dict]) -> None:
+    SERVERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SERVERS_FILE.write_text(yaml.safe_dump({"servers": servers}, sort_keys=True))
+
+
+def load_server(name: str) -> Optional[dict]:
+    """Look up one registered server. Used by `co deploy --to`."""
+    return _load().get(name)
+
+
+def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
+    """Run one command on the target through the system ssh binary.
+
+    We shell out rather than reimplement ssh, so the operator's own agent,
+    `~/.ssh/config`, jump hosts and key selection all keep working — the same
+    principle as `co browser` driving a real browser.
+    """
+    return subprocess.run(
+        [
+            "ssh",
+            "-o", "BatchMode=yes",                    # never prompt; fail instead
+            "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
+            "-o", "StrictHostKeyChecking=accept-new",
+            target,
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=SSH_TIMEOUT_SECONDS + 20,
+    )
+
+
+def handle_server_add(name: str, ssh_target: str) -> bool:
+    """Register a machine under a short name.
+
+    Takes an ssh target, not a credential. Nothing secret is written.
+    """
+    if not shutil.which("ssh"):
+        console.print("\n[red]No ssh binary found on PATH.[/red]")
+        console.print("[dim]co talks to servers through your own ssh, so it needs one installed.[/dim]\n")
+        return False
+
+    console.print(f"\n[dim]Checking {ssh_target} …[/dim]")
+    result = _ssh(ssh_target, "echo ok")
+
+    if result.returncode != 0:
+        # Surface ssh's own words — it explains permission, DNS and host-key
+        # problems better than a message we would invent.
+        console.print(f"[red]Cannot reach {ssh_target}.[/red]")
+        detail = (result.stderr or result.stdout).strip()
+        if detail:
+            for line in detail.splitlines():
+                console.print(f"  [dim]{line}[/dim]")
+        console.print("\n[dim]Nothing was saved. Fix the ssh target and try again.[/dim]")
+        console.print(f"[dim]Tip: your derived key is [bold]co keys --ssh[/bold] — it has to be in "
+                      f"authorized_keys on that host.[/dim]\n")
+        return False
+
+    servers = _load()
+    existed = name in servers
+    servers[name] = {"ssh": ssh_target, "last_check": None}
+    _save(servers)
+
+    verb = "Updated" if existed else "Added"
+    console.print(f"[green]✓[/green] {verb} [cyan]{name}[/cyan] → {ssh_target}")
+    console.print(f"\n[dim]Next:[/dim] co server check {name}\n")
+    return True
+
+
+def handle_server_list() -> bool:
+    """Show what you can deploy to."""
+    servers = _load()
+
+    if not servers:
+        console.print("\n[dim]No servers registered.[/dim]")
+        console.print("[cyan]co server add prod --ssh user@host[/cyan]\n")
+        return True
+
+    table = Table(box=None, padding=(0, 2))
+    table.add_column("NAME", style="cyan")
+    table.add_column("TARGET")
+    table.add_column("LAST CHECK")
+
+    for name in sorted(servers):
+        entry = servers[name] or {}
+        last = entry.get("last_check")
+        if last is None:
+            shown = "[dim]never checked[/dim]"
+        elif last == "ok":
+            shown = "[green]ok[/green]"
+        else:
+            shown = f"[red]{last}[/red]"
+        table.add_row(name, entry.get("ssh", "[red]?[/red]"), shown)
+
+    console.print()
+    console.print(table)
+    console.print(f"\n[dim]{_short(SERVERS_FILE)}[/dim]\n")
+    return True
+
+
+def _short(p: Path) -> str:
+    home = str(Path.home())
+    s = str(p)
+    return "~" + s[len(home):] if s.startswith(home) else s
+
+
+# One command, one round trip. Each line is `KEY=value` so a missing tool
+# reports as an empty value rather than derailing the whole probe.
+_PROBE = r"""
+. /etc/os-release 2>/dev/null
+echo "distro=${ID:-unknown}"
+echo "version=${VERSION_ID:-unknown}"
+echo "python=$( (command -v python3 >/dev/null && python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])') 2>/dev/null )"
+echo "systemd=$( [ -d /run/systemd/system ] && echo yes )"
+echo "systemctl=$( command -v systemctl >/dev/null && echo yes )"
+echo "sudo=$( sudo -n true 2>/dev/null && echo yes )"
+echo "diskgb=$( df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9' )"
+"""
+
+
+def _parse_probe(stdout: str) -> Dict[str, str]:
+    facts = {}
+    for line in stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            facts[key.strip()] = value.strip()
+    return facts
+
+
+def _requirement_failures(facts: Dict[str, str]) -> list:
+    """Return the requirements that are not met, each as (name, detail)."""
+    failures = []
+
+    if facts.get("distro") != "ubuntu":
+        failures.append(("Ubuntu", f"found {facts.get('distro') or 'unknown'}"))
+    elif facts.get("version") != SUPPORTED_UBUNTU:
+        failures.append(("Ubuntu " + SUPPORTED_UBUNTU, f"found {facts.get('version') or 'unknown'}"))
+
+    python = facts.get("python") or ""
+    if not python:
+        failures.append(("python3", "not on PATH"))
+    else:
+        parts = python.split(".")
+        if tuple(int(p) for p in parts[:2]) < MIN_PYTHON:
+            failures.append((f"python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+", f"found {python}"))
+
+    if facts.get("systemd") != "yes" or facts.get("systemctl") != "yes":
+        failures.append(("systemd", "not present"))
+    elif facts.get("sudo") != "yes":
+        # Managing a unit needs more than systemd existing.
+        failures.append(("permission to manage units", "passwordless sudo unavailable"))
+
+    disk = facts.get("diskgb") or ""
+    if not disk:
+        failures.append(("free disk", "could not read df"))
+    elif int(disk) < MIN_FREE_DISK_GB:
+        failures.append((f"{MIN_FREE_DISK_GB} GB free disk", f"found {disk} GB"))
+
+    return failures
+
+
+def handle_server_check(name: str) -> bool:
+    """Preflight a target and say which requirement failed, by name."""
+    entry = load_server(name)
+    if not entry:
+        console.print(f"\n[red]No server named '{name}'.[/red]")
+        console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
+        return False
+
+    target = entry["ssh"]
+    console.print(f"\n[dim]Checking {name} ({target}) …[/dim]")
+
+    result = _ssh(target, _PROBE)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        console.print(f"[red]✗ unreachable[/red]")
+        for line in detail:
+            console.print(f"  [dim]{line}[/dim]")
+        _record(name, "unreachable")
+        console.print()
+        return False
+
+    failures = _requirement_failures(_parse_probe(result.stdout))
+
+    if not failures:
+        console.print(f"[green]✓ {name} is ready to deploy to[/green]\n")
+        _record(name, "ok")
+        return True
+
+    for requirement, detail in failures:
+        console.print(f"[red]✗ {requirement}[/red] [dim]— {detail}[/dim]")
+    console.print(f"\n[dim]co deploy --to {name} needs all of these. "
+                  f"Only Ubuntu {SUPPORTED_UBUNTU} is supported.[/dim]\n")
+    _record(name, failures[0][0])
+    return False
+
+
+def _record(name: str, outcome: str) -> None:
+    servers = _load()
+    if name in servers:
+        servers[name]["last_check"] = outcome
+        _save(servers)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -287,6 +287,47 @@ def announce(
     handle_announce(relay=relay, dry_run=dry_run)
 
 
+# Server command group — the machines `co deploy --to` can target
+server_app = typer.Typer(help="Register, list and preflight the servers you can deploy to")
+app.add_typer(server_app, name="server")
+
+
+@server_app.callback(invoke_without_command=True)
+def server_callback(ctx: typer.Context):
+    """Deploy targets."""
+    if ctx.invoked_subcommand is None:
+        from .commands.server_commands import handle_server_list
+        handle_server_list()
+
+
+@server_app.command("add")
+def server_add(
+    name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
+    ssh: str = typer.Option(..., "--ssh", help="ssh target, e.g. user@1.2.3.4 or a Host from ~/.ssh/config"),
+):
+    """Register a machine. Stores a name → ssh target mapping, no credential."""
+    from .commands.server_commands import handle_server_add
+    if not handle_server_add(name=name, ssh_target=ssh):
+        raise typer.Exit(1)
+
+
+@server_app.command("ls")
+def server_ls():
+    """Show what you can deploy to."""
+    from .commands.server_commands import handle_server_list
+    handle_server_list()
+
+
+@server_app.command("check")
+def server_check(
+    name: str = typer.Argument(..., help="Registered server name"),
+):
+    """Preflight a target and name the requirement that failed."""
+    from .commands.server_commands import handle_server_check
+    if not handle_server_check(name=name):
+        raise typer.Exit(1)
+
+
 # Skills command group
 skills_app = typer.Typer(help="Discover, copy, and list SKILL.md files from agent tool directories")
 app.add_typer(skills_app, name="skills")

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -1,0 +1,198 @@
+"""Unit tests for `co server` — register, list and preflight a deploy target.
+
+The requirement checks are tested by feeding the probe output a box would return
+if it were missing each requirement in turn. That is the point of the command:
+"it doesn't work on my box" is only answerable if the failure is named.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+
+from connectonion.cli.commands import server_commands as sc
+
+
+@pytest.fixture
+def servers_file(tmp_path, monkeypatch):
+    """Point the registry at a temp file so tests never touch ~/.co."""
+    path = tmp_path / "servers.yaml"
+    monkeypatch.setattr(sc, "SERVERS_FILE", path)
+    return path
+
+
+def _probe(**overrides) -> str:
+    """Build probe stdout for a box that meets every requirement, minus overrides."""
+    facts = {
+        "distro": "ubuntu",
+        "version": "24.04",
+        "python": "3.12",
+        "systemd": "yes",
+        "systemctl": "yes",
+        "sudo": "yes",
+        "diskgb": "40",
+    }
+    facts.update(overrides)
+    return "\n".join(f"{k}={v}" for k, v in facts.items())
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr):
+    return subprocess.CompletedProcess(args=[], returncode=255, stdout="", stderr=stderr)
+
+
+class TestRequirementFailuresAreNamed:
+    """Each requirement, missing in turn, must be reported by name."""
+
+    def test_a_box_meeting_everything_has_no_failures(self):
+        assert sc._requirement_failures(sc._parse_probe(_probe())) == []
+
+    def test_wrong_distro(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(distro="debian")))
+        assert failures and failures[0][0] == "Ubuntu"
+        assert "debian" in failures[0][1]
+
+    def test_wrong_ubuntu_version(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(version="22.04")))
+        assert failures and failures[0][0] == "Ubuntu 24.04"
+        assert "22.04" in failures[0][1]
+
+    def test_python_missing_entirely(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(python="")))
+        assert ("python3", "not on PATH") in failures
+
+    def test_python_too_old(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(python="3.10")))
+        names = [name for name, _ in failures]
+        assert "python 3.11+" in names
+
+    def test_systemd_absent(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(systemd="", systemctl="")))
+        assert ("systemd", "not present") in failures
+
+    def test_systemd_present_but_units_not_manageable(self):
+        """systemd existing is not the same as being allowed to manage a unit."""
+        failures = sc._requirement_failures(sc._parse_probe(_probe(sudo="")))
+        names = [name for name, _ in failures]
+        assert "permission to manage units" in names
+        assert "systemd" not in names  # systemd itself is fine, don't muddy the report
+
+    def test_disk_too_small(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(diskgb="2")))
+        names = [name for name, _ in failures]
+        assert "5 GB free disk" in names
+
+    def test_df_unreadable(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(diskgb="")))
+        assert ("free disk", "could not read df") in failures
+
+    def test_several_missing_requirements_are_all_reported(self):
+        failures = sc._requirement_failures(
+            sc._parse_probe(_probe(distro="alpine", python="3.9", diskgb="1"))
+        )
+        assert len(failures) >= 3
+
+
+class TestServerAdd:
+    def test_unreachable_host_saves_nothing(self, servers_file):
+        """An unreachable host must fail with ssh's own words, and save nothing."""
+        with patch.object(sc, "_ssh", return_value=_fail("ssh: Could not resolve hostname nope")):
+            assert sc.handle_server_add("prod", "user@nope") is False
+
+        assert not servers_file.exists()
+
+    def test_reachable_host_is_recorded(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            assert sc.handle_server_add("prod", "user@1.2.3.4") is True
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["ssh"] == "user@1.2.3.4"
+        assert saved["servers"]["prod"]["last_check"] is None
+
+    def test_nothing_secret_is_written(self, servers_file):
+        """The file holds a target, never a credential."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        text = servers_file.read_text().lower()
+        for forbidden in ("private", "begin openssh", "password", "secret", "token", "key"):
+            assert forbidden not in text
+
+    def test_readding_the_same_name_updates_the_target(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@old")
+            sc.handle_server_add("prod", "user@new")
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["ssh"] == "user@new"
+
+    def test_ssh_is_called_in_batch_mode_so_it_cannot_hang_on_a_prompt(self, servers_file):
+        with patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        argv = run.call_args.args[0]
+        assert "BatchMode=yes" in argv
+        assert any(a.startswith("ConnectTimeout=") for a in argv)
+
+
+class TestServerCheck:
+    def test_unknown_name_is_rejected(self, servers_file):
+        assert sc.handle_server_check("nope") is False
+
+    def test_a_ready_box_passes_and_is_recorded(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_ok(_probe())):
+            assert sc.handle_server_check("prod") is True
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "ok"
+
+    def test_a_failing_box_records_the_failing_requirement(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_ok(_probe(version="22.04"))):
+            assert sc.handle_server_check("prod") is False
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "Ubuntu 24.04"
+
+    def test_an_unreachable_box_records_unreachable(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_fail("Connection refused")):
+            assert sc.handle_server_check("prod") is False
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "unreachable"
+
+
+class TestServerList:
+    def test_empty_registry_is_not_an_error(self, servers_file):
+        assert sc.handle_server_list() is True
+
+    def test_lists_registered_servers(self, servers_file, capsys):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+            sc.handle_server_add("staging", "user@5.6.7.8")
+
+        sc.handle_server_list()
+        out = capsys.readouterr().out
+        assert "prod" in out and "staging" in out
+        assert "1.2.3.4" in out
+
+
+class TestLoadServer:
+    def test_returns_none_for_unknown(self, servers_file):
+        assert sc.load_server("nope") is None
+
+    def test_returns_the_entry_deploy_will_use(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        assert sc.load_server("prod")["ssh"] == "user@1.2.3.4"


### PR DESCRIPTION
Closes #311. Second link in the #309 chain. No dependencies — it can target a box you made by hand, which is how #312 gets tested before provisioning exists.

## What's here

```bash
co server add prod --ssh aaron@1.2.3.4   # register
co server ls                             # what you can deploy to
co server check prod                     # preflight
```

**`add` takes an ssh target, not a credential.** We shell out to the system `ssh`, so the operator's own agent, `~/.ssh/config`, jump hosts and key selection all keep working — same principle as `co browser` driving a real browser instead of reimplementing one. `~/.co/servers.yaml` holds a name, a target and the last check result. Nothing secret.

**`check` names the requirement that failed.** One probe, one ssh round trip, one `KEY=value` line per fact — so a missing tool reports as an empty value instead of derailing the probe. The list is deliberately short: Ubuntu 24.04, python 3.11+, systemd **the user may actually manage**, ≥5 GB free.

That systemd distinction is worth calling out: `systemd` existing and *being allowed to restart a unit* are different requirements, and a box can pass the first and fail the second. They are reported separately, and a box with systemd but no passwordless sudo is not told "systemd not present" — that would send someone debugging the wrong thing.

## Verification

**`tests/unit/test_server_commands.py` — 23 cases.** The requirement checks are tested by feeding the probe exactly what a box missing each requirement in turn would return, which is what #311's definition of done asks for: wrong distro, wrong Ubuntu version, python absent, python too old, systemd absent, systemd present but units unmanageable, disk too small, `df` unreadable, and several missing at once.

Also asserted:

- **Nothing secret is written.** The saved file is read back and scanned for `private`, `begin openssh`, `password`, `secret`, `token`, `key`.
- **An unreachable host saves nothing** — the registry file is not even created.
- **ssh is invoked with `BatchMode=yes` and a `ConnectTimeout`**, asserted on the actual argv, so it can never hang on a password prompt.

Real run against a hostname that does not resolve:

```
$ time co server add nope --ssh user@does-not-exist.invalid
Cannot reach user@does-not-exist.invalid.
  ssh: Could not resolve hostname ... not known
Nothing was saved. Fix the ssh target and try again.
Tip: your derived key is co keys --ssh — it has to be in authorized_keys on that host.
6.4s total
```

Fails with ssh's own words, in seconds, not a timeout. Most of those 6.4s are Python startup.

Full suite: **2387 passed, 3 skipped**. Confirmed the tests do not touch the real `~/.co/servers.yaml`.

## Depends on

Nothing in code. Pairs with #315 (`co keys --ssh`) in practice — the error message points there, since the derived key has to be in `authorized_keys` for any of this to connect.