### PR TITLE
co server new quotes the price against spendable credit, not lifetime top-ups

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -436,14 +436,24 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
 
 
 def _fetch_balance(api_key: str) -> Optional[float]:
-    """Best effort — the prompt is more useful with it and still works without."""
+    """What is actually left to spend. Best effort — the prompt is more useful
+    with it and still works without.
+
+    `balance_usd`, not `credits_usd`. The latter is lifetime top-ups and ignores
+    everything already spent, so an account that had added $315 and spent $291
+    reads as $315 of headroom. The prompt would then tell someone a $180 server
+    leaves them $135, they say yes, and the backend correctly refuses with 402 —
+    a purchase they were just told they could afford. The same confusion is what
+    openonion/oo-api#42 fixed inside the balance check; this is the display side
+    of it, and `co status` and `co auth` already read the right field.
+    """
     import requests
 
     try:
         response = requests.get(f"{API_BASE}/api/v1/auth/me",
                                 headers={"Authorization": f"Bearer {api_key}"}, timeout=15)
         if response.status_code == 200:
-            value = response.json().get("credits_usd")
+            value = response.json().get("balance_usd")
             return float(value) if value is not None else None
     except (requests.RequestException, ValueError, TypeError):
         pass

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -441,3 +441,26 @@ class TestServerNewFailureReporting:
             sc.handle_server_new("prod")
 
         assert sc.load_server("prod") is None
+
+
+def _response(status, payload=None):
+    return Mock(status_code=status, json=Mock(return_value=payload or {}))
+
+
+class TestThePriceIsQuotedAgainstSpendableCredit:
+    """`co server new` is the one command that shows someone their balance before
+    spending a large amount of it. Showing the wrong number there is worse than
+    showing none: they say yes to a purchase they cannot afford."""
+
+    def test_it_reads_balance_not_lifetime_topups(self):
+        """credits_usd ignores everything already spent — an account that added
+        $315 and spent $291 reads as $315 of headroom. The backend then correctly
+        refuses with 402, for a purchase the prompt just said they could afford."""
+        payload = {"credits_usd": 315.0, "total_cost_usd": 291.0, "balance_usd": 24.0}
+
+        with patch("requests.get", return_value=_response(200, payload)):
+            assert sc._fetch_balance("k") == 24.0
+
+    def test_a_failed_lookup_shows_no_balance_rather_than_a_wrong_one(self):
+        with patch("requests.get", return_value=_response(500)):
+            assert sc._fetch_balance("k") is None


### PR DESCRIPTION
Found while reviewing what landed across sessions. In `main` today, on the one command where the number decides whether someone spends $180.

## The bug

`_fetch_balance` reads `credits_usd` from `/api/v1/auth/me`. That field is the **sum of every top-up ever made** and ignores everything already spent. The endpoint returns all three:

```json
{ "credits_usd": 315.0, "total_cost_usd": 291.0, "balance_usd": 24.0 }
```

So an account with **$24 left** is shown as:

```
  cost          $180.00  (12 months, charged now)
  your balance  $315.00 → $135.00 after
```

They say yes. The backend does the arithmetic correctly and refuses with **402 insufficient credits** — for a purchase the prompt had just told them they could afford.

## Why it happened

This is the *display* side of the mistake openonion/oo-api#42 fixed inside the balance check. That PR's own commit message describes it exactly:

> an account that had added $315 and spent $291 reads as $315 of headroom and passes a $180 check it should fail

The server-side check was fixed. The prompt that quotes the number to the human was not.

`co status` and `co auth` both already read `balance_usd`. `co server new` was the only place in the CLI reading the wrong field — and the only one where the number gates a large discrete purchase.

## Verification

The regression test fails on unpatched code, verified by stashing the fix:

```
1 failed, 43 deselected      # test_it_reads_balance_not_lifetime_topups
```

Full unit suite: **2478 passed, 3 skipped**.

## Scope

One field, plus two tests. Deliberately not folded into #329 — that PR is green and reviewed, and this is a separate defect with its own story.