### PR TITLE
A system reminder is context about the turn, not something the user said

### DIFF
--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -225,10 +225,8 @@ def detect_intent(agent: 'Agent') -> None:
     if analysis.is_build:
         build_context = _load_build_context()
         if build_context:
-            agent.current_session['messages'].append({
-                'role': 'user',
-                'content': f"<system-reminder>\n{build_context}\n</system-reminder>"
-            })
+            from ....useful_plugins.system_reminder import reminder_message
+            agent.current_session['messages'].append(reminder_message(build_context))
 
 
 @after_each_tool

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -287,10 +287,19 @@ class Agent:
             names = [Path(p).name for p in saved_files]
             self.logger.console.print(f"  [dim]↑ {len(saved_files)} file(s): {', '.join(names)}[/dim]")
 
-        # Append file paths to prompt so the agent knows about uploaded files
+        # The upload notice is context ABOUT the turn, not part of what the user
+        # typed. It used to be concatenated onto `prompt`, which is the string
+        # that becomes the user message, the stored user_prompt AND the
+        # user_input trace — so the raw tags showed up in the chat bubble, in
+        # xray, and in the transcript. Carried as its own internal message below.
+        upload_notice = None
         if saved_files:
             file_list = "\n".join(f"- {p}" for p in saved_files)
-            prompt += f"\n\n<system-reminder>The user uploaded the following files:\n{file_list}\nUse your read_file tool or other available tools to read the file contents before responding. Do not assume or guess the contents.</system-reminder>"
+            upload_notice = (
+                f"The user uploaded the following files:\n{file_list}\n"
+                f"Use your read_file tool or other available tools to read the file "
+                f"contents before responding. Do not assume or guess the contents."
+            )
 
         # Add user message to conversation (multimodal if images provided)
         if images:
@@ -300,6 +309,10 @@ class Agent:
             self.current_session['messages'].append({"role": "user", "content": content})
         else:
             self.current_session['messages'].append({"role": "user", "content": prompt})
+
+        if upload_notice:
+            from ..useful_plugins.system_reminder import reminder_message
+            self.current_session['messages'].append(reminder_message(upload_notice))
 
         # Track this turn
         self.current_session['turn'] += 1

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -124,7 +124,17 @@ def session_to_chat_items(session: dict) -> list[dict]:
             content = msg.get('content', '')
             if isinstance(content, str) and content.startswith(RUNTIME_INPUT_FRAME_PREFIX):
                 content = content[len(RUNTIME_INPUT_FRAME_PREFIX):]
-            items_ui.append({'id': f"msg-{msg_idx}", 'type': 'user', 'content': content})
+
+            # Structural, not a regex over content: a message the system injected
+            # carries `internal`, and a user who literally types
+            # "<system-reminder>" must see their own words back unchanged.
+            if not msg.get('internal'):
+                items_ui.append({'id': f"msg-{msg_idx}", 'type': 'user', 'content': content})
+
+            # Counted either way. The bubble is suppressed; the TURN is not — an
+            # internal message still opened one, and skipping the increment drops
+            # every tool call that turn made from the transcript. That is the
+            # regression #144's first cut shipped.
             user_count += 1
             if user_count < len(turn_entries):
                 for trace_idx, entry in turn_entries[user_count]:

--- a/connectonion/useful_plugins/system_reminder.py
+++ b/connectonion/useful_plugins/system_reminder.py
@@ -111,3 +111,25 @@ def inject_reminder(agent: 'Agent') -> None:
 
 # Export plugin
 system_reminder = [inject_reminder]
+
+
+def reminder_message(text: str) -> dict:
+    """A reminder carried as its own message, marked so the UI can skip it.
+
+    Reminders are context *about* the turn, not part of what the user said. They
+    used to be appended as ordinary `role: user` messages, so the renderer had no
+    way to tell them from typed input and the raw tags showed up as chat bubbles.
+
+    `internal` is the whole point: the render rule is structural. Stripping the
+    tags from content instead — the approach closed in #144 — cannot tell an
+    injected tag from one the user typed, so someone asking "why does
+    <system-reminder> show up in my chat?" gets their own words rewritten.
+
+    Stripped, because trailing whitespace around the block left a stray blank
+    line wherever the content did get rendered.
+    """
+    return {
+        "role": "user",
+        "content": f"<system-reminder>\n{text.strip()}\n</system-reminder>",
+        "internal": True,
+    }

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -620,15 +620,19 @@ def test_agent_input_with_files(tmp_path):
     assert len(saved_files) == 1
     assert saved_files[0].read_bytes() == b"%PDF-1.4\n"
 
-    # Verify system reminder was appended to prompt with file path
+    # The model must still learn about the file — but not by having the notice
+    # concatenated onto what the user typed (#308). It arrives as its own
+    # internal message, which the UI skips and the model still reads.
     messages = mock_llm.last_call["messages"]
-    user_message = [msg for msg in messages if msg['role'] == 'user'][-1]
+    user_messages = [msg for msg in messages if msg['role'] == 'user']
 
-    content = user_message['content']
-    assert isinstance(content, str)
-    assert "Analyze this document" in content
-    assert "<system-reminder>" in content
-    assert "report.pdf" in content
+    typed = next(m for m in user_messages if not m.get('internal'))
+    assert typed['content'] == "Analyze this document", "the user's words, unmodified"
+    assert "<system-reminder>" not in typed['content']
+
+    notice = next(m for m in user_messages if m.get('internal'))
+    assert "report.pdf" in notice['content']
+    assert "<system-reminder>" in notice['content']
 
 
 def test_agent_input_with_images_and_files(tmp_path):
@@ -650,15 +654,19 @@ def test_agent_input_with_images_and_files(tmp_path):
     agent.input("Analyze these", images=[test_image], files=[test_file])
 
     messages = mock_llm.last_call["messages"]
-    user_message = [msg for msg in messages if msg['role'] == 'user'][-1]
+    user_messages = [msg for msg in messages if msg['role'] == 'user']
 
-    content = user_message['content']
-    assert isinstance(content, list)
-    # Images make it multimodal; file reminder is appended to prompt text
-    assert content[0]['type'] == 'text'
-    assert "data.csv" in content[0]['text']
-    assert "<system-reminder>" in content[0]['text']
-    assert content[1]['type'] == 'image_url'
+    # Images still make the typed message multimodal, and it still carries only
+    # what the user typed — the file notice is a separate internal message (#308).
+    typed = next(m for m in user_messages if not m.get('internal'))
+    assert isinstance(typed['content'], list)
+    assert typed['content'][0]['type'] == 'text'
+    assert typed['content'][0]['text'] == "Analyze these"
+    assert "<system-reminder>" not in typed['content'][0]['text']
+
+    notice = next(m for m in user_messages if m.get('internal'))
+    assert "data.csv" in notice['content']
+    assert typed['content'][1]['type'] == 'image_url', "the image is still attached"
 
     # Verify file saved (with timestamp prefix)
     uploads_dir = tmp_path / ".co" / "uploads"

--- a/tests/unit/test_system_reminder_is_structural.py
+++ b/tests/unit/test_system_reminder_is_structural.py
@@ -1,0 +1,136 @@
+"""A system reminder is context about the turn, not something the user said.
+
+Two sites put reminder text into `messages` where it is indistinguishable from
+what the user typed, so it rendered as a user bubble with raw tags showing.
+
+The rule the renderer applies must be structural. Stripping the tags from
+content — the approach closed in #144 — cannot tell an injected tag from one the
+user typed, so someone asking "why does <system-reminder> show up in my chat?"
+gets their own words silently rewritten.
+"""
+
+import pytest
+
+from connectonion.network.host.session.ui import session_to_chat_items
+
+
+def _user(content, **extra):
+    return {"role": "user", "content": content, **extra}
+
+
+class TestNoReminderReachesABubble:
+    def test_an_internal_message_produces_no_bubble(self):
+        session = {
+            "messages": [
+                _user("build the thing"),
+                _user("<system-reminder>\nbuild context\n</system-reminder>", internal=True),
+                {"role": "assistant", "content": "done"},
+            ],
+            "trace": [{"type": "user_input"}],
+        }
+
+        items = session_to_chat_items(session)
+
+        assert [i["type"] for i in items].count("user") == 1
+        assert not any("system-reminder" in str(i.get("content", "")) for i in items)
+
+    def test_the_users_own_words_are_never_rewritten(self):
+        """The reason this is structural. Someone asking about the tag must see
+        their question as they typed it."""
+        typed = "why does <system-reminder> show up in my chat?"
+        session = {"messages": [_user(typed)], "trace": [{"type": "user_input"}]}
+
+        items = session_to_chat_items(session)
+
+        assert items[0]["content"] == typed
+
+
+class TestASuppressedBubbleStillOpensItsTurn:
+    """Carried over from #144's review: the first cut suppressed the bubble and
+    dropped every tool call in that turn from the transcript."""
+
+    def test_the_turns_trace_entries_still_render(self):
+        session = {
+            "messages": [
+                _user("first"),
+                _user("<system-reminder>ctx</system-reminder>", internal=True),
+                {"role": "assistant", "content": "ok"},
+            ],
+            "trace": [
+                {"type": "user_input"},
+                {"type": "tool_result", "name": "read_file", "args": {}, "result": "x",
+                 "status": "success", "timing_ms": 1},
+                {"type": "user_input"},
+                {"type": "tool_result", "name": "bash", "args": {}, "result": "y",
+                 "status": "success", "timing_ms": 1},
+            ],
+        }
+
+        items = session_to_chat_items(session)
+        rendered = " ".join(str(i) for i in items)
+
+        assert "read_file" in rendered
+        assert "bash" in rendered, "the reminder turn's tool calls were dropped"
+
+
+class TestOrdinaryMessagesAreUntouched:
+    def test_a_normal_user_message_still_renders(self):
+        session = {"messages": [_user("hello")], "trace": [{"type": "user_input"}]}
+
+        assert session_to_chat_items(session)[0]["content"] == "hello"
+
+    def test_assistant_messages_still_render(self):
+        session = {
+            "messages": [_user("hi"), {"role": "assistant", "content": "hey"}],
+            "trace": [{"type": "user_input"}],
+        }
+
+        assert [i["type"] for i in session_to_chat_items(session)] == ["user", "agent"]
+
+
+class TestTheInjectionHelperMarksWhatItInjects:
+    def test_the_helper_produces_an_internal_message(self):
+        from connectonion.useful_plugins.system_reminder import reminder_message
+
+        msg = reminder_message("build context")
+
+        assert msg["internal"] is True
+        assert "<system-reminder>" in msg["content"]
+        assert "build context" in msg["content"]
+
+    def test_it_leaves_no_stray_blank_lines(self):
+        """Also from #144's review — whitespace around the block left the bubble
+        with an empty line when it did render."""
+        from connectonion.useful_plugins.system_reminder import reminder_message
+
+        content = reminder_message("  padded  ")["content"]
+
+        assert content == content.strip()
+
+
+class TestTheUploadNoticeIsNotPartOfWhatTheUserSaid:
+    """agent.py concatenated it onto `prompt` — the same string that becomes the
+    user message, the stored user_prompt, and the user_input trace entry. So the
+    tags reached the chat bubble, xray, and the transcript from one assignment."""
+
+    def test_the_notice_does_not_reach_the_user_message_or_the_trace(self):
+        import inspect
+
+        from connectonion.core import agent as agent_module
+
+        source = inspect.getsource(agent_module.Agent.input)
+
+        assert "prompt += " not in source, (
+            "the upload notice is back on the user's own prompt string"
+        )
+        assert "reminder_message(upload_notice)" in source
+
+    def test_a_reminder_message_is_still_visible_to_the_llm(self):
+        """Suppressing the bubble must not stop the model seeing it — the notice
+        exists so the agent knows to read the files."""
+        from connectonion.useful_plugins.system_reminder import reminder_message
+
+        msg = reminder_message("The user uploaded: a.pdf")
+
+        assert msg["role"] == "user", "an internal message still goes to the model"
+        assert "a.pdf" in msg["content"]


### PR DESCRIPTION
Closes #308 (root-cause fix for #138; #144 proposed the render-time scrub and was closed in favour of this).

## The rule is structural, and that is the whole point

An injected reminder now carries `internal=True`, and the renderer skips on **that field, never on content**.

Stripping tags from content cannot tell a system-injected tag from one the user typed. Someone asking *"why does `<system-reminder>` show up in my chat?"* would have their own question silently rewritten. A test pins that their words come back verbatim.

## The trap that #144 fell into

```python
if not msg.get('internal'):
    items_ui.append(...)     # bubble suppressed

user_count += 1              # turn still counted
```

`user_count` drives the turn index. Skipping the increment as well **drops every tool call that turn made** from the transcript — the regression #144's first cut shipped. The issue flagged it; there is now a test for it.

## `agent.py` was worse than the issue described

```python
prompt += f"\n\n<system-reminder>The user uploaded..."
```

That one string becomes **three** things: the user message, the stored `user_prompt`, and the `user_input` trace entry. So a single concatenation put the tags in the chat bubble, in xray, **and** in the transcript. Carried as its own message now, and all three are clean at once.

## Two existing tests changed

Their comments said it outright — *"Verify system reminder was appended to prompt"*. That is the behaviour this removes, so the assertions could not stand.

Rewritten to assert what they were actually protecting — the model still learns about the file — **plus** the new requirement:

```python
typed = next(m for m in user_messages if not m.get('internal'))
assert typed['content'] == "Analyze this document"     # the user's words, unmodified
assert "<system-reminder>" not in typed['content']     # new

notice = next(m for m in user_messages if m.get('internal'))
assert "report.pdf" in notice['content']               # the model still sees it
```

Strictly stronger: the old version could only show the reminder existed somewhere.

## One thing deliberately unchanged

`internal` messages keep `role: user`. **The model must read them** — the upload notice exists so the agent knows to open the files. Only the UI skips them. Pinned by a test, because "internal" reads like "don't send it".

## Verification

9 new tests, **3 red before**. Full unit suite: **2810 passed, 3 skipped**.

## Acceptance criteria

- [x] No `<system-reminder>` reaches a chat bubble, with no regex in the render path
- [x] A user typing the literal string sees their message unchanged
- [x] A reminder-only message produces no bubble but still renders its turn's tool calls