### PR TITLE
One unreadable skill must not stop the agent from starting

### DIFF
--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -114,17 +114,37 @@ def discover_skills(base_path: Optional[Path] = None) -> List[SkillInfo]:
             if skill_dir.is_dir():
                 skill_file = skill_dir / "SKILL.md"
                 if skill_file.exists():
-                    skill_info = _parse_skill_file(skill_file)
+                    skill_info = _read_skill_or_skip(skill_file)
                     if skill_info:
                         skills.append(skill_info)
 
             # Also support single .md files
             elif skill_dir.suffix == ".md" and skill_dir.stem != "SKILL":
-                skill_info = _parse_skill_file(skill_dir)
+                skill_info = _read_skill_or_skip(skill_dir)
                 if skill_info:
                     skills.append(skill_info)
 
     return skills
+
+
+def _read_skill_or_skip(path: Path) -> Optional[SkillInfo]:
+    """Parse one skill, or report it and move on.
+
+    This loop runs inside create_agent(), before the CLI is usable, so an
+    exception escaping here is not "that skill failed to load" — it is "co ai
+    does not start", with nothing said about which of the user's skills caused
+    it. One file saved as Windows-1252, or a compiled asset copied in by
+    accident, is enough.
+
+    The failure is named rather than swallowed: skipping silently trades a crash
+    for a mystery, where the agent behaves differently and nothing points at the
+    cause.
+    """
+    try:
+        return _parse_skill_file(path)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        print(f"Skipping unreadable skill {path}: {type(exc).__name__}: {exc}")
+        return None
 
 
 def _parse_skill_file(path: Path) -> Optional[SkillInfo]:

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -246,9 +246,19 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
             if name in seen:
                 continue
 
+            # Named and skipped rather than allowed to escape. This runs during
+            # agent construction, so one file saved as Windows-1252 — or a
+            # compiled asset copied in by accident — would otherwise stop the
+            # agent from being created at all, saying nothing about which of the
+            # user's skills did it.
+            try:
+                content = skill_file.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                print(f"Skipping unreadable skill {skill_file}: {type(exc).__name__}: {exc}")
+                continue
+
             seen.add(name)
 
-            content = skill_file.read_text(encoding="utf-8")
             frontmatter, _ = _parse_skill_content(content)
             description = frontmatter.get('description', 'No description')
 

--- a/tests/unit/test_skill_loading_survives_a_bad_file.py
+++ b/tests/unit/test_skill_loading_survives_a_bad_file.py
@@ -1,0 +1,104 @@
+"""One unreadable skill must not take the whole CLI down with it.
+
+`load_skills()` runs inside `create_agent()`, before the CLI is usable — so an
+exception escaping discovery is not "that skill failed", it is "co ai does not
+start", with nothing said about which file caused it.
+"""
+
+import sys
+
+import pytest
+
+import connectonion.cli.co_ai.skills.loader as loader
+
+skills_plugin = sys.modules["connectonion.useful_plugins.skills"]
+
+
+def _write_skill(root, name, body="---\nname: %s\ndescription: works\n---\ndo it\n"):
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(body % name if "%s" in body else body, encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project holding one good skill, with $HOME redirected away from the
+    developer's own ~/.co and ~/.claude so the test sees only what it created."""
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+    project = tmp_path / "project"
+    _write_skill(project / ".co" / "skills", "good")
+    return project
+
+
+class TestCoAiLoader:
+    def test_a_non_utf8_skill_is_skipped_and_the_others_still_load(self, project, capsys):
+        """A compiled asset copied in by accident, or smart quotes saved as
+        Windows-1252, is enough to produce this."""
+        broken = project / ".co" / "skills" / "broken"
+        broken.mkdir()
+        (broken / "SKILL.md").write_bytes(b"---\nname: broken\ndesc: \xff\xfe binary\n---\n")
+
+        found = loader.discover_skills(project)
+
+        assert "good" in {s.name for s in found}, "the healthy skill must still load"
+        assert "broken" not in {s.name for s in found}
+
+    def test_it_says_which_file_was_skipped(self, project, capsys):
+        """Skipping silently trades a crash for a mystery: the agent behaves
+        differently and nothing points at the cause."""
+        broken = project / ".co" / "skills" / "broken"
+        broken.mkdir()
+        (broken / "SKILL.md").write_bytes(b"\xff\xfe\x00 not text at all")
+
+        loader.discover_skills(project)
+
+        assert "broken" in capsys.readouterr().out
+
+    def test_a_directory_that_cannot_be_read_does_not_abort_discovery(self, project):
+        """SKILL.md present but unreadable — a permission or a race, not a
+        malformed file. Same requirement: skip it, keep going."""
+        weird = project / ".co" / "skills" / "weird"
+        weird.mkdir()
+        (weird / "SKILL.md").mkdir()          # a directory where a file is expected
+
+        found = loader.discover_skills(project)
+
+        assert "good" in {s.name for s in found}
+
+
+class TestAgentSkillDiscovery:
+    """The same loop exists a second time in useful_plugins/skills.py, and the
+    issue reports both. A fix to one is not a fix."""
+
+    def test_a_non_utf8_skill_is_skipped_and_the_others_still_load(self, project):
+        broken = project / ".co" / "skills" / "broken"
+        broken.mkdir()
+        (broken / "SKILL.md").write_bytes(b"---\nname: broken\n\xff\xfe\n---\n")
+
+        found = skills_plugin._discover_all_skills(project_dir=project)
+
+        assert "good" in {s.name for s in found}
+        assert "broken" not in {s.name for s in found}
+
+    def test_a_broken_skill_does_not_shadow_a_working_one_of_the_same_name(self, tmp_path, monkeypatch):
+        """Discovery takes the first of each name and skips the rest, so a broken
+        file must not claim the name on its way out — otherwise a corrupted
+        project skill silently disables the user-level one it was overriding,
+        which is a harder failure to explain than either alone."""
+        home = tmp_path / "home"
+        _write_skill(home / ".co" / "skills", "notes")           # the fallback, healthy
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        project = tmp_path / "project"
+        broken = project / ".co" / "skills" / "notes"            # higher priority, broken
+        broken.mkdir(parents=True)
+        (broken / "SKILL.md").write_bytes(b"\xff\xfe not text")
+
+        found = skills_plugin._discover_all_skills(project_dir=project)
+
+        assert "notes" in {s.name for s in found}
+        assert next(s for s in found if s.name == "notes").location == "user"


### PR DESCRIPTION
Closes #370. First of the eight remaining 1.5.3 bugs; none of them had a PR.

## Why this one first, ahead of its place in the sequence

It was queued 7th of 11, but it is the only one at *cannot use the tool at all* severity. The others break a feature; this one stops `co ai` from starting, and says nothing about why.

It is also the most reachable. Users write their own skills, `co skills copy` other people's, and hand-edit YAML. On this machine that is **1 of 121 skills** able to hold the entire CLI hostage.

## The failure

Discovery reads every `SKILL.md` with no guard, inside a loop with no per-entry guard, called from `create_agent()` **before the CLI is usable**. So a `UnicodeDecodeError` from one file does not mean "that skill failed to load":

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 23
```

…and `co ai` is gone. One file saved as Windows-1252, or a compiled asset copied into a skill directory by accident, is enough.

## The fix

**Both loops.** `cli/co_ai/skills/loader.py` and `useful_plugins/skills.py` both have it, and fixing one is not a fix.

**Named, not swallowed.** Skipping silently trades a crash for a mystery — the agent behaves differently and nothing points at the cause. The path and the exception type are printed.

## One deliberate behaviour change, worth reviewing

The name is claimed **after** the read succeeds, not before.

Discovery takes the first of each name and skips the rest. So a broken higher-priority file used to claim the name on its way out and **silently disable the working lower-priority skill it was overriding** — a corrupted `.co/skills/notes/SKILL.md` would take out `~/.co/skills/notes` too. That is harder to explain than either failure alone. Pinned by `test_a_broken_skill_does_not_shadow_a_working_one_of_the_same_name`.

## Verification

5 new tests, all of them **red on unpatched code** (verified by stashing the fix):

```
5 failed        ← before
5 passed        ← after
```

They use real bad bytes on disk (`\xff\xfe`), a `SKILL.md` that is a directory, and `Path.home` redirected away from the developer's own `~/.co` and `~/.claude` so the fixture sees only what it created.

Full unit suite: **2581 passed, 3 skipped**.

## Next

#367 (skill precedence inverted) is the natural follow-on — same subsystem, and it also makes a documented override silently not happen.