### PR TITLE
feat(server): co server new provisions a server and shows what it costs (#313)

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -288,3 +288,190 @@ def handle_server_forget(name: str) -> bool:
     console.print("[dim]Tearing one down needs the server API (openonion/oo-api#36); until "
                   "then, delete it where it lives.[/dim]\n")
     return True
+
+
+API_BASE = "https://oo.openonion.ai"
+
+
+def _derive_ssh_public_line() -> Optional[str]:
+    """The operator's SSH key, so a new server is reachable with no second secret."""
+    from ... import address
+    from .keys_commands import _find_co_dir
+
+    co_dir = _find_co_dir()
+    if not co_dir:
+        return None
+    data = address.load(co_dir)
+    if not data or not data.get("seed_phrase"):
+        return None
+    return address.derive_ssh_key(data["seed_phrase"])["public_line"]
+
+
+def _fetch_pricing() -> Optional[dict]:
+    import requests
+
+    try:
+        response = requests.get(f"{API_BASE}/api/v1/servers/pricing", timeout=15)
+    except requests.RequestException:
+        return None
+    return response.json() if response.status_code == 200 else None
+
+
+def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[float]) -> bool:
+    """Show what this costs and what is left, then ask.
+
+    Every other `co` command is either free or spends metered credit in
+    fractions of a cent. This is the first one that spends a large discrete
+    amount, and the verb cannot carry that — `new` is honest about the machine
+    and says nothing about the money. The prompt has to.
+
+    Balance-after is shown rather than just the price: what decides whether
+    someone can afford it is what is left, not what it costs.
+    """
+    from datetime import datetime, timedelta
+
+    entry = pricing["machine_types"][machine_type]
+    price = entry["usd_12mo"]
+    months = pricing["term_months"]
+    expires = (datetime.now() + timedelta(days=365)).strftime("%Y-%m-%d")
+
+    console.print()
+    console.print(f"  [cyan]name[/cyan]          {name}")
+    console.print(f"  [cyan]region[/cyan]        {pricing['region']}")
+    console.print(f"  [cyan]machine[/cyan]       {machine_type} [dim]— {entry['description']}[/dim]")
+    console.print(f"  [cyan]cost[/cyan]          [bold]${price:.2f}[/bold] "
+                  f"[dim]({months} months, charged now)[/dim]")
+    if balance is not None:
+        console.print(f"  [cyan]your balance[/cyan]  ${balance:.2f} → "
+                      f"[bold]${balance - price:.2f}[/bold] after")
+    console.print(f"  [cyan]expires[/cyan]       {expires} "
+                  f"[dim]— the server stops on that date unless renewed[/dim]")
+    console.print()
+
+    import questionary
+    return bool(questionary.confirm("Create it?", default=False).ask())
+
+
+def handle_server_new(name: str, machine_type: Optional[str] = None,
+                      yes: bool = False) -> bool:
+    """Have a server created for you, and register it locally."""
+    import requests
+
+    from .project_cmd_lib import DEPLOY_NAME_PATTERN, load_api_key
+
+    if not DEPLOY_NAME_PATTERN.match(name):
+        console.print(f"\n[red]Invalid server name: {name}[/red]")
+        console.print("[dim]1-39 lowercase letters, digits and hyphens, starting with a "
+                      "letter or digit — it becomes a DNS label.[/dim]\n")
+        return False
+
+    if load_server(name):
+        console.print(f"\n[red]'{name}' is already registered locally.[/red]")
+        console.print(f"[dim]co server ls  ·  or pick another name[/dim]\n")
+        return False
+
+    api_key = load_api_key()
+    if not api_key:
+        console.print("\n[red]Not authenticated.[/red]")
+        console.print("[cyan]co auth[/cyan] first — creating a server spends credit.\n")
+        return False
+
+    ssh_public_line = _derive_ssh_public_line()
+    if not ssh_public_line:
+        console.print("\n[red]No SSH key to install.[/red]")
+        console.print("[dim]The key is derived from your recovery phrase; without it the "
+                      "server would be created with no way in.[/dim]")
+        console.print("[cyan]co keys --ssh[/cyan] to check.\n")
+        return False
+
+    pricing = _fetch_pricing()
+    if not pricing:
+        console.print(f"\n[red]Could not reach {API_BASE} for pricing.[/red]")
+        console.print("[dim]Nothing was created or charged.[/dim]\n")
+        return False
+
+    machine_type = machine_type or pricing["default"]
+    if machine_type not in pricing["machine_types"]:
+        console.print(f"\n[red]Unknown machine type: {machine_type}[/red]")
+        console.print(f"[dim]Available: {', '.join(sorted(pricing['machine_types']))}[/dim]\n")
+        return False
+
+    if not yes:
+        if not _confirm(name, machine_type, pricing, _fetch_balance(api_key)):
+            console.print("[dim]Nothing was created or charged.[/dim]\n")
+            return False
+
+    console.print(f"\n[dim]Creating {name} … this takes about a minute.[/dim]")
+    try:
+        response = requests.post(
+            f"{API_BASE}/api/v1/servers",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"name": name, "ssh_public_key": ssh_public_line,
+                  "machine_type": machine_type},
+            timeout=300,
+        )
+    except requests.RequestException as exc:
+        console.print(f"[red]Request failed: {exc}[/red]")
+        console.print("[dim]If the server was created you will see it in "
+                      "[bold]co server ls[/bold].[/dim]\n")
+        return False
+
+    if response.status_code != 200:
+        _report_failure(response)
+        return False
+
+    server = response.json()
+
+    # Register it ourselves so the operator never types an IP.
+    servers = _load()
+    servers[name] = {"ssh": server["ssh_target"], "last_check": None}
+    _save(servers)
+
+    console.print(f"\n[green]✓ {name} is ready[/green]")
+    console.print(f"  [cyan]{server['ssh_target']}[/cyan]")
+    console.print(f"  [dim]expires {server['expires_at'][:10]} — "
+                  f"${server['charged_usd']:.2f} charged[/dim]")
+    console.print(f"\n[dim]Next:[/dim] co server check {name}  ·  co deploy --to {name}\n")
+    return True
+
+
+def _fetch_balance(api_key: str) -> Optional[float]:
+    """Best effort — the prompt is more useful with it and still works without."""
+    import requests
+
+    try:
+        response = requests.get(f"{API_BASE}/api/v1/auth/me",
+                                headers={"Authorization": f"Bearer {api_key}"}, timeout=15)
+        if response.status_code == 200:
+            value = response.json().get("credits_usd")
+            return float(value) if value is not None else None
+    except (requests.RequestException, ValueError, TypeError):
+        pass
+    return None
+
+
+def _report_failure(response) -> None:
+    """Say what happened to the money, first."""
+    try:
+        detail = response.json().get("detail", {})
+    except ValueError:
+        detail = {}
+
+    if isinstance(detail, str):
+        console.print(f"\n[red]{detail}[/red]\n")
+        return
+
+    error = detail.get("error")
+    if error == "insufficient_credits":
+        console.print(f"\n[red]Not enough credit.[/red]")
+        console.print(f"  have      ${detail.get('balance', 0):.2f}")
+        console.print(f"  need      ${detail.get('required', 0):.2f}")
+        console.print(f"  short by  [bold]${detail.get('shortfall', 0):.2f}[/bold]")
+        console.print("\n[dim]Nothing was created or charged.[/dim]")
+        console.print("[dim]https://discord.gg/4xfD9k8AUF to top up.[/dim]\n")
+    elif error == "provisioning_failed":
+        colour = "yellow" if detail.get("refunded") else "red"
+        console.print(f"\n[{colour}]{detail.get('message', 'Provisioning failed.')}[/{colour}]\n")
+    else:
+        console.print(f"\n[red]Server creation failed ({response.status_code}).[/red]")
+        console.print(f"[dim]{detail or response.text[:300]}[/dim]\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -347,6 +347,18 @@ def server_check(
         raise typer.Exit(1)
 
 
+@server_app.command("new")
+def server_new(
+    name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
+    machine: Optional[str] = typer.Option(None, "--machine", help="Machine type (default: the smallest)"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the price confirmation"),
+):
+    """Have a server created for you. Charges 12 months of credit up front."""
+    from .commands.server_commands import handle_server_new
+    if not handle_server_new(name=name, machine_type=machine, yes=yes):
+        raise typer.Exit(1)
+
+
 @server_app.command("ssh")
 def server_ssh(
     name: str = typer.Argument(..., help="Registered server name"),

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -281,3 +281,163 @@ class TestServerForget:
         out = capsys.readouterr().out.lower()
         assert "untouched" in out
         assert "billed" in out
+
+
+PRICING = {
+    "term_months": 12,
+    "region": "asia-southeast1",
+    "default": "e2-small",
+    "machine_types": {"e2-small": {"usd_12mo": 180.0, "description": "2 vCPU, 2 GB"}},
+}
+
+
+class TestServerNewSpendsNothingWithoutConsent:
+    """This is the first co command that spends a large discrete amount.
+
+    Every guard below is about that: nothing may be charged before the operator
+    has seen the price and said yes.
+    """
+
+    def test_declining_the_prompt_creates_nothing(self, servers_file):
+        with patch.object(sc, "load_api_key", create=True), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=False), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod") is False
+
+        post.assert_not_called()
+        assert not servers_file.exists()
+
+    def test_no_api_key_stops_before_the_prompt(self, servers_file):
+        """Do not show a price to someone who cannot be charged anyway."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value=None), \
+             patch.object(sc, "_fetch_pricing") as pricing, \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod") is False
+
+        pricing.assert_not_called()
+        post.assert_not_called()
+
+    def test_a_missing_ssh_key_stops_before_charging(self, servers_file):
+        """A server created with no way in is worse than no server."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value=None), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod") is False
+
+        post.assert_not_called()
+
+    def test_an_invalid_name_is_rejected_locally(self, servers_file):
+        with patch("requests.post") as post:
+            assert sc.handle_server_new("Not A Name") is False
+        post.assert_not_called()
+
+    def test_a_name_already_registered_is_rejected_before_spending(self, servers_file):
+        """Otherwise you pay for a second machine and cannot address it."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch("requests.post") as post:
+            assert sc.handle_server_new("prod") is False
+        post.assert_not_called()
+
+    def test_unreachable_pricing_endpoint_does_not_guess_a_price(self, servers_file):
+        """Showing a made-up number and then charging a different one is worse
+        than refusing."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=None), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod") is False
+
+        post.assert_not_called()
+
+
+class TestServerNewSuccess:
+    def test_a_created_server_is_registered_so_no_ip_is_ever_typed(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {
+            "ssh_target": "co@1.2.3.4", "expires_at": "2027-07-31T00:00:00+00:00",
+            "charged_usd": 180.0,
+        }
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response):
+            assert sc.handle_server_new("prod") is True
+
+        assert sc.load_server("prod")["ssh"] == "co@1.2.3.4"
+
+    def test_the_derived_key_is_what_gets_sent(self, servers_file):
+        """The server must trust the key the operator already has."""
+        line = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAtest connectonion"
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value=line), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod")
+
+        assert post.call_args.kwargs["json"]["ssh_public_key"] == line
+
+
+class TestServerNewFailureReporting:
+    def test_insufficient_credit_says_nothing_was_charged(self, servers_file, capsys):
+        response = Mock(status_code=402)
+        response.json.return_value = {"detail": {
+            "error": "insufficient_credits", "balance": 5.0, "required": 180.0,
+            "shortfall": 175.0}}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=5.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response):
+            assert sc.handle_server_new("prod") is False
+
+        out = capsys.readouterr().out.lower()
+        assert "nothing was created or charged" in out
+
+    def test_a_failed_refund_is_shown_in_red_not_buried(self, servers_file, capsys):
+        response = Mock(status_code=502)
+        response.json.return_value = {"detail": {
+            "error": "provisioning_failed", "refunded": False, "amount": 180.0,
+            "message": "charged for a machine that does not exist — contact support"}}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response):
+            sc.handle_server_new("prod")
+
+        assert "contact support" in capsys.readouterr().out.lower()
+
+    def test_a_failed_creation_registers_nothing_locally(self, servers_file):
+        response = Mock(status_code=502)
+        response.json.return_value = {"detail": {"error": "provisioning_failed",
+                                                 "refunded": True, "amount": 180.0,
+                                                 "message": "zone full, refunded"}}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response):
+            sc.handle_server_new("prod")
+
+        assert sc.load_server("prod") is None


### PR DESCRIPTION
Closes #313. The CLI half; the backend is openonion/oo-api#39.

```bash
co server new prod          # provisions, charges 12 months, registers it locally
co server new prod --machine e2-medium
co server new prod --yes    # skip the prompt, for scripts
```

## The confirmation is the substance, not decoration

This is the **first `co` command that spends a large discrete amount**. Everything else is free or spends metered credit in fractions of a cent, invisibly. `new` is the honest verb for what happens to the machine and says nothing at all about the money — so the prompt has to carry it:

```
  name          prod
  region        asia-southeast1
  machine       e2-small — 2 vCPU (shared), 2 GB — fine for one agent
  cost          $180.00 (12 months, charged now)
  your balance  $500.00 → $320.00 after
  expires       2027-07-31 — the server stops on that date unless renewed

  Create it? [y/N]
```

Two deliberate choices there:

- **Balance-after, not just the price.** What decides whether someone can afford this is what is left, not what it costs.
- **Default is No.** A stray Enter must not spend a year of credit.

This is #318's second item.

## Everything checkable locally is checked before the prompt

In order, each stopping before anything is spent:

| Check | Why it is *before* the charge |
|---|---|
| name matches the DNS label rule | it becomes a hostname; failing after would mean a paid-for machine with an unusable name |
| name not already registered | otherwise you pay for a second machine and cannot address it — `co deploy --to prod` would be ambiguous |
| authenticated | do not show a price to someone who cannot be charged anyway |
| **SSH key derivable** | **a server created with no way in is worse than no server** |
| pricing endpoint reachable | refuse rather than guess a number and then charge a different one |

Six tests assert `requests.post` is never called on each of these paths.

## Failure reporting leads with the money

```
$ co server new prod          # not enough credit
Not enough credit.
  have      $5.00
  need      $180.00
  short by  $175.00
Nothing was created or charged.
```

And when provisioning failed *after* the charge, the refund status is the headline — red if the refund itself failed, with "contact support", because that is the one case a user cannot resolve alone.

## On success it registers itself

The response carries `ssh_target`, so `co server new` writes it into `~/.co/servers.yaml` in #311's format. **The operator never sees an IP.** Next steps are printed as `co server check prod` and `co deploy --to prod`, which is the whole chain from #309 closing.

## Tests

`tests/unit/test_server_commands.py` — **42 cases** (was 31). The new ones are grouped as `TestServerNewSpendsNothingWithoutConsent`, which is the property that matters: declining the prompt, no API key, no SSH key, bad name, duplicate name, and unreachable pricing all assert nothing was posted. Plus: the derived key is what gets sent, a created server is registered, and a failed creation registers nothing.

Full suite: **2476 passed, 3 skipped**.

## Not verified end to end

The backend does not exist in production yet — openonion/oo-api#39 is open. So this is tested against mocked responses shaped like that PR's contract, not against a live provision. Once #39 is deployed the honest test is: `co server new`, then `co server check`, then `co deploy --to`, then ssh in, edit a file, deploy again, and confirm the edit survived — the same sequence I ran against the hand-made box for #312.
