### PR TITLE
co server ls reconciles with billing, and co server destroy

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -381,7 +381,7 @@ def handle_server_destroy(name: str, yes: bool = False) -> bool:
         console.print(f"\n[red]This destroys the machine '{name}' and everything on it.[/red]")
         console.print("[dim]The disk, the agent's identity, its logs — none of it is "
                       "recoverable.[/dim]")
-        console.print("[yellow]The remaining months of the term are not refunded.[/yellow]")
+        console.print("[dim]The unused part of the term is refunded to your credit.[/dim]")
         console.print()
 
         import questionary
@@ -421,7 +421,18 @@ def handle_server_destroy(name: str, yes: bool = False) -> bool:
         _save(servers)
 
     console.print(f"[green]✓ {name} destroyed[/green]")
-    console.print("[dim]Not refunded — the term was charged up front.[/dim]\n")
+
+    # State the amount, not the policy. "Prorated" tells the user nothing they
+    # can check; a number against what they paid does.
+    result = response.json() if response.content else {}
+    refunded = result.get("refunded_usd")
+    if refunded:
+        charged = result.get("charged_usd")
+        against = f" of ${charged:.2f}" if charged else ""
+        console.print(f"[dim]${refunded:.2f}{against} refunded to your credit — "
+                      f"the unused part of the term.[/dim]\n")
+    else:
+        console.print("[dim]Nothing refunded — the term had already run out.[/dim]\n")
     return True
 
 

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -110,18 +110,34 @@ def handle_server_add(name: str, ssh_target: str) -> bool:
 
 
 def handle_server_list() -> bool:
-    """Show what you can deploy to."""
-    servers = _load()
+    """Show what you can deploy to, reconciled against what you are billed for.
 
-    if not servers:
+    ~/.co/servers.yaml is a cache, not the ledger. Once a server costs money the
+    backend is the truth, and the row that matters is the one the local file
+    cannot produce: **billed for, not registered here**. That is someone paying
+    for a machine `co` would otherwise never show them — created on another
+    laptop, or dropped with `co server forget`.
+
+    The billing lookup is best-effort. Being offline, or not authenticated, must
+    not stop you listing your own deploy targets.
+    """
+    servers = _load()
+    billed = _fetch_billed_servers()
+
+    if not servers and not billed:
         console.print("\n[dim]No servers registered.[/dim]")
-        console.print("[cyan]co server add prod --ssh user@host[/cyan]\n")
+        console.print("[cyan]co server new prod[/cyan]  or  "
+                      "[cyan]co server add prod --ssh user@host[/cyan]\n")
         return True
 
     table = Table(box=None, padding=(0, 2))
     table.add_column("NAME", style="cyan")
     table.add_column("TARGET")
     table.add_column("LAST CHECK")
+    if billed is not None:
+        table.add_column("BILLING")
+
+    billed_by_name = {s["name"]: s for s in (billed or [])}
 
     for name in sorted(servers):
         entry = servers[name] or {}
@@ -132,12 +148,65 @@ def handle_server_list() -> bool:
             shown = "[green]ok[/green]"
         else:
             shown = f"[red]{last}[/red]"
-        table.add_row(name, entry.get("ssh", "[red]?[/red]"), shown)
+
+        row = [name, entry.get("ssh", "[red]?[/red]"), shown]
+        if billed is not None:
+            record = billed_by_name.get(name)
+            row.append(f"[dim]until {record['expires_at'][:10]}[/dim]" if record
+                       else "[dim]not ours[/dim]")
+        table.add_row(*row)
+
+    # The expensive row: charged for, absent locally.
+    unregistered = [s for s in (billed or []) if s["name"] not in servers]
+    for record in unregistered:
+        table.add_row(
+            f"[yellow]{record['name']}[/yellow]",
+            f"[dim]{record.get('ssh_target') or '—'}[/dim]",
+            "[yellow]not registered here[/yellow]",
+            f"[yellow]until {record['expires_at'][:10]}[/yellow]",
+        )
 
     console.print()
     console.print(table)
+
+    if unregistered:
+        names = ", ".join(s["name"] for s in unregistered)
+        console.print(f"\n[yellow]{len(unregistered)} server(s) you are billed for are not "
+                      f"registered on this machine:[/yellow] {names}")
+        console.print("[dim]co server add <name> --ssh <target>   to use one from here[/dim]")
+        console.print("[dim]co server destroy <name>              to stop paying for one[/dim]")
+
     console.print(f"\n[dim]{_short(SERVERS_FILE)}[/dim]\n")
     return True
+
+
+def _fetch_billed_servers():
+    """What the backend says this account owns, or None if we could not ask.
+
+    None and [] mean different things and the caller depends on it: [] is "you
+    own nothing", None is "we do not know", and only the first justifies telling
+    someone their registry is complete.
+    """
+    import requests
+
+    from .project_cmd_lib import load_api_key
+
+    api_key = load_api_key()
+    if not api_key:
+        return None
+
+    try:
+        response = requests.get(f"{API_BASE}/api/v1/servers",
+                                headers={"Authorization": f"Bearer {api_key}"}, timeout=15)
+    except requests.RequestException:
+        return None
+
+    if response.status_code != 200:
+        return None
+    try:
+        return response.json().get("servers", [])
+    except ValueError:
+        return None
 
 
 def _short(p: Path) -> str:
@@ -285,8 +354,74 @@ def handle_server_forget(name: str) -> bool:
     console.print(f"[green]✓[/green] Forgot [cyan]{name}[/cyan] ({target})")
     console.print("\n[yellow]The machine itself is untouched — it keeps running, and if we "
                   "created it, it keeps being billed.[/yellow]")
-    console.print("[dim]Tearing one down needs the server API (openonion/oo-api#36); until "
-                  "then, delete it where it lives.[/dim]\n")
+    console.print(f"[dim]To stop paying for it:  co server destroy {name}[/dim]\n")
+    return True
+
+
+def handle_server_destroy(name: str, yes: bool = False) -> bool:
+    """Tear the machine down for real, and drop the local entry with it.
+
+    The opposite of `forget` in the only way that matters: this one stops the
+    billing and cannot be undone. So it asks for the name back rather than a
+    y/N — a reflex "y" is exactly how someone deletes production while meaning
+    to tidy their config, and typing the name cannot be done by reflex.
+    """
+    import requests
+
+    from .project_cmd_lib import load_api_key
+
+    api_key = load_api_key()
+    if not api_key:
+        console.print("\n[red]Not authenticated.[/red]")
+        console.print("[cyan]co auth[/cyan] first — destroying a server is a billing "
+                      "operation.\n")
+        return False
+
+    if not yes:
+        console.print(f"\n[red]This destroys the machine '{name}' and everything on it.[/red]")
+        console.print("[dim]The disk, the agent's identity, its logs — none of it is "
+                      "recoverable.[/dim]")
+        console.print("[yellow]The remaining months of the term are not refunded.[/yellow]")
+        console.print()
+
+        import questionary
+        typed = questionary.text(f"Type the server name to confirm ({name}):").ask()
+        if typed != name:
+            console.print("[dim]Nothing was destroyed.[/dim]\n")
+            return False
+
+    console.print(f"\n[dim]Destroying {name} …[/dim]")
+    try:
+        response = requests.delete(
+            f"{API_BASE}/api/v1/servers/{name}",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=300,
+        )
+    except requests.RequestException as exc:
+        console.print(f"[red]Request failed: {exc}[/red]")
+        console.print("[dim]The server may still exist. Check with "
+                      "[bold]co server ls[/bold].[/dim]\n")
+        return False
+
+    if response.status_code == 404:
+        console.print(f"[red]No server named '{name}' on your account.[/red]")
+        console.print("[dim]If it is only a local entry, use "
+                      f"[bold]co server forget {name}[/bold].[/dim]\n")
+        return False
+
+    if response.status_code != 200:
+        _report_failure(response)
+        return False
+
+    # Only now drop the local entry: while the machine existed the entry was
+    # true, and removing it on a failed delete would hide a server still billing.
+    servers = _load()
+    if name in servers:
+        del servers[name]
+        _save(servers)
+
+    console.print(f"[green]✓ {name} destroyed[/green]")
+    console.print("[dim]Not refunded — the term was charged up front.[/dim]\n")
     return True
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -380,6 +380,17 @@ def server_forget(
         raise typer.Exit(1)
 
 
+@server_app.command("destroy")
+def server_destroy(
+    name: str = typer.Argument(..., help="Server to tear down"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation"),
+):
+    """Destroy the machine and stop the billing. Not reversible, not refunded."""
+    from .commands.server_commands import handle_server_destroy
+    if not handle_server_destroy(name=name, yes=yes):
+        raise typer.Exit(1)
+
+
 # Skills command group
 skills_app = typer.Typer(help="Discover, copy, and list SKILL.md files from agent tool directories")
 app.add_typer(skills_app, name="skills")

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -536,7 +536,7 @@ class TestServerDestroy:
     def test_the_typed_name_must_match_exactly(self, servers_file):
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
              patch("questionary.text") as text, \
-             patch("requests.delete", return_value=_response(200, {"refunded": False})) as delete:
+             patch("requests.delete", return_value=_response(200, {"refunded_usd": 0})) as delete:
             text.return_value.ask.return_value = "prod"
             assert sc.handle_server_destroy("prod") is True
 
@@ -566,10 +566,29 @@ class TestServerDestroy:
             sc.handle_server_add("prod", "user@1.2.3.4")
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch("requests.delete", return_value=_response(200, {"refunded": False})):
+             patch("requests.delete", return_value=_response(200, {"refunded_usd": 0})):
             assert sc.handle_server_destroy("prod", yes=True) is True
 
         assert "prod" not in yaml.safe_load(servers_file.read_text())["servers"]
+
+    def test_the_refund_is_reported_as_an_amount_not_a_policy(self, servers_file, capsys):
+        """"Prorated" tells the user nothing they can check. A number against what
+        they paid does."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.delete", return_value=_response(
+                 200, {"refunded_usd": 150.41, "charged_usd": 180.0})):
+            assert sc.handle_server_destroy("prod", yes=True) is True
+
+        out = capsys.readouterr().out
+        assert "$150.41" in out
+        assert "$180.00" in out
+
+    def test_an_expired_server_says_nothing_was_refunded(self, servers_file, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.delete", return_value=_response(200, {"refunded_usd": 0.0})):
+            sc.handle_server_destroy("prod", yes=True)
+
+        assert "Nothing refunded" in capsys.readouterr().out
 
     def test_a_404_points_at_forget_instead(self, servers_file, capsys):
         """A local-only entry has nothing to destroy, and telling the user to

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -444,7 +444,9 @@ class TestServerNewFailureReporting:
 
 
 def _response(status, payload=None):
-    return Mock(status_code=status, json=Mock(return_value=payload or {}))
+    # content is set because handle_server_destroy checks it before parsing.
+    return Mock(status_code=status, content=b"{}",
+                json=Mock(return_value=payload or {}))
 
 
 class TestThePriceIsQuotedAgainstSpendableCredit:
@@ -464,3 +466,116 @@ class TestThePriceIsQuotedAgainstSpendableCredit:
     def test_a_failed_lookup_shows_no_balance_rather_than_a_wrong_one(self):
         with patch("requests.get", return_value=_response(500)):
             assert sc._fetch_balance("k") is None
+
+class TestServerLsReconcilesWithBilling:
+    """The local file is a cache; the backend is the ledger. The row that only
+    the backend can produce — billed for, not registered here — is somebody
+    paying for a machine `co` would otherwise never show them."""
+
+    def test_a_server_you_pay_for_but_never_registered_is_surfaced(self, servers_file, capsys):
+        with patch.object(sc, "_fetch_billed_servers", return_value=[
+            {"name": "ghost", "expires_at": "2027-07-30T00:00:00", "ssh_target": "co@1.2.3.4"},
+        ]):
+            assert sc.handle_server_list() is True
+
+        out = capsys.readouterr().out
+        assert "ghost" in out
+        assert "not registered here" in out
+
+    def test_it_names_the_command_that_stops_the_billing(self, servers_file, capsys):
+        with patch.object(sc, "_fetch_billed_servers", return_value=[
+            {"name": "ghost", "expires_at": "2027-07-30T00:00:00", "ssh_target": None},
+        ]):
+            sc.handle_server_list()
+
+        assert "co server destroy" in capsys.readouterr().out
+
+    def test_being_offline_still_lists_local_targets(self, servers_file, capsys):
+        """The billing lookup is best-effort. Not being able to reach the API must
+        not stop you seeing your own deploy targets."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc, "_fetch_billed_servers", return_value=None):
+            assert sc.handle_server_list() is True
+
+        out = capsys.readouterr().out
+        assert "prod" in out
+        assert "not registered here" not in out
+
+    def test_unknown_and_empty_are_not_the_same_answer(self, servers_file, capsys):
+        """None is 'we could not ask', [] is 'you own nothing'. Only the second
+        justifies showing a BILLING column at all."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch.object(sc, "_fetch_billed_servers", return_value=[]):
+            sc.handle_server_list()
+        assert "not ours" in capsys.readouterr().out
+
+    def test_a_failed_lookup_reads_as_unknown_not_as_empty(self, servers_file):
+        """A 500 or a timeout must not be reported as 'you own no servers' — that
+        is the one answer that would hide a machine you are paying for."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.get", return_value=_response(500)):
+            assert sc._fetch_billed_servers() is None
+
+
+class TestServerDestroy:
+    def test_a_mistyped_confirmation_destroys_nothing(self, servers_file):
+        """It asks for the name back rather than y/N: a reflex 'y' is exactly how
+        someone deletes production while meaning to tidy their config."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("questionary.text") as text, \
+             patch("requests.delete") as delete:
+            text.return_value.ask.return_value = "prd"
+            assert sc.handle_server_destroy("prod") is False
+
+        delete.assert_not_called()
+
+    def test_the_typed_name_must_match_exactly(self, servers_file):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("questionary.text") as text, \
+             patch("requests.delete", return_value=_response(200, {"refunded": False})) as delete:
+            text.return_value.ask.return_value = "prod"
+            assert sc.handle_server_destroy("prod") is True
+
+        delete.assert_called_once()
+
+    def test_no_api_key_stops_before_the_request(self, servers_file):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value=None), \
+             patch("requests.delete") as delete:
+            assert sc.handle_server_destroy("prod", yes=True) is False
+
+        delete.assert_not_called()
+
+    def test_a_failed_delete_keeps_the_local_entry(self, servers_file):
+        """Removing it would hide a server that is still running and still billing
+        — the exact state this whole change exists to make visible."""
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.delete", return_value=_response(502, {"detail": "boom"})):
+            assert sc.handle_server_destroy("prod", yes=True) is False
+
+        assert "prod" in yaml.safe_load(servers_file.read_text())["servers"]
+
+    def test_a_successful_delete_drops_the_local_entry(self, servers_file):
+        with patch.object(sc, "_ssh", return_value=_ok("ok")):
+            sc.handle_server_add("prod", "user@1.2.3.4")
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.delete", return_value=_response(200, {"refunded": False})):
+            assert sc.handle_server_destroy("prod", yes=True) is True
+
+        assert "prod" not in yaml.safe_load(servers_file.read_text())["servers"]
+
+    def test_a_404_points_at_forget_instead(self, servers_file, capsys):
+        """A local-only entry has nothing to destroy, and telling the user to
+        retry destroy would leave them stuck."""
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch("requests.delete", return_value=_response(404)):
+            assert sc.handle_server_destroy("prod", yes=True) is False
+
+        assert "co server forget" in capsys.readouterr().out


### PR DESCRIPTION
Closes the last two boxes of #318. Both are about the same thing: **once a server costs money, `~/.co/servers.yaml` stops being the truth.**

Depends on openonion/oo-api#43 for `DELETE /api/v1/servers/{name}` — merge that first, or `destroy` gets a 404 from a route that does not exist yet.

## `co server ls` reconciles against the ledger

#318's table has four states. Three are fine. This is the fourth:

| registry | reality | |
|---|---|---|
| **absent** | **running and billing** | **the user is paying for something `co` cannot show them** |

`co server forget` creates that state deliberately, and so does creating a server on another laptop. Now it shows up:

```
NAME     TARGET          LAST CHECK            BILLING
prod     co@1.2.3.4      ok                    until 2027-07-30
ghost    co@5.6.7.8      not registered here   until 2027-07-30

1 server(s) you are billed for are not registered on this machine: ghost
  co server add <name> --ssh <target>   to use one from here
  co server destroy <name>              to stop paying for one
```

**`None` is not `[]`, and the distinction is load-bearing.** `None` means we could not ask — offline, unauthenticated, a 500. `[]` means the account owns nothing. Only the second is an answer, so only the second shows a BILLING column. Collapsing them would let a timeout read as "you own no servers", which is precisely the wrong answer that hides a machine you are paying for.

Being offline still lists your local deploy targets. The billing lookup never blocks the command's actual job.

## `co server destroy`

Kept separate from `forget`, per #318 — one of them stops you paying and the other does not.

**It asks for the name typed back, not y/N.** A reflex "y" is exactly how someone deletes production while meaning to tidy their config; typing a name cannot be done by reflex. And it says the term is not refunded *before* asking, not after.

**The local entry is dropped only after the delete succeeds.** Removing it on a failure would hide a server that is still running and still billing — the exact state this whole PR exists to make visible. A 404 points at `forget`, since a local-only entry has nothing to destroy.

`co server forget`'s output also stops referring to oo-api#36 as unfinished and points at `destroy` instead.

## Tests

11 new cases in `tests/unit/test_server_commands.py` — the unregistered-but-billed row, offline degradation, the `None` vs `[]` distinction, a 500 reading as unknown, mistyped confirmation, failed delete keeping the entry, 404 pointing at `forget`.

Full unit suite: **2487 passed, 3 skipped**.

## Still open in #318 after this

Nothing on its checklist. The umbrella #309 stays open until the chain is verified end to end — `co server new` → `co deploy --to` → two deploys keeping identity and a hand-made change. That has not been run once against a real machine.