### PR TITLE
Say which tier a skill came from, and which ones will not travel

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -209,6 +209,35 @@ def _add_deployer_as_admin(tar: tarfile.TarFile) -> None:
     tar.addfile(info, io.BytesIO(payload))
 
 
+def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) -> None:
+    """Name the skills that work here and will not exist on the server.
+
+    A user-tier skill (~/.co/skills, ~/.claude/skills) is usually a symlink into a
+    separate repo, which is invisible to anything that packages a project. So it can
+    look installed, work for months, and be absent everywhere else — and the agent
+    then behaves differently for a reason nothing in its output explains.
+
+    A warning, not a failure: leaving a personal skill behind is often exactly what
+    the operator wants. The cost is only that it happens silently.
+    """
+    from ...useful_plugins.skills import skills_that_will_not_travel, find_skill_problems
+
+    bundled = {path.name for path in skills_paths}
+    staying = [s for s in skills_that_will_not_travel(project_dir=project_dir)
+               if s.name not in bundled]
+
+    if staying:
+        console.print(
+            f"  [yellow]![/yellow] {len(staying)} skill(s) stay on this machine: "
+            + ", ".join(s.name for s in staying[:5])
+            + (f" (+{len(staying) - 5} more)" if len(staying) > 5 else "")
+        )
+        console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
+
+    for location, name, reason in find_skill_problems(project_dir=project_dir):
+        console.print(f"  [red]✗[/red] {location}/{name} — {reason}")
+
+
 def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
     """Package git-tracked files when available, otherwise the initialized folder.
 
@@ -385,6 +414,7 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     # contents; non-git projects upload the initialized folder. Either way .env is
     # sent as secrets below, never included in the tarball, and --skills merge in.
     tarball_path = _build_tarball(project_dir, skills_paths)
+    _warn_about_skills_left_behind(project_dir, skills_paths)
 
     tarball_size = tarball_path.stat().st_size
     size_str = _format_bytes(tarball_size)

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -76,6 +76,28 @@ def _read_project(project_dir: Path) -> Optional[dict]:
     return {"name": name, "entrypoint": str(config.get("entrypoint") or "agent.py")}
 
 
+def _warn_about_skills_left_behind(project_dir: Path) -> None:
+    """Name the skills that work here and will not exist on the server.
+
+    The rsync carries the project tree, so ~/.co/skills and ~/.claude/skills — usually
+    symlinks into a separate repo — are simply absent there. The agent then behaves
+    differently for a reason nothing in its output explains.
+    """
+    from ...useful_plugins.skills import skills_that_will_not_travel, find_skill_problems
+
+    staying = skills_that_will_not_travel(project_dir=project_dir)
+    if staying:
+        console.print(
+            f"  [yellow]![/yellow] {len(staying)} skill(s) stay on this machine: "
+            + ", ".join(s.name for s in staying[:5])
+            + (f" (+{len(staying) - 5} more)" if len(staying) > 5 else "")
+        )
+        console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
+
+    for location, name, reason in find_skill_problems(project_dir=project_dir):
+        console.print(f"  [red]✗[/red] {location}/{name} — {reason}")
+
+
 def _read_provision(target: str, agent: str) -> dict:
     """Read the convergence marker. A missing or unreadable one means schema 0."""
     result = _ssh(target, f"cat {SRV}/{agent}/.co/provision.json 2>/dev/null", timeout=60)
@@ -338,6 +360,7 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
         return False
 
     console.print(f"\n[bold]{agent}[/bold] → [cyan]{server}[/cyan] [dim]({target})[/dim]")
+    _warn_about_skills_left_behind(project_dir)
 
     provision = _read_provision(target, agent)
     ssh_public_line = _derive_ssh_public_line()

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -147,6 +147,36 @@ def handle_doctor():
     console.print(Panel(browser_table, title="[bold]Browser[/bold]", border_style="cyan"))
     console.print()
 
+    # Skills — which tier each came from, because that decides whether it survives
+    # a deploy. A user-tier skill works for months and is simply absent everywhere
+    # else, and nothing in the agent's output ever says so.
+    from ...useful_plugins.skills import (
+        _discover_all_skills, find_skill_problems, TRAVELS_ON_DEPLOY,
+    )
+
+    skills = _discover_all_skills()
+    problems = find_skill_problems()
+
+    skills_table = Table(show_header=False, box=box.SIMPLE, padding=(0, 1))
+    skills_table.add_column("Check", style="cyan")
+    skills_table.add_column("Status")
+
+    counts = {}
+    for skill in skills:
+        counts[skill.location] = counts.get(skill.location, 0) + 1
+    for location, count in sorted(counts.items()):
+        mark = "[green]✓[/green]" if location in TRAVELS_ON_DEPLOY else "[yellow]○[/yellow]"
+        note = "" if location in TRAVELS_ON_DEPLOY else "  [dim]stays on this machine[/dim]"
+        skills_table.add_row(location, f"{mark} {count}{note}")
+    if not counts:
+        skills_table.add_row("Skills", "[dim]none found[/dim]")
+
+    for location, name, reason in problems:
+        skills_table.add_row(f"{location}/{name}", f"[red]✗[/red] {reason}")
+
+    console.print(Panel(skills_table, title="[bold]Skills[/bold]", border_style="yellow"))
+    console.print()
+
     # Connectivity checks (only if API key exists)
     if api_key:
         connectivity_table = Table(show_header=False, box=box.SIMPLE, padding=(0, 1))

--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -300,32 +300,51 @@ def handle_skills_manifest(
 
 
 def handle_skills_list():
-    """List skills currently materialized in ~/.co/skills/."""
-    if not SKILLS_DIR.exists():
-        console.print("[dim]~/.co/skills/ is empty.[/dim]")
-        return
-    rows = []
-    for child in sorted(SKILLS_DIR.iterdir()):
-        if not child.is_dir():
-            continue
-        skill_file = child / "SKILL.md"
-        if not skill_file.exists():
-            continue
-        fm = parse_frontmatter(skill_file.read_text(encoding="utf-8", errors="replace"))
-        rows.append((fm.get("name") or child.name, fm.get("description") or ""))
+    """List every skill the agent can see, and say which of them travel.
 
-    if not rows:
-        console.print("[dim]No skills installed in ~/.co/skills/.[/dim]")
-        return
+    Used to list only ~/.co/skills/, which is the one tier that does NOT survive a
+    deploy — so the command showing you your skills was showing you exactly the ones
+    the deployed agent would not have.
+    """
+    from ...useful_plugins.skills import (
+        _discover_all_skills, find_skill_problems, TRAVELS_ON_DEPLOY,
+    )
 
-    table = Table(title=f"~/.co/skills ({len(rows)})")
-    table.add_column("Name", style="cyan")
-    table.add_column("Description", style="dim", overflow="fold")
-    for name, desc in rows:
-        if len(desc) > 100:
-            desc = desc[:97] + "..."
-        table.add_row(name, desc)
-    console.print(table)
+    skills = _discover_all_skills()
+    problems = find_skill_problems()
+
+    if not skills:
+        console.print("[dim]No skills found.[/dim]")
+    else:
+        table = Table(title=f"Skills ({len(skills)})")
+        table.add_column("Name", style="cyan")
+        table.add_column("Where", style="magenta")
+        table.add_column("Deploys", justify="center")
+        table.add_column("Description", style="dim", overflow="fold")
+        for skill in skills:
+            travels = skill.location in TRAVELS_ON_DEPLOY
+            desc = skill.description or ""
+            if len(desc) > 80:
+                desc = desc[:77] + "..."
+            table.add_row(
+                skill.name,
+                skill.location,
+                "[green]✓[/green]" if travels else "[yellow]✗[/yellow]",
+                desc,
+            )
+        console.print(table)
+
+        staying = [s for s in skills if s.location not in TRAVELS_ON_DEPLOY]
+        if staying:
+            console.print(
+                f"\n[yellow]{len(staying)} skill(s) stay on this machine.[/yellow] "
+                "[dim]Move one into .co/skills/ to make it travel.[/dim]"
+            )
+
+    if problems:
+        console.print(f"\n[red]{len(problems)} broken link(s):[/red]")
+        for location, name, reason in problems:
+            console.print(f"  [dim]{location}[/dim]  {name} — {reason}")
 
 
 # Write direction: publish the skills bundled with ConnectOnion into the

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -95,6 +95,16 @@ class SkillInfo:
 # so offering a skill outside it produces a button that can never run.
 PUBLISHED_SKILL_LOCATIONS = ("project", "claude-project")
 
+# The locations that survive a deploy. Both packaging paths carry the project tree
+# and nothing outside it, so a skill in ~/.co/skills or ~/.claude/skills is simply
+# absent on the server — those two are the operator's laptop, not the agent.
+#
+# builtin is here and NOT in PUBLISHED_SKILL_LOCATIONS: it ships inside the installed
+# connectonion package, so a deployed agent has it, but it is framework noise nobody
+# should see in a public directory. That divergence is why these are two constants
+# and not one — travelling and being publishable are different questions.
+TRAVELS_ON_DEPLOY = ("project", "claude-project", "builtin")
+
 
 # =============================================================================
 # SKILL DISCOVERY
@@ -187,6 +197,26 @@ def _parse_skill_content(content: str) -> tuple[Dict[str, Any], str]:
     return frontmatter, instructions
 
 
+def _skill_search_paths(co_dir: Optional[Path] = None,
+                        project_dir: Optional[Path] = None) -> List[tuple]:
+    """The five (location, directory) pairs, in priority order.
+
+    One definition, so discovery and any diagnosis of it look in the same places —
+    a second copy would eventually report on directories the loader no longer reads.
+    """
+    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
+    co_base = co_dir or (base / '.co')
+    builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
+
+    return [
+        ('project', co_base / 'skills'),
+        ('claude-project', base / '.claude' / 'skills'),
+        ('user', Path.home() / '.co' / 'skills'),
+        ('claude-user', Path.home() / '.claude' / 'skills'),
+        ('builtin', builtin_base),
+    ]
+
+
 def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Path] = None) -> List['SkillInfo']:
     """Discover all available skills from ConnectOnion and Claude Code directories.
 
@@ -197,22 +227,10 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
     Returns:
         List of SkillInfo with 'name', 'description', 'location'
     """
-    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
-    co_base = co_dir or (base / '.co')
-    builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
-
     seen = set()
     result = []
 
-    search_paths = [
-        ('project', co_base / 'skills'),
-        ('claude-project', base / '.claude' / 'skills'),
-        ('user', Path.home() / '.co' / 'skills'),
-        ('claude-user', Path.home() / '.claude' / 'skills'),
-        ('builtin', builtin_base),
-    ]
-
-    for location, skills_dir in search_paths:
+    for location, skills_dir in _skill_search_paths(co_dir, project_dir):
         if not skills_dir.exists():
             continue
 
@@ -237,6 +255,64 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
             result.append(SkillInfo(name=name, description=description, location=location))
 
     return result
+
+
+def find_skill_problems(co_dir: Optional[Path] = None,
+                        project_dir: Optional[Path] = None) -> List[tuple]:
+    """Entries that look like skills but can never load. Returns (location, name, reason).
+
+    Discovery is deliberately forgiving — it skips anything without a readable
+    SKILL.md and says nothing. That is right for loading and wrong for diagnosing:
+    most of our own skills are symlinks into a separate repo, so a dangling link
+    looks exactly like "no skill here" and the agent quietly behaves differently.
+
+    Reported, not raised: a broken link is a thing to tell the operator about, not
+    a reason to refuse to run.
+    """
+    problems = []
+
+    for location, skills_dir in _skill_search_paths(co_dir, project_dir):
+        if not skills_dir.exists():
+            continue
+
+        for entry in skills_dir.iterdir():
+            if entry.name.startswith('.'):
+                continue
+
+            if not entry.is_symlink():
+                # A plain directory without a SKILL.md is not a broken skill — people
+                # keep notes, scratch dirs and shared assets in here. Only links are
+                # checked: a link is a claim that a skill lives somewhere, and that
+                # claim can be false.
+                continue
+
+            # exists() follows the link, so False here means the target is gone.
+            if not entry.exists():
+                problems.append((location, entry.name, 'broken symlink'))
+                continue
+
+            resolved = entry.resolve()
+            if resolved == skills_dir.resolve() or resolved in skills_dir.resolve().parents:
+                problems.append((location, entry.name, 'symlink points at its own ancestor'))
+                continue
+
+            if entry.is_dir() and not (entry / 'SKILL.md').exists():
+                problems.append((location, entry.name, 'linked directory has no SKILL.md'))
+
+    return problems
+
+
+def skills_that_will_not_travel(co_dir: Optional[Path] = None,
+                                project_dir: Optional[Path] = None) -> List[SkillInfo]:
+    """Discovered skills that exist only on this machine.
+
+    A user-tier skill works perfectly for months and is simply absent the moment the
+    agent runs anywhere else — deployed, in CI, on a teammate's checkout. Naming them
+    before the deploy is the whole point: afterwards the agent just behaves differently
+    for a reason nothing in the output explains.
+    """
+    return [s for s in _discover_all_skills(co_dir, project_dir)
+            if s.location not in TRAVELS_ON_DEPLOY]
 
 
 # =============================================================================

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -89,6 +89,26 @@ Skills are discovered from three locations (priority order):
 
 Skills are loaded once at agent creation, descriptions injected into system prompt.
 
+### Which of them survive a deploy
+
+Only what is inside the project tree, plus what ships with ConnectOnion itself:
+
+| Location | Deploys? | Why |
+|---|---|---|
+| `.co/skills/` | ✓ | in the project — packaged and rsynced |
+| `.claude/skills/` | ✓ | same |
+| `builtin/` | ✓ | installed with the `connectonion` package |
+| `~/.co/skills/` | ✗ | your machine, not the agent's |
+| `~/.claude/skills/` | ✗ | same |
+
+A user-level skill is usually a symlink into a separate repo, so it can look
+installed, work perfectly for months, and simply not exist on the server — the
+agent then behaves differently for a reason nothing in its output explains.
+
+`co skills list` marks each one, `co doctor` counts them per tier, and both deploy
+paths name the ones being left behind. **To make a skill travel, move it into the
+project's `.co/skills/`** (or pass it with `co deploy --skills PATH`).
+
 ### 2. Invocation
 
 **Two ways to invoke:**

--- a/tests/unit/test_skill_tiers.py
+++ b/tests/unit/test_skill_tiers.py
@@ -1,0 +1,75 @@
+"""Tier visibility: which skills travel, and which links are broken."""
+import pytest
+from pathlib import Path
+
+# useful_plugins/__init__ rebinds the name `skills` to the plugin LIST, so
+# `import ...skills as sk` hands back a list. Reach the module through sys.modules.
+import sys
+import connectonion.useful_plugins.skills  # noqa: F401  (registers the module)
+
+sk = sys.modules["connectonion.useful_plugins.skills"]
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """A project with a project-tier skill and a user-tier one."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    (project / ".co" / "skills" / "ships").mkdir(parents=True)
+    (project / ".co" / "skills" / "ships" / "SKILL.md").write_text(
+        "---\nname: ships\ndescription: travels\n---\ndo it\n")
+    (home / ".co" / "skills" / "stays").mkdir(parents=True)
+    (home / ".co" / "skills" / "stays" / "SKILL.md").write_text(
+        "---\nname: stays\ndescription: personal\n---\ndo it\n")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    return project, home
+
+
+class TestWhatTravels:
+    def test_a_user_tier_skill_is_named_as_staying_behind(self, tree):
+        project, _ = tree
+        staying = sk.skills_that_will_not_travel(project_dir=project)
+        assert [s.name for s in staying] == ["stays"]
+
+    def test_a_project_tier_skill_is_not_reported(self, tree):
+        project, _ = tree
+        assert "ships" not in {s.name for s in sk.skills_that_will_not_travel(project_dir=project)}
+
+    def test_builtin_travels_because_it_ships_inside_the_package(self):
+        """It is installed with connectonion, so a deployed agent has it — even
+        though it is deliberately not published to clients."""
+        assert "builtin" in sk.TRAVELS_ON_DEPLOY
+        assert "builtin" not in sk.PUBLISHED_SKILL_LOCATIONS
+
+
+class TestBrokenLinks:
+    def test_a_dangling_symlink_is_reported_not_skipped(self, tree):
+        project, _ = tree
+        link = project / ".co" / "skills" / "ghost"
+        link.symlink_to(project / "nowhere")
+
+        problems = sk.find_skill_problems(project_dir=project)
+
+        assert ("project", "ghost", "broken symlink") in problems
+
+    def test_a_symlink_to_its_own_ancestor_is_reported(self, tree):
+        project, _ = tree
+        skills_dir = project / ".co" / "skills"
+        (skills_dir / "loop").symlink_to(skills_dir)
+
+        problems = sk.find_skill_problems(project_dir=project)
+
+        assert any(name == "loop" and "ancestor" in reason
+                   for _, name, reason in problems)
+
+    def test_a_plain_directory_without_a_skill_file_is_not_a_problem(self, tree):
+        """People keep notes and scratch dirs in here. Only a link makes a claim
+        that can be false."""
+        project, _ = tree
+        (project / ".co" / "skills" / "notes").mkdir()
+
+        assert sk.find_skill_problems(project_dir=project) == []
+
+    def test_a_healthy_tree_reports_nothing(self, tree):
+        project, _ = tree
+        assert sk.find_skill_problems(project_dir=project) == []


### PR DESCRIPTION
Closes #302.

## The failure it fixes

The loader searches five locations and says nothing about which one a skill came from. Two of them — `~/.co/skills`, `~/.claude/skills` — exist only on the machine that wrote them, and most of ours are **symlinks into a separate repo**, invisible to anything that packages a project.

So a skill can look installed, work perfectly for months, and simply be absent on a deployed agent, in CI, or on a teammate's checkout. Nothing fails. The agent just behaves differently, for a reason nothing in its output explains.

## What you now see

```
co skills list      every tier, with a Deploys column
co doctor           counts per tier + any broken links
co deploy           names the skills being left behind (both deploy paths)
```

`co skills list` previously listed **only `~/.co/skills/`** — that is, exactly the tier that does *not* travel. The command for looking at your skills was showing you the ones the deployed agent would not have.

```
╭───────────── Skills ─────────────╮
│   builtin       ✓ 3              │
│   claude-user   ○ 55  stays on this machine
│   project       ✓ 23             │
│   user          ○ 37  stays on this machine
╰──────────────────────────────────╯
```

## Two decisions worth reviewing

**1. `TRAVELS_ON_DEPLOY` is a separate constant from `PUBLISHED_SKILL_LOCATIONS`**, even though they nearly agree. `builtin` **travels** — it is installed with the `connectonion` package, so a deployed agent has it — but it is **not published**, being framework noise nobody should see in a public directory. I wrote them as one alias first and the doctor panel immediately printed "builtin — stays on this machine", which is false. Travelling and being publishable are different questions.

**2. Only symlinks are checked for breakage.** A plain directory without a `SKILL.md` is somebody's notes or a scratch dir, not a broken skill — the first version flagged `research/` and `tests/` in this very repo. A *link* is a claim that a skill lives somewhere, and that claim can be false; a directory makes no claim.

The five search paths are now defined once (`_skill_search_paths`), so discovery and the diagnosis of it cannot end up looking in different places.

## Tests

7 new cases in `tests/unit/test_skill_tiers.py` against a real temp tree with a real dangling symlink and a real self-referential one — no mocks.

Full suite: **2455 passed, 3 skipped**. Deploy CLI e2e: 33 passed.

## Docs

`docs/features/skills.md` gains a table of what survives a deploy and the one-line fix (move it into `.co/skills/`, or `co deploy --skills PATH`).