### PR TITLE
The Home page is a control panel, not a folder listing

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -507,15 +507,16 @@ def host(
     agent_metadata, sample = _extract_agent_metadata(create_agent, config.get("name"))
 
     # Auto-generate summary from system_prompt if not set
-    if summary is None:
+    # An operator-written summary is the only thing worth putting on the Home page
+    # as a tagline: the fallback below is prompt text, addressed to the agent in
+    # the second person, and reads as a mistake when shown to a person.
+    if summary is not None:
+        agent_metadata['tagline'] = summary
+    else:
         summary = sample.system_prompt[:1000] if sample.system_prompt else f"{agent_metadata['name']} agent"
 
     agent_metadata['summary'] = summary
     agent_metadata['examples'] = examples
-
-    # Give the agent a polished Home on day zero (no-op if dashboard.html exists).
-    from .ws_router.dashboard import ensure_dashboard
-    ensure_dashboard(agent_metadata)
 
     # Load whitelist/blacklist: code param (list) takes priority, else load from YAML file path
     if whitelist is None:
@@ -532,6 +533,13 @@ def host(
         address.save(addr_data, co_dir)
 
     agent_metadata["address"] = addr_data['address']
+    agent_metadata["trust"] = trust if isinstance(trust, str) else "custom"
+
+    # Rendered here and not earlier: the Home shows the address and the trust
+    # level, and neither exists until this point. Called above, it rendered a
+    # page missing both and nothing said so.
+    from .ws_router.dashboard import ensure_dashboard
+    ensure_dashboard(agent_metadata)
 
     storage = SessionStorage()
 
@@ -636,6 +644,7 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     # Agent's own name stands as before.
     agent_metadata, sample = _extract_agent_metadata(create_agent, name)
     agent_metadata["address"] = get_agent_address(sample)
+    agent_metadata["trust"] = trust if isinstance(trust, str) else "custom"
 
     # Give the agent a polished Home on day zero (no-op if dashboard.html exists).
     from .ws_router.dashboard import ensure_dashboard

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -173,36 +173,19 @@ def published_skills(skills):
     return [s for s in skills if s.get("location") in PUBLISHED_SKILL_LOCATIONS]
 
 
-# A flat list stays readable to about a dozen rows in a 440px pane. Past that it is
-# a wall, and the honest structure to impose is the one already in the names: skills
-# ship in families (lark-base, lark-doc, lark-sheets; vercel:deploy, vercel:env), and
-# an author who names three things alike has told you they belong together.
+# A flat list stays readable to about a dozen rows in a 440px pane. Past that,
+# show the first PREVIEW_ROWS and fold the rest behind one control.
 FLAT_MAX = 12
-FAMILY_MIN = 3
 
-
-def group_skills(skills):
-    """Split skills into ``(families, loose)`` by the prefix in their names.
-
-    A family is a prefix with at least ``FAMILY_MIN`` members, so two lark-* skills
-    stay in the open rather than hiding behind a group of two. Both halves come back
-    sorted: a Home page that reorders itself between runs is one you have to re-read
-    every time.
-    """
-    families = {}
-    for s in skills:
-        families.setdefault(re.split(r"[-:]", s["name"], 1)[0], []).append(s)
-
-    grouped = sorted(
-        (prefix, sorted(members, key=lambda s: s["name"]))
-        for prefix, members in families.items()
-        if len(members) >= FAMILY_MIN
-    )
-    loose = sorted(
-        (s for members in families.values() if len(members) < FAMILY_MIN for s in members),
-        key=lambda s: s["name"],
-    )
-    return grouped, loose
+# Eight, because the fold decides it rather than the content. A row is 56px plus
+# a 2px gap; the header block is ~135px and the disclosure ~44px, so 135 + 8x58 +
+# 44 lands the "more" control itself above the fold of a 440x800 pane. At nine
+# rows the escape hatch sits below the fold — something you must scroll to
+# discover, which is the problem it exists to solve.
+#
+# The gap to FLAT_MAX is deliberate: a fold can never hold fewer than four items,
+# so the page never offers "1 more skill" behind a click.
+PREVIEW_ROWS = 8
 
 
 def _parse_starter(path):
@@ -247,6 +230,30 @@ def _starter_templates():
     return page, fragments
 
 
+# What an author writes when they have nothing to say. Rendered literally it is
+# a line of body text whose content is an apology. An empty description already
+# collapses; these should too.
+_NON_DESCRIPTIONS = {"no description", "none", "n/a", "-", "todo"}
+
+
+def first_sentence(text, limit=None):
+    """The human-facing part of a description.
+
+    Skill descriptions are written for a model: a sentence of purpose followed by
+    paragraphs of instruction. Only the first sentence belongs on a Home page.
+    Clamping by pixels instead gave every row a different height and every
+    description a mid-word ellipsis — "Use only for…", "verify exact…" — which is
+    noise exactly where the page most needs to be read.
+    """
+    text = " ".join(str(text or "").split())
+    if text.lower() in _NON_DESCRIPTIONS:
+        return ""
+    head = re.split(r"(?<=[.!?])\s", text, maxsplit=1)[0]
+    if limit is None or len(head) <= limit:
+        return head
+    return head[:limit].rsplit(" ", 1)[0] + "…"
+
+
 def _skill_row(skill):
     """One skill as a button: its real name, and what it does underneath.
 
@@ -257,46 +264,47 @@ def _skill_row(skill):
     _, fragments = _starter_templates()
     return fragments["skill"].substitute(
         name=escape(str(skill.get("name", "")), quote=True),
-        description=escape(str(skill.get("description") or "").strip()),
+        description=escape(first_sentence(skill.get("description"))),
     ).strip()
 
 
 def _skill_sections(skills):
     """The body of the starter dashboard: every published skill, reachable.
 
-    Three shapes, because "a few skills" and "a hundred skills" are different pages:
-    nothing at all gets a note saying so; a short list is shown flat, because
-    collapsing six items hides them behind a click for no reason; a long one is
-    grouped, with the first family open so the page opens on something to click
-    rather than a row of shut drawers.
+    One alphabetical list. Past ``FLAT_MAX`` the first ``PREVIEW_ROWS`` are shown
+    and the rest sit behind a single disclosure.
+
+    This used to group by the prefix in the names — lark-*, stripe-* — an
+    inferred taxonomy built on a naming coincidence, and it was paid for at full
+    structural price: fifteen skills rendered as four group headers, three
+    visible rows, and a bucket called "other" holding the skills that belonged to
+    no family, sorted last. The page showed a fifth of its content and spent four
+    rows describing drawers.
+
+    Sorting alphabetically clusters those families anyway — ``lark-base`` and
+    ``lark-doc`` land next to each other with no header, no bucket and nothing
+    hidden. The taxonomy bought a label nobody needed and cost twelve skills of
+    visibility.
     """
     _, fragments = _starter_templates()
     if not skills:
         return "  " + fragments["empty"].template.strip()
 
+    ordered = sorted(skills, key=lambda s: s["name"])
+
     def rows(members, indent):
         return "\n".join(indent + _skill_row(s) for s in members)
 
-    if len(skills) <= FLAT_MAX:
-        listing = fragments["list"].substitute(
-            rows=rows(sorted(skills, key=lambda s: s["name"]), "      ")
-        )
-        return "  " + listing.strip()
+    if len(ordered) <= FLAT_MAX:
+        return "  " + fragments["list"].substitute(rows=rows(ordered, "    ")).strip()
 
-    families, loose = group_skills(skills)
-    if loose:
-        families.append(("other", loose))
-
-    group = fragments["group"]
-    return "\n".join(
-        "  " + group.substitute(
-            open="open" if i == 0 else "",
-            prefix=escape(prefix),
-            count=len(members),
-            rows=rows(members, "        "),
-        ).strip()
-        for i, (prefix, members) in enumerate(families)
-    )
+    head, tail = ordered[:PREVIEW_ROWS], ordered[PREVIEW_ROWS:]
+    return ("  " + fragments["list"].substitute(rows=rows(head, "    ")).strip()
+            + "\n  " + fragments["more"].substitute(
+                count=len(tail),
+                plural="s" if len(tail) != 1 else "",
+                rows=rows(tail, "      "),
+            ).strip())
 
 
 def _subtitle(agent_metadata, skill_count):
@@ -306,13 +314,15 @@ def _subtitle(agent_metadata, skill_count):
     reads as a broken agent instead of an unreported number.
     """
     parts = []
-    if agent_metadata.get("model"):
-        parts.append(escape(str(agent_metadata["model"])))
     if skill_count:
         parts.append(f"{skill_count} skill{'s' if skill_count != 1 else ''}")
     tools = agent_metadata.get("tools") or []
     if tools:
         parts.append(f"{len(tools)} tool{'s' if len(tools) != 1 else ''}")
+    # Last, and only after what the agent can do: which model runs it is the least
+    # interesting true thing on the page, and it used to lead.
+    if agent_metadata.get("model"):
+        parts.append(escape(str(agent_metadata["model"])))
     if agent_metadata.get("trust"):
         # Who this agent will talk to. The operator set it in code and cannot
         # otherwise see what the running agent actually resolved it to.
@@ -349,9 +359,24 @@ def render_starter(agent_metadata):
     """
     skills = published_skills(agent_metadata.get("skills") or [])
     page, _ = _starter_templates()
+    name = str(agent_metadata.get("name") or "Agent")
     return page.safe_substitute(
-        name=escape(str(agent_metadata.get("name") or "Agent")),
+        name=escape(name),
+        initial=escape(name.strip()[:1] or "A"),
+        tagline=_tagline(agent_metadata),
         subtitle=_subtitle(agent_metadata, len(skills)),
         address=_address_line(agent_metadata),
         body=_skill_sections(skills),
     )
+
+
+def _tagline(agent_metadata):
+    """One sentence saying what this agent is for, or nothing.
+
+    Only an operator-written summary. The host also derives one from the first
+    1000 characters of the system prompt, and that is prompt text rather than a
+    description: rendering it put "# Agent You are an autonomous agent working on
+    someone's behalf." at the top of the page, in the second person, addressed to
+    the agent instead of to the person reading it. Better to say nothing.
+    """
+    return escape(first_sentence(agent_metadata.get("tagline"), limit=140))

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -11,12 +11,12 @@
      have to be inlined as data: URIs, so there are none. */
   :root {
     color-scheme: light dark;
-    --bg: #fbfbfa; --fg: #171717; --muted: #737373; --faint: #a3a3a3;
-    --card: #fff; --line: #e7e7e5; --hover: #fafaf9; --accent: #16a34a;
+    --bg: #fbfbfa; --fg: #171717; --muted: #6b6b6b; --faint: #8a8a8a;
+    --card: #fff; --line: #e7e7e5; --hover: #f4f4f2; --accent: #16a34a;
   }
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #131313; --fg: #ededed; --muted: #9a9a9a; --faint: #6f6f6f;
+      --bg: #131313; --fg: #ededed; --muted: #a0a0a0; --faint: #8b8b8b;
       --card: #1a1a1a; --line: #2b2b2b; --hover: #212121; --accent: #22c55e;
     }
   }
@@ -25,7 +25,7 @@
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
     background: var(--bg); color: var(--fg); line-height: 1.5;
     -webkit-font-smoothing: antialiased;
-    padding: 28px 20px 48px;
+    padding: 32px 18px 56px;
   }
   /* The Home pane is ~440px wide in oo-chat, full-width on mobile, and sometimes a
      whole browser window. One centred column with a max-width covers all three;
@@ -46,88 +46,149 @@
      up off the right edge behind a scrollbar. */
   main { max-width: 680px; margin: 0 auto; }
 
-  header { margin-bottom: 20px; }
-  h1 { font-size: 22px; font-weight: 650; letter-spacing: -0.02em; }
-  .sub {
-    color: var(--muted); font-size: 12.5px; margin-top: 3px;
-    font-variant-numeric: tabular-nums;
+  header { margin-bottom: 24px; }
+  /* Name and mark on one line. The mark is a letter, not an image: the CSP allows
+     images only as data: URIs, and an agent has no artwork anyway. It is the only
+     saturated colour above the fold, which is what makes the page feel like it
+     belongs to something rather than being a listing of a folder. */
+  .id { display: flex; align-items: center; gap: 10px; }
+  .mark {
+    flex: none; width: 34px; height: 34px; border-radius: 9px;
+    background: var(--accent); color: #fff;
+    font-size: 16px; font-weight: 650; line-height: 34px; text-align: center;
+    text-transform: uppercase; user-select: none;
   }
+  h1 { font-size: 24px; font-weight: 680; letter-spacing: -0.025em; line-height: 1.15; }
+  /* What the agent is for, in the agent's own words. The manifest below answers
+     "what is it made of", which is a different and much less interesting question. */
+  .tagline { font-size: 13.5px; line-height: 1.45; margin-top: 10px; }
+  .tagline:empty { display: none; }
+  .sub { color: var(--muted); font-size: 12px; margin-top: 8px; }
 
-  /* The address is 66 characters and this pane can be 440px wide. It wraps
-     rather than shrinking or truncating: it is here to be read and copied, and
-     an ellipsis would defeat the only reason it is on the page. */
+  /* 66 characters in a 440px pane. It wraps rather than truncating — an ellipsis
+     would defeat the only reason it is here (a deployed agent's address cannot be
+     known before its first boot) — and it is boxed so it reads as a value you can
+     copy rather than as a mistake in the layout. Below the skills, because you
+     read it once, on the day you deploy. */
   .addr {
-    color: var(--muted); opacity: .75; margin-top: 6px;
+    color: var(--muted); margin-top: 22px; padding: 8px 10px;
+    background: var(--hover); border: 1px solid var(--line); border-radius: 8px;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11px; line-height: 1.45; word-break: break-all;
+    font-size: 10.5px; line-height: 1.5; word-break: break-all;
     user-select: all;
   }
 
-  .card {
-    background: var(--card); border: 1px solid var(--line); border-radius: 12px;
-    margin-bottom: 10px; overflow: hidden;
+  /* No card around the rows. At 440px a bordered box whose background differs
+     from the page by one percent of luminance renders as its border alone, and
+     that border then duplicates the hairlines of the rows inside it — two
+     separator systems stacked. The rows carry themselves. */
+  .section {
+    font-size: 11px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+    color: var(--faint); margin: 0 0 8px 2px;
   }
-  .empty { padding: 20px 18px; }
+  .empty {
+    background: var(--card); border: 1px solid var(--line); border-radius: 12px;
+    padding: 20px 18px;
+  }
   .empty p { color: var(--muted); font-size: 13.5px; }
   .empty code {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;
     background: var(--hover); padding: 1px 5px; border-radius: 4px;
   }
 
-  /* <summary> is the only disclosure that works without JS, so the whole
-     many-skills layout hangs off it. */
-  summary {
-    display: flex; align-items: center; gap: 8px; cursor: pointer;
-    padding: 12px 16px; font-size: 13px; font-weight: 600;
-    letter-spacing: 0.02em; color: var(--fg); list-style: none;
-  }
-  summary::-webkit-details-marker { display: none; }
-  summary::before {
-    content: ""; width: 0; height: 0; flex: none;
-    border-left: 4px solid var(--faint); border-top: 3.5px solid transparent;
-    border-bottom: 3.5px solid transparent;
-    transition: transform .15s;
-  }
-  details[open] > summary::before { transform: rotate(90deg); }
-  summary:hover { background: var(--hover); }
-  .count {
-    margin-left: auto; font-size: 11.5px; font-weight: 550; color: var(--faint);
-    font-variant-numeric: tabular-nums;
-  }
-  details[open] > summary { border-bottom: 1px solid var(--line); }
+  /* The one disclosure on the page. A details element is the only fold that
+     works with no JavaScript. It is centred and bordered so it cannot be
+     mistaken for a skill row — left-aligned, borderless, chevroned right:
+     pressing it must not feel like it might run something.
 
-  /* Rows, not cards: a hundred bordered boxes is noise. One hairline between each. */
+     A down-chevron under a sentence, not a sideways triangle beside a slug. The
+     triangle is the file-tree idiom, and this page spent a redesign getting out
+     of the file browser. */
+  .more { margin-top: 6px; }
+  .more > summary {
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+    padding: 11px 12px; cursor: pointer; list-style: none;
+    border: 1px solid var(--line); border-radius: 9px;
+    font-size: 12.5px; font-weight: 600; color: var(--muted);
+    transition: background .12s, border-color .12s, color .12s;
+  }
+  .more > summary::-webkit-details-marker { display: none; }
+  .more > summary::after {
+    content: ""; flex: none; width: 6px; height: 6px; margin-top: -3px;
+    border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
+    transform: rotate(45deg); transition: transform .15s;
+  }
+  .more[open] > summary::after { transform: rotate(-135deg); margin-top: 3px; }
+  .more > summary:hover { background: var(--hover); color: var(--fg); border-color: var(--faint); }
+  .more > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .more > summary:active { background: var(--line); }
+  .more[open] > .rows { margin-top: 6px; }
+  /* <summary> text cannot change without JS; two labels and a swap can. */
+  .lbl-less { display: none; }
+  .more[open] .lbl-more { display: none; }
+  .more[open] .lbl-less { display: inline; }
+
+
+  .rows { display: flex; flex-direction: column; gap: 2px; }
+
+  /* Every row is a control, and has to look like one when nobody is hovering it.
+     Hover is the wrong place to put the only affordance: it does not exist on a
+     touch screen, and on a desktop it arrives after you have already guessed. */
   .skill {
-    display: block; width: 100%; text-align: left; font: inherit; cursor: pointer;
-    background: none; border: 0; border-top: 1px solid var(--line);
-    padding: 11px 16px; color: var(--fg);
+    position: relative; display: flex; flex-direction: column; justify-content: center;
+    width: 100%; min-height: 56px; text-align: left; font: inherit; cursor: pointer;
+    background: none; border: 0; border-radius: 9px;
+    padding: 11px 34px 11px 12px; color: var(--fg);
     transition: background .12s;
   }
-  .rows > .skill:first-child { border-top: 0; }
-  .skill:hover { background: var(--hover); }
+  /* A chevron drawn in CSS — the CSP forbids an icon font or a remote SVG, and a
+     border-box rotated 45° costs nothing. */
+  .skill::after {
+    content: ""; position: absolute; right: 14px; top: 50%;
+    width: 6px; height: 6px; margin-top: -4px;
+    border-right: 1.5px solid var(--faint); border-top: 1.5px solid var(--faint);
+    transform: rotate(45deg);
+    transition: transform .12s, border-color .12s;
+  }
+  .skill:hover, .skill:focus-visible { background: var(--hover); }
+  .skill:hover::after, .skill:focus-visible::after {
+    border-color: var(--accent); transform: rotate(45deg) translate(2px, -2px);
+  }
+  .skill:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .skill:active { background: var(--line); }
+  /* The name stays the literal skill name — it is what you would type — but in the
+     UI face. In monospace a hyphenated slug reads as a file path, which is most of
+     why this page used to look like a directory listing. */
   .skill .name {
-    display: block; font-size: 13.5px; font-weight: 550;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    letter-spacing: -0.01em;
+    display: block; font-size: 14px; font-weight: 600;
+    letter-spacing: -0.006em;
   }
-  .skill:hover .name { color: var(--accent); }
+  /* One line, and the server already cut it at a sentence. Uniform row height is
+     what turns a list into something scannable; ragged two-line clamps gave every
+     row a different height and nothing for the eye to lock onto. */
   .skill .desc {
-    display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
-    overflow: hidden; margin-top: 2px;
-    font-size: 12.5px; line-height: 1.45; color: var(--muted);
+    display: block; margin-top: 3px;
+    font-size: 12.5px; line-height: 1.4; color: var(--muted);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  /* Undescribed skills are common; an empty span must not leave a gap. */
   .skill .desc:empty { display: none; }
+
+  /* A pane dragged out to a full window is one column of 56px rows with a field of
+     white either side. Past ~720px there is room for two. */
+  @media (min-width: 720px) {
+    .rows { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; }
+  }
 </style>
 </head>
 <body>
   <main>
     <header>
-      <h1>$name</h1>
+      <div class="id"><span class="mark">$initial</span><h1>$name</h1></div>
+      <p class="tagline">$tagline</p>
       <p class="sub">$subtitle</p>
-$address
     </header>
 $body
+$address
   </main>
 </body>
 </html>
@@ -148,14 +209,12 @@ Placeholders are $name-style (string.Template). Do not use $ for anything else.
 
 <template id="skill"><button class="skill" data-ochat-skill="$name"><span class="name">$name</span><span class="desc">$description</span></button></template>
 
-<template id="list"><section class="card">
-    <div class="rows">
+<template id="list"><div class="rows">
 $rows
-    </div>
-  </section></template>
+  </div></template>
 
-<template id="group"><details class="card group" $open>
-    <summary>$prefix<span class="count">$count</span></summary>
+<template id="more"><details class="more">
+    <summary><span class="lbl-more">$count more skill$plural</span><span class="lbl-less">Show fewer</span></summary>
     <div class="rows">
 $rows
     </div>

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -8,7 +8,6 @@ from connectonion.network.host.ws_router.dashboard import (
     MAX_DASHBOARD_BYTES,
     read_dashboard_snapshot,
     ensure_dashboard,
-    group_skills,
     published_skills,
     render_starter,
     send_dashboard,
@@ -101,12 +100,39 @@ def test_a_short_list_is_not_hidden_behind_a_disclosure():
     assert "<details" not in html
 
 
-def test_a_long_list_is_grouped_and_opens_on_something():
+def test_a_long_list_shows_the_first_few_and_folds_the_rest():
+    """One fold, not a taxonomy. Grouping by name prefix rendered fifteen skills
+    as four headers, three visible rows and a bucket called "other" — a page
+    showing a fifth of its content."""
     skills = [{"name": f"lark-{i}", "description": "", "location": "project"} for i in range(20)]
     skills += [{"name": f"x-{i}", "description": "", "location": "project"} for i in range(5)]
     html = render_starter({"name": "Many", "skills": skills})
-    assert "<details" in html
-    assert "<details class=\"card group\" open>" in html  # never a wall of shut drawers
+
+    assert html.count("<details") == 1
+    assert "17 more skills" in html          # 25 total, 8 shown
+    assert "other" not in html.lower()
+
+
+def test_every_skill_is_on_the_page_even_when_folded():
+    """Folded is not dropped. The count in the control has to be the truth."""
+    skills = [{"name": f"skill-{i:02d}", "description": "", "location": "project"}
+              for i in range(25)]
+    html = render_starter({"name": "Many", "skills": skills})
+
+    for skill in skills:
+        assert f'data-ochat-skill="{skill["name"]}"' in html
+
+
+def test_the_list_is_alphabetical_so_families_land_together():
+    """What replaced the grouping: sorting clusters lark-* on its own, with no
+    header, no bucket, and nothing hidden."""
+    skills = [{"name": n, "description": "", "location": "project"}
+              for n in ["tweet", "lark-doc", "alpha", "lark-base"]]
+    html = render_starter({"name": "Sorted", "skills": skills})
+
+    order = [html.index(f'data-ochat-skill="{n}"')
+             for n in ["alpha", "lark-base", "lark-doc", "tweet"]]
+    assert order == sorted(order)
 
 
 def test_skill_rows_carry_their_description():
@@ -322,25 +348,6 @@ def test_starter_lists_published_skills_past_unpublished_ones():
     html = render_starter({"name": "Many", "skills": skills})
     assert html.count("data-ochat-skill") == 6
     assert "personal-" not in html
-
-
-def test_group_skills_needs_a_third_member_to_form_a_family():
-    """Two lark-* skills behind a group of two is a click that buys nothing."""
-    skills = [{"name": n} for n in ["lark-base", "lark-doc", "lark-im", "x-api", "x-write", "tweet"]]
-    families, loose = group_skills(skills)
-
-    assert [(p, [s["name"] for s in m]) for p, m in families] == [
-        ("lark", ["lark-base", "lark-doc", "lark-im"]),
-    ]
-    assert [s["name"] for s in loose] == ["tweet", "x-api", "x-write"]
-
-
-def test_group_skills_splits_colon_prefixes_too():
-    skills = [{"name": n} for n in ["vercel:deploy", "vercel:env", "vercel:nextjs"]]
-    families, loose = group_skills(skills)
-
-    assert families[0][0] == "vercel"
-    assert loose == []
 
 
 def test_the_subtitle_omits_what_it_does_not_know():


### PR DESCRIPTION
The owner's verdict on the default Home was that it "looks sucks". A UI review named the cause better than I could: **it renders as a table of contents for a folder, not a control panel.** Someone looking at it sees a directory listing of `.co/skills/`; nothing says "press this and something happens".

Every change below was checked by rendering it at the real 440px pane width and looking, in light and dark, at 0 / 7 / 15 skills and at 900px.

## Why it read as a folder

- **Rows were not visibly controls.** `background:none; border:0`, and the only feedback was `:hover` — which does not exist on touch and arrives after you have already guessed. `:focus` was styled nowhere, and the focus ring was being *clipped* by the card's `overflow:hidden`. Now every row carries a permanent CSS chevron, plus hover, active and `:focus-visible`.
- **Names were monospace.** A hyphenated slug in mono reads as a file path. Still the literal name — it is what you type — but in the UI face.
- **Green-on-hover names** were the tell for a link, on a page that by contract never navigates. Gone.

## The descriptions were noise

`-webkit-line-clamp: 2` over 300-character text **written for a model** produced seven rows of grey, each cut mid-word, each a different height: 62/78/78/78/62px, nothing for the eye to lock onto. Now cut server-side at the first sentence and clamped to one line, so every row is 56px.

`No description` was arriving as a literal string and rendering as body text — a line whose content is an apology. Filtered, along with `none`, `n/a`, `-`, `todo`.

## Prefix grouping is deleted

This is the substantive change. Past 12 skills the page grouped by name prefix (`lark-*`, `stripe-*`). Rendered, 15 skills became **four group headers, three visible rows, and a bucket named `other`** holding the skills that belonged to no family, sorted last — a page showing a fifth of its content and spending four rows describing drawers. Which group was open was decided by alphabetical order.

The argument that settles it: **sorting alphabetically clusters those families anyway.** `lark-base` and `lark-doc` land adjacent with no header, no bucket and nothing hidden. The taxonomy bought a label nobody needed and cost twelve skills of visibility.

So: one alphabetical list, first **8** rows, one disclosure — *"7 more skills"*.

**Why 8:** the fold decides it, not the content. A row is 56px + 2px gap; header ≈135px, disclosure ≈44px. `135 + 8×58 + 44` lands the control itself above the fold of a 440×800 pane. At nine rows the escape hatch is something you must scroll to discover, which is the problem it exists to solve. The gap to `FLAT_MAX=12` is deliberate hysteresis: a fold never holds fewer than four items, so the page never offers "1 more skill" behind a click.

The control is centred and bordered with a down-chevron, deliberately unlike a skill row (left-aligned, borderless, chevron right) — pressing it must not feel like it might run something. `group_skills` and `FAMILY_MIN` are gone.

## Header

An initial mark (the only saturated colour above the fold — the CSP allows no images, so it is a letter), then a tagline, then the manifest. The subtitle now reads `15 skills · 3 tools · co/gemini-3.6-flash`: the model led before and is the least interesting true thing on the page.

**The tagline is operator-written only.** Wired to the host's derived `summary` first, it rendered `# Agent You are an autonomous agent working on someone's behalf.` — prompt text, in the second person, addressed to the agent rather than the reader. Only an explicit `host(summary=…)` becomes a tagline now.

## Two metadata defects, found by looking rather than testing

Both are mine, from #515:

- **`trust` never reached the page.** `agent_metadata` never carried it. My test passed a dict containing `trust` and asserted it rendered; nothing checked that a real host produces one.
- **`address` reached only one of two startup paths.** In `host()` the Home was rendered *before* the identity was loaded, so it always rendered without one.

## Contrast

`--faint` was `#a3a3a3` on white (2.5:1) and `#6f6f6f` on `#1a1a1a` (3.0:1) — both fail AA, on the text asking to be read character by character. Fixed in both schemes, and the address is boxed so it reads as a value you can copy.

## Tests

Grouping tests are replaced, not deleted — each states the new contract:

- a long list shows the first few and folds the rest (one `<details>`, `17 more skills`, no `other`)
- **every skill is on the page even when folded** — the count in the control has to be the truth
- the list is alphabetical, so families land together

`2931 passed`.

Stacks under #517 (address placement), which this supersedes — close that one if this lands.