### PR TITLE
release: 1.5.10

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -7,37 +7,38 @@ Example: `0.0.2`
 
 ## Update Rules
 
-### 1. **PATCH Version (0.0.X)**
-- Increment by 1 for each release
-- When PATCH reaches 10, roll over to MINOR version
-- Examples: 
-  - 0.0.1 → 0.0.2 → 0.0.3 ... → 0.0.9 → 0.1.0
+### 1. **PATCH Version (X.Y.Z)**
+- Increment by 1 for each release. That is the whole rule.
+- It does not roll over. `1.5.9 → 1.5.10 → 1.5.11 → …` for as long as the work
+  takes. Two digits are not a problem; a milestone nobody earned is.
 
-### 2. **MINOR Version (0.X.0)**
-- Increment when PATCH reaches 10
-- Reset PATCH to 0
-- When MINOR reaches 10, roll over to MAJOR version
-- Examples:
-  - 0.0.9 → 0.1.0
-  - 0.9.9 → 1.0.0
+### 2. **A whole number is earned, never reached**
 
-### 3. **`X.Y.0` is the stable release**
+`X.Y.0` and `X.0.0` do not arrive because a counter filled up. They are cut,
+deliberately, when there is something to say — a body of work that is finished
+and has been exercised end to end, not merely merged.
 
-A minor is not just where the patch counter rolls over — it is the version people are
-meant to sit on. So features do **not** ship straight into one:
+So there is no automatic `0.0.9 → 0.1.0`, and no automatic `0.9.9 → 1.0.0`.
+If the next release is not that kind of release, it is another patch.
 
-- while a feature is being stabilised it ships in **patch** releases (1.5.3, 1.5.4, …)
-- `X.Y.0` is cut once that work has actually been exercised end to end
+This rule exists because the alternative was tried. 1.5.9 was followed by a
+1.6.0 bump on the mechanical reading — a minor, the version people are meant to
+sit on — for a scheduler that had not been tested yet. Testing it immediately
+found four bugs, including a weekly job that was silently skipped for a whole
+week after any downtime. It shipped as **1.5.10** instead, and 1.6.0 stayed
+available for a release that has earned it.
 
-Merged features on `main` therefore do not force the next release to be a minor bump.
-That is semver's rule, not this project's.
+### 3. **What a `X.Y.0` claims**
+
+That the work in it is done being stabilised, and that someone has run it, not
+only that its tests pass. While a feature is still being proven it ships in
+patch releases; the minor is the statement that it no longer needs to be.
 
 ### 4. **MAJOR Version (X.0.0)**
-- Increment when MINOR reaches 10
-- Reset MINOR and PATCH to 0
-- Reserved for major breaking changes or stable releases
+- Reserved for breaking changes, or for a stable release worth naming
+- Same rule as any whole number: earned, not reached
 
-## Current Version: 1.6.0
+## Current Version: 1.5.10
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -106,40 +107,39 @@ Increment PATCH for:
 - Update wiki documentation → 0.2.1 → 0.2.2
 - Refactor internal LLM code → 0.2.2 → 0.2.3
 
-### MINOR (0.X.0)
-Increment MINOR when:
-- PATCH reaches 10 (automatic rollover)
-- OR adding new features (backward compatible)
-- OR significant improvements
+### MINOR (X.Y.0)
+Cut a MINOR when:
+- a body of work is finished being stabilised, and someone has run it end to end
+- OR the API gained something worth announcing, backward compatible
+
+Never because the patch counter got long. `1.5.11` is a fine version number.
 
 **Examples:**
-- 0.2.9 → 0.3.0 (automatic rollover)
-- Add new model provider → 0.2.5 → 0.3.0 (new feature)
-- New CLI commands → 0.2.3 → 0.3.0 (new feature)
+- Scheduler proven on a real deployment → 1.5.10 → 1.6.0
+- Add new model provider → 0.2.5 → 0.3.0
 
 ### MAJOR (X.0.0)
-Increment MAJOR when:
-- MINOR reaches 10 (automatic rollover)
-- OR breaking API changes
-- OR major architecture changes
+Cut a MAJOR when:
+- the API breaks
+- OR the architecture changed enough that the old mental model no longer fits
 
 **Examples:**
-- 0.9.9 → 1.0.0 (automatic rollover or stable release)
 - Remove deprecated functions → 0.5.0 → 1.0.0 (breaking change)
 - Complete API redesign → 0.7.0 → 1.0.0 (breaking change)
 
 ## Example Version Progression
 
 ```
-0.0.1 → 0.0.2 → 0.0.3 → 0.0.4 → 0.0.5 →
-0.0.6 → 0.0.7 → 0.0.8 → 0.0.9 → 0.1.0 →
-0.1.1 → 0.1.2 → ... → 0.1.9 → 0.2.0 →
-...
-0.9.9 → 1.0.0 (Major release)
+1.5.7 → 1.5.8 → 1.5.9 → 1.5.10 → 1.5.11 → …
+                                    ↓
+                        proven end to end, so:
+                                  1.6.0
 ```
+
+The patch line runs as long as the work does. The whole number is a separate
+decision, made by a person, about whether there is something to stand behind.
 
 ## Notes
 - We moved from beta (0.0.1bX) to production (0.0.2)
-- Each update increments the last digit by 1
-- When last digit reaches 10, it rolls over to the next level
-- This ensures predictable, incremental versioning
+- Each release increments the last digit by 1
+- Nothing rolls over automatically — see rule 2

--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.5.10"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.6.0"
+version = "1.5.10"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
**1.5.10, not 1.6.0** — and the rule that said otherwise is gone rather than patched.

## The versioning change

`VERSIONING.md` said the patch counter rolls over at 10 (`0.0.9 → 0.1.0`, `0.9.9 → 1.0.0`). Taken literally that made 1.5.9 the last of its line and forced 1.6.0 next — a **minor**, the version people are meant to sit on, for a scheduler nobody had run yet.

Testing it immediately found four bugs, one of them a weekly job silently skipped for a whole week after any downtime. That release would have carried all four and claimed to be stable.

So the automatic rollover is removed everywhere in the file, not annotated:

- **The patch counter does not roll over.** `1.5.9 → 1.5.10 → 1.5.11 → …` for as long as the work takes. Two digits are not a problem; a milestone nobody earned is.
- **A whole number is earned, never reached.** `X.Y.0` and `X.0.0` are cut deliberately, when a body of work is finished *and someone has run it end to end* — not when a counter fills up.

Three later sections of the file still described automatic rollover; changing only the header would have left the document contradicting itself. They are updated too.

## What is in the release

**#532** — a schedule that will never fire now says so. Four faults, all found by testing #524 against what a hand-written deployed file actually produces:

- a **clock entry missed during downtime was skipped for good** — down through Monday meant the weekly summary was not late, it was gone, while interval entries caught up. The two forms of one feature disagreed about the property #521 exists to preserve, invisibly, because `not yet run` is also what a healthy schedule shows.
- **`every: 0m`** parsed and busy-looped — a full agent turn every tick, forever, on a typo whose symptom is a bill.
- **two entries could share a name** and overwrite each other's state, each running half as often as written.
- **a malformed `at:` and an unknown timezone** failed silently — one never fires, the other by eight hours.

All four are now reported at startup and on Home, where a dropped entry otherwise renders as nothing — which is also what a not-yet-due schedule renders as.

**#529** — Recent no longer says the same sentence three times: a scheduled prompt is fixed, so repeats fold into `检查新合同 ×3`, labelled by the entry's name rather than its instruction.

Plus the rest of the 1.5.9 series: the schedule itself (#524), Home rendering live (#518), rows as controls (#523), Home reporting activity (#525), tail-reading the session log (#526).

2993 tests pass. End-to-end verification on a deployed agent comes next — and is what would justify 1.6.0.