### PR TITLE
fix(trust): a decision says what it decided, and to whom

### DIFF
--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -82,13 +82,23 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     """
     import logging
     logger = logging.getLogger("connectonion.trust.fast_rules")
-    logger.warning(f"[FAST_RULES] Evaluating client_id={client_id[:20]}... config={config}")
+
+    # The id goes out whole. The operator's next move after reading this line is to
+    # paste it into admins.txt or whitelist.txt, and a prefix cannot be pasted — one
+    # that reads like a complete short id even less so.
+    #
+    # The config does not go out at all: it carries the agent's invite codes, and it
+    # was being printed at warning level on every single request.
+    logger.warning(
+        f"[FAST_RULES] Evaluating client_id={client_id} "
+        f"allow={config.get('allow', [])} default={config.get('default', 'deny')}"
+    )
 
     # 1. Check deny list first (blocked users)
     deny_list = config.get('deny', ['blocked'])
     for condition in deny_list:
         if condition == 'blocked' and is_blocked(client_id):
-            logger.warning(f"[FAST_RULES] Client {client_id[:20]}... is BLOCKED, returning 'deny'")
+            logger.warning(f"[FAST_RULES] Client {client_id} is BLOCKED, returning 'deny'")
             return 'deny'
 
     # 2. Check allow list (whitelisted, contacts)
@@ -99,11 +109,18 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
         # never consulted here, so a freshly deployed agent answered its own
         # owner with "requires onboarding", for a machine they had just paid for
         # and installed their key on.
+        #
+        # Each of these says so on the way out. A log that recorded only the denials
+        # left "did not grow" meaning either *allowed* or *never asked*, and those are
+        # the two states an operator debugging a silent client most needs to separate.
         if condition == 'admin' and is_admin(client_id):
+            logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is admin")
             return 'allow'
         if condition == 'whitelisted' and is_whitelisted(client_id):
+            logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is whitelisted")
             return 'allow'
         if condition == 'contact' and is_contact(client_id):
+            logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is contact")
             return 'allow'
 
     # 3. Try onboarding (stranger → contact)
@@ -114,6 +131,13 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     request_code = request.get('invite_code')
     if request_code and request_code in valid_codes:
         promote_to_contact(client_id)
+        # Promotion is durable — this client is a contact from now on. That is a
+        # change to who can reach the agent, so it belongs in the record. The code
+        # itself does not.
+        logger.warning(
+            f"[FAST_RULES] Returning 'allow' — {client_id} onboarded by invite code, "
+            f"promoted to contact"
+        )
         return 'allow'
 
     # Check payment
@@ -121,6 +145,10 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     request_payment = request.get('payment', 0)
     if required_payment and request_payment >= required_payment:
         promote_to_contact(client_id)
+        logger.warning(
+            f"[FAST_RULES] Returning 'allow' — {client_id} onboarded by payment, "
+            f"promoted to contact"
+        )
         return 'allow'
 
     # 4. Default action for strangers without onboarding

--- a/tests/unit/test_trust_decisions_are_logged.py
+++ b/tests/unit/test_trust_decisions_are_logged.py
@@ -1,0 +1,96 @@
+"""A trust decision has to be readable afterwards.
+
+The operator's whole diagnostic surface for "why can't my client talk to my agent"
+is this log. Today it records the denials and stays silent on the allows, so a log
+that did not grow is ambiguous between *allowed* and *never asked* — the two states
+that most need telling apart. It also truncates the one string the operator has to
+copy into admins.txt, and prints the invite codes on every request.
+"""
+
+import logging
+
+import pytest
+
+from connectonion.network.trust import fast_rules
+
+
+FULL_ID = "0xb2df62c9094c42eb5413731304b867e7c4a1762edcd6b3f572c1111e071bdc01"
+CODE = "B7HSW-6Y6P4-BZC5Z"
+
+
+@pytest.fixture
+def log(caplog):
+    caplog.set_level(logging.DEBUG, logger="connectonion.trust.fast_rules")
+    return caplog
+
+
+def decisions(log):
+    """The lines that state an outcome.
+
+    The opening line echoes the whole config, which contains the words "allow",
+    "whitelisted" and "contact" whatever happens. Matching against it would let
+    these tests pass on a build that decides silently, which is the bug.
+    """
+    return [r.message for r in log.records if "Evaluating" not in r.message]
+
+
+def _config(default="deny"):
+    return {
+        "allow": ["admin", "whitelisted", "contact"],
+        "deny": ["blocked"],
+        "onboard": {"invite_code": [CODE]},
+        "default": default,
+    }
+
+
+def test_an_allow_says_which_condition_matched(log, monkeypatch):
+    monkeypatch.setattr(fast_rules, "is_blocked", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_admin", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_whitelisted", lambda _: True)
+    monkeypatch.setattr(fast_rules, "is_contact", lambda _: False)
+
+    assert fast_rules.evaluate_request(_config(), FULL_ID, {}) == "allow"
+
+    assert any(
+        "allow" in m and "whitelisted" in m for m in decisions(log)
+    ), "no line says the client was allowed, and by which condition"
+
+
+def test_onboarding_by_invite_code_is_recorded(log, monkeypatch):
+    monkeypatch.setattr(fast_rules, "is_blocked", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_admin", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_whitelisted", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_contact", lambda _: False)
+    monkeypatch.setattr(fast_rules, "promote_to_contact", lambda _: None)
+
+    result = fast_rules.evaluate_request(_config(), FULL_ID, {"invite_code": CODE})
+
+    assert result == "allow"
+    assert any(
+        "allow" in m and "invite" in m.lower() for m in decisions(log)
+    ), "a stranger was promoted to contact and no line says why"
+
+
+def test_the_client_id_is_logged_whole(log, monkeypatch):
+    monkeypatch.setattr(fast_rules, "is_blocked", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_admin", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_whitelisted", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_contact", lambda _: False)
+
+    fast_rules.evaluate_request(_config(), FULL_ID, {})
+
+    assert FULL_ID in log.text, (
+        "the operator's next step is to paste this id into admins.txt, "
+        "and the log gives them a prefix"
+    )
+
+
+def test_invite_codes_are_not_written_to_the_log(log, monkeypatch):
+    monkeypatch.setattr(fast_rules, "is_blocked", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_admin", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_whitelisted", lambda _: False)
+    monkeypatch.setattr(fast_rules, "is_contact", lambda _: False)
+
+    fast_rules.evaluate_request(_config(), FULL_ID, {})
+
+    assert CODE not in log.text, "every request prints the agent's invite codes"


### PR DESCRIPTION
Half of #434 — the half that lives in this repo.

#434 describes a denial that is invisible from both ends. The client half (a `DENIED`
frame the UI can render) is a protocol change and is not attempted here. This is the
server half: making the record legible enough that an operator can find the answer at all.

## What changed

**Allows are logged, with the condition that matched.**

```python
if condition == 'whitelisted' and is_whitelisted(client_id):
    logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is whitelisted")
    return 'allow'
```

Before, every deny logged twice and no allow logged at all. So a log that did not grow
meant either *allowed* or *never asked*. Debugging the case in #434, that ambiguity
produced a wrong conclusion twice — first "still denied" when it had started allowing,
then the reverse — because the only available signal was whether the line count moved.

Onboarding logs too, and says the client was promoted to contact. That promotion is
durable: it changes who can reach the agent from then on, which is the kind of thing a
record exists for.

**`client_id` is printed whole.**

```python
- f"[FAST_RULES] Evaluating client_id={client_id[:20]}... config={config}"
+ f"[FAST_RULES] Evaluating client_id={client_id} allow=… default=…"
```

The operator's next action after reading this line is to paste that string into
`admins.txt` or `whitelist.txt`. A prefix cannot be pasted. Worse, `0x` + 18 hex reads
like a complete short identifier, so the truncation is not self-announcing — in #434 it
cost a full cycle of adding the 20-character prefix to the list and watching it still fail.

**The config dict is no longer dumped.**

It contains `onboard.invite_code`. Every request was writing the agent's invite codes to
the log at warning level. The two fields an operator actually needs to read a decision
against — `allow` and `default` — are printed instead.

## Tests

`tests/unit/test_trust_decisions_are_logged.py`, four cases, all failing before this change.

Worth noting how they assert. The obvious version — `assert "whitelisted" in caplog.text`
— **passes on the unfixed code**, because the echoed config contains the words "allow",
"whitelisted" and "contact" whatever the outcome was. The first draft of these tests did
exactly that and reported 2 passed against a build that decided silently. They now filter
out the `Evaluating` line and assert against decision lines only.

## Not covered

- The client is still told nothing. That needs a frame the UI can act on — #434.
- There is still no way to send an invite code from a browser — #435.

385 existing trust/auth/host tests pass.
