### PR TITLE
release: 1.5.7

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.6
+## Current Version: 1.5.7
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.6"
+__version__ = "1.5.7"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.6"
+version = "1.5.7"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Three fixes, all on the path between a released fix and a running agent.

## A release now actually reaches the server

**#462** — `co deploy` compared only the text of `requirements.txt`, and the template names the framework without a version. An unpinned line's text never changes, so its resolved version stayed frozen at first install: upgrading the CLI and redeploying reported success at every stage and left the old runtime in place. 1.5.6 shipped the fix that stops agents calling themselves `oo`, and a redeploy did not carry it.

Two faults, and either one alone keeps the property broken — the install was skipped, and `pip install -r` then leaves an already-satisfied unpinned requirement where it is. The digest now covers the deploying CLI's version, and the install uses `-U`.

Filed as #460 after hitting it on a real deployment.

## The relay stops rejecting its own heartbeat

**#459** — the heartbeat fallback mutated `timestamp` on the announce frame without re-signing it. The relay verifies over the message minus its signature, so that frame could only ever be rejected: every agent printed

```
[host] Relay error: Invalid signature
```

on a connection that was otherwise fine. Noise, but the misleading kind — it sent me looking for a signing problem twice during a deployment that had none.

## Per-server SSH keys

**#428** — a key derived per server from the tree, beside the old one.

## Verified

Deployed to a fresh Ubuntu 24.04 GCE instance through `co server add` → `check` → `co deploy --to`, with the server deliberately downgraded to 1.5.5 first:

```
installing dependencies …
✓ naturewill is running on nw-e2e

Version: 1.5.6          ← was 1.5.5, carried by the deploy
name= naturewill        ← was "oo"
skills= 1               ← the project's own contract-ledger
```

Service active, relay connected, dashboard rendered in the client, `default: deny` held, and `/srv/<agent>/.env` does not exist.