### PR TITLE
dashboard: a Home page that survives an agent with 115 skills

### DIFF
--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -12,8 +12,11 @@ changed since this connection last saw it.
 """
 
 import asyncio
+import re
 from html import escape
 from pathlib import Path
+from functools import lru_cache
+from string import Template
 
 from ....console import Console
 
@@ -122,86 +125,154 @@ def ensure_dashboard(agent_metadata, project_dir=None):
     Console().print(f"[dim]Created {DASHBOARD_FILE} — your agent's Home page.[/dim]")
 
 
-def featured_skills(skills, limit=4):
-    """Pick the skills the starter dashboard offers as one-click actions.
+def published_skills(skills):
+    """The skills the starter dashboard may offer as one-click actions.
 
     Only published (project-tree) skills qualify. A client validates every button
     against the agent's published profile, which carries exactly these — so a button
     for a user or builtin skill would render and then silently refuse to run.
     """
     from ....useful_plugins.skills import PUBLISHED_SKILL_LOCATIONS
-    return [s for s in skills if s.get("location") in PUBLISHED_SKILL_LOCATIONS][:limit]
+    return [s for s in skills if s.get("location") in PUBLISHED_SKILL_LOCATIONS]
+
+
+# A flat list stays readable to about a dozen rows in a 440px pane. Past that it is
+# a wall, and the honest structure to impose is the one already in the names: skills
+# ship in families (lark-base, lark-doc, lark-sheets; vercel:deploy, vercel:env), and
+# an author who names three things alike has told you they belong together.
+FLAT_MAX = 12
+FAMILY_MIN = 3
+
+
+def group_skills(skills):
+    """Split skills into ``(families, loose)`` by the prefix in their names.
+
+    A family is a prefix with at least ``FAMILY_MIN`` members, so two lark-* skills
+    stay in the open rather than hiding behind a group of two. Both halves come back
+    sorted: a Home page that reorders itself between runs is one you have to re-read
+    every time.
+    """
+    families = {}
+    for s in skills:
+        families.setdefault(re.split(r"[-:]", s["name"], 1)[0], []).append(s)
+
+    grouped = sorted(
+        (prefix, sorted(members, key=lambda s: s["name"]))
+        for prefix, members in families.items()
+        if len(members) >= FAMILY_MIN
+    )
+    loose = sorted(
+        (s for members in families.values() if len(members) < FAMILY_MIN for s in members),
+        key=lambda s: s["name"],
+    )
+    return grouped, loose
+
+
+@lru_cache(maxsize=1)
+def _starter_templates():
+    """``(page, fragments)`` from ``starter.html`` — the one file the starter lives in.
+
+    The file is a complete page, then a ``<!--FRAGMENTS`` marker, then the repeated
+    pieces as ``<template id="...">`` tags. Splitting on the marker rather than on
+    the tags means the authoring notes below it never reach an agent's
+    dashboard.html — and that anything written there is free to mention ``$`` or a
+    template tag without being substituted or half-stripped into the output.
+
+    ``string.Template`` rather than ``str.format``: the page is mostly CSS, and every
+    rule in it is a pair of braces that ``format`` would read as a field.
+    """
+    raw = (Path(__file__).parent / "starter.html").read_text(encoding="utf-8")
+    page, _, scaffolding = raw.partition("<!--FRAGMENTS")
+    fragments = re.findall(r'<template id="([^"]+)">(.*?)</template>', scaffolding, re.DOTALL)
+    return Template(page.rstrip() + "\n"), {name: Template(body) for name, body in fragments}
+
+
+def _skill_row(skill):
+    """One skill as a button: its real name, and what it does underneath.
+
+    The name is shown verbatim — it is what you type (``/lark-base``), and
+    title-casing it turns ``nano-banana-us`` into "Nano Banana Us", which names
+    nothing. The description is what makes a list of 115 names usable at all.
+    """
+    _, fragments = _starter_templates()
+    return fragments["skill"].substitute(
+        name=escape(str(skill.get("name", "")), quote=True),
+        description=escape(str(skill.get("description") or "").strip()),
+    ).strip()
+
+
+def _skill_sections(skills):
+    """The body of the starter dashboard: every published skill, reachable.
+
+    Three shapes, because "a few skills" and "a hundred skills" are different pages:
+    nothing at all gets a note saying so; a short list is shown flat, because
+    collapsing six items hides them behind a click for no reason; a long one is
+    grouped, with the first family open so the page opens on something to click
+    rather than a row of shut drawers.
+    """
+    _, fragments = _starter_templates()
+    if not skills:
+        return "  " + fragments["empty"].template.strip()
+
+    def rows(members, indent):
+        return "\n".join(indent + _skill_row(s) for s in members)
+
+    if len(skills) <= FLAT_MAX:
+        listing = fragments["list"].substitute(
+            rows=rows(sorted(skills, key=lambda s: s["name"]), "      ")
+        )
+        return "  " + listing.strip()
+
+    families, loose = group_skills(skills)
+    if loose:
+        families.append(("other", loose))
+
+    group = fragments["group"]
+    return "\n".join(
+        "  " + group.substitute(
+            open="open" if i == 0 else "",
+            prefix=escape(prefix),
+            count=len(members),
+            rows=rows(members, "        "),
+        ).strip()
+        for i, (prefix, members) in enumerate(families)
+    )
+
+
+def _subtitle(agent_metadata, skill_count):
+    """Model, skills, tools — the three facts that say what this agent can do.
+
+    Each part is dropped when it is unknown rather than printed as "0 tools", which
+    reads as a broken agent instead of an unreported number.
+    """
+    parts = []
+    if agent_metadata.get("model"):
+        parts.append(escape(str(agent_metadata["model"])))
+    if skill_count:
+        parts.append(f"{skill_count} skill{'s' if skill_count != 1 else ''}")
+    tools = agent_metadata.get("tools") or []
+    if tools:
+        parts.append(f"{len(tools)} tool{'s' if len(tools) != 1 else ''}")
+    return " · ".join(parts)
 
 
 def render_starter(agent_metadata):
-    """Build the day-zero dashboard HTML: an empty-first, visual-over-textual Home
-    with the agent name and up to four of its skills as one-click actions."""
-    name = escape(str(agent_metadata.get("name") or "Agent"))
-    featured = featured_skills(agent_metadata.get("skills") or [])
+    """Build the day-zero dashboard HTML: who this agent is, and every skill it
+    publishes as a one-click action.
 
-    if featured:
-        buttons = "\n".join(
-            f'      <button class="action" data-ochat-skill="{escape(s["name"], quote=True)}">'
-            f'{escape(s["name"].replace("-", " ").replace("_", " ").title())}</button>'
-            for s in featured
-        )
-        actions = f'    <section class="card">\n      <h2>Quick actions</h2>\n{buttons}\n    </section>'
-    else:
-        actions = (
-            '    <section class="card empty">\n'
-            '      <h2>Quick actions</h2>\n'
-            '      <p>Add skills to your agent and they show up here as one-click actions.</p>\n'
-            '    </section>'
-        )
+    Written once, then owned by the agent — so it has to be worth keeping, and it
+    has to hold up at both ends of the range. The pane it renders into is ~440px
+    wide (oo-chat's Home column), full-width on mobile, and occasionally a whole
+    browser window, which is why the layout is a single centred column with a
+    max-width rather than anything that stretches.
 
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<style>
-  :root {{ color-scheme: light dark; }}
-  * {{ box-sizing: border-box; margin: 0; }}
-  body {{
-    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-    background: #fafafa; color: #171717; padding: 40px 28px; line-height: 1.5;
-    -webkit-font-smoothing: antialiased;
-  }}
-  header {{ margin-bottom: 28px; }}
-  h1 {{ font-size: 28px; font-weight: 650; letter-spacing: -0.02em; }}
-  .sub {{ color: #737373; font-size: 14px; margin-top: 4px; }}
-  .card {{
-    background: #fff; border: 1px solid #e5e5e5; border-radius: 12px;
-    padding: 22px 24px; margin-bottom: 16px;
-  }}
-  .card h2 {{
-    font-size: 12px; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase;
-    color: #a3a3a3; margin-bottom: 14px;
-  }}
-  .action {{
-    display: block; width: 100%; text-align: left; font: inherit; font-size: 15px; font-weight: 550;
-    padding: 14px 16px; margin-bottom: 8px; cursor: pointer;
-    background: #fff; color: #171717; border: 1px solid #d4d4d4; border-radius: 8px;
-    transition: border-color .15s, transform .15s;
-  }}
-  .action:last-child {{ margin-bottom: 0; }}
-  .action:hover {{ border-color: #16a34a; transform: translateY(-1px); }}
-  .empty p {{ color: #a3a3a3; font-size: 14px; }}
-  @media (prefers-color-scheme: dark) {{
-    body {{ background: #121212; color: #ededed; }}
-    .sub {{ color: #a3a3a3; }}
-    .card {{ background: #1b1b1b; border-color: #2e2e2e; }}
-    .action {{ background: #1b1b1b; color: #ededed; border-color: #3f3f3f; }}
-    .action:hover {{ border-color: #1eae54; }}
-  }}
-</style>
-</head>
-<body>
-  <header>
-    <h1>{name}</h1>
-    <p class="sub">Home</p>
-  </header>
-{actions}
-</body>
-</html>
-"""
+    The markup and CSS live in ``starter/*.html`` — this function only decides what
+    goes in them. Design notes are in those files, next to the rules they explain.
+    """
+    skills = published_skills(agent_metadata.get("skills") or [])
+    page, _ = _starter_templates()
+    return page.substitute(
+        name=escape(str(agent_metadata.get("name") or "Agent")),
+        subtitle=_subtitle(agent_metadata, len(skills)),
+        body=_skill_sections(skills),
+    )

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  /* No JavaScript anywhere in this file, by contract: the client renders a
+     dashboard under a CSP that runs only its own bridge script, so an agent's
+     own script tag or inline handler is dropped. Every affordance here — the
+     disclosure groups, the hover states — is CSS or plain HTML. Images would
+     have to be inlined as data: URIs, so there are none. */
+  :root {
+    color-scheme: light dark;
+    --bg: #fbfbfa; --fg: #171717; --muted: #737373; --faint: #a3a3a3;
+    --card: #fff; --line: #e7e7e5; --hover: #fafaf9; --accent: #16a34a;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #131313; --fg: #ededed; --muted: #9a9a9a; --faint: #6f6f6f;
+      --card: #1a1a1a; --line: #2b2b2b; --hover: #212121; --accent: #22c55e;
+    }
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: var(--bg); color: var(--fg); line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    padding: 28px 20px 48px;
+  }
+  /* The Home pane is ~440px wide in oo-chat, full-width on mobile, and sometimes a
+     whole browser window. One centred column with a max-width covers all three;
+     anything that stretches turns an eight-character button into a 1400px bar. */
+  main { max-width: 680px; margin: 0 auto; }
+
+  header { margin-bottom: 20px; }
+  h1 { font-size: 22px; font-weight: 650; letter-spacing: -0.02em; }
+  .sub {
+    color: var(--muted); font-size: 12.5px; margin-top: 3px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .card {
+    background: var(--card); border: 1px solid var(--line); border-radius: 12px;
+    margin-bottom: 10px; overflow: hidden;
+  }
+  .empty { padding: 20px 18px; }
+  .empty p { color: var(--muted); font-size: 13.5px; }
+  .empty code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;
+    background: var(--hover); padding: 1px 5px; border-radius: 4px;
+  }
+
+  /* <summary> is the only disclosure that works without JS, so the whole
+     many-skills layout hangs off it. */
+  summary {
+    display: flex; align-items: center; gap: 8px; cursor: pointer;
+    padding: 12px 16px; font-size: 13px; font-weight: 600;
+    letter-spacing: 0.02em; color: var(--fg); list-style: none;
+  }
+  summary::-webkit-details-marker { display: none; }
+  summary::before {
+    content: ""; width: 0; height: 0; flex: none;
+    border-left: 4px solid var(--faint); border-top: 3.5px solid transparent;
+    border-bottom: 3.5px solid transparent;
+    transition: transform .15s;
+  }
+  details[open] > summary::before { transform: rotate(90deg); }
+  summary:hover { background: var(--hover); }
+  .count {
+    margin-left: auto; font-size: 11.5px; font-weight: 550; color: var(--faint);
+    font-variant-numeric: tabular-nums;
+  }
+  details[open] > summary { border-bottom: 1px solid var(--line); }
+
+  /* Rows, not cards: a hundred bordered boxes is noise. One hairline between each. */
+  .skill {
+    display: block; width: 100%; text-align: left; font: inherit; cursor: pointer;
+    background: none; border: 0; border-top: 1px solid var(--line);
+    padding: 11px 16px; color: var(--fg);
+    transition: background .12s;
+  }
+  .rows > .skill:first-child { border-top: 0; }
+  .skill:hover { background: var(--hover); }
+  .skill .name {
+    display: block; font-size: 13.5px; font-weight: 550;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    letter-spacing: -0.01em;
+  }
+  .skill:hover .name { color: var(--accent); }
+  .skill .desc {
+    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+    overflow: hidden; margin-top: 2px;
+    font-size: 12.5px; line-height: 1.45; color: var(--muted);
+  }
+  /* Undescribed skills are common; an empty span must not leave a gap. */
+  .skill .desc:empty { display: none; }
+</style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>$name</h1>
+      <p class="sub">$subtitle</p>
+    </header>
+$body
+  </main>
+</body>
+</html>
+
+<!--FRAGMENTS
+
+Everything below this marker is authoring scaffolding, not part of the page: the
+repeated pieces the body is built from. Python splits the file here, so none of
+this reaches an agent's dashboard.html.
+
+They live in this file rather than in Python or in files of their own — one file
+to keep in sync, and a browser never renders template content, so the page above
+still opens and previews as the thing it renders.
+
+Placeholders are $name-style (string.Template). Do not use $ for anything else.
+
+-->
+
+<template id="skill"><button class="skill" data-ochat-skill="$name"><span class="name">$name</span><span class="desc">$description</span></button></template>
+
+<template id="list"><section class="card">
+    <div class="rows">
+$rows
+    </div>
+  </section></template>
+
+<template id="group"><details class="card group" $open>
+    <summary>$prefix<span class="count">$count</span></summary>
+    <div class="rows">
+$rows
+    </div>
+  </details></template>
+
+<template id="empty"><section class="card empty">
+    <p>No skills yet. Add one to <code>.co/skills/</code> and it shows up here as a one-click action.</p>
+  </section></template>

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -18,7 +18,8 @@ on. There's no extra endpoint, no build step, and no sidecar JSON.
 ## It starts working on its own
 
 The first time you run `host()`, if there's no `dashboard.html`, ConnectOnion writes a
-starter one: your agent's name, and up to four of its skills as one-click buttons.
+starter one: your agent's name, what it runs on, and **every** skill it publishes as a
+one-click button with its description underneath.
 
 ```python
 from connectonion import Agent
@@ -29,6 +30,56 @@ host(lambda: Agent("lisa", tools=[...]))
 ```
 
 After that the file is yours. ConnectOnion never overwrites it.
+
+### Where it lives, and why there
+
+`dashboard.html` sits at the **project root**, next to `agent.py`. Not in `.co/`, and
+that is not cosmetic:
+
+- `co deploy --to` rsyncs the project tree **excluding `.co/`**. A dashboard under
+  `.co/` would silently not travel, and the deployed agent would look like it had no
+  Home.
+- The template Dockerfile does `COPY . .`, so the root is in the image.
+- The `.gitignore` `co create` writes does not ignore it, so it gets committed — a
+  dashboard you edited is part of your agent, like its prompt.
+
+**`co create` and `co init` deliberately do not scaffold one.** At create time the
+project has no skills yet, and `ensure_dashboard` never overwrites an existing file —
+scaffolding then would freeze an empty Home forever. It is written on the first
+`host()`, which is the first moment the agent's skills are actually known.
+
+On a deployed agent the same rule applies on the server: `host()` writes a starter
+there if the rsync carried none. That means an agent deployed without a dashboard gets
+one built from the skills that actually made it onto the server, which is the honest
+answer rather than a copy of what your laptop had.
+
+### It scales with the agent
+
+A dozen skills or fewer are listed flat — collapsing six items hides them behind a
+click for nothing. Past that they're grouped by the family already in their names
+(`lark-base`, `lark-doc`, `lark-sheets` → **lark**), with the count on each group and
+the first one open. Names that share no prefix with two others land in **other**. A
+115-skill agent is one screen you can scan instead of a list you have to scroll.
+
+Skill names are shown verbatim, because that's what you type to run one — `/lark-base`,
+not "Lark Base".
+
+### Where the markup lives
+
+One file: `connectonion/network/host/ws_router/starter.html`. It is a complete page —
+open it in a browser and you see what a starter dashboard looks like — followed by a
+`<!--FRAGMENTS` marker and the repeated pieces (a skill row, a group, a flat list, the
+empty state) as `<template>` tags. Python splits on the marker, fills in the
+placeholders, and contains no HTML of its own. Everything below the marker, including
+its notes, is stripped before anything is written.
+
+Edit that file to change how a starter dashboard looks.
+
+Anything you write there has to survive the client's contract: **no JavaScript** (the
+CSP runs only the client's own bridge script, so an agent's script tag or inline
+handler never executes), images only as `data:` URIs, and no links out. The starter is
+CSS-only for exactly that reason — the disclosure groups are `<details>`/`<summary>`,
+which is the one thing that works without scripting.
 
 ## Editing it
 
@@ -132,7 +183,9 @@ See [websocket-protocol.md](websocket-protocol.md) for the full frame reference.
 | `read_dashboard_snapshot(session_id=None)` | Build the frame, or `None` if the file is missing, too large, unreadable, or not UTF-8 |
 | `send_dashboard(send_msg, session_id, conn=None)` | Send it unless this connection already has the current file; reads off the event loop |
 | `ensure_dashboard(agent_metadata, project_dir=None)` | Write the starter if absent, and anchor the directory later reads resolve against |
-| `render_starter(agent_metadata)` | The day-zero HTML |
+| `render_starter(agent_metadata)` | The day-zero HTML, from `starter.html` |
+| `published_skills(skills)` | The project-tree skills a starter may offer as buttons |
+| `group_skills(skills)` | `(families, loose)` split by name prefix, for long lists |
 | `MAX_DASHBOARD_BYTES` | 2MB size cap |
 
 The path is resolved against the project directory captured at host startup, not the

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -8,7 +8,8 @@ from connectonion.network.host.ws_router.dashboard import (
     MAX_DASHBOARD_BYTES,
     read_dashboard_snapshot,
     ensure_dashboard,
-    featured_skills,
+    group_skills,
+    published_skills,
     render_starter,
     send_dashboard,
 )
@@ -52,7 +53,7 @@ def test_ensure_dashboard_creates_starter(in_tmp):
     assert "Lisa" in html
     assert 'data-ochat-skill="daily-brief"' in html
     assert 'data-ochat-skill="meeting_prep"' in html
-    assert "Daily Brief" in html          # label prettified
+    assert ">daily-brief<" in html        # the name you actually type
     assert "<script" not in html.lower()  # no scripting in agent HTML
 
 
@@ -65,13 +66,63 @@ def test_ensure_dashboard_does_not_clobber_existing(in_tmp):
 def test_render_starter_empty_skills_has_no_invalid_buttons():
     html = render_starter({"name": "Bare", "skills": []})
     assert "data-ochat-skill" not in html
-    assert "Quick actions" in html
+    assert ".co/skills/" in html  # tells the operator how to get one
 
 
-def test_render_starter_features_at_most_four_skills():
-    skills = [{"name": f"skill-{i}", "description": "", "location": "project"} for i in range(9)]
+def test_every_published_skill_is_reachable():
+    """The old starter showed 4 and dropped the rest, which on a real agent meant
+    111 skills the Home page silently pretended did not exist."""
+    skills = [{"name": f"skill-{i:03d}", "description": "", "location": "project"} for i in range(115)]
     html = render_starter({"name": "Many", "skills": skills})
-    assert html.count("data-ochat-skill") == 4
+    assert html.count("data-ochat-skill") == 115
+
+
+def test_a_short_list_is_not_hidden_behind_a_disclosure():
+    skills = [{"name": f"skill-{i}", "description": "", "location": "project"} for i in range(6)]
+    html = render_starter({"name": "Few", "skills": skills})
+    assert "<details" not in html
+
+
+def test_a_long_list_is_grouped_and_opens_on_something():
+    skills = [{"name": f"lark-{i}", "description": "", "location": "project"} for i in range(20)]
+    skills += [{"name": f"x-{i}", "description": "", "location": "project"} for i in range(5)]
+    html = render_starter({"name": "Many", "skills": skills})
+    assert "<details" in html
+    assert "<details class=\"card group\" open>" in html  # never a wall of shut drawers
+
+
+def test_skill_rows_carry_their_description():
+    html = render_starter({"name": "D", "skills": [
+        {"name": "ship-feature", "description": "release a version", "location": "project"},
+    ]})
+    assert "release a version" in html
+
+
+def test_skill_names_are_shown_verbatim():
+    """Title-casing turned nano-banana-us into "Nano Banana Us", which names nothing
+    and is not what you type to run it."""
+    html = render_starter({"name": "N", "skills": [
+        {"name": "nano-banana-us", "description": "", "location": "project"},
+    ]})
+    assert ">nano-banana-us<" in html
+    assert "Nano Banana Us" not in html
+
+
+def test_the_starter_carries_no_javascript():
+    """The client's CSP runs only its own bridge script; an agent <script> is blocked,
+    so anything this page relies on JS for is simply dead on arrival."""
+    skills = [{"name": f"lark-{i}", "description": "d", "location": "project"} for i in range(20)]
+    html = render_starter({"name": "Many", "skills": skills})
+    assert "<script" not in html
+    assert "onclick" not in html
+
+
+def test_render_starter_escapes_a_hostile_skill_name():
+    html = render_starter({"name": "X", "skills": [
+        {"name": "<img src=x>", "description": "<script>y</script>", "location": "project"},
+    ]})
+    assert "<img src=x>" not in html
+    assert "<script>y</script>" not in html
 
 
 def test_render_starter_escapes_agent_name():
@@ -224,7 +275,7 @@ async def test_send_dashboard_sends_nothing_when_there_is_no_file(in_tmp):
 # --- Only publishable skills become buttons, or they render and can never run ---
 
 
-def test_featured_skills_excludes_unpublished_locations():
+def test_published_skills_excludes_unpublished_locations():
     skills = [
         {"name": "daily-brief", "description": "", "location": "project"},
         {"name": "my-notes", "description": "", "location": "user"},
@@ -232,7 +283,7 @@ def test_featured_skills_excludes_unpublished_locations():
         {"name": "review", "description": "", "location": "claude-project"},
         {"name": "future", "description": "", "location": "something-new"},
     ]
-    assert [s["name"] for s in featured_skills(skills)] == ["daily-brief", "review"]
+    assert [s["name"] for s in published_skills(skills)] == ["daily-brief", "review"]
 
 
 def test_starter_has_no_buttons_for_unpublished_skills(in_tmp):
@@ -244,15 +295,41 @@ def test_starter_has_no_buttons_for_unpublished_skills(in_tmp):
     ]})
     html = (in_tmp / "dashboard.html").read_text(encoding="utf-8")
     assert "data-ochat-skill" not in html
-    assert "Quick actions" in html  # falls back to the empty state
+    assert ".co/skills/" in html  # falls back to the empty state
 
 
-def test_starter_features_four_published_skills_past_unpublished_ones():
+def test_starter_lists_published_skills_past_unpublished_ones():
     skills = [{"name": f"personal-{i}", "description": "", "location": "user"} for i in range(5)]
     skills += [{"name": f"shipped-{i}", "description": "", "location": "project"} for i in range(6)]
     html = render_starter({"name": "Many", "skills": skills})
-    assert html.count("data-ochat-skill") == 4
+    assert html.count("data-ochat-skill") == 6
     assert "personal-" not in html
+
+
+def test_group_skills_needs_a_third_member_to_form_a_family():
+    """Two lark-* skills behind a group of two is a click that buys nothing."""
+    skills = [{"name": n} for n in ["lark-base", "lark-doc", "lark-im", "x-api", "x-write", "tweet"]]
+    families, loose = group_skills(skills)
+
+    assert [(p, [s["name"] for s in m]) for p, m in families] == [
+        ("lark", ["lark-base", "lark-doc", "lark-im"]),
+    ]
+    assert [s["name"] for s in loose] == ["tweet", "x-api", "x-write"]
+
+
+def test_group_skills_splits_colon_prefixes_too():
+    skills = [{"name": n} for n in ["vercel:deploy", "vercel:env", "vercel:nextjs"]]
+    families, loose = group_skills(skills)
+
+    assert families[0][0] == "vercel"
+    assert loose == []
+
+
+def test_the_subtitle_omits_what_it_does_not_know():
+    """"0 tools" reads as a broken agent; a missing count reads as a quiet one."""
+    html = render_starter({"name": "Quiet", "skills": [], "tools": [], "model": None})
+    assert "0 tool" not in html
+    assert "0 skill" not in html
 
 
 def test_starter_skill_names_match_what_the_profile_publishes():
@@ -305,3 +382,19 @@ def test_ensure_dashboard_warns_instead_of_crashing_on_an_unwritable_dir(in_tmp,
 
     assert "Could not write" in capsys.readouterr().err
     assert read_dashboard_snapshot() is None
+
+
+def test_the_starter_template_ships_in_the_wheel():
+    """The markup lives in starter.html beside the module; a wheel that drops it
+    turns every `co ai` startup into a FileNotFoundError."""
+    assert (Path(dashboard_module.__file__).parent / "starter.html").is_file()
+
+
+def test_the_fragment_templates_do_not_leak_into_the_page():
+    """<template> tags are lifted out and dropped — a browser would ignore them
+    anyway, but shipping them means shipping an unsubstituted $name."""
+    html = render_starter({"name": "X", "skills": [
+        {"name": "a-skill", "description": "d", "location": "project"},
+    ]})
+    assert "<template" not in html
+    assert "$" not in html


### PR DESCRIPTION
## What it looked like

The starter dashboard showed **four** skills. This machine's agent publishes **115**.

So Home was four arbitrary buttons — whichever four discovery happened to return first — and 111 skills the page silently pretended did not exist. The four it did show were full-width bars stretched across the pane carrying an eight-character label, no description, and a title-cased name ("Nano Banana Us") that is neither the skill's real name nor what you type to run it.

## What it looks like now

Every published skill is on the page, and the layout changes shape with the count:

- **≤ 12 skills** — listed flat. Collapsing six items hides them behind a click for nothing.
- **more** — grouped by the family already in the names (`lark-base`, `lark-doc`, `lark-sheets` → **lark**), count on each group, first one open so the page opens on something to click rather than a row of shut drawers. Names sharing no prefix with two others land in **other**.

115 skills is now one scannable screen instead of a list you scroll. Each row is the skill's real name plus its description, clamped to two lines; rows are hairline-separated instead of 115 bordered cards. The header says what the agent runs on and how much it has, omitting any part it doesn't know rather than printing "0 tools".

Verified by rendering the real 115-skill agent at the pane's actual width (440–500px in oo-chat's Home column) and at full-window width.

## The markup moved out of Python

`render_starter` was a 50-line f-string of HTML and CSS. It now only decides *what* goes on the page; the markup lives in `starter/*.html` — `page.html` for the shell and its CSS, then one file each for a skill row, a group, a flat list, and the empty state. Design notes sit next to the rules they explain, and the CSS is editable without picking it out of an f-string.

`string.Template`, not `str.format`: the page is mostly CSS, and every rule in it is a pair of braces `format` would read as a field.

The shell template is `page.html` rather than `dashboard.html` on purpose — `.gitignore` has a `dashboard.html` rule for the run artifact `host()` writes into the cwd, and a template with that name is invisible to git and at risk of being dropped from a build.

## Constraints this had to respect

Everything here is **CSS-only**, and has to be: the client renders a dashboard under a CSP that runs only its own bridge script, so an agent's script tag or inline handler never executes. The disclosure groups are `<details>`/`<summary>`, which is the one affordance that works without scripting. Images would have to be inlined as `data:` URIs, so there are none, and a dashboard does not link out.

## Tests

Cover what actually broke, not the rendering:

- every published skill reachable (115 in → 115 buttons out)
- a short list is not hidden behind a disclosure
- a long list is grouped, and something is open
- names verbatim, descriptions present
- no script tag, hostile skill names escaped
- a family needs a third member to form (two lark-* behind a group of two buys nothing)
- the template files are present beside the module — a wheel that drops them turns every host startup into a `FileNotFoundError`

`2551 passed` on the full unit suite. Wheel build checked: all five templates ship.