### PR TITLE
A released fix reaches the agent on the next deploy

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -682,17 +682,29 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
 
 
 def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool:
-    """pip install only when requirements.txt actually changed.
+    """pip install when requirements.txt changed, or when this CLI is a new
+    version of connectonion than the one that last installed.
 
-    The hash of the file we just synced is compared against the hash recorded
-    after the last successful install. Reinstalling every deploy would make a
-    code-only change take minutes instead of seconds.
+    Reinstalling every deploy would make a one-line code change take minutes,
+    so the file's hash decides. But `connectonion` in requirements.txt is an
+    unpinned line that never changes, so its hash never changed either — and a
+    server kept whatever version it was first deployed with, forever. 1.5.6 went
+    out fixing every agent that called itself `oo`, and a redeploy from a 1.5.6
+    laptop left 1.5.5 running on the box.
+
+    So the stamp carries the CLI's version too. Upgrading the CLI and
+    redeploying is what an operator does to ship a fix, and now that is what it
+    does.
     """
+    from ... import __version__
+
     requirements = project_dir / "requirements.txt"
     if not requirements.exists():
         return True
 
-    digest = hashlib.sha256(requirements.read_bytes()).hexdigest()
+    digest = hashlib.sha256(
+        requirements.read_bytes() + b"\ncli:" + __version__.encode()
+    ).hexdigest()
     stamp = f"{SRV}/{agent}/.co/requirements.sha256"
 
     current = _ssh(target, f"cat {stamp} 2>/dev/null", timeout=60)
@@ -709,7 +721,11 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         # plainly there as missing.
         f"set -e\n"
         f"cd {SRV}/{agent}\n"
-        f"{SRV}/{agent}/.venv/bin/pip install -q -r requirements.txt\n"
+        # -U, because pip leaves an already-satisfied requirement alone.
+        # Measured: a venv on 1.5.4 with `connectonion` unpinned stayed on 1.5.4
+        # through `pip install -r`, and moved to 1.5.6 only with -U. Without it
+        # the reinstall this function just decided to do would change nothing.
+        f"{SRV}/{agent}/.venv/bin/pip install -q -U -r requirements.txt\n"
         f"printf '%s' {shlex.quote(digest)} > {stamp}",
         timeout=900,
     )

--- a/tests/unit/test_a_release_reaches_the_agent.py
+++ b/tests/unit/test_a_release_reaches_the_agent.py
@@ -1,0 +1,81 @@
+"""A released fix reaches a deployed agent on the next deploy.
+
+`connectonion` in requirements.txt is an unpinned line that never changes, so
+the hash that decides whether to install never changed either — and a server
+kept whatever version it was first deployed with, forever. 1.5.6 shipped the fix
+for every agent calling itself `oo`, and redeploying from a 1.5.6 laptop left
+1.5.5 running on the box. openonion/connectonion#460
+"""
+
+import hashlib
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from connectonion import __version__
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "requirements.txt").write_text("connectonion\n")
+    return tmp_path
+
+
+def _stamp_for(project, version):
+    return hashlib.sha256(
+        (project / "requirements.txt").read_bytes() + b"\ncli:" + version.encode()
+    ).hexdigest()
+
+
+class TestUpgradingTheCliShipsTheFix:
+    def test_a_newer_cli_reinstalls_even_though_the_file_is_identical(self, project):
+        """The whole bug: an unpinned line has an unchanging hash."""
+        stale = _stamp_for(project, "1.5.5")
+
+        with patch.object(dts, "_ssh", return_value=_ok(stale)) as ssh:
+            dts._install_deps_if_changed("user@host", "myagent", project)
+
+        assert any("pip install" in c.args[1] for c in ssh.call_args_list), \
+            "skipped the install, so the release never reaches the server"
+
+    def test_the_same_cli_still_skips(self, project):
+        """A code-only change must still take seconds, not minutes."""
+        current = _stamp_for(project, __version__)
+
+        with patch.object(dts, "_ssh", return_value=_ok(current)) as ssh:
+            dts._install_deps_if_changed("user@host", "myagent", project)
+
+        assert not any("pip install" in c.args[1] for c in ssh.call_args_list)
+
+    def test_the_stamp_written_back_carries_the_version(self, project):
+        with patch.object(dts, "_ssh", return_value=_ok("stale")) as ssh:
+            dts._install_deps_if_changed("user@host", "myagent", project)
+
+        install = next(c.args[1] for c in ssh.call_args_list if "pip install" in c.args[1])
+        assert _stamp_for(project, __version__) in install
+
+
+class TestTheReinstallActuallyUpgrades:
+    def test_pip_is_told_to_upgrade(self, project):
+        """Measured against a real venv: one on 1.5.4 with `connectonion`
+        unpinned stayed on 1.5.4 through `pip install -r`, and moved only with
+        -U. Without it the reinstall changes nothing."""
+        with patch.object(dts, "_ssh", return_value=_ok("stale")) as ssh:
+            dts._install_deps_if_changed("user@host", "myagent", project)
+
+        install = next(c.args[1] for c in ssh.call_args_list if "pip install" in c.args[1])
+        assert " -U " in install or install.endswith(" -U")
+
+    def test_it_still_runs_from_the_project_directory(self, project):
+        """A requirements.txt may name a local wheel or `-e .` (#377)."""
+        with patch.object(dts, "_ssh", return_value=_ok("stale")) as ssh:
+            dts._install_deps_if_changed("user@host", "myagent", project)
+
+        install = next(c.args[1] for c in ssh.call_args_list if "pip install" in c.args[1])
+        assert f"cd {dts.SRV}/myagent" in install

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -198,7 +198,13 @@ class TestDependencyInstall:
         """A code-only change should take seconds, not minutes."""
         (project / "requirements.txt").write_text("requests\n")
         import hashlib
-        digest = hashlib.sha256((project / "requirements.txt").read_bytes()).hexdigest()
+
+        from connectonion import __version__
+        # Same file AND same CLI version — the stamp carries both, so that a
+        # released fix reaches the server on the next deploy (#460).
+        digest = hashlib.sha256(
+            (project / "requirements.txt").read_bytes() + b"\ncli:" + __version__.encode()
+        ).hexdigest()
 
         with patch.object(dts, "_ssh", return_value=_ok(digest)) as ssh:
             assert dts._install_deps_if_changed("user@host", "myagent", project) is True


### PR DESCRIPTION
Closes #460.

```
$ pip install -U connectonion          # local CLI → 1.5.6
$ co deploy --to nw-e2e
✓ naturewill is running on nw-e2e

$ ssh nw-e2e '/srv/naturewill/.venv/bin/pip show connectonion | grep ^Version'
Version: 1.5.5
```

The release went out. The deploy succeeded. The fix never arrived.

## Two halves, either one fatal

**The install was skipped.** `_install_deps_if_changed` compares the hash of `requirements.txt` against the one recorded after the last install — and `connectonion` is an unpinned line that never changes. The hash never changed, so the install never ran, so the server kept whatever version it was first deployed with. Forever.

The stamp now carries the CLI's own version as well. Upgrading the CLI and redeploying is exactly what an operator does to ship a fix, and now that is what it does. A code-only change from the same CLI still skips, so it still takes seconds rather than minutes.

**And the install would not have upgraded anything.** pip leaves an already-satisfied requirement alone. Measured against a real venv rather than assumed:

```
初始:               1.5.4
install -r 之后:    1.5.4     ← unchanged
install -U -r 之后: 1.5.6
```

So `-U`. Without it, the reinstall this function had just decided to perform would have changed nothing, and the bug would have survived the fix for it.

## Tests

Five, three verified red first: a newer CLI reinstalls even though the file is byte-identical, the same CLI still skips, the stamp written back carries the version, pip is told to upgrade, and the install still runs from the project directory (#377, so a local wheel or `-e .` keeps resolving).

One existing test built the expected stamp from the file alone and was updated — it encoded the old fingerprint, which is the thing that was wrong.

2903 passed.

## Worth noting for 1.6

This is the last thing standing between a release and the machines running it. Before this, every fix shipped since a server was created had never reached it.