### PR TITLE
Support async tool functions (#184 by @sanmaxdev, rebased onto main)

### DIFF
--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -13,6 +13,7 @@ import time
 import json
 import asyncio
 import inspect
+import threading
 from typing import List, Dict, Any, Optional, Callable
 
 from ..debug.xray import (
@@ -22,25 +23,37 @@ from ..debug.xray import (
 )
 
 
+_async_loop: Optional[asyncio.AbstractEventLoop] = None
+_async_loop_lock = threading.Lock()
+
+
+def _get_async_tool_loop():
+    """Return the long-lived event loop used by asynchronous tools."""
+    global _async_loop
+
+    with _async_loop_lock:
+        if _async_loop is None or _async_loop.is_closed():
+            ready = threading.Event()
+
+            def run_loop():
+                global _async_loop
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                _async_loop = loop
+                ready.set()
+                loop.run_forever()
+
+            threading.Thread(target=run_loop, name="connectonion-async-tools", daemon=True).start()
+            ready.wait()
+
+    assert _async_loop is not None
+    return _async_loop
+
+
 def _run_async_tool(coro):
-    """Run a coroutine to completion, handling nested event loops.
-
-    When no event loop is running in the current thread, ``asyncio.run``
-    creates a fresh loop and drives the coroutine. When a loop is already
-    running (e.g. the agent is driven from an async context), ``asyncio.run``
-    raises ``RuntimeError``; in that case we run the coroutine in a separate
-    thread with its own loop so the calling loop is not disturbed.
-    """
-    try:
-        return asyncio.run(coro)
-    except RuntimeError:
-        # A loop is already running in this thread. Run the coroutine
-        # in a separate thread with its own event loop.
-        import concurrent.futures
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, coro)
-            return future.result()
+    """Run a coroutine on the shared asynchronous-tool event loop."""
+    future = asyncio.run_coroutine_threadsafe(coro, _get_async_tool_loop())
+    return future.result()
 
 
 def execute_and_record_tools(

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -11,6 +11,8 @@ LLM-Note:
 
 import time
 import json
+import asyncio
+import inspect
 from typing import List, Dict, Any, Optional, Callable
 
 from ..debug.xray import (
@@ -18,6 +20,27 @@ from ..debug.xray import (
     clear_xray_context,
     is_xray_enabled
 )
+
+
+def _run_async_tool(coro):
+    """Run a coroutine to completion, handling nested event loops.
+
+    When no event loop is running in the current thread, ``asyncio.run``
+    creates a fresh loop and drives the coroutine. When a loop is already
+    running (e.g. the agent is driven from an async context), ``asyncio.run``
+    raises ``RuntimeError``; in that case we run the coroutine in a separate
+    thread with its own loop so the calling loop is not disturbed.
+    """
+    try:
+        return asyncio.run(coro)
+    except RuntimeError:
+        # A loop is already running in this thread. Run the coroutine
+        # in a separate thread with its own event loop.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
+            return future.result()
 
 
 def execute_and_record_tools(
@@ -192,7 +215,10 @@ def execute_single_tool(
         if getattr(tool_func, '_needs_agent', False):
             tool_args['agent'] = agent
 
-        result = tool_func(**tool_args)
+        if inspect.iscoroutinefunction(tool_func):
+            result = _run_async_tool(tool_func(**tool_args))
+        else:
+            result = tool_func(**tool_args)
         tool_duration = (time.time() - tool_start) * 1000  # milliseconds
 
         trace_entry["timing_ms"] = tool_duration

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -14,6 +14,7 @@ import json
 import asyncio
 import inspect
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Any, Optional, Callable
 
 from ..debug.xray import (
@@ -24,12 +25,13 @@ from ..debug.xray import (
 
 
 _async_loop: Optional[asyncio.AbstractEventLoop] = None
+_async_loop_thread: Optional[threading.Thread] = None
 _async_loop_lock = threading.Lock()
 
 
 def _get_async_tool_loop():
     """Return the long-lived event loop used by asynchronous tools."""
-    global _async_loop
+    global _async_loop, _async_loop_thread
 
     with _async_loop_lock:
         if _async_loop is None or _async_loop.is_closed():
@@ -43,7 +45,10 @@ def _get_async_tool_loop():
                 ready.set()
                 loop.run_forever()
 
-            threading.Thread(target=run_loop, name="connectonion-async-tools", daemon=True).start()
+            _async_loop_thread = threading.Thread(
+                target=run_loop, name="connectonion-async-tools", daemon=True
+            )
+            _async_loop_thread.start()
             ready.wait()
 
     assert _async_loop is not None
@@ -51,9 +56,25 @@ def _get_async_tool_loop():
 
 
 def _run_async_tool(coro):
-    """Run a coroutine on the shared asynchronous-tool event loop."""
-    future = asyncio.run_coroutine_threadsafe(coro, _get_async_tool_loop())
-    return future.result()
+    """Run a coroutine on the shared asynchronous-tool event loop.
+
+    Async tools share one loop so loop-bound resources (aiohttp sessions,
+    playwright handles) stay usable across calls.
+
+    Nested case: an async tool can drive another tool execution — a sub-agent
+    tool calls agent.input(), which executes the sub-agent's own async tool.
+    That second call arrives on the shared loop's own thread, and submitting
+    back to a single-threaded loop that is blocked waiting on us would hang
+    forever. Give the nested coroutine its own throwaway loop instead: it loses
+    affinity with the outer loop's resources, but it completes.
+    """
+    loop = _get_async_tool_loop()
+
+    if threading.current_thread() is _async_loop_thread:
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="co-async-nested") as pool:
+            return pool.submit(asyncio.run, coro).result()
+
+    return asyncio.run_coroutine_threadsafe(coro, loop).result()
 
 
 def execute_and_record_tools(

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -10,6 +10,8 @@ Components under test:
 """
 
 
+import asyncio
+
 import pytest
 from unittest.mock import Mock, patch
 from connectonion.core.tool_executor import execute_single_tool, _add_assistant_message
@@ -124,6 +126,79 @@ class TestToolExecutor:
         assert trace["status"] == "error"
         assert trace["error_type"] == "ValueError"
         assert "boom" in str(trace["result"])
+
+    def test_execute_async_tool_preserves_runtime_error(self):
+        """RuntimeError from a tool is preserved without retrying its coroutine."""
+        calls = 0
+
+        async def async_fail() -> None:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("original tool failure")
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(async_fail))
+
+        trace = execute_single_tool(
+            tool_name="async_fail",
+            tool_args={},
+            tool_id="call_async_error",
+            tools=tools,
+            agent=FakeAgent(),
+            logger=Logger("test-agent", log=False),
+        )
+
+        assert trace["status"] == "error"
+        assert trace["error_type"] == "RuntimeError"
+        assert trace["error"] == "original tool failure"
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_async_tool_with_running_caller_loop(self):
+        """Async tools run when the caller thread already owns a running loop."""
+        caller_loop = asyncio.get_running_loop()
+
+        async def get_loop_id() -> int:
+            return id(asyncio.get_running_loop())
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(get_loop_id))
+
+        trace = execute_single_tool(
+            tool_name="get_loop_id",
+            tool_args={},
+            tool_id="call_async_running_loop",
+            tools=tools,
+            agent=FakeAgent(),
+            logger=Logger("test-agent", log=False),
+        )
+
+        assert trace["status"] == "success"
+        assert trace["result"] != str(id(caller_loop))
+
+    def test_execute_async_tools_share_loop_bound_resource(self):
+        """Sequential async tool calls retain event-loop affinity."""
+        resource_loop = None
+
+        async def use_resource() -> int:
+            nonlocal resource_loop
+            current_loop = asyncio.get_running_loop()
+            if resource_loop is None:
+                resource_loop = current_loop
+            assert current_loop is resource_loop
+            return id(current_loop)
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(use_resource))
+        agent = FakeAgent()
+        logger = Logger("test-agent", log=False)
+
+        first = execute_single_tool("use_resource", {}, "call_async_resource_1", tools, agent, logger)
+        second = execute_single_tool("use_resource", {}, "call_async_resource_2", tools, agent, logger)
+
+        assert first["status"] == "success"
+        assert second["status"] == "success"
+        assert first["result"] == second["result"]
 
     def test_sync_tool_unaffected_by_async_support(self):
         """Sync tools continue to work exactly as before."""

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -82,6 +82,70 @@ class TestToolExecutor:
         )
         assert trace["status"] == "not_found"
 
+    def test_execute_async_tool_success(self):
+        """Async tool functions are detected and awaited correctly."""
+        async def async_double(x: int) -> int:
+            return x * 2
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(async_double))
+
+        agent = FakeAgent()
+        logger = Logger("test-agent", log=False)
+        trace = execute_single_tool(
+            tool_name="async_double",
+            tool_args={"x": 21},
+            tool_id="call_async_1",
+            tools=tools,
+            agent=agent,
+            logger=logger,
+        )
+        assert trace["status"] == "success"
+        assert "42" in str(trace["result"])
+
+    def test_execute_async_tool_error(self):
+        """Errors raised inside async tools are captured in the trace."""
+        async def async_fail(msg: str) -> str:
+            raise ValueError(msg)
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(async_fail))
+
+        agent = FakeAgent()
+        logger = Logger("test-agent", log=False)
+        trace = execute_single_tool(
+            tool_name="async_fail",
+            tool_args={"msg": "boom"},
+            tool_id="call_async_2",
+            tools=tools,
+            agent=agent,
+            logger=logger,
+        )
+        assert trace["status"] == "error"
+        assert trace["error_type"] == "ValueError"
+        assert "boom" in str(trace["result"])
+
+    def test_sync_tool_unaffected_by_async_support(self):
+        """Sync tools continue to work exactly as before."""
+        def sync_echo(text: str) -> str:
+            return text
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(sync_echo))
+
+        agent = FakeAgent()
+        logger = Logger("test-agent", log=False)
+        trace = execute_single_tool(
+            tool_name="sync_echo",
+            tool_args={"text": "hello"},
+            tool_id="call_sync_1",
+            tools=tools,
+            agent=agent,
+            logger=logger,
+        )
+        assert trace["status"] == "success"
+        assert "hello" in str(trace["result"])
+
 
 class TestAddAssistantMessage:
     """Tests for _add_assistant_message null handling (Gemini compatibility)."""

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -11,6 +11,7 @@ Components under test:
 
 
 import asyncio
+import threading
 
 import pytest
 from unittest.mock import Mock, patch
@@ -220,6 +221,44 @@ class TestToolExecutor:
         )
         assert trace["status"] == "success"
         assert "hello" in str(trace["result"])
+
+    def test_nested_async_tool_does_not_deadlock(self):
+        """An async tool that drives another tool execution must not hang.
+
+        Real shape: an async sub-agent tool calls agent.input(), and the
+        sub-agent runs its own async tool. The inner call lands on the shared
+        loop's thread while that thread is blocked on the outer call.
+        """
+        async def inner() -> str:
+            return "inner-done"
+
+        async def outer() -> str:
+            inner_tools = ToolRegistry()
+            inner_tools.add(create_tool_from_function(inner))
+            inner_trace = execute_single_tool(
+                "inner", {}, "call_nested_inner", inner_tools,
+                FakeAgent(), Logger("test-agent", log=False),
+            )
+            return f"outer saw {inner_trace['result']}"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(outer))
+
+        finished = threading.Event()
+        box = {}
+
+        def run():
+            box["trace"] = execute_single_tool(
+                "outer", {}, "call_nested_outer", tools,
+                FakeAgent(), Logger("test-agent", log=False),
+            )
+            finished.set()
+
+        threading.Thread(target=run, daemon=True).start()
+
+        assert finished.wait(timeout=10), "nested async tool deadlocked"
+        assert box["trace"]["status"] == "success"
+        assert "inner-done" in str(box["trace"]["result"])
 
 
 class TestAddAssistantMessage:


### PR DESCRIPTION
@sanmaxdev's #184, cherry-picked onto current main with their commits and authorship intact. Closes #125.

#184 went `CONFLICTING` — but the conflict is **a comment**. `main` had since made the identical `secrets.OPENONION_API_KEY || 'test-key'` change with different wording, and `tool_executor.py` merges cleanly. Rather than ask a contributor to rebase a fork branch across our workflow history (which needs `workflow` scope they do not have), the three code commits are replayed here and the now-redundant CI commit is dropped.

## What it does

`inspect.iscoroutinefunction` at the call site, and async tools run on **one long-lived loop** on a daemon thread, so loop-bound resources — aiohttp sessions, playwright handles — stay usable across calls. The nested case is handled explicitly: an async tool can drive another agent whose own tool is async, and that inner call arrives on the shared loop's thread, where submitting back to a loop that is blocked waiting on you hangs forever. It gets a throwaway loop instead.

## Verified by driving it, not by reading it

A real `Agent` with a real async tool against a real model:

```
calls: [('async', 'one'), ('sync', 'two')]
async ran on a live loop: True
same loop across separate agent runs: True     ← the stated reason for the design
```

And the deadlock commit earns its keep — I removed just that branch and re-ran the nested case:

```
without the fix:  exit=124   (timed out; the deadlock is real)
with the fix:     exit=0     NO DEADLOCK
```

`2925 passed` in the full unit suite on top of today's main.

## On the CI change in the original PR

`OPENONION_API_KEY: ${{ secrets.OPENONION_API_KEY || 'test-key' }}` — a fork PR receives no repository secrets, so the variable expanded empty and the offline suite could not construct managed-model Agents. Benign, correctly reasoned, and main independently arrived at the same line. Dropped here only because it is already there.

Credit stays with @sanmaxdev — the design decision to share one loop, rather than `asyncio.run` per call, is the part that makes async tools actually useful.