### PR TITLE
fix(session): a turn that died with its process is not running

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -563,6 +563,11 @@ def host(
 
     storage = SessionStorage()
 
+    # Any session still marked `running` belongs to a process that is gone —
+    # this one just started and owns none. Left alone they are permanent, since
+    # `running` is exempt from TTL, and every mid-turn restart adds one (#545).
+    storage.reconcile_interrupted()
+
     # Create Active Session Registry for WebSocket reconnection
     registry = ActiveSessionRegistry()
     start_cleanup_job(registry)  # Start background cleanup
@@ -664,6 +669,7 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
 
     if storage is None:
         storage = SessionStorage()
+    storage.reconcile_interrupted()      # see the note at the other call site
 
     # Create Active Session Registry for WebSocket reconnection
     registry = ActiveSessionRegistry()

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -55,6 +55,42 @@ class SessionStorage:
                 return None  # Expired
         return None
 
+    def reconcile_interrupted(self):
+        """Close out sessions left `running` by a process that no longer exists.
+
+        Call at startup. That is the one moment the answer is certain: this
+        process has just begun and owns no sessions, so anything still marked
+        running belongs to a process that died between the two records a turn
+        writes — one when it starts, one when it returns.
+
+        Nothing corrected this before, and `running` is exempt from TTL
+        (see get/list), so the rows were not merely wrong but permanent. On a
+        deployed agent four of the five most recent rows on Home were turns
+        killed by a restart, all claiming to be running. Restarting mid-turn is
+        not an edge case; it is what deploying does.
+
+        `interrupted` rather than `failed`: the turn may well have finished its
+        work before the process went away, and for a scheduled entry that
+        writes to a shared ledger, "failed" invites a rerun that duplicates.
+        This says what is known — it stopped, and how far it got is not
+        recorded anywhere.
+        """
+        for session in self._latest_by_id().values():
+            if session.status == "running":
+                session.status = "interrupted"
+                self.save(session)
+
+    def _latest_by_id(self) -> dict:
+        """The newest record for each session, whatever its status or age."""
+        if not self.path.exists():
+            return {}
+        out = {}
+        with open(self.path, encoding="utf-8") as f:
+            for line in f:
+                data = json.loads(line)
+                out[data["session_id"]] = Session(**data)
+        return out
+
     def list(self) -> list[Session]:
         if not self.path.exists():
             return []

--- a/tests/unit/test_interrupted_sessions.py
+++ b/tests/unit/test_interrupted_sessions.py
@@ -1,0 +1,102 @@
+"""A turn that died with its process is not running.
+
+From a deployed agent's Home, all four rows rendered as `running`:
+
+    检查新合同 ×2                        running · 12m ago
+    /contract-ledger 检查云盘…            running · 43m ago
+    /contract-ledger 检查云盘…            running · 59m ago
+    /contract-ledger 检查云盘…            running · 1h ago
+
+None were. The process had been restarted three times mid-turn. `running`
+sessions are also exempt from TTL expiry, so these do not age out — they are
+permanent.
+"""
+
+import json
+import time
+
+from connectonion.network.host.session.storage import Session, SessionStorage
+
+
+def write(storage, session_id, status, created=None):
+    storage.save(Session(
+        session_id=session_id, status=status, prompt="go",
+        created=created if created is not None else time.time(),
+        expires=time.time() + 86400,
+    ))
+
+
+def test_a_session_left_running_is_marked_interrupted(tmp_path):
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    write(storage, "dead", "running")
+
+    storage.reconcile_interrupted()
+
+    assert storage.get("dead").status == "interrupted"
+
+
+def test_a_finished_session_is_untouched(tmp_path):
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    write(storage, "ok", "running")
+    write(storage, "ok", "done")
+
+    storage.reconcile_interrupted()
+
+    assert storage.get("ok").status == "done"
+
+
+def test_it_keeps_what_the_session_was(tmp_path):
+    """The row still has to render: prompt and timing survive."""
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    created = time.time() - 600
+    storage.save(Session(session_id="dead", status="running",
+                         prompt="/contract-ledger 检查云盘", created=created,
+                         expires=time.time() + 86400))
+
+    storage.reconcile_interrupted()
+
+    s = storage.get("dead")
+    assert s.prompt == "/contract-ledger 检查云盘"
+    assert s.created == created
+
+
+def test_it_is_append_only(tmp_path):
+    """History is not rewritten — the running record stays, a new one lands."""
+    path = tmp_path / "s.jsonl"
+    storage = SessionStorage(str(path))
+    write(storage, "dead", "running")
+
+    storage.reconcile_interrupted()
+
+    rows = [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines()]
+    assert [r["status"] for r in rows] == ["running", "interrupted"]
+
+
+def test_no_file_is_not_an_error(tmp_path):
+    SessionStorage(str(tmp_path / "missing.jsonl")).reconcile_interrupted()
+
+
+def test_it_does_not_rewrite_on_every_boot(tmp_path):
+    """Twice in a row must not append a second interrupted record."""
+    path = tmp_path / "s.jsonl"
+    storage = SessionStorage(str(path))
+    write(storage, "dead", "running")
+
+    storage.reconcile_interrupted()
+    storage.reconcile_interrupted()
+
+    rows = [json.loads(l) for l in path.read_text(encoding="utf-8").splitlines()]
+    assert [r["status"] for r in rows] == ["running", "interrupted"]
+
+
+def test_an_interrupted_session_expires_like_any_other(tmp_path):
+    """The reason phantoms were permanent: `running` is exempt from TTL."""
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    storage.save(Session(session_id="old", status="running", prompt="go",
+                         created=time.time() - 90000,
+                         expires=time.time() - 10))     # already past TTL
+
+    storage.reconcile_interrupted()
+
+    assert storage.get("old") is None
+    assert [s.session_id for s in storage.list()] == []


### PR DESCRIPTION
Closes #545. Found on the same deployed agent as #542 and #544.

## What Home showed

```
RECENT
  检查新合同 ×2                     running · 12m ago
  /contract-ledger 检查云盘…         running · 43m ago
  /contract-ledger 检查云盘…         running · 59m ago
  /contract-ledger 检查云盘…         running · 1h ago
```

None of them were running. The process had been restarted three times mid-turn. Four of the five most recent rows in the section meant to answer *what has this agent been doing* were things it was not doing.

## Why nothing corrected it

A turn writes two records — one when it starts, one when it returns:

```
{"session_id": "…", "status": "running", …}
{"session_id": "…", "status": "done",    …}
```

A process that dies between them never writes the second, and the next boot has no reason to believe a session it has never heard of is finished.

**They are also permanent.** `running` is exempt from TTL in both `get()` and `list()` — sensible for a turn genuinely in flight, fatal for one that will never finish. These rows do not age out.

And restarting mid-turn is not an edge case. It is what deploying does.

## Fix

Startup is the one moment the answer is certain: this process has just begun and owns no sessions, so anything still marked running belongs to a process that is gone. One pass over the file the page already reads.

**`interrupted`, not `failed`.** The turn may well have finished its work before the process went away — and for a scheduled entry that writes to a shared ledger, "failed" invites a rerun that duplicates. `interrupted` says what is actually known: it stopped, and how far it got is recorded nowhere.

Append-only, so history stays intact. Idempotent, so a boot that finds nothing writes nothing — the test asserts two reconciles produce one record, since a hook that appends on every boot would grow the file forever. And once reconciled the record expires like any other, which is what finally makes the phantoms clearable.

3026 tests pass.