### PR TITLE
fix(schedule): two writers no longer destroy each other's state

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -17,6 +17,7 @@ is one implementation. The argument in full is #521.
 import asyncio
 import json
 import os
+import threading
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -256,26 +257,40 @@ def is_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
     return False
 
 
-def _lock(path: Path):
-    """Exclusive, non-blocking, released by the OS on death.
+def _lock(path: Path, attempts: int = 50, pause: float = 0.02):
+    """Exclusive, released by the OS on death, and worth waiting a moment for.
+
+    Retries rather than giving up at the first refusal. The lock used to be
+    single-shot LOCK_NB, and every caller treated a refusal as permission to
+    proceed — so under contention nobody held it and every writer did a
+    read-modify-write on the same file. Measured: twelve threads, 240 writes,
+    one whole entry silently missing from the result.
+
+    Still bounded. A second of retries is generous for a write of a few hundred
+    bytes, and blocking forever on a lock held by a process that died in a way
+    the OS did not notice is worse than proceeding.
 
     Same shape as cli/browser_agent/transport.py — POSIX flock, Windows
     msvcrt. A scheduler that imports fcntl at module level is a scheduler that
     does not import on Windows.
     """
-    handle = open(path, "a+", encoding="utf-8")
-    try:
-        if os.name == "nt":
-            import msvcrt
-            handle.seek(0)
-            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
-        else:
-            import fcntl
-            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        handle.close()
-        return None
-    return handle
+    import time as _time
+    for attempt in range(attempts):
+        handle = open(path, "a+", encoding="utf-8")
+        try:
+            if os.name == "nt":
+                import msvcrt
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except OSError:
+            handle.close()
+            if attempt < attempts - 1:
+                _time.sleep(pause)
+    return None
 
 
 def load_state(co_dir: Path) -> dict:
@@ -325,9 +340,19 @@ def record_run(co_dir: Path, name: str, *, when: datetime, status: str,
         }
         if reason:
             state[name]["reason"] = reason
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)      # readers see the old file or the new one
+        # A name of its own. One shared `.tmp` meant concurrent writers wrote
+        # over each other's file and then raced to rename it: the first
+        # os.replace consumed it and the second raised FileNotFoundError, out
+        # of the scheduler's own tick.
+        tmp = path.with_suffix(f"{path.suffix}.{os.getpid()}.{threading.get_ident()}.tmp")
+        try:
+            tmp.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
+            os.replace(tmp, path)  # readers see the old file or the new one
+        finally:
+            # A crash between write and replace would otherwise leave one temp
+            # file per incident, in the directory the agent reads on every boot.
+            if tmp.exists():
+                tmp.unlink(missing_ok=True)
     finally:
         if handle:
             handle.close()

--- a/tests/unit/test_schedule_state_under_contention.py
+++ b/tests/unit/test_schedule_state_under_contention.py
@@ -1,0 +1,82 @@
+"""Two writers must not destroy each other's state.
+
+`record_run` is called whenever an entry finishes. One process running entries
+in sequence rarely overlaps — but a deploy restart does: the old process is
+still finishing a turn while the new one boots and records its own, and the
+lock beside the file exists precisely for that case.
+"""
+
+import json
+import threading
+from datetime import datetime, timezone
+
+from connectonion.network.host.schedule import record_run, load_state
+
+
+def test_concurrent_writers_do_not_raise(tmp_path):
+    """The temp file was one shared name, so writers deleted each other's."""
+    now = datetime.now(timezone.utc)
+    errors = []
+
+    def write(i):
+        try:
+            for _ in range(20):
+                record_run(tmp_path, f"entry{i % 4}", when=now,
+                           status="done", session_id=f"s{i}")
+        except Exception as exc:      # noqa: BLE001 - the assertion is the message
+            errors.append(f"{type(exc).__name__}: {exc}")
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(12)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    assert not errors, errors[:3]
+
+
+def test_no_entry_is_lost(tmp_path):
+    """Every name that was written must survive. A dropped entry means the
+    scheduler forgets an entry ever ran, and runs it again."""
+    now = datetime.now(timezone.utc)
+
+    def write(i):
+        for _ in range(20):
+            record_run(tmp_path, f"entry{i % 4}", when=now,
+                       status="done", session_id=f"s{i}")
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(12)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    state = load_state(tmp_path)
+    assert sorted(state) == ["entry0", "entry1", "entry2", "entry3"]
+
+
+def test_the_file_is_never_left_unparseable(tmp_path):
+    now = datetime.now(timezone.utc)
+
+    def write(i):
+        for _ in range(15):
+            record_run(tmp_path, f"e{i}", when=now, status="done", session_id="s")
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    raw = (tmp_path / "schedule-state.json").read_text(encoding="utf-8")
+    json.loads(raw)          # must not raise
+
+
+def test_no_temp_files_are_left_behind(tmp_path):
+    """A unique temp name must still be cleaned up, or the directory fills."""
+    now = datetime.now(timezone.utc)
+
+    def write(i):
+        for _ in range(10):
+            record_run(tmp_path, f"e{i}", when=now, status="done", session_id="s")
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(8)]
+    for t in threads: t.start()
+    for t in threads: t.join()
+
+    leftovers = [p.name for p in tmp_path.iterdir() if ".tmp" in p.name]
+    assert not leftovers, leftovers[:5]


### PR DESCRIPTION
Closes #559. Found auditing main for 1.6.0.

```
FileNotFoundError: …/schedule-state.json.tmp -> …/schedule-state.json
entries: 3 -> ['entry0', 'entry2', 'entry3']     # entry1 simply gone
```

Twelve threads, 240 writes. Two defects, compounding.

## The lock was advisory in the worst sense

```python
fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
except OSError:
    handle.close()
    return None          # ← and record_run carries on regardless
```

One non-blocking attempt, and every caller treats a refusal as permission to proceed. Under contention **nobody holds it** and every writer does its own read-modify-write of the whole file. Last writer wins.

**A lost entry is not cosmetic.** `last_run` is what `is_due` reads — an entry the scheduler forgets about **runs again**.

## One shared temp filename

Every writer used `schedule-state.json.tmp`. They overwrote each other's file and raced to rename it: the first `os.replace` consumed it, the second raised `FileNotFoundError` **out of the scheduler's own tick**.

## Reachability

Not the common path — one process runs entries in sequence. It is the **restart** path: a deploy starts a new process while the old one is still finishing a turn and recording it. That is exactly the case the lock beside the file was put there for, and the case where a lost `last_run` reruns something that writes to a shared ledger.

## Change

The lock retries briefly rather than giving up at the first refusal — bounded, because blocking forever on a lock held by a process the OS never noticed dying is worse than proceeding. Each writer gets its own temp name (`pid.thread`), removed if the replace never happens, so a crash between write and rename does not leave one temp file per incident in the directory the agent reads at boot.

3040 tests pass, 4 of them new — including one that asserts no temp files are left behind, because a unique name that is never cleaned up trades one bug for another.