### PR TITLE
Seed the deployer as admin, and scope the admin list per agent

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -14,6 +14,7 @@ import json
 import re
 import shutil
 import subprocess
+import io
 import tarfile
 import tempfile
 import time
@@ -171,6 +172,43 @@ def _add_directory_to_tarball(
         tar.add(path, arcname=str(rel), recursive=False)
 
 
+def _add_deployer_as_admin(tar: tarfile.TarFile) -> None:
+    """Ship the deployer's address as the agent's one admin.
+
+    A deployed agent generates its own keypair on first boot, and ADMIN_ADD is gated
+    on super-admin — which is that same address, whose private key never leaves the
+    server. So nobody could ever become admin: the only account that could grant it
+    is the one nobody can sign as.
+
+    The public address is enough to break that: the agent recognises it in its admin
+    list and grants the role to whoever signs as it. Nothing secret travels, and
+    revoking is deleting a line. Same idea as ssh-copy-id, one layer up.
+
+    Written into the package on every deploy so the list self-heals, and synthesized
+    here rather than read from disk because .co/ is excluded from the package.
+
+    The identity resolved is the one `co call` signs with — project .co/ first, then
+    ~/.co/ — and deliberately not `project_dir/.co`: a --template deploy builds a
+    throwaway project whose address is deleted with it, so seeding that would name an
+    admin nobody can ever be.
+    """
+    from ... import address
+    from .keys_commands import _find_co_dir
+
+    co_dir = _find_co_dir()
+    if not co_dir:
+        return
+    data = address.load(co_dir)
+    if not data or not data.get("address"):
+        return
+
+    payload = f"{data['address']}\n".encode()
+    info = tarfile.TarInfo(name=".co/admins.txt")
+    info.size = len(payload)
+    info.mode = 0o600
+    tar.addfile(info, io.BytesIO(payload))
+
+
 def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
     """Package git-tracked files when available, otherwise the initialized folder.
 
@@ -206,6 +244,7 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                 arc_prefix,
                 _load_deploy_ignore_patterns(skills_path),
             )
+        _add_deployer_as_admin(tar)
     return tarball
 
 

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -111,7 +111,8 @@ WantedBy=multi-user.target
 
 
 def _ensure_setup(target: str, agent: str, entrypoint: str, schema: int,
-                  ssh_public_line: Optional[str]) -> bool:
+                  ssh_public_line: Optional[str],
+                  deployer_address: Optional[str] = None) -> bool:
     """Bring the server to the state a deploy assumes. Idempotent.
 
     Runs on every deploy, and is a no-op once the schema matches — which is why
@@ -140,6 +141,22 @@ dpkg -s python3-venv >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get
 mkdir -p ~/.ssh && chmod 700 ~/.ssh
 touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
 grep -qxF {quoted} ~/.ssh/authorized_keys || echo {quoted} >> ~/.ssh/authorized_keys
+""")
+
+    if deployer_address:
+        # The same idea one layer up: authorized_keys is who may enter the machine,
+        # admins.txt is who may command the agent. Without this nobody can — ADMIN_ADD
+        # is gated on super-admin, super-admin is the agent's OWN address, and that
+        # private key exists only on the server. The one account that could grant admin
+        # is the one nobody can sign as.
+        #
+        # Written every deploy, like the SSH key, so it self-heals. It lives in .co/,
+        # which the rsync excludes, so it has to be written over ssh rather than shipped.
+        quoted_admin = shlex.quote(deployer_address)
+        admins = f"{SRV}/{agent}/.co/admins.txt"
+        steps.append(f"""
+touch {admins}
+grep -qxF {quoted_admin} {admins} || echo {quoted_admin} >> {admins}
 """)
 
     if not steps:
@@ -324,8 +341,10 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
 
     provision = _read_provision(target, agent)
     ssh_public_line = _derive_ssh_public_line()
+    deployer_address = _deployer_address()
 
-    if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0), ssh_public_line):
+    if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0),
+                         ssh_public_line, deployer_address):
         return False
     if not _sync_code(target, agent, project_dir):
         return False
@@ -340,8 +359,28 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
 
     console.print(f"\n[green]✓ {agent} is running on {server}[/green]")
     console.print(f"[dim]  logs:  co server ssh {server} 'journalctl -u {agent} -f'[/dim]")
-    console.print(f"[dim]  state: {SRV}/{agent}/.co/  — untouched by deploys[/dim]\n")
+    console.print(f"[dim]  state: {SRV}/{agent}/.co/  — untouched by deploys[/dim]")
+    if deployer_address:
+        console.print(f"[dim]  admin: {deployer_address[:16]}…  (your key)[/dim]")
+    console.print()
     return True
+
+
+def _deployer_address() -> Optional[str]:
+    """The operator's own agent address — the public half only, never the key.
+
+    This is what the deployed agent will accept admin commands from. Returns None
+    when there is no local identity; the deploy proceeds, and the agent simply has
+    no reachable admin, which is the state before this existed.
+    """
+    from ... import address
+    from .keys_commands import _find_co_dir
+
+    co_dir = _find_co_dir()
+    if not co_dir:
+        return None
+    data = address.load(co_dir)
+    return data.get("address") if data else None
 
 
 def _derive_ssh_public_line() -> Optional[str]:

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -21,6 +21,17 @@ from typing import List, Callable
 CO_DIR = Path.home() / ".co"
 
 
+def _admins_file(co_dir: Path = None) -> Path:
+    """Where this agent's admin list lives — beside its identity, not in $HOME.
+
+    The list used to be the single global ~/.co/admins.txt while the address it is
+    compared against came from the project's .co/, so every agent on one machine
+    shared one set of admins: making someone admin of one deployed agent made them
+    admin of all of them. Scope it the same way the identity is scoped.
+    """
+    return (co_dir or Path.cwd() / ".co") / "admins.txt"
+
+
 def _check_list(list_name: str, agent_id: str) -> bool:
     """Check if agent_id is in a list file. Supports wildcards."""
     list_path = CO_DIR / f"{list_name}.txt"
@@ -269,7 +280,7 @@ def get_trust_verification_tools() -> List[Callable]:
 
 def load_admins(co_dir: Path = None) -> set:
     """
-    Load admins list: self address (default) + ~/.co/admins.txt.
+    Load admins list: self address (default) + the agent's .co/admins.txt.
 
     Args:
         co_dir: Project .co directory (for self address). Defaults to cwd/.co
@@ -294,8 +305,8 @@ def load_admins(co_dir: Path = None) -> set:
         except Exception:
             pass
 
-    # Additional admins from ~/.co/admins.txt
-    admins_file = CO_DIR / "admins.txt"
+    # Additional admins from this agent's own admins.txt
+    admins_file = _admins_file(co_dir)
     if admins_file.exists():
         try:
             for line in admins_file.read_text(encoding='utf-8').splitlines():
@@ -335,10 +346,10 @@ def is_super_admin(client_id: str, co_dir: Path = None) -> bool:
     return client_id == get_self_address(co_dir)
 
 
-def add_admin(admin_id: str) -> str:
-    """Add an admin to ~/.co/admins.txt. Super admin only."""
-    CO_DIR.mkdir(parents=True, exist_ok=True)
-    admins_file = CO_DIR / "admins.txt"
+def add_admin(admin_id: str, co_dir: Path = None) -> str:
+    """Add an admin to this agent's .co/admins.txt. Super admin only."""
+    admins_file = _admins_file(co_dir)
+    admins_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Check if already admin
     existing = set()
@@ -355,9 +366,9 @@ def add_admin(admin_id: str) -> str:
     return f"{admin_id} added as admin."
 
 
-def remove_admin(admin_id: str) -> str:
-    """Remove an admin from ~/.co/admins.txt. Super admin only."""
-    admins_file = CO_DIR / "admins.txt"
+def remove_admin(admin_id: str, co_dir: Path = None) -> str:
+    """Remove an admin from this agent's .co/admins.txt. Super admin only."""
+    admins_file = _admins_file(co_dir)
 
     if not admins_file.exists():
         return f"{admin_id} is not an admin."

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -776,3 +776,63 @@ class TestDeployPackaging:
         assert project_dir.name == "co-ai-agent"
         assert project_dir.parent.exists()
         shutil.rmtree(project_dir.parent)
+
+
+class TestDeployerSeededAsAdmin:
+    """The package carries the deployer's address so the agent has an admin.
+
+    A deployed agent generates its own keypair on first boot, and ADMIN_ADD is gated
+    on super-admin — which is that same address, whose private key only ever exists
+    on the server. Without a seeded list nobody can ever administer it.
+    """
+
+    def _make_repo(self, root: Path):
+        subprocess.run(['git', 'init'], cwd=root, capture_output=True)
+        subprocess.run(['git', 'config', 'user.email', 'test@test.com'], cwd=root, capture_output=True)
+        subprocess.run(['git', 'config', 'user.name', 'Test'], cwd=root, capture_output=True)
+        (root / ".co").mkdir()
+        (root / ".co" / "host.yaml").write_text("name: demo\nentrypoint: agent.py\n")
+        (root / "agent.py").write_text("from connectonion import host\nhost(None)\n")
+        subprocess.run(['git', 'add', '.'], cwd=root, capture_output=True)
+        subprocess.run(['git', 'commit', '-m', 'init'], cwd=root, capture_output=True)
+
+    def test_package_carries_the_deployers_address(self, tmp_path, monkeypatch):
+        import tarfile
+        from connectonion import address
+        from connectonion.cli.commands.deploy_commands import _build_tarball
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._make_repo(repo)
+
+        # A real identity, not a mock: the point of the test is that the address
+        # the operator actually signs with is the one that lands in the package.
+        identity = tmp_path / "identity" / ".co"
+        identity.mkdir(parents=True)
+        keys = address.generate()
+        address.save(keys, identity)
+        monkeypatch.setattr(
+            "connectonion.cli.commands.keys_commands._find_co_dir", lambda: identity
+        )
+
+        tarball = _build_tarball(repo, [])
+        with tarfile.open(tarball) as tar:
+            assert ".co/admins.txt" in tar.getnames()
+            shipped = tar.extractfile(".co/admins.txt").read().decode().strip()
+        assert shipped == keys["address"]
+
+    def test_no_identity_ships_no_admin_file(self, tmp_path, monkeypatch):
+        """Not an error — the agent simply has no admin, as before this existed."""
+        import tarfile
+        from connectonion.cli.commands.deploy_commands import _build_tarball
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        self._make_repo(repo)
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.keys_commands._find_co_dir", lambda: None
+        )
+
+        tarball = _build_tarball(repo, [])
+        assert ".co/admins.txt" not in tarfile.open(tarball).getnames()

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -305,3 +305,40 @@ class TestHandleDeployTo:
             assert dts.handle_deploy_to("prod", project) is True
 
         mark.assert_called_once()
+
+
+class TestAdminSeeding:
+    """The deploying key must be able to command the agent it just deployed.
+
+    Without this the agent has no reachable admin at all: ADMIN_ADD is gated on
+    super-admin, super-admin is the agent's OWN address, and that private key only
+    ever exists on the server.
+    """
+
+    ADDR = "0x" + "ab" * 32
+
+    def test_the_deployer_is_written_into_the_agents_admin_list(self):
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py",
+                              dts.PROVISION_SCHEMA, None, self.ADDR)
+
+        script = ssh.call_args.args[1]
+        assert "/srv/myagent/.co/admins.txt" in script
+        assert self.ADDR in script
+
+    def test_it_is_ensured_every_deploy_and_appended_only_once(self):
+        """Same reasoning as authorized_keys: it self-heals, and a deploy loop must
+        not grow the file by one line every time."""
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py",
+                              dts.PROVISION_SCHEMA, None, self.ADDR)
+
+        assert "grep -qxF" in ssh.call_args.args[1]
+
+    def test_no_local_identity_means_no_admin_line(self):
+        """Not an error — the deploy proceeds, the agent just has no admin, which
+        is the state before this existed."""
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._ensure_setup("user@host", "myagent", "agent.py", 0, None, None)
+
+        assert "admins.txt" not in ssh.call_args.args[1]

--- a/tests/unit/test_trust_functions.py
+++ b/tests/unit/test_trust_functions.py
@@ -179,3 +179,50 @@ class TestIntegration:
 
         assert is_blocked("new-agent") is True
         assert "blocked" in check_blocklist("new-agent").lower()
+
+
+class TestAdminListIsPerAgent:
+    """admins.txt lives beside the agent's identity, not in $HOME.
+
+    It used to be the single global ~/.co/admins.txt while the self address it is
+    compared against came from the project's .co/ — so every agent on one machine
+    shared one set of admins, and making someone admin of one deployed agent made
+    them admin of all of them.
+    """
+
+    def test_add_admin_writes_beside_the_identity(self, tmp_path):
+        co_dir = tmp_path / "agent-a" / ".co"
+        co_dir.mkdir(parents=True)
+
+        tools.add_admin("0xdeadbeef", co_dir)
+
+        assert (co_dir / "admins.txt").read_text().strip() == "0xdeadbeef"
+        assert tools._admins_file(co_dir) != Path.home() / ".co" / "admins.txt"
+
+    def test_two_agents_on_one_machine_have_separate_admins(self, tmp_path):
+        a = tmp_path / "agent-a" / ".co"
+        b = tmp_path / "agent-b" / ".co"
+        a.mkdir(parents=True)
+        b.mkdir(parents=True)
+
+        tools.add_admin("0xalice", a)
+
+        assert tools.is_admin("0xalice", a) is True
+        assert tools.is_admin("0xalice", b) is False
+
+    def test_remove_admin_targets_the_same_file_add_wrote(self, tmp_path):
+        co_dir = tmp_path / "agent" / ".co"
+        co_dir.mkdir(parents=True)
+
+        tools.add_admin("0xalice", co_dir)
+        tools.remove_admin("0xalice", co_dir)
+
+        assert tools.is_admin("0xalice", co_dir) is False
+
+    def test_a_seeded_admins_file_is_honoured(self, tmp_path):
+        """This is the file a deploy ships: the operator's address, one line."""
+        co_dir = tmp_path / "agent" / ".co"
+        co_dir.mkdir(parents=True)
+        (co_dir / "admins.txt").write_text("0xdeployer\n")
+
+        assert tools.is_admin("0xdeployer", co_dir) is True


### PR DESCRIPTION
Closes #305. Milestone 1.6.0.

## The deadlock

A deployed agent had **no reachable admin at all**:

- `ADMIN_ADD` is gated on `is_super_admin`
- super-admin is defined as **the agent's own address**
- that keypair is generated on the server and the private half never leaves it
- promoting anyone else requires an existing admin

So the only account that could grant admin is the one nobody can sign as. There was no way in — not a missing feature, a closed loop.

## Fix: ship the public address, like ssh-copy-id one layer up

The deploy sends the operator's **address only**. The agent finds it in its own admin list and grants the role to whoever signs as it. Nothing secret travels; revoking is deleting a line.

Both paths, **written on every deploy** so the list self-heals across redeploys — the same reasoning `authorized_keys` already gets in `_ensure_setup`:

| path | how |
|---|---|
| `co deploy` (cloud) | `.co/admins.txt` synthesized into the package |
| `co deploy --to` (your server) | written over ssh — `.co/` is excluded from the rsync, so it cannot be shipped |

The identity resolved is the one **`co call` signs with** (project `.co/`, then `~/.co/`), deliberately *not* `project_dir/.co`. A `--template` deploy builds a throwaway project whose address is deleted with it, so seeding that would name an admin nobody can ever be. That is the one subtle choice in this PR.

## Second defect, same area

`admins.txt` was the single **global** `~/.co/admins.txt`, while the self address it is compared against came from the **project's** `.co/`. Every agent on one machine therefore shared one set of admins: making someone admin of one deployed agent made them admin of all of them — the multi-agent collision people expect from the keypair, hiding one file over.

The list now lives beside the identity it belongs to. `add_admin`/`remove_admin` take the same `co_dir` `is_admin` reads.

**No compatibility shim for the old global file.** The only writer was `ADMIN_ADD`, which nobody could reach — so there is nothing out there to migrate. (#305 described this as a write/read path mismatch; it is not, both used `CO_DIR`. The real defect is that the scope is global. Corrected here.)

## Tests

8 new cases across three files. All 8 **fail on unpatched code**, verified by stashing the diff:

```
8 failed, 1 passed        # the 1 pass is the no-identity guard, correct before and after
```

Full suite: **2455 passed, 3 skipped**. `tests/e2e/cli/test_cli_deploy.py`: 35 passed.

## Not in scope

`whitelist.txt` / `blocklist.txt` / `contacts.txt` are still global via `CO_DIR` and have the same multi-agent collision. Real, but a separate change with a wider blast radius — this PR fixes the one that made a deployed agent unadministrable.