### PR TITLE
The schema must keep the constraints the function has

### DIFF
--- a/connectonion/core/tool_factory.py
+++ b/connectonion/core/tool_factory.py
@@ -12,7 +12,8 @@ LLM-Note:
 
 import inspect
 import functools
-from typing import Callable, Dict, Any, get_type_hints, List, get_origin, get_args, Union
+import enum
+from typing import Callable, Dict, Any, Literal, get_type_hints, List, get_origin, get_args, Union
 
 # Map Python types to JSON Schema types
 TYPE_MAP = {
@@ -25,17 +26,53 @@ TYPE_MAP = {
 }
 
 
+def _enum_schema(values) -> dict:
+    """A closed set of values, typed by what is in it.
+
+    The type matters as much as the list: calling Literal[1, 2] a string makes
+    every valid value invalid on arrival.
+    """
+    json_type = "string"
+    if values and all(isinstance(v, bool) for v in values):
+        json_type = "boolean"
+    elif values and all(isinstance(v, int) and not isinstance(v, bool) for v in values):
+        json_type = "integer"
+    elif values and all(isinstance(v, float) for v in values):
+        json_type = "number"
+    return {"type": json_type, "enum": list(values)}
+
+
 def get_json_schema_type(param_type) -> dict:
-    """Convert a Python type hint to JSON Schema type, handling generics."""
+    """Convert a Python type hint to JSON Schema type, handling generics.
+
+    The schema is the only thing telling the model what a tool accepts, so a
+    constraint the function enforces and the schema omits costs a round trip:
+    the model sends a plausible value, the tool rejects it, and nothing in the
+    schema had said it would.
+    """
     origin = get_origin(param_type)
 
-    # Handle Optional[X] which is Union[X, None]
+    # Literal["fast", "slow"] — the values ARE the constraint.
+    if origin is Literal:
+        return _enum_schema(get_args(param_type))
+
+    # An Enum class publishes its VALUES, not its member names: the model has to
+    # send "fast", not "FAST".
+    if isinstance(param_type, type) and issubclass(param_type, enum.Enum):
+        return _enum_schema([member.value for member in param_type])
+
     if origin is Union:
         args = get_args(param_type)
         # Filter out NoneType to get the actual type
         non_none_args = [a for a in args if a is not type(None)]
-        if non_none_args:
+        if len(non_none_args) == 1:
+            # Optional[X] — a nullable X is still an X, not a one-branch union.
             return get_json_schema_type(non_none_args[0])
+        if non_none_args:
+            # A real multi-type union. Taking the first arm silently made every
+            # other type unrepresentable: Union[str, int] said "string", so int
+            # was never a legal value as far as the model could tell.
+            return {"anyOf": [get_json_schema_type(a) for a in non_none_args]}
         return {"type": "string"}
 
     # Handle List[X]

--- a/tests/unit/test_schema_keeps_constraints.py
+++ b/tests/unit/test_schema_keeps_constraints.py
@@ -1,0 +1,96 @@
+"""The schema is the only thing telling the model what a tool accepts.
+
+Where it drops a constraint the function actually enforces, the model has no
+way to know — it sends a plausible value, the tool rejects it at runtime, and
+the round trip is spent discovering something the schema could have said.
+"""
+
+from enum import Enum
+from typing import List, Literal, Optional, Union
+
+from connectonion.core.tool_factory import get_json_schema_type
+
+
+class Mode(str, Enum):
+    FAST = "fast"
+    SLOW = "slow"
+
+
+class Priority(Enum):
+    LOW = 1
+    HIGH = 2
+
+
+class TestLiteral:
+    def test_the_allowed_values_reach_the_schema(self):
+        """`Literal["fast","slow"]` used to fall through to a bare string, so
+        the model could send "turbo" and only find out at runtime."""
+        schema = get_json_schema_type(Literal["fast", "slow"])
+
+        assert schema["type"] == "string"
+        assert schema["enum"] == ["fast", "slow"]
+
+    def test_an_integer_literal_is_typed_as_an_integer(self):
+        """Saying "string" for Literal[1, 2] would make every valid value
+        invalid on arrival."""
+        schema = get_json_schema_type(Literal[1, 2])
+
+        assert schema["type"] == "integer"
+        assert schema["enum"] == [1, 2]
+
+    def test_optional_literal_keeps_its_values(self):
+        schema = get_json_schema_type(Optional[Literal["fast", "slow"]])
+
+        assert schema["enum"] == ["fast", "slow"]
+
+
+class TestEnum:
+    def test_a_string_enum_publishes_its_values_not_its_member_names(self):
+        """The model must send "fast", which is the value — not "FAST"."""
+        schema = get_json_schema_type(Mode)
+
+        assert schema["type"] == "string"
+        assert schema["enum"] == ["fast", "slow"]
+
+    def test_an_int_enum_is_typed_as_an_integer(self):
+        schema = get_json_schema_type(Priority)
+
+        assert schema["type"] == "integer"
+        assert schema["enum"] == [1, 2]
+
+
+class TestUnion:
+    def test_a_two_type_union_offers_both(self):
+        """Union[str, int] used to collapse to string, so int was never a legal
+        value as far as the model could tell."""
+        schema = get_json_schema_type(Union[str, int])
+
+        assert "anyOf" in schema
+        assert {"type": "string"} in schema["anyOf"]
+        assert {"type": "integer"} in schema["anyOf"]
+
+    def test_optional_is_still_the_inner_type_not_an_anyOf(self):
+        """Optional[X] is Union[X, None] and already worked; a nullable
+        parameter should stay a plain X rather than become a two-branch union."""
+        assert get_json_schema_type(Optional[str]) == {"type": "string"}
+
+    def test_optional_union_of_several_types_still_offers_them_all(self):
+        schema = get_json_schema_type(Optional[Union[str, int]])
+
+        assert "anyOf" in schema
+
+
+class TestUntouched:
+    """The shapes that already worked must keep working."""
+
+    def test_plain_types(self):
+        assert get_json_schema_type(str) == {"type": "string"}
+        assert get_json_schema_type(int) == {"type": "integer"}
+        assert get_json_schema_type(bool) == {"type": "boolean"}
+
+    def test_list_of_strings(self):
+        assert get_json_schema_type(List[str]) == {"type": "array", "items": {"type": "string"}}
+
+    def test_an_unknown_type_still_falls_back_to_string(self):
+        class Whatever: pass
+        assert get_json_schema_type(Whatever) == {"type": "string"}


### PR DESCRIPTION
Closes #373. Fifth of the 1.5.3 bugs.

## Why this matters more than it looks

The schema is the **only** thing telling the model what a tool accepts. Where it drops a constraint the function enforces, the model cannot know: it sends a plausible value, the tool rejects it at runtime, and a whole round trip is spent discovering something the schema could have stated.

Three constraints were being dropped:

| Written | Schema said | Model could send |
|---|---|---|
| `Literal["fast","slow"]` | `{"type": "string"}` | `"turbo"` |
| `Mode(str, Enum)` | `{"type": "string"}` | anything |
| `Union[str, int]` | `{"type": "string"}` | never an int |

## The type matters as much as the list

`Literal[1, 2]` typed as `"string"` would make **every valid value invalid on arrival** — the model sends `"1"` and the function wanted `1`. `_enum_schema` picks the JSON type from the values themselves, so int literals stay integers and bool literals stay booleans.

An `Enum` publishes its **values**, not its member names: the model has to send `"fast"`, not `"FAST"`.

## What deliberately did not change

`Optional[X]` stays a plain `X`, not a one-branch `anyOf`. A nullable X is still an X, that shape already worked, and turning it into a union would churn every existing optional parameter's schema for nothing. Pinned by a test.

The string fallback for genuinely unknown types is also unchanged.

## Verification

11 tests, **7 red before / 11 green after**.

(The 4 that pass either way are the "already worked" guards — plain types, `List[str]`, `Optional[str]`, unknown-type fallback. They exist to catch a fix that improves unions by breaking something adjacent.)

Full unit suite: **2607 passed, 3 skipped**.