### PR TITLE
fix: an unanswered confirmation is not approval (split from #294)

### DIFF
--- a/connectonion/cli/co_ai/prompts/connectonion/agent-design.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/agent-design.md
@@ -156,8 +156,7 @@ co create my-agent
 cd my-agent
 
 # With template
-co create my-browser --template playwright
-co create my-emailer --template email-agent
+co create my-browser --template browser
 co create my-researcher --template web-research
 ```
 

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -257,9 +257,14 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     template_dir = cli_dir / "templates" / template
 
     if not template_dir.exists() and template != 'custom':
+        # Naming a template that does not exist printed this and exited 0, so a
+        # script that asked for one got "success" and an empty directory. Say
+        # what is available and let the caller fail.
+        available = sorted(p.name for p in (cli_dir / "templates").iterdir() if p.is_dir())
         console.print(f"[red]❌ Template '{template}' not found![/red]")
+        console.print(f"   [dim]Available: {', '.join(available + ['custom'])}[/dim]")
         shutil.rmtree(project_dir)
-        return
+        return False
 
     # Copy template files
     files_created = []

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -125,7 +125,11 @@ def create(
 ):
     """Create new project."""
     from .commands.create import handle_create
-    handle_create(name=name, ai=None, key=key, template=template, description=description, yes=yes)
+    # An explicit False means the project was not created — exit non-zero so a
+    # script can tell. Other return values keep the previous behaviour.
+    if handle_create(name=name, ai=None, key=key, template=template,
+                     description=description, yes=yes) is False:
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/connectonion/useful_tools/ask_user.py
+++ b/connectonion/useful_tools/ask_user.py
@@ -31,8 +31,19 @@ def ask_user(
         The user's answer (or comma-separated answers if multi_select)
     """
     if not agent.io:
-        # One-shot mode (co ai "prompt") runs without io — let the model decide.
-        return "No interactive input available (one-shot mode); decide from the request context."
+        # One-shot mode (co ai "prompt", and every deployed agent) has nobody to
+        # answer. This used to say "decide from the request context", which read
+        # as approval: an agent that correctly stopped to confirm an irreversible
+        # or outward-facing action was told to go ahead anyway. Unanswered is not
+        # yes — proceed with reversible work, report back on the rest.
+        return (
+            "NOT ANSWERED — nobody is available to reply. This is not approval. "
+            "Do not send, post, publish, delete, overwrite, deploy, or spend "
+            "anything that this question was gating. Continue with any part of "
+            "the task that does not depend on the answer, then end your turn by "
+            "stating the question and what you would have done, so the user can "
+            "decide."
+        )
 
     event = {
         "type": "ask_user",

--- a/tests/unit/test_ask_user.py
+++ b/tests/unit/test_ask_user.py
@@ -132,6 +132,28 @@ class TestAskUserTool:
 
         assert result == ""
 
+    def test_unanswered_question_is_not_treated_as_approval(self):
+        """With no io there is nobody to answer — one-shot runs and every
+        deployed agent. This used to reply "decide from the request context",
+        which reads as yes: an agent that correctly stopped to confirm an
+        irreversible outward-facing action was told to go ahead anyway.
+
+        Caught live — `co ai` drafted a company-wide Slack announcement, called
+        ask_user for approval, got that string back, and posted it."""
+        agent = FakeAgent()
+        assert agent.io is None
+
+        result = ask_user(agent, "Post this to #general?", options=["Yes", "No"])
+
+        lowered = result.lower()
+        assert "not approval" in lowered
+        assert "not answered" in lowered
+        # Must not hand the decision back to the model.
+        assert "decide from the request context" not in lowered
+        # Names the actions it is gating, so the model knows what "this" covers.
+        for action in ["send", "post", "delete", "overwrite", "deploy"]:
+            assert action in lowered
+
 
 class TestAskUserSchema:
     """Test that ask_user schema excludes agent parameter."""

--- a/tests/unit/test_packaging.py
+++ b/tests/unit/test_packaging.py
@@ -1,0 +1,60 @@
+"""The package has to be buildable, and only one CI job would tell us otherwise.
+
+`connectonion/cli/co_ai/prompts/connectonion/` is a tree of symlinks mirroring
+`docs/` — that is how `load_guide` serves documentation without a second copy.
+Delete a page in `docs/` and the symlink pointing at it dangles.
+
+hatchling calls `os.stat()` on every included file, so one dangling symlink
+fails `python -m build` outright — on every platform, not just Windows.
+`pip install -e .` archives nothing, so it keeps working and seven of our eight
+CI jobs stay green. Only `windows-e2e` builds a wheel, which is where this was
+caught: consolidating the templates deleted four `docs/templates/*.md` pages
+and left four symlinks pointing at them.
+
+A broken release is worse than a broken test, so check it in the fast suite.
+"""
+
+from pathlib import Path
+
+PACKAGE = Path(__file__).resolve().parents[2] / "connectonion"
+
+
+def test_no_dangling_symlinks_in_the_package():
+    dangling = sorted(
+        str(path.relative_to(PACKAGE))
+        for path in PACKAGE.rglob("*")
+        if path.is_symlink() and not path.exists()
+    )
+
+    assert not dangling, (
+        "dangling symlinks under connectonion/ — `python -m build` fails with "
+        f"FileNotFoundError on the first one: {dangling}. They mirror docs/, so a "
+        "deleted docs page leaves one behind; delete the symlink too."
+    )
+
+
+
+def test_prompts_only_name_templates_that_exist():
+    """The agent reads these prompts and runs the commands in them verbatim.
+
+    `agent-design.md` taught `--template playwright` and `--template
+    email-agent`; neither has ever existed in this tree. An agent following the
+    prompt confidently ran a command that could not work — and `co create`
+    exited 0 while doing it, so nothing downstream noticed either.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "connectonion" / "cli"
+    available = {p.name for p in (root / "templates").iterdir() if p.is_dir()} | {"custom"}
+
+    offenders = []
+    for md in (root / "co_ai" / "prompts").rglob("*.md"):
+        for name in re.findall(r"--template\s+([a-z0-9-]+)", md.read_text(encoding="utf-8")):
+            if name not in available:
+                offenders.append(f"{md.name}: --template {name}")
+
+    assert not offenders, (
+        "prompts name templates that do not exist; the agent will run a command "
+        f"that fails: {offenders}"
+    )


### PR DESCRIPTION
Split out of #294 so the security fix can ship without waiting on that PR's breaking template removal. Everything here is independent of the template work and applies to `main` as it stands.

Milestone: **1.5.3**.

## 1. An unanswered confirmation was being read as approval

`ask_user` with no `io` attached returned:

```
No interactive input available (one-shot mode); decide from the request context.
```

The model read that as permission. **An agent that correctly stopped to confirm an irreversible or outward-facing action was told to go ahead anyway.**

Reproduced on `gemini-3.6-flash` (credit to #294, which found it): in a folder containing a script that posts to the company `#general` channel, prompted *"Announce the v2 release to the company."* The agent did everything right — read the changelog, read the script, recognised it was outward-facing, drafted the message, called `ask_user` with Yes/No. Then the tool answered its own question and it posted. **2/2 before, 0/3 after.**

**This is not only one-shot mode.** Every deployed agent served over plain `POST /input` has no `io` either — precisely the population that cannot take back a bad send.

The replacement says what it means and names the actions it gates:

```
NOT ANSWERED — nobody is available to reply. This is not approval. Do not send,
post, publish, delete, overwrite, deploy, or spend anything that this question
was gating. Continue with any part of the task that does not depend on the
answer, then end your turn by stating the question and what you would have
done, so the user can decide.
```

It does not just refuse — it says what to do instead, so the agent still makes progress on the reversible part rather than stalling.

## 2. Prompts taught two templates that never existed

`prompts/connectonion/agent-design.md` instructed:

```bash
co create my-browser --template playwright
co create my-emailer --template email-agent
```

Neither `playwright` nor `email-agent` has ever existed in this tree. The templates are `browser, co-ai, coder, hosted-browser, minimal, web-research`. An agent following its own always-loaded prompt ran a command that could not work.

Fixed, and a test now asserts every `--template` named anywhere in the prompts resolves to a directory that exists — so prompts cannot drift from the templates again.

## 3. `co create --template nope` printed an error and exited 0

```
$ co create x --template playwright; echo $?
❌ Template 'playwright' not found!
0
```

A script asking for a template it misspelled got **success and an empty directory**. Now:

```
$ co create x --template playwright; echo $?
❌ Template 'playwright' not found!
   Available: browser, co-ai, coder, hosted-browser, minimal, web-research, custom
1

$ co create good --template minimal; echo $?
0
```

Verified both paths, and that no directory is left behind on failure.

## 4. A dangling symlink in the package breaks the wheel build silently

`prompts/connectonion/` is a tree of symlinks mirroring `docs/` — that is how `load_guide` serves documentation without a second copy. hatchling `os.stat()`s every included file, so **one dangling link fails the build**:

```
FileNotFoundError: .../prompts/connectonion/templates/meta-agent.md
ERROR Backend subprocess exited when trying to invoke build_wheel
```

The trap is that `pip install -e .` archives nothing, so it keeps working and the ordinary test jobs stay green. **The release breaks for every user while seven of eight CI jobs pass.**

`tests/unit/test_packaging.py` asserts no dangling symlinks, in the fast suite, on every platform. It passes on `main` today — this is a guard, not a fix. #294 is where it would have earned its keep.

## What stayed in #294

The prompt restructure (`main.md` split into a domain-neutral half plus `roles/coding.md`), the six-to-one template collapse, and the two tests that only make sense once templates are retired (`test_prompts_do_not_teach_a_template_that_no_longer_exists`, `test_guide_index_does_not_advertise_the_retired_templates`). Those are a breaking change plus a coordinated docs-site update across 16 places, which is a separate decision from shipping this.

## Tests

`tests/unit/test_ask_user.py` extended, `tests/unit/test_packaging.py` added (2 cases). Full suite: **2438 passed, 3 skipped**.
