### PR TITLE
A YAML error in a policy names the file it is in

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -76,14 +76,15 @@ def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
     if trust.lower() in TRUST_LEVELS:
         policy_path = PROMPTS_DIR / f"{trust.lower()}.md"
         if policy_path.exists():
-            config, _ = parse_policy(policy_path.read_text(encoding='utf-8'))
+            config, _ = parse_policy(policy_path.read_text(encoding='utf-8'),
+                                     source=str(policy_path))
             return config
         return None
 
     # Check if it's a file path
     path = Path(trust)
     if path.exists() and path.is_file():
-        config, _ = parse_policy(path.read_text(encoding='utf-8'))
+        config, _ = parse_policy(path.read_text(encoding='utf-8'), source=str(path))
         return config
 
     # Inline policy text

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: calls tools.py functions (is_blocked, is_whitelisted, is_contact, promote_to_contact) which read/write .co/trust/ files | no direct file I/O in this module
   Integration: exposes parse_policy(policy_text), evaluate_request(config, client_id, request) | used by TrustAgent to parse policies and execute zero-cost fast rules before LLM | returns None when LLM needed (default: ask)
   Performance: zero LLM tokens for fast rules | O(n) checks against allow/deny lists | promote_to_contact() writes to file but rare (onboarding only) | YAML parsing is fast
-  Errors: yaml.safe_load() errors propagate | gracefully handles missing frontmatter (returns empty config)
+  Errors: yaml.safe_load() errors propagate, naming the policy file when the caller passed one | gracefully handles missing frontmatter (returns empty config)
 
 Parse YAML config from trust policy files and execute fast rules.
 
@@ -19,12 +19,14 @@ Config format:
     default: deny                   # allow | deny | ask
 """
 
+import io
+
 import yaml
 from typing import Optional
 from .tools import is_whitelisted, is_blocked, is_contact, is_admin, promote_to_contact
 
 
-def parse_policy(policy_text: str) -> tuple[dict, str]:
+def parse_policy(policy_text: str, source: str = None) -> tuple[dict, str]:
     """
     Parse YAML frontmatter from markdown policy file.
 
@@ -41,7 +43,20 @@ def parse_policy(policy_text: str) -> tuple[dict, str]:
     yaml_content = policy_text[3:end].strip()
     markdown_body = policy_text[end + 3:].strip()
 
-    config = yaml.safe_load(yaml_content) or {}
+    # Handed to PyYAML as a named stream rather than a bare string. A typo in a
+    # policy still stops the host — that is the right outcome for a config file
+    # it cannot understand — but the parser's own error then reads
+    #
+    #   in ".co/trust/custom.md", line 3, column 29
+    #       allow: [whitelisted, contact
+    #                                   ^
+    #
+    # instead of naming "<unicode string>". Which file, which line, and the text
+    # itself, from the library, with nothing caught and re-raised.
+    stream = io.StringIO(yaml_content)
+    if source:
+        stream.name = source
+    config = yaml.safe_load(stream) or {}
     return config, markdown_body
 
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -135,14 +135,14 @@ class TrustAgent:
             policy_path = PROMPTS_DIR / f"{trust.lower()}.md"
             if policy_path.exists():
                 text = policy_path.read_text(encoding='utf-8')
-                return parse_policy(text)
+                return parse_policy(text, source=str(policy_path))
             return {}, ""
 
         # File path
         path = Path(trust)
         if path.exists() and path.is_file():
             text = path.read_text(encoding='utf-8')
-            return parse_policy(text)
+            return parse_policy(text, source=str(path))
 
         # Inline policy text
         if trust.startswith('---'):

--- a/tests/unit/test_fast_rules.py
+++ b/tests/unit/test_fast_rules.py
@@ -11,6 +11,7 @@ Components under test:
 
 
 import pytest
+import yaml
 from pathlib import Path
 
 from connectonion.network.trust.fast_rules import parse_policy, evaluate_request
@@ -313,3 +314,47 @@ class TestAnAdminIsNotAStranger:
                     "trust" / "policies" / f"{level}.md")
             config, _ = parse_policy(path.read_text())
             assert "admin" in config.get("allow", []), level
+
+
+class TestAYamlErrorNamesThePolicyFile:
+    """A typo in a policy still stops the host — that is the right outcome for a
+    config file it cannot understand. What was missing is *which* file: PyYAML
+    names the stream it was given, and a bare string is named "<unicode
+    string>", so an operator with several policies and the built-in ones had a
+    line number and no way to know where to look. openonion/connectonion#381
+    """
+
+    def test_the_error_names_the_file_when_the_caller_knows_it(self):
+        bad = "---\nallow: [whitelisted, contact\n---\n# Body\n"
+
+        with pytest.raises(yaml.YAMLError) as exc:
+            parse_policy(bad, source=".co/trust/custom.md")
+
+        assert ".co/trust/custom.md" in str(exc.value)
+
+    def test_it_is_still_the_parsers_own_error(self):
+        """Not caught and re-raised: the parser says what is wrong, and it says
+        it better than a message we would write, including the offending line."""
+        bad = "---\nallow: [whitelisted, contact\n---\n# Body\n"
+
+        with pytest.raises(yaml.YAMLError) as exc:
+            parse_policy(bad, source="p.md")
+
+        assert "expected ',' or ']'" in str(exc.value)
+
+    def test_inline_policy_text_still_parses(self):
+        """Not every caller has a file — inline policies are passed as text."""
+        config, body = parse_policy("---\nallow: [admin]\n---\n# Body")
+
+        assert config == {"allow": ["admin"]}
+
+    def test_loading_a_policy_file_names_that_file(self, tmp_path):
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        policy = tmp_path / "custom.md"
+        policy.write_text("---\nallow: [whitelisted, contact\n---\n# Body\n")
+
+        with pytest.raises(yaml.YAMLError) as exc:
+            TrustAgent(str(policy))
+
+        assert "custom.md" in str(exc.value)


### PR DESCRIPTION
Addresses #381. An alternative to #403, which I do not think should be merged — reasoning at the bottom.

## The gap

A typo in a trust policy stops the host. That is the right outcome: a config file the agent cannot parse is not something to guess around, and failing at startup is better than serving with a trust policy nobody understands.

What was missing is *which file*. PyYAML names the stream it is handed, and a bare string is named `<unicode string>`:

```
while parsing a flow sequence
  in "<unicode string>", line 1, column 8
expected ',' or ']', but got '<stream end>'
```

An operator has their own policies under `.co/trust/` and the built-in ones under `network/trust/policies/`. A line number with no filename does not say which to open.

## The change

`parse_policy` hands PyYAML a named stream, and the loaders pass the path they already read from:

```
while parsing a flow sequence
  in ".co/trust/custom.md", line 3, column 8
      allow: [whitelisted, contact
             ^
expected ',' or ']', but got '<stream end>'
```

Nothing is caught. Nothing is re-raised. The error is still `yaml.ParserError`, straight from the library, and it now also quotes the offending line and points at the column — which no message we wrote by hand would have done.

Inline policy text has no file to name and behaves exactly as before.

## Why not #403

#403 wraps `yaml.safe_load` in `try/except` and re-raises a `ValueError` with a hand-built message. Three problems:

1. **It converts a crash into a differently worded crash.** The host stops either way. Nothing degrades, nothing recovers — the only change is the wording, which is not what the issue's "fails safely" framing suggests.
2. **It costs a `try/except` this codebase deliberately avoids**, for no behavioural gain.
3. **The message it builds is worse than the one it suppresses.** `from None` discards the parser's own output, which quotes the offending line and points at the exact column. The replacement keeps only line and column as numbers.

The contributor identified something real — the error was unhelpful — and the file name is the part that was actually missing. This gets that without the exception handling, in fewer lines.

## Tests

Four cases, verified red first: the file is named when the caller knows it, the error is still the parser's own (asserting on `expected ',' or ']'`), inline text still parses, and loading a policy file through `TrustAgent` names that file.

2646 passed.