### PR TITLE
Paid onboarding could not succeed, and failed open when it could not run

### DIFF
--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -348,11 +348,30 @@ def is_admin(client_id: str, co_dir: Path = None) -> bool:
 
 
 def get_self_address(co_dir: Path = None) -> str | None:
-    """Get self address (super admin) from .co/address.json."""
+    """The agent's own address — who a payment onboarding is paid to.
+
+    Read the same way every other part of the codebase reads it. It used to be
+    read straight out of ``.co/address.json``, a file `co create` has not
+    written for some time: keys live in ``.co/keys/``. So this answered None for
+    every project made since, which is not a visible error anywhere —
+    ONBOARD_REQUIRED simply goes out with no payment address for the card to
+    show, and `verify_payment` returns False before it asks anything. Paid
+    onboarding could not succeed, and the card could not say where to send the
+    money (openonion/oo-chat#28).
+
+    ``address.json`` is still honoured, because a project created before the
+    move has one and nothing else.
+    """
     import json
 
     if co_dir is None:
         co_dir = Path.cwd() / ".co"
+
+    from ... import address
+
+    keys = address.load(co_dir)
+    if keys and keys.get("address"):
+        return keys["address"]
 
     addr_file = co_dir / "address.json"
     if addr_file.exists():

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -278,8 +278,10 @@ Should this client be allowed access?"""
         try:
             import httpx
         except ImportError:
-            # httpx not available, fall back to simple amount check
-            return True
+            # Fails closed. This used to return True — a missing dependency
+            # admitted anyone who claimed to have paid, which is the one
+            # direction this check must never fail in.
+            return False
 
         # Load agent's keys for signing the request
         from ... import address as addr
@@ -296,14 +298,17 @@ Should this client be allowed access?"""
 
         # Create signed auth request
         timestamp = int(time.time())
-        message = f"ConnectOnion-Auth-{keys['public_key']}-{timestamp}"
+        message = f"ConnectOnion-Auth-{keys['address']}-{timestamp}"
         signature = addr.sign(keys, message.encode()).hex()
 
         # Get JWT token
         auth_response = httpx.post(
-            f"{base_url}/auth",
+            f"{base_url}/api/v1/auth",
             json={
-                "public_key": keys['public_key'],
+                # `address.load` has never returned a "public_key"; this raised
+                # KeyError on the line below before it could reach the 404 that
+                # `/auth` answers. Both had to be wrong for either to hide.
+                "public_key": keys['address'],
                 "message": message,
                 "signature": signature
             },

--- a/tests/unit/test_trust_functions.py
+++ b/tests/unit/test_trust_functions.py
@@ -226,3 +226,81 @@ class TestAdminListIsPerAgent:
         (co_dir / "admins.txt").write_text("0xdeployer\n")
 
         assert tools.is_admin("0xdeployer", co_dir) is True
+
+
+class TestThePaymentAddressAPaidOnboardingShows:
+    """openonion/oo-chat#28. The card says "Transfer $X to:" — and the address it
+    shows is `get_self_address()`, which is also the address `verify_payment`
+    checks the transfer arrived at. Both read it from the same place on purpose:
+    an onboarding where the displayed address and the verified address can
+    disagree sends somebody's money somewhere nobody is watching.
+    """
+
+    def _project(self, tmp_path):
+        """A project as `co create` leaves it: keys under .co/keys/, and no
+        .co/address.json, which is the file this used to read."""
+        from connectonion import address
+
+        co_dir = tmp_path / ".co"
+        co_dir.mkdir()
+        keys = address.generate()
+        address.save(keys, co_dir)
+        assert not (co_dir / "address.json").exists(), \
+            "the fixture no longer reflects what co create writes"
+        return co_dir, keys["address"]
+
+    def test_a_project_made_by_co_create_has_a_payment_address(self, tmp_path):
+        from connectonion.network.trust.tools import get_self_address
+
+        co_dir, expected = self._project(tmp_path)
+
+        assert get_self_address(co_dir) == expected
+
+    def test_an_older_project_still_answers_from_address_json(self, tmp_path):
+        """Nothing rewrites these on upgrade, so the old file stays readable."""
+        import json
+
+        from connectonion.network.trust.tools import get_self_address
+
+        co_dir = tmp_path / ".co"
+        co_dir.mkdir()
+        (co_dir / "address.json").write_text(json.dumps({"address": "0xold"}))
+
+        assert get_self_address(co_dir) == "0xold"
+
+    def test_the_card_and_the_check_are_given_the_same_address(self, tmp_path):
+        """ONBOARD_REQUIRED tells the payer where to send it; verify_payment
+        decides whether it arrived. One value, read once."""
+        from types import SimpleNamespace
+
+        from connectonion.network.trust.tools import get_self_address
+        from connectonion.network.trust.ws_admin import get_onboard_requirements
+
+        co_dir, expected = self._project(tmp_path)
+        trust_agent = SimpleNamespace(
+            config={"onboard": {"payment": 5}},
+            get_self_address=lambda: get_self_address(co_dir),
+        )
+
+        assert get_onboard_requirements(trust_agent)["payment_address"] == expected
+
+
+class TestPaymentVerificationFailsClosed:
+    def test_a_missing_dependency_does_not_admit_the_payer(self, monkeypatch):
+        """It returned True — a machine without httpx let anyone in who claimed
+        to have paid. This is the one direction the check must never fail in."""
+        import builtins
+
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        real_import = builtins.__import__
+
+        def no_httpx(name, *args, **kwargs):
+            if name == "httpx":
+                raise ImportError("no httpx here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", no_httpx)
+
+        agent = TrustAgent.__new__(TrustAgent)
+        assert agent._verify_transfer_via_api("0xpayer", "0xagent", 5.0) is False


### PR DESCRIPTION
Found while investigating openonion/oo-chat#28 ("the payment card shows the wrong agent address"). The card is not showing the wrong address — there is no address to show, and nothing downstream works either. Three defects stacked in one path, each hiding the next.

## 1. The payment address has been `None` since keys moved

`get_self_address()` read `.co/address.json`. `co create` has not written that file for some time — keys live in `.co/keys/`. Verified against a real project directory: it answered `None`.

Nothing reports this. `ONBOARD_REQUIRED` simply goes out with no `payment_address`, so the card has nothing to render, and `verify_payment` returns `False` before it asks anybody anything:

```python
self_addr = self.get_self_address()
if not self_addr:
    return False
```

Now read the way the rest of the codebase reads it, `address.load(co_dir)["address"]`, with `address.json` still honoured for projects created before the move.

## 2. `keys['public_key']` — a key `address.load` has never returned

```python
>>> sorted(address.load(Path.home() / ".co"))
['address', 'email', 'email_active', 'legacy_derivation', 'seed_phrase', 'short_address', 'signing_key']
```

`KeyError`, uncaught, on the way to the API.

## 3. `POST {base_url}/auth` — 404 on the real backend

```
POST https://oo.openonion.ai/auth        -> 404
POST https://oo.openonion.ai/api/v1/auth -> 422 (reached; rejecting an empty body)
```

Both #2 and #3 had to be wrong for either to be noticed: the `KeyError` fired first, so the 404 never got a chance to.

## 4. And it failed **open**

```python
except ImportError:
    # httpx not available, fall back to simple amount check
    return True
```

A machine without `httpx` admitted anyone who claimed to have paid. That is the one direction this check must never fail in — it now returns `False`.

## Verified against reality, not just tests

Against a real `co create` project and the live backend:

```
a real project made by co create -> 0x1fb7e0b740ff70df2408c5979e55d24516f6ab1e8daf8dc78187d56c78e8bf20
POST /api/v1/auth -> 200  token: True
```

The address is the same one that project's host announces on `/info`, which is the property that matters: the address on the card and the address the transfer is checked against are one value, read once.

## Tests

4 new — 3 verified red against the unpatched source (the fourth guards old `address.json` projects and passes either way by design):

- a project made by `co create` has a payment address
- an older project still answers from `address.json`
- the card and the check are given the same address
- a missing dependency does not admit the payer

`2918 passed` in the full unit suite.

Closes openonion/oo-chat#28.