### PR TITLE
release: 1.6.0

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -37,7 +37,7 @@ That is semver's rule, not this project's.
 - Reset MINOR and PATCH to 0
 - Reserved for major breaking changes or stable releases
 
-## Current Version: 1.5.9
+## Current Version: 1.6.0
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.9"
+__version__ = "1.6.0"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.9"
+version = "1.6.0"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
A minor, on both of the rules that call for one.

`VERSIONING.md` rolls the patch counter at 9 → 1.5.9 was the last of that series. And rule 3 says `X.Y.0` is cut *once the work has actually been exercised end to end*, which is what happened between 1.5.9 and now: the schedule and the page that reports it were both run against a real deployed agent, and the last defect in them was found that way rather than in a test.

## What 1.5.x was stabilising

**An agent keeps its own schedule** (#524, closes #521). `.co/schedule.yaml`, a tick inside the agent process rather than in `systemd` — because `co` runs on three platforms and the OS scheduler is three implementations of which two rot. Catch-up after downtime and a cross-platform lock give back what the OS was providing. Runs go through the same path as `POST /input`, so scheduled work is inspectable afterwards instead of being the one kind nobody can see.

**Home became a page worth opening** (#515, #518, #523, #525, #529). It renders live rather than freezing on first boot; rows are controls rather than a folder listing; and it says what the agent has been *doing* — what is scheduled, how it last went, the last few turns with durations — while rendering byte-for-byte what it used to on an agent with nothing to report.

## The last two defects, and where they came from

Neither was found by a test. Both were found by pointing the thing at a real deployed agent and looking.

**#526** — fourteen turns had already produced a 322 KB session log, because every record embeds the turn's full message list. Home read all of it to show five rows, on every message. 190.9 ms on a 44 MB log; now 1.1 ms and flat in history.

**#528** — a schedule entry's prompt is one fixed sentence sent verbatim every firing, so Recent showed three indistinguishable rows plus a fourth copy in the section above. On a fixture with distinct prompts it read fine; distinct prompts are precisely what a scheduled agent does not have.

## Also in this series

- **#512** — async tool functions (#184, by @sanmaxdev)
- **#509 / #514 / #516** — dashboard authoring docs: measuring the pane, `<co-filter>`, `<co-table>`
- **#519** — the React hooks are `@connectonion/react`

2979 tests pass.