### PR TITLE
fix(session): a torn line costs itself, not the boot

### DIFF
--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -40,16 +40,37 @@ class SessionStorage:
         with open(self.path, "a", encoding="utf-8") as f:
             f.write(session.model_dump_json() + "\n")
 
-    def get(self, session_id: str) -> Session | None:
+    def _records(self) -> list:
+        """Every parseable record, oldest first. A torn line costs itself, nothing more.
+
+        This file is appended from more than one thread, so a crash, a full disk
+        or an interleaved write can leave a partial line. `json.loads` on that
+        line used to raise out of get(), list() *and* reconcile_interrupted() —
+        and since reconcile runs at startup, one torn line stopped the agent from
+        booting at all.
+
+        The schedule's own state file settled this long ago: "Refusing to boot
+        over it costs the agent, so a truncated write or a hand edit is not
+        allowed to be fatal." Same file shape, same rule, applied late.
+        """
         if not self.path.exists():
-            return None
-        now = time.time()
+            return []
+        out = []
         with open(self.path, encoding="utf-8") as f:
-            lines = f.readlines()
-        for line in reversed(lines):
-            data = json.loads(line)
-            if data["session_id"] == session_id:
-                session = Session(**data)
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(Session(**json.loads(line)))
+                except Exception:
+                    continue      # one unreadable record, not an unreadable file
+        return out
+
+    def get(self, session_id: str) -> Session | None:
+        now = time.time()
+        for session in reversed(self._records()):
+            if session.session_id == session_id:
                 if session.status == "running" or not session.expires or session.expires > now:
                     return session
                 return None  # Expired
@@ -95,24 +116,11 @@ class SessionStorage:
 
     def _latest_by_id(self) -> dict:
         """The newest record for each session, whatever its status or age."""
-        if not self.path.exists():
-            return {}
-        out = {}
-        with open(self.path, encoding="utf-8") as f:
-            for line in f:
-                data = json.loads(line)
-                out[data["session_id"]] = Session(**data)
-        return out
+        return {s.session_id: s for s in self._records()}
 
     def list(self) -> list[Session]:
-        if not self.path.exists():
-            return []
-        sessions = {}
         now = time.time()
-        with open(self.path, encoding="utf-8") as f:
-            for line in f:
-                data = json.loads(line)
-                sessions[data["session_id"]] = Session(**data)
+        sessions = self._latest_by_id()
         valid = [s for s in sessions.values()
                  if s.status == "running" or not s.expires or s.expires > now]
         return sorted(valid, key=lambda s: s.created or 0, reverse=True)

--- a/tests/unit/test_interrupted_sessions.py
+++ b/tests/unit/test_interrupted_sessions.py
@@ -128,3 +128,48 @@ def test_an_answered_question_is_untouched(tmp_path):
     storage.reconcile_interrupted()
 
     assert storage.get("asked").status == "done"
+
+
+class TestATornLineIsNotFatal:
+    """An append-only file can be torn. Booting over it is not optional.
+
+    `.co/session_results.jsonl` is appended from more than one thread, and a
+    crash, a full disk, or an interleaved write leaves a partial line. The
+    schedule's own state file decided this years ago — "Refusing to boot over it
+    costs the agent, so a truncated write or a hand edit is not allowed to be
+    fatal" — and this file never got the same treatment.
+
+    It became a boot failure rather than a display bug when reconcile started
+    running at startup.
+    """
+
+    def torn(self, tmp_path, body):
+        path = tmp_path / "s.jsonl"
+        path.write_text(body, encoding="utf-8")
+        return SessionStorage(str(path))
+
+    def test_reconcile_survives_a_torn_line(self, tmp_path):
+        storage = self.torn(tmp_path, '{"session_id": "a", "status": "runni')
+        storage.reconcile_interrupted()          # must not raise
+
+    def test_list_survives_a_torn_line(self, tmp_path):
+        storage = self.torn(tmp_path, 'not json at all\n')
+        assert storage.list() == []
+
+    def test_get_survives_a_torn_line(self, tmp_path):
+        storage = self.torn(tmp_path, 'not json at all\n')
+        assert storage.get("a") is None
+
+    def test_the_good_lines_around_it_still_count(self, tmp_path):
+        """A torn line costs that one record, not the file."""
+        good = json.dumps({"session_id": "b", "status": "running", "prompt": "go",
+                           "created": time.time(), "expires": time.time() + 86400})
+        storage = self.torn(tmp_path, f'{{"broken\n{good}\n')
+
+        storage.reconcile_interrupted()
+
+        assert storage.get("b").status == "interrupted"
+
+    def test_a_blank_line_is_not_a_record(self, tmp_path):
+        storage = self.torn(tmp_path, '\n\n')
+        assert storage.list() == []


### PR DESCRIPTION
Closes #555. Found auditing main for 1.6.0.

```python
>>> open('.co/session_results.jsonl','w').write('{"session_id": "a", "sta')
>>> SessionStorage(path).reconcile_interrupted()
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

`get()`, `list()` and `reconcile_interrupted()` each called `json.loads` on every line with nothing around it. One malformed record raised out of all three.

**`reconcile_interrupted` runs at startup**, so this is not a display bug — the agent does not boot. And that is new in 1.5.11, where reconcile started running at startup. The file is appended from more than one thread; a crash, a full disk, or an interleaved write is all it takes.

## The codebase had already decided this, twice

`schedule.py`, on its own state file:

> Losing this costs one duplicated run. **Refusing to boot over it costs the agent**, so a truncated write or a hand edit is not allowed to be fatal.

`dashboard.py`, reading *this very file*:

```python
except (ValueError, UnicodeDecodeError):
    continue          # a torn write must not cost the whole page
```

Same file, same shape, two places that got it right and one that did not.

## Change

One tolerant reader behind all three: blank lines skipped, unparseable records skipped, everything else kept — **including the good records on either side of the tear**, which is what the last test pins.

3041 tests pass, 5 of them new.