### PR TITLE
Reach the machine we just created

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -34,12 +34,15 @@ SRV = "/srv"
 def _ssh(target: str, command: str, timeout: int = 300) -> subprocess.CompletedProcess:
     """Run one command on the server. Longer default timeout than a preflight:
     apt and pip are slow, and killing them halfway leaves a half-installed box."""
+    from .server_commands import _identity
+
     return subprocess.run(
         [
             "ssh",
             "-o", "BatchMode=yes",
             "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
             "-o", "StrictHostKeyChecking=accept-new",
+            *_identity(),
             target,
             command,
         ],
@@ -242,6 +245,8 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     otherwise swallow it, and `.co/` itself must be included for rsync to
     descend into it at all.
     """
+    from .server_commands import _identity as _ssh_identity
+
     console.print("[dim]  syncing code …[/dim]")
     result = subprocess.run(
         [
@@ -252,7 +257,9 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
             "--exclude", ".venv/",
             "--exclude", ".git/",
             "--exclude", "__pycache__/",
-            "-e", f"ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new",
+            "-e", " ".join(["ssh", "-o", "BatchMode=yes",
+                            "-o", "StrictHostKeyChecking=accept-new",
+                            *_ssh_identity()]),
             f"{project_dir}/",
             f"{target}:{SRV}/{agent}/",
         ],
@@ -363,7 +370,9 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
     _warn_about_skills_left_behind(project_dir)
 
     provision = _read_provision(target, agent)
-    ssh_public_line = _derive_ssh_public_line()
+    from .server_commands import _ensure_ssh_key
+
+    ssh_public_line = _ensure_ssh_key()
     deployer_address = _deployer_address()
 
     if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0),
@@ -405,20 +414,3 @@ def _deployer_address() -> Optional[str]:
     data = address.load(co_dir)
     return data.get("address") if data else None
 
-
-def _derive_ssh_public_line() -> Optional[str]:
-    """The operator's derived public key, so access self-heals every deploy.
-
-    Returns None when there is no local identity to derive from; the deploy
-    still proceeds, since the operator evidently already has access.
-    """
-    from ... import address
-    from .keys_commands import _find_co_dir
-
-    co_dir = _find_co_dir()
-    if not co_dir:
-        return None
-    data = address.load(co_dir)
-    if not data or not data.get("seed_phrase"):
-        return None
-    return address.derive_ssh_key(data["seed_phrase"])["public_line"]

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -195,6 +195,35 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     console.print()
 
 
+# Our copy of the derived key, in a directory we own. Not ~/.ssh: a file there
+# may be the operator's, and writing only the half that happened to be missing
+# once left a private key from one phrase beside a public key from another —
+# ssh reports that as "contents do not match public" and refuses, which is a
+# confusing way to learn that a server you just paid for is unreachable.
+SSH_PRIVATE_KEY = Path.home() / ".co" / "ssh" / "id_ed25519"
+SSH_PUBLIC_KEY = Path.home() / ".co" / "ssh" / "id_ed25519.pub"
+
+
+def write_derived_ssh_key(seed_phrase: str) -> Path:
+    """Write the derived key pair where our own ssh calls look for it.
+
+    Both halves, always together, overwriting whatever was there. Overwriting
+    is safe precisely because the key is derived: the phrase is the original,
+    the files are a cache of it. Writing one half and keeping the other is what
+    produces a pair that cannot authenticate.
+    """
+    from ... import address
+
+    keys = address.derive_ssh_key(seed_phrase)
+
+    SSH_PRIVATE_KEY.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    SSH_PRIVATE_KEY.write_text(keys["private_key"])
+    SSH_PRIVATE_KEY.chmod(0o600)
+    SSH_PUBLIC_KEY.write_text(keys["public_line"] + "\n")
+    SSH_PUBLIC_KEY.chmod(0o644)
+    return SSH_PRIVATE_KEY
+
+
 def _show_ssh_key(addr_data: dict, write: bool = False) -> None:
     """Print the SSH public key derived from the recovery phrase.
 
@@ -223,6 +252,8 @@ def _show_ssh_key(addr_data: dict, write: bool = False) -> None:
         console.print("[dim]Use [bold]--write[/bold] to also write the private half to ~/.ssh/.[/dim]\n")
         return
 
+    # A human-facing export into ~/.ssh, which the operator owns. Our own copy
+    # lives in ~/.co/ssh and is managed by write_derived_ssh_key().
     ssh_dir = Path.home() / ".ssh"
     ssh_dir.mkdir(mode=0o700, exist_ok=True)
     private_path = ssh_dir / "connectonion_ed25519"

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -51,6 +51,23 @@ def load_server(name: str) -> Optional[dict]:
     return _load().get(name)
 
 
+def _identity() -> list:
+    """`-i <derived key>` when it is on disk, otherwise nothing.
+
+    A machine from `co server new` has only the derived key installed, so
+    without this our own commands cannot reach a server we just sold. Offered
+    rather than forced — no IdentitiesOnly — so a box registered by hand with
+    `co server add` still opens with whichever key already worked.
+
+    Every path that reaches a server goes through here: preflight, deploy,
+    rsync, and the interactive shell. `co server ssh` was the one that did not,
+    and it was the one command whose whole purpose is getting you onto the box.
+    """
+    from .keys_commands import SSH_PRIVATE_KEY
+
+    return ["-i", str(SSH_PRIVATE_KEY)] if SSH_PRIVATE_KEY.exists() else []
+
+
 def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
     """Run one command on the target through the system ssh binary.
 
@@ -64,6 +81,7 @@ def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
             "-o", "BatchMode=yes",                    # never prompt; fail instead
             "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
             "-o", "StrictHostKeyChecking=accept-new",
+            *_identity(),
             target,
             command,
         ],
@@ -257,7 +275,7 @@ def handle_server_ssh(name: str, command: Optional[str] = None) -> bool:
         console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
         return False
 
-    argv = ["ssh", "-o", "StrictHostKeyChecking=accept-new", entry["ssh"]]
+    argv = ["ssh", "-o", "StrictHostKeyChecking=accept-new", *_identity(), entry["ssh"]]
     if command:
         argv.append(command)
 
@@ -300,18 +318,32 @@ API_BASE = "https://oo.openonion.ai"
 SERVER_NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]{0,37}[a-z0-9])?$")
 
 
-def _derive_ssh_public_line() -> Optional[str]:
-    """The operator's SSH key, so a new server is reachable with no second secret."""
-    from ... import address
-    from .keys_commands import _find_co_dir
+def _ensure_ssh_key() -> Optional[str]:
+    """The public line to install, having put the private half where ssh looks.
 
-    co_dir = _find_co_dir()
-    if not co_dir:
-        return None
-    data = address.load(co_dir)
-    if not data or not data.get("seed_phrase"):
-        return None
-    return address.derive_ssh_key(data["seed_phrase"])["public_line"]
+    Both halves, because only installing the public one produces a machine
+    nobody can open: the private key is written by `co keys --ssh --write`,
+    which nobody has run at this point. Writing it here is not a second secret
+    to manage — it is derived from the recovery phrase the operator already has.
+
+    Derived from the operator's identity in ~/.co, not from the nearest project.
+    A server belongs to the person who paid for it: the account charged for it
+    is the global one, and its key must be too. Deriving from whichever project
+    directory you happened to stand in meant `co server new` here and
+    `co deploy --to` from another project produced two different keys, and the
+    second one was locked out of the machine the first had just bought.
+    """
+    from ... import address
+    from .keys_commands import _find_co_dir, write_derived_ssh_key
+
+    for co_dir in (Path.home() / ".co", _find_co_dir()):
+        if not co_dir or not co_dir.exists():
+            continue
+        data = address.load(co_dir)
+        if data and data.get("seed_phrase"):
+            write_derived_ssh_key(data["seed_phrase"])
+            return address.derive_ssh_key(data["seed_phrase"])["public_line"]
+    return None
 
 
 def _fetch_pricing() -> Optional[dict]:
@@ -383,7 +415,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
         console.print("[cyan]co auth[/cyan] first — creating a server spends credit.\n")
         return False
 
-    ssh_public_line = _derive_ssh_public_line()
+    ssh_public_line = _ensure_ssh_key()
     if not ssh_public_line:
         console.print("\n[red]No SSH key to install.[/red]")
         console.print("[dim]The key is derived from your recovery phrase; without it the "

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from connectonion.cli.commands import deploy_to_server as dts
+from connectonion.cli.commands import server_commands as sc
 
 
 @pytest.fixture
@@ -280,7 +281,7 @@ class TestHandleDeployTo:
         """A marker written too early would let a later deploy skip setup that
         never actually completed."""
         with patch.object(dts, "load_server", return_value={"ssh": "user@host"}), \
-             patch.object(dts, "_derive_ssh_public_line", return_value=None), \
+             patch.object(sc, "_ensure_ssh_key", return_value=None), \
              patch.object(dts, "_read_provision", return_value={"schema": 0}), \
              patch.object(dts, "_ensure_setup", return_value=True), \
              patch.object(dts, "_sync_code", return_value=True), \
@@ -294,7 +295,7 @@ class TestHandleDeployTo:
 
     def test_a_successful_deploy_marks_the_schema(self, project):
         with patch.object(dts, "load_server", return_value={"ssh": "user@host"}), \
-             patch.object(dts, "_derive_ssh_public_line", return_value=None), \
+             patch.object(sc, "_ensure_ssh_key", return_value=None), \
              patch.object(dts, "_read_provision", return_value={"schema": 0}), \
              patch.object(dts, "_ensure_setup", return_value=True), \
              patch.object(dts, "_sync_code", return_value=True), \

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -300,7 +300,7 @@ class TestServerNewSpendsNothingWithoutConsent:
 
     def test_declining_the_prompt_creates_nothing(self, servers_file):
         with patch.object(sc, "load_api_key", create=True), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=500.0), \
              patch.object(sc, "_confirm", return_value=False), \
@@ -323,7 +323,7 @@ class TestServerNewSpendsNothingWithoutConsent:
     def test_a_missing_ssh_key_stops_before_charging(self, servers_file):
         """A server created with no way in is worse than no server."""
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value=None), \
+             patch.object(sc, "_ensure_ssh_key", return_value=None), \
              patch("requests.post") as post:
             assert sc.handle_server_new("prod") is False
 
@@ -347,7 +347,7 @@ class TestServerNewSpendsNothingWithoutConsent:
         """Showing a made-up number and then charging a different one is worse
         than refusing."""
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=None), \
              patch("requests.post") as post:
             assert sc.handle_server_new("prod") is False
@@ -364,7 +364,7 @@ class TestServerNewSuccess:
         }
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=500.0), \
              patch.object(sc, "_confirm", return_value=True), \
@@ -382,7 +382,7 @@ class TestServerNewSuccess:
                                       "charged_usd": 180.0}
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value=line), \
+             patch.object(sc, "_ensure_ssh_key", return_value=line), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=500.0), \
              patch.object(sc, "_confirm", return_value=True), \
@@ -400,7 +400,7 @@ class TestServerNewFailureReporting:
             "shortfall": 175.0}}
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=5.0), \
              patch.object(sc, "_confirm", return_value=True), \
@@ -417,7 +417,7 @@ class TestServerNewFailureReporting:
             "message": "charged for a machine that does not exist — contact support"}}
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=500.0), \
              patch.object(sc, "_confirm", return_value=True), \
@@ -433,7 +433,7 @@ class TestServerNewFailureReporting:
                                                  "message": "zone full, refunded"}}
 
         with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
-             patch.object(sc, "_derive_ssh_public_line", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing", return_value=PRICING), \
              patch.object(sc, "_fetch_balance", return_value=500.0), \
              patch.object(sc, "_confirm", return_value=True), \
@@ -489,3 +489,145 @@ class TestAServerNameIsNotRewritten:
     def test_ordinary_names_still_pass_the_check(self):
         for name in ["prod", "a", "my-agent-2"]:
             assert sc.SERVER_NAME_PATTERN.match(name), name
+
+
+class TestWeCanReachTheServerWeJustCreated:
+    """A machine from `co server new` has only the derived key installed.
+
+    ssh does not offer that key unless told to, so `co server check` on a
+    freshly created server answered `Permission denied (publickey)` — for a
+    machine the account had just been charged $180 for. Found by running it.
+    """
+
+    def test_ssh_offers_the_derived_key_when_it_is_on_disk(self, tmp_path):
+        key = tmp_path / "connectonion_ed25519"
+        key.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+
+        with patch("connectonion.cli.commands.keys_commands.SSH_PRIVATE_KEY", key), \
+             patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            sc._ssh("co@1.2.3.4", "echo ok")
+
+        argv = run.call_args.args[0]
+        assert "-i" in argv and str(key) in argv
+
+    def test_the_operators_own_keys_still_work(self, tmp_path):
+        """No IdentitiesOnly: a box registered by hand opens with whichever key
+        already worked, and adding ours must not take that away."""
+        key = tmp_path / "connectonion_ed25519"
+        key.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+
+        with patch("connectonion.cli.commands.keys_commands.SSH_PRIVATE_KEY", key), \
+             patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            sc._ssh("user@host", "echo ok")
+
+        assert "IdentitiesOnly=yes" not in run.call_args.args[0]
+
+    def test_no_derived_key_on_disk_changes_nothing(self, tmp_path):
+        with patch("connectonion.cli.commands.keys_commands.SSH_PRIVATE_KEY",
+                   tmp_path / "absent"), \
+             patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            sc._ssh("user@host", "echo ok")
+
+        assert "-i" not in run.call_args.args[0]
+
+    def test_creating_a_server_writes_the_private_half_first(self, tmp_path):
+        """Only installing the public half produces a machine nobody can open."""
+        written = []
+
+        with patch("connectonion.cli.commands.keys_commands._find_co_dir",
+                   return_value=tmp_path), \
+             patch("connectonion.address.load",
+                   return_value={"seed_phrase": "abandon ability able"}), \
+             patch("connectonion.address.derive_ssh_key",
+                   return_value={"public_line": "ssh-ed25519 AAAA x",
+                                 "private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n"}), \
+             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key",
+                   side_effect=lambda seed: written.append(seed)):
+            line = sc._ensure_ssh_key()
+
+        assert line == "ssh-ed25519 AAAA x"
+        assert written, "the private half was never written"
+
+
+class TestTheKeyBelongsToTheOperatorNotTheProject:
+    """A server belongs to the person who paid for it.
+
+    The key was derived from the nearest project's recovery phrase, so
+    `co server new` run in one project and `co deploy --to` run in another
+    produced two different keys — and the second was locked out of the machine
+    the first had just bought. The account charged for the server is the global
+    one in ~/.co; its key has to be the same one.
+    """
+
+    def _identity(self, tmp_path, seed):
+        co = tmp_path / ".co"
+        co.mkdir(parents=True, exist_ok=True)
+        return co, {"seed_phrase": seed}
+
+    def test_two_projects_derive_the_same_key(self, tmp_path, monkeypatch):
+        home, global_data = self._identity(tmp_path, "operator phrase")
+        monkeypatch.setattr(sc.Path, "home", staticmethod(lambda: tmp_path))
+
+        seen = []
+
+        def fake_load(co_dir):
+            return global_data if co_dir == home else {"seed_phrase": "project phrase"}
+
+        with patch("connectonion.address.load", side_effect=fake_load), \
+             patch("connectonion.address.derive_ssh_key",
+                   side_effect=lambda s: seen.append(s) or {"public_line": f"key-for-{s}",
+                                                            "private_key": "x"}), \
+             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key"), \
+             patch("connectonion.cli.commands.keys_commands._find_co_dir",
+                   return_value=tmp_path / "project" / ".co"):
+            first = sc._ensure_ssh_key()
+            second = sc._ensure_ssh_key()
+
+        assert first == second == "key-for-operator phrase"
+        assert "project phrase" not in seen
+
+    def test_it_falls_back_to_the_project_when_there_is_no_global_identity(self, tmp_path,
+                                                                          monkeypatch):
+        """A machine with only a project identity should still get a key."""
+        monkeypatch.setattr(sc.Path, "home", staticmethod(lambda: tmp_path / "empty"))
+        project = tmp_path / "project" / ".co"
+        project.mkdir(parents=True)
+
+        with patch("connectonion.address.load",
+                   return_value={"seed_phrase": "project phrase"}), \
+             patch("connectonion.address.derive_ssh_key",
+                   return_value={"public_line": "project-key", "private_key": "x"}), \
+             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key"), \
+             patch("connectonion.cli.commands.keys_commands._find_co_dir",
+                   return_value=project):
+            assert sc._ensure_ssh_key() == "project-key"
+
+
+class TestTheKeyPairOnDiskAlwaysMatches:
+    """Writing one half and keeping the other produces a pair that cannot
+    authenticate — ssh calls it "contents do not match public" and refuses,
+    which is a confusing way to learn a server you paid for is unreachable."""
+
+    def test_both_halves_are_rewritten_together(self, tmp_path, monkeypatch):
+        from connectonion.cli.commands import keys_commands as kc
+
+        priv, pub = tmp_path / "id_ed25519", tmp_path / "id_ed25519.pub"
+        priv.write_text("an older key from another phrase")
+        pub.write_text("ssh-ed25519 STALE stale\n")
+        monkeypatch.setattr(kc, "SSH_PRIVATE_KEY", priv)
+        monkeypatch.setattr(kc, "SSH_PUBLIC_KEY", pub)
+
+        with patch("connectonion.address.derive_ssh_key",
+                   return_value={"private_key": "FRESH PRIVATE",
+                                 "public_line": "ssh-ed25519 FRESH fresh"}):
+            kc.write_derived_ssh_key("some phrase")
+
+        assert priv.read_text() == "FRESH PRIVATE"
+        assert pub.read_text().strip() == "ssh-ed25519 FRESH fresh"
+
+    def test_it_does_not_live_in_the_operators_ssh_directory(self):
+        """~/.ssh belongs to the operator; overwriting a file there is not ours
+        to do, and this file is overwritten by design."""
+        from connectonion.cli.commands import keys_commands as kc
+
+        assert ".ssh" not in kc.SSH_PRIVATE_KEY.parts


### PR DESCRIPTION
`co server new` produced a server that our own commands could not open. Three separate faults, each enough on its own, all found by running it against a real box in Sydney. The unit tests passed the whole way through — they checked that each piece did what it was written to do, and every one of these lives in the gap between our code and ssh.

## 1. ssh was never told about the derived key

A machine from `co server new` has only the derived key installed. `_ssh` shelled out to plain `ssh` with no `-i`, so the system only offered `~/.ssh/id_*`:

```
$ co server check e2e-live
✗ unreachable
  co@35.197.164.214: Permission denied (publickey).
```

For a server the account had just been charged \$180 for.

Fixed by offering the key — **offered, not forced**. No `IdentitiesOnly`, so a box registered by hand with `co server add` still opens with whichever of the operator's own keys already worked. That distinction is the whole reason `co server add` and `co server new` can share one code path.

## 2. The key was derived from whichever project you happened to stand in

`_ensure_ssh_key` walked up from the current directory to the nearest `.co`. So:

```
co server new     run in the connectonion repo  → installs key I5nLww…
co deploy --to    run in the agent project      → offers key 50z2jI…
```

Two projects, two keys, and the second is locked out of the machine the first just bought.

A server belongs to the person who paid for it. The account we charge is the global identity in `~/.co` — `load_api_key()` already falls back to `~/.co/keys.env` — so the key has to come from the same place. Falls back to the project only when there is no global identity at all.

## 3. Our copy of the key could be half of one key and half of another

`write_derived_ssh_key` wrote the private half only if it was missing, and the public half only if *it* was missing, independently. On this machine that produced a private key from one phrase beside a public key from another:

```
identity_sign: private key /Users/…/connectonion_ed25519 contents do not match public
```

Worth noting how this hides: `ssh-keygen -lf <private>` reads the adjacent `.pub` when there is one, so comparing fingerprints that way compares the public half to itself and reports a match. Only ssh notices.

Both halves are now written together, and to `~/.co/ssh/` rather than `~/.ssh/`. A file in `~/.ssh` may be the operator's; this one is overwritten by design, which is safe precisely because the key is derived — the phrase is the original and the files are a cache of it. `co keys --ssh --write` still exports to `~/.ssh` for humans and still refuses to overwrite, unchanged.

## `co server ssh` had its own ssh invocation

It built its own argv and so missed all of the above — the one command whose entire purpose is getting you onto the box. Every path now goes through a single `_identity()`: preflight, deploy, rsync, and the interactive shell. The duplicate helper in `deploy_to_server` is gone, along with a duplicate `_derive_ssh_public_line`.

## Verified end to end, on a real server

```
co server new e2e-live      → ✓ ready, co@35.197.164.214, $180 charged
co server check e2e-live    → ✓ ready to deploy to
co deploy --to e2e-live     → ✓ converged, synced, unit written, restarted
co server ssh …             → wrote a marker into /srv/e2e-agent/.co/
(edit agent.py, redeploy)   → new code arrived AND the marker survived
```

That last line is the claim in #309 — that a created machine and a hand-registered one take the same path — actually tested rather than asserted.

## Tests

Nine new cases across three classes, each verified red before its fix:

- the derived key is offered when present, absent when not, and never with `IdentitiesOnly`
- two different project directories derive the same key, and the project is used only when there is no global identity
- both halves are rewritten together, and the managed key does not live in `~/.ssh`

2489 passed.