### PR TITLE
fix(auth): a trust list the agent cannot read still answers the client

### DIFF
--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: TrustAgent handles all trust state (whitelist, contacts, blocklist in ~/.co/)
   Integration: exposes verify_signature(), extract_and_authenticate(), get_agent_address(), is_custom_trust() | used by host() to enforce authentication
   Performance: TrustAgent.should_allow() runs fast rules first (zero tokens), only uses LLM for 'ask' cases
-  Errors: returns error strings: "unauthorized: ...", "forbidden: ..." | does NOT raise exceptions
+  Errors: returns error strings: "unauthorized: ...", "forbidden: ...", "misconfigured: ..." (a trust list the agent cannot read) | does NOT raise exceptions
 Authentication and signature verification for hosted agents.
 
 Trust evaluation (via TrustAgent.should_allow()):
@@ -129,7 +129,19 @@ def extract_and_authenticate(data: dict, trust, *, blacklist=None, whitelist=Non
         # Unknown type (e.g., Agent) - use default "careful"
         trust_agent = TrustAgent("careful")
 
-    decision = trust_agent.should_allow(agent_address, request_data)
+    # A trust list this agent cannot read raises rather than answering "not
+    # blocked" (#585). That is right, and it needs an exit here: the WebSocket
+    # session loop lets exceptions propagate out, so an unhandled one closes the
+    # socket with nothing sent — the client sees a connection that died and no
+    # reason, which is #434 arriving by a new route.
+    #
+    # This module's contract is to return error strings, so it keeps it: refuse,
+    # name the file, and let the ERROR frame carry it to whoever is holding the
+    # other end. Fail closed, and say why.
+    try:
+        decision = trust_agent.should_allow(agent_address, request_data)
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, agent_address, True, f"misconfigured: {exc}"
 
     if decision.allow:
         return prompt, agent_address, True, None

--- a/tests/unit/test_a_broken_list_still_answers.py
+++ b/tests/unit/test_a_broken_list_still_answers.py
@@ -1,0 +1,110 @@
+"""What the client hears when the agent's own config is broken.
+
+#585 made an unreadable trust list raise instead of quietly answering "not
+blocked". That was right — a blocklist that cannot be read was admitting
+everyone on it — but it moved the failure somewhere with no exit.
+
+`auth.py` documents its contract as:
+
+    Errors: returns error strings: "unauthorized: ...", "forbidden: ..."
+            | does NOT raise exceptions
+
+and the WebSocket session loop documents the other side of it:
+
+    other exceptions propagate out (transport-level errors, programmer bugs)
+
+So a GBK-saved blocklist.txt now kills the connection with nothing sent. The
+client sees a socket close and no reason — which is exactly the shape of #434,
+arriving by a new route.
+
+An agent whose config it cannot read should say so, to the person holding the
+other end of the socket, and refuse. Not guess, and not vanish.
+"""
+
+import importlib
+import json
+import time
+
+import pytest
+
+from connectonion.network.host.auth import extract_and_authenticate
+
+tools = importlib.import_module('connectonion.network.trust.tools')
+
+
+def _signed_request(tmp_path):
+    """A properly signed CONNECT, so the failure under test is the list read."""
+    from nacl.signing import SigningKey
+
+    key = SigningKey.generate()
+    address = "0x" + key.verify_key.encode().hex()
+    payload = {"prompt": "hello", "timestamp": time.time()}
+    canonical = json.dumps(payload, sort_keys=True, separators=(',', ':'))
+    return {
+        "payload": payload,
+        "from": address,
+        "signature": key.sign(canonical.encode()).signature.hex(),
+    }
+
+
+@pytest.fixture
+def agent_with_a_broken_blocklist(tmp_path, monkeypatch):
+    co = tmp_path / '.co'
+    co.mkdir()
+    # What a Windows editor saving as GBK leaves behind.
+    (co / 'blocklist.txt').write_bytes(b'\xd6\xd0\xce\xc4\n')
+    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestTheClientIsToldRatherThanDropped:
+
+    def test_it_does_not_raise_out_of_the_auth_boundary(
+            self, agent_with_a_broken_blocklist):
+        """The module's documented contract, and the socket's only chance to
+        say anything."""
+        from connectonion.network.trust import TrustAgent
+
+        prompt, address, sig_ok, error = extract_and_authenticate(
+            _signed_request(agent_with_a_broken_blocklist), TrustAgent('careful'))
+
+        assert error, "a broken blocklist produced no error for the client"
+
+    def test_the_error_names_the_file(self, agent_with_a_broken_blocklist):
+        from connectonion.network.trust import TrustAgent
+
+        _, _, _, error = extract_and_authenticate(
+            _signed_request(agent_with_a_broken_blocklist), TrustAgent('careful'))
+
+        assert 'blocklist' in error, (
+            f"the operator has to know which file to fix; got: {error!r}"
+        )
+
+    def test_it_refuses_rather_than_admits(self, agent_with_a_broken_blocklist):
+        """Fail closed. The list that could not be read is a deny list."""
+        from connectonion.network.trust import TrustAgent
+
+        prompt, _, _, error = extract_and_authenticate(
+            _signed_request(agent_with_a_broken_blocklist), TrustAgent('careful'))
+
+        assert prompt is None
+        assert error
+
+
+class TestAWorkingAgentIsUnaffected:
+
+    def test_a_readable_list_still_authenticates(self, tmp_path, monkeypatch):
+        from connectonion.network.trust import TrustAgent
+
+        co = tmp_path / '.co'
+        co.mkdir()
+        (co / 'blocklist.txt').write_text('')
+        monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+        monkeypatch.chdir(tmp_path)
+
+        _, _, sig_ok, error = extract_and_authenticate(
+            _signed_request(tmp_path), TrustAgent('open'))
+
+        assert sig_ok
+        assert error is None


### PR DESCRIPTION
Follow-on to #585, and an example of the thing this loop keeps finding: a fix for one silent failure creating another.

#585 made an unreadable trust list raise instead of quietly answering "not blocked" — correct, because a blocklist that could not be read was admitting everyone on it. But it moved the failure somewhere with no exit.

`auth.py` states its contract:

```
Errors: returns error strings: "unauthorized: ...", "forbidden: ..."
        | does NOT raise exceptions
```

and the WebSocket session loop states the other half:

```
other exceptions propagate out (transport-level errors, programmer bugs)
```

So a GBK-saved `blocklist.txt` closed the socket with **nothing sent**. The client saw a connection that died and no reason — #434, arriving by a new route, introduced by the fix for a different silent failure.

Proven red:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd6 in position 0:
  …/.co/blocklist.txt is not UTF-8 …
   ↑ raised straight out of extract_and_authenticate()
```

## The fix

The auth boundary keeps its contract — refuse, name the file, and let the ERROR frame carry it:

```
misconfigured: .co/blocklist.txt is not UTF-8 — an editor may have saved it
in a local code page; re-save it as UTF-8
```

Fail closed, and say why. openonion/connectonion-react#8 is what makes that frame land as a message rather than a 30-second timeout, so the two halves meet.

## The other paths, checked rather than assumed

- **Scheduler**: already catches per entry and records `failed` with the reason — that is what produces the `<entry> failed:` lines in a live agent's log.
- **WS input thread**: stores the exception, and the forwarder emits it as `ERROR`.

Both had exits. This one did not.

3139 unit tests pass.
