### PR TITLE
fix(dashboard): a failed entry says why

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -295,12 +295,18 @@ def load_state(co_dir: Path) -> dict:
 
 
 def record_run(co_dir: Path, name: str, *, when: datetime, status: str,
-               session_id: Optional[str]) -> None:
+               session_id: Optional[str], reason: Optional[str] = None) -> None:
     """Remember one run, pointing at the session it produced.
 
     Only a pointer: .co/session_results.jsonl already holds the prompt, the
     transcript, the result and the duration. Copying any of that here would be
     a second source of truth that drifts.
+
+    `reason` is the exception from a run that raised, and is the exception to
+    that rule — a run that dies before producing a session leaves no session to
+    point at, so this file is the only place its cause can live. Without it Home
+    says `failed` and finding out that the account was out of credits costs an
+    ssh session (#541).
     """
     co_dir = Path(co_dir)
     co_dir.mkdir(parents=True, exist_ok=True)
@@ -309,11 +315,16 @@ def record_run(co_dir: Path, name: str, *, when: datetime, status: str,
     handle = _lock(co_dir / f"{STATE_FILE}.lock")
     try:
         state = load_state(co_dir)
+        # Rebuilt rather than updated, so a later success drops the reason a
+        # previous failure left behind. A stale cause on a healthy entry is a
+        # worse lie than no cause at all.
         state[name] = {
             "last_run": when.astimezone(timezone.utc).isoformat(),
             "status": status,
             "session_id": session_id,
         }
+        if reason:
+            state[name]["reason"] = reason
         tmp = path.with_suffix(path.suffix + ".tmp")
         tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
         os.replace(tmp, path)      # readers see the old file or the new one
@@ -395,7 +406,8 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
                 # One entry failing is not the scheduler failing. Record it and
                 # keep the others on time.
                 _say(f"[red]{entry.name} failed: {exc}[/red]")
-                record_run(co_dir, entry.name, when=now, status="failed", session_id=None)
+                record_run(co_dir, entry.name, when=now, status="failed",
+                           session_id=None, reason=str(exc))
                 continue
             finally:
                 # Released whatever happened. A flag that outlived a crash would

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -515,8 +515,21 @@ def scheduled_entries():
             "status": st.get("status"),
             "last_run": when,
             "running": e.name in _running,
+            "reason": st.get("reason"),
         })
     return out, problems
+
+
+def _why(reason, limit=60):
+    """The first line of a failure, short enough to sit in a row.
+
+    Naming the failure is the job; the traceback belongs to the log, and the
+    row now tells the reader which log to open and roughly when. A 500-character
+    exception rendered in full would push the panel sideways to say what its
+    first six words already said.
+    """
+    head = str(reason).strip().splitlines()[0] if str(reason).strip() else ""
+    return head if len(head) <= limit else head[:limit - 1] + "…"
 
 
 def _cadence(entry):
@@ -609,7 +622,14 @@ def _activity_sections():
                 # `failed` is different: the turn raised, and the scheduler
                 # genuinely knows that.
                 if s["status"] == "failed":
-                    meta, tone = f"failed · {ago}", "bad"
+                    # The reason, when the scheduler caught one. A deployed
+                    # agent's console is on a machine nobody is watching, so
+                    # `failed` alone costs an ssh session to turn into
+                    # "the account is out of credits" (#541).
+                    meta = f"failed · {ago}"
+                    if s.get("reason"):
+                        meta += f" · {_why(s['reason'])}"
+                    tone = "bad"
                 else:
                     meta, tone = f"ran · {ago}", ""
             rows.append(row.safe_substitute(

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -521,15 +521,28 @@ def scheduled_entries():
 
 
 def _why(reason, limit=60):
-    """The first line of a failure, short enough to sit in a row.
+    """The first line of a failure that carries information, short enough to
+    sit in a row.
+
+    Not literally the first line. Providers format refusals as banners, and the
+    real one this was built for opens with a row of equals signs:
+
+        ======================================================================
+        ❌ Insufficient ConnectOnion Credits
+        ======================================================================
+
+    The sentence a reader needs is the third line. Rendering line one turned
+    the row into punctuation.
 
     Naming the failure is the job; the traceback belongs to the log, and the
-    row now tells the reader which log to open and roughly when. A 500-character
-    exception rendered in full would push the panel sideways to say what its
-    first six words already said.
+    row already tells the reader which log to open and roughly when.
     """
-    head = str(reason).strip().splitlines()[0] if str(reason).strip() else ""
-    return head if len(head) <= limit else head[:limit - 1] + "…"
+    for line in str(reason).splitlines():
+        line = line.strip()
+        # A line with no letters or digits is decoration, not a message.
+        if line and any(ch.isalnum() for ch in line):
+            return line if len(line) <= limit else line[:limit - 1] + "…"
+    return ""
 
 
 def _cadence(entry):

--- a/tests/unit/test_schedule_failure_reason.py
+++ b/tests/unit/test_schedule_failure_reason.py
@@ -116,3 +116,27 @@ def test_the_tick_records_what_the_run_raised(tmp_path, monkeypatch):
     entry = sched.load_state(tmp_path).get("nightly") or {}
     assert entry.get("status") == "failed"
     assert "Insufficient ConnectOnion Credits" in (entry.get("reason") or "")
+
+
+def test_a_banner_shaped_error_does_not_render_as_a_row_of_equals_signs(tmp_path,
+                                                                        monkeypatch):
+    """The real one. Taking literally the first line showed the separator.
+
+    This is what the deployed agent actually wrote into its state file — the
+    provider formats the refusal as a banner, and the sentence a reader needs
+    is the third line, not the first.
+    """
+    co = setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    sched.record_run(co, "nightly", when=datetime.now(timezone.utc),
+                     status="failed", session_id=None, reason="""
+======================================================================
+❌ Insufficient ConnectOnion Credits
+======================================================================
+Account:     0x561605f3...dbe4
+Balance:     $0.0018
+""")
+
+    html = dashboard._activity_sections()
+
+    assert "Insufficient ConnectOnion Credits" in html
+    assert "=====" not in html

--- a/tests/unit/test_schedule_failure_reason.py
+++ b/tests/unit/test_schedule_failure_reason.py
@@ -1,0 +1,118 @@
+"""A failed entry says why, on the page rather than only in the log.
+
+The failure these tests are about is the one nobody watched happen — a
+deployed agent failing every fifteen minutes for an hour. By the time anyone
+looks, the console line is on a machine they have to ssh into. The state file
+is what the page reads, so the reason has to survive into the state file.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion.network.host import schedule as sched
+from connectonion.network.host.ws_router import dashboard
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    sched.running_entries().clear()
+    yield
+    sched.running_entries().clear()
+
+
+def setup_page(tmp_path, monkeypatch, body):
+    """Point the page at a project dir holding one schedule entry."""
+    co = tmp_path / ".co"
+    co.mkdir(parents=True, exist_ok=True)
+    (co / "schedule.yaml").write_text(body, encoding="utf-8")
+    monkeypatch.setattr(dashboard, "_project_dir", tmp_path)
+    return co
+
+
+ONE_ENTRY = "- name: nightly\n  every: 15m\n  run: go\n"
+
+
+def test_the_reason_survives_into_the_state_file(tmp_path):
+    sched.record_run(tmp_path, "nightly", when=datetime.now(timezone.utc),
+                     status="failed", session_id=None,
+                     reason="Insufficient ConnectOnion Credits")
+
+    entry = sched.load_state(tmp_path)["nightly"]
+    assert entry["reason"] == "Insufficient ConnectOnion Credits"
+
+
+def test_a_successful_run_carries_no_reason(tmp_path):
+    """A stale reason left on a now-healthy entry would be worse than none."""
+    sched.record_run(tmp_path, "nightly", when=datetime.now(timezone.utc),
+                     status="failed", session_id=None, reason="out of credits")
+    sched.record_run(tmp_path, "nightly", when=datetime.now(timezone.utc),
+                     status="done", session_id="s1")
+
+    assert not sched.load_state(tmp_path)["nightly"].get("reason")
+
+
+def test_the_page_shows_the_reason_next_to_the_failure(tmp_path, monkeypatch):
+    co = setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    sched.record_run(co, "nightly",
+                     when=datetime.now(timezone.utc) - timedelta(minutes=5),
+                     status="failed", session_id=None,
+                     reason="Insufficient ConnectOnion Credits")
+
+    html = dashboard._activity_sections()
+
+    assert "failed" in html
+    assert "Insufficient ConnectOnion Credits" in html
+
+
+def test_a_long_reason_is_cut_to_fit_the_panel(tmp_path, monkeypatch):
+    """The row names the failure; the log holds the traceback."""
+    co = setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    sched.record_run(co, "nightly", when=datetime.now(timezone.utc),
+                     status="failed", session_id=None,
+                     reason="boom\n" + "x" * 500)
+
+    html = dashboard._activity_sections()
+
+    assert "x" * 500 not in html
+    # The page is a fixed-width panel; a 500-character row would push the
+    # whole layout sideways to say what its first six words already said.
+    assert "x" * 90 not in html
+
+
+def test_a_failure_with_no_reason_still_renders(tmp_path, monkeypatch):
+    """State written by an older version has no reason key."""
+    co = setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    sched.record_run(co, "nightly", when=datetime.now(timezone.utc),
+                     status="failed", session_id=None)
+
+    assert "failed" in dashboard._activity_sections()
+
+
+def test_the_tick_records_what_the_run_raised(tmp_path, monkeypatch):
+    """The end-to-end point: an exception in the run reaches the state file."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "schedule.yaml").write_text(
+        "- name: nightly\n  every: 1m\n  run: go\n", encoding="utf-8")
+
+    def boom(*a, **kw):
+        raise RuntimeError("Insufficient ConnectOnion Credits")
+
+    monkeypatch.setattr(sched, "_run_entry", boom, raising=False)
+
+    import asyncio
+
+    startup, shutdown = sched.create_schedule_lifespan(
+        tmp_path, boom, storage=None, result_ttl=60,
+    )
+
+    async def one_tick():
+        await startup()
+        await asyncio.sleep(0.4)
+        await shutdown()
+
+    asyncio.run(one_tick())
+
+    entry = sched.load_state(tmp_path).get("nightly") or {}
+    assert entry.get("status") == "failed"
+    assert "Insufficient ConnectOnion Credits" in (entry.get("reason") or "")


### PR DESCRIPTION
Closes #541. Stacked on #540.

## What it looked like

A deployed agent had been failing every fifteen minutes for an hour. Home said:

```
检查新合同 (every 15m)          failed · 5m ago
```

That is all the operator gets. Finding the cause took an ssh session:

```
❌ Insufficient ConnectOnion Credits
Balance: $0.0018   Required: $0.0878
```

One line, entirely actionable — and the scheduler had **already caught it**. `record_run` was called with `status="failed"` at that exact moment. It wrote the exception to the console and dropped it from the state file, and on a deployed agent nobody is reading the console. That is what *deployed* means.

## Why it matters more than it looks

The failures this row exists for are the ones nobody watched happen. A failure you see, you diagnose from the log. A failure you find on Home an hour later is exactly the one whose log line has scrolled past, or is on a machine you have to ssh into.

And `session_id` is `null` for these — the run died before a session existed — so the page cannot even fall back on "click through for the transcript". The dead end is total.

Both failures I have seen in the wild were one line and self-explanatory: out of credits, and `lark-cli` not configured. Neither needed a stack trace to act on.

## After

```
检查新合同 (every 15m)   failed · 5m ago · Insufficient ConnectOnion Credits
```

First line, sixty characters. Naming the failure is the job; the row now tells the reader which log to open and roughly when.

Two things the tests pin that are easy to get wrong:

- The state entry is **rebuilt**, not updated, so a later success drops the previous failure's reason. A stale cause on a healthy entry would be a worse lie than no cause.
- State written by an older version has no `reason` key and still renders.

3011 tests pass.