### PR TITLE
release: 1.5.9

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.8
+## Current Version: 1.5.9
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.8"
+__version__ = "1.5.9"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.8"
+version = "1.5.9"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
An agent can now do things on its own time, and its Home page says whether it did.

## An agent keeps its own schedule (#524, closes #521)

```yaml
# .co/schedule.yaml
- every: 15m
  run: "/contract-ledger check for new contracts"
- at: "Mon 09:00"
  tz: Asia/Shanghai
  run: "/contract-ledger weekly summary"
```

The clock lives in the agent process, not in the OS. `co` runs on macOS, Windows and Linux; `systemd` does not, and three schedulers means two that nobody runs day to day and both rot. The agent is already a long-lived process everywhere, so this is one implementation.

The two things the OS gave for free are given back: a run missed while the process was down fires **once** on the next tick, and the state write holds a cross-platform lock. A turn runs in a thread — four minutes is normal for real work — so the heartbeat continues and the agent stays reachable while its own job runs.

Runs go through `input_handler`, the same path as `POST /input`, so scheduled work lands in `.co/session_results.jsonl` beside interactive turns and is inspectable afterwards.

Verified on a deployed agent: fired at 08:43:15, correctly did not re-fire 75s later, fired again at 08:45:33.

## Home became a page worth opening (#515, #518, #523, #525)

- **#518** — Home is the starter *rendered*, not a copy frozen on the agent's first boot. Every agent's Home had been a fossil of the version installed the day it first ran; no later improvement could reach it.
- **#523** — the rows are controls, not a folder listing. Permanent chevrons, focus rings that are not clipped, names that read as names.
- **#515** — address and trust level.
- **#525** (closes #522, #526) — what the agent has been *doing*: what is scheduled and how it last went, the last five turns with durations. Absent entirely when there is nothing to say, so a fresh agent renders exactly what it did before.

```
SCHEDULED
  /contract-ledger check (every 15m)        done · just now
  /contract-ledger weekly (Mon 09:00)         not yet run
RECENT
  list the ones needing review           running · 1m ago
  /contract-ledger check                  17.6s · 2m ago
  tidy up this month's contracts          4m 3s · 1h ago
```

#526 came out of reviewing that against a deployed agent rather than a fixture: fourteen turns had already made a 322 KB log, because every record embeds the turn's full message list. Reading it whole to show five rows would have been paid on every message, forever — 190.9 ms on a 44 MB log, now 1.1 ms and flat.

## Also

- **#512** — async tool functions (#184, by @sanmaxdev)
- **#509 / #514 / #516** — dashboard authoring docs: measuring the pane, `<co-filter>`, `<co-table>`
- **#519** — the React hooks are `@connectonion/react`

2973 tests pass.