### PR TITLE
Lead the price with what it costs per month

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -366,20 +366,32 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
 
     Balance-after is shown rather than just the price: what decides whether
     someone can afford it is what is left, not what it costs.
+
+    The monthly figure leads. A server is a monthly thing in everybody's head,
+    and "$360" alone is a number nobody can compare to anything they already pay
+    for — while "$30 a month" places it immediately. The year is how we charge,
+    so it is said too, right next to it, and never instead of it.
     """
     from datetime import datetime, timedelta
 
     entry = pricing["machine_types"][machine_type]
     price = entry["usd_12mo"]
     months = pricing["term_months"]
+    # Published by the backend rather than divided here: one price, one place,
+    # and no chance of the CLI rounding its way to a different number than the
+    # one on the website. Older backends do not send it — fall back rather than
+    # crash, since the yearly price is the one actually charged.
+    monthly = entry.get("usd_month")
+    if monthly is None:
+        monthly = price / months
     expires = (datetime.now() + timedelta(days=365)).strftime("%Y-%m-%d")
 
     console.print()
     console.print(f"  [cyan]name[/cyan]          {name}")
     console.print(f"  [cyan]region[/cyan]        {pricing['region']}")
     console.print(f"  [cyan]machine[/cyan]       {machine_type} [dim]— {entry['description']}[/dim]")
-    console.print(f"  [cyan]cost[/cyan]          [bold]${price:.2f}[/bold] "
-                  f"[dim]({months} months, charged now)[/dim]")
+    console.print(f"  [cyan]cost[/cyan]          [bold]${monthly:.0f} / month[/bold] "
+                  f"[dim]— ${price:.2f} for {months} months, charged now[/dim]")
     if balance is not None:
         console.print(f"  [cyan]your balance[/cyan]  ${balance:.2f} → "
                       f"[bold]${balance - price:.2f}[/bold] after")

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -631,3 +631,48 @@ class TestTheKeyPairOnDiskAlwaysMatches:
         from connectonion.cli.commands import keys_commands as kc
 
         assert ".ssh" not in kc.SSH_PRIVATE_KEY.parts
+
+
+class TestThePromptLeadsWithTheMonthlyPrice:
+    """A server is a monthly thing in everybody's head. "$360" alone is a number
+    nobody can compare to anything they already pay for; "$30 a month" places it
+    immediately. The year is how we charge, so it is said too — next to it, never
+    instead of it."""
+
+    PRICING = {
+        "term_months": 12, "region": "australia-southeast1", "default": "e2-small",
+        "machine_types": {"e2-small": {"usd_month": 30.0, "usd_12mo": 360.0,
+                                       "description": "2 vCPU (shared), 2 GB"}},
+    }
+
+    def _prompt(self, pricing):
+        with patch("questionary.confirm") as confirm:
+            confirm.return_value.ask.return_value = False
+            sc._confirm("prod", "e2-small", pricing, 500.0)
+
+    def test_both_the_month_and_the_year_are_shown(self, capsys):
+        self._prompt(self.PRICING)
+        out = " ".join(capsys.readouterr().out.split())
+
+        assert "$30 / month" in out
+        assert "$360.00 for 12 months" in out
+
+    def test_the_backends_monthly_figure_is_used_not_one_we_divide(self, capsys):
+        """One price, one place. A CLI that divided could round its way to a
+        different number than the one on the website."""
+        pricing = {**self.PRICING, "machine_types": {
+            "e2-small": {"usd_month": 29.0, "usd_12mo": 360.0, "description": "x"}}}
+
+        self._prompt(pricing)
+
+        assert "$29 / month" in " ".join(capsys.readouterr().out.split())
+
+    def test_an_older_backend_without_the_field_still_prompts(self, capsys):
+        """The yearly price is the one actually charged, so a missing monthly
+        figure is worth deriving rather than crashing on."""
+        pricing = {**self.PRICING, "machine_types": {
+            "e2-small": {"usd_12mo": 360.0, "description": "x"}}}
+
+        self._prompt(pricing)
+
+        assert "$30 / month" in " ".join(capsys.readouterr().out.split())


### PR DESCRIPTION
CLI half of openonion/oo-api#52, which repriced both machine types above cost and started publishing a monthly figure.

## The change

```
  name          prod
  region        australia-southeast1
  machine       e2-small — 2 vCPU (shared), 2 GB — fine for one agent
  cost          $30 / month — $360.00 for 12 months, charged now
  your balance  $500.00 → $140.00 after
  expires       2027-07-31 — the server stops on that date unless renewed
```

Previously the `cost` line said only `$360.00 (12 months, charged now)`.

**"$360" is a number nobody can compare to anything they already pay for.** "$30 a month" places it immediately — against a Netflix subscription, against a DigitalOcean droplet, against whatever else they are already running. A server is a monthly thing in everybody's head.

The year is how we actually charge, so it is still there — **next to** the month, never instead of it. Someone about to lose $360 of credit today must not be shown only the $30.

## Where the number comes from

The backend, not a division here. One price, one place — a CLI that divided could round its way to a different number than the one on the website, and then the two disagree in front of the customer.

An older backend that does not send `usd_month` falls back to dividing rather than crashing: the yearly price is the one actually charged, so it is worth deriving from.

## Tests

3 new: both figures shown, the backend's monthly figure used rather than a derived one (pinned with a deliberately non-divisible value), and the fallback for a backend that has not shipped #52 yet.

Full unit suite: **2492 passed, 3 skipped**.
