### PR TITLE
fix(approval): the approval dialog belongs to the operator

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -32,7 +32,7 @@ from .session import Session, SessionStorage, merge_sessions, session_to_chat_it
 
 def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, result_ttl: int,
                   session: dict | None = None, connection=None, images: list[str] | None = None,
-                  files: list[dict] | None = None) -> dict:
+                  files: list[dict] | None = None, requester: dict | None = None) -> dict:
     """POST /input (and WebSocket /ws) with session merge and UI conversion."""
     agent = create_agent()
     agent.io = connection
@@ -51,6 +51,16 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
             client_session=session,
             server_session=stored.session
         )
+
+    # After the merge, and overwriting whatever arrived. The session dict
+    # round-trips through the client, so anything read out of it is their
+    # input — a level taken from there would make "I am the operator" a matter
+    # of editing one JSON field. The caller recomputes this every turn from the
+    # signature-verified address.
+    if requester is not None:
+        session['requester'] = requester
+    else:
+        session.pop('requester', None)
 
     record = Session(
         session_id=session_id,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -191,9 +191,21 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         validate_files(files, config)
         return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
 
-    def handle_ws_input(storage, prompt, connection, session=None, images=None, files=None):
+    def handle_ws_input(storage, prompt, connection, session=None, images=None,
+                        files=None, requester_address=None):
         validate_files(files, config)
-        return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
+        # Resolved here, not carried in the session — see input_handler.
+        # `admin` is not one of get_level's answers — it returns stranger /
+        # contact / whitelist / blocked. The operator is whoever is in
+        # .co/admins.txt, which is a separate question, and conflating them
+        # would have refused the owner as loudly as everyone else.
+        requester = None
+        if requester_address:
+            level = ('admin' if trust_agent.is_admin(requester_address)
+                     else trust_agent.get_level(requester_address))
+            requester = {'address': requester_address, 'level': level}
+        return input_handler(create_agent, storage, prompt, result_ttl, session,
+                             connection, images, files, requester=requester)
 
     def handle_ws_exec(tool_name, args):
         return exec_handler(create_agent, exec_permissions, tool_name, args)

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -17,10 +17,11 @@ from ...io import WebSocketIO
 console = Console()
 
 
-def _agent_thread_body(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder):
+def _agent_thread_body(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder, requester_address=None):
     """Thread target: run agent and store result. Calls io.mark_agent_done() when done."""
     try:
-        result_holder[0] = route_handlers["ws_input"](storage, prompt, io, session, images, files)
+        result_holder[0] = route_handlers["ws_input"](storage, prompt, io, session, images, files,
+                                                      requester_address=requester_address)
         registry.mark_session_connected(session_id)
     except Exception as e:
         result_holder[0] = e
@@ -130,7 +131,8 @@ async def start_agent(data, send_msg, conn, route_handlers, storage, registry):
 
     agent_thread = threading.Thread(
         target=_agent_thread_body,
-        args=(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder),
+        args=(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder,
+              agent_address),
         daemon=True,
     )
     # Register BEFORE start: thread may complete before .start() returns control,

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -392,6 +392,20 @@ def matches_permission_pattern(tool_name: str, tool_args: dict, pattern: str) ->
 # Event Handlers
 # =============================================================================
 
+def _permission_line(pending: dict) -> str:
+    """The exact host.yaml key that would allow this call in future.
+
+    Capitalised `Bash(...)` because that is the form the loader matches. A
+    suggestion that pastes cleanly and then silently does nothing is worse than
+    no suggestion — the operator stops looking for the real cause.
+    """
+    name = pending['name']
+    if name.lower() not in ('bash', 'shell', 'run'):
+        return name
+    binary = (pending.get('arguments') or {}).get('command', '').strip().split(' ')[0]
+    return f"Bash({binary} *)" if binary else "Bash"
+
+
 @before_each_tool
 def check_approval(agent: 'Agent') -> None:
     """Check if tool needs approval based on current mode.
@@ -525,6 +539,31 @@ def check_approval(agent: 'Agent') -> None:
     # Unknown tools (not in SAFE or DANGEROUS) are treated as safe
     if tool_name not in DANGEROUS_TOOLS:
         return
+
+    # =================================================================
+    # The dialog belongs to the operator, not to whoever is connected
+    # =================================================================
+    # Placed here, at the one line that is about to prompt — not earlier. An
+    # earlier check refused `read_file` for a contact, which gates access
+    # rather than approval and makes the agent useless to the people it was
+    # shared with. Only a call that would have opened the dialog is affected.
+    #
+    # The host knows who is on this socket: CONNECT is signed and the trust
+    # layer classified them before the session existed. That answer used to be
+    # dropped, so a contact saw the owner's "Allow" button and an invite code
+    # carried command execution.
+    #
+    # No requester recorded means the session did not arrive through the host —
+    # a local `co ai` run — and behaves as before.
+    requester = agent.current_session.get('requester')
+    if requester and requester.get('level') != 'admin':
+        raise ValueError(
+            f"{tool_name} needs the operator's approval, and you are "
+            f"{requester.get('level', 'not the operator')}. Only they can "
+            f"answer that prompt. Ask them to allow it in .co/host.yaml under "
+            f"`permissions` — the entry for this call is "
+            f"`{_permission_line(pending)}`."
+        )
 
     # Get approval key for this tool
     approval_key = _get_approval_key(tool_name, tool_args)

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -161,7 +161,7 @@ class TestHandleWebSocket:
 
         handlers = {
             "auth": lambda *args, **kwargs: ("prompt", "identity", True, None),
-            "ws_input": lambda storage, prompt, conn, session=None: {"result": "result", "session_id": "123", "duration_ms": 100, "session": {}},
+            "ws_input": lambda storage, prompt, conn, session=None, images=None, files=None, requester_address=None: {"result": "result", "session_id": "123", "duration_ms": 100, "session": {}},
         }
 
         registry = ActiveSessionRegistry()
@@ -228,7 +228,8 @@ class TestHandleWebSocket:
         agent_called = [False]
         connection_received = [None]
 
-        def mock_ws_input(storage, prompt, connection, session=None, images=None, files=None):
+        def mock_ws_input(storage, prompt, connection, session=None, images=None, files=None,
+                          requester_address=None):
             agent_called[0] = True
             connection_received[0] = connection
             return {"result": "Agent response", "session_id": "123", "duration_ms": 100, "session": {}, "status": "done"}
@@ -275,7 +276,7 @@ class TestHandleWebSocket:
 
         handlers = {
             "auth": lambda *args, **kwargs: ("test", "0x", True, None),
-            "ws_input": lambda storage, p, c, session=None, images=None, files=None: {"result": "Expected result", "session_id": "abc-123", "duration_ms": 50, "session": {}, "status": "done"},
+            "ws_input": lambda storage, p, c, session=None, images=None, files=None, requester_address=None: {"result": "Expected result", "session_id": "abc-123", "duration_ms": 50, "session": {}, "status": "done"},
             "trust_agent": Mock(config={}),
         }
 
@@ -316,7 +317,7 @@ class TestHandleWebSocket:
 
         handlers = {
             "auth": lambda *args, **kwargs: (None, "0x", False, "unauthorized: invalid signature"),
-            "ws_input": lambda storage, p, c, session=None: {"result": "result", "session_id": "123", "duration_ms": 100, "session": {}},
+            "ws_input": lambda storage, p, c, session=None, images=None, files=None, requester_address=None: {"result": "result", "session_id": "123", "duration_ms": 100, "session": {}},
         }
         registry = ActiveSessionRegistry()
 

--- a/tests/unit/test_only_the_owner_approves.py
+++ b/tests/unit/test_only_the_owner_approves.py
@@ -1,0 +1,229 @@
+"""Who is allowed to answer an approval prompt.
+
+The host knows exactly who is on the socket: CONNECT is signed, and the trust
+layer classifies the caller as admin / whitelisted / contact / blocked before
+the session exists. That answer was computed and dropped — `approval.py` had
+zero references to the requester.
+
+So the dialog went to whoever was connected. A contact — anyone who typed the
+invite code — was shown the owner's dialog and could click "Allow". An invite
+code carried command execution.
+
+The dialog is the operator's. Anyone else gets a refusal that names what the
+operator would have to pre-authorise, which is a thing they can paste into a
+message and ask for.
+"""
+
+import pytest
+
+from connectonion.useful_plugins.tool_approval import check_approval
+
+
+class FakeIO:
+    def __init__(self, responses=None):
+        self.responses = responses or [{'approved': True}]
+        self.sent = []
+        self.i = 0
+
+    def send(self, event):
+        self.sent.append(event)
+
+    def receive(self):
+        if self.i < len(self.responses):
+            self.i += 1
+            return self.responses[self.i - 1]
+        return {'type': 'io_closed'}
+
+    def receive_all(self, msg_type=None):
+        return []
+
+
+class FakeAgent:
+    def __init__(self, io=None, requester=None):
+        self.io = io
+        self.storage = None
+        self.current_session = {'messages': [], 'trace': [], 'pending_tool': None}
+        if requester is not None:
+            self.current_session['requester'] = requester
+
+
+DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
+                                           'description': 'clean'}}
+
+
+class TestOnlyAnAdminIsAsked:
+
+    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'stranger'])
+    def test_a_non_admin_is_not_shown_the_dialog(self, level):
+        io = FakeIO()
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': level})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        with pytest.raises(ValueError):
+            check_approval(agent)
+
+        assert io.sent == [], (
+            f"a {level} was offered the operator's approval dialog and could "
+            "have clicked Allow"
+        )
+
+    def test_the_refusal_names_what_to_ask_for(self):
+        """The requester cannot fix this themselves, so tell them what to ask.
+
+        A refusal that just says no turns into a message to the operator
+        saying 'it did not work', which costs a round trip to learn nothing.
+        """
+        agent = FakeAgent(io=FakeIO(), requester={'address': '0x' + 'e' * 64,
+                                                  'level': 'contact'})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        with pytest.raises(ValueError) as exc:
+            check_approval(agent)
+
+        message = str(exc.value)
+        assert 'host.yaml' in message
+        assert 'bash' in message
+
+    def test_an_admin_is_still_asked(self):
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'f' * 64,
+                                            'level': 'admin'})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert len(io.sent) == 1
+        assert io.sent[0]['type'] == 'approval_needed'
+
+    def test_a_safe_tool_is_unaffected_for_everyone(self):
+        """This gates approval, not access. A contact may still use the agent."""
+        io = FakeIO()
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': 'contact'})
+        agent.current_session['pending_tool'] = {'name': 'read_file',
+                                                 'arguments': {'path': 'a.md'}}
+
+        check_approval(agent)
+
+        assert io.sent == []
+
+
+class TestAnUnknownRequester:
+    """No requester recorded means the session did not come through the host.
+
+    A local `co ai` run is exactly that, and it must keep working. The rule is
+    about a socket with someone else on it, not about the absence of a field.
+    """
+
+    def test_no_requester_recorded_behaves_as_before(self):
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io)
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert len(io.sent) == 1
+
+
+class TestTheClientCannotDeclareItsOwnLevel:
+    """The session dict round-trips through the client, so it is their input.
+
+    A client sends its session back on every turn and the server merges it. If
+    the requester's level were read from there, claiming to be the operator
+    would be a matter of editing one JSON field — a worse hole than the one
+    this closes, introduced by closing it.
+
+    So the level is recomputed from the signed address every turn and
+    overwrites whatever arrived.
+    """
+
+    def test_a_forged_requester_is_overwritten(self, tmp_path, monkeypatch):
+        from connectonion.network.host.http_router import input_handler
+        from connectonion.network.host.session import SessionStorage
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / '.co').mkdir()
+        seen = {}
+
+        class Agent:
+            def __init__(self):
+                self.io = None
+                self.storage = None
+                self.current_session = {}
+
+            def input(self, prompt, session=None, **kw):
+                seen['requester'] = (session or {}).get('requester')
+                self.current_session = dict(session or {})
+                return 'ok'
+
+        forged = {'session_id': 'abc', 'requester': {'address': '0xdead',
+                                                     'level': 'admin'}}
+
+        input_handler(Agent, SessionStorage(tmp_path / '.co' / 'sessions.jsonl'), 'hi', 60,
+                      session=forged, requester={'address': '0xbeef',
+                                                 'level': 'contact'})
+
+        assert seen['requester'] == {'address': '0xbeef', 'level': 'contact'}, (
+            "the client's own claim about its level survived into the session"
+        )
+
+
+class TestTheLevelTheHostActuallyComputes:
+    """The gate compares against a value real code has to be able to produce.
+
+    The first version of this compared `get_level(...) != 'admin'`, and every
+    test passed — because every test wrote `level: 'admin'` by hand. `get_level`
+    returns stranger / contact / whitelist / blocked and never 'admin', so the
+    gate would have refused the owner too: nobody could approve anything over
+    a socket.
+
+    This test goes through the resolver the host uses, so agreeing with the
+    implementation is not enough to pass it.
+    """
+
+    def _resolve(self, address, tmp_path):
+        from connectonion.network.trust import TrustAgent
+        trust = TrustAgent('careful')
+        return {'address': address,
+                'level': 'admin' if trust.is_admin(address)
+                         else trust.get_level(address)}
+
+    def test_an_address_in_admins_txt_resolves_to_admin(self, tmp_path, monkeypatch):
+        owner = '0x' + '1' * 64
+        co = tmp_path / '.co'
+        co.mkdir()
+        (co / 'admins.txt').write_text(owner + '\n')
+        monkeypatch.chdir(tmp_path)
+
+        requester = self._resolve(owner, tmp_path)
+
+        assert requester['level'] == 'admin', (
+            "the owner does not resolve to the level the gate requires, so "
+            "nobody could approve anything"
+        )
+
+    def test_the_owner_is_still_shown_the_dialog(self, tmp_path, monkeypatch):
+        owner = '0x' + '1' * 64
+        co = tmp_path / '.co'
+        co.mkdir()
+        (co / 'admins.txt').write_text(owner + '\n')
+        monkeypatch.chdir(tmp_path)
+
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester=self._resolve(owner, tmp_path))
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert len(io.sent) == 1
+
+    def test_someone_not_in_admins_txt_is_not_admin(self, tmp_path, monkeypatch):
+        co = tmp_path / '.co'
+        co.mkdir()
+        (co / 'admins.txt').write_text('0x' + '1' * 64 + '\n')
+        monkeypatch.chdir(tmp_path)
+
+        requester = self._resolve('0x' + '2' * 64, tmp_path)
+
+        assert requester['level'] != 'admin'


### PR DESCRIPTION
Closes #551.

The host knows exactly who is on the socket — CONNECT is signed, and the trust layer classifies the caller as admin / whitelisted / contact / blocked before the session exists. That answer was computed and then dropped:

```
$ grep -c 'client_id\|requester\|trust_level' useful_plugins/tool_approval/approval.py
0
```

So the dialog went to whoever was connected. **A contact — anyone who typed the invite code — was shown the owner's "Allow" button.** An invite code carried command execution.

Now the requester's address and level ride from CONNECT to the approval point, and only an admin is prompted. Everyone else gets a refusal naming the `host.yaml` entry the operator would have to add — something they can paste into a message and ask for, rather than "it didn't work".

## Three things I got wrong, each caught by a test

**1. The gate was too early.** I put it above the mode logic, and it refused `read_file` for a contact. That gates *access*, not *approval*, and makes the agent useless to the people it was shared with:

```
ValueError: read_file needs the operator's approval, and you are contact.
```

It now sits at the one line that is about to prompt. Only a call that would have opened the dialog is affected.

**2. The level was read from the session dict** — which round-trips through the client and is merged back in on every turn. Claiming to be the operator would have been a matter of editing one JSON field: a worse hole than the one being closed, introduced by closing it. It is recomputed from the signed address each turn and **overwrites** whatever arrived. There is a test that sends a forged `{'level': 'admin'}` and checks it does not survive.

**3. The gate compared against a value nothing can produce.**

```python
if requester.get('level') != 'admin':     # get_level never returns 'admin'
```

`get_level` returns `stranger` / `contact` / `whitelist` / `blocked`. **Every test passed because every test wrote `level: 'admin'` by hand** — the tests agreed with the implementation, and both were wrong about the system. In production the owner would have been refused as loudly as everyone else, and nobody could have approved anything over a socket.

Admin is `.co/admins.txt`, a separate question:

```python
level = 'admin' if trust_agent.is_admin(addr) else trust_agent.get_level(addr)
```

There is now a test that goes through the resolver the host actually uses, so agreeing with the implementation is not enough to pass it.

## Scope

- A session with no requester recorded — a local `co ai` run — behaves exactly as before. The rule is about a socket with someone else on it, not about a missing field.
- HTTP `POST /input` has no interactive connection, so no dialog was ever possible there; it is unchanged.
- `route_handlers["ws_input"]` gained a keyword argument. Four fake handlers in `test_asgi.py` were updated to match the contract.

3104 unit tests pass.
