### PR TITLE
fix(schedule): a schedule that will never fire says so

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -56,86 +56,172 @@ def _parse_duration(text) -> Optional[timedelta]:
     return timedelta(**{_UNITS[m.group(2)]: int(m.group(1))})
 
 
-def load_entries(co_dir: Path) -> list:
-    """The schedule as authored, minus anything that does not parse.
+def load_entries(co_dir, report=False):
+    """The schedule as authored, minus anything that cannot mean something.
 
     One bad line must not take the others with it, and must not stop the agent
     booting: this file is hand-written and deployed, so a typo reaches
-    production and the agent has to survive it. What does not parse is dropped;
-    what does, runs.
+    production. But dropping it *silently* leaves absence as the only signal,
+    and absence is what a correct schedule looks like most of the time — so the
+    reasons are collected and the caller can say them out loud (#531).
+
+    Pass ``report=True`` for ``(entries, problems)``.
     """
     path = Path(co_dir) / SCHEDULE_FILE
+    problems = []
+
+    def done(entries):
+        return (entries, problems) if report else entries
+
     if not path.is_file():
-        return []
+        return done([])
 
     try:
         raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except Exception:
-        return []
+    except Exception as exc:
+        problems.append(f"{SCHEDULE_FILE} does not parse: {exc}")
+        return done([])
     if not isinstance(raw, list):
-        return []
+        problems.append(f"{SCHEDULE_FILE} should be a list of entries")
+        return done([])
 
-    entries = []
-    for item in raw:
+    entries, seen = [], set()
+    for i, item in enumerate(raw, 1):
+        where = f"entry {i}"
         if not isinstance(item, dict):
+            problems.append(f"{where}: not a mapping")
             continue
         run = item.get("run")
         if not isinstance(run, str) or not run.strip():
+            problems.append(f"{where}: no run")
             continue
 
-        interval = _parse_duration(item["every"]) if item.get("every") is not None else None
-        at = item.get("at")
-        if interval is None and not at:
-            continue          # neither a valid interval nor a clock time
+        interval = at = None
+        if item.get("every") is not None:
+            interval = _parse_duration(item["every"])
+            if interval is None:
+                problems.append(f"{where}: {item['every']!r} is not a duration like 15m or 2h")
+                continue
+            if interval <= timedelta(0):
+                # `every: 0m` is always due, so it ran a full agent turn on every
+                # tick, forever, and looked like a working schedule while doing it.
+                problems.append(f"{where}: every {item['every']!r} must be greater than zero")
+                continue
+        elif item.get("at"):
+            at = str(item["at"]).strip()
+        else:
+            problems.append(f"{where}: needs every or at")
+            continue
 
-        entries.append(Entry(
-            # State is keyed by name, and requiring one would be ceremony for the
-            # single-entry case. The command is a serviceable identity.
-            name=str(item.get("name") or run).strip(),
-            run=run.strip(),
-            interval=interval,
-            at=str(at).strip() if at else None,
-            tz=str(item["tz"]).strip() if item.get("tz") else None,
-        ))
-    return entries
+        name = str(item.get("name") or run).strip()
+        entry = Entry(name=name, run=run.strip(), interval=interval, at=at,
+                      tz=str(item["tz"]).strip() if item.get("tz") else None)
+
+        if at is not None and _parse_at(entry) is None:
+            problems.append(f"{where}: {at!r} is not a time like '09:00' or 'Mon 09:00'")
+            continue
+        if entry.tz and _zone_or_none(entry.tz) is None:
+            # Kept, because refusing to run is worse than running in UTC — but
+            # eight hours off is not a thing to discover from a missed report.
+            problems.append(f"{where}: unknown timezone {entry.tz!r}, using UTC")
+        if name in seen:
+            # State is keyed by name: two entries sharing one overwrite each
+            # other's last_run and each ends up running half as often as written.
+            problems.append(f"{where}: duplicate name {name!r}")
+            continue
+        seen.add(name)
+        entries.append(entry)
+
+    return done(entries)
+
+
+def _zone_or_none(name):
+    try:
+        from zoneinfo import ZoneInfo
+        return ZoneInfo(name)
+    except Exception:
+        return None
 
 
 def _zone(entry: Entry):
     if not entry.tz:
         return timezone.utc
-    try:
-        from zoneinfo import ZoneInfo
-        return ZoneInfo(entry.tz)
-    except Exception:
-        # An unknown zone name is a typo in a deployed file. UTC is wrong by
-        # hours; refusing to run is wrong by everything.
-        return timezone.utc
+    # An unknown zone name is a typo in a deployed file. UTC is wrong by hours;
+    # refusing to run is wrong by everything. load_entries reports it.
+    return _zone_or_none(entry.tz) or timezone.utc
 
 
-def _clock_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
-    """`at: "09:00"` or `at: "Mon 09:00"` — due once per matching moment."""
-    parts = entry.at.split()
+def _parse_at(entry):
+    """(weekday|None, hour, minute), or None when the string is not a time.
+
+    Returns None rather than raising: the caller decides whether that means
+    "drop this entry" (load) or "never fire" (evaluate).
+    """
+    parts = str(entry.at or "").split()
+    if not parts or len(parts) > 2:
+        return None
     day = None
     if len(parts) == 2:
         day = _WEEKDAYS.get(parts[0][:3].lower())
         if day is None:
-            return False
+            return None
     try:
         hour, minute = (int(x) for x in parts[-1].split(":"))
     except ValueError:
-        return False
+        return None
+    if not (0 <= hour < 24 and 0 <= minute < 60):
+        return None
+    return day, hour, minute
+
+
+def _last_occurrence(entry, now):
+    """The most recent moment this entry was supposed to fire, at or before now.
+
+    Comparing against *that* rather than against "is it that weekday right now"
+    is what makes a missed run catch up. An agent down through Monday used to
+    skip its weekly summary for a whole week, silently, while interval entries
+    caught up — the two forms of one feature disagreeing about the property
+    #521 exists to preserve.
+    """
+    parsed = _parse_at(entry)
+    if parsed is None:
+        return None
+    day, hour, minute = parsed
 
     local = now.astimezone(_zone(entry))
-    if day is not None and local.weekday() != day:
-        return False
-    if (local.hour, local.minute) < (hour, minute):
+    candidate = local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if day is None:
+        # Daily: today's time if it has passed, else yesterday's.
+        if candidate > local:
+            candidate -= timedelta(days=1)
+        return candidate
+
+    # Weekly: walk back to the most recent matching weekday at that time.
+    behind = (local.weekday() - day) % 7
+    candidate -= timedelta(days=behind)
+    if candidate > local:
+        candidate -= timedelta(days=7)
+    return candidate
+
+
+def _clock_due(entry, last_run, now):
+    """Due when the most recent scheduled moment has not been served yet.
+
+    Fires once for any number of missed occurrences: a month of downtime is one
+    catch-up summary, not four.
+    """
+    occurrence = _last_occurrence(entry, now)
+    if occurrence is None:
         return False
 
     if last_run is None:
-        return True
-    # Once per day. Compared in the entry's own zone, so a run at 09:00 Shanghai
-    # does not re-fire because it is still yesterday in UTC.
-    return last_run.astimezone(_zone(entry)).date() < local.date()
+        # A new entry has nothing to catch up: last Monday happened before it
+        # existed. It fires when its own next occurrence arrives, which means
+        # today, if today is the day and the time has passed.
+        local = now.astimezone(_zone(entry))
+        return occurrence.date() == local.date()
+
+    return last_run.astimezone(_zone(entry)) < occurrence
 
 
 def is_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
@@ -293,7 +379,12 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
             await asyncio.sleep(TICK_SECONDS)
 
     async def on_startup() -> None:
-        entries = load_entries(co_dir)
+        entries, problems = load_entries(co_dir, report=True)
+        # Said once, at startup, where the operator is already looking. A
+        # dropped entry is otherwise indistinguishable from one that is simply
+        # not due yet — and that is what a working schedule looks like too.
+        for problem in problems:
+            _say(f"[yellow]{problem}[/yellow]")
         if not entries:
             return          # nothing scheduled: no task, no noise
         _say(f"{len(entries)} scheduled")

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -497,12 +497,12 @@ def scheduled_entries():
     try:
         from ..schedule import load_entries, load_state, last_run
     except Exception:
-        return []
+        return [], []
     try:
-        entries = load_entries(_co())
+        entries, problems = load_entries(_co(), report=True)
         state = load_state(_co())
     except Exception:
-        return []
+        return [], []
     out = []
     for e in entries:
         st = state.get(e.name) or {}
@@ -514,7 +514,7 @@ def scheduled_entries():
             "status": st.get("status"),
             "last_run": when,
         })
-    return out
+    return out, problems
 
 
 def _cadence(entry):
@@ -583,7 +583,7 @@ def _activity_sections():
     now = datetime.now(timezone.utc)
     out = []
 
-    scheduled = scheduled_entries()
+    scheduled, problems = scheduled_entries()
     if scheduled:
         rows = []
         for s in scheduled:
@@ -601,6 +601,16 @@ def _activity_sections():
                 meta=escape(meta), tone=tone).strip())
         out.append(section.safe_substitute(
             title="Scheduled", rows="\n".join("      " + r for r in rows)).strip())
+
+    if problems:
+        # A dropped entry renders as nothing, and so does a schedule that is
+        # merely not due yet. Saying which line was thrown away is the whole
+        # difference between the two.
+        rows = [row.safe_substitute(what=escape(p), meta="ignored", tone="bad").strip()
+                for p in problems]
+        out.append(section.safe_substitute(
+            title="Schedule problems",
+            rows="\n".join("      " + r for r in rows)).strip())
 
     runs = recent_runs()
     if runs:

--- a/tests/unit/test_dashboard_activity.py
+++ b/tests/unit/test_dashboard_activity.py
@@ -217,3 +217,24 @@ class TestReadingCost:
                                     "duration_ms": 5, "created": 1}) + "\n",
                         encoding="utf-8")
         assert [r["prompt"] for r in dash.recent_runs()] == ["huge"]
+
+
+class TestScheduleProblemsAreVisible:
+    """A dropped entry is invisible on Home too: it renders as nothing, which
+    is what a schedule that has not fired yet also renders as. #531."""
+
+    def test_a_rejected_entry_is_named_on_the_page(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            '- every: 0m\n  run: "/spin"\n- every: 1h\n  run: "/fine"\n', encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+
+        assert "/fine" in html
+        assert "entry 1" in html, "the entry that was dropped is not mentioned anywhere"
+
+    def test_a_clean_schedule_adds_no_warning(self, project):
+        (project / ".co" / "schedule.yaml").write_text(
+            '- every: 1h\n  run: "/fine"\n', encoding="utf-8")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        assert "entry " not in html

--- a/tests/unit/test_schedule_validation.py
+++ b/tests/unit/test_schedule_validation.py
@@ -1,0 +1,113 @@
+"""A schedule file is hand-written and deployed, so every way to get it wrong
+reaches a server. #531.
+
+Dropping what does not parse is right — one bad line must not take an agent
+down — but dropping *silently* leaves absence as the only signal, and absence
+is what a correct schedule looks like most of the time.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host import schedule as sched
+
+
+def write(tmp_path, text):
+    co = tmp_path / ".co"
+    co.mkdir(exist_ok=True)
+    (co / "schedule.yaml").write_text(text, encoding="utf-8")
+    return co
+
+
+class TestCatchUpForClockEntries:
+    """The property #521 set out to preserve, which only interval entries got."""
+
+    def test_a_weekly_missed_during_downtime_runs_when_the_agent_returns(self):
+        e = sched.Entry(name="w", run="/x", at="Mon 09:00", tz="Asia/Shanghai")
+        monday = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)     # 09:00 Shanghai
+        tuesday = monday + timedelta(days=1)
+        # It ran the *previous* Monday, then the agent was down through this one.
+        week_before = monday - timedelta(days=7)
+
+        assert sched.is_due(e, last_run=week_before, now=tuesday), (
+            "the agent was down through Monday; a late summary beats none"
+        )
+
+    def test_it_catches_up_once_not_once_per_missed_week(self):
+        e = sched.Entry(name="w", run="/x", at="Mon 09:00", tz="Asia/Shanghai")
+        monday = datetime(2026, 8, 3, 1, 0, tzinfo=timezone.utc)
+        month_later = monday + timedelta(days=28)
+
+        assert sched.is_due(e, last_run=monday, now=month_later)
+        # having just run, it must not immediately be due again
+        assert not sched.is_due(e, last_run=month_later, now=month_later)
+
+    def test_a_daily_entry_still_runs_once_a_day(self):
+        e = sched.Entry(name="d", run="/x", at="09:00", tz="UTC")
+        nine = datetime(2026, 8, 3, 9, 0, tzinfo=timezone.utc)
+
+        assert sched.is_due(e, None, nine)
+        assert not sched.is_due(e, last_run=nine, now=nine + timedelta(hours=6))
+        assert sched.is_due(e, last_run=nine, now=nine + timedelta(days=1))
+
+    def test_a_new_entry_does_not_fire_for_an_occurrence_that_predates_it(self):
+        """Last Monday happened before this entry existed; there is nothing to
+        catch up. It waits for its own next occurrence."""
+        e = sched.Entry(name="w", run="/x", at="Mon 09:00", tz="Asia/Shanghai")
+        sunday = datetime(2026, 8, 2, 1, 0, tzinfo=timezone.utc)
+        assert not sched.is_due(e, None, sunday)
+
+
+class TestEntriesThatCannotMeanAnything:
+    def test_a_zero_interval_is_rejected(self, tmp_path):
+        """`every: 0m` ran a full agent turn every tick, forever, on a typo."""
+        co = write(tmp_path, '- every: 0m\n  run: "/spin"\n')
+        assert sched.load_entries(co) == []
+
+    def test_a_time_that_is_not_a_time_is_rejected(self, tmp_path):
+        co = write(tmp_path, '- at: "25:99"\n  run: "/bad"\n')
+        assert sched.load_entries(co) == []
+
+    def test_an_unknown_weekday_is_rejected(self, tmp_path):
+        co = write(tmp_path, '- at: "Funday 09:00"\n  run: "/bad"\n')
+        assert sched.load_entries(co) == []
+
+    def test_a_duplicate_name_is_rejected_not_silently_merged(self, tmp_path):
+        """State is keyed by name: two entries sharing one would overwrite each
+        other's last_run and each end up running half as often as configured."""
+        co = write(tmp_path, '- name: dup\n  every: 1h\n  run: "/a"\n'
+                             '- name: dup\n  every: 1h\n  run: "/b"\n')
+        entries = sched.load_entries(co)
+
+        assert [e.run for e in entries] == ["/a"]
+
+    def test_the_valid_entries_around_a_bad_one_still_load(self, tmp_path):
+        co = write(tmp_path, '- every: 0m\n  run: "/spin"\n- every: 1h\n  run: "/fine"\n')
+        assert [e.run for e in sched.load_entries(co)] == ["/fine"]
+
+
+class TestSayingSo:
+    def test_problems_are_reported(self, tmp_path):
+        co = write(tmp_path, '- every: 0m\n  run: "/spin"\n'
+                             '- at: "25:99"\n  run: "/bad"\n'
+                             '- every: 1h\n  run: "/fine"\n')
+        entries, problems = sched.load_entries(co, report=True)
+
+        assert [e.run for e in entries] == ["/fine"]
+        assert len(problems) == 2
+        assert any("0m" in p or "interval" in p.lower() for p in problems)
+
+    def test_an_unknown_timezone_is_reported_but_still_runs(self, tmp_path):
+        """Falling back to UTC is deliberate — refusing to run is worse — but
+        eight hours off is not something to discover from a missed report."""
+        co = write(tmp_path, '- at: "Mon 09:00"\n  tz: Asia/Shanghia\n  run: "/x"\n')
+        entries, problems = sched.load_entries(co, report=True)
+
+        assert len(entries) == 1
+        assert any("Shanghia" in p for p in problems)
+
+    def test_a_clean_schedule_reports_nothing(self, tmp_path):
+        co = write(tmp_path, '- every: 15m\n  run: "/ok"\n')
+        entries, problems = sched.load_entries(co, report=True)
+        assert len(entries) == 1 and problems == []


### PR DESCRIPTION
Closes #531. Found testing #524 against the cases a hand-written deployed file actually produces — **before 1.6.0 was tagged**, which is why it is not.

Four faults, one shape: the schedule is authored by a person and shipped to a server, and every way of getting it wrong was silent.

## 1. A clock entry missed during downtime was skipped for good

```python
>>> is_due(Entry(at="Mon 09:00"), last_run=<last Monday>, now=<Tuesday>)
False        # the agent was down through Monday; the summary is lost
```

Interval entries caught up. So the two forms of one feature disagreed about the exact property #521 exists to preserve, and the disagreement was invisible — Home said `not yet run`, which is also what a healthy schedule says.

Due is now *"the most recent scheduled moment has not been served"*. Fires **once** for any number of missed occurrences: a month of downtime is one late summary, not four.

A **new** entry is deliberately not caught up — last Monday happened before it existed. Writing that rule down resolved two tests of mine that contradicted each other, both of which I had written and both of which passed on the old code for different reasons.

## 2. `every: 0m` parsed, and busy-looped

`now - last_run >= timedelta(0)` is always true, so it ran a full agent turn every tick, forever. Nothing in the file looks wrong; the symptom is an LLM bill.

## 3. Two entries could share a name

State is keyed by name, so each overwrote the other's `last_run` and both ended up running half as often as written, while the file said otherwise. Only reachable with an explicit `name:` — which #529 has just made the thing to do.

## 4. A malformed `at:` and an unknown timezone failed silently

`at: "25:99"` produced an entry that never fires. `tz: Asia/Shanghia` (one letter off) fires eight hours from where the author meant. The timezone still falls back to UTC — refusing to run is worse — it just says so now.

## Saying so

Reported at startup, and on Home:

```
SCHEDULED
  检查新合同 (every 15m)                                    not yet run
SCHEDULE PROBLEMS
  entry 2: 'Mon 25:99' is not a time like '09:00' or 'Mon 09:00'   ignored
  entry 3: every '0m' must be greater than zero                    ignored
  entry 4: duplicate name '检查新合同'                              ignored
```

Dropping a bad line is still right — one typo must not take an agent down (#521). Dropping it *silently* was the bug: absence is also what a correct, not-yet-due schedule looks like.

23 new tests, 2993 pass.