### PR TITLE
Say when a parameter's schema type was guessed

### DIFF
--- a/connectonion/core/tool_factory.py
+++ b/connectonion/core/tool_factory.py
@@ -13,7 +13,12 @@ LLM-Note:
 import inspect
 import functools
 import enum
+import warnings
 from typing import Callable, Dict, Any, Literal, get_type_hints, List, get_origin, get_args, Union
+
+class UnannotatedParameterWarning(UserWarning):
+    """A tool parameter has no type hint, so its schema type was guessed."""
+
 
 # Map Python types to JSON Schema types
 TYPE_MAP = {
@@ -152,6 +157,32 @@ def create_tool_from_function(func: Callable) -> Callable:
             f"{owner}.{func.__name__} is an unbound method — pass an instance, "
             f"not the class: tools=[{owner}().{func.__name__}] "
             f"instead of tools=[{owner}.{func.__name__}]"
+        )
+
+    # Ordered deliberately: an unbound method is a mistake to refuse, so it is
+    # refused before we bother warning about annotations on a function that was
+    # never going to work anyway.
+    #
+    # Named before the loop so the developer gets one line listing all of them,
+    # rather than one warning per parameter buried in startup output.
+    unannotated = [
+        p.name for p in sig.parameters.values()
+        if p.name not in ("self", "agent") and p.name not in type_hints
+    ]
+    if unannotated:
+        # A guess is not a crash, so it survives: `def add(a, b)` types both as
+        # string, the model correctly sends "2" and "3" per that schema, and
+        # a + b evaluates to "23" — a wrong answer with no exception anywhere.
+        #
+        # Warned rather than refused. Refusing would break every agent whose
+        # tools work today, for a defect that is about visibility: the schema is
+        # unchanged, and the developer is now told which parameters it guessed.
+        warnings.warn(
+            f"Tool '{name}' has unannotated parameter(s): {', '.join(unannotated)}. "
+            f"Their schema type was guessed as string, so a model may send "
+            f"\"2\" where the function expects 2. Add type hints.",
+            UnannotatedParameterWarning,
+            stacklevel=2,
         )
 
     properties = {}

--- a/tests/unit/test_unannotated_tool_params.py
+++ b/tests/unit/test_unannotated_tool_params.py
@@ -1,0 +1,96 @@
+"""An unannotated tool parameter must not be guessed silently.
+
+`param_type = type_hints.get(param_name, str)` typed anything unannotated as a
+string. For `def add(a, b)` the model then correctly sent "2" and "3" per the
+schema, and `a + b` evaluated to "23" — a wrong answer with no exception
+anywhere, which is the kind of bug that survives for months.
+"""
+
+import warnings
+
+import pytest
+
+from connectonion.core.tool_factory import (
+    UnannotatedParameterWarning,
+    create_tool_from_function,
+)
+
+
+class TestItSaysSomething:
+    def test_an_unannotated_parameter_warns(self):
+        def add(a, b) -> int:
+            """Add two numbers."""
+            return a + b
+
+        with pytest.warns(UnannotatedParameterWarning):
+            create_tool_from_function(add)
+
+    def test_the_warning_names_the_function_and_the_parameters(self):
+        """A warning that does not say where to look costs as much time as no
+        warning."""
+        def add(a, b) -> int:
+            """Add two numbers."""
+            return a + b
+
+        with pytest.warns(UnannotatedParameterWarning) as caught:
+            create_tool_from_function(add)
+
+        message = str(caught[0].message)
+        assert "add" in message
+        assert "a" in message and "b" in message
+
+    def test_it_still_registers_rather_than_refusing(self):
+        """Guessing is wrong; refusing would break every agent whose tools work
+        today. The tool loads, and the developer is told."""
+        def add(a, b) -> int:
+            """Add two numbers."""
+            return a + b
+
+        with pytest.warns(UnannotatedParameterWarning):
+            tool = create_tool_from_function(add)
+
+        assert tool(a=2, b=3) == 5
+
+    def test_the_guess_is_still_string_so_behaviour_is_unchanged(self):
+        """This PR adds visibility, not a new schema. Changing the guess as well
+        would move the failure rather than surface it."""
+        def add(a, b) -> int:
+            """Add two numbers."""
+            return a + b
+
+        with pytest.warns(UnannotatedParameterWarning):
+            tool = create_tool_from_function(add)
+
+        assert tool.get_parameters_schema()["properties"]["a"] == {"type": "string"}
+
+
+class TestItStaysQuietWhenItShould:
+    def test_a_fully_annotated_function_warns_about_nothing(self):
+        def add(a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnannotatedParameterWarning)
+            create_tool_from_function(add)
+
+    def test_agent_and_self_are_not_reported(self):
+        """Both are injected rather than sent by the model, so neither is
+        something the developer forgot to annotate."""
+        class Tools:
+            def act(self, agent, thing: str) -> str:
+                """Do a thing."""
+                return thing
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnannotatedParameterWarning)
+            create_tool_from_function(Tools().act)
+
+    def test_a_function_with_no_parameters_warns_about_nothing(self):
+        def ping() -> str:
+            """Ping."""
+            return "pong"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UnannotatedParameterWarning)
+            create_tool_from_function(ping)


### PR DESCRIPTION
Closes #374. Last of the 1.5.3 batch that had sequencing.

## The bug

```python
param_type = type_hints.get(param_name, str)     # silently
```

For `def add(a, b) -> int`, both parameters are typed `{"type": "string"}`. The model then does exactly what the schema says — sends `"2"` and `"3"` — and `a + b` evaluates to `"23"`.

**A wrong answer, with no exception anywhere.** That is the kind of defect that survives for months, because nothing ever crashes and the output looks like output.

## Warn, not refuse — and I measured before choosing

The issue offered both, and the project's fail-fast instinct says refuse. I checked the blast radius first rather than arguing from principle:

```
public tool functions in useful_tools:  16
with an unannotated parameter:           1     (synology.save_credentials)
```

So our own code would survive a hard failure. **Users' code is what we cannot see** — and this defect is about *visibility*, not about the schema being wrong to produce. Refusing would break agents that work today to fix a problem they may not have.

The schema is deliberately unchanged (a test pins that `a` is still `{"type": "string"}`). Changing the guess *and* adding the warning in one PR would move the failure rather than surface it.

## Details worth a look

**One warning listing every parameter**, not one per parameter — a per-parameter warning is noise that gets filtered, which defeats the point.

**`self` and `agent` are excluded.** Both are injected rather than sent by the model, so neither is something anyone forgot to annotate. Pinned by a test.

**The message says what goes wrong**, not just that something is missing:

```
Tool 'add' has unannotated parameter(s): a, b. Their schema type was guessed as
string, so a model may send "2" where the function expects 2. Add type hints.
```

## Verification

7 tests, **4 red before / 7 green after**.

Red-first checked by removing only the `warnings.warn` call and keeping the warning class — stashing the whole change gives a collection error, which proves the import broke and nothing else. (Same trap as #379; worth stating since it looks like a passing verification.)

Full unit suite: **2603 passed, 3 skipped** — 7 warnings where main has 6, the new one being this.