### PR TITLE
Tell agents about <co-filter> (#38)

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -28,12 +28,33 @@ A button that runs something MUST be a real, user-invocable skill, wired like th
 - Only reference skills that actually exist. Never invent skill names, and don't add buttons for internal/bootstrap skills.
 - **Only project skills work as buttons** — the ones in `.co/skills/` or `.claude/skills/`. Your personal skills (`~/.co/skills/`) and builtin skills aren't published to clients, so a button for one renders but silently refuses to run. Check the skill's location before wiring it up.
 
+## Filtering a long list
+
+A Home pane that lists thirty skills is a wall. Declare the list filterable and
+the client renders the box and does the filtering:
+
+```html
+<co-filter target="#skills" placeholder="Filter skills"></co-filter>
+<div id="skills">
+  <button data-ochat-skill="daily-brief">Build today's brief</button>
+  <button data-ochat-skill="meeting-prep">Prepare my next meeting</button>
+</div>
+```
+
+- `target` is a CSS selector for the container. Its **direct children** are what
+  get shown and hidden, so wrap each row in one element.
+- Matching is case-insensitive and anywhere in the row's text.
+- You write the tag; you never write the behaviour. There is no script to add,
+  and adding one would not run.
+- If `target` matches nothing, no box is rendered — a filter that filters
+  nothing looks like a working control and is not one.
+
 ## Rules
 
 - One file: `.co/dashboard.html`. No sidecar JSON, no build step.
 - Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
 - **A media query here measures the Home pane, not the browser window.** The page renders inside its own iframe, so `@media (max-width: 560px)` means "when the pane is narrower than 560px" — the question you wanted to ask. No container queries needed. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.
-- Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting; only the `data-ochat-skill` button contract works.
+- Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting. Interactivity comes from the declared tags (`data-ochat-skill`, `<co-filter>`), which the client renders for you.
 - Keep styles inline in the file (external URLs are blocked in the sandbox).
 - **No links out.** A Home page is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.


### PR DESCRIPTION
The other half of openonion/oo-chat#41. The client can now render a filter box for a long list; this is what tells the agent writing `dashboard.html` that the tag exists — without it nobody emits it and the feature is invisible.

Adds a short section to the dashboard skill:

```html
<co-filter target="#skills" placeholder="Filter skills"></co-filter>
<div id="skills">…</div>
```

and states the four things an author needs: `target` is a selector, its **direct children** are the rows, matching is case-insensitive and mid-string, and no box appears if the target matches nothing.

Also fixes a line that is now misleading. It read:

> Do not add `<script>` tags … only the `data-ochat-skill` button contract works.

which invites the reader to conclude a dashboard cannot be interactive. It can — through declared tags the client renders. That distinction is the point of #38, and the skill file is where an agent actually reads it.

**Merge after oo-chat#41 ships.** Either half is safe alone (an unknown tag renders as nothing and the list stays unfiltered), but there is no reason to describe a tag before it is honoured.