### PR TITLE
Refresh a token that names another account (oo-api#67)

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -9,6 +9,9 @@ LLM-Note:
   Errors: validate_project_name() returns (False, error_msg) for invalid names | detect_api_provider() returns ("unknown", "unknown") for unrecognized keys | generate_custom_template_with_name() may fail if LLM API unreachable | api_key_setup_menu() catches KeyboardInterrupt and returns ("", "", None) | no try-except blocks (follows fail-fast principle)
 """
 
+import base64
+import binascii
+import json
 import os
 import re
 import sys
@@ -978,8 +981,61 @@ def load_api_key() -> Optional[str]:
         if env_path.exists():
             load_dotenv(env_path)
             if api_key := os.getenv("OPENONION_API_KEY"):
-                return api_key
+                return _token_for_this_account(api_key)
     return None
+
+
+def account_in_token(token: str) -> Optional[str]:
+    """The public key a JWT claims, read without verifying it.
+
+    Not authentication — the server does that. This is only to notice that the
+    token in hand names a different account than the key on disk, which the
+    server cannot tell us until we have already asked it the wrong question.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)          # base64url, padding stripped
+    try:
+        return json.loads(base64.urlsafe_b64decode(payload)).get("public_key")
+    except (ValueError, binascii.Error):
+        return None
+
+
+def _token_for_this_account(token: str) -> str:
+    """Re-authenticate when the stored token names an account we are not.
+
+    `co server new` and `co deploy` bill whatever the token says; `co status`
+    signs fresh and reads the key on disk. After `co account migrate` those are
+    two different accounts, and nothing fails — `/api/v1/auth` creates an
+    account for any key that authenticates, so the old address quietly becomes a
+    fresh, empty, working one. The operator sees a balance that is not theirs
+    and spends credit they did not migrate. One $180 server was bought that way.
+
+    The CLI holds the signing key, so it can see the mismatch itself rather than
+    waiting for a balance to look wrong. Cheap: a local decode, and a network
+    call only when the two disagree.
+    """
+    from .auth_commands import authenticate
+
+    co_dir = Path.home() / ".co"
+    identity = address.load(co_dir)
+    if not identity:
+        return token
+
+    claimed = account_in_token(token)
+    if not claimed or claimed == identity["address"]:
+        return token
+
+    console.print(f"[dim]Your saved token is for {claimed[:16]}…, but this "
+                  f"machine is {identity['address'][:16]}…. "
+                  f"Authenticating again.[/dim]")
+    if authenticate(co_dir, save_to_project=False, quiet=True):
+        from dotenv import load_dotenv
+        load_dotenv(co_dir / "keys.env", override=True)
+        return os.getenv("OPENONION_API_KEY", token)
+    return token
 
 
 def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> None:

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -52,3 +52,74 @@ class TestUpsertEnv:
 
         if sys.platform != "win32":
             assert env_file.stat().st_mode & 0o777 == 0o600
+
+
+class TestATokenThatNamesAnotherAccount:
+    """oo-api#67. After `co account migrate` the stored token names the address
+    the account left. Nothing errors: `/api/v1/auth` creates an account for any
+    key that authenticates, so the old address becomes a fresh, empty, working
+    one and every command keeps succeeding against the wrong row. `co status`
+    read the migrated balance while `co server new` spent $180 of an account the
+    operator did not know existed.
+    """
+
+    MINE = "0x" + "a" * 64
+    THEIRS = "0x" + "b" * 64
+
+    def _token(self, public_key):
+        import base64
+        import json
+
+        body = base64.urlsafe_b64encode(
+            json.dumps({"public_key": public_key, "iat": 1}).encode()).rstrip(b"=")
+        return "header." + body.decode() + ".signature"
+
+    def _patched(self, monkeypatch, identity_address, refreshed_to=None):
+        from connectonion.cli.commands import project_cmd_lib as lib
+
+        calls = []
+
+        def fake_authenticate(co_dir, save_to_project=True, quiet=False):
+            calls.append(co_dir)
+            if refreshed_to:
+                monkeypatch.setenv("OPENONION_API_KEY", refreshed_to)
+                return True
+            return False
+
+        monkeypatch.setattr(lib.address, "load",
+                            lambda co_dir: {"address": identity_address})
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", fake_authenticate)
+        monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **k: True)
+        return lib, calls
+
+    def test_the_token_is_refreshed_when_it_names_a_different_account(
+            self, monkeypatch):
+        fresh = self._token(self.MINE)
+        lib, calls = self._patched(monkeypatch, self.MINE, refreshed_to=fresh)
+
+        assert lib._token_for_this_account(self._token(self.THEIRS)) == fresh
+        assert calls, "a token for another account was used as-is"
+
+    def test_a_token_for_this_account_costs_no_network_call(self, monkeypatch):
+        lib, calls = self._patched(monkeypatch, self.MINE)
+        token = self._token(self.MINE)
+
+        assert lib._token_for_this_account(token) == token
+        assert not calls, "re-authenticated for no reason"
+
+    def test_an_unreadable_token_is_left_alone(self, monkeypatch):
+        """It may be a shape we do not know. The server is the authority on
+        whether a token is valid — guessing here would lock somebody out of a
+        working setup."""
+        lib, calls = self._patched(monkeypatch, self.MINE)
+
+        assert lib._token_for_this_account("not-a-jwt") == "not-a-jwt"
+        assert not calls
+
+    def test_the_claim_is_read_without_verifying_it(self):
+        from connectonion.cli.commands.project_cmd_lib import account_in_token
+
+        assert account_in_token(self._token(self.THEIRS)) == self.THEIRS
+        assert account_in_token("garbage") is None
+        assert account_in_token("a.b.c") is None


### PR DESCRIPTION
The client half of openonion/oo-api#67. The backend half (openonion/oo-api#71) is merged and deployed; the issue says this half alone would have prevented the incident, and it is the cheaper of the two.

## What went wrong

After `co account migrate`, the CLI was split across two accounts:

| command | authenticates with | account it saw |
|---|---|---|
| `co status` | a fresh signature over the key on disk | the new one — correct |
| `co server new`, `co deploy` | the stored JWT | the **old** one |

Nothing errored. `/api/v1/auth` creates an account for any key that authenticates, so the migrated-from address did not become an error — it became a fresh, empty, working account. `co status` showed the migrated balance while `co server new` reported "not enough credit" against an account the operator did not know existed, and then bought a $180 server from it.

## The fix

The CLI holds the signing key, so it can see the mismatch itself instead of waiting for a balance to look wrong. `load_api_key()` now reads the `public_key` the token claims and compares it against `address.load()`:

```
Your saved token is for 0x1a2b3c4d5e6f7890…, but this machine is
0x9f8e7d6c5b4a3210…. Authenticating again.
```

- **A local base64 decode, not verification.** The server is the authority on whether a token is valid; this only notices that it names someone else — which the server cannot tell us until we have already asked it the wrong question.
- **Network call only on mismatch.** The common path is a string comparison.
- **An unreadable token is left alone.** It may be a shape we do not know, and guessing would lock somebody out of a working setup.

## Tests

4 new, verified red against the unpatched source:

- a token naming a different account is refreshed
- a token for this account costs no network call
- an unreadable token is returned untouched
- the claim is read without verifying it

`2914 passed` in the full unit suite.

## Checked against reality

Ran against this machine's real token and real identity: the two match, so the check stays silent and makes no call — which is the path every existing user is on.

The mismatch path was not driven against the live backend, because doing so means rewriting `~/.co/keys.env` on a real account. It is covered by tests, and the 401 it now cooperates with was verified against the deployed backend.