### PR TITLE
The skill in your project must be the one that runs

### DIFF
--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -105,6 +105,13 @@ def discover_skills(base_path: Optional[Path] = None) -> List[SkillInfo]:
     if builtin_skills.exists():
         search_paths.append(builtin_skills)
 
+    # search_paths is in priority order, so the FIRST match for a name wins and
+    # later tiers are skipped. Dropping the duplicate here, rather than letting a
+    # later one overwrite it, is what makes the documented precedence real: the
+    # registry is built with `{s.name: s for s in skills}`, and last-write-wins
+    # hands every contested name to builtin, which is appended last.
+    seen = set()
+
     for skills_dir in search_paths:
         if not skills_dir.exists():
             continue
@@ -115,13 +122,15 @@ def discover_skills(base_path: Optional[Path] = None) -> List[SkillInfo]:
                 skill_file = skill_dir / "SKILL.md"
                 if skill_file.exists():
                     skill_info = _read_skill_or_skip(skill_file)
-                    if skill_info:
+                    if skill_info and skill_info.name not in seen:
+                        seen.add(skill_info.name)
                         skills.append(skill_info)
 
             # Also support single .md files
             elif skill_dir.suffix == ".md" and skill_dir.stem != "SKILL":
                 skill_info = _read_skill_or_skip(skill_dir)
-                if skill_info:
+                if skill_info and skill_info.name not in seen:
+                    seen.add(skill_info.name)
                     skills.append(skill_info)
 
     return skills

--- a/tests/unit/test_skill_precedence.py
+++ b/tests/unit/test_skill_precedence.py
@@ -1,0 +1,118 @@
+"""The skill you put in your project must be the one that runs.
+
+`loader.py`'s docstring states the contract outright — "priority: project > user
+> builtin, highest > lowest" — and `co ai` builds its system prompt from this
+registry, so getting it backwards means the agent silently follows different
+instructions than the ones in the repo.
+"""
+
+import pytest
+
+import connectonion.cli.co_ai.skills.loader as loader
+
+
+def _skill(root, name, description):
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\ndo the {description} thing\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def tiers(tmp_path, monkeypatch):
+    """A `commit` skill at all three tiers, each identifiable by its description."""
+    home = tmp_path / "home"
+    _skill(home / ".co" / "skills", "commit", "USER")
+    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+    builtin = tmp_path / "builtin"
+    _skill(builtin, "commit", "BUILTIN")
+    monkeypatch.setattr(loader, "__file__", str(tmp_path / "skills" / "loader.py"))
+    (tmp_path / "skills").mkdir(exist_ok=True)
+    monkeypatch.setattr(
+        loader.Path, "cwd", staticmethod(lambda: tmp_path / "project")
+    )
+
+    project = tmp_path / "project"
+    _skill(project / ".co" / "skills", "commit", "PROJECT")
+    return project, builtin
+
+
+class TestPrecedence:
+    def test_a_project_skill_beats_the_user_one(self, tmp_path, monkeypatch):
+        """The case a team hits: someone customises a skill in the repo and the
+        agent keeps serving the personal copy from their laptop."""
+        home = tmp_path / "home"
+        _skill(home / ".co" / "skills", "commit", "USER")
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        project = tmp_path / "project"
+        _skill(project / ".co" / "skills", "commit", "PROJECT")
+
+        registry = loader.load_skills(project)
+
+        assert registry["commit"].description == "PROJECT"
+
+    def test_a_project_skill_beats_the_bundled_one(self, tmp_path, monkeypatch):
+        """The case in the issue: customise the bundled `commit` skill by adding
+        .co/skills/commit/SKILL.md, and the stock one is served instead."""
+        home = tmp_path / "home"
+        (home / ".co").mkdir(parents=True)
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        builtin_dir = tmp_path / "fake_pkg" / "builtin"
+        _skill(builtin_dir, "commit", "BUILTIN")
+        monkeypatch.setattr(loader, "__file__", str(tmp_path / "fake_pkg" / "loader.py"))
+
+        project = tmp_path / "project"
+        _skill(project / ".co" / "skills", "commit", "PROJECT")
+
+        registry = loader.load_skills(project)
+
+        assert registry["commit"].description == "PROJECT"
+
+    def test_a_user_skill_beats_the_bundled_one(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        _skill(home / ".co" / "skills", "commit", "USER")
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        builtin_dir = tmp_path / "fake_pkg" / "builtin"
+        _skill(builtin_dir, "commit", "BUILTIN")
+        monkeypatch.setattr(loader, "__file__", str(tmp_path / "fake_pkg" / "loader.py"))
+
+        project = tmp_path / "project"
+        (project / ".co").mkdir(parents=True)
+
+        registry = loader.load_skills(project)
+
+        assert registry["commit"].description == "USER"
+
+    def test_skills_with_different_names_all_survive(self, tmp_path, monkeypatch):
+        """Precedence must not become "keep only one of everything"."""
+        home = tmp_path / "home"
+        _skill(home / ".co" / "skills", "mine", "USER")
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        project = tmp_path / "project"
+        _skill(project / ".co" / "skills", "ours", "PROJECT")
+
+        registry = loader.load_skills(project)
+
+        assert {"mine", "ours"} <= set(registry)
+
+    def test_discover_skills_reports_the_winner_first(self, tmp_path, monkeypatch):
+        """load_skills() is not the only consumer — anything reading the list
+        directly should see the winning entry, not a later shadow of it."""
+        home = tmp_path / "home"
+        _skill(home / ".co" / "skills", "commit", "USER")
+        monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: home))
+
+        project = tmp_path / "project"
+        _skill(project / ".co" / "skills", "commit", "PROJECT")
+
+        found = [s for s in loader.discover_skills(project) if s.name == "commit"]
+
+        assert len(found) == 1, "a shadowed duplicate is still in the list"
+        assert found[0].description == "PROJECT"


### PR DESCRIPTION
Closes #367. Second of the eight remaining 1.5.3 bugs.

## The bug

`load_skills()` builds the registry with a dict comprehension:

```python
SKILLS_REGISTRY.update({s.name: s for s in skills})   # last write wins
```

and `discover_skills()` appends **builtin last**. So on every contested name the bundled skill won — the exact opposite of the priority `loader.py`'s own docstring states:

> priority: project > user > builtin, highest > lowest

A team adding `.co/skills/commit/SKILL.md` to customise the bundled `commit` skill got **the stock one**, with no error and no warning. `co ai` builds its system prompt from this registry, so the agent silently followed different instructions than the ones in the repo — the failure mode where you edit a file, nothing changes, and nothing tells you why.

## The fix

The `seen` set that `useful_plugins/skills.py` already uses correctly for exactly this job. Same subsystem, two implementations, one of them right — now both.

The duplicate is dropped **at discovery**, so it is absent from `discover_skills()`' list too, not merely outranked in the registry. Anything reading that list directly would otherwise still see both entries with the wrong one last.

## Verification

5 tests, **4 red before / 5 green after**. The one that passed either way (`different names all survive`) is the guard against "fix precedence by keeping only one skill".

Each tier is identifiable by its description, so the assertion is on *which* skill won rather than on a count:

```python
assert registry["commit"].description == "PROJECT"
```

Full unit suite: **2585 passed, 3 skipped**.