### PR TITLE
A second agent on the same server gets its own port

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -172,8 +172,52 @@ def _read_provision(target: str, agent: str) -> dict:
         return {"schema": 0}
 
 
+# 8000 is what host() defaults to and what a lone agent keeps; a second agent on
+# the same machine gets the next free port, so the common case reads exactly as
+# it always did.
+DEFAULT_PORT = 8000
+PORT_LIMIT = 8100
+
+
+def _port_for(target: str, agent: str, wanted: int) -> int:
+    """The port this agent will bind on this machine.
+
+    A server can host more than one agent — `/srv/<agent>/` is per-agent and so
+    is the unit — and only the port stopped it. Two agents defaulting to 8000
+    means the second dies on "address already in use" while `Restart=always`
+    keeps it flapping, so `systemctl is-active` answers `active` and the deploy
+    reports success for an agent that has never served a request.
+
+    The choice is made on the server, because that is where the answer lives.
+    Recorded in `.co/port` so a redeploy keeps the same one: the Caddyfile
+    points at it, and a port that moved would leave the hostname proxying to
+    nothing.
+
+    A port the project asked for explicitly is honoured — if it collides, that
+    is the operator's own arrangement and not ours to reroute.
+    """
+    recorded = _ssh(target, f"cat {SRV}/{agent}/.co/port 2>/dev/null", timeout=60)
+    if recorded.returncode == 0 and recorded.stdout.strip().isdigit():
+        return int(recorded.stdout.strip())
+
+    if wanted != DEFAULT_PORT:
+        return wanted
+
+    # `ss -ltn` lists listening TCP sockets; the first port in range that none
+    # of them holds is ours. Asked once, then written down.
+    probe = _ssh(target, (
+        f"used=$(ss -ltnH 2>/dev/null | grep -oE ':[0-9]+' | tr -d ':' | sort -u)\n"
+        f"for p in $(seq {DEFAULT_PORT} {PORT_LIMIT}); do\n"
+        f"  echo \"$used\" | grep -qx \"$p\" || {{ echo $p; exit 0; }}\n"
+        f"done\n"
+        f"echo none"
+    ), timeout=60)
+    chosen = probe.stdout.strip()
+    return int(chosen) if chosen.isdigit() else wanted
+
+
 def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
-               user: str = "root") -> str:
+               user: str = "root", port: Optional[int] = None) -> str:
     """The systemd unit. Restart=always and enable are what the container was for.
 
     AGENT_PUBLIC_DOMAIN is what makes the agent reachable to anything but ssh.
@@ -199,6 +243,11 @@ def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
                   f"/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
     if hostname:
         environment += f"Environment=AGENT_PUBLIC_DOMAIN={hostname}\n"
+    if port:
+        # host() reads this when neither code nor host.yaml names a port, which
+        # is how a second agent on this machine avoids 8000 without its author
+        # knowing anything about what else runs here.
+        environment += f"Environment=AGENT_PORT={port}\n"
     return f"""[Unit]
 Description=ConnectOnion agent {agent}
 After=network-online.target
@@ -317,7 +366,8 @@ def _remote_user(target: str) -> str:
 
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
                            hostname: Optional[str] = None,
-                           user: Optional[str] = None) -> bool:
+                           user: Optional[str] = None,
+                           port: Optional[int] = None) -> bool:
     """Write the systemd unit only when its content differs.
 
     Rewriting it every deploy would mean a daemon-reload every deploy for no
@@ -329,7 +379,7 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
     # working for direct callers.
     if user is None:
         user = _remote_user(target)
-    wanted = _unit_text(agent, entrypoint, hostname, user=user)
+    wanted = _unit_text(agent, entrypoint, hostname, user=user, port=port)
     unit_path = f"/etc/systemd/system/{agent}.service"
 
     current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)
@@ -750,12 +800,21 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
         return False
     if not _install_deps_if_changed(target, agent, project_dir):
         return False
-    if hostname and not _ensure_caddy(target, hostname, project["port"]):
+    # Decided on the server, where the answer lives, and recorded so a redeploy
+    # keeps it — the Caddyfile points at this number.
+    port = _port_for(target, agent, project["port"])
+    if port != project["port"]:
+        console.print(f"  [dim]port {port} — 8000 is taken on this machine[/dim]")
+    _ssh(target, f"mkdir -p {SRV}/{agent}/.co && echo {port} > {SRV}/{agent}/.co/port",
+         timeout=60)
+
+    if hostname and not _ensure_caddy(target, hostname, port):
         return False
     # Once per deploy: the unit and the ownership fix-up both need it, and it
     # costs an ssh round trip.
     user = _remote_user(target)
-    if not _write_unit_if_changed(target, agent, entrypoint, hostname, user=user):
+    if not _write_unit_if_changed(target, agent, entrypoint, hostname, user=user,
+                                  port=port):
         return False
     if not _restart(target, agent):
         return False

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -28,6 +28,7 @@ don't interfere between concurrent requests.
 import asyncio
 import random
 from functools import partial
+import os
 from pathlib import Path
 from typing import Callable, Union
 
@@ -467,6 +468,15 @@ def host(
     # Resolve co_dir: explicit > cwd/.co (project default)
     if co_dir is None:
         co_dir = Path.cwd() / '.co'
+
+    # A server can host more than one agent, and only the port stops it: two of
+    # them defaulting to 8000 means the second dies on "address already in use"
+    # while systemd keeps restarting it. `co deploy --to` picks a free port on
+    # the machine and passes it here, so the operator's agent.py needs no change
+    # and no knowledge of what else lives on that box. An explicit port in code
+    # or host.yaml still wins — this only replaces the default.
+    if port is None and os.getenv("AGENT_PORT"):
+        port = int(os.environ["AGENT_PORT"])
 
     # Load config: host.yaml (optional) → code param overrides
     config = load_host_config(

--- a/tests/unit/test_second_agent_gets_its_own_port.py
+++ b/tests/unit/test_second_agent_gets_its_own_port.py
@@ -1,0 +1,91 @@
+"""A server can host more than one agent, and only the port stopped it.
+
+Two agents defaulting to 8000 means the second dies on "address already in use"
+while `Restart=always` keeps it flapping — so `systemctl is-active` answers
+`active` and the deploy reports success for an agent that has never served a
+request. openonion/connectonion#450
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+class TestChoosingThePort:
+    def test_a_lone_agent_still_gets_8000(self):
+        """The common case must read exactly as it always did."""
+        def fake_ssh(target, command, timeout=300):
+            if "cat" in command:
+                return _ok("")                      # nothing recorded yet
+            return _ok("8000")                      # nothing listening
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._port_for("co@h", "solo", dts.DEFAULT_PORT) == 8000
+
+    def test_a_second_agent_gets_the_next_free_one(self):
+        def fake_ssh(target, command, timeout=300):
+            if "cat" in command:
+                return _ok("")
+            return _ok("8001")                      # 8000 held by the first agent
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._port_for("co@h", "second", dts.DEFAULT_PORT) == 8001
+
+    def test_a_redeploy_keeps_the_port_it_had(self):
+        """The Caddyfile points at this number; a port that moved would leave
+        the hostname proxying to nothing."""
+        def fake_ssh(target, command, timeout=300):
+            if "cat" in command:
+                return _ok("8003\n")
+            raise AssertionError("should not have probed — it was recorded")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._port_for("co@h", "known", dts.DEFAULT_PORT) == 8003
+
+    def test_a_port_the_project_asked_for_is_honoured(self):
+        """An explicit port is the operator's own arrangement, not ours to move."""
+        with patch.object(dts, "_ssh", side_effect=lambda *a, **k: _ok("")):
+            assert dts._port_for("co@h", "explicit", 9000) == 9000
+
+    def test_an_unreadable_probe_falls_back_rather_than_guessing(self):
+        with patch.object(dts, "_ssh", side_effect=lambda *a, **k: _ok("none")):
+            assert dts._port_for("co@h", "x", dts.DEFAULT_PORT) == dts.DEFAULT_PORT
+
+
+class TestTheAgentIsToldWhichPort:
+    def test_the_unit_carries_it(self):
+        unit = dts._unit_text("a", "agent.py", user="co", port=8001)
+
+        assert "Environment=AGENT_PORT=8001" in unit
+
+    def test_a_default_port_needs_no_variable(self):
+        """Nothing is added when there is nothing to say."""
+        unit = dts._unit_text("a", "agent.py", user="co")
+
+        assert "AGENT_PORT" not in unit
+
+
+class TestHostReadsIt:
+    def test_the_environment_supplies_the_default(self, monkeypatch):
+        """host() must pick it up without the author's agent.py changing."""
+        import inspect
+        from connectonion.network.host import server
+
+        src = inspect.getsource(server.host)
+        assert "AGENT_PORT" in src
+        assert src.index("AGENT_PORT") < src.index("load_host_config")
+
+    def test_an_explicit_port_still_wins(self, monkeypatch):
+        """Only the default is replaced — code and host.yaml outrank the box."""
+        import inspect
+        from connectonion.network.host import server
+
+        src = inspect.getsource(server.host)
+        assert "if port is None" in src


### PR DESCRIPTION
Closes #450.

## What happened

`co deploy --to` always bound 8000:

```
ERROR: [Errno 98] error while attempting to bind on address ('0.0.0.0', 8000): address already in use
systemd[1]: dash-e2e.service: Scheduled restart job, restart counter is at 1.
```

The rsync succeeded, every file landed, the unit was written and started — and the agent never served a request.

**And the deploy said it worked.** `Restart=always` means the unit is `active` in the gaps between crashes, so anything reading unit state sees a healthy service. The operator is told the deploy succeeded and finds out otherwise by reading the journal of a service they have no reason to suspect.

## What changed

A server can obviously host more than one agent — `/srv/<agent>/` is per-agent, the unit is per-agent. Only the port was not.

The port is chosen **on the server**, because that is where the answer lives:

```
ss -ltnH | …          # what is already listening
seq 8000 8100         # the first one nobody holds
```

and recorded in `.co/port`, so a redeploy keeps it. That matters: the Caddyfile proxies to that number, and a port that moved between deploys would leave the hostname pointing at nothing.

`host()` reads `AGENT_PORT` when neither code nor `host.yaml` names a port, so the author's `agent.py` needs no change and no knowledge of what else runs on that machine. An explicit port still wins — that is the operator's own arrangement, not ours to reroute.

A lone agent still gets 8000, so the common case reads exactly as it did.

## Tests

Nine cases, verified red first: a lone agent still gets 8000, a second gets the next free one, a redeploy keeps the port it had (asserted by making the probe raise if it is reached), an explicit port is honoured, an unreadable probe falls back rather than guessing, the unit carries the variable only when there is something to say, and `host()` consults it before `load_host_config` and only when `port is None`.

2842 passed.

## Not in this PR

Two agents on one server still share one hostname — Caddy has one `:443` and one name. That is the other half of "several agents on one machine" and is worth its own change; #309 raised it and this does not close it.