### PR TITLE
xray.trace() can print again

### DIFF
--- a/connectonion/debug/xray.py
+++ b/connectonion/debug/xray.py
@@ -227,9 +227,13 @@ class XrayDecorator:
             return
 
         # Get trace data from agent session
+        # 'tool_result' is what tool_executor writes. This filtered for
+        # 'tool_execution', which nothing has ever written, so trace() always
+        # took the "no history" branch below — even when called from inside a
+        # tool. The vocabulary was renamed and this was not renamed with it.
         execution_history = [
             entry for entry in target_agent.current_session.get('trace', [])
-            if entry.get('type') == 'tool_execution'
+            if entry.get('type') == 'tool_result'
         ]
         user_prompt = target_agent.current_session.get('user_prompt', '')
 
@@ -246,7 +250,9 @@ class XrayDecorator:
         # Display each tool execution with visual formatting
         for i, entry in enumerate(execution_history, 1):
             # Format timing with appropriate precision (timing is in milliseconds)
-            timing = entry.get('timing', 0)
+            # 'timing_ms' is the written field; 'timing' is kept as a fallback
+            # so a trace captured by an older build still renders.
+            timing = entry.get('timing_ms', entry.get('timing', 0))
             if timing >= 1000:
                 timing_str = f"{timing/1000:.1f}s"  # Show seconds for long operations
             elif timing >= 1:
@@ -255,9 +261,9 @@ class XrayDecorator:
                 timing_str = f"{timing:.2f}ms"      # Sub-millisecond precision
 
             # Format function call
-            func_name = entry.get('tool_name', 'unknown')
+            func_name = entry.get('name', entry.get('tool_name', 'unknown'))
             # Check both 'arguments' (new format) and 'parameters' (old format)
-            params = entry.get('arguments', entry.get('parameters', {}))
+            params = entry.get('args', entry.get('arguments', entry.get('parameters', {})))
 
             # Build parameter preview for function signature
             # Shows first 2 params inline to keep the main line readable

--- a/tests/unit/test_xray_trace_prints.py
+++ b/tests/unit/test_xray_trace_prints.py
@@ -1,0 +1,88 @@
+"""xray.trace() must print the history that exists.
+
+It filtered for type == 'tool_execution', which nothing writes, so it always
+took the "no history" branch — even when called from inside a tool with
+xray.previous_tools proving the history was right there. The trace vocabulary
+was renamed and trace() was not renamed with it.
+
+The field names moved too, so fixing only the type would render `unknown()`
+and `0.00ms` for every row: a fix that looks like a fix.
+
+trace() finds the agent by walking the stack for a local named `agent`, so each
+test binds one — the name is load-bearing.
+"""
+
+import pytest
+
+from connectonion.debug.xray import xray
+
+
+class FakeAgent:
+    def __init__(self, trace):
+        self.current_session = {"trace": trace, "user_prompt": "how many left?"}
+
+
+def _tool_result(name="check_stock", args=None, result="7 units",
+                 timing_ms=12.0, status="success", **extra):
+    """Exactly the shape tool_executor writes."""
+    return {"type": "tool_result", "tool_id": "call_1", "name": name,
+            "args": args if args is not None else {"sku": "A1"},
+            "status": status, "result": result, "timing_ms": timing_ms, **extra}
+
+
+def _session_with_a_tool_call():
+    return FakeAgent([
+        {"type": "user_input", "content": "how many left?"},
+        {"type": "llm_call"},
+        {"type": "tool_call", "tool_id": "call_1", "name": "check_stock", "args": {"sku": "A1"}},
+        _tool_result(),
+        {"type": "llm_result"},
+    ])
+
+
+class TestItPrintsAtAll:
+    def test_a_session_with_tool_history_is_not_reported_as_empty(self, capsys):
+        agent = _session_with_a_tool_call()
+        xray.trace()
+        assert "No tool execution history" not in capsys.readouterr().out
+
+    def test_the_tool_name_is_rendered_not_unknown(self, capsys):
+        """The renderer reads `tool_name`; the writer writes `name`. Fixing only
+        the type filter would print `unknown()` on every row."""
+        agent = _session_with_a_tool_call()
+        xray.trace()
+        assert "check_stock" in capsys.readouterr().out
+
+    def test_the_arguments_are_rendered(self, capsys):
+        """Renderer reads `arguments`/`parameters`; writer writes `args`."""
+        agent = _session_with_a_tool_call()
+        xray.trace()
+        out = capsys.readouterr().out
+        assert "sku" in out and "A1" in out
+
+    def test_the_timing_is_rendered_not_zero(self, capsys):
+        """Renderer reads `timing`; writer writes `timing_ms`."""
+        agent = _session_with_a_tool_call()
+        xray.trace()
+        out = capsys.readouterr().out
+        assert "12ms" in out or "12.00ms" in out
+
+    def test_the_result_is_rendered(self, capsys):
+        agent = _session_with_a_tool_call()
+        xray.trace()
+        assert "7 units" in capsys.readouterr().out
+
+
+class TestItStillSaysNothingWhenThereIsNothing:
+    def test_a_session_with_no_tool_calls_reports_empty(self, capsys):
+        """The message is right when it is true. This fix must not replace it
+        with an empty table."""
+        agent = FakeAgent([{"type": "user_input"}, {"type": "llm_call"}])
+        xray.trace()
+        assert "No tool execution history" in capsys.readouterr().out
+
+    def test_an_error_entry_is_rendered_as_an_error(self, capsys):
+        agent = FakeAgent([_tool_result(result="Error: boom", status="error", error="boom")])
+        xray.trace()
+        out = capsys.readouterr().out
+        assert "check_stock" in out and "boom" in out


### PR DESCRIPTION
Closes #303.

## The bug

```python
if entry.get('type') == 'tool_execution'
```

**Nothing has ever written that type.** `tool_executor` writes `tool_result`. So the filter always matched nothing and `trace()` printed:

```
No tool execution history available.
Make sure the agent has executed some tools first.
```

every time — including when called from inside a tool with `xray.previous_tools == ['check_stock']` proving the history was right there. The trace vocabulary was renamed at some point and `trace()` was not renamed with it.

## The issue was half the story

Correcting only the type filter leaves it broken, because **the field names moved too**:

| the renderer reads | the writer writes |
|---|---|
| `type == 'tool_execution'` | `tool_result` |
| `tool_name` | `name` |
| `arguments` / `parameters` | `args` |
| `timing` | `timing_ms` |

A type-only fix renders `unknown()` and `0.00ms` on every row — **a fix that looks like a fix**, and one that a test asserting "it no longer says there is no history" would happily pass.

That is why each field gets its own test: name, arguments, timing and result are checked separately.

Old field names are kept as fallbacks, so a trace captured by an older build still renders.

## What deliberately still happens

`No tool execution history` is correct when it is *true*. A test pins that a session with no tool calls still says so, rather than printing an empty table.

## A note for whoever refactors the tests

`trace()` locates the agent by **walking the stack for a local named `agent`**. The tests bind exactly that name, so it is load-bearing — renaming the variable makes every test fail for a reason that has nothing to do with the code under test. Said at the top of the file.

## Verification

7 tests, **6 red before / 7 green after**. Full unit suite: **2665 passed, 3 skipped**.