### PR TITLE
fix(relay): a reconnect does not leak a socket

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -357,14 +357,27 @@ def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: 
             failures = 0
             while True:
                 try:
-                    ws = await relay.connect(relay_url)
-                    announce_msg = announce.create_announce_message(
-                        addr_data, summary, endpoints=endpoints, relay=relay_url, profile=profile
-                    )
-                    await relay.serve_loop(
-                        ws, announce_msg,
+                    # serve_once owns the socket's whole life. Opening it here
+                    # and dropping it on either exit path left one in
+                    # CLOSE-WAIT per reconnect (#548). The announce message is
+                    # built by callback, after the connection, because it is
+                    # signed and has to be fresh for the socket it announces on.
+                    await relay.serve_once(
+                        relay_url,
+                        lambda: announce.create_announce_message(
+                            addr_data, summary, endpoints=endpoints,
+                            relay=relay_url, profile=profile,
+                        ),
                         addr_data=addr_data, session_handler=relay_session_runner,
                     )
+                    if failures:
+                        # Say so. The log printed `Relay disconnected` and then
+                        # nothing, so a journal read as a permanent outage when
+                        # the truth was a three-second blip — telling them apart
+                        # meant inspecting sockets on the box.
+                        relay_console.print(
+                            f"[magenta]\\[host][/magenta] [dim]relay reconnected[/dim]"
+                        )
                     failures = 0  # clean disconnect — next reconnect is immediate
                 except asyncio.CancelledError:
                     raise  # shutdown — propagate so on_shutdown can await it cleanly

--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -163,6 +163,47 @@ async def _run_session(session_id, first_msg, sessions, relay_ws, session_handle
         del sessions[session_id]
 
 
+async def serve_once(
+    relay_url: str,
+    make_announce,
+    *,
+    addr_data: Dict[str, Any] = None,
+    session_handler=None,
+):
+    """One connection, from open to closed, however it ends.
+
+    The supervisor in host() used to open the socket itself and drop it on
+    both exit paths — `serve_loop` returning on a clean disconnect, and any
+    exception mid-serve. Neither closed it, so each reconnect left the old
+    one in CLOSE-WAIT: the relay had sent FIN and nothing on this side ever
+    answered (#548).
+
+    A leaked descriptor is invisible until the limit, and at the limit the
+    failure surfaces somewhere else entirely — a file that will not open, a
+    request that will not go out, with the relay nowhere in the message. An
+    agent meant to run for weeks reaches that limit.
+
+    Errors propagate: the supervisor's backoff and its escalation after five
+    consecutive failures both depend on seeing them. A close that itself
+    fails is suppressed rather than raised, because the socket is already
+    gone and the serve failure is the one worth reporting.
+
+    `make_announce` is a callable rather than a message because the message
+    is signed and must be fresh for the connection it announces on. Building
+    it before connecting also means a bad key spins the supervisor without
+    ever attempting a connection, which reports the wrong failure.
+    """
+    ws = await connect(relay_url)
+    try:
+        await serve_loop(ws, make_announce(), addr_data=addr_data,
+                         session_handler=session_handler)
+    finally:
+        try:
+            await ws.close()
+        except Exception:
+            pass
+
+
 async def serve_loop(
     websocket,
     announce_message: Dict[str, Any],

--- a/tests/unit/test_relay_socket_is_closed.py
+++ b/tests/unit/test_relay_socket_is_closed.py
@@ -1,0 +1,100 @@
+"""A relay connection that ends gets closed.
+
+From a deployed agent, twenty-five minutes and two disconnects after boot:
+
+    ESTAB       0   0  …:58944  35.197.139.111:443  fd=6
+    CLOSE-WAIT  25  0  …:52190  35.197.139.111:443  fd=8
+
+CLOSE-WAIT means the relay sent FIN and this side never called close(). The
+process is meant to run for weeks, and there is no symptom until the
+descriptor limit — where the failure will look like something else entirely.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from connectonion.network import relay
+
+
+class FakeWS:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def test_a_clean_disconnect_closes_the_socket(monkeypatch):
+    ws = FakeWS()
+    monkeypatch.setattr(relay, "connect", AsyncMock(return_value=ws))
+    monkeypatch.setattr(relay, "serve_loop", AsyncMock(return_value=None))
+
+    asyncio.run(relay.serve_once("wss://example", lambda: {},
+                                 addr_data=None, session_handler=None))
+
+    assert ws.closed
+
+
+def test_an_error_mid_serve_closes_the_socket(monkeypatch):
+    """The other exit, and the one the supervisor retries on."""
+    ws = FakeWS()
+    monkeypatch.setattr(relay, "connect", AsyncMock(return_value=ws))
+    monkeypatch.setattr(relay, "serve_loop",
+                        AsyncMock(side_effect=OSError("network went away")))
+
+    with pytest.raises(OSError):
+        asyncio.run(relay.serve_once("wss://example", lambda: {},
+                                     addr_data=None, session_handler=None))
+
+    assert ws.closed, "a socket dropped by an exception leaks the same way"
+
+
+def test_the_error_still_reaches_the_supervisor(monkeypatch):
+    """Closing must not swallow the failure — the backoff depends on it."""
+    monkeypatch.setattr(relay, "connect", AsyncMock(return_value=FakeWS()))
+    monkeypatch.setattr(relay, "serve_loop",
+                        AsyncMock(side_effect=OSError("boom")))
+
+    with pytest.raises(OSError, match="boom"):
+        asyncio.run(relay.serve_once("wss://example", lambda: {},
+                                     addr_data=None, session_handler=None))
+
+
+def test_a_failed_connect_is_not_a_close(monkeypatch):
+    """Nothing was opened, so there is nothing to close and no AttributeError."""
+    monkeypatch.setattr(relay, "connect",
+                        AsyncMock(side_effect=OSError("dns")))
+
+    with pytest.raises(OSError):
+        asyncio.run(relay.serve_once("wss://example", lambda: {},
+                                     addr_data=None, session_handler=None))
+
+
+def test_a_close_that_itself_fails_does_not_mask_the_real_error(monkeypatch):
+    """A socket already torn down can raise on close. The serve failure is
+    the one worth reporting."""
+    class BadWS(FakeWS):
+        async def close(self):
+            raise OSError("already gone")
+
+    monkeypatch.setattr(relay, "connect", AsyncMock(return_value=BadWS()))
+    monkeypatch.setattr(relay, "serve_loop",
+                        AsyncMock(side_effect=RuntimeError("the real problem")))
+
+    with pytest.raises(RuntimeError, match="the real problem"):
+        asyncio.run(relay.serve_once("wss://example", lambda: {},
+                                     addr_data=None, session_handler=None))
+
+
+def test_the_supervisor_goes_through_serve_once(monkeypatch):
+    """The fix only helps if host()'s loop actually calls it."""
+    import inspect
+    from connectonion.network.host import server
+
+    src = inspect.getsource(server)
+    body = src[src.index("async def relay_loop"):
+               src.index("relay_task = asyncio.create_task")]
+
+    assert "serve_once" in body


### PR DESCRIPTION
Closes #548.

## Evidence

Deployed agent, twenty-five minutes and two disconnects after boot:

```
ESTAB       0   0  …:58944  35.197.139.111:443  fd=6
CLOSE-WAIT  25  0  …:52190  35.197.139.111:443  fd=8
```

`CLOSE-WAIT` means the relay sent FIN and this side never called `close()`. Twenty-five bytes sitting unread in a socket nobody will read again.

The supervisor opened the connection itself and dropped it on **both** exits — `serve_loop` returning on a clean disconnect, and any exception mid-serve. Neither closed it. The object becomes garbage, but `websockets` keeps internal task references, and a file descriptor is not something to leave to the collector.

## Why it matters despite being slow

Two disconnects in twenty-five minutes reaches the default 1024-descriptor limit in roughly two to three weeks of uptime — and an agent meant to run for weeks is exactly what this is.

There is no symptom before the limit. At the limit, the failure surfaces somewhere else entirely: a file that will not open, a request that will not go out, with the relay nowhere in the message.

## Change

`serve_once` owns the socket from open to close, so both exits go through one `finally`. Errors still propagate — the backoff and its escalation after five consecutive failures depend on seeing them. A close that itself raises is suppressed, since the socket is already gone and the serve failure is the one worth reporting.

**One thing worth reviewing:** the announce message is now built by callback rather than passed in. My first version constructed it before connecting, which was a regression — a bad signing key would spin the supervisor without ever attempting a connection, reporting the wrong failure. The existing resilience test caught that, which is the second time this week an existing test earned its keep.

## Also

Say when it comes back. The log printed `Relay disconnected` and then nothing on recovery, so a journal reads as a permanent outage when the truth was a three-second blip. Telling those apart meant inspecting sockets on the box — which is how this leak was found at all.

3025 tests pass.