### PR TITLE
The same failure raises the same type whichever provider handled it

### DIFF
--- a/connectonion/core/exceptions.py
+++ b/connectonion/core/exceptions.py
@@ -12,7 +12,49 @@ LLM-Note:
 """
 
 
-class InsufficientCreditsError(Exception):
+class LLMProviderError(Exception):
+    """Base for every failure that came from an LLM provider.
+
+    Exists so `except LLMProviderError` means "the model call failed" regardless
+    of which provider handled it. Before this, the same auth failure surfaced as
+    openai.AuthenticationError on gpt-*, anthropic.AuthenticationError on
+    claude-*, and a bare ValueError("Groq API Error: ...") on groq/* — so the
+    only portable handler was `except Exception`, which also swallows bugs.
+
+    The original SDK exception is always chained as __cause__: translating must
+    not cost the traceback that says what actually happened.
+    """
+
+
+class LLMAuthenticationError(LLMProviderError):
+    """The provider rejected the credentials (401/403)."""
+
+    def __init__(self, original_error, model: str = "unknown"):
+        self.model = model
+        self.status_code = getattr(original_error, "status_code", None)
+        super().__init__(
+            f"Authentication failed for {model}. Check the API key for this "
+            f"provider — the key that works for one provider is not the key for "
+            f"another. Original: {type(original_error).__name__}: {original_error}"
+        )
+        self.__cause__ = original_error
+
+
+class LLMRateLimitError(LLMProviderError):
+    """The provider is rate limiting or the quota is exhausted (429)."""
+
+    def __init__(self, original_error, model: str = "unknown"):
+        self.model = model
+        self.status_code = getattr(original_error, "status_code", 429)
+        super().__init__(
+            f"Rate limited by the provider for {model}. Retry after a pause, or "
+            f"check the plan's quota. Original: "
+            f"{type(original_error).__name__}: {original_error}"
+        )
+        self.__cause__ = original_error
+
+
+class InsufficientCreditsError(LLMProviderError):
     """
     Raised when an LLM request fails due to insufficient ConnectOnion credits.
 
@@ -74,7 +116,7 @@ class InsufficientCreditsError(Exception):
         )
 
 
-class LLMConnectionError(Exception):
+class LLMConnectionError(LLMProviderError):
     """
     Raised when the LLM API request times out or fails to connect.
 
@@ -115,7 +157,7 @@ class LLMConnectionError(Exception):
         )
 
 
-class ProviderServiceError(Exception):
+class ProviderServiceError(LLMProviderError):
     """Raised when the LLM provider API returns a service error (503)."""
 
     def __init__(self, original_error):

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -189,7 +189,14 @@ class ToolCall:
 
 # Import TokenUsage from usage module
 from .usage import TokenUsage, calculate_cost
-from .exceptions import InsufficientCreditsError, LLMConnectionError, ProviderServiceError
+from .exceptions import (
+    InsufficientCreditsError,
+    LLMAuthenticationError,
+    LLMConnectionError,
+    LLMProviderError,
+    LLMRateLimitError,
+    ProviderServiceError,
+)
 
 
 @dataclass
@@ -203,6 +210,48 @@ class LLMResponse:
 
 class LLM(ABC):
     """Abstract base class for LLM providers."""
+
+    def _call_provider(self, send, base_url: str = ""):
+        """Run one provider request and translate its failure to a shared type.
+
+        The same auth failure used to surface three different ways depending on
+        the model prefix — openai.AuthenticationError on gpt-*,
+        anthropic.AuthenticationError on claude-*, and a bare
+        ValueError("Groq API Error: ...") on groq/* — so the only portable
+        handler was `except Exception`, which also swallows bugs.
+
+        Every provider goes through here, so `except LLMAuthenticationError`
+        means the same thing whichever model was used.
+
+        Translating never costs the original: it is chained as __cause__, so the
+        traceback still says what the SDK actually reported.
+        """
+        model = getattr(self, "model", "unknown")
+        try:
+            return send()
+        except LLMProviderError:
+            # Already translated, and by something that knew more than we do
+            # here — OpenOnionLLM maps 402 to InsufficientCreditsError. Wrapping
+            # it again would bury the specific type under a vaguer one.
+            raise
+        except (openai.AuthenticationError, openai.PermissionDeniedError,
+                anthropic.AuthenticationError, anthropic.PermissionDeniedError) as e:
+            raise LLMAuthenticationError(e, model=model) from e
+        except (openai.RateLimitError, anthropic.RateLimitError) as e:
+            raise LLMRateLimitError(e, model=model) from e
+        except (openai.APITimeoutError, openai.APIConnectionError,
+                anthropic.APITimeoutError, anthropic.APIConnectionError) as e:
+            raise LLMConnectionError(e, model=model, base_url=base_url) from e
+        except (openai.APIStatusError, anthropic.APIStatusError) as e:
+            # A status the SDK did not give its own class to is still a provider
+            # failure. Map the two that matter and let the rest surface as-is
+            # rather than inventing a category for them.
+            status = getattr(e, "status_code", None)
+            if status == 429:
+                raise LLMRateLimitError(e, model=model) from e
+            if status in (401, 403):
+                raise LLMAuthenticationError(e, model=model) from e
+            raise
 
     @abstractmethod
     def complete(self, messages: List[Dict[str, str]], tools: Optional[List[Dict[str, Any]]] = None) -> LLMResponse:
@@ -249,7 +298,8 @@ class OpenAILLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        response = self.client.chat.completions.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
         message = response.choices[0].message
 
         # Parse tool calls if present
@@ -341,7 +391,8 @@ class AnthropicLLM(LLM):
         if tools:
             api_kwargs["tools"] = self._convert_tools(tools)
 
-        response = self.client.messages.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.messages.create(**api_kwargs))
         
         # Parse tool calls if present
         tool_calls = []
@@ -407,7 +458,8 @@ class AnthropicLLM(LLM):
             api_kwargs["system"] = system
 
         # Force the model to use this tool
-        response = self.client.messages.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.messages.create(**api_kwargs))
 
         # Extract structured data from tool call
         for block in response.content:
@@ -572,7 +624,8 @@ class GeminiLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        response = self.client.chat.completions.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
         message = response.choices[0].message
 
         # Parse tool calls if present
@@ -613,12 +666,12 @@ class GeminiLLM(LLM):
 
     def structured_complete(self, messages: List[Dict], output_schema: Type[BaseModel], **kwargs) -> BaseModel:
         """Get structured Pydantic output using Gemini's OpenAI-compatible endpoint with beta.chat.completions.parse."""
-        completion = self.client.beta.chat.completions.parse(
+        completion = self._call_provider(lambda: self.client.beta.chat.completions.parse(
             model=self.model,
             messages=messages,
             response_format=output_schema,
             **kwargs
-        )
+        ))
         return completion.choices[0].message.parsed
 
 
@@ -648,10 +701,8 @@ class GroqLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        try:
-            response = self.client.chat.completions.create(**api_kwargs)
-        except openai.APIError as e:
-            raise ValueError(f"Groq API Error: {str(e)}") from e
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
 
         message = response.choices[0].message
 
@@ -691,12 +742,12 @@ class GroqLLM(LLM):
 
         structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
 
-        completion = self.client.chat.completions.create(
+        completion = self._call_provider(lambda: self.client.chat.completions.create(
             model=self.model,
             messages=structured_messages,
             response_format={"type": "json_object"},
             **kwargs,
-        )
+        ))
         content = completion.choices[0].message.content or "{}"
         return output_schema.model_validate_json(content)
 
@@ -727,7 +778,8 @@ class GrokLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        response = self.client.chat.completions.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
         message = response.choices[0].message
 
         tool_calls = []
@@ -762,12 +814,12 @@ class GrokLLM(LLM):
 
         structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
 
-        completion = self.client.chat.completions.create(
+        completion = self._call_provider(lambda: self.client.chat.completions.create(
             model=self.model,
             messages=structured_messages,
             response_format={"type": "json_object"},
             **kwargs,
-        )
+        ))
         content = completion.choices[0].message.content or "{}"
         return output_schema.model_validate_json(content)
 
@@ -810,7 +862,8 @@ class OpenRouterLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        response = self.client.chat.completions.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
         message = response.choices[0].message
 
         tool_calls = []
@@ -849,12 +902,12 @@ class OpenRouterLLM(LLM):
 
         structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
 
-        completion = self.client.chat.completions.create(
+        completion = self._call_provider(lambda: self.client.chat.completions.create(
             model=self.model,
             messages=structured_messages,
             response_format={"type": "json_object"},
             **kwargs,
-        )
+        ))
         content = completion.choices[0].message.content or "{}"
         return output_schema.model_validate_json(content)
 
@@ -885,7 +938,8 @@ class MistralLLM(LLM):
             api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
             api_kwargs["tool_choice"] = "auto"
 
-        response = self.client.chat.completions.create(**api_kwargs)
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
         message = response.choices[0].message
 
         tool_calls = []
@@ -924,12 +978,12 @@ class MistralLLM(LLM):
 
         structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
 
-        completion = self.client.chat.completions.create(
+        completion = self._call_provider(lambda: self.client.chat.completions.create(
             model=self.model,
             messages=structured_messages,
             response_format={"type": "json_object"},
             **kwargs,
-        )
+        ))
         content = completion.choices[0].message.content or "{}"
         return output_schema.model_validate_json(content)
 

--- a/tests/unit/test_groq_llm.py
+++ b/tests/unit/test_groq_llm.py
@@ -165,7 +165,7 @@ class TestGroqLLMComplete:
         assert result.usage.input_tokens == 100
         assert result.usage.output_tokens == 50
 
-    def test_complete_api_error_raises_value_error(self):
+    def test_complete_api_error_raises_the_shared_provider_type(self):
         """complete() converts openai.APIError into ValueError with context."""
         llm = self._make_llm()
 
@@ -182,10 +182,20 @@ class TestGroqLLMComplete:
 
         llm.client.chat.completions.create = Mock(side_effect=api_error)
 
-        with pytest.raises(ValueError) as exc_info:
+        # Was: pytest.raises(ValueError), asserting on "Groq API Error".
+        #
+        # That is the behaviour #372 removed. A ValueError says nothing about
+        # what failed — a caller could not tell a rate limit from a bad argument
+        # — and it was Groq's alone, so no handler worked across providers. A
+        # 429 is now LLMRateLimitError here exactly as it is on gpt-* and
+        # claude-*, with the original chained as __cause__.
+        from connectonion.core.exceptions import LLMProviderError, LLMRateLimitError
+
+        with pytest.raises(LLMRateLimitError) as exc_info:
             llm.complete([{"role": "user", "content": "test"}])
 
-        assert "Groq API Error" in str(exc_info.value)
+        assert isinstance(exc_info.value, LLMProviderError)
+        assert exc_info.value.__cause__ is api_error
 
     def test_complete_parses_dict_tool_arguments(self):
         """complete() handles tool arguments that are already dicts (not JSON strings)."""

--- a/tests/unit/test_uniform_provider_errors.py
+++ b/tests/unit/test_uniform_provider_errors.py
@@ -1,0 +1,129 @@
+"""The same failure must raise the same type whichever provider handled it.
+
+Before this, an auth rejection surfaced as openai.AuthenticationError on gpt-*,
+anthropic.AuthenticationError on claude-*, and a bare
+ValueError("Groq API Error: ...") on groq/* — so the only handler that worked
+everywhere was `except Exception`, which also swallows bugs.
+"""
+
+import anthropic
+import httpx
+import openai
+import pytest
+
+from connectonion.core.exceptions import (
+    LLMAuthenticationError,
+    LLMConnectionError,
+    LLMProviderError,
+    LLMRateLimitError,
+)
+from connectonion.core.llm import create_llm
+
+
+def _openai_error(cls, code):
+    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    response = httpx.Response(code, request=request, json={"error": {"message": "no"}})
+    return cls("denied", response=response, body=None)
+
+
+def _anthropic_error(cls, code):
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(code, request=request, json={"error": {"message": "no"}})
+    return cls("denied", response=response, body=None)
+
+
+def _make_fail(llm, exc):
+    """Make the next provider call raise, whichever client shape it uses."""
+    raiser = lambda **kw: (_ for _ in ()).throw(exc)
+    if hasattr(llm.client, "messages"):          # anthropic
+        llm.client.messages.create = raiser
+    else:                                        # openai-compatible
+        llm.client.chat.completions.create = raiser
+
+
+OPENAI_LIKE = ["gpt-4o", "groq/llama-3.3-70b-versatile", "grok/grok-4",
+               "openrouter/meta-llama/llama-3-8b", "mistral/mistral-small"]
+
+
+class TestAuthFailsTheSameWayEverywhere:
+    @pytest.mark.parametrize("model", OPENAI_LIKE)
+    def test_openai_compatible_providers(self, model, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        for var in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY"):
+            monkeypatch.setenv(var, "k")
+        llm = create_llm(model, api_key="k")
+        _make_fail(llm, _openai_error(openai.AuthenticationError, 401))
+
+        with pytest.raises(LLMAuthenticationError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+    def test_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        llm = create_llm("claude-3-5-sonnet-20241022", api_key="k")
+        _make_fail(llm, _anthropic_error(anthropic.AuthenticationError, 401))
+
+        with pytest.raises(LLMAuthenticationError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+    def test_groq_no_longer_raises_a_bare_ValueError(self, monkeypatch):
+        """Groq was the loudest inconsistency: it caught openai.APIError and
+        re-raised ValueError, so callers could not even tell an auth failure
+        from a bad argument."""
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        llm = create_llm("groq/llama-3.3-70b-versatile", api_key="k")
+        _make_fail(llm, _openai_error(openai.AuthenticationError, 401))
+
+        with pytest.raises(LLMAuthenticationError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+
+class TestRateLimit:
+    def test_openai(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        llm = create_llm("gpt-4o", api_key="k")
+        _make_fail(llm, _openai_error(openai.RateLimitError, 429))
+
+        with pytest.raises(LLMRateLimitError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+    def test_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+        llm = create_llm("claude-3-5-sonnet-20241022", api_key="k")
+        _make_fail(llm, _anthropic_error(anthropic.RateLimitError, 429))
+
+        with pytest.raises(LLMRateLimitError):
+            llm.complete([{"role": "user", "content": "hi"}])
+
+
+class TestOneBaseCatchesThemAll:
+    def test_every_translated_type_is_an_LLMProviderError(self):
+        """The point of the change: one `except` that means "the model call
+        failed" without also swallowing TypeErrors from our own code."""
+        from connectonion.core.exceptions import (
+            InsufficientCreditsError, ProviderServiceError)
+
+        for cls in (LLMAuthenticationError, LLMRateLimitError, LLMConnectionError,
+                    InsufficientCreditsError, ProviderServiceError):
+            assert issubclass(cls, LLMProviderError)
+
+    def test_the_original_error_is_still_reachable(self, monkeypatch):
+        """Translating must not cost the traceback that says what happened."""
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        llm = create_llm("gpt-4o", api_key="k")
+        original = _openai_error(openai.AuthenticationError, 401)
+        _make_fail(llm, original)
+
+        with pytest.raises(LLMAuthenticationError) as caught:
+            llm.complete([{"role": "user", "content": "hi"}])
+
+        assert caught.value.__cause__ is original
+
+    def test_an_unmapped_status_is_not_reclassified(self, monkeypatch):
+        """A 400 is a bad request, not an auth failure. Inventing a category for
+        it would make the shared types mean less, not more."""
+        monkeypatch.setenv("OPENAI_API_KEY", "k")
+        llm = create_llm("gpt-4o", api_key="k")
+        _make_fail(llm, _openai_error(openai.BadRequestError, 400))
+
+        with pytest.raises(openai.BadRequestError):
+            llm.complete([{"role": "user", "content": "hi"}])


### PR DESCRIPTION
Closes #372. Last of the 11 sequenced 1.5.3 bugs, and the largest.

## The bug

One auth rejection, four shapes:

| model | what surfaced |
|---|---|
| `gpt-*` | `openai.AuthenticationError` |
| `claude-*` | `anthropic.AuthenticationError` |
| `groq/*` | **`ValueError("Groq API Error: ...")`** |
| `co/*` | 402/503 wrapped, everything else raw |

Groq's is the worst of them: a `ValueError` says nothing about *what* failed, so a caller could not tell a rate limit from a bad argument.

The only handler that worked everywhere was `except Exception` — which also swallows `TypeError`s from our own code, so the portable option was also the one that hides bugs.

## The fix

`LLMProviderError` is now the base of every provider failure, and the three existing exceptions **inherit** it — so `except InsufficientCreditsError` keeps working unchanged. `LLMAuthenticationError` and `LLMRateLimitError` join them, and **all 13 provider call sites** go through one `_call_provider()` on the base class.

## Three deliberate limits

**An already-translated error passes through untouched.** `OpenOnionLLM` maps 402 → `InsufficientCreditsError`; re-wrapping would bury a specific type under a vaguer one.

**An unmapped status is re-raised as itself.** A 400 is a bad request. Inventing a category for it would make the shared types mean *less*, not more.

**`__cause__` is always the original.** Translating must not cost the traceback that says what actually happened — pinned by a test asserting identity, not just presence.

## An existing test changed, deliberately

`test_complete_api_error_raises_value_error` asserted the Groq `ValueError`. That is the behaviour this removes, so the assertion could not stand. It now checks the shared type, that the shared base catches it, and that `__cause__` is the original — with the reason recorded where the old assertion was, and the test renamed so nobody reads it as still testing `ValueError`.

**It was the full suite that caught this**, not the new tests. Worth noting: the new file passed on its own while a pre-existing test was locking in the old contract.

## Verification

12 new tests, parametrized across 6 providers. **10 red before / 12 green after** — verified by reverting only `llm.py` and keeping `exceptions.py`, since stashing both gives a collection error that proves nothing.

Full unit suite: **2654 passed, 3 skipped**.