### PR TITLE
A project is not tied to the machine that made it

### DIFF
--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -95,14 +95,19 @@ def authenticate(co_dir: Path, save_to_project: bool = True, quiet: bool = False
                 "AGENT_EMAIL": agent_email,
                 "IS_EMAIL_ACTIVE": "true",
             })
-            # Ensure AGENT_ADDRESS and AGENT_CONFIG_PATH exist (append-only, don't overwrite)
+            # Ensure AGENT_ADDRESS exists (append-only, don't overwrite).
+            #
+            # AGENT_CONFIG_PATH is not written. It used to be, and `co create`
+            # copies this whole file into every new project's .env — so an
+            # absolute home directory travelled with the project and named a
+            # path that does not exist on any other machine (#438). Every tool
+            # that reads it already defaults to ~/.co on the machine it is
+            # running on, so the line only ever did harm.
             if global_keys_env.exists():
                 existing = global_keys_env.read_text(encoding="utf-8")
                 append_lines = []
                 if 'AGENT_ADDRESS=' not in existing:
                     append_lines.append(f"AGENT_ADDRESS={public_key}\n")
-                if 'AGENT_CONFIG_PATH=' not in existing:
-                    append_lines.append(f"AGENT_CONFIG_PATH={co_dir}\n")
                 if append_lines:
                     with open(global_keys_env, 'a', encoding='utf-8') as f:
                         f.writelines(append_lines)

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -319,10 +319,16 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         with open(global_keys_env, 'r', encoding='utf-8') as f:
             env_content = f.read()
 
-        # Add config path and default model comment if not already present
+        # AGENT_CONFIG_PATH is deliberately not written here. Every tool that
+        # reads it already falls back to ~/.co on the machine it is running on
+        # (gmail.py, outlook.py, gdrive.py, synology.py and both calendars all
+        # spell the same default), so writing it buys nothing — and it is an
+        # absolute path in a file that gets copied. Deployed, cloned or handed to
+        # a colleague, it names a home directory that does not exist there, and
+        # every one of those tools then looks for keys.env somewhere it can never
+        # be. `co deploy --to` still sets it in the unit's environment, where it
+        # describes the machine it is on rather than the one that made the file.
         lines_to_add = []
-        if "AGENT_CONFIG_PATH=" not in env_content:
-            lines_to_add.append(f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n")
         if "# Default model:" not in env_content:
             lines_to_add.append("# Default model: co/gemini-3.6-flash (managed keys with free credits)\n")
 
@@ -333,7 +339,6 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     else:
         # Fallback - create minimal .env with detected keys
         env_lines = [
-            f"AGENT_CONFIG_PATH={Path.home() / '.co'}",
             "# Default model: co/gemini-3.6-flash (managed keys with free credits)",
             "",
         ]

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -170,8 +170,11 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     global_dir = Path.home() / ".co"
     global_keys_env = global_dir / "keys.env"
 
-    # Identity keys: always overwrite from global (co reset must propagate)
-    IDENTITY_KEYS = {'AGENT_CONFIG_PATH', 'AGENT_ADDRESS', 'OPENONION_API_KEY',
+    # Identity keys: always overwrite from global (co reset must propagate).
+    # AGENT_CONFIG_PATH is not one of them — it describes the machine, not the
+    # identity, and copying an absolute home directory into a file that travels
+    # is what made a project only work where it was made (#438).
+    IDENTITY_KEYS = {'AGENT_ADDRESS', 'OPENONION_API_KEY',
                      'AGENT_EMAIL', 'IS_EMAIL_ACTIVE'}
 
     # Read global keys.env into a dict
@@ -214,8 +217,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # Write .env
     if not env_existed:
         if keys_to_add or global_keys:
-            env_content = f"AGENT_CONFIG_PATH={Path.home() / '.co'}\n"
-            env_content += "# Default model: co/gemini-3.6-flash (managed keys with free credits)\n\n"
+            env_content = "# Default model: co/gemini-3.6-flash (managed keys with free credits)\n\n"
             # Add all global keys + detected keys
             all_keys = list(global_keys.values()) + [k for k in keys_to_add if k not in global_keys.values()]
             env_content += '\n'.join(all_keys) + '\n'

--- a/tests/unit/test_a_project_travels.py
+++ b/tests/unit/test_a_project_travels.py
@@ -1,0 +1,80 @@
+"""A project must work on a machine other than the one that made it.
+
+`AGENT_CONFIG_PATH` was written as an absolute path — `/Users/changxing/.co` —
+into the global keys.env, which `co create` copies wholesale into every new
+project's `.env`. Deploy that project, clone it, or hand it to a colleague, and
+the variable names a home directory that does not exist there. Six tools build
+their keys.env path from it, and every one of them then looks for credentials
+somewhere they can never be. openonion/connectonion#438
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestNothingWritesTheMachinesOwnPath:
+    @pytest.mark.parametrize("module", [
+        "connectonion/cli/commands/create.py",
+        "connectonion/cli/commands/init.py",
+        "connectonion/cli/commands/auth_commands.py",
+    ])
+    def test_no_absolute_config_path_is_written(self, module):
+        source = (Path(__file__).parent.parent.parent / module).read_text()
+
+        assert "AGENT_CONFIG_PATH={Path.home()" not in source
+        assert "AGENT_CONFIG_PATH={co_dir}" not in source
+
+    def test_it_is_not_treated_as_an_identity_key(self):
+        """`co init` copies identity keys from the global file into the project.
+        A path describes the machine, not the identity."""
+        from connectonion.cli.commands import init
+
+        source = (Path(init.__file__)).read_text()
+        block = source[source.index("IDENTITY_KEYS"):source.index("IDENTITY_KEYS") + 200]
+
+        assert "AGENT_CONFIG_PATH" not in block
+
+
+class TestTheDefaultIsEnough:
+    """Removing the variable is only safe because every reader already has the
+    right fallback — and they must keep having it."""
+
+    @pytest.mark.parametrize("tool", [
+        "gmail", "outlook", "gdrive", "synology",
+        "google_calendar", "microsoft_calendar",
+    ])
+    def test_every_tool_falls_back_to_the_local_home(self, tool):
+        source = (Path(__file__).parent.parent.parent /
+                  "connectonion" / "useful_tools" / f"{tool}.py").read_text()
+
+        assert 'getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")' in source
+
+    def test_the_fallback_resolves_on_this_machine(self, monkeypatch):
+        monkeypatch.delenv("AGENT_CONFIG_PATH", raising=False)
+
+        resolved = Path(os.getenv("AGENT_CONFIG_PATH",
+                                  os.path.expanduser("~/.co"))) / "keys.env"
+
+        assert str(resolved).endswith(".co/keys.env")
+        assert "/Users/" not in str(resolved) or resolved.is_absolute()
+
+
+class TestTheDeployStillSetsIt:
+    """The one place it belongs: the unit's environment on the server, where it
+    describes the machine it is on rather than the one that made the file."""
+
+    def test_the_deploy_rewrites_it_for_the_server(self):
+        from connectonion.cli.commands import deploy_to_server as dts
+
+        out = dts._env_for_server({"AGENT_CONFIG_PATH": "/Users/someone/.co"}, "my-agent")
+
+        assert out["AGENT_CONFIG_PATH"] == f"{dts.SRV}/my-agent/.co"
+
+    def test_a_project_without_it_needs_no_rewriting(self):
+        from connectonion.cli.commands import deploy_to_server as dts
+
+        out = dts._env_for_server({"OPENONION_API_KEY": "k"}, "my-agent")
+
+        assert "AGENT_CONFIG_PATH" not in out


### PR DESCRIPTION
Closes #438.

Every project created by `co create` carried this:

```
AGENT_CONFIG_PATH=/Users/changxing/.co
```

Deploy it, clone it, or hand it to a colleague, and that names a home directory which does not exist there. Six tools — `gmail`, `outlook`, `gdrive`, `synology`, and both calendars — build their `keys.env` path from it, so on any other machine every one of them looks for credentials somewhere they can never be.

## Why removing it is safe

Because every reader already has the right answer without it:

```python
os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))
```

All six spell it identically. The variable added nothing on the machine that wrote it and broke the project everywhere else, so nothing writes it now.

## Three write sites, and the issue named two

`create.py` and `init.py` were the obvious ones. Removing both, creating a project, and looking at the result — it was still there:

```
新项目 .env 里的 AGENT_CONFIG_PATH 行数: 1
```

`co auth` writes it into the **global** `keys.env`, and `co create` copies that file wholesale. That was the source; the other two only re-stated it. Worth noting because the fix looked complete after the first two edits and was not.

It is also removed from `init.py`'s `IDENTITY_KEYS`, which is the set copied from the global file into each project. A path describes the machine, not the identity.

## What still sets it, correctly

`co deploy --to` puts it in the systemd unit's environment as `/srv/<agent>/.co`. There it describes the machine it is on rather than the one that made the file, which is the whole distinction.

## Verified

With the line removed from the global file first, so it reads as a fresh install:

```
新项目 .env 里的 AGENT_CONFIG_PATH 行数: 0
解析到: /Users/changxing/.co/keys.env | 存在: True
```

Portable, and the tools still find their keys.

## Tests

Thirteen, four verified red first: no write site emits an absolute path, it is not treated as an identity key, all six tools keep the fallback (parametrised, so a tool that drops it fails), the fallback resolves, and the deploy still rewrites it for the server — including that a project without the variable needs no rewriting.

3239 passed.