### PR TITLE
feat(dashboard): Home says what the agent has been doing

### DIFF
--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -423,31 +423,67 @@ def _ago(seconds):
     return "a while ago"
 
 
+def _tail_lines(path, wanted, chunk=65536):
+    """The last lines of an append-only file, newest first, read from the end.
+
+    Bounded by the answer rather than by the history. A record here carries the
+    turn's whole message list — 23 KB on a real agent, 85 KB at the top end — and
+    nothing trims the file, so reading it whole to show five rows is a cost that
+    grows forever and is paid on every turn (#526).
+
+    The chunk size is a starting point, not a window: one record can be larger
+    than it, so the walk continues until enough lines are found or the file is
+    exhausted.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return []
+    if not size:
+        return []
+
+    lines, buf, pos = [], b"", size
+    with open(path, "rb") as f:
+        while pos > 0 and len(lines) < wanted:
+            step = min(chunk, pos)
+            pos -= step
+            f.seek(pos)
+            buf = f.read(step) + buf
+            parts = buf.split(b"\n")
+            # The first part may be half a record; leave it for the next chunk,
+            # unless we have reached the start of the file and it is whole.
+            buf = parts[0] if pos > 0 else b""
+            complete = parts[1:] if pos > 0 else parts
+            lines = [c for c in complete if c.strip()] + lines
+    return list(reversed(lines[-wanted:] if wanted else lines))
+
+
 def recent_runs(limit=MAX_ACTIVITY_ROWS):
     """The last few turns, newest first, one entry per session.
 
     The log is append-only and a session appears twice — once as ``running``,
     again as ``done``. The later line wins, or the page would report every
-    finished run as still in flight.
+    finished run as still in flight. Reading from the end means the later line
+    is also the one seen first.
     """
     import json as _json
     path = _co() / "session_results.jsonl"
     if not path.is_file():
         return []
+
     latest = {}
-    try:
-        for line in path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                rec = _json.loads(line)
-            except ValueError:
-                continue          # a torn write must not cost the whole page
-            if isinstance(rec, dict) and rec.get("session_id"):
-                latest[rec["session_id"]] = rec
-    except OSError:
-        return []
+    # More lines than sessions wanted: each session writes at least twice, and a
+    # torn line costs nothing but itself.
+    for raw in _tail_lines(path, wanted=limit * 4):
+        try:
+            rec = _json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            continue          # a torn write must not cost the whole page
+        if isinstance(rec, dict) and rec.get("session_id"):
+            latest.setdefault(rec["session_id"], rec)   # newest first: first wins
+        if len(latest) >= limit:
+            break
+
     runs = sorted(latest.values(), key=lambda r: r.get("created") or 0, reverse=True)
     return runs[:limit]
 

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -382,6 +382,7 @@ def render_starter(agent_metadata):
         tagline=_tagline(agent_metadata),
         subtitle=_subtitle(agent_metadata, len(skills)),
         address=_address_line(agent_metadata),
+        activity=_activity_sections(),
         body=_skill_sections(skills),
     )
 
@@ -396,3 +397,161 @@ def _tagline(agent_metadata):
     the agent instead of to the person reading it. Better to say nothing.
     """
     return escape(first_sentence(agent_metadata.get("tagline"), limit=140))
+
+
+# ---------------------------------------------------------------- activity
+
+MAX_ACTIVITY_ROWS = 5
+
+
+def _co():
+    """The .co directory this agent renders from."""
+    from pathlib import Path as _P
+    root = _project_dir or project_root()
+    return _P(root) / ".co"
+
+
+def _ago(seconds):
+    """Coarse on purpose. "3h ago" is what the question deserves; a timestamp
+    makes the reader do subtraction to answer "is this thing still alive"."""
+    if seconds < 60:
+        return "just now"
+    for size, unit in ((3600, "m"), (86400, "h"), (float("inf"), "d")):
+        if seconds < size:
+            n = int(seconds // (60 if unit == "m" else 3600 if unit == "h" else 86400))
+            return f"{n}{unit} ago"
+    return "a while ago"
+
+
+def recent_runs(limit=MAX_ACTIVITY_ROWS):
+    """The last few turns, newest first, one entry per session.
+
+    The log is append-only and a session appears twice — once as ``running``,
+    again as ``done``. The later line wins, or the page would report every
+    finished run as still in flight.
+    """
+    import json as _json
+    path = _co() / "session_results.jsonl"
+    if not path.is_file():
+        return []
+    latest = {}
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = _json.loads(line)
+            except ValueError:
+                continue          # a torn write must not cost the whole page
+            if isinstance(rec, dict) and rec.get("session_id"):
+                latest[rec["session_id"]] = rec
+    except OSError:
+        return []
+    runs = sorted(latest.values(), key=lambda r: r.get("created") or 0, reverse=True)
+    return runs[:limit]
+
+
+def scheduled_entries():
+    """What this agent runs on its own, and how each last went.
+
+    Reads the schedule module rather than reparsing the file, so the page and
+    the scheduler cannot disagree about what an entry means.
+    """
+    try:
+        from ..schedule import load_entries, load_state, last_run
+    except Exception:
+        return []
+    try:
+        entries = load_entries(_co())
+        state = load_state(_co())
+    except Exception:
+        return []
+    out = []
+    for e in entries:
+        st = state.get(e.name) or {}
+        when = last_run(state, e.name)
+        out.append({
+            "run": e.run,
+            "cadence": f"every {_cadence(e)}" if e.interval else str(e.at or ""),
+            "status": st.get("status"),
+            "last_run": when,
+        })
+    return out
+
+
+def _cadence(entry):
+    total = int(entry.interval.total_seconds())
+    for size, unit in ((86400, "d"), (3600, "h"), (60, "m")):
+        if total % size == 0 and total >= size:
+            return f"{total // size}{unit}"
+    return f"{total}s"
+
+
+
+def _took(ms):
+    """How long a turn took, in the unit a reader can hold.
+
+    Seconds stop being readable at about a minute, and the runs this section
+    exists for are the long ones — a full extraction pass is four minutes, and
+    "243.0s" makes you do the division to find that out.
+    """
+    seconds = ms / 1000
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, rest = divmod(int(seconds), 60)
+    if minutes < 60:
+        return f"{minutes}m {rest}s" if rest else f"{minutes}m"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m" if minutes else f"{hours}h"
+
+def _activity_sections():
+    """Both sections, or nothing at all.
+
+    A fresh agent has neither a schedule nor a history, and a box that is empty
+    on every new agent is worse than no box — it is prime space on the first
+    page anyone sees, spent saying nothing.
+    """
+    from datetime import datetime, timezone
+
+    _, fragments = _starter_templates()
+    section, row = fragments["activity"], fragments["act"]
+    now = datetime.now(timezone.utc)
+    out = []
+
+    scheduled = scheduled_entries()
+    if scheduled:
+        rows = []
+        for s in scheduled:
+            if s["last_run"] is None:
+                meta, tone = "not yet run", ""
+            else:
+                ago = _ago((now - s["last_run"]).total_seconds())
+                meta = f"{s['status'] or 'ran'} · {ago}"
+                tone = "bad" if s["status"] == "failed" else ""
+            rows.append(row.safe_substitute(
+                what=escape(f"{s['run']}  ({s['cadence']})"),
+                meta=escape(meta), tone=tone).strip())
+        out.append(section.safe_substitute(
+            title="Scheduled", rows="\n".join("      " + r for r in rows)).strip())
+
+    runs = recent_runs()
+    if runs:
+        rows = []
+        for r in runs:
+            if r.get("status") == "running":
+                meta, tone = "running", "live"
+            else:
+                ms = r.get("duration_ms")
+                meta = _took(ms) if isinstance(ms, (int, float)) else "done"
+                tone = ""
+            created = r.get("created")
+            if created:
+                meta += " · " + _ago(now.timestamp() - float(created))
+            rows.append(row.safe_substitute(
+                what=escape(str(r.get("prompt") or "")[:80]),
+                meta=escape(meta), tone=tone).strip())
+        out.append(section.safe_substitute(
+            title="Recent", rows="\n".join("      " + r for r in rows)).strip())
+
+    return "\n".join(out)

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -178,6 +178,25 @@
   @media (min-width: 720px) {
     .rows { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; }
   }
+
+  /* Activity and schedule. Both are absent on a fresh agent — an empty box on
+     the day-zero page would be the first thing a new user sees, saying nothing. */
+  .act { display: flex; align-items: baseline; gap: 8px; padding: 7px 0;
+         border-top: 1px solid var(--line); font-size: 12.5px; }
+  .act:first-child { border-top: 0; }
+  .act .what { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+               white-space: nowrap; color: var(--fg); }
+  .act .meta { flex: none; color: var(--faint); font-variant-numeric: tabular-nums;
+               font-size: 11.5px; }
+  /* Three outcomes, three weights. "failed" has to survive being read at a
+     glance in a 440px column, so it carries colour; "running" is the one that
+     means "look again in a minute", not "something is wrong". */
+  .act .bad { color: #dc2626; }
+  .act .live { color: var(--accent); }
+  @media (prefers-color-scheme: dark) { .act .bad { color: #f87171; } }
+  .sec { padding: 12px 16px 14px; }
+  .sec > h2 { font-size: 11px; font-weight: 650; letter-spacing: 0.08em;
+              text-transform: uppercase; color: var(--faint); margin-bottom: 6px; }
 </style>
 </head>
 <body>
@@ -188,6 +207,7 @@
       <p class="sub">$subtitle</p>
     </header>
 $body
+$activity
 $address
   </main>
 </body>
@@ -223,3 +243,10 @@ $rows
 <template id="empty"><section class="card empty">
     <p>No skills yet. Add one to <code>.co/skills/</code> and it shows up here as a one-click action.</p>
   </section></template>
+
+<template id="activity"><section class="card sec">
+    <h2>$title</h2>
+$rows
+  </section></template>
+
+<template id="act"><div class="act"><span class="what">$what</span><span class="meta $tone">$meta</span></div></template>

--- a/tests/unit/test_dashboard_activity.py
+++ b/tests/unit/test_dashboard_activity.py
@@ -1,0 +1,164 @@
+"""Home says what the agent has been doing, not only what it is.
+
+#522. The page rendered a name, an address and a list of skills — everything an
+agent *is*, and nothing about whether it had run today, whether the last run
+worked, or what it is going to do next. All of that was already on disk beside
+the file that renders the page, and none of it was read.
+
+The rule these tests mostly defend: **an agent with no schedule and no history
+must render exactly what it rendered before.** A section that appears empty on
+every fresh agent is worse than no section — it is the first thing a new user
+sees, and it says nothing.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host.ws_router import dashboard as dash
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    (tmp_path / ".co").mkdir()
+    monkeypatch.setattr(dash, "_project_dir", tmp_path)
+    return tmp_path
+
+
+def sessions(project, *records):
+    path = project / ".co" / "session_results.jsonl"
+    with open(path, "a", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def done(prompt, *, result="ok", ms=1200, ago_s=60):
+    created = (datetime.now(timezone.utc) - timedelta(seconds=ago_s)).timestamp()
+    return {"session_id": prompt, "status": "done", "prompt": prompt,
+            "result": result, "duration_ms": ms, "created": created}
+
+
+class TestNothingToSay:
+    def test_a_fresh_agent_gets_no_activity_section(self, project):
+        """The day-zero page must not grow an empty box."""
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "Recent" not in html
+        assert "Scheduled" not in html
+
+    def test_an_agent_with_a_schedule_but_no_runs_still_shows_the_schedule(self, project):
+        """Configured-but-never-fired is exactly the state someone needs to see:
+        it is indistinguishable from broken until the page says otherwise."""
+        (project / ".co" / "schedule.yaml").write_text(
+            '- every: 15m\n  run: "/check"\n', encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "/check" in html
+        assert "every 15m" in html
+
+
+class TestRecentRuns:
+    def test_the_last_runs_appear_newest_first(self, project):
+        # Distinctive prompts on purpose. "first"/"second" would match the
+        # stylesheet — `.act:first-child` — and the assertion would be about
+        # CSS ordering while claiming to be about runs.
+        sessions(project,
+                 done("zzolder-run", ago_s=300),
+                 done("zznewer-run", ago_s=60))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert html.index("zznewer-run") < html.index("zzolder-run")
+
+    def test_only_finished_runs_carry_a_duration(self, project):
+        sessions(project, done("quick", ms=1500))
+        html = dash.render_starter({"name": "billing", "skills": []})
+        assert "1.5s" in html
+
+    def test_a_run_that_never_finished_is_shown_as_still_running(self, project):
+        """status stays 'running' forever when a turn dies mid-flight, which
+        makes it a free stuck-detector — but only if something looks."""
+        created = (datetime.now(timezone.utc) - timedelta(hours=2)).timestamp()
+        sessions(project, {"session_id": "s", "status": "running",
+                           "prompt": "long one", "result": None,
+                           "duration_ms": None, "created": created})
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "long one" in html
+        assert "running" in html
+
+    def test_the_newest_state_of_a_session_wins(self, project):
+        """The log is append-only: one line for running, another for done. The
+        page must show the outcome, not the first thing that was written."""
+        created = datetime.now(timezone.utc).timestamp()
+        sessions(project,
+                 {"session_id": "s", "status": "running", "prompt": "x",
+                  "result": None, "duration_ms": None, "created": created},
+                 {"session_id": "s", "status": "done", "prompt": "x",
+                  "result": "finished", "duration_ms": 900, "created": created})
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "running" not in html.split("Recent")[-1]
+
+    def test_a_corrupt_line_does_not_take_the_page_down(self, project):
+        path = project / ".co" / "session_results.jsonl"
+        path.write_text('{"broken\n' + json.dumps(done("good")) + "\n", encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "good" in html
+
+    def test_prompts_are_escaped(self, project):
+        sessions(project, done("<script>alert(1)</script>"))
+        html = dash.render_starter({"name": "billing", "skills": []})
+        assert "<script>alert(1)</script>" not in html
+
+
+class TestSchedule:
+    def test_a_scheduled_entry_shows_when_it_last_ran_and_how_it_went(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            '- every: 1h\n  run: "/nightly"\n', encoding="utf-8")
+        (project / ".co" / "schedule-state.json").write_text(json.dumps({
+            "/nightly": {"last_run": datetime.now(timezone.utc).isoformat(),
+                         "status": "done", "session_id": "abc"}}), encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "/nightly" in html
+        assert "every 1h" in html
+
+    def test_a_failed_scheduled_run_is_visible_as_failed(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            '- every: 1h\n  run: "/nightly"\n', encoding="utf-8")
+        (project / ".co" / "schedule-state.json").write_text(json.dumps({
+            "/nightly": {"last_run": datetime.now(timezone.utc).isoformat(),
+                         "status": "failed", "session_id": None}}), encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "failed" in html
+
+    def test_a_malformed_schedule_does_not_break_the_page(self, project):
+        (project / ".co" / "schedule.yaml").write_text("- every: [oops\n", encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "billing" in html      # the page still renders
+
+
+class TestDurations:
+    """The runs this section exists for are the long ones."""
+
+    @pytest.mark.parametrize("ms,shown", [
+        (1500, "1.5s"),
+        (59000, "59.0s"),
+        (60000, "1m"),
+        (243000, "4m 3s"),      # a full extraction pass, not "243.0s"
+        (7860000, "2h 11m"),
+    ])
+    def test_a_long_run_is_not_reported_in_seconds(self, ms, shown):
+        assert dash._took(ms) == shown

--- a/tests/unit/test_dashboard_activity.py
+++ b/tests/unit/test_dashboard_activity.py
@@ -162,3 +162,58 @@ class TestDurations:
     ])
     def test_a_long_run_is_not_reported_in_seconds(self, ms, shown):
         assert dash._took(ms) == shown
+
+
+class TestReadingCost:
+    """Five rows must cost five rows, not the whole history.
+
+    Each record embeds the turn's full message list — 23 KB on average on a real
+    agent, 85 KB at the top end — and the file is append-only with nothing
+    trimming it. Home is re-read on connect *and after every run*, so a whole-file
+    read is paid per turn, forever. #526.
+    """
+
+    def test_only_the_tail_is_read(self, project, monkeypatch):
+        path = project / ".co" / "session_results.jsonl"
+        # 200 fat records: what a few months of hourly scheduled work looks like.
+        big = "x" * 20_000
+        with open(path, "w", encoding="utf-8") as f:
+            for i in range(200):
+                f.write(json.dumps({"session_id": f"s{i}", "status": "done",
+                                    "prompt": f"turn-{i}", "result": big,
+                                    "duration_ms": 100, "created": 1000 + i}) + "\n")
+
+        read_bytes = []
+        real_read = type(path).read_bytes
+
+        def counting_read(self, *a, **kw):
+            data = real_read(self, *a, **kw)
+            read_bytes.append(len(data))
+            return data
+
+        monkeypatch.setattr(type(path), "read_bytes", counting_read, raising=False)
+        monkeypatch.setattr(type(path), "read_text",
+                            lambda self, *a, **kw: (_ for _ in ()).throw(
+                                AssertionError("read_text reads the whole file")),
+                            raising=False)
+
+        runs = dash.recent_runs(limit=5)
+
+        assert [r["prompt"] for r in runs] == [f"turn-{i}" for i in (199, 198, 197, 196, 195)]
+        assert sum(read_bytes) < path.stat().st_size / 4, (
+            f"read {sum(read_bytes)} bytes of a {path.stat().st_size}-byte file "
+            "to show five rows"
+        )
+
+    def test_a_file_shorter_than_the_window_still_works(self, project):
+        sessions(project, done("only-one"))
+        assert [r["prompt"] for r in dash.recent_runs()] == ["only-one"]
+
+    def test_a_record_larger_than_the_window_is_still_found(self, project):
+        """One 85 KB record is normal. A fixed byte window would return nothing."""
+        path = project / ".co" / "session_results.jsonl"
+        path.write_text(json.dumps({"session_id": "s", "status": "done",
+                                    "prompt": "huge", "result": "y" * 200_000,
+                                    "duration_ms": 5, "created": 1}) + "\n",
+                        encoding="utf-8")
+        assert [r["prompt"] for r in dash.recent_runs()] == ["huge"]


### PR DESCRIPTION
Closes #522. Builds on #524 (the schedule) and #518 (Home renders live rather than being frozen on first boot — without that, an activity section would be a fossil).

## What was missing

Open a deployed agent's Home and you could not answer: has this run today, did the last run work, what is it going to do next. Every one of those was already on disk next to the file that renders the page.

`.co/session_results.jsonl` has been recording `session_id`, `status`, `prompt`, `result` and `duration_ms` for every turn all along, and nothing has ever read it.

## Two sections, both absent when empty

**Scheduled** — what the agent runs on its own, when it last ran, how it went. *Configured but never fired* is the state most worth showing: it is indistinguishable from broken until the page says otherwise.

**Recent** — the last five turns, newest first, with durations.

An agent with no schedule and no history renders **exactly** what it rendered before. That is the property most of the tests defend. A box that is empty on every fresh agent is worse than no box: it is prime space on the first page anyone sees, spent saying nothing.

## Two details that are easy to get wrong

**The log is append-only and a session appears twice** — once as `running`, again as `done`. Taking the first line would report every finished run as still in flight. The later line wins.

**A turn that died mid-way stays `running` forever.** That makes it a free stuck-detector, and it is now visible as such, in the accent colour rather than the error colour — it means "look again in a minute", not "something is wrong".

## Durations

`243.0s` for a four-minute extraction makes the reader do the division. Now `4m 3s`, `2h 11m`, and still `1.5s` for short ones — the boundaries are asserted, because the runs this section exists for are precisely the long ones.

## Rendered, not just tested

Built a page with a realistic mix — two scheduled entries (one never run), a turn still running, a 17.6s turn, a 4-minute one — and looked at it:

```
SCHEDULED
  /contract-ledger 检查新合同 (every 15m)          done · just now
  /contract-ledger 本周汇总 (Mon 09:00)              not yet run
RECENT
  列出待人工确认的                                running · 1m ago
  /contract-ledger 检查新合同                      17.6s · 2m ago
  整理一下这个月的合同                              4m 3s · 1h ago
```

The `243.0s` problem was found that way, not by a test — it read wrong on the screen before anything failed.

## Robustness

Reads the schedule through the schedule module rather than reparsing the file, so the page and the scheduler cannot disagree about what an entry means. A torn JSONL line, an unreadable state file or a malformed schedule costs that one section and never the page — the same rule the trust policy loader ended up at in #422.

16 new tests, 2970 existing pass.

## One test bug worth naming

The first version of the ordering test used prompts called `first` and `second`, and failed — because `html.index("first")` was matching `.act:first-child` in the stylesheet. An assertion that succeeds or fails for a reason other than the one it states; same class as the false-green in #504, caught from the other direction. The prompts are now distinctive and the comment says why.