### PR TITLE
fix(co-ai): an agent is named by its project, not by its template

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -66,6 +66,30 @@ PROMPTS_DIR = Path(__file__).parent / "prompts"
 GLOBAL_CO_DIR = Path.home() / ".co"
 
 
+def agent_name(co_dir: Path = Path(".co")) -> str:
+    """What this agent is called, according to its own host.yaml.
+
+    co-ai is the only template, so a hardcoded name meant every agent anyone
+    deployed announced itself identically. The author already wrote the name
+    they chose, in `.co/host.yaml`, in a field called `name` — it just was not
+    being read.
+
+    Falls back to "oo" when there is no host.yaml, no `name` in it, or it does
+    not parse. A name is not worth failing a startup over; a broken host.yaml
+    is reported for what it is elsewhere.
+    """
+    host_yaml = co_dir / "host.yaml"
+    if not host_yaml.exists():
+        return "oo"
+    try:
+        import yaml
+        config = yaml.safe_load(host_yaml.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return "oo"
+    name = config.get("name") if isinstance(config, dict) else None
+    return name if isinstance(name, str) and name.strip() else "oo"
+
+
 def create_agent(
     model: str = "co/gemini-3.6-flash",
     max_iterations: int = 100,
@@ -128,7 +152,7 @@ def create_agent(
     ]
 
     agent = Agent(
-        name="oo",
+        name=agent_name(co_dir),
         tools=tools,
         plugins=plugins,
         on_events=[],

--- a/tests/unit/test_co_ai_agent_name.py
+++ b/tests/unit/test_co_ai_agent_name.py
@@ -1,0 +1,53 @@
+"""An agent is named by the project it is, not by the template it came from.
+
+`create_agent()` hardcoded name="oo", so every agent built from the co-ai
+template — which is the only template — announced itself as "oo". The author's
+own .co/host.yaml says what they called it, in a field named `name`, and it
+never reached the network. Three agents in one client list, all "oo".
+"""
+
+import textwrap
+
+import pytest
+
+from connectonion.cli.co_ai import agent as co_ai
+
+
+def co_dir_with(tmp_path, host_yaml: str = None):
+    d = tmp_path / ".co"
+    d.mkdir()
+    if host_yaml is not None:
+        (d / "host.yaml").write_text(textwrap.dedent(host_yaml), encoding="utf-8")
+    return d
+
+
+def test_the_name_in_host_yaml_is_the_agent_s_name(tmp_path):
+    co_dir = co_dir_with(tmp_path, """
+        name: billing
+        entrypoint: agent.py
+    """)
+
+    assert co_ai.agent_name(co_dir) == "billing"
+
+
+def test_without_host_yaml_it_falls_back(tmp_path):
+    co_dir = co_dir_with(tmp_path, host_yaml=None)
+
+    assert co_ai.agent_name(co_dir) == "oo"
+
+
+def test_a_host_yaml_without_a_name_falls_back(tmp_path):
+    co_dir = co_dir_with(tmp_path, """
+        entrypoint: agent.py
+        port: 8000
+    """)
+
+    assert co_ai.agent_name(co_dir) == "oo"
+
+
+def test_malformed_host_yaml_does_not_take_the_agent_down(tmp_path):
+    # The agent's name is not worth crashing over — a broken host.yaml is
+    # reported elsewhere (#381/#422), and here it just means "no name given".
+    co_dir = co_dir_with(tmp_path, "name: [unclosed\n")
+
+    assert co_ai.agent_name(co_dir) == "oo"


### PR DESCRIPTION
Closes #436.

Found while deploying to a fresh server: `/info` on the deployed agent returned

```json
{"name": "oo", …}
```

for a project whose `.co/host.yaml` starts with `name: naturewill`.

## Cause

`cli/co_ai/agent.py`:

```python
agent = Agent(
    name="oo",
```

Hardcoded, and co-ai is the only template — so this is every agent, everywhere. In the client's list ours sat next to two others, all three called `oo`.

## Change

`agent_name(co_dir)` reads `.co/host.yaml`. The function already receives `co_dir`, so nothing new has to be threaded through.

Falls back to `"oo"` when there is no host.yaml, no `name` in it, or it does not parse. A name is not worth failing a startup over, and a malformed policy/config is reported properly elsewhere (#381 / #422) rather than surfacing here as a crash.

## Tests

`tests/unit/test_co_ai_agent_name.py` — four cases, all failing before this change: the name is used, and each of the three fallback paths.

463 existing co_ai/agent/host tests pass.