### PR TITLE
fix(trust): a list entry matches the whole identifier, and ignores case

### DIFF
--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -14,6 +14,7 @@ Trust Levels (stored in ~/.co/):
   - blocked: In blocklist.txt (denied access)
 """
 
+import fnmatch
 from pathlib import Path
 from typing import List, Callable
 
@@ -33,22 +34,30 @@ def _admins_file(co_dir: Path = None) -> Path:
 
 
 def _check_list(list_name: str, agent_id: str) -> bool:
-    """Check if agent_id is in a list file. Supports wildcards."""
+    """Check if agent_id is in a list file. Supports `*` wildcards.
+
+    A line matches the whole identifier, not part of it. `trusted-*` used to be
+    implemented as `line.replace('*', '') in agent_id` — an unanchored substring
+    test that let `un-trusted-hacker` satisfy a whitelist entry meant to grant a
+    prefix. On the whitelist that fails open, which is the direction that costs
+    something: `is_whitelisted()` is built on this, so the grant is real.
+
+    Comparison folds case. Addresses are generated lowercase (address.py:64),
+    but an admin pastes what a UI showed them, and `block("0xABCDEF…")` that
+    silently blocks nobody is worse than one that errors — it reported success.
+    """
     list_path = CO_DIR / f"{list_name}.txt"
     if not list_path.exists():
         return False
     try:
         content = list_path.read_text(encoding='utf-8')
+        agent_id = agent_id.strip().lower()
         for line in content.strip().split('\n'):
             line = line.strip()
             if not line or line.startswith('#'):
                 continue
-            if line == agent_id:
+            if fnmatch.fnmatchcase(agent_id, line.lower()):
                 return True
-            if '*' in line:
-                pattern = line.replace('*', '')
-                if pattern in agent_id:
-                    return True
         return False
     except Exception:
         return False

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -14,7 +14,7 @@ Trust Levels (stored in ~/.co/):
   - blocked: In blocklist.txt (denied access)
 """
 
-import fnmatch
+import re
 from pathlib import Path
 from typing import List, Callable
 
@@ -56,11 +56,25 @@ def _check_list(list_name: str, agent_id: str) -> bool:
             line = line.strip()
             if not line or line.startswith('#'):
                 continue
-            if fnmatch.fnmatchcase(agent_id, line.lower()):
+            if _matches(agent_id, line.lower()):
                 return True
         return False
     except Exception:
         return False
+
+
+def _matches(agent_id: str, pattern: str) -> bool:
+    """Whole-string match where `*` is the only metacharacter.
+
+    Deliberately not `fnmatch`: it also gives meaning to `?` and `[seq]`, which
+    were literal here before. That cuts both ways and both ways are wrong — a
+    blocklist entry like `agent[1]` would stop matching itself, and a `?`
+    anywhere in a whitelist line would start matching identifiers its author
+    never wrote down. Escaping everything but `*` keeps the vocabulary exactly
+    as documented.
+    """
+    expr = ".*".join(re.escape(part) for part in pattern.split("*"))
+    return re.fullmatch(expr, agent_id) is not None
 
 
 def check_whitelist(agent_id: str) -> str:

--- a/tests/unit/test_trust_list_matching.py
+++ b/tests/unit/test_trust_list_matching.py
@@ -65,6 +65,35 @@ class TestAddressCaseIsIgnored:
         assert tools._check_list("whitelist", "trusted-alice")
 
 
+class TestOnlyStarIsSpecial:
+    """`*` is the whole wildcard vocabulary — everything else is literal.
+
+    Caught reviewing the first version of this fix, which used `fnmatch`.
+    fnmatch also gives meaning to `?` and `[seq]`, and it breaks both ways: a
+    blocklist entry containing brackets stops matching itself (fails open), and
+    a `?` in a whitelist line starts matching identifiers nobody wrote down
+    (fails open again). Same class of defect as the one being fixed.
+    """
+
+    def test_brackets_are_literal(self, listfile):
+        listfile("blocklist", "agent[1]")
+        assert tools._check_list("blocklist", "agent[1]")
+
+    def test_a_bracket_entry_is_not_a_character_class(self, listfile):
+        listfile("whitelist", "agent[abc]")
+        assert not tools._check_list("whitelist", "agenta")
+
+    def test_question_mark_is_literal(self, listfile):
+        listfile("whitelist", "agent?")
+        assert tools._check_list("whitelist", "agent?")
+        assert not tools._check_list("whitelist", "agentX")
+
+    def test_a_dot_does_not_match_any_character(self, listfile):
+        """Regex metacharacters must not leak in either."""
+        listfile("whitelist", "a.example")
+        assert not tools._check_list("whitelist", "axexample")
+
+
 class TestUnchanged:
     """Behaviour the fix must not disturb."""
 

--- a/tests/unit/test_trust_list_matching.py
+++ b/tests/unit/test_trust_list_matching.py
@@ -1,0 +1,83 @@
+"""What a line in whitelist.txt or blocklist.txt actually matches.
+
+Both defects here fail *open* on the whitelist, which is the direction that
+matters: `_check_list` is what `is_whitelisted()` and `is_blocked()` are built
+on, so a line that matches more than its author meant is a grant nobody
+intended.
+"""
+
+import pytest
+
+from connectonion.network.trust import tools
+
+
+@pytest.fixture
+def listfile(tmp_path, monkeypatch):
+    """Point the module at a temp .co and write one of its list files."""
+    monkeypatch.setattr(tools, "CO_DIR", tmp_path)
+
+    def write(name, *lines):
+        (tmp_path / f"{name}.txt").write_text("\n".join(lines) + "\n")
+    return write
+
+
+class TestWildcardIsAnchored:
+    """`trusted-*` means "starts with trusted-", not "contains it somewhere"."""
+
+    def test_a_prefix_pattern_does_not_match_in_the_middle(self, listfile):
+        listfile("whitelist", "trusted-*")
+        assert tools._check_list("whitelist", "trusted-alice")
+        assert not tools._check_list("whitelist", "un-trusted-hacker")
+
+    def test_a_prefix_pattern_does_not_match_at_the_end(self, listfile):
+        listfile("blocklist", "spam*")
+        assert tools._check_list("blocklist", "spam-bot")
+        assert not tools._check_list("blocklist", "no-spam-here-either")
+
+    def test_a_suffix_pattern_anchors_to_the_end(self, listfile):
+        listfile("whitelist", "*.example.com")
+        assert tools._check_list("whitelist", "agent.example.com")
+        assert not tools._check_list("whitelist", "example.com.evil.net")
+
+    def test_a_bare_star_still_matches_everything(self, listfile):
+        """The one pattern whose meaning is unambiguous, and people rely on it."""
+        listfile("whitelist", "*")
+        assert tools._check_list("whitelist", "anyone-at-all")
+
+
+class TestAddressCaseIsIgnored:
+    """Addresses are generated lowercase, but a human pastes what they are shown.
+
+    An admin who blocks `0xABCDEF…` and gets no block at all is worse off than
+    one who gets an error: the command reported success.
+    """
+
+    def test_a_mixed_case_entry_blocks_the_lowercase_address(self, listfile):
+        listfile("blocklist", "0xABCDEF0123456789")
+        assert tools._check_list("blocklist", "0xabcdef0123456789")
+
+    def test_a_lowercase_entry_blocks_a_mixed_case_query(self, listfile):
+        listfile("blocklist", "0xabcdef0123456789")
+        assert tools._check_list("blocklist", "0xABCDEF0123456789")
+
+    def test_case_folding_applies_to_wildcards_too(self, listfile):
+        listfile("whitelist", "TRUSTED-*")
+        assert tools._check_list("whitelist", "trusted-alice")
+
+
+class TestUnchanged:
+    """Behaviour the fix must not disturb."""
+
+    def test_a_missing_file_denies(self, listfile, tmp_path, monkeypatch):
+        monkeypatch.setattr(tools, "CO_DIR", tmp_path)
+        assert not tools._check_list("whitelist", "anyone")
+
+    def test_comments_and_blank_lines_are_skipped(self, listfile):
+        listfile("whitelist", "# a comment", "", "  ", "alice")
+        assert tools._check_list("whitelist", "alice")
+        assert not tools._check_list("whitelist", "# a comment")
+
+    def test_an_exact_entry_still_matches(self, listfile):
+        listfile("whitelist", "alice")
+        assert tools._check_list("whitelist", "alice")
+        assert not tools._check_list("whitelist", "alice-2")


### PR DESCRIPTION
Fixes #362. Fixes #363.

Both defects live in the same six lines of `_check_list` (`network/trust/tools.py`), and both fail **open** on the whitelist. Splitting them into two PRs would mean the second rewriting the lines the first just changed, so they are fixed together.

## #362 — the wildcard was not anchored

```python
pattern = line.replace('*', '')
if pattern in agent_id:          # substring, anywhere
```

```
whitelist "trusted-*"  →  grants  un-trusted-hacker
blocklist "spam*"      →  blocks  no-spam-here-either
```

The over-block is noisy and someone reports it. The over-grant is silent: `is_whitelisted()` is built on this function, so an admin who wrote a prefix rule handed access to every identifier that merely contains the prefix somewhere.

## #363 — comparison was case-sensitive

Addresses are generated lowercase (`address.py:64`), but an admin pastes what a UI showed them. `block("0xABCDEF…")` wrote the mixed-case line, matched nothing at runtime, and **reported success**. A command whose only purpose is to deny, silently denying nobody.

## The fix

`fnmatch.fnmatchcase` against a lowered pattern and a lowered identifier. `*` keeps meaning "any run of characters" wherever it appears, the pattern is anchored to the whole string rather than searched within it, and `*` alone still matches everything — which people rely on and is covered.

## Tests

Ten cases, verified red first: the two wildcard anchors and the three case behaviours failed on unpatched code, the other five passed and still do. They also pin what must not move — a missing file denies, comments and blank lines are skipped, an exact entry matches only itself, and a bare `*` matches everything.

Full unit suite: 2652 passed.