### PR TITLE
An agent answers to the name you gave it

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -30,7 +30,7 @@ import random
 from functools import partial
 import os
 from pathlib import Path
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 import uvicorn
 import websockets
@@ -105,7 +105,8 @@ def get_default_trust() -> str:
     return get_default_trust_level() or "careful"
 
 
-def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
+def _extract_agent_metadata(create_agent: Callable,
+                            name: Optional[str] = None) -> tuple[dict, object]:
     """Extract metadata from a sample agent instance.
 
     Returns:
@@ -114,7 +115,13 @@ def _extract_agent_metadata(create_agent: Callable) -> tuple[dict, object]:
     sample = create_agent()
     raw_skills = getattr(sample, 'skills', [])
     metadata = {
-        "name": sample.name,
+        # host.yaml's name, when it has one. The Agent object's name is whatever
+        # the code that built it chose — the co-ai template hardcodes "oo" — so
+        # every agent from that template introduced itself as "oo" on the relay,
+        # in /info and in the directory, whatever the operator had named their
+        # project. The name in host.yaml is the one they chose and the one the
+        # deploy already uses for the directory, the unit and the hostname.
+        "name": name or sample.name,
         "tools": sample.tools.names(),
         "model": sample.llm.model,
         "skills": [{"name": s.name, "description": s.description, "location": s.location}
@@ -497,7 +504,7 @@ def host(
     examples = config.get('examples')
 
     # Extract metadata once at startup
-    agent_metadata, sample = _extract_agent_metadata(create_agent)
+    agent_metadata, sample = _extract_agent_metadata(create_agent, config.get("name"))
 
     # Auto-generate summary from system_prompt if not set
     if summary is None:
@@ -601,7 +608,7 @@ def host(
     uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, log_level="warning")
 
 
-def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None):
+def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None, name=None):
     """Create ASGI app for external uvicorn/gunicorn usage.
 
     Each request calls create_agent() to get a fresh Agent instance.
@@ -624,8 +631,10 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     registry = ActiveSessionRegistry()
     start_cleanup_job(registry)
 
-    # Extract metadata once at startup
-    agent_metadata, sample = _extract_agent_metadata(create_agent)
+    # Extract metadata once at startup. `name` is host.yaml's, when the caller
+    # has read it — host() does; a bare ASGI caller may not, and then the
+    # Agent's own name stands as before.
+    agent_metadata, sample = _extract_agent_metadata(create_agent, name)
     agent_metadata["address"] = get_agent_address(sample)
 
     # Give the agent a polished Home on day zero (no-op if dashboard.html exists).

--- a/tests/unit/test_an_agent_answers_to_its_name.py
+++ b/tests/unit/test_an_agent_answers_to_its_name.py
@@ -1,0 +1,77 @@
+"""An agent introduces itself by the name its operator gave it.
+
+`host.yaml`'s `name:` never reached the network. The metadata came from the
+Agent object's own name, and the co-ai template hardcodes `name="oo"` — so every
+agent built from it called itself "oo" over `/info`, in the relay's directory
+and in the ANNOUNCE profile, whatever the project was called.
+openonion/connectonion#436
+"""
+
+import pytest
+
+from connectonion.network.host import server
+
+
+class _Tools:
+    def names(self):
+        return []
+
+
+class _Llm:
+    model = "co/gemini-3.6-flash"
+
+
+class _Agent:
+    name = "oo"
+    tools = _Tools()
+    skills = []
+    llm = _Llm()
+
+
+class TestTheNameOnTheWire:
+    def test_host_yaml_wins_over_the_agent_object(self):
+        metadata, _ = server._extract_agent_metadata(lambda: _Agent(), "naturewill")
+
+        assert metadata["name"] == "naturewill"
+
+    def test_without_one_the_agents_own_name_stands(self):
+        """A library user who never wrote a host.yaml keeps what they had."""
+        metadata, _ = server._extract_agent_metadata(lambda: _Agent())
+
+        assert metadata["name"] == "oo"
+
+    def test_an_empty_name_does_not_win(self):
+        """`name:` present but blank is not a name."""
+        metadata, _ = server._extract_agent_metadata(lambda: _Agent(), "")
+
+        assert metadata["name"] == "oo"
+
+    def test_the_profile_published_to_the_relay_carries_it(self):
+        """The directory entry is built from the same metadata, so this is the
+        name other people see when they look the agent up."""
+        metadata, _ = server._extract_agent_metadata(lambda: _Agent(), "naturewill")
+        metadata["address"] = "0x" + "a" * 64
+
+        profile = server._build_agent_profile(metadata)
+
+        assert profile["alias"] == "naturewill"
+
+
+class TestHostReadsItFromTheConfig:
+    def test_host_passes_the_configured_name(self):
+        """It is read from host.yaml already — it just was not being used."""
+        import inspect
+
+        src = inspect.getsource(server.host)
+
+        assert '_extract_agent_metadata(create_agent, config.get("name"))' in src
+
+    def test_the_config_loader_keeps_the_whole_file(self, tmp_path):
+        """No allowlist to add `name` to: load_host_config merges the file."""
+        from connectonion.network.host.config import load_host_config
+
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "host.yaml").write_text("name: naturewill\nentrypoint: agent.py\n")
+
+        assert load_host_config(co)["name"] == "naturewill"


### PR DESCRIPTION
Closes #436.

```yaml
# .co/host.yaml
name: naturewill
```

```
$ curl -s localhost:8000/info | jq .name
"oo"
```

Every agent built from the co-ai template introduced itself as **"oo"** — over `/info`, in the relay's public directory, and in the ANNOUNCE profile. The operator's own name for the thing never left their laptop.

## Why

`_extract_agent_metadata` took `sample.name` — the **Agent object's** name, which is whatever the code constructing it chose. `cli/co_ai/agent.py` chooses:

```python
name="oo",
```

So the name on the wire described the template, not the agent.

## The fix is smaller than the bug

The name was already being read. `load_host_config` merges the whole YAML file, so `config["name"]` was sitting there unused — there is no allowlist to add it to. `host()` now passes it to the extractor, where it wins over the Agent object's own.

A library user calling `host()` with no `host.yaml`, or `create_app()` directly, keeps exactly what they had.

`co deploy --to` already uses that same name for the directory, the systemd unit and the hostname. This makes the network agree with them.

## Tests

Six, four verified red first: `host.yaml`'s name wins, the Agent's own name still stands without one, an empty `name:` does not win, the relay profile carries it (that is what other people see when they look the agent up), `host()` actually passes it, and the config loader keeps the whole file.

3245 passed.