### PR TITLE
test: the release gate does not depend on four funded provider accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,12 @@ test-integration:
 test-cli:
 	$(PYTEST) -m cli
 
+# End-to-end against our own system. Not the paid-provider tests under
+# tests/e2e/real_api/ — those need four funded accounts and answer a different
+# question, so they are opt-in via `make test-real`. A release gate that turns
+# red because a laptop is unfunded teaches people to ignore red.
 test-e2e:
-	$(PYTEST) -m e2e
+	$(PYTEST) -m "e2e and not real_api"
 
 test-real:
 	$(PYTEST) -m real_api

--- a/tests/unit/test_paid_tests_are_opt_in.py
+++ b/tests/unit/test_paid_tests_are_opt_in.py
@@ -1,0 +1,68 @@
+"""The release gate does not depend on four funded provider accounts.
+
+`make test-e2e` is `pytest -m e2e`, and tests/conftest.py auto-marks by folder:
+everything under tests/e2e/ gets `e2e`, everything under tests/e2e/real_api/
+also gets `real_api`. So the gate swept in 140 tests that call Anthropic,
+OpenAI, Gemini and Codex for real, and on a machine that is not funded for all
+four it read like this:
+
+    52 failed, 492 passed, 59 skipped
+
+every failure a 401 from a provider, none of them about our code. A check that
+answers "is this laptop funded" instead of "is this release sound" trains
+people to read red as normal — which is not a state a long-term-support
+release should ship in.
+
+The paid tests stay; they are just no longer what stands between a release and
+the door.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _collect(*args: str) -> int:
+    """How many tests the given selection collects."""
+    result = subprocess.run(
+        [sys.executable, '-m', 'pytest', '--collect-only', '-q',
+         '-p', 'no:cacheprovider', *args],
+        cwd=REPO, capture_output=True, text=True, timeout=600,
+    )
+    match = re.search(r'(\d+)/(\d+) tests collected|(\d+) tests collected',
+                      result.stdout)
+    if match:
+        return int(match.group(1) or match.group(3))
+    match = re.search(r'collected (\d+) items? / (\d+) deselected / (\d+) selected',
+                      result.stdout)
+    if match:
+        return int(match.group(3))
+    match = re.search(r'collected (\d+) items?', result.stdout)
+    return int(match.group(1)) if match else -1
+
+
+def test_the_e2e_gate_collects_no_paid_tests():
+    """What `make test-e2e` runs."""
+    assert _collect('tests/e2e/real_api', '-m', 'e2e and not real_api') == 0
+
+
+def test_the_e2e_gate_still_covers_our_own_system():
+    """Excluding paid providers must not empty the gate."""
+    assert _collect('tests/e2e', '-m', 'e2e and not real_api') > 100
+
+
+def test_the_paid_tests_remain_reachable():
+    """Opt-in, not deleted."""
+    assert _collect('tests/e2e/real_api', '-m', 'real_api') > 100
+
+
+def test_the_makefile_uses_the_narrowed_selection():
+    """The gate is only as good as what the Makefile actually invokes."""
+    makefile = (REPO / 'Makefile').read_text()
+    target = makefile.split('test-e2e:')[1].split('\n\n')[0]
+    assert 'not real_api' in target, (
+        f"`make test-e2e` still selects paid tests: {target.strip()!r}"
+    )


### PR DESCRIPTION
Part of #577.

`make test-e2e` was `pytest -m e2e`. `tests/conftest.py` auto-marks by folder — everything under `tests/e2e/` gets `e2e`, everything under `tests/e2e/real_api/` *also* gets `real_api` — so the release gate pulled in 140 tests that call Anthropic, OpenAI, Gemini and Codex for real.

**Before:**
```
52 failed, 492 passed, 59 skipped in 427.53s
```
Every failure a 401 from a provider. None about our code. The system tests underneath were green the whole time and nobody could see it.

**After:**
```
445 passed, 18 skipped, 3229 deselected in 325.06s
```

## The guard exists and is the wrong shape

`tests/conftest.py` does try to protect this:

```python
has_any_key = has_openai or has_anthropic or has_google or has_openonion
if not has_any_key:
    # skip every real_api test
```

All-or-nothing, where the requirement is per-provider. One key present — here `OPENONION_API_KEY` — and *everything* runs, including the tests that need the three keys this machine does not have. That is precisely how 52 tests failed on a machine that was correctly configured for the provider it actually uses.

Fixing that properly means knowing which provider each test needs, which `tests/e2e/real_api/conftest.py` already has decorators for. It is a separate change and stays in #577.

## I was wrong about this once already

While diagnosing I grepped for `pytestmark` and found it in only 8 of 21 files, and said the other 13 were unmarked — that `make test` would run them too. It does not:

```
$ pytest tests/e2e/real_api -m "not real_api" --collect-only
collected 140 items / 140 deselected / 0 selected
```

The marker comes from the folder hook, not the files. `make test` was always clean; only `make test-e2e` was affected. Correcting it here because the wrong version is the more alarming one.

## Four tests

Including one that reads the `Makefile` itself. The gate is only as good as what it actually invokes, and a marker expression is exactly the kind of thing that gets widened back in a hurry.
