### PR TITLE
Tell agents about <co-table> (#38)

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -49,12 +49,34 @@ the client renders the box and does the filtering:
 - If `target` matches nothing, no box is rendered — a filter that filters
   nothing looks like a working control and is not one.
 
+## Sorting a table
+
+Declare the table sortable and the client makes its headers clickable:
+
+```html
+<co-table target="#runs"></co-table>
+<table id="runs">
+  <thead><tr><th>skill</th><th>runs</th></tr></thead>
+  <tbody>
+    <tr><td>daily-brief</td><td>128</td></tr>
+    <tr><td>meeting-prep</td><td>9</td></tr>
+  </tbody>
+</table>
+```
+
+- `target` is a CSS selector for the `<table>`. It needs a `<thead>` and a
+  `<tbody>`, or nothing is rendered.
+- **Do not label the column types.** Numbers sort as numbers because the cells
+  are read, not because you said so — `$1,200`, `30%` and `1,000` all count.
+- First click sorts ascending, second descending.
+- Sorting and `<co-filter>` compose: one reorders, the other hides.
+
 ## Rules
 
 - One file: `.co/dashboard.html`. No sidecar JSON, no build step.
 - Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
 - **A media query here measures the Home pane, not the browser window.** The page renders inside its own iframe, so `@media (max-width: 560px)` means "when the pane is narrower than 560px" — the question you wanted to ask. No container queries needed. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.
-- Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting. Interactivity comes from the declared tags (`data-ochat-skill`, `<co-filter>`), which the client renders for you.
+- Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting. Interactivity comes from the declared tags (`data-ochat-skill`, `<co-filter>`, `<co-table>`), which the client renders for you.
 - Keep styles inline in the file (external URLs are blocked in the sandbox).
 - **No links out.** A Home page is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.


### PR DESCRIPTION
The agent-facing half of openonion/oo-chat#42, same as #514 was for `<co-filter>`.

Adds a short section showing the tag and the four things an author needs:

- `target` selects the `<table>`; it needs a `<thead>` and a `<tbody>` or nothing renders
- **do not label the column types** — numbers sort as numbers because the cells are read, not because the agent said so
- first click ascending, second descending
- it composes with `<co-filter>`: one reorders, the other hides

That third-from-last point is the one worth having in writing. The obvious instinct when documenting a sortable table is to invent `data-ochat-sort="number"`, and an agent that guesses at such an attribute would get silence.

Merge after oo-chat#42 ships.