### PR TITLE
feat(server): co server ssh and co server forget (#318)

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -242,3 +242,49 @@ def _record(name: str, outcome: str) -> None:
     if name in servers:
         servers[name]["last_check"] = outcome
         _save(servers)
+
+
+def handle_server_ssh(name: str, command: Optional[str] = None) -> bool:
+    """Open a shell on a registered server, or run one command there.
+
+    We already hold the target. Making the operator retype an IP defeats the
+    point of having registered it.
+    """
+    entry = load_server(name)
+    if not entry:
+        console.print(f"\n[red]No server named '{name}'.[/red]")
+        console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
+        return False
+
+    argv = ["ssh", "-o", "StrictHostKeyChecking=accept-new", entry["ssh"]]
+    if command:
+        argv.append(command)
+
+    # Hand the terminal over rather than capturing: an interactive shell needs a
+    # tty, and a captured one would hang with no prompt visible.
+    return subprocess.run(argv).returncode == 0
+
+
+def handle_server_forget(name: str) -> bool:
+    """Drop the local entry. The machine is untouched.
+
+    Deliberately not merged with `destroy`. One of these stops you paying and
+    the other does not, and a single verb would mean either a user who thinks
+    they stopped the billing and did not, or a user tidying their config who
+    deletes a live machine.
+    """
+    servers = _load()
+    if name not in servers:
+        console.print(f"\n[red]No server named '{name}'.[/red]\n")
+        return False
+
+    target = servers[name].get("ssh", "?")
+    del servers[name]
+    _save(servers)
+
+    console.print(f"[green]✓[/green] Forgot [cyan]{name}[/cyan] ({target})")
+    console.print("\n[yellow]The machine itself is untouched — it keeps running, and if we "
+                  "created it, it keeps being billed.[/yellow]")
+    console.print("[dim]Tearing one down needs the server API (openonion/oo-api#36); until "
+                  "then, delete it where it lives.[/dim]\n")
+    return True

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -330,6 +330,27 @@ def server_check(
         raise typer.Exit(1)
 
 
+@server_app.command("ssh")
+def server_ssh(
+    name: str = typer.Argument(..., help="Registered server name"),
+    command: Optional[str] = typer.Argument(None, help="Command to run instead of opening a shell"),
+):
+    """Open a shell on a registered server, or run one command there."""
+    from .commands.server_commands import handle_server_ssh
+    if not handle_server_ssh(name=name, command=command):
+        raise typer.Exit(1)
+
+
+@server_app.command("forget")
+def server_forget(
+    name: str = typer.Argument(..., help="Registered server name"),
+):
+    """Drop the local entry. Does NOT touch the machine or stop any billing."""
+    from .commands.server_commands import handle_server_forget
+    if not handle_server_forget(name=name):
+        raise typer.Exit(1)
+
+
 # Skills command group
 skills_app = typer.Typer(help="Discover, copy, and list SKILL.md files from agent tool directories")
 app.add_typer(skills_app, name="skills")

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -196,3 +196,88 @@ class TestLoadServer:
             sc.handle_server_add("prod", "user@1.2.3.4")
 
         assert sc.load_server("prod")["ssh"] == "user@1.2.3.4"
+
+
+class TestServerSSH:
+    def test_unknown_name_is_rejected(self, servers_file):
+        assert sc.handle_server_ssh("nope") is False
+
+    def test_opens_a_shell_on_the_registered_target(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc.subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)) as run:
+            assert sc.handle_server_ssh("prod") is True
+
+        argv = run.call_args.args[0]
+        assert argv[0] == "ssh"
+        assert argv[-1] == "user@1.2.3.4"
+
+    def test_runs_one_command_when_given_one(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc.subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)) as run:
+            sc.handle_server_ssh("prod", command="uptime")
+
+        assert run.call_args.args[0][-1] == "uptime"
+
+    def test_does_not_capture_output(self, servers_file):
+        """An interactive shell needs the terminal.
+
+        Capturing would hang with no prompt visible, which reads as the command
+        being broken rather than waiting.
+        """
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc.subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)) as run:
+            sc.handle_server_ssh("prod")
+
+        assert "capture_output" not in run.call_args.kwargs
+
+
+class TestServerForget:
+    def test_unknown_name_is_rejected(self, servers_file):
+        assert sc.handle_server_forget("nope") is False
+
+    def test_removes_only_the_named_entry(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+            sc.handle_server_add("staging", "user@5.6.7.8")
+
+        assert sc.handle_server_forget("prod") is True
+
+        remaining = yaml.safe_load(servers_file.read_text())["servers"]
+        assert "prod" not in remaining
+        assert "staging" in remaining
+
+    def test_never_contacts_the_machine(self, servers_file):
+        """forget is local-only. Touching the host would blur it into destroy.
+
+        This is the guard that keeps the two commands honest: if forget ever
+        starts reaching out, the difference between 'stop tracking it' and
+        'stop paying for it' has been lost.
+        """
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc, "_ssh") as ssh, \
+             patch.object(sc.subprocess, "run") as run:
+            sc.handle_server_forget("prod")
+
+        ssh.assert_not_called()
+        run.assert_not_called()
+
+    def test_says_the_machine_keeps_billing(self, servers_file, capsys):
+        """The warning is the whole safety story — assert it is actually printed."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        sc.handle_server_forget("prod")
+        out = capsys.readouterr().out.lower()
+        assert "untouched" in out
+        assert "billed" in out


### PR DESCRIPTION
Two of the five items in #318. Both build directly on the `co server` registry that #316 landed.

## `co server ssh <name> [command]`

```
$ co server ssh test "uptime; echo I-AM $(hostname)"
 11:10:26 up 29 min,  1 user,  load average: 0.00, 0.00, 0.00
I-AM co-test-deploy.asia-southeast1-b.c.connectonion.internal
```

We already hold the target and the key. Making the operator retype an IP defeats the point of having registered the machine.

It hands the terminal over rather than capturing output — an interactive shell needs a tty, and a captured one hangs with no prompt visible, which reads as the command being broken rather than waiting. There is a test asserting `capture_output` is not passed, because that is an easy "improvement" for someone to add later.

## `co server forget <name>`

Drops the local entry. Touches nothing else.

```
$ co server forget test
✓ Forgot test (co-test-deploy)

The machine itself is untouched — it keeps running, and if we created it, it keeps being billed.
Tearing one down needs the server API (openonion/oo-api#36); until then, delete it where it lives.

$ gcloud compute instances describe co-test-deploy --format='value(status)'
RUNNING
```

**Kept separate from `destroy` deliberately**, per #318. One of the two stops you paying and the other does not. A single `co server rm` would mean one of two failures depending on which behaviour we picked: a user who believes they stopped the billing and did not, or a user tidying their local config who deletes a production machine.

The guard that keeps this honest is a test asserting **`forget` never contacts the host** — neither `_ssh` nor `subprocess.run` is called. If forget ever starts reaching out, the difference between "stop tracking it" and "stop paying for it" has been lost, and the test fails rather than the distinction quietly eroding.

## What is NOT here, and why

**`co server destroy`.** It needs openonion/oo-api#36 to actually tear an instance down — the CLI holds no GCP credential by design, so it cannot do this itself. **A command called `destroy` that cannot stop the billing is worse than no command at all**, so it waits for the backend rather than shipping as a stub. `forget`'s output says where teardown currently has to happen instead of pointing at a command that does not exist.

Also still open from #318: the price confirmation on `co server new` (needs #313), and `co server ls` reconciling against the backend (needs oo-api#36 to have something to reconcile with).

## Verification

`tests/unit/test_server_commands.py` — **31 cases** (was 23). New ones cover: unknown name for both commands, ssh targeting the registered address, ssh passing a command through, ssh not capturing output, forget removing only the named entry, forget never contacting the host, and the billing warning actually being printed.

Also run against the live GCE box from #316's verification: `ssh` executed a real command, `forget` removed the entry, and `gcloud` confirmed the instance was still `RUNNING` afterwards.

Full suite: **2406 passed, 3 skipped**.
