### PR TITLE
docs: the relay ANNOUNCE profile is a third surface, not the AGENT_PROFILE frame

### DIFF
--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -362,6 +362,16 @@ entitled to see.
 TypeScript SDK: `agent.profile` and `useAgentForHuman().profile`, `null` until the frame
 lands.
 
+**There is a third profile surface, and it is not this one.** `host()` also sends a
+profile to the relay inside its `ANNOUNCE` frame — that is what registers the agent and
+puts it in the public directory, and it is built separately by
+`_build_agent_profile()` in `network/host/server.py`. Same public skill subset as
+`/info`, different code path, different size limits, enforced by the relay rather than
+by the agent. If an agent starts cleanly but reads as offline, that is the surface to
+look at: the relay rejects the whole ANNOUNCE when the profile fails validation, and
+`host()` prints the reason as `Relay error: <reason>` and keeps heartbeating. The
+contract is documented in `oo-api/docs/relay-announce-profile.md`.
+
 #### DASHBOARD_SNAPSHOT
 
 The agent's `dashboard.html` — its Home page — for the client to render beside the


### PR DESCRIPTION
`websocket-protocol.md` explains the public `/info` profile and the authenticated `AGENT_PROFILE` frame, and #323 set out the rule between them clearly enough that it reads like the complete picture.

It isn't. `host()` also sends a profile to the relay inside its `ANNOUNCE` frame, built by `_build_agent_profile()` in `network/host/server.py` — a separate code path with size limits enforced on the relay side. That is the one that decides whether the agent is reachable at all.

Missing that costs real debugging time. An agent whose ANNOUNCE profile is rejected starts cleanly, prints one `Relay error:` line, keeps heartbeating, and then reads as offline everywhere — which looks nothing like a profile problem. That is exactly how openonion/oo-api#55 presented.

Docs only.