### PR TITLE
fix(trust): an unreadable list is not an empty one

### DIFF
--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -81,18 +81,36 @@ def _check_list(list_name: str, agent_id: str) -> bool:
     if not list_path.exists():
         _mention_a_legacy_list(list_name)
         return False
+    # An unreadable file is not an empty file.
+    #
+    # This used to be `except Exception: return False`, which is the safe
+    # direction for whitelist and contacts and fail-open for blocklist: a
+    # blocklist.txt saved as GBK by a Windows editor, or left root-owned by a
+    # deploy, raises on read and every blocked address is admitted. Same
+    # swallow, safe one way and dangerous the other, which is why it lasted —
+    # the direction that matters is the one nobody tests.
+    #
+    # Absent is an answer, and still returns False above. Unreadable is a
+    # question this agent cannot answer, so it says which file and stops.
     try:
         content = list_path.read_text(encoding='utf-8')
-        agent_id = agent_id.strip().lower()
-        for line in content.strip().split('\n'):
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if _matches(agent_id, line.lower()):
-                return True
-        return False
-    except Exception:
-        return False
+    except OSError as exc:
+        raise OSError(f"cannot read {list_path}: {exc}") from exc
+    except UnicodeDecodeError as exc:
+        raise UnicodeDecodeError(
+            exc.encoding, exc.object, exc.start, exc.end,
+            f"{list_path} is not UTF-8 — an editor may have saved it in a "
+            f"local code page; re-save it as UTF-8"
+        ) from None
+
+    agent_id = agent_id.strip().lower()
+    for line in content.strip().split('\n'):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if _matches(agent_id, line.lower()):
+            return True
+    return False
 
 
 def _matches(agent_id: str, pattern: str) -> bool:
@@ -361,15 +379,27 @@ def load_admins(co_dir: Path = None) -> set:
             pass
 
     # Additional admins from this agent's own admins.txt
+    # Same reasoning as _check_list, and the cost is higher since #579: the
+    # approval dialog is admins-only, so an admins.txt that cannot be read does
+    # not merely lose a permission — every approval the owner attempts comes
+    # back "you are stranger", naming the wrong reason, about a file nothing
+    # mentions.
     admins_file = _admins_file(co_dir)
     if admins_file.exists():
         try:
-            for line in admins_file.read_text(encoding='utf-8').splitlines():
-                line = line.strip()
-                if line and not line.startswith('#'):
-                    admins.add(line)
-        except Exception:
-            pass
+            content = admins_file.read_text(encoding='utf-8')
+        except OSError as exc:
+            raise OSError(f"cannot read {admins_file}: {exc}") from exc
+        except UnicodeDecodeError as exc:
+            raise UnicodeDecodeError(
+                exc.encoding, exc.object, exc.start, exc.end,
+                f"{admins_file} is not UTF-8 — an editor may have saved it in "
+                f"a local code page; re-save it as UTF-8"
+            ) from None
+        for line in content.splitlines():
+            line = line.strip()
+            if line and not line.startswith('#'):
+                admins.add(line)
 
     return admins
 

--- a/tests/unit/test_an_unreadable_list_is_not_empty.py
+++ b/tests/unit/test_an_unreadable_list_is_not_empty.py
@@ -1,0 +1,115 @@
+"""What a trust list that cannot be read should mean.
+
+`_check_list` wrapped its read in `except Exception: return False`. For the
+whitelist that is the safe direction — an unreadable grant grants nothing. For
+the **blocklist it is fail-open**: `is_blocked()` answers False, and everyone on
+the list is admitted.
+
+The way to get there is ordinary. An operator opens `blocklist.txt` in a Windows
+editor and saves it as GBK; the next read raises UnicodeDecodeError. Or the file
+ends up owned by root after a deploy and the agent cannot read it. Either way
+the deny list silently stops denying, and nothing anywhere says so.
+
+Same swallow, safe in one direction and dangerous in the other, which is why it
+survived: the direction that matters is the one nobody tests.
+
+An unreadable file is not an empty file. It is a question this agent cannot
+answer, and the honest response is to say so rather than to guess "no".
+"""
+
+import importlib
+
+import pytest
+
+tools = importlib.import_module('connectonion.network.trust.tools')
+
+BLOCKED = '0x' + 'b' * 64
+
+
+@pytest.fixture
+def agent_dir(tmp_path, monkeypatch):
+    (tmp_path / '.co').mkdir()
+    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path / '.co'
+
+
+class TestABrokenBlocklistDoesNotUnblock:
+
+    def test_undecodable_bytes_do_not_read_as_not_blocked(self, agent_dir):
+        # What a Windows editor saving as GBK leaves behind.
+        (agent_dir / 'blocklist.txt').write_bytes(
+            BLOCKED.encode() + b'\n\xd6\xd0\xce\xc4\n')
+
+        with pytest.raises(Exception) as exc:
+            tools.is_blocked(BLOCKED)
+
+        assert 'blocklist' in str(exc.value), (
+            "the failure must name the file the operator has to fix"
+        )
+
+    def test_an_unreadable_file_does_not_read_as_not_blocked(self, agent_dir):
+        path = agent_dir / 'blocklist.txt'
+        path.write_text(BLOCKED + '\n')
+        path.chmod(0o000)
+        try:
+            with pytest.raises(Exception):
+                tools.is_blocked(BLOCKED)
+        finally:
+            path.chmod(0o644)
+
+
+class TestTheOtherListsSayItToo:
+    """A whitelist that cannot be read already failed closed. It failed closed
+    *silently*, which is how an operator spends an afternoon on 'why is my
+    colleague being asked to onboard again'."""
+
+    def test_a_broken_whitelist_is_loud(self, agent_dir):
+        (agent_dir / 'whitelist.txt').write_bytes(b'\xd6\xd0\xce\xc4\n')
+
+        with pytest.raises(Exception) as exc:
+            tools.is_whitelisted('0x' + 'a' * 64)
+
+        assert 'whitelist' in str(exc.value)
+
+
+class TestNothingElseChanges:
+
+    def test_a_missing_file_is_still_simply_absent(self, agent_dir):
+        """Absent is an answer. Unreadable is not."""
+        assert tools.is_blocked(BLOCKED) is False
+        assert tools.is_whitelisted('0x' + 'a' * 64) is False
+
+    def test_a_readable_list_still_works(self, agent_dir):
+        (agent_dir / 'blocklist.txt').write_text(BLOCKED + '\n')
+
+        assert tools.is_blocked(BLOCKED) is True
+        assert tools.is_blocked('0x' + 'c' * 64) is False
+
+
+class TestAnUnreadableAdminsFileDoesNotDemoteTheOwner:
+    """`load_admins` swallowed the same way, and the cost went up in #579.
+
+    Since the approval dialog belongs to admins only, an admins.txt that cannot
+    be read no longer just loses a permission — it makes every approval the
+    owner attempts come back "you are stranger". They would be reading a
+    refusal that names the wrong reason, about a file nothing mentions.
+    """
+
+    def test_undecodable_admins_txt_is_loud(self, agent_dir):
+        (agent_dir / 'admins.txt').write_bytes(b'\xd6\xd0\xce\xc4\n')
+
+        with pytest.raises(Exception) as exc:
+            tools.load_admins(agent_dir)
+
+        assert 'admins' in str(exc.value)
+
+    def test_a_missing_admins_txt_is_still_fine(self, agent_dir):
+        """A fresh project has no admins.txt and must still start."""
+        assert isinstance(tools.load_admins(agent_dir), set)
+
+    def test_a_readable_admins_txt_still_works(self, agent_dir):
+        owner = '0x' + '1' * 64
+        (agent_dir / 'admins.txt').write_text(owner + '\n')
+
+        assert owner in tools.load_admins(agent_dir)


### PR DESCRIPTION
`_check_list` wrapped its read in one line:

```python
except Exception:
    return False
```

For `whitelist` and `contacts` that is the safe direction — an unreadable grant grants nothing. **For the blocklist it is fail-open**: `is_blocked()` answers `False`, and everyone on the list is admitted.

Getting there is ordinary:

- an operator opens `blocklist.txt` in a Windows editor and saves it as GBK → `UnicodeDecodeError` on the next read
- a deploy leaves the file root-owned → `PermissionError`

Either way the deny list stops denying and nothing anywhere says so.

Same swallow, safe one way and dangerous the other — which is why it lasted. **The direction that matters is the one nobody tests.** Proven red:

```
Failed: DID NOT RAISE <class 'Exception'>   ← is_blocked() on a GBK blocklist
```

## `load_admins` did it too, and #579 raised the price

The approval dialog is admins-only since #579. So an `admins.txt` that cannot be read no longer merely loses a permission — **every approval the owner attempts comes back "you are stranger"**, naming the wrong reason, about a file nothing mentions. They would debug the trust layer for an afternoon over a file their editor re-encoded.

## What changed, exactly

- **Absent is still an answer.** A fresh project has no `blocklist.txt` and must start; that still returns `False`.
- **Unreadable is not an answer.** It names the file and stops.
- For the encoding case it also says what to do, because "this file is not UTF-8" is not obvious when your editor did it silently:

```
.co/blocklist.txt is not UTF-8 — an editor may have saved it in a local
code page; re-save it as UTF-8
```

This follows the project's stated preference for letting things crash rather than adding `try/except/pass` — here the swallow was not merely hiding an error, it was inverting a security decision.

3135 unit tests pass.
