### PR TITLE
fix(init): a new project does not inherit your Gmail and Outlook tokens

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -316,8 +316,13 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     # Always copy from global keys.env (includes AGENT_ADDRESS, AGENT_EMAIL, and API keys)
     if global_keys_env.exists() and global_keys_env.stat().st_size > 0:
         # Copy global keys to project
+        from .env_inheritance import is_personal_account_credential
+
         with open(global_keys_env, 'r', encoding='utf-8') as f:
-            env_content = f.read()
+            env_content = "".join(
+                line for line in f
+                if not is_personal_account_credential(line.strip().split('=', 1)[0])
+            )
 
         # AGENT_CONFIG_PATH is deliberately not written here. Every tool that
         # reads it already falls back to ~/.co on the machine it is running on

--- a/connectonion/cli/commands/env_inheritance.py
+++ b/connectonion/cli/commands/env_inheritance.py
@@ -1,0 +1,27 @@
+"""What a new project inherits from the machine that made it.
+
+Shared by `co init` and `co create`, which each build the project .env
+from ~/.co/keys.env and had drifted into doing it differently.
+"""
+
+# Credentials that authorise reaching into someone's personal accounts. They
+# live in ~/.co/keys.env because a tool integration put them there — `co gmail
+# auth`, `co outlook auth` — and they belong to that machine's operator, not to
+# every project made on it.
+#
+# `co init` used to copy the whole of keys.env into the new project's .env. On a
+# machine with Gmail and Outlook connected that meant live OAuth *refresh*
+# tokens in every project directory, with a .gitignore written only when the
+# directory was already a git repo — one `git add .` from being published — and
+# `co deploy` then delivering them to a server made for an unrelated agent.
+#
+# A prefix rule rather than a list of names, so a scope or an expiry field added
+# next to them later is covered without anyone remembering to.
+PERSONAL_ACCOUNT_PREFIXES = ('GOOGLE_', 'MICROSOFT_')
+
+
+def is_personal_account_credential(key: str) -> bool:
+    """Whether this keys.env entry authorises access to a person's own account."""
+    return key.startswith(PERSONAL_ACCOUNT_PREFIXES)
+
+

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -165,6 +165,8 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # Authenticate to get OPENONION_API_KEY (always, for everyone)
     auth_success = authenticate(global_co_dir, save_to_project=False)
 
+    from .env_inheritance import is_personal_account_credential
+
     # Handle .env file - append API keys from global config
     env_path = Path(current_dir) / ".env"
     global_dir = Path.home() / ".co"
@@ -185,6 +187,13 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
                 line = line.strip()
                 if line and not line.startswith('#') and '=' in line:
                     key = line.split('=')[0].strip()
+                    if is_personal_account_credential(key):
+                        # Filtered at the source, so both write paths are clean.
+                        # Filtering only where keys are appended left the branch
+                        # that creates a fresh .env pouring the whole file in —
+                        # the unit tests were green and a real `co init` still
+                        # wrote the refresh tokens.
+                        continue
                     global_keys[key] = line
 
     # Read existing .env: overwrite identity keys, track existing keys

--- a/tests/unit/test_init_does_not_copy_your_tokens.py
+++ b/tests/unit/test_init_does_not_copy_your_tokens.py
@@ -1,0 +1,91 @@
+"""What a new project inherits from the machine that made it.
+
+`co init` appended every entry of ~/.co/keys.env to the new project's .env:
+
+    for key, line in global_keys.items():
+        if key not in existing_keys:
+            keys_to_add.append(line)
+
+That file accumulates. On a machine where `co gmail auth` and `co outlook auth`
+have run it holds live OAuth *refresh* tokens for both. Observed from a clean
+install of the wheel, in an empty directory:
+
+    GOOGLE_ACCESS_TOKEN      MICROSOFT_ACCESS_TOKEN
+    GOOGLE_REFRESH_TOKEN     MICROSOFT_REFRESH_TOKEN
+    GOOGLE_EMAIL             MICROSOFT_EMAIL
+
+A .gitignore is written only when the directory is already a git repo, so
+`co init` followed by `git init` leaves them untracked-but-not-ignored, one
+`git add .` from publication. `co deploy` also delivers .env to the server,
+which puts a personal Gmail refresh token on a box built for an unrelated agent.
+
+The identity keys are a different case and are left alone: AGENT_ADDRESS,
+OPENONION_API_KEY, AGENT_EMAIL and IS_EMAIL_ACTIVE are propagated on purpose —
+the code says so, "co reset must propagate" — and that is a design decision, not
+an oversight.
+
+`co create` built the same file by a different route and had the same hole. Both
+now ask the same question.
+"""
+
+import pytest
+
+from connectonion.cli.commands.env_inheritance import is_personal_account_credential
+
+
+class TestSomeonesOwnAccountsStayBehind:
+
+    @pytest.mark.parametrize("key", [
+        "GOOGLE_ACCESS_TOKEN", "GOOGLE_REFRESH_TOKEN", "GOOGLE_EMAIL",
+        "GOOGLE_SCOPES", "GOOGLE_TOKEN_EXPIRES_AT",
+        "MICROSOFT_ACCESS_TOKEN", "MICROSOFT_REFRESH_TOKEN",
+        "MICROSOFT_EMAIL", "MICROSOFT_SCOPES", "MICROSOFT_TOKEN_EXPIRES_AT",
+    ])
+    def test_it_is_recognised(self, key):
+        assert is_personal_account_credential(key), (
+            f"{key} would be written into every new project on this machine"
+        )
+
+    def test_a_field_added_next_to_them_later_is_covered(self):
+        """A prefix rule, so nobody has to remember to extend a list."""
+        assert is_personal_account_credential("GOOGLE_ID_TOKEN")
+        assert is_personal_account_credential("MICROSOFT_TENANT_ID")
+
+
+class TestWhatANewProjectStillGets:
+
+    @pytest.mark.parametrize("key", [
+        "OPENONION_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+        "ANTHROPIC_API_KEY", "GROQ_API_KEY",
+    ])
+    def test_provider_keys_are_inherited(self, key):
+        assert not is_personal_account_credential(key)
+
+    @pytest.mark.parametrize("key", ["AGENT_ADDRESS", "AGENT_EMAIL",
+                                     "IS_EMAIL_ACTIVE"])
+    def test_identity_keys_are_left_alone(self, key):
+        """Propagated on purpose — see IDENTITY_KEYS in init.py. Not this
+        change's business to reverse."""
+        assert not is_personal_account_credential(key)
+
+    def test_the_invite_code_is_not_swept_up(self):
+        assert not is_personal_account_credential("CO_INVITE_CODE")
+
+
+class TestBothCommandsAskTheSameQuestion:
+    """`co init` and `co create` build this file by different routes. Only one
+    of them was fixed on the first attempt, and the real CLI showed it — the
+    unit tests were green while a real `co init` still wrote the tokens."""
+
+    @pytest.mark.parametrize("module", [
+        "connectonion.cli.commands.init",
+        "connectonion.cli.commands.create",
+    ])
+    def test_it_consults_the_shared_rule(self, module):
+        import importlib
+        import inspect
+
+        source = inspect.getsource(importlib.import_module(module))
+        assert "is_personal_account_credential" in source, (
+            f"{module} builds a project .env without asking"
+        )


### PR DESCRIPTION
**`co init` in an empty directory wrote the operator's live OAuth refresh tokens into the project.**

It copied `~/.co/keys.env` into the new project's `.env`. That file accumulates: on a machine where `co gmail auth` and `co outlook auth` have run it holds refresh tokens for both. Observed from a clean install of the built wheel, in a directory that was empty a second earlier:

```
GOOGLE_ACCESS_TOKEN      MICROSOFT_ACCESS_TOKEN
GOOGLE_REFRESH_TOKEN     MICROSOFT_REFRESH_TOKEN
GOOGLE_EMAIL             MICROSOFT_EMAIL
```

Where they go from there:

- `.gitignore` is written **only when the directory is already a git repo**. `co init` then `git init` leaves them untracked-but-not-ignored — one `git add .` from being published.
- `co deploy` delivers `.env` to the server, putting a personal Gmail refresh token on a box built for an unrelated agent.

The comment immediately above that read already reasons about this file being *"deployed, cloned or handed to a colleague"* — about an absolute path — while copying the refresh tokens.

## Scope

Filtered where `keys.env` is read, so both write paths are covered, and by **prefix** rather than a list of names, so a scope or expiry field added beside them later is included without anyone remembering to.

**The identity keys are left alone.** `AGENT_ADDRESS`, `OPENONION_API_KEY`, `AGENT_EMAIL`, `IS_EMAIL_ACTIVE` are propagated on purpose — the code says `co reset must propagate` — and that is a design decision, not this change's to reverse.

`co create` builds the same file by a different route and had the same hole. Both now ask the same question, and a test reads their source to check they do.

## Two wrong versions before this one

Both had green unit tests while a real `co init` still wrote the tokens:

1. **Patched `create.py`.** That is what `co create` uses; `co init` uses `init.py`.
2. **Filtered the append loop in `init.py`.** A *fresh* `.env` is written by the other branch, which poured the whole file in.

Verified from a built wheel in a clean venv, which is the only reason either mistake surfaced:

```
OPENONION_API_KEY  AGENT_EMAIL  IS_EMAIL_ACTIVE  AGENT_ADDRESS
AGENT_CONFIG_PATH  CO_INVITE_CODE  GEMINI_API_KEY
```

3167 unit tests pass.
