### PR TITLE
keys: SLIP-0010 derivation, so the twelve words mean something outside our code

### DIFF
--- a/connectonion/derive.py
+++ b/connectonion/derive.py
@@ -1,0 +1,167 @@
+"""SLIP-0010 key derivation — one recovery phrase, a tree of keys.
+
+LLM-Note:
+  Dependencies: imports from [hashlib, hmac, struct] — stdlib only, no crypto library | imported by [address.py] | tested by [tests/unit/test_derive.py]
+  Data flow: BIP-39 seed (64 bytes) → master_key() → (key, chain_code) → derive_child() per hardened index → derive_path(seed, "m/13'/…") → 32-byte private key for SigningKey()
+  State/Effects: none — pure functions, no I/O, no globals
+  Integration: exposes derive_path(seed, path), slip13_path(uri, index=0), identity_uri/ssh_uri/ACCOUNT_URI | the 32 bytes returned are an Ed25519 seed, i.e. what nacl.signing.SigningKey() takes
+  Performance: one HMAC-SHA512 per path level; a five-level path is five HMACs, microseconds
+  Errors: raises ValueError on a non-hardened index, a malformed path, or a seed of the wrong length — never silently derives something else
+
+What this replaces and why
+--------------------------
+Identity used to be ``SigningKey(seed[:32])``: standards-compliant BIP-39 right up
+to the last step, then a bare slice that corresponds to no BIP, no SLIP, and no
+derivation path. Import the phrase into Ledger, Trezor, Phantom or Keplr and you
+never arrive at the same address, on any path any of them offers (see #400).
+
+SLIP-0010 is BIP-32 adapted to Ed25519 — what Solana, Brave and Trezor's own
+SSH/GPG features use. The twelve words stop meaning something only inside our own
+software: any SLIP-0010 implementation recovers the tree.
+
+Hardened-only, and that is the point
+------------------------------------
+SLIP-0010 offers **hardened derivation only** for Ed25519. Ed25519 clamps bits of
+the private key and its group order carries a cofactor, so BIP-32's "add a scalar
+to both the private and public side" trick does not survive; there is no
+parent-public → child-public step, and therefore no watch-only.
+
+That is the property we want, not a compromise. Non-hardened derivation has an
+inverse: ``child = parent + t`` where ``t`` is computable from public data, so one
+leaked child private key plus the public tree recovers the parent — and the parent
+generates everything else. Our agent identities and SSH keys live on servers,
+which can be breached or snapshotted. Under SLIP-0010 that exposes one key. The
+watch-only we give up answers a question nobody here asks: our balances live in a
+Postgres row keyed by public key and need a signature to read.
+
+This module therefore refuses a non-hardened index rather than accepting one and
+quietly deriving something else.
+"""
+
+import hashlib
+import hmac
+import struct
+
+# SLIP-0010's domain separator for the ed25519 curve. Changing this string
+# changes every key in the tree.
+ED25519_CURVE = b"ed25519 seed"
+
+HARDENED = 0x80000000
+
+# SLIP-0013 (authentication identities) rather than BIP-44. It needs no coin-type
+# registration, and it is what trezor-agent already uses for SSH. SLIP-0044 assigns
+# coin types only where "there is a wallet implementing BIP-0044 for desired coin"
+# — we are not a coin, and squatting an unregistered index risks colliding with a
+# real assignment later. m/44'/<chain>' stays free for on-chain assets, using that
+# chain's own coin type, if they ever exist.
+SLIP13_PURPOSE = 13
+
+# The account identity — the operator's own key, the one holding the balance.
+ACCOUNT_URI = "https://oo.openonion.ai"
+
+
+def master_key(seed: bytes) -> tuple[bytes, bytes]:
+    """The SLIP-0010 master key and chain code for a BIP-39 seed.
+
+    ``I = HMAC-SHA512(key="ed25519 seed", data=seed)``; the left half is the
+    private key, the right half the chain code. Ed25519 needs no "is this scalar
+    in range" retry loop — every 32-byte string is a valid ed25519 seed — so
+    unlike secp256k1 this cannot fail.
+    """
+    if not 16 <= len(seed) <= 64:
+        raise ValueError(f"seed must be 16-64 bytes, got {len(seed)}")
+    digest = hmac.new(ED25519_CURVE, seed, hashlib.sha512).digest()
+    return digest[:32], digest[32:]
+
+
+def derive_child(key: bytes, chain_code: bytes, index: int) -> tuple[bytes, bytes]:
+    """One hardened SLIP-0010 step.
+
+    ``I = HMAC-SHA512(key=chain_code, data=0x00 || key || index_be)``. The leading
+    zero byte is what makes this the *private* derivation; there is no public one
+    on this curve.
+    """
+    if index < HARDENED:
+        raise ValueError(
+            f"index {index} is not hardened. SLIP-0010 ed25519 has no public "
+            f"derivation, so every level must be hardened (>= 2**31)."
+        )
+    data = b"\x00" + key + struct.pack(">I", index)
+    digest = hmac.new(chain_code, data, hashlib.sha512).digest()
+    return digest[:32], digest[32:]
+
+
+def derive_path(seed: bytes, path: str) -> bytes:
+    """The 32-byte private key at ``path``, e.g. ``m/13'/1444947841'/…``.
+
+    The result is an Ed25519 seed — hand it straight to ``SigningKey()``.
+
+    Every level must be hardened; a path written without the apostrophe is a
+    mistake, not a request for public derivation, so it raises rather than
+    deriving a different key.
+    """
+    key, chain_code = master_key(seed)
+    for level in _parse_path(path):
+        key, chain_code = derive_child(key, chain_code, level)
+    return key
+
+
+def _parse_path(path: str) -> list[int]:
+    """``"m/13'/7'"`` → ``[13 + 2**31, 7 + 2**31]``."""
+    parts = path.strip().split("/")
+    if not parts or parts[0] != "m":
+        raise ValueError(f"path must start with 'm', got {path!r}")
+
+    indices = []
+    for part in parts[1:]:
+        if not part.endswith(("'", "h", "H")):
+            raise ValueError(
+                f"path level {part!r} is not hardened. Write it as {part}' — "
+                f"SLIP-0010 ed25519 has no unhardened derivation."
+            )
+        number = part[:-1]
+        if not number.isdigit():
+            raise ValueError(f"path level {part!r} is not a number")
+        value = int(number)
+        if value >= HARDENED:
+            raise ValueError(f"path level {part!r} is out of range")
+        indices.append(value + HARDENED)
+    return indices
+
+
+def slip13_path(uri: str, index: int = 0) -> str:
+    """The SLIP-0013 path for an identity URI.
+
+    ``m/13'/A'/B'/C'/D'`` where ``A..D`` are the first 16 bytes of
+    ``SHA256(index_le || uri)`` read as four little-endian uint32s, each hardened.
+
+    The name *is* the path, which is what lets ``co keys`` print an agent's
+    address before anything is deployed, and makes the same name always return the
+    same key. ``index`` is the rotation counter: bump it and the old key simply
+    stops being derived.
+
+    The cost, accepted: a path is opaque — ``m/13'/1444947841'/…`` does not say
+    which agent it is — and a mistyped name is a different key rather than an
+    error. That is why callers must go through :func:`identity_uri` / :func:`ssh_uri`,
+    which canonicalise before hashing.
+    """
+    digest = hashlib.sha256(struct.pack("<I", index) + uri.encode("utf-8")).digest()
+    levels = struct.unpack("<4I", digest[:16])
+    return "m/13'/" + "/".join(f"{level & 0x7FFFFFFF}'" for level in levels)
+
+
+def identity_uri(name: str) -> str:
+    """``agent://<name>``, canonicalised.
+
+    Trimmed and lowercased, because a different string is a different identity and
+    an address is a name people retype.
+    """
+    canonical = name.strip().lower()
+    if not canonical:
+        raise ValueError("agent name is empty")
+    return f"agent://{canonical}"
+
+
+def ssh_uri(user: str, host: str) -> str:
+    """``ssh://<user>@<host>``, matching what trezor-agent derives for SSH."""
+    return f"ssh://{user.strip().lower()}@{host.strip().lower()}"

--- a/tests/unit/test_derive.py
+++ b/tests/unit/test_derive.py
@@ -1,0 +1,152 @@
+"""SLIP-0010 / SLIP-0013 derivation.
+
+The vectors below are the published ones from the SLIP-0010 spec, not values
+copied out of this implementation — a test that records what the code does would
+pass just as happily if the code were wrong, and "wrong" here means every key in
+the tree is wrong.
+
+They were additionally cross-checked against Trezor's `slip10` package: 20
+derivations across both seeds and every path used here, byte-identical. That
+package is not a test dependency (installing a crypto library to test a
+40-line one would be its own risk), so the vectors are pinned here instead.
+"""
+
+import pytest
+
+from connectonion.derive import (
+    ACCOUNT_URI,
+    HARDENED,
+    derive_path,
+    identity_uri,
+    master_key,
+    slip13_path,
+    ssh_uri,
+)
+
+# SLIP-0010, Test vector 1 for ed25519. Seed 000102030405060708090a0b0c0d0e0f.
+VECTOR_1_SEED = bytes.fromhex("000102030405060708090a0b0c0d0e0f")
+VECTOR_1 = {
+    "m": "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7",
+    "m/0'": "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3",
+    "m/0'/1'": "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2",
+    "m/0'/1'/2'": "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9",
+    "m/0'/1'/2'/2'": "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662",
+    "m/0'/1'/2'/2'/1000000000'": "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793",
+}
+
+# SLIP-0010, Test vector 2 for ed25519.
+VECTOR_2_SEED = bytes.fromhex(
+    "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a2"
+    "9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542"
+)
+VECTOR_2 = {
+    "m": "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012",
+    "m/0'": "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635",
+}
+
+
+@pytest.mark.parametrize("path,expected", VECTOR_1.items())
+def test_slip10_vector_1(path, expected):
+    assert derive_path(VECTOR_1_SEED, path).hex() == expected
+
+
+@pytest.mark.parametrize("path,expected", VECTOR_2.items())
+def test_slip10_vector_2(path, expected):
+    assert derive_path(VECTOR_2_SEED, path).hex() == expected
+
+
+def test_master_chain_code_matches_the_spec():
+    """The chain code is half the master output and never leaves this module, so
+    a wrong one shows up only as wrong children — pin it directly."""
+    _, chain_code = master_key(VECTOR_1_SEED)
+    assert chain_code.hex() == "90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb"
+
+
+# --- Hardened-only: the property we are buying ---
+
+
+def test_an_unhardened_path_level_is_refused():
+    """Ed25519 has no public derivation. Accepting m/13/7 and quietly treating it
+    as m/13'/7' would hand back a different key than the caller asked for."""
+    with pytest.raises(ValueError, match="not hardened"):
+        derive_path(VECTOR_1_SEED, "m/13'/7")
+
+
+def test_a_path_must_start_at_the_master():
+    with pytest.raises(ValueError, match="must start with 'm'"):
+        derive_path(VECTOR_1_SEED, "13'/7'")
+
+
+def test_a_non_numeric_level_is_refused():
+    with pytest.raises(ValueError, match="not a number"):
+        derive_path(VECTOR_1_SEED, "m/abc'")
+
+
+def test_h_and_apostrophe_mean_the_same_thing():
+    assert derive_path(VECTOR_1_SEED, "m/0h") == derive_path(VECTOR_1_SEED, "m/0'")
+
+
+# --- SLIP-0013 identity paths ---
+
+# Computed independently in the design note for #404, before this implementation
+# existed. Matching them is the check that the name→path rule is the standard one
+# and not something only this code agrees with.
+def test_slip13_paths_match_the_published_examples():
+    assert slip13_path(identity_uri("customer-bot")) == \
+        "m/13'/1444947841'/1033670849'/1098573961'/1372853139'"
+    assert slip13_path(identity_uri("linkedin")) == \
+        "m/13'/473400136'/1637201591'/27483200'/1850547836'"
+    assert slip13_path(ssh_uri("co", "server")) == \
+        "m/13'/2092296577'/727006075'/1801353878'/1387973565'"
+
+
+def test_a_name_is_canonicalised_before_it_becomes_a_path():
+    """An address is a name people retype. ' LinkedIn ' and 'linkedin' must not be
+    two different agents."""
+    assert identity_uri("  LinkedIn  ") == "agent://linkedin"
+    assert slip13_path(identity_uri("LinkedIn")) == slip13_path(identity_uri("linkedin"))
+
+
+def test_an_empty_name_is_refused():
+    with pytest.raises(ValueError, match="empty"):
+        identity_uri("   ")
+
+
+def test_rotation_changes_the_key_and_nothing_else_does():
+    uri = identity_uri("customer-bot")
+    assert slip13_path(uri, 0) != slip13_path(uri, 1)
+    assert slip13_path(uri, 0) == slip13_path(uri, 0)
+
+
+def test_every_slip13_level_is_hardened_and_in_range():
+    """slip13_path writes the masked value; _parse_path adds the hardened bit.
+    If those two disagreed, paths would round-trip to a different key."""
+    from connectonion.derive import _parse_path
+
+    for level in _parse_path(slip13_path(identity_uri("customer-bot"))):
+        assert level >= HARDENED
+        assert level < 2 ** 32
+
+
+def test_different_purposes_from_one_seed_are_different_keys():
+    """The whole point of the tree: an SSH login key that leaks must not be the
+    agent's protocol key, and neither must be the account key."""
+    keys = {
+        derive_path(VECTOR_1_SEED, slip13_path(identity_uri("bot"))),
+        derive_path(VECTOR_1_SEED, slip13_path(ssh_uri("co", "server"))),
+        derive_path(VECTOR_1_SEED, slip13_path(ACCOUNT_URI)),
+    }
+    assert len(keys) == 3
+
+
+def test_derived_keys_are_usable_ed25519_seeds():
+    from nacl.signing import SigningKey
+
+    key = derive_path(VECTOR_1_SEED, slip13_path(identity_uri("bot")))
+    signed = SigningKey(key).sign(b"hello")
+    assert SigningKey(key).verify_key.verify(signed) == b"hello"
+
+
+def test_a_seed_of_the_wrong_size_is_refused():
+    with pytest.raises(ValueError, match="16-64 bytes"):
+        master_key(b"too short")


### PR DESCRIPTION
First step of #404 / #400. **Nothing is rewired — no address changes in this PR.**

## What is wrong today

```python
seed_phrase = mnemo.generate(strength=128)   # BIP-39 ✅
seed = mnemo.to_seed(seed_phrase)            # BIP-39 ✅
signing_key = SigningKey(seed[:32])          # ours alone ❌
```
`address.py:52-59`

That last line is a bare slice. It corresponds to no BIP, no SLIP, no derivation path — import the phrase into Ledger, Trezor, Phantom or Keplr and you never reach the same address on any path any of them offers. No hardware wallet can hold an agent identity, and the signing key exists only as a file on disk on every machine that runs the agent.

## What this adds

`connectonion/derive.py` — SLIP-0010 (BIP-32 adapted to Ed25519, what Solana, Brave and Trezor's own SSH/GPG features use) and SLIP-0013 identity paths, where **the name is the path**:

```python
slip13_path(identity_uri("customer-bot"))
# m/13'/1444947841'/1033670849'/1098573961'/1372853139'
```

So `co keys --agent customer-bot` can print an address before anything is deployed, and the same name always returns the same key — which is what #396 needs.

## Why this PR stops here

Switching identity over re-keys **every** agent at once: the account address, the agent email, every whitelist entry, every deployed agent's identity. That deserves its own review, not to be smuggled in beside a new HMAC loop. This PR is the primitive plus its proof; the switch is the next one.

## Hardened-only is the property, not a limitation

SLIP-0010 has no public derivation on Ed25519, and we don't want one. Non-hardened derivation has an inverse — `parent = child - t`, `t` computable from public data — so one leaked child private key plus the public tree recovers the parent, and the parent generates everything else. Agent identities and SSH keys **live on servers**, which get breached and snapshotted; under SLIP-0010 that exposes one key.

The watch-only we give up answers a question nobody here asks: balances live in a Postgres row keyed by public key and need a signature to read.

So a non-hardened index raises rather than quietly deriving something else.

## Verified, not asserted

- **Published SLIP-0010 ed25519 vectors** — both seeds, every level, pinned in the test file rather than recorded from this implementation. (A test that records what the code does passes just as happily when the code is wrong, and "wrong" here means every key in the tree is wrong.)
- **Cross-checked against Trezor's `slip10` package**: 20 derivations across both seeds and every path shape used here, byte-identical. Deliberately *not* added as a test dependency — installing a crypto library to test a 40-line one is its own risk — so the vectors are pinned instead.
- **The three SLIP-0013 example paths from #404's design note**, computed before this code existed, reproduce exactly — including `LinkedIn` canonicalising to `linkedin`.

`21` new tests, `2606` unit pass.

## Not in scope here

The migration (#404's "one switch, once"), absorbing `co keys --ssh`'s HKDF construction into the tree (#310), and the customer-handover question — an identity its author can derive is an identity its author holds.