### PR TITLE
The test suite must not be able to reach the real ~/.co

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,28 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+@pytest.fixture(autouse=True)
+def _never_touch_the_real_home(monkeypatch, tmp_path_factory):
+    """No test may read or write the operator's real ~/.co.
+
+    `CliRunner.isolated_filesystem()` isolates the working directory and
+    nothing else, so a test that ran `co auth microsoft` against mocked HTTP
+    still wrote its fake tokens into the real ~/.co/keys.env — overwriting a
+    live Outlook session with `access_token='eyJ0eXAi.test'`. The failure
+    surfaced days later as "Microsoft session expired", which is the last thing
+    anyone would trace back to a test run.
+
+    Isolating HOME is the only guard that holds: the paths are resolved deep
+    inside the commands, from Path.home() and from AGENT_CONFIG_PATH, and a
+    per-test patch has to be remembered by every future test.
+    """
+    home = tmp_path_factory.mktemp("home")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))       # Windows
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(home / ".co"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+
 @pytest.fixture
 def temp_dir():
     """Create a temporary directory for tests."""

--- a/tests/unit/test_home_isolation.py
+++ b/tests/unit/test_home_isolation.py
@@ -1,0 +1,40 @@
+"""The test suite must not be able to reach the operator's real ~/.co.
+
+This is not hypothetical. `tests/e2e/cli/test_cli_auth_microsoft.py` ran
+`co auth microsoft` against mocked HTTP inside `CliRunner.isolated_filesystem()`,
+which isolates the working directory and nothing else — so the fake credentials
+it asserts on were also written to the real `~/.co/keys.env`, replacing a live
+Outlook session with `access_token='eyJ0eXAi.test'`.
+
+It surfaced days later as "Microsoft session expired, reconnect with
+co auth microsoft", which is the last thing anyone would trace back to a test.
+"""
+
+import os
+from pathlib import Path
+
+
+SANDBOX_PREFIXES = ("/private/", "/tmp", "/var", "C:\\Users\\RUNNER")
+
+
+class TestTheRealHomeIsOutOfReach:
+    def test_the_home_env_var_is_a_sandbox(self):
+        """$HOME is what the shell-facing paths resolve against."""
+        assert os.environ["HOME"].startswith(SANDBOX_PREFIXES), os.environ["HOME"]
+
+    def test_path_home_is_redirected_too(self):
+        """Commands resolve ~/.co through Path.home(), which reads $HOME only on
+        some platforms — so it is patched directly as well."""
+        assert str(Path.home()).startswith(SANDBOX_PREFIXES), str(Path.home())
+
+    def test_agent_config_path_points_inside_it(self):
+        """The other way a command finds the global directory."""
+        assert os.environ["AGENT_CONFIG_PATH"].startswith(str(Path.home()))
+
+    def test_writing_the_global_keys_file_lands_in_the_sandbox(self):
+        keys = Path(os.environ["AGENT_CONFIG_PATH"]) / "keys.env"
+        keys.parent.mkdir(parents=True, exist_ok=True)
+        keys.write_text("MICROSOFT_ACCESS_TOKEN=would-have-clobbered-a-real-one\n")
+
+        assert keys.exists()
+        assert not str(keys).startswith("/Users/"), str(keys)


### PR DESCRIPTION
A test overwrote a live Outlook session with its own fixtures. This is how.

## What was in the operator's keys.env

```
MICROSOFT_ACCESS_TOKEN     = 'eyJ0eXAi.test'      (13 chars; a real one is ~1000)
MICROSOFT_REFRESH_TOKEN    = '0.ATcA.test'        (11 chars)
MICROSOFT_TOKEN_EXPIRES_AT = 2025-12-31T23:59:59
MICROSOFT_EMAIL            = test@outlook.com
```

Those are the exact values asserted in `tests/e2e/cli/test_cli_auth_microsoft.py`.

## How they got there

The test runs `co auth microsoft` against mocked HTTP inside `CliRunner.isolated_filesystem()`. That isolates the **working directory**, and nothing else. `co auth` writes two places — the project `.env` the test asserts on, and the global `~/.co/keys.env` it does not.

So the test passed, and the operator's Outlook connection was replaced by an 11-character refresh token.

It does not fail loudly. It fails days later as:

```
ValueError: Microsoft session expired and refresh failed (400).
Reconnect with: co auth microsoft
```

which reads like a Microsoft token lifetime problem — a refresh token is good for 90 days — and is the last thing anyone would trace back to their own test run.

## Why a global fixture and not four patches

Four test files use `isolated_filesystem()` with no HOME isolation at all:

```
0  tests/e2e/cli/test_cli.py
0  tests/e2e/cli/test_cli_auth_microsoft.py
0  tests/e2e/cli/test_cli_deploy.py
0  tests/e2e/cli/argparse_runner.py
```

The paths are resolved deep inside the commands — from `Path.home()` and from `AGENT_CONFIG_PATH` — so a per-test patch is a rule every future test has to remember. An autouse fixture in `tests/conftest.py` points `HOME`, `USERPROFILE`, `AGENT_CONFIG_PATH` and `Path.home()` at a per-test temp directory, and no test can reach the real one whether or not its author thought about it.

## Verified with a sentinel

Not by reading:

```
放入哨兵                                          1
without the fixture, does the sentinel survive?   0    ← erased
with the fixture, does the sentinel survive?      1    ← intact
```

`tests/unit/test_home_isolation.py` pins the rule itself, and fails (3 of 4) when the fixture is removed.

2920 passed, no other test depended on reaching the real home.

## Related

- oo-api#25 and #180 are about token refresh being server-authoritative. Worth noting this incident was *not* a refresh bug — the refresh failed because the token it was given was `'0.ATcA.test'`.