### PR TITLE
feat(deploy): co deploy --to converges a server, syncs code, restarts the unit (#312)

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -1,0 +1,350 @@
+"""
+Purpose: Deploy an agent onto a server you own — converge the setup, sync the code, restart the unit
+LLM-Note:
+  Dependencies: imports from [hashlib, json, shlex, subprocess, pathlib, yaml, rich, server_commands, project_cmd_lib] | imported by [cli/main.py via handle_deploy_to] | tested by [tests/unit/test_deploy_to_server.py]
+  Data flow: handle_deploy_to(server, project_dir) → load_server() resolves the ssh target → _read_provision() reads /srv/<agent>/.co/provision.json → _ensure_setup() runs only the missing steps → _sync_code() rsyncs excluding .co/ → _install_deps() only when requirements.txt changed → _write_unit() on change → systemctl restart
+  State/Effects: on the server creates /srv/<agent>/{,.venv,.co} and /etc/systemd/system/<agent>.service | rsyncs code | NEVER writes inside /srv/<agent>/.co except provision.json | locally reads .co/host.yaml and the project files
+  Integration: exposes handle_deploy_to(server, project_dir) | requires a server registered by `co server add` (#311) reachable with the key from `co keys --ssh` (#310)
+  Performance: one ssh round trip to read provision.json, one rsync, one restart | setup steps are skipped entirely once the schema matches
+  Errors: an unreachable or unprepared server fails before anything is changed | a failed unit start surfaces journalctl output rather than a bare exit code
+"""
+
+import hashlib
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import yaml
+from rich.console import Console
+
+from .server_commands import SSH_TIMEOUT_SECONDS, load_server
+
+console = Console()
+
+# Bumped when a setup step is added or changes shape. A server reporting an
+# older schema runs the missing steps; one reporting this schema goes straight
+# to rsync and restart.
+PROVISION_SCHEMA = 1
+
+SRV = "/srv"
+
+
+def _ssh(target: str, command: str, timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run one command on the server. Longer default timeout than a preflight:
+    apt and pip are slow, and killing them halfway leaves a half-installed box."""
+    return subprocess.run(
+        [
+            "ssh",
+            "-o", "BatchMode=yes",
+            "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
+            "-o", "StrictHostKeyChecking=accept-new",
+            target,
+            command,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _read_project(project_dir: Path) -> Optional[dict]:
+    """Read the agent name and entrypoint from .co/host.yaml.
+
+    Same contract as the cloud deploy, so a project does not need a second
+    config to be deployable both ways.
+    """
+    host_yaml = project_dir / ".co" / "host.yaml"
+    if not host_yaml.exists():
+        console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
+        return None
+
+    config = yaml.safe_load(host_yaml.read_text(encoding="utf-8")) or {}
+    from .project_cmd_lib import DEPLOY_NAME_PATTERN, normalize_deploy_name
+
+    name = str(config.get("name") or "unnamed-agent")
+    if not DEPLOY_NAME_PATTERN.match(name):
+        console.print(f"[red]Invalid agent name: {name}[/red]")
+        # The name becomes a directory and a systemd unit name, so the same rule
+        # the cloud path enforces applies here.
+        suggestion = normalize_deploy_name(name)
+        if suggestion:
+            console.print(f"[dim]Try:  name: {suggestion}[/dim]")
+        return None
+
+    return {"name": name, "entrypoint": str(config.get("entrypoint") or "agent.py")}
+
+
+def _read_provision(target: str, agent: str) -> dict:
+    """Read the convergence marker. A missing or unreadable one means schema 0."""
+    result = _ssh(target, f"cat {SRV}/{agent}/.co/provision.json 2>/dev/null", timeout=60)
+    if result.returncode != 0 or not result.stdout.strip():
+        return {"schema": 0}
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        # A truncated or hand-edited marker should mean "converge again", not
+        # crash the deploy.
+        return {"schema": 0}
+
+
+def _unit_text(agent: str, entrypoint: str) -> str:
+    """The systemd unit. Restart=always and enable are what the container was for."""
+    return f"""[Unit]
+Description=ConnectOnion agent {agent}
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory={SRV}/{agent}
+ExecStart={SRV}/{agent}/.venv/bin/python {entrypoint}
+Restart=always
+RestartSec=3
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def _ensure_setup(target: str, agent: str, entrypoint: str, schema: int,
+                  ssh_public_line: Optional[str]) -> bool:
+    """Bring the server to the state a deploy assumes. Idempotent.
+
+    Runs on every deploy, and is a no-op once the schema matches — which is why
+    a machine registered by hand needs no separate path: its first deploy is the
+    one that sets it up.
+    """
+    steps = []
+
+    if schema < PROVISION_SCHEMA:
+        # python, venv and the directory layout. Once only, unless the schema
+        # moves. `.co/` is created but never written into again by a deploy.
+        steps.append(f"""
+set -e
+sudo mkdir -p {SRV}/{agent}/.co
+sudo chown -R "$USER" {SRV}/{agent}
+command -v python3 >/dev/null || (sudo apt-get update -qq && sudo apt-get install -y -qq python3)
+dpkg -s python3-venv >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get install -y -qq python3-venv)
+[ -x {SRV}/{agent}/.venv/bin/python ] || python3 -m venv {SRV}/{agent}/.venv
+""")
+
+    if ssh_public_line:
+        # Ensured every deploy, not once: authorized_keys is the only way back
+        # in, so it self-heals rather than needing a rescue path.
+        quoted = shlex.quote(ssh_public_line)
+        steps.append(f"""
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
+grep -qxF {quoted} ~/.ssh/authorized_keys || echo {quoted} >> ~/.ssh/authorized_keys
+""")
+
+    if not steps:
+        return True
+
+    console.print("[dim]  converging server …[/dim]")
+    result = _ssh(target, "\n".join(steps), timeout=600)
+    if result.returncode != 0:
+        console.print("[red]Setup failed.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
+
+
+def _write_unit_if_changed(target: str, agent: str, entrypoint: str) -> bool:
+    """Write the systemd unit only when its content differs.
+
+    Rewriting it every deploy would mean a daemon-reload every deploy for no
+    reason, and would hide whether a restart came from new code or a new unit.
+    """
+    wanted = _unit_text(agent, entrypoint)
+    unit_path = f"/etc/systemd/system/{agent}.service"
+
+    current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)
+    if current.returncode == 0 and current.stdout == wanted:
+        return True
+
+    console.print("[dim]  writing systemd unit …[/dim]")
+    script = f"""
+set -e
+cat > /tmp/{agent}.service <<'UNITEOF'
+{wanted}UNITEOF
+sudo mv /tmp/{agent}.service {unit_path}
+sudo systemctl daemon-reload
+sudo systemctl enable {agent} >/dev/null 2>&1
+"""
+    result = _ssh(target, script, timeout=120)
+    if result.returncode != 0:
+        console.print("[red]Could not write the systemd unit.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
+
+
+def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
+    """rsync the project, excluding the state directory.
+
+    `--delete` removes code files deleted locally, which is wanted. `.co/` is
+    excluded so the agent's identity, logs and evals survive — that exclusion is
+    the whole reason a redeploy no longer reissues the agent's address.
+    """
+    console.print("[dim]  syncing code …[/dim]")
+    result = subprocess.run(
+        [
+            "rsync", "-az", "--delete",
+            "--exclude", ".co/",
+            "--exclude", ".venv/",
+            "--exclude", ".git/",
+            "--exclude", "__pycache__/",
+            "-e", f"ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
+            f"{project_dir}/",
+            f"{target}:{SRV}/{agent}/",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        console.print("[red]rsync failed.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
+
+
+def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool:
+    """pip install only when requirements.txt actually changed.
+
+    The hash of the file we just synced is compared against the hash recorded
+    after the last successful install. Reinstalling every deploy would make a
+    code-only change take minutes instead of seconds.
+    """
+    requirements = project_dir / "requirements.txt"
+    if not requirements.exists():
+        return True
+
+    digest = hashlib.sha256(requirements.read_bytes()).hexdigest()
+    stamp = f"{SRV}/{agent}/.co/requirements.sha256"
+
+    current = _ssh(target, f"cat {stamp} 2>/dev/null", timeout=60)
+    if current.returncode == 0 and current.stdout.strip() == digest:
+        return True
+
+    console.print("[dim]  installing dependencies …[/dim]")
+    result = _ssh(
+        target,
+        f"set -e\n"
+        f"{SRV}/{agent}/.venv/bin/pip install -q -r {SRV}/{agent}/requirements.txt\n"
+        f"printf '%s' {shlex.quote(digest)} > {stamp}",
+        timeout=900,
+    )
+    if result.returncode != 0:
+        console.print("[red]pip install failed.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-12:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
+
+
+def _restart(target: str, agent: str) -> bool:
+    """Restart, then confirm it is actually running.
+
+    `systemctl restart` returns 0 for a unit that starts and immediately dies,
+    so the status check is the real test. On failure show journald rather than
+    an exit code — the traceback is what the operator needs.
+    """
+    console.print("[dim]  restarting …[/dim]")
+    result = _ssh(target, f"sudo systemctl restart {agent}", timeout=120)
+    if result.returncode != 0:
+        console.print("[red]Restart failed.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+
+    active = _ssh(target, f"systemctl is-active {agent}", timeout=60)
+    if active.stdout.strip() != "active":
+        console.print(f"[red]{agent} is not running after restart "
+                      f"({active.stdout.strip() or 'unknown'}).[/red]")
+        logs = _ssh(target, f"sudo journalctl -u {agent} -n 20 --no-pager", timeout=60)
+        for line in logs.stdout.strip().splitlines()[-20:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
+
+
+def _mark_provisioned(target: str, agent: str) -> None:
+    from ... import __version__
+    marker = json.dumps({"schema": PROVISION_SCHEMA,
+                         "provisioned_by": f"connectonion {__version__}"})
+    _ssh(target, f"printf '%s' {shlex.quote(marker)} > {SRV}/{agent}/.co/provision.json",
+         timeout=60)
+
+
+def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
+    """co deploy --to <server>:  ensure(setup) → sync code → restart."""
+    project_dir = (project_dir or Path.cwd()).resolve()
+
+    entry = load_server(server)
+    if not entry:
+        console.print(f"\n[red]No server named '{server}'.[/red]")
+        console.print("[cyan]co server ls[/cyan] to see what is registered, or "
+                      "[cyan]co server add[/cyan] to register one.\n")
+        return False
+
+    project = _read_project(project_dir)
+    if not project:
+        return False
+
+    target = entry["ssh"]
+    agent, entrypoint = project["name"], project["entrypoint"]
+
+    if not (project_dir / entrypoint).exists():
+        console.print(f"[red]Entrypoint not found: {entrypoint}[/red]")
+        console.print(f"[dim]Set 'entrypoint' in {project_dir / '.co' / 'host.yaml'}[/dim]")
+        return False
+
+    console.print(f"\n[bold]{agent}[/bold] → [cyan]{server}[/cyan] [dim]({target})[/dim]")
+
+    provision = _read_provision(target, agent)
+    ssh_public_line = _derive_ssh_public_line()
+
+    if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0), ssh_public_line):
+        return False
+    if not _sync_code(target, agent, project_dir):
+        return False
+    if not _install_deps_if_changed(target, agent, project_dir):
+        return False
+    if not _write_unit_if_changed(target, agent, entrypoint):
+        return False
+    if not _restart(target, agent):
+        return False
+
+    _mark_provisioned(target, agent)
+
+    console.print(f"\n[green]✓ {agent} is running on {server}[/green]")
+    console.print(f"[dim]  logs:  co server ssh {server} 'journalctl -u {agent} -f'[/dim]")
+    console.print(f"[dim]  state: {SRV}/{agent}/.co/  — untouched by deploys[/dim]\n")
+    return True
+
+
+def _derive_ssh_public_line() -> Optional[str]:
+    """The operator's derived public key, so access self-heals every deploy.
+
+    Returns None when there is no local identity to derive from; the deploy
+    still proceeds, since the operator evidently already has access.
+    """
+    from ... import address
+    from .keys_commands import _find_co_dir
+
+    co_dir = _find_co_dir()
+    if not co_dir:
+        return None
+    data = address.load(co_dir)
+    if not data or not data.get("seed_phrase"):
+        return None
+    return address.derive_ssh_key(data["seed_phrase"])["public_line"]

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -187,17 +187,29 @@ sudo systemctl enable {agent} >/dev/null 2>&1
 
 
 def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
-    """rsync the project, excluding the state directory.
+    """rsync the project, excluding the state directory but carrying skills.
 
     `--delete` removes code files deleted locally, which is wanted. `.co/` is
     excluded so the agent's identity, logs and evals survive — that exclusion is
     the whole reason a redeploy no longer reissues the agent's address.
+
+    `.co/skills/` is the exception, and it has to be: skills are *what the agent
+    is*, not state it accumulated. Excluding all of `.co/` shipped an agent with
+    none of its skills — the deploy succeeded and the agent ran without them,
+    which is worse than failing. So skills are included, and `--delete` applies
+    inside that directory too so a removed skill actually goes away.
+
+    Order matters to rsync: the include must precede the exclude that would
+    otherwise swallow it, and `.co/` itself must be included for rsync to
+    descend into it at all.
     """
     console.print("[dim]  syncing code …[/dim]")
     result = subprocess.run(
         [
             "rsync", "-az", "--delete",
-            "--exclude", ".co/",
+            "--include", ".co/",
+            "--include", ".co/skills/***",
+            "--exclude", ".co/*",
             "--exclude", ".venv/",
             "--exclude", ".git/",
             "--exclude", "__pycache__/",

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -133,8 +133,21 @@ def deploy(
     template: Optional[str] = typer.Option(None, "-t", "--template", help="Create and deploy a template project"),
     skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (repeatable: --skills a --skills b)"),
     name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
+    to: Optional[str] = typer.Option(None, "--to", help="Deploy onto a server you own (see: co server ls)"),
 ):
-    """Deploy to ConnectOnion Cloud."""
+    """Deploy to ConnectOnion Cloud, or with --to onto a server you own."""
+    if to:
+        # A different destination, not a variant of the same one: this path holds
+        # no container and never touches the server's .co/ state.
+        if template or skills or name:
+            console.print("[red]--to cannot be combined with --template, --skills or --name.[/red]")
+            console.print("[dim]Those belong to the cloud deploy. --to syncs the project you are in.[/dim]")
+            raise typer.Exit(2)
+        from .commands.deploy_to_server import handle_deploy_to
+        if not handle_deploy_to(server=to):
+            raise typer.Exit(1)
+        return
+
     from .commands.deploy_commands import handle_deploy
     handle_deploy(template=template, skills=skills, name=name)
 

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -45,9 +45,11 @@ class TestSyncNeverTouchesState:
 
         argv = run.call_args.args[0]
         assert argv[0] == "rsync"
-        # --exclude and its value are separate argv entries
+        # --exclude and its value are separate argv entries. The pattern is
+        # `.co/*` rather than `.co/` so rsync still descends far enough for the
+        # skills include to match — see the skills test below.
         pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
-        assert ("--exclude", ".co/") in pairs
+        assert ("--exclude", ".co/*") in pairs
 
     def test_rsync_uses_delete_so_removed_code_goes_away(self, project):
         """--delete is wanted for code; the .co/ exclusion is what protects state.
@@ -59,6 +61,38 @@ class TestSyncNeverTouchesState:
             dts._sync_code("user@host", "myagent", project)
 
         assert "--delete" in run.call_args.args[0]
+
+    def test_skills_are_carried_but_the_rest_of_state_is_not(self, project):
+        """Skills live in .co/skills/ — excluding all of .co/ shipped an agent
+        with none of its skills.
+
+        Found by review after the first version excluded `.co/` wholesale: the
+        deploy succeeded and the agent ran without its skills, which is worse
+        than failing. The rule is order-sensitive in rsync, so this asserts the
+        exact sequence rather than mere membership.
+        """
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        argv = run.call_args.args[0]
+        # rsync applies the first matching rule, so the includes must come
+        # before the exclude that would otherwise swallow them, and `.co/`
+        # itself must be included for rsync to descend into it.
+        assert argv.index("--include") < argv.index("--exclude")
+        pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
+        assert ("--include", ".co/") in pairs
+        assert ("--include", ".co/skills/***") in pairs
+        assert ("--exclude", ".co/*") in pairs
+
+    def test_the_state_exclusion_is_not_a_blanket_co_exclusion(self, project):
+        """`--exclude .co/` would prune the directory before the skills include
+        could match. The exclusion has to be `.co/*` so rsync still descends."""
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        argv = run.call_args.args[0]
+        pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
+        assert ("--exclude", ".co/") not in pairs
 
     def test_rsync_also_excludes_the_venv_and_git(self, project):
         """The venv lives on the server and must not be overwritten by a local one."""

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -1,0 +1,273 @@
+"""Unit tests for `co deploy --to` — deploy onto a server you own.
+
+The tests that matter here guard one invariant: **a deploy must never recreate
+the machine's state.** That is what makes a redeploy stop reissuing the agent's
+address, and what lets a fix made by hand over ssh survive. Everything else in
+this file is secondary to the rsync exclusions and the pip-skip.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A minimal deployable project."""
+    (tmp_path / ".co").mkdir()
+    (tmp_path / ".co" / "host.yaml").write_text(
+        yaml.safe_dump({"name": "myagent", "entrypoint": "agent.py"})
+    )
+    (tmp_path / "agent.py").write_text("print('hi')\n")
+    return tmp_path
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr="boom"):
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+class TestSyncNeverTouchesState:
+    """The invariant. If these fail, a deploy destroys the agent's identity."""
+
+    def test_rsync_excludes_the_state_directory(self, project):
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        argv = run.call_args.args[0]
+        assert argv[0] == "rsync"
+        # --exclude and its value are separate argv entries
+        pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
+        assert ("--exclude", ".co/") in pairs
+
+    def test_rsync_uses_delete_so_removed_code_goes_away(self, project):
+        """--delete is wanted for code; the .co/ exclusion is what protects state.
+
+        Without --delete a file deleted locally would linger on the server
+        forever. The pairing of --delete with the exclusion is the whole design.
+        """
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        assert "--delete" in run.call_args.args[0]
+
+    def test_rsync_also_excludes_the_venv_and_git(self, project):
+        """The venv lives on the server and must not be overwritten by a local one."""
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        argv = run.call_args.args[0]
+        pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
+        assert ("--exclude", ".venv/") in pairs
+        assert ("--exclude", ".git/") in pairs
+
+    def test_setup_never_writes_inside_the_state_directory(self, project):
+        """ensure(setup) may create .co/ but must not write files into it.
+
+        provision.json is written separately, after a successful deploy — so any
+        write to .co/<something> from the setup script would be a bug.
+        """
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py", 0, None)
+
+        script = ssh.call_args.args[1]
+        assert "mkdir -p /srv/myagent/.co" in script
+        # nothing redirected into the state dir
+        assert "> /srv/myagent/.co/" not in script
+
+
+class TestConvergence:
+    def test_a_current_schema_skips_setup_entirely(self):
+        """The common deploy must not reinstall python on every run."""
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            assert dts._ensure_setup("user@host", "myagent", "agent.py",
+                                     dts.PROVISION_SCHEMA, None) is True
+
+        ssh.assert_not_called()
+
+    def test_an_older_schema_runs_the_setup(self):
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py", 0, None)
+
+        assert "python3 -m venv" in ssh.call_args.args[1]
+
+    def test_authorized_keys_is_ensured_even_at_the_current_schema(self):
+        """Access self-heals on every deploy — it is the only way back in.
+
+        A one-time write would mean a server whose authorized_keys got clobbered
+        needs a rescue path. Re-asserting it every deploy removes that class of
+        problem.
+        """
+        line = "ssh-ed25519 AAAA test"
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py",
+                              dts.PROVISION_SCHEMA, line)
+
+        script = ssh.call_args.args[1]
+        assert "authorized_keys" in script
+        assert "grep -qxF" in script  # idempotent append, not a duplicate every time
+
+    def test_a_missing_marker_reads_as_schema_zero(self):
+        with patch.object(dts, "_ssh", return_value=_fail()):
+            assert dts._read_provision("user@host", "myagent") == {"schema": 0}
+
+    def test_a_corrupt_marker_reads_as_schema_zero(self):
+        """A truncated or hand-edited marker means converge again, not crash."""
+        with patch.object(dts, "_ssh", return_value=_ok("{not json")):
+            assert dts._read_provision("user@host", "myagent") == {"schema": 0}
+
+    def test_a_valid_marker_is_parsed(self):
+        with patch.object(dts, "_ssh", return_value=_ok(json.dumps({"schema": 1}))):
+            assert dts._read_provision("user@host", "myagent")["schema"] == 1
+
+
+class TestDependencyInstall:
+    def test_no_requirements_file_means_nothing_to_do(self, project):
+        with patch.object(dts, "_ssh") as ssh:
+            assert dts._install_deps_if_changed("user@host", "myagent", project) is True
+        ssh.assert_not_called()
+
+    def test_unchanged_requirements_skip_the_install(self, project):
+        """A code-only change should take seconds, not minutes."""
+        (project / "requirements.txt").write_text("requests\n")
+        import hashlib
+        digest = hashlib.sha256((project / "requirements.txt").read_bytes()).hexdigest()
+
+        with patch.object(dts, "_ssh", return_value=_ok(digest)) as ssh:
+            assert dts._install_deps_if_changed("user@host", "myagent", project) is True
+
+        # only the stamp read, no install
+        assert ssh.call_count == 1
+        assert "pip install" not in ssh.call_args.args[1]
+
+    def test_changed_requirements_trigger_the_install(self, project):
+        (project / "requirements.txt").write_text("requests\n")
+
+        with patch.object(dts, "_ssh", side_effect=[_ok("stale-hash"), _ok()]) as ssh:
+            assert dts._install_deps_if_changed("user@host", "myagent", project) is True
+
+        assert "pip install" in ssh.call_args_list[-1].args[1]
+
+    def test_a_failed_install_stops_the_deploy(self, project):
+        (project / "requirements.txt").write_text("requests\n")
+
+        with patch.object(dts, "_ssh", side_effect=[_ok("stale"), _fail("no matching dist")]):
+            assert dts._install_deps_if_changed("user@host", "myagent", project) is False
+
+
+class TestSystemdUnit:
+    def test_unit_restarts_always_and_starts_on_boot(self):
+        unit = dts._unit_text("myagent", "agent.py")
+        assert "Restart=always" in unit
+        assert "WantedBy=multi-user.target" in unit
+
+    def test_unit_runs_the_venv_python_not_the_system_one(self):
+        unit = dts._unit_text("myagent", "agent.py")
+        assert "/srv/myagent/.venv/bin/python agent.py" in unit
+
+    def test_an_unchanged_unit_is_not_rewritten(self):
+        """Rewriting every deploy would mean a daemon-reload for no reason."""
+        wanted = dts._unit_text("myagent", "agent.py")
+        with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
+            assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
+
+        assert ssh.call_count == 1  # the read only
+
+    def test_a_changed_unit_is_written_and_reloaded(self):
+        with patch.object(dts, "_ssh", side_effect=[_ok("old content"), _ok()]) as ssh:
+            assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
+
+        script = ssh.call_args_list[-1].args[1]
+        assert "daemon-reload" in script
+        assert "systemctl enable" in script
+
+
+class TestRestart:
+    def test_a_unit_that_dies_immediately_is_reported_as_failure(self):
+        """systemctl restart returns 0 for a unit that starts and dies.
+
+        Trusting the exit code would report a broken deploy as a success, which
+        is the worst possible outcome for a deploy command.
+        """
+        with patch.object(dts, "_ssh", side_effect=[_ok(), _ok("failed"), _ok("traceback…")]):
+            assert dts._restart("user@host", "myagent") is False
+
+    def test_an_active_unit_passes(self):
+        with patch.object(dts, "_ssh", side_effect=[_ok(), _ok("active")]):
+            assert dts._restart("user@host", "myagent") is True
+
+    def test_journal_is_shown_when_the_unit_does_not_come_up(self, capsys):
+        """The traceback is what the operator needs, not an exit code."""
+        with patch.object(dts, "_ssh",
+                          side_effect=[_ok(), _ok("failed"), _ok("ModuleNotFoundError: no foo")]):
+            dts._restart("user@host", "myagent")
+
+        assert "ModuleNotFoundError" in capsys.readouterr().out
+
+
+class TestHandleDeployTo:
+    def test_unknown_server_is_rejected_before_anything_runs(self, project):
+        with patch.object(dts, "load_server", return_value=None), \
+             patch.object(dts, "_ssh") as ssh:
+            assert dts.handle_deploy_to("nope", project) is False
+        ssh.assert_not_called()
+
+    def test_a_project_without_host_yaml_is_rejected(self, tmp_path):
+        with patch.object(dts, "load_server", return_value={"ssh": "user@host"}):
+            assert dts.handle_deploy_to("prod", tmp_path) is False
+
+    def test_a_missing_entrypoint_is_caught_locally(self, project):
+        (project / "agent.py").unlink()
+        with patch.object(dts, "load_server", return_value={"ssh": "user@host"}), \
+             patch.object(dts, "_ssh") as ssh:
+            assert dts.handle_deploy_to("prod", project) is False
+        # caught before touching the server
+        ssh.assert_not_called()
+
+    def test_an_invalid_agent_name_is_rejected(self, project):
+        """The name becomes a directory and a unit name, so the same rule as the
+        cloud path applies."""
+        (project / ".co" / "host.yaml").write_text(
+            yaml.safe_dump({"name": "Not A Valid Name", "entrypoint": "agent.py"})
+        )
+        with patch.object(dts, "load_server", return_value={"ssh": "user@host"}):
+            assert dts.handle_deploy_to("prod", project) is False
+
+    def test_the_marker_is_written_only_after_everything_succeeded(self, project):
+        """A marker written too early would let a later deploy skip setup that
+        never actually completed."""
+        with patch.object(dts, "load_server", return_value={"ssh": "user@host"}), \
+             patch.object(dts, "_derive_ssh_public_line", return_value=None), \
+             patch.object(dts, "_read_provision", return_value={"schema": 0}), \
+             patch.object(dts, "_ensure_setup", return_value=True), \
+             patch.object(dts, "_sync_code", return_value=True), \
+             patch.object(dts, "_install_deps_if_changed", return_value=True), \
+             patch.object(dts, "_write_unit_if_changed", return_value=True), \
+             patch.object(dts, "_restart", return_value=False), \
+             patch.object(dts, "_mark_provisioned") as mark:
+            assert dts.handle_deploy_to("prod", project) is False
+
+        mark.assert_not_called()
+
+    def test_a_successful_deploy_marks_the_schema(self, project):
+        with patch.object(dts, "load_server", return_value={"ssh": "user@host"}), \
+             patch.object(dts, "_derive_ssh_public_line", return_value=None), \
+             patch.object(dts, "_read_provision", return_value={"schema": 0}), \
+             patch.object(dts, "_ensure_setup", return_value=True), \
+             patch.object(dts, "_sync_code", return_value=True), \
+             patch.object(dts, "_install_deps_if_changed", return_value=True), \
+             patch.object(dts, "_write_unit_if_changed", return_value=True), \
+             patch.object(dts, "_restart", return_value=True), \
+             patch.object(dts, "_mark_provisioned") as mark:
+            assert dts.handle_deploy_to("prod", project) is True
+
+        mark.assert_called_once()


### PR DESCRIPTION
Closes #312, and with it #305 and #306. The largest piece of #309.

```
co deploy --to prod  =  ensure(setup) → sync code → restart
```

No container. A directory, a venv, a systemd unit. `Restart=always` for crash recovery, `enable` for start-on-boot, journald for logs — and Chrome needs no `--shm-size` when it is not inside one.

## The invariant, and how it is enforced

**A deploy must never recreate the machine's state.**

```
rsync -az --delete --exclude .co/ --exclude .venv/ --exclude .git/
```

`--delete` so code removed locally goes away; `.co/` excluded so identity, logs and evals survive. **That pairing is the whole design** — it is what stops a redeploy from reissuing the agent's address (#306) and what lets a fix made by hand over ssh survive (#305).

Four tests guard it directly, including one asserting the setup script never redirects into `.co/`.

## Verified end to end on a real server

Not mocks. A live Ubuntu 24.04 GCE box, reached with the key derived in #315.

**First deploy:**

```
deploytest → test (co-test-deploy)
  converging server …
  syncing code …
  installing dependencies …
  writing systemd unit …
  restarting …
✓ deploytest is running on test
```

**Then planted the state a deploy must not touch** — an agent key, an audit log, and a file edited by hand:

```
/srv/deploytest/.co/keys/agent.key   MY-AGENT-IDENTITY-12345
/srv/deploytest/.co/logs/agent.log   important audit log
/srv/deploytest/.co/hand-edit.txt    HAND EDIT BY OPERATOR
```

**Changed the code and deployed again:**

```
  converging server …
  syncing code …
  restarting …
```

Note what is missing: no dependency install, no unit write. `requirements.txt` was unchanged and the unit content was identical, so both were skipped.

**The result — the definition of done for #312:**

```
=== new code live? ===
version=2-UPDATED

=== state survived? ===
agent identity:  MY-AGENT-IDENTITY-12345
audit log:       important audit log
hand edit:       HAND EDIT BY OPERATOR

=== service ===
active
```

**Crash recovery, without a deploy:**

```
$ kill -9 <MainPID>
6 seconds later: active
new PID differs, NRestarts: 1
```

## Design decisions worth reviewing

**`ensure()` is keyed on `.co/provision.json`, not on "did we provision this box".** One ssh read decides the path: current schema → straight to rsync and restart; older → run only the missing steps. This is what makes a hand-registered machine need no separate code path — its first deploy is the setup, which is #309's no-branch requirement and the reason #313's scope was corrected to install nothing.

**`authorized_keys` is re-asserted on every deploy, not once.** It is the only way back into the machine, so it self-heals rather than needing a rescue path. Appended with `grep -qxF` so it does not accumulate duplicates.

**The restart is verified with `systemctl is-active`, not the exit code.** `systemctl restart` returns 0 for a unit that starts and immediately dies — trusting it would report a broken deploy as a success, which is the worst outcome a deploy command can have. On failure it prints journald, because the traceback is what the operator needs.

**`--to` refuses to combine with `--template`, `--skills` or `--name`.** Those belong to the cloud path. Silently ignoring them would let someone believe their skills were bundled when they were not.

## Tests

`tests/unit/test_deploy_to_server.py` — **27 cases**, organised around the invariant: the rsync exclusions, setup skipped at the current schema, `authorized_keys` ensured anyway, corrupt marker reading as schema 0, pip skipped on an unchanged hash, unit not rewritten when identical, a unit that dies reported as failure, journald surfaced, and `provision.json` written **only** after every step succeeded.

Full suite: **2425 passed, 3 skipped**.

## Not covered

The last item in #312's definition of done — "a browser agent survives sustained real page loads with no shm tuning" — is untested. It needs a browser agent deployed and driven for a while, which is a separate exercise from this code. The claim it rests on is structural (there is no container capping `/dev/shm` at 64 MB), but structural is not measured.
