### PR TITLE
A deployed agent's identity is derived, not minted on the machine

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -22,7 +22,7 @@ import yaml
 from dotenv import dotenv_values
 from rich.console import Console
 
-from .server_commands import SSH_TIMEOUT_SECONDS, load_server
+from .server_commands import SSH_TIMEOUT_SECONDS, derived_agent_identity, load_server
 
 console = Console()
 
@@ -222,7 +222,8 @@ WantedBy=multi-user.target
 
 def _ensure_setup(target: str, agent: str, entrypoint: str, schema: int,
                   ssh_public_line: Optional[str],
-                  deployer_address: Optional[str] = None) -> bool:
+                  deployer_address: Optional[str] = None,
+                  agent_identity: Optional[dict] = None) -> bool:
     """Bring the server to the state a deploy assumes. Idempotent.
 
     Runs on every deploy, and is a no-op once the schema matches — which is why
@@ -267,6 +268,25 @@ grep -qxF {quoted} ~/.ssh/authorized_keys || echo {quoted} >> ~/.ssh/authorized_
         steps.append(f"""
 touch {admins}
 grep -qxF {quoted_admin} {admins} || echo {quoted_admin} >> {admins}
+""")
+
+    if agent_identity:
+        # The identity the operator's phrase says this agent has. Written only
+        # when the server has none: an agent that was given its own key — by
+        # `--own-identity`, or by an older deploy that let it mint one — keeps
+        # it, because overwriting an identity is not a thing a deploy may do.
+        #
+        # `keys/` sits under `.co/`, which the rsync excludes, so it travels
+        # over ssh like admins.txt rather than in the tarball.
+        key_b64 = base64.b64encode(agent_identity["key_bytes"]).decode()
+        keys_dir = f"{SRV}/{agent}/.co/keys"
+        steps.append(f"""
+mkdir -p {keys_dir}
+if [ ! -f {keys_dir}/agent.key ]; then
+  umask 077
+  echo {shlex.quote(key_b64)} | base64 -d > {keys_dir}/agent.key
+  chmod 600 {keys_dir}/agent.key
+fi
 """)
 
     if not steps:
@@ -662,7 +682,8 @@ def _mark_provisioned(target: str, agent: str) -> None:
          timeout=60)
 
 
-def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
+def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
+                     own_identity: bool = False) -> bool:
     """co deploy --to <server>:  ensure(setup) → sync code → restart."""
     project_dir = (project_dir or Path.cwd()).resolve()
 
@@ -710,8 +731,18 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None) -> bool:
     ssh_public_line = _ensure_ssh_key()
     deployer_address = _deployer_address()
 
+    # An agent that will be handed to a customer must have an identity its author
+    # cannot derive — otherwise the author holds the customer's private key,
+    # whatever they intend. `--own-identity` means "mint it on the machine, and
+    # I accept that only this machine can ever be it."
+    agent_identity = None if own_identity else derived_agent_identity(agent)
+    if agent_identity:
+        console.print(f"  [dim]identity {agent_identity['address'][:16]}… "
+                      f"(derived from your recovery phrase)[/dim]")
+
     if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0),
-                         ssh_public_line, deployer_address):
+                         ssh_public_line, deployer_address,
+                         agent_identity=agent_identity):
         return False
     if not _sync_code(target, agent, project_dir):
         return False

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -604,6 +604,42 @@ def _wait_until_it_accepts_your_key(ssh_target: str) -> bool:
     return False
 
 
+def derived_agent_identity(name: str) -> Optional[dict]:
+    """The identity `name` will have, derived from the operator's phrase.
+
+    The same name always returns the same key, so an agent's address can be
+    printed before it is deployed and recomputed after its machine is gone —
+    which is the whole of #396. Letting the server mint one on first boot gives
+    an address nobody can know in advance and nobody can recover once the disk
+    is gone: #306's failure mode moved up a level, from "changes every deploy"
+    to "changes every machine", which is rarer and therefore worse.
+
+    Derived from ~/.co rather than from the project, for the same reason the SSH
+    key is: a server belongs to the operator, as does the account charged for it.
+    """
+    from mnemonic import Mnemonic
+    from nacl.signing import SigningKey
+
+    from ... import address as address_mod
+    from ...derive import derive_path, identity_uri, slip13_path
+    from .keys_commands import _find_co_dir
+
+    for co_dir in (Path.home() / ".co", _find_co_dir()):
+        if not co_dir or not co_dir.exists():
+            continue
+        data = address_mod.load(co_dir)
+        if not (data and data.get("seed_phrase")):
+            continue
+
+        seed = Mnemonic("english").to_seed(data["seed_phrase"])
+        signing_key = SigningKey(derive_path(seed, slip13_path(identity_uri(name))))
+        return {
+            "address": "0x" + bytes(signing_key.verify_key).hex(),
+            "key_bytes": bytes(signing_key),
+        }
+    return None
+
+
 def handle_server_new(name: str, machine_type: Optional[str] = None,
                       yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -138,6 +138,7 @@ def deploy(
     skills: Optional[List[str]] = typer.Option(None, "--skills", help="Skill directory (contains SKILL.md) or directory of skills to bundle into .co/skills/ (repeatable: --skills a --skills b)"),
     name: Optional[str] = typer.Option(None, "--name", help="Project name for template deploys (default: {template}-agent)"),
     to: Optional[str] = typer.Option(None, "--to", help="Deploy onto a server you own (see: co server ls)"),
+    own_identity: bool = typer.Option(False, "--own-identity", help="With --to, let the agent mint its own identity instead of deriving it from your recovery phrase — for an agent you are handing to someone else"),
 ):
     """Deploy to ConnectOnion Cloud, or with --to onto a server you own."""
     if to:
@@ -148,9 +149,14 @@ def deploy(
             console.print("[dim]Those belong to the cloud deploy. --to syncs the project you are in.[/dim]")
             raise typer.Exit(2)
         from .commands.deploy_to_server import handle_deploy_to
-        if not handle_deploy_to(server=to):
+        if not handle_deploy_to(server=to, own_identity=own_identity):
             raise typer.Exit(1)
         return
+
+    if own_identity:
+        console.print("[red]--own-identity only applies with --to.[/red]")
+        console.print("[dim]A Cloud deploy does not carry an identity you derived.[/dim]")
+        raise typer.Exit(2)
 
     from .commands.deploy_commands import handle_deploy
     handle_deploy(template=template, skills=skills, name=name)
@@ -173,10 +179,23 @@ def auth(service: Optional[str] = typer.Argument(None, help="Service: google, mi
 @app.command()
 def keys(
     reveal: bool = typer.Option(False, "--reveal", "-r", help="Show full key values"),
+    agent: Optional[str] = typer.Option(None, "--agent", help="Print the address an agent of this name will have, before it is deployed"),
     ssh: bool = typer.Option(False, "--ssh", help="Print the SSH public key derived from your recovery phrase"),
     write: bool = typer.Option(False, "--write", help="With --ssh, also write the private half to ~/.ssh/"),
 ):
     """Show agent keys and credentials."""
+    if agent:
+        from .commands.server_commands import derived_agent_identity
+        identity = derived_agent_identity(agent)
+        if not identity:
+            console.print("\n[red]No recovery phrase to derive from.[/red]")
+            console.print("[cyan]co init[/cyan] first.\n")
+            raise typer.Exit(1)
+        console.print(f"\n[cyan]{identity['address']}[/cyan]")
+        console.print(f"[dim]agent://{agent} — the address this name will have, "
+                      f"on any machine, before or after it exists[/dim]\n")
+        return
+
     from .commands.keys_commands import handle_keys
     handle_keys(reveal=reveal, ssh=ssh, write=write)
 

--- a/tests/unit/test_derived_agent_identity.py
+++ b/tests/unit/test_derived_agent_identity.py
@@ -1,0 +1,105 @@
+"""A deployed agent's identity is derived, not minted on the machine.
+
+Letting the server mint one on first boot gives an address nobody can know in
+advance and nobody can recover once the disk is gone — #306's failure mode moved
+up a level, from "changes every deploy" to "changes every machine", which is
+rarer and therefore worse: it is discovered during an outage.
+openonion/connectonion#396
+"""
+
+import base64
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+from connectonion.cli.commands import server_commands as sc
+
+
+PHRASE = ("abandon abandon abandon abandon abandon abandon "
+          "abandon abandon abandon abandon abandon about")
+
+
+@pytest.fixture
+def operator(tmp_path, monkeypatch):
+    """An operator identity in ~/.co, which is where a server's keys come from."""
+    monkeypatch.setattr(sc.Path, "home", staticmethod(lambda: tmp_path))
+    co = tmp_path / ".co"
+    co.mkdir(parents=True)
+    monkeypatch.setattr("connectonion.address.load",
+                        lambda d: {"seed_phrase": PHRASE, "address": "0xoperator"})
+    return tmp_path
+
+
+class TestTheAddressIsKnowableInAdvance:
+    def test_the_same_name_always_gives_the_same_address(self, operator):
+        first = sc.derived_agent_identity("customer-bot")
+        second = sc.derived_agent_identity("customer-bot")
+
+        assert first["address"] == second["address"]
+
+    def test_a_different_name_is_a_different_agent(self, operator):
+        assert (sc.derived_agent_identity("customer-bot")["address"]
+                != sc.derived_agent_identity("linkedin-bot")["address"])
+
+    def test_the_key_is_a_real_ed25519_seed(self, operator):
+        from nacl.signing import SigningKey
+
+        identity = sc.derived_agent_identity("customer-bot")
+
+        assert len(identity["key_bytes"]) == 32
+        derived = "0x" + bytes(SigningKey(identity["key_bytes"]).verify_key).hex()
+        assert derived == identity["address"]
+
+    def test_without_a_phrase_there_is_nothing_to_derive(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sc.Path, "home", staticmethod(lambda: tmp_path / "empty"))
+        monkeypatch.setattr("connectonion.address.load", lambda d: None)
+        monkeypatch.setattr(
+            "connectonion.cli.commands.keys_commands._find_co_dir", lambda: None)
+
+        assert sc.derived_agent_identity("customer-bot") is None
+
+
+class TestSeedingTheServer:
+    def _steps(self, **kwargs):
+        sent = []
+
+        def fake_ssh(target, command, timeout=300):
+            sent.append(command)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            dts._ensure_setup("co@h", "my-agent", "agent.py", 99, None, None, **kwargs)
+        return "\n".join(sent)
+
+    def test_the_key_travels_over_ssh_not_in_the_tarball(self):
+        """.co/keys is excluded from the rsync, like admins.txt."""
+        identity = {"address": "0xabc", "key_bytes": b"\x01" * 32}
+
+        script = self._steps(agent_identity=identity)
+
+        assert base64.b64encode(identity["key_bytes"]).decode() in script
+        assert "/.co/keys" in script
+
+    def test_an_existing_identity_is_never_overwritten(self):
+        """An agent given its own key — by --own-identity, or by an older deploy
+        that let it mint one — keeps it. Overwriting an identity is not a thing
+        a deploy may do."""
+        script = self._steps(agent_identity={"address": "0xabc",
+                                             "key_bytes": b"\x01" * 32})
+
+        assert "if [ ! -f" in script
+        assert "agent.key" in script
+
+    def test_the_key_file_is_not_world_readable(self):
+        script = self._steps(agent_identity={"address": "0xabc",
+                                             "key_bytes": b"\x01" * 32})
+
+        assert "chmod 600" in script
+
+    def test_nothing_is_written_when_the_agent_owns_its_identity(self):
+        script = self._steps(agent_identity=None)
+
+        assert "agent.key" not in script


### PR DESCRIPTION
Closes #396. Builds on the derivation tree from #415.

## What was wrong

`host()` minted an identity on first boot when it found none. So a deployed agent's address was:

- **unknowable before the deploy** — anything wanting it up front (telling a counterparty "our agent is 0x…", pre-seeding a whitelist, a DNS record) had to wait for first boot and then ssh in to read it back
- **unrecoverable after the machine was gone** — `recovery.txt` lived only in `/srv/<agent>/.co/keys/`. Rebuild the server and every trust relationship, whitelist entry and `@mail.openonion.ai` address went with it

That is #306's failure mode one level up: from "changes every deploy" to "changes every machine". Rarer, and therefore worse — it is found during an outage.

## What it does now

The name is the path, so the address is a function of something you already know:

```
$ co keys --agent customer-bot
0xf7dd76820796b08df4077813…
agent://customer-bot — the address this name will have, on any machine, before or after it exists
```

`co deploy --to` derives that key and seeds it over ssh — `.co/keys/` is excluded from the rsync, so it travels the same way `admins.txt` does.

**It never overwrites.** An agent that already holds a key keeps it, whether that came from `--own-identity` or from an older deploy that let it mint one. Overwriting an identity is not something a deploy may do — it would silently replace an agent with a different agent.

## `--own-identity`

```
co deploy --to prod --own-identity
```

For an agent being handed to a customer. **An identity its author can derive is an identity its author holds**, whatever they intend — so anything delivered to someone else needs a key that came from a seed we never see. The flag means "mint it on the machine, and I accept that only this machine can ever be it".

It is rejected with a Cloud deploy, which carries no identity you derived.

## Where the key comes from

`~/.co`, not the project — the same rule as the SSH key and the account that gets charged. A server belongs to the operator, not to whichever directory they were standing in.

## Tests

Eight cases, all verified red before the change: the same name always gives the same address, a different name a different agent, the bytes are a real Ed25519 seed whose public half matches the printed address, no phrase means nothing to derive, the key travels over ssh rather than in the tarball, an existing `agent.key` is never overwritten, the file is not world-readable, and nothing is written at all when the agent owns its identity.

2833 passed.