### PR TITLE
co server new refuses a name it cannot use, before charging

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -9,6 +9,7 @@ LLM-Note:
   Errors: an unreachable host fails with ssh's own message and a short timeout, never a hang | a missing requirement is named
 """
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -292,6 +293,12 @@ def handle_server_forget(name: str) -> bool:
 
 API_BASE = "https://oo.openonion.ai"
 
+# Stricter than DEPLOY_NAME_PATTERN, which allows a leading digit: a server name
+# becomes the machine's own name, and those must start with a letter. Checked
+# here so the answer arrives before the confirmation prompt rather than after the
+# charge. The backend enforces the same rule — this only saves the round trip.
+SERVER_NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]{0,37}[a-z0-9])?$")
+
 
 def _derive_ssh_public_line() -> Optional[str]:
     """The operator's SSH key, so a new server is reachable with no second secret."""
@@ -357,12 +364,12 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
     """Have a server created for you, and register it locally."""
     import requests
 
-    from .project_cmd_lib import DEPLOY_NAME_PATTERN, load_api_key
+    from .project_cmd_lib import load_api_key
 
-    if not DEPLOY_NAME_PATTERN.match(name):
+    if not SERVER_NAME_PATTERN.match(name):
         console.print(f"\n[red]Invalid server name: {name}[/red]")
         console.print("[dim]1-39 lowercase letters, digits and hyphens, starting with a "
-                      "letter or digit — it becomes a DNS label.[/dim]\n")
+                      "letter — it becomes the machine's name.[/dim]\n")
         return False
 
     if load_server(name):

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -464,3 +464,25 @@ class TestThePriceIsQuotedAgainstSpendableCredit:
     def test_a_failed_lookup_shows_no_balance_rather_than_a_wrong_one(self):
         with patch("requests.get", return_value=_response(500)):
             assert sc._fetch_balance("k") is None
+
+class TestAServerNameIsNotRewritten:
+    """The name you type is the name of the machine.
+
+    GCE instance names must start with a letter, so `co server new 1prod` used to
+    pass validation, take the $180 charge, and fail at the API. Refusing it here
+    is one rule; rewriting it into something GCE accepts would mean the name you
+    typed and the machine you got differ, and only for some names.
+    """
+
+    def test_a_leading_digit_is_refused_before_anything_is_charged(self):
+        with patch("requests.post") as post:
+            assert sc.handle_server_new("1prod") is False
+        post.assert_not_called()
+
+    def test_the_message_says_what_is_wrong(self, capsys):
+        sc.handle_server_new("1prod")
+        assert "starting with a letter" in capsys.readouterr().out
+
+    def test_ordinary_names_still_pass_the_check(self):
+        for name in ["prod", "a", "my-agent-2"]:
+            assert sc.SERVER_NAME_PATTERN.match(name), name

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -481,7 +481,10 @@ class TestAServerNameIsNotRewritten:
 
     def test_the_message_says_what_is_wrong(self, capsys):
         sc.handle_server_new("1prod")
-        assert "starting with a letter" in capsys.readouterr().out
+        # Rich wraps to the terminal width, so a phrase can arrive split across
+        # lines — collapse the whitespace before looking for it.
+        printed = " ".join(capsys.readouterr().out.split())
+        assert "starting with a letter" in printed
 
     def test_ordinary_names_still_pass_the_check(self):
         for name in ["prod", "a", "my-agent-2"]:


### PR DESCRIPTION
Pairs with openonion/oo-api#46.

A server name becomes the machine's own name, and GCE requires those to start with a letter. `co server new 1prod` passed `DEPLOY_NAME_PATTERN` (which allows a leading digit), showed the confirmation prompt quoting $180, took the charge, and only then failed at the API.

Now checked before the prompt, so the answer arrives before the money moves. The rule lives in the backend — this only saves the round trip.

`SERVER_NAME_PATTERN` is separate from `DEPLOY_NAME_PATTERN` on purpose: deploy names become DNS labels and Docker image tags, neither of which restricts the first character, and existing deployments use leading digits. Only server names have the extra constraint.

45 passed.