### PR TITLE
docs: point the React section at @connectonion/react

### DIFF
--- a/docs/network/connect.md
+++ b/docs/network/connect.md
@@ -535,12 +535,23 @@ println(agent.ui)        // All events for rendering
 
 ## React: useAgentForHuman() Hook
 
-The `connectonion/react` subpath exports a React hook with state management and localStorage persistence.
+The [`@connectonion/react`](https://www.npmjs.com/package/@connectonion/react) package
+(repo: [openonion/connectonion-react](https://github.com/openonion/connectonion-react))
+exports a React hook with state management and localStorage persistence. It takes
+`connectonion` as a peer dependency:
+
+```bash
+npm install @connectonion/react connectonion
+```
+
+> These hooks used to ship inside the SDK at `connectonion/react`. That subpath was removed
+> in `connectonion@0.3.0` — import from `@connectonion/react` instead. Same hooks, same
+> signatures, same `localStorage` keys.
 
 ### Basic Usage
 
 ```tsx
-import { useAgentForHuman } from 'connectonion/react'
+import { useAgentForHuman } from '@connectonion/react'
 
 function ChatPage() {
   const {
@@ -657,7 +668,7 @@ respondToPlanReview("Skip step 2")
 │                                                   │
 │  app/[address]/[sessionId]/page.tsx               │
 │    └─ useAgentSDK()     ← elapsed time, pending   │
-│         └─ useAgentForHuman()   ← connectonion/react      │
+│         └─ useAgentForHuman()  ← @connectonion/react│
 │              └─ connect()  ← WebSocket to agent   │
 │                                                   │
 │  <Chat />                                         │


### PR DESCRIPTION
The TypeScript SDK's React layer moved to its own package and repo: [`@connectonion/react`](https://www.npmjs.com/package/@connectonion/react) / [openonion/connectonion-react](https://github.com/openonion/connectonion-react). The `connectonion/react` subpath is removed in `connectonion@0.3.0` (openonion/connectonion-ts#28).

`docs/network/connect.md` was the only file in this repo still describing the old shape — it told readers to import from a subpath that will not resolve.

Updated:

- the section intro now names the package, its repo, and the install line (`npm install @connectonion/react connectonion` — `connectonion` is a peer)
- the import example
- the architecture diagram's annotation
- a migration note, so a reader who arrives with the old import learns why it stopped working rather than assuming the docs are wrong

Everything else — hooks, signatures, `localStorage` keys — is unchanged, and the note says so.