### PR TITLE
A skill is not a project

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -87,6 +87,25 @@ def _load_deploy_ignore_patterns(project_dir: Path) -> list[str]:
     return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
 
 
+def _load_skill_ignore_patterns(skill_dir: Path) -> list[str]:
+    """What to leave out of a skill, which is not a project.
+
+    A skill's `build/` is a compiled helper it shells out to; its `todo.md` may
+    be a document it reads. The project defaults call both of those noise, so a
+    skill bundled with them lost files silently — the deploy succeeded and the
+    skill failed later, on the server, reaching for something that was never
+    sent.
+
+    Only a `.gitignore` the skill's own author wrote applies here, plus the
+    caches nobody means to ship.
+    """
+    lines = ["__pycache__/", "*.py[cod]", ".DS_Store", ".git/"]
+    gitignore = skill_dir / ".gitignore"
+    if gitignore.exists():
+        lines.extend(gitignore.read_text(encoding="utf-8").splitlines())
+    return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+
+
 def _path_matches_ignore_pattern(rel: Path, pattern: str) -> bool:
     rel_text = rel.as_posix()
     pattern = pattern.lstrip("/")
@@ -271,7 +290,7 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                 tar,
                 skills_path,
                 arc_prefix,
-                _load_deploy_ignore_patterns(skills_path),
+                _load_skill_ignore_patterns(skills_path),
             )
         _add_deployer_as_admin(tar)
     return tarball

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -1,0 +1,49 @@
+"""What `co deploy` puts in the tarball, and what it leaves out.
+
+The rules for a project and the rules for a skill are not the same, and using
+one for the other loses files quietly — which is the worst way to lose them,
+because the deploy still reports success.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import deploy_commands as dc
+
+
+class TestASkillIsNotAProject:
+    """A skill's `build/` is a compiled helper it shells out to; its `todo.md`
+    may be a document it reads. The project ignore defaults call both noise, so
+    a skill bundled with them lost files silently — the deploy succeeded and the
+    skill failed later, on the server, reaching for something never sent.
+    openonion/connectonion#380
+    """
+
+    def test_a_skills_build_directory_is_not_ignored(self, tmp_path):
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        assert not any(p.startswith("build") for p in patterns)
+        assert not any("node_modules" in p for p in patterns)
+        assert not any("todo" in p.lower() for p in patterns)
+
+    def test_the_project_defaults_still_ignore_those(self, tmp_path):
+        """The contrast is the point: a project wants them gone, a skill does not."""
+        patterns = dc._load_deploy_ignore_patterns(tmp_path)
+
+        assert any(p.startswith("build") for p in patterns)
+
+    def test_caches_are_still_left_out(self, tmp_path):
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        assert "__pycache__/" in patterns
+        assert ".git/" in patterns
+
+    def test_a_skill_author_can_still_say_what_to_leave_out(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("secrets.env\n# a comment\n\nscratch/\n")
+
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        assert "secrets.env" in patterns
+        assert "scratch/" in patterns
+        assert not any(p.startswith("#") for p in patterns)


### PR DESCRIPTION
Fixes #380.

`_build_tarball` called `_load_deploy_ignore_patterns(skills_path)` for every `--skills` directory, and that unconditionally prepends the project defaults: `build/`, `dist/`, `node_modules/`, `todo.md`, and the rest.

Those are the right rules for a project and the wrong ones for a skill. A skill's `build/` is a compiled helper it shells out to. Its `todo.md` may be a document it reads. A skill wrapping a JS tool brings `node_modules/` on purpose.

So the files were dropped from the tarball with no warning, and — this is the part that matters — **the deploy still reported success**. The failure surfaced later, on the server, when the skill reached for something that had never been sent.

## What applies to a skill now

Only what nobody means to ship, plus what the skill's own author asked for:

```python
["__pycache__/", "*.py[cod]", ".DS_Store", ".git/"] + skill/.gitignore
```

The project loader is untouched — a project still wants `build/` and `node_modules/` gone. The contrast is the point, and there is a test asserting both halves so neither drifts into the other.

## Tests

Four cases, verified red first: a skill's `build/` is not ignored, the project defaults still ignore it, caches are still left out, and a skill author's own `.gitignore` is still honoured (comments and blanks stripped).

2550 passed.