### PR TITLE
fix(trust): an invite code per agent, not one published in this repo

### DIFF
--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -206,6 +206,23 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
 
     # Collect keys to append (not already in .env)
     keys_to_add = []
+
+    # The agent's own way in. Minted here, once, and never again if it already
+    # exists — regenerating it would silently lock out everyone already holding
+    # the old one.
+    #
+    # In .env because that is already the secret channel: git ignores it, the
+    # rsync in `co deploy` excludes it, and deploy delivers it separately as a
+    # root-owned 0600 file. The alternative was the shipped policy's literal
+    # `invite_code: [OpenOnion]` — one password for every deployment, published
+    # in this repository and printed by every agent on startup (#561).
+    if "CO_INVITE_CODE" not in existing_keys:
+        import secrets as _secrets
+        alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"   # no O/0, no I/1 — it gets typed by hand
+        code = "-".join("".join(_secrets.choice(alphabet) for _ in range(5)) for _ in range(3))
+        keys_to_add.append(f"CO_INVITE_CODE={code}")
+        global_keys["CO_INVITE_CODE"] = f"CO_INVITE_CODE={code}"
+
     for key, line in global_keys.items():
         if key not in existing_keys:
             keys_to_add.append(line)

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -60,6 +60,33 @@ def parse_policy(policy_text: str, source: str = None) -> tuple[dict, str]:
     return config, markdown_body
 
 
+def _resolve_codes(codes) -> list:
+    """Turn what the policy declares into the codes that actually open the door.
+
+    `$NAME` reads NAME from the environment — which on a deployed agent is the
+    root-owned 0600 env file, the same channel every other secret takes, and the
+    one thing `co deploy` neither rsyncs nor overwrites.
+
+    An unset variable resolves to *nothing*, never to the placeholder and never
+    to a default. That last part is the whole point: the shipped policy used to
+    carry `invite_code: [OpenOnion]`, a constant published in this repository
+    and printed by every agent on startup, and a stranger who typed it was
+    admitted as a contact in five seconds (#561). A missing code is a closed
+    door, not an open one.
+    """
+    import os as _os
+    out = []
+    for code in codes or []:
+        text = str(code)
+        if text.startswith('$'):
+            value = _os.environ.get(text[1:], '').strip()
+            if value:
+                out.append(value)
+        elif text:
+            out.append(text)
+    return out
+
+
 def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[str]:
     """
     Evaluate request using fast rules (no LLM).
@@ -127,7 +154,7 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     onboard = config.get('onboard', {})
 
     # Check invite code
-    valid_codes = onboard.get('invite_code', [])
+    valid_codes = _resolve_codes(onboard.get('invite_code', []))
     request_code = request.get('invite_code')
     if request_code and request_code in valid_codes:
         promote_to_contact(client_id)

--- a/connectonion/network/trust/policies/careful.md
+++ b/connectonion/network/trust/policies/careful.md
@@ -13,7 +13,9 @@ deny:
 
 # How strangers become contacts
 onboard:
-  invite_code: [OpenOnion]
+  # Read from the environment, so every agent has its own. A literal here
+  # would be one password for every deployment, published in this repo.
+  invite_code: [$CO_INVITE_CODE]
   payment: 10
 
 # Strangers without credentials

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -230,7 +230,11 @@ Should this client be allowed access?"""
         Returns:
             True if valid and promoted, False otherwise
         """
-        valid_codes = self._config.get('onboard', {}).get('invite_code', [])
+        # Through the same resolver as evaluate_request, because this is the path
+        # ONBOARD_SUBMIT actually takes — fixing only the other one would have
+        # left the real door open (#561).
+        from .fast_rules import _resolve_codes
+        valid_codes = _resolve_codes(self._config.get('onboard', {}).get('invite_code', []))
         if invite_code in valid_codes:
             self.promote_to_contact(client_id)
             return True

--- a/tests/unit/test_invite_code_is_not_a_constant.py
+++ b/tests/unit/test_invite_code_is_not_a_constant.py
@@ -1,0 +1,75 @@
+"""The way in must not be a string published in this repository.
+
+A stock `co init -t co-ai` + `co deploy` produced an agent that announced
+`Invite: OpenOnion` in its own logs — the constant from
+trust/policies/careful.md. Opening its public URL in a fresh browser context
+and typing that word got a working session in five seconds.
+
+`contact` is in the default allow list, so admission is a session, not a
+read-only peek; and the approval prompt does not know who is asking (#551), so
+the stranger is offered "Trust bash for this session" and their answer counts.
+"""
+
+import pytest
+
+from connectonion.network.trust.fast_rules import parse_policy, evaluate_request
+
+
+CAREFUL = (
+    "connectonion/network/trust/policies/careful.md"
+)
+
+
+def policy(text):
+    config, _ = parse_policy(text)
+    return config
+
+
+class TestTheShippedPolicies:
+    def test_no_policy_ships_a_literal_invite_code(self):
+        """Whatever the default is, it cannot be a value in the repository."""
+        import pathlib
+        for path in pathlib.Path("connectonion/network/trust/policies").glob("*.md"):
+            config, _ = parse_policy(path.read_text(encoding="utf-8"))
+            codes = (config.get("onboard") or {}).get("invite_code") or []
+            literals = [c for c in codes if not str(c).startswith("$")]
+            assert not literals, f"{path.name} ships {literals}"
+
+
+class TestReadingTheCodeFromTheEnvironment:
+    def test_a_placeholder_resolves_from_the_environment(self, monkeypatch):
+        monkeypatch.setenv("CO_INVITE_CODE", "REAL-CODE-123")
+        config = policy("---\nonboard:\n  invite_code: [$CO_INVITE_CODE]\n"
+                        "default: deny\n---\n")
+
+        assert evaluate_request(config, "0xstranger",
+                                {"invite_code": "REAL-CODE-123"}) == "allow"
+
+    def test_the_placeholder_itself_is_never_a_code(self, monkeypatch):
+        """Typing the literal text of the placeholder must not work."""
+        monkeypatch.setenv("CO_INVITE_CODE", "REAL-CODE-123")
+        config = policy("---\nonboard:\n  invite_code: [$CO_INVITE_CODE]\n"
+                        "default: deny\n---\n")
+
+        assert evaluate_request(config, "0xstranger",
+                                {"invite_code": "$CO_INVITE_CODE"}) != "allow"
+
+    def test_an_unset_variable_closes_the_door(self, monkeypatch):
+        """No code configured is not an invitation — it is a closed door.
+
+        The alternative, falling back to a default, is exactly how a published
+        constant became every agent's password.
+        """
+        monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+        config = policy("---\nonboard:\n  invite_code: [$CO_INVITE_CODE]\n"
+                        "default: deny\n---\n")
+
+        for attempt in ["", "$CO_INVITE_CODE", "OpenOnion", "anything"]:
+            assert evaluate_request(config, "0xstranger",
+                                    {"invite_code": attempt}) != "allow", attempt
+
+    def test_a_literal_code_still_works(self, monkeypatch):
+        """An operator who writes their own code into trust.md keeps working."""
+        config = policy("---\nonboard:\n  invite_code: [B7HSW-6Y6P4]\n"
+                        "default: deny\n---\n")
+        assert evaluate_request(config, "0xs", {"invite_code": "B7HSW-6Y6P4"}) == "allow"

--- a/tests/unit/test_trust_agent_class.py
+++ b/tests/unit/test_trust_agent_class.py
@@ -111,14 +111,28 @@ class TestShouldAllow:
 class TestVerification:
     """Test verification methods."""
 
-    def test_verify_invite_valid_code(self, co_dir):
-        """Valid invite code promotes to contact."""
-        trust = TrustAgent("careful")  # careful.md has invite_code: [OpenOnion]
+    def test_verify_invite_valid_code(self, co_dir, monkeypatch):
+        """Valid invite code promotes to contact.
 
-        result = trust.verify_invite("new-user", "OpenOnion")
+        careful.md now declares `invite_code: [$CO_INVITE_CODE]` — this used to
+        assert the shipped constant `OpenOnion`, which was one password for every
+        deployment, published in this repository (#561).
+        """
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E-LGWG4")
+        trust = TrustAgent("careful")
+
+        result = trust.verify_invite("new-user", "U262R-7WA6E-LGWG4")
 
         assert result is True
         assert trust.get_level("new-user") == "contact"
+
+    def test_the_old_shipped_constant_no_longer_works(self, co_dir, monkeypatch):
+        """The exact string a stranger used to get in with."""
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E-LGWG4")
+        trust = TrustAgent("careful")
+
+        assert trust.verify_invite("stranger", "OpenOnion") is False
+        assert trust.get_level("stranger") != "contact"
 
     def test_verify_invite_invalid_code(self, co_dir):
         """Invalid invite code does not promote."""


### PR DESCRIPTION
Closes #561. **Blocks 1.6.0.**

A stock `co init -t co-ai` + `co deploy --to <server>`, nothing customised, printed this on startup:

```
Invite: OpenOnion
```

That is `trust/policies/careful.md:16` — in this repository, on the public internet, and announced by every agent in its own logs.

**Verified end to end.** A fresh browser context with no keys and no prior session opened the deployed agent's public chat URL, typed that word, and was admitted in **five seconds** with a working composer. The agent has been stopped.

It is not a read-only peek: `contact` is in the default allow list, so admission is a session — and the approval prompt does not know who is asking (#551), so the stranger is shown `Trust bash for this session` and their answer is honoured. A published constant reached **arbitrary commands on the operator's machine**.

## Change

`invite_code: [$CO_INVITE_CODE]`, resolved from the environment.

**`.env` because it is already the secret channel** — git ignores it, `co deploy`'s rsync excludes it, and deploy delivers it separately as a root-owned 0600 file that a later deploy will not overwrite. Nothing new had to be invented to carry it.

**An unset variable resolves to nothing.** Never to the placeholder text, never to a default. That is the point: falling back is exactly how one constant became every agent's password.

`co init` mints it once and leaves it alone if it already exists — regenerating would silently lock out everyone holding the old one. The alphabet omits `O/0` and `I/1`, because this gets typed by hand on a phone.

## Two doors, one obvious

`evaluate_request` goes through `fast_rules`. The **real** door — `ONBOARD_SUBMIT` — calls `TrustAgent.verify_invite`, which read the raw config. Fixing only the first would have left the actual entry point wide open; an existing test caught it.

## Tests

3042 pass. The test that asserted `verify_invite("new-user", "OpenOnion") is True` now asserts the opposite and says why, and a new one pins that **no shipped policy carries a literal code** — so this cannot come back by someone editing a markdown file.