### PR TITLE
test(e2e): the multi-turn test now tests the system, and is proven to

### DIFF
--- a/tests/e2e/test_relay_e2e.py
+++ b/tests/e2e/test_relay_e2e.py
@@ -181,18 +181,57 @@ class TestRelayE2E:
         assert response.done
 
     def test_relay_multiturn(self, agent_server):
-        """Multi-turn conversation through relay preserves session."""
+        """A second client resuming the session is handed the first turn's history.
+
+        Three versions of this test, and the first two could not see the bug
+        they existed to catch.
+
+        It began by asking the model to remember a number and asserting the
+        number came back — a *model behaviour*, not a system property. It failed
+        for three releases because gemini-3.6-flash replies "I am an LLM and I
+        do not have memory of past conversations" to being asked to remember
+        something, on the FIRST turn, before any session round-trip exists. The
+        red test then pointed at the session layer, which was working.
+
+        The second version asserted on `agent.current_session` after two turns.
+        That passed — and *kept* passing with server-side restoration
+        deliberately sabotaged, because RemoteAgent accumulates history on the
+        client. It was testing the client's own bookkeeping.
+
+        So: turn one on one client, turn two on a **fresh** client that knows
+        only the session id. Any history it sees can only have come from the
+        server. Sabotaging `storage.get` now turns this red, which is the whole
+        point of it existing.
+        """
         keys = agent_server
+        first = "Say the word apple."
+        second = "Say the word banana."
+
         agent = connect(keys["address"], keys=keys, relay_url=RELAY_URL)
         agent._resolved_endpoint = None
         agent._endpoint_resolved = True
 
-        r1 = agent.input("Remember this number: 7742. Just confirm.", timeout=60)
+        r1 = agent.input(first, timeout=60)
         assert r1.done
+        session_id = (agent.current_session or {}).get("session_id")
+        assert session_id, "no session id came back from the first turn"
 
-        r2 = agent.input("What number did I ask you to remember?", timeout=60)
+        # A different client, with nothing but the id. It cannot know the history.
+        resumed = connect(keys["address"], keys=keys, relay_url=RELAY_URL)
+        resumed._resolved_endpoint = None
+        resumed._endpoint_resolved = True
+        resumed._current_session = {"session_id": session_id}
+
+        r2 = resumed.input(second, timeout=60)
         assert r2.done
-        assert "7742" in r2.text
+
+        messages = (resumed.current_session or {}).get("messages") or []
+        contents = [str(m.get("content") or "") for m in messages]
+        assert any(first in c for c in contents), (
+            "the first turn is missing — the server did not restore the session: "
+            f"{[c[:40] for c in contents]}"
+        )
+        assert any(second in c for c in contents), "the second turn never landed"
 
     def test_raw_websocket_session_id(self, agent_server):
         """Every WebSocket event must carry session_id."""


### PR DESCRIPTION
Relates to #564.

Three versions of this test, and **the first two could not see the bug they existed to catch.**

## v1 — asserted a model behaviour

```python
r1 = agent.input("Remember this number: 7742. Just confirm.")
r2 = agent.input("What number did I ask you to remember?")
assert "7742" in r2.text
```

Red for three releases. Not because sessions were broken — because `gemini-3.6-flash` answers *"I am an LLM and I do not have memory of past conversations"* to being asked to remember something, **on the first turn**, before any session round-trip exists. The red test pointed squarely at the session layer, which was working the whole time, and cost a full investigation to clear.

## v2 — asserted the client's own bookkeeping

```python
messages = agent.current_session["messages"]
assert any(first in c for c in contents)
```

Green. **And still green with server-side restoration deliberately sabotaged** — because `RemoteAgent` accumulates history client-side. A test that passes when the thing it tests is removed is worse than no test.

## v3 — the history can only come from the server

Turn one on one client; turn two on a **fresh** client that knows nothing but the session id.

Proven, not assumed:

```
both restoration paths sabotaged → messages=2, RED
  "the first turn is missing — the server did not restore the session"
restored                         → messages=4, GREEN
```

## What "both" means, and why it is worth knowing

The investigation turned up an architectural fact nobody had written down: **session restoration has two independent paths** —

1. the merge into `conn['session']` at CONNECT, and
2. `input_handler`'s own `storage.get` + `merge_sessions`.

Either alone carries the history. That is why sabotaging one at a time left the test green and made it look powerless — it isn't; it needs both gone, which is the right sensitivity for a test whose claim is "the server remembers".

It also means the system is more robust here than assumed: losing either path is invisible to users. That is good, and it is exactly the kind of redundancy that hides a regression until both halves rot.