### PR TITLE
fix(schedule): a write that gave up on the lock says so

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -328,6 +328,15 @@ def record_run(co_dir: Path, name: str, *, when: datetime, status: str,
     path = co_dir / STATE_FILE
 
     handle = _lock(co_dir / f"{STATE_FILE}.lock")
+    if handle is None:
+        # Proceeding unlocked is the deliberate choice — blocking forever on a
+        # lock held by a process the OS never noticed dying is worse. But this
+        # write is a read-modify-write of the whole file, so it can drop another
+        # writer's entry, and a lost last_run makes the scheduler run something
+        # a second time. Say it, so that duplicate run is findable in the log
+        # instead of being inferred weeks later.
+        print(f"[schedule] writing {name} without the state lock — another "
+              f"process is holding it; an entry may be lost")
     try:
         state = load_state(co_dir)
         # Rebuilt rather than updated, so a later success drops the reason a

--- a/tests/unit/test_schedule_state_under_contention.py
+++ b/tests/unit/test_schedule_state_under_contention.py
@@ -80,3 +80,36 @@ def test_no_temp_files_are_left_behind(tmp_path):
 
     leftovers = [p.name for p in tmp_path.iterdir() if ".tmp" in p.name]
     assert not leftovers, leftovers[:5]
+
+
+def test_writing_without_the_lock_is_not_silent(tmp_path, capsys, monkeypatch):
+    """Giving up on the lock and writing anyway is a decision, not a detail.
+
+    _lock retries for a second and then returns None, and record_run proceeds
+    regardless — deliberately, because blocking forever on a lock held by a
+    process the OS never noticed dying is worse. But an unlocked
+    read-modify-write can still lose another writer's entry, and a lost
+    last_run makes the scheduler run something twice. That has to be findable
+    afterwards, in the log, not inferred from a duplicate run.
+    """
+    from datetime import datetime, timezone
+    from connectonion.network.host import schedule as sch
+
+    monkeypatch.setattr(sch, "_lock", lambda *a, **k: None)
+
+    sch.record_run(tmp_path, "nightly", when=datetime.now(timezone.utc),
+                   status="done", session_id="s1")
+
+    out = capsys.readouterr().out + capsys.readouterr().err
+    assert "lock" in out.lower(), f"nothing said about the missing lock: {out!r}"
+
+
+def test_a_normal_write_says_nothing(tmp_path, capsys):
+    """The warning has to be rare enough to mean something."""
+    from datetime import datetime, timezone
+    from connectonion.network.host.schedule import record_run
+
+    record_run(tmp_path, "nightly", when=datetime.now(timezone.utc),
+               status="done", session_id="s1")
+
+    assert "lock" not in capsys.readouterr().out.lower()


### PR DESCRIPTION
Found reviewing #560, not by it failing.

`_lock` retries for about a second and then returns `None` — and `record_run` proceeds regardless. That is the deliberate choice, and I still think it is the right one: blocking forever on a lock held by a process the OS never noticed dying is worse than proceeding.

**But it was silent, and the consequence is not.** The write is a read-modify-write of the whole state file. Unlocked, it can drop another writer's entry — and a lost `last_run` makes the scheduler run that entry a second time. On an agent whose schedule writes to a shared ledger, that is a duplicate row somebody has to find and explain, weeks later, with nothing in the log connecting it to a lock contention that lasted a second.

One line now:

```
[schedule] writing 检查新合同 without the state lock — another process is holding it; an entry may be lost
```

Two tests, and the second matters as much as the first: the warning appears when the lock is unavailable, **and a normal write stays quiet**. A warning nobody ever sees is useless; one that fires on every write is noise that trains people to ignore it.

3064 tests pass.