### PR TITLE
fix(deploy): a deploy that left root-owned files says so

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -670,19 +670,32 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
         text=True,
         timeout=600,
     )
-    if result.returncode == 0:
-        # Every deploy, not only when the unit changes: the files have to belong
-        # to the user the service runs as. An agent that ran as root before left
-        # root-owned logs and state behind, and the first thing the unprivileged
-        # process does is fail to write its own log —
-        # PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
-        _ssh(target, f"sudo chown -R {_remote_user(target)}: {SRV}/{agent}", timeout=120)
-
     if result.returncode != 0:
         console.print("[red]rsync failed.[/red]")
         for line in (result.stderr or result.stdout).strip().splitlines()[-8:]:
             console.print(f"  [dim]{line}[/dim]")
         return False
+
+    # Every deploy, not only when the unit changes: the files have to belong
+    # to the user the service runs as. An agent that ran as root before left
+    # root-owned logs and state behind, and the first thing the unprivileged
+    # process does is fail to write its own log —
+    # PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
+    #
+    # And the result is checked, because this step exists to prevent a specific
+    # failure and used to discard whether it happened. A box where sudo wants a
+    # password reported a successful deploy and an agent that broke on its first
+    # write — and, since #585, on its first read of a trust list, with an error
+    # naming a file whose real cause was this line.
+    chown = _ssh(target, f"sudo chown -R {_remote_user(target)}: {SRV}/{agent}",
+                 timeout=120)
+    if chown.returncode != 0:
+        console.print("[red]chown failed — the deployed files may still be "
+                      "root-owned, and the agent cannot read or write them.[/red]")
+        for line in (chown.stderr or chown.stdout).strip().splitlines()[-4:]:
+            console.print(f"  [dim]{line}[/dim]")
+        return False
+
     return True
 
 
@@ -814,6 +827,29 @@ def _restart(target: str, agent: str) -> bool:
     return True
 
 
+def _record_port(target: str, agent: str, port: int) -> None:
+    """Write down the port this agent keeps, and say so if that did not work.
+
+    `_port_for` reads this file on the next deploy. When it is missing the port
+    is probed again — and the old one is now held by the running agent, so a
+    different one is chosen, Caddy is rewritten to follow, and the operator
+    reads "8000 is taken on this machine" every deploy with no cause they can
+    find. The port climbs by one each time.
+
+    Not an outage, so not a reason to fail the deploy. Worth one line.
+    """
+    result = _ssh(
+        target,
+        f"mkdir -p {SRV}/{agent}/.co && echo {port} > {SRV}/{agent}/.co/port",
+        timeout=60,
+    )
+    if result.returncode != 0:
+        console.print(f"[yellow]could not record port {port} on the server — "
+                      f"the next deploy will choose a new one[/yellow]")
+        for line in (result.stderr or result.stdout).strip().splitlines()[-2:]:
+            console.print(f"  [dim]{line}[/dim]")
+
+
 def _mark_provisioned(target: str, agent: str) -> None:
     from ... import __version__
     marker = json.dumps({"schema": PROVISION_SCHEMA,
@@ -898,8 +934,7 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
     port = _port_for(target, agent, project["port"])
     if port != project["port"]:
         console.print(f"  [dim]port {port} — 8000 is taken on this machine[/dim]")
-    _ssh(target, f"mkdir -p {SRV}/{agent}/.co && echo {port} > {SRV}/{agent}/.co/port",
-         timeout=60)
+    _record_port(target, agent, port)
 
     if hostname and not _ensure_caddy(target, agent, hostname, port):
         return False

--- a/tests/unit/test_a_deploy_reports_what_it_left_behind.py
+++ b/tests/unit/test_a_deploy_reports_what_it_left_behind.py
@@ -1,0 +1,116 @@
+"""The deploy step whose whole job is preventing a permission failure.
+
+`_sync_code` chowns the deployed tree to the user the service runs as, and the
+comment above it says exactly why:
+
+    An agent that ran as root before left root-owned logs and state behind, and
+    the first thing the unprivileged process does is fail to write its own log —
+    PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
+
+Then it discarded whether the chown worked:
+
+    _ssh(target, f"sudo chown -R {user}: {SRV}/{agent}", timeout=120)
+
+If sudo is not passwordless on that box, or the chown fails for any other
+reason, the deploy prints success and the agent breaks on its first write. Since
+#585 it also breaks on its first *read* of a trust list, with "cannot read
+.co/blocklist.txt" — a runtime error whose cause was a deploy that said it was
+fine.
+
+A step that exists to prevent a specific failure has to say when it did not.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def _ok(stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail(stderr="sudo: a password is required"):
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / 'agent.py').write_text("# agent\n")
+    return tmp_path
+
+
+class TestAFailedChownFailsTheDeploy:
+
+    def test_it_does_not_report_success(self, project, capsys):
+        with patch.object(dts.subprocess, 'run', return_value=_ok()), \
+             patch.object(dts, '_ssh', return_value=_fail()), \
+             patch.object(dts, '_remote_user', return_value='co'):
+            ok = dts._sync_code('host', 'ledger', project)
+
+        assert ok is False, (
+            "the tree may still be root-owned and the deploy said it was fine"
+        )
+
+    def test_it_says_what_is_wrong(self, project, capsys):
+        with patch.object(dts.subprocess, 'run', return_value=_ok()), \
+             patch.object(dts, '_ssh', return_value=_fail()), \
+             patch.object(dts, '_remote_user', return_value='co'):
+            dts._sync_code('host', 'ledger', project)
+
+        out = capsys.readouterr().out
+        assert 'chown' in out.lower() or 'owner' in out.lower(), out
+        assert 'sudo' in out, "the reason sudo gave is the actionable part"
+
+
+class TestNothingElseChanges:
+
+    def test_a_working_deploy_still_succeeds(self, project):
+        with patch.object(dts.subprocess, 'run', return_value=_ok()), \
+             patch.object(dts, '_ssh', return_value=_ok()), \
+             patch.object(dts, '_remote_user', return_value='co'):
+            assert dts._sync_code('host', 'ledger', project) is True
+
+    def test_a_failed_rsync_still_fails_first(self, project, capsys):
+        """rsync failing means there is nothing to chown; that message wins."""
+        with patch.object(dts.subprocess, 'run', return_value=_fail("rsync: boom")), \
+             patch.object(dts, '_ssh', return_value=_ok()), \
+             patch.object(dts, '_remote_user', return_value='co'):
+            assert dts._sync_code('host', 'ledger', project) is False
+
+        assert 'rsync' in capsys.readouterr().out.lower()
+
+
+class TestTheRecordedPortIsWrittenOrMentioned:
+    """`.co/port` is how the next deploy knows which port this agent kept.
+
+    The write was unchecked. When it fails, `_port_for` finds nothing recorded
+    on the next deploy, probes for a free port — and the old one is now held by
+    the running agent, so it picks a different one. Caddy is rewritten to
+    follow, so this is not an outage; it is a port that climbs by one every
+    deploy while the operator reads "8000 is taken on this machine" with no
+    cause they can find.
+
+    Not worth failing a deploy over. Worth one line.
+    """
+
+    def test_a_failed_write_is_mentioned(self, capsys):
+        from unittest.mock import patch
+
+        with patch.object(dts, '_ssh', return_value=_fail("Read-only file system")):
+            dts._record_port('host', 'ledger', 8003)
+
+        out = capsys.readouterr().out
+        assert 'port' in out.lower()
+        assert '8003' in out
+
+    def test_a_successful_write_says_nothing(self, capsys):
+        from unittest.mock import patch
+
+        with patch.object(dts, '_ssh', return_value=_ok()):
+            dts._record_port('host', 'ledger', 8003)
+
+        assert capsys.readouterr().out == ""


### PR DESCRIPTION
`_sync_code` chowns the deployed tree to the user the service runs as. The comment above that line says exactly why it exists:

```python
# An agent that ran as root before left root-owned logs and state behind, and
# the first thing the unprivileged process does is fail to write its own log —
# PermissionError: [Errno 13] Permission denied: '.co/logs/oo.log'
_ssh(target, f"sudo chown -R {_remote_user(target)}: {SRV}/{agent}", timeout=120)
```

…and then discarded whether it worked.

On a box where `sudo` wants a password, the deploy printed success and the agent broke on its first write. **Since #585 it also breaks on its first read of a trust list** — `cannot read .co/blocklist.txt` — a runtime error whose real cause was a deploy that said it was fine.

Proven red:

```
assert True is False
  — the tree may still be root-owned and the deploy said it was fine
```

A step that exists to prevent a specific failure has to say when it did not, so this one now fails the deploy and prints what sudo said.

## The other two unchecked writes, graded honestly

**`.co/port` — a warning, not a failure.** It is what `_port_for` reads next time. When it is missing the port is probed again; the old one is now held by the running agent, so a different one is chosen, and Caddy is rewritten to follow. **Not an outage** — I initially thought it was a 502 and checked rather than shipped that claim. What it actually is: a port that climbs by one every deploy while the operator reads `port N — 8000 is taken on this machine` with no cause they can find. One line of warning is the right weight.

**`_mark_provisioned` — left unchecked on purpose.** Losing that marker re-runs an idempotent setup on the next deploy. It costs time and nothing else.

3145 unit tests pass.
