### PR TITLE
feat(host): an agent keeps its own schedule

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -1,0 +1,313 @@
+"""
+Purpose: An agent's own recurring work — read the schedule, decide what is due, run it, remember that it ran
+LLM-Note:
+  Dependencies: imports from [asyncio, dataclasses, datetime, json, os, pathlib, re, sys, uuid, yaml, zoneinfo, host.http_router] | imported by [network/host/server.py via create_schedule_lifespan()] | tested by [tests/unit/test_schedule.py]
+  Data flow: load_entries(.co/schedule.yaml) → tick() every 60s → is_due(entry, last_run, now) → input_handler() in a worker thread → record_run() into .co/schedule-state.json
+  State/Effects: reads .co/schedule.yaml (authored, deployed) | reads and writes .co/schedule-state.json (the server's own, never deployed over) | holds an OS lock while writing state | runs agent turns through the same path as POST /input, so every run lands in .co/session_results.jsonl
+  Integration: exposes load_entries(), is_due(), load_state(), record_run(), last_run(), create_schedule_lifespan() | the lifespan pair composes with the relay's in host()
+  Performance: one tick a minute, a dict comparison per entry | the run itself is a full agent turn, off the event loop in a thread
+  Errors: a malformed schedule yields the entries that parse and never raises | unreadable state reads as empty | a failed run is recorded as failed and the tick continues
+
+The clock lives in this process rather than in systemd, because `co` runs on
+macOS, Windows and Linux and the OS scheduler does not — three implementations
+of which two rot. The agent is already a long-lived process everywhere, so this
+is one implementation. The argument in full is #521.
+"""
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+SCHEDULE_FILE = "schedule.yaml"
+STATE_FILE = "schedule-state.json"
+
+# The relay already wakes once a minute to heartbeat, so a minute is what the
+# process costs anyway. It is also the resolution this is for: "every 15
+# minutes", "weekday mornings". Nothing here wants a second hand.
+TICK_SECONDS = 60
+
+_UNITS = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+_DURATION = re.compile(r"^(\d+)([smhd])$")
+_WEEKDAYS = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
+
+
+@dataclass
+class Entry:
+    """One line of the schedule: what to run, and how often or when."""
+    name: str
+    run: str
+    interval: Optional[timedelta] = None
+    at: Optional[str] = None
+    tz: Optional[str] = None
+
+
+def _parse_duration(text) -> Optional[timedelta]:
+    m = _DURATION.match(str(text).strip())
+    if not m:
+        return None
+    return timedelta(**{_UNITS[m.group(2)]: int(m.group(1))})
+
+
+def load_entries(co_dir: Path) -> list:
+    """The schedule as authored, minus anything that does not parse.
+
+    One bad line must not take the others with it, and must not stop the agent
+    booting: this file is hand-written and deployed, so a typo reaches
+    production and the agent has to survive it. What does not parse is dropped;
+    what does, runs.
+    """
+    path = Path(co_dir) / SCHEDULE_FILE
+    if not path.is_file():
+        return []
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(raw, list):
+        return []
+
+    entries = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        run = item.get("run")
+        if not isinstance(run, str) or not run.strip():
+            continue
+
+        interval = _parse_duration(item["every"]) if item.get("every") is not None else None
+        at = item.get("at")
+        if interval is None and not at:
+            continue          # neither a valid interval nor a clock time
+
+        entries.append(Entry(
+            # State is keyed by name, and requiring one would be ceremony for the
+            # single-entry case. The command is a serviceable identity.
+            name=str(item.get("name") or run).strip(),
+            run=run.strip(),
+            interval=interval,
+            at=str(at).strip() if at else None,
+            tz=str(item["tz"]).strip() if item.get("tz") else None,
+        ))
+    return entries
+
+
+def _zone(entry: Entry):
+    if not entry.tz:
+        return timezone.utc
+    try:
+        from zoneinfo import ZoneInfo
+        return ZoneInfo(entry.tz)
+    except Exception:
+        # An unknown zone name is a typo in a deployed file. UTC is wrong by
+        # hours; refusing to run is wrong by everything.
+        return timezone.utc
+
+
+def _clock_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
+    """`at: "09:00"` or `at: "Mon 09:00"` — due once per matching moment."""
+    parts = entry.at.split()
+    day = None
+    if len(parts) == 2:
+        day = _WEEKDAYS.get(parts[0][:3].lower())
+        if day is None:
+            return False
+    try:
+        hour, minute = (int(x) for x in parts[-1].split(":"))
+    except ValueError:
+        return False
+
+    local = now.astimezone(_zone(entry))
+    if day is not None and local.weekday() != day:
+        return False
+    if (local.hour, local.minute) < (hour, minute):
+        return False
+
+    if last_run is None:
+        return True
+    # Once per day. Compared in the entry's own zone, so a run at 09:00 Shanghai
+    # does not re-fire because it is still yesterday in UTC.
+    return last_run.astimezone(_zone(entry)).date() < local.date()
+
+
+def is_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
+    """Whether this entry should run now.
+
+    A run missed while the process was down fires on the next tick — this is
+    what `Persistent=true` gives a systemd timer, and it is the one thing
+    in-process scheduling would otherwise lose. It fires *once*, not once per
+    interval that elapsed: three days of downtime is one catch-up run, not
+    seventy-two.
+    """
+    if entry.interval is not None:
+        return last_run is None or (now - last_run) >= entry.interval
+    if entry.at:
+        return _clock_due(entry, last_run, now)
+    return False
+
+
+def _lock(path: Path):
+    """Exclusive, non-blocking, released by the OS on death.
+
+    Same shape as cli/browser_agent/transport.py — POSIX flock, Windows
+    msvcrt. A scheduler that imports fcntl at module level is a scheduler that
+    does not import on Windows.
+    """
+    handle = open(path, "a+", encoding="utf-8")
+    try:
+        if os.name == "nt":
+            import msvcrt
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+    return handle
+
+
+def load_state(co_dir: Path) -> dict:
+    """What has run, and how it went. Unreadable reads as empty.
+
+    Losing this costs one duplicated run. Refusing to boot over it costs the
+    agent, so a truncated write or a hand edit is not allowed to be fatal.
+    """
+    path = Path(co_dir) / STATE_FILE
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def record_run(co_dir: Path, name: str, *, when: datetime, status: str,
+               session_id: Optional[str]) -> None:
+    """Remember one run, pointing at the session it produced.
+
+    Only a pointer: .co/session_results.jsonl already holds the prompt, the
+    transcript, the result and the duration. Copying any of that here would be
+    a second source of truth that drifts.
+    """
+    co_dir = Path(co_dir)
+    co_dir.mkdir(parents=True, exist_ok=True)
+    path = co_dir / STATE_FILE
+
+    handle = _lock(co_dir / f"{STATE_FILE}.lock")
+    try:
+        state = load_state(co_dir)
+        state[name] = {
+            "last_run": when.astimezone(timezone.utc).isoformat(),
+            "status": status,
+            "session_id": session_id,
+        }
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)      # readers see the old file or the new one
+    finally:
+        if handle:
+            handle.close()
+
+
+def last_run(state: dict, name: str) -> Optional[datetime]:
+    raw = (state.get(name) or {}).get("last_run")
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: int,
+                             console=None):
+    """Start and stop the tick alongside the ASGI app.
+
+    Returns (on_startup, on_shutdown), the same pair shape the relay uses, so
+    host() can compose them.
+    """
+    task: dict = {}
+
+    def _say(message: str) -> None:
+        if console:
+            console.print(f"[dim][schedule][/dim] {message}")
+
+    def _run_entry(entry: Entry) -> tuple:
+        """One turn, through the same path as POST /input.
+
+        Reusing input_handler is what puts a scheduled run in
+        .co/session_results.jsonl beside the interactive ones — same record,
+        same fields, visible to anything that reads them. A separate execution
+        path here would mean background work is the one kind nobody can inspect.
+        """
+        from .http_router import input_handler
+
+        session_id = str(uuid.uuid4())
+        out = input_handler(create_agent, storage, entry.run, result_ttl,
+                            session={"session_id": session_id})
+        return out.get("status", "done"), session_id
+
+    async def tick_once(now: Optional[datetime] = None) -> None:
+        now = now or datetime.now(timezone.utc)
+        entries = load_entries(co_dir)
+        if not entries:
+            return
+        state = load_state(co_dir)
+
+        for entry in entries:
+            if not is_due(entry, last_run(state, entry.name), now):
+                continue
+            _say(f"running {entry.name}")
+            try:
+                # A turn takes as long as it takes — four minutes is normal for
+                # real work. In a thread, so the heartbeat keeps going and the
+                # agent stays reachable while it runs.
+                status, session_id = await asyncio.to_thread(_run_entry, entry)
+            except Exception as exc:
+                # One entry failing is not the scheduler failing. Record it and
+                # keep the others on time.
+                _say(f"[red]{entry.name} failed: {exc}[/red]")
+                record_run(co_dir, entry.name, when=now, status="failed", session_id=None)
+                continue
+            record_run(co_dir, entry.name, when=now, status=status, session_id=session_id)
+
+    async def loop() -> None:
+        while True:
+            try:
+                await tick_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                _say(f"[red]tick failed: {exc}[/red]")
+            await asyncio.sleep(TICK_SECONDS)
+
+    async def on_startup() -> None:
+        entries = load_entries(co_dir)
+        if not entries:
+            return          # nothing scheduled: no task, no noise
+        _say(f"{len(entries)} scheduled")
+        task["handle"] = asyncio.create_task(loop())
+
+    async def on_shutdown() -> None:
+        handle = task.get("handle")
+        if not handle:
+            return
+        handle.cancel()
+        try:
+            await handle
+        except asyncio.CancelledError:
+            pass
+
+    on_startup.tick_once = tick_once      # the seam tests drive
+    return on_startup, on_shutdown

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -40,6 +40,7 @@ from ... import address
 from .. import announce, relay
 from ..asgi import create_app as asgi_create_app
 from .ws_router import run_ws_session
+from .schedule import create_schedule_lifespan
 from ..trust import TrustAgent, get_default_trust_level, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
 from .auth import extract_and_authenticate
@@ -299,6 +300,25 @@ def _print_host_banner(
             console.print()
 
     console.print()
+
+
+def _both(first, second):
+    """Run two lifespan callbacks as one, in order.
+
+    The ASGI app takes a single on_startup and a single on_shutdown, and there
+    are now two things that want them — the relay and the schedule. Either may
+    be absent, so this also has to handle None.
+    """
+    if first is None:
+        return second
+    if second is None:
+        return first
+
+    async def run_both():
+        await first()
+        await second()
+
+    return run_both
 
 
 def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner, *, profile: dict | None = None):
@@ -582,6 +602,16 @@ def host(
             relay_url, addr_data, summary, port, relay_session_runner,
             profile=_build_agent_profile(agent_metadata),
         )
+
+    # The schedule is not conditional on the relay. An agent reachable only on
+    # localhost still has recurring work to do, and tying its clock to whether
+    # it happens to be announced would make "it stopped running at night" a
+    # networking question.
+    sched_startup, sched_shutdown = create_schedule_lifespan(
+        co_dir, create_agent, storage, result_ttl, console=Console(),
+    )
+    on_startup = _both(on_startup, sched_startup)
+    on_shutdown = _both(sched_shutdown, on_shutdown)   # stop the clock first
 
     app = asgi_create_app(
         route_handlers=route_handlers,

--- a/tests/unit/test_schedule.py
+++ b/tests/unit/test_schedule.py
@@ -1,0 +1,147 @@
+"""An agent's own schedule: what it runs, when it is due, and what it remembers.
+
+The design argument is in #521. The short version: the OS scheduler is three
+implementations (systemd / launchd / Task Scheduler) of which two rot, while the
+agent is already a long-lived process on all three platforms. So the clock lives
+in the process, and the two things the OS gave us for free — catch-up after
+downtime, and not running twice at once — are what these tests are mostly about.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host import schedule as sched
+
+
+def write(co_dir, text):
+    co_dir.mkdir(parents=True, exist_ok=True)
+    (co_dir / "schedule.yaml").write_text(text, encoding="utf-8")
+    return co_dir
+
+
+class TestReadingTheSchedule:
+    def test_no_file_is_not_an_error(self, tmp_path):
+        """Most agents have no schedule. That is the common case, not a problem."""
+        assert sched.load_entries(tmp_path / ".co") == []
+
+    def test_an_interval_entry(self, tmp_path):
+        co = write(tmp_path / ".co", """
+            - every: 15m
+              run: "/contract-ledger check"
+        """)
+        entry, = sched.load_entries(co)
+
+        assert entry.run == "/contract-ledger check"
+        assert entry.interval == timedelta(minutes=15)
+
+    @pytest.mark.parametrize("text,expected", [
+        ("30s", timedelta(seconds=30)),
+        ("15m", timedelta(minutes=15)),
+        ("2h", timedelta(hours=2)),
+        ("1d", timedelta(days=1)),
+    ])
+    def test_interval_units(self, tmp_path, text, expected):
+        co = write(tmp_path / ".co", f'- every: {text}\n  run: "x"\n')
+        assert sched.load_entries(co)[0].interval == expected
+
+    def test_a_clock_entry_carries_its_timezone(self, tmp_path):
+        """The server is in one country and the reader is in another. Without a
+        zone, 09:00 means 09:00 wherever the machine happens to be."""
+        co = write(tmp_path / ".co", """
+            - at: "Mon 09:00"
+              tz: Asia/Shanghai
+              run: "/weekly"
+        """)
+        entry, = sched.load_entries(co)
+
+        assert entry.at == "Mon 09:00"
+        assert entry.tz == "Asia/Shanghai"
+
+    def test_a_broken_entry_does_not_take_the_others_down(self, tmp_path):
+        """A schedule is authored by hand and deployed. One bad line must not
+        stop the entries that parse, and must not stop the agent booting."""
+        co = write(tmp_path / ".co", """
+            - every: "not-a-duration"
+              run: "/broken"
+            - every: 1h
+              run: "/fine"
+        """)
+        entries = sched.load_entries(co)
+
+        assert [e.run for e in entries] == ["/fine"]
+
+    def test_malformed_yaml_yields_nothing_rather_than_raising(self, tmp_path):
+        co = write(tmp_path / ".co", "- every: [unclosed\n")
+        assert sched.load_entries(co) == []
+
+
+class TestWhenAnEntryIsDue:
+    def test_an_interval_entry_is_due_immediately_when_never_run(self):
+        e = sched.Entry(name="x", run="/x", interval=timedelta(minutes=15))
+        assert sched.is_due(e, last_run=None, now=datetime.now(timezone.utc))
+
+    def test_and_not_again_until_the_interval_passes(self):
+        now = datetime.now(timezone.utc)
+        e = sched.Entry(name="x", run="/x", interval=timedelta(minutes=15))
+
+        assert not sched.is_due(e, last_run=now - timedelta(minutes=5), now=now)
+        assert sched.is_due(e, last_run=now - timedelta(minutes=16), now=now)
+
+    def test_a_run_missed_while_the_agent_was_down_fires_on_the_next_tick(self):
+        """This is `Persistent=true`, which is the one thing in-process
+        scheduling would otherwise lose. Three days of downtime, one catch-up
+        run — not three."""
+        now = datetime.now(timezone.utc)
+        e = sched.Entry(name="x", run="/x", interval=timedelta(hours=1))
+
+        assert sched.is_due(e, last_run=now - timedelta(days=3), now=now)
+
+
+class TestState:
+    def test_a_run_is_remembered_with_the_session_it_produced(self, tmp_path):
+        """The point of recording session_id: a background run is inspectable
+        afterwards. .co/session_results.jsonl already holds the transcript, the
+        result and the duration, so the state file only has to point at it."""
+        co = tmp_path / ".co"
+        co.mkdir()
+        now = datetime.now(timezone.utc)
+
+        sched.record_run(co, "nightly", when=now, status="done", session_id="abc")
+        state = sched.load_state(co)
+
+        assert state["nightly"]["status"] == "done"
+        assert state["nightly"]["session_id"] == "abc"
+        assert sched.last_run(state, "nightly") == now
+
+    def test_state_survives_a_reread(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        now = datetime.now(timezone.utc)
+        sched.record_run(co, "a", when=now, status="done", session_id=None)
+        sched.record_run(co, "b", when=now, status="failed", session_id=None)
+
+        state = sched.load_state(co)
+        assert set(state) == {"a", "b"}
+        assert state["b"]["status"] == "failed"
+
+    def test_unreadable_state_reads_as_empty_rather_than_crashing(self, tmp_path):
+        """A truncated write, a hand edit. Losing the memory of past runs costs
+        one duplicated run; refusing to boot costs the whole agent."""
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule-state.json").write_text("{not json", encoding="utf-8")
+
+        assert sched.load_state(co) == {}
+
+
+class TestNaming:
+    def test_an_entry_without_a_name_is_identified_by_what_it_runs(self, tmp_path):
+        """State is keyed by name. Requiring one would be ceremony for the
+        single-entry case, so the command doubles as the identity."""
+        co = write(tmp_path / ".co", '- every: 1h\n  run: "/nightly report"\n')
+        assert sched.load_entries(co)[0].name == "/nightly report"
+
+    def test_an_explicit_name_wins(self, tmp_path):
+        co = write(tmp_path / ".co", '- name: nightly\n  every: 1h\n  run: "/x"\n')
+        assert sched.load_entries(co)[0].name == "nightly"

--- a/tests/unit/test_schedule_lifespan.py
+++ b/tests/unit/test_schedule_lifespan.py
@@ -1,0 +1,127 @@
+"""The schedule has to actually be wired into the host, and run without a relay.
+
+The module tests prove the clock is right. These prove it is plugged in — and
+that plugging it in did not break the case where two things now want the one
+on_startup slot the ASGI app offers.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.network.host import http_router
+from connectonion.network.host import schedule as sched
+from connectonion.network.host import server
+
+
+class TestComposingLifespans:
+    """The relay had the slot to itself. Now the schedule wants it too."""
+
+    @pytest.mark.asyncio
+    async def test_both_run_in_order(self):
+        order = []
+
+        async def first():
+            order.append("first")
+
+        async def second():
+            order.append("second")
+
+        await server._both(first, second)()
+        assert order == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_either_may_be_absent(self):
+        ran = []
+
+        async def only():
+            ran.append(1)
+
+        await server._both(None, only)()
+        await server._both(only, None)()
+        assert ran == [1, 1]
+
+        assert server._both(None, None) is None
+
+
+class TestTheTickRuns:
+    @pytest.mark.asyncio
+    async def test_a_due_entry_runs_and_is_recorded(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule.yaml").write_text('- every: 1h\n  run: "/nightly"\n', encoding="utf-8")
+
+        seen = {}
+
+        def fake_input_handler(create_agent, storage, prompt, ttl, session=None, **kw):
+            seen["prompt"] = prompt
+            seen["session_id"] = session["session_id"]
+            return {"status": "done"}
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        with patch.object(http_router, "input_handler", fake_input_handler):
+            await start.tick_once()
+
+        assert seen["prompt"] == "/nightly"
+
+        state = sched.load_state(co)
+        assert state["/nightly"]["status"] == "done"
+        assert state["/nightly"]["session_id"] == seen["session_id"], (
+            "the state must point at the session the run produced, or a "
+            "background run is not inspectable afterwards"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_entry_that_is_not_due_does_not_run(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule.yaml").write_text('- every: 1h\n  run: "/nightly"\n', encoding="utf-8")
+        sched.record_run(co, "/nightly", when=datetime.now(timezone.utc),
+                         status="done", session_id="prior")
+
+        called = []
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        with patch.object(http_router, "input_handler",
+                          lambda *a, **k: called.append(1) or {"status": "done"}):
+            await start.tick_once()
+
+        assert not called
+
+    @pytest.mark.asyncio
+    async def test_one_failing_entry_does_not_stop_the_others(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule.yaml").write_text(
+            '- every: 1h\n  run: "/breaks"\n- every: 1h\n  run: "/works"\n', encoding="utf-8")
+
+        ran = []
+
+        def handler(create_agent, storage, prompt, ttl, session=None, **kw):
+            ran.append(prompt)
+            if prompt == "/breaks":
+                raise RuntimeError("boom")
+            return {"status": "done"}
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        with patch.object(http_router, "input_handler", handler):
+            await start.tick_once()
+
+        assert ran == ["/breaks", "/works"]
+
+        state = sched.load_state(co)
+        assert state["/breaks"]["status"] == "failed"
+        assert state["/works"]["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_no_schedule_starts_no_task(self, tmp_path):
+        """An agent with nothing scheduled should not acquire a background task,
+        and should not print anything about it."""
+        co = tmp_path / ".co"
+        co.mkdir()
+
+        start, stop = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start()
+        await stop()          # must be safe with nothing running


### PR DESCRIPTION
Closes #521.

## The design decision, and what settles it

An agent had no way to do anything on its own time. The instinct is to reach for the OS scheduler — and that is where it breaks: `co` runs on macOS, Windows and Linux, and the scheduler does not. Three implementations (`systemd` / `launchd` / Task Scheduler), of which the two that are not Linux are the ones nobody runs day to day, so they rot. A capability that only works on the deploy target is a deployment script, not a framework capability, and every project ends up writing its own.

**The agent is already a long-lived process on all three platforms.** `host()` is uvicorn plus the relay loop, identical everywhere. So the clock lives in the process, and there is one of it.

## The two objections, and what they actually cost

**"It blocks the event loop."** Only if the work runs inline. A turn runs in a thread — four minutes is normal for real work, and the heartbeat continues through it. The agent stays reachable while its own scheduled job runs.

**"No `Persistent=true`."** This is the one real loss and the state file gives it back: a run missed while the process was down fires on the next tick, **once**. Three days of downtime is one catch-up run, not seventy-two. Five portable lines against three OS integrations.

A third objection is not a bug: if the agent is down, nothing runs. For a hosted agent that is the correct coupling — there is nothing to receive the result, nowhere to record the session, no way to report the failure. Keeping the process alive is the OS's job (`co deploy --to` already writes a unit). Deciding when a task is due is not.

## Shape

```yaml
# .co/schedule.yaml — authored, travels with the project (#417)
- every: 15m
  run: "/contract-ledger check for new contracts"
- at: "Mon 09:00"
  tz: Asia/Shanghai
  run: "/contract-ledger weekly summary"
```

```json
// .co/schedule-state.json — the server's own, never deployed over (#392/#417)
{"/contract-ledger check…": {"last_run": "…", "status": "done", "session_id": "…"}}
```

The split is load-bearing: editing the schedule locally and deploying must not reset what the server has run, and a redeploy must not re-fire a job that fired an hour ago.

Runs go through `input_handler` — the same path as `POST /input` — so a scheduled run lands in `.co/session_results.jsonl` beside the interactive ones, same record, same fields. The state file stores only `session_id`; the transcript, result and duration are already there and copying them would be a second source of truth. **Background work being the one kind nobody can inspect is how #434 happened.**

## Cross-platform details

The state write holds an OS lock — POSIX `flock`, Windows `msvcrt` — reusing the shape from `cli/browser_agent/transport.py:216`. It locks a stable `.lock` file rather than the state file itself: the state is written via `os.replace`, so locking it directly would leave two processes holding locks on different inodes after a swap.

## What it does not do

Cron syntax. `every: 15m` and `at: "Mon 09:00"` cover what agents need; `*/15 * * * *` is a language people look up every time.

## Verified on a real deployment

Installed on the Ubuntu 24.04 box running the naturewill agent, with `- every: 2m`:

```
08:43:15  ran, state: {"status": "done", "session_id": "ffe233b7…"}
08:44:30  75s later — last_run unchanged, correctly not due
08:45:33  second run fired, new session 91180f26, status done
```

Following the recorded `session_id` into `session_results.jsonl` returns the prompt, the result and `duration_ms: 17572` — a background run, inspectable after the fact, which was the point.

23 new unit tests (`test_schedule.py`, `test_schedule_lifespan.py`); 2954 existing pass.

## One bug this caught in review

The first wiring passed `console=console` into the lifespan. `console` is only bound inside `host()`'s `if not callable(create_agent)` branch, so every agent built with a factory — the documented form — would have died with `NameError` at startup. Caught before pushing; there is now no path that reads a conditionally-bound name.