### PR TITLE
Document co server, deploying onto it, and the AGENT_PROFILE frame

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1045,6 +1045,23 @@ Agent URL: https://my-agent-abc123.agents.openonion.ai
 
 > **Beta**: This feature is in beta. See [Deploy Guide](../network/deploy.md) for details.
 
+#### `co server` - Servers You Own
+
+A server a deploy goes *onto*, so the agent keeps its address, its logs and any fix you
+made by hand — and answers on its own https hostname.
+
+```bash
+co server new prod                       # have one created ($30/month, charged yearly)
+co server add prod --ssh you@1.2.3.4     # or register one you already have
+co server ls                             # reconciled against what you are billed for
+co deploy --to prod
+```
+
+`co server forget` drops the local entry and the machine keeps billing;
+`co server destroy` tears it down and refunds the unused term. Two commands on purpose.
+
+See [server.md](server.md).
+
 ---
 
 ## Command Reference Summary
@@ -1060,6 +1077,7 @@ Agent URL: https://my-agent-abc123.agents.openonion.ai
 | `co auth` | Get managed keys | No | ✅ Yes |
 | `co status` | Check balance and deployments | No | ✅ Yes |
 | `co deploy` | Deploy to cloud | No | ✅ Yes |
+| `co server` | Servers you own, and deploy targets | No | ✅ Yes (except `destroy`) |
 | `co reset` | Reset account | Yes | ⚠️ Destructive |
 | `co doctor` | Diagnose issues | No | ✅ Yes |
 | `co browser` | Browser command (local) | No | ✅ Yes |

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -1,0 +1,166 @@
+# co server
+
+A server you own, that a deploy goes *onto* — not a container that is rebuilt and
+thrown away each time.
+
+```bash
+co server new prod                       # have one created for you
+co server add prod --ssh you@1.2.3.4     # or register one you already have
+co server ls                             # what you can deploy to
+co server check prod                     # preflight
+co server ssh prod                        # a shell on it
+co deploy --to prod                       # put an agent there
+```
+
+---
+
+## Why a server rather than a container
+
+The cloud path (`co deploy`) rebuilds an image and starts a fresh container every
+time. That is fine until you want any of this:
+
+- **an identity that survives.** A redeploy used to mint a new agent address, which
+  changed the agent's email and voided every trust relationship other agents had
+  granted it.
+- **history that is continuous.** `.co/logs/` and `.co/evals/` are what a dashboard
+  shows about the past.
+- **a fix you made by hand at 2am to still be there tomorrow.** With an image as the
+  source of truth it is discarded on the next deploy.
+
+On your own server the deploy syncs code and restarts a systemd unit. `.co/` is never
+touched, so all three hold.
+
+---
+
+## co server new
+
+Has a server created for you, and registers it locally so you never type an IP.
+
+```
+$ co server new prod
+
+  name          prod
+  region        australia-southeast1
+  machine       e2-small — 2 vCPU (shared), 2 GB — fine for one agent
+  cost          $30 / month — $360.00 for 12 months, charged now
+  your balance  $500.00 → $140.00 after
+  expires       2027-07-31 — the server stops on that date unless renewed
+
+? Create it? (y/N)
+```
+
+**This is the only `co` command that spends a large discrete amount.** Everything else
+is free or costs fractions of a cent, so the prompt says the price, what your balance
+becomes, and when the term ends. `--yes` skips it; nothing else does.
+
+The machine is created in **Sydney**, boots Ubuntu 24.04, and carries the SSH key
+derived from your recovery phrase — nothing else is installed. The first
+`co deploy --to` sets up python, the venv, systemd and Caddy.
+
+| Flag | |
+|---|---|
+| `--machine e2-medium` | 4 GB, for browser agents |
+| `--yes` | skip the price confirmation |
+
+---
+
+## co server add
+
+Registers a machine you already have. Takes an **ssh target, not a credential** — we
+shell out to `ssh`, so your agent and `~/.ssh/config` do the work.
+
+```bash
+co server add pi --ssh pi@192.168.1.50
+```
+
+Everything downstream is the same code as a server we created. The one difference: a
+hand-registered machine has no hostname of ours, so the deploy sets up no https for it.
+
+---
+
+## co server ls
+
+What you can deploy to — reconciled against what you are **billed** for.
+
+```
+NAME     TARGET          LAST CHECK            BILLING
+prod     co@1.2.3.4      ok                    until 2027-07-31
+ghost    co@5.6.7.8      not registered here   until 2027-07-31
+
+1 server(s) you are billed for are not registered on this machine: ghost
+  co server add <name> --ssh <target>   to use one from here
+  co server destroy <name>              to stop paying for one
+```
+
+`~/.co/servers.yaml` is a cache; the backend is the ledger. The row that only the
+backend can produce — **billed for, not registered here** — is a server you are paying
+for that `co` would otherwise never show you: created on another laptop, or dropped
+with `co server forget`.
+
+Offline or unauthenticated, the BILLING column is omitted and your local targets still
+list. "We could not ask" and "you own nothing" are different answers and are never
+collapsed.
+
+---
+
+## co server check
+
+Preflight, so "it doesn't work on my box" stays answerable. Ubuntu 24.04, python
+3.11+, systemd, enough disk — and it names the requirement that failed rather than
+reporting a generic failure.
+
+---
+
+## co server ssh
+
+```bash
+co server ssh prod                                   # a shell
+co server ssh prod 'journalctl -u myagent -f'        # logs
+co server ssh prod 'systemctl status myagent'
+```
+
+---
+
+## forget vs destroy
+
+Two commands on purpose, because one of them stops the billing and the other does not.
+
+| | what it does | the machine |
+|---|---|---|
+| `co server forget prod` | drops the local entry | keeps running, keeps billing |
+| `co server destroy prod` | tears it down | gone, and the unused term is refunded |
+
+A single "remove" would mean one of two failures depending on which it implemented:
+you believe you stopped paying and are billed for a year, or you tidy your config and
+delete production.
+
+`destroy` asks you to **type the name back**, not y/N — a reflex "y" is exactly how
+the second one happens. The refund is the unused part of the term, credited back:
+
+```
+$ co server destroy prod
+✓ prod destroyed
+$150.41 of $360.00 refunded to your credit — the unused part of the term.
+```
+
+---
+
+## What lives on the server
+
+```
+/srv/<agent>/            code, rsynced each deploy
+/srv/<agent>/.venv       dependencies
+/srv/<agent>/.co/        identity, logs, evals — a deploy never touches this
+/etc/systemd/system/<agent>.service
+/etc/caddy/Caddyfile     the hostname, proxied to the agent
+```
+
+`systemctl` gives what the container was for: `Restart=always` for crash recovery,
+`enable` for start-on-boot, journald for logs.
+
+---
+
+## See also
+
+- [deploy.md](../network/deploy.md) — the three ways to deploy
+- [host.md](../network/host.md) — what `host()` does

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -6,12 +6,17 @@ Get your agent running in production.
 
 ---
 
-## Two Options
+## Three Options
 
-| Option | Best For |
-|--------|----------|
-| **`co deploy`** | Quick deployment, managed hosting |
-| **Self-host** | Full control, your own infrastructure |
+| Option | Best For | Identity survives a redeploy |
+|--------|----------|------------------------------|
+| **`co deploy`** | Quick deployment, managed hosting | no — a fresh container each time |
+| **`co deploy --to <server>`** | A server you own, that you can ssh into | yes |
+| **Self-host** | Full control, your own infrastructure | yours to arrange |
+
+Pick the middle one when you want the agent to keep its address, its logs and any fix
+you made by hand — and to answer on `https://<name>.agents.openonion.ai`. See
+[co server](../cli/server.md).
 
 ---
 
@@ -261,6 +266,74 @@ curl -X POST https://my-agent-0x7a9f3b2c.agents.openonion.ai/input \
 
 ---
 
+## co deploy --to (a server you own)
+
+```bash
+co server new prod          # or: co server add prod --ssh you@1.2.3.4
+co deploy --to prod
+```
+
+```
+myagent → prod (co@1.2.3.4)
+  converging server …
+  syncing code …
+  installing dependencies …
+  configuring https …
+  restarting …
+
+✓ myagent is running on prod
+  https://prod-abc.agents.openonion.ai — the certificate lands within a minute
+  logs:  co server ssh prod 'journalctl -u myagent -f'
+  state: /srv/myagent/.co/  — untouched by deploys
+```
+
+### What a deploy does
+
+```
+ensure(setup) → sync code → install deps if changed → write unit if changed → restart
+```
+
+`ensure(setup)` is idempotent and a no-op once the server is converged, which is why a
+machine registered by hand needs no separate path: its **first** deploy is the one that
+sets it up. A marker at `/srv/<agent>/.co/provision.json` is read in one ssh call to
+decide whether to spend seconds or tens of seconds.
+
+### What survives, and what does not
+
+The rsync carries the project tree and **excludes `.co/`**, with one exception:
+
+| | |
+|---|---|
+| `.co/keys/` | **kept** — the agent's address, so its email and every trust relationship hold |
+| `.co/logs/`, `.co/evals/` | **kept** — history a dashboard can actually show |
+| `.co/skills/` | **synced** — skills are what the agent *is*, not state it accumulated |
+| everything else in the project | synced, with `--delete`, so a deleted file goes away |
+
+A change you make over ssh survives the next deploy, as long as it is not a file the
+sync owns.
+
+### https and the hostname
+
+A server created by `co server new` gets a DNS record of its own, and the deploy
+installs Caddy in front of the agent. `AGENT_PUBLIC_DOMAIN` goes into the systemd unit
+so the agent announces `https://<hostname>` to the relay rather than an IP and a port
+that is closed — without it clients probe an endpoint that can never answer.
+
+A hand-registered machine gets no https: there is no name of ours to get a certificate
+for, and inventing one would fail the challenge rather than fail honestly.
+
+One agent per hostname — there is one name and one `:443`.
+
+### Admin
+
+The deploy writes your **public address** into the agent's `.co/admins.txt`, every
+time. A deployed agent generates its own keypair, and admin actions are gated on it,
+so without this nobody could ever administer it — the only account that could grant
+admin is the one nobody can sign as. Same idea as `ssh-copy-id`, one layer up: nothing
+secret travels, and revoking is deleting a line.
+
+---
+
 ## Self-Host
 
 Deploy to your own VPS or infrastructure using `host()`.
@@ -298,6 +371,12 @@ For full API reference, see [host()](host.md).
 
 ## When to Use Which
 
-**Use `co deploy`:** Fastest path to production, no infrastructure management.
+**Use `co deploy`:** Fastest path to production, no infrastructure management. Right
+until you need the agent to keep its address across deploys.
+
+**Use `co deploy --to <server>`:** The agent keeps its identity, its logs and any fix
+you made by hand, and it answers on its own https hostname. You can `ssh` in. Costs a
+server ($30/month for the small one, charged yearly) — or nothing, if you point it at a
+machine you already have.
 
 **Use self-hosting:** Full control, custom domains, compliance requirements.

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -328,6 +328,40 @@ Keep-alive. Sent every 30 seconds.
 | `plan_review` | Plan ready for review |
 | `compact` | Context compaction |
 
+#### AGENT_PROFILE
+
+What the agent is — name, model, tools, **every** skill, and the account balance for
+managed-key agents. Sent once, right after `CONNECTED`.
+
+```json
+{
+  "type": "AGENT_PROFILE",
+  "session_id": "550e8400-...",
+  "name": "my-agent",
+  "address": "0x3d4017c3...",
+  "model": "co/gemini-3.6-flash",
+  "tools": ["search", "shell"],
+  "skills": [
+    {"name": "co-browser", "description": "drive a browser", "location": "project"},
+    {"name": "my-notes", "description": "personal", "location": "user"}
+  ],
+  "balance_usd": 25.34
+}
+```
+
+**This is the authenticated answer, and it is deliberately larger than the public one.**
+`GET /info` and the relay directory are reachable by anyone and publish only skills from
+the project tree (`project`, `claude-project`); the operator's personal skills in
+`~/.co/skills` and `~/.claude/skills` stay private there. This frame arrives past the
+signature check and the trust gate, so it carries all of them.
+
+A client that has not connected — or has not passed onboarding — should show the public
+answer and not treat it as an incomplete version of this one. It is what that viewer is
+entitled to see.
+
+TypeScript SDK: `agent.profile` and `useAgentForHuman().profile`, `null` until the frame
+lands.
+
 #### DASHBOARD_SNAPSHOT
 
 The agent's `dashboard.html` — its Home page — for the client to render beside the


### PR DESCRIPTION
Three things shipped with no documentation at all.

## `co server` and `co deploy --to` — zero mentions in `docs/`

```
$ grep -rc "co server\|--to" docs/
0
```

The entire one-server-per-agent path was undocumented, **including the command that spends $360**.

- **`docs/cli/server.md`** (new) — the command group, and the parts that are actually surprising: why `forget` and `destroy` are two commands rather than one, why `co server ls` reconciles against the backend at all, what survives a deploy and what does not, why a hand-registered machine deliberately gets no https.
- **`docs/network/deploy.md`** — "Two Options" is now three. The comparison table gains the column that decides it: *does the identity survive a redeploy*.
- **`docs/cli/README.md`** — index row and a section.

## `AGENT_PROFILE` — merged in #323, documented nowhere

Added to `docs/network/websocket-protocol.md` beside `DASHBOARD_SNAPSHOT`.

The paragraph that matters is the one about what it is *not*: it is easy to read this frame as "the complete `/info`", when the point is the opposite. The **public answer is narrower on purpose**, and a client that has not passed the trust gate should render that rather than treat it as a partial version of this one.

## Docs-only

No code touched. Full unit suite run twice: **2489 passed, 3 skipped**. (One earlier run had a single failure under random ordering — `test_move_path_is_curved_not_straight`, the known flake tracked in #287.)

## Not covered here

- `docs-site/` and `wiki/` are separate repos and are not updated by this PR.
- The `docs/network/deploy.md` cloud section still describes the container path as it is today; the state-mount fix (openonion/oo-api#37) changed its behaviour and that paragraph could say so. Worth a follow-up, not a reason to hold this.