### PR TITLE
fix(deploy): the stamp follows what was installed, not what was asked for

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -726,6 +726,23 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         # through `pip install -r`, and moved to 1.5.6 only with -U. Without it
         # the reinstall this function just decided to do would change nothing.
         f"{SRV}/{agent}/.venv/bin/pip install -q -U -r requirements.txt\n"
+        # Then the runtime, by name and version.
+        #
+        # -U asks the index for "newest", which is a race with our own release:
+        # a deploy run minutes after 1.5.7 was published installed 1.5.6, because
+        # that is what the index served at that moment. Measured, not theorised —
+        # the same server took 1.5.7 when asked for it directly a minute later.
+        #
+        # The pin also fixes the reverse skew: an older CLI deploying onto a
+        # server that resolves a *newer* connectonion than the one writing the
+        # systemd unit and the .co/ layout it will read.
+        f"{SRV}/{agent}/.venv/bin/pip install -q "
+        f"{shlex.quote('connectonion==' + __version__)}\n"
+        # Last, and only if everything above succeeded — `set -e` is what makes
+        # that true. The stamp is the claim "this server is current for this
+        # CLI", and a deploy that could not converge must not leave that claim
+        # behind: the next deploy would match it, skip the install, and freeze
+        # the mismatch for good.
         f"printf '%s' {shlex.quote(digest)} > {stamp}",
         timeout=900,
     )

--- a/tests/unit/test_deploy_stamp_follows_reality.py
+++ b/tests/unit/test_deploy_stamp_follows_reality.py
@@ -1,0 +1,75 @@
+"""A deploy that did not converge must not record that it did.
+
+#462 made the install run and made it upgrade. Then a deploy minutes after
+1.5.7 was published put 1.5.6 on the server — `-U` resolves to whatever the
+index serves at that moment, and it was still serving the previous release.
+The stamp was written anyway, keyed on the CLI's version, so every later
+deploy matched it and skipped the install. A transient resolution problem
+became a permanent one, silently.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def run(stdout="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def install_script(tmp_path, version="1.5.7"):
+    (tmp_path / "requirements.txt").write_text("connectonion\npymupdf>=1.28\n")
+    scripts = []
+
+    def fake_ssh(target, command, timeout=None, **kwargs):
+        scripts.append(command)
+        if command.startswith("cat ") and "requirements.sha256" in command:
+            return run("stale")
+        return run()
+
+    with patch.object(dts, "__version__", version, create=True):
+        with patch.object(dts, "_ssh", side_effect=fake_ssh):
+            dts._install_deps_if_changed("user@host", "billing", tmp_path)
+
+    return next(s for s in scripts if "pip install" in s)
+
+
+def test_the_runtime_is_pinned_to_the_deploying_cli():
+    """`-U` asks for 'newest'. Only a pin asks for 'the one that is deploying'."""
+    import tempfile, pathlib
+    with tempfile.TemporaryDirectory() as d:
+        script = install_script(pathlib.Path(d), version="1.5.7")
+
+    assert "connectonion==1.5.7" in script, (
+        "the deploy asks the index for whatever is newest, so a deploy run "
+        "just after a release lands the previous version"
+    )
+
+
+def test_a_failed_install_leaves_the_stamp_unwritten():
+    """set -e plus ordering: the stamp is the last thing, after the pin.
+
+    If the wanted version cannot be installed the step fails, the stamp stays
+    as it was, and the next deploy tries again — instead of recording success
+    and skipping forever.
+    """
+    import tempfile, pathlib
+    with tempfile.TemporaryDirectory() as d:
+        script = install_script(pathlib.Path(d))
+
+    assert "set -e" in script
+    pin_at = script.index("connectonion==")
+    stamp_at = script.index("requirements.sha256")
+    assert pin_at < stamp_at, (
+        "the stamp is written before the version is pinned, so it records an "
+        "install that may not have converged"
+    )
+
+
+def test_the_projects_own_requirements_are_still_installed():
+    import tempfile, pathlib
+    with tempfile.TemporaryDirectory() as d:
+        script = install_script(pathlib.Path(d))
+
+    assert "-r requirements.txt" in script


### PR DESCRIPTION
Closes #465. Follow-up to #462 — the third fault, visible only once the two it named are gone.

## What happened

1.5.7 published. Server put back to 1.5.5, deployed from a 1.5.7 CLI:

```
  installing dependencies …
✓ naturewill is running on nw-e2e

$ ssh nw-e2e 'pip show connectonion | grep ^Version'
Version: 1.5.6
```

`-U` asks the index for *newest*, and newest was still 1.5.6 at that moment — a race with our own publish. Not something the deploy can prevent; the same server took 1.5.7 when asked for it by name a minute later:

```
$ ssh nw-e2e 'pip index versions connectonion'      → connectonion (1.5.7)
$ ssh nw-e2e 'pip install -q -U connectonion; pip show connectonion'  → 1.5.7
```

## Why it does not heal

The stamp is keyed on the **CLI's** version and written whenever the install exits 0. So it recorded *current for 1.5.7* with 1.5.6 on disk. The next deploy compares, matches, and skips the install entirely — the skew survives every subsequent deploy until `requirements.txt` changes or the CLI moves again.

A transient resolution problem converted into a durable one, with nothing reporting it. Same shape as the bug it follows: a record of intent where only a record of outcome is safe.

## Change

```python
 pip install -q -U -r requirements.txt
+pip install -q connectonion==<this CLI's version>
 printf '%s' <digest> > <stamp>
```

- **The pin.** Only naming the version makes "the server runs the version that deployed to it" true rather than likely. It also closes the reverse skew — an older CLI writing a systemd unit and `.co/` layout that a newer runtime reads.
- **The stamp goes last.** `set -e` was already in the script, so a version that cannot be installed now fails the step and leaves the stamp as it was. The next deploy tries again instead of recording success and skipping forever.

`-U -r requirements.txt` stays, for the project's own dependencies.

## Verified

Server put back to 1.5.5, stamp cleared, deployed from a patched 1.5.7 CLI:

```
Version: 1.5.7      ← exactly the CLI's version, not 'newest'
active, NRestarts=0
name: naturewill  skills: 1
```

Three unit tests in `tests/unit/test_deploy_stamp_follows_reality.py`; the two that assert the pin and the ordering fail before this change. 205 deploy/server tests pass.