### PR TITLE
structured_complete() must fail the way complete() does

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1037,20 +1037,7 @@ class OpenOnionLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        try:
-            response = self.client.chat.completions.create(**api_kwargs)
-        except openai.APIStatusError as e:
-            if e.status_code == 402:
-                raise InsufficientCreditsError(e) from e
-            elif e.status_code == 503:
-                raise ProviderServiceError(e) from e
-            logger.error(f"APIStatusError: status={e.status_code}, message={e.message}, body={getattr(e, 'body', None)}")
-            raise
-        except (openai.APITimeoutError, openai.APIConnectionError) as e:
-            raise LLMConnectionError(e, model=f"co/{self.model}", base_url=self.base_url) from e
-        except Exception as e:
-            logger.error(f"LLM error: {type(e).__name__}: {e}")
-            raise
+        response = self._call(lambda: self.client.chat.completions.create(**api_kwargs))
 
         message = response.choices[0].message
 
@@ -1091,18 +1078,46 @@ class OpenOnionLLM(LLM):
             usage=usage,
         )
 
+    def _call(self, send):
+        """Make one request and translate the failures callers are written against.
+
+        Shared by complete() and structured_complete(), because a depleted
+        balance is a depleted balance whichever one you called. structured_complete()
+        had no handling at all, so the documented InsufficientCreditsError — the
+        one carrying balance, required, shortfall and address — surfaced as a raw
+        openai.APIStatusError, and every `except InsufficientCreditsError` written
+        against the documented behaviour missed it.
+
+        One helper rather than a copied block: two copies of a translation table
+        drift, and the half that drifts is the half nobody tested.
+        """
+        try:
+            return send()
+        except openai.APIStatusError as e:
+            if e.status_code == 402:
+                raise InsufficientCreditsError(e) from e
+            elif e.status_code == 503:
+                raise ProviderServiceError(e) from e
+            logger.error(f"APIStatusError: status={e.status_code}, message={e.message}, body={getattr(e, 'body', None)}")
+            raise
+        except (openai.APITimeoutError, openai.APIConnectionError) as e:
+            raise LLMConnectionError(e, model=f"co/{self.model}", base_url=self.base_url) from e
+        except Exception as e:
+            logger.error(f"LLM error: {type(e).__name__}: {e}")
+            raise
+
     def structured_complete(self, messages: List[Dict], output_schema: Type[BaseModel], **kwargs) -> BaseModel:
         """Get structured Pydantic output using OpenAI-compatible chat completions API.
 
         Uses beta.chat.completions.parse() which routes through /v1/chat/completions,
         allowing proper provider routing for Gemini, OpenAI, and other models.
         """
-        completion = self.client.beta.chat.completions.parse(
+        completion = self._call(lambda: self.client.beta.chat.completions.parse(
             model=self.model,
             messages=messages,
             response_format=output_schema,
             **kwargs
-        )
+        ))
         return completion.choices[0].message.parsed
 
     def get_balance(self) -> Optional[float]:

--- a/tests/unit/test_structured_complete_errors.py
+++ b/tests/unit/test_structured_complete_errors.py
@@ -1,0 +1,98 @@
+"""structured_complete() must fail the same way complete() does.
+
+A depleted balance is a depleted balance whichever method you called. The
+documented InsufficientCreditsError carries balance/required/shortfall/address
+(CLAUDE.md), and code is written to catch it specifically — so a raw
+openai.APIStatusError from one of the two paths is a silent hole in that
+contract.
+"""
+
+import httpx
+import openai
+import pytest
+from pydantic import BaseModel
+
+from connectonion.core.exceptions import (
+    InsufficientCreditsError,
+    LLMConnectionError,
+    ProviderServiceError,
+)
+from connectonion.core.llm import OpenOnionLLM
+
+
+class Answer(BaseModel):
+    text: str
+
+
+def _status_error(code: int) -> openai.APIStatusError:
+    request = httpx.Request("POST", "https://oo.openonion.ai/v1/chat/completions")
+    body = {"detail": {"error": "insufficient_credits", "balance": 0.01,
+                       "required": 0.5, "shortfall": 0.49, "address": "0xabc"}}
+    response = httpx.Response(code, request=request, json=body)
+    return openai.APIStatusError("boom", response=response, body=body)
+
+
+@pytest.fixture
+def llm(monkeypatch):
+    monkeypatch.setenv("OPENONION_API_KEY", "test-key")
+    return OpenOnionLLM(model="co/gemini-3.6-flash", api_key="test-key")
+
+
+def _make_parse_raise(llm, exc):
+    class FakeParse:
+        def parse(self, **kwargs):
+            raise exc
+
+    class FakeCompletions:
+        parse = None
+
+    llm.client.beta.chat.completions.parse = lambda **kw: (_ for _ in ()).throw(exc)
+
+
+class TestStructuredCompleteTranslatesFailures:
+    def test_402_becomes_insufficient_credits(self, llm):
+        """The case in the issue: an agent asking for structured output on a
+        depleted account got a raw APIStatusError, so `except
+        InsufficientCreditsError` never fired."""
+        _make_parse_raise(llm, _status_error(402))
+
+        with pytest.raises(InsufficientCreditsError):
+            llm.structured_complete([{"role": "user", "content": "hi"}], Answer)
+
+    def test_503_becomes_provider_service_error(self, llm):
+        _make_parse_raise(llm, _status_error(503))
+
+        with pytest.raises(ProviderServiceError):
+            llm.structured_complete([{"role": "user", "content": "hi"}], Answer)
+
+    def test_a_timeout_becomes_a_connection_error(self, llm):
+        request = httpx.Request("POST", "https://oo.openonion.ai/v1/chat/completions")
+        _make_parse_raise(llm, openai.APITimeoutError(request=request))
+
+        with pytest.raises(LLMConnectionError):
+            llm.structured_complete([{"role": "user", "content": "hi"}], Answer)
+
+    def test_an_unmapped_status_still_surfaces(self, llm):
+        """Translating is not swallowing — a 500 is still a 500."""
+        _make_parse_raise(llm, _status_error(500))
+
+        with pytest.raises(openai.APIStatusError):
+            llm.structured_complete([{"role": "user", "content": "hi"}], Answer)
+
+
+class TestCompleteStillBehavesTheSame:
+    """The shared helper must not have changed the path that already worked."""
+
+    def test_402_becomes_insufficient_credits(self, llm):
+        llm.client.chat.completions.create = lambda **kw: (_ for _ in ()).throw(_status_error(402))
+
+        with pytest.raises(InsufficientCreditsError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+    def test_a_timeout_becomes_a_connection_error(self, llm):
+        request = httpx.Request("POST", "https://oo.openonion.ai/v1/chat/completions")
+        llm.client.chat.completions.create = lambda **kw: (_ for _ in ()).throw(
+            openai.APITimeoutError(request=request))
+
+        with pytest.raises(LLMConnectionError):
+            llm.complete([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
Closes #369. Third of the eight remaining 1.5.3 bugs.

## The bug

`complete()` translates the failures callers are written against:

```python
402 → InsufficientCreditsError    503 → ProviderServiceError    timeout → LLMConnectionError
```

`structured_complete()` had **no try/except at all**. So an agent asking for structured output on a depleted account got a raw `openai.APIStatusError`, and every `except InsufficientCreditsError` — the pattern CLAUDE.md teaches, carrying `balance`, `required`, `shortfall`, `address` — silently missed it.

Same account, same balance, same request. Which method you called decided whether the error was the documented one.

## The fix

One `_call()` helper both methods go through, rather than a copied block. Two copies of a translation table drift, and **the half that drifts is the half nobody tested** — which is precisely how these two came apart.

## The part worth reading the diff for

The first version of this patch **landed in `GeminiLLM` instead of `OpenOnionLLM`**. The same request/except shape exists in several providers, and a first-match replace found the wrong one — the helper was defined in one class and called from another that could never reach it.

The tests caught it: the fix was "applied" and three of them were still red. Without a red-first test that patch would have merged looking correct, with the actual path untouched.

The final patch is scoped inside the `OpenOnionLLM` class body and asserts each pattern occurs **exactly once** there.

## Verification

6 tests. **3 red before / 6 green after** — the other 3 pin `complete()`'s existing behaviour so the extraction cannot have changed the path that already worked.

Also covered: an unmapped status (500) still surfaces as itself. Translating is not swallowing.

Full unit suite: **2591 passed, 3 skipped**.