### PR TITLE
Home is a control panel: a verdict, a schedule, and the future

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -224,6 +224,30 @@ def _clock_due(entry, last_run, now):
     return last_run.astimezone(_zone(entry)) < occurrence
 
 
+def next_run(entry: Entry, last_run: Optional[datetime], now: datetime) -> Optional[datetime]:
+    """The moment this entry is next supposed to fire.
+
+    Deliberately returns a time in the *past* when the entry is already owed a
+    run. The caller wants to know how late, and collapsing that to "now" hides
+    the only signal that says the scheduler has stopped ticking: an entry that
+    runs every day and last ran five days ago has not failed — it did not run at
+    all, which is a different fault with a different fix.
+
+    Mirrors ``is_due`` exactly — same catch-up rule, read forwards — because a
+    page that computes due-ness on its own is a page that can disagree with the
+    scheduler about what an entry means.
+    """
+    if entry.interval is not None:
+        return now if last_run is None else last_run + entry.interval
+    parsed = _parse_at(entry)
+    occurrence = _last_occurrence(entry, now)
+    if parsed is None or occurrence is None:
+        return None                    # never fires; load_entries reports it
+    if is_due(entry, last_run, now):
+        return occurrence              # the one it owes you, in the past
+    return occurrence + (timedelta(days=7) if parsed[0] is not None else timedelta(days=1))
+
+
 def is_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
     """Whether this entry should run now.
 

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -357,7 +357,8 @@ def _address_line(agent_metadata):
     address = agent_metadata.get("address")
     if not address:
         return ""
-    return '<p class="addr">' + escape(str(address)) + '</p>'
+    _, fragments = _starter_templates()
+    return fragments["addr"].safe_substitute(address=escape(str(address))).strip()
 
 
 def render_starter(agent_metadata):
@@ -375,6 +376,12 @@ def render_starter(agent_metadata):
     """
     skills = published_skills(agent_metadata.get("skills") or [])
     page, _ = _starter_templates()
+    # Read once. Three separate calls meant three reads of schedule.yaml and its
+    # state file per render, which is not just wasted work: they are read at
+    # three different instants, so a run landing mid-render could have the
+    # verdict and the row it points at disagreeing about the same entry.
+    scheduled, problems = scheduled_entries()
+    now = _now()
     name = str(agent_metadata.get("name") or "Agent")
     return page.safe_substitute(
         name=escape(name),
@@ -382,9 +389,9 @@ def render_starter(agent_metadata):
         tagline=_tagline(agent_metadata),
         subtitle=_subtitle(agent_metadata, len(skills)),
         address=_address_line(agent_metadata),
-        alert=_alert(*scheduled_entries(), now=_now()),
-        schedule=_schedule_card(scheduled_entries()[0], _now()),
-        activity=_activity_sections(),
+        alert=_alert(scheduled, problems, now),
+        schedule=_schedule_card(scheduled, now),
+        activity=_activity_sections(scheduled),
         body=_skill_sections(skills),
     )
 
@@ -629,28 +636,33 @@ def _alert(scheduled, problems, now):
     late = [s for s in scheduled if states[s["name"]] == "late"]
     failed = [s for s in scheduled if states[s["name"]] == "bad"]
 
+    # Subject and verdict are separate slots because the emphasis around the
+    # subject is markup, and markup belongs in starter.html. Building "<b>" here
+    # would put a design decision in Python and hand the template a string it is
+    # not allowed to escape.
     if len(late) + len(failed) > 1:
-        headline = escape(f"{len(late) + len(failed)} schedules need attention")
+        subject = f"{len(late) + len(failed)} schedules"
+        verdict = "need attention"
         detail = ", ".join(s["name"] for s in late + failed)
     elif late:
         entry = late[0]
-        headline = (f"<b>{escape(entry['name'])}</b> has not run — "
-                    f"{escape(_schedule_state(entry, now)[1])}")
+        subject, verdict = entry["name"], f"has not run — {_schedule_state(entry, now)[1]}"
         detail = (f"{entry['cadence']} · last ran "
                   f"{_ago((now - entry['last_run']).total_seconds())}"
                   if entry["last_run"] else f"{entry['cadence']} · never ran")
     elif failed:
         entry = failed[0]
-        headline = f"<b>{escape(entry['name'])}</b> failed on its last run"
+        subject, verdict = entry["name"], "failed on its last run"
         detail = entry["cadence"]
     elif problems:
-        headline = escape(f"{len(problems)} schedule entr"
-                          f"{'ies' if len(problems) != 1 else 'y'} ignored")
+        plural = "ies" if len(problems) != 1 else "y"
+        subject, verdict = f"{len(problems)} schedule entr{plural}", "ignored"
         detail = problems[0] + (", …" if len(problems) > 1 else "")
     else:
         return ""
     return "      " + fragments["alert"].safe_substitute(
-        headline=headline, detail=escape(detail)).strip()
+        subject=escape(subject), verdict=escape(verdict),
+        detail=escape(detail)).strip()
 
 
 def _schedule_card(scheduled, now):
@@ -673,7 +685,7 @@ def _schedule_card(scheduled, now):
         title="Schedule", rows="\n".join(rows)).strip()
 
 
-def _activity_sections():
+def _activity_sections(scheduled):
     """Both sections, or nothing at all.
 
     A fresh agent has neither a schedule nor a history, and a box that is empty
@@ -692,8 +704,6 @@ def _activity_sections():
     # two formats — on a three-entry agent, three of four "Recent" rows were
     # restatements. Problems moved into the verdict banner, which is where a
     # config error that means "this will never fire" belongs.
-    scheduled, _ = scheduled_entries()
-
     runs = recent_runs()
     if runs:
         rows = []

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -382,6 +382,8 @@ def render_starter(agent_metadata):
         tagline=_tagline(agent_metadata),
         subtitle=_subtitle(agent_metadata, len(skills)),
         address=_address_line(agent_metadata),
+        alert=_alert(*scheduled_entries(), now=_now()),
+        schedule=_schedule_card(scheduled_entries()[0], _now()),
         activity=_activity_sections(),
         body=_skill_sections(skills),
     )
@@ -495,7 +497,7 @@ def scheduled_entries():
     the scheduler cannot disagree about what an entry means.
     """
     try:
-        from ..schedule import load_entries, load_state, last_run
+        from ..schedule import load_entries, load_state, last_run, next_run
     except Exception:
         return [], []
     try:
@@ -503,6 +505,7 @@ def scheduled_entries():
         state = load_state(_co())
     except Exception:
         return [], []
+    now = _now()
     out = []
     for e in entries:
         st = state.get(e.name) or {}
@@ -513,6 +516,7 @@ def scheduled_entries():
             "cadence": f"every {_cadence(e)}" if e.interval else str(e.at or ""),
             "status": st.get("status"),
             "last_run": when,
+            "next_run": next_run(e, when, now),
         })
     return out, problems
 
@@ -569,6 +573,106 @@ def _collapse(runs, scheduled):
                        "run": r})
     return folded
 
+def _now():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc)
+
+
+# Three ticks. One missed tick is a slow turn, not a fault.
+GRACE_SECONDS = 3 * 60
+
+
+def _until(seconds):
+    """How long until something fires, coarsely.
+
+    The mirror of ``_ago``, coarse for its reasons plus one more: this page is
+    rendered on connect and after a run, so a value can be an hour stale by the
+    time anybody reads it. "in 3h" survives that; "in 2h 47m" is wrong the moment
+    it is painted, and a countdown that cannot count is worse than none.
+    """
+    if seconds <= 120:
+        return "due now"                      # the tick is 60s; this is true
+    if seconds < 3600:
+        return f"in {int(seconds // 60)}m"
+    if seconds < 86400:
+        return f"in {int(seconds // 3600)}h"
+    return f"in {int(seconds // 86400)}d"
+
+
+def _schedule_state(entry, now):
+    """``(tone, when)`` for one entry — the whole health model, in one place.
+
+    ``late`` is the state this page could not previously express, and it is not a
+    louder ``failed``: failed means the run happened and broke, late means no run
+    happened at all. A daily entry that last ran five days ago has been owed a
+    run for four of them, which says the scheduler stopped rather than the work.
+    """
+    next_at = entry.get("next_run")
+    if next_at is None:
+        return "off", "never"
+    behind = (now - next_at).total_seconds()
+    if behind > GRACE_SECONDS:
+        return "late", _ago(behind).replace(" ago", " late")
+    if entry.get("status") == "failed":
+        return "bad", _until(-behind)
+    return "ok", _until(-behind)
+
+
+def _alert(scheduled, problems, now):
+    """The verdict, or nothing at all.
+
+    Nothing at all is the important half — see the note beside `.alert` in
+    starter.html.
+    """
+    _, fragments = _starter_templates()
+    states = {s["name"]: _schedule_state(s, now)[0] for s in scheduled}
+    late = [s for s in scheduled if states[s["name"]] == "late"]
+    failed = [s for s in scheduled if states[s["name"]] == "bad"]
+
+    if len(late) + len(failed) > 1:
+        headline = escape(f"{len(late) + len(failed)} schedules need attention")
+        detail = ", ".join(s["name"] for s in late + failed)
+    elif late:
+        entry = late[0]
+        headline = (f"<b>{escape(entry['name'])}</b> has not run — "
+                    f"{escape(_schedule_state(entry, now)[1])}")
+        detail = (f"{entry['cadence']} · last ran "
+                  f"{_ago((now - entry['last_run']).total_seconds())}"
+                  if entry["last_run"] else f"{entry['cadence']} · never ran")
+    elif failed:
+        entry = failed[0]
+        headline = f"<b>{escape(entry['name'])}</b> failed on its last run"
+        detail = entry["cadence"]
+    elif problems:
+        headline = escape(f"{len(problems)} schedule entr"
+                          f"{'ies' if len(problems) != 1 else 'y'} ignored")
+        detail = problems[0] + (", …" if len(problems) > 1 else "")
+    else:
+        return ""
+    return "      " + fragments["alert"].safe_substitute(
+        headline=headline, detail=escape(detail)).strip()
+
+
+def _schedule_card(scheduled, now):
+    """What runs without you, soonest first."""
+    if not scheduled:
+        return ""
+    _, fragments = _starter_templates()
+    rows = []
+    for entry in sorted(scheduled, key=lambda e: e["next_run"] or now):
+        tone, when = _schedule_state(entry, now)
+        if entry["last_run"]:
+            sub = (f"{entry['cadence']} · {entry['status'] or 'ran'} "
+                   f"{_ago((now - entry['last_run']).total_seconds())}")
+        else:
+            sub = f"{entry['cadence']} · not yet run"
+        rows.append("      " + fragments["sched"].safe_substitute(
+            tone=tone, name=escape(entry["name"]), sub=escape(sub),
+            when=escape(when)).strip())
+    return "  " + fragments["activity"].safe_substitute(
+        title="Schedule", rows="\n".join(rows)).strip()
+
+
 def _activity_sections():
     """Both sections, or nothing at all.
 
@@ -583,39 +687,25 @@ def _activity_sections():
     now = datetime.now(timezone.utc)
     out = []
 
-    scheduled, problems = scheduled_entries()
-    if scheduled:
-        rows = []
-        for s in scheduled:
-            if s["last_run"] is None:
-                meta, tone = "not yet run", ""
-            else:
-                ago = _ago((now - s["last_run"]).total_seconds())
-                meta = f"{s['status'] or 'ran'} · {ago}"
-                tone = "bad" if s["status"] == "failed" else ""
-            rows.append(row.safe_substitute(
-                # The entry's name, not its run text: an entry can be called
-                # "check for new contracts" while its instruction stays a
-                # paragraph. Entry.name falls back to run when none is given.
-                what=escape(f"{s['name']}  ({s['cadence']})"),
-                meta=escape(meta), tone=tone).strip())
-        out.append(section.safe_substitute(
-            title="Scheduled", rows="\n".join("      " + r for r in rows)).strip())
-
-    if problems:
-        # A dropped entry renders as nothing, and so does a schedule that is
-        # merely not due yet. Saying which line was thrown away is the whole
-        # difference between the two.
-        rows = [row.safe_substitute(what=escape(p), meta="ignored", tone="bad").strip()
-                for p in problems]
-        out.append(section.safe_substitute(
-            title="Schedule problems",
-            rows="\n".join("      " + r for r in rows)).strip())
+    # The Schedule card owns every scheduled entry, with its own cadence, status
+    # and next run. Listing them again here said the same three things twice in
+    # two formats — on a three-entry agent, three of four "Recent" rows were
+    # restatements. Problems moved into the verdict banner, which is where a
+    # config error that means "this will never fire" belongs.
+    scheduled, _ = scheduled_entries()
 
     runs = recent_runs()
     if runs:
         rows = []
-        for item in _collapse(runs, scheduled):
+        # Only what a person asked for. A scheduled firing has its own row in
+        # the Schedule card carrying cadence, status and next run; repeating it
+        # here said the same thing twice in two formats.
+        interactive = [i for i in _collapse(runs, scheduled) if i.get("key") is None]
+        if not interactive:
+            # An agent whose every run is scheduled has nothing to say here, and
+            # an empty card with a heading is worse than no card.
+            return "\n".join(out)
+        for item in interactive:
             r = item["run"]          # the newest of a folded group
             if r.get("status") == "running":
                 meta, tone = "running", "live"

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -11,13 +11,15 @@
      have to be inlined as data: URIs, so there are none. */
   :root {
     color-scheme: light dark;
-    --bg: #fbfbfa; --fg: #171717; --muted: #6b6b6b; --faint: #8a8a8a;
-    --card: #fff; --line: #e7e7e5; --hover: #f4f4f2; --accent: #16a34a;
+    --bg: #f2f2f0; --fg: #171717; --muted: #6b6b6b; --faint: #8a8a8a;
+    --card: #fff; --line: #e6e6e3; --hover: #f6f6f4; --accent: #16a34a;
+    --alert: #b91c1c; --alert-bg: #fef2f2; --alert-line: #f2cccc;
   }
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #131313; --fg: #ededed; --muted: #a0a0a0; --faint: #8b8b8b;
-      --card: #1a1a1a; --line: #2b2b2b; --hover: #212121; --accent: #22c55e;
+      --bg: #0e0e0e; --fg: #ededed; --muted: #a0a0a0; --faint: #8b8b8b;
+      --card: #1a1a1a; --line: #2b2b2b; --hover: #232323; --accent: #22c55e;
+      --alert: #fca5a5; --alert-bg: #251617; --alert-line: #4a2224;
     }
   }
   * { box-sizing: border-box; margin: 0; }
@@ -82,52 +84,81 @@
      from the page by one percent of luminance renders as its border alone, and
      that border then duplicates the hairlines of the rows inside it — two
      separator systems stacked. The rows carry themselves. */
-  .section {
-    font-size: 11px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
-    color: var(--faint); margin: 0 0 8px 2px;
-  }
-  .empty {
+  /* Cards, because a panel is a set of separate objects each answering one
+     question — is anything wrong, what runs next, what can I run, what happened
+     — and stacking them as identical bare lists made the page read as one long
+     catalogue with no primary. The page background is deliberately darker than
+     a card: the previous palette put #fff on #fbfbfa, one percent apart, so the
+     card was invisible and only its border drew. */
+  .card {
     background: var(--card); border: 1px solid var(--line); border-radius: 12px;
-    padding: 20px 18px;
+    padding: 14px; margin-bottom: 10px;
   }
-  .empty p { color: var(--muted); font-size: 13.5px; }
-  .empty code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;
-    background: var(--hover); padding: 1px 5px; border-radius: 4px;
+  .card > h2 {
+    font-size: 11px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
+    color: var(--faint); margin: 0 0 10px 2px;
   }
 
-  /* The one disclosure on the page. A details element is the only fold that
-     works with no JavaScript. It is centred and bordered so it cannot be
-     mistaken for a skill row — left-aligned, borderless, chevroned right:
-     pressing it must not feel like it might run something.
+  /* The verdict. Above everything except the agent's name, because "is anything
+     wrong" outranks "what is this made of" — a failing schedule used to render as
+     an eleven-pixel right-aligned red word in the third list down the page.
 
-     A down-chevron under a sentence, not a sideways triangle beside a slug. The
-     triangle is the file-tree idiom, and this page spent a redesign getting out
-     of the file browser. */
-  .more { margin-top: 6px; }
-  .more > summary {
-    display: flex; align-items: center; justify-content: center; gap: 7px;
-    padding: 11px 12px; cursor: pointer; list-style: none;
-    border: 1px solid var(--line); border-radius: 9px;
-    font-size: 12.5px; font-weight: 600; color: var(--muted);
-    transition: background .12s, border-color .12s, color .12s;
+     Absent when nothing is wrong. A permanent green "all systems ok" badge is
+     worse than useless: it teaches the eye to skip the exact region the alarm
+     will one day appear in. Healthy is expressed by this being missing and by a
+     column of green dots below. */
+  .alert {
+    margin-top: 14px; padding: 10px 12px 11px 13px;
+    background: var(--alert-bg);
+    border: 1px solid var(--alert-line); border-left: 3px solid var(--alert);
+    border-radius: 8px;
+    font-size: 13px; line-height: 1.4; font-weight: 550; color: var(--alert);
   }
-  .more > summary::-webkit-details-marker { display: none; }
-  .more > summary::after {
-    content: ""; flex: none; width: 6px; height: 6px; margin-top: -3px;
-    border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
-    transform: rotate(45deg); transition: transform .15s;
+  .alert b { font-weight: 700; }
+  .alert .detail {
+    display: block; margin-top: 3px; font-size: 11.5px; font-weight: 400; opacity: .85;
   }
-  .more[open] > summary::after { transform: rotate(-135deg); margin-top: 3px; }
-  .more > summary:hover { background: var(--hover); color: var(--fg); border-color: var(--faint); }
-  .more > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .more > summary:active { background: var(--line); }
-  .more[open] > .rows { margin-top: 6px; }
-  /* <summary> text cannot change without JS; two labels and a swap can. */
-  .lbl-less { display: none; }
-  .more[open] .lbl-more { display: none; }
-  .more[open] .lbl-less { display: inline; }
+  .alert:empty { display: none; }
 
+  /* What runs without you. Not a button — nothing here can be pressed yet — so
+     it deliberately has no chevron: promising a click that does nothing is what
+     the skill rows were fixed to stop doing.
+
+     The dot column is the point. Three states down a left edge is the fastest
+     read on the page: a column of green means fine, one red means there, and
+     neither needs a word read. */
+  .sched {
+    display: flex; align-items: center; gap: 10px; width: 100%;
+    padding: 9px 6px; border-radius: 9px; text-align: left; font: inherit;
+    border: 0; background: none; color: var(--fg);
+  }
+  .sched .dot {
+    flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--faint);
+  }
+  .sched.ok .dot { background: var(--accent); }
+  .sched.bad .dot, .sched.late .dot { background: var(--alert); }
+  /* Late is the loudest state on the page and the only halo: it does not mean a
+     run failed, it means no run happened — the scheduler stopped. */
+  .sched.late .dot { box-shadow: 0 0 0 3px var(--alert-bg); }
+
+  .sched-main { flex: 1; min-width: 0; }
+  .sched-name {
+    display: block; font-size: 13.5px; font-weight: 600; letter-spacing: -0.004em;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .sched-sub {
+    display: block; margin-top: 2px; font-size: 11.5px; color: var(--muted);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .sched.bad .sched-sub, .sched.late .sched-sub { color: var(--alert); }
+
+  /* The future, not the past. This column is why the page is a panel and not a
+     log — and it is coarse because it is rendered once and read later. */
+  .sched-when {
+    flex: none; font-size: 12px; font-weight: 600;
+    font-variant-numeric: tabular-nums; color: var(--muted);
+  }
+  .sched.bad .sched-when, .sched.late .sched-when { color: var(--alert); font-weight: 700; }
 
   .rows { display: flex; flex-direction: column; gap: 2px; }
 
@@ -205,7 +236,9 @@
       <div class="id"><span class="mark">$initial</span><h1>$name</h1></div>
       <p class="tagline">$tagline</p>
       <p class="sub">$subtitle</p>
+$alert
     </header>
+$schedule
 $body
 $activity
 $address
@@ -229,9 +262,12 @@ Placeholders are $name-style (string.Template). Do not use $ for anything else.
 
 <template id="skill"><button class="skill" data-ochat-skill="$name"><span class="name">$name</span><span class="desc">$description</span></button></template>
 
-<template id="list"><div class="rows">
+<template id="list"><section class="card">
+    <h2>Skills</h2>
+    <div class="rows">
 $rows
-  </div></template>
+    </div>
+  </section></template>
 
 <template id="more"><details class="more">
     <summary><span class="lbl-more">$count more skill$plural</span><span class="lbl-less">Show fewer</span></summary>
@@ -241,12 +277,17 @@ $rows
   </details></template>
 
 <template id="empty"><section class="card empty">
+    <h2>Skills</h2>
     <p>No skills yet. Add one to <code>.co/skills/</code> and it shows up here as a one-click action.</p>
   </section></template>
 
-<template id="activity"><section class="card sec">
+<template id="activity"><section class="card">
     <h2>$title</h2>
 $rows
   </section></template>
+
+<template id="alert"><p class="alert">$headline<span class="detail">$detail</span></p></template>
+
+<template id="sched"><div class="sched $tone"><span class="dot"></span><span class="sched-main"><span class="sched-name">$name</span><span class="sched-sub">$sub</span></span><span class="sched-when">$when</span></div></template>
 
 <template id="act"><div class="act"><span class="what">$what</span><span class="meta $tone">$meta</span></div></template>

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -286,7 +286,9 @@ $rows
 $rows
   </section></template>
 
-<template id="alert"><p class="alert">$headline<span class="detail">$detail</span></p></template>
+<template id="addr"><p class="addr">$address</p></template>
+
+<template id="alert"><p class="alert"><b>$subject</b> $verdict<span class="detail">$detail</span></p></template>
 
 <template id="sched"><div class="sched $tone"><span class="dot"></span><span class="sched-main"><span class="sched-name">$name</span><span class="sched-sub">$sub</span></span><span class="sched-when">$when</span></div></template>
 

--- a/tests/unit/test_dashboard_recent_repeats.py
+++ b/tests/unit/test_dashboard_recent_repeats.py
@@ -3,6 +3,12 @@
 A schedule entry's prompt is one fixed sentence sent verbatim every firing, so
 the more useful the schedule, the more the section fills with the same row —
 and the distinct rows, the interactive ones, are the first evicted.
+
+Recent now carries only what a person asked for: a scheduled entry has its own
+row in the Schedule card, with its cadence, its status and when it next fires,
+so repeating it here said the same thing twice in two formats. The collapse
+itself is still what keeps a firing from being counted twice while it is being
+matched, so these cases still guard it.
 """
 
 import json
@@ -26,6 +32,10 @@ def sessions(project, *records):
             f.write(json.dumps(r) + "\n")
 
 
+def _iso(*, ago_s):
+    return (datetime.now(timezone.utc) - timedelta(seconds=ago_s)).isoformat()
+
+
 def run(prompt, *, ago_s, ms=1000, sid=None):
     return {"session_id": sid or f"{prompt}-{ago_s}", "status": "done",
             "prompt": prompt, "result": "ok", "duration_ms": ms,
@@ -36,7 +46,10 @@ CHECK = "/contract-ledger check the drive for new contracts, extract only what i
 
 
 class TestRepeatsCollapse:
-    def test_three_firings_of_one_entry_become_one_row(self, project):
+    def test_three_firings_of_one_entry_do_not_reach_recent_at_all(self, project):
+        """They have a row of their own in the Schedule card, which says the
+        cadence, the status and when it fires next — everything this row said
+        and more."""
         (project / ".co" / "schedule.yaml").write_text(
             f'- name: check for new contracts\n  every: 15m\n  run: "{CHECK}"\n',
             encoding="utf-8")
@@ -44,10 +57,9 @@ class TestRepeatsCollapse:
                  run(CHECK, ago_s=2280), run(CHECK, ago_s=1380), run(CHECK, ago_s=420))
 
         html = dash.render_starter({"name": "billing", "skills": []})
-        recent = html.split("Recent")[-1]
 
-        assert recent.count("check for new contracts") == 1
-        assert "×3" in recent
+        assert "Recent" not in html
+        assert html.count("check for new contracts") == 1     # the Schedule row
 
     def test_the_schedule_entrys_name_is_used_not_the_prompt(self, project):
         (project / ".co" / "schedule.yaml").write_text(
@@ -72,7 +84,9 @@ class TestRepeatsCollapse:
         html = dash.render_starter({"name": "billing", "skills": []})
         recent = html.split("Recent")[-1]
 
-        assert recent.count(">check<") == 2 or recent.count("check</span>") == 2
+        # The two firings belong to the Schedule card; only the question a person
+        # typed between them is Recent's business.
+        assert "what did you find?" in recent
         assert "×" not in recent
 
     def test_a_single_firing_carries_no_count(self, project):
@@ -92,14 +106,20 @@ class TestRepeatsCollapse:
         assert "hello" in recent and "goodbye" in recent
         assert "×" not in recent
 
-    def test_the_duration_shown_is_the_most_recent_one(self, project):
+    def test_a_scheduled_entry_reports_its_latest_run_not_an_older_one(self, project):
+        """This assertion used to live in Recent, where several firings folded to
+        the newest. Firings are not in Recent any more, so the fact moved with
+        them: the entry's own Schedule row is what reports how it last went."""
         (project / ".co" / "schedule.yaml").write_text(
             f'- name: check\n  every: 15m\n  run: "{CHECK}"\n', encoding="utf-8")
+        state = {"check": {"last_run": _iso(ago_s=60), "status": "ok"}}
+        (project / ".co" / "schedule-state.json").write_text(
+            json.dumps(state), encoding="utf-8")
         sessions(project,
-                 run(CHECK, ago_s=900, ms=542000),     # 9m 2s, older
-                 run(CHECK, ago_s=60, ms=42800))       # 42.8s, newest
+                 run(CHECK, ago_s=900, ms=542000),
+                 run(CHECK, ago_s=60, ms=42800))
 
         html = dash.render_starter({"name": "billing", "skills": []})
 
-        assert "42.8s" in html
-        assert "9m 2s" not in html
+        assert "ok 1m ago" in html
+        assert "15m ago" not in html


### PR DESCRIPTION
The owner's verdict on the Home page after the schedule feature landed: *"this doesn't look like a control panel at all — no information, no control."* He is right, and the reason a UI review surfaced is worse than a layout problem.

## The page could not express the most important thing about this agent

`chase unpaid invoices` is `every 1d` and last ran 5 days ago. The page called that **failed**. It isn't.

Failed means the run happened and broke. This entry *did not run at all* — `is_due` has been true for four days and nothing served it, which means the scheduler stopped ticking or the host was down. Different fault, different fix, and the page had no way to say it, because it computed **last** run everywhere and **next** run nowhere.

So `next_run()` is not a nicety. It unlocks a third health state we could not previously detect:

| state | meaning | fix |
|---|---|---|
| ok | ran, succeeded, next run in the future | nothing |
| failed | it ran and the turn errored | fix the prompt or the tool |
| **late** | its moment passed by more than 3 ticks and nothing ran | the scheduler or the host is down |

`next_run` deliberately returns a time **in the past** for an entry already owed a run — collapsing that to "now" would hide the only signal that says the scheduler stopped. It mirrors `is_due` exactly and lives beside it, for the reason `scheduled_entries` already gives: a page that computes due-ness on its own is a page that can disagree with the scheduler about what an entry means.

## What the page is now

```
identity          mark · name · tagline · manifest
VERDICT           only when something is wrong
SCHEDULE          dot · name · cadence + last · WHEN IT NEXT FIRES
SKILLS            what you run by hand
RECENT            only what a person typed
address
```

**Schedule above skills**, because the schedule is the part that changed since you last looked; skills only change when you act. Also: schedules are bounded (2–6), skills are not, so putting the unbounded list first buries the urgent one below the fold forever.

**The verdict is absent when healthy.** A permanent green "all systems ok" badge is worse than useless — it teaches the eye to skip the exact region the alarm will one day appear in. Healthy is expressed by the banner being missing and by a column of small green dots down the schedule rows: a column of green means fine, one red means *there*, and neither needs a word read.

**One alert colour.** Red for both bad states, with the words carrying the difference. Red-vs-amber at 11px in a 440px column is a distinction nobody reliably decodes, and both states mean "go look now".

**"Next" is coarse on purpose** — `in 3h`, not `in 2h 47m`. The page is rendered on connect and after a run, and has no JavaScript, so a value can be an hour stale when it is read. `in 3h` survives that; `in 2h 47m` is wrong the moment it is painted, and a countdown that cannot count is worse than none.

## Cards

Sections are cards now. The earlier review killed a *decorative wrapper* — a `#fff` box on a `#fbfbfa` page, one percent apart, so only its border drew and that border duplicated the row hairlines it contained. That is a different question from cards as the organising principle of a panel, which is what a set of separate objects each answering one question actually wants. The page background moved to `#f2f2f0` (`#0e0e0e` dark) so a card is a card rather than a rectangle of border.

## Recent stopped repeating the Schedule

Every scheduled firing has a row in the Schedule card carrying its cadence, status and next run. Listing them again in Recent said the same three things twice in two formats — on the sample agent, **three of four Recent rows were restatements**. Recent now shows only runs that matched no schedule entry, and renders nothing at all when there are none, rather than a heading over an empty card.

The "Schedule problems" section is gone: a config error meaning *this entry will never fire* belongs in the verdict, not in its own list at the bottom.

## Tests

`2993 passed`. Three tests in `test_dashboard_recent_repeats.py` asserted the old contract and are rewritten rather than deleted — including one whose fact moved rather than disappeared: "the latest run is what's reported" is now asserted on the entry's Schedule row, which is where that fact lives.

I also wrote a test asserting that repeated *interactive* prompts collapse, discovered they do not, and deleted it rather than assert a behaviour I had not built.

## Not in this PR — and it is the honest gap

**There is still no control.** `data-ochat-skill` plus `<details>` gives one verb and one fold; *run now* and *pause* are not skills, so they cannot be expressed at all. Faking them would produce dead buttons, which is precisely what the first review had us remove. The next step is a client capability — a `<co-run entry="…">` tag resolved against the loaded schedule server-side, so no prompt text crosses the boundary — and that belongs in oo-chat's bridge alongside `<co-filter>` and `<co-table>`.