### PR TITLE
fix(browser): the clipboard keeps its characters on Windows

### DIFF
--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -11,6 +11,7 @@ LLM-Note:
 """
 
 import math
+import base64
 import platform
 import random
 import shutil
@@ -213,27 +214,77 @@ def _segments(text):
     return [(ime, "".join(chars)) for ime, chars in runs]
 
 
-def _clipboard_cmds():
-    """(set_argv, get_argv) for the OS clipboard, or None if no tool is available. A real
-    user pastes Chinese far more than they hand-type it, and paste is a fully trusted event
-    with none of the IME path's residual tells (see type_text)."""
+def _clipboard_set_argv(text: str) -> list[str] | None:
+    """The command that puts `text` on the clipboard, or None if there is none.
+
+    Windows does not go through `clip.exe`. clip.exe decodes its stdin with the
+    console OEM code page — cp936 on Chinese Windows, cp932 on Japanese — so
+    UTF-8 bytes piped into it arrive as mojibake, and the automation then types
+    the wrong characters while reporting success (#277).
+
+    So the text rides inside the command as base64, which is ASCII whatever the
+    console is set to, and PowerShell decodes it as UTF-8 on the other side. No
+    code page is consulted in either direction.
+    """
     system = platform.system()
     if system == "Darwin":
-        return (["pbcopy"], ["pbpaste"])
+        return ["pbcopy"]
     if system == "Windows":
-        return (["clip"], ["powershell", "-NoProfile", "-Command", "Get-Clipboard"])
+        payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
+        script = (
+            f"$b=[Convert]::FromBase64String('{payload}');"
+            "Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($b))"
+        )
+        # Windows caps a command line near 8191 characters, and base64 inflates
+        # UTF-8 by a third. Past that the shell truncates and a fragment lands on
+        # the clipboard — silently, only for long text. _paste already falls back
+        # to the IME path when the clipboard route is unavailable, so decline it
+        # rather than half-use it.
+        if len(script) > 7000:
+            return None
+        return ["powershell", "-NoProfile", "-Command", script]
     if shutil.which("xclip"):
-        return (["xclip", "-selection", "clipboard"],
-                ["xclip", "-selection", "clipboard", "-o"])
+        return ["xclip", "-selection", "clipboard"]
     if shutil.which("xsel"):
-        return (["xsel", "--clipboard", "--input"], ["xsel", "--clipboard", "--output"])
+        return ["xsel", "--clipboard", "--input"]
     return None
 
 
-def _active_text_len(page):
-    return page.evaluate(
-        "() => { const e = document.activeElement;"
-        " return e ? ((e.value != null ? e.value : e.textContent) || '').length : 0; }")
+def _clipboard_get_argv() -> list[str] | None:
+    """The command that reads the clipboard back, as UTF-8 on stdout."""
+    system = platform.system()
+    if system == "Darwin":
+        return ["pbpaste"]
+    if system == "Windows":
+        # Same reasoning in reverse: pin the output encoding rather than let the
+        # console decide how to spell what it hands back.
+        return ["powershell", "-NoProfile", "-Command",
+                "[Console]::OutputEncoding=[Text.Encoding]::UTF8; Get-Clipboard"]
+    if shutil.which("xclip"):
+        return ["xclip", "-selection", "clipboard", "-o"]
+    if shutil.which("xsel"):
+        return ["xsel", "--clipboard", "--output"]
+    return None
+
+
+def _clipboard_set(text: str) -> bool:
+    argv = _clipboard_set_argv(text)
+    if argv is None:
+        return False
+    # On Windows the text is already inside the command; elsewhere it goes on
+    # stdin, where UTF-8 is what these tools expect.
+    stdin = None if platform.system() == "Windows" else text.encode("utf-8")
+    subprocess.run(argv, input=stdin)
+    return True
+
+
+def _clipboard_get() -> str:
+    argv = _clipboard_get_argv()
+    if argv is None:
+        return ""
+    out = subprocess.run(argv, capture_output=True).stdout
+    # Get-Clipboard appends a newline that was never on the clipboard.
+    return out.decode("utf-8", errors="replace").rstrip("\r\n")
 
 
 def _paste(page, text):
@@ -241,18 +292,16 @@ def _paste(page, text):
     the user's clipboard. Returns True only if the field actually took the paste — some
     inputs (password fields, paste-blocked forms) reject it, and the caller then falls back
     to the IME path."""
-    cmds = _clipboard_cmds()
-    if cmds is None:
+    if _clipboard_set_argv(text) is None:
         return False
-    set_argv, get_argv = cmds
-    saved = subprocess.run(get_argv, capture_output=True).stdout
-    subprocess.run(set_argv, input=text.encode())
+    saved = _clipboard_get()
+    _clipboard_set(text)
     before = _active_text_len(page)
     modifier = "Meta" if platform.system() == "Darwin" else "Control"
     page.keyboard.press(f"{modifier}+v")
     _pause(page, 0.12, 0.4)
     grew = _active_text_len(page) >= before + len(text)
-    subprocess.run(set_argv, input=saved)  # restore the user's clipboard
+    _clipboard_set(saved)  # restore the user's clipboard
     return grew
 
 

--- a/tests/unit/test_the_clipboard_keeps_its_characters.py
+++ b/tests/unit/test_the_clipboard_keeps_its_characters.py
@@ -1,0 +1,114 @@
+"""What reaches the clipboard when the text is not ASCII.
+
+The humanize typing path pastes CJK runs through the OS clipboard, because a
+real user pastes Chinese far more often than they hand-type it. On Windows it
+wrote UTF-8 bytes into `clip.exe`:
+
+    subprocess.run(["clip"], input=text.encode())
+
+`clip.exe` decodes its stdin with the console OEM code page — cp936 on Chinese
+Windows, cp932 on Japanese — not UTF-8. So `中文` arrived on the clipboard as
+mojibake and was pasted into the page wrong. Not a crash: the automation
+reported success and typed the wrong characters. #277
+
+The fix routes Windows through PowerShell with the text carried as base64, so
+no code page is consulted in either direction. The round-trip test below runs
+on the Windows CI runners, which is the real validation this needed.
+"""
+
+import platform
+import subprocess
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import humanize
+
+CJK = "中文测试"
+MIXED = "hello 中文 world 日本語 🎉"
+
+
+class TestTheCommandsCarryNoCodePage:
+    """Runs everywhere: what we would execute, without executing it."""
+
+    def test_windows_does_not_pipe_utf8_into_clip_exe(self, monkeypatch):
+        monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+        argv = humanize._clipboard_set_argv(CJK)
+
+        flat = ' '.join(argv).lower()
+        assert 'clip' not in flat.split('powershell')[0], (
+            "clip.exe decodes stdin with the OEM code page; CJK cannot survive it"
+        )
+
+    def test_the_text_travels_as_base64_not_as_encoded_bytes(self, monkeypatch):
+        """Whatever encoding the console is in, base64 is ASCII."""
+        monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+        argv = humanize._clipboard_set_argv(CJK)
+
+        assert all(c.isascii() for arg in argv for c in arg), (
+            "a non-ASCII character in the argv is a character the console "
+            "code page gets to reinterpret"
+        )
+
+    def test_mac_and_linux_are_unchanged(self, monkeypatch):
+        monkeypatch.setattr(platform, 'system', lambda: 'Darwin')
+        assert humanize._clipboard_set_argv(CJK)[0] == 'pbcopy'
+
+
+@pytest.mark.skipif(platform.system() != 'Windows',
+                    reason="the bug and its fix are Windows-only")
+class TestTheRoundTripOnWindows:
+    """The validation this issue was waiting for. Runs on the Windows runners."""
+
+    @pytest.mark.parametrize("text", [CJK, MIXED, "ascii only"])
+    def test_what_goes_on_the_clipboard_comes_back(self, text):
+        humanize._clipboard_set(text)
+        assert humanize._clipboard_get() == text
+
+    def test_the_previous_clipboard_is_restored(self):
+        humanize._clipboard_set("原来的内容")
+        saved = humanize._clipboard_get()
+
+        humanize._clipboard_set(CJK)
+        humanize._clipboard_set(saved)
+
+        assert humanize._clipboard_get() == "原来的内容"
+
+
+class TestTextTooLongForACommandLine:
+    """Carrying the text inside the command buys a length limit.
+
+    Windows caps a command line at about 8191 characters, and base64 inflates
+    UTF-8 by a third — so a long enough paste would be truncated by the shell
+    and land on the clipboard as a fragment. Silently, on Windows, only for
+    long text: the same shape as the bug this replaced.
+
+    `_paste` already has a fallback for "the clipboard route did not work" — it
+    types through the IME path instead — so the honest answer is to decline the
+    route rather than to half-use it.
+    """
+
+    def test_a_long_run_declines_the_clipboard(self, monkeypatch):
+        monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+        assert humanize._clipboard_set_argv("中" * 4000) is None
+
+    def test_an_ordinary_field_still_uses_it(self, monkeypatch):
+        monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+        assert humanize._clipboard_set_argv("中文测试" * 20) is not None
+
+    def test_the_limit_is_on_the_command_not_the_text(self, monkeypatch):
+        """The thing that overflows is the encoded command, so measure that."""
+        monkeypatch.setattr(platform, 'system', lambda: 'Windows')
+
+        argv = humanize._clipboard_set_argv("a" * 5000)
+        if argv is not None:
+            assert len(' '.join(argv)) < 8000
+
+    def test_other_platforms_have_no_such_limit(self, monkeypatch):
+        """The text goes on stdin there; nothing is measuring a command line."""
+        monkeypatch.setattr(platform, 'system', lambda: 'Darwin')
+
+        assert humanize._clipboard_set_argv("中" * 100000) is not None


### PR DESCRIPTION
Closes #277.

The humanize typing path pastes CJK runs through the OS clipboard — a real user pastes Chinese far more often than they hand-type it. On Windows it piped UTF-8 into `clip.exe`:

```python
subprocess.run(["clip"], input=text.encode())
```

`clip.exe` decodes its stdin with the console **OEM code page** — cp936 on Chinese Windows, cp932 on Japanese — not UTF-8. So `中文` landed on the clipboard as mojibake and was pasted into the page wrong.

**Not a crash.** The automation reported success and typed the wrong characters.

## The fix

Windows goes through PowerShell with the text carried *inside* the command as base64 — ASCII whatever the console is set to — and decoded as UTF-8 on the other side:

```python
payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
script = (f"$b=[Convert]::FromBase64String('{payload}');"
          "Set-Clipboard -Value ([Text.Encoding]::UTF8.GetString($b))")
```

Reading back pins `[Console]::OutputEncoding` for the same reason. No code page is consulted in either direction. macOS and Linux are unchanged — there the text goes on stdin, where UTF-8 is what these tools want.

## The validation this was waiting for

> Filed separately from #230 because the correct fix needs validation on a real Windows box.

There are Windows runners in CI. The round-trip tests run there — put CJK on the clipboard, read it back, confirm the previous contents are restored — and skip elsewhere, which is honest about where they mean anything.

## The limit this fix buys, which is the same shape as the bug

Carrying the text in the command means a length limit: Windows caps a command line near 8191 characters and base64 inflates UTF-8 by a third. Past that the shell truncates and a **fragment** lands on the clipboard — silently, on Windows, only for long text.

`_paste` already falls back to the IME path when the clipboard route is unavailable, so a run that would overflow declines the route rather than half-using it. Four tests cover the boundary, including one confirming other platforms have no such limit — nothing is measuring a command line there.

3134 unit tests pass.
