### PR TITLE
fix(skills): a turn's permissions end where the turn began

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -341,9 +341,27 @@ def _grant_skill_permissions(agent: 'Agent', skill_name: str, patterns: List[str
         skill_name: Skill name for reason
         patterns: List of tool patterns (e.g., ["Bash(git *)", "read_file"])
     """
-    # Take snapshot of current permissions to restore later
-    current_perms = agent.current_session.get('permissions', {})
-    agent.current_session['_permission_snapshot'] = deepcopy(current_perms)
+    # Where this turn began — written once, by whichever skill runs first.
+    #
+    # A second skill in the same turn used to overwrite this with a state that
+    # already contained the first one's grants, so restore returned to "after
+    # skill A" and A's patterns were permanent for the rest of the session.
+    # Skills reference other skills; two in a turn is ordinary.
+    #
+    # A stack would be the answer if restore ran per skill. It does not —
+    # cleanup_scope is @on_complete and fires once, at the end of the turn — so
+    # the only snapshot worth having is the first.
+    # It also records which turn it describes. `on_complete` is not in a finally
+    # block, so a turn that raises — a rejected approval does exactly that —
+    # never restores and leaves its snapshot behind. Trusting that one would
+    # send the next turn back two turns.
+    turn_now = agent.current_session.get('turn', 0)
+    snapshot = agent.current_session.get('_permission_snapshot')
+    if snapshot is None or snapshot.get('turn') != turn_now:
+        current_perms = agent.current_session.get('permissions', {})
+        agent.current_session['_permission_snapshot'] = {
+            'turn': turn_now, 'permissions': deepcopy(current_perms),
+        }
 
     # Initialize permissions dict if needed
     if 'permissions' not in agent.current_session:
@@ -378,8 +396,20 @@ def _restore_permissions(agent: 'Agent') -> None:
 
     This ensures user approvals are preserved and skill permissions are cleared.
     """
-    if '_permission_snapshot' in agent.current_session:
-        agent.current_session['permissions'] = agent.current_session.pop('_permission_snapshot')
+    if '_permission_snapshot' not in agent.current_session:
+        return
+
+    restored = agent.current_session.pop('_permission_snapshot')['permissions']
+
+    # An approval the operator gave *during* the skill is theirs, not the
+    # skill's. It lives only in the live dict — the snapshot predates it — so a
+    # wholesale replace threw it away: they answered a dialog with "trust this
+    # for the session" and it silently did not stick.
+    for key, permission in (agent.current_session.get('permissions') or {}).items():
+        if permission.get('source') == 'user':
+            restored[key] = permission
+
+    agent.current_session['permissions'] = restored
 
 
 # =============================================================================

--- a/tests/unit/test_skill_permissions_lifecycle.py
+++ b/tests/unit/test_skill_permissions_lifecycle.py
@@ -1,0 +1,149 @@
+"""What a turn's permissions look like after the skills in it are done.
+
+Two faults in the same two functions.
+
+`_grant_skill_permissions` snapshots the current permissions so they can be put
+back. It writes that snapshot into one slot, and a second skill in the same
+turn overwrites it — with a state that already contains the first skill's
+grants. Restore then returns to "after skill A", and A's patterns are permanent
+for the rest of the session. Skills reference other skills; two in a turn is
+ordinary.
+
+`_restore_permissions` replaces the whole permissions dict with the snapshot.
+Anything the operator approved *during* the skill — the dialog they answered
+with "trust this for the session" — is in the live dict and not in the snapshot,
+so it is discarded. They approved something and it silently did not stick.
+
+Restore fires once per turn (`@on_complete`), not once per skill, so the first
+snapshot is the one that describes where the turn began. That is the one to
+keep.
+"""
+
+import pytest
+
+from connectonion.useful_plugins.skills import (
+    _grant_skill_permissions,
+    _restore_permissions,
+)
+
+
+class FakeAgent:
+    def __init__(self, permissions=None):
+        self.current_session = {'turn': 1, 'permissions': permissions or {}}
+
+
+class TestNestedSkillsDoNotLeak:
+
+    def test_two_skills_in_one_turn_both_end(self):
+        agent = FakeAgent()
+
+        _grant_skill_permissions(agent, 'deploy', ['Bash(rsync *)'])
+        _grant_skill_permissions(agent, 'notify', ['Bash(curl *)'])
+        _restore_permissions(agent)
+
+        left = set(agent.current_session.get('permissions', {}))
+        assert left == set(), (
+            f"a skill's permissions outlived the turn: {sorted(left)}"
+        )
+
+    def test_the_turn_returns_to_where_it_started(self):
+        agent = FakeAgent({'read_file': {'allowed': True, 'source': 'safe'}})
+
+        _grant_skill_permissions(agent, 'a', ['Bash(git *)'])
+        _grant_skill_permissions(agent, 'b', ['Bash(npm *)'])
+        _restore_permissions(agent)
+
+        assert set(agent.current_session['permissions']) == {'read_file'}
+
+    def test_three_deep_is_no_different(self):
+        agent = FakeAgent()
+
+        for name, pattern in [('a', 'Bash(a *)'), ('b', 'Bash(b *)'),
+                              ('c', 'Bash(c *)')]:
+            _grant_skill_permissions(agent, name, [pattern])
+        _restore_permissions(agent)
+
+        assert agent.current_session.get('permissions', {}) == {}
+
+
+class TestAnApprovalGivenDuringASkillSurvives:
+    """The operator answered a dialog. That answer is not the skill's to undo."""
+
+    def test_a_session_approval_is_kept(self):
+        agent = FakeAgent()
+
+        _grant_skill_permissions(agent, 'deploy', ['Bash(rsync *)'])
+        # What check_approval writes when someone picks "trust for this session".
+        agent.current_session['permissions']['bash'] = {
+            'allowed': True, 'source': 'user', 'reason': 'approved for session',
+            'expires': {'type': 'session_end'},
+        }
+
+        _restore_permissions(agent)
+
+        assert 'bash' in agent.current_session['permissions'], (
+            "the operator approved something during a skill and it vanished "
+            "when the skill cleaned up"
+        )
+        assert agent.current_session['permissions']['bash']['source'] == 'user'
+
+    def test_the_skills_own_grants_still_go(self):
+        """Keeping user approvals must not keep everything."""
+        agent = FakeAgent()
+
+        _grant_skill_permissions(agent, 'deploy', ['Bash(rsync *)'])
+        agent.current_session['permissions']['bash'] = {
+            'allowed': True, 'source': 'user', 'reason': 'approved',
+        }
+
+        _restore_permissions(agent)
+
+        remaining = agent.current_session['permissions']
+        assert 'bash' in remaining
+        assert not any(v.get('source') == 'skill' for v in remaining.values())
+
+
+class TestATurnThatDiedDoesNotPoisonTheNextOne:
+    """`on_complete` is not in a finally block.
+
+        result = self._run_iteration_loop(...)
+        ...
+        self._invoke_events('on_complete')
+
+    A turn that raises — a rejected approval does exactly that — never restores,
+    and leaves its snapshot behind.
+
+    That was self-healing while the snapshot was overwritten by whoever granted
+    next. Making the first write win removed the self-healing: the stale
+    snapshot would survive, and the following turn would restore to a point two
+    turns back. So the snapshot records which turn it describes, and a snapshot
+    from an older turn is replaced rather than trusted.
+    """
+
+    def test_a_snapshot_from_a_dead_turn_is_not_reused(self):
+        agent = FakeAgent()
+
+        # Turn 1 grants and then dies — no restore.
+        _grant_skill_permissions(agent, 'deploy', ['Bash(rsync *)'])
+
+        # Turn 2 starts where turn 1 left off, as the session actually does.
+        agent.current_session['turn'] = 2
+        _grant_skill_permissions(agent, 'notify', ['Bash(curl *)'])
+        _restore_permissions(agent)
+
+        left = set(agent.current_session.get('permissions', {}))
+        assert 'Bash(curl *)' not in left, "turn 2's own grant outlived turn 2"
+        assert left == {'Bash(rsync *)'}, (
+            f"turn 2 restored to somewhere that is not where turn 2 began: "
+            f"{sorted(left)}"
+        )
+
+    def test_two_grants_in_the_same_turn_still_share_one_snapshot(self):
+        """The fix for the dead turn must not undo the fix for nesting."""
+        agent = FakeAgent()
+
+        _grant_skill_permissions(agent, 'a', ['Bash(a *)'])
+        _grant_skill_permissions(agent, 'b', ['Bash(b *)'])
+        _restore_permissions(agent)
+
+        assert agent.current_session.get('permissions', {}) == {}

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -57,11 +57,14 @@ class TestPermissionGranting:
 
         _grant_skill_permissions(agent, 'commit', ['Bash(git status)', 'read_file'])
 
-        # Snapshot should exist
-        assert '_permission_snapshot' in agent.current_session
+        # Snapshot should exist, and record which turn it describes — a turn
+        # that raises never restores, and its leftover snapshot must not be
+        # mistaken for the next turn's starting point.
+        snapshot = agent.current_session['_permission_snapshot']
+        assert snapshot['turn'] == agent.current_session['turn']
         # Snapshot should contain user approval
-        assert 'write' in agent.current_session['_permission_snapshot']
-        assert agent.current_session['_permission_snapshot']['write']['source'] == 'user'
+        assert 'write' in snapshot['permissions']
+        assert snapshot['permissions']['write']['source'] == 'user'
 
     def test_grant_skill_permissions_adds_patterns(self):
         """Test that skill permissions are added to permissions dict."""
@@ -116,7 +119,10 @@ class TestPermissionGranting:
                 'expires': {'type': 'session_end'}
             }
         }
-        agent.current_session['_permission_snapshot'] = deepcopy(agent.current_session['permissions'])
+        agent.current_session['_permission_snapshot'] = {
+            'turn': agent.current_session['turn'],
+            'permissions': deepcopy(agent.current_session['permissions']),
+        }
 
         # Add skill permission
         agent.current_session['permissions']['Bash(git status)'] = {
@@ -353,7 +359,8 @@ class TestCleanup:
             'bash': {'source': 'skill', 'when': {'command': 'git status'}}
         }
         agent.current_session['_permission_snapshot'] = {
-            'write': {'source': 'user'}
+            'turn': agent.current_session['turn'],
+            'permissions': {'write': {'source': 'user'}},
         }
 
         cleanup_scope(agent)


### PR DESCRIPTION
Closes #371 and #204 — two faults in the same two functions.

## The leak (#371)

`_grant_skill_permissions` wrote its snapshot into one slot:

```python
agent.current_session['_permission_snapshot'] = deepcopy(current_perms)
```

A second skill in the same turn overwrote it — with a state that already contained the first skill's grants. Restore returned to "after skill A", and A's patterns were **permanent for the rest of the session**. Skills reference other skills; two in a turn is ordinary.

```
AssertionError: assert {'Bash(rsync *)'} == set()
   — a skill's permissions outlived the turn
```

**I did not implement the stack the issue asks for.** A stack is right if restore runs per skill, and it does not — `cleanup_scope` is `@on_complete` and fires once, at the end of the turn. With one restore, the only snapshot worth having is the first. So: first write wins.

## The erasure (#204)

`_restore_permissions` replaced the whole dict with the snapshot, discarding anything approved *during* the skill. The operator answered a dialog with "trust this for the session" — that entry is in the live dict, not the snapshot — and it silently did not stick.

User-sourced entries now survive; skill-sourced ones still go. A test covers both halves, because keeping user approvals must not turn into keeping everything.

## The safety net my own fix removed

`on_complete` is not in a finally block:

```python
result = self._run_iteration_loop(...)
...
self._invoke_events('on_complete')
```

A turn that raises — **a rejected approval does exactly that** — never restores and leaves its snapshot behind. That was self-healing while the next grant overwrote it. First-write-wins removed the self-healing: the stale snapshot would survive and send the following turn back two turns.

```
AssertionError: assert set() == {'Bash(rsync *)'}
   — turn 2 restored to somewhere that is not where turn 2 began
```

So the snapshot records which turn it describes, and one from an older turn is replaced rather than trusted.

## What the existing tests were worth

Three of them asserted the snapshot's internal shape and needed updating. All three passed the entire time permissions were leaking across nested skills — they checked the structure, not what a turn leaves behind.

3111 unit tests pass.
