### PR TITLE
fix(session): a question nobody can answer is dead too, and a killed turn is not done

### DIFF
--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -55,8 +55,14 @@ class SessionStorage:
                 return None  # Expired
         return None
 
+    # A turn that is still owed something by this process. Both are equally dead
+    # once the process is gone: `running` had work in flight, `waiting_approval`
+    # had a question outstanding, and the thread that would have finished either
+    # one no longer exists.
+    UNFINISHED = ('running', 'waiting_approval')
+
     def reconcile_interrupted(self):
-        """Close out sessions left `running` by a process that no longer exists.
+        """Close out sessions this process cannot possibly finish.
 
         Call at startup. That is the one moment the answer is certain: this
         process has just begun and owns no sessions, so anything still marked
@@ -74,9 +80,16 @@ class SessionStorage:
         writes to a shared ledger, "failed" invites a rerun that duplicates.
         This says what is known — it stopped, and how far it got is not
         recorded anywhere.
+
+        `waiting_approval` was missed the first time this shipped, and it is the
+        worse of the two. A run that stopped mid-work at least looks unfinished;
+        a session that asked a question renders as *waiting for you*, so the
+        reader is invited to answer something no thread is listening for. Nine
+        hours after the first version deployed, that agent held five of them —
+        the oldest 52 hours old.
         """
         for session in self._latest_by_id().values():
-            if session.status == "running":
+            if session.status in self.UNFINISHED:
                 session.status = "interrupted"
                 self.save(session)
 

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -669,8 +669,18 @@ def _activity_sections():
         rows = []
         for item in _collapse(runs, scheduled):
             r = item["run"]          # the newest of a folded group
-            if r.get("status") == "running":
+            status = r.get("status")
+            if status == "running":
                 meta, tone = "running", "live"
+            elif status == "waiting_approval":
+                # It stopped and asked. Saying "done" here invites nobody to answer.
+                meta, tone = "waiting on you", "live"
+            elif status == "interrupted":
+                # Killed with its process — usually by a deploy. It may have
+                # finished its work first; nothing recorded how far it got, and
+                # "done" would claim it did. This is the same lie #536 took out
+                # of the Scheduled row, arriving through the other door.
+                meta, tone = "interrupted", "bad"
             else:
                 ms = r.get("duration_ms")
                 meta = _took(ms) if isinstance(ms, (int, float)) else "done"

--- a/tests/unit/test_interrupted_sessions.py
+++ b/tests/unit/test_interrupted_sessions.py
@@ -100,3 +100,31 @@ def test_an_interrupted_session_expires_like_any_other(tmp_path):
 
     assert storage.get("old") is None
     assert [s.session_id for s in storage.list()] == []
+
+
+def test_a_session_waiting_for_an_answer_is_also_reconciled(tmp_path):
+    """A question nobody can answer any more is as dead as a run nobody finished.
+
+    `waiting_approval` means a turn stopped and asked. After a restart the thread
+    that would receive the answer is gone, so the question cannot be answered by
+    anyone — but it kept claiming to be waiting. Measured on a deployed agent
+    nine hours after the reconcile shipped: five such sessions, the oldest 52
+    hours old, three of them still inside their TTL and still rendering as
+    waiting for a decision nobody could make.
+    """
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    write(storage, "asked", "waiting_approval")
+
+    storage.reconcile_interrupted()
+
+    assert storage.get("asked").status == "interrupted"
+
+
+def test_an_answered_question_is_untouched(tmp_path):
+    storage = SessionStorage(str(tmp_path / "s.jsonl"))
+    write(storage, "asked", "waiting_approval")
+    write(storage, "asked", "done")
+
+    storage.reconcile_interrupted()
+
+    assert storage.get("asked").status == "done"

--- a/tests/unit/test_schedule_failure_reason.py
+++ b/tests/unit/test_schedule_failure_reason.py
@@ -6,6 +6,8 @@ looks, the console line is on a machine they have to ssh into. The state file
 is what the page reads, so the reason has to survive into the state file.
 """
 
+import json
+import time
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -140,3 +142,35 @@ Balance:     $0.0018
 
     assert "Insufficient ConnectOnion Credits" in html
     assert "=====" not in html
+
+
+def test_an_interrupted_run_does_not_render_as_done(tmp_path, monkeypatch):
+    """A turn killed by a restart must not read as one that finished.
+
+    Recent branched on `running` and sent everything else to a duration — and
+    with no duration, to the word "done". That is the lie #536 removed from the
+    Scheduled row, arriving through the other door: reconcile marks a killed turn
+    `interrupted`, and the page called it done.
+    """
+    setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    (tmp_path / ".co" / "session_results.jsonl").write_text(
+        json.dumps({"session_id": "s1", "status": "interrupted",
+                    "prompt": "zzkilled-run", "created": time.time() - 300},
+                   ensure_ascii=False) + "\n", encoding="utf-8")
+
+    html = dashboard._activity_sections()
+
+    assert "zzkilled-run" in html
+    assert "done" not in html.lower().split("zzkilled-run")[1][:120]
+
+
+def test_a_session_still_waiting_says_so(tmp_path, monkeypatch):
+    setup_page(tmp_path, monkeypatch, ONE_ENTRY)
+    (tmp_path / ".co" / "session_results.jsonl").write_text(
+        json.dumps({"session_id": "s2", "status": "waiting_approval",
+                    "prompt": "zzasked-you", "created": time.time() - 60},
+                   ensure_ascii=False) + "\n", encoding="utf-8")
+
+    html = dashboard._activity_sections()
+    assert "zzasked-you" in html
+    assert "done" not in html.lower().split("zzasked-you")[1][:120]


### PR DESCRIPTION
Closes #553. Found while checking whether main was safe to bless as 1.6.0. It was not.

Read off a deployed agent nine hours after 1.5.11 landed:

```
Counter({'done': 82, 'waiting_approval': 5, 'interrupted': 5})
```

`interrupted: 5` is the reconcile working. `waiting_approval: 5` is it being incomplete.

## 1. Half the dead sessions were not reconciled

`running` means a turn had work in flight. `waiting_approval` means a turn stopped and asked. **After a restart both are equally dead** — the thread that would receive the answer is gone — and only the first was closed out.

It is the worse of the two, because of how it reads: an unfinished run merely looks unfinished, while a session that asked a question renders as *waiting for you*, inviting the reader to answer something no thread is listening for. The oldest on that agent was **52 hours old**, and three of the five still had 9–14 hours of TTL left to keep claiming it.

## 2. The first fix made a second lie reachable

```python
if r.get("status") == "running": …
else:
    meta = _took(ms) if isinstance(ms, (int, float)) else "done"
```

Everything not `running` falls to a duration, and a turn that never finished has none — so it renders **done**. Marking killed sessions `interrupted` in 1.5.11 meant a turn killed by a deploy started reading as one that completed.

That is precisely the lie #536 took out of the Scheduled row, arriving through the other door.

## Change

`reconcile_interrupted` closes out both statuses. Recent gets branches for each: `waiting on you` for a live question, `interrupted` for a turn killed with its process — never a duration it does not have.

3036 tests pass.

## Why this was worth blocking a release for

1.6.0 is meant to be the version someone can sit on. A stable release whose dashboard reports killed turns as completed, and invites answers to questions nothing is listening for, is not that — and both defects came from a fix shipped four hours earlier, which is the argument for reading the deployment rather than the diff.