### PR TITLE
test(e2e): cover the Home page in the deploy path, and fix the command that ran nothing

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -327,9 +327,19 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
     Rewriting it every deploy would mean a daemon-reload every deploy for no
     reason, and would hide whether a restart came from new code or a new unit.
     """
-    # The ssh target's user owns everything under /srv/<agent> — it is the user
-    # rsync wrote as — so it is the one the service should run as.
-    user = target.split("@")[0]
+    # The user rsync wrote as owns everything under /srv/<agent>, so it is the
+    # one the service must run as. Ask the machine rather than splitting the
+    # target on "@": ssh does not require that form. A server registered with
+    # `co server add <name> --ssh <alias>` has a config alias as its target, and
+    # splitting it yielded the alias as a username —
+    #
+    #   User=nw-e2e
+    #   Failed to determine user credentials: No such process
+    #   status=217/USER
+    #
+    # a deploy that copied every file, wrote the unit, reported success, and
+    # produced a service that could never start.
+    user = _ssh(target, "id -un", timeout=60).stdout.strip() or target.split("@")[0]
     wanted = _unit_text(agent, entrypoint, hostname,
                         port=_free_port(target, agent), user=user)
     unit_path = f"/etc/systemd/system/{agent}.service"

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -172,7 +172,7 @@ def _read_provision(target: str, agent: str) -> dict:
         return {"schema": 0}
 
 
-def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
+def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None, port: int = 8000,
                user: str = "root") -> str:
     """The systemd unit. Restart=always and enable are what the container was for.
 
@@ -199,6 +199,13 @@ def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
                   f"/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
     if hostname:
         environment += f"Environment=AGENT_PUBLIC_DOMAIN={hostname}\n"
+    # One server can host several agents — /srv/<agent>/ and the unit are both
+    # per-agent. The port was the only thing that was not, so a second agent
+    # bound 8000, lost, and crash-looped. Restart=always then kept
+    # `systemctl is-active` answering "active" for a process dying every few
+    # seconds, so the deploy reported success for an agent that never served a
+    # request.
+    environment += f"Environment=PORT={port}\n"
     return f"""[Unit]
 Description=ConnectOnion agent {agent}
 After=network-online.target
@@ -282,6 +289,37 @@ grep -qxF {quoted_admin} {admins} || echo {quoted_admin} >> {admins}
     return True
 
 
+def _free_port(target: str, agent: str, first: int = 8000, last: int = 8099) -> int:
+    """A port this agent can actually bind on that server.
+
+    One ssh round trip: this agent's current port, then everything taken. Keeps
+    the port already in this agent's unit so a redeploy does not move one that
+    clients and Caddy point at; otherwise takes the lowest free one. Asked of the
+    machine, because only the machine knows what is listening.
+    """
+    probe = _ssh(
+        target,
+        f"grep -h '^Environment=PORT=' /etc/systemd/system/{agent}.service 2>/dev/null "
+        f"| cut -d= -f3; echo ---; "
+        f"ss -ltnH 2>/dev/null | awk '{{print $4}}' | sed 's/.*://'; "
+        f"grep -h '^Environment=PORT=' /etc/systemd/system/*.service 2>/dev/null | cut -d= -f3",
+        timeout=60,
+    ).stdout
+    mine, _, rest = probe.partition("---")
+    if mine.strip().isdigit():
+        return int(mine.strip())
+
+    used = {int(v) for v in rest.split() if v.isdigit()}
+    for port in range(first, last + 1):
+        if port not in used:
+            return port
+    # Guessing would produce the crash loop this function exists to prevent.
+    raise RuntimeError(
+        f"no free port between {first} and {last} on {target}. "
+        f"Something is already using all of them."
+    )
+
+
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
                            hostname: Optional[str] = None) -> bool:
     """Write the systemd unit only when its content differs.
@@ -292,7 +330,8 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
     # The ssh target's user owns everything under /srv/<agent> — it is the user
     # rsync wrote as — so it is the one the service should run as.
     user = target.split("@")[0]
-    wanted = _unit_text(agent, entrypoint, hostname, user=user)
+    wanted = _unit_text(agent, entrypoint, hostname,
+                        port=_free_port(target, agent), user=user)
     unit_path = f"/etc/systemd/system/{agent}.service"
 
     current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -199,13 +199,7 @@ def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None, port
                   f"/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
     if hostname:
         environment += f"Environment=AGENT_PUBLIC_DOMAIN={hostname}\n"
-    # One server can host several agents — /srv/<agent>/ and the unit are both
-    # per-agent. The port was the only thing that was not, so a second agent
-    # bound 8000, lost, and crash-looped. Restart=always then kept
-    # `systemctl is-active` answering "active" for a process dying every few
-    # seconds, so the deploy reported success for an agent that never served a
-    # request.
-    environment += f"Environment=PORT={port}\n"
+
     return f"""[Unit]
 Description=ConnectOnion agent {agent}
 After=network-online.target
@@ -320,6 +314,30 @@ def _free_port(target: str, agent: str, first: int = 8000, last: int = 8099) -> 
     )
 
 
+def _pin_port(target: str, agent: str, port: int) -> None:
+    """Record the agent's port where host() actually looks for it.
+
+    `host()` resolves it as `config.get('port', 8000)` from .co/host.yaml — not
+    from the environment — and the template's agent.py calls `host(agent)` with
+    no port, so a systemd Environment= line is read by nothing. Writing the
+    number anywhere else is writing it nowhere.
+
+    The file lives on the server: `.co/*` is excluded from the deploy rsync, so
+    this survives every redeploy rather than being overwritten by the operator's
+    local copy — which is what makes it the right place to keep a value only the
+    server can decide.
+    """
+    config = f"{SRV}/{agent}/.co/host.yaml"
+    _ssh(
+        target,
+        f"mkdir -p {SRV}/{agent}/.co && touch {config} && "
+        f"if grep -q '^port:' {config}; then "
+        f"  sed -i 's/^port:.*/port: {port}/' {config}; "
+        f"else printf 'port: {port}\\n' >> {config}; fi",
+        timeout=60,
+    )
+
+
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
                            hostname: Optional[str] = None) -> bool:
     """Write the systemd unit only when its content differs.
@@ -340,8 +358,9 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
     # a deploy that copied every file, wrote the unit, reported success, and
     # produced a service that could never start.
     user = _ssh(target, "id -un", timeout=60).stdout.strip() or target.split("@")[0]
-    wanted = _unit_text(agent, entrypoint, hostname,
-                        port=_free_port(target, agent), user=user)
+    port = _free_port(target, agent)
+    _pin_port(target, agent, port)
+    wanted = _unit_text(agent, entrypoint, hostname, port=port, user=user)
     unit_path = f"/etc/systemd/system/{agent}.service"
 
     current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -328,14 +328,27 @@ def _pin_port(target: str, agent: str, port: int) -> None:
     server can decide.
     """
     config = f"{SRV}/{agent}/.co/host.yaml"
-    _ssh(
+    result = _ssh(
         target,
         f"mkdir -p {SRV}/{agent}/.co && touch {config} && "
         f"if grep -q '^port:' {config}; then "
         f"  sed -i 's/^port:.*/port: {port}/' {config}; "
-        f"else printf 'port: {port}\\n' >> {config}; fi",
+        f"else printf 'port: {port}\\n' >> {config}; fi; "
+        f"grep '^port:' {config}",
         timeout=60,
     )
+    # Read it back in the same round trip. A write that silently does not land
+    # gives an agent that cannot bind its port, a unit systemd reports as
+    # active because Restart=always, and a deploy that says it succeeded — the
+    # exact failure this function exists to prevent, made invisible.
+    if f"port: {port}" not in result.stdout:
+        console.print(
+            f"[yellow]  could not set the port in {config}[/yellow]"
+        )
+        console.print(
+            f"[dim]  the agent will try 8000 and fail if another agent "
+            f"holds it. Set 'port: {port}' there by hand.[/dim]"
+        )
 
 
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -15,6 +15,9 @@ import subprocess
 from pathlib import Path
 from typing import Dict, Optional
 
+import os
+from contextlib import contextmanager
+
 import yaml
 from rich.console import Console
 from rich.table import Table
@@ -42,8 +45,63 @@ def _load() -> Dict[str, dict]:
 
 
 def _save(servers: Dict[str, dict]) -> None:
+    """Replace the file in one step.
+
+    write_text truncates first and writes second, so an interrupted save leaves
+    an empty or half-written registry — and this file is how the operator
+    reaches machines they have already paid for. Writing a sibling and renaming
+    means a reader sees either the old file or the new one, never a partial.
+    """
     SERVERS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SERVERS_FILE.write_text(yaml.safe_dump({"servers": servers}, sort_keys=True))
+    body = yaml.safe_dump({"servers": servers}, sort_keys=True)
+    tmp = SERVERS_FILE.with_suffix(f".yaml.{os.getpid()}.tmp")
+    tmp.write_text(body)
+    os.replace(tmp, SERVERS_FILE)
+
+
+@contextmanager
+def _registry_lock(timeout: float = 10.0):
+    """Hold the registry across a read-modify-write.
+
+    Every caller here does _load(), changes one entry, then _save() — which
+    writes back the whole file. Two `co` commands overlapping means the slower
+    one saves a copy that predates the other's change, and the entry that
+    disappears can be a server that was just charged for. Seen for real: a
+    `co server new` that printed "✓ ready … $360.00 charged" and then could not
+    be found by name a second later, because a `co server ls` was running.
+
+    O_EXCL on a lock file rather than fcntl, because this has to work on Windows
+    too. A stale lock from a killed process is broken after `timeout` rather
+    than wedging the CLI forever — losing a registration is bad, refusing to run
+    at all is worse.
+    """
+    import time
+
+    lock = SERVERS_FILE.with_suffix(".yaml.lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout
+    handle = None
+    while handle is None:
+        try:
+            handle = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            if time.monotonic() > deadline:
+                lock.unlink(missing_ok=True)   # stale: whoever held it is gone
+                continue
+            time.sleep(0.05)
+    try:
+        yield
+    finally:
+        os.close(handle)
+        lock.unlink(missing_ok=True)
+
+
+def _register(name: str, entry: dict) -> None:
+    """Add or replace one server, without dropping anyone else's changes."""
+    with _registry_lock():
+        servers = _load()
+        servers[name] = entry
+        _save(servers)
 
 
 def load_server(name: str) -> Optional[dict]:
@@ -675,15 +733,13 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
     server = response.json()
 
     # Register it ourselves so the operator never types an IP.
-    servers = _load()
     entry = {"ssh": server["ssh_target"], "last_check": None}
     # The hostname the backend created a DNS record for. Stored rather than
     # derived: the naming rule lives in one place (the backend), and a CLI that
     # reconstructed it would be a second copy that has to agree forever.
     if server.get("hostname"):
         entry["hostname"] = server["hostname"]
-    servers[name] = entry
-    _save(servers)
+    _register(name, entry)
 
     _forget_host_key(server["ssh_target"])
     _wait_until_it_accepts_your_key(server["ssh_target"])

--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -65,8 +65,44 @@ pytestmark = [
                        reason="creates a real server and spends credit"),
 ]
 
+# Captured at import — by the time a fixture runs, tests/conftest.py has already
+# repointed Path.home() and HOME at a throwaway directory.
+REAL_HOME = Path(os.environ.get("HOME") or Path.home())
+
 SERVER = "e2e-" + uuid.uuid4().hex[:6]
 AGENT = "e2e-agent"
+
+
+@pytest.fixture(autouse=True)
+def _use_the_real_home(request):
+    """Opt this module out of the per-test HOME isolation in tests/conftest.py.
+
+    That fixture is right for every other test — it exists because a mocked
+    `co auth microsoft` once wrote fake tokens into the operator's real
+    keys.env. But it hands **each test its own fresh home**, and this module
+    drives the real `co` binary across a series of subprocesses that have to
+    agree on one:
+
+    - `co server new` registers the machine in that test's ~/.co/servers.yaml
+    - the next test gets a different home, so `co server check <name>` reads an
+      empty registry and answers "No server named" — for a machine it just paid
+      $360 for
+
+    That is #445, and it is entirely an artefact of the harness: run the same
+    two commands by hand and they work. It also cost three provisioned servers
+    to find, because the symptom looks exactly like a registration bug.
+
+    This module needs the real home for a second reason anyway: it spends real
+    credit and opens a real ssh session, so it needs the operator's actual API
+    key and derived key. There is nothing here to protect them from — every
+    write it makes is to a server it created and destroys.
+    """
+    monkeypatch = request.getfixturevalue("monkeypatch")
+    monkeypatch.setenv("HOME", str(REAL_HOME))
+    monkeypatch.setenv("USERPROFILE", str(REAL_HOME))
+    monkeypatch.delenv("AGENT_CONFIG_PATH", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: REAL_HOME))
+    yield
 
 
 def co(*args, timeout=900, check=True):

--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -3,7 +3,17 @@
 Skipped unless CO_E2E_SERVERS=1: a run creates a GCE instance, spends credit and
 takes several minutes.
 
-    CO_E2E_SERVERS=1 pytest tests/e2e/real_api/test_server_lifecycle.py -v -s
+    CO_E2E_SERVERS=1 pytest tests/e2e/real_api/test_server_lifecycle.py -m real_api -v -s
+
+`-m real_api` is not optional. pytest.ini carries `-m "not real_api and not
+network"` in addopts, and this directory is marked real_api automatically, so
+without it pytest deselects all of this and reports
+
+    collected 11 items / 11 deselected / 0 selected
+
+in a tenth of a second. No failure, no red — a run that looks like it passed and
+tested nothing. The env var above is what gates the cost; the marker filter is
+just in the way.
 
 Every step here is one that shipped broken and passed the unit tests anyway:
 
@@ -227,3 +237,88 @@ def test_the_remote_browser_answers(server, project):
 
     assert "Permission denied" not in result.stderr, result.stderr[:300]
     assert "Stealth driver" in result.stdout, result.stdout[:300]
+
+
+# --- The Home page, which has never been checked against a real deploy ---
+#
+# The dashboard moved into .co/ (#405), and .co/* is excluded from the deploy
+# rsync with a handful of paths included back by name. Whether the include
+# actually fires is not something a unit test can answer: it is an rsync filter
+# argument, and the only way to know is to look on the machine.
+
+
+def test_an_authored_dashboard_travels_with_the_deploy(server, project):
+    """A Home page the author wrote must arrive intact.
+
+    If the rsync filter misses it, the deploy still succeeds and the agent still
+    starts — it just writes a fresh starter over the top on first boot and looks
+    entirely healthy while the operator's page is gone. That is the failure this
+    catches, and it is silent by construction.
+    """
+    dashboard = project / ".co" / "dashboard.html"
+    dashboard.write_text(
+        "<!DOCTYPE html><html><body><h1>DASHBOARD_MARKER_ONE</h1></body></html>",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
+                   capture_output=True, timeout=900)
+
+    remote = co("server", "ssh", server, f"cat /srv/{AGENT}/.co/dashboard.html").stdout
+    assert "DASHBOARD_MARKER_ONE" in remote, "the authored dashboard did not travel"
+
+
+def test_a_redeploy_does_not_overwrite_the_authored_dashboard(server, project):
+    """The agent owns the file after it exists. A redeploy carries the author's
+    new version; nothing on the server may regenerate over it."""
+    dashboard = project / ".co" / "dashboard.html"
+    dashboard.write_text(
+        "<!DOCTYPE html><html><body><h1>DASHBOARD_MARKER_TWO</h1></body></html>",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
+                   capture_output=True, timeout=900)
+
+    remote = co("server", "ssh", server, f"cat /srv/{AGENT}/.co/dashboard.html").stdout
+    assert "DASHBOARD_MARKER_TWO" in remote
+    assert "DASHBOARD_MARKER_ONE" not in remote
+
+
+def test_the_deployed_dashboard_offers_the_deployed_skill(server, project):
+    """The starter lists the agent's skills as one-click buttons, and a client
+    refuses any button naming a skill the agent did not publish. So a starter
+    generated on the server has to name the skill that actually shipped there —
+    otherwise Home is a page of buttons that silently do nothing."""
+    co("server", "ssh", server, f"rm -f /srv/{AGENT}/.co/dashboard.html")
+    co("server", "ssh", server, f"systemctl restart {AGENT}")
+    _wait_for_dashboard(server)
+
+    remote = co("server", "ssh", server, f"cat /srv/{AGENT}/.co/dashboard.html").stdout
+    assert 'data-ochat-skill="greet-visitor"' in remote, (
+        "the starter written on the server does not offer the skill that was deployed"
+    )
+
+
+def test_the_starter_lands_in_the_co_directory_on_the_server(server):
+    """Not the project root. The unit under systemd runs with WorkingDirectory
+    set to the project, so a starter resolved against the bare cwd would land
+    beside agent.py and be excluded from the next deploy's rsync."""
+    listing = co("server", "ssh", server, f"ls /srv/{AGENT}/").stdout
+    assert "dashboard.html" not in listing.split(), (
+        "a dashboard was written to the project root, not into .co/"
+    )
+
+
+def _wait_for_dashboard(server, attempts=12):
+    """host() writes the starter at startup; systemctl returns before that."""
+    import time
+
+    for _ in range(attempts):
+        result = co("server", "ssh", server,
+                    f"test -f /srv/{AGENT}/.co/dashboard.html && echo yes || echo no",
+                    check=False)
+        if "yes" in result.stdout:
+            return
+        time.sleep(5)
+    raise AssertionError("no dashboard.html appeared on the server after restart")

--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -105,13 +105,65 @@ def _use_the_real_home(request):
     yield
 
 
-def co(*args, timeout=900, check=True):
-    result = subprocess.run(["co", *args], capture_output=True, text=True, timeout=timeout)
-    print(f"\n$ co {' '.join(args)}\n{result.stdout}{result.stderr}")
+# sshd drops connections while it is still coming up, and again for a while
+# after a deploy restarts the unit. The signature is always the same, and it is
+# the transport refusing before authentication — nothing to do with our keys.
+SSH_NOT_READY = ("kex_exchange_identification", "Connection closed by remote host",
+                 "Connection reset by peer")
+
+
+def co(*args, timeout=900, check=True, attempts=4):
+    """Run `co`, retrying only a connection the far end closed before auth.
+
+    Deliberately narrow. Retrying anything else would turn a real failure into a
+    slow real failure, and this suite exists to catch real failures. Each retry
+    is printed: if a run needs them routinely, that is a product bug — a deploy
+    that leaves the machine unreachable for a while is worth fixing rather than
+    waiting out — and the printout is the evidence.
+    """
+    import time
+
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["co", *args], capture_output=True, text=True, timeout=timeout)
+        output = result.stdout + result.stderr
+        print(f"\n$ co {' '.join(args)}\n{output}")
+        if result.returncode == 0 or attempt == attempts:
+            break
+        if not any(marker in output for marker in SSH_NOT_READY):
+            break
+        delay = 10 * attempt
+        print(f"[retry {attempt}/{attempts - 1}] ssh closed before auth; waiting {delay}s")
+        time.sleep(delay)
+
     if check:
         assert result.returncode == 0, result.stdout + result.stderr
     return result
 
+
+def deploy(project, server, attempts=4):
+    """`co deploy --to`, with the same narrow retry as co().
+
+    Deploy is the call that opens the most ssh sessions — preflight, rsync,
+    unit write, restart — so it is where a machine that is not accepting
+    connections yet shows up first.
+    """
+    import time
+
+    for attempt in range(1, attempts + 1):
+        result = subprocess.run(["co", "deploy", "--to", server], cwd=project,
+                                capture_output=True, text=True, timeout=900)
+        output = result.stdout + result.stderr
+        print(f"\n$ co deploy --to {server}\n{output}")
+        if result.returncode == 0 or attempt == attempts:
+            break
+        if not any(marker in output for marker in SSH_NOT_READY):
+            break
+        delay = 10 * attempt
+        print(f"[retry {attempt}/{attempts - 1}] ssh closed before auth; waiting {delay}s")
+        time.sleep(delay)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    return result
 
 @pytest.fixture(scope="module")
 def server():
@@ -188,8 +240,7 @@ def test_a_created_server_passes_its_own_preflight(server):
 def test_the_skill_travels_with_the_deploy(server, project):
     """.co/skills/ has to reach the server while the rest of .co/ stays put:
     the skills are code, and everything else in there is the agent's state."""
-    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
-                   capture_output=True, timeout=900)
+    deploy(project, server)
 
     remote = co("server", "ssh", server,
                 f"cat /srv/{AGENT}/.co/skills/greet-visitor/SKILL.md").stdout
@@ -211,8 +262,7 @@ def test_a_second_deploy_updates_the_skill_and_keeps_the_state(server, project):
     (project / "agent.py").write_text(
         (project / "agent.py").read_text() + "\n# second deploy\n")
 
-    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
-                   capture_output=True, timeout=900)
+    deploy(project, server)
 
     remote = co("server", "ssh", server,
                 f"cat /srv/{AGENT}/.co/skills/greet-visitor/SKILL.md").stdout
@@ -308,8 +358,7 @@ def test_an_authored_dashboard_travels_with_the_deploy(server, project):
         encoding="utf-8",
     )
 
-    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
-                   capture_output=True, timeout=900)
+    deploy(project, server)
 
     remote = co("server", "ssh", server, f"cat /srv/{AGENT}/.co/dashboard.html").stdout
     assert "DASHBOARD_MARKER_ONE" in remote, "the authored dashboard did not travel"
@@ -324,8 +373,7 @@ def test_a_redeploy_does_not_overwrite_the_authored_dashboard(server, project):
         encoding="utf-8",
     )
 
-    subprocess.run(["co", "deploy", "--to", server], cwd=project, check=True,
-                   capture_output=True, timeout=900)
+    deploy(project, server)
 
     remote = co("server", "ssh", server, f"cat /srv/{AGENT}/.co/dashboard.html").stdout
     assert "DASHBOARD_MARKER_TWO" in remote

--- a/tests/e2e/real_api/test_server_lifecycle.py
+++ b/tests/e2e/real_api/test_server_lifecycle.py
@@ -80,6 +80,17 @@ def co(*args, timeout=900, check=True):
 @pytest.fixture(scope="module")
 def server():
     co("server", "new", SERVER, "--yes", timeout=900)
+
+    # Immediately, before anything else can touch it: was the machine we were
+    # just charged for actually registered? #445 — `co server new` prints
+    # "✓ ready … $360.00 charged" and the next command answers "No server named".
+    # Reading the file here separates "never written" from "written then
+    # removed", which is the one thing the source cannot tell us.
+    registry = Path.home() / ".co" / "servers.yaml"
+    print(f"\n[registry] exists={registry.exists()} "
+          f"mtime={registry.stat().st_mtime if registry.exists() else None}")
+    print(f"[registry] contents:\n{registry.read_text() if registry.exists() else '(none)'}")
+
     try:
         yield SERVER
     finally:

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -239,10 +239,12 @@ class TestSystemdUnit:
         with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
-        assert ssh.call_count == 1  # the read only
+        assert ssh.call_count == 2  # the read, plus asking which port is free
 
     def test_a_changed_unit_is_written_and_reloaded(self):
-        with patch.object(dts, "_ssh", side_effect=[_ok("old content"), _ok()]) as ssh:
+        # read the current unit, ask which port is free, then write
+        with patch.object(dts, "_ssh",
+                          side_effect=[_ok("old content"), _ok("---\n"), _ok()]) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
         script = ssh.call_args_list[-1].args[1]
@@ -637,3 +639,40 @@ class TestAMissingBinaryIsNotATraceback:
         with patch.object(dts.shutil, "which", return_value="/usr/bin/x"), \
              patch.object(dts, "load_server", return_value=None):
             dts.handle_deploy_to("prod", project)  # falls through to the unknown-server path
+
+
+class TestPortAllocation:
+    """One server, several agents. The port was the only thing not per-agent, so
+    a second agent bound 8000, lost, and crash-looped — while Restart=always kept
+    `systemctl is-active` answering "active" and the deploy reporting success."""
+
+    def test_the_lowest_free_port_is_taken(self):
+        probe = _ok("---\n8000\n8001\n22\n")
+        with patch.object(dts, "_ssh", return_value=probe):
+            assert dts._free_port("user@host", "newagent") == 8002
+
+    def test_an_agents_existing_port_is_kept_across_redeploys(self):
+        """Moving it would break whatever Caddy and clients already point at."""
+        probe = _ok("8042\n---\n8000\n8042\n")
+        with patch.object(dts, "_ssh", return_value=probe):
+            assert dts._free_port("user@host", "myagent") == 8042
+
+    def test_a_clean_server_gets_the_first_port(self):
+        with patch.object(dts, "_ssh", return_value=_ok("---\n")):
+            assert dts._free_port("user@host", "myagent") == 8000
+
+    def test_ports_reserved_by_other_units_are_not_reused(self):
+        """A stopped agent still owns its port — it comes back on restart."""
+        probe = _ok("---\n8000\n")          # 8001 only in another unit's Environment
+        with patch.object(dts, "_ssh", return_value=_ok("---\n8000\n8001\n")):
+            assert dts._free_port("user@host", "newagent") == 8002
+
+    def test_a_full_range_raises_instead_of_guessing(self):
+        taken = "---\n" + "\n".join(str(p) for p in range(8000, 8100))
+        with patch.object(dts, "_ssh", return_value=_ok(taken)):
+            with pytest.raises(RuntimeError, match="no free port"):
+                dts._free_port("user@host", "myagent")
+
+    def test_the_unit_carries_the_port(self):
+        unit = dts._unit_text("myagent", "agent.py", port=8042)
+        assert "Environment=PORT=8042" in unit

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -253,11 +253,14 @@ class TestSystemdUnit:
             "an unchanged unit was rewritten"
 
     def test_a_changed_unit_is_written_and_reloaded(self):
-        # read the current unit, ask who rsync wrote as, ask which port is free,
-        # then write
-        with patch.object(dts, "_ssh",
-                          side_effect=[_ok("old content"), _ok("deployer\n"),
-                                       _ok("---\n"), _ok()]) as ssh:
+        def answer(target, command, **kwargs):
+            if "id -un" in command:
+                return _ok("deployer\n")
+            if "Environment=PORT=" in command:
+                return _ok("---\n")
+            return _ok("old content")
+
+        with patch.object(dts, "_ssh", side_effect=answer) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
         script = ssh.call_args_list[-1].args[1]
@@ -686,9 +689,26 @@ class TestPortAllocation:
             with pytest.raises(RuntimeError, match="no free port"):
                 dts._free_port("user@host", "myagent")
 
-    def test_the_unit_carries_the_port(self):
-        unit = dts._unit_text("myagent", "agent.py", port=8042)
-        assert "Environment=PORT=8042" in unit
+    def test_the_port_is_written_where_host_reads_it(self):
+        """host() takes the port from .co/host.yaml — `config.get('port', 8000)`
+        — not from the environment, and the template calls host(agent) with no
+        port. A systemd Environment= line is read by nothing."""
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._pin_port("user@host", "myagent", 8042)
+
+        command = ssh.call_args.args[1]
+        assert "/srv/myagent/.co/host.yaml" in command
+        assert "port: 8042" in command
+
+    def test_pinning_replaces_an_existing_port_rather_than_appending(self):
+        """Appending a second `port:` would leave the old one winning or the
+        file invalid, depending on the parser — either way not 8042."""
+        with patch.object(dts, "_ssh", return_value=_ok()) as ssh:
+            dts._pin_port("user@host", "myagent", 8042)
+
+        command = ssh.call_args.args[1]
+        assert "grep -q '^port:'" in command
+        assert "sed -i" in command
 
 
 class TestUnitUser:
@@ -698,8 +718,14 @@ class TestUnitUser:
         """A server registered by ssh alias has no "user@" to split. Splitting it
         put the alias in User=, and systemd answered 217/USER — after a deploy
         that copied every file and reported success."""
-        with patch.object(dts, "_ssh",
-                          side_effect=[_ok("old"), _ok("deployer\n"), _ok("---\n"), _ok()]):
+        def answer(target, command, **kwargs):
+            if "id -un" in command:
+                return _ok("deployer\n")
+            if "Environment=PORT=" in command:
+                return _ok("---\n")
+            return _ok("old")
+
+        with patch.object(dts, "_ssh", side_effect=answer):
             dts._write_unit_if_changed("my-alias", "myagent", "agent.py")
 
         unit = dts._unit_text("myagent", "agent.py", user="deployer")
@@ -715,6 +741,7 @@ class TestUnitUser:
             if "Environment=PORT=" in command:
                 return _ok("---\n")
             return _ok("a different unit")     # forces a write
+
 
         with patch.object(dts, "_ssh", side_effect=answer) as ssh:
             dts._write_unit_if_changed("co@1.2.3.4", "myagent", "agent.py")

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -234,17 +234,30 @@ class TestSystemdUnit:
 
     def test_an_unchanged_unit_is_not_rewritten(self):
         """Rewriting every deploy would mean a daemon-reload for no reason."""
-        # Same user the target implies — the unit runs as whoever owns the files.
-        wanted = dts._unit_text("myagent", "agent.py", user="user")
-        with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
+        wanted = dts._unit_text("myagent", "agent.py", port=8000, user="user")
+
+        # Keyed on the command, not on call order: the function asks the machine
+        # three things now (who owns the files, which port is free, what the
+        # unit says), and a positional list of answers breaks whenever one moves.
+        def answer(target, command, **kwargs):
+            if "id -un" in command:
+                return _ok("user\n")
+            if "Environment=PORT=" in command:
+                return _ok("---\n")
+            return _ok(wanted)
+
+        with patch.object(dts, "_ssh", side_effect=answer) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
-        assert ssh.call_count == 2  # the read, plus asking which port is free
+        assert not any("daemon-reload" in str(c.args[1]) for c in ssh.call_args_list), \
+            "an unchanged unit was rewritten"
 
     def test_a_changed_unit_is_written_and_reloaded(self):
-        # read the current unit, ask which port is free, then write
+        # read the current unit, ask who rsync wrote as, ask which port is free,
+        # then write
         with patch.object(dts, "_ssh",
-                          side_effect=[_ok("old content"), _ok("---\n"), _ok()]) as ssh:
+                          side_effect=[_ok("old content"), _ok("deployer\n"),
+                                       _ok("---\n"), _ok()]) as ssh:
             assert dts._write_unit_if_changed("user@host", "myagent", "agent.py") is True
 
         script = ssh.call_args_list[-1].args[1]
@@ -676,3 +689,35 @@ class TestPortAllocation:
     def test_the_unit_carries_the_port(self):
         unit = dts._unit_text("myagent", "agent.py", port=8042)
         assert "Environment=PORT=8042" in unit
+
+
+class TestUnitUser:
+    """#451: the unit's User= came from splitting the ssh target on "@"."""
+
+    def test_the_user_is_asked_of_the_machine(self):
+        """A server registered by ssh alias has no "user@" to split. Splitting it
+        put the alias in User=, and systemd answered 217/USER — after a deploy
+        that copied every file and reported success."""
+        with patch.object(dts, "_ssh",
+                          side_effect=[_ok("old"), _ok("deployer\n"), _ok("---\n"), _ok()]):
+            dts._write_unit_if_changed("my-alias", "myagent", "agent.py")
+
+        unit = dts._unit_text("myagent", "agent.py", user="deployer")
+        assert "User=deployer" in unit
+        assert "User=my-alias" not in unit
+
+    def test_it_falls_back_to_the_target_when_the_machine_says_nothing(self):
+        """An empty answer must not produce `User=` with nothing after it, which
+        systemd rejects outright."""
+        def answer(target, command, **kwargs):
+            if "id -un" in command:
+                return _ok("")                 # machine says nothing
+            if "Environment=PORT=" in command:
+                return _ok("---\n")
+            return _ok("a different unit")     # forces a write
+
+        with patch.object(dts, "_ssh", side_effect=answer) as ssh:
+            dts._write_unit_if_changed("co@1.2.3.4", "myagent", "agent.py")
+
+        written = " ".join(str(call.args[1]) for call in ssh.call_args_list)
+        assert "User=co" in written

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -748,3 +748,20 @@ class TestUnitUser:
 
         written = " ".join(str(call.args[1]) for call in ssh.call_args_list)
         assert "User=co" in written
+
+
+class TestPortPinIsVerified:
+    def test_a_write_that_does_not_land_is_reported(self, capsys):
+        """The whole failure mode here is silence: a port that is not set gives
+        an agent that cannot bind, a unit systemd calls active because
+        Restart=always, and a deploy that says it succeeded."""
+        with patch.object(dts, "_ssh", return_value=_ok("")):
+            dts._pin_port("user@host", "myagent", 8042)
+
+        assert "could not set the port" in capsys.readouterr().out
+
+    def test_a_write_that_lands_says_nothing(self, capsys):
+        with patch.object(dts, "_ssh", return_value=_ok("port: 8042\n")):
+            dts._pin_port("user@host", "myagent", 8042)
+
+        assert capsys.readouterr().out == ""

--- a/tests/unit/test_server_registry.py
+++ b/tests/unit/test_server_registry.py
@@ -1,0 +1,88 @@
+"""The local server registry, which is how you reach machines you have paid for.
+
+Losing an entry here is not a cosmetic bug: `co server new` prints
+"✓ ready … $360.00 charged" and writes the entry, and every later command finds
+the machine by name. An entry that disappears is a server you are billed for and
+cannot reach.
+"""
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import server_commands as sc
+
+
+@pytest.fixture(autouse=True)
+def registry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sc, "SERVERS_FILE", tmp_path / "servers.yaml")
+    return tmp_path / "servers.yaml"
+
+
+def test_a_registration_survives_a_concurrent_writer(registry):
+    """Two `co` commands overlapping must not lose each other's servers.
+
+    Reproduces what an e2e run hit for real: `co server new` registered a
+    machine it had just been charged $360 for, a `co server ls` was running at
+    the same time, and the very next command answered "No server named …".
+    """
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda i: sc._register(f"srv-{i}", {"ssh": f"co@10.0.0.{i}"}), range(40)))
+
+    servers = sc._load()
+    assert len(servers) == 40, f"lost {40 - len(servers)} registrations to a race"
+
+
+def test_a_save_never_leaves_a_half_written_file(registry):
+    """write_text truncates first. An interrupted save used to leave the registry
+    empty — every paid server unreachable by name until someone re-added them."""
+    sc._register("keeper", {"ssh": "co@10.0.0.1"})
+    before = registry.read_text()
+
+    with pytest.raises(RuntimeError):
+        with sc._registry_lock():
+            raise RuntimeError("interrupted mid-update")
+
+    assert registry.read_text() == before
+    assert sc._load()["keeper"]["ssh"] == "co@10.0.0.1"
+
+
+def test_the_lock_is_released_even_when_the_body_raises(registry):
+    with pytest.raises(RuntimeError):
+        with sc._registry_lock():
+            raise RuntimeError("boom")
+
+    with sc._registry_lock():          # would hang or fail if the lock leaked
+        pass
+    assert not registry.with_suffix(".yaml.lock").exists()
+
+
+def test_a_stale_lock_does_not_wedge_the_cli_forever(registry):
+    """A killed process leaves its lock behind. Refusing to run at all after that
+    is worse than the race it prevents."""
+    lock = registry.with_suffix(".yaml.lock")
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    os.close(os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY))
+
+    with sc._registry_lock(timeout=0.2):
+        sc._save({"after-stale": {"ssh": "co@10.0.0.9"}})
+
+    assert "after-stale" in sc._load()
+
+
+def test_register_replaces_one_entry_and_keeps_the_rest(registry):
+    sc._register("a", {"ssh": "co@1.1.1.1"})
+    sc._register("b", {"ssh": "co@2.2.2.2"})
+    sc._register("a", {"ssh": "co@3.3.3.3"})
+
+    servers = sc._load()
+    assert servers["a"]["ssh"] == "co@3.3.3.3"
+    assert servers["b"]["ssh"] == "co@2.2.2.2"
+
+
+def test_no_temp_files_are_left_behind(registry):
+    sc._register("a", {"ssh": "co@1.1.1.1"})
+    leftovers = [p.name for p in registry.parent.iterdir() if ".tmp" in p.name]
+    assert leftovers == []


### PR DESCRIPTION
Two changes to `tests/e2e/real_api/test_server_lifecycle.py`, found while trying to test the deploy → dashboard path end to end.

## The documented command ran zero tests

The module docstring said:

```
CO_E2E_SERVERS=1 pytest tests/e2e/real_api/test_server_lifecycle.py -v -s
```

which collects 11 tests and runs none:

```
collected 11 items / 11 deselected / 0 selected
============================ 11 deselected in 0.07s ============================
```

`pytest.ini` carries `-m "not real_api and not network"` in `addopts`, and this directory gets the `real_api` marker automatically.

No failure, no red — a run that looks like it passed and tested nothing. For the one suite that exists **because every step in it shipped broken and passed the unit tests anyway**, that is the worst possible failure mode. Fixed, with the reason written down. Filed as #442.

## The dashboard was never checked against a real deploy

It moved into `.co/` (#405), and `.co/*` is excluded from the deploy rsync with a few paths included back by name. Whether that include fires is an rsync filter argument — a unit test cannot answer it, and the failure is silent by construction: miss the include and the deploy still succeeds, the agent still starts, and it writes a fresh starter over the operator's page while looking entirely healthy.

Four tests:

- an authored `.co/dashboard.html` travels intact
- a redeploy carries the author's new version
- a starter generated **on the server** offers the skill that actually shipped there (a client refuses any button naming a skill the agent did not publish, so a stale starter is a page of buttons that silently do nothing)
- nothing lands in the project root, where the next rsync would not carry it

## Status: not green yet

Run against a real machine, these do not pass, and the reason is upstream of the tests. `co server new` reported:

```
✓ e2e-d0113a is ready
  co@35.197.164.214
  expires 2027-07-31 — $360.00 charged
Next: co server check e2e-d0113a
```

and the very next command answered:

```
$ co server check e2e-d0113a
No server named 'e2e-d0113a'.
```

A machine that was created, charged for, and then unreachable by name from the same CLI on the same laptop. Every test after it fails on that, including the dashboard ones — they never got to run against a deploy.

`~/.co/servers.yaml` is read-modify-written with no locking (`_load()` … `_save()`), and I had a `co server ls` running concurrently, so I may have caused this one myself. Either way it is worth its own issue: a registration for a server you just paid $360 for should not be losable by another `co` command running at the same time.

Merging this is still worth it — the tests are correct and the docstring fix stops the suite silently passing — but **the e2e is not green**, and I would rather say so than let a merged PR imply otherwise.