### PR TITLE
Copy a skill into the tier that deploys

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -111,7 +111,7 @@ def _warn_about_skills_left_behind(project_dir: Path) -> None:
             + ", ".join(s.name for s in staying[:5])
             + (f" (+{len(staying) - 5} more)" if len(staying) > 5 else "")
         )
-        console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
+        console.print("    [dim]co skills copy <name> --to-project   to ship one[/dim]")
 
     for location, name, reason in find_skill_problems(project_dir=project_dir):
         console.print(f"  [red]✗[/red] {location}/{name} — {reason}")

--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -148,11 +148,11 @@ def _load_index() -> Optional[dict]:
 SOURCE_PRIORITY = {src: i for i, (src, _, _) in enumerate(SOURCES)}
 
 
-def _copy_entry(entry: dict, force: bool) -> bool:
-    """Copy a single index entry into ~/.co/skills/<name>/. Returns True if copied."""
+def _copy_entry(entry: dict, force: bool, skills_dir: Optional[Path] = None) -> bool:
+    """Copy a single index entry into <skills_dir>/<name>/. Returns True if copied."""
     name = entry["name"]
     src_path = Path(entry["path"])
-    dest_dir = SKILLS_DIR / name
+    dest_dir = (skills_dir or SKILLS_DIR) / name
     dest_file = dest_dir / "SKILL.md"
 
     if src_path.resolve() == dest_file.resolve():
@@ -185,14 +185,22 @@ def handle_skills_copy(
     source: Optional[str] = None,
     force: bool = False,
     all_: bool = False,
+    to_project: bool = False,
 ):
-    """Copy one or more discovered skills into ~/.co/skills/<name>/."""
+    """Copy one or more discovered skills into a skills directory.
+
+    Which directory is the whole question. ~/.co/skills is the operator's
+    library and does not travel — `co skills list` marks it `Deploys ✗`. Only
+    the project's .co/skills reaches a server, which is what every deploy tells
+    you ("move one into .co/skills/ to ship it") and what no command did.
+    """
     index = _load_index()
     if not index:
         console.print("[yellow]No index found. Run `co skills discover` first.[/yellow]")
         return
 
-    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    skills_dir = (Path.cwd() / ".co" / "skills") if to_project else SKILLS_DIR
+    skills_dir.mkdir(parents=True, exist_ok=True)
 
     by_name: dict = {}
     for s in index["skills"]:
@@ -209,13 +217,13 @@ def handle_skills_copy(
 
         copied = skipped = 0
         for entry in chosen.values():
-            if _copy_entry(entry, force):
+            if _copy_entry(entry, force, skills_dir):
                 copied += 1
             else:
                 skipped += 1
         console.print(f"\n[bold]Copied {copied} skill(s)[/bold]"
                       + (f", skipped {skipped}" if skipped else "")
-                      + f" → {SKILLS_DIR}")
+                      + f" → {skills_dir}")
         return
 
     if not names:
@@ -233,7 +241,7 @@ def handle_skills_copy(
             sources = ", ".join(m["source"] for m in matches)
             console.print(f"[yellow]{name} exists in: {sources}. Use --source to pick one.[/yellow]")
             continue
-        _copy_entry(matches[0], force)
+        _copy_entry(matches[0], force, skills_dir)
 
 
 def handle_skills_manifest(

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -421,10 +421,12 @@ def skills_copy(
     source: Optional[str] = typer.Option(None, "--source", "-s", help="Restrict to a specific source (claude, codex, cursor, kiro, co-user, co-project)"),
     force: bool = typer.Option(False, "--force", "-f", help="Overwrite existing skill"),
     all_: bool = typer.Option(False, "--all", "-a", help="Copy every discovered skill (dedupe by SOURCES priority)"),
+    to_project: bool = typer.Option(False, "--to-project", help="Copy into this project's .co/skills/ — the only tier that deploys"),
 ):
-    """Copy a discovered skill into ~/.co/skills/<name>/."""
+    """Copy a discovered skill into ~/.co/skills/<name>/, or --to-project to ship it."""
     from .commands.skills_commands import handle_skills_copy
-    handle_skills_copy(names=names or [], source=source, force=force, all_=all_)
+    handle_skills_copy(names=names or [], source=source, force=force, all_=all_,
+                       to_project=to_project)
 
 
 @skills_app.command("manifest")

--- a/tests/unit/test_skills_copy_destination.py
+++ b/tests/unit/test_skills_copy_destination.py
@@ -1,0 +1,60 @@
+"""Which directory `co skills copy` writes to, and why it decides everything.
+
+`~/.co/skills` is the operator's library and does not travel — `co skills list`
+marks it `Deploys ✗`. Only a project's `.co/skills` reaches a server. Every
+deploy printed "move one into .co/skills/ to ship it" and no command did that,
+so the operator was left to `cp -R` by hand. openonion/connectonion#408
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import skills_commands as sc
+
+
+@pytest.fixture
+def discovered(tmp_path, monkeypatch):
+    """One skill in the index, living outside any project."""
+    library = tmp_path / "library" / "greeter"
+    library.mkdir(parents=True)
+    (library / "SKILL.md").write_text("---\nname: greeter\n---\n\nhello\n")
+    (library / "helper.py").write_text("print('shipped too')\n")
+
+    index = {"skills": [{"name": "greeter", "source": "claude",
+                         "path": str(library / "SKILL.md")}]}
+    monkeypatch.setattr(sc, "_load_index", lambda: index)
+    monkeypatch.setattr(sc, "SKILLS_DIR", tmp_path / "user-tier" / "skills")
+    monkeypatch.chdir(tmp_path / "project")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def project_dir(tmp_path):
+    (tmp_path / "project").mkdir(parents=True, exist_ok=True)
+
+
+class TestCopyingIntoTheProject:
+    def test_to_project_lands_in_the_tier_that_deploys(self, discovered):
+        sc.handle_skills_copy(["greeter"], to_project=True)
+
+        assert (Path.cwd() / ".co" / "skills" / "greeter" / "SKILL.md").exists()
+
+    def test_the_skills_own_files_come_with_it(self, discovered):
+        """A skill is a directory, not a single markdown file."""
+        sc.handle_skills_copy(["greeter"], to_project=True)
+
+        assert (Path.cwd() / ".co" / "skills" / "greeter" / "helper.py").exists()
+
+    def test_without_the_flag_it_still_goes_to_the_user_library(self, discovered):
+        sc.handle_skills_copy(["greeter"])
+
+        assert (sc.SKILLS_DIR / "greeter" / "SKILL.md").exists()
+        assert not (Path.cwd() / ".co" / "skills" / "greeter").exists()
+
+    def test_all_respects_the_destination_too(self, discovered):
+        sc.handle_skills_copy([], all_=True, to_project=True)
+
+        assert (Path.cwd() / ".co" / "skills" / "greeter" / "SKILL.md").exists()


### PR DESCRIPTION
Closes #408.

Every `co deploy --to` printed this:

```
! 112 skill(s) stay on this machine: nano-banana-us, content-quality, tweet, …
  co skills list  ·  move one into .co/skills/ to ship it
```

and no command moved anything into `.co/skills/`. `co skills copy` writes `~/.co/skills` — the operator's library, which `co skills list` marks `Deploys ✗` in its own output. The two halves of the workflow pointed at different directories, and the way across was `cp -R`.

## What changed

```
co skills copy oo-init --to-project
```

lands in `./.co/skills/oo-init/`, and the deploy's hint now names that command rather than describing a step the tool did not offer.

The default is unchanged: without the flag it still goes to the user library. The docstring now says which tier it writes to, because the tier is the thing that decides whether a skill ever reaches a server.

## Verified end to end

```
$ co skills copy oo-init --to-project --source co-user
…/demo/.co/skills/oo-init

$ co skills list
│ oo-init │ project │ ✓ │      ← was: user ✗
```

## Tests

Four cases, verified red first: `--to-project` lands in the deploying tier, the skill's own files travel with it (a skill is a directory, not one markdown file), the default still goes to the user library, and `--all` respects the destination too.

2580 passed.