### PR TITLE
fix(dashboard): an entry that is running right now says so

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -39,6 +39,22 @@ _DURATION = re.compile(r"^(\d+)([smhd])$")
 _WEEKDAYS = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
 
 
+
+# Entry names with a run in flight right now.
+#
+# Module level rather than a closure so the Home page can read it: while a run
+# is in flight, record_run has not landed and the Scheduled row shows the
+# *previous* completion — which for an entry that takes longer than its
+# interval reads as overdue (#539). The page needs to know the difference
+# between "late" and "working".
+_RUNNING: set = set()
+
+
+def running_entries() -> set:
+    """The live set of entry names currently executing."""
+    return _RUNNING
+
+
 @dataclass
 class Entry:
     """One line of the schedule: what to run, and how often or when."""
@@ -324,7 +340,7 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
     host() can compose them.
     """
     task: dict = {}
-    in_flight: set = set()
+    in_flight = _RUNNING
 
     def _say(message: str) -> None:
         if console:

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -495,7 +495,8 @@ def scheduled_entries():
     the scheduler cannot disagree about what an entry means.
     """
     try:
-        from ..schedule import load_entries, load_state, last_run
+        from ..schedule import load_entries, load_state, last_run, running_entries
+        _running = running_entries()
     except Exception:
         return [], []
     try:
@@ -513,6 +514,7 @@ def scheduled_entries():
             "cadence": f"every {_cadence(e)}" if e.interval else str(e.at or ""),
             "status": st.get("status"),
             "last_run": when,
+            "running": e.name in _running,
         })
     return out, problems
 
@@ -587,7 +589,13 @@ def _activity_sections():
     if scheduled:
         rows = []
         for s in scheduled:
-            if s["last_run"] is None:
+            if s.get("running"):
+                # While a run is in flight record_run has not landed, so
+                # last_run is the *previous* completion. Showing that for an
+                # entry configured every 15m whose run takes longer reads as
+                # eight minutes late when it is in fact working (#539).
+                meta, tone = "running", "live"
+            elif s["last_run"] is None:
                 meta, tone = "not yet run", ""
             else:
                 ago = _ago((now - s["last_run"]).total_seconds())

--- a/tests/unit/test_schedule_running_visible.py
+++ b/tests/unit/test_schedule_running_visible.py
@@ -1,0 +1,110 @@
+"""An entry that is running right now must not read as overdue. #539.
+
+`record_run` lands after the turn returns, so while a run is in flight the
+Scheduled row shows the *previous* completion — and for an entry configured
+every 15m whose run takes longer, that reads as a job running late.
+
+#538 made a long run legitimately hold its slot across ticks, which makes this
+display state more common, not less.
+"""
+
+import asyncio
+import json
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host import http_router
+from connectonion.network.host import schedule as sched
+from connectonion.network.host.ws_router import dashboard as dash
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    sched.running_entries().clear()
+    yield
+    sched.running_entries().clear()
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    co = tmp_path / ".co"
+    co.mkdir()
+    (co / "schedule.yaml").write_text(
+        '- name: check\n  every: 15m\n  run: "/check"\n', encoding="utf-8")
+    (co / "schedule-state.json").write_text(json.dumps({
+        "check": {"last_run": (datetime.now(timezone.utc) - timedelta(minutes=23)).isoformat(),
+                  "status": "done", "session_id": "s"}}), encoding="utf-8")
+    monkeypatch.setattr(dash, "_project_dir", tmp_path)
+    return tmp_path
+
+
+class TestTheRowTellsTheTruth:
+    def test_an_entry_in_flight_shows_as_running(self, project):
+        sched.running_entries().add("check")
+
+        html = dash.render_starter({"name": "billing", "skills": []})
+        scheduled = html.split("Scheduled")[-1].split("</section>")[0]
+
+        assert "running" in scheduled, (
+            "the row says 'ran · 23m ago' for a 15m entry that is working "
+            "right now, which reads as eight minutes late"
+        )
+
+    def test_an_entry_not_in_flight_still_shows_when_it_last_ran(self, project):
+        """The case the row is really for: last run long ago and nothing
+        happening is genuinely stuck, and must stay visible."""
+        html = dash.render_starter({"name": "billing", "skills": []})
+        scheduled = html.split("Scheduled")[-1].split("</section>")[0]
+
+        assert "ran ·" in scheduled
+        assert "running" not in scheduled
+
+    def test_running_is_not_styled_as_an_error(self, project):
+        sched.running_entries().add("check")
+        html = dash.render_starter({"name": "billing", "skills": []})
+        scheduled = html.split("Scheduled")[-1].split("</section>")[0]
+
+        assert "bad" not in scheduled      # working is not failing
+
+
+class TestTheRegistryIsAccurate:
+    @pytest.mark.asyncio
+    async def test_it_is_populated_while_a_run_is_in_flight(self, tmp_path, monkeypatch):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule.yaml").write_text(
+            '- name: slow\n  every: 1m\n  run: "/slow"\n', encoding="utf-8")
+
+        seen = []
+
+        def handler(create_agent, storage, prompt, ttl, session=None, **kw):
+            seen.append(set(sched.running_entries()))
+            return {"status": "done"}
+
+        monkeypatch.setattr(http_router, "input_handler", handler)
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start.tick_once()
+
+        assert seen == [{"slow"}]
+        assert sched.running_entries() == set(), "not cleared after the run"
+
+    @pytest.mark.asyncio
+    async def test_it_is_cleared_when_a_run_raises(self, tmp_path, monkeypatch):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "schedule.yaml").write_text(
+            '- name: boom\n  every: 1m\n  run: "/boom"\n', encoding="utf-8")
+
+        def blows_up(*a, **k):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(http_router, "input_handler", blows_up)
+        start, _ = sched.create_schedule_lifespan(co, lambda: None, None, 86400)
+        await start.tick_once()
+
+        assert sched.running_entries() == set(), (
+            "a stuck flag would make Home claim the entry is running forever"
+        )


### PR DESCRIPTION
Closes #539. Stacked on #538, whose in-flight set is exactly the fact this needs.

## What it looked like

Rendered from a live deployed agent, at the width Home renders in:

```
SCHEDULED
  检查新合同 (every 15m)          ran · 23m ago
RECENT
  检查新合同 ×2                  running · 3m ago
```

Fifteen-minute entry, last run twenty-three minutes ago — at a glance, eight minutes late. It was not. A new run had started three minutes earlier and was still going, and only Recent said so.

Scheduled is the row someone reads to answer *is this job healthy*. It was silent about the run happening right now, so getting the truth meant reading two sections and doing arithmetic.

## Not an edge case

`ran · Nm ago` where N exceeds the interval **is what an entry looks like while it works** — `record_run` only lands after the turn returns. The longer a run takes, the longer its row misreports it, and long runs are the ones worth watching.

#538 makes it more common rather than less: a long run now legitimately holds its slot across ticks instead of being joined by a second copy.

## Change

```
  检查新合同 (every 15m)          running
```

The in-flight set from #538 becomes a module-level registry the page can read, instead of a closure variable. Styled with the accent tone, not the error tone — working is not failing.

The fallback is the point of the row: an entry whose last run was long ago **and** which is not running is genuinely stuck, and stays visible as `ran · Nm ago` rather than hidden behind an optimistic "running".

Two of the five tests guard the registry itself — populated during a run, cleared after, and cleared when the run raises. A flag that outlived a crash would make Home claim the entry is running forever, which is a worse lie than the one being fixed.

3005 tests pass.