### PR TITLE
fix: report malformed trust policy YAML clearly

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -76,14 +76,15 @@ def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
     if trust.lower() in TRUST_LEVELS:
         policy_path = PROMPTS_DIR / f"{trust.lower()}.md"
         if policy_path.exists():
-            config, _ = parse_policy(policy_path.read_text(encoding='utf-8'))
+            config, _ = parse_policy(policy_path.read_text(encoding='utf-8'),
+                                     source=str(policy_path))
             return config
         return None
 
     # Check if it's a file path
     path = Path(trust)
     if path.exists() and path.is_file():
-        config, _ = parse_policy(path.read_text(encoding='utf-8'))
+        config, _ = parse_policy(path.read_text(encoding='utf-8'), source=str(path))
         return config
 
     # Inline policy text

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -24,12 +24,18 @@ from typing import Optional
 from .tools import is_whitelisted, is_blocked, is_contact, is_admin, promote_to_contact
 
 
-def parse_policy(policy_text: str) -> tuple[dict, str]:
+def parse_policy(policy_text: str, source: str = None) -> tuple[dict, str]:
     """
     Parse YAML frontmatter from markdown policy file.
 
     Returns:
         (config_dict, markdown_body)
+
+    Args:
+        policy_text: The policy file's contents.
+        source: Where it came from, named in the error. A line number is only
+            half an answer when an operator has several policies and the
+            built-in ones as well.
 
     Raises:
         ValueError: If the YAML frontmatter is malformed.
@@ -57,8 +63,9 @@ def parse_policy(policy_text: str) -> tuple[dict, str]:
         )
         detail = f': {problem}' if problem else ''
 
+        where = f' in {source}' if source else ' in trust policy'
         raise ValueError(
-            f'Malformed YAML frontmatter in trust policy{location}{detail}. '
+            f'Malformed YAML frontmatter{where}{location}{detail}. '
             'Fix the YAML syntax before starting the agent host.'
         ) from None
 

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: calls tools.py functions (is_blocked, is_whitelisted, is_contact, promote_to_contact) which read/write .co/trust/ files | no direct file I/O in this module
   Integration: exposes parse_policy(policy_text), evaluate_request(config, client_id, request) | used by TrustAgent to parse policies and execute zero-cost fast rules before LLM | returns None when LLM needed (default: ask)
   Performance: zero LLM tokens for fast rules | O(n) checks against allow/deny lists | promote_to_contact() writes to file but rare (onboarding only) | YAML parsing is fast
-  Errors: yaml.safe_load() errors propagate | gracefully handles missing frontmatter (returns empty config)
+  Errors: malformed YAML frontmatter raises an actionable ValueError | gracefully handles missing frontmatter (returns empty config)
 
 Parse YAML config from trust policy files and execute fast rules.
 
@@ -30,6 +30,9 @@ def parse_policy(policy_text: str) -> tuple[dict, str]:
 
     Returns:
         (config_dict, markdown_body)
+
+    Raises:
+        ValueError: If the YAML frontmatter is malformed.
     """
     if not policy_text.startswith('---'):
         return {}, policy_text
@@ -41,7 +44,24 @@ def parse_policy(policy_text: str) -> tuple[dict, str]:
     yaml_content = policy_text[3:end].strip()
     markdown_body = policy_text[end + 3:].strip()
 
-    config = yaml.safe_load(yaml_content) or {}
+    try:
+        config = yaml.safe_load(yaml_content) or {}
+    except yaml.YAMLError as exc:
+        problem = getattr(exc, 'problem', None)
+        mark = getattr(exc, 'problem_mark', None)
+
+        location = (
+            f' at line {mark.line + 1}, column {mark.column + 1}'
+            if mark is not None
+            else ''
+        )
+        detail = f': {problem}' if problem else ''
+
+        raise ValueError(
+            f'Malformed YAML frontmatter in trust policy{location}{detail}. '
+            'Fix the YAML syntax before starting the agent host.'
+        ) from None
+
     return config, markdown_body
 
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -135,14 +135,14 @@ class TrustAgent:
             policy_path = PROMPTS_DIR / f"{trust.lower()}.md"
             if policy_path.exists():
                 text = policy_path.read_text(encoding='utf-8')
-                return parse_policy(text)
+                return parse_policy(text, source=str(policy_path))
             return {}, ""
 
         # File path
         path = Path(trust)
         if path.exists() and path.is_file():
             text = path.read_text(encoding='utf-8')
-            return parse_policy(text)
+            return parse_policy(text, source=str(path))
 
         # Inline policy text
         if trust.startswith('---'):

--- a/tests/unit/test_fast_rules.py
+++ b/tests/unit/test_fast_rules.py
@@ -330,3 +330,39 @@ class TestAnAdminIsNotAStranger:
                     "trust" / "policies" / f"{level}.md")
             config, _ = parse_policy(path.read_text())
             assert "admin" in config.get("allow", []), level
+
+
+class TestTheErrorNamesTheFile:
+    """A line number is half an answer. An operator has their own policies and
+    the built-in ones, and "line 1, column 29" does not say which file to open.
+    """
+
+    def test_the_source_is_named_when_given(self):
+        bad = "---\nallow: [whitelisted, contact\n---\n# Body\n"
+
+        with pytest.raises(ValueError) as exc:
+            parse_policy(bad, source=".co/trust/custom.md")
+
+        assert ".co/trust/custom.md" in str(exc.value)
+
+    def test_it_still_reads_sensibly_without_a_source(self):
+        """Inline policy text has no file to name."""
+        bad = "---\nallow: [whitelisted, contact\n---\n# Body\n"
+
+        with pytest.raises(ValueError) as exc:
+            parse_policy(bad)
+
+        assert "trust policy" in str(exc.value)
+
+    def test_loading_a_policy_file_names_that_file(self, tmp_path):
+        """The path is known by the loader, which is the one that has it."""
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        policy = tmp_path / "custom.md"
+        policy.write_text("---\nallow: [whitelisted, contact\n---\n# Body\n")
+
+        with pytest.raises(ValueError) as exc:
+            TrustAgent(str(policy))
+
+        assert "custom.md" in str(exc.value)
+        assert "line" in str(exc.value)

--- a/tests/unit/test_fast_rules.py
+++ b/tests/unit/test_fast_rules.py
@@ -79,6 +79,23 @@ default: ask
         assert config == {}
         assert "Body" in body
 
+    def test_parse_malformed_yaml_raises_actionable_error(self):
+        """Report malformed YAML frontmatter as a clear config error."""
+        policy = """---
+allow: [whitelisted, contact
+---
+# Body
+"""
+
+        with pytest.raises(ValueError) as exc_info:
+            parse_policy(policy)
+
+        message = str(exc_info.value)
+        assert "Malformed YAML frontmatter in trust policy" in message
+        assert "line" in message
+        assert "column" in message
+        assert "Fix the YAML syntax before starting the agent host." in message
+
 
 class TestEvaluateRequestOpenMode:
     """Test evaluate_request with default: allow config."""


### PR DESCRIPTION



## Description

Handle malformed YAML frontmatter in trust policy files as a clear configuration error instead of exposing an uncaught `yaml.YAMLError`.

The new error includes available YAML line and column information and tells the operator to fix the policy before starting the agent host. Existing behavior for policies without frontmatter and policies with empty frontmatter remains unchanged.

## Related Issue

Fixes #381

## Type of Change

- [x] Bug fix

## Changes Made

- Catch `yaml.YAMLError` inside `parse_policy`
- Raise an actionable `ValueError` with YAML location and parser details
- Suppress the raw PyYAML traceback with `from None`
- Add a distinct unit test for malformed YAML frontmatter
- Update the module error-handling note
- Preserve existing missing-frontmatter and empty-frontmatter behavior

## Testing

- [x] `python -m pytest tests/unit/test_fast_rules.py::TestParsePolicy::test_parse_malformed_yaml_raises_actionable_error -q`
- [x] `python -m pytest tests/unit/test_fast_rules.py -q`
- [x] Manually verified that malformed YAML raises an actionable `ValueError`
- [x] Manually verified that valid, missing, and empty frontmatter behavior is unchanged
- [x] Verified `fast_rules.py` targeted coverage at 95 percent
- [x] Ran `git diff --check`

### Local Environment Note

Full unit and non-real API test suites were attempted but do not complete cleanly on this Windows host because of existing browser, symbolic-link permission, and CLI environment failures.

These failures are outside `connectonion/network/trust/fast_rules.py` and `tests/unit/test_fast_rules.py`. The affected fast-rules test file passes all 29 tests locally.

## Example Usage

A malformed policy such as:

```yaml
---
allow: [whitelisted, contact
---
```

now produces an error similar to:

```text
ValueError: Malformed YAML frontmatter in trust policy at line 1, column 29: expected ',' or ']', but got '<stream end>'. Fix the YAML syntax before starting the agent host.
```

instead of exposing an uncaught PyYAML parser exception.

## Checklist

- [x] My code follows the existing style of the affected files
- [x] I have performed a self-review
- [x] I have added a docstring entry for the new error behavior
- [x] My changes generate no new warnings in the affected test suite
- [x] New and existing fast-rules unit tests pass locally
- [x] No project dependencies were added
- [x] No public documentation changes are required

## Screenshots

Not applicable.

## Additional Notes

This change intentionally fails fast instead of silently falling back to another trust configuration. Continuing with an unintended policy could change security behavior without the operator noticing.
```