### PR TITLE
fix(dashboard): Recent does not say the same sentence three times

### DIFF
--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -508,6 +508,7 @@ def scheduled_entries():
         st = state.get(e.name) or {}
         when = last_run(state, e.name)
         out.append({
+            "name": e.name,
             "run": e.run,
             "cadence": f"every {_cadence(e)}" if e.interval else str(e.at or ""),
             "status": st.get("status"),
@@ -541,6 +542,33 @@ def _took(ms):
     hours, minutes = divmod(minutes, 60)
     return f"{hours}h {minutes}m" if minutes else f"{hours}h"
 
+
+def _collapse(runs, scheduled):
+    """Label scheduled runs by their entry, and fold consecutive repeats.
+
+    A schedule entry's prompt is one fixed sentence sent verbatim every firing,
+    so an agent that checks something every fifteen minutes fills this section
+    with the same row — and the rows that differ, the typed ones, are the first
+    pushed out. What varies between firings is what each found, which is in the
+    result, not the prompt (#528).
+
+    Only *consecutive* repeats fold. A typed turn between two firings separates
+    them, because it did.
+    """
+    by_run = {s["run"]: s["name"] for s in scheduled}
+    folded = []
+    for r in runs:
+        label = by_run.get(r.get("prompt"))
+        key = label or None
+        if key and folded and folded[-1]["key"] == key:
+            folded[-1]["count"] += 1
+            continue
+        folded.append({"key": key,
+                       "label": label or str(r.get("prompt") or ""),
+                       "count": 1,
+                       "run": r})
+    return folded
+
 def _activity_sections():
     """Both sections, or nothing at all.
 
@@ -566,7 +594,10 @@ def _activity_sections():
                 meta = f"{s['status'] or 'ran'} · {ago}"
                 tone = "bad" if s["status"] == "failed" else ""
             rows.append(row.safe_substitute(
-                what=escape(f"{s['run']}  ({s['cadence']})"),
+                # The entry's name, not its run text: an entry can be called
+                # "check for new contracts" while its instruction stays a
+                # paragraph. Entry.name falls back to run when none is given.
+                what=escape(f"{s['name']}  ({s['cadence']})"),
                 meta=escape(meta), tone=tone).strip())
         out.append(section.safe_substitute(
             title="Scheduled", rows="\n".join("      " + r for r in rows)).strip())
@@ -574,7 +605,8 @@ def _activity_sections():
     runs = recent_runs()
     if runs:
         rows = []
-        for r in runs:
+        for item in _collapse(runs, scheduled):
+            r = item["run"]          # the newest of a folded group
             if r.get("status") == "running":
                 meta, tone = "running", "live"
             else:
@@ -584,9 +616,11 @@ def _activity_sections():
             created = r.get("created")
             if created:
                 meta += " · " + _ago(now.timestamp() - float(created))
+            what = item["label"][:80]
+            if item["count"] > 1:
+                what += f"  ×{item['count']}"
             rows.append(row.safe_substitute(
-                what=escape(str(r.get("prompt") or "")[:80]),
-                meta=escape(meta), tone=tone).strip())
+                what=escape(what), meta=escape(meta), tone=tone).strip())
         out.append(section.safe_substitute(
             title="Recent", rows="\n".join("      " + r for r in rows)).strip())
 

--- a/tests/unit/test_dashboard_recent_repeats.py
+++ b/tests/unit/test_dashboard_recent_repeats.py
@@ -1,0 +1,105 @@
+"""Recent must not spend three rows saying one thing. #528.
+
+A schedule entry's prompt is one fixed sentence sent verbatim every firing, so
+the more useful the schedule, the more the section fills with the same row —
+and the distinct rows, the interactive ones, are the first evicted.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host.ws_router import dashboard as dash
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    (tmp_path / ".co").mkdir()
+    monkeypatch.setattr(dash, "_project_dir", tmp_path)
+    return tmp_path
+
+
+def sessions(project, *records):
+    with open(project / ".co" / "session_results.jsonl", "a", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def run(prompt, *, ago_s, ms=1000, sid=None):
+    return {"session_id": sid or f"{prompt}-{ago_s}", "status": "done",
+            "prompt": prompt, "result": "ok", "duration_ms": ms,
+            "created": (datetime.now(timezone.utc) - timedelta(seconds=ago_s)).timestamp()}
+
+
+CHECK = "/contract-ledger check the drive for new contracts, extract only what is new"
+
+
+class TestRepeatsCollapse:
+    def test_three_firings_of_one_entry_become_one_row(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            f'- name: check for new contracts\n  every: 15m\n  run: "{CHECK}"\n',
+            encoding="utf-8")
+        sessions(project,
+                 run(CHECK, ago_s=2280), run(CHECK, ago_s=1380), run(CHECK, ago_s=420))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        recent = html.split("Recent")[-1]
+
+        assert recent.count("check for new contracts") == 1
+        assert "×3" in recent
+
+    def test_the_schedule_entrys_name_is_used_not_the_prompt(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            f'- name: check for new contracts\n  every: 15m\n  run: "{CHECK}"\n',
+            encoding="utf-8")
+        sessions(project, run(CHECK, ago_s=60))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "check for new contracts" in html
+        assert "extract only what is new" not in html
+
+    def test_an_interactive_turn_between_two_firings_keeps_them_apart(self, project):
+        """Collapsing across a gap would claim a run of three that never happened."""
+        (project / ".co" / "schedule.yaml").write_text(
+            f'- name: check\n  every: 15m\n  run: "{CHECK}"\n', encoding="utf-8")
+        sessions(project,
+                 run(CHECK, ago_s=1800),
+                 run("what did you find?", ago_s=900),
+                 run(CHECK, ago_s=300))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        recent = html.split("Recent")[-1]
+
+        assert recent.count(">check<") == 2 or recent.count("check</span>") == 2
+        assert "×" not in recent
+
+    def test_a_single_firing_carries_no_count(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            f'- name: check\n  every: 15m\n  run: "{CHECK}"\n', encoding="utf-8")
+        sessions(project, run(CHECK, ago_s=60))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        assert "×" not in html.split("Recent")[-1]
+
+    def test_unscheduled_turns_are_untouched(self, project):
+        sessions(project, run("hello", ago_s=120), run("goodbye", ago_s=60))
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        recent = html.split("Recent")[-1]
+
+        assert "hello" in recent and "goodbye" in recent
+        assert "×" not in recent
+
+    def test_the_duration_shown_is_the_most_recent_one(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            f'- name: check\n  every: 15m\n  run: "{CHECK}"\n', encoding="utf-8")
+        sessions(project,
+                 run(CHECK, ago_s=900, ms=542000),     # 9m 2s, older
+                 run(CHECK, ago_s=60, ms=42800))       # 42.8s, newest
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "42.8s" in html
+        assert "9m 2s" not in html


### PR DESCRIPTION
Closes #528. Found by rendering a real deployed agent's Home at 440px and looking at it — on a fixture with distinct prompts the section reads fine, and distinct prompts are exactly what a scheduled agent does not have.

## Before

```
SCHEDULED
  /contract-ledger 检查云盘里有没有新合同。有新增…      done · just now
RECENT
  /contract-ledger 检查云盘里有没有新合同。有…      42.8s · 7m ago
  /contract-ledger 检查云盘里有没有新合同。…      2m 35s · 23m ago
  /contract-ledger 检查云盘里有没有新合同。有…      9m 2s · 38m ago
```

Three indistinguishable rows, plus a fourth copy of the same string one section up. A section whose whole job is "what has this agent been doing" answered "it ran the check", four times — and the rows that *do* differ, the typed ones, are the first evicted from a five-row list.

## After

```
SCHEDULED
  检查新合同 (every 15m)                            done · just now
  上周汇总 (Mon 09:00)                                not yet run
RECENT
  检查新合同 ×3                                   42.8s · 11m ago
```

## Two changes, one code path

**A scheduled run is labelled by its entry.** `.co/schedule.yaml` already takes `name:`, so an entry can be called `检查新合同` while its `run` stays a full paragraph of instruction. Both sections now use the name, and `Entry.name` already falls back to the run text when none is given — so nothing changes for entries without one.

**Consecutive firings fold, with a count.** Three firings of one entry are one fact. Only *consecutive* ones fold: a typed turn between two firings keeps them apart, because it did happen between them. The duration shown is the newest of the group, since that is the one that answers "is it still working".

## Considered and not done

Showing `result` instead of `prompt`. It is the genuinely informative field — what each run *found* is what differs between firings — but results are prose of arbitrary length and the pane is 440px wide. It would truncate to noise. Duration and timestamp already carry "did it work, and when"; the missing piece was only which entry ran.

6 new tests, 2979 pass.