### PR TITLE
ci: stop fork PRs failing on an empty OPENONION_API_KEY

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,11 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          OPENONION_API_KEY: ${{ secrets.OPENONION_API_KEY }}
+          # A fork PR gets no repository secrets, so this expands to an empty
+          # string — and an empty key reads as "not authenticated", which makes
+          # the auth CLI bail before it reaches the code these tests exercise.
+          # Unset would be fine; empty is not. Fall back to a placeholder.
+          OPENONION_API_KEY: ${{ secrets.OPENONION_API_KEY || 'test-key' }}
         run: |
           pytest tests/ -v --tb=short -m "not slow and not real_api and not network"
 


### PR DESCRIPTION
Split out of #184 as discussed there — that PR bundled this CI fix with the async-tool feature, which is now deferred to 1.8.0. This half shouldn't wait for a release, because it's currently breaking CI for every outside contributor.

## The problem

A fork PR receives no repository secrets, so `${{ secrets.OPENONION_API_KEY }}` expands to an empty string and the step exports `OPENONION_API_KEY=""`.

**An empty key is not the same as an absent one.** The auth CLI checks the key for truthiness, so `""` reads as "not authenticated" and the command bails with a help message before it ever reaches the OAuth code the tests are driving. The tests then fail asserting on output that was never produced:

```
AssertionError: assert ('Failed to initialize OAuth' in
  '\n❌ Not authenticated with OpenOnion\n\nAuthenticate first:\n  co auth ...')
```

## Verification

On `origin/main` (`4f289cf`), against `tests/e2e/cli/test_cli_auth_google.py` and `test_cli_auth_microsoft.py`:

| `OPENONION_API_KEY` | Result |
|---|---|
| unset (local default) | **20 passed** |
| `""` (what a fork PR gets) | **6 failed**, 14 passed |
| `test-key` (this fix) | **20 passed** |

The failing set is the three OAuth-flow tests in each file.

## Why it matters

Every fork PR currently shows red CI for a reason unrelated to its own diff. #293 — a correct fix for a severe bug, since merged — failed this way. That is a false wall in front of exactly the contributors we want, and it costs a maintainer round-trip every time to explain that the red is ours, not theirs.

## Safety

The fallback only applies when the real secret is unavailable. The suite selected in this job excludes `real_api`, so nothing here calls out with the key — the value just has to be non-empty for the CLI to take the authenticated path. Where a real secret exists, behaviour is unchanged.

Credit to @sanmaxdev, who diagnosed this while working on #184.

---

**Note for merging:** this touches `.github/workflows/`, so it needs a maintainer with `workflow` scope (`gh auth refresh -s workflow`). That's on our side.
