### PR TITLE
The Home page shows the agent's address and trust (#38)

### DIFF
--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -313,7 +313,25 @@ def _subtitle(agent_metadata, skill_count):
     tools = agent_metadata.get("tools") or []
     if tools:
         parts.append(f"{len(tools)} tool{'s' if len(tools) != 1 else ''}")
+    if agent_metadata.get("trust"):
+        # Who this agent will talk to. The operator set it in code and cannot
+        # otherwise see what the running agent actually resolved it to.
+        parts.append(f"trust: {escape(str(agent_metadata['trust']))}")
     return " · ".join(parts)
+
+
+def _address_line(agent_metadata):
+    """The agent's address, in full, or nothing.
+
+    In full because a truncated address is decoration: a deployed agent's address
+    cannot be known before its first boot (#396), so learning it today means
+    opening an ssh session and reading the logs. Half of it does not save that
+    trip. It wraps rather than shrinks, so it stays selectable in a 440px pane.
+    """
+    address = agent_metadata.get("address")
+    if not address:
+        return ""
+    return '<p class="addr">' + escape(str(address)) + '</p>'
 
 
 def render_starter(agent_metadata):
@@ -331,8 +349,9 @@ def render_starter(agent_metadata):
     """
     skills = published_skills(agent_metadata.get("skills") or [])
     page, _ = _starter_templates()
-    return page.substitute(
+    return page.safe_substitute(
         name=escape(str(agent_metadata.get("name") or "Agent")),
         subtitle=_subtitle(agent_metadata, len(skills)),
+        address=_address_line(agent_metadata),
         body=_skill_sections(skills),
     )

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -53,6 +53,16 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* The address is 66 characters and this pane can be 440px wide. It wraps
+     rather than shrinking or truncating: it is here to be read and copied, and
+     an ellipsis would defeat the only reason it is on the page. */
+  .addr {
+    color: var(--muted); opacity: .75; margin-top: 6px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px; line-height: 1.45; word-break: break-all;
+    user-select: all;
+  }
+
   .card {
     background: var(--card); border: 1px solid var(--line); border-radius: 12px;
     margin-bottom: 10px; overflow: hidden;
@@ -115,6 +125,7 @@
     <header>
       <h1>$name</h1>
       <p class="sub">$subtitle</p>
+$address
     </header>
 $body
   </main>

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -517,3 +517,70 @@ def test_the_deploy_rsync_carries_the_dashboard(tmp_path):
     )
 
     assert (server / ".co" / "dashboard.html").read_text() == "<h1>mine</h1>"
+
+
+ADDRESS = "0x" + "9f" * 32
+
+
+def test_the_home_page_shows_the_agents_address():
+    """The one fact that otherwise costs an ssh session.
+
+    A deployed agent's address cannot be known before its first boot (#396), so
+    today you learn it by opening a shell and reading the logs — while the Home
+    pane has been receiving it in agent_metadata and rendering it nowhere.
+    """
+    html = render_starter({"name": "A", "address": ADDRESS, "skills": []})
+
+    assert ADDRESS in html
+
+
+def test_the_address_is_shown_in_full():
+    """A truncated address is decoration: half of it does not save the trip."""
+    html = render_starter({"name": "A", "address": ADDRESS, "skills": []})
+
+    assert "…" not in html and "..." not in html
+    assert html.count(ADDRESS) == 1
+
+
+def test_an_agent_with_no_address_gets_no_empty_line():
+    html = render_starter({"name": "A", "skills": []})
+
+    assert 'class="addr"' not in html
+
+
+def test_the_subtitle_says_who_the_agent_will_talk_to():
+    """`trust` was also arriving and being dropped. It is the difference between
+    an agent strangers can reach and one they cannot."""
+    html = render_starter({"name": "A", "trust": "careful", "skills": []})
+
+    assert "trust: careful" in html
+
+
+def test_a_hostile_address_is_escaped():
+    html = render_starter({"name": "A", "skills": [],
+                           "address": '"><script>alert(1)</script>'})
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_an_operator_override_without_the_new_field_still_renders(tmp_path,
+                                                                  monkeypatch):
+    """~/.co/starter.html replaces the bundled template. One written before this
+    change has no $address in it, and must keep working — losing the address is
+    their layout's business; raising KeyError is ours."""
+    from connectonion.network.host.ws_router import dashboard
+
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "starter.html").write_text(
+        "<html><body><h1>$name</h1><p>$subtitle</p>$body</body></html>",
+        encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    dashboard._starter_templates.cache_clear()
+    try:
+        html = render_starter({"name": "A", "address": ADDRESS, "skills": []})
+    finally:
+        dashboard._starter_templates.cache_clear()
+
+    assert "<h1>A</h1>" in html


### PR DESCRIPTION
From the last section of openonion/oo-chat#38: `render_starter` already receives `address` and `trust` in `agent_metadata` and renders neither.

## Why the address in particular

A deployed agent's address cannot be known before its first boot (#396). So today, learning the address of an agent you just deployed means opening an ssh session and reading the logs — while the Home pane has been handed it all along and shown it nowhere.

```
prod-agent
co/gemini-2.5-pro · 2 tools · trust: careful
0x9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f9f
```

**Shown in full.** A truncated address is decoration — half of it does not save the ssh trip, which is the entire reason it is on the page. 66 characters in a 440px pane means it wraps rather than shrinks, and `user-select: all` makes it one click to select.

**`trust` goes in the subtitle** because it answers a different question: whether strangers can reach this agent at all. The operator set it in code and otherwise cannot see what the running agent resolved it to.

## The one non-obvious change

`page.substitute` → `page.safe_substitute`. `~/.co/starter.html` replaces the bundled template, and one written before today has no `$address` in it. With `substitute` that is a `KeyError` and a blank Home; with `safe_substitute` their page renders exactly as it did. Losing the address is their layout's business — crashing is ours. There is a test that stands up an override without the field and asserts it still renders.

## Deliberately not done

The green "live" dot #38 warns about. With no script it would be green whether or not the agent is running, and a decoration that implies liveness it cannot observe is worse than none.

## Tests

6 new, verified red against the unpatched source (3 of them; the others guard the absent-field and override paths and pass either way by design):

- the Home page shows the agent's address, in full, exactly once
- an agent with no address gets no empty line
- the subtitle says who the agent will talk to
- a hostile address is escaped
- an operator override without the new field still renders

`2931 passed`.