### PR TITLE
release: 1.5.8

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.7
+## Current Version: 1.5.8
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.7"
+__version__ = "1.5.8"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.7"
+version = "1.5.8"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Two changes, both on the deploy path.

## A deploy that did not converge no longer records that it did

**#466** — third and last fault in the chain that started at #460. A deploy run minutes after 1.5.7 was published installed **1.5.6**: `-U` asks the index for *newest*, and newest was still the previous release at that moment — a race with our own publish. The same server took 1.5.7 when asked for it by name a minute later, so the resolver could see it; it just had not yet.

What made that permanent was the stamp. Keyed on the CLI's version and written whenever the install exited 0, it recorded *current for 1.5.7* with 1.5.6 on disk — and every later deploy matched it and skipped the install. A transient resolution problem frozen into a durable one, silently.

Now the runtime is installed by name and version (`connectonion==<the deploying CLI's>`), and the stamp is written last, after the pin. `set -e` was already there, so a version that cannot be installed fails the step and leaves the stamp alone — the next deploy tries again.

The pin also closes the reverse skew: an older CLI writing a systemd unit and `.co/` layout that a newer runtime reads.

## Per-server SSH key

**#464** — the derived key is installed and offered (#427, step 1).

## Verified

Server put back to 1.5.5, stamp cleared, deployed from a 1.5.8-candidate CLI:

```
installing dependencies …
✓ naturewill is running on nw-e2e

Version: 1.5.7      ← exactly the CLI's version, not 'newest'
active, NRestarts=0
name: naturewill  skills: 1
```