### PR TITLE
release: 1.5.11

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,7 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.10"
+__version__ = "1.5.11"
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.10"
+version = "1.5.11"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
Everything in this release came from one deployed agent that had been failing every fifteen minutes for an hour. None of it was found by reading code.

## What is in it

**Your schedule tells you what it is doing.**

A scheduled entry that is running now says `running` instead of showing its last completion — which, for an entry that takes longer than its interval, read as *overdue* while it was in fact working (#540). An entry that failed says why, right in the row: `failed · 5m ago · Insufficient ConnectOnion Credits` (#542). Before, finding that out meant an ssh session and `journalctl`.

**An entry no longer starts a second copy of itself.** A run that overruns its interval holds its slot instead of being joined by another (#538). Two copies of a pipeline that writes to a shared table race each other.

**Turns that died with their process stop claiming to be running.** A restart mid-turn — which is what deploying *is* — used to leave a permanent `running` row, because `running` is exempt from TTL. Four of the five most recent rows on one agent's Home were phantoms (#547).

**Scoring the work no longer stops the work.** Two `@after_user_input` handlers called a hardcoded provider before the first tool ran, and took the whole turn down when it refused. What they produce is a guess at what success would look like, and a sentence telling the user they were understood (#544). Being unable to say "I understand" is not a reason to refuse to do the work.

**A relay reconnect no longer leaks a socket.** Every disconnect left one in `CLOSE-WAIT` — a rate that reaches the descriptor limit in two to three weeks of uptime, on a process designed to run for weeks, with no symptom until it does (#549). The relay also says when it comes back now, not only when it goes away.

## Upgrade

```
pip install --upgrade connectonion
```

No API changes. 3032 tests pass; the wheel was built and its contents verified before this PR.