### PR TITLE
Publish the agent's full picture over the authenticated socket, not over /info

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -167,6 +167,18 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
 
     file_config = host_config or DEFAULT_FILE_LIMITS
 
+    # /info is unauthenticated: anyone who can reach the agent can read it, and on a
+    # deployed agent that is the whole internet. Publish the same skill subset the
+    # relay directory does, from the same constant, so the two answers to "what is
+    # public" cannot drift apart. The operator's own toolboxes — user (~/.co/skills)
+    # and claude-user (~/.claude/skills) — are not shipped with the agent and must not
+    # be advertised by it; a full list here leaks which tools, SaaS accounts and
+    # internal workflows the operator has on their machine.
+    #
+    # The complete list goes to authenticated clients over the WebSocket instead, in
+    # the AGENT_PROFILE frame sent once CONNECT has passed the trust gate.
+    from ...useful_plugins.skills import PUBLISHED_SKILL_LOCATIONS
+
     result = {
         "name": agent_metadata["name"],
         "address": agent_metadata["address"],
@@ -174,7 +186,10 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
         "model": agent_metadata.get("model", "unknown"),
         "trust": trust.trust,
         "version": __version__,
-        "skills": agent_metadata.get("skills", []),
+        "skills": [
+            s for s in agent_metadata.get("skills", [])
+            if s.get("location") in PUBLISHED_SKILL_LOCATIONS
+        ],
         "accepted_inputs": {
             "text": True,
             "images": True,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -228,6 +228,10 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         # Super admin routes
         "admin_admins_add": partial(admin_admins_add_handler, trust_agent),
         "admin_admins_remove": partial(admin_admins_remove_handler, trust_agent),
+        # Full metadata for the AGENT_PROFILE frame. /info and the relay directory are
+        # unauthenticated and carry the published subset only; this is the copy a client
+        # gets after CONNECT has passed the trust gate.
+        "agent_metadata": agent_metadata,
     }
 
 

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -47,14 +47,20 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         await send_msg({"type": "ERROR", "message": err})
         return
 
-    return await establish_connection(data, agent_address, send_msg, conn, storage, registry)
+    return await establish_connection(
+        data, agent_address, send_msg, conn, storage, registry, route_handlers
+    )
 
 
-async def establish_connection(data, agent_address, send_msg, conn, storage, registry):
+async def establish_connection(data, agent_address, send_msg, conn, storage, registry,
+                               route_handlers=None):
     """Post-auth half of CONNECT: populate conn, merge sessions, send CONNECTED.
 
     Called by handle_connect and, after a successful onboard, with the stashed
     pending CONNECT — the agent_address is then the one verified on ONBOARD_SUBMIT.
+
+    ``route_handlers`` is optional so a caller that only needs the session half can
+    omit it; without it no AGENT_PROFILE is sent.
     """
     conn["authenticated"] = True
     conn["agent_address"] = agent_address
@@ -94,6 +100,26 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
         connected_msg["session"] = conn["session"]
         connected_msg["chat_items"] = session_to_chat_items(conn["session"])
     await send_msg(connected_msg)
+
+    # This socket is now past signature verification and the trust gate, so it is the
+    # one channel entitled to the agent's full picture. /info and the relay directory
+    # are unauthenticated and deliberately carry the published subset; everything the
+    # agent actually has — including skills that live only on the operator's machine —
+    # goes here and nowhere else.
+    if route_handlers is not None:
+        metadata = route_handlers.get("agent_metadata")
+        if metadata:
+            await send_msg({
+                "type": "AGENT_PROFILE",
+                "session_id": session_id,
+                "name": metadata.get("name"),
+                "address": metadata.get("address"),
+                "model": metadata.get("model"),
+                "tools": metadata.get("tools", []),
+                "skills": metadata.get("skills", []),
+                **({"balance_usd": metadata["balance_usd"]}
+                   if metadata.get("balance_usd") is not None else {}),
+            })
 
     # Push the current dashboard.html so Home paints immediately, before any input.
     # This connection has seen nothing yet, so it always sends when a file exists.

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -80,7 +80,8 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                             # Finish the CONNECT the trust gate interrupted: the client
                             # is a contact now and resumes its input once CONNECTED lands.
                             result = await establish_connection(
-                                pending_connect, agent_address, send_msg, conn, storage, registry
+                                pending_connect, agent_address, send_msg, conn, storage, registry,
+                                route_handlers
                             )
                             if result:
                                 active_io, forward_task = result

--- a/tests/unit/test_agent_profile.py
+++ b/tests/unit/test_agent_profile.py
@@ -1,0 +1,55 @@
+"""Tests for the authenticated AGENT_PROFILE frame and the public /info subset."""
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+FULL_SKILLS = [
+    {"name": "ship-feature", "description": "ship", "location": "builtin"},
+    {"name": "my-project-skill", "description": "proj", "location": "project"},
+    {"name": "lark-approval", "description": "private", "location": "user"},
+    {"name": "aaron-review", "description": "private", "location": "claude-user"},
+]
+METADATA = {"name": "oo", "address": "0xabc", "model": "gemini-3.6-flash",
+            "tools": ["read_file", "bash"], "skills": FULL_SKILLS, "balance_usd": 12.5}
+
+
+def test_info_publishes_only_project_tree_skills():
+    from connectonion.network.host.http_router import info_handler
+    trust = Mock(); trust.trust = "careful"
+    result = info_handler(METADATA, trust)
+
+    names = {s["name"] for s in result["skills"]}
+    assert names == {"my-project-skill"}, "/info is unauthenticated; only published skills belong in it"
+    # The operator's machine must not be advertised by the agent.
+    assert "lark-approval" not in names and "aaron-review" not in names
+
+
+@pytest.mark.asyncio
+async def test_authenticated_connect_gets_the_full_skill_list():
+    from connectonion.network.host.ws_router.connect import establish_connection
+    sent = []
+    send_msg = AsyncMock(side_effect=lambda m: sent.append(m))
+    storage = Mock(); storage.get.return_value = None
+    registry = Mock(); registry.get.return_value = None
+
+    await establish_connection({}, "0xvisitor", send_msg, {}, storage, registry,
+                               {"agent_metadata": METADATA})
+
+    profile = next(m for m in sent if m["type"] == "AGENT_PROFILE")
+    assert {s["name"] for s in profile["skills"]} == {s["name"] for s in FULL_SKILLS}
+    assert profile["balance_usd"] == 12.5
+    types = [m["type"] for m in sent]
+    assert types.index("CONNECTED") < types.index("AGENT_PROFILE")
+
+
+@pytest.mark.asyncio
+async def test_no_profile_frame_without_route_handlers():
+    """The optional argument keeps callers that only need the session half working."""
+    from connectonion.network.host.ws_router.connect import establish_connection
+    sent = []
+    storage = Mock(); storage.get.return_value = None
+    registry = Mock(); registry.get.return_value = None
+
+    await establish_connection({}, "0xvisitor", AsyncMock(side_effect=lambda m: sent.append(m)),
+                               {}, storage, registry)
+
+    assert "AGENT_PROFILE" not in [m["type"] for m in sent]


### PR DESCRIPTION
## The problem

**The unauthenticated path was handing out more than the authenticated one.**

`info_handler` takes no auth argument at all and returned `agent_metadata["skills"]` whole:

```python
def info_handler(agent_metadata, trust, trust_config=None, host_config=None):
    result = { ..., "skills": agent_metadata.get("skills", []) }   # everything
```

On a developer machine that is 117 entries, of which **114 are `user` and `claude-user`** — the operator's own `~/.co/skills` and `~/.claude/skills`. Those never ship with the agent and do not exist on it once deployed, yet any caller could read the list. A sample of what was exposed:

```
connectonion:aaron-build-my-agent      ← a person's name
lark-approval · lark-attendance · lark-okr   ← 30+, revealing the SaaS stack
generate-invoice · email-outreach · deploy-oo-chat
```

`_build_agent_profile` already treats exactly these locations as private and filters them out of the relay directory, with the comment *"none may leak into the public directory"*. So the codebase had two disagreeing answers to "what is public", and the unguarded one won.

Meanwhile the WebSocket — which **does** verify an Ed25519 signature and clear the trust gate — carried no agent information at all. None of its 18 frame types mentions skills.

| Channel | Auth | Skills |
|---|---|---|
| relay `/api/agents/{addr}` → DB | none | published subset ✅ |
| agent `/info` | **none** | **all of them** ❌ |
| agent WebSocket | signature + trust gate | **nothing** ❌ |

The channel entitled to the full picture sent nothing; the channel entitled to nothing sent everything.

## Changes

- **`/info` publishes the same subset as the relay directory**, reusing `PUBLISHED_SKILL_LOCATIONS` rather than restating the rule, so the two cannot drift apart
- **New `AGENT_PROFILE` frame** sent after `CONNECTED`, carrying the complete metadata — every skill, tools, model, balance — to a client that has authenticated
- `establish_connection` takes `route_handlers` optionally, so callers that only need the session half are unaffected

## Verified live

Against a hosted `co-ai` agent on the default `careful` trust level:

```
unauthenticated  GET /info        → 0 skills
authenticated    WS AGENT_PROFILE → 117 skills, 24 tools, balance 25.34
```

The second was captured through the real SDK client (`connect()` with onboarding), not a mock:

```
>>> AGENT_PROFILE 到达: skills= 117 | tools= 24 | balance= 25.3436
frames: ['AGENT_PROFILE', 'DASHBOARD_SNAPSHOT', 'eval', 'intent', 'llm_call', ...]
```

Three unit tests cover the `/info` subset, the frame's contents and its ordering after `CONNECTED`, and the no-`route_handlers` path. Full unit suite: **2441 passed**.

## Follow-up needed in the TypeScript SDK

`fetchAgentInfo` probes each endpoint's `/info` and lets that response override the relay profile:

```js
const info = await fetch(`${httpUrl}/info`)
if (info?.address === agentAddress) {
    return { ...fallbackInfo, ...toAgentInfo(info), online: true }   // overrides the filtered profile
}
```

Until it consumes `AGENT_PROFILE`, a browser client sees the published subset only. That is the correct **pre-auth** answer, but it does mean the chat surface shows fewer skills than before this change until the SDK follows.