### PR TITLE
fix(host): the startup line says which door this is, and never the key

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -291,15 +291,63 @@ def _print_host_banner(
 
     # Trust/Invite (belongs to host layer)
     if trust_config and isinstance(trust, str) and trust.lower() in TRUST_LEVELS:
-        onboard = trust_config.get("onboard", {})
-        invite_codes = onboard.get("invite_code", [])
-        if invite_codes:
-            codes = invite_codes if isinstance(invite_codes, list) else [invite_codes]
-            codes_str = ", ".join(codes)
-            console.print(f"{indent}[bold yellow]Invite: {codes_str}[/bold yellow]")
+        line = _invite_line(trust_config)
+        if line:
+            console.print(f"{indent}[bold yellow]{line}[/bold yellow]")
             console.print()
 
     console.print()
+
+
+def _invite_line(trust_config) -> str | None:
+    """One line about the agent's door, or nothing.
+
+    Three things it must not do.
+
+    **Print the code.** It is a password, and this line goes to stdout, which on
+    a deployed agent is journalctl — readable by anyone with the box, kept as
+    long as the logs are kept, and copied into every paste of a startup dump.
+    Saying a door exists is not the same as publishing its key.
+
+    **Print the placeholder.** `$CO_INVITE_CODE` rendered verbatim reads as the
+    code to anyone who has not seen the policy file.
+
+    **Say nothing when nobody can get in.** A policy that declares
+    `$CO_INVITE_CODE` on a machine where it is unset refuses every code. That is
+    the safe direction, and it is the one an upgrade produces on any deployment
+    that relied on the old shipped constant — so it has to be said out loud, or
+    the operator learns it from a person who could not get in.
+    """
+    onboard = (trust_config or {}).get("onboard") or {}
+    declared = onboard.get("invite_code") or []
+    declared = declared if isinstance(declared, list) else [declared]
+    if not declared:
+        return None
+
+    from ..trust.fast_rules import _resolve_codes
+    from_env = [str(c)[1:] for c in declared if str(c).startswith("$")]
+    literals = [c for c in declared if not str(c).startswith("$")]
+    live = _resolve_codes(declared)
+
+    if live:
+        # Say *where* the code is, not just that there is one. Telling an
+        # operator whose code is a literal in trust.md to "get it from .env"
+        # sends them looking for something that is not there.
+        resolved_from_env = [n for n in from_env if os.environ.get(n, "").strip()]
+        if resolved_from_env and literals:
+            where = f"{', '.join(resolved_from_env)} in .env, and one in the trust policy"
+        elif resolved_from_env:
+            where = f"{', '.join(resolved_from_env)} in .env"
+        else:
+            where = "in the trust policy"
+        dead = [n for n in from_env if not os.environ.get(n, "").strip()]
+        note = f" ({', '.join(dead)} is declared but unset)" if dead else ""
+        return f"Invite: set — {where}, not printed here{note}"
+
+    if from_env:
+        return (f"Invite: no one can onboard — {', '.join(from_env)} is not set. "
+                f"Add it to .env, or run `co init` to mint one.")
+    return None
 
 
 def _both(first, second):

--- a/tests/unit/test_invite_startup_line.py
+++ b/tests/unit/test_invite_startup_line.py
@@ -1,0 +1,70 @@
+"""What the agent says about its own door on startup.
+
+Three things it must not do: print the placeholder as if it were a code, print
+the real code into the log, or stay silent when the door cannot be opened at
+all.
+
+The last one is a migration hazard this release creates. An existing deployment
+on the default `careful` policy, upgraded, with no CO_INVITE_CODE in its .env,
+refuses every invite code — correct direction, but the operator sees only that
+nobody can get in.
+"""
+
+import pytest
+
+from connectonion.network.host.server import _invite_line
+
+
+class TestWhatItPrints:
+    def test_a_configured_code_is_not_printed(self, monkeypatch):
+        """The code is a password. Passwords do not go in journalctl."""
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E-LGWG4")
+        line = _invite_line({"onboard": {"invite_code": ["$CO_INVITE_CODE"]}})
+
+        assert line
+        assert "U262R-7WA6E-LGWG4" not in line
+
+    def test_the_placeholder_is_never_shown_as_a_code(self, monkeypatch):
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E-LGWG4")
+        line = _invite_line({"onboard": {"invite_code": ["$CO_INVITE_CODE"]}})
+
+        assert "$CO_INVITE_CODE" not in line
+
+    def test_an_unresolvable_code_says_nobody_can_get_in(self, monkeypatch):
+        """The silent lockout this release would otherwise ship."""
+        monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+        line = _invite_line({"onboard": {"invite_code": ["$CO_INVITE_CODE"]}})
+
+        assert line
+        assert "CO_INVITE_CODE" in line          # names the variable to set
+        assert any(w in line.lower() for w in ("no one", "nobody", "cannot"))
+
+    def test_a_literal_code_is_still_not_printed(self):
+        """An operator's own code in trust.md is just as much a password."""
+        line = _invite_line({"onboard": {"invite_code": ["B7HSW-6Y6P4-BZC5Z"]}})
+
+        assert "B7HSW-6Y6P4-BZC5Z" not in line
+
+    def test_it_says_where_the_code_lives(self, monkeypatch):
+        """Sending someone to .env for a code that is in trust.md wastes their
+        afternoon. The line names the place it actually is."""
+        monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+        literal = _invite_line({"onboard": {"invite_code": ["B7HSW-6Y6P4"]}})
+        assert ".env" not in literal
+        assert "policy" in literal.lower()
+
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E")
+        from_env = _invite_line({"onboard": {"invite_code": ["$CO_INVITE_CODE"]}})
+        assert ".env" in from_env
+        assert "CO_INVITE_CODE" in from_env
+
+    def test_a_dead_declaration_beside_a_live_one_is_still_mentioned(self, monkeypatch):
+        """One working code does not make an unset variable stop mattering —
+        whoever was given that half of the door still cannot open it."""
+        monkeypatch.delenv("NOPE", raising=False)
+        line = _invite_line({"onboard": {"invite_code": ["WORKS", "$NOPE"]}})
+        assert "NOPE" in line
+
+    def test_no_onboarding_configured_says_nothing(self):
+        assert _invite_line({"onboard": {}}) is None
+        assert _invite_line({}) is None


### PR DESCRIPTION
Closes #566. Found **reviewing** #563, not by it failing — which is the point of the review step.

## Three problems in one line

**1. Upgrading closed the door silently.** An existing deployment on the default `careful` policy, with no `CO_INVITE_CODE` in `.env`, now refuses every code:

```
>>> TrustAgent("careful").verify_invite("someone", "OpenOnion")   → False
>>> TrustAgent("careful").verify_invite("someone", "anything")    → False
```

Correct direction — the old constant was a published password — but the operator saw only that nobody could get in.

**2. It printed the code.** `Invite: OpenOnion` goes to stdout, which on a deployed agent is journalctl: readable by anyone with the box, kept as long as the logs, copied into every pasted startup dump. Making the code unique per agent does not make publishing it fine.

**3. With the placeholder it printed `Invite: $CO_INVITE_CODE`** — which reads as the code to anyone who hasn't seen the policy file.

## After

```
Invite: set — CO_INVITE_CODE in .env, not printed here
Invite: set — in the trust policy, not printed here
Invite: no one can onboard — CO_INVITE_CODE is not set. Add it to .env, or run `co init` to mint one.
```

## The bug inside the fix

My first draft printed *"share the code from .env"* for every configured agent. That is wrong for anyone whose code is a literal in `trust.md` — including the one real deployment we have — and would have sent them hunting through a file that does not contain it. Caught by walking all six branches after the tests were green, which is the only reason it isn't in this PR.

A declared-but-unset variable is still mentioned when another code works, because whoever holds that half of the door still cannot open it.

3058 tests pass, 7 of them new.