### PR TITLE
fix(schedule): an entry does not start a second copy of itself

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -324,6 +324,7 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
     host() can compose them.
     """
     task: dict = {}
+    in_flight: set = set()
 
     def _say(message: str) -> None:
         if console:
@@ -352,9 +353,23 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
         state = load_state(co_dir)
 
         for entry in entries:
+            if entry.name in in_flight:
+                # record_run only happens after the turn returns, so last_run is
+                # stale for the whole duration — an entry whose work outlives its
+                # interval is "due" again while the first copy is still going, and
+                # again after that. Two copies of a pipeline that downloads,
+                # extracts and writes to one table race each other into the same
+                # rows (#537).
+                #
+                # Said out loud rather than skipped quietly: an entry that
+                # overruns every time is a misconfiguration — the schedule claims
+                # fifteen minutes and the truth is twenty-five.
+                _say(f"[yellow]{entry.name} still running, skipping this tick[/yellow]")
+                continue
             if not is_due(entry, last_run(state, entry.name), now):
                 continue
             _say(f"running {entry.name}")
+            in_flight.add(entry.name)
             try:
                 # A turn takes as long as it takes — four minutes is normal for
                 # real work. In a thread, so the heartbeat keeps going and the
@@ -366,6 +381,11 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
                 _say(f"[red]{entry.name} failed: {exc}[/red]")
                 record_run(co_dir, entry.name, when=now, status="failed", session_id=None)
                 continue
+            finally:
+                # Released whatever happened. A flag that outlived a crash would
+                # mean the entry never runs again, which is worse than the
+                # overlap it prevents.
+                in_flight.discard(entry.name)
             record_run(co_dir, entry.name, when=now, status=status, session_id=session_id)
 
     async def loop() -> None:

--- a/tests/unit/test_schedule_overlap.py
+++ b/tests/unit/test_schedule_overlap.py
@@ -1,0 +1,117 @@
+"""An entry that overruns its interval must not be started again. #537.
+
+`record_run` happens after the turn returns, so `last_run` is stale for the
+whole duration of a run. An entry configured `every: 15m` whose work takes
+twenty minutes is due again at minute fifteen — while the first copy is still
+working — and again at thirty.
+
+Not only wasted compute: two copies of the contract pipeline download, extract
+and write to the same table, racing each other into the same rows.
+
+The runs here take 200ms rather than blocking, so a missing fix shows up as a
+failed assertion rather than a hung test.
+"""
+
+import asyncio
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host import http_router
+from connectonion.network.host import schedule as sched
+
+
+def a_schedule(tmp_path, text='- name: slow\n  every: 1m\n  run: "/slow"\n'):
+    co = tmp_path / ".co"
+    co.mkdir(exist_ok=True)
+    (co / "schedule.yaml").write_text(text, encoding="utf-8")
+    return co
+
+
+class Recorder:
+    """Counts how many copies of each entry are inside the handler at once."""
+
+    def __init__(self, seconds=0.2):
+        self.seconds = seconds
+        self.lock = threading.Lock()
+        self.inside = 0
+        self.peak = 0
+        self.starts = []
+
+    def __call__(self, create_agent, storage, prompt, ttl, session=None, **kw):
+        with self.lock:
+            self.starts.append(prompt)
+            self.inside += 1
+            self.peak = max(self.peak, self.inside)
+        try:
+            time.sleep(self.seconds)
+            return {"status": "done"}
+        finally:
+            with self.lock:
+                self.inside -= 1
+
+
+class TestOneAtATime:
+    @pytest.mark.asyncio
+    async def test_a_tick_does_not_start_a_run_already_in_flight(self, tmp_path, monkeypatch):
+        co = a_schedule(tmp_path)
+        rec = Recorder()
+        monkeypatch.setattr(http_router, "input_handler", rec)
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+
+        first = asyncio.create_task(start.tick_once())
+        await asyncio.sleep(0.05)                 # the first run is inside
+        await start.tick_once()                   # a tick lands mid-run
+        await first
+
+        assert rec.peak == 1, (
+            f"{rec.peak} copies of one entry ran at once; two copies of a "
+            "pipeline race each other into the same table"
+        )
+        assert len(rec.starts) == 1
+
+    @pytest.mark.asyncio
+    async def test_it_runs_again_once_the_first_has_finished(self, tmp_path, monkeypatch):
+        co = a_schedule(tmp_path)
+        rec = Recorder(seconds=0)
+        monkeypatch.setattr(http_router, "input_handler", rec)
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start.tick_once()
+        await start.tick_once(now=datetime.now(timezone.utc) + timedelta(hours=1))
+
+        assert len(rec.starts) == 2, "the in-flight flag outlived the run"
+
+    @pytest.mark.asyncio
+    async def test_a_run_that_raised_does_not_stay_marked_in_flight(self, tmp_path, monkeypatch):
+        """If the flag survived a crash the entry would never run again."""
+        co = a_schedule(tmp_path)
+        calls = []
+
+        def blows_up(create_agent, storage, prompt, ttl, session=None, **kw):
+            calls.append(prompt)
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(http_router, "input_handler", blows_up)
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start.tick_once()
+        await start.tick_once(now=datetime.now(timezone.utc) + timedelta(hours=1))
+
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_busy_entry_does_not_hold_up_a_different_one(self, tmp_path, monkeypatch):
+        co = a_schedule(tmp_path,
+                        '- name: slow\n  every: 1m\n  run: "/slow"\n'
+                        '- name: quick\n  every: 1m\n  run: "/quick"\n')
+        rec = Recorder()
+        monkeypatch.setattr(http_router, "input_handler", rec)
+
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start.tick_once()
+
+        assert set(rec.starts) == {"/slow", "/quick"}


### PR DESCRIPTION
Closes #537.

`record_run` happens **after** the turn returns, so `last_run` is stale for the whole duration of a run. An entry configured `every: 15m` whose work takes twenty minutes is due again at minute fifteen — while the first copy is still working — and again at thirty.

## Why it matters more than wasted compute

Two copies of the contract pipeline this was built for download, extract and **write to one shared table**. They race each other into the same rows, through an extraction cache both are writing into.

## Reachable, not theoretical

Five consecutive scheduled runs of one entry on a deployed agent:

```
46fcb045   7m 14s
352029e9   2m 21s
48de1e0d   3m 34s
80e0d631   3m 53s
3f18e627   3m 52s
```

Nothing overlapped. But those are runs that **failed at stage one** because a dependency was unconfigured. The work they were meant to do is four minutes for a full pass over 74 contracts, longer for long ones — and a first run, or twenty new files arriving at once, lands squarely on fifteen.

Short intervals make it likelier, and short intervals are the design: poll cheaply and often so the expensive path runs rarely.

## Change

The tick keeps the entry names it has in flight and skips them. Released in a `finally`, so a crash cannot leave an entry marked busy forever — that failure mode is worse than the overlap it prevents, and there is a test for it.

Skipping is said out loud rather than swallowed. An entry that overruns every interval is a misconfiguration: the schedule claims fifteen minutes, the truth is twenty-five, and the operator should hear that rather than infer it.

The lock in `record_run` is untouched — that guards concurrent *processes*; this is one process racing itself.

## Note on the tests

The first version blocked the handler on an event. Without the fix that does not fail, it **hangs** — the second tick waits on the same event forever. Rewritten so runs take 200ms and the assertion is on peak concurrency, which fails loudly instead.

4 new tests, 3000 pass.