### PR TITLE
The heartbeat never sends a frame it cannot sign

### DIFF
--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -230,10 +230,23 @@ async def serve_loop(
                     addr_data, summary, endpoints=endpoints, relay=relay_url
                 )
                 await send_announce(websocket, fresh_announce)
+                console.print(f"{prefix} [red]♥[/red]")
             else:
-                announce_message["timestamp"] = int(asyncio.get_event_loop().time())
-                await send_announce(websocket, announce_message)
-            console.print(f"{prefix} [red]♥[/red]")
+                # Nothing is sent. The fallback used to re-stamp the original
+                # frame and send it again, which could only ever be rejected:
+                # the relay verifies the signature over every field, so a
+                # changed timestamp invalidates it — and the value written was
+                # a monotonic clock rather than epoch seconds, off by decades
+                # from what the freshness check expects.
+                #
+                # Re-signing is not possible here either: without addr_data
+                # there is no private key in this process. A frame that cannot
+                # be signed cannot be sent, so the honest move is to say the
+                # registration will lapse rather than to send something the
+                # relay is certain to refuse.
+                console.print(f"{prefix} [yellow]♥ cannot refresh — no signing "
+                              f"key in this process; registration will lapse"
+                              f"[/yellow]")
 
         except websockets.exceptions.ConnectionClosed:
             # Relay WS closed cleanly (relay redeployed, network blip, NAT idle

--- a/tests/unit/test_heartbeat_must_be_signable.py
+++ b/tests/unit/test_heartbeat_must_be_signable.py
@@ -1,0 +1,70 @@
+"""The heartbeat never sends a frame the relay is certain to refuse.
+
+The fallback re-stamped the original ANNOUNCE and sent it again. Two faults
+stacked: the relay verifies the signature over every field, so a changed
+timestamp invalidates it — and the value written was `asyncio.get_event_loop().
+time()`, a monotonic clock, which is decades away from the epoch seconds the
+freshness check compares against. openonion/connectonion#429
+"""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from connectonion.network import relay
+
+
+class TestTheFallbackDoesNotSendSomethingUnsignable:
+    def test_no_frame_is_sent_without_a_signing_key(self):
+        """Re-signing needs the private key, and the branch exists precisely
+        because it is absent. Sending anyway is a guaranteed rejection."""
+        source = inspect.getsource(relay)
+        fallback = source[source.index("heartbeat_interval (60s) elapsed"):]
+        fallback = fallback[:fallback.index("except websockets")]
+
+        else_branch = fallback[fallback.index("else:"):]
+        assert "send_announce" not in else_branch, \
+            "still sends a frame it cannot sign"
+
+    def test_the_timestamp_is_never_overwritten_in_place(self):
+        """Mutating a signed message is what invalidated it."""
+        source = inspect.getsource(relay)
+
+        assert 'announce_message["timestamp"] =' not in source
+
+    def test_the_monotonic_clock_is_not_used_as_a_timestamp(self):
+        """get_event_loop().time() counts from an arbitrary origin — here it was
+        off from epoch by more than fifty years, against a 300-second window."""
+        source = inspect.getsource(relay)
+
+        assert "get_event_loop().time()" not in source
+
+    def test_the_operator_is_told_the_registration_will_lapse(self):
+        """Silence would leave an agent that reads as online and is not."""
+        source = inspect.getsource(relay)
+
+        assert "registration will lapse" in source
+
+
+class TestTheHealthyPathIsUnchanged:
+    def test_a_signing_key_still_produces_a_fresh_signed_frame(self):
+        """The branch that works builds a new message rather than editing one,
+        which is the only way it can carry a valid signature."""
+        source = inspect.getsource(relay)
+        fallback = source[source.index("heartbeat_interval (60s) elapsed"):]
+
+        assert "create_announce_message(" in fallback
+        assert fallback.index("create_announce_message(") < fallback.index("else:")
+
+
+class TestTheClockTheRelayActuallyChecks:
+    def test_a_monotonic_value_would_fail_the_freshness_window(self):
+        """Not an assumption about the relay — the arithmetic, run."""
+        import asyncio
+        import time
+
+        async def gap():
+            return int(time.time()) - int(asyncio.get_event_loop().time())
+
+        assert abs(asyncio.run(gap())) > 300

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -308,8 +308,14 @@ class TestServeLoop:
             assert error_printed
 
     @pytest.mark.asyncio
-    async def test_serve_loop_heartbeat_on_timeout(self):
-        """Test that heartbeat ANNOUNCE is sent after timeout."""
+    async def test_serve_loop_heartbeat_without_a_key_sends_nothing(self):
+        """Without addr_data there is no private key in this process, so the
+        heartbeat cannot produce a signed frame.
+
+        This used to re-stamp the original ANNOUNCE and send it, which the relay
+        rejects every time — the signature covers every field. The test asserted
+        that send, treating the bug as the contract. openonion/connectonion#429
+        """
         mock_ws = AsyncMock()
         announce_msg = {
             "type": "ANNOUNCE",
@@ -331,12 +337,15 @@ class TestServeLoop:
                 mock_loop.return_value.time.return_value = 99999
                 await relay.serve_loop(mock_ws, announce_msg, heartbeat_interval=1, session_handler=AsyncMock())
 
-        # Should have sent at least 2 ANNOUNCEs (initial + heartbeat)
+        # The initial ANNOUNCE, and nothing from the heartbeat: a frame that
+        # cannot be signed is a frame the relay is certain to refuse.
         announce_count = sum(
             1 for call in mock_ws.send.call_args_list
             if json.loads(call[0][0]).get("type") == "ANNOUNCE"
         )
-        assert announce_count >= 2, "Should send initial ANNOUNCE + heartbeat ANNOUNCE"
+        assert announce_count == 1, (
+            f"sent {announce_count} ANNOUNCEs; the heartbeat should send none "
+            f"without a signing key")
 
     @pytest.mark.asyncio
     async def test_serve_loop_exits_on_connection_closed(self):


### PR DESCRIPTION
Closes #429.

The heartbeat's fallback branch re-stamped the original ANNOUNCE and sent it again:

```python
announce_message["timestamp"] = int(asyncio.get_event_loop().time())
await send_announce(websocket, announce_message)
```

Two faults, either fatal on its own.

**The signature covers every field.** The relay verifies over `json.dumps(message minus signature, sort_keys=True)`, so changing the timestamp invalidates it. The frame is rejected every time, as `Invalid signature` — pointing at the key rather than at the mutation.

**The clock is the wrong one.** `asyncio.get_event_loop().time()` is monotonic, counting from an arbitrary origin. Measured rather than assumed:

```
monotonic:  486600
epoch:      1785520855
gap:        1785034255 seconds
```

against a 300-second freshness window. Even a correctly re-signed frame carrying that value would be refused.

## Why it sends nothing now

The branch exists because `addr_data` is absent — which is exactly the private key it would need to re-sign. There is no frame it could construct that the relay would accept.

So it sends none, and says so:

```
♥ cannot refresh — no signing key in this process; registration will lapse
```

Silence would leave an operator with an agent that reads as online and is about to be dropped by the relay's stale-agent cleanup. The branch that *does* have a key is untouched: it builds a fresh message through `create_announce_message`, which is the only way to carry a valid signature.

## The existing test asserted the bug

`test_serve_loop_heartbeat_on_timeout` passed no `addr_data` and then required an ANNOUNCE to be sent — it encoded the broken behaviour as the contract, so the fix broke it. It now asserts that exactly one ANNOUNCE goes out (the initial one) and explains why.

That is the same shape as openonion/oo-api#68 earlier today: a test written from the implementation rather than from what the caller needs, which then defends the defect.

## Tests

Six new, four verified red first: no frame is sent without a signing key, the timestamp is never overwritten in place, the monotonic clock is not used as a timestamp, the operator is told the registration will lapse, the healthy path still builds a fresh message, and — run rather than assumed — a monotonic value fails the freshness window.

2892 passed.