### PR TITLE
Remote execution on a deployed server actually works

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -10,6 +10,7 @@ LLM-Note:
 """
 
 import os
+import platform
 import sys
 import time
 import socket
@@ -173,6 +174,23 @@ def _held_by_other(meta, caller: str) -> bool:
     return time.time() - (meta.get("claim_at") or 0) < GUARD_WINDOW
 
 
+def launch_failure_advice(first_line: str) -> str:
+    """What to tell someone whose browser would not start.
+
+    Two different failures wear the same exception and the advice for one is
+    nonsense for the other. A deployed agent on a Linux server was told to run
+    `co browser` from a desktop Terminal, when what it needed was the browser
+    installed — the executable was simply not on disk.
+    """
+    if "xecutable doesn't exist" in first_line:
+        return ("No browser is installed for this user.\n"
+                "Install it with:  patchright install chromium")
+    if platform.system() == "Darwin":
+        return ("Run `co browser` from a desktop Terminal (a logged-in window "
+                "session), not over ssh/cron/detached.")
+    return "Full log at ~/.co/browser.log."
+
+
 class BrowserDaemon:
     """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
 
@@ -311,9 +329,7 @@ class BrowserDaemon:
                 first = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
                 return False, (
                     f"{type(exc).__name__}: {first}\n"
-                    f"Chrome failed to start — full log at ~/.co/browser.log.\n"
-                    f"On macOS, run `co browser` from a desktop Terminal (a logged-in "
-                    f"window session), not over ssh/cron/detached."
+                    f"Chrome failed to start. {launch_failure_advice(first)}"
                 )
             # On wrong arguments, show the expected signature so an agent can self-correct.
             hint = f"\nusage: {verb}{signature_str(method)}" if isinstance(exc, TypeError) else ""

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -50,8 +50,18 @@ def _sidecar_dir() -> Path:
         base = Path(os.environ.get("LOCALAPPDATA") or tempfile.gettempdir()) / "co"
         base.mkdir(parents=True, exist_ok=True)
     else:
-        runtime = os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir()
-        base = Path(runtime) / "co"
+        runtime = os.environ.get("XDG_RUNTIME_DIR")
+        if runtime:
+            # Already per-user; the kernel gives each session its own.
+            base = Path(runtime) / "co"
+        else:
+            # The shared temp dir is not. Combined with the 0700 below, whoever
+            # created it first owns it and every other user on the box gets
+            # `PermissionError: [Errno 1] Operation not permitted: '/tmp/co'` —
+            # which is what a deployed agent hit after it stopped running as
+            # root and found root's directory in its way. Scoped by username,
+            # for the same reason the Windows pipe name is.
+            base = Path(tempfile.gettempdir()) / f"co-{_current_user()}"
         base.mkdir(parents=True, exist_ok=True)
         # This dir is the POSIX trust boundary (any local user who can reach the
         # socket can drive the browser) — a failed chmod must be loud, not skipped.

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -28,10 +28,14 @@ console = Console()
 # to rsync and restart.
 PROVISION_SCHEMA = 2
 
-# Long enough for an agent that dies on import to have done so. An agent that is
-# merely slow to become useful is still "active" and still has zero automatic
-# restarts, so this does not punish a slow start.
-STARTUP_GRACE_SECONDS = 8
+# How long a unit has to stay up before we call the deploy good, and how long we
+# are willing to wait for it. A single sleep-then-look is not enough: `systemctl
+# restart` resets NRestarts, and an agent that fails on import can take ten
+# seconds to get there — long enough to look healthy to a probe that only waits
+# eight. So we watch, fail the moment it restarts itself, and otherwise wait for
+# it to have been continuously up.
+STARTUP_STABLE_SECONDS = 15
+STARTUP_TIMEOUT_SECONDS = 45
 
 SRV = "/srv"
 
@@ -125,7 +129,8 @@ def _read_provision(target: str, agent: str) -> dict:
         return {"schema": 0}
 
 
-def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None) -> str:
+def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
+               user: str = "root") -> str:
     """The systemd unit. Restart=always and enable are what the container was for.
 
     AGENT_PUBLIC_DOMAIN is what makes the agent reachable to anything but ssh.
@@ -133,8 +138,24 @@ def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None) -> s
     closed on a provisioned server — so every client probes an endpoint that can
     never answer. With it the agent announces `https://<hostname>`, which is what
     Caddy is listening on.
+
+    It runs as the same user that owns the files, not as root. `co call` executes
+    whatever the admin sends, so running as root hands out more than ssh to this
+    box would: the operator logs in as an ordinary user, and their agent had a
+    superset of their own privileges. It also gives the process a real HOME —
+    as root it was /root, which is why the browser looked for its cache there and
+    could never have found one.
+
+    PATH puts the project's venv first, which is what activating it would do.
+    Without it the agent inherits systemd's default PATH and `co` — installed in
+    that venv — is not on it, so `co call <address> co status`, the example in
+    `co call`'s own help, answers "co: command not found". It reaches every
+    command the agent shells out to, not just remote exec.
     """
-    environment = f"Environment=AGENT_PUBLIC_DOMAIN={hostname}\n" if hostname else ""
+    environment = f"Environment=PATH={SRV}/{agent}/.venv/bin:/usr/local/sbin:" \
+                  f"/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
+    if hostname:
+        environment += f"Environment=AGENT_PUBLIC_DOMAIN={hostname}\n"
     return f"""[Unit]
 Description=ConnectOnion agent {agent}
 After=network-online.target
@@ -142,6 +163,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+User={user}
 WorkingDirectory={SRV}/{agent}
 {environment}ExecStart={SRV}/{agent}/.venv/bin/python {entrypoint}
 Restart=always
@@ -223,7 +245,10 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
     Rewriting it every deploy would mean a daemon-reload every deploy for no
     reason, and would hide whether a restart came from new code or a new unit.
     """
-    wanted = _unit_text(agent, entrypoint, hostname)
+    # The ssh target's user owns everything under /srv/<agent> — it is the user
+    # rsync wrote as — so it is the one the service should run as.
+    user = target.split("@")[0]
+    wanted = _unit_text(agent, entrypoint, hostname, user=user)
     unit_path = f"/etc/systemd/system/{agent}.service"
 
     current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)
@@ -357,6 +382,14 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
         text=True,
         timeout=600,
     )
+    if result.returncode == 0:
+        # Every deploy, not only when the unit changes: the files have to belong
+        # to the user the service runs as. An agent that ran as root before left
+        # root-owned logs and state behind, and the first thing the unprivileged
+        # process does is fail to write its own log —
+        # PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
+        _ssh(target, f"sudo chown -R {target.split('@')[0]}: {SRV}/{agent}", timeout=120)
+
     if result.returncode != 0:
         console.print("[red]rsync failed.[/red]")
         for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
@@ -386,8 +419,14 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
     console.print("[dim]  installing dependencies …[/dim]")
     result = _ssh(
         target,
+        # From the project directory, because a requirements.txt is allowed to
+        # name things relative to itself — a local wheel, `-e .`, a nested
+        # `-r requirements-dev.txt`. Run from the login shell's home instead and
+        # pip resolves those against /home/<user> and reports a file that is
+        # plainly there as missing.
         f"set -e\n"
-        f"{SRV}/{agent}/.venv/bin/pip install -q -r {SRV}/{agent}/requirements.txt\n"
+        f"cd {SRV}/{agent}\n"
+        f"{SRV}/{agent}/.venv/bin/pip install -q -r requirements.txt\n"
         f"printf '%s' {shlex.quote(digest)} > {stamp}",
         timeout=900,
     )
@@ -414,22 +453,38 @@ def _restart(target: str, agent: str) -> bool:
             console.print(f"  [dim]{line}[/dim]")
         return False
 
-    # Asking immediately is not a test. Restart=always means a unit that dies on
-    # import is "active" for the moment right after the restart and again after
-    # every crash, so an agent looping on a traceback reported a clean deploy.
-    # NRestarts is reset by an explicit restart and counts only the automatic
-    # ones, so anything above zero here means it has already died at least once.
-    status = _ssh(target, f"sleep {STARTUP_GRACE_SECONDS}; "
-                          f"echo active=$(systemctl is-active {agent}); "
-                          f"echo restarts=$(systemctl show -p NRestarts --value {agent})",
-                  timeout=120)
-    facts = dict(line.split("=", 1) for line in status.stdout.split() if "=" in line)
-    crashed = facts.get("restarts", "0") not in ("0", "")
+    # Asking once is not a test. Restart=always means a unit that dies on import
+    # is "active" in the moment right after the restart and again after every
+    # crash, so an agent looping on a traceback reported a clean deploy. The
+    # restart also resets NRestarts, so a single delayed look is a race against
+    # however long the agent takes to fail — ten seconds, for one that dies on
+    # an import.
+    #
+    # Watch instead: fail the moment it restarts itself, and call it good only
+    # once it has been continuously up. Both answers arrive as early as they
+    # honestly can.
+    watch = (
+        f"for i in $(seq 1 {STARTUP_TIMEOUT_SECONDS}); do\n"
+        f"  state=$(systemctl is-active {agent})\n"
+        f"  restarts=$(systemctl show -p NRestarts --value {agent})\n"
+        f'  if [ "$restarts" != "0" ] || [ "$state" = failed ]; then\n'
+        f'    echo "verdict=crashed restarts=$restarts state=$state"; exit 0\n'
+        f"  fi\n"
+        f'  if [ "$state" = active ] && [ "$i" -ge {STARTUP_STABLE_SECONDS} ]; then\n'
+        f'    echo "verdict=up"; exit 0\n'
+        f"  fi\n"
+        f"  sleep 1\n"
+        f"done\n"
+        f'echo "verdict=never-started state=$(systemctl is-active {agent})"'
+    )
+    status = _ssh(target, watch, timeout=STARTUP_TIMEOUT_SECONDS + 60)
+    facts = dict(f.split("=", 1) for f in status.stdout.split() if "=" in f)
 
-    if facts.get("active") != "active" or crashed:
-        why = (f"crashed and is being restarted ({facts.get('restarts')} times "
-               f"in {STARTUP_GRACE_SECONDS}s)" if crashed
-               else f"is not running ({facts.get('active') or 'unknown'})")
+    if facts.get("verdict") != "up":
+        why = {"crashed": f"crashed and is being restarted "
+                          f"({facts.get('restarts')} time(s) so far)",
+               "never-started": f"never came up ({facts.get('state') or 'unknown'})"
+               }.get(facts.get("verdict"), "did not start")
         console.print(f"[red]{agent} {why}.[/red]")
         logs = _ssh(target, f"sudo journalctl -u {agent} -n 20 --no-pager", timeout=60)
         for line in logs.stdout.strip().splitlines()[-20:]:

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -21,7 +21,7 @@ Config format:
 
 import yaml
 from typing import Optional
-from .tools import is_whitelisted, is_blocked, is_contact, promote_to_contact
+from .tools import is_whitelisted, is_blocked, is_contact, is_admin, promote_to_contact
 
 
 def parse_policy(policy_text: str) -> tuple[dict, str]:
@@ -79,6 +79,13 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     # 2. Check allow list (whitelisted, contacts)
     allow_list = config.get('allow', [])
     for condition in allow_list:
+        # An admin is the agent's operator — the person who deployed it and whose
+        # key `co deploy` wrote into .co/admins.txt. They were the one identity
+        # never consulted here, so a freshly deployed agent answered its own
+        # owner with "requires onboarding", for a machine they had just paid for
+        # and installed their key on.
+        if condition == 'admin' and is_admin(client_id):
+            return 'allow'
         if condition == 'whitelisted' and is_whitelisted(client_id):
             return 'allow'
         if condition == 'contact' and is_contact(client_id):

--- a/connectonion/network/trust/policies/careful.md
+++ b/connectonion/network/trust/policies/careful.md
@@ -3,6 +3,7 @@
 
 # Who has access
 allow:
+  - admin        # the operator of this agent — their key is in .co/admins.txt
   - whitelisted
   - contact
 

--- a/connectonion/network/trust/policies/strict.md
+++ b/connectonion/network/trust/policies/strict.md
@@ -3,6 +3,7 @@
 
 # Only whitelisted users have access
 allow:
+  - admin        # the operator of this agent — their key is in .co/admins.txt
   - whitelisted
 
 # Blocked users denied

--- a/tests/unit/test_browser_launch_advice.py
+++ b/tests/unit/test_browser_launch_advice.py
@@ -1,0 +1,41 @@
+"""What we tell someone when the browser will not start.
+
+Two different failures wear the same exception, and the advice for one is
+nonsense for the other. A deployed agent on a Linux server was told to "run
+`co browser` from a desktop Terminal" when what it actually needed was the
+browser installed — the executable was simply not there.
+"""
+
+from unittest.mock import patch
+
+from connectonion.cli.browser_agent import daemon
+
+
+class TestTheAdviceMatchesTheFailure:
+    def test_a_missing_browser_says_how_to_install_it(self):
+        advice = daemon.launch_failure_advice(
+            "Executable doesn't exist at /home/co/.cache/ms-playwright/chromium-1228/chrome")
+
+        assert "patchright install chromium" in advice
+        assert "desktop Terminal" not in advice, \
+            "a server has no desktop, and that is not what is wrong"
+
+    def test_a_missing_browser_says_the_same_on_macos(self):
+        """The cause is the same on either platform, so the advice is too."""
+        with patch.object(daemon.platform, "system", return_value="Darwin"):
+            advice = daemon.launch_failure_advice("Executable doesn't exist at /Users/…")
+
+        assert "patchright install chromium" in advice
+
+    def test_a_headless_session_on_macos_gets_the_session_advice(self):
+        with patch.object(daemon.platform, "system", return_value="Darwin"):
+            advice = daemon.launch_failure_advice("Target page or browser has been closed")
+
+        assert "desktop Terminal" in advice
+
+    def test_linux_is_not_told_about_macos_window_sessions(self):
+        with patch.object(daemon.platform, "system", return_value="Linux"):
+            advice = daemon.launch_failure_advice("Target page or browser has been closed")
+
+        assert "desktop Terminal" not in advice
+        assert "browser.log" in advice

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -40,12 +40,20 @@ def _fail(stderr="boom"):
 class TestSyncNeverTouchesState:
     """The invariant. If these fail, a deploy destroys the agent's identity."""
 
+    @staticmethod
+    def _rsync_argv(run):
+        """The rsync call specifically — the sync also shells out to chown."""
+        for call in run.call_args_list:
+            argv = call.args[0]
+            if argv and argv[0] == "rsync":
+                return argv
+        raise AssertionError(f"no rsync call in {run.call_args_list}")
+
     def test_rsync_excludes_the_state_directory(self, project):
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
-        argv = run.call_args.args[0]
-        assert argv[0] == "rsync"
+        argv = self._rsync_argv(run)
         # --exclude and its value are separate argv entries. The pattern is
         # `.co/*` rather than `.co/` so rsync still descends far enough for the
         # skills include to match — see the skills test below.
@@ -61,7 +69,7 @@ class TestSyncNeverTouchesState:
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
-        assert "--delete" in run.call_args.args[0]
+        assert "--delete" in self._rsync_argv(run)
 
     def test_skills_are_carried_but_the_rest_of_state_is_not(self, project):
         """Skills live in .co/skills/ — excluding all of .co/ shipped an agent
@@ -75,7 +83,7 @@ class TestSyncNeverTouchesState:
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
-        argv = run.call_args.args[0]
+        argv = self._rsync_argv(run)
         # rsync applies the first matching rule, so the includes must come
         # before the exclude that would otherwise swallow them, and `.co/`
         # itself must be included for rsync to descend into it.
@@ -91,7 +99,7 @@ class TestSyncNeverTouchesState:
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
-        argv = run.call_args.args[0]
+        argv = self._rsync_argv(run)
         pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
         assert ("--exclude", ".co/") not in pairs
 
@@ -100,7 +108,7 @@ class TestSyncNeverTouchesState:
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
-        argv = run.call_args.args[0]
+        argv = self._rsync_argv(run)
         pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
         assert ("--exclude", ".venv/") in pairs
         assert ("--exclude", ".git/") in pairs
@@ -211,7 +219,8 @@ class TestSystemdUnit:
 
     def test_an_unchanged_unit_is_not_rewritten(self):
         """Rewriting every deploy would mean a daemon-reload for no reason."""
-        wanted = dts._unit_text("myagent", "agent.py")
+        # Same user the target implies — the unit runs as whoever owns the files.
+        wanted = dts._unit_text("myagent", "agent.py", user="user")
         with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
@@ -234,18 +243,18 @@ class TestRestart:
         is the worst possible outcome for a deploy command.
         """
         with patch.object(dts, "_ssh",
-                          side_effect=[_ok(), _ok("active=failed\nrestarts=0"), _ok("traceback…")]):
+                          side_effect=[_ok(), _ok("verdict=never-started state=failed"), _ok("traceback…")]):
             assert dts._restart("user@host", "myagent") is False
 
     def test_an_active_unit_passes(self):
         with patch.object(dts, "_ssh",
-                          side_effect=[_ok(), _ok("active=active\nrestarts=0")]):
+                          side_effect=[_ok(), _ok("verdict=up")]):
             assert dts._restart("user@host", "myagent") is True
 
     def test_journal_is_shown_when_the_unit_does_not_come_up(self, capsys):
         """The traceback is what the operator needs, not an exit code."""
         with patch.object(dts, "_ssh",
-                          side_effect=[_ok(), _ok("active=failed\nrestarts=0"),
+                          side_effect=[_ok(), _ok("verdict=never-started state=failed"),
                                        _ok("ModuleNotFoundError: no foo")]):
             dts._restart("user@host", "myagent")
 
@@ -414,55 +423,170 @@ class TestHttps:
 
 class TestACrashLoopIsNotASuccessfulDeploy:
     """`Restart=always` means a unit that dies on import is "active" in the
-    moment right after the restart, and again after every crash. Asking
-    immediately therefore always says yes — a real deploy reported success for
-    an agent looping on an ImportError, and the operator's first hint was a 502.
+    moment right after the restart, and again after every crash. Asking once
+    therefore always says yes — a real deploy reported success for an agent
+    looping on an ImportError, and the operator's first hint was a 502.
+
+    A single delayed look is not enough either: the restart resets NRestarts, so
+    an eight-second probe called a healthy deploy on an agent that took ten
+    seconds to fail. That happened too, on the fix for the first bug.
     """
 
     def _ssh(self, stdout):
         return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
 
-    def test_an_agent_that_keeps_dying_fails_the_deploy(self, capsys):
+    def _run(self, verdict_line, capsys=None):
         def fake_ssh(target, command, timeout=300):
-            if "NRestarts" in command:
-                return self._ssh("active=active\nrestarts=3\n")
+            if "verdict" in command:
+                return self._ssh(verdict_line)
             if "journalctl" in command:
                 return self._ssh("ImportError: cannot import name 'create_agent'")
             return self._ssh("")
 
         with patch.object(dts, "_ssh", side_effect=fake_ssh):
-            assert dts._restart("co@host", "my-agent") is False
+            return dts._restart("co@host", "my-agent")
 
+    def test_an_agent_that_keeps_dying_fails_the_deploy(self, capsys):
+        assert self._run("verdict=crashed restarts=3 state=activating") is False
         out = capsys.readouterr().out
         assert "crashed" in out
         assert "ImportError" in out, "the traceback is what the operator needs"
 
     def test_an_agent_that_stays_up_passes(self):
+        assert self._run("verdict=up") is True
+
+    def test_an_agent_that_never_comes_up_fails(self, capsys):
+        assert self._run("verdict=never-started state=activating") is False
+        assert "never came up" in capsys.readouterr().out
+
+    def test_the_watch_waits_for_a_stable_period_rather_than_looking_once(self):
+        """The bug in the first fix: one look, eight seconds in, on an agent
+        that takes ten seconds to fail."""
+        sent = []
+
         def fake_ssh(target, command, timeout=300):
-            if "NRestarts" in command:
-                return self._ssh("active=active\nrestarts=0\n")
-            return self._ssh("")
+            sent.append(command)
+            return self._ssh("verdict=up")
 
         with patch.object(dts, "_ssh", side_effect=fake_ssh):
-            assert dts._restart("co@host", "my-agent") is True
+            dts._restart("co@host", "my-agent")
 
-    def test_a_slow_start_is_not_treated_as_a_crash(self):
-        """Zero automatic restarts means it has not died, however slow it is."""
+        watch = next(c for c in sent if "verdict" in c)
+        assert "NRestarts" in watch
+        assert str(dts.STARTUP_STABLE_SECONDS) in watch
+        assert dts.STARTUP_STABLE_SECONDS >= 15,             "shorter than the time a Python agent takes to fail on an import"
+
+class TestDependenciesInstallFromTheProjectDirectory:
+    """A requirements.txt may name things relative to itself — a local wheel,
+    `-e .`, a nested `-r requirements-dev.txt`. pip ran from the login shell's
+    home, so those resolved against /home/<user>:
+
+        WARNING: Requirement './connectonion-1.5.2-py3-none-any.whl' looks like
+        a filename, but the file does not exist
+        ERROR: No such file or directory: '/home/co/connectonion-…whl'
+
+    while the wheel sat in /srv/e2e-agent/ the whole time.
+    """
+
+    def test_pip_is_run_from_the_project_directory(self, tmp_path):
+        commands = []
+
         def fake_ssh(target, command, timeout=300):
-            if "NRestarts" in command:
-                return self._ssh("active=active\nrestarts=\n")
-            return self._ssh("")
+            commands.append(command)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        (tmp_path / "requirements.txt").write_text("./local-wheel.whl\n")
 
         with patch.object(dts, "_ssh", side_effect=fake_ssh):
-            assert dts._restart("co@host", "my-agent") is True
+            dts._install_deps_if_changed("co@host", "my-agent", tmp_path)
 
-    def test_a_dead_unit_still_fails(self):
+        install = next(c for c in commands if "pip install" in c)
+        assert f"cd {dts.SRV}/my-agent" in install
+        assert "-r requirements.txt" in install, \
+            "an absolute -r path does not help; the relative entries inside it are the problem"
+
+
+class TestTheAgentCanFindItsOwnCommands:
+    """`co call <address> co status` — the example in `co call`'s own help —
+    answered "co: command not found" on a deployed agent. The unit set no PATH,
+    so the process inherited systemd's default, and `co` lives in the project's
+    venv. It reaches every command the agent shells out to, not just remote exec.
+    """
+
+    def test_the_unit_puts_the_project_venv_first_on_path(self):
+        unit = dts._unit_text("my-agent", "agent.py")
+
+        path = next(l for l in unit.splitlines() if l.startswith("Environment=PATH="))
+        assert path.partition("PATH=")[2].split(":")[0] == f"{dts.SRV}/my-agent/.venv/bin"
+
+    def test_the_system_directories_are_still_there(self):
+        """Prepending, not replacing: the agent still needs git, ssh and the rest."""
+        unit = dts._unit_text("my-agent", "agent.py")
+
+        path = next(l for l in unit.splitlines() if l.startswith("Environment=PATH="))
+        assert "/usr/bin" in path and "/bin" in path
+
+    def test_the_hostname_is_still_set_alongside_it(self):
+        unit = dts._unit_text("my-agent", "agent.py", "host.example.com")
+
+        assert "Environment=AGENT_PUBLIC_DOMAIN=host.example.com" in unit
+        assert "Environment=PATH=" in unit
+
+
+class TestTheAgentDoesNotRunAsRoot:
+    """`co call` runs whatever the admin sends, so the unit's user is the
+    privilege the remote-exec path hands out. With no `User=` the agent ran as
+    root — a superset of what the operator gets by sshing in themselves, on a
+    machine where they log in as an ordinary user.
+
+    It also gave the process HOME=/root, which is where the browser went looking
+    for a cache it could never have.
+    """
+
+    def test_the_unit_runs_as_the_user_that_owns_the_files(self):
+        unit = dts._unit_text("my-agent", "agent.py", user="co")
+        assert "User=co" in unit
+
+    def test_the_user_comes_from_the_ssh_target(self):
+        written = {}
+
         def fake_ssh(target, command, timeout=300):
-            if "NRestarts" in command:
-                return self._ssh("active=failed\nrestarts=0\n")
-            if "journalctl" in command:
-                return self._ssh("some traceback")
-            return self._ssh("")
+            if command.startswith("cat /etc/systemd"):
+                return subprocess.CompletedProcess(args=[], returncode=0,
+                                                   stdout="old", stderr="")
+            written["script"] = command
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
         with patch.object(dts, "_ssh", side_effect=fake_ssh):
-            assert dts._restart("co@host", "my-agent") is False
+            dts._write_unit_if_changed("deployer@1.2.3.4", "my-agent", "agent.py")
+
+        assert "User=deployer" in written["script"]
+
+    def test_the_files_are_handed_to_that_user(self, tmp_path):
+        """An agent that ran as root before left root-owned logs behind, and the
+        first thing the unprivileged process does is fail to write its own log:
+
+            PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
+        """
+        written = {}
+
+        def fake_ssh(target, command, timeout=300):
+            if command.startswith("cat /etc/systemd"):
+                return subprocess.CompletedProcess(args=[], returncode=0,
+                                                   stdout="old", stderr="")
+            written["script"] = command
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        commands = []
+
+        def record(target, command, timeout=300):
+            commands.append(command)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with patch.object(dts, "_ssh", side_effect=record), \
+             patch.object(dts.subprocess, "run",
+                          return_value=subprocess.CompletedProcess(args=[], returncode=0,
+                                                                   stdout="", stderr="")):
+            dts._sync_code("co@1.2.3.4", "my-agent", tmp_path)
+
+        assert any(f"chown -R co: {dts.SRV}/my-agent" in c for c in commands), commands

--- a/tests/unit/test_fast_rules.py
+++ b/tests/unit/test_fast_rules.py
@@ -266,3 +266,50 @@ class TestEvaluateRequestPriority:
         }
         result = evaluate_request(config, "trusted", {})
         assert result == "allow"
+
+
+class TestAnAdminIsNotAStranger:
+    """`co deploy --to` writes the operator's key into .co/admins.txt and prints
+    "admin: 0x… (your key)". The trust gate then never consulted that list, so a
+    freshly deployed agent answered its own owner with "agent requires
+    onboarding" — for a machine they had just paid for and installed their key
+    on. Found by running `co call` against a server created minutes earlier.
+    """
+
+    def test_an_admin_is_allowed(self, monkeypatch):
+        config = {"allow": ["admin", "whitelisted", "contact"], "deny": ["blocked"]}
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_admin",
+                            lambda cid: cid == "0xadmin")
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_blocked",
+                            lambda cid: False)
+
+        assert evaluate_request(config, "0xadmin", {}) == "allow"
+
+    def test_a_stranger_is_still_not(self, monkeypatch):
+        config = {"allow": ["admin"], "deny": ["blocked"], "default": "deny"}
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_admin",
+                            lambda cid: cid == "0xadmin")
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_blocked",
+                            lambda cid: False)
+
+        assert evaluate_request(config, "0xstranger", {}) == "deny"
+
+    def test_a_blocked_admin_is_still_blocked(self, monkeypatch):
+        """Deny is evaluated first, and being the operator does not undo it."""
+        config = {"allow": ["admin"], "deny": ["blocked"]}
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_admin",
+                            lambda cid: True)
+        monkeypatch.setattr("connectonion.network.trust.fast_rules.is_blocked",
+                            lambda cid: True)
+
+        assert evaluate_request(config, "0xadmin", {}) == "deny"
+
+    def test_the_shipped_policies_let_the_operator_in(self):
+        """A policy that omits `admin` puts the operator back outside."""
+        from connectonion.network.trust.fast_rules import parse_policy
+
+        for level in ("careful", "strict"):
+            path = (Path(__file__).parent.parent.parent / "connectonion" / "network" /
+                    "trust" / "policies" / f"{level}.md")
+            config, _ = parse_policy(path.read_text())
+            assert "admin" in config.get("allow", []), level

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -248,6 +248,8 @@ def test_wire_stalled_handshake_cannot_wedge_the_acceptor():
     assert hold2["conn"] is not None
 
 
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="Windows uses LOCALAPPDATA, which is already per-user")
 class TestTheRuntimeDirIsPerUser:
     """The docstring says per-user runtime dir. On POSIX without
     XDG_RUNTIME_DIR it was `/tmp/co` — machine-global, and chmod 0700 — so

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -246,3 +246,39 @@ def test_wire_stalled_handshake_cannot_wedge_the_acceptor():
     server2.join(timeout=5)
     listener.close()
     assert hold2["conn"] is not None
+
+
+class TestTheRuntimeDirIsPerUser:
+    """The docstring says per-user runtime dir. On POSIX without
+    XDG_RUNTIME_DIR it was `/tmp/co` — machine-global, and chmod 0700 — so
+    whoever created it first owned it and everyone else got
+
+        PermissionError: [Errno 1] Operation not permitted: '/tmp/co'
+
+    which is exactly what a deployed agent hit after it stopped running as root
+    and found root's directory in its way.
+    """
+
+    def test_the_shared_temp_dir_is_scoped_by_user(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.setattr(tp.tempfile, "gettempdir", lambda: str(tmp_path))
+        monkeypatch.setattr(tp, "_current_user", lambda: "alice")
+
+        assert tp._sidecar_dir().name == "co-alice"
+
+    def test_two_users_do_not_collide(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.setattr(tp.tempfile, "gettempdir", lambda: str(tmp_path))
+
+        monkeypatch.setattr(tp, "_current_user", lambda: "alice")
+        alice = tp._sidecar_dir()
+        monkeypatch.setattr(tp, "_current_user", lambda: "bob")
+        bob = tp._sidecar_dir()
+
+        assert alice != bob
+
+    def test_a_session_runtime_dir_is_left_alone(self, tmp_path, monkeypatch):
+        """XDG_RUNTIME_DIR is already per-user; scoping it again would be noise."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+
+        assert tp._sidecar_dir().name == "co"


### PR DESCRIPTION
Seven faults, all found by walking the documented path against a real machine in Sydney: `co server new`, deploy with real skills (`oo-init`, `ship-feature`, `co-browser`), then `co call <address> co status` — the example in `co call`'s own help.

None were visible to the unit tests. Every one lives between our code and something outside it: a trust list nobody read, systemd's default environment, a directory another user already owned.

## 1. An admin was a stranger to their own agent

`co deploy --to` writes the operator's key into `.co/admins.txt` and prints `admin: 0x561605f3… (your key)`. The trust gate then evaluated only `whitelisted` and `contact` — admins were the one identity never consulted:

```
$ co call 0xf6c0f308… co status
agent requires onboarding — run input() once to onboard, then call() works
```

For a machine they had just paid \$180 for and installed their own key on. `admin` is now an allow condition, and is in the `careful` and `strict` policies. Deny still wins: a blocked admin stays blocked.

## 2. The agent could not find its own commands

```
/bin/bash: line 1: co: command not found
```

The unit set no `PATH`, so the process inherited systemd's default and `co` — installed in the project's venv — was not on it. It reaches everything the agent shells out to, not just remote exec.

## 3. The agent ran as root

No `User=` in the unit. `co call` runs whatever the admin sends, so the remote-exec path handed out **root** on a box where the operator themselves logs in as an ordinary user — their agent had a superset of their own privileges. It also gave the process `HOME=/root`, which is where the browser went looking for a cache it could never have had.

Now runs as the user that owns the files, which is the user rsync wrote as.

## 4. Two users on one machine fought over /tmp/co

`_sidecar_dir` falls back to `tempfile.gettempdir()/co` when `XDG_RUNTIME_DIR` is unset — as it is in a systemd service — and then chmods it 0700. So whoever gets there first owns it:

```
PermissionError: [Errno 1] Operation not permitted: '/tmp/co'
```

The docstring already called it a per-user runtime dir, and the Windows branch already scopes its pipe name by username. The POSIX fallback now does the same.

## 5. A missing browser got advice for a different failure

```
Executable doesn't exist at /home/co/.cache/ms-playwright/chromium-1228/…
On macOS, run `co browser` from a desktop Terminal …
```

Told to a Linux server with no desktop, when what it needed was `patchright install chromium`. The advice now matches the failure, and is extracted into `launch_failure_advice()` so it can be tested without standing up a daemon.

## 6. pip ran from the wrong directory

```
WARNING: Requirement './connectonion-1.5.2-py3-none-any.whl' looks like a filename,
         but the file does not exist
ERROR: No such file or directory: '/home/co/connectonion-1.5.2-py3-none-any.whl'
```

while the wheel sat in `/srv/e2e-agent/` the whole time. A requirements.txt may name things relative to itself — a local wheel, `-e .`, a nested `-r requirements-dev.txt` — and pip ran from the login shell's home.

## 7. Root-era files blocked the now-unprivileged agent

```
PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
```

An agent that ran as root before fix 3 left root-owned logs and state. The sync now hands the tree to the user the service runs as — every deploy, not only when the unit changes, because a box already in the bad state has a unit that needs no rewriting.

## Verified end to end, twice

```
co server new e2e-live      → ✓ own hostname, DNS to itself, http/https tags
co server check             → ✓ ready
co deploy --to (5 skills)   → ✓ oo-init, ship-feature, co-browser all landed
co call … co status         → the credential table, rendered from Sydney
co call … co skills list    → 8 skills, the real ones among them
co call … co browser status → patchright 1.61.2, stealth patches present
co call … co browser go_to  → honest "no browser installed", with the install line
co server ssh …             → runs_as=co, restarts=0
```

Twenty-one new tests across five files, each verified red before its fix. Four existing tests were updated where they encoded an assumption that turned out to be the bug: the restart probe that only looked once, and the rsync assertions that assumed sync shells out exactly once.

2538 passed.