### PR TITLE
release: 1.5.6

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.5
+## Current Version: 1.5.6
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.5"
+version = "1.5.6"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Fourteen fixes since 1.5.5. No features, no breaking changes — 1.5.5's key derivation switch is the last of those and is already out.

Most of this came from deploying an agent to a customer's server for real and writing down what stopped it.

## Deploying to your own server now works end to end

This is the theme. Every step of `co server add` → `check` → `co deploy --to` had something in it.

- **#443** — the systemd unit named the ssh *alias* as its Unix user, so the service never started: `status=217/USER`, in a `Restart=always` loop, after every deploy stage had reported success. `co server add --ssh <alias>` is a form the help text recommends.
- **#448** — a deployed agent's identity is derived rather than minted on the machine, so its address is knowable before first boot and survives the machine (#396).
- **#456** — a project is no longer tied to the machine that made it. `AGENT_CONFIG_PATH` was written as an absolute path, so every OAuth-backed tool looked for credentials under the *creating* machine's home directory and silently found nothing (#438).
- **#452 / #453** — a second agent on the same server gets its own port and stops taking the first one's hostname.
- **#454** — a server you were charged for ends up in the registry.
- **#455** — `co server fix-key`, for a machine that will not take your key.
- **#432** — a server that stops answering is reported as that, not as a crash.
- **#447** — `co server new` declines instead of raising `OSError: [Errno 22]` when stdin is not a terminal. It is the one command that spends money, and a bare traceback said nothing about whether the charge went through (#437).

## Trust decisions are legible

- **#439** — allows are logged too, with the condition that matched; the `client_id` is printed whole rather than truncated to 20 characters; the config dict — which carries the agent's invite codes — is no longer dumped on every request. Previously only denials were logged, so "the log did not grow" meant either *allowed* or *never asked*. Diagnosing one denial took an hour (#434).

## An agent has its own name

- **#446 / #457** — `create_agent()` passed `name="oo"` literally, and co-ai is the only template, so every deployed agent announced itself identically. Three of them in one client list during a real deployment. The name in `.co/host.yaml` is now the name it answers to (#436).

## Correctness

- **#440** — a system reminder is context about the turn, not something the user said.
- **#433** — the agent is told to call `skill()`, rather than told that it can.

## Verified

Deployed to a fresh Ubuntu 24.04 GCE instance through the product path, not by hand:

```
$ systemctl is-active naturewill     → active
$ systemctl show -p NRestarts        → 0
$ grep ^User= …/naturewill.service   → User=changxing
$ ls /srv/naturewill/.env            → No such file or directory
$ ls /srv/naturewill/.co/            → OO.md admins.txt host.yaml keys logs skills trust.md
```

The agent connected to the relay, its dashboard rendered in the client, and the project's
own skill — not a bundled one of the same name — was the one loaded. `default: deny` held
throughout.

Eight of the ten issues labelled `production-blocker` are closed by this release. The two
that remain (#434's client half, #435) need a protocol frame and a client affordance, and
are not in this repo.
