### PR TITLE
fix(trace): the agent is plumbing, not an argument

### DIFF
--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -2,7 +2,7 @@
 Purpose: Execute agent tools with xray context injection, timing, error handling, and trace recording
 LLM-Note:
   Dependencies: imports from [time, json, typing, xray.py] | imported by [agent.py] | tested by [tests/test_tool_executor.py]
-  Data flow: receives from Agent → tool_calls: List[ToolCall], tools: ToolRegistry, agent: Agent, logger: Logger → for each tool: injects xray context via inject_xray_context() → if tool._needs_agent, injects agent into tool_args → executes tool_func(**tool_args) → records timing and result → appends to agent.current_session['trace'] → clears xray context → adds tool result to messages
+  Data flow: receives from Agent → tool_calls: List[ToolCall], tools: ToolRegistry, agent: Agent, logger: Logger → for each tool: injects xray context via inject_xray_context() → if tool._needs_agent, passes agent in a call-only copy → executes tool_func(**call_args) → records timing and result → appends to agent.current_session['trace'] → clears xray context → adds tool result to messages
   State/Effects: mutates agent.current_session['messages'] by appending assistant message with tool_calls and tool result messages | mutates agent.current_session['trace'] by appending tool_execution entries | calls logger.log_tool_call() and logger.log_tool_result() for user feedback | injects/clears xray context via thread-local storage
   Integration: exposes execute_and_record_tools(tool_calls, tools, agent, logger), execute_single_tool(...) | uses logger.log_tool_call(name, args) for natural function-call style output: greet(name='Alice') | creates trace entries with type, tool_name, arguments, call_id, result, status, timing, iteration, timestamp
   Performance: times each tool execution in milliseconds | executes tools sequentially (not parallel) | trace entry added BEFORE auto-trace so xray.trace() sees it | agent injection uses cached _needs_agent flag (set by tool_factory) instead of inspect.signature() for zero overhead
@@ -246,13 +246,24 @@ def execute_single_tool(
         # Inject agent for tools that declare 'agent' in their signature.
         # _needs_agent is cached by tool_factory at registration time.
         # This lets tools access agent.io for frontend communication (ask_user, DiffWriter, etc.)
+        # A separate dict for the call, not a mutation of the caller's.
+        #
+        # This used to be `tool_args['agent'] = agent`, and the trace entry holds
+        # `tool_args` by reference — so between recording the trace and the
+        # `finally` that popped the field, an entry containing a live Agent was
+        # reachable. In host mode the forwarder thread is draining and encoding
+        # those entries concurrently, so the mitigation was a race. #382.
+        #
+        # `agent` is plumbing, not something the model asked for, and it does not
+        # belong in the record of what was called.
+        call_args = tool_args
         if getattr(tool_func, '_needs_agent', False):
-            tool_args['agent'] = agent
+            call_args = {**tool_args, 'agent': agent}
 
         if inspect.iscoroutinefunction(tool_func):
-            result = _run_async_tool(tool_func(**tool_args))
+            result = _run_async_tool(tool_func(**call_args))
         else:
-            result = tool_func(**tool_args)
+            result = tool_func(**call_args)
         tool_duration = (time.time() - tool_start) * 1000  # milliseconds
 
         trace_entry["timing_ms"] = tool_duration
@@ -300,10 +311,7 @@ def execute_single_tool(
         # Note: on_error event will fire in execute_and_record_tools after result message added
 
     finally:
-        # Remove injected agent from tool_args to prevent serialization issues.
-        # Trace entries reference tool_args, so leaving 'agent' would cause
-        # "Non-JSON-serializable object: Agent" warnings when session_sync sends traces.
-        tool_args.pop('agent', None)
+        # No `tool_args.pop('agent')` here any more: nothing was ever put in.
         # Clear xray context after tool execution
         clear_xray_context()
 

--- a/tests/unit/test_the_agent_is_not_an_argument.py
+++ b/tests/unit/test_the_agent_is_not_an_argument.py
@@ -1,0 +1,171 @@
+"""What a trace entry is allowed to hold.
+
+Tools that declare `agent` in their signature get the live Agent injected so
+they can reach `agent.io`. That injection mutated the caller's dict in place:
+
+    trace_entry["args"] = tool_args      # by reference
+    ...
+    tool_args['agent'] = agent           # now the trace holds an Agent
+    ...
+    agent._record_trace(trace_entry)     # forwarded over the socket
+    ...
+    finally:
+        tool_args.pop('agent', None)     # too late to matter
+
+In host/WebSocket mode the agent runs on its own thread while the forwarder
+drains queued messages, so the window between recording the trace and clearing
+the field is a window in which an Agent object is being JSON-encoded. The
+existing comment on that `pop` says it exists to prevent exactly that warning,
+so the hazard was known and the mitigation was a race.
+
+The fix is not a narrower window. `agent` is not an argument the model supplied
+— it is plumbing — and it does not belong in the record of what was called.
+"""
+
+import json
+
+import pytest
+
+from connectonion.core.tool_executor import execute_single_tool
+
+
+class FakeLogger:
+    def print(self, *a, **k): pass
+    def log_tool_call(self, *a, **k): pass
+
+
+class RecordingAgent:
+    """Captures every trace at the moment it is recorded, not afterwards."""
+
+    def __init__(self):
+        self.io = None
+        self.recorded = []
+        self.current_session = {'messages': [], 'trace': [], 'turn': 1,
+                                'iteration': 0}
+
+    def _invoke_events(self, name):
+        # The real path calls this between recording the tool_call trace and
+        # injecting the agent. A fake without it raises, gets swallowed by the
+        # except, and the test passes having exercised nothing.
+        pass
+
+    def _record_trace(self, entry):
+        # A copy, because the point is what the entry held *then* — the finally
+        # block cleans up after, and asserting later would test the cleanup.
+        self.recorded.append({k: dict(v) if isinstance(v, dict) else v
+                              for k, v in entry.items()})
+
+
+def _tools_with(func, name='needs_agent_tool'):
+    func._needs_agent = True
+    func.__name__ = name
+
+    class Registry:
+        def get(self, n):
+            return func if n == name else None
+    return Registry()
+
+
+class TestATraceCarriesNoLiveObjects:
+
+    def test_the_injected_agent_never_reaches_a_recorded_trace(self):
+        def tool(x, agent=None):
+            return f"got {x}"
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        assert agent.recorded, "nothing was recorded"
+        for entry in agent.recorded:
+            assert 'agent' not in entry.get('args', {}), (
+                "a live Agent was in the trace at the moment it was recorded — "
+                "the forwarder thread can serialise it there"
+            )
+
+    def test_a_recorded_trace_is_json_encodable(self):
+        """The property that actually matters downstream."""
+        def tool(x, agent=None):
+            return "ok"
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        for entry in agent.recorded:
+            json.dumps(entry)  # raises TypeError if an Agent slipped in
+
+    def test_it_holds_for_the_error_path_too(self):
+        """Both paths record before the finally runs."""
+        def tool(x, agent=None):
+            raise RuntimeError('boom')
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        for entry in agent.recorded:
+            assert 'agent' not in entry.get('args', {})
+            json.dumps(entry)
+
+    def test_the_tool_still_receives_the_agent(self):
+        """Keeping it out of the trace must not keep it from the tool."""
+        seen = {}
+
+        def tool(x, agent=None):
+            seen['agent'] = agent
+            return "ok"
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        assert seen['agent'] is agent
+
+    def test_the_callers_dict_is_not_mutated(self):
+        """The caller passed these arguments; they are not ours to edit."""
+        def tool(x, agent=None):
+            return "ok"
+
+        args = {'x': 1}
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', args, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        assert args == {'x': 1}
+
+
+class TestBothCallPaths:
+    """There are two invocations, and only one of them was changed at first.
+
+    A sync-only test passes while an async tool that declares `agent` gets
+    called without it — a TypeError at the point the tool runs, in the path
+    no unit test was covering.
+    """
+
+    def test_an_async_tool_also_receives_the_agent(self):
+        seen = {}
+
+        async def tool(x, agent=None):
+            seen['agent'] = agent
+            return "ok"
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        assert seen.get('agent') is agent, (
+            "the async call site still passes the un-injected dict"
+        )
+
+    def test_an_async_tools_trace_is_also_clean(self):
+        async def tool(x, agent=None):
+            return "ok"
+
+        agent = RecordingAgent()
+        execute_single_tool('needs_agent_tool', {'x': 1}, 'id1',
+                            _tools_with(tool), agent, FakeLogger())
+
+        for entry in agent.recorded:
+            assert 'agent' not in entry.get('args', {})
+            json.dumps(entry)


### PR DESCRIPTION
Closes #382.

Tools that declare `agent` in their signature get the live Agent injected. That injection mutated the caller's dict, and the trace entry holds that dict **by reference**:

```python
"args": tool_args              # by reference
...
tool_args['agent'] = agent     # the trace now holds an Agent
...
agent._record_trace(entry)     # forwarded over the socket
...
finally:
    tool_args.pop('agent')     # after the window that mattered
```

In host mode the agent runs on its own thread while `forward_agent_msgs_to_client` drains and encodes those entries. So the `pop` was a race, not a fix — and its own comment says it exists to prevent `"Non-JSON-serializable object: Agent"` warnings. The hazard was known; the mitigation was timing.

Proven before the fix:

```
AssertionError: a live Agent was in the trace at the moment it was recorded
assert 'agent' not in {'agent': <RecordingAgent object at 0x…>, 'x': 1}
TypeError: Object of type RecordingAgent is not JSON serializable
```

The agent now goes into a call-only copy:

```python
call_args = tool_args
if getattr(tool_func, '_needs_agent', False):
    call_args = {**tool_args, 'agent': agent}
```

Nothing is put into `tool_args`, so there is nothing to take out and no window to lose it in. `agent` is plumbing — not something the model asked for — and does not belong in the record of what was called.

## Two things I got wrong on the way

**The fake agent had no `_invoke_events`.** The real path calls it between recording the tool_call trace and injecting the agent, so the fake raised, the `except` swallowed it, and **four of five tests passed having exercised nothing**:

```
工具拿到 agent: False
record 次数: 2
  args: {'x': 1} | status: error
```

Third time this session a fake diverged from the real object and turned a test green while the code under test never ran.

**Only the sync call site was updated.** `grep` found the other one:

```
264:  result = _run_async_tool(tool_func(**tool_args))   ← still un-injected
266:  result = tool_func(**call_args)
```

An async tool declaring `agent` would have been called without it — a `TypeError` where the tool runs, in a path no unit test covered. Both call sites now, both covered.

3124 unit tests pass.
