### PR TITLE
Show the agent's Home page before onboarding, not after

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -1,0 +1,244 @@
+"""
+Purpose: Register, list and preflight the machines `co deploy --to` can target
+LLM-Note:
+  Dependencies: imports from [subprocess, shutil, pathlib, yaml, rich] | imported by [cli/main.py via handle_server_*] | tested by [tests/unit/test_server_commands.py]
+  Data flow: handle_server_add(name, ssh_target) → _load()/_save() ~/.co/servers.yaml → handle_server_list() renders the table | handle_server_check(name) → _ssh(target, probe script) → parses one KEY=value line per requirement → prints the first failure by name
+  State/Effects: reads and writes ~/.co/servers.yaml (name → ssh target, last check result) | shells out to the system ssh binary | never stores a credential
+  Integration: exposes handle_server_add(), handle_server_list(), handle_server_check(), load_server() for deploy | requirement list is Ubuntu 24.04, python 3.11+, systemd the user may manage, free disk
+  Performance: one ssh round trip per check; the probe is a single command, not one per requirement
+  Errors: an unreachable host fails with ssh's own message and a short timeout, never a hang | a missing requirement is named
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+SERVERS_FILE = Path.home() / ".co" / "servers.yaml"
+
+# Deliberately short. "It doesn't work on my box" is only answerable if we
+# stated a narrow promise and `co server check` says which item is missing.
+MIN_PYTHON = (3, 11)
+MIN_FREE_DISK_GB = 5
+SUPPORTED_UBUNTU = "24.04"
+
+# ssh must fail fast rather than hang: an unreachable host is the common case
+# when a name is typed wrong, and a hang looks like a bug in us.
+SSH_TIMEOUT_SECONDS = 10
+
+
+def _load() -> Dict[str, dict]:
+    if not SERVERS_FILE.exists():
+        return {}
+    data = yaml.safe_load(SERVERS_FILE.read_text()) or {}
+    return data.get("servers", {})
+
+
+def _save(servers: Dict[str, dict]) -> None:
+    SERVERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SERVERS_FILE.write_text(yaml.safe_dump({"servers": servers}, sort_keys=True))
+
+
+def load_server(name: str) -> Optional[dict]:
+    """Look up one registered server. Used by `co deploy --to`."""
+    return _load().get(name)
+
+
+def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
+    """Run one command on the target through the system ssh binary.
+
+    We shell out rather than reimplement ssh, so the operator's own agent,
+    `~/.ssh/config`, jump hosts and key selection all keep working — the same
+    principle as `co browser` driving a real browser.
+    """
+    return subprocess.run(
+        [
+            "ssh",
+            "-o", "BatchMode=yes",                    # never prompt; fail instead
+            "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
+            "-o", "StrictHostKeyChecking=accept-new",
+            target,
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=SSH_TIMEOUT_SECONDS + 20,
+    )
+
+
+def handle_server_add(name: str, ssh_target: str) -> bool:
+    """Register a machine under a short name.
+
+    Takes an ssh target, not a credential. Nothing secret is written.
+    """
+    if not shutil.which("ssh"):
+        console.print("\n[red]No ssh binary found on PATH.[/red]")
+        console.print("[dim]co talks to servers through your own ssh, so it needs one installed.[/dim]\n")
+        return False
+
+    console.print(f"\n[dim]Checking {ssh_target} …[/dim]")
+    result = _ssh(ssh_target, "echo ok")
+
+    if result.returncode != 0:
+        # Surface ssh's own words — it explains permission, DNS and host-key
+        # problems better than a message we would invent.
+        console.print(f"[red]Cannot reach {ssh_target}.[/red]")
+        detail = (result.stderr or result.stdout).strip()
+        if detail:
+            for line in detail.splitlines():
+                console.print(f"  [dim]{line}[/dim]")
+        console.print("\n[dim]Nothing was saved. Fix the ssh target and try again.[/dim]")
+        console.print(f"[dim]Tip: your derived key is [bold]co keys --ssh[/bold] — it has to be in "
+                      f"authorized_keys on that host.[/dim]\n")
+        return False
+
+    servers = _load()
+    existed = name in servers
+    servers[name] = {"ssh": ssh_target, "last_check": None}
+    _save(servers)
+
+    verb = "Updated" if existed else "Added"
+    console.print(f"[green]✓[/green] {verb} [cyan]{name}[/cyan] → {ssh_target}")
+    console.print(f"\n[dim]Next:[/dim] co server check {name}\n")
+    return True
+
+
+def handle_server_list() -> bool:
+    """Show what you can deploy to."""
+    servers = _load()
+
+    if not servers:
+        console.print("\n[dim]No servers registered.[/dim]")
+        console.print("[cyan]co server add prod --ssh user@host[/cyan]\n")
+        return True
+
+    table = Table(box=None, padding=(0, 2))
+    table.add_column("NAME", style="cyan")
+    table.add_column("TARGET")
+    table.add_column("LAST CHECK")
+
+    for name in sorted(servers):
+        entry = servers[name] or {}
+        last = entry.get("last_check")
+        if last is None:
+            shown = "[dim]never checked[/dim]"
+        elif last == "ok":
+            shown = "[green]ok[/green]"
+        else:
+            shown = f"[red]{last}[/red]"
+        table.add_row(name, entry.get("ssh", "[red]?[/red]"), shown)
+
+    console.print()
+    console.print(table)
+    console.print(f"\n[dim]{_short(SERVERS_FILE)}[/dim]\n")
+    return True
+
+
+def _short(p: Path) -> str:
+    home = str(Path.home())
+    s = str(p)
+    return "~" + s[len(home):] if s.startswith(home) else s
+
+
+# One command, one round trip. Each line is `KEY=value` so a missing tool
+# reports as an empty value rather than derailing the whole probe.
+_PROBE = r"""
+. /etc/os-release 2>/dev/null
+echo "distro=${ID:-unknown}"
+echo "version=${VERSION_ID:-unknown}"
+echo "python=$( (command -v python3 >/dev/null && python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])') 2>/dev/null )"
+echo "systemd=$( [ -d /run/systemd/system ] && echo yes )"
+echo "systemctl=$( command -v systemctl >/dev/null && echo yes )"
+echo "sudo=$( sudo -n true 2>/dev/null && echo yes )"
+echo "diskgb=$( df -BG --output=avail / 2>/dev/null | tail -1 | tr -dc '0-9' )"
+"""
+
+
+def _parse_probe(stdout: str) -> Dict[str, str]:
+    facts = {}
+    for line in stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            facts[key.strip()] = value.strip()
+    return facts
+
+
+def _requirement_failures(facts: Dict[str, str]) -> list:
+    """Return the requirements that are not met, each as (name, detail)."""
+    failures = []
+
+    if facts.get("distro") != "ubuntu":
+        failures.append(("Ubuntu", f"found {facts.get('distro') or 'unknown'}"))
+    elif facts.get("version") != SUPPORTED_UBUNTU:
+        failures.append(("Ubuntu " + SUPPORTED_UBUNTU, f"found {facts.get('version') or 'unknown'}"))
+
+    python = facts.get("python") or ""
+    if not python:
+        failures.append(("python3", "not on PATH"))
+    else:
+        parts = python.split(".")
+        if tuple(int(p) for p in parts[:2]) < MIN_PYTHON:
+            failures.append((f"python {MIN_PYTHON[0]}.{MIN_PYTHON[1]}+", f"found {python}"))
+
+    if facts.get("systemd") != "yes" or facts.get("systemctl") != "yes":
+        failures.append(("systemd", "not present"))
+    elif facts.get("sudo") != "yes":
+        # Managing a unit needs more than systemd existing.
+        failures.append(("permission to manage units", "passwordless sudo unavailable"))
+
+    disk = facts.get("diskgb") or ""
+    if not disk:
+        failures.append(("free disk", "could not read df"))
+    elif int(disk) < MIN_FREE_DISK_GB:
+        failures.append((f"{MIN_FREE_DISK_GB} GB free disk", f"found {disk} GB"))
+
+    return failures
+
+
+def handle_server_check(name: str) -> bool:
+    """Preflight a target and say which requirement failed, by name."""
+    entry = load_server(name)
+    if not entry:
+        console.print(f"\n[red]No server named '{name}'.[/red]")
+        console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
+        return False
+
+    target = entry["ssh"]
+    console.print(f"\n[dim]Checking {name} ({target}) …[/dim]")
+
+    result = _ssh(target, _PROBE)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        console.print(f"[red]✗ unreachable[/red]")
+        for line in detail:
+            console.print(f"  [dim]{line}[/dim]")
+        _record(name, "unreachable")
+        console.print()
+        return False
+
+    failures = _requirement_failures(_parse_probe(result.stdout))
+
+    if not failures:
+        console.print(f"[green]✓ {name} is ready to deploy to[/green]\n")
+        _record(name, "ok")
+        return True
+
+    for requirement, detail in failures:
+        console.print(f"[red]✗ {requirement}[/red] [dim]— {detail}[/dim]")
+    console.print(f"\n[dim]co deploy --to {name} needs all of these. "
+                  f"Only Ubuntu {SUPPORTED_UBUNTU} is supported.[/dim]\n")
+    _record(name, failures[0][0])
+    return False
+
+
+def _record(name: str, outcome: str) -> None:
+    servers = _load()
+    if name in servers:
+        servers[name]["last_check"] = outcome
+        _save(servers)

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -287,6 +287,47 @@ def announce(
     handle_announce(relay=relay, dry_run=dry_run)
 
 
+# Server command group — the machines `co deploy --to` can target
+server_app = typer.Typer(help="Register, list and preflight the servers you can deploy to")
+app.add_typer(server_app, name="server")
+
+
+@server_app.callback(invoke_without_command=True)
+def server_callback(ctx: typer.Context):
+    """Deploy targets."""
+    if ctx.invoked_subcommand is None:
+        from .commands.server_commands import handle_server_list
+        handle_server_list()
+
+
+@server_app.command("add")
+def server_add(
+    name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
+    ssh: str = typer.Option(..., "--ssh", help="ssh target, e.g. user@1.2.3.4 or a Host from ~/.ssh/config"),
+):
+    """Register a machine. Stores a name → ssh target mapping, no credential."""
+    from .commands.server_commands import handle_server_add
+    if not handle_server_add(name=name, ssh_target=ssh):
+        raise typer.Exit(1)
+
+
+@server_app.command("ls")
+def server_ls():
+    """Show what you can deploy to."""
+    from .commands.server_commands import handle_server_list
+    handle_server_list()
+
+
+@server_app.command("check")
+def server_check(
+    name: str = typer.Argument(..., help="Registered server name"),
+):
+    """Preflight a target and name the requirement that failed."""
+    from .commands.server_commands import handle_server_check
+    if not handle_server_check(name=name):
+        raise typer.Exit(1)
+
+
 # Skills command group
 skills_app = typer.Typer(help="Discover, copy, and list SKILL.md files from agent tool directories")
 app.add_typer(skills_app, name="skills")

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -219,6 +219,11 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         "admin_sessions": admin_sessions_handler,
         # TrustAgent instance for direct access in http.py/websocket.py
         "trust_agent": trust_agent,
+        # Whether dashboard.html may be shown to a visitor who has not onboarded yet.
+        # A Home page that only appears after you are let in cannot invite anyone in, so
+        # this defaults to True; set `public_home: false` in .co/host.yaml when the
+        # dashboard is written for the operator rather than for visitors.
+        "public_home": config.get("public_home", True),
         # Admin trust routes (partial injects trust_agent as first arg)
         "admin_trust_promote": partial(admin_trust_promote_handler, trust_agent),
         "admin_trust_demote": partial(admin_trust_demote_handler, trust_agent),

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -40,6 +40,20 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
             # INPUT resumes. Cleared on pop; a failed onboard leaves it for a retry.
             conn["pending_connect"] = data
             await send_msg({"type": "ONBOARD_REQUIRED", "identity": agent_address, **onboard_info})
+
+            # Then the Home page, so the visitor can see what they are being asked to
+            # join. dashboard.html is the agent's front door: gating it behind the
+            # onboard it is meant to introduce leaves a first-time visitor staring at a
+            # bare prompt, which is what happened on the default `careful` trust level —
+            # the snapshot only ever went out from establish_connection() below.
+            #
+            # ONBOARD_REQUIRED goes first so the client learns it is gated before any
+            # content arrives and cannot read a snapshot as a successful connect.
+            # send_dashboard stamps conn, so the resend after a successful onboard is
+            # skipped as an unchanged file rather than shipping the page twice.
+            if route_handlers.get("public_home", True):
+                from .dashboard import send_dashboard
+                await send_dashboard(send_msg, data.get("session_id"), conn)
             return
 
     if err:

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -305,3 +305,81 @@ def test_ensure_dashboard_warns_instead_of_crashing_on_an_unwritable_dir(in_tmp,
 
     assert "Could not write" in capsys.readouterr().err
     assert read_dashboard_snapshot() is None
+
+
+# --- Home is reachable before onboarding -------------------------------------
+# A dashboard that only ships from establish_connection() is invisible on the default
+# `careful` trust level: the gate answers ONBOARD_REQUIRED and returns, so a first-time
+# visitor never sees the page whose job is to invite them in.
+
+def _gated_handlers(public_home=True):
+    """route_handlers whose auth refuses with 'forbidden' so the onboard gate fires."""
+    return {
+        "auth": Mock(return_value=(None, "0xvisitor", True, "forbidden: must onboard")),
+        "trust_agent": Mock(),
+        "public_home": public_home,
+    }
+
+
+async def _connect_gated(handlers, sent):
+    from connectonion.network.host.ws_router import connect as connect_module
+    send_msg = AsyncMock(side_effect=lambda m: sent.append(m))
+    conn = {}
+    with _pytest.MonkeyPatch.context() as mp:
+        mp.setattr(connect_module, "get_onboard_requirements",
+                   lambda _ta: {"methods": ["invite_code"]})
+        await connect_module.handle_connect(
+            {}, send_msg, conn, handlers, Mock(), Mock(), "careful", None, None
+        )
+    return conn
+
+
+@_pytest.mark.asyncio
+async def test_gated_connect_still_sends_home(in_tmp):
+    (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
+    sent = []
+    await _connect_gated(_gated_handlers(), sent)
+
+    types = [m["type"] for m in sent]
+    assert "ONBOARD_REQUIRED" in types, "the gate must still ask for onboarding"
+    assert "DASHBOARD_SNAPSHOT" in types, "Home must be visible before onboarding"
+    # State before content: the client learns it is gated before any page arrives, so a
+    # snapshot can never be mistaken for a successful connect.
+    assert types.index("ONBOARD_REQUIRED") < types.index("DASHBOARD_SNAPSHOT")
+    assert next(m for m in sent if m["type"] == "DASHBOARD_SNAPSHOT")["html"] == "<h1>home</h1>"
+
+
+@_pytest.mark.asyncio
+async def test_gated_connect_respects_public_home_false(in_tmp):
+    (in_tmp / "dashboard.html").write_text("<h1>private</h1>", encoding="utf-8")
+    sent = []
+    await _connect_gated(_gated_handlers(public_home=False), sent)
+
+    types = [m["type"] for m in sent]
+    assert types == ["ONBOARD_REQUIRED"], "a dashboard written for the operator stays private"
+
+
+@_pytest.mark.asyncio
+async def test_gated_connect_without_a_dashboard_file(in_tmp):
+    sent = []
+    await _connect_gated(_gated_handlers(), sent)
+    assert [m["type"] for m in sent] == ["ONBOARD_REQUIRED"]
+
+
+@_pytest.mark.asyncio
+async def test_home_is_not_shipped_twice_across_the_onboard(in_tmp):
+    """The pre-auth send stamps conn, so the post-onboard establish_connection is a no-op."""
+    from connectonion.network.host.ws_router.connect import establish_connection
+    (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
+
+    sent = []
+    conn = await _connect_gated(_gated_handlers(), sent)
+    assert [m["type"] for m in sent].count("DASHBOARD_SNAPSHOT") == 1
+
+    storage = Mock(); storage.get.return_value = None
+    registry = Mock(); registry.get.return_value = None
+    await establish_connection({}, "0xvisitor", AsyncMock(side_effect=lambda m: sent.append(m)),
+                               conn, storage, registry)
+
+    assert [m["type"] for m in sent].count("DASHBOARD_SNAPSHOT") == 1, \
+        "the same file must not be shipped again after onboarding"

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -1,0 +1,198 @@
+"""Unit tests for `co server` — register, list and preflight a deploy target.
+
+The requirement checks are tested by feeding the probe output a box would return
+if it were missing each requirement in turn. That is the point of the command:
+"it doesn't work on my box" is only answerable if the failure is named.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import yaml
+
+from connectonion.cli.commands import server_commands as sc
+
+
+@pytest.fixture
+def servers_file(tmp_path, monkeypatch):
+    """Point the registry at a temp file so tests never touch ~/.co."""
+    path = tmp_path / "servers.yaml"
+    monkeypatch.setattr(sc, "SERVERS_FILE", path)
+    return path
+
+
+def _probe(**overrides) -> str:
+    """Build probe stdout for a box that meets every requirement, minus overrides."""
+    facts = {
+        "distro": "ubuntu",
+        "version": "24.04",
+        "python": "3.12",
+        "systemd": "yes",
+        "systemctl": "yes",
+        "sudo": "yes",
+        "diskgb": "40",
+    }
+    facts.update(overrides)
+    return "\n".join(f"{k}={v}" for k, v in facts.items())
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr):
+    return subprocess.CompletedProcess(args=[], returncode=255, stdout="", stderr=stderr)
+
+
+class TestRequirementFailuresAreNamed:
+    """Each requirement, missing in turn, must be reported by name."""
+
+    def test_a_box_meeting_everything_has_no_failures(self):
+        assert sc._requirement_failures(sc._parse_probe(_probe())) == []
+
+    def test_wrong_distro(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(distro="debian")))
+        assert failures and failures[0][0] == "Ubuntu"
+        assert "debian" in failures[0][1]
+
+    def test_wrong_ubuntu_version(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(version="22.04")))
+        assert failures and failures[0][0] == "Ubuntu 24.04"
+        assert "22.04" in failures[0][1]
+
+    def test_python_missing_entirely(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(python="")))
+        assert ("python3", "not on PATH") in failures
+
+    def test_python_too_old(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(python="3.10")))
+        names = [name for name, _ in failures]
+        assert "python 3.11+" in names
+
+    def test_systemd_absent(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(systemd="", systemctl="")))
+        assert ("systemd", "not present") in failures
+
+    def test_systemd_present_but_units_not_manageable(self):
+        """systemd existing is not the same as being allowed to manage a unit."""
+        failures = sc._requirement_failures(sc._parse_probe(_probe(sudo="")))
+        names = [name for name, _ in failures]
+        assert "permission to manage units" in names
+        assert "systemd" not in names  # systemd itself is fine, don't muddy the report
+
+    def test_disk_too_small(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(diskgb="2")))
+        names = [name for name, _ in failures]
+        assert "5 GB free disk" in names
+
+    def test_df_unreadable(self):
+        failures = sc._requirement_failures(sc._parse_probe(_probe(diskgb="")))
+        assert ("free disk", "could not read df") in failures
+
+    def test_several_missing_requirements_are_all_reported(self):
+        failures = sc._requirement_failures(
+            sc._parse_probe(_probe(distro="alpine", python="3.9", diskgb="1"))
+        )
+        assert len(failures) >= 3
+
+
+class TestServerAdd:
+    def test_unreachable_host_saves_nothing(self, servers_file):
+        """An unreachable host must fail with ssh's own words, and save nothing."""
+        with patch.object(sc, "_ssh", return_value=_fail("ssh: Could not resolve hostname nope")):
+            assert sc.handle_server_add("prod", "user@nope") is False
+
+        assert not servers_file.exists()
+
+    def test_reachable_host_is_recorded(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            assert sc.handle_server_add("prod", "user@1.2.3.4") is True
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["ssh"] == "user@1.2.3.4"
+        assert saved["servers"]["prod"]["last_check"] is None
+
+    def test_nothing_secret_is_written(self, servers_file):
+        """The file holds a target, never a credential."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        text = servers_file.read_text().lower()
+        for forbidden in ("private", "begin openssh", "password", "secret", "token", "key"):
+            assert forbidden not in text
+
+    def test_readding_the_same_name_updates_the_target(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@old")
+            sc.handle_server_add("prod", "user@new")
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["ssh"] == "user@new"
+
+    def test_ssh_is_called_in_batch_mode_so_it_cannot_hang_on_a_prompt(self, servers_file):
+        with patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        argv = run.call_args.args[0]
+        assert "BatchMode=yes" in argv
+        assert any(a.startswith("ConnectTimeout=") for a in argv)
+
+
+class TestServerCheck:
+    def test_unknown_name_is_rejected(self, servers_file):
+        assert sc.handle_server_check("nope") is False
+
+    def test_a_ready_box_passes_and_is_recorded(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_ok(_probe())):
+            assert sc.handle_server_check("prod") is True
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "ok"
+
+    def test_a_failing_box_records_the_failing_requirement(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_ok(_probe(version="22.04"))):
+            assert sc.handle_server_check("prod") is False
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "Ubuntu 24.04"
+
+    def test_an_unreachable_box_records_unreachable(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+        with patch.object(sc, "_ssh", return_value=_fail("Connection refused")):
+            assert sc.handle_server_check("prod") is False
+
+        saved = yaml.safe_load(servers_file.read_text())
+        assert saved["servers"]["prod"]["last_check"] == "unreachable"
+
+
+class TestServerList:
+    def test_empty_registry_is_not_an_error(self, servers_file):
+        assert sc.handle_server_list() is True
+
+    def test_lists_registered_servers(self, servers_file, capsys):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+            sc.handle_server_add("staging", "user@5.6.7.8")
+
+        sc.handle_server_list()
+        out = capsys.readouterr().out
+        assert "prod" in out and "staging" in out
+        assert "1.2.3.4" in out
+
+
+class TestLoadServer:
+    def test_returns_none_for_unknown(self, servers_file):
+        assert sc.load_server("nope") is None
+
+    def test_returns_the_entry_deploy_will_use(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        assert sc.load_server("prod")["ssh"] == "user@1.2.3.4"


### PR DESCRIPTION
Closes #314.

## The bug

On the default `careful` trust level a first-time visitor never saw the dashboard.
`send_dashboard` only ran inside `establish_connection`, and the trust gate answers
`ONBOARD_REQUIRED` and returns before reaching it — so the page whose whole job is to
invite someone in was withheld until after they had already been let in.

Verified in oo-chat against a real hosted agent, changing one variable:

| `trust` | Before this PR |
|---|---|
| `careful` (default) | no Home panel — just the bare agent card |
| `open` | Home renders correctly |

The host log shows where it stops:

```
[FAST_RULES] No match, using default=ask
[FAST_RULES] Returning None (needs LLM)
```

## Why showing it is the right default

The starter Home is public by construction. `featured_skills()` keeps only project-tree
skills *precisely because* those are the ones already carried in the agent's published
relay profile — user and builtin skills are excluded as private. So the page was built
entirely from data the agent already publishes, and was then gated behind private
authorization.

## Changes

- send the snapshot on the `ONBOARD_REQUIRED` path, **after** that frame so the client
  learns it is gated before any content arrives and cannot read a snapshot as a
  successful connect
- `public_home` in `.co/host.yaml`, default `true`, for the case where a dashboard is
  written for the operator rather than for visitors
- `send_dashboard` stamps `conn`, so the resend from `establish_connection` after a
  successful onboard is skipped as an unchanged file rather than shipping the page twice

## Testing

End to end in the browser against a real relay-connected agent:

| trust | `public_home` | Result |
|---|---|---|
| `careful` | default | Home appears |
| `careful` | `false` | Home hidden |
| `open` | — | Home appears (unchanged) |

Plus four unit tests in `test_dashboard.py` covering the gated path, the opt-out, the
no-file case, and the no-double-send guarantee. Full unit suite: 2391 passed.