### PR TITLE
fix(trust): one place decides how open a host is, and it is not the environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ ConnectOnion is a Python framework for creating AI agents with automatic activit
 - Three levels: "open" (dev), "careful" (staging), "strict" (prod)
 - Custom policies: markdown files or inline text describing verification rules
 - Custom agents: Pass your own Agent instance with verification tools
-- Environment-based defaults: `CONNECTONION_ENV` sets trust level automatically
+- Trust is set in `.co/host.yaml`. No environment variable can change it
 - Module structure: `factory.py` (creation), `fast_rules.py` (policy parsing/evaluation), `tools.py` (verification tools), `trust_agent.py` (TrustAgent class), `policies/` (level policy markdown)
 - Onboard methods: `invite_code` (verify against configured codes), `payment` (verify via oo-api credit transfer)
 - Payment verification: `TrustAgent.verify_payment()` calls oo-api `/api/v1/onboard/verify` to check for recent transfers
@@ -251,7 +251,7 @@ Tools that need access to `agent.io` (for frontend communication) declare `agent
 - The LLM never sees the `agent` parameter
 
 ### Trust Verification (`connectonion/network/trust/`)
-- Environment defaults: `CONNECTONION_ENV=development` → trust="open"
+- No environment defaults: how open a host is lives in the operator's own file
 - Custom policies loaded from markdown files or inline strings
 - Trust agent created lazily when trust parameter provided
 - Prevents infinite recursion: trust agents don't have their own trust agents

--- a/connectonion/cli/co_ai/prompts/connectonion/concepts/trust.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/concepts/trust.md
@@ -211,9 +211,9 @@ host(agent, trust=trust)
 # No trust specified - auto-detected from environment
 host(agent)
 
-# CONNECTONION_ENV=development → trust="open"
-# CONNECTONION_ENV=staging     → trust="careful"
-# CONNECTONION_ENV=production  → trust="strict"
+# Trust is set in .co/host.yaml, not from the environment — there is no
+# CONNECTONION_ENV shortcut, because a stale shell variable must never be able
+# to open a host to everyone.
 ```
 
 ## List Management

--- a/connectonion/network/__init__.py
+++ b/connectonion/network/__init__.py
@@ -24,7 +24,7 @@ from .io import IO, WebSocketIO
 from .connect import connect, RemoteAgent, Response, ExecResult
 from .relay import connect as relay_connect, serve_loop
 from .announce import create_announce_message
-from .trust import TrustAgent, Decision, get_default_trust_level, TRUST_LEVELS, parse_policy
+from .trust import TrustAgent, Decision, TRUST_LEVELS, parse_policy
 from . import relay, announce
 
 __all__ = [
@@ -44,7 +44,6 @@ __all__ = [
     # Trust (TrustAgent is the single interface)
     "TrustAgent",
     "Decision",
-    "get_default_trust_level",
     "TRUST_LEVELS",
     "parse_policy",
     "relay",

--- a/connectonion/network/host/__init__.py
+++ b/connectonion/network/host/__init__.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [session/, auth.py, http_router.py, server.py, ws_router/] | imported by [network/__init__.py, user code] | tested via integration tests
   Data flow: pure re-export module aggregating host functionality
   State/Effects: no state
-  Integration: exposes host(agent, port, trust) main entry point, Session/SessionStorage for persistence, auth utilities (verify_signature, extract_and_authenticate, get_agent_address, is_custom_trust), route handlers (input_handler, session_handler, health_handler, info_handler, admin_*), create_app() ASGI factory, get_default_trust() helper
+  Integration: exposes host(agent, port, trust) main entry point, Session/SessionStorage for persistence, auth utilities (verify_signature, extract_and_authenticate, get_agent_address, is_custom_trust), route handlers (input_handler, session_handler, health_handler, info_handler, admin_*), create_app() ASGI factory
   Performance: trivial
   Errors: none
 Host an agent over HTTP/WebSocket.
@@ -37,7 +37,6 @@ from .http_router import (
 )
 from .server import (
     host,
-    get_default_trust,
     create_app,
 )
 
@@ -67,6 +66,5 @@ __all__ = [
     "admin_logs_handler",
     "admin_sessions_handler",
     # Helpers
-    "get_default_trust",
     "create_app",
 ]

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -41,7 +41,7 @@ from .. import announce, relay
 from ..asgi import create_app as asgi_create_app
 from .ws_router import run_ws_session
 from .schedule import create_schedule_lifespan
-from ..trust import TrustAgent, get_default_trust_level, parse_policy, TRUST_LEVELS
+from ..trust import TrustAgent, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
 from .auth import extract_and_authenticate
 from .config import load_host_config, load_list_file, validate_files, DEFAULT_FILE_LIMITS
@@ -95,15 +95,6 @@ def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
         return config
 
     return None
-
-
-def get_default_trust() -> str:
-    """Get default trust based on environment.
-
-    Returns:
-        Trust level based on CONNECTONION_ENV, defaults to 'careful'
-    """
-    return get_default_trust_level() or "careful"
 
 
 def _extract_agent_metadata(create_agent: Callable,

--- a/connectonion/network/trust/__init__.py
+++ b/connectonion/network/trust/__init__.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [trust_agent, factory, fast_rules] | imported by [network/host/server.py, network/host/auth.py, network/__init__.py] | tested via TrustAgent usage
   Data flow: module exports TrustAgent class and helper functions → users import and create TrustAgent("careful") → TrustAgent delegates to factory for policy loading and tools for file operations
   State/Effects: no direct state (delegates to TrustAgent, factory, tools) | reads policy files | reads/writes .co/trust/ directory via tools
-  Integration: exposes TrustAgent, Decision, get_default_trust_level(), validate_trust_level(), TRUST_LEVELS, parse_policy() | single entry point for trust operations | __all__ controls public API
+  Integration: exposes TrustAgent, Decision, validate_trust_level(), TRUST_LEVELS, parse_policy() | single entry point for trust operations | __all__ controls public API
   Performance: imports are static (no lazy loading) | TrustAgent cached per instance
   Errors: no error handling at module level (errors from TrustAgent/factory propagate)
 
@@ -32,7 +32,7 @@ Subclass to customize behavior (e.g., database-backed admin storage).
 """
 
 from .trust_agent import TrustAgent, Decision
-from .factory import get_default_trust_level, validate_trust_level, TRUST_LEVELS
+from .factory import validate_trust_level, TRUST_LEVELS
 from .fast_rules import parse_policy
 
 __all__ = [
@@ -40,7 +40,6 @@ __all__ = [
     "TrustAgent",
     "Decision",
     # Helpers
-    "get_default_trust_level",
     "validate_trust_level",
     "TRUST_LEVELS",
     "parse_policy",

--- a/connectonion/network/trust/factory.py
+++ b/connectonion/network/trust/factory.py
@@ -2,9 +2,9 @@
 Purpose: Factory functions for trust level validation and deprecated trust agent creation
 LLM-Note:
   Dependencies: imports from [os, pathlib, typing, tools, fast_rules] | imported by [trust/__init__.py, trust/trust_agent.py] | tested via TrustAgent initialization
-  Data flow: get_default_trust_level() → reads CONNECTONION_ENV → returns trust level | validate_trust_level(level) → checks against TRUST_LEVELS list | create_trust_agent(trust, api_key, model) [DEPRECATED] → resolves policy string/path/Agent → loads policy file → creates Agent with trust tools
-  State/Effects: reads environment variable CONNECTONION_ENV | reads policy files from network/trust/policies/{level}.md | no writes | PROMPTS_DIR constant points to trust module policies/
-  Integration: exposes get_default_trust_level(), validate_trust_level(), TRUST_LEVELS, create_trust_agent() [DEPRECATED] | TRUST_LEVELS = ["open", "careful", "strict"] | create_trust_agent emits DeprecationWarning (use TrustAgent instead)
+  Data flow: validate_trust_level(level) → checks against TRUST_LEVELS list | create_trust_agent(trust, api_key, model) [DEPRECATED] → resolves policy string/path/Agent → loads policy file → creates Agent with trust tools
+  State/Effects: reads policy files from network/trust/policies/{level}.md | no writes | PROMPTS_DIR constant points to trust module policies/
+  Integration: exposes validate_trust_level(), TRUST_LEVELS, create_trust_agent() [DEPRECATED] | TRUST_LEVELS = ["open", "careful", "strict"] | create_trust_agent emits DeprecationWarning (use TrustAgent instead)
   Performance: file I/O only when loading policies | parse_policy() extracts YAML frontmatter | environment check is O(1)
   Errors: raises FileNotFoundError if policy file doesn't exist | raises TypeError for invalid trust type | raises ValueError if trust Agent has no tools
   ⚠️ create_trust_agent() is deprecated - use TrustAgent class instead for better API
@@ -43,25 +43,6 @@ PROMPTS_DIR = Path(__file__).parent / "policies"
 
 # Trust level constants
 TRUST_LEVELS = ["open", "careful", "strict"]
-
-
-def get_default_trust_level() -> Optional[str]:
-    """
-    Get default trust level based on environment.
-    
-    Returns:
-        Default trust level or None
-    """
-    env = os.environ.get('CONNECTONION_ENV', '').lower()
-    
-    if env == 'development':
-        return 'open'
-    elif env == 'production':
-        return 'strict'
-    elif env in ['staging', 'test']:
-        return 'careful'
-    
-    return None
 
 
 def create_trust_agent(trust: Union[str, Path, 'Agent', None], api_key: Optional[str] = None, model: str = "gpt-5-mini") -> Optional['Agent']:

--- a/docs/features/trust.md
+++ b/docs/features/trust.md
@@ -591,16 +591,22 @@ abuser-123
 spam-bot-*
 ```
 
-## Environment-Based Defaults
+## One place decides: `.co/host.yaml`
 
-```python
-# No trust specified - auto-detected from environment
-host(agent)
-
-# CONNECTONION_ENV=development → trust="open"
-# CONNECTONION_ENV=staging     → trust="careful"
-# CONNECTONION_ENV=production  → trust="strict"
+```yaml
+# .co/host.yaml
+trust: careful      # open | careful | strict
 ```
+
+There is no environment variable for this, on purpose. `CONNECTONION_ENV` used
+to be documented as setting trust automatically, with `development` meaning
+`open`. It never actually did anything — and wiring it up would have meant a
+variable sitting in someone's shell profile could open their host to everyone,
+at the moment they were least likely to be reading this page.
+
+How open a host is, is written down in a file its operator owns and can read
+back. Different machines get different files; `co deploy` copies the one you
+mean to the machine you mean.
 
 ## Architecture
 

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -1001,17 +1001,22 @@ guardian = Agent(
 host(agent, trust=guardian)
 ```
 
-### Environment-Based Defaults
+### One place decides: `.co/host.yaml`
 
-```python
-# No trust parameter needed - auto-detected!
-host(agent)
-
-# CONNECTONION_ENV=development → trust="open"
-# CONNECTONION_ENV=test        → trust="careful"
-# CONNECTONION_ENV=staging     → trust="careful"
-# CONNECTONION_ENV=production  → trust="strict"
+```yaml
+# .co/host.yaml
+trust: careful      # open | careful | strict
 ```
+
+There is no environment variable for this, on purpose. `CONNECTONION_ENV` used
+to be documented as setting trust automatically, with `development` meaning
+`open`. It never actually did anything — and wiring it up would have meant a
+variable sitting in someone's shell profile could open their host to everyone,
+at the moment they were least likely to be reading this page.
+
+How open a host is, is written down in a file its operator owns and can read
+back. Different machines get different files; `co deploy` copies the one you
+mean to the machine you mean.
 
 ---
 
@@ -1253,9 +1258,11 @@ services:
     build: .
     ports:
       - "8000:8000"
-    environment:
-      - CONNECTONION_ENV=production
 ```
+
+Trust comes from `.co/host.yaml` inside the image, not from the environment
+block — so what a container will accept is visible in the repo, not in the
+orchestrator's config.
 
 ### Reverse Proxy (Caddy)
 

--- a/tests/unit/test_additional_modules.py
+++ b/tests/unit/test_additional_modules.py
@@ -36,7 +36,6 @@ def test_event_decorators_tag_function():
 def test_parse_trust_config_inline():
     cfg = host_server._parse_trust_config("---\ndefault: allow\n---\n")
     assert cfg and cfg.get("default") == "allow"
-    assert host_server.get_default_trust()
 
 
 def test_io_classes():

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -22,7 +22,6 @@ from unittest.mock import patch, Mock
 from connectonion.network.host import (
     extract_and_authenticate,
     is_custom_trust,
-    get_default_trust,
 )
 from connectonion.network.trust import TrustAgent, validate_trust_level, TRUST_LEVELS
 
@@ -73,30 +72,11 @@ class TestTrustLevels:
         assert validate_trust_level("CAREFUL") is True
         assert validate_trust_level("Strict") is True
 
-    def test_get_default_trust_development(self):
-        """Test default trust in development environment."""
-        with patch.dict(os.environ, {"CONNECTONION_ENV": "development"}):
-            assert get_default_trust() == "open"
-
-    def test_get_default_trust_production(self):
-        """Test default trust in production environment."""
-        with patch.dict(os.environ, {"CONNECTONION_ENV": "production"}):
-            assert get_default_trust() == "strict"
-
-    def test_get_default_trust_staging(self):
-        """Test default trust in staging environment."""
-        with patch.dict(os.environ, {"CONNECTONION_ENV": "staging"}):
-            assert get_default_trust() == "careful"
-
-    def test_get_default_trust_test(self):
-        """Test default trust in test environment."""
-        with patch.dict(os.environ, {"CONNECTONION_ENV": "test"}):
-            assert get_default_trust() == "careful"
-
-    def test_get_default_trust_unset(self):
-        """Test default trust when environment is unset."""
-        with patch.dict(os.environ, {"CONNECTONION_ENV": ""}):
-            assert get_default_trust() == "careful"
+    # The five tests that used to sit here checked get_default_trust() in
+    # isolation and passed for as long as it existed. It was never called from
+    # anywhere — a green test on a function nothing invokes is how that goes
+    # unnoticed for a year. Trust now comes from .co/host.yaml only; see
+    # test_trust_comes_from_host_yaml.py and #366.
 
 
 class TestIsCustomTrust:

--- a/tests/unit/test_trust_comes_from_host_yaml.py
+++ b/tests/unit/test_trust_comes_from_host_yaml.py
@@ -1,0 +1,61 @@
+"""Who decides how open a host is.
+
+One place: `.co/host.yaml`, a file the operator owns and can read back.
+
+The docs used to promise a second channel — `CONNECTONION_ENV=development`
+would set trust to "open" — and shipped two functions implementing it that
+nothing ever called. Trust stayed "careful" whatever the variable said.
+
+Wiring it up as documented was the obvious fix and is the wrong one. It makes
+an environment variable able to *widen* a host to everyone, and
+`CONNECTONION_ENV=development` is exactly the kind of thing that sits in a
+shell profile for months. The person running `co host` on their laptop would
+not be reading the docs at that moment.
+
+So the promise is gone and these tests pin its absence. They are green today —
+what they defend against is someone implementing the removed promise later
+because the docs used to describe it.
+"""
+
+import pytest
+
+from connectonion.network.host.config import load_host_config
+
+
+ENVS = ['development', 'production', 'staging', 'test', 'nonsense', '']
+
+
+@pytest.mark.parametrize("env", ENVS)
+def test_the_environment_does_not_decide_trust(env, tmp_path, monkeypatch):
+    monkeypatch.setenv('CONNECTONION_ENV', env)
+    co_dir = tmp_path / '.co'
+    co_dir.mkdir()
+    (co_dir / 'host.yaml').write_text("name: a\nentrypoint: agent.py\ntrust: careful\n")
+
+    config = load_host_config(co_dir)
+
+    assert config.get('trust') == 'careful', (
+        f"CONNECTONION_ENV={env!r} changed trust; host.yaml is the only place "
+        "that may decide how open a host is"
+    )
+
+
+def test_host_yaml_is_read_back_as_written(tmp_path, monkeypatch):
+    """The operator's file, not a default that happens to agree with it."""
+    monkeypatch.setenv('CONNECTONION_ENV', 'development')
+    co_dir = tmp_path / '.co'
+    co_dir.mkdir()
+    (co_dir / 'host.yaml').write_text("name: a\nentrypoint: agent.py\ntrust: strict\n")
+
+    assert load_host_config(co_dir).get('trust') == 'strict'
+
+
+def test_the_removed_helpers_are_still_removed():
+    """A function whose only purpose is a mechanism we decided against is how
+    that mechanism comes back."""
+    import importlib
+    trust_pkg = importlib.import_module('connectonion.network.trust')
+    server = importlib.import_module('connectonion.network.host.server')
+
+    assert not hasattr(trust_pkg, 'get_default_trust_level')
+    assert not hasattr(server, 'get_default_trust')


### PR DESCRIPTION
Closes #366.

`CONNECTONION_ENV` 被文档承诺可以自动设置 trust（`development → open`），实现它的两个函数 `get_default_trust_level()` 和 `get_default_trust()` 也确实存在 —— **但从来没有任何地方调用过**。`host()` 读的一直是 `config.get('trust', 'careful')`。

这个承诺出现在 5 处，**包括 `co ai` 自己读的提示词** —— 也就是说 agent 会很有把握地教用户去设一个什么都不做的变量。

## 我没有按 issue 说的方向修

#366 建议把它接上。我认为那是错的，这个 PR 做的是相反的事：**承诺和死代码一起删掉**。

一个能把信任**放宽**的环境变量，无论实现得多小心都是个坏机制。`CONNECTONION_ENV=development` 恰恰是那种在 shell profile 里一躺就是几个月的东西，而在笔记本上敲 `co host` 的那一刻，人是最不可能在读信任文档的。失败是静默且彻底的：一个对所有人敞开的 host，配着一份写着 `careful` 的 host.yaml。

现在「这个 host 有多开放」只写在一个地方 —— 运营者自己拥有、随时能读回来的文件。不同机器给不同的文件，`co deploy` 把你想要的那份送到你想要的机器上。

顺带删掉了 docker-compose 例子里的 `CONNECTONION_ENV=production`，它同样什么都不做，留着只会让人以为编排层能决定容器接受谁。

## 它为什么藏了这么久

**五条单元测试孤立地覆盖 `get_default_trust()`，而且一直是绿的。**

```python
def test_get_default_trust_development(self):
    with patch.dict(os.environ, {"CONNECTONION_ENV": "development"}):
        assert get_default_trust() == "open"      # 一直通过
```

一个从没被调用的函数上的绿灯，看起来和一个正常工作的功能一模一样。

替换的测试钉的是**系统行为**：六种 `CONNECTONION_ENV` 取值下 trust 都不变；外加一条，删掉的辅助函数如果被加回来就会红。

3072 个单测通过。
