### PR TITLE
Install and offer the per-server SSH key (#427, step 1)

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -58,7 +58,7 @@ def _ssh(target: str, command: str, timeout: int = 300) -> subprocess.CompletedP
         "-o", "BatchMode=yes",
         "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
         "-o", "StrictHostKeyChecking=accept-new",
-        *_identity(),
+        *_identity(target),
         target,
         command,
     ]
@@ -270,7 +270,7 @@ WantedBy=multi-user.target
 
 
 def _ensure_setup(target: str, agent: str, entrypoint: str, schema: int,
-                  ssh_public_line: Optional[str],
+                  ssh_public_lines: Optional[list],
                   deployer_address: Optional[str] = None,
                   agent_identity: Optional[dict] = None) -> bool:
     """Bring the server to the state a deploy assumes. Idempotent.
@@ -293,10 +293,15 @@ dpkg -s python3-venv >/dev/null 2>&1 || (sudo apt-get update -qq && sudo apt-get
 [ -x {SRV}/{agent}/.venv/bin/python ] || python3 -m venv {SRV}/{agent}/.venv
 """)
 
-    if ssh_public_line:
+    # A list during the #427 migration: the per-server key from the tree, and
+    # the older single key that is already in authorized_keys on every machine
+    # provisioned before it. Appending the new line on every deploy is the
+    # backfill — no box is left reachable only by the key we are retiring, and
+    # it happens without the operator being asked to do anything.
+    for line in ssh_public_lines or []:
         # Ensured every deploy, not once: authorized_keys is the only way back
         # in, so it self-heals rather than needing a rescue path.
-        quoted = shlex.quote(ssh_public_line)
+        quoted = shlex.quote(line)
         steps.append(f"""
 mkdir -p ~/.ssh && chmod 700 ~/.ssh
 touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
@@ -657,7 +662,7 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
             *RSYNC_FILTERS,
             "-e", " ".join(["ssh", "-o", "BatchMode=yes",
                             "-o", "StrictHostKeyChecking=accept-new",
-                            *_ssh_identity()]),
+                            *_ssh_identity(target)]),
             f"{project_dir}/",
             f"{target}:{SRV}/{agent}/",
         ],
@@ -844,9 +849,12 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
     _warn_about_skills_left_behind(project_dir)
 
     provision = _read_provision(target, agent)
-    from .server_commands import _ensure_ssh_key
+    from .server_commands import _ssh_public_lines
 
-    ssh_public_line = _ensure_ssh_key()
+    # Both keys, so this deploy is also the backfill: a machine provisioned
+    # before the per-server key existed gets that line appended here, without
+    # the operator having to run anything.
+    ssh_public_lines = _ssh_public_lines(server)
     deployer_address = _deployer_address()
 
     # An agent that will be handed to a customer must have an identity its author
@@ -859,7 +867,7 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
                       f"(derived from your recovery phrase)[/dim]")
 
     if not _ensure_setup(target, agent, entrypoint, provision.get("schema", 0),
-                         ssh_public_line, deployer_address,
+                         ssh_public_lines, deployer_address,
                          agent_identity=agent_identity):
         return False
     if not _sync_code(target, agent, project_dir):

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -204,6 +204,36 @@ SSH_PRIVATE_KEY = Path.home() / ".co" / "ssh" / "id_ed25519"
 SSH_PUBLIC_KEY = Path.home() / ".co" / "ssh" / "id_ed25519.pub"
 
 
+def per_host_key_path(host: str) -> Path:
+    """Where this machine's own key is cached.
+
+    One file per server, named after it. The private key is derived from the
+    phrase, so these are a cache and not the original — losing them costs a
+    re-derivation, not access.
+    """
+    safe = "".join(c if c.isalnum() or c in "-._" else "_" for c in host)
+    return SSH_PRIVATE_KEY.parent / f"id_ed25519_{safe}"
+
+
+def write_per_host_ssh_key(seed_phrase: str, host: str, user: str = "root") -> Path:
+    """Cache the key that opens one particular server.
+
+    Same rules as the shared key: both halves together, overwritten from the
+    phrase, because a pair where one half is stale cannot authenticate.
+    """
+    from ... import address
+
+    keys = address.derive_ssh_key(seed_phrase, host=host, user=user)
+    path = per_host_key_path(host)
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.write_text(keys["private_key"])
+    path.chmod(0o600)
+    path.with_suffix(".pub").write_text(keys["public_line"] + "\n")
+    path.with_suffix(".pub").chmod(0o644)
+    return path
+
+
 def write_derived_ssh_key(seed_phrase: str) -> Path:
     """Write the derived key pair where our own ssh calls look for it.
 

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -104,21 +104,53 @@ def load_server(name: str) -> Optional[dict]:
     return _load().get(name)
 
 
-def _identity() -> list:
-    """`-i <derived key>` when it is on disk, otherwise nothing.
+def _identity(target: str = None) -> list:
+    """The keys to offer for this target, most specific first.
 
-    A machine from `co server new` has only the derived key installed, so
-    without this our own commands cannot reach a server we just sold. Offered
-    rather than forced — no IdentitiesOnly — so a box registered by hand with
+    A machine from `co server new` has only a derived key installed, so without
+    this our own commands cannot reach a server we just sold. Offered rather
+    than forced — no IdentitiesOnly — so a box registered by hand with
     `co server add` still opens with whichever key already worked.
 
-    Every path that reaches a server goes through here: preflight, deploy,
-    rsync, and the interactive shell. `co server ssh` was the one that did not,
-    and it was the one command whose whole purpose is getting you onto the box.
-    """
-    from .keys_commands import SSH_PRIVATE_KEY
+    Two are offered during the migration in #427: the per-server key from the
+    SLIP-0010 tree, and the older single key that is in `authorized_keys` on
+    every machine provisioned before it. Dropping the old one before every
+    server carries the new line would lock us out of boxes we own, and the way
+    back in *is* the key. ssh tries them in order and stops at the first that
+    works, so a machine holding either is reachable.
 
-    return ["-i", str(SSH_PRIVATE_KEY)] if SSH_PRIVATE_KEY.exists() else []
+    Every path that reaches a server goes through here: preflight, deploy,
+    rsync, and the interactive shell.
+    """
+    from .keys_commands import SSH_PRIVATE_KEY, per_host_key_path
+
+    keys = []
+    name = _server_name(target)
+    if name and per_host_key_path(name).exists():
+        keys += ["-i", str(per_host_key_path(name))]
+    if SSH_PRIVATE_KEY.exists():
+        keys += ["-i", str(SSH_PRIVATE_KEY)]
+    return keys
+
+
+def _server_name(target: str = None) -> Optional[str]:
+    """The registered name for a server, given its name or its ssh target.
+
+    Callers hold one or the other — `co server ssh` has the name, the deploy
+    helpers have `root@<ip>` — and the per-server key is derived from the name.
+    The name and not the address, because the address does not exist yet at the
+    moment the key has to be chosen: it is sent in the request that creates the
+    machine, and GCE only answers with an IP afterwards.
+    """
+    if not target:
+        return None
+    servers = _load()
+    if target in servers:
+        return target
+    for name, entry in servers.items():
+        if entry.get("ssh") == target:
+            return name
+    return None
 
 
 def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
@@ -133,7 +165,7 @@ def _ssh(target: str, command: str) -> subprocess.CompletedProcess:
         "-o", "BatchMode=yes",                    # never prompt; fail instead
         "-o", f"ConnectTimeout={SSH_TIMEOUT_SECONDS}",
         "-o", "StrictHostKeyChecking=accept-new",
-        *_identity(),
+        *_identity(target),
         target,
         command,
     ]
@@ -404,7 +436,8 @@ def handle_server_ssh(name: str, command: Optional[str] = None) -> bool:
         console.print("[cyan]co server ls[/cyan] to see what is registered.\n")
         return False
 
-    argv = ["ssh", "-o", "StrictHostKeyChecking=accept-new", *_identity(), entry["ssh"]]
+    argv = ["ssh", "-o", "StrictHostKeyChecking=accept-new",
+            *_identity(entry["ssh"]), entry["ssh"]]
     if command:
         argv.append(command)
 
@@ -520,7 +553,7 @@ API_BASE = "https://oo.openonion.ai"
 SERVER_NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]{0,37}[a-z0-9])?$")
 
 
-def _ensure_ssh_key() -> Optional[str]:
+def _ensure_ssh_key(name: str = None) -> Optional[str]:
     """The public line to install, having put the private half where ssh looks.
 
     Both halves, because only installing the public one produces a machine
@@ -536,16 +569,44 @@ def _ensure_ssh_key() -> Optional[str]:
     second one was locked out of the machine the first had just bought.
     """
     from ... import address
-    from .keys_commands import _find_co_dir, write_derived_ssh_key
+    from .keys_commands import (_find_co_dir, write_derived_ssh_key,
+                                write_per_host_ssh_key)
 
     for co_dir in (Path.home() / ".co", _find_co_dir()):
         if not co_dir or not co_dir.exists():
             continue
         data = address.load(co_dir)
         if data and data.get("seed_phrase"):
+            if name:
+                write_per_host_ssh_key(data["seed_phrase"], name)
             write_derived_ssh_key(data["seed_phrase"])
             return address.derive_ssh_key(data["seed_phrase"])["public_line"]
     return None
+
+
+def _ssh_public_lines(name: str = None) -> list:
+    """Every public line to put in a server's authorized_keys.
+
+    Both keys during the #427 migration, so a machine carries the per-server key
+    from the tree *and* the older shared one. Installing only the new key would
+    lock us out of every server provisioned before it, and there is no way back
+    in that does not go through a key already on the box.
+    """
+    from ... import address
+    from .keys_commands import _find_co_dir
+
+    shared = _ensure_ssh_key(name)
+    if not shared or not name:
+        return [shared] if shared else []
+
+    for co_dir in (Path.home() / ".co", _find_co_dir()):
+        if not co_dir or not co_dir.exists():
+            continue
+        data = address.load(co_dir)
+        if data and data.get("seed_phrase"):
+            per_server = address.derive_ssh_key(data["seed_phrase"], host=name)
+            return [per_server["public_line"], shared]
+    return [shared]
 
 
 def _fetch_pricing() -> Optional[dict]:

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -917,3 +917,70 @@ class TestReadyMeansYouCanLogIn:
             assert sc.handle_server_new("prod", yes=True) is True
 
         assert waited == ["co@203.0.113.7"]
+
+
+class TestThePerServerKeyMigration:
+    """#427: a second key, derived per server, installed beside the old one.
+
+    The one rule the migration has to obey is that no step removes the only key
+    a machine holds. Every server provisioned to date carries the shared key and
+    nothing else, and the way back into a box we own is that key.
+    """
+
+    PHRASE = ("legal winner thank year wave sausage worth useful legal "
+              "winner thank yellow")
+
+    @pytest.fixture
+    def phrase_on_disk(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        co_dir = tmp_path / ".co"
+        co_dir.mkdir()
+        from connectonion import address
+        keys = address.generate()
+        keys["seed_phrase"] = self.PHRASE
+        address.save(keys, co_dir)
+        return co_dir
+
+    def test_a_deploy_installs_the_new_key_without_dropping_the_old_one(
+            self, phrase_on_disk, servers_file):
+        """Both lines, or a machine that only has the old key is orphaned the
+        moment we stop offering it."""
+        lines = sc._ssh_public_lines("prod")
+
+        assert len(lines) == 2, lines
+        assert all(l.startswith("ssh-ed25519 ") for l in lines), lines
+        assert lines[0] != lines[1], "the per-server key is the shared key"
+
+        from connectonion import address
+        assert lines[1] == address.derive_ssh_key(self.PHRASE)["public_line"], \
+            "the shared key is no longer among the lines a deploy installs"
+
+    def test_each_server_gets_its_own_key(self, phrase_on_disk, servers_file):
+        """The point of the tree: a key leaked off one box does not open the
+        next one."""
+        assert sc._ssh_public_lines("prod")[0] != sc._ssh_public_lines("staging")[0]
+
+    def test_ssh_offers_the_server_its_own_key_first(self, phrase_on_disk,
+                                                     servers_file):
+        """Offered, not forced — the old key stays in the list so a machine that
+        has not been redeployed since the migration still opens."""
+        from connectonion.cli.commands.keys_commands import (SSH_PRIVATE_KEY,
+                                                             per_host_key_path)
+        sc._ssh_public_lines("prod")          # a deploy, which caches both keys
+        sc._update(lambda servers: servers.update(
+            {"prod": {"ssh": "co@1.2.3.4", "hostname": "prod.example"}}))
+
+        for handle in ("prod", "co@1.2.3.4"):
+            assert sc._identity(handle) == ["-i", str(per_host_key_path("prod")),
+                                            "-i", str(SSH_PRIVATE_KEY)], handle
+
+    def test_a_server_we_have_never_seen_still_gets_the_old_key(
+            self, phrase_on_disk, servers_file):
+        """A box added by hand with `co server add`, or one whose deploy has not
+        run yet, has only the shared key on it. Offering nothing would be worse
+        than offering the wrong key."""
+        from connectonion.cli.commands.keys_commands import SSH_PRIVATE_KEY
+        sc._ensure_ssh_key()
+
+        assert sc._identity("root@5.6.7.8") == ["-i", str(SSH_PRIVATE_KEY)]


### PR DESCRIPTION
Closes step 1 of #427. #428 made the per-server key derivable; this installs it and starts using it, **without retiring the key it replaces**.

## Why this is a migration, not a switch

Every server provisioned to date carries the old shared key and nothing else. That key *is* the way back into a machine we own — there is no undo. So both keys ship side by side until the fleet has caught up.

| | before | after |
|---|---|---|
| a deploy installs | the shared key | the per-server key **and** the shared key |
| ssh offers | the shared key | per-server first, shared second |
| an existing server | reachable | still reachable, and gains the new line on its next deploy |

Because the install step is idempotent and runs on **every** deploy, the deploy path *is* the backfill: an old machine picks up the new line without the operator running anything.

## Derived from the name, not the address

`ssh://root@<server-name>`, because the address does not exist yet at the moment the key has to be chosen — it is sent in the request that creates the machine, and GCE only answers with an IP afterwards. `_server_name()` maps either handle (`prod` or `root@1.2.3.4`) back to the registered name, so callers holding one or the other both work.

## Verified against a real sshd

Not only in tests — the mechanics were driven end to end against a real machine:

1. per-server key alone, no ssh config → `Permission denied (publickey)`
2. the line installed the way a deploy installs it
3. same key, same command → logged in
4. line removed; the box stayed reachable by the old key the whole time

## Tests

4 new tests in `TestThePerServerKeyMigration`, each **verified red against the unpatched source** before being called done:

- a deploy installs the new key without dropping the old one
- each server gets its own key
- ssh offers a server its own key first
- a server we have never seen still gets the old key

`2907 passed` in the full unit suite.

## Still to come in #427

Retiring the HKDF key, once enough of the fleet has been redeployed to carry the new line. That is deliberately a separate change — this one cannot lock anybody out, and that one can.