### PR TITLE
fix(session): a paused turn remembers what it was

### DIFF
--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -130,12 +130,22 @@ class SessionStorage:
         session_id = session.get('session_id')
         if not session_id:
             return
+        # The prompt, from the session this checkpoint is *of*. It used to be
+        # hardcoded empty, which is what Home renders as the row's label — so a
+        # deployed agent showed five rows reading only "interrupted · 13h ago",
+        # with nothing saying what had been interrupted. The dict in hand has
+        # had `user_prompt` all along.
+        #
+        # `created` from the earlier record for the same reason: it is what
+        # Recent turns into "13h ago", and stamping it at pause time makes a turn
+        # that began this morning look like it began when it stopped.
+        earlier = self.get(session_id)
         record = Session(
             session_id=session_id,
             status="waiting_approval",
-            prompt="",
+            prompt=str(session.get('user_prompt') or (earlier.prompt if earlier else '') or ''),
             session=session,
-            created=time.time(),
+            created=(earlier.created if earlier and earlier.created else time.time()),
             expires=time.time() + 86400,
         )
         self.save(record)

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -591,8 +591,14 @@ def _collapse(runs, scheduled):
         if key and folded and folded[-1]["key"] == key:
             folded[-1]["count"] += 1
             continue
+        # The fallback is a whole paragraph when the run came from a schedule
+        # entry whose text has since been edited — it no longer matches any
+        # entry, and a scheduled prompt is instructions, by design. Pasted in
+        # with its newlines it renders as three lines inside a one-line row,
+        # truncated mid-token (#546). Same rule as _why: the first line that
+        # carries information. The whole prompt is still in the session record.
         folded.append({"key": key,
-                       "label": label or str(r.get("prompt") or ""),
+                       "label": label or _why(r.get("prompt") or "", limit=80),
                        "count": 1,
                        "run": r})
     return folded

--- a/tests/unit/test_interrupted_sessions.py
+++ b/tests/unit/test_interrupted_sessions.py
@@ -173,3 +173,58 @@ class TestATornLineIsNotFatal:
     def test_a_blank_line_is_not_a_record(self, tmp_path):
         storage = self.torn(tmp_path, '\n\n')
         assert storage.list() == []
+
+
+class TestACheckpointRemembersItsTurn:
+    """A row that says only "interrupted · 13h ago" tells nobody anything.
+
+    Read off the deployed agent after the reconcile shipped:
+
+        Recent
+                        interrupted · 13h ago
+                        interrupted · 13h ago
+                        interrupted · 17h ago
+
+    Five rows, no labels. `checkpoint()` writes the record that a turn pausing
+    for approval leaves behind, and it hardcoded `prompt=""` — while holding a
+    session dict with `user_prompt` in it.
+    """
+
+    def test_the_checkpoint_keeps_the_prompt(self, tmp_path):
+        storage = SessionStorage(str(tmp_path / "s.jsonl"))
+
+        storage.checkpoint({"session_id": "s1",
+                            "user_prompt": "/contract-ledger 检查云盘里有没有新合同",
+                            "messages": []})
+
+        assert "检查云盘里有没有新合同" in storage.get("s1").prompt
+
+    def test_a_checkpoint_does_not_reset_the_turn_s_age(self, tmp_path):
+        """`created` is what Recent renders as "13h ago". Stamping it at
+        checkpoint time makes a turn that began this morning look like it began
+        when it paused."""
+        storage = SessionStorage(str(tmp_path / "s.jsonl"))
+        began = time.time() - 3600
+        storage.save(Session(session_id="s1", status="running", prompt="go",
+                             created=began, expires=time.time() + 86400))
+
+        storage.checkpoint({"session_id": "s1", "user_prompt": "go", "messages": []})
+
+        assert abs((storage.get("s1").created or 0) - began) < 1
+
+    def test_a_checkpoint_with_no_earlier_record_still_works(self, tmp_path):
+        storage = SessionStorage(str(tmp_path / "s.jsonl"))
+        storage.checkpoint({"session_id": "fresh", "user_prompt": "hello", "messages": []})
+        assert storage.get("fresh").prompt == "hello"
+
+    def test_the_label_survives_the_reconcile(self, tmp_path):
+        """The whole point: after a restart the row still says what it was."""
+        storage = SessionStorage(str(tmp_path / "s.jsonl"))
+        storage.checkpoint({"session_id": "s1", "user_prompt": "count the files",
+                            "messages": []})
+
+        storage.reconcile_interrupted()
+
+        row = storage.get("s1")
+        assert row.status == "interrupted"
+        assert row.prompt == "count the files"


### PR DESCRIPTION
Closes #568. Found by installing the release candidate on the live agent and reading its Home page — step 6 of the release loop, and the fourth time it has produced the round's best finding.

```
Recent
                interrupted · 13h ago
                interrupted · 13h ago
                interrupted · 17h ago
```

`<span class="what"></span>` — five rows, no labels. The operator learns that five things were interrupted, and nothing about **what**.

## Cause

```python
record = Session(
    status="waiting_approval",
    prompt="",                 # ← hardcoded; Home renders this as the label
    session=session,           # ← and this dict has user_prompt in it
    created=time.time(),       # ← stamped at pause time
)
```

`created` is the same shape of mistake: it is what Recent turns into "13h ago", so stamping it when a turn *pauses* makes one that began this morning look like it began when it stopped. Taken from the earlier record now.

**Neither was visible until last night.** These records used to sit as `waiting_approval` forever and nobody looked at them. Reconciling them into `interrupted` (#553) put them on the page — the fix made the older bug legible, which is the pattern this loop keeps finding.

## Also: a correction to #546

I closed that issue saying the multi-line label collapse "shipped alongside #542". **It did not.** main still had:

```python
"label": label or str(r.get("prompt") or ""),
```

The `_why()` fallback lived only in a working branch and never reached the PR, so a scheduled run whose entry text had since been edited still pasted its whole instruction paragraph into a one-line row. Restored here, and the issue comment corrected.

3062 tests pass, 4 of them new.