### PR TITLE
fix(server): co server new declines instead of crashing without a terminal

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Optional
@@ -599,6 +600,19 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
     console.print(f"  [cyan]expires[/cyan]       {expires} "
                   f"[dim]— the server stops on that date unless renewed[/dim]")
     console.print()
+
+    # Nothing can be answered on a stdin that is not a terminal, and the prompt
+    # library does not decline politely — it registers the descriptor with
+    # asyncio and raises OSError: [Errno 22]. On the one command that spends
+    # money, a bare traceback also leaves the reader unable to tell whether the
+    # charge went through.
+    if not sys.stdin.isatty():
+        console.print(
+            f"[red]Cannot confirm: stdin is not a terminal.[/red]\n"
+            f"  ${price:.2f} would be charged now. "
+            f"Re-run with [bold]--yes[/bold] to confirm without being asked."
+        )
+        return False
 
     import questionary
     return bool(questionary.confirm("Create it?", default=False).ask())

--- a/tests/unit/test_server_new_without_a_terminal.py
+++ b/tests/unit/test_server_new_without_a_terminal.py
@@ -1,0 +1,57 @@
+"""The one command that spends money must not die on a traceback.
+
+`co server new` charges twelve months up front. Asked to confirm on a stdin
+that cannot be polled — CI, a script, an agent driving the CLI — prompt_toolkit
+registered the file descriptor with asyncio and raised
+
+    OSError: [Errno 22] Invalid argument
+
+as a bare traceback, saying nothing about whether anything had been charged.
+"""
+
+import sys
+from unittest.mock import patch
+
+from connectonion.cli.commands import server_commands as sc
+
+
+PRICING = {
+    "region": "australia-southeast1",
+    "term_months": 12,
+    "machine_types": {
+        "e2-small": {
+            "usd_12mo": 360.0,
+            "usd_month": 30.0,
+            "description": "2 vCPU (shared), 2 GB",
+        }
+    },
+}
+
+
+def confirm_without_a_tty(capsys):
+    with patch.object(sys.stdin, "isatty", return_value=False):
+        with patch("questionary.confirm") as prompt:
+            answer = sc._confirm("my-box", "e2-small", PRICING, balance=1000.0)
+    return answer, prompt, capsys.readouterr().out
+
+
+def test_it_declines_instead_of_crashing(capsys):
+    answer, _, _ = confirm_without_a_tty(capsys)
+
+    assert answer is False, "a spend must not be approved by a prompt nobody answered"
+
+
+def test_it_never_reaches_the_prompt(capsys):
+    _, prompt, _ = confirm_without_a_tty(capsys)
+
+    assert not prompt.called, (
+        "questionary was called on a stdin that cannot be polled — "
+        "that is the OSError"
+    )
+
+
+def test_it_says_what_to_do_and_what_it_costs(capsys):
+    _, _, out = confirm_without_a_tty(capsys)
+
+    assert "--yes" in out, "the way to proceed is not named"
+    assert "360" in out, "the amount at stake is not repeated in the error"


### PR DESCRIPTION
Closes #437.

```
$ co server new my-box < /dev/null
╭─ Traceback ─╮
│ asyncio/selector_events.py:258 in _add_reader │
╰─────────────╯
OSError: [Errno 22] Invalid argument
```

`questionary` registers stdin with the asyncio selector; a descriptor that cannot be polled raises before anything is printed about what went wrong.

## Why this one matters more than a rough edge

`co server new` charges twelve months up front. A bare traceback on a spend command leaves the reader unable to tell whether the charge went through — reading the source shows it happens after confirmation, but nothing in the output says so, and that is not a thing to have to guess.

It also stops the command being callable at all from CI, a provisioning script, or an agent driving the CLI — not even to be told it needs `--yes`.

## Change

Check `sys.stdin.isatty()` before prompting, and say the two things that matter:

```
Cannot confirm: stdin is not a terminal.
  $360.00 would be charged now. Re-run with --yes to confirm without being asked.
Nothing was created or charged.
```

The last line was already there — it just never got reached.

## Tests

`tests/unit/test_server_new_without_a_terminal.py` — three cases, all failing before: it declines rather than crashing, `questionary` is never reached (that call *is* the OSError), and the message names both `--yes` and the amount.

Verified against the real pricing endpoint with stdin closed: exit code 1, no traceback. 159 existing server/deploy tests pass.