### PR TITLE
The address is a footnote, not a headline

### DIFF
--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -53,13 +53,16 @@
     font-variant-numeric: tabular-nums;
   }
 
-  /* The address is 66 characters and this pane can be 440px wide. It wraps
-     rather than shrinking or truncating: it is here to be read and copied, and
-     an ellipsis would defeat the only reason it is on the page. */
+  /* Below the skills, not under the title. It has to be on the page — it is the
+     one fact you cannot get without an ssh session (#396) — but you read it once,
+     when you deploy, and never again. At the top it was two lines of hex shouting
+     above a page whose subject is what the agent can do. It wraps rather than
+     truncating: an ellipsis would defeat the only reason it is here. */
   .addr {
-    color: var(--muted); opacity: .75; margin-top: 6px;
+    color: var(--muted); opacity: .55; margin-top: 18px; padding-top: 12px;
+    border-top: 1px solid var(--line);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11px; line-height: 1.45; word-break: break-all;
+    font-size: 10.5px; line-height: 1.5; word-break: break-all;
     user-select: all;
   }
 
@@ -125,9 +128,9 @@
     <header>
       <h1>$name</h1>
       <p class="sub">$subtitle</p>
-$address
     </header>
 $body
+$address
   </main>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #515, which put the agent's address on the Home page. Right fact, wrong place — found by rendering it at the real pane width instead of reading the HTML.

At 440px the address is two full lines of monospace hex sitting directly under the title. It is the second-loudest thing on the page, above the skills, and it is the fact you look at **once**, when you deploy, and never again.

It moves below the skills, behind a hairline rule, at `opacity: .5`. Still selectable, still in full — the reason it exists (a deployed agent's address cannot be known before its first boot, #396) is unchanged.

No test changed: every assertion in #515 was about the address being present, in full, escaped, and absent when unknown. All still true, which is the honest summary of what those tests were and were not checking — none of them could see that it looked wrong.

`50 passed`.