### PR TITLE
fix(init): the invite code is written once, not twice

### DIFF
--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -231,6 +231,12 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
         code = "-".join("".join(_secrets.choice(alphabet) for _ in range(5)) for _ in range(3))
         keys_to_add.append(f"CO_INVITE_CODE={code}")
         global_keys["CO_INVITE_CODE"] = f"CO_INVITE_CODE={code}"
+        # In global_keys so the branch that writes a *fresh* .env includes it,
+        # and in existing_keys so the branch that appends to one does not add it
+        # a second time. Without this the file got the same code on two lines,
+        # and a duplicate in the file holding the agent's way in is how people
+        # stop trusting the file.
+        existing_keys.add("CO_INVITE_CODE")
 
     for key, line in global_keys.items():
         if key not in existing_keys:

--- a/tests/unit/test_the_env_has_no_duplicate_lines.py
+++ b/tests/unit/test_the_env_has_no_duplicate_lines.py
@@ -1,0 +1,86 @@
+"""One line per key in the file that carries the secrets.
+
+`co init` into a directory that already has a .env without an invite code wrote
+CO_INVITE_CODE twice:
+
+    8:CO_INVITE_CODE=LYA8Q-HM596-SWE8A
+   14:CO_INVITE_CODE=LYA8Q-HM596-SWE8A
+
+Same value both times, so nothing was granted twice — but a duplicated line in
+the file that holds the agent's way in is the kind of thing that makes people
+stop trusting the file, and the next reader has to work out which one wins
+before they can change it.
+
+The cause is one key on two paths. It is appended to keys_to_add when minted,
+and also put into global_keys so the branch that writes a *fresh* .env includes
+it — and the branch that appends to an existing .env then walks global_keys and
+adds it a second time.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _duplicate_keys(text: str) -> list:
+    seen, dupes = set(), []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if '=' not in stripped or stripped.startswith('#'):
+            continue
+        key = stripped.split('=', 1)[0].strip()
+        if key in seen:
+            dupes.append(key)
+        seen.add(key)
+    return dupes
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    (tmp_path / 'home' / '.co').mkdir(parents=True)
+    (tmp_path / 'home' / '.co' / 'keys.env').write_text(
+        "OPENONION_API_KEY=key\nAGENT_ADDRESS=0xabc\n")
+    return tmp_path
+
+
+class TestNoKeyIsWrittenTwice:
+
+    def test_an_existing_env_without_a_code_gets_exactly_one(self, project):
+        from connectonion.cli.commands.init import handle_init
+
+        (project / '.env').write_text("OPENAI_API_KEY=sk-mine\n")
+        handle_init(ai=None, key=None, template='co-ai', description=None,
+                    yes=True, force=True)
+
+        text = (project / '.env').read_text()
+        assert _duplicate_keys(text) == [], (
+            f"written twice: {_duplicate_keys(text)}\n{text}"
+        )
+
+    def test_a_fresh_env_gets_exactly_one(self, project):
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=None, key=None, template='co-ai', description=None,
+                    yes=True, force=True)
+
+        text = (project / '.env').read_text()
+        assert text.count("CO_INVITE_CODE=") == 1, text
+
+    def test_a_second_init_does_not_mint_a_new_code(self, project):
+        """The comment in the code is explicit: regenerating it would silently
+        lock out everyone already holding the old one."""
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=None, key=None, template='co-ai', description=None,
+                    yes=True, force=True)
+        first = re.search(r"CO_INVITE_CODE=(\S+)", (project / '.env').read_text()).group(1)
+
+        handle_init(ai=None, key=None, template='co-ai', description=None,
+                    yes=True, force=True)
+        text = (project / '.env').read_text()
+
+        assert text.count("CO_INVITE_CODE=") == 1, text
+        assert re.search(r"CO_INVITE_CODE=(\S+)", text).group(1) == first


### PR DESCRIPTION
`co init` into a directory that already had a `.env` without an invite code wrote `CO_INVITE_CODE` on two lines:

```
 8:CO_INVITE_CODE=LYA8Q-HM596-SWE8A
14:CO_INVITE_CODE=LYA8Q-HM596-SWE8A
```

Same value, so nothing was granted twice. But a duplicated line in the file holding the agent's way in is how people stop trusting the file, and whoever changes it next has to work out which one wins before they can.

## Cause

One key on two paths:

- appended to `keys_to_add` when minted
- also put into `global_keys`, so the branch that writes a **fresh** `.env` includes it

…after which the branch that **appends to an existing** `.env` walks `global_keys` and adds it a second time. It is now also added to `existing_keys`, which is what that branch checks.

## How it surfaced

Step 7 on #589 — checking whether filtering OAuth tokens out of inheritance had broken a project that legitimately holds Google tokens.

It had not. `co auth google` writes them to the project's own `.env` deliberately (`auth_commands.py:273`), and re-running `co init` preserves what is already there:

```
=== after re-init ===
GOOGLE_ACCESS_TOKEN  GOOGLE_REFRESH_TOKEN  GOOGLE_SCOPES  OPENAI_API_KEY  …
=== deliberate token still present ===
1
```

So the separation holds: tokens a project asked for stay, tokens it never asked for no longer arrive. The same run is where the duplicate showed up.

A third test pins the thing the original comment cares about — a second `co init` does not mint a *new* code, because "regenerating it would silently lock out everyone already holding the old one".

3170 unit tests pass.
