### PR TITLE
fix(deploy): after a deploy, the server runs the version that deployed to it

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -22,6 +22,7 @@ import yaml
 from dotenv import dotenv_values
 from rich.console import Console
 
+from ... import __version__
 from .server_commands import SSH_TIMEOUT_SECONDS, derived_agent_identity, load_server
 
 console = Console()
@@ -692,7 +693,20 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
     if not requirements.exists():
         return True
 
-    digest = hashlib.sha256(requirements.read_bytes()).hexdigest()
+    # The deploying CLI's version is part of what makes an install current.
+    #
+    # Comparing the requirements text alone froze every unpinned line at the
+    # version resolved on first install — and the template pins nothing, so
+    # `connectonion` itself never moved. Upgrading the CLI and redeploying, the
+    # mechanism by which a released fix reaches production, reported success at
+    # every stage and left the old runtime in place.
+    #
+    # It also let the two halves of a deploy drift apart: this CLI writes the
+    # systemd unit, the .co/ layout and the secrets file, and a runtime of some
+    # older version reads them.
+    digest = hashlib.sha256(
+        requirements.read_bytes() + __version__.encode()
+    ).hexdigest()
     stamp = f"{SRV}/{agent}/.co/requirements.sha256"
 
     current = _ssh(target, f"cat {stamp} 2>/dev/null", timeout=60)
@@ -710,6 +724,15 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         f"set -e\n"
         f"cd {SRV}/{agent}\n"
         f"{SRV}/{agent}/.venv/bin/pip install -q -r requirements.txt\n"
+        # …and then the runtime, at this CLI's version.
+        #
+        # `pip install -r` leaves an already-satisfied unpinned requirement
+        # alone, and the template names the framework without a version. So the
+        # install above ran, reported success, and left 1.5.5 in place while
+        # 1.5.6 was doing the deploying. Naming the version is the only way the
+        # two halves of a deploy stay the same software.
+        f"{SRV}/{agent}/.venv/bin/pip install -q "
+        f"{shlex.quote('connectonion==' + __version__)}\n"
         f"printf '%s' {shlex.quote(digest)} > {stamp}",
         timeout=900,
     )

--- a/tests/unit/test_deploy_carries_its_own_version.py
+++ b/tests/unit/test_deploy_carries_its_own_version.py
@@ -1,0 +1,97 @@
+"""After a deploy, the server runs the connectonion that deployed to it.
+
+The install step was skipped whenever requirements.txt was byte-identical to
+last time. The template pins nothing — `connectonion` on its own line — so an
+unpinned line's text never changes and its resolved version stayed frozen at
+whatever was installed first. Upgrading the CLI and redeploying reported
+success at every stage and left the old library in place, which is the
+mechanism by which every released fix is supposed to arrive.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def run(stdout="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+REQUIREMENTS = "connectonion\npymupdf>=1.28\n"
+
+
+def deploy_against(tmp_path, recorded_stamp, version):
+    """Returns (did_install, the ssh commands it ran).
+
+    Does not touch requirements.txt — a test that changes it would otherwise
+    have its change written back underneath it.
+    """
+    calls = []
+
+    def fake_ssh(target, command, timeout=None, **kwargs):
+        calls.append(command)
+        if command.startswith("cat ") and "requirements.sha256" in command:
+            return run(recorded_stamp)
+        return run()
+
+    with patch.object(dts, "__version__", version, create=True):
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            dts._install_deps_if_changed("user@host", "billing", tmp_path)
+
+    installed = any("pip install" in c for c in calls)
+    return installed, calls
+
+
+def stamp_for(tmp_path, version):
+    """Whatever the code would record after installing under this version."""
+    (tmp_path / "requirements.txt").write_text(REQUIREMENTS)
+    _, calls = deploy_against(tmp_path, recorded_stamp="", version=version)
+    write = next(c for c in calls if "pip install" in c)
+    # the digest is the quoted argument of the printf that follows
+    return write.split("printf '%s' ")[1].split(" >")[0].strip("'")
+
+
+def test_a_cli_upgrade_reinstalls(tmp_path):
+    old_stamp = stamp_for(tmp_path, "1.5.5")
+
+    installed, _ = deploy_against(tmp_path, recorded_stamp=old_stamp, version="1.5.6")
+
+    assert installed, (
+        "the CLI moved 1.5.5 → 1.5.6 and the server kept the old runtime; "
+        "this is how a released fix fails to arrive"
+    )
+
+
+def test_an_unchanged_deploy_still_skips(tmp_path):
+    # The optimisation this protects is real: a code-only deploy must not pay
+    # for a pip install.
+    same_stamp = stamp_for(tmp_path, "1.5.6")
+
+    installed, _ = deploy_against(tmp_path, recorded_stamp=same_stamp, version="1.5.6")
+
+    assert not installed, "a deploy that changed nothing reinstalled anyway"
+
+
+def test_the_install_names_the_version_it_wants(tmp_path):
+    # Triggering the install is not enough: `pip install -r` leaves an
+    # already-satisfied unpinned requirement alone, so the server kept 1.5.5
+    # while 1.5.6 deployed to it — the install ran and changed nothing.
+    (tmp_path / "requirements.txt").write_text(REQUIREMENTS)
+
+    _, calls = deploy_against(tmp_path, recorded_stamp="stale", version="1.5.6")
+
+    install = next(c for c in calls if "pip install" in c)
+    assert "connectonion==1.5.6" in install, (
+        "the install does not name a version, so an already-installed "
+        "connectonion is left where it was"
+    )
+
+
+def test_changed_requirements_still_reinstall(tmp_path):
+    stamp = stamp_for(tmp_path, "1.5.6")
+    (tmp_path / "requirements.txt").write_text("connectonion\npymupdf>=1.28\nhttpx\n")
+
+    installed, _ = deploy_against(tmp_path, recorded_stamp=stamp, version="1.5.6")
+
+    assert installed

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -198,7 +198,13 @@ class TestDependencyInstall:
         """A code-only change should take seconds, not minutes."""
         (project / "requirements.txt").write_text("requests\n")
         import hashlib
-        digest = hashlib.sha256((project / "requirements.txt").read_bytes()).hexdigest()
+        from connectonion import __version__
+        # The stamp covers the deploying CLI's version too, so that upgrading it
+        # carries the new runtime to the server (#460). Unchanged here means
+        # unchanged in both.
+        digest = hashlib.sha256(
+            (project / "requirements.txt").read_bytes() + __version__.encode()
+        ).hexdigest()
 
         with patch.object(dts, "_ssh", return_value=_ok(digest)) as ssh:
             assert dts._install_deps_if_changed("user@host", "myagent", project) is True


### PR DESCRIPTION
Closes #460.

1.5.6 shipped #446/#457 — the fix that stops every agent calling itself `oo`. Then:

```
$ pip install -U connectonion          # local CLI → 1.5.6
$ co deploy --to nw-e2e
✓ naturewill is running on nw-e2e

$ ssh nw-e2e 'pip show connectonion | grep ^Version'   → 1.5.5
$ ssh nw-e2e 'curl -s localhost:8001/info | jq -r .name' → oo
```

Success at every stage. The fix that was the point of the release was not on the server.

## Two faults, stacked

**The install was skipped.** The stamp hashed `requirements.txt`, and the template names the framework without a version:

```
connectonion
pymupdf>=1.28
```

An unpinned line's text never changes, so its resolved version was frozen at first install. The stamp now covers the deploying CLI's version as well — a CLI upgrade reinstalls once; code-only deploys still skip, which is what that optimisation was protecting.

**The install then did nothing.** `pip install -r` leaves an already-satisfied unpinned requirement alone. I found this by fixing the first fault and watching `installing dependencies …` print while `pip show` did not move. The runtime is now named explicitly:

```
pip install -q connectonion==<this CLI's version>
```

Fixing either fault alone leaves the property broken, which is why both are here.

## Why version skew matters beyond staleness

The local CLI writes the systemd unit, the `.co/` layout and the secrets file; the server-side runtime reads them. #443 and #448 both changed what gets written. An old runtime reading new config is a failure mode nobody is testing, and until now nothing kept the two halves the same software.

## Verified

Downgraded a real server to 1.5.5, deployed from a 1.5.6 CLI:

```
installing dependencies …
✓ naturewill is running on nw-e2e

Version: 1.5.6
name= naturewill  skills= 1
```

Unit tests: `tests/unit/test_deploy_carries_its_own_version.py`, four cases — a CLI upgrade reinstalls, an unchanged deploy still skips, changed requirements still reinstall, and the install names the version it wants. The first and last fail before this change.

One existing test updated: `test_unchanged_requirements_skip_the_install` computed the stamp itself and had to learn the version is part of it. Its intent — a code-only change takes seconds — is unchanged and still asserted.

206 deploy/server tests pass.