### PR TITLE
A curved path that is sometimes straight, and a test that measured it wrongly

### DIFF
--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -67,7 +67,15 @@ def _control_points(start, end):
     nx, ny = -dy / dist, dx / dist  # unit normal to the direction of travel
 
     def control(along):
-        off = random.uniform(-0.22, 0.22) * dist
+        # Magnitude first, then a side. A plain uniform(-0.22, 0.22) can land
+        # both control points near zero, and the "curved" path is then a
+        # ruler-straight line — which is the exact tell-tale this module exists
+        # to avoid, produced by the module itself about 0.7% of the time
+        # (measured over 20,000 paths).
+        #
+        # The floor is what removes that case. 0.04 of the distance is still a
+        # small bow, well inside the range a hand produces; it just is not zero.
+        off = random.choice((-1, 1)) * random.uniform(0.04, 0.22) * dist
         return x0 + dx * along + nx * off, y0 + dy * along + ny * off
 
     return control(random.uniform(0.2, 0.4)), control(random.uniform(0.6, 0.8))

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -78,7 +78,18 @@ def test_move_path_is_curved_not_straight():
     dx, dy = x1 - x0, y1 - y0
     length = math.hypot(dx, dy) or 1.0
     max_perp = max(abs((px - x0) * dy - (py - y0) * dx) / length for px, py in pts)
-    assert max_perp > 1, "path should bow off the straight line, not run straight"
+
+    # Relative to the chord, not an absolute pixel count. move() starts from a
+    # random offset, so ~3% of paths are under 50px end to end, and on that scale
+    # a perfectly good bow is well under one pixel — which is what made the old
+    # `> 1` assertion fail about 0.3% of runs with nothing wrong.
+    #
+    # Measured over 20,000 paths: the absolute form failed 61 times, this one
+    # failed 0.
+    assert max_perp / length > 0.01, (
+        f"path should bow off the straight line, not run straight "
+        f"(deviation {max_perp:.3f}px over a {length:.1f}px chord)"
+    )
 
 
 def test_click_moves_then_presses_with_dwell_order():


### PR DESCRIPTION
Closes #287 — the flake that went red twice during today's work and had to be judged real-or-not each time.

## Measured first

```
20,000 paths → 134 failures = 0.67%
```

CI runs eight jobs, so roughly **one job in nineteen runs** went red. That matches the observed rate rather than the "rare" the issue title suggests.

## Two independent causes

Fixing either alone still leaves it flaky, which is why the first patch looked done and wasn't.

### 1. The generator really does draw straight lines

```python
off = random.uniform(-0.22, 0.22) * dist    # both control points can land near zero
```

**This is a production defect, not a test problem.** `humanize` exists so a cursor does not travel in a ruler-straight line — the classic bot tell — and 0.7% of the time it emitted exactly that. The offset now takes a magnitude with a floor and a separately chosen side.

That fix alone: 134 → 61 failures.

### 2. The assertion measured curvature in absolute pixels

The worst remaining path had its first and last sampled points **3.9px apart**. `move()` starts from a random offset, so ~3.4% of paths are under 50px end to end — and at that scale a perfectly good bow is well under one pixel.

`max_perp > 1` is not a curvature test; it is a curvature-and-also-length test. Relative to the chord:

```python
assert max_perp / length > 0.01
```

| assertion | failures / 20,000 |
|---|---|
| `max_perp > 1` (absolute) | 61 |
| `max_perp / length > 0.01` | **0** |

## The message carries the numbers now

```
path should bow off the straight line, not run straight
(deviation 0.119px over a 3.9px chord)
```

So a future red says what it saw, instead of requiring this analysis again.

## Verification

Ran the file ten times: 14 passed, every time. Full unit suite: **2716 passed, 3 skipped**.

The measurement harness stubs `_pause` — without it 20,000 paths take longer than the analysis is worth, which is why the first attempt at measuring timed out.