### PR TITLE
How to tell a wrong key from a wrong machine

### DIFF
--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -23,6 +23,19 @@ Every step here is one that shipped broken and passed the unit tests anyway:
 
 The unit tests could not have caught any of them. They all live between our code
 and ssh, and the only way to see them is to talk to a real box.
+
+If a run fails with `Permission denied (publickey)`, check where you are before
+suspecting the code. Compare the host key the address presents to you against
+the machine's own, reaching it out of band:
+
+    ssh-keyscan -t ed25519 <ip> | ssh-keygen -lf -
+    gcloud compute ssh <instance> --zone=<zone> --tunnel-through-iap \
+      --command="sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub"
+
+Different fingerprints mean you are not talking to that machine, and nothing on
+it is wrong. That cost an afternoon once: an address that failed from one
+laptop, worked from a GCE box, and had our key correctly installed the whole
+time.
 """
 
 import os


### PR DESCRIPTION
A note in the e2e test's docstring, from a failure that took a while to place.

## What happened

Runs of the server lifecycle test failed with:

```
✗ unreachable
  co@35.197.164.214: Permission denied (publickey).
```

Across seven creations GCP alternated between two addresses, and the failure correlated perfectly with one of them. Every plausible product explanation was checked and eliminated:

- the recorded address matched what GCE actually assigned
- the key in the instance's metadata matched the key we offer, byte for byte
- `authorized_keys` on the box had it, installed by the guest agent
- the instance's own view of its external IP was that address
- `~/.ssh/config` resolved identically for both addresses

Then the two-command check:

```
ssh-keyscan -t ed25519 35.197.164.214 | ssh-keygen -lf -
  → SHA256:+/5F8nx1BbWEYgRafmo/QZWH+jUP/D4QAbG3XGMvd5M

gcloud compute ssh probe1-… --tunnel-through-iap \
  --command="sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub"
  → SHA256:qeKwmHwgAe1eNgrA2lvuZJ1xsp3osmfDMx3Q6Kc6W7Q
```

Different machines. From the oo-api box the same address presents the *correct* fingerprint, and the same derived private key logs in first try:

```
LOGIN_OK
co
probe1-561605f3.australia-southeast1-a.c.connectonion.internal
```

So nothing was wrong with the server, the key, or the deploy — that one address is answered by something else from the environment I was running in.

## Why write it down

`Permission denied (publickey)` reads like a key problem, and this repo has had four real key problems in the last day, so every instinct points at the code. The check that distinguishes them is two commands and costs nothing. It belongs where someone will be standing when they need it.