### PR TITLE
Ready means you can log in

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -566,6 +566,37 @@ def _forget_host_key(ssh_target: str) -> None:
     subprocess.run(["ssh-keygen", "-R", host], capture_output=True, text=True)
 
 
+# The machine answers on 22 before the guest agent has copied our key into
+# authorized_keys — about ten seconds, in practice.
+KEY_INSTALL_TIMEOUT_SECONDS = 120
+
+
+def _wait_until_it_accepts_your_key(ssh_target: str) -> bool:
+    """Block until the machine actually lets you in.
+
+    The API returns as soon as the instance has an address, which is before the
+    key works. Printing "✓ ready" then suggesting `co server check` next meant
+    the very next command answered "Permission denied (publickey)" — the most
+    alarming way to say "wait ten seconds", on a machine just paid for.
+
+    Returns False on timeout rather than failing the command: the server exists
+    and is charged for either way, so the honest thing is to say what is true
+    and let the operator retry.
+    """
+    import time
+
+    deadline = time.monotonic() + KEY_INSTALL_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if _ssh(ssh_target, "echo ok").returncode == 0:
+            return True
+        time.sleep(3)
+
+    console.print("[yellow]It is not accepting your key yet.[/yellow]")
+    console.print("[dim]The machine exists and is charged for; this is usually a "
+                  "slow first boot. Try [bold]co server check[/bold] in a minute.[/dim]")
+    return False
+
+
 def handle_server_new(name: str, machine_type: Optional[str] = None,
                       yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""
@@ -648,6 +679,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
     _save(servers)
 
     _forget_host_key(server["ssh_target"])
+    _wait_until_it_accepts_your_key(server["ssh_target"])
 
     console.print(f"\n[green]✓ {name} is ready[/green]")
     console.print(f"  [cyan]{server['ssh_target']}[/cyan]")

--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -15,15 +15,23 @@ Every step here is one that shipped broken and passed the unit tests anyway:
   refuses with "contents do not match public"
 - a skill in .co/skills/ never reached the server, because the rsync filter
   excluded all of .co/
+- the agent ran as root, so `co call` handed out more than ssh to the box would
+- `co` was not on the unit's PATH, so `co call <address> co status` — the example
+  in `co call`'s own help — answered "co: command not found"
+- the operator was a stranger to their own agent: their key was written into
+  .co/admins.txt and the trust gate never looked at that list
 
 The unit tests could not have caught any of them. They all live between our code
 and ssh, and the only way to see them is to talk to a real box.
 """
 
 import os
+import shutil
 import subprocess
+import sys
 import textwrap
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -57,10 +65,26 @@ def server():
 
 @pytest.fixture(scope="module")
 def project(tmp_path_factory):
-    """An agent carrying a skill, because a skill is the thing that did not ship."""
+    """An agent carrying a skill, because a skill is the thing that did not ship.
+
+    It installs the working tree, not the last release. `co deploy --to` reads
+    requirements.txt, and a bare `connectonion` there means the server runs
+    whatever PyPI has today — so this test would exercise the previous release
+    while claiming to test the change in front of you. The template is generated
+    by the CLI under test and can reference an API that has not shipped yet;
+    against PyPI that is a crash loop, and the failure says nothing about
+    versions.
+    """
     root = tmp_path_factory.mktemp("e2e")
     subprocess.run(["co", "create", AGENT], cwd=root, check=True, capture_output=True)
     path = root / AGENT
+
+    wheel = _build_wheel(tmp_path_factory.mktemp("wheel"))
+    shutil.copy(wheel, path / wheel.name)
+    requirements = path / "requirements.txt"
+    kept = [l for l in requirements.read_text().splitlines()
+            if not l.strip().startswith("connectonion")]
+    requirements.write_text("\n".join([f"./{wheel.name}", *kept]) + "\n")
 
     skill = path / ".co" / "skills" / "greet-visitor"
     skill.mkdir(parents=True, exist_ok=True)
@@ -73,6 +97,16 @@ def project(tmp_path_factory):
         VERSION_MARKER_ONE
         """))
     return path
+
+
+def _build_wheel(into: Path) -> Path:
+    """A wheel of the working tree, for the server to install."""
+    repo = Path(__file__).resolve().parents[3]
+    subprocess.run([sys.executable, "-m", "build", "--wheel", "-o", str(into)],
+                   cwd=repo, check=True, capture_output=True, timeout=900)
+    wheels = sorted(into.glob("connectonion-*.whl"))
+    assert wheels, f"no wheel built into {into}"
+    return wheels[-1]
 
 
 def test_a_created_server_passes_its_own_preflight(server):
@@ -129,3 +163,54 @@ def test_the_server_is_listed_with_what_it_costs(server):
     """`co server ls` reconciles against billing, so a machine you are paying
     for cannot be invisible."""
     assert server in co("server", "ls").stdout
+
+
+def _agent_address(server: str) -> str:
+    """The deployed agent's address, read off its own logs."""
+    import re
+
+    logs = co("server", "ssh", server,
+              f"journalctl -u {AGENT} --no-pager -n 200").stdout
+    found = re.findall(r"0x[0-9a-f]{64}", logs)
+    assert found, "the agent never printed its address"
+    return found[0]
+
+
+def test_the_agent_does_not_run_as_root(server, project):
+    """`co call` runs whatever the admin sends, so the unit's user is the
+    privilege the remote-exec path hands out. As root that was more than the
+    operator gets by sshing in themselves."""
+    user = co("server", "ssh", server,
+              f"ps -o user= -p $(systemctl show -p MainPID --value {AGENT})").stdout
+
+    assert user.strip() and user.strip() != "root", user
+
+
+def test_the_operator_can_run_a_command_on_their_own_agent(server, project):
+    """The whole point of `co call`, and the example in its own help.
+
+    It failed twice over: the trust gate never consulted .co/admins.txt, so the
+    owner was a stranger; and once past that, `co` was not on the unit's PATH.
+    """
+    address = _agent_address(server)
+
+    result = co("call", address, "co", "status", timeout=300)
+
+    assert "onboarding" not in result.stdout + result.stderr, \
+        "the operator was treated as a stranger by their own agent"
+    assert "command not found" not in result.stdout + result.stderr, \
+        "the agent could not find co on its own PATH"
+    assert "Credential Sources" in result.stdout, result.stdout[:400]
+
+
+def test_the_remote_browser_answers(server, project):
+    """`co browser` over `co call` is the remote twin of the local command.
+
+    A shared /tmp/co owned by another user used to stop it before it started.
+    """
+    address = _agent_address(server)
+
+    result = co("call", address, "co", "browser", "status", timeout=300)
+
+    assert "Permission denied" not in result.stderr, result.stderr[:300]
+    assert "Stealth driver" in result.stdout, result.stdout[:300]

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -15,6 +15,17 @@ import yaml
 from connectonion.cli.commands import server_commands as sc
 
 
+_REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY = sc._wait_until_it_accepts_your_key
+
+
+@pytest.fixture(autouse=True)
+def _do_not_wait_for_a_real_machine(monkeypatch):
+    """`co server new` blocks until the box accepts the key. A unit test has no
+    box, so it would block for the full timeout. TestReadyMeansYouCanLogIn
+    patches this itself and asserts the call, so the behaviour stays covered."""
+    monkeypatch.setattr(sc, "_wait_until_it_accepts_your_key", lambda target: True)
+
+
 @pytest.fixture
 def servers_file(tmp_path, monkeypatch):
     """Point the registry at a temp file so tests never touch ~/.co."""
@@ -850,3 +861,58 @@ class TestARecreatedServerDoesNotLookLikeAnAttack:
             assert sc.handle_server_new("prod", yes=True) is True
 
         assert forgotten == ["co@203.0.113.7"]
+
+
+class TestReadyMeansYouCanLogIn:
+    """The API returns as soon as the instance has an address, which is before
+    the guest agent has copied the key into authorized_keys — about ten seconds.
+    `co server new` printed "✓ ready" and suggested `co server check` next, and
+    that command answered "Permission denied (publickey)": the most alarming
+    possible way to say "wait ten seconds", on a machine just paid for.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _use_the_real_wait(self, monkeypatch):
+        """This class is the one testing it, so it opts out of the module fixture."""
+        monkeypatch.setattr(sc, "_wait_until_it_accepts_your_key",
+                            _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY)
+
+    def test_it_waits_until_ssh_succeeds(self):
+        attempts = []
+
+        def flaky(target, command):
+            attempts.append(target)
+            return _ok("ok") if len(attempts) >= 3 else _fail("Permission denied (publickey)")
+
+        with patch.object(sc, "_ssh", side_effect=flaky), patch("time.sleep"):
+            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4") is True
+
+        assert len(attempts) == 3
+
+    def test_a_machine_that_never_opens_says_so_instead_of_hanging(self, capsys):
+        with patch.object(sc, "_ssh", return_value=_fail("Permission denied (publickey)")), \
+             patch.object(sc, "KEY_INSTALL_TIMEOUT_SECONDS", 0):
+            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4") is False
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "charged for" in out, "the operator has paid; say so"
+        assert "co server check" in out
+
+    def test_creating_a_server_waits_before_calling_it_ready(self, servers_file):
+        waited = []
+        server = {"ssh_target": "co@203.0.113.7", "expires_at": "2027-07-31T00:00:00",
+                  "charged_usd": 180.0}
+
+        with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing",
+                          return_value={"default": "e2-small",
+                                        "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
+             patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
+                   return_value="k"), \
+             patch("requests.post", return_value=_response(200, server)), \
+             patch.object(sc, "_forget_host_key"), \
+             patch.object(sc, "_wait_until_it_accepts_your_key",
+                          side_effect=lambda t: waited.append(t) or True):
+            assert sc.handle_server_new("prod", yes=True) is True
+
+        assert waited == ["co@203.0.113.7"]


### PR DESCRIPTION
Both found by running the repo's own end-to-end test against a real machine, which is the first time it had been run as a test rather than by hand.

## "✓ ready" was not true yet

```
$ co server new e2e-5a7dd2 --yes
✓ e2e-5a7dd2 is ready
Next: co server check e2e-5a7dd2  ·  co deploy --to e2e-5a7dd2

$ co server check e2e-5a7dd2
✗ unreachable
  co@…: Permission denied (publickey).
```

The API returns as soon as the instance has an address. The guest agent copies the key into `authorized_keys` about ten seconds later — measured: a fresh box refused at t=0 and accepted at t=10.

So the command printed a claim that was not yet true, suggested a next step that could not work, and the failure it produced — `Permission denied (publickey)` — is the most alarming possible way to say "wait ten seconds", on a machine the operator has just been charged \$180 for.

It now waits until the machine actually accepts the key. On timeout it does not fail the command: the server exists and is charged for either way, so it says that plainly and points at `co server check`.

## The end-to-end test was testing the last release

`co deploy --to` reads `requirements.txt`, and a bare `connectonion` there means the server installs whatever PyPI has today. So the test exercised the previous release while claiming to test the change in front of you.

Worse, the template is generated by the CLI under test and can name an API that has not shipped yet — `create_agent`, renamed from `create_coding_agent` in #294, is exactly that today. Against PyPI that is a crash loop, and the `ImportError` says nothing about versions.

The fixture now builds a wheel of the working tree and pins it in the project it deploys.

## Three more cases

For what this run's fixes were about, none of which had e2e coverage:

- the agent does not run as root — `co call` runs whatever the admin sends, so the unit's user is the privilege that path hands out
- the operator can run a command on their own agent — it failed twice over, once at the trust gate and once on PATH
- the remote browser answers — a shared `/tmp/co` owned by another user used to stop it before it started

## Verified

Against a real server in Sydney, the whole path in one go:

```
co server new       → ✓ ready, and check passes immediately after
co deploy --to      → skill landed, service active, restarts=0, runs as co
co call … co status → the credential table
co call … co browser status → patchright, stealth patches present
co call … co skills list    → greet-visitor among them
second deploy       → skill updated, new skill added, no old marker left,
                      .co/ state survived, new code present, still active
co server destroy   → $179.99 of $180.00 refunded
```

2541 passed.

## One thing this did not resolve

Across seven creations GCP alternated between two addresses, and every run that got one of them failed with `Permission denied (publickey)` even after waiting the full two minutes, while every run that got the other worked immediately. That address currently answers ssh while belonging to no instance of ours. I could not prove the cause from here and have not guessed at a fix; the readiness wait above is a real fix for a real race, not an explanation for this.