### PR TITLE
fix(deploy): the service runs as the user the server says we are

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -282,16 +282,33 @@ grep -qxF {quoted_admin} {admins} || echo {quoted_admin} >> {admins}
     return True
 
 
+def _remote_user(target: str) -> str:
+    """The account the ssh session lands as, according to the server.
+
+    Falls back to parsing the target only if the server cannot be asked, which
+    keeps the `user@host` form working even on a machine without `id`.
+    """
+    result = _ssh(target, "id -un", timeout=30)
+    name = (result.stdout or "").strip()
+    if result.returncode == 0 and name:
+        return name
+    return target.split("@")[0]
+
+
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
-                           hostname: Optional[str] = None) -> bool:
+                           hostname: Optional[str] = None,
+                           user: Optional[str] = None) -> bool:
     """Write the systemd unit only when its content differs.
 
     Rewriting it every deploy would mean a daemon-reload every deploy for no
     reason, and would hide whether a restart came from new code or a new unit.
     """
     # The ssh target's user owns everything under /srv/<agent> — it is the user
-    # rsync wrote as — so it is the one the service should run as.
-    user = target.split("@")[0]
+    # rsync wrote as — so it is the one the service should run as. The caller
+    # resolves it once per deploy; falling back here keeps the old signature
+    # working for direct callers.
+    if user is None:
+        user = _remote_user(target)
     wanted = _unit_text(agent, entrypoint, hostname, user=user)
     unit_path = f"/etc/systemd/system/{agent}.service"
 
@@ -532,7 +549,7 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
         # root-owned logs and state behind, and the first thing the unprivileged
         # process does is fail to write its own log —
         # PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
-        _ssh(target, f"sudo chown -R {target.split('@')[0]}: {SRV}/{agent}", timeout=120)
+        _ssh(target, f"sudo chown -R {_remote_user(target)}: {SRV}/{agent}", timeout=120)
 
     if result.returncode != 0:
         console.print("[red]rsync failed.[/red]")
@@ -704,7 +721,10 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
         return False
     if hostname and not _ensure_caddy(target, hostname, project["port"]):
         return False
-    if not _write_unit_if_changed(target, agent, entrypoint, hostname):
+    # Once per deploy: the unit and the ownership fix-up both need it, and it
+    # costs an ssh round trip.
+    user = _remote_user(target)
+    if not _write_unit_if_changed(target, agent, entrypoint, hostname, user=user):
         return False
     if not _restart(target, agent):
         return False

--- a/tests/unit/test_deploy_service_user.py
+++ b/tests/unit/test_deploy_service_user.py
@@ -1,0 +1,60 @@
+"""The service runs as the user the server says we are.
+
+`co server add --ssh` documents two target forms, `user@host` and a Host alias
+from ~/.ssh/config. Deriving the account name by splitting the target on "@"
+only reads the first one; an alias has no "@", so the whole alias became the
+username, and systemd refused to start the unit with 217/USER — after every
+stage of the deploy had reported success.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def run(stdout="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def unit_written(target, remote_user):
+    """Deploy against a fake server and return the unit text it wanted to write."""
+    written = {}
+
+    def fake_ssh(tgt, command, timeout=None, **kwargs):
+        if command.strip() == "id -un":
+            return run(remote_user + "\n")
+        if command.startswith("cat /etc/systemd/system/"):
+            return run("", returncode=1)          # no unit there yet
+        if "UNITEOF" in command:                  # the heredoc carrying the unit
+            written["text"] = command
+        return run()
+
+    with patch.object(dts, "_ssh", side_effect=fake_ssh):
+        dts._write_unit_if_changed(target, "billing", "agent.py")
+
+    return written.get("text", "")
+
+
+def test_a_host_alias_is_not_a_username():
+    text = unit_written(target="nw-e2e", remote_user="changxing")
+
+    assert "User=changxing" in text, (
+        "the unit names the ssh alias as its user; systemd exits 217/USER "
+        "because no such account exists on the machine"
+    )
+    assert "User=nw-e2e" not in text
+
+
+def test_the_user_at_host_form_still_works():
+    text = unit_written(target="deploy@10.0.0.4", remote_user="deploy")
+
+    assert "User=deploy" in text
+
+
+def test_a_host_block_overriding_user_is_honoured():
+    # ~/.ssh/config: Host box / User svc — the target string says nothing about
+    # who we land as, and only the server can answer that.
+    text = unit_written(target="box", remote_user="svc")
+
+    assert "User=svc" in text

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -237,13 +237,19 @@ class TestSystemdUnit:
         # Same user the target implies — the unit runs as whoever owns the files.
         wanted = dts._unit_text("myagent", "agent.py", user="user")
         with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
-            assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
+            # The deploy flow resolves the account once and passes it down, so
+            # this call counts only the ssh the unit write itself does.
+            assert dts._write_unit_if_changed(
+                "user@host", "myagent", "agent.py", user="user"
+            ) is True
 
         assert ssh.call_count == 1  # the read only
 
     def test_a_changed_unit_is_written_and_reloaded(self):
         with patch.object(dts, "_ssh", side_effect=[_ok("old content"), _ok()]) as ssh:
-            assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
+            assert dts._write_unit_if_changed(
+                "user@host", "myagent", "agent.py", user="user"
+            ) is True
 
         script = ssh.call_args_list[-1].args[1]
         assert "daemon-reload" in script


### PR DESCRIPTION
Closes #441.

Found by deploying to a fresh Ubuntu 24.04 box registered the way `co server add`'s own
help suggests — by alias rather than `user@host`.

## What happened

```
$ co server add nw-e2e --ssh nw-e2e     # Host block in ~/.ssh/config, User changxing
$ co server check nw-e2e
✓ nw-e2e is ready to deploy to
$ co deploy --to nw-e2e
  writing systemd unit …
  restarting …
naturewill crashed and is being restarted (1 time(s) so far).
  systemd[1]: naturewill.service: Failed to determine user credentials: No such process
  systemd[1]: naturewill.service: Main process exited, code=exited, status=217/USER
```

```ini
User=nw-e2e     # the alias. The machine's users are ubuntu, changxing, yfshuu.
```

Every stage reported success before that, `check` passed, and `Restart=always` made it a
loop. `217/USER` is not an exit code many people read at sight.

## Cause

```python
# The ssh target's user owns everything under /srv/<agent> — it is the user
# rsync wrote as — so it is the one the service should run as.
user = target.split("@")[0]
```

The comment has the rule right. The expression implements it for one of the two target
forms the CLI documents. With no `@`, `split("@")[0]` returns the whole string.

A `Host` block that sets `User` can't be read off the target string at all, so no amount
of parsing fixes this — only the server knows.

## Change

`_remote_user(target)` asks it: `id -un`, falling back to the old parse if the server
can't answer, which keeps `user@host` working on a machine without `id`.

Resolved **once per deploy** in `_deploy()` and passed down, rather than inside
`_write_unit_if_changed()`. That preserves the existing invariant — an unchanged unit
costs exactly one ssh read — which two existing tests assert and which my first attempt
broke. Those two now pass `user=` explicitly, the way the real caller does.

The same expression in the ownership fix-up is fixed too:

```python
- _ssh(target, f"sudo chown -R {target.split('@')[0]}: {SRV}/{agent}")
+ _ssh(target, f"sudo chown -R {_remote_user(target)}: {SRV}/{agent}")
```

That one was naming a nonexistent user, failing quietly (its result is not checked), and
doing no visible harm only because rsync's ownership was already correct.

## Verified

Unit: `tests/unit/test_deploy_service_user.py` — three cases. The alias cases fail before
this change; `user@host` passes before and after, which is the point.

On the real box, same alias, after the fix:

```
$ systemctl is-active naturewill        → active
$ systemctl show -p NRestarts --value   → 0
$ grep ^User= /etc/systemd/system/naturewill.service
User=changxing
```

184 existing deploy/server tests pass.

While there, the same deploy confirmed #417 and #420 hold on a real server: `.co/host.yaml`,
`OO.md`, `trust.md`, `admins.txt` and `skills/` all arrived, and `/srv/naturewill/.env`
does not exist.
