### PR TITLE
dashboard: keep the Home page in .co/, and find it from the project root

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -5,11 +5,11 @@ description: Update the agent's Home dashboard. Use when the user says "update m
 
 # Dashboard Skill
 
-The agent's Home is a single file, `dashboard.html`, in the project root. OChat renders it in a sandboxed iframe beside the chat and re-reads it after every run. You edit it with your normal file tools (Read, Edit, Write, Bash) — there is no special API.
+The agent's Home is a single file, `.co/dashboard.html`, beside `.co/skills/`. (Older agents keep theirs in the project root — if `dashboard.html` is there, that is the one being served: edit it where it is, don't create a second one.) OChat renders it in a sandboxed iframe beside the chat and re-reads it after every run. You edit it with your normal file tools (Read, Edit, Write, Bash) — there is no special API.
 
 ## Instructions
 
-1. **Read `dashboard.html` first** so you preserve its structure and styles before changing anything.
+1. **Read the file first** — `.co/dashboard.html`, or the root `dashboard.html` if that is where this agent's already is — so you preserve its structure and styles before changing anything.
 2. **Make the smallest edit that satisfies the request** — change the data or add a section; don't rewrite the whole file unless the user asks for a redesign.
 3. **Keep it visual, not textual.** Lead with big numbers, generous whitespace, and clear action buttons. A dashboard is a glanceable Home, not a document.
 4. **Write the file** and stop. OChat picks up the change automatically after the run.
@@ -30,7 +30,7 @@ A button that runs something MUST be a real, user-invocable skill, wired like th
 
 ## Rules
 
-- One file: `dashboard.html`. No sidecar JSON, no build step.
+- One file: `.co/dashboard.html`. No sidecar JSON, no build step.
 - Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
 - Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting; only the `data-ochat-skill` button contract works.

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -380,6 +380,10 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     which is worse than failing. So skills are included, and `--delete` applies
     inside that directory too so a removed skill actually goes away.
 
+    `.co/dashboard.html` is included for the same reason: the Home page you wrote
+    is part of the agent. Left out, a deploy silently replaces it with a generated
+    starter — the agent looks fine and your dashboard is gone.
+
     Order matters to rsync: the include must precede the exclude that would
     otherwise swallow it, and `.co/` itself must be included for rsync to
     descend into it at all.
@@ -392,6 +396,7 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
             "rsync", "-az", "--delete",
             "--include", ".co/",
             "--include", ".co/skills/***",
+            "--include", ".co/dashboard.html",
             "--exclude", ".co/*",
             "--exclude", ".venv/",
             "--exclude", ".git/",

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -21,6 +21,10 @@ from string import Template
 from ....console import Console
 
 DASHBOARD_FILE = "dashboard.html"
+CO_DIR = ".co"
+# An operator's own starting point for every agent they host. Optional; the bundled
+# template is used when it isn't there.
+STARTER_OVERRIDE = Path.home() / CO_DIR / "starter.html"
 
 # Generous on purpose: the client's CSP allows images only as `data:` URIs, so the one
 # way to put a chart or logo on a dashboard is to inline it, and base64 adds ~33%. A
@@ -33,15 +37,47 @@ DASHBOARD_FILE = "dashboard.html"
 # — a log accidentally named dashboard.html, or an agent dumping a dataset into it.
 MAX_DASHBOARD_BYTES = 2 * 1024 * 1024
 
-# Where dashboard.html lives, captured at host startup. Resolving cwd per read
-# would follow any later os.chdir (a tool, a plugin) and start serving whatever
-# file happened to be in the new directory.
+# The project directory, resolved once at host startup. Resolving it per read would
+# follow any later os.chdir (a tool, a plugin) and start serving whatever file
+# happened to be in the new directory.
 _project_dir = None
 
 
+def project_root(start=None):
+    """The directory that owns ``.co/`` — the project, not wherever you ran from.
+
+    Walks up from ``start``. Everything else the agent is made of is found this way
+    (``.co/skills``, ``.co/host.yaml``), and the Home page had no such notion: it
+    resolved against the bare cwd, so running the agent from a subdirectory created
+    a second dashboard.html there and served that one instead.
+
+    Falls back to ``start`` when there is no ``.co/`` above it — an agent hosted
+    outside a project still gets a Home, it just lives where it was started.
+    """
+    start = Path(start or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        if (directory / CO_DIR).is_dir():
+            return directory
+    return start
+
+
 def dashboard_path():
-    """Path to ``dashboard.html`` in the agent's project directory."""
-    return (_project_dir or Path.cwd()) / DASHBOARD_FILE
+    """Where this agent's Home page lives.
+
+    ``.co/dashboard.html``, beside ``.co/skills/`` — both are what the agent *is*,
+    as opposed to the logs and evals it accumulates.
+
+    A ``dashboard.html`` in the project root is the older location. One that is
+    already there is still served, and never moved or overwritten: an agent whose
+    Home silently disappeared on upgrade would be a worse bug than an inconsistent
+    path. New ones are written to ``.co/``.
+    """
+    root = _project_dir or project_root()
+    preferred = root / CO_DIR / DASHBOARD_FILE
+    if preferred.exists():
+        return preferred
+    legacy = root / DASHBOARD_FILE
+    return legacy if legacy.exists() else preferred
 
 
 def read_dashboard_snapshot(session_id=None):
@@ -110,12 +146,13 @@ def ensure_dashboard(agent_metadata, project_dir=None):
     owns it after that). Gives every agent a polished Home on day zero.
     """
     global _project_dir
-    _project_dir = Path(project_dir) if project_dir else Path.cwd()
+    _project_dir = Path(project_dir) if project_dir else project_root()
 
     path = dashboard_path()
     if path.exists():
         return
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(render_starter(agent_metadata), encoding="utf-8")
     except OSError as e:
         # A read-only or missing project dir is a fine reason to have no dashboard;
@@ -168,9 +205,8 @@ def group_skills(skills):
     return grouped, loose
 
 
-@lru_cache(maxsize=1)
-def _starter_templates():
-    """``(page, fragments)`` from ``starter.html`` — the one file the starter lives in.
+def _parse_starter(path):
+    """``(page, fragments)`` from a starter file.
 
     The file is a complete page, then a ``<!--FRAGMENTS`` marker, then the repeated
     pieces as ``<template id="...">`` tags. Splitting on the marker rather than on
@@ -181,10 +217,34 @@ def _starter_templates():
     ``string.Template`` rather than ``str.format``: the page is mostly CSS, and every
     rule in it is a pair of braces that ``format`` would read as a field.
     """
-    raw = (Path(__file__).parent / "starter.html").read_text(encoding="utf-8")
+    raw = path.read_text(encoding="utf-8")
     page, _, scaffolding = raw.partition("<!--FRAGMENTS")
-    fragments = re.findall(r'<template id="([^"]+)">(.*?)</template>', scaffolding, re.DOTALL)
-    return Template(page.rstrip() + "\n"), {name: Template(body) for name, body in fragments}
+    found = re.findall(r'<template id="([^"]+)">(.*?)</template>', scaffolding, re.DOTALL)
+    return Template(page.rstrip() + "\n"), {name: Template(body) for name, body in found}
+
+
+# maxsize=1 caches the parse for the process; tests that swap the override call
+# _starter_templates.cache_clear().
+@lru_cache(maxsize=1)
+def _starter_templates():
+    """The starter to render from — the bundled one, or the operator's.
+
+    ``~/.co/starter.html`` replaces it when present, so "all my agents start from my
+    styling" needs no per-project copy. It replaces the *template*, not the page:
+    every agent still renders its own name and its own skills, which a shared
+    finished page could not do — the client validates each button against that
+    agent's published skills, so someone else's Home renders as dead buttons.
+
+    An override only has to carry the parts it wants to change. Its fragments are
+    layered over the bundled ones, so restyling the page shell — the common case —
+    does not mean copying the skill row and the group markup along with it, or
+    silently losing them.
+    """
+    page, fragments = _parse_starter(Path(__file__).parent / "starter.html")
+    if STARTER_OVERRIDE.is_file():
+        override_page, override_fragments = _parse_starter(STARTER_OVERRIDE)
+        page, fragments = override_page, {**fragments, **override_fragments}
+    return page, fragments
 
 
 def _skill_row(skill):

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -1,14 +1,15 @@
 # Dashboard — your agent's Home page
 
-Every hosted agent can have a **Home page**: a single file, `dashboard.html`, in the
-project root. A chat client renders it beside the conversation, so opening your agent
-shows something useful before you type anything.
+Every hosted agent can have a **Home page**: a single file, `.co/dashboard.html`. A
+chat client renders it beside the conversation, so opening your agent shows something
+useful before you type anything.
 
 ```
 my-agent/
 ├── agent.py
-├── dashboard.html      ← the Home page
 └── .co/
+    ├── dashboard.html   ← the Home page
+    └── skills/          ← and the skills it offers
 ```
 
 The browser can't read a file inside your agent's container, so the Host reads
@@ -31,27 +32,59 @@ host(lambda: Agent("lisa", tools=[...]))
 
 After that the file is yours. ConnectOnion never overwrites it.
 
-### Where it lives, and why there
+### Where it lives, and how it's found
 
-`dashboard.html` sits at the **project root**, next to `agent.py`. Not in `.co/`, and
-that is not cosmetic:
+`.co/dashboard.html`, beside `.co/skills/`. Both are **what the agent is**, as opposed
+to the logs and evals it accumulates — and that distinction is what `.co/` is sorted
+by, not "config vs content".
 
-- `co deploy --to` rsyncs the project tree **excluding `.co/`**. A dashboard under
-  `.co/` would silently not travel, and the deployed agent would look like it had no
-  Home.
-- The template Dockerfile does `COPY . .`, so the root is in the image.
-- The `.gitignore` `co create` writes does not ignore it, so it gets committed — a
-  dashboard you edited is part of your agent, like its prompt.
+The project is located by walking up for a `.co/` directory, the same way skills are
+found. So it doesn't matter which directory you start the agent from:
 
-**`co create` and `co init` deliberately do not scaffold one.** At create time the
-project has no skills yet, and `ensure_dashboard` never overwrites an existing file —
-scaffolding then would freeze an empty Home forever. It is written on the first
-`host()`, which is the first moment the agent's skills are actually known.
+```
+my-agent/           ← found, because .co/ is here
+├── .co/dashboard.html
+└── src/
+    └── run.py      ← `python run.py` from in here still serves the same Home
+```
 
-On a deployed agent the same rule applies on the server: `host()` writes a starter
-there if the rsync carried none. That means an agent deployed without a dashboard gets
-one built from the skills that actually made it onto the server, which is the honest
-answer rather than a copy of what your laptop had.
+With no `.co/` above you, the Home lands where the agent was started.
+
+**An older `dashboard.html` in the project root still works.** If one is there it is
+the file being served, and nothing moves, copies, or overwrites it — an agent whose
+Home vanished on upgrade would be a worse bug than an inconsistent path. Move it to
+`.co/` yourself when you feel like it. If both exist, `.co/` wins.
+
+#### It travels
+
+`co deploy --to` rsyncs the project **excluding `.co/*`**, because that directory
+holds the agent's identity, logs and evals — that exclusion is why a redeploy doesn't
+reissue your agent's address. Two things are included back in: `.co/skills/` and
+`.co/dashboard.html`. Same reason for both. A deploy that dropped your Home page would
+regenerate a starter over it, and the agent would look fine.
+
+#### It isn't scaffolded
+
+`co create` and `co init` deliberately do not write one. At create time the project has
+no skills yet, and the starter is never written over an existing file — scaffolding
+then would freeze an empty Home forever. It is written on the first `host()`, the first
+moment the agent's skills are actually known. On a server the same rule applies: an
+agent deployed without a dashboard gets one built from the skills that actually made it
+onto the server, rather than a copy of what your laptop had.
+
+### One starter for all your agents
+
+Write `~/.co/starter.html` and every agent you host starts from that instead of the
+bundled template.
+
+It replaces the **template**, not the page: each agent still renders its own name and
+its own skills. That matters — a client validates every button against the skills
+*that* agent published, so serving one agent's finished Home for another gives a page
+of buttons that silently do nothing.
+
+An override only needs the parts you want to change. Its `<template>` fragments are
+layered over the bundled ones, so restyling the page shell doesn't mean copying the
+skill-row and group markup along with it.
 
 ### It scales with the agent
 
@@ -83,7 +116,7 @@ which is the one thing that works without scripting.
 
 ## Editing it
 
-`dashboard.html` is a plain HTML file — edit it with any editor. Or ask the agent: the
+`.co/dashboard.html` is a plain HTML file — edit it with any editor. Or ask the agent: the
 built-in `dashboard` skill teaches it the file's contract.
 
 ```
@@ -155,10 +188,10 @@ The Host sends the file at two moments:
 
 The post-run send is skipped when the file hasn't changed since that connection last
 saw it, so an unchanged Home costs nothing per turn. Nothing is polled and nothing
-watches the filesystem — if you edit `dashboard.html` by hand while a client is
+watches the filesystem — if you edit it by hand while a client is
 connected, the change shows up after the next run.
 
-An agent with no `dashboard.html` sends nothing, and clients simply show no Home pane.
+An agent with no dashboard file sends nothing, and clients simply show no Home pane.
 
 ## Wire format
 
@@ -183,6 +216,8 @@ See [websocket-protocol.md](websocket-protocol.md) for the full frame reference.
 | `read_dashboard_snapshot(session_id=None)` | Build the frame, or `None` if the file is missing, too large, unreadable, or not UTF-8 |
 | `send_dashboard(send_msg, session_id, conn=None)` | Send it unless this connection already has the current file; reads off the event loop |
 | `ensure_dashboard(agent_metadata, project_dir=None)` | Write the starter if absent, and anchor the directory later reads resolve against |
+| `project_root(start=None)` | Walk up for `.co/`; the project, not the cwd |
+| `dashboard_path()` | `.co/dashboard.html`, or a legacy root one if that is what exists |
 | `render_starter(agent_metadata)` | The day-zero HTML, from `starter.html` |
 | `published_skills(skills)` | The project-tree skills a starter may offer as buttons |
 | `group_skills(skills)` | `(families, loose)` split by name prefix, for long lists |

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -49,7 +49,7 @@ def test_ensure_dashboard_creates_starter(in_tmp):
         {"name": "meeting_prep", "description": "d", "location": "project"},
     ]}
     ensure_dashboard(meta)
-    html = (in_tmp / "dashboard.html").read_text(encoding="utf-8")
+    html = (in_tmp / ".co" / "dashboard.html").read_text(encoding="utf-8")
     assert "Lisa" in html
     assert 'data-ochat-skill="daily-brief"' in html
     assert 'data-ochat-skill="meeting_prep"' in html
@@ -293,7 +293,7 @@ def test_starter_has_no_buttons_for_unpublished_skills(in_tmp):
         {"name": "my-notes", "description": "", "location": "user"},
         {"name": "dashboard", "description": "", "location": "builtin"},
     ]})
-    html = (in_tmp / "dashboard.html").read_text(encoding="utf-8")
+    html = (in_tmp / ".co" / "dashboard.html").read_text(encoding="utf-8")
     assert "data-ochat-skill" not in html
     assert ".co/skills/" in html  # falls back to the empty state
 
@@ -370,7 +370,7 @@ def test_ensure_dashboard_takes_an_explicit_project_dir(tmp_path, monkeypatch):
 
     ensure_dashboard({"name": "Explicit", "skills": []}, project_dir=project)
 
-    assert (project / "dashboard.html").exists()
+    assert (project / ".co" / "dashboard.html").exists()
 
 
 def test_ensure_dashboard_warns_instead_of_crashing_on_an_unwritable_dir(in_tmp, monkeypatch, capsys):
@@ -398,3 +398,88 @@ def test_the_fragment_templates_do_not_leak_into_the_page():
     ]})
     assert "<template" not in html
     assert "$" not in html
+
+
+# --- Where the Home page lives: .co/, found from the project root ---
+
+
+def test_the_starter_is_written_into_the_co_directory(in_tmp):
+    (in_tmp / ".co").mkdir()
+    ensure_dashboard({"name": "Lisa", "skills": []})
+
+    assert (in_tmp / ".co" / "dashboard.html").is_file()
+    assert not (in_tmp / "dashboard.html").exists()
+
+
+def test_the_project_is_found_from_a_subdirectory(in_tmp, monkeypatch):
+    """Resolving against the bare cwd meant running the agent from a subdirectory
+    created a second dashboard.html there and served that one."""
+    (in_tmp / ".co").mkdir()
+    nested = in_tmp / "src" / "deep"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    ensure_dashboard({"name": "Lisa", "skills": []})
+
+    assert (in_tmp / ".co" / "dashboard.html").is_file()
+    assert not (nested / "dashboard.html").exists()
+    assert dashboard_module.dashboard_path() == in_tmp / ".co" / "dashboard.html"
+
+
+def test_an_existing_root_dashboard_is_still_served(in_tmp):
+    """Agents written before the move keep their Home. Silently dropping it on
+    upgrade would be worse than an inconsistent path."""
+    (in_tmp / ".co").mkdir()
+    (in_tmp / "dashboard.html").write_text("<h1>mine</h1>", encoding="utf-8")
+
+    ensure_dashboard({"name": "Lisa", "skills": []})
+
+    assert dashboard_module.dashboard_path() == in_tmp / "dashboard.html"
+    assert read_dashboard_snapshot()["html"] == "<h1>mine</h1>"
+    assert not (in_tmp / ".co" / "dashboard.html").exists()  # not moved, not copied
+
+
+def test_the_co_copy_wins_when_both_exist(in_tmp):
+    (in_tmp / ".co").mkdir()
+    (in_tmp / "dashboard.html").write_text("<h1>old</h1>", encoding="utf-8")
+    (in_tmp / ".co" / "dashboard.html").write_text("<h1>current</h1>", encoding="utf-8")
+
+    assert read_dashboard_snapshot()["html"] == "<h1>current</h1>"
+
+
+def test_an_agent_outside_a_project_still_gets_a_home(in_tmp):
+    """No .co/ anywhere above: the Home lands where the agent was started."""
+    ensure_dashboard({"name": "Loose", "skills": []})
+
+    assert (in_tmp / ".co" / "dashboard.html").is_file()
+
+
+def test_a_personal_starter_template_replaces_the_bundled_one(in_tmp, monkeypatch, tmp_path):
+    """~/.co/starter.html is a template, not a finished page — the agent's own name
+    and skills still get rendered into it."""
+    override = tmp_path / "home" / ".co" / "starter.html"
+    override.parent.mkdir(parents=True)
+    override.write_text("<h1>$name</h1><p>$subtitle</p>\n$body\n", encoding="utf-8")
+    monkeypatch.setattr(dashboard_module, "STARTER_OVERRIDE", override)
+    dashboard_module._starter_templates.cache_clear()
+
+    html = render_starter({"name": "Mine", "model": "co/x", "skills": [
+        {"name": "daily-brief", "description": "d", "location": "project"},
+    ]})
+    dashboard_module._starter_templates.cache_clear()
+
+    assert "<h1>Mine</h1>" in html
+    assert "co/x" in html
+    # Restyling the shell must not mean copying — or losing — the row markup.
+    assert 'data-ochat-skill="daily-brief"' in html
+
+
+def test_the_deploy_rsync_carries_the_dashboard():
+    """.co/* is excluded to protect identity and logs; the Home page is not state,
+    and a deploy that drops it silently regenerates a starter over your page."""
+    import inspect
+    from connectonion.cli.commands import deploy_to_server
+
+    source = inspect.getsource(deploy_to_server._sync_code)
+    assert '".co/dashboard.html"' in source
+    assert source.index('".co/dashboard.html"') < source.index('".co/*"')


### PR DESCRIPTION
Follow-up to #391. Two things were wrong with **where** the Home page lived.

## It resolved against the bare cwd

Start the agent from a subdirectory and `ensure_dashboard` created a *second* `dashboard.html` there and served that one. An agent with a Home page you had written came up blank because you ran it from `src/`.

Everything else the agent is made of is found by walking up for `.co/` — skills, `host.yaml`. The dashboard had no notion of a project at all.

## It was on the wrong side of the `.co/` line

The dashboard sat in the project root while `.co/skills/` sat in `.co/`. What `.co/` is actually sorted by is not "config vs content" — `deploy_to_server` says it outright:

> `.co/skills/` is the exception, and it has to be: skills are *what the agent is*, not state it accumulated. Excluding all of `.co/` shipped an agent with none of its skills — the deploy succeeded and the agent ran without them, which is worse than failing.

A Home page is the same kind of thing. State (identity, logs, evals) stays excluded; what the agent *is* gets included.

## The change

- `.co/dashboard.html`, located by walking up for `.co/` — cwd no longer decides.
- `--include ".co/dashboard.html"` in the deploy rsync, next to skills. Without it a deploy silently drops your Home page and the server regenerates a starter over it: the deploy succeeds, the agent looks fine, your page is gone.
- **A root `dashboard.html` is still served**, and is never moved, copied, or overwritten. An agent whose Home vanished on upgrade would be a worse bug than an inconsistent path. `.co/` wins if both exist.
- `~/.co/starter.html`: write one and every agent you host starts from it instead of the bundled template.

## On the personal starter

It replaces the **template**, not the page — deliberately. Each agent still renders its own name and its own skills, because the client validates every button against the skills *that* agent published; one agent's finished Home served for another is a page of buttons that silently do nothing.

An override carries only what it changes: its `<template>` fragments layer over the bundled ones, so restyling the page shell doesn't mean copying the skill-row and group markup along with it — or quietly losing them.

## Tests

Confirmed **red against the current code first** (6 of 7 fail without the change):

- written into `.co/`
- found from a subdirectory, with nothing created in the subdirectory
- a legacy root file still served, and *not* migrated
- `.co/` winning when both exist
- an agent outside any project still getting a Home
- a personal starter rendering this agent's own name and skills
- the rsync carrying `.co/dashboard.html`, ordered ahead of the `.co/*` exclude

`2572 unit + 366 cli e2e` pass. Smoke-tested for real: started from `src/` inside a project, the file landed in that project's `.co/` and nowhere else.

Docs rewritten (the "project root, and that is not cosmetic" section from #391 is now the opposite, with the reasoning), plus the built-in `dashboard` skill's file contract so the agent edits the right file — including the legacy case.