### PR TITLE
perf(session): finding one session no longer parses the whole log

### DIFF
--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -67,13 +67,53 @@ class SessionStorage:
                     continue      # one unreadable record, not an unreadable file
         return out
 
+    def _lines_from_the_end(self, chunk: int = 65536):
+        """Yield whole lines newest-first, reading backwards in chunks.
+
+        get() answers "what is the latest record for this one session", and the
+        answer is almost always near the end — a turn asks about the session it
+        is in. Parsing forwards meant every lookup cost the whole file.
+
+        That file is append-only and never shrinks: 17 MB and 222 sessions on an
+        agent up for thirteen hours, each record carrying its full message list.
+        get() runs on every turn and inside every checkpoint(), so a full parse
+        there is a cost that grows for as long as the agent stays alive.
+        """
+        with open(self.path, "rb") as f:
+            f.seek(0, 2)
+            end = f.tell()
+            tail = b""
+            while end > 0:
+                size = min(chunk, end)
+                end -= size
+                f.seek(end)
+                block = f.read(size) + tail
+                lines = block.split(b"\n")
+                tail = lines.pop(0)          # may be half a line; carry it back
+                for raw in reversed(lines):
+                    if raw.strip():
+                        yield raw
+            if tail.strip():
+                yield tail
+
     def get(self, session_id: str) -> Session | None:
+        if not self.path.exists():
+            return None
         now = time.time()
-        for session in reversed(self._records()):
-            if session.session_id == session_id:
-                if session.status == "running" or not session.expires or session.expires > now:
-                    return session
-                return None  # Expired
+        for raw in self._lines_from_the_end():
+            try:
+                data = json.loads(raw.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                continue          # one torn record, not an unreadable file
+            if not isinstance(data, dict) or data.get("session_id") != session_id:
+                continue
+            try:
+                session = Session(**data)
+            except Exception:
+                continue
+            if session.status == "running" or not session.expires or session.expires > now:
+                return session
+            return None  # Expired
         return None
 
     # A turn that is still owed something by this process. Both are equally dead

--- a/tests/unit/test_session_lookup_is_cheap.py
+++ b/tests/unit/test_session_lookup_is_cheap.py
@@ -1,0 +1,81 @@
+"""Looking up one session must not cost the whole log.
+
+`.co/session_results.jsonl` is append-only and never shrinks — 17 MB and 222
+sessions on an agent that had been up thirteen hours. `get()` runs on every
+turn (input_handler) and inside every `checkpoint()`, so a full parse there is
+a cost that grows every day the agent stays alive.
+"""
+
+import json
+import time
+
+import pytest
+
+from connectonion.network.host.session import storage as storage_mod
+from connectonion.network.host.session.storage import Session, SessionStorage
+
+
+@pytest.fixture
+def big_log(tmp_path):
+    """60 sessions with a realistic payload — enough to prove a full scan, and
+    small enough that pinning this behaviour does not cost CI two minutes."""
+    st = SessionStorage(str(tmp_path / "s.jsonl"))
+    payload = {"messages": [{"role": "user", "content": "x" * 200} for _ in range(10)]}
+    for i in range(60):
+        st.save(Session(session_id=f"s{i}", status="done", prompt=f"p{i}",
+                        session=payload, created=time.time(),
+                        expires=time.time() + 86400))
+    return st
+
+
+def count_parses(monkeypatch):
+    """Count json.loads calls inside the storage module."""
+    calls = {"n": 0}
+    real = json.loads
+
+    def counting(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(storage_mod.json, "loads", counting)
+    return calls
+
+
+def test_get_stops_at_the_record_it_wants(big_log, monkeypatch):
+    """The newest session is the last line. Finding it should read about one."""
+    calls = count_parses(monkeypatch)
+
+    assert big_log.get("s59").prompt == "p59"
+
+    assert calls["n"] <= 5, f"parsed {calls['n']} records to find the last one"
+
+
+def test_get_does_not_parse_everything_for_a_middle_record(big_log, monkeypatch):
+    """Even a record halfway back should not cost the whole file."""
+    calls = count_parses(monkeypatch)
+
+    assert big_log.get("s30").prompt == "p30"
+
+    assert calls["n"] < 60, f"parsed {calls['n']} of 60"
+
+
+def test_a_missing_session_is_still_answered(big_log):
+    assert big_log.get("nope") is None
+
+
+def test_checkpoint_does_not_reparse_the_log(big_log, monkeypatch):
+    calls = count_parses(monkeypatch)
+
+    big_log.checkpoint({"session_id": "s59", "user_prompt": "pause", "messages": []})
+
+    assert calls["n"] <= 5, f"checkpoint parsed {calls['n']} records"
+
+
+def test_a_torn_line_near_the_end_is_still_survived(tmp_path):
+    """The tolerance from #555 must survive the tail read."""
+    path = tmp_path / "s.jsonl"
+    good = json.dumps({"session_id": "a", "status": "done", "prompt": "kept",
+                       "created": time.time(), "expires": time.time() + 86400})
+    path.write_text(f"{good}\n{{torn\n", encoding="utf-8")
+
+    assert SessionStorage(str(path)).get("a").prompt == "kept"


### PR DESCRIPTION
Closes #570. Found doing step 7 of the release loop — assume the last fix spawned the next bug — and it had, twice over.

## Measured, on the live agent

`.co/session_results.jsonl` is **17 MB across 222 sessions** after thirteen hours of uptime. Append-only; it never shrinks.

```
4 MB log, 10 checkpoints → 0.9s     (90ms each)
```

At 17 MB that is roughly 380ms, and it grows for as long as the agent stays alive.

Both callers are hot:
- `input_handler` calls `get()` on **every turn**.
- `checkpoint()` runs before **every blocking operation** — every approval, every `ask_user`.

Each record carries its whole message list, so a `Session` was being constructed from megabytes of history just to find one `session_id`.

## Self-inflicted, in two steps

`get()` used to read backwards and stop at the first match.

1. **#555** replaced it with a shared tolerant reader so a torn line could not stop the agent booting. Correct — and it turned every lookup into a full forward parse.
2. **#568** then added a `get()` inside `checkpoint()`, putting that parse on the pause path too.

Neither showed up in tests, because a fixture writes five sessions and the cost is invisible under a megabyte. It took reading the byte size on a real machine.

## After

```
10 checkpoints:  0.9s → 0.007s
50 gets:               0.022s
```

Reads backwards in chunks, stops at the first match, **keeps #555's tolerance** — a torn line is skipped, and one test pins that a tear near the end still leaves the good record readable.

The cost is pinned by **counting `json.loads` calls**, not by timing: finding the newest session must parse about one record, not sixty. Deterministic, and it fails on a fast machine too.

The fixture is deliberately 60 sessions rather than 200 — my first version proved the same thing and added two minutes to every CI run.

3067 tests pass.