### PR TITLE
docs: require AI disclosure and an honest weakness statement on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,28 @@ Brief description of what this PR does.
 ## Related Issue
 Fixes #(issue number)
 
+## How this was written
+
+- [ ] I wrote this myself
+- [ ] AI-assisted — I reviewed every line and can explain why each change is there
+- [ ] Mostly AI-generated
+
+**Which model?** e.g. Claude Opus 4.5, GPT-5, Gemini 3 Pro — and the tool, e.g. Claude Code, Cursor, Codex.
+
+> 
+
+Model capability directly affects code quality, and knowing which one wrote this tells a reviewer where to look. It is not used to reject anything — an AI-assisted PR is as welcome as any other. It calibrates review.
+
+**If AI was involved at all, answer these in prose. "I'm not sure" is a fine answer — pretending to be sure is not.**
+
+- Which part of this are you least confident about?
+- What did you *not* verify — which paths did you never actually run?
+- If this is wrong, what breaks first?
+
+> 
+
+A PR that says *"I didn't test the Windows path and I'm unsure the retry logic is right"* gets reviewed. A PR that claims everything is correct and complete, when nobody read it, gets closed.
+
 ## Type of Change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -16,9 +38,23 @@ Fixes #(issue number)
 - Include any dependencies that were added
 
 ## Testing
-- [ ] I have tested this code locally
-- [ ] All existing tests pass
+
+Paste the actual command and its real output. The output is the evidence — a ticked box is not.
+
+```
+$ pytest tests/ -m "not real_api and not network"
+
+```
+
 - [ ] I have added tests for new functionality
+
+## Scope
+
+Which files does this touch, and why does each one need to change?
+
+> 
+
+Keep a PR to one concern. A change that spans several subsystems at once is hard to review and hard to own — and that is the most common reason we close an otherwise-correct PR. Not because the code is wrong, but because nobody can say what the resulting design is.
 
 ## Example Usage
 ```python
@@ -30,11 +66,10 @@ from connectonion import Agent
 
 ## Checklist
 - [ ] My code follows the project's code style
-- [ ] I have performed a self-review of my own code
+- [ ] I have read every line of this diff and can defend each change
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] New and existing unit tests pass locally
 - [ ] Any dependent changes have been merged and published
 
 ## Screenshots (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,36 @@ Unsure where to begin? You can start by looking through these issues:
    ```
    Then create a Pull Request on GitHub.
 
+### Using AI to write your contribution
+
+**AI-assisted contributions are welcome. Undisclosed, unreviewed ones are not.**
+
+We don't care whether a human or a model typed the diff. We care whether someone
+read it and can defend it. If AI wrote any part of your change, the PR template
+asks you for three things:
+
+**1. Which model, and which tool.** Say `Claude Opus 4.5 via Claude Code`, not
+"AI". Model capability directly affects code quality, and knowing which one wrote
+a change tells a reviewer where to look first. This is never a reason to reject a
+PR — it calibrates review.
+
+**2. What you are unsure about.** Which part is weakest, what you never actually
+ran, what breaks first if you're wrong. *"I'm not sure"* is a fine answer.
+Claiming confidence you don't have is not, and it is the fastest way to get a PR
+closed — once a reviewer finds one confident claim that isn't true, they have to
+re-check everything else you said.
+
+**3. Real test output.** Paste the command and what it printed. Green CI is not
+review: a change can pass every test and still be the wrong shape.
+
+That last point is worth stating plainly, because it is the most common reason we
+close a PR that is *not* wrong. A change that spans several subsystems at once —
+each hunk defensible, all tests passing — can still leave behind a design nobody
+owns. Fixing one bug is not a licence to reshape three modules. If your diff is
+growing past the bug, stop and open an issue about the design instead.
+
+If you can't say what's weak about your own change, you haven't reviewed it.
+
 ## Style Guidelines
 
 ### Python Style


### PR DESCRIPTION
Unreviewed AI-generated PRs are arriving, and the current template actively rewards them.

## The problem with the template we have

Every gate in it is a checkbox:

```
- [ ] I have tested this code locally
- [ ] I have performed a self-review of my own code
```

An agent ticks both at zero cost. A checkbox cannot distinguish someone who read the diff from someone who did not, so it filters nothing — it just produces a PR that *looks* reviewed.

## What this changes

Replace the parts that are cheap to fake with prose that isn't.

**1. Which model, and which tool.** Named exactly — `Claude Opus 4.5 via Claude Code`, not "AI". Capability differs enough between models to change where a reviewer looks first. Stated explicitly in the template: this is never grounds for rejection, it calibrates review.

**2. What the author is unsure about.** Which part is weakest, what they never actually ran, what breaks first if it's wrong.

`"I'm not sure"` is explicitly allowed, and that matters more than it looks — without an acceptable way to admit uncertainty, people assert confidence instead, and the question stops doing any work.

**3. Real test output**, pasted, instead of a ticked "I tested it" box. The output is the evidence.

**4. Scope**: which files this touches and why each one needs to change.

Also swaps `I have performed a self-review of my own code` for `I have read every line of this diff and can defend each change` — a claim someone has to be willing to stand behind when asked.

## Why the scope question is in here

It's doing separate work from the AI disclosure, and it addresses the most common reason a *correct-looking* PR gets closed in this repo: not wrong code, but a change that spans three subsystems at once — every hunk defensible, CI green — leaving a permission model or an interface that nobody owns. Asking up front surfaces that before the review instead of after it.

Both CONTRIBUTING.md and the template say the same thing in one line: **green CI is not review.**

## Design notes

- **No new checkbox for the AI question.** Adding one would have reproduced the exact failure being fixed.
- **Not anti-AI.** Both files open by saying AI-assisted contributions are welcome. The thing being filtered is undisclosed *unreviewed* work, not the tool.
- **Disclosed as required by this PR's own template:** written with AI assistance (Claude Opus 5 via Claude Code), reviewed line by line by a maintainer before opening. It is documentation only — no code paths, no tests. The judgement worth a second opinion is the wording, particularly whether the scope section belongs here or in its own PR.

## Scope

`.github/pull_request_template.md`, `CONTRIBUTING.md`. Documentation only. Does not touch `.github/workflows/`, so no `workflow` scope is needed to merge.
