### PR TITLE
Tell the agent to call skill(), instead of mentioning that it can

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -496,14 +496,32 @@ def _inject_skills_to_system_prompt(agent: 'Agent') -> None:
     if not skills_list:
         return
 
-    # Build skills section
+    # Project skills first: with dozens installed, the one that lives in this
+    # repository is the one meant to win when several could apply, and order is
+    # a signal the model reads.
+    priority = {loc: i for i, loc in enumerate(
+        ("project", "claude-project", "user", "claude-user", "builtin"))}
+    skills_list = sorted(skills_list, key=lambda s: priority.get(s.location, 99))
+
+    # An instruction, not a description of a capability. This used to end with
+    # "you can call the skill() tool", and the agent did not — asked in a
+    # skill's own trigger words it ran glob, then glob again, then `find`,
+    # hunting for a file it could never see, because skills live under dot
+    # directories.
     skills_text = "\n\n# Available Skills\n\n"
-    skills_text += "Pre-packaged workflows you can invoke:\n\n"
+    skills_text += (
+        "Pre-packaged workflows. When a request matches a skill's description, "
+        "**your first action is `skill(name=...)`** to load its full "
+        "instructions — before planning, and before touching any files.\n\n"
+        "Do not use glob/grep/find to locate a skill. They live under dot "
+        "directories and file search will not find them; the list below is the "
+        "whole set.\n\n"
+    )
 
     for skill in skills_list:
-        skills_text += f"- `/{skill.name}`: {skill.description}\n"
+        skills_text += f"- `/{skill.name}` ({skill.location}): {skill.description}\n"
 
-    skills_text += "\nUser can type `/skill-name` or you can call the skill() tool.\n"
+    skills_text += "\nA user can also type `/skill-name` directly.\n"
 
     # Find system message and append
     messages = agent.current_session.get('messages', [])

--- a/tests/unit/test_skill_prompt_tells_agent_to_call.py
+++ b/tests/unit/test_skill_prompt_tells_agent_to_call.py
@@ -1,0 +1,90 @@
+"""The skill list has to tell the agent what to do with it.
+
+A project skill whose description named its trigger phrases was never invoked:
+asked in exactly those words, the agent ran glob, then glob again, then `find`
+— hunting for a file it could never see, because skills live under dot
+directories. The list said "you can call the skill() tool", which is a
+description of a capability, not an instruction to use it.
+"""
+
+import sys
+
+import pytest
+
+skills_plugin = sys.modules.get("connectonion.useful_plugins.skills")
+if skills_plugin is None:
+    import connectonion.useful_plugins.skills  # noqa: F401
+    skills_plugin = sys.modules["connectonion.useful_plugins.skills"]
+
+
+class FakeAgent:
+    def __init__(self):
+        self.co_dir = None
+        self.current_session = {"messages": [{"role": "system", "content": "BASE."}]}
+
+    @property
+    def prompt(self):
+        return self.current_session["messages"][0]["content"]
+
+
+@pytest.fixture
+def injected(monkeypatch):
+    from connectonion.useful_plugins.skills import SkillInfo
+
+    monkeypatch.setattr(skills_plugin, "_discover_all_skills", lambda **kw: [
+        SkillInfo(name="contract-ledger",
+                  description="use when the user says 整理合同 / 更新台账",
+                  location="project"),
+        SkillInfo(name="commit", description="Create git commits", location="builtin"),
+    ])
+    agent = FakeAgent()
+    skills_plugin._inject_skills_to_system_prompt(agent)
+    return agent.prompt
+
+
+class TestItInstructsRatherThanDescribes:
+    def test_loading_a_matching_skill_is_stated_as_the_first_action(self, injected):
+        """"You can call skill()" is a capability. The agent needs to be told
+        that a matching description means call it, before doing anything else."""
+        assert "first action" in injected.lower()
+
+    def test_it_says_not_to_search_the_filesystem_for_skills(self, injected):
+        """The observed failure was glob, glob, find — a hunt that cannot
+        succeed, because skills live under dot directories."""
+        lowered = injected.lower()
+        assert "glob" in lowered or "search" in lowered
+        assert "skill" in lowered
+
+    def test_the_skill_tool_is_named_so_the_agent_can_call_it(self, injected):
+        assert "skill(" in injected
+
+
+class TestItKeepsSayingWhatIsAvailable:
+    def test_every_discovered_skill_is_listed(self, injected):
+        assert "contract-ledger" in injected
+        assert "commit" in injected
+
+    def test_descriptions_are_kept(self, injected):
+        """The description is what the agent matches the user's words against —
+        dropping it to save tokens would remove the trigger."""
+        assert "整理合同" in injected
+
+    def test_the_scope_of_each_skill_is_visible(self, injected):
+        """With dozens of skills, "this one is the project's" is what breaks a
+        tie between similar names."""
+        assert "project" in injected
+
+    def test_project_skills_come_before_builtin_ones(self, injected):
+        """Order is a signal too: the project's own skill is the one meant to
+        win when both could apply."""
+        assert injected.index("contract-ledger") < injected.index("commit")
+
+
+class TestNothingToSayStaysQuiet:
+    def test_no_skills_means_no_section(self, monkeypatch):
+        monkeypatch.setattr(skills_plugin, "_discover_all_skills", lambda **kw: [])
+        agent = FakeAgent()
+
+        skills_plugin._inject_skills_to_system_prompt(agent)
+
+        assert agent.prompt == "BASE."


### PR DESCRIPTION
Closes #324.

## The symptom

A project skill's description named its trigger phrases outright — *"use when the user says 整理合同 / 更新台账"*. Asked in **exactly those words**:

```
co ai "帮我整理一下合同台账，先告诉我第一步该做什么"
```

The agent never called `skill()`. It went looking for files:

```
▸ glob(pattern="*contract-ledger*")     → 0 results
▸ glob(pattern="**/*skill*/**")
▸ bash(command="find ~/.co ~/.co...")
```

A search that **cannot succeed** — skills live under dot directories.

## The cause is one line of wording

```
User can type `/skill-name` or you can call the skill() tool.
```

That describes a capability. It does not say *when* to use it, and it says nothing about not searching for the files.

```
When a request matches a skill's description, **your first action is
`skill(name=...)`** to load its full instructions — before planning, and before
touching any files.

Do not use glob/grep/find to locate a skill. They live under dot directories and
file search will not find them; the list below is the whole set.
```

## Scope, and order as a signal

```
- `/contract-ledger` (project): use when the user says 整理合同 / 更新台账
- `/my-notes` (user): personal notes
- `/commit` (builtin): Create git commits
```

Project skills first. With dozens installed — **121 on the machine where this was found** — order is what breaks a tie between plausible matches, and the skill living in this repository is the one meant to win.

## The test worth keeping

`test_descriptions_are_kept` asserts `整理合同` survives injection. The description is **what the agent matches the user's words against**, so trimming it to save tokens would remove the trigger and reintroduce this exact bug. That is not obvious from reading the code, so it is pinned.

## Verification

8 tests, **3 red before / 8 green after**. Full unit suite: **2803 passed, 3 skipped**.

## Related, not fixed here

#301 (a skill cannot declare its runtime dependencies) and #302 (user-level skills vanish remotely, already closed). This one is upstream of both — the skill was never invoked at all.