### PR TITLE
keys: retire seed[:32] — identity is derived through SLIP-0010

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -14,6 +14,8 @@ import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
 
+from .derive import ACCOUNT_URI, derive_path, slip13_path
+
 try:
     from nacl.signing import SigningKey, VerifyKey
     from mnemonic import Mnemonic
@@ -23,6 +25,44 @@ except ImportError:
     VerifyKey = None
     Mnemonic = None
     
+
+# ---------------------------------------------------------------------------
+# Where the identity key comes from
+#
+# BIP-39 gives the phrase and the seed; SLIP-0010 turns that seed into a tree
+# (connectonion/derive.py), and this is the account leaf of it:
+#
+#     twelve words ──BIP-39──▶ seed ──SLIP-0010/SLIP-0013──▶ m/13'/…
+#
+# It used to be `SigningKey(seed[:32])` — a bare slice matching no BIP, no SLIP
+# and no path, so the twelve words meant something only inside this software.
+# Retiring it re-keys every address at once, which is why it happened while the
+# user base made that affordable rather than later, when it would not (#404).
+#
+# Existing installs are unaffected until they recover: load() reads
+# .co/keys/agent.key, and that file still holds whatever key wrote it. The break
+# is that a phrase now derives a *different* key than the one on disk beside it —
+# which load() detects and says out loud rather than leaving you with two
+# identities and no hint of it.
+# ---------------------------------------------------------------------------
+
+
+def _account_key(seed: bytes) -> "SigningKey":
+    """The Ed25519 key at the account's SLIP-0013 path."""
+    return SigningKey(derive_path(seed, slip13_path(ACCOUNT_URI)))
+
+
+def derives_from(seed_phrase: str, signing_key) -> bool:
+    """Does this phrase produce this key under the current derivation?
+
+    False for a key minted before the SLIP-0010 switch — that is the whole
+    reason this exists.
+    """
+    mnemo = Mnemonic("english")
+    if not mnemo.check(seed_phrase):
+        return False
+    return bytes(_account_key(mnemo.to_seed(seed_phrase))) == bytes(signing_key)
+
 
 def generate() -> Dict[str, Any]:
     """
@@ -55,9 +95,9 @@ def generate() -> Dict[str, Any]:
     
     # Derive seed from phrase
     seed = mnemo.to_seed(seed_phrase)
-    
-    # Create Ed25519 signing key from first 32 bytes
-    signing_key = SigningKey(seed[:32])
+
+    # SLIP-0010 down the SLIP-0013 account path. See _account_key().
+    signing_key = _account_key(seed)
     
     # Create address (hex-encoded public key with 0x prefix)
     public_key_bytes = bytes(signing_key.verify_key)
@@ -111,9 +151,9 @@ def recover(seed_phrase: str) -> Dict[str, Any]:
     
     # Derive seed from phrase
     seed = mnemo.to_seed(seed_phrase)
-    
-    # Recreate signing key
-    signing_key = SigningKey(seed[:32])
+
+    # Must match generate() exactly, or a phrase recovers a different agent.
+    signing_key = _account_key(seed)
     
     # Recreate address
     public_key_bytes = bytes(signing_key.verify_key)
@@ -219,6 +259,16 @@ def load(co_dir: Path) -> Optional[Dict[str, Any]]:
         seed_phrase = None
         if recovery_file.exists():
             seed_phrase = recovery_file.read_text(encoding='utf-8').strip()
+
+        # A key minted before the SLIP-0010 switch still works — it is right here
+        # on disk and this is the identity the agent has been using. What has
+        # changed is that the phrase beside it now derives a *different* key, so
+        # `co auth recover` with those same words lands on another address.
+        #
+        # Saying nothing would leave two identities for one phrase and no hint of
+        # it, which is how someone recovers onto a fresh agent and wonders where
+        # their credits went. Say it once, here, where both halves are in hand.
+        legacy_derivation = bool(seed_phrase) and not derives_from(seed_phrase, signing_key)
         
         # Load email and activation status from environment
         email = os.getenv("AGENT_EMAIL", f"{address[:10]}@mail.openonion.ai")
@@ -229,6 +279,7 @@ def load(co_dir: Path) -> Optional[Dict[str, Any]]:
             "short_address": short_address,
             "email": email,
             "email_active": email_active,
+            "legacy_derivation": legacy_derivation,
             "signing_key": signing_key
         }
         

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -325,6 +325,25 @@ def handle_status(reveal: bool = False):
         console.print("[yellow]Run 'co auth' first.[/yellow]\n")
         return
 
+    # This key predates the SLIP-0010 switch, so the phrase saved beside it now
+    # derives a different address. The key itself is fine and stays in use — the
+    # warning is that recovering from those words lands somewhere else, which is
+    # only discoverable at the moment someone tries it, on a new machine, with no
+    # way back.
+    if addr_data.get("legacy_derivation"):
+        console.print(
+            "\n[yellow]⚠ This identity was created before ConnectOnion adopted "
+            "SLIP-0010 key derivation.[/yellow]"
+        )
+        console.print(
+            "[dim]  It keeps working. But your recovery phrase now derives a "
+            "different address,\n"
+            "  so 'co auth recover' with those words gives you a new, empty "
+            "agent — not this one.\n"
+            "  Keep .co/keys/agent.key backed up; the phrase alone no longer "
+            "restores it.[/dim]"
+        )
+
     public_key = addr_data["address"]
     timestamp = int(time.time())
     message = f"ConnectOnion-Auth-{public_key}-{timestamp}"

--- a/docs/co-directory-structure.md
+++ b/docs/co-directory-structure.md
@@ -58,6 +58,10 @@ permissions:
 
 The `keys/` directory contains your agent's cryptographic identity. **This directory should NEVER be committed to version control.**
 
+> **Keys are derived through SLIP-0010** from your BIP-39 phrase — see
+> [key-derivation.md](key-derivation.md). If your identity predates that change,
+> `agent.key` is the only copy of it: the phrase alone no longer restores it.
+
 ### agent.key
 - **Format**: Binary Ed25519 private key (32 bytes)
 - **Purpose**: Signs messages for agent-to-agent communication

--- a/docs/key-derivation.md
+++ b/docs/key-derivation.md
@@ -1,0 +1,117 @@
+# Key derivation — one phrase, a tree of keys
+
+Your twelve words are a BIP-39 recovery phrase, and every key ConnectOnion uses is
+derived from it through **SLIP-0010**: the standard Ledger, Trezor, Solana and Brave
+all use for Ed25519.
+
+```
+twelve words ──BIP-39──▶ seed ──SLIP-0010──▶ a tree of keys
+```
+
+That matters for one practical reason: **the phrase means something outside our
+software.** If ConnectOnion disappeared tomorrow, any SLIP-0010 implementation
+recovers your keys from those words.
+
+## The account key
+
+```
+m/13'/…   derived from the identity URI  https://oo.openonion.ai
+```
+
+Paths come from **SLIP-0013**, the authentication-identity scheme — the same one
+`trezor-agent` uses for SSH. The path is a hash of the identity's URI:
+
+```
+path = m/13' / A' / B' / C' / D'      A..D = SHA256(index_le || uri)[:16]
+```
+
+The name *is* the path, so a name always returns the same key, and a key can be
+derived before anything using it exists.
+
+The cost is that the path is opaque — `m/13'/1444947841'/…` doesn't say which
+identity it is — and a mistyped name is a different key rather than an error. Names
+are therefore trimmed and lowercased before hashing: `LinkedIn` and `linkedin` are
+one identity.
+
+## Hardened-only, deliberately
+
+SLIP-0010 offers **no public derivation** on Ed25519, so there is no xpub and no
+watch-only. That is the property we want, not a limitation we tolerate.
+
+Non-hardened derivation has an inverse: `child = parent + t`, where `t` is computable
+from public data, so `parent = child − t`. One leaked child private key plus the
+public tree recovers the parent — and the parent generates everything else.
+
+Agent identities and SSH keys **live on servers**, which get breached, snapshotted,
+and handed to other people. Under SLIP-0010 that exposes one key. The watch-only we
+give up answers a question nobody here asks: balances live in a database row keyed by
+public key and need a signature to read.
+
+Passing a non-hardened index raises rather than quietly deriving something else.
+
+## What changed, and what it means for you
+
+Identity used to be derived like this:
+
+```python
+seed = mnemo.to_seed(seed_phrase)
+signing_key = SigningKey(seed[:32])   # a bare slice — no BIP, no SLIP, no path
+```
+
+A slice of the seed corresponds to no standard, so those twelve words could only ever
+be restored by ConnectOnion itself. No hardware wallet could hold an agent identity.
+
+**Every address derived from a phrase has therefore moved once.** This happened while
+the project was small enough for that to be affordable; the alternative was carrying
+the bespoke slice forever.
+
+### If you have an agent from before the switch
+
+**It keeps working, and its address does not change.** `.co/keys/agent.key` holds the
+key that identity has always used, and that file is what gets loaded.
+
+What changed is the phrase beside it. Those twelve words now derive a *different* key,
+so:
+
+> `co auth recover` with your old phrase gives you a **new, empty agent** — not the
+> one you have been using.
+
+`co status` says so when it sees a key that predates the switch:
+
+```
+⚠ This identity was created before ConnectOnion adopted SLIP-0010 key derivation.
+  It keeps working. But your recovery phrase now derives a different address,
+  so 'co auth recover' with those words gives you a new, empty agent — not this one.
+  Keep .co/keys/agent.key backed up; the phrase alone no longer restores it.
+```
+
+So: **back up `.co/keys/agent.key`**. For a pre-switch identity it is the only copy.
+
+To move onto the current scheme, generate a fresh identity and migrate what points at
+the old address — whitelists, the agent's email, anything a counterparty recorded.
+There is no in-place upgrade, because the address *is* the identity.
+
+## Reference
+
+`connectonion/derive.py`:
+
+| Function | Purpose |
+|---|---|
+| `derive_path(seed, path)` | The 32-byte key at a path — hand it to `SigningKey()` |
+| `master_key(seed)` | SLIP-0010 master key and chain code |
+| `slip13_path(uri, index=0)` | `m/13'/A'/B'/C'/D'` for an identity URI; `index` is the rotation counter |
+| `identity_uri(name)` | `agent://<name>`, canonicalised |
+| `ssh_uri(user, host)` | `ssh://<user>@<host>`, matching `trezor-agent` |
+| `ACCOUNT_URI` | `https://oo.openonion.ai` — the account identity |
+
+## Still on the old scheme
+
+`co keys --ssh` derives with HKDF and the label `connectonion:ssh:v1`, not through the
+tree. That is deliberate for now: the SSH public key is in `authorized_keys` on every
+server already provisioned, so changing it locks you out of machines you own. Folding
+it in is a migration — add the new key, then retire the old — not a switch.
+
+## See also
+
+- [co-directory-structure.md](co-directory-structure.md) — where keys live on disk
+- [cli/setup.md](cli/setup.md) — `co init`, `co auth`

--- a/tests/unit/test_address_derivation.py
+++ b/tests/unit/test_address_derivation.py
@@ -1,0 +1,110 @@
+"""Identity is derived through SLIP-0010, not from a slice of the seed.
+
+The address vector below is pinned deliberately. It is the whole contract of a
+recovery phrase: if a refactor moves it, every agent that ever wrote those twelve
+words down has silently lost its identity, and nothing else in the suite would
+notice.
+"""
+
+from pathlib import Path
+
+import pytest
+from nacl.signing import SigningKey
+
+from connectonion import address
+from connectonion.derive import ACCOUNT_URI, derive_path, slip13_path
+
+# A BIP-39 test phrase — never use it for anything real.
+PHRASE = "legal winner thank year wave sausage worth useful legal winner thank yellow"
+EXPECTED = "0xf8405257284c15e67fd759703d0c04afdf2f216153b9781946f096cae1990a95"
+
+
+
+def test_a_phrase_derives_the_slip10_account_address():
+    assert address.recover(PHRASE)["address"] == EXPECTED
+
+
+def test_recover_matches_the_documented_path():
+    """Pinning the address is not enough on its own — it would also pass if
+    recover() hard-coded a constant. Derive it the long way and compare."""
+    from mnemonic import Mnemonic
+
+    seed = Mnemonic("english").to_seed(PHRASE)
+    key = SigningKey(derive_path(seed, slip13_path(ACCOUNT_URI)))
+
+    assert address.recover(PHRASE)["address"] == "0x" + bytes(key.verify_key).hex()
+
+
+def test_generate_and_recover_agree():
+    """They are two code paths to one key. If they drift, an agent generated
+    today cannot be recovered tomorrow."""
+    generated = address.generate()
+    recovered = address.recover(generated["seed_phrase"])
+
+    assert recovered["address"] == generated["address"]
+    assert bytes(recovered["signing_key"]) == bytes(generated["signing_key"])
+
+
+def test_the_seed_slice_is_retired():
+    """The exact thing #400 is about: seed[:32] must no longer be the identity."""
+    from mnemonic import Mnemonic
+
+    seed = Mnemonic("english").to_seed(PHRASE)
+    old_style = "0x" + bytes(SigningKey(seed[:32]).verify_key).hex()
+
+    assert address.recover(PHRASE)["address"] != old_style
+
+
+def test_email_follows_the_new_address():
+    assert address.recover(PHRASE)["email"] == f"{EXPECTED[:10]}@mail.openonion.ai"
+
+
+# --- The break, and saying it out loud ---
+
+
+def _write_keys(co_dir: Path, signing_key: SigningKey, phrase: str) -> None:
+    keys = co_dir / "keys"
+    keys.mkdir(parents=True)
+    (keys / "agent.key").write_bytes(bytes(signing_key))
+    (keys / "recovery.txt").write_text(phrase, encoding="utf-8")
+
+
+def test_a_pre_switch_key_still_loads_and_is_flagged(tmp_path):
+    """The key on disk is the identity the agent has been using; it keeps working.
+    What must not happen is loading it silently, because the phrase saved beside
+    it now recovers a different agent."""
+    from mnemonic import Mnemonic
+
+    seed = Mnemonic("english").to_seed(PHRASE)
+    _write_keys(tmp_path, SigningKey(seed[:32]), PHRASE)
+
+    loaded = address.load(tmp_path)
+
+    assert loaded is not None
+    assert loaded["legacy_derivation"] is True
+
+
+def test_a_current_key_is_not_flagged(tmp_path):
+    generated = address.generate()
+    _write_keys(tmp_path, generated["signing_key"], generated["seed_phrase"])
+
+    assert address.load(tmp_path)["legacy_derivation"] is False
+
+
+def test_a_key_with_no_saved_phrase_is_not_flagged(tmp_path):
+    """Nothing to compare against is not evidence of a legacy key — claiming it
+    would warn every agent whose recovery.txt the operator moved somewhere safe."""
+    keys = tmp_path / "keys"
+    keys.mkdir(parents=True)
+    (keys / "agent.key").write_bytes(bytes(address.generate()["signing_key"]))
+
+    assert address.load(tmp_path)["legacy_derivation"] is False
+
+
+def test_derives_from_rejects_an_invalid_phrase():
+    assert address.derives_from("not even a mnemonic", address.generate()["signing_key"]) is False
+
+
+def test_derives_from_is_true_for_a_matching_pair():
+    generated = address.generate()
+    assert address.derives_from(generated["seed_phrase"], generated["signing_key"]) is True

--- a/tests/unit/test_address_ssh.py
+++ b/tests/unit/test_address_ssh.py
@@ -17,33 +17,39 @@ from connectonion import address
 # expected outputs be hardcoded.
 PHRASE = "legal winner thank year wave sausage worth useful legal winner thank yellow"
 
-EXPECTED_ADDRESS = "0xc6f2ac5598970c79633714d3eb5c34d7bfc3e92da58c7354b37996d9a4af3ab2"
+# The address this phrase produced before #404 retired seed[:32]. Kept as the
+# thing we must NOT derive any more, not as a target.
+PRE_SLIP10_ADDRESS = "0xc6f2ac5598970c79633714d3eb5c34d7bfc3e92da58c7354b37996d9a4af3ab2"
 EXPECTED_SSH_LINE = (
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBs9N4V0K4pXPZNr5XPKmSJusfyalyjdi4xN36gqLt8U"
     " connectonion"
 )
 
 
-class TestAgentAddressIsUnchanged:
-    """The agent identity must not move. This is the whole risk of the change."""
+class TestAgentAddressMovedOnPurpose:
+    """These two tests used to assert the opposite, and were right to.
 
-    def test_known_phrase_produces_the_same_address(self):
-        assert address.recover(PHRASE)["address"] == EXPECTED_ADDRESS
+    #310 pinned the agent address precisely so that a later "tidy-up" could not
+    reissue every identity by accident. #404 is that change made on purpose: the
+    bare seed[:32] slice is retired for SLIP-0010, every address moves once, and
+    it happened while the user base made that affordable.
 
-    def test_agent_key_still_uses_the_bare_first_half_of_the_seed(self):
-        """Explicitly pin the derivation, not just its output.
+    So the guard is kept and inverted. It still fails loudly if the derivation
+    moves again — just in the other direction.
+    """
 
-        The SSH key uses HKDF; the agent key deliberately does not. If someone
-        "tidies up" by routing both through HKDF, this fails immediately instead
-        of silently reissuing every address.
-        """
+    def test_the_phrase_no_longer_derives_the_old_address(self):
+        assert address.recover(PHRASE)["address"] != PRE_SLIP10_ADDRESS
+
+    def test_the_agent_key_no_longer_uses_the_bare_first_half_of_the_seed(self):
         from mnemonic import Mnemonic
         from nacl.signing import SigningKey
 
         seed = Mnemonic("english").to_seed(PHRASE)
-        expected = "0x" + bytes(SigningKey(seed[:32]).verify_key).hex()
+        old_style = "0x" + bytes(SigningKey(seed[:32]).verify_key).hex()
 
-        assert address.recover(PHRASE)["address"] == expected
+        assert old_style == PRE_SLIP10_ADDRESS  # the old scheme, for the record
+        assert address.recover(PHRASE)["address"] != old_style
 
 
 class TestDeriveSSHKey:


### PR DESCRIPTION
The breaking half of #404, on top of #415. Closes #400.

## What was wrong

```python
seed = mnemo.to_seed(seed_phrase)     # BIP-39 ✅
signing_key = SigningKey(seed[:32])   # ← no BIP, no SLIP, no path ❌
```

BIP-39 right up to the last step, then a bare slice. It matches no standard, so those twelve words could only ever be restored by ConnectOnion itself — no hardware wallet could hold an agent identity, and none of the wallet ecosystem's tooling applied to any of it.

Identity now derives at the account's SLIP-0013 path on the tree #415 added.

## ⚠️ Every address derived from a phrase moves

That is the change, not a side effect. Taken now because re-keying is affordable today and won't be later — #404's "one switch, once".

**Existing installs keep their identity.** `load()` reads `.co/keys/agent.key`, and that file still holds whatever key wrote it. Nothing on disk is rewritten.

**What breaks is the phrase saved beside it.** Those twelve words now derive a different key, so `co auth recover` lands on a new, empty agent rather than the one you've been using.

Left silent, that gets discovered on a new machine, at the moment the old one is gone. So:

- `load()` compares `agent.key` against `recovery.txt` and reports `legacy_derivation`
- `co status` says it in words:

```
⚠ This identity was created before ConnectOnion adopted SLIP-0010 key derivation.
  It keeps working. But your recovery phrase now derives a different address,
  so 'co auth recover' with those words gives you a new, empty agent — not this one.
  Keep .co/keys/agent.key backed up; the phrase alone no longer restores it.
```

A key with no `recovery.txt` beside it is *not* flagged — nothing to compare against isn't evidence, and warning there would nag everyone who moved their phrase somewhere safe.

## The guard from #310, kept and inverted

#310 pinned the agent address with two fixed-vector tests precisely so a later "tidy-up" couldn't reissue every identity by accident. They failed on this branch, which is exactly what they were for.

They're kept and inverted rather than deleted — they now fail if the derivation moves *again*, and they record the pre-switch address for what it is. `TestAgentAddressIsUnchanged` → `TestAgentAddressMovedOnPurpose`.

## `co keys --ssh` deliberately stays put

Still on its HKDF label `connectonion:ssh:v1`. Its public key is in `authorized_keys` on every server already provisioned, so changing it **locks you out of machines you own**. Folding it into the tree is a migration — add the new key, then retire the old — not a switch. That's written into the new doc rather than left as an inconsistency for someone to rediscover.

## Tests

Pinned vectors, because this is the whole contract of a recovery phrase — if a refactor moves it, every agent that wrote those twelve words down has silently lost its identity and nothing else in the suite would notice.

- a known phrase derives the pinned SLIP-0013 account address
- …and the same address arrives by deriving the long way, so the test would still catch `recover()` hard-coding a constant
- `generate()` and `recover()` agree (two code paths, one key — drift means an agent generated today can't be recovered tomorrow)
- `seed[:32]` is explicitly *not* what comes out any more
- a pre-switch key loads, works, and is flagged; a current one isn't; one with no saved phrase isn't

`2652 unit + 366 cli e2e` pass.

`docs/key-derivation.md` is new: the tree, why hardened-only is the property we want rather than a limitation we tolerate, and what a pre-switch agent should do.