### PR TITLE
Passing the class instead of an instance must fail at registration

### DIFF
--- a/connectonion/core/tool_factory.py
+++ b/connectonion/core/tool_factory.py
@@ -58,6 +58,38 @@ def get_json_schema_type(param_type) -> dict:
     # Default to string
     return {"type": "string"}
 
+def _unbound_method_owner(func):
+    """The class name if `func` is a method accessed off the class, else None.
+
+    `MyTools.do_thing` and `MyTools().do_thing` are both callable, so the wrong
+    one is easy to pass — and in Python 3 the first is a plain function, so
+    inspect.ismethod() cannot tell them apart.
+
+    __qualname__ can: a method carries its owner ("Calculator.add"), while a
+    plain function does not, and one defined inside another scope carries
+    "<locals>" instead of a class. A function that merely names its first
+    parameter `self` is unusual but legal, and must keep working.
+    """
+    if inspect.ismethod(func):
+        return None
+
+    try:
+        params = list(inspect.signature(func).parameters)
+    except (TypeError, ValueError):
+        return None
+    if not params or params[0] != "self":
+        return None
+
+    parts = getattr(func, "__qualname__", "").split(".")
+    if len(parts) < 2 or parts[-2] == "<locals>":
+        return None
+
+    owner = getattr(inspect.getmodule(func), parts[-2], None)
+    if owner is not None and not isinstance(owner, type):
+        return None
+    return parts[-2]
+
+
 def create_tool_from_function(func: Callable) -> Callable:
     """
     Converts a Python function into a tool that is compatible with the Agent,
@@ -72,6 +104,19 @@ def create_tool_from_function(func: Callable) -> Callable:
     sig = inspect.signature(func)
     type_hints = get_type_hints(func)
     
+    owner = _unbound_method_owner(func)
+    if owner:
+        # Refused here rather than at call time. Stripping `self` made the schema
+        # look correct, so the mistake surfaced later as
+        # "add() missing 1 required positional argument: 'self'" — raised inside
+        # the agent loop, describing the symptom, nowhere near the line that
+        # registered the tool.
+        raise TypeError(
+            f"{owner}.{func.__name__} is an unbound method — pass an instance, "
+            f"not the class: tools=[{owner}().{func.__name__}] "
+            f"instead of tools=[{owner}.{func.__name__}]"
+        )
+
     properties = {}
     required = []
 

--- a/tests/unit/test_unbound_method_registration.py
+++ b/tests/unit/test_unbound_method_registration.py
@@ -1,0 +1,62 @@
+"""Passing the class instead of an instance must fail where the mistake is.
+
+`MyTools.do_thing` and `MyTools().do_thing` are both callable, so the wrong one
+is easy to pass. Schema generation accepted it — `self` was stripped, the schema
+looked right — and every call then failed with a TypeError about `self`, raised
+inside the agent loop, far from the line that registered the tool.
+"""
+
+import pytest
+
+from connectonion.core.tool_factory import create_tool_from_function
+
+
+class Calculator:
+    def __init__(self, offset: int = 0):
+        self.offset = offset
+
+    def add(self, a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b + self.offset
+
+
+class TestUnboundMethods:
+    def test_passing_the_class_method_is_refused_at_registration(self):
+        with pytest.raises(TypeError):
+            create_tool_from_function(Calculator.add)
+
+    def test_the_message_says_what_to_do_instead(self):
+        """A TypeError about `self` at call time describes the symptom. The
+        registration site is where the fix is, so the message belongs here and
+        has to name the correction."""
+        with pytest.raises(TypeError) as caught:
+            create_tool_from_function(Calculator.add)
+
+        message = str(caught.value)
+        assert "Calculator.add" in message
+        assert "instance" in message.lower()
+
+    def test_a_bound_method_still_works(self):
+        tool = create_tool_from_function(Calculator(offset=10).add)
+
+        assert tool(a=1, b=2) == 13
+        assert "self" not in tool.get_parameters_schema()["properties"]
+
+    def test_a_plain_function_still_works(self):
+        def multiply(a: int, b: int) -> int:
+            """Multiply two numbers."""
+            return a * b
+
+        assert create_tool_from_function(multiply)(a=3, b=4) == 12
+
+    def test_a_function_whose_first_arg_is_named_self_is_not_a_method(self):
+        """Nothing about the name `self` makes something a method. A plain
+        function using it is unusual but legal, and refusing it would break a
+        tool that works."""
+        def odd(self: int, other: int) -> int:
+            """Add, with a confusingly named first parameter."""
+            return self + other
+
+        tool = create_tool_from_function(odd)
+
+        assert tool(self=1, other=2) == 3


### PR DESCRIPTION
Closes #375. Sixth of the 1.5.3 bugs.

## The mistake, and why it was so hard to trace

```python
Agent(tools=[MyTools.do_thing])      # wrong
Agent(tools=[MyTools().do_thing])    # right
```

Both are callable, so the wrong one is easy to pass. Schema generation **accepted it** — `self` was stripped, the schema looked correct — and every call then failed with:

```
TypeError: do_thing() missing 1 required positional argument: 'self'
```

raised inside the agent loop. It describes the symptom, and it is nowhere near the line that registered the tool.

## Why `inspect.ismethod()` could not be the check

In Python 3, `MyTools.do_thing` **is a plain function**. `ismethod()` is `False` for it, which is exactly why the existing `if inspect.ismethod(func)` branch never caught this.

`__qualname__` can tell them apart:

| | `__qualname__` |
|---|---|
| `Calculator.add` | `"Calculator.add"` — carries its owner |
| a module-level `odd` | `"odd"` |
| a nested `odd` | `"...<locals>.odd"` |

## The test that shaped the implementation

A plain function whose first parameter happens to be named `self` is unusual but **legal**:

```python
def odd(self: int, other: int) -> int: ...
```

The obvious implementation — refuse anything whose first parameter is `self` — would break it. There is a test pinning that it keeps working, and it is the reason the check is on `__qualname__` rather than on the parameter name alone.

## The message names the fix, not the symptom

```
Calculator.add is an unbound method — pass an instance, not the class:
tools=[Calculator().add] instead of tools=[Calculator.add]
```

## Verification

5 tests, **2 red before / 5 green after**.

One of them initially failed for my own reason: the test asserted on `tool.__tool_schema__`, an attribute I assumed rather than checked. The real API is `get_parameters_schema()`. Caught by running it, not by reading it.

Full unit suite: **2601 passed, 3 skipped**.