### PR TITLE
fix(trust): a whitelist belongs to one agent, not to the machine

### DIFF
--- a/connectonion/cli/commands/trust_commands.py
+++ b/connectonion/cli/commands/trust_commands.py
@@ -30,7 +30,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ...network.trust.tools import (
-    CO_DIR,
+    list_file,
     get_level,
     promote_to_contact,
     promote_to_whitelist,
@@ -48,7 +48,7 @@ console = Console()
 
 def _read_list(list_name: str) -> list[str]:
     """Read entries from a list file."""
-    list_path = CO_DIR / f"{list_name}.txt"
+    list_path = list_file(list_name)
     if not list_path.exists():
         return []
     content = list_path.read_text(encoding='utf-8')
@@ -103,7 +103,7 @@ def handle_trust_list():
         console.print("  [dim]Empty[/dim]")
     console.print()
 
-    console.print(f"[dim]Lists stored in: {CO_DIR}[/dim]")
+    console.print(f"[dim]Lists stored in: {list_file('whitelist').parent}[/dim]")
 
 
 def handle_trust_level(address: str):

--- a/connectonion/cli/commands/trust_commands.py
+++ b/connectonion/cli/commands/trust_commands.py
@@ -58,6 +58,18 @@ def _read_list(list_name: str) -> list[str]:
 
 def handle_trust_list():
     """List all trust lists."""
+    # These lists belong to one agent, so being in the wrong directory shows
+    # four empty sections — which reads as "my whitelist was wiped" rather than
+    # "you are not standing in an agent". Say which it is.
+    agent_dir = list_file("whitelist").parent
+    if not agent_dir.is_dir():
+        console.print()
+        console.print(f"[yellow]No agent here[/yellow] — {agent_dir} does not exist.")
+        console.print("[dim]Trust lists belong to one agent. Run this from its "
+                      "directory, or 'co init' to make one.[/dim]")
+        console.print()
+        return
+
     contacts = _read_list("contacts")
     whitelist = _read_list("whitelist")
     blocklist = _read_list("blocklist")

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -19,7 +19,38 @@ from pathlib import Path
 from typing import List, Callable
 
 
-CO_DIR = Path.home() / ".co"
+def list_file(list_name: str) -> Path:
+    """Where one of this agent's trust lists lives — beside its identity.
+
+    These used to sit in a single ~/.co/ shared by every agent on the machine,
+    while the address they are compared against came from the project's .co/.
+    One box hosting two agents meant one whitelist: an address promoted while
+    poking at a throwaway agent was promoted on the production one too, with
+    nothing in either agent's directory recording it.
+
+    `admins.txt` was moved for exactly this reason. These three are the rest of
+    the same list, and whitelist is the one that grants.
+    """
+    return Path.cwd() / ".co" / f"{list_name}.txt"
+
+
+# One line per list per process. The entries in the old global file are not read
+# — reading them would be the bug this moved away from — so saying where they
+# went is the only thing left to do. Silence here is a colleague who cannot
+# connect and no reason anywhere.
+_announced_legacy = set()
+
+
+def _mention_a_legacy_list(list_name: str) -> None:
+    legacy = Path.home() / ".co" / f"{list_name}.txt"
+    if list_name in _announced_legacy or not legacy.exists():
+        return
+    _announced_legacy.add(list_name)
+    if not legacy.read_text(encoding="utf-8").strip():
+        return
+    print(f"[trust] {legacy} is no longer read — these lists now live beside "
+          f"each agent, in its own .co/. Copy the lines you still want into "
+          f"{list_file(list_name)}.")
 
 
 def _admins_file(co_dir: Path = None) -> Path:
@@ -46,8 +77,9 @@ def _check_list(list_name: str, agent_id: str) -> bool:
     but an admin pastes what a UI showed them, and `block("0xABCDEF…")` that
     silently blocks nobody is worse than one that errors — it reported success.
     """
-    list_path = CO_DIR / f"{list_name}.txt"
+    list_path = list_file(list_name)
     if not list_path.exists():
+        _mention_a_legacy_list(list_name)
         return False
     try:
         content = list_path.read_text(encoding='utf-8')
@@ -148,8 +180,8 @@ def verify_agent(agent_id: str, agent_info: str = "") -> str:
 
 def _add_to_list(list_name: str, client_id: str) -> bool:
     """Add client_id to a list file."""
-    CO_DIR.mkdir(parents=True, exist_ok=True)
-    list_path = CO_DIR / f"{list_name}.txt"
+    list_path = list_file(list_name)
+    list_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Check if already in list
     if _check_list(list_name, client_id):
@@ -163,7 +195,7 @@ def _add_to_list(list_name: str, client_id: str) -> bool:
 
 def _remove_from_list(list_name: str, client_id: str) -> bool:
     """Remove client_id from a list file."""
-    list_path = CO_DIR / f"{list_name}.txt"
+    list_path = list_file(list_name)
     if not list_path.exists():
         return True
 

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -74,10 +74,11 @@ def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
 
 def test_trust_commands_list_and_actions(tmp_path, monkeypatch):
     # Point CO_DIR at temp path and create lists
-    monkeypatch.setattr(trust_mod, "CO_DIR", tmp_path)
-    (tmp_path / "contacts.txt").write_text("c1\n", encoding="utf-8")
-    (tmp_path / "whitelist.txt").write_text("w1\n", encoding="utf-8")
-    (tmp_path / "blocklist.txt").write_text("b1\n", encoding="utf-8")
+    co = tmp_path / ".co"; co.mkdir()
+    monkeypatch.chdir(tmp_path)
+    (co / "contacts.txt").write_text("c1\n", encoding="utf-8")
+    (co / "whitelist.txt").write_text("w1\n", encoding="utf-8")
+    (co / "blocklist.txt").write_text("b1\n", encoding="utf-8")
 
     monkeypatch.setattr(trust_mod, "load_admins", lambda: ["a1"])
     monkeypatch.setattr(trust_mod, "get_self_address", lambda: "a1")

--- a/tests/unit/test_fast_rules.py
+++ b/tests/unit/test_fast_rules.py
@@ -20,10 +20,16 @@ from connectonion.network.trust import tools
 
 @pytest.fixture
 def temp_co_dir(tmp_path, monkeypatch):
-    """Create temp ~/.co/ directory for tests."""
+    """A directory that *is* this agent — the lists live inside it.
+
+    These fixtures used to redirect a module-level CO_DIR, which is the shape
+    of the bug they were working around: one global path meant one whitelist
+    for every agent on the machine. Now the agent's cwd decides, so the way to
+    isolate a test is to give it its own agent directory.
+    """
     co_dir = tmp_path / ".co"
-    co_dir.mkdir()
-    monkeypatch.setattr(tools, "CO_DIR", co_dir)
+    co_dir.mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
     return co_dir
 
 

--- a/tests/unit/test_host_auth.py
+++ b/tests/unit/test_host_auth.py
@@ -331,7 +331,7 @@ class TestExtractAndAuthenticate:
         # Set up temp ~/.co directory
         co_path = tmp_path / ".co"
         co_path.mkdir()
-        monkeypatch.setattr("connectonion.network.trust.tools.CO_DIR", co_path)
+        monkeypatch.chdir(tmp_path)
 
         signing_key = SigningKey.generate()
         verify_key = signing_key.verify_key

--- a/tests/unit/test_trust_agent_class.py
+++ b/tests/unit/test_trust_agent_class.py
@@ -24,7 +24,7 @@ def co_dir(tmp_path, monkeypatch):
     """Set up temp ~/.co directory."""
     co_path = tmp_path / ".co"
     co_path.mkdir()
-    monkeypatch.setattr("connectonion.network.trust.tools.CO_DIR", co_path)
+    monkeypatch.chdir(tmp_path)   # the lists live beside the agent, so cwd is the agent
     return co_path
 
 

--- a/tests/unit/test_trust_functions.py
+++ b/tests/unit/test_trust_functions.py
@@ -35,10 +35,16 @@ from connectonion.network.trust.tools import (
 
 @pytest.fixture
 def temp_co_dir(tmp_path, monkeypatch):
-    """Create temp ~/.co/ directory for tests."""
+    """A directory that *is* this agent — the lists live inside it.
+
+    These fixtures used to redirect a module-level CO_DIR, which is the shape
+    of the bug they were working around: one global path meant one whitelist
+    for every agent on the machine. Now the agent's cwd decides, so the way to
+    isolate a test is to give it its own agent directory.
+    """
     co_dir = tmp_path / ".co"
-    co_dir.mkdir()
-    monkeypatch.setattr(tools, "CO_DIR", co_dir)
+    co_dir.mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
     return co_dir
 
 

--- a/tests/unit/test_trust_list_matching.py
+++ b/tests/unit/test_trust_list_matching.py
@@ -13,11 +13,12 @@ from connectonion.network.trust import tools
 
 @pytest.fixture
 def listfile(tmp_path, monkeypatch):
-    """Point the module at a temp .co and write one of its list files."""
-    monkeypatch.setattr(tools, "CO_DIR", tmp_path)
+    """Give the test its own agent directory and write one of its list files."""
+    (tmp_path / ".co").mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
 
     def write(name, *lines):
-        (tmp_path / f"{name}.txt").write_text("\n".join(lines) + "\n")
+        (tmp_path / ".co" / f"{name}.txt").write_text("\n".join(lines) + "\n")
     return write
 
 
@@ -98,7 +99,6 @@ class TestUnchanged:
     """Behaviour the fix must not disturb."""
 
     def test_a_missing_file_denies(self, listfile, tmp_path, monkeypatch):
-        monkeypatch.setattr(tools, "CO_DIR", tmp_path)
         assert not tools._check_list("whitelist", "anyone")
 
     def test_comments_and_blank_lines_are_skipped(self, listfile):

--- a/tests/unit/test_trust_lists_are_per_agent.py
+++ b/tests/unit/test_trust_lists_are_per_agent.py
@@ -123,3 +123,36 @@ class TestTheOldGlobalListsAreNotLostSilently:
         monkeypatch.chdir(a)
         tools.is_whitelisted(STRANGER)
         assert capsys.readouterr().out == ""
+
+
+class TestTheDeployedAgentRunsFromItsOwnDirectory:
+    """The line that makes all of the above work in production.
+
+    Scoping the lists to the agent means resolving them from the working
+    directory. On a deployed agent that only holds because the unit file says
+    so. Drop `WorkingDirectory` and every list resolves under `/`, quietly
+    empty: the whitelist stops granting, the blocklist stops blocking, and
+    nothing anywhere says why.
+
+    Nothing pinned this before. It was one uncommented line in a unit template.
+    """
+
+    def test_the_unit_pins_the_working_directory(self):
+        from connectonion.cli.commands.deploy_to_server import _unit_text, SRV
+
+        unit = _unit_text("ledger", "agent.py")
+
+        assert f"WorkingDirectory={SRV}/ledger" in unit, (
+            "without this the agent's trust lists resolve under / and are "
+            "silently empty"
+        )
+
+    def test_the_working_directory_is_where_the_lists_are(self):
+        """Same directory the deploy puts .co/ in — one place, not two."""
+        from connectonion.cli.commands.deploy_to_server import _unit_text, SRV
+
+        unit = _unit_text("ledger", "agent.py")
+        workdir = next(l.split('=', 1)[1] for l in unit.splitlines()
+                       if l.startswith('WorkingDirectory='))
+
+        assert f"{workdir}/.co" == f"{SRV}/ledger/.co"

--- a/tests/unit/test_trust_lists_are_per_agent.py
+++ b/tests/unit/test_trust_lists_are_per_agent.py
@@ -1,0 +1,125 @@
+"""Whose whitelist is it.
+
+`admins.txt` was moved out of `~/.co/` and beside the agent's own identity,
+because one machine hosting two agents meant making someone an admin of one
+made them an admin of both. The other three lists — whitelist, contacts,
+blocklist — were left on the old global path.
+
+Whitelist is the one that grants. `is_whitelisted()` is a real allow, so
+promoting an address while poking at a throwaway agent silently promotes it on
+the production agent running on the same box. Nothing in either agent's
+directory records that it happened.
+
+These tests put two agents in two directories and check that what one grants,
+the other has never heard of.
+"""
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+tools = importlib.import_module('connectonion.network.trust.tools')
+
+
+STRANGER = '0x' + 'c' * 64
+
+
+@pytest.fixture
+def two_agents(tmp_path, monkeypatch):
+    """Two agent directories, the way one machine hosting two agents looks."""
+    a, b = tmp_path / 'agent-a', tmp_path / 'agent-b'
+    (a / '.co').mkdir(parents=True)
+    (b / '.co').mkdir(parents=True)
+    # A $HOME of its own, so a stray real ~/.co cannot make these pass.
+    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    return a, b
+
+
+def test_a_whitelist_grant_does_not_reach_the_other_agent(two_agents, monkeypatch):
+    a, b = two_agents
+
+    monkeypatch.chdir(a)
+    tools.promote_to_whitelist(STRANGER)
+    assert tools.is_whitelisted(STRANGER), "the grant did not take effect where it was made"
+
+    monkeypatch.chdir(b)
+    assert not tools.is_whitelisted(STRANGER), (
+        "an address whitelisted on one agent is whitelisted on every agent "
+        "sharing the machine"
+    )
+
+
+def test_a_contact_does_not_reach_the_other_agent(two_agents, monkeypatch):
+    a, b = two_agents
+
+    monkeypatch.chdir(a)
+    tools.promote_to_contact(STRANGER)
+    assert tools.is_contact(STRANGER)
+
+    monkeypatch.chdir(b)
+    assert not tools.is_contact(STRANGER)
+
+
+def test_a_block_does_not_reach_the_other_agent(two_agents, monkeypatch):
+    """Blocking leaks in the safe direction, and still should not leak.
+
+    An operator who blocks someone from a public agent has not asked to cut
+    them off from a private one they also run.
+    """
+    a, b = two_agents
+
+    monkeypatch.chdir(a)
+    tools.block(STRANGER)
+    assert tools.is_blocked(STRANGER)
+
+    monkeypatch.chdir(b)
+    assert not tools.is_blocked(STRANGER)
+
+
+def test_the_list_files_live_beside_the_agent(two_agents, monkeypatch):
+    """Where they are is the whole fix — visible in the agent's own directory,
+    next to the identity they are compared against."""
+    a, _ = two_agents
+
+    monkeypatch.chdir(a)
+    tools.promote_to_whitelist(STRANGER)
+
+    assert (a / '.co' / 'whitelist.txt').exists()
+    assert not (Path.home() / '.co' / 'whitelist.txt').exists()
+
+
+class TestTheOldGlobalListsAreNotLostSilently:
+    """Upgrading moves where these live. Nobody should find out from a lockout.
+
+    An operator who whitelisted a colleague in ~/.co/whitelist.txt gets, after
+    the upgrade, a colleague who cannot connect and no reason anywhere. The
+    entries are not read any more — reading them would be the bug — so the one
+    thing left to do is say where they went.
+    """
+
+    def test_a_legacy_list_with_entries_is_announced_once(self, two_agents,
+                                                          monkeypatch, capsys):
+        a, _ = two_agents
+        legacy = Path.home() / '.co'
+        legacy.mkdir(parents=True, exist_ok=True)
+        (legacy / 'whitelist.txt').write_text(STRANGER + '\n')
+
+        monkeypatch.setattr(tools, '_announced_legacy', set())
+        monkeypatch.chdir(a)
+        tools.is_whitelisted(STRANGER)
+        tools.is_whitelisted(STRANGER)
+        tools.is_whitelisted(STRANGER)
+
+        out = capsys.readouterr().out
+        assert str(legacy / 'whitelist.txt') in out
+        # The line names both paths, so count the lines, not the filename.
+        assert out.count('[trust]') == 1, "said once, not on every check"
+
+    def test_nothing_is_said_when_there_is_no_legacy_file(self, two_agents,
+                                                          monkeypatch, capsys):
+        a, _ = two_agents
+        monkeypatch.setattr(tools, '_announced_legacy', set())
+        monkeypatch.chdir(a)
+        tools.is_whitelisted(STRANGER)
+        assert capsys.readouterr().out == ""

--- a/tests/unit/test_trust_lists_are_per_agent.py
+++ b/tests/unit/test_trust_lists_are_per_agent.py
@@ -156,3 +156,35 @@ class TestTheDeployedAgentRunsFromItsOwnDirectory:
                        if l.startswith('WorkingDirectory='))
 
         assert f"{workdir}/.co" == f"{SRV}/ledger/.co"
+
+
+class TestCoTrustSaysWhereItLooked:
+    """Four empty lists and no agent look identical, and mean opposite things."""
+
+    def test_no_agent_here_is_not_reported_as_empty_lists(self, tmp_path,
+                                                          monkeypatch, capsys):
+        from connectonion.cli.commands.trust_commands import handle_trust_list
+
+        monkeypatch.chdir(tmp_path)          # no .co/ in it
+        handle_trust_list()
+
+        out = capsys.readouterr().out
+        assert 'No agent here' in out
+        assert 'Whitelist' not in out, (
+            "listing empty sections here reads as 'my whitelist was wiped'"
+        )
+
+    def test_a_real_agent_still_lists_its_entries(self, tmp_path, monkeypatch,
+                                                  capsys):
+        from connectonion.cli.commands.trust_commands import handle_trust_list
+
+        co = tmp_path / '.co'
+        co.mkdir()
+        (co / 'whitelist.txt').write_text('0xabc\n')
+        monkeypatch.chdir(tmp_path)
+
+        handle_trust_list()
+
+        out = capsys.readouterr().out
+        assert 'Whitelist' in out
+        assert '0xabc' in out

--- a/tests/unit/test_trust_state.py
+++ b/tests/unit/test_trust_state.py
@@ -33,10 +33,16 @@ from connectonion.network.trust.tools import (
 
 @pytest.fixture
 def temp_co_dir(tmp_path, monkeypatch):
-    """Create temp ~/.co/ directory for tests."""
+    """A directory that *is* this agent — the lists live inside it.
+
+    These fixtures used to redirect a module-level CO_DIR, which is the shape
+    of the bug they were working around: one global path meant one whitelist
+    for every agent on the machine. Now the agent's cwd decides, so the way to
+    isolate a test is to give it its own agent directory.
+    """
     co_dir = tmp_path / ".co"
-    co_dir.mkdir()
-    monkeypatch.setattr(tools, "CO_DIR", co_dir)
+    co_dir.mkdir(exist_ok=True)
+    monkeypatch.chdir(tmp_path)
     return co_dir
 
 


### PR DESCRIPTION
Closes #507.

`admins.txt` was moved out of `~/.co/` and beside the agent's own identity, because one box hosting two agents meant that making someone an admin of one made them an admin of both. **`whitelist`, `contacts` and `blocklist` were left on the old global path.** Same bug, and `whitelist` is the file that grants.

```python
CO_DIR = Path.home() / ".co"     # module-level, shared by every agent on the machine
```

`is_whitelisted()` is a real allow. Promoting an address while poking at a throwaway agent promoted it on the production agent running on the same box — and nothing in either agent's directory recorded that it had happened.

## Proven before it was fixed

Four tests, two agent directories, one machine. All four were red:

```
AssertionError: an address whitelisted on one agent is whitelisted on
                every agent sharing the machine
```

Blocking is included even though it leaks in the safe direction. An operator who blocks someone from a public agent has not asked to cut them off from a private one they also run.

## Upgrading, without a lockout

The move means an operator's existing `~/.co/whitelist.txt` stops applying. Someone finds a colleague locked out and there is nothing anywhere explaining why.

Those entries are not read — reading them is the bug this moves away from — so the read path says, once per list per process, where they went:

```
[trust] /Users/x/.co/whitelist.txt is no longer read — these lists now live
        beside each agent, in its own .co/. Copy the lines you still want
        into /srv/agent/.co/whitelist.txt.
```

Two tests cover it: it is said when a legacy file has entries, and nothing is said when there is none. A warning that fires on every check is noise that trains people to ignore it.

## The fixtures were the tell

Eight test fixtures monkeypatched the module-level `CO_DIR` so tests could not see each other's lists. That is exactly the shape of the defect — isolation required reaching into a process global. They now `chdir` into an agent directory, which is also what a second agent on the same machine does.

`co trust` was reading the same constant to build its own paths, so it now goes through the same helper. Otherwise the CLI would list one file while the agent read another.

3078 unit tests pass.
