### PR TITLE
The default Home is the starter itself, not a frozen copy of it

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -74,6 +74,11 @@ Declare the table sortable and the client makes its headers clickable:
 ## Rules
 
 - One file: `.co/dashboard.html`. No sidecar JSON, no build step.
+- **It does not exist until you write it.** Until then the client shows a built-in
+  starter Home — name, model, skills, tools, trust, address — rendered fresh each
+  time, so it follows the agent as skills come and go. Writing the file replaces
+  that for good: from then on it is yours, nothing regenerates it, and a skill you
+  add later will not appear until you add its button.
 - Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
 - **A media query here measures the Home pane, not the browser window.** The page renders inside its own iframe, so `@media (max-width: 560px)` means "when the pane is narrower than 560px" — the question you wanted to ask. No container queries needed. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -42,6 +42,10 @@ MAX_DASHBOARD_BYTES = 2 * 1024 * 1024
 # happened to be in the new directory.
 _project_dir = None
 
+# What to render when the agent has not written a Home page of its own. Set once
+# at host startup, for the same reason as _project_dir.
+_agent_metadata = None
+
 
 def project_root(start=None):
     """The directory that owns ``.co/`` — the project, not wherever you ran from.
@@ -89,6 +93,17 @@ def read_dashboard_snapshot(session_id=None):
     every other server→client frame.
     """
     path = dashboard_path()
+    if not path.exists():
+        if _agent_metadata is None:
+            # ensure_dashboard has not run, so there is nothing to render *about*.
+            # An embedder that never starts a host gets no Home, as before.
+            return None
+        # No file means "not customised", not "no Home": render the starter.
+        html = render_starter(_agent_metadata)
+        frame = {"type": "DASHBOARD_SNAPSHOT", "html": html}
+        if session_id:
+            frame["session_id"] = session_id
+        return frame
     try:
         size = path.stat().st_size
     except OSError:
@@ -124,9 +139,12 @@ async def send_dashboard(send_msg, session_id, conn=None):
     """
     try:
         stat = dashboard_path().stat()
+        stamp = (stat.st_mtime_ns, stat.st_size)
     except OSError:
-        return
-    stamp = (stat.st_mtime_ns, stat.st_size)
+        # No file: the starter is rendered from metadata fixed at startup, so it
+        # cannot change within a run. One stamp for the whole run means each
+        # client is sent it once, like any other unchanged page.
+        stamp = ("starter", None)
     if conn is not None and conn.get("dashboard_stamp") == stamp:
         return
 
@@ -139,27 +157,25 @@ async def send_dashboard(send_msg, session_id, conn=None):
 
 
 def ensure_dashboard(agent_metadata, project_dir=None):
-    """Write a starter ``dashboard.html`` if the agent has none, and anchor the
-    directory every later read resolves against.
+    """Anchor the project directory, and remember what to render a Home from.
 
-    Called once at host startup; a no-op when the file already exists (the agent
-    owns it after that). Gives every agent a polished Home on day zero.
+    Called once at host startup. **No file is written.** An agent that has not
+    written its own Home gets the bundled starter, rendered fresh on every read.
+
+    This used to write ``dashboard.html`` on first boot and then never touch it
+    again, which sounds harmless and is not: the file froze whatever the starter
+    looked like the first time that agent ever started, and no later improvement
+    to the starter could reach it. Every agent's Home was a fossil of the version
+    that happened to be installed on its first day, and the only way to see a
+    change was to delete the file and remember why.
+
+    An agent that wants its own Home still writes ``.co/dashboard.html``; from
+    that moment the file wins and nothing here overwrites it. The difference is
+    that not having one is now a state rather than a one-time event.
     """
-    global _project_dir
+    global _project_dir, _agent_metadata
     _project_dir = Path(project_dir) if project_dir else project_root()
-
-    path = dashboard_path()
-    if path.exists():
-        return
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(render_starter(agent_metadata), encoding="utf-8")
-    except OSError as e:
-        # A read-only or missing project dir is a fine reason to have no dashboard;
-        # it is not a reason to refuse to start the host. Say so and move on.
-        Console().print(f"[yellow]Could not write {path}: {e}[/yellow]")
-        return
-    Console().print(f"[dim]Created {DASHBOARD_FILE} — your agent's Home page.[/dim]")
+    _agent_metadata = agent_metadata or {}
 
 
 def published_skills(skills):

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -39,12 +39,21 @@ def in_tmp(tmp_path, monkeypatch):
     # ensure_dashboard anchors the module-level project dir at startup; clear it so
     # each test resolves against its own tmp_path instead of a previous test's.
     monkeypatch.setattr(dashboard_module, "_project_dir", None)
+    # Same for the metadata the starter is rendered from: leaking one test's agent
+    # into the next would make a Home appear where the test never started a host.
+    monkeypatch.setattr(dashboard_module, "_agent_metadata", None)
     return tmp_path
 
 
-def test_read_snapshot_returns_none_when_missing(in_tmp):
-    assert read_dashboard_snapshot() is None
-    assert read_dashboard_snapshot("sid") is None
+def test_no_file_means_the_starter_not_no_home(in_tmp):
+    """Not having customised a Home is a state, not an absence. This used to
+    answer None, which is why the starter had to be written to disk on first
+    boot — and why every agent's Home then froze at that version."""
+    ensure_dashboard({"name": "Lisa", "skills": []})
+
+    frame = read_dashboard_snapshot()
+    assert frame and "Lisa" in frame["html"]
+    assert read_dashboard_snapshot("sid")["session_id"] == "sid"
 
 
 def test_read_snapshot_returns_frame(in_tmp):
@@ -61,13 +70,13 @@ def test_read_snapshot_stamps_session_id(in_tmp):
     assert "session_id" not in read_dashboard_snapshot()
 
 
-def test_ensure_dashboard_creates_starter(in_tmp):
+def test_the_starter_is_what_an_uncustomised_agent_serves(in_tmp):
     meta = {"name": "Lisa", "skills": [
         {"name": "daily-brief", "description": "d", "location": "project"},
         {"name": "meeting_prep", "description": "d", "location": "project"},
     ]}
     ensure_dashboard(meta)
-    html = (in_tmp / ".co" / "dashboard.html").read_text(encoding="utf-8")
+    html = read_dashboard_snapshot()["html"]
     assert "Lisa" in html
     assert 'data-ochat-skill="daily-brief"' in html
     assert 'data-ochat-skill="meeting_prep"' in html
@@ -311,7 +320,7 @@ def test_starter_has_no_buttons_for_unpublished_skills(in_tmp):
         {"name": "my-notes", "description": "", "location": "user"},
         {"name": "dashboard", "description": "", "location": "builtin"},
     ]})
-    html = (in_tmp / ".co" / "dashboard.html").read_text(encoding="utf-8")
+    html = read_dashboard_snapshot()["html"]
     assert "data-ochat-skill" not in html
     assert ".co/skills/" in html  # falls back to the empty state
 
@@ -388,18 +397,21 @@ def test_ensure_dashboard_takes_an_explicit_project_dir(tmp_path, monkeypatch):
 
     ensure_dashboard({"name": "Explicit", "skills": []}, project_dir=project)
 
-    assert (project / ".co" / "dashboard.html").exists()
+    assert dashboard_module._project_dir == project
+    assert dashboard_module.dashboard_path() == project / ".co" / "dashboard.html"
 
 
-def test_ensure_dashboard_warns_instead_of_crashing_on_an_unwritable_dir(in_tmp, monkeypatch, capsys):
+def test_a_read_only_project_still_gets_a_home(in_tmp, monkeypatch):
+    """This used to be a warning and no Home at all: the starter was written to
+    disk, and a read-only project could not be written to. Rendering it instead
+    of storing it removes the failure mode rather than handling it."""
     def refuse(*args, **kwargs):
         raise PermissionError("read-only file system")
     monkeypatch.setattr(Path, "write_text", refuse)
 
-    ensure_dashboard({"name": "Locked", "skills": []})  # host startup must survive
+    ensure_dashboard({"name": "Locked", "skills": []})
 
-    assert "Could not write" in capsys.readouterr().err
-    assert read_dashboard_snapshot() is None
+    assert "Locked" in read_dashboard_snapshot()["html"]
 
 
 def test_the_starter_template_ships_in_the_wheel():
@@ -421,11 +433,13 @@ def test_the_fragment_templates_do_not_leak_into_the_page():
 # --- Where the Home page lives: .co/, found from the project root ---
 
 
-def test_the_starter_is_written_into_the_co_directory(in_tmp):
+def test_starting_a_host_writes_no_file(in_tmp):
+    """The whole point. A file written once is a fossil of the starter that
+    happened to be installed that day, and nothing ever refreshes it."""
     (in_tmp / ".co").mkdir()
     ensure_dashboard({"name": "Lisa", "skills": []})
 
-    assert (in_tmp / ".co" / "dashboard.html").is_file()
+    assert not (in_tmp / ".co" / "dashboard.html").exists()
     assert not (in_tmp / "dashboard.html").exists()
 
 
@@ -439,8 +453,6 @@ def test_the_project_is_found_from_a_subdirectory(in_tmp, monkeypatch):
 
     ensure_dashboard({"name": "Lisa", "skills": []})
 
-    assert (in_tmp / ".co" / "dashboard.html").is_file()
-    assert not (nested / "dashboard.html").exists()
     assert dashboard_module.dashboard_path() == in_tmp / ".co" / "dashboard.html"
 
 
@@ -466,10 +478,10 @@ def test_the_co_copy_wins_when_both_exist(in_tmp):
 
 
 def test_an_agent_outside_a_project_still_gets_a_home(in_tmp):
-    """No .co/ anywhere above: the Home lands where the agent was started."""
+    """No .co/ anywhere above, and nowhere to write one — still a Home."""
     ensure_dashboard({"name": "Loose", "skills": []})
 
-    assert (in_tmp / ".co" / "dashboard.html").is_file()
+    assert "Loose" in read_dashboard_snapshot()["html"]
 
 
 def test_a_personal_starter_template_replaces_the_bundled_one(in_tmp, monkeypatch, tmp_path):


### PR DESCRIPTION
`ensure_dashboard` wrote `dashboard.html` on an agent's first boot and was a no-op ever after — "the agent owns it after that".

That sounds harmless. It is not. **The file froze whatever the starter looked like the first day that agent ever started**, and no later improvement could reach it. Every agent's Home was a fossil of the version installed on its first run, and the only way to see a change was to delete the file and remember why.

Found the concrete way: a Home page still showing `Home` as its subtitle and title-cased skill names with no descriptions — a July 31 artifact of a starter that no longer exists. Today's starter renders the model, skill count, tools, trust and address, and gives every skill its description. None of it was reachable.

## The change

No file is written. An agent that has not customised its Home gets the starter **rendered on every read**, so it follows the starter as it improves and follows the agent as skills come and go. Writing `.co/dashboard.html` still takes ownership for good — the difference is that *not* having one is now a state rather than a one-time event.

Three things fall out:

- **A read-only project gets a Home.** It used to print `Could not write …` and serve nothing; rendering instead of storing removes the failure mode rather than handling it. There is a test that was a warning-path test and is now a works-anyway test.
- **Debugging the starter is edit-and-restart.** Verified below.
- **`_agent_metadata is None` still means no Home**, so an embedder that never starts a host is unaffected.

## Verified against a real host, not only in tests

```
host starts            → .co/dashboard.html: No such file            ✓ nothing written
client CONNECTs        → GOT SNAPSHOT 5762 bytes, name in it: True   ✓ Home without a file
edit starter.html,
  restart, reconnect   → GOT SNAPSHOT 5785 bytes, MARKER True        ✓ the edit is live
```

## Tests

Ten tests encoded the old contract. They are rewritten, not deleted — each now asserts the new one, and the pair that says "no metadata → no Home" is untouched because it is still true:

- `test_starting_a_host_writes_no_file` (was `test_the_starter_is_written_into_the_co_directory`)
- `test_no_file_means_the_starter_not_no_home` (was `…returns_none_when_missing`)
- `test_a_read_only_project_still_gets_a_home` (was `…warns_instead_of_crashing…`)
- …and the rest read the snapshot rather than the file on disk.

The `in_tmp` fixture now also resets `_agent_metadata`, or one test's agent leaks into the next and a Home appears where no host was started.

`2931 passed`.

## Docs

The dashboard skill now says the file does not exist until the agent writes it, and that writing it is permanent — a skill added later will not appear until its button is added. That trade is the reason to leave it alone.