### PR TITLE
release: 1.5.4

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.3
+## Current Version: 1.5.4
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -55,6 +55,7 @@ That is semver's rule, not this project's.
 - 1.5.0 (agent Home pages: the host pushes `dashboard.html` over the agent WebSocket and chat clients render it beside the conversation, with a built-in dashboard skill; `co syno` for Synology NAS; `co ai` YOLO mode; `co ai` and the templates drive the browser through `co browser` instead of 40 in-process tools; agents can declare how long they need a tab; deploy polls the full build window and validates project names locally; hermetic unit tests)
 - 1.5.1 (`co status` says where every API key comes from and flags keys defined in more than one place, with an opt-in `--reveal`; the project states Apache-2.0 everywhere, matching the LICENSE file)
 - 1.5.3 (servers you own: `co server new/add/ls/check/ssh/forget/destroy` and `co deploy --to`, with an SSH key derived from the same recovery phrase; a deploy no longer reissues the agent's address, keeps its logs, seeds the deploying key as admin, and serves it over https on its own hostname; the agent's full picture now travels over the authenticated socket instead of the open `/info`, which had been publishing the operator's personal skills to anyone; `co skills list` and `co doctor` say which tier a skill came from and which ones will not survive a deploy)
+- 1.5.4 (a deployed agent is reachable and controllable: it runs as the user that owns its files rather than root, `co` is on its PATH so `co call <address> co status` works, and the operator's own key is recognised by their agent's trust gate instead of being asked to onboard; a deploy that leaves the agent crash-looping now says so and prints the traceback, where it used to report success and a URL; `co server new` waits until the machine actually accepts your key before calling it ready, and clears the stale host key when a cloud address is reused; skills carry their own files but never their secrets, and `co skills copy --to-project` puts one where a deploy will find it; the test suite can no longer write to the operator's real ~/.co, which had silently replaced a live Outlook session with test credentials)
 - 1.5.2 (Claude calls carry the system prompt again — Anthropic requests had been dropping it entirely and silently; `.co/docs/` is no longer empty on a PyPI install, the 194 docs files now ship inside the wheel)
 
 ## Files to Update When Versioning

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -11,6 +11,9 @@ co skills discover
 # Pull a discovered skill into ~/.co/skills/
 co skills copy ship-feature
 
+# Or into this project, which is the tier a deploy carries
+co skills copy ship-feature --to-project
+
 # See what's already imported
 co skills list
 
@@ -38,6 +41,28 @@ Skills you've written for one tool (for example Claude Code) are usually stored 
                                                       ~/.co/skills/<name>/SKILL.md
                                                       (now visible to co ai, skills plugin, publishing)
 ```
+
+## Which tier travels
+
+`~/.co/skills/` is your library — every project on this machine can use what is in it,
+and none of it leaves the machine. A deploy carries the **project's** `.co/skills/` and
+nothing else. That is what the `Deploys` column means:
+
+```
+Name           Where     Deploys
+ship-feature   user         ✗      in your library, stays here
+greet-visitor  project      ✓      in .co/skills/, goes with the deploy
+```
+
+`--to-project` copies into the one that travels:
+
+```bash
+co skills copy ship-feature --to-project    # → ./.co/skills/ship-feature/
+```
+
+The skill's own files come with it — a skill is a directory, not a single markdown
+file — but `.env*` and private keys never travel, whatever a skill's own `.gitignore`
+says.
 
 The generated `index.json` records where skills came from, while `agent.json.skills` records the skill metadata that publishing needs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.3"
+version = "1.5.4"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Patch release. Thirteen commits since v1.5.3, all fixes or small additions to existing commands — nothing changes an interface anyone depends on, so this is not a minor.

## What it fixes for someone

**A deployed agent is reachable and controllable.** Remote execution was broken end to end and every part of it is fixed: the agent runs as the user that owns its files rather than as root, `co` is on the unit's PATH so `co call <address> co status` — the example in `co call`'s own help — works, and the operator's key is recognised by their own agent's trust gate instead of being told to onboard.

**A deploy that leaves the agent crash-looping says so.** It used to print a success line and a URL while the unit restarted on an ImportError; the first hint was a 502. It now watches until the unit is either stable or has restarted itself, and prints the traceback.

**`co server new` waits until the machine actually accepts your key** before calling it ready — the API returns about ten seconds ahead of the guest agent installing it, and the suggested next command was failing with `Permission denied (publickey)`. It also clears the stale host key when a cloud provider hands back a reused address, which had been reported as a possible attack.

**Skills carry their own files and none of their secrets.** A skill's `build/` and `todo.md` now travel; `.env*` and private keys never do. `co skills copy --to-project` puts a skill where a deploy will find it, which every deploy's own hint had been asking for with no command behind it.

**The test suite can no longer write to the operator's real `~/.co`.** A CLI test running `co auth microsoft` against mocked HTTP replaced a live Outlook session with `access_token='eyJ0eXAi.test'`, and surfaced days later as an expired session.

## Version files

- `pyproject.toml`, `connectonion/__init__.py`, `VERSIONING.md` (current + history)
- `docs-site/lib/version.ts` — **was still on 1.5.2**, missed by the 1.5.3 release. Pushed separately with `npm run build` green first. This is exactly the drift #299 describes.

## Docs

`co skills copy --to-project` shipped in #409 with no docs entry; `docs/cli/skills.md` now covers it, including which tier travels and what never does. `grep -rc to-project docs/` was 0 before, 3 after.

## Order

Nothing else has to ship with this. The backend changes it pairs with (relay skill limits, profile degradation, deploy resource ceilings) are already deployed, and this SDK works against the old backend as well as the new one.