### PR TITLE
A server that stops answering is not a crash

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -53,20 +53,32 @@ def _ssh(target: str, command: str, timeout: int = 300) -> subprocess.CompletedP
     apt and pip are slow, and killing them halfway leaves a half-installed box."""
     from .server_commands import _identity
 
-    return subprocess.run(
-        [
-            "ssh",
-            "-o", "BatchMode=yes",
-            "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
-            "-o", "StrictHostKeyChecking=accept-new",
-            *_identity(),
-            target,
-            command,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    argv = [
+        "ssh",
+        "-o", "BatchMode=yes",
+        "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
+        "-o", "StrictHostKeyChecking=accept-new",
+        *_identity(),
+        target,
+        command,
+    ]
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # A hung resolver or a box that stops answering mid-deploy raises here.
+        # Uncaught it printed a Python traceback, which tells the operator we
+        # crashed — when what happened is that their server went quiet.
+        #
+        # Returned as a failed CompletedProcess rather than raised, because every
+        # caller already treats a non-zero return as a failed step and reports it
+        # with the server name. One shape of failure, one place that renders it.
+        return subprocess.CompletedProcess(
+            argv, returncode=124,          # the conventional exit code for a timeout
+            stdout="",
+            stderr=f"ssh to {target} timed out after {timeout}s — the server did "
+                   f"not answer. Check it is running and reachable: "
+                   f"co server check <name>",
+        )
 
 
 def _read_project(project_dir: Path) -> Optional[dict]:

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -75,20 +75,27 @@ def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
     `~/.ssh/config`, jump hosts and key selection all keep working — the same
     principle as `co browser` driving a real browser.
     """
-    return subprocess.run(
-        [
-            "ssh",
-            "-o", "BatchMode=yes",                    # never prompt; fail instead
-            "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
-            "-o", "StrictHostKeyChecking=accept-new",
-            *_identity(),
-            target,
-            command,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=SSH_TIMEOUT_SECONDS + 20,
-    )
+    argv = [
+        "ssh",
+        "-o", "BatchMode=yes",                    # never prompt; fail instead
+        "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
+        "-o", "StrictHostKeyChecking=accept-new",
+        *_identity(),
+        target,
+        command,
+    ]
+    limit = SSH_TIMEOUT_SECONDS + 20
+    try:
+        return subprocess.run(argv, capture_output=True, text=True, timeout=limit)
+    except subprocess.TimeoutExpired:
+        # ConnectTimeout covers a refused connection; this covers one that is
+        # accepted and then never answers. Same shape as any other failed probe,
+        # so `co server check` reports it instead of crashing.
+        return subprocess.CompletedProcess(
+            argv, returncode=124,
+            stdout="",
+            stderr=f"ssh to {target} timed out after {limit}s — the server did not answer.",
+        )
 
 
 def handle_server_add(name: str, ssh_target: str) -> bool:

--- a/tests/unit/test_ssh_timeout_is_not_a_traceback.py
+++ b/tests/unit/test_ssh_timeout_is_not_a_traceback.py
@@ -1,0 +1,86 @@
+"""A hung ssh must read like a deploy failure, not like a crash.
+
+subprocess.run(timeout=) raises TimeoutExpired, and nothing caught it. A resolver
+that hangs or a box that stops answering mid-deploy therefore printed a Python
+traceback — which tells the operator we crashed, when what happened is their
+server did not answer.
+
+The tests inject TimeoutExpired directly, so nothing here waits for a timeout.
+"""
+
+import subprocess
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+from connectonion.cli.commands import server_commands as sc
+
+
+def _timeout(cmd="ssh", seconds=60):
+    return subprocess.TimeoutExpired(cmd=cmd, timeout=seconds)
+
+
+class TestDeployToServer:
+    def test_a_timed_out_ssh_returns_a_failure_not_a_traceback(self, capsys):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            result = dts._ssh("co@1.2.3.4", "true", timeout=30)
+
+        assert result.returncode != 0, "a timeout is not a success"
+
+    def test_the_message_names_the_server_and_says_it_timed_out(self, capsys):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            result = dts._ssh("co@1.2.3.4", "true", timeout=30)
+
+        combined = (result.stderr or "") + (result.stdout or "")
+        assert "1.2.3.4" in combined
+        assert "timed out" in combined.lower()
+
+    def test_a_deploy_stops_cleanly_when_the_server_stops_answering(self, capsys, tmp_path):
+        """The caller already treats a non-zero return as a failed step, so the
+        existing error path does the reporting — this only has to stop the
+        exception escaping."""
+        (tmp_path / ".co").mkdir()
+        (tmp_path / ".co" / "host.yaml").write_text("name: myagent\nentrypoint: agent.py\n")
+        (tmp_path / "agent.py").write_text("from connectonion import host\nhost(None)\n")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sc, "load_server", lambda name: {"ssh": "co@1.2.3.4"})
+            mp.setattr(dts, "load_server", lambda name: {"ssh": "co@1.2.3.4"})
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            assert dts.handle_deploy_to("prod", tmp_path) is False
+
+        assert "Traceback" not in capsys.readouterr().out
+
+
+class TestServerCommands:
+    def test_a_timed_out_preflight_returns_a_failure(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            result = sc._ssh("co@1.2.3.4", "true")
+
+        assert result.returncode != 0
+
+    def test_server_check_reports_unreachable_rather_than_crashing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sc, "SERVERS_FILE", tmp_path / "servers.yaml")
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run",
+                       lambda *a, **k: subprocess.CompletedProcess([], 0, "ok", ""))
+            sc.handle_server_add("prod", "co@1.2.3.4")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            assert sc.handle_server_check("prod") is False
+
+
+class TestTheTimeoutIsStillDistinguishable:
+    def test_a_timeout_does_not_look_like_a_command_that_failed(self):
+        """An exit code alone cannot tell "the box said no" from "the box said
+        nothing" — and the second is a connectivity problem, not a broken
+        command."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(subprocess, "run", lambda *a, **k: (_ for _ in ()).throw(_timeout()))
+            result = dts._ssh("co@1.2.3.4", "true", timeout=30)
+
+        assert "timed out" in (result.stderr or "").lower()


### PR DESCRIPTION
Closes #399. Last of this batch.

## The bug

`subprocess.run(timeout=)` raises `TimeoutExpired`, and nothing caught it. A hung resolver, or a box that goes quiet mid-deploy, printed a Python traceback.

That tells the operator **we crashed**. What actually happened is **their server did not answer** — two problems whose next steps have nothing in common.

## Both helpers, not one

`deploy_to_server._ssh` and `server_commands._ssh` each call `subprocess.run` with a timeout. Fixing only the first would leave `co server check` crashing on the same condition — and that is the command someone runs *precisely because* the server is not responding.

## Returned, not raised

A failed `CompletedProcess` rather than a new exception:

- every caller **already** treats a non-zero return as a failed step and reports it with the server name
- a new exception type would be a second shape of failure for one condition, needing handling again at each of the ~15 call sites

`returncode = 124` is the timeout convention (`timeout(1)` uses it), so it stays distinguishable from a command that ran and failed. **An exit code alone cannot tell "the box said no" from "the box said nothing"**, and only the second is a connectivity problem — so the message says which it was:

```
ssh to co@1.2.3.4 timed out after 30s — the server did not answer.
Check it is running and reachable: co server check <name>
```

## Verification

6 tests, **6 red before / 6 green after**.

Per the issue's requirement, they **inject `TimeoutExpired` directly** — nothing here waits for a timeout, so the suite stays fast.

Full unit suite: **2801 passed, 3 skipped**.