### PR TITLE
fix(eval): scoring the work is not the work

### DIFF
--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -186,12 +186,23 @@ def detect_intent(agent: 'Agent') -> None:
         agent.logger.console.print("[dim]▸ understanding request...[/dim]")
 
     # Use llm_do with structured output
-    analysis = llm_do(
-        INTENT_PROMPT.format(user_prompt=user_prompt),
-        model="co/gemini-3.6-flash",
-        output=IntentAnalysis,
-        temperature=0,
-    )
+    #
+    # Follows agent.model, and cannot stop the run. This handler is the reason
+    # a deployed agent failed every fifteen minutes for an hour: it fires
+    # before the first tool, and what it produces is a sentence telling the
+    # user they were understood. Being unable to say "I understand" is not a
+    # reason to refuse to do the work (#543).
+    try:
+        analysis = llm_do(
+            INTENT_PROMPT.format(user_prompt=user_prompt),
+            model=getattr(agent, "model", None) or "co/gemini-3.6-flash",
+            output=IntentAnalysis,
+            temperature=0,
+        )
+    except Exception as exc:
+        if agent.logger.console:
+            agent.logger.console.print(f"[dim]▸ understanding unavailable ({exc})[/dim]")
+        return
 
     # Log acknowledgment to terminal
     if agent.logger.console:

--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -55,6 +55,21 @@ Focus on the USER'S INTENT, not exact text matching:
 Be lenient - if the core task was done, mark it passed."""
 
 
+DEFAULT_SCORING_MODEL = "co/gemini-3.6-flash"
+
+
+def _scoring_model(agent: 'Agent') -> str:
+    """Score with the model the agent was built with.
+
+    This used to be the literal below. An agent explicitly created with
+    `model="gemini-2.5-pro"` still sent these calls to `co/`, which is not a
+    detail when the reason for the override was that the co/ account was empty
+    (#543). Configuring a provider is rarely cosmetic — it is billing, data
+    residency, or simply the key that works.
+    """
+    return getattr(agent, "model", None) or DEFAULT_SCORING_MODEL
+
+
 def _generate_expected(agent: 'Agent') -> str:
     """Generate expected outcome for the task (called internally before evaluation)."""
     user_prompt = agent.current_session.get('user_prompt', '')
@@ -72,7 +87,7 @@ What should happen to complete this task? (1-2 sentences)"""
 
     return llm_do(
         prompt,
-        model="co/gemini-3.6-flash",
+        model=_scoring_model(agent),
         temperature=0.2,
         system_prompt=EXPECTED_PROMPT
     )
@@ -91,7 +106,17 @@ def generate_expected(agent: 'Agent') -> None:
     if agent.current_session.get('expected'):
         return
 
-    agent.current_session['expected'] = _generate_expected(agent)
+    # Scoring is not the work. This handler runs before the first tool, so an
+    # unreachable or unaffordable model here used to take the whole turn with
+    # it — a deployed agent failed every fifteen minutes for an hour on a
+    # $0.0025 call describing work it never got to do (#543).
+    #
+    # Losing the expectation costs the score and nothing else, which is why
+    # this one call earns a catch that most do not.
+    try:
+        agent.current_session['expected'] = _generate_expected(agent)
+    except Exception as exc:
+        agent.logger.print(f"[dim]/expected unavailable ({exc})[/dim]")
 
 
 def _summarize_trace(trace: List[Dict]) -> str:
@@ -184,13 +209,21 @@ Is this task truly complete? What was achieved or what's missing?"""
     agent.logger.print("[dim]/evaluating...[/dim]")
 
     # Use structured output for clear pass/fail
-    eval_result = llm_do(
-        prompt,
-        output=EvalResult,
-        model="co/gemini-3.6-flash",
-        temperature=0,
-        system_prompt=EVALUATE_PROMPT_TEXT
-    )
+    #
+    # Less dangerous than the expectation call — the work is already done — but
+    # an exception here still turns a run that succeeded into a run that
+    # reports failure, which is the same lie in the other direction (#543).
+    try:
+        eval_result = llm_do(
+            prompt,
+            output=EvalResult,
+            model=_scoring_model(agent),
+            temperature=0,
+            system_prompt=EVALUATE_PROMPT_TEXT
+        )
+    except Exception as exc:
+        agent.logger.print(f"[dim]/evaluation unavailable ({exc})[/dim]")
+        return
 
     # Support tests that patch llm_do to return a raw string
     if isinstance(eval_result, EvalResult):

--- a/tests/unit/test_eval_plugin_is_not_load_bearing.py
+++ b/tests/unit/test_eval_plugin_is_not_load_bearing.py
@@ -1,0 +1,77 @@
+"""The eval plugin scores the work. It is not the work.
+
+Both tests come from one deployed agent that failed every fifteen minutes for
+an hour: the account was out of credits, and the call that wanted the credits
+was a one-sentence guess at what success would look like — $0.0025 for a
+sentence, and the run it was describing never happened.
+"""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# The package exports a plugin list under this name, which shadows the module.
+eval_plugin = importlib.import_module("connectonion.useful_plugins.eval")
+
+
+def make_agent(model="gemini-2.5-pro", prompt="整理合同"):
+    agent = MagicMock()
+    agent.model = model
+    agent.current_session = {"user_prompt": prompt}
+    agent.tools.names.return_value = ["bash"]
+    return agent
+
+
+def test_a_refused_call_does_not_stop_the_turn():
+    """The failure that motivated this: out of credits, before the first tool."""
+    agent = make_agent()
+
+    with patch.object(eval_plugin, "llm_do",
+                      side_effect=RuntimeError("Insufficient ConnectOnion Credits")):
+        eval_plugin.generate_expected(agent)      # must not raise
+
+    # No expectation to score against, and that is the whole cost.
+    assert not agent.current_session.get("expected")
+
+
+def test_the_call_follows_the_model_the_agent_was_built_with():
+    """A hardcoded co/ model billed an account the agent was configured away from."""
+    agent = make_agent(model="gemini-2.5-pro")
+
+    with patch.object(eval_plugin, "llm_do", return_value="ok") as called:
+        eval_plugin.generate_expected(agent)
+
+    assert called.call_args.kwargs["model"] == "gemini-2.5-pro"
+
+
+def test_an_agent_with_no_model_still_has_a_default():
+    agent = make_agent()
+    del agent.model
+
+    with patch.object(eval_plugin, "llm_do", return_value="ok") as called:
+        eval_plugin.generate_expected(agent)
+
+    assert called.call_args.kwargs["model"]
+
+
+def test_a_working_call_is_still_stored():
+    agent = make_agent()
+
+    with patch.object(eval_plugin, "llm_do", return_value="the ledger is updated"):
+        eval_plugin.generate_expected(agent)
+
+    assert agent.current_session["expected"] == "the ledger is updated"
+
+
+def test_scoring_after_the_work_is_also_not_fatal():
+    """on_complete is safer — the work is done — but it can still turn a
+    successful run into a failed one."""
+    agent = make_agent()
+    agent.current_session.update({
+        "mode": "normal", "expected": "x", "trace": [], "messages": [],
+    })
+
+    with patch.object(eval_plugin, "llm_do",
+                      side_effect=RuntimeError("Insufficient ConnectOnion Credits")):
+        eval_plugin.evaluate_completion(agent)    # must not raise

--- a/tests/unit/test_intent_detection_is_not_load_bearing.py
+++ b/tests/unit/test_intent_detection_is_not_load_bearing.py
@@ -1,0 +1,41 @@
+"""Acknowledging the request is not doing the request.
+
+Same shape as the eval plugin, same deployed agent: an @after_user_input
+handler that calls a hardcoded provider, before the first tool, and takes the
+turn down when that provider says no. What this one produces is a sentence
+telling the user they were understood.
+"""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+# The package exports a plugin list under this name, which shadows the module.
+system_reminder = importlib.import_module(
+    "connectonion.cli.co_ai.plugins.system_reminder")
+
+
+def make_agent(model="gemini-2.5-pro"):
+    agent = MagicMock()
+    agent.model = model
+    agent.current_session = {"user_prompt": "整理合同", "messages": []}
+    agent.io = None
+    agent.logger.console = None
+    return agent
+
+
+def test_a_refused_call_does_not_stop_the_turn():
+    agent = make_agent()
+
+    with patch.object(system_reminder, "llm_do",
+                      side_effect=RuntimeError("Insufficient ConnectOnion Credits")):
+        system_reminder.detect_intent(agent)      # must not raise
+
+
+def test_it_follows_the_model_the_agent_was_built_with():
+    agent = make_agent(model="gemini-2.5-pro")
+
+    with patch.object(system_reminder, "llm_do") as called:
+        called.return_value = MagicMock(ack="ok", is_build=False)
+        system_reminder.detect_intent(agent)
+
+    assert called.call_args.kwargs["model"] == "gemini-2.5-pro"


### PR DESCRIPTION
Closes #543.

## The failure

A deployed agent checking a drive for new contracts every fifteen minutes failed **every single time for over an hour**:

```
03:58:43  running 检查新合同
03:58:48  检查新合同 failed:
❌ Insufficient ConnectOnion Credits
Account: 0x561605f3...dbe4   Balance: $0.0018   Required: $0.0025
```

Five seconds in, before the first tool call.

## Two defects that only bite together

**It ignored the agent's model.** The account was out of credits, so I pointed the agent at Gemini directly — same model, a funded key already on the box. It kept failing, identically. The call that fails is not the agent's: `_generate_expected` passed a literal `"co/gemini-3.6-flash"` and never looked at `agent.model`. Configuring a provider is rarely cosmetic; here the override existed *precisely because* the co/ account was empty.

**Its failure was fatal to work it has nothing to do with.** That call runs `@after_user_input`, before any tool. What it produces is a one-to-two-sentence guess at what success would look like, used to score the run afterwards. $0.0025 for a sentence describing work that then never happened.

## Fix

Both halves. The scoring calls follow `agent.model`, and neither handler can stop the run — losing the expectation costs the score and nothing else, which is why these two calls earn a catch that most calls do not.

`evaluate_completion` gets the same treatment. It is less dangerous (the work is already done) but an exception there turns a run that succeeded into one that reports failure — the same lie in the other direction.

## Note for whoever reviews

The `Required` figure was the tell. $0.0025 is far too small to be the turn itself, which is the only reason this was found rather than written off as a deployment that had not landed. Two siblings have the same hardcoded literal in `@after_user_input` handlers — `re_act.py:137` and `useful_events_handlers/reflect.py:115` — neither in the `co ai` default plugin list, so they are not fixed here. Worth a follow-up.

3010 tests pass, including the 15 existing eval tests.