### PR TITLE
Write the eleven guides the agent was already being offered

### DIFF
--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/auto_compact.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/auto_compact.md
@@ -1,0 +1,33 @@
+# auto_compact
+
+Summarise the conversation before it overflows the context window.
+
+Fires on `after_llm`. When context usage reaches **90%** and there are at least
+8 messages, it replaces the older messages with an LLM-written summary and keeps
+the system prompt, the summary, and the **last 5 messages**.
+
+```
+COMPACT_THRESHOLD = 90
+```
+
+The summarising call uses a fast, cheap model rather than the agent's own — the
+job is compression, not reasoning, and paying the agent's model rate for it on
+every long session adds up.
+
+## Why 90 and not 100
+
+Compaction itself needs room to run. Waiting for the window to be full means the
+summarisation call has nowhere to go.
+
+## What survives
+
+The system prompt, always. The summary, in place of what it replaced. The last
+five messages verbatim, because recent turns are the ones the next reply
+actually depends on.
+
+## What it costs you
+
+Detail. Anything older than the last five messages exists only as the summary
+said it did. For work where the early conversation matters — a long debugging
+session, a spec being assembled — start a fresh session rather than letting it
+compact.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/prefer_write_tool.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/prefer_write_tool.md
@@ -1,0 +1,24 @@
+# prefer_write_tool
+
+Stop the agent creating files through bash, and remind it to read them with
+`read_file`.
+
+## Why block it
+
+`bash("cat > config.py <<EOF ...")` writes a file with no diff, no approval
+prompt, and nothing for the user to review. The `write` tool does the same job
+through `DiffWriter`, which shows the change and — depending on mode — asks
+first. The two are not equivalent, and the model reaches for bash out of habit.
+
+File **creation** through bash is blocked outright. Reading gets a soft reminder
+rather than a block, because `cat` in the middle of a pipeline is legitimate and
+refusing it would break real commands.
+
+## What is still allowed
+
+Everything bash is actually for: git, builds, package managers, pipelines. This
+plugin narrows one path, it does not police the shell.
+
+## If you hit the block
+
+You wanted `write`. That is the whole message.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
@@ -1,0 +1,32 @@
+# tool_approval
+
+Ask the user before a tool call that can change something, and remember the
+answer for as long as the answer should last.
+
+## Modes
+
+The plugin is the same in every mode; what moves is the gate.
+
+| mode | behaviour |
+|---|---|
+| `safe` | dangerous tool calls are confirmed one at a time |
+| `plan` | the agent proposes a plan and waits for review before doing anything |
+| `accept_edits` | file edits land without asking; other dangerous calls still ask |
+| `ulw` | runs unattended for a bounded number of turns — see `useful_plugins/ulw` |
+
+Mode changes arrive over the WebSocket, so a client can move between them
+mid-session without restarting the agent.
+
+## Scope of an approval
+
+An approval can be granted **once** or **for the session**. Session-scoped
+approvals are held in the session's permission state, which is why a skill's
+temporary grants are snapshotted and restored around the skill rather than
+merged into it — a permission the user gave for one turn must not survive
+into the next.
+
+## What it does not do
+
+It does not decide what is dangerous. That comes from the tool's own
+declaration and the permission patterns, so adding a tool does not mean editing
+this plugin.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/ulw.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/ulw.md
@@ -1,0 +1,33 @@
+# ulw
+
+Ultra Light Work — let the agent run unattended for a bounded number of turns,
+then stop and ask.
+
+## The bound is the point
+
+Autonomy without a stopping condition is how an agent spends an hour going the
+wrong way. ULW grants a **turn budget**: the agent works without per-tool
+approval until the budget is spent, then pauses and reports, and the user
+decides whether to extend it.
+
+```
+mode: ulw, turns: 20
+```
+
+The remaining count is part of session state, so a client can show it and a
+reconnecting client still knows where things stand.
+
+## What it changes
+
+Tool approval stops asking per call. That is all — it does not widen what the
+agent is allowed to do, only how often it stops to confirm doing it.
+
+## What it does not change
+
+The permission patterns. A tool that was never permitted is still not permitted;
+ULW removes the prompt, not the rule.
+
+## When to use it
+
+Work that is mechanical and long: a migration across many files, a sweep of
+similar fixes. Not exploratory work, where the checkpoints are the value.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/bash.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/bash.md
@@ -1,0 +1,32 @@
+# bash
+
+Run a shell command and get its output back. Unix and macOS only — on Windows use
+`terminal` instead.
+
+```python
+bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120) -> str
+```
+
+| | |
+|---|---|
+| `command` | the command line to run |
+| `description` | shown to the user instead of the raw command, when the raw command is noisy |
+| `cwd` | working directory; defaults to where the agent is running |
+| `timeout` | seconds before the command is killed. Default 120 |
+
+## Use it for
+
+Anything a shell does better than a dedicated tool: `git`, package managers,
+build commands, one-off pipelines.
+
+## Do not use it for
+
+Reading, writing, searching or listing files. `read_file`, `write`, `grep` and
+`glob` exist for those and return structured results the model can act on —
+`bash("cat x.py")` gives you the same bytes with none of the handling. The
+`prefer_write_tool` plugin blocks file creation through bash for this reason.
+
+## Timeouts
+
+A command that hits the timeout is killed and the output collected so far is
+returned. Long builds need `timeout` raised deliberately rather than assumed.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/browser_tools.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/browser_tools.md
@@ -1,0 +1,31 @@
+# browser_tools
+
+Drive a real browser: navigate, click, type, upload, screenshot.
+
+In current versions the agent drives the browser through the **`co browser`
+CLI** against one shared, already-logged-in browser, rather than through
+in-process tools. That is what makes a login survive between runs and lets
+several agents share one session.
+
+```bash
+co browser tab open work --who agent --for "fill the form"
+co browser -t work go_to https://example.com
+co browser -t work click_element_by_selector 'button[type=submit]'
+co browser -t work take_screenshot /tmp/after.png
+co browser tab close work
+```
+
+## The rules that matter
+
+**One task, one tab.** Open your own tab and pass `-t <tab>` to every command.
+The browser is shared; a bare command on `main` collides with whatever else is
+running.
+
+**Verify with your eyes.** After any state-changing step, take a screenshot and
+read it before the next one. A click that reported success is not proof the page
+did what you expected.
+
+**Never `pkill` the browser to fix a busy daemon** — it destroys other agents'
+sessions. Open your own tab and wait instead.
+
+See the `co-browser` skill for the full command reference.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/edit.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/edit.md
@@ -1,0 +1,32 @@
+# edit
+
+Replace an exact string in a file.
+
+```python
+edit(file_path: str, old_string: str, new_string: str, replace_all: bool = False) -> str
+```
+
+`old_string` must appear in the file **exactly**, whitespace included, and by
+default must appear **exactly once**. Both rules are deliberate: an edit that
+matches loosely, or matches in three places when you meant one, is an edit you
+cannot review.
+
+| | |
+|---|---|
+| no match | the edit fails and says so — usually the file is not what you assumed |
+| several matches | the edit fails unless `replace_all=True` |
+
+## Use it for
+
+Surgical changes to a file you have already read.
+
+## Do not use it for
+
+Creating a file, or rewriting most of one. Use `write`. Editing a file you have
+not read: the match will fail on whitespace you did not know was there.
+
+## Making a match unique
+
+Include a line above or below the target rather than reaching for
+`replace_all`. `replace_all` is for renaming something that genuinely occurs
+everywhere.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/glob.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/glob.md
@@ -1,0 +1,25 @@
+# glob
+
+Find files by name pattern.
+
+```python
+glob(pattern: str, path: Optional[str] = None) -> str
+```
+
+```
+glob("**/*.py")                    every Python file under the tree
+glob("test_*.py", path="tests")    by name, in one directory
+```
+
+Results come back sorted by modification time, newest first — the files someone
+has been working on are the ones you usually want.
+
+## Use it for
+
+"Where is the config file", "which test files exist", "what did this project
+just change".
+
+## Do not use it for
+
+Searching inside files. That is `grep`. Reading one file whose path you already
+know — just `read_file` it.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/grep.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/grep.md
@@ -1,0 +1,30 @@
+# grep
+
+Search file contents with a regular expression.
+
+```python
+grep(pattern: str, path: Optional[str] = None, file_pattern: Optional[str] = None,
+     output_mode: Literal["files", "content", "count"] = "files",
+     context_lines: int = 0, ignore_case: bool = False, max_results: int = 50) -> str
+```
+
+| `output_mode` | what you get |
+|---|---|
+| `files` (default) | the paths that matched — cheapest, and usually the next question is "read one" |
+| `content` | the matching lines, with `context_lines` around each |
+| `count` | how many matches per file |
+
+## Use it for
+
+Finding where a symbol is defined or used, checking whether something exists at
+all, and measuring how widespread a pattern is before changing it.
+
+## Do not use it for
+
+Finding files by name — `glob` is direct. Reading a whole file: `content` mode
+with a huge `max_results` is a worse `read_file`.
+
+## Scoping
+
+`file_pattern` narrows by name (`"*.py"`), `path` narrows by directory. Both
+together are what keeps a search over a large repository fast and readable.

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/read_file.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/read_file.md
@@ -1,0 +1,26 @@
+# read_file
+
+Read a file and hand back its contents. Dispatches on the extension, so one tool
+covers text and images.
+
+```python
+read_file(path: str) -> str
+```
+
+| extension | what comes back |
+|---|---|
+| text, code, `.md`, `.csv`, `.json`, `.tex` | the file's text, as-is |
+| `.png` `.jpg` `.jpeg` `.gif` `.webp` | the image enters your vision — after reading, you can see and describe it |
+
+The image case is the one worth remembering: you do not get a path or a
+description to reason about, you get the picture.
+
+## Use it for
+
+Anything you are about to change, quote, or answer questions about. Read before
+you edit — `edit` matches on exact text, so a guess about what a file contains
+becomes a failed edit.
+
+## Do not use it for
+
+Finding which file to read. That is `glob` (by name) or `grep` (by content).

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_tools/write.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_tools/write.md
@@ -1,0 +1,25 @@
+# write
+
+Create a file, or replace one entirely.
+
+Writing goes through `DiffWriter`, which shows the change and — depending on the
+approval mode — asks before it lands. That is why writing a file is not the same
+as `bash("cat > f")`: the user sees what is about to happen.
+
+## Use it for
+
+New files, and rewrites large enough that a diff of the whole file is easier to
+read than a series of edits.
+
+## Do not use it for
+
+Changing a few lines in an existing file. That is `edit`, and a full rewrite
+loses the reviewer's ability to see what actually changed.
+
+Overwriting a file you have not read: you cannot know what you are destroying.
+
+## Approval
+
+In `safe` mode each write is confirmed. In `accept_edits` they land and are
+shown. `ulw` runs unattended for a bounded number of turns. The tool is the same
+in all three; only the gate moves.

--- a/tests/unit/test_guide_menu_matches_disk.py
+++ b/tests/unit/test_guide_menu_matches_disk.py
@@ -1,0 +1,51 @@
+"""Every guide the agent is offered must exist.
+
+index.md is the menu the agent reads to decide what to load_guide(). A row
+pointing at a file that was never written is not a gap in the docs — it is a
+tool call the agent will make and that will fail, every time, for as long as the
+row is there.
+
+This test is the point of the fix. Correcting today's eleven without it just
+resets the clock until the next guide is listed before it is written.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+GUIDES = Path(__file__).resolve().parents[2] / "connectonion/cli/co_ai/prompts/connectonion"
+
+
+def _listed():
+    rows = re.findall(r"^\|\s*`([a-z0-9][a-z0-9_/-]*)`\s*\|", (GUIDES / "index.md").read_text(), re.M)
+    return sorted(set(rows))
+
+
+def _on_disk():
+    return sorted(str(p.relative_to(GUIDES).with_suffix("")) for p in GUIDES.rglob("*.md"))
+
+
+def test_every_listed_guide_exists():
+    missing = [g for g in _listed() if g not in _on_disk()]
+
+    assert not missing, (
+        "index.md offers guides with no file behind them, so load_guide() fails "
+        f"on each: {missing}"
+    )
+
+
+def test_the_menu_is_not_empty():
+    """A guard on the guard: a regex that stopped matching would make the test
+    above pass by finding nothing to check."""
+    assert len(_listed()) > 40
+
+
+@pytest.mark.parametrize("guide", _listed())
+def test_each_guide_has_content(guide):
+    """An empty file satisfies "the file exists" while still wasting the call."""
+    path = GUIDES / f"{guide}.md"
+    if not path.exists():
+        pytest.skip("covered by test_every_listed_guide_exists")
+
+    assert len(path.read_text().strip()) > 80, f"{guide}.md is a stub"


### PR DESCRIPTION
Closes #297.

## The bug

`index.md` is the menu the agent reads to decide what to `load_guide()`. **Eleven rows pointed at files that had never been written** — so each was a tool call the agent would make, and that would fail, every time, for as long as the row was there.

## I did the opposite of what the issue proposed

The issue suggested deleting the eleven rows. Checking what was behind them first showed why not:

| listed guide | real code |
|---|---|
| `useful_tools/bash` | `useful_tools/bash.py` |
| `useful_tools/read_file` | `useful_tools/read_file.py` |
| `edit` / `glob` / `grep` | `useful_tools/file_tools/` |
| `write` | `useful_tools/diff_writer.py` |
| `tool_approval` | `useful_plugins/tool_approval/` |
| `auto_compact` | `useful_plugins/auto_compact.py` |
| `prefer_write_tool` | `useful_plugins/prefer_write_tool.py` |
| `ulw` | `useful_plugins/ulw/` |

**All eleven are real, shipped features.** Deleting the rows would have turned "undocumented" into "undocumented and undiscoverable" — the menu is the only place these are advertised.

## The guides are written from the implementation

Real signatures and real constants, not the names: `auto_compact`'s 90% threshold and five-message tail, `grep`'s three output modes, `edit`'s exactly-once matching rule, `bash`'s 120s default timeout.

Each says what the thing is **not** for, because the failure these prevent is reaching for the wrong tool rather than misusing the right one — `bash("cat x.py")` instead of `read_file`, `grep` instead of `glob`, `write` instead of `edit`.

## The test is the part that lasts

Fixing today's eleven without it resets the clock until the next guide is listed before it is written.

```python
test_every_listed_guide_exists()    # menu ⊆ disk
test_the_menu_is_not_empty()        # a guard on the guard
test_each_guide_has_content()       # an empty file still wastes the call
```

The middle one matters: if `index.md`'s format changed so the regex matched nothing, the first test would pass by having **nothing to check**. That is the failure mode of every "compare two lists" test.

## Verification

Red before: the sync test names all eleven. Green after. Full unit suite: **2726 passed, 3 skipped**.