### PR TITLE
test: the dashboard suite must not render from the developer's own starter

### DIFF
--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -15,6 +15,24 @@ from connectonion.network.host.ws_router.dashboard import (
 )
 
 
+@pytest.fixture(autouse=True)
+def no_personal_starter(tmp_path, monkeypatch):
+    """Keep the operator's own ~/.co/starter.html out of this suite.
+
+    It is a real feature, and one this file tests — so a developer who actually
+    uses it would otherwise have every render here come from their page. A
+    starter without a $body placeholder fails nine of these tests, and one with a
+    script tag fails two, for no reason connected to the change being made.
+
+    Tests that want an override set STARTER_OVERRIDE themselves; monkeypatch
+    applies in order, so theirs wins.
+    """
+    monkeypatch.setattr(dashboard_module, "STARTER_OVERRIDE", tmp_path / "absent-starter.html")
+    dashboard_module._starter_templates.cache_clear()
+    yield
+    dashboard_module._starter_templates.cache_clear()
+
+
 @pytest.fixture
 def in_tmp(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -462,11 +480,9 @@ def test_a_personal_starter_template_replaces_the_bundled_one(in_tmp, monkeypatc
     override.write_text("<h1>$name</h1><p>$subtitle</p>\n$body\n", encoding="utf-8")
     monkeypatch.setattr(dashboard_module, "STARTER_OVERRIDE", override)
     dashboard_module._starter_templates.cache_clear()
-
     html = render_starter({"name": "Mine", "model": "co/x", "skills": [
         {"name": "daily-brief", "description": "d", "location": "project"},
     ]})
-    dashboard_module._starter_templates.cache_clear()
 
     assert "<h1>Mine</h1>" in html
     assert "co/x" in html


### PR DESCRIPTION
#405 added `~/.co/starter.html` — write one and every agent you host starts from it. It is read by `render_starter`, which this test file calls constantly, so a developer who actually uses the feature has the whole dashboard suite rendering from *their* page.

Measured with a real override in place:

| `~/.co/starter.html` | result |
|---|---|
| none | 44 passed |
| no `$body` placeholder | **9 failed** |
| contains a script tag | **2 failed** |

None of it connected to whatever change was being made. This is the same class of problem as `fix/tests-must-not-touch-the-real-home`.

An autouse fixture points `STARTER_OVERRIDE` at a path that does not exist and clears the template cache either side. Tests that *want* an override still set it themselves — monkeypatch applies in order, so theirs wins.

Verified both ways: with a hostile `~/.co/starter.html` present, 9 failures before the fixture and 44 passing after. `2572` unit pass.