### PR TITLE
keys: derive a per-server SSH key from the tree, beside the old one

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -14,7 +14,7 @@ import sys
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-from .derive import ACCOUNT_URI, derive_path, slip13_path
+from .derive import ACCOUNT_URI, derive_path, slip13_path, ssh_uri
 
 try:
     from nacl.signing import SigningKey, VerifyKey
@@ -399,8 +399,18 @@ def _hkdf_sha512(seed: bytes, info: bytes, length: int = 32) -> bytes:
     return out[:length]
 
 
-def derive_ssh_key(seed_phrase: str) -> Dict[str, str]:
+def derive_ssh_key(seed_phrase: str, host: str = None, user: str = "root") -> Dict[str, str]:
     """Derive an Ed25519 SSH keypair from a recovery phrase.
+
+    With a ``host``, the key comes off the SLIP-0010 tree at the SLIP-0013 path
+    for ``ssh://<user>@<host>`` — one key per server, and rotatable by bumping
+    the URI's index. That is where this is going (#427).
+
+    Without one, it is the original HKDF key: a single key shared by every
+    server. That key cannot simply be dropped, because it is the line sitting in
+    ``authorized_keys`` on every machine provisioned to date, and it is the way
+    back into them. It stays derivable until those are backfilled, and goes in
+    1.6.
 
     Ed25519 is a native OpenSSH type, so the public half is an ordinary
     `ssh-ed25519 AAAA…` line that needs nothing custom on any server.
@@ -427,8 +437,12 @@ def derive_ssh_key(seed_phrase: str) -> Dict[str, str]:
         raise ValueError("Invalid recovery phrase")
 
     seed = mnemo.to_seed(seed_phrase)
-    ssh_seed = _hkdf_sha512(seed, SSH_DERIVATION_INFO)
-    signing_key = SigningKey(ssh_seed)
+    if host is None:
+        # The pre-tree key. Still derived because it is in authorized_keys on
+        # every server provisioned so far — see derive_ssh_key's docstring.
+        signing_key = SigningKey(_hkdf_sha512(seed, SSH_DERIVATION_INFO))
+    else:
+        signing_key = SigningKey(derive_path(seed, slip13_path(ssh_uri(user, host))))
 
     return {
         "public_line": _openssh_public_line(bytes(signing_key.verify_key)),

--- a/tests/unit/test_address_ssh.py
+++ b/tests/unit/test_address_ssh.py
@@ -136,3 +136,60 @@ class TestOpenSSHEncoding:
         priv_len = int.from_bytes(body[offset:offset + 4], "big")
 
         assert priv_len % 8 == 0
+
+
+def _openssh_b64(verify_key) -> str:
+    """The base64 blob inside an `ssh-ed25519 AAAA…` line, for comparing keys."""
+    import base64
+    import struct
+
+    def field(b: bytes) -> bytes:
+        return struct.pack(">I", len(b)) + b
+
+    return base64.b64encode(field(b"ssh-ed25519") + field(bytes(verify_key))).decode()
+
+
+class TestPerHostSSHKeys:
+    """Step 1 of #427: the tree-derived key exists beside the old one.
+
+    Nothing is wired into provisioning yet — that needs the API to accept two
+    keys, and a decision to key on the server's name rather than its address.
+    """
+
+    def test_a_host_derives_from_the_tree_not_the_hkdf_label(self):
+        from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
+
+        from connectonion.derive import derive_path, slip13_path, ssh_uri
+
+        seed = Mnemonic("english").to_seed(PHRASE)
+        expected = SigningKey(derive_path(seed, slip13_path(ssh_uri("root", "box-1"))))
+        line = address.derive_ssh_key(PHRASE, host="box-1")["public_line"]
+
+        assert line.split()[1] == _openssh_b64(expected.verify_key)
+
+    def test_each_host_gets_its_own_key(self):
+        """A snapshot of one box must not yield the key that opens the others —
+        which is the whole reason for going per-host."""
+        a = address.derive_ssh_key(PHRASE, host="box-1")["public_line"]
+        b = address.derive_ssh_key(PHRASE, host="box-2")["public_line"]
+
+        assert a != b
+
+    def test_the_user_is_part_of_the_identity(self):
+        assert (address.derive_ssh_key(PHRASE, host="box-1", user="root")
+                != address.derive_ssh_key(PHRASE, host="box-1", user="deploy"))
+
+    def test_a_host_name_is_canonicalised(self):
+        assert (address.derive_ssh_key(PHRASE, host="Box-1")
+                == address.derive_ssh_key(PHRASE, host="box-1"))
+
+    def test_derivation_is_stable_per_host(self):
+        assert (address.derive_ssh_key(PHRASE, host="box-1")
+                == address.derive_ssh_key(PHRASE, host="box-1"))
+
+    def test_the_legacy_key_is_untouched(self):
+        """Every server provisioned so far has this line in authorized_keys. If
+        this moves, we are locked out of machines we own — #427 step 4 is where
+        it goes, after they are backfilled."""
+        assert address.derive_ssh_key(PHRASE)["public_line"] == EXPECTED_SSH_LINE


### PR DESCRIPTION
Step 1 of #427 — the **add** half of add → verify → backfill → retire. Non-breaking.

`derive_ssh_key(phrase, host=…)` now comes off the SLIP-0010 tree at the SLIP-0013 path for `ssh://<user>@<host>`, which is what `trezor-agent` derives. Without a host it is unchanged: the HKDF label, one key for every server.

**Both, on purpose.** The old key's public line is in `authorized_keys` on every machine provisioned to date, and it is the way back into them. It stays derivable until they are backfilled; retiring it is 1.6.

Per-server buys what one shared key cannot:
- a snapshot of one box no longer yields the key that opens the others
- rotation is bumping the URI's index, instead of changing the recovery phrase and re-keying everything at once

## Two findings that stop this going further in one step

**1. There is no host to derive from when the key is needed.**

`co server new` derives the public line *before* the machine exists — no IP, no hostname. The durable identifier is the **server's name**: chosen up front, and it survives the IP changing underneath it.

So the URI should be `ssh://<user>@<name>`, not the address. That is worth deciding explicitly now rather than discovering it after keys are installed under one identifier and looked up under another.

**2. The provisioning API takes one key.**

```python
ssh_public_key: str = Field(..., description="The line `co keys --ssh` prints")
...
if not body.ssh_public_key.startswith("ssh-"):
```
`oo-api/servers/routes.py`

GCE's `ssh-keys` metadata *does* accept several newline-separated entries, so passing two lines would slip through that check and work — accidentally. Installing both keys should go through an API that says it takes several, not a field documented as "the line `co keys --ssh` prints" quietly carrying two.

That is an oo-api change, so it belongs in its own PR rather than being smuggled through a string.

## Tests

Pin both derivations, including that **the legacy line has not moved** — that assertion is what stands between us and a locked-out server.

- a host derives from the tree, not the HKDF label (checked by deriving the long way, not by comparing to a recorded blob)
- each host gets its own key; the user is part of the identity
- host names are canonicalised, so `Box-1` and `box-1` are one server
- the legacy no-host key still equals the pinned vector from #310

`2722 unit` pass.

## Next in #427

- decide `ssh://<user>@<name>` and wire provisioning to install both lines (needs the oo-api change above)
- verify against a real box provisioned before this
- backfill existing servers on their next deploy
- **1.6: retire the HKDF key**, which is what #427 exists to make sure happens