### PR TITLE
fix(deploy): carry the config the author wrote, delete nothing the server owns

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -367,26 +367,49 @@ def _caddy_running(target: str) -> bool:
     return _ssh(target, "systemctl is-active caddy", timeout=60).stdout.strip() == "active"
 
 
+# Everything the author wrote ships, and `--delete` removes what they deleted.
+# `.co/` gets two carve-outs, both because the server owns that data:
+#
+#   P .co/**       nothing under .co/ is ever *deleted* on the server. Identity,
+#                  logs, admins.txt, provision.json and anything a future
+#                  version writes there survive a deploy without being listed.
+#   --exclude ...  identity and accumulated state are never *sent*, so a stale
+#                  local copy cannot overwrite the live one.
+#
+# This replaced an include-list that named the `.co/` files worth carrying.
+# That default — exclude unless remembered — lost `.co/skills/` in its first
+# version and `.co/dashboard.html` in its second, and was silently dropping
+# `host.yaml`, `OO.md` and `commands/` when this was written. Forgetting to
+# carry config is invisible: the deploy succeeds and a different agent runs.
+RSYNC_FILTERS = [
+    "--filter", "P .co/**",
+    "--exclude", ".co/keys/",
+    "--exclude", ".co/logs/",
+    "--exclude", ".co/evals/",
+    "--exclude", ".co/sessions/",
+    "--exclude", ".venv/",
+    "--exclude", ".git/",
+    "--exclude", "__pycache__/",
+]
+
+
 def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
-    """rsync the project, excluding the state directory but carrying skills.
+    """rsync the project, carrying everything the author wrote and deleting
+    nothing the server owns.
 
-    `--delete` removes code files deleted locally, which is wanted. `.co/` is
-    excluded so the agent's identity, logs and evals survive — that exclusion is
-    the whole reason a redeploy no longer reissues the agent's address.
+    `--delete` removes code files deleted locally, which is wanted. It stops at
+    `.co/`, where the server keeps the agent's identity, its logs, the admins
+    list and the convergence marker — data the project has never heard of and
+    an include-list could not enumerate.
 
-    `.co/skills/` is the exception, and it has to be: skills are *what the agent
-    is*, not state it accumulated. Excluding all of `.co/` shipped an agent with
-    none of its skills — the deploy succeeded and the agent ran without them,
-    which is worse than failing. So skills are included, and `--delete` applies
-    inside that directory too so a removed skill actually goes away.
+    What the author writes under `.co/` — `host.yaml`, `OO.md`, `skills/`,
+    `commands/`, `dashboard.html` — is not state. It is what makes this agent
+    this agent, so it ships like the rest of the tree. `host.yaml` in particular
+    carries the permission whitelist and the port: without it the agent runs on
+    template defaults behind a proxy pointed at the wrong port, and reports
+    success either way.
 
-    `.co/dashboard.html` is included for the same reason: the Home page you wrote
-    is part of the agent. Left out, a deploy silently replaces it with a generated
-    starter — the agent looks fine and your dashboard is gone.
-
-    Order matters to rsync: the include must precede the exclude that would
-    otherwise swallow it, and `.co/` itself must be included for rsync to
-    descend into it at all.
+    See RSYNC_FILTERS for the two rules and why the default is now "carry".
     """
     from .server_commands import _identity as _ssh_identity
 
@@ -394,13 +417,7 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     result = subprocess.run(
         [
             "rsync", "-az", "--delete",
-            "--include", ".co/",
-            "--include", ".co/skills/***",
-            "--include", ".co/dashboard.html",
-            "--exclude", ".co/*",
-            "--exclude", ".venv/",
-            "--exclude", ".git/",
-            "--exclude", "__pycache__/",
+            *RSYNC_FILTERS,
             "-e", " ".join(["ssh", "-o", "BatchMode=yes",
                             "-o", "StrictHostKeyChecking=accept-new",
                             *_ssh_identity()]),

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -383,7 +383,17 @@ def _caddy_running(target: str) -> bool:
 # carry config is invisible: the deploy succeeds and a different agent runs.
 RSYNC_FILTERS = [
     "--filter", "P .co/**",
+    # Generated on the server, or written there over ssh by the deploy itself.
+    # The protect rule above keeps them from being deleted; these keep a local
+    # copy from overwriting them, which is the other half of the same rule.
+    # `address.json` decides super-admin (trust/tools.py:328) and `admins.txt`
+    # decides who may command the agent — a stale local copy of either is a
+    # change of who is in charge, made silently by a deploy.
     "--exclude", ".co/keys/",
+    "--exclude", ".co/address.json",
+    "--exclude", ".co/admins.txt",
+    "--exclude", ".co/provision.json",
+    "--exclude", ".co/requirements.sha256",
     "--exclude", ".co/logs/",
     "--exclude", ".co/evals/",
     "--exclude", ".co/sessions/",

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -490,12 +490,30 @@ def test_a_personal_starter_template_replaces_the_bundled_one(in_tmp, monkeypatc
     assert 'data-ochat-skill="daily-brief"' in html
 
 
-def test_the_deploy_rsync_carries_the_dashboard():
-    """.co/* is excluded to protect identity and logs; the Home page is not state,
-    and a deploy that drops it silently regenerates a starter over your page."""
-    import inspect
-    from connectonion.cli.commands import deploy_to_server
+def test_the_deploy_rsync_carries_the_dashboard(tmp_path):
+    """The Home page is not state, and a deploy that drops it silently
+    regenerates a starter over your page.
 
-    source = inspect.getsource(deploy_to_server._sync_code)
-    assert '".co/dashboard.html"' in source
-    assert source.index('".co/dashboard.html"') < source.index('".co/*"')
+    Asserted by running the filters rather than by reading the argv: the
+    previous version of this test checked that `.co/dashboard.html` appeared
+    before `.co/*` in the source, which stayed true while `host.yaml` and
+    `OO.md` were being dropped by the same rule.
+    """
+    import shutil
+    import subprocess
+    from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+
+    if shutil.which("rsync") is None:
+        pytest.skip("needs rsync on PATH")
+
+    local, server = tmp_path / "local", tmp_path / "server"
+    (local / ".co").mkdir(parents=True)
+    (server / ".co").mkdir(parents=True)
+    (local / ".co" / "dashboard.html").write_text("<h1>mine</h1>")
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *RSYNC_FILTERS, f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+
+    assert (server / ".co" / "dashboard.html").read_text() == "<h1>mine</h1>"

--- a/tests/unit/test_deploy_sync_filters.py
+++ b/tests/unit/test_deploy_sync_filters.py
@@ -1,0 +1,107 @@
+"""What a deploy actually leaves on the server.
+
+The existing tests in test_deploy_to_server.py assert the shape of the rsync
+argv. That is how `.co/host.yaml` and `.co/OO.md` went missing for a release
+without anyone noticing: the argv was exactly as asserted, and the outcome was
+still wrong. These tests run the real rsync against two directories and look at
+the files, so they answer the only question that matters — after a deploy, what
+is on the server?
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("rsync") is None, reason="needs rsync on PATH"
+)
+
+
+@pytest.fixture
+def synced(tmp_path):
+    """Run the real filters over a project that has every kind of file.
+
+    Returns the server directory, after one deploy.
+    """
+    local, server = tmp_path / "local", tmp_path / "server"
+
+    # What the author writes.
+    (local / ".co" / "skills" / "billing").mkdir(parents=True)
+    (local / ".co" / "commands").mkdir()
+    (local / ".co" / "host.yaml").write_text("name: myagent\n")
+    (local / ".co" / "OO.md").write_text("call the billing skill first\n")
+    (local / ".co" / "commands" / "report.md").write_text("# report\n")
+    (local / ".co" / "skills" / "billing" / "SKILL.md").write_text("# billing\n")
+    (local / "agent.py").write_text("print('hi')\n")
+
+    # What the server owns and the author must never overwrite.
+    (server / ".co" / "keys").mkdir(parents=True)
+    (server / ".co" / "logs").mkdir()
+    (server / ".co" / "keys" / "agent.key").write_text("SERVER IDENTITY")
+    (server / ".co" / "logs" / "run.log").write_text("history\n")
+    (server / ".co" / "admins.txt").write_text("0xdeadbeef\n")
+    (server / ".co" / "provision.json").write_text("{}\n")
+    # Code the author deleted locally, which should go away.
+    (server / "stale.py").write_text("old\n")
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *RSYNC_FILTERS, f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+    return server
+
+
+@pytest.mark.parametrize("relpath", [
+    ".co/host.yaml",
+    ".co/OO.md",
+    ".co/commands/report.md",
+    ".co/skills/billing/SKILL.md",
+    "agent.py",
+])
+def test_what_the_author_wrote_arrives(synced, relpath):
+    """Config is what makes the agent this agent. Dropping it silently ships a
+    different agent than the one that was tested."""
+    assert (synced / relpath).exists(), f"{relpath} never reached the server"
+
+
+def test_the_agent_keeps_its_identity(synced):
+    """The reason `.co/` was excluded in the first place (#306). Overwriting this
+    reissues the address and voids every trust relationship keyed to it."""
+    assert (synced / ".co" / "keys" / "agent.key").read_text() == "SERVER IDENTITY"
+
+
+@pytest.mark.parametrize("relpath", [
+    ".co/logs/run.log",     # history a dashboard shows
+    ".co/admins.txt",       # who may command the agent
+    ".co/provision.json",   # convergence marker
+])
+def test_server_owned_state_survives_the_delete(synced, relpath):
+    """`--delete` removes whatever the source lacks. Everything here exists only
+    on the server, so without protection each deploy would wipe it."""
+    assert (synced / relpath).exists(), f"{relpath} was deleted by the sync"
+
+
+def test_deleted_code_still_goes_away(synced):
+    """The protection must not turn `--delete` off for the rest of the tree."""
+    assert not (synced / "stale.py").exists()
+
+
+def test_a_local_key_cannot_take_over_the_server(tmp_path):
+    """A project that has ever run `host()` locally has its own `.co/keys/`.
+    That key must not be able to replace the server's identity."""
+    local, server = tmp_path / "local", tmp_path / "server"
+    (local / ".co" / "keys").mkdir(parents=True)
+    (server / ".co" / "keys").mkdir(parents=True)
+    (local / ".co" / "keys" / "agent.key").write_text("LOCAL")
+    (server / ".co" / "keys" / "agent.key").write_text("SERVER")
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *RSYNC_FILTERS, f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+
+    assert (server / ".co" / "keys" / "agent.key").read_text() == "SERVER"

--- a/tests/unit/test_deploy_sync_filters.py
+++ b/tests/unit/test_deploy_sync_filters.py
@@ -90,6 +90,33 @@ def test_deleted_code_still_goes_away(synced):
     assert not (synced / "stale.py").exists()
 
 
+@pytest.mark.parametrize("relpath, server_value", [
+    (".co/address.json", '{"address": "0xSERVER"}'),   # decides super-admin
+    (".co/admins.txt", "0xSERVER\n"),                  # decides who may command
+    (".co/provision.json", '{"schema": 3}'),
+    (".co/requirements.sha256", "server-digest"),
+])
+def test_a_local_copy_cannot_overwrite_what_the_server_owns(
+        tmp_path, relpath, server_value):
+    """Protection stops `--delete`; it does not stop a *transfer*. These four
+    are generated on the server or written there over ssh, so a stale local
+    copy — `add_admin()` writes `.co/admins.txt` in the cwd when run locally —
+    would silently change who is in charge of the deployed agent.
+    """
+    local, server = tmp_path / "local", tmp_path / "server"
+    (local / ".co").mkdir(parents=True)
+    (server / ".co").mkdir(parents=True)
+    (local / relpath).write_text("LOCAL")
+    (server / relpath).write_text(server_value)
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *RSYNC_FILTERS, f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+
+    assert (server / relpath).read_text() == server_value
+
+
 def test_a_local_key_cannot_take_over_the_server(tmp_path):
     """A project that has ever run `host()` locally has its own `.co/keys/`.
     That key must not be able to replace the server's identity."""

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -49,16 +49,17 @@ class TestSyncNeverTouchesState:
                 return argv
         raise AssertionError(f"no rsync call in {run.call_args_list}")
 
-    def test_rsync_excludes_the_state_directory(self, project):
+    def test_rsync_never_sends_a_local_identity(self, project):
+        """The one rule that must never regress: a local `.co/keys/` cannot be
+        pushed over the server's. What the filters *achieve* is asserted against
+        a real rsync in test_deploy_sync_filters.py; this only pins the argv so
+        the exclusion cannot be dropped by accident."""
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
         argv = self._rsync_argv(run)
-        # --exclude and its value are separate argv entries. The pattern is
-        # `.co/*` rather than `.co/` so rsync still descends far enough for the
-        # skills include to match — see the skills test below.
         pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
-        assert ("--exclude", ".co/*") in pairs
+        assert ("--exclude", ".co/keys/") in pairs
 
     def test_rsync_uses_delete_so_removed_code_goes_away(self, project):
         """--delete is wanted for code; the .co/ exclusion is what protects state.
@@ -71,27 +72,23 @@ class TestSyncNeverTouchesState:
 
         assert "--delete" in self._rsync_argv(run)
 
-    def test_skills_are_carried_but_the_rest_of_state_is_not(self, project):
-        """Skills live in .co/skills/ — excluding all of .co/ shipped an agent
-        with none of its skills.
+    def test_nothing_under_co_is_ever_deleted_on_the_server(self, project):
+        """`--delete` must not reach inside `.co/`. admins.txt, provision.json
+        and the agent's own keys exist only there, and no include-list can
+        anticipate what a future version writes beside them.
 
-        Found by review after the first version excluded `.co/` wholesale: the
-        deploy succeeded and the agent ran without its skills, which is worse
-        than failing. The rule is order-sensitive in rsync, so this asserts the
-        exact sequence rather than mere membership.
+        This replaced a test that asserted an include-list carried `.co/skills/`
+        past a `.co/*` exclude. That assertion held while the same rule was
+        dropping `host.yaml`, `OO.md` and `commands/` — which is why the
+        outcome, not the argv, is now the thing under test
+        (test_deploy_sync_filters.py).
         """
         with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
             dts._sync_code("user@host", "myagent", project)
 
         argv = self._rsync_argv(run)
-        # rsync applies the first matching rule, so the includes must come
-        # before the exclude that would otherwise swallow them, and `.co/`
-        # itself must be included for rsync to descend into it.
-        assert argv.index("--include") < argv.index("--exclude")
         pairs = [(argv[i], argv[i + 1]) for i in range(len(argv) - 1)]
-        assert ("--include", ".co/") in pairs
-        assert ("--include", ".co/skills/***") in pairs
-        assert ("--exclude", ".co/*") in pairs
+        assert ("--filter", "P .co/**") in pairs
 
     def test_the_state_exclusion_is_not_a_blanket_co_exclusion(self, project):
         """`--exclude .co/` would prune the directory before the skills include


### PR DESCRIPTION
Fixes #392.

## The bug

`_sync_code` excluded `.co/*` and re-included the files worth carrying. That default — exclude unless remembered — lost `.co/skills/` in its first version and `.co/dashboard.html` in its second, and was still dropping `host.yaml`, `OO.md` and `commands/`.

`host.yaml` is the expensive one. It carries the permission whitelist that `load_permission_patterns()` merges over the template defaults, so a project that **tightened** its permissions ran looser in production than on the author's laptop, and one that **widened** them stalled on a headless box waiting for an approval nobody could give. It also carries `port`: the deploy reads it locally to configure Caddy while the server, lacking the file, falls back to 8000. Set `port: 9000` and Caddy proxies a port nothing is listening on — with every step reporting success.

## The fix

Invert the default. Everything ships; `.co/` gets two carve-outs, both because the server owns that data:

```
--filter 'P .co/**'      never delete anything under .co/ on the server
--exclude .co/keys/ …    never send identity or accumulated state
```

Identity, logs, `admins.txt`, `provision.json` and anything a future version writes beside them now survive **without being listed**, and new config ships **without being remembered**. Forgetting to carry config was invisible — the deploy succeeded and a different agent ran. Forgetting to protect state is loud.

## On the tests

Three existing tests failed, and all three asserted the shape of the argv. That is how this went unnoticed for two releases: the argv was exactly as asserted, and the outcome was still wrong. `test_the_deploy_rsync_carries_the_dashboard` even asserted that `.co/dashboard.html` appeared before `.co/*` in the source — true the whole time `host.yaml` was being dropped by that same rule.

They now assert what lands on the server, by running a real rsync into a temp directory:

- config the author wrote arrives (`host.yaml`, `OO.md`, `commands/`, `skills/`)
- the agent keeps its identity
- server-owned state survives `--delete`
- code deleted locally still goes away
- a local `.co/keys/` cannot take over the server

Verified red before the change — `host.yaml`, `OO.md` and `commands/report.md` each failed with "never reached the server" — and green after. Full unit suite: 2607 passed, 0 failed.

## Related

- #324 — the agent does not call the skill tool unprompted. The workaround is an imperative in `.co/OO.md`, which this PR is what makes reach the server; until now the two bugs cancelled any fix for either.
- #393 — same rsync call, opposite direction: `.env` ships when it should not.