### PR TITLE
fix(session): a restored session keeps what plugins put in it

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -246,12 +246,21 @@ class Agent:
 
         # Session restoration: if session passed, restore it (stateless API continuation)
         if session is not None:
-            self.current_session = {
-                'session_id': session.get('session_id'),
-                'messages': list(session.get('messages', [])),
-                'trace': list(session.get('trace', [])),
-                'turn': session.get('turn', 0)
-            }
+            # Everything the caller passed, not four chosen keys. Plugins keep
+            # their state here — ULW's mode and turn budget, the approval gate's
+            # requester — and rebuilding from a whitelist silently dropped all of
+            # it: ULW fell back to Safe after a turn, and the approval gate saw
+            # every requester as unknown. #191.
+            #
+            # Which of these keys a client is allowed to state is decided before
+            # this point, in input_handler: a session arriving over the wire has
+            # the server-owned ones stripped and re-applied from what the server
+            # stored. Here we only restore what we were handed.
+            self.current_session = dict(session)
+            self.current_session['session_id'] = session.get('session_id')
+            self.current_session['messages'] = list(session.get('messages', []))
+            self.current_session['trace'] = list(session.get('trace', []))
+            self.current_session['turn'] = session.get('turn', 0)
             # Start YAML session logging with session_id for thread safety
             self.logger.start_session(self.system_prompt, session_id=session.get('session_id'))
         elif self.current_session is None:

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -27,6 +27,15 @@ from .session import Session, SessionStorage, merge_sessions, session_to_chat_it
 
 
 # ═══════════════════════════════════════════════════════
+# State a client carries but does not author. Set server-side — by a validated
+# mode_change, by the trust layer at CONNECT — and restored from storage so it
+# survives the round trip without the client being able to invent it.
+SERVER_OWNED_SESSION_KEYS = (
+    'mode', 'ulw_turns', 'ulw_turns_used', 'skip_tool_approval',
+    'permissions', 'approval', 'requester',
+)
+
+
 # Handlers
 # ═══════════════════════════════════════════════════════
 
@@ -51,6 +60,18 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
             client_session=session,
             server_session=stored.session
         )
+
+    # Answers the server already gave, which the client does not get to change.
+    #
+    # merge_sessions picks one whole session, so a client that wins the merge
+    # would otherwise hand the agent its own `skip_tool_approval: True` and skip
+    # every approval check. These come from what the server stored, or from
+    # nowhere.
+    stored_session = (stored.session if stored and stored.session else {}) or {}
+    for key in SERVER_OWNED_SESSION_KEYS:
+        session.pop(key, None)
+        if key in stored_session:
+            session[key] = stored_session[key]
 
     # After the merge, and overwriting whatever arrived. The session dict
     # round-trips through the client, so anything read out of it is their

--- a/tests/unit/test_session_keeps_plugin_state.py
+++ b/tests/unit/test_session_keeps_plugin_state.py
@@ -1,0 +1,125 @@
+"""What survives a session round-trip, and who gets to decide it.
+
+`Agent.input(session=…)` rebuilt current_session from four keys — session_id,
+messages, trace, turn — and dropped everything else. Plugins keep their state
+there, so ULW lost `mode` and `skip_tool_approval` on every turn and silently
+fell back to Safe: the web client visibly stepped back to "Safe" after a turn
+or two, and over HTTP, where mode_change messages do not exist, ULW never
+worked at all. #191.
+
+The same drop quietly disabled the approval gate added in #579: the host writes
+`session['requester']`, input() threw it away, and every requester looked
+unknown — which is the path that behaves as before.
+
+Keeping everything is not the fix. `merge_sessions` picks the client's session
+or the server's wholesale, so a client that wins the merge would be handing the
+agent its own `skip_tool_approval: True`. A defined set of keys is therefore
+the server's to state, taken from what it stored and never from what arrived.
+"""
+
+import importlib
+
+import pytest
+
+from connectonion import Agent
+from connectonion.network.host.http_router import input_handler
+from connectonion.network.host.session import SessionStorage, Session
+from tests.utils.mock_helpers import MockLLM
+
+
+class TestInputKeepsWhatItIsGiven:
+
+    def test_plugin_fields_survive_a_restore(self):
+        agent = Agent("a", llm=MockLLM())
+
+        agent.input("hi", session={
+            'session_id': 's1', 'messages': [], 'trace': [], 'turn': 0,
+            'mode': 'ulw', 'ulw_turns': 5, 'ulw_turns_used': 1,
+            'skip_tool_approval': True,
+        })
+
+        assert agent.current_session.get('mode') == 'ulw'
+        assert agent.current_session.get('ulw_turns') == 5
+        assert agent.current_session.get('skip_tool_approval') is True
+
+    def test_the_requester_survives_a_restore(self):
+        """#579's gate reads this. Dropped, it silently does nothing."""
+        agent = Agent("a", llm=MockLLM())
+
+        agent.input("hi", session={
+            'session_id': 's1', 'messages': [], 'trace': [], 'turn': 0,
+            'requester': {'address': '0xbeef', 'level': 'contact'},
+        })
+
+        assert agent.current_session.get('requester') == {
+            'address': '0xbeef', 'level': 'contact'}
+
+    def test_the_known_four_are_still_normalised(self):
+        agent = Agent("a", llm=MockLLM())
+        messages = [{'role': 'user', 'content': 'x'}]
+
+        agent.input("hi", session={'session_id': 's2', 'messages': messages,
+                                   'trace': [], 'turn': 3})
+
+        assert agent.current_session['session_id'] == 's2'
+        assert agent.current_session['turn'] == 4, "the turn continued from 3"
+        assert agent.current_session['messages'] is not messages, (
+            "the caller's list must not be aliased into the live session"
+        )
+
+
+class TestTheClientDoesNotGrantItself:
+    """A session dict arrives from the client. Some of its keys are answers the
+    server already gave, and those it does not get to change."""
+
+    def _run(self, tmp_path, client_session, stored_session=None):
+        seen = {}
+
+        class Probe:
+            def __init__(self):
+                self.io = None
+                self.storage = None
+                self.current_session = {}
+
+            def input(self, prompt, session=None, **kw):
+                seen.update(session or {})
+                self.current_session = dict(session or {})
+                return 'ok'
+
+        storage = SessionStorage(tmp_path / '.co' / 'sessions.jsonl')
+        if stored_session is not None:
+            storage.save(Session(session_id='s1', status='done', prompt='p',
+                                 session=stored_session))
+        input_handler(Probe, storage, 'hi', 60, session=client_session)
+        return seen
+
+    def test_a_client_cannot_bring_its_own_approval_bypass(self, tmp_path):
+        seen = self._run(tmp_path, {
+            'session_id': 's1', 'messages': [], 'trace': [], 'turn': 0,
+            'skip_tool_approval': True,
+        })
+
+        assert not seen.get('skip_tool_approval'), (
+            "a client handed itself a bypass of every approval check"
+        )
+
+    def test_a_client_cannot_bring_its_own_permissions(self, tmp_path):
+        seen = self._run(tmp_path, {
+            'session_id': 's1', 'messages': [], 'trace': [], 'turn': 0,
+            'permissions': {'bash': {'allowed': True, 'source': 'user'}},
+        })
+
+        assert not seen.get('permissions')
+
+    def test_the_servers_own_ulw_state_is_restored(self, tmp_path):
+        """The point of keeping these at all: state the server set, persisting."""
+        seen = self._run(
+            tmp_path,
+            {'session_id': 's1', 'messages': [], 'trace': [], 'turn': 0},
+            stored_session={'session_id': 's1', 'messages': [], 'trace': [],
+                            'turn': 0, 'mode': 'ulw', 'ulw_turns': 5,
+                            'skip_tool_approval': True},
+        )
+
+        assert seen.get('mode') == 'ulw'
+        assert seen.get('skip_tool_approval') is True


### PR DESCRIPTION
Closes #191.

`Agent.input(session=…)` rebuilt `current_session` from four keys and dropped everything else:

```python
self.current_session = {
    'session_id': …, 'messages': …, 'trace': …, 'turn': …,
}
```

Plugins keep their state there. ULW lost `mode` and `skip_tool_approval` on every turn and fell back to Safe — the web client visibly stepping back after a turn or two, and over HTTP, where `mode_change` messages do not exist, ULW never worked at all.

## It had also disabled #579, merged two hours ago

That PR added `session['requester']` so the approval gate could tell who is asking. `input()` threw it away, so the gate saw every requester as unknown — **the branch that behaves as before**. A contact could still click Allow.

The tests passed because they used a fake agent that keeps what it is given. The real one did not:

```
requester survived: None
mode survived:      None
keys: ['iteration','messages','result','session_id','trace','turn','user_prompt']
```

Same trap as the `'admin'` level last round: the test agreed with the implementation, and neither matched the system. Verified now against the real `Agent`, and the gate does what it claims:

```
requester survived: {'address': '0xbeef', 'level': 'contact'}
result:             refused — "bash needs the operator's approval, and you are contact"
dialogs sent:       0
```

## Keeping everything is not the fix on its own

`merge_sessions` picks the client's session **or** the server's, wholesale:

```python
if server_iter > client_iter: return server_session, True
elif client_iter > server_iter: return client_session, False
```

So a client that wins the merge would hand the agent its own `skip_tool_approval: True` and skip every approval check — a bigger hole than the one being closed.

`input_handler` now strips a defined set of keys from whatever arrives and re-applies them from what the server stored:

```python
SERVER_OWNED_SESSION_KEYS = (
    'mode', 'ulw_turns', 'ulw_turns_used', 'skip_tool_approval',
    'permissions', 'approval', 'requester',
)
```

State the server set — by a validated `mode_change`, by the trust layer at CONNECT. The client carries it for continuity; it does not author it. Three tests cover that: an incoming bypass is dropped, incoming permissions are dropped, and the server's own ULW state is restored.

3117 unit tests pass.
