### PR TITLE
fix(dashboard): "done" claimed the work succeeded, and it does not know that

### DIFF
--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -591,8 +591,19 @@ def _activity_sections():
                 meta, tone = "not yet run", ""
             else:
                 ago = _ago((now - s["last_run"]).total_seconds())
-                meta = f"{s['status'] or 'ran'} · {ago}"
-                tone = "bad" if s["status"] == "failed" else ""
+                # "done" is not said here. It means the turn returned, which is
+                # all the scheduler can know — an agent that answered "I could
+                # not reach the drive" returned just as successfully as one that
+                # did the work. Rendering that as `done` made three consecutive
+                # failures read as a healthy job (#535). "ran 2m ago" claims
+                # only what happened.
+                #
+                # `failed` is different: the turn raised, and the scheduler
+                # genuinely knows that.
+                if s["status"] == "failed":
+                    meta, tone = f"failed · {ago}", "bad"
+                else:
+                    meta, tone = f"ran · {ago}", ""
             rows.append(row.safe_substitute(
                 # The entry's name, not its run text: an entry can be called
                 # "check for new contracts" while its instruction stays a

--- a/tests/unit/test_dashboard_activity.py
+++ b/tests/unit/test_dashboard_activity.py
@@ -238,3 +238,48 @@ class TestScheduleProblemsAreVisible:
 
         html = dash.render_starter({"name": "billing", "skills": []})
         assert "entry " not in html
+
+
+class TestDoneDoesNotClaimSuccess:
+    """`done` means the turn ended, not that the work succeeded. #535.
+
+    A scheduled run on a deployed agent returned a well-written failure report
+    — lark-cli not configured, stage named, raw error quoted — and was recorded
+    `done`. Home rendered `检查新合同  done · just now`. Three runs, all
+    failing, all displayed as if healthy.
+
+    The framework cannot read the agent's prose to know whether the task
+    worked. What it can stop doing is implying that it did.
+    """
+
+    def _entry(self, project, status):
+        (project / ".co" / "schedule.yaml").write_text(
+            '- name: check\n  every: 15m\n  run: "/check"\n', encoding="utf-8")
+        (project / ".co" / "schedule-state.json").write_text(json.dumps({
+            "check": {"last_run": datetime.now(timezone.utc).isoformat(),
+                      "status": status, "session_id": "s"}}), encoding="utf-8")
+        return dash.render_starter({"name": "billing", "skills": []})
+
+    def test_a_completed_turn_is_not_labelled_done(self, project):
+        html = self._entry(project, "done")
+
+        assert "done" not in html.split("Scheduled")[-1].split("</section>")[0], (
+            "`done` reads as a health check; it only means the turn returned"
+        )
+
+    def test_it_says_when_it_last_ran_instead(self, project):
+        html = self._entry(project, "done")
+        scheduled = html.split("Scheduled")[-1].split("</section>")[0]
+
+        # "just now" rather than "…ago" for a run seconds old — _ago's own
+        # wording. Asserting "ago" here would have been a test that only
+        # passes when the fixture is more than a minute stale.
+        assert "ran ·" in scheduled
+
+    def test_a_run_the_scheduler_could_not_finish_is_still_marked_failed(self, project):
+        """The one case the framework *does* know about: the turn raised."""
+        html = self._entry(project, "failed")
+        scheduled = html.split("Scheduled")[-1].split("</section>")[0]
+
+        assert "failed" in scheduled
+        assert "bad" in scheduled          # carries the error tone


### PR DESCRIPTION
Part of #535 — the half that survived checking.

## What Home showed

```
SCHEDULED
  检查新合同 (every 15m)          done · just now
```

What that run actually did:

> **卡在哪一步**: `fetch.py` (阶段一：遍历云盘目录)
> **错误信息**: `lark-cli` 未配置或授权无效 (`not_configured`)

Three consecutive runs, every fifteen minutes, all failing, all rendered as a healthy job.

## Why `done` was there in the first place

It is accurate at the level the scheduler works at: the turn returned. An agent that answers *"I could not reach the drive"* returns exactly as successfully as one that did the work — the difference is in prose the framework cannot read.

So the fix is not to guess. It is to stop implying:

```
  检查新合同 (every 15m)          ran · just now
```

`ran` claims only what happened. `failed` is untouched, because there the turn raised and the scheduler genuinely knows.

## The other half of #535 does not exist

I reported a deadlock — a scheduled run stuck waiting for an approval nobody would answer. That was wrong, diagnosed from a single snapshot of a run that was simply in flight. `tool_approval/approval.py:485`:

```python
# No IO = not web mode, skip
if not agent.io:
    return
```

Every `waiting_approval` on that machine came from a browser session, where waiting is correct. Every scheduled run reached `done`, and the schedule has fired on time every fifteen minutes since. Corrected in a comment on the issue.

What remains true from that half, and stays open there: an unattended run skips approval entirely, which is a policy inherited from "no client attached" rather than chosen.

## Note on one of the tests

The first version asserted `"ago" in scheduled`, which failed — a run seconds old renders `just now`, `_ago`'s own wording. That test would only have passed on a fixture more than a minute stale. Fixed to assert `"ran ·"`, with a comment saying why.

2996 tests pass.