### PR TITLE
A skill still keeps its secrets

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -182,13 +182,14 @@ def launch_failure_advice(first_line: str) -> str:
     `co browser` from a desktop Terminal, when what it needed was the browser
     installed — the executable was simply not on disk.
     """
+    log = "Full log at ~/.co/browser.log."
     if "xecutable doesn't exist" in first_line:
         return ("No browser is installed for this user.\n"
-                "Install it with:  patchright install chromium")
+                f"Install it with:  patchright install chromium\n{log}")
     if platform.system() == "Darwin":
         return ("Run `co browser` from a desktop Terminal (a logged-in window "
-                "session), not over ssh/cron/detached.")
-    return "Full log at ~/.co/browser.log."
+                f"session), not over ssh/cron/detached.\n{log}")
+    return log
 
 
 class BrowserDaemon:

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -97,9 +97,12 @@ def _load_skill_ignore_patterns(skill_dir: Path) -> list[str]:
     sent.
 
     Only a `.gitignore` the skill's own author wrote applies here, plus the
-    caches nobody means to ship.
+    caches nobody means to ship — and secrets, which are the one thing the
+    project defaults were right about. `.env*` and `.co/keys/` leave the machine
+    over a network to a server, so they never travel, whatever the skill wants.
     """
-    lines = ["__pycache__/", "*.py[cod]", ".DS_Store", ".git/"]
+    lines = ["__pycache__/", "*.py[cod]", ".DS_Store", ".git/",
+             ".env*", ".co/keys/", "*.pem", "id_rsa", "id_ed25519"]
     gitignore = skill_dir / ".gitignore"
     if gitignore.exists():
         lines.extend(gitignore.read_text(encoding="utf-8").splitlines())

--- a/tests/unit/test_browser_launch_advice.py
+++ b/tests/unit/test_browser_launch_advice.py
@@ -39,3 +39,17 @@ class TestTheAdviceMatchesTheFailure:
 
         assert "desktop Terminal" not in advice
         assert "browser.log" in advice
+
+
+class TestTheLogIsAlwaysNamed:
+    """Whatever else is wrong, the full log is where the rest of it is. A rewrite
+    of this message dropped the pointer from two of the three branches, and a
+    test that had asserted it since before the rewrite caught it."""
+
+    def test_every_branch_names_the_log(self):
+        for system in ("Darwin", "Linux"):
+            with patch.object(daemon.platform, "system", return_value=system):
+                for line in ("Executable doesn't exist at /x",
+                             "Target page or browser has been closed"):
+                    assert "~/.co/browser.log" in daemon.launch_failure_advice(line), \
+                        (system, line)

--- a/tests/unit/test_deploy_commands.py
+++ b/tests/unit/test_deploy_commands.py
@@ -47,3 +47,29 @@ class TestASkillIsNotAProject:
         assert "secrets.env" in patterns
         assert "scratch/" in patterns
         assert not any(p.startswith("#") for p in patterns)
+
+
+class TestASkillStillKeepsItsSecrets:
+    """Letting a skill ship its own files must not let it ship its own keys.
+
+    The first cut of #380 dropped the project defaults wholesale, and `.env.local`
+    — which those defaults had been excluding — started travelling to the server
+    inside the tarball. That is a worse bug than the one being fixed.
+    """
+
+    def test_env_files_never_travel(self, tmp_path):
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        assert ".env*" in patterns
+
+    def test_private_keys_never_travel(self, tmp_path):
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        for name in ("*.pem", "id_rsa", "id_ed25519", ".co/keys/"):
+            assert name in patterns, name
+
+    def test_the_files_the_fix_was_about_still_travel(self, tmp_path):
+        patterns = dc._load_skill_ignore_patterns(tmp_path)
+
+        assert not any(p.startswith("build") for p in patterns)
+        assert not any("node_modules" in p for p in patterns)


### PR DESCRIPTION
A regression I introduced in #401, caught by a test that had been asserting this since before either change.

#401 stopped applying the project ignore defaults to skill directories, so a skill could ship its `build/` and its `todo.md`. It dropped them wholesale — and `.env.local`, which those defaults had been excluding, started travelling to the server inside the tarball.

```
AssertionError: assert '.co/skills/world/.env.local' not in {
  '.co/skills/world/.env.local', '.co/skills/world/SKILL.md', ...}
```

A secret leaving the machine is a worse bug than a `build/` directory not leaving it.

## What changed

The project defaults were right about exactly one thing. That one thing is kept:

```python
[".env*", ".co/keys/", "*.pem", "id_rsa", "id_ed25519"]
```

These leave the machine over a network to a server, so they never travel, whatever the skill's own `.gitignore` says. `build/`, `node_modules/` and `todo.md` still do — which is what #380 was about.

## How it got in

I merged #401 without reading its CI. The failure was there — `test_external_skills_skip_nested_local_only_files`, on 3.10 and 3.11 — and I ran the merge in the same command that polled for it, then acted on the poll's exit rather than its result.