### PR TITLE
release: 1.5.3

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -21,12 +21,23 @@ Example: `0.0.2`
   - 0.0.9 → 0.1.0
   - 0.9.9 → 1.0.0
 
-### 3. **MAJOR Version (X.0.0)**
+### 3. **`X.Y.0` is the stable release**
+
+A minor is not just where the patch counter rolls over — it is the version people are
+meant to sit on. So features do **not** ship straight into one:
+
+- while a feature is being stabilised it ships in **patch** releases (1.5.3, 1.5.4, …)
+- `X.Y.0` is cut once that work has actually been exercised end to end
+
+Merged features on `main` therefore do not force the next release to be a minor bump.
+That is semver's rule, not this project's.
+
+### 4. **MAJOR Version (X.0.0)**
 - Increment when MINOR reaches 10
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.2
+## Current Version: 1.5.3
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -43,6 +54,7 @@ Example: `0.0.2`
 
 - 1.5.0 (agent Home pages: the host pushes `dashboard.html` over the agent WebSocket and chat clients render it beside the conversation, with a built-in dashboard skill; `co syno` for Synology NAS; `co ai` YOLO mode; `co ai` and the templates drive the browser through `co browser` instead of 40 in-process tools; agents can declare how long they need a tab; deploy polls the full build window and validates project names locally; hermetic unit tests)
 - 1.5.1 (`co status` says where every API key comes from and flags keys defined in more than one place, with an opt-in `--reveal`; the project states Apache-2.0 everywhere, matching the LICENSE file)
+- 1.5.3 (servers you own: `co server new/add/ls/check/ssh/forget/destroy` and `co deploy --to`, with an SSH key derived from the same recovery phrase; a deploy no longer reissues the agent's address, keeps its logs, seeds the deploying key as admin, and serves it over https on its own hostname; the agent's full picture now travels over the authenticated socket instead of the open `/info`, which had been publishing the operator's personal skills to anyone; `co skills list` and `co doctor` say which tier a skill came from and which ones will not survive a deploy)
 - 1.5.2 (Claude calls carry the system prompt again — Anthropic requests had been dropping it entirely and silently; `.co/docs/` is no longer empty on a PyPI install, the 194 docs files now ship inside the wheel)
 
 ## Files to Update When Versioning

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -385,7 +385,7 @@ def server_destroy(
     name: str = typer.Argument(..., help="Server to tear down"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the confirmation"),
 ):
-    """Destroy the machine and stop the billing. Not reversible, not refunded."""
+    """Destroy the machine and stop the billing. The unused term is refunded."""
     from .commands.server_commands import handle_server_destroy
     if not handle_server_destroy(name=name, yes=yes):
         raise typer.Exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.2"
+version = "1.5.3"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
19 commits since 1.5.2, all of the server/deploy and skills-visibility work.

## Why 1.5.3 and not 1.6.0

**`X.Y.0` is the version people sit on.** The work in this release is still being stabilised — three fixes landed on `main` while this branch was being prepared (#354, #385, and the e2e lifecycle test). Shipping that into a `.0` breaks what a minor is supposed to mean.

`VERSIONING.md` documented only the mechanical rule (PATCH rolls to MINOR at 10), which reads as *"merged features force a minor bump"* — that is semver's rule, not this project's. I reasoned my way to exactly that wrong conclusion earlier, so the policy is now written down beside the roll-over rule rather than left to be inferred.

1.6.0 gets cut when `co server new` → `co deploy --to` → https → dashboard has actually been run end to end against a real machine.

## What's in it

**Servers you own** — `co server new/add/ls/check/ssh/forget/destroy`, `co deploy --to`, and an SSH key derived from the recovery phrase you already have.

- a deploy no longer **reissues the agent's address**, which used to change its email and void every trust relationship other agents had granted it
- `.co/logs/` and `.co/evals/` survive, so a dashboard can show history that is real
- the deploying key is **seeded as admin** — a deployed agent previously had no reachable admin at all, since admin actions were gated on a key that only ever existed on the server
- served over **https on its own hostname**, with `AGENT_PUBLIC_DOMAIN` set so the agent announces a URL that actually answers
- `co server ls` reconciles against billing, so a server you are paying for but never registered is visible rather than silent
- `co server destroy` refunds the unused term; `forget` deliberately does not touch the machine

**Skills visibility** — the agent's full picture travels over the authenticated socket instead of the open `/info`, which had been publishing the operator's personal skills (117 of them on the machine where this was found) to anyone who could reach the agent. `co skills list` and `co doctor` now say which tier each skill came from, and both deploy paths name the ones being left behind.

## Verification

`pytest tests/unit` → **2520 passed, 3 skipped**
`pytest tests/e2e/cli` → **366 passed, 3 skipped**
`import connectonion` → 1.5.3

## Known gap at the moment of release

oo-api has #47 (inbound 80/443) and #48 (DNS) merged but **not deployed**. Until that deploy happens, `co server new` produces a machine you can ssh into and deploy to, but with no hostname and no https — the client degrades cleanly rather than failing, but the domain half is inert. Deploying the backend closes it with no client change.