### PR TITLE
fix(deploy): .env is a secret on --to, the way it already is on Cloud

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from dotenv import dotenv_values
 from rich.console import Console
 
 from .server_commands import SSH_TIMEOUT_SECONDS, load_server
@@ -27,7 +28,12 @@ console = Console()
 # Bumped when a setup step is added or changes shape. A server reporting an
 # older schema runs the missing steps; one reporting this schema goes straight
 # to rsync and restart.
-PROVISION_SCHEMA = 2
+PROVISION_SCHEMA = 3
+
+# Secrets live outside the rsync root on purpose. Inside `/srv/<agent>/` the
+# next deploy's `--delete` would overwrite them with the laptop's copy, so a key
+# rotated in production could not stay rotated.
+ENV_FILE_TEMPLATE = "/etc/connectonion/{agent}.env"
 
 # How long a unit has to stay up before we call the deploy good, and how long we
 # are willing to wait for it. A single sleep-then-look is not enough: `systemctl
@@ -189,6 +195,7 @@ Wants=network-online.target
 Type=simple
 User={user}
 WorkingDirectory={SRV}/{agent}
+EnvironmentFile=-{ENV_FILE_TEMPLATE.format(agent=agent)}
 {environment}ExecStart={SRV}/{agent}/.venv/bin/python {entrypoint}
 Restart=always
 RestartSec=3
@@ -383,6 +390,11 @@ def _caddy_running(target: str) -> bool:
 # carry config is invisible: the deploy succeeds and a different agent runs.
 RSYNC_FILTERS = [
     "--filter", "P .co/**",
+    # `.env` is a secret, not source. It reaches the server through
+    # _sync_env(), as a root-owned 0600 file systemd reads — not as a
+    # world-readable file that happens to land in the working directory.
+    "--exclude", ".env",
+    "--exclude", ".env.*",
     # Generated on the server, or written there over ssh by the deploy itself.
     # The protect rule above keeps them from being deleted; these keep a local
     # copy from overwriting them, which is the other half of the same rule.
@@ -401,6 +413,56 @@ RSYNC_FILTERS = [
     "--exclude", ".git/",
     "--exclude", "__pycache__/",
 ]
+
+
+def _env_for_server(env_vars: dict, agent: str) -> dict:
+    """The project's `.env`, corrected for the machine it is going to.
+
+    `AGENT_CONFIG_PATH` is written by `co init` as an absolute path to the
+    author's own `~/.co`. Shipped verbatim it names a directory that does not
+    exist on the server, and `useful_tools/gmail.py`, `outlook.py`, `gdrive.py`
+    and `google_calendar.py` all build their `keys.env` path from it — so those
+    tools fail there rather than falling back. The Cloud path already rewrites
+    it to `/app/.co`; this is the same correction for `/srv/<agent>/.co`.
+    """
+    out = dict(env_vars)
+    if out.get("AGENT_CONFIG_PATH"):
+        out["AGENT_CONFIG_PATH"] = f"{SRV}/{agent}/.co"
+    return out
+
+
+def _sync_env(target: str, agent: str, project_dir: Path) -> bool:
+    """Write the project's secrets where systemd can read them and nobody else.
+
+    Sent over ssh rather than rsync, to a path outside the rsync root: the file
+    is owned by root at 0600, so `co call`'s remote exec — which runs as the
+    service user — cannot read it back out, and `--delete` cannot overwrite a
+    key that was rotated on the server.
+    """
+    env_path = project_dir / ".env"
+    if not env_path.exists():
+        return True
+
+    env_vars = _env_for_server(dotenv_values(env_path), agent)
+    if not env_vars:
+        return True
+
+    body = "".join(f"{k}={v}\n" for k, v in env_vars.items() if v is not None)
+    dest = ENV_FILE_TEMPLATE.format(agent=agent)
+
+    console.print(f"[dim]  writing secrets … ({len(env_vars)} keys)[/dim]")
+    result = _ssh(target, f"""
+sudo mkdir -p {shlex.quote(str(Path(dest).parent))}
+sudo tee {shlex.quote(dest)} >/dev/null <<'CO_ENV_EOF'
+{body}CO_ENV_EOF
+sudo chmod 600 {shlex.quote(dest)}
+""", timeout=120)
+    if result.returncode != 0:
+        console.print("[red]Could not write the env file.[/red]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-5:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+    return True
 
 
 def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
@@ -609,6 +671,8 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
                          ssh_public_line, deployer_address):
         return False
     if not _sync_code(target, agent, project_dir):
+        return False
+    if not _sync_env(target, agent, project_dir):
         return False
     if not _install_deps_if_changed(target, agent, project_dir):
         return False

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -9,6 +9,7 @@ LLM-Note:
   Errors: an unreachable or unprepared server fails before anything is changed | a failed unit start surfaces journalctl output rather than a bare exit code
 """
 
+import base64
 import hashlib
 import json
 import shlex
@@ -444,17 +445,30 @@ def _sync_env(target: str, agent: str, project_dir: Path) -> bool:
         return True
 
     env_vars = _env_for_server(dotenv_values(env_path), agent)
+
+    # A newline inside a value would end the KEY=VALUE line and turn the rest
+    # into junk entries. Say so rather than write a file that looks fine.
+    multiline = [k for k, v in env_vars.items() if v is not None and "\n" in v]
+    for key in multiline:
+        console.print(f"[yellow]  skipping {key}: multi-line values are not "
+                      f"supported in an EnvironmentFile[/yellow]")
+    env_vars = {k: v for k, v in env_vars.items()
+                if v is not None and k not in multiline}
     if not env_vars:
         return True
 
-    body = "".join(f"{k}={v}\n" for k, v in env_vars.items() if v is not None)
+    body = "".join(f"{k}={v}\n" for k, v in env_vars.items())
     dest = ENV_FILE_TEMPLATE.format(agent=agent)
+
+    # base64 over the wire so no value is ever shell syntax. A heredoc would be
+    # terminated early by a value that happened to equal the delimiter, and the
+    # remainder of the file would then run as commands — under sudo.
+    payload = base64.b64encode(body.encode("utf-8")).decode("ascii")
 
     console.print(f"[dim]  writing secrets … ({len(env_vars)} keys)[/dim]")
     result = _ssh(target, f"""
 sudo mkdir -p {shlex.quote(str(Path(dest).parent))}
-sudo tee {shlex.quote(dest)} >/dev/null <<'CO_ENV_EOF'
-{body}CO_ENV_EOF
+printf %s {shlex.quote(payload)} | base64 -d | sudo tee {shlex.quote(dest)} >/dev/null
 sudo chmod 600 {shlex.quote(dest)}
 """, timeout=120)
     if result.returncode != 0:

--- a/tests/unit/test_deploy_env_is_secret.py
+++ b/tests/unit/test_deploy_env_is_secret.py
@@ -1,0 +1,74 @@
+"""`.env` is a secret on both deploy paths, or it is a secret on neither.
+
+`co deploy` parses `.env`, uploads the pairs as secrets, and keeps the file out
+of the tarball. `co deploy --to` had no notion of a secret at all: `.env` was
+ordinary source, so it rsynced to the server as a world-readable file — and
+because `co init` copies the whole of `~/.co/keys.env` into a new project's
+`.env`, what travelled was the operator's Google and Microsoft refresh tokens.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+
+
+needs_rsync = pytest.mark.skipif(
+    shutil.which("rsync") is None, reason="needs rsync on PATH"
+)
+
+
+@needs_rsync
+@pytest.mark.parametrize("name", [".env", ".env.local", ".env.production"])
+def test_env_files_never_reach_the_server_as_source(tmp_path, name):
+    local, server = tmp_path / "local", tmp_path / "server"
+    (local / ".co").mkdir(parents=True)
+    server.mkdir()
+    (local / name).write_text("GOOGLE_REFRESH_TOKEN=1//secret\n")
+    (local / "agent.py").write_text("print('hi')\n")
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *RSYNC_FILTERS, f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+
+    assert (server / "agent.py").exists(), "code should still ship"
+    assert not (server / name).exists(), f"{name} was rsynced as source"
+
+
+def test_the_unit_reads_the_env_file_systemd_owns():
+    """Secrets reach the process through systemd, not by happening to sit in
+    the working directory.
+
+    The `-` prefix is deliberate: a project with no `.env` has no file to read,
+    and that must not be a boot failure.
+    """
+    unit = dts._unit_text("myagent", "agent.py")
+    assert f"EnvironmentFile=-{dts.ENV_FILE_TEMPLATE.format(agent='myagent')}" in unit
+
+
+def test_the_env_file_lives_outside_the_rsync_root(tmp_path):
+    """/srv/<agent>/ is the rsync destination, and `--delete` owns it. A secret
+    stored there could never be rotated on the server: the next deploy would
+    overwrite it with the laptop's copy."""
+    path = dts.ENV_FILE_TEMPLATE.format(agent="myagent")
+    assert not path.startswith(f"{dts.SRV}/myagent/"), path
+
+
+def test_local_config_path_is_rewritten_for_the_server():
+    """AGENT_CONFIG_PATH in a project .env is an absolute macOS path. Shipped
+    verbatim it points at a directory that cannot exist on Linux, and the OAuth
+    tools that build their keys.env path from it fail there."""
+    out = dts._env_for_server({"AGENT_CONFIG_PATH": "/Users/someone/.co",
+                               "OPENONION_API_KEY": "jwt"}, "myagent")
+
+    assert out["AGENT_CONFIG_PATH"] == f"{dts.SRV}/myagent/.co"
+    assert out["OPENONION_API_KEY"] == "jwt"
+
+
+def test_a_project_without_config_path_gains_nothing():
+    """Only rewrite what is there — do not invent the variable."""
+    assert "AGENT_CONFIG_PATH" not in dts._env_for_server({"X": "1"}, "myagent")

--- a/tests/unit/test_deploy_env_is_secret.py
+++ b/tests/unit/test_deploy_env_is_secret.py
@@ -9,11 +9,16 @@ because `co init` copies the whole of `~/.co/keys.env` into a new project's
 
 import shutil
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
 from connectonion.cli.commands import deploy_to_server as dts
 from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+
+
+def _ok():
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
 
 
 needs_rsync = pytest.mark.skipif(
@@ -72,3 +77,51 @@ def test_local_config_path_is_rewritten_for_the_server():
 def test_a_project_without_config_path_gains_nothing():
     """Only rewrite what is there — do not invent the variable."""
     assert "AGENT_CONFIG_PATH" not in dts._env_for_server({"X": "1"}, "myagent")
+
+
+class TestAValueIsNeverShellSyntax:
+    """A `.env` value is attacker-influenced input in the general case, and it
+    is written to the server under sudo. The first version of this sent it in a
+    heredoc, so a value equal to the delimiter would close the heredoc early and
+    hand the rest of the file to the shell — as root.
+    """
+
+    @staticmethod
+    def _ssh_script(project, env_text):
+        (project / ".env").write_text(env_text)
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._sync_env("user@host", "myagent", project)
+        return ssh.call_args.args[1] if ssh.call_args else ""
+
+    def test_a_value_equal_to_a_heredoc_delimiter_is_inert(self, tmp_path):
+        script = self._ssh_script(tmp_path, "K=CO_ENV_EOF\n")
+        assert "K=CO_ENV_EOF" not in script, "the value reached the shell verbatim"
+
+    def test_a_value_with_a_command_substitution_is_inert(self, tmp_path):
+        script = self._ssh_script(tmp_path, "K=$(touch /tmp/pwned)\n")
+        assert "touch /tmp/pwned" not in script
+
+    def test_the_values_still_arrive(self, tmp_path):
+        """Inert must not mean lost — decode what the server would decode."""
+        import base64
+        import re
+
+        script = self._ssh_script(tmp_path, "A=1\nB=two words\n")
+        payload = re.search(r"printf %s \'?([A-Za-z0-9+/=]+)\'?", script).group(1)
+        assert base64.b64decode(payload).decode() == "A=1\nB=two words\n"
+
+
+def test_a_multiline_value_is_skipped_not_silently_mangled(tmp_path):
+    """A newline inside a value ends the KEY=VALUE line, so the remainder
+    becomes junk entries. systemd would read the file without complaint."""
+    import base64
+    import re
+
+    (tmp_path / ".env").write_text('PEM="line1\nline2"\nOK=fine\n')
+    with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+        dts._sync_env("user@host", "myagent", tmp_path)
+
+    payload = re.search(r"printf %s \'?([A-Za-z0-9+/=]+)\'?", ssh.call_args.args[1]).group(1)
+    written = base64.b64decode(payload).decode()
+    assert "OK=fine" in written
+    assert "PEM" not in written


### PR DESCRIPTION
Fixes #393. **Stacked on #417** — same rsync filter list, opposite direction. Review that one first; the base will retarget to main when it merges.

## What was happening

`co deploy` parses `.env`, uploads the pairs as secrets, and keeps the file out of the tarball. `co deploy --to` had no notion of a secret at all — the string `.env` does not appear anywhere in `deploy_to_server.py`. It rsynced as ordinary source and then worked by accident: systemd sets `WorkingDirectory`, `load_dotenv()` reads the cwd, and the agent found its keys because a file happened to land beside it.

What travelled is the problem. `create.py:317` copies the whole of `~/.co/keys.env` into every new project's `.env`, so a real project here carried:

```
GOOGLE_REFRESH_TOKEN      MICROSOFT_REFRESH_TOKEN
GOOGLE_ACCESS_TOKEN       MICROSOFT_ACCESS_TOKEN
OPENONION_API_KEY         AGENT_EMAIL  …
```

Long-lived credentials for the operator's personal Gmail and Outlook, rsynced to the server in plaintext, on every deploy. The documentation says the opposite — *"Local-only files such as `.env` … are skipped"* — which is true of the other path, and is exactly why nobody looks.

## The change

| | |
|---|---|
| rsync | excludes `.env` and `.env.*` — secrets stop shipping as source |
| `_sync_env()` | writes them over ssh to `/etc/connectonion/<agent>.env`, root-owned, `0600` |
| the unit | gains `EnvironmentFile=-<path>` — systemd hands them to the process |

The path is **outside the rsync root** deliberately. Inside `/srv/<agent>/`, the next deploy's `--delete` would overwrite it with the laptop's copy, so a key rotated in production could never stay rotated. `0600` and root ownership also mean `co call`'s remote exec, which runs as the service user, cannot read it back out.

`_env_for_server()` additionally rewrites `AGENT_CONFIG_PATH`, which `co init` writes as an absolute path to the author's own `~/.co`. Shipped verbatim it names a directory that cannot exist on Linux, and `gmail.py:181`, `outlook.py:167`, `gdrive.py` and `google_calendar.py` all build their `keys.env` path from it — so those tools fail on the server rather than degrading. Cloud has done this rewrite since it shipped (`deploy_commands.py:429-433`); `--to` had not.

`PROVISION_SCHEMA` → 3, so servers already provisioned pick up the new unit.

## Tests

Verified red first — `.env`, `.env.local` and `.env.production` each failed with *"was rsynced as source"*, and the three new symbols did not exist. Then green. Full unit suite: 2614 passed.

The rsync assertions run a real rsync into a temp directory rather than inspecting argv, for the reason given in #417.

## Not fixed here

`create.py:317` still copies the operator's whole credential file into every new project. Everything above is a patch over that; with it fixed, a leaked project `.env` would cost a project key instead of a mailbox. Worth its own issue.