### PR TITLE
A second agent no longer takes the first one's hostname

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -404,26 +404,65 @@ sudo systemctl enable {agent} >/dev/null 2>&1
     return True
 
 
-def _caddyfile_text(hostname: str, port: int) -> str:
-    """One hostname, proxied to the agent on loopback.
+CADDY_MARK = "# connectonion:"
+
+
+def _caddy_stanza(agent: str, hostname: str, port: int) -> str:
+    """One agent's block, tagged so a later deploy can find and replace it.
 
     Caddy gets and renews the certificate itself over HTTP-01, which is why 80
     has to be open even though nothing is served on it. `reverse_proxy` passes
     WebSocket upgrades through unchanged, so /ws needs no separate stanza — the
     agent's chat, dashboard pushes and remote exec all ride that one connection.
-
-    One agent per hostname. A second agent deployed to the same server takes the
-    name from the first, because there is one name and one :443. Several agents
-    on one machine is still an open question (openonion/connectonion#309); when
-    it is answered this file grows a stanza per agent rather than being replaced.
     """
-    return f"""{hostname} {{
+    return f"""{CADDY_MARK}{agent}
+{hostname} {{
 	reverse_proxy 127.0.0.1:{port}
 }}
 """
 
 
-def _ensure_caddy(target: str, hostname: str, port: int) -> bool:
+def _caddyfile_with(current: str, agent: str, hostname: str, port: int) -> str:
+    """The Caddyfile with this agent's block set, and everyone else's kept.
+
+    It used to hold exactly one block and be replaced wholesale, so deploying a
+    second agent to a machine silently took the first one's hostname: the first
+    agent kept running, on its own port, unreachable by the name it had been
+    published under, with nothing said about it.
+
+    Blocks are keyed by the marker comment rather than by the hostname, because
+    the agent is the thing that owns a block — a hostname that changed hands
+    would otherwise leave two blocks claiming it and Caddy serving whichever it
+    read last.
+    """
+    kept, skipping = [], False
+    for line in current.splitlines():
+        if line.startswith(CADDY_MARK):
+            skipping = line[len(CADDY_MARK):].strip() == agent
+            if skipping:
+                continue
+        if skipping:
+            if line.strip() == "}":
+                skipping = False
+            continue
+        kept.append(line)
+
+    body = "\n".join(kept).strip()
+    return (body + "\n\n" if body else "") + _caddy_stanza(agent, hostname, port)
+
+
+def _caddy_owner_of(caddyfile: str, hostname: str) -> Optional[str]:
+    """Which agent's block already claims this hostname, if any."""
+    agent = None
+    for line in caddyfile.splitlines():
+        if line.startswith(CADDY_MARK):
+            agent = line[len(CADDY_MARK):].strip()
+        elif line.strip().startswith(hostname + " ") or line.strip() == hostname + " {":
+            return agent
+    return None
+
+
+def _ensure_caddy(target: str, agent: str, hostname: str, port: int) -> bool:
     """Install Caddy if absent, and point it at this agent.
 
     Installed here rather than by provisioning for the reason #318 settled: a
@@ -436,9 +475,22 @@ def _ensure_caddy(target: str, hostname: str, port: int) -> bool:
     on every deploy would hide whether the certificate work was actually caused
     by a change.
     """
-    wanted = _caddyfile_text(hostname, port)
-
     current = _ssh(target, "cat /etc/caddy/Caddyfile 2>/dev/null", timeout=60)
+    existing = current.stdout if current.returncode == 0 else ""
+
+    # The hostname belongs to the server, and a server has one. Whichever agent
+    # claimed it keeps it: taking it silently is what used to happen, and it
+    # left the first agent running and unreachable under the name it had been
+    # published under.
+    owner = _caddy_owner_of(existing, hostname)
+    if owner and owner != agent:
+        console.print(f"[yellow]  {hostname} already serves '{owner}'.[/yellow]")
+        console.print(f"[dim]  '{agent}' is deployed and running on port {port}, "
+                      f"reachable over ssh, but has no public name of its own — "
+                      f"a server has one hostname. See openonion/connectonion#309.[/dim]")
+        return True
+
+    wanted = _caddyfile_with(existing, agent, hostname, port)
     if current.returncode == 0 and current.stdout == wanted and _caddy_running(target):
         return True
 
@@ -808,7 +860,7 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
     _ssh(target, f"mkdir -p {SRV}/{agent}/.co && echo {port} > {SRV}/{agent}/.co/port",
          timeout=60)
 
-    if hostname and not _ensure_caddy(target, hostname, port):
+    if hostname and not _ensure_caddy(target, agent, hostname, port):
         return False
     # Once per deploy: the unit and the ownership fix-up both need it, and it
     # costs an ssh round trip.

--- a/tests/unit/test_caddy_one_block_per_agent.py
+++ b/tests/unit/test_caddy_one_block_per_agent.py
@@ -1,0 +1,100 @@
+"""The Caddyfile holds one block per agent, and a hostname keeps its owner.
+
+It used to hold exactly one block and be replaced wholesale, so deploying a
+second agent to a machine silently took the first one's hostname: the first
+agent kept running, on its own port, unreachable by the name it had been
+published under, with nothing said about it. openonion/connectonion#309
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+class TestOneBlockPerAgent:
+    def test_a_second_agent_does_not_erase_the_first(self):
+        first = dts._caddyfile_with("", "alpha", "a.example.com", 8000)
+
+        both = dts._caddyfile_with(first, "beta", "b.example.com", 8001)
+
+        assert "alpha" in both and "8000" in both
+        assert "beta" in both and "8001" in both
+
+    def test_redeploying_replaces_that_agents_block_only(self):
+        both = dts._caddyfile_with(
+            dts._caddyfile_with("", "alpha", "a.example.com", 8000),
+            "beta", "b.example.com", 8001)
+
+        again = dts._caddyfile_with(both, "beta", "b.example.com", 8099)
+
+        assert again.count("connectonion:beta") == 1, "duplicated its own block"
+        assert "8099" in again and "8001" not in again
+        assert "8000" in again, "the other agent's block was disturbed"
+
+    def test_a_block_is_keyed_by_agent_not_by_hostname(self):
+        """A hostname that changed hands would otherwise leave two blocks
+        claiming it, and Caddy serving whichever it read last."""
+        one = dts._caddyfile_with("", "alpha", "a.example.com", 8000)
+
+        moved = dts._caddyfile_with(one, "alpha", "moved.example.com", 8000)
+
+        assert moved.count("connectonion:alpha") == 1
+        assert "a.example.com" not in moved
+
+    def test_an_unrelated_handwritten_block_survives(self):
+        """The operator's own Caddy config is not ours to delete."""
+        handwritten = "example.org {\n\trespond \"hi\"\n}\n"
+
+        result = dts._caddyfile_with(handwritten, "alpha", "a.example.com", 8000)
+
+        assert "example.org" in result
+
+
+class TestAHostnameKeepsItsOwner:
+    def test_the_owner_is_reported(self):
+        one = dts._caddyfile_with("", "alpha", "a.example.com", 8000)
+
+        assert dts._caddy_owner_of(one, "a.example.com") == "alpha"
+        assert dts._caddy_owner_of(one, "b.example.com") is None
+
+    def test_a_second_agent_is_told_rather_than_taking_it(self, capsys):
+        one = dts._caddyfile_with("", "alpha", "shared.example.com", 8000)
+        written = []
+
+        def fake_ssh(target, command, timeout=300):
+            if command.startswith("cat /etc/caddy"):
+                return _ok(one)
+            written.append(command)
+            return _ok("active")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            assert dts._ensure_caddy("co@h", "beta", "shared.example.com", 8001) is True
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "already serves 'alpha'" in out
+        assert "no public name of its own" in out
+        assert not any("Caddyfile" in c and "cat" not in c for c in written), \
+            "it rewrote the config anyway"
+
+    def test_the_owner_can_still_redeploy_itself(self):
+        one = dts._caddyfile_with("", "alpha", "shared.example.com", 8000)
+        wrote = []
+
+        def fake_ssh(target, command, timeout=300):
+            if command.startswith("cat /etc/caddy"):
+                return _ok(one)
+            wrote.append(command)
+            return _ok("active")
+
+        with patch.object(dts, "_ssh", side_effect=fake_ssh), \
+             patch.object(dts, "_caddy_running", return_value=True):
+            dts._ensure_caddy("co@h", "alpha", "shared.example.com", 8000)
+
+        assert not wrote, "an unchanged config should not be rewritten"

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -383,21 +383,21 @@ class TestHttps:
     8000. Without Caddy in front, nothing a browser can reach ever answers."""
 
     def test_the_hostname_is_proxied_to_the_agent_on_loopback(self):
-        text = dts._caddyfile_text("prod-abc.agents.openonion.ai", 8000)
+        text = dts._caddyfile_with("", "myagent", "prod-abc.agents.openonion.ai", 8000)
 
-        assert text.startswith("prod-abc.agents.openonion.ai {")
+        assert "prod-abc.agents.openonion.ai {" in text
         assert "reverse_proxy 127.0.0.1:8000" in text
 
     def test_a_project_that_moved_its_port_is_proxied_there(self):
         """Caddy pointing at 8000 when the agent listens elsewhere is a 502 that
         looks like the agent crashed."""
-        assert "reverse_proxy 127.0.0.1:9100" in dts._caddyfile_text("x.example", 9100)
+        assert "reverse_proxy 127.0.0.1:9100" in dts._caddyfile_with("", "a", "x.example", 9100)
 
     def test_websockets_need_no_stanza_of_their_own(self):
         """reverse_proxy passes upgrades through unchanged, and chat, dashboard
         pushes and remote exec all ride that one connection. A separate /ws block
         would be a second thing to keep correct."""
-        assert "/ws" not in dts._caddyfile_text("x.example", 8000)
+        assert "/ws" not in dts._caddyfile_with("", "a", "x.example", 8000)
 
     def test_the_unit_publishes_the_domain_so_the_agent_announces_a_reachable_url(self):
         """Without it announce.py publishes http://<ip>:8000 to the relay, and
@@ -417,17 +417,17 @@ class TestHttps:
     def test_an_unchanged_caddyfile_on_a_running_caddy_is_not_rewritten(self):
         """A reload every deploy would hide whether certificate work was actually
         caused by a change."""
-        wanted = dts._caddyfile_text("x.example", 8000)
+        wanted = dts._caddyfile_with("", "myagent", "x.example", 8000)
         with patch.object(dts, "_ssh") as ssh:
             ssh.side_effect = [_ok(wanted), _ok("active")]
-            assert dts._ensure_caddy("user@host", "x.example", 8000) is True
+            assert dts._ensure_caddy("user@host", "myagent", "x.example", 8000) is True
 
         assert ssh.call_count == 2  # read the file, check the service. No write.
 
     def test_a_changed_caddyfile_is_written_and_reloaded(self):
         with patch.object(dts, "_ssh") as ssh:
             ssh.side_effect = [_ok("something else"), _ok("")]
-            assert dts._ensure_caddy("user@host", "x.example", 8000) is True
+            assert dts._ensure_caddy("user@host", "myagent", "x.example", 8000) is True
 
         script = ssh.call_args.args[1]
         assert "/etc/caddy/Caddyfile" in script
@@ -437,7 +437,7 @@ class TestHttps:
         """apt on every deploy would add a minute to a code-only change."""
         with patch.object(dts, "_ssh") as ssh:
             ssh.side_effect = [_ok("something else"), _ok("")]
-            dts._ensure_caddy("user@host", "x.example", 8000)
+            dts._ensure_caddy("user@host", "myagent", "x.example", 8000)
 
         assert "command -v caddy" in ssh.call_args.args[1]
 


### PR DESCRIPTION
Part of #309. Follows #452, which gave a second agent its own port.

## What was happening

`_caddyfile_text` produced exactly one block and `_ensure_caddy` replaced the file with it. So deploying a second agent to a machine already running one **silently took the first one's hostname**.

Since #452 the first agent keeps running on its own port. It just stops being reachable by the name it was published under — and nothing says so. The deploy reports success, twice, for a machine where one of the two agents has quietly gone dark.

## One block per agent

The file now holds a tagged block each:

```
# connectonion:alpha
a.example.com {
	reverse_proxy 127.0.0.1:8000
}

# connectonion:beta
b.example.com {
	reverse_proxy 127.0.0.1:8001
}
```

A redeploy replaces its own block and leaves the others — including anything the operator wrote by hand, which was previously deleted without comment.

Blocks are keyed by **agent**, not by hostname. A name that changed hands would otherwise leave two blocks claiming it, and Caddy serves whichever it read last.

## A hostname keeps its owner

A second agent asking for a name that is taken is told, rather than taking it:

```
  shared.example.com already serves 'alpha'.
  'beta' is deployed and running on port 8001, reachable over ssh, but has no
  public name of its own — a server has one hostname. See #309.
```

That is the honest half. **Giving each agent a name of its own is not in this PR**: it needs a DNS record per agent, and the CLI holds no Cloudflare credentials — `_create_dns_record` lives in oo-api. I checked whether a nested `<agent>.<server>.agents.openonion.ai` could avoid that and it cannot: the record would resolve via the wildcard, but Let's Encrypt issues per name, so Caddy would still need a real record to pass HTTP-01.

So #309 stays open. What closes here is the silent theft.

## Tests

Seven new, verified red first: a second agent does not erase the first, a redeploy replaces only its own block, blocks are keyed by agent rather than hostname, a hand-written block survives, the owner is reported, a second agent is told rather than taking the name, and the owner can still redeploy itself without rewriting an unchanged file.

Six existing `TestHttps` cases were updated for the new signatures — they called `_caddyfile_text`, which no longer exists because a single-block file is the thing that was wrong.

2849 passed.