### PR TITLE
co server fix-key — a machine that will not take your key is recoverable

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -626,7 +626,7 @@ def _forget_host_key(ssh_target: str) -> None:
 KEY_INSTALL_TIMEOUT_SECONDS = 120
 
 
-def _wait_until_it_accepts_your_key(ssh_target: str) -> bool:
+def _wait_until_it_accepts_your_key(ssh_target: str, name: str = "<name>") -> bool:
     """Block until the machine actually lets you in.
 
     The API returns as soon as the instance has an address, which is before the
@@ -647,8 +647,10 @@ def _wait_until_it_accepts_your_key(ssh_target: str) -> bool:
         time.sleep(3)
 
     console.print("[yellow]It is not accepting your key yet.[/yellow]")
-    console.print("[dim]The machine exists and is charged for; this is usually a "
-                  "slow first boot. Try [bold]co server check[/bold] in a minute.[/dim]")
+    console.print("[dim]The machine exists and is charged for. Usually a slow first "
+                  "boot — try [bold]co server check[/bold] in a minute.[/dim]")
+    console.print(f"[dim]If it still refuses: [bold]co server fix-key {name}[/bold] "
+                  f"reinstalls the key on the machine you already paid for.[/dim]")
     return False
 
 
@@ -686,6 +688,67 @@ def derived_agent_identity(name: str) -> Optional[dict]:
             "key_bytes": bytes(signing_key),
         }
     return None
+
+
+def handle_server_fix_key(name: str) -> bool:
+    """Reinstall the derived key on a server you already own.
+
+    The route out of a machine that was charged for and never accepted the key.
+    Before this the only repair was destroy and pay again — the wait said "try
+    again in a minute", and trying again did the same thing.
+
+    Also the repair after rotating: the derived key changes and the machine
+    should follow it, without losing what is on the disk.
+    """
+    import requests
+
+    from .project_cmd_lib import load_api_key
+
+    entry = load_server(name)
+    if not entry:
+        console.print(f"\n[red]No server named '{name}'.[/red]")
+        console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
+        return False
+
+    api_key = load_api_key()
+    if not api_key:
+        console.print("\n[red]Not authenticated.[/red]")
+        console.print("[cyan]co auth[/cyan] first — the key is reinstalled through "
+                      "the server API.\n")
+        return False
+
+    ssh_public_line = _ensure_ssh_key()
+    if not ssh_public_line:
+        console.print("\n[red]No SSH key to install.[/red]")
+        console.print("[dim]It is derived from your recovery phrase. "
+                      "[bold]co keys --ssh[/bold] to check.[/dim]\n")
+        return False
+
+    console.print(f"\n[dim]Reinstalling your key on {name} …[/dim]")
+    try:
+        response = requests.post(
+            f"{API_BASE}/api/v1/servers/{name}/key",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"ssh_public_key": ssh_public_line},
+            timeout=120,
+        )
+    except requests.RequestException as exc:
+        console.print(f"[red]Request failed: {exc}[/red]\n")
+        return False
+
+    if response.status_code != 200:
+        _report_failure(response)
+        return False
+
+    _forget_host_key(entry["ssh"])
+    if _wait_until_it_accepts_your_key(entry["ssh"], name):
+        console.print(f"[green]✓ {name} accepts your key[/green]")
+        console.print(f"\n[dim]Next:[/dim] co server check {name}\n")
+        return True
+
+    console.print("[dim]The key was reinstalled but the machine has not picked it "
+                  "up yet. It is charged for either way — try again shortly.[/dim]\n")
+    return False
 
 
 def handle_server_new(name: str, machine_type: Optional[str] = None,
@@ -771,7 +834,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
     _update(lambda servers: servers.update({name: entry}))
 
     _forget_host_key(server["ssh_target"])
-    _wait_until_it_accepts_your_key(server["ssh_target"])
+    _wait_until_it_accepts_your_key(server["ssh_target"], name)
 
     console.print(f"\n[green]✓ {name} is ready[/green]")
     console.print(f"  [cyan]{server['ssh_target']}[/cyan]")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -389,6 +389,16 @@ def server_ssh(
         raise typer.Exit(1)
 
 
+@server_app.command("fix-key")
+def server_fix_key(
+    name: str = typer.Argument(..., help="Registered server name"),
+):
+    """Reinstall your SSH key on a server you own, without recreating it."""
+    from .commands.server_commands import handle_server_fix_key
+    if not handle_server_fix_key(name=name):
+        raise typer.Exit(1)
+
+
 @server_app.command("forget")
 def server_forget(
     name: str = typer.Argument(..., help="Registered server name"),

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -23,7 +23,8 @@ def _do_not_wait_for_a_real_machine(monkeypatch):
     """`co server new` blocks until the box accepts the key. A unit test has no
     box, so it would block for the full timeout. TestReadyMeansYouCanLogIn
     patches this itself and asserts the call, so the behaviour stays covered."""
-    monkeypatch.setattr(sc, "_wait_until_it_accepts_your_key", lambda target: True)
+    monkeypatch.setattr(sc, "_wait_until_it_accepts_your_key",
+                        lambda target, name="": True)
 
 
 @pytest.fixture
@@ -885,14 +886,14 @@ class TestReadyMeansYouCanLogIn:
             return _ok("ok") if len(attempts) >= 3 else _fail("Permission denied (publickey)")
 
         with patch.object(sc, "_ssh", side_effect=flaky), patch("time.sleep"):
-            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4") is True
+            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4", "prod") is True
 
         assert len(attempts) == 3
 
     def test_a_machine_that_never_opens_says_so_instead_of_hanging(self, capsys):
         with patch.object(sc, "_ssh", return_value=_fail("Permission denied (publickey)")), \
              patch.object(sc, "KEY_INSTALL_TIMEOUT_SECONDS", 0):
-            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4") is False
+            assert _REAL_WAIT_UNTIL_IT_ACCEPTS_YOUR_KEY("co@1.2.3.4", "prod") is False
 
         out = " ".join(capsys.readouterr().out.split())
         assert "charged for" in out, "the operator has paid; say so"
@@ -912,7 +913,7 @@ class TestReadyMeansYouCanLogIn:
              patch("requests.post", return_value=_response(200, server)), \
              patch.object(sc, "_forget_host_key"), \
              patch.object(sc, "_wait_until_it_accepts_your_key",
-                          side_effect=lambda t: waited.append(t) or True):
+                          side_effect=lambda t, name="": waited.append(t) or True):
             assert sc.handle_server_new("prod", yes=True) is True
 
         assert waited == ["co@203.0.113.7"]

--- a/tests/unit/test_server_fix_key.py
+++ b/tests/unit/test_server_fix_key.py
@@ -1,0 +1,91 @@
+"""A server that will not take your key is recoverable without paying again.
+
+`_wait_until_it_accepts_your_key` returns False rather than failing the command,
+which is right — the machine exists and is charged for either way. But the
+operator was then left with a $360 machine, a ✓ ready banner and no route in:
+`co server check` reported the same failure, and the only repair was destroy and
+recreate. openonion/connectonion#449
+"""
+
+import subprocess
+from unittest.mock import Mock, patch
+
+import pytest
+
+from connectonion.cli.commands import server_commands as sc
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr="Permission denied (publickey)."):
+    return subprocess.CompletedProcess(args=[], returncode=255, stdout="", stderr=stderr)
+
+
+def _response(status, payload=None):
+    return Mock(status_code=status, json=Mock(return_value=payload or {}), content=b"{}")
+
+
+@pytest.fixture
+def registered(tmp_path, monkeypatch):
+    monkeypatch.setattr(sc, "SERVERS_FILE", tmp_path / "servers.yaml")
+    sc._update(lambda s: s.update({"prod": {"ssh": "co@1.2.3.4", "last_check": None}}))
+
+
+class TestTheWaitPointsAtSomethingThatCanFixIt:
+    def test_the_timeout_names_the_repair(self, capsys):
+        with patch.object(sc, "_ssh", return_value=_fail()), \
+             patch.object(sc, "KEY_INSTALL_TIMEOUT_SECONDS", 0):
+            sc._wait_until_it_accepts_your_key("co@1.2.3.4", "prod")
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "co server fix-key prod" in out, \
+            "told the operator to wait, with nothing that could change the outcome"
+        assert "charged for" in out
+
+
+class TestFixKey:
+    def test_it_reinstalls_and_confirms(self, registered, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
+                   return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch("requests.post", return_value=_response(200, {"name": "prod"})) as post, \
+             patch.object(sc, "_forget_host_key"), \
+             patch.object(sc, "_wait_until_it_accepts_your_key", return_value=True):
+            assert sc.handle_server_fix_key("prod") is True
+
+        assert post.call_args.kwargs["json"]["ssh_public_key"] == "ssh-ed25519 AAAA x"
+        assert "/servers/prod/key" in post.call_args.args[0]
+        assert "accepts your key" in capsys.readouterr().out
+
+    def test_the_stale_host_key_is_dropped_first(self, registered):
+        """The address may have been handed back by the provider; a key that
+        changed is refused before authentication is even attempted."""
+        forgotten = []
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
+                   return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch("requests.post", return_value=_response(200)), \
+             patch.object(sc, "_forget_host_key", side_effect=forgotten.append), \
+             patch.object(sc, "_wait_until_it_accepts_your_key", return_value=True):
+            sc.handle_server_fix_key("prod")
+
+        assert forgotten == ["co@1.2.3.4"]
+
+    def test_an_unknown_server_is_refused_before_anything_is_sent(self, registered):
+        with patch("requests.post") as post:
+            assert sc.handle_server_fix_key("nope") is False
+        post.assert_not_called()
+
+    def test_a_machine_that_still_refuses_says_it_is_charged_for(self, registered, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
+                   return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch("requests.post", return_value=_response(200)), \
+             patch.object(sc, "_forget_host_key"), \
+             patch.object(sc, "_wait_until_it_accepts_your_key", return_value=False):
+            assert sc.handle_server_fix_key("prod") is False
+
+        assert "charged for either way" in " ".join(capsys.readouterr().out.split())


### PR DESCRIPTION
The CLI half of #449. Needs openonion/oo-api#69.

## What the operator was left with

```
Creating e2e-cefd85 … this takes about a minute.
It is not accepting your key yet.
The machine exists and is charged for; this is usually a slow first boot.
Try co server check in a minute.

✓ e2e-cefd85 is ready
  expires 2027-07-31 — $360.00 charged
```

The honesty was right — the machine exists and is billing either way. The advice was not: `co server check` only re-probes, so trying again does the same thing. **Nothing in the product could change the outcome.** The only repair was `destroy` and pay again.

## What this adds

```
co server fix-key prod
```

Reinstalls the derived key through the server API, then waits for the machine to take it. The timeout message now names it:

```
It is not accepting your key yet.
The machine exists and is charged for. Usually a slow first boot — try
co server check in a minute.
If it still refuses: co server fix-key prod reinstalls the key on the machine
you already paid for.
```

It drops the stale host key for the address before trying. A provider that handed an address back means the host key changed, and ssh refuses that before authentication is even attempted — so a repair that skipped this would fail for a second, unrelated reason.

## What I did not do

The issue's first two suggestions were to find out whether the reused IP causes this, and if so make `co server new` wait for a genuinely free address.

**The reused address is not the cause.** Both failing runs got `35.197.164.214`, and that address answers a *different machine* from this execution environment specifically — verified earlier by comparing the host key it presents here against the instance's own (`sudo ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` over IAP), and confirming a third vantage point sees the correct one and logs in with the same key first try. That is a local network artefact, not something GCE or the product does.

So chasing "wait for the address to be free" would have been building on a wrong premise. The third suggestion — make the wait recoverable — is the real gap, and it is what this does.

#449 stays open until the backend lands and this can be exercised against a real machine.

## Tests

Five, verified red first: the timeout names the repair rather than suggesting a bare wait, the fix reinstalls and confirms, the stale host key is dropped first, an unknown server is refused before anything is sent, and a machine that still refuses is told it is charged for either way.

2860 passed.