### PR TITLE
A crash loop is not a successful deploy

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -28,6 +28,11 @@ console = Console()
 # to rsync and restart.
 PROVISION_SCHEMA = 2
 
+# Long enough for an agent that dies on import to have done so. An agent that is
+# merely slow to become useful is still "active" and still has zero automatic
+# restarts, so this does not punish a slow start.
+STARTUP_GRACE_SECONDS = 8
+
 SRV = "/srv"
 
 
@@ -409,10 +414,23 @@ def _restart(target: str, agent: str) -> bool:
             console.print(f"  [dim]{line}[/dim]")
         return False
 
-    active = _ssh(target, f"systemctl is-active {agent}", timeout=60)
-    if active.stdout.strip() != "active":
-        console.print(f"[red]{agent} is not running after restart "
-                      f"({active.stdout.strip() or 'unknown'}).[/red]")
+    # Asking immediately is not a test. Restart=always means a unit that dies on
+    # import is "active" for the moment right after the restart and again after
+    # every crash, so an agent looping on a traceback reported a clean deploy.
+    # NRestarts is reset by an explicit restart and counts only the automatic
+    # ones, so anything above zero here means it has already died at least once.
+    status = _ssh(target, f"sleep {STARTUP_GRACE_SECONDS}; "
+                          f"echo active=$(systemctl is-active {agent}); "
+                          f"echo restarts=$(systemctl show -p NRestarts --value {agent})",
+                  timeout=120)
+    facts = dict(line.split("=", 1) for line in status.stdout.split() if "=" in line)
+    crashed = facts.get("restarts", "0") not in ("0", "")
+
+    if facts.get("active") != "active" or crashed:
+        why = (f"crashed and is being restarted ({facts.get('restarts')} times "
+               f"in {STARTUP_GRACE_SECONDS}s)" if crashed
+               else f"is not running ({facts.get('active') or 'unknown'})")
+        console.print(f"[red]{agent} {why}.[/red]")
         logs = _ssh(target, f"sudo journalctl -u {agent} -n 20 --no-pager", timeout=60)
         for line in logs.stdout.strip().splitlines()[-20:]:
             console.print(f"  [dim]{line}[/dim]")

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -549,6 +549,23 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
     return bool(questionary.confirm("Create it?", default=False).ask())
 
 
+def _forget_host_key(ssh_target: str) -> None:
+    """Drop any host key we hold for this address.
+
+    Cloud providers reuse addresses. When one comes back attached to a machine
+    we just created, the key in known_hosts belongs to a machine that no longer
+    exists, and ssh refuses with a warning about a possible attack —
+    StrictHostKeyChecking=accept-new covers a host it has never seen, not one
+    whose key changed. The operator's first command after paying for a server
+    then fails, alarmingly, for a reason that is entirely our doing.
+
+    Safe here precisely because we are the ones who created the machine: we know
+    the previous key is dead. Nothing else in `co` removes host keys.
+    """
+    host = ssh_target.split("@")[-1]
+    subprocess.run(["ssh-keygen", "-R", host], capture_output=True, text=True)
+
+
 def handle_server_new(name: str, machine_type: Optional[str] = None,
                       yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""
@@ -629,6 +646,8 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
         entry["hostname"] = server["hostname"]
     servers[name] = entry
     _save(servers)
+
+    _forget_host_key(server["ssh_target"])
 
     console.print(f"\n[green]✓ {name} is ready[/green]")
     console.print(f"  [cyan]{server['ssh_target']}[/cyan]")

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -233,17 +233,20 @@ class TestRestart:
         Trusting the exit code would report a broken deploy as a success, which
         is the worst possible outcome for a deploy command.
         """
-        with patch.object(dts, "_ssh", side_effect=[_ok(), _ok("failed"), _ok("traceback…")]):
+        with patch.object(dts, "_ssh",
+                          side_effect=[_ok(), _ok("active=failed\nrestarts=0"), _ok("traceback…")]):
             assert dts._restart("user@host", "myagent") is False
 
     def test_an_active_unit_passes(self):
-        with patch.object(dts, "_ssh", side_effect=[_ok(), _ok("active")]):
+        with patch.object(dts, "_ssh",
+                          side_effect=[_ok(), _ok("active=active\nrestarts=0")]):
             assert dts._restart("user@host", "myagent") is True
 
     def test_journal_is_shown_when_the_unit_does_not_come_up(self, capsys):
         """The traceback is what the operator needs, not an exit code."""
         with patch.object(dts, "_ssh",
-                          side_effect=[_ok(), _ok("failed"), _ok("ModuleNotFoundError: no foo")]):
+                          side_effect=[_ok(), _ok("active=failed\nrestarts=0"),
+                                       _ok("ModuleNotFoundError: no foo")]):
             dts._restart("user@host", "myagent")
 
         assert "ModuleNotFoundError" in capsys.readouterr().out
@@ -407,3 +410,59 @@ class TestHttps:
             dts._ensure_caddy("user@host", "x.example", 8000)
 
         assert "command -v caddy" in ssh.call_args.args[1]
+
+
+class TestACrashLoopIsNotASuccessfulDeploy:
+    """`Restart=always` means a unit that dies on import is "active" in the
+    moment right after the restart, and again after every crash. Asking
+    immediately therefore always says yes — a real deploy reported success for
+    an agent looping on an ImportError, and the operator's first hint was a 502.
+    """
+
+    def _ssh(self, stdout):
+        return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+    def test_an_agent_that_keeps_dying_fails_the_deploy(self, capsys):
+        def fake_ssh(target, command, timeout=300):
+            if "NRestarts" in command:
+                return self._ssh("active=active\nrestarts=3\n")
+            if "journalctl" in command:
+                return self._ssh("ImportError: cannot import name 'create_agent'")
+            return self._ssh("")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._restart("co@host", "my-agent") is False
+
+        out = capsys.readouterr().out
+        assert "crashed" in out
+        assert "ImportError" in out, "the traceback is what the operator needs"
+
+    def test_an_agent_that_stays_up_passes(self):
+        def fake_ssh(target, command, timeout=300):
+            if "NRestarts" in command:
+                return self._ssh("active=active\nrestarts=0\n")
+            return self._ssh("")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._restart("co@host", "my-agent") is True
+
+    def test_a_slow_start_is_not_treated_as_a_crash(self):
+        """Zero automatic restarts means it has not died, however slow it is."""
+        def fake_ssh(target, command, timeout=300):
+            if "NRestarts" in command:
+                return self._ssh("active=active\nrestarts=\n")
+            return self._ssh("")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._restart("co@host", "my-agent") is True
+
+    def test_a_dead_unit_still_fails(self):
+        def fake_ssh(target, command, timeout=300):
+            if "NRestarts" in command:
+                return self._ssh("active=failed\nrestarts=0\n")
+            if "journalctl" in command:
+                return self._ssh("some traceback")
+            return self._ssh("")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._restart("co@host", "my-agent") is False

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -810,3 +810,43 @@ class TestThePromptLeadsWithTheMonthlyPrice:
         self._prompt(pricing)
 
         assert "$30 / month" in " ".join(capsys.readouterr().out.split())
+
+class TestARecreatedServerDoesNotLookLikeAnAttack:
+    """Cloud providers reuse addresses.
+
+    When one comes back attached to a machine we just created, the key in
+    known_hosts belongs to a machine that no longer exists and ssh refuses with
+    a warning about a possible attack — accept-new covers a host never seen, not
+    one whose key changed. The operator's first command after paying for a
+    server failed exactly this way.
+    """
+
+    def test_creating_a_server_drops_the_old_host_key_for_its_address(self):
+        with patch.object(sc.subprocess, "run", return_value=_ok("")) as run:
+            sc._forget_host_key("co@203.0.113.7")
+
+        assert run.call_args.args[0] == ["ssh-keygen", "-R", "203.0.113.7"]
+
+    def test_it_uses_the_host_not_the_whole_target(self):
+        with patch.object(sc.subprocess, "run", return_value=_ok("")) as run:
+            sc._forget_host_key("someuser@example.com")
+
+        assert run.call_args.args[0][-1] == "example.com"
+
+    def test_a_created_server_forgets_its_addresss_old_key(self, servers_file):
+        """The point is that it happens on create, without being asked."""
+        forgotten = []
+        server = {"ssh_target": "co@203.0.113.7", "expires_at": "2027-07-31T00:00:00",
+                  "charged_usd": 180.0}
+
+        with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing",
+                          return_value={"default": "e2-small",
+                                        "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
+             patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
+                   return_value="k"), \
+             patch("requests.post", return_value=_response(200, server)), \
+             patch.object(sc, "_forget_host_key", side_effect=forgotten.append):
+            assert sc.handle_server_new("prod", yes=True) is True
+
+        assert forgotten == ["co@203.0.113.7"]


### PR DESCRIPTION
Two faults, both found by running the whole lifecycle against a real machine twice — create, deploy, iterate, destroy, create again.

## A deploy reported success for an agent that never ran

```
✓ e2e-agent is running on e2e-live
  https://e2e-live-561605f3.agents.openonion.ai
```

It was not running. It was looping on an `ImportError`, and the first hint was a 502 from the page we had just called live.

`_restart` did check — but immediately, and `Restart=always` means a unit that dies on import is `active` in the moment right after the restart, and again after every crash. The check could only ever say yes.

`NRestarts` is reset by an explicit restart and counts only the automatic ones, so after a short grace period anything above zero means it has already died at least once. On failure the journal tail is printed, because the traceback is what the operator needs and an exit code is not.

A slow agent is not punished: it is still `active` with zero automatic restarts.

## A recreated server looked like an attack

```
$ co server new e2e-live --yes     → ✓ ready
$ co server check e2e-live
  Offending ECDSA key in /Users/…/.ssh/known_hosts:143
  Host key verification failed.
```

Cloud providers reuse addresses. GCP handed the new machine the address the destroyed one had, so `known_hosts` held a key for a machine that no longer exists — and `StrictHostKeyChecking=accept-new` covers a host ssh has never seen, not one whose key *changed*. The operator's first command after paying for a server fails, alarmingly, for a reason entirely of our making.

`co server new` now drops the host key for the address it was just handed. Safe precisely because we created the machine: we know the previous key is dead. Nothing else in `co` removes host keys.

## Verified in both directions, on a real server in Sydney

- agent healthy → deploy passes, `https://…` answers with a valid Let's Encrypt certificate
- library on the box rolled back so the agent cannot import → the same deploy now **fails and prints the ImportError**, where before it printed a success line and a URL

Nine tests across the two behaviours, each verified red first. The three existing `TestRestart` cases were updated: they modelled a probe that only reported `is-active`, which is the assumption that was wrong.