### PR TITLE
The marker is a claim, not proof

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -12,6 +12,7 @@ LLM-Note:
 import hashlib
 import json
 import shlex
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -117,12 +118,35 @@ def _warn_about_skills_left_behind(project_dir: Path) -> None:
 
 
 def _read_provision(target: str, agent: str) -> dict:
-    """Read the convergence marker. A missing or unreadable one means schema 0."""
-    result = _ssh(target, f"cat {SRV}/{agent}/.co/provision.json 2>/dev/null", timeout=60)
-    if result.returncode != 0 or not result.stdout.strip():
+    """Read the convergence marker, and check the one thing it claims.
+
+    The marker survives every rsync, by design — it is the record of work that
+    does not need doing again. But it records what *was* true, and the venv it
+    speaks for can be gone: a disk cleanup, a restored snapshot, an `rm -rf`
+    during debugging. The marker knows nothing about that, so the deploy skipped
+    creating the venv, pip short-circuited on an unchanged requirements hash,
+    and the restart failed with a systemd error naming a python that is not
+    there — the one cause never mentioned.
+
+    So the interpreter is checked in the same round trip that reads the marker.
+    Not a re-verification of everything it implies; one test for the file the
+    systemd unit will execute.
+    """
+    result = _ssh(target,
+                  f"cat {SRV}/{agent}/.co/provision.json 2>/dev/null; "
+                  f"echo; test -x {SRV}/{agent}/.venv/bin/python && echo VENV_PRESENT",
+                  timeout=60)
+    if result.returncode != 0:
+        return {"schema": 0}
+
+    marker, _, tail = result.stdout.rpartition("\n")
+    if "VENV_PRESENT" not in result.stdout:
+        # Whatever the marker says, the work has to be done again.
+        return {"schema": 0}
+    if not marker.strip():
         return {"schema": 0}
     try:
-        return json.loads(result.stdout)
+        return json.loads(marker)
     except json.JSONDecodeError:
         # A truncated or hand-edited marker should mean "converge again", not
         # crash the deploy.
@@ -504,6 +528,17 @@ def _mark_provisioned(target: str, agent: str) -> None:
 def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
     """co deploy --to <server>:  ensure(setup) → sync code → restart."""
     project_dir = (project_dir or Path.cwd()).resolve()
+
+    # Checked here rather than discovered inside subprocess.run, which raises
+    # FileNotFoundError and prints a traceback — for the one failure a person can
+    # fix in a sentence. `co server add` has always checked; this path did not,
+    # and it is the one that runs after the server is already paid for.
+    for binary in ("ssh", "rsync"):
+        if not shutil.which(binary):
+            console.print(f"\n[red]No {binary} binary found on PATH.[/red]")
+            console.print(f"[dim]co deploys through your own {binary}, so it needs "
+                          f"one installed.[/dim]\n")
+            return False
 
     entry = load_server(server)
     if not entry:

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -165,12 +165,30 @@ class TestConvergence:
 
     def test_a_corrupt_marker_reads_as_schema_zero(self):
         """A truncated or hand-edited marker means converge again, not crash."""
-        with patch.object(dts, "_ssh", return_value=_ok("{not json")):
+        with patch.object(dts, "_ssh", return_value=_ok("{not json\nVENV_PRESENT")):
             assert dts._read_provision("user@host", "myagent") == {"schema": 0}
 
     def test_a_valid_marker_is_parsed(self):
-        with patch.object(dts, "_ssh", return_value=_ok(json.dumps({"schema": 1}))):
+        probe = json.dumps({"schema": 1}) + "\nVENV_PRESENT"
+        with patch.object(dts, "_ssh", return_value=_ok(probe)):
             assert dts._read_provision("user@host", "myagent")["schema"] == 1
+
+    def test_a_marker_without_the_venv_it_speaks_for_reads_as_schema_zero(self):
+        """The marker records what *was* true. A venv removed by a disk cleanup
+        or a restored snapshot leaves it standing, and the deploy then skipped
+        creating one — pip short-circuited on an unchanged requirements hash, and
+        the restart failed naming a python that is not there. openonion/connectonion#376
+        """
+        with patch.object(dts, "_ssh", return_value=_ok(json.dumps({"schema": 2}))):
+            assert dts._read_provision("user@host", "myagent") == {"schema": 0}
+
+    def test_the_interpreter_is_checked_in_the_same_round_trip(self):
+        """Not a second ssh call: the marker read already costs one."""
+        with patch.object(dts, "_ssh", return_value=_ok("{}\nVENV_PRESENT")) as ssh:
+            dts._read_provision("user@host", "myagent")
+
+        assert ssh.call_count == 1
+        assert ".venv/bin/python" in ssh.call_args.args[1]
 
 
 class TestDependencyInstall:
@@ -590,3 +608,35 @@ class TestTheAgentDoesNotRunAsRoot:
             dts._sync_code("co@1.2.3.4", "my-agent", tmp_path)
 
         assert any(f"chown -R co: {dts.SRV}/my-agent" in c for c in commands), commands
+
+
+class TestAMissingBinaryIsNotATraceback:
+    """`co server add` has always checked for ssh. This path did not — and it is
+    the one that runs after the server is already paid for, so the failure it
+    produced was a raw FileNotFoundError traceback for the single problem a
+    person can fix in one sentence. openonion/connectonion#377
+    """
+
+    def test_no_ssh_says_so_and_changes_nothing(self, capsys, project):
+        with patch.object(dts.shutil, "which", side_effect=lambda b: None if b == "ssh" else "/usr/bin/rsync"), \
+             patch.object(dts, "_ssh") as ssh:
+            assert dts.handle_deploy_to("prod", project) is False
+
+        ssh.assert_not_called()
+        out = " ".join(capsys.readouterr().out.split())
+        assert "No ssh binary found" in out
+
+    def test_no_rsync_says_so_too(self, capsys, project):
+        """The sync is rsync, not scp — a box with ssh but no rsync fails halfway."""
+        with patch.object(dts.shutil, "which", side_effect=lambda b: None if b == "rsync" else "/usr/bin/ssh"), \
+             patch.object(dts, "_ssh") as ssh:
+            assert dts.handle_deploy_to("prod", project) is False
+
+        ssh.assert_not_called()
+        assert "No rsync binary found" in " ".join(capsys.readouterr().out.split())
+
+    def test_both_present_proceeds(self, project):
+        """The check must not become the thing that blocks a working deploy."""
+        with patch.object(dts.shutil, "which", return_value="/usr/bin/x"), \
+             patch.object(dts, "load_server", return_value=None):
+            dts.handle_deploy_to("prod", project)  # falls through to the unknown-server path


### PR DESCRIPTION
Two reported deploy bugs, both in the path a paid server takes.

## #376 — a marker that outlived what it describes

`.co/provision.json` survives every rsync, by design: it is the record of work that does not need doing again. But it records what *was* true.

Remove `/srv/<agent>/.venv` — a disk cleanup, a restored snapshot, an `rm -rf` while debugging — and the marker is untouched. The next deploy reads a matching schema, takes the `else` branch, and **skips creating the venv**. `_install_deps_if_changed` then short-circuits on an unchanged requirements hash, so pip never runs either. The restart fails with a systemd error naming a python that does not exist, and the actual cause is the one thing nothing mentions.

The interpreter is now checked in the same round trip that already reads the marker:

```
cat .co/provision.json 2>/dev/null; echo; test -x .venv/bin/python && echo VENV_PRESENT
```

Not a re-verification of everything the marker implies — one test for the file the systemd unit will execute. No extra ssh call; the test asserts that.

## #377 — a traceback for a one-sentence problem

`subprocess.run(["ssh", ...])` raises `FileNotFoundError` when ssh is absent, and nothing caught it. `co server add` has checked `shutil.which("ssh")` since it was written; this path never did — and it is the one that runs *after* the server is paid for.

Checked up front, before anything is contacted or changed. `rsync` is checked too: the sync is rsync, so ssh alone gets you through convergence and then fails at the step that moves the code.

No exception handling was added. The check makes the failure impossible to reach rather than catching it after the fact, which is the same shape `co server add` already uses.

## Tests

Seven cases, each verified red first:

- a marker without the venv it speaks for reads as schema 0
- a valid marker plus a present venv still parses
- the interpreter check costs no extra round trip
- a corrupt marker still means converge again
- no ssh, no rsync, and both-present each behave, and nothing is contacted when a binary is missing

2546 passed.