### PR TITLE
docs(dashboard): a media query in a Home page measures the pane, not the window

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -33,6 +33,7 @@ A button that runs something MUST be a real, user-invocable skill, wired like th
 - One file: `.co/dashboard.html`. No sidecar JSON, no build step.
 - Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
+- **A media query here measures the Home pane, not the browser window.** The page renders inside its own iframe, so `@media (max-width: 560px)` means "when the pane is narrower than 560px" — the question you wanted to ask. No container queries needed. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.
 - Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting; only the `data-ochat-skill` button contract works.
 - Keep styles inline in the file (external URLs are blocked in the sandbox).
 - **No links out.** A Home page is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -29,7 +29,21 @@
   }
   /* The Home pane is ~440px wide in oo-chat, full-width on mobile, and sometimes a
      whole browser window. One centred column with a max-width covers all three;
-     anything that stretches turns an eight-character button into a 1400px bar. */
+     anything that stretches turns an eight-character button into a 1400px bar.
+
+     A media query here measures THE PANE, not the browser window. The client
+     renders this page inside its own iframe, and a media query inside an iframe
+     evaluates against that frame's viewport — so `@media (max-width: 560px)` in a
+     dashboard means "when the pane is narrower than 560px", which is the question
+     you actually wanted to ask. Verified: with the pane at 320px the frame reports
+     innerWidth 319 and the query matches; dragged to 900px it reports 899 and does
+     not. No container queries needed — the isolation already gives you one.
+
+     This matters more now that the pane is resizable: one dashboard has to hold up
+     across the whole 320–900px range, not at the two or three widths the client
+     used to pick. Design for the narrow end first; a four-column table needs about
+     500px, so give it a stacked form below that or the column you care about ends
+     up off the right edge behind a scrollbar. */
   main { max-width: 680px; margin: 0 auto; }
 
   header { margin-bottom: 20px; }

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -140,6 +140,27 @@ Keep it under **2MB**. The Host won't send a larger file, and the Home pane goes
 blank. Inline images are base64, which is ~33% larger than the source file — compress
 screenshots before embedding them.
 
+### A media query here measures the pane, not the window
+
+The same sandbox that locks the page down also gives you something useful for free.
+Your page renders inside its own iframe, and a media query inside an iframe evaluates
+against **that frame's** viewport — so this means "when the Home pane is narrower than
+560px", which is the question you actually wanted to ask:
+
+```css
+@media (max-width: 560px) { /* pane is narrow — stack the rows */ }
+```
+
+Measured, not assumed: with the pane at 320px the frame reports `innerWidth` 319 and
+the query matches; dragged out to 900px it reports 899 and it does not. You do not
+need container queries — the isolation already is one.
+
+This matters because the pane is **resizable**: one dashboard has to hold up anywhere
+from 320px to 900px, not at the two or three widths a client used to pick. Design for
+the narrow end first. A four-column table needs roughly 500px, so below that give it a
+stacked form — otherwise the column the table exists for ends up off the right edge
+behind a horizontal scrollbar, which nobody scrolls to find a number they came for.
+
 > **Why so locked down?** The client renders your `dashboard.html` in a sandboxed
 > iframe with a strict Content-Security-Policy, because from its side the file is
 > untrusted, agent-authored HTML. Everything above follows from that: nothing loads


### PR DESCRIPTION
Nothing anywhere said this, and it is the single most useful fact for anyone writing a `dashboard.html`.

The page renders inside its own iframe. A media query inside an iframe evaluates against **that frame's** viewport — so `@media (max-width: 560px)` in a dashboard already means *"when the Home pane is narrower than 560px"*, which is the question the author wanted to ask. The isolation that locks the page down hands you a container query for free.

**Measured, not assumed.** Probing the live frame while dragging the pane:

| pane | frame `innerWidth` | `matchMedia('(max-width: 560px)')` | table rows |
|---|---|---|---|
| 320px | 319 | `true` | `display: grid` — stacked |
| 900px | 899 | `false` | `display: table-row` |

The parent window sat at 1920 throughout and matched nothing, which is exactly the confusion this note prevents.

## Why now

The Home pane is becoming resizable (oo-chat#39), so one dashboard has to hold up across roughly **320–900px** rather than at the two or three widths the client used to pick. A four-column table needs about 500px; below that the column the table exists for ends up off the right edge behind a horizontal scrollbar. That is not hypothetical — the naturewill contract dashboard rendered its amounts as `¥4,500,0` at 440px and as a bare `¥` at 390px until it got a stacked form for narrow panes.

## Three places, three readers

- **`starter.html`** — next to the layout rule it explains, for whoever opens the starter to copy from it
- **`docs/network/dashboard.md`** — for a human reading the feature docs
- **`skills/builtin/dashboard/SKILL.md`** — the one that matters most, because the author is usually a model, and a model assumes media queries track the browser window

I nearly rewrote the naturewill dashboard's media query as a container query before checking whether it was broken. It was not. That is the mistake this note exists to stop.

44 dashboard tests pass.