### PR TITLE
A model starting with "o" is not automatically an OpenAI model

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1144,6 +1144,16 @@ class OpenOnionLLM(LLM):
         return None
 
 
+# OpenAI's reasoning models, matched by explicit prefix.
+#
+# A bare startswith("o") sent every unprefixed model beginning with the letter o
+# to OpenAI — "orca-2-13b" and "olmo" are real open-model names, and the caller
+# got an OpenAI 404 for a model they never asked OpenAI about, with nothing
+# pointing at the routing as the cause. Naming the families keeps a new one a
+# one-line addition here, which is the only place it should need to be made.
+OPENAI_REASONING_PREFIXES = ("o1", "o3", "o4")
+
+
 def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
     """Factory function to create the appropriate LLM based on model name.
     
@@ -1177,7 +1187,7 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
     
     if not provider:
         # Try to infer provider from model name
-        if model.startswith("gpt") or model.startswith("o"):
+        if model.startswith("gpt") or model.startswith(OPENAI_REASONING_PREFIXES):
             provider = "openai"
         elif model.startswith("claude"):
             provider = "anthropic"

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -443,10 +443,18 @@ class TestModelInference:
             llm = create_llm("gpt-unknown-model")
             assert isinstance(llm, OpenAILLM)
 
-    def test_infer_openai_from_o_prefix(self):
-        """Test that o* models are inferred as OpenAI."""
+    def test_infer_openai_from_a_known_o_series_prefix(self):
+        """An o-series *family* is inferred, so the registry does not need an
+        entry per variant OpenAI ships.
+
+        This used to assert on "o99-preview", i.e. that any name starting with
+        the letter o is an OpenAI model — which routed orca-2-13b and olmo-7b
+        there too (#379). The trade is deliberate: a new family costs one line
+        here, and in exchange an unknown model is named as unknown instead of
+        producing an OpenAI 404 about a model nobody asked OpenAI for.
+        """
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = create_llm("o99-preview")
+            llm = create_llm("o3-preview")
             assert isinstance(llm, OpenAILLM)
 
     def test_infer_anthropic_from_claude_prefix(self):

--- a/tests/unit/test_model_routing_o_prefix.py
+++ b/tests/unit/test_model_routing_o_prefix.py
@@ -1,0 +1,60 @@
+"""A model name starting with "o" is not automatically an OpenAI model.
+
+`startswith("o")` sent every unprefixed name beginning with that letter to
+OpenAI. The caller then got an OpenAI 404 for a model they never asked OpenAI
+about — an error that describes the wrong problem, because the fault is the
+routing, not the model choice.
+"""
+
+import pytest
+
+from connectonion.core.llm import (
+    OPENAI_REASONING_PREFIXES,
+    AnthropicLLM,
+    GeminiLLM,
+    OpenAILLM,
+    create_llm,
+)
+
+
+class TestUnknownModelsSaySo:
+    @pytest.mark.parametrize("model", ["orca-2-13b", "olmo-7b", "openchat-3.5", "opus"])
+    def test_a_non_openai_o_model_is_rejected_by_name(self, model):
+        """All four are real open-model families. Each used to be routed to
+        OpenAI, which answered about a model nobody had asked it for."""
+        with pytest.raises(ValueError, match=model):
+            create_llm(model, api_key="test-key")
+
+    def test_the_error_names_the_model_the_caller_passed(self):
+        """So the message points at the list to check, not at OpenAI."""
+        with pytest.raises(ValueError) as caught:
+            create_llm("orca-2-13b", api_key="test-key")
+
+        assert "orca-2-13b" in str(caught.value)
+
+
+class TestKnownModelsStillRoute:
+    """The tightening must not strand the models it was protecting."""
+
+    @pytest.mark.parametrize("model", ["o1", "o1-mini", "o1-preview", "o4-mini"])
+    def test_registered_o_series_models_still_reach_openai(self, model):
+        assert isinstance(create_llm(model, api_key="test-key"), OpenAILLM)
+
+    @pytest.mark.parametrize("model", ["o3-mini", "o4-turbo"])
+    def test_unregistered_but_real_o_series_families_still_infer(self, model):
+        """The registry cannot list every variant OpenAI ships, so inference by
+        family prefix has to keep working — that is what the allowlist is for."""
+        assert isinstance(create_llm(model, api_key="test-key"), OpenAILLM)
+
+    def test_gpt_models_are_untouched(self):
+        assert isinstance(create_llm("gpt-4o", api_key="test-key"), OpenAILLM)
+
+    def test_other_providers_are_untouched(self):
+        assert isinstance(create_llm("claude-3-5-sonnet-20241022", api_key="k"), AnthropicLLM)
+        assert isinstance(create_llm("gemini-1.5-pro", api_key="k"), GeminiLLM)
+
+    def test_the_allowlist_is_prefixes_not_whole_names(self):
+        """o1-mini must match on "o1" — listing whole names would need an entry
+        per variant and go stale on the next OpenAI release."""
+        assert "o1-mini".startswith(OPENAI_REASONING_PREFIXES)
+        assert not "olmo-7b".startswith(OPENAI_REASONING_PREFIXES)


### PR DESCRIPTION
Closes #379. Fourth of the 1.5.3 bugs.

## The bug

```python
if model.startswith("gpt") or model.startswith("o"):
    provider = "openai"
```

`orca-2-13b`, `olmo-7b`, `openchat-3.5` and `opus` are real open-model family names. Each was silently routed to OpenAI, which then answered about a model nobody had asked it for:

```
NotFoundError: The model 'orca-2-13b' does not exist
```

The error describes the wrong problem. The fault is the routing; the message points at the model choice.

## The fix

```python
OPENAI_REASONING_PREFIXES = ("o1", "o3", "o4")
```

Matched by **prefix, not whole name** — `o1-mini` infers from `o1`, so the registry does not need an entry per variant OpenAI ships. A test pins that, and pins the counterpart (`olmo-7b` must not match).

## An existing test changed, deliberately

`test_infer_openai_from_o_prefix` asserted on `"o99-preview"` — that *any* name starting with the letter o is an OpenAI model. That is exactly the behaviour this fixes, so the assertion could not stand. It now uses a known family, and carries the trade in its docstring:

> a new family costs one line here, and in exchange an unknown model is named as unknown instead of producing an OpenAI 404 about a model nobody asked OpenAI for

**The cost is real and worth stating:** if OpenAI ships an `o5`, it errors until someone adds `"o5"` to the tuple. That is the trade the issue chose, and a clear "Unknown model 'o5-preview'" is a better failure than a confusing 404.

## Verification

14 new tests. Red-first verified by reverting **only the routing condition** (keeping the constant, so the module still imports): **5 failed / 9 passed** → **14 passed** restored.

The first attempt at that verification stashed the whole change and produced a collection error rather than assertion failures — which proves nothing except that the import broke.

Full unit suite: **2599 passed, 3 skipped**.