### PR TITLE
A server you were charged for ends up in the registry

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -9,9 +9,11 @@ LLM-Note:
   Errors: an unreachable host fails with ssh's own message and a short timeout, never a hang | a missing requirement is named
 """
 
+import os
 import re
 import shutil
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -42,8 +44,58 @@ def _load() -> Dict[str, dict]:
 
 
 def _save(servers: Dict[str, dict]) -> None:
+    """Replace the whole registry. Prefer _update() unless you mean to."""
     SERVERS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    SERVERS_FILE.write_text(yaml.safe_dump({"servers": servers}, sort_keys=True))
+    _write_atomically(SERVERS_FILE, yaml.safe_dump({"servers": servers}, sort_keys=True))
+
+
+def _write_atomically(path: Path, text: str) -> None:
+    """Write via a temporary file in the same directory, then rename.
+
+    `write_text` truncates before it writes, so a process killed in between —
+    or two writing at once — leaves a file that parses as an empty registry.
+    A rename on the same filesystem is atomic: readers see the old file or the
+    new one, never half of either.
+    """
+    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
+
+
+@contextmanager
+def _registry_lock():
+    """Hold the registry while reading and writing it.
+
+    `co server new` reads the file, spends a minute creating a machine, and
+    writes it back. Anything else that registered in that minute was silently
+    dropped — including by another session on the same laptop, which is the
+    normal case here rather than an exotic one. The operator is charged either
+    way, and the entry that vanishes is the one nothing points at.
+    """
+    SERVERS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = SERVERS_FILE.with_suffix(".lock")
+    with open(lock_path, "w") as handle:
+        try:
+            import fcntl
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        except (ImportError, OSError):
+            # Windows, or a filesystem without flock. Losing an entry is worse
+            # than not locking, but crashing here would be worse than both.
+            pass
+        yield
+
+
+def _update(mutate) -> Dict[str, dict]:
+    """Read, change and write the registry without losing a concurrent change.
+
+    The read happens inside the lock, so `co server new` picks up anything that
+    landed while it was waiting on the API rather than overwriting it.
+    """
+    with _registry_lock():
+        servers = _load()
+        mutate(servers)
+        _save(servers)
+        return servers
 
 
 def load_server(name: str) -> Optional[dict]:
@@ -124,10 +176,9 @@ def handle_server_add(name: str, ssh_target: str) -> bool:
                       f"authorized_keys on that host.[/dim]\n")
         return False
 
-    servers = _load()
-    existed = name in servers
-    servers[name] = {"ssh": ssh_target, "last_check": None}
-    _save(servers)
+    existed = name in _load()
+    _update(lambda servers: servers.update(
+        {name: {"ssh": ssh_target, "last_check": None}}))
 
     verb = "Updated" if existed else "Added"
     console.print(f"[green]✓[/green] {verb} [cyan]{name}[/cyan] → {ssh_target}")
@@ -333,10 +384,11 @@ def handle_server_check(name: str) -> bool:
 
 
 def _record(name: str, outcome: str) -> None:
-    servers = _load()
-    if name in servers:
-        servers[name]["last_check"] = outcome
-        _save(servers)
+    def note(servers):
+        if name in servers:
+            servers[name]["last_check"] = outcome
+
+    _update(note)
 
 
 def handle_server_ssh(name: str, command: Optional[str] = None) -> bool:
@@ -374,8 +426,7 @@ def handle_server_forget(name: str) -> bool:
         return False
 
     target = servers[name].get("ssh", "?")
-    del servers[name]
-    _save(servers)
+    _update(lambda s: s.pop(name, None))
 
     console.print(f"[green]✓[/green] Forgot [cyan]{name}[/cyan] ({target})")
     console.print("\n[yellow]The machine itself is untouched — it keeps running, and if we "
@@ -441,10 +492,7 @@ def handle_server_destroy(name: str, yes: bool = False) -> bool:
 
     # Only now drop the local entry: while the machine existed the entry was
     # true, and removing it on a failed delete would hide a server still billing.
-    servers = _load()
-    if name in servers:
-        del servers[name]
-        _save(servers)
+    _update(lambda servers: servers.pop(name, None))
 
     console.print(f"[green]✓ {name} destroyed[/green]")
 
@@ -710,16 +758,17 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
 
     server = response.json()
 
-    # Register it ourselves so the operator never types an IP.
-    servers = _load()
+    # Register it ourselves so the operator never types an IP. Under a lock,
+    # with the read inside it: this is the write that follows a minute-long API
+    # call, so anything another session registered meanwhile would otherwise be
+    # overwritten — and the operator was charged for both.
     entry = {"ssh": server["ssh_target"], "last_check": None}
     # The hostname the backend created a DNS record for. Stored rather than
     # derived: the naming rule lives in one place (the backend), and a CLI that
     # reconstructed it would be a second copy that has to agree forever.
     if server.get("hostname"):
         entry["hostname"] = server["hostname"]
-    servers[name] = entry
-    _save(servers)
+    _update(lambda servers: servers.update({name: entry}))
 
     _forget_host_key(server["ssh_target"])
     _wait_until_it_accepts_your_key(server["ssh_target"])

--- a/tests/unit/test_registry_is_not_lost.py
+++ b/tests/unit/test_registry_is_not_lost.py
@@ -1,0 +1,91 @@
+"""A server the operator was charged for must end up in the registry.
+
+`co server new` read the registry, spent a minute creating a machine, and wrote
+it back — so anything that registered during that minute was silently dropped.
+The operator is charged either way, and the entry that vanishes is the one
+nothing points at: `co server check` answers "No server named …" for a machine
+that exists and is billing. openonion/connectonion#445
+"""
+
+import threading
+import time
+
+import pytest
+import yaml
+
+from connectonion.cli.commands import server_commands as sc
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sc, "SERVERS_FILE", tmp_path / "servers.yaml")
+    return tmp_path / "servers.yaml"
+
+
+class TestConcurrentRegistrationsSurvive:
+    def test_a_slow_write_does_not_drop_a_fast_one(self, registry):
+        """The shape of the bug: read, wait on the API, write."""
+        def add(name, delay):
+            def mutate(servers):
+                time.sleep(delay)
+                servers[name] = {"ssh": f"co@{name}"}
+            sc._update(mutate)
+
+        threads = [threading.Thread(target=add, args=(n, 0.15))
+                   for n in ("alpha", "beta", "gamma")]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sorted(sc._load()) == ["alpha", "beta", "gamma"]
+
+    def test_the_read_happens_inside_the_lock(self, registry):
+        """Reading before taking the lock is the same bug with extra steps."""
+        sc._update(lambda s: s.update({"first": {"ssh": "co@a"}}))
+
+        seen = {}
+
+        def mutate(servers):
+            seen.update(servers)
+            servers["second"] = {"ssh": "co@b"}
+
+        sc._update(mutate)
+
+        assert "first" in seen, "the mutation ran against a stale copy"
+
+
+class TestTheFileIsNeverHalfWritten:
+    def test_a_write_replaces_the_file_atomically(self, registry, monkeypatch):
+        """write_text truncates first, so a process killed mid-write leaves a
+        file that parses as an empty registry."""
+        sc._update(lambda s: s.update({"prod": {"ssh": "co@1.2.3.4"}}))
+
+        renamed = []
+        monkeypatch.setattr(sc.os, "replace",
+                            lambda a, b: renamed.append((a, b)) or None)
+        sc._save({"prod": {"ssh": "co@x"}})
+
+        assert renamed, "wrote in place instead of renaming"
+
+    def test_no_temporary_file_is_left_behind(self, registry):
+        sc._update(lambda s: s.update({"prod": {"ssh": "co@1.2.3.4"}}))
+
+        leftovers = list(registry.parent.glob("*.tmp"))
+        assert not leftovers, leftovers
+
+    def test_what_was_written_reads_back(self, registry):
+        sc._update(lambda s: s.update({"prod": {"ssh": "co@1.2.3.4"}}))
+
+        assert yaml.safe_load(registry.read_text())["servers"]["prod"]["ssh"] == "co@1.2.3.4"
+
+
+class TestTheRegistrationItself:
+    def test_a_created_server_is_registered_before_it_is_announced(self):
+        """The success line is printed after the write, so a reader who trusts
+        the output is not trusting something that failed silently."""
+        import inspect
+
+        src = inspect.getsource(sc.handle_server_new)
+
+        assert src.index("_update(") < src.index("is ready")


### PR DESCRIPTION
Closes #445.

```
$ co server new e2e-06ed0c --yes
✓ e2e-06ed0c is ready
  expires 2027-07-31 — $360.00 charged
Next: co server check e2e-06ed0c

$ co server check e2e-06ed0c
No server named 'e2e-06ed0c'.
```

Charged, created, running — and absent from the registry, so the command's own suggested next step fails.

## Why

`servers.yaml` was read, held across a minute-long API call, and written back whole:

```python
servers = _load()          # read
response = requests.post(…, timeout=300)   # a minute passes
servers[name] = entry
_save(servers)             # write everything back
```

Anything that registered in that minute was overwritten. Reproduced directly — three concurrent registrations, one survivor:

```
最终注册表: ['alpha']
```

The issue notes it happened "with no other `co` process running". On this machine there usually is one: several sessions drive `co` concurrently, which here is the normal case rather than an exotic one. It does not need two `server new` calls either — a `co server check` recording its result, or a `co server forget`, writes the same file.

There is a second way to lose everything: `write_text` truncates before it writes, so a process killed in between leaves a file that parses as an empty registry. Not "one entry lost" — all of them.

## The fix

Every read-modify-write goes through `_update()`, which takes an exclusive `flock` and **reads inside it**, so a slow write picks up what landed while it waited instead of replacing it. Reading before locking is the same bug with extra steps, and there is a test that fails if it drifts back.

Writes go to a temporary file and are renamed into place. A rename on one filesystem is atomic: a reader sees the old file or the new one, never half of either.

Where `flock` is unavailable — Windows, or an exotic filesystem — the lock is skipped rather than raising. Losing an entry is bad; refusing to run at all is worse.

## Tests

Six, verified red first: three concurrent registrations all survive, the read happens inside the lock, the write renames rather than truncating, no temporary file is left behind, what was written reads back, and the registration precedes the success line — so a reader trusting the output is not trusting something that failed silently.

2855 passed.