### PR TITLE
fix(announce): an agent publishes addresses another machine can reach

### DIFF
--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -38,6 +38,13 @@ def get_ips() -> List[str]:
     return ips
 
 
+def _is_loopback(host: str) -> bool:
+    """Whether this address only means anything on the machine that has it."""
+    if host in ("localhost", "::1"):
+        return True
+    return host.startswith("127.")
+
+
 def get_endpoints(port: int) -> List[str]:
     """Get all endpoints as full URLs (http and ws for each IP)."""
     domain = os.getenv("AGENT_PUBLIC_DOMAIN", "").strip().rstrip("/")
@@ -46,6 +53,18 @@ def get_endpoints(port: int) -> List[str]:
 
     endpoints = []
     for ip in get_ips():
+        if _is_loopback(ip):
+            # Not a place another machine can go, and the relay record is read
+            # by other machines. Published, it made a browser client walking the
+            # list probe port `port` on *the reader's own* machine — the address
+            # check was the only thing that stopped it talking to whatever
+            # answered. Fixed on the client side in @connectonion/react 0.3.2;
+            # this is the same bug at the source.
+            #
+            # Private addresses are deliberately kept: two agents in one VPC or
+            # on one LAN can use them, and the relay would otherwise carry a
+            # connection that did not need it.
+            continue
         endpoints.append(f"http://{ip}:{port}")
         endpoints.append(f"ws://{ip}:{port}/ws")
     return endpoints

--- a/tests/unit/test_announce.py
+++ b/tests/unit/test_announce.py
@@ -31,13 +31,17 @@ class TestGetEndpoints:
         ]
 
     def test_uses_ip_discovery_without_public_domain(self, monkeypatch):
-        """Local hosts keep the existing localhost/IP endpoint behavior."""
+        """Addresses another machine can reach — which loopback is not.
+
+        This used to assert localhost was published, and it was: the relay
+        record for a live agent listed http://localhost:8001 to anyone who
+        asked. A browser client walking that list then probed port 8001 on the
+        reader's own machine.
+        """
         monkeypatch.delenv("AGENT_PUBLIC_DOMAIN", raising=False)
         monkeypatch.setattr("connectonion.network.announce.get_ips", lambda: ["localhost", "10.0.0.2"])
 
         assert get_endpoints(8000) == [
-            "http://localhost:8000",
-            "ws://localhost:8000/ws",
             "http://10.0.0.2:8000",
             "ws://10.0.0.2:8000/ws",
         ]

--- a/tests/unit/test_announce_publishes_reachable_addresses.py
+++ b/tests/unit/test_announce_publishes_reachable_addresses.py
@@ -1,0 +1,76 @@
+"""What an agent tells a public directory about where to find it.
+
+`get_endpoints` published a URL for every address on the machine, loopback
+included. Fetched from the relay for a live agent, by anyone who asks:
+
+    http://localhost:8001          ws://localhost:8001/ws
+    http://10.152.0.16:8001        ws://10.152.0.16:8001/ws
+    http://34.151.137.226:8001     ws://34.151.137.226:8001/ws
+
+`localhost` is not a place another machine can go. Published to a public
+directory it is worse than useless: a browser client that walks the list probes
+port 8001 on **the reader's own machine**, and the address check is the only
+thing that stopped it talking to whatever answered. That was fixed on the
+client side in @connectonion/react 0.3.2; this is the same bug at the source.
+
+The private address is left in on purpose — two agents in one VPC or on one LAN
+can use it, and that is a real connection the relay would otherwise have to
+carry. It is a judgement call rather than an oversight, so it is written down
+here.
+"""
+
+import pytest
+
+from connectonion.network import announce
+
+
+class TestLoopbackIsNotAPlaceToVisit:
+
+    def test_it_is_not_in_the_published_endpoints(self, monkeypatch):
+        monkeypatch.setattr(announce, 'get_ips',
+                            lambda: ['localhost', '10.0.0.5', '203.0.113.9'])
+
+        published = announce.get_endpoints(8001)
+
+        assert not [e for e in published if 'localhost' in e], published
+
+    @pytest.mark.parametrize("loopback", ['localhost', '127.0.0.1', '::1',
+                                          '127.0.1.1'])
+    def test_every_spelling_of_it(self, monkeypatch, loopback):
+        monkeypatch.setattr(announce, 'get_ips', lambda: [loopback, '203.0.113.9'])
+
+        published = announce.get_endpoints(8001)
+
+        assert all('203.0.113.9' in e for e in published), published
+
+
+class TestWhatIsStillPublished:
+
+    def test_the_public_address_is(self, monkeypatch):
+        monkeypatch.setattr(announce, 'get_ips', lambda: ['localhost', '203.0.113.9'])
+
+        published = announce.get_endpoints(8001)
+
+        assert 'http://203.0.113.9:8001' in published
+        assert 'ws://203.0.113.9:8001/ws' in published
+
+    def test_a_private_address_still_is(self, monkeypatch):
+        """Deliberate: two agents in one VPC can use it, and the relay would
+        otherwise carry a connection that did not need it."""
+        monkeypatch.setattr(announce, 'get_ips', lambda: ['localhost', '10.0.0.5'])
+
+        assert 'http://10.0.0.5:8001' in announce.get_endpoints(8001)
+
+    def test_a_configured_domain_still_wins_outright(self, monkeypatch):
+        monkeypatch.setenv('AGENT_PUBLIC_DOMAIN', 'agent.example.com')
+
+        assert announce.get_endpoints(8001) == ['https://agent.example.com',
+                                                'wss://agent.example.com/ws']
+
+    def test_an_agent_with_only_loopback_publishes_nothing(self, monkeypatch):
+        """A laptop with no route out announces no direct endpoint and is
+        reached through the relay — which is what already happens when every
+        published endpoint fails, only without the wasted probes."""
+        monkeypatch.setattr(announce, 'get_ips', lambda: ['localhost'])
+
+        assert announce.get_endpoints(8001) == []


### PR DESCRIPTION
Found by reading what the relay actually serves about a live production agent, rather than by reading the code that builds it:

```
$ curl https://oo.openonion.ai/api/agents/0xfae4…
endpoints:
  http://localhost:8001          ws://localhost:8001/ws
  http://10.152.0.16:8001        ws://10.152.0.16:8001/ws
  http://34.151.137.226:8001     ws://34.151.137.226:8001/ws
```

Anyone who asks the relay gets that list.

**`localhost` is not a place another machine can go.** Published to a public directory it is worse than useless: a browser client walking the list probes port 8001 on *the reader's own machine*, and an address check is the only thing that stopped it talking to whatever answered.

That was fixed on the client side in openonion/connectonion-react#6 (0.3.2) by refusing http endpoints from an https page. This is the same bug at the source — the address should not have been advertised in the first place.

## The private address stays, on purpose

Two agents in one VPC or on one LAN can use `10.x`, and the relay would otherwise carry a connection that did not need carrying. That is a judgement call rather than an oversight, so it is written into the code comment and pinned by a test that would fail if someone "tidied" it away later.

## An old test said the opposite

```python
"""Local hosts keep the existing localhost/IP endpoint behavior."""
assert get_endpoints(8000) == [
    "http://localhost:8000", "ws://localhost:8000/ws", …
]
```

It was accurate about what the code did. It now says why that changed.

3179 unit tests pass.

---

Housekeeping from the same round: the test run hit `No space left on device`, which was my own doing — a dozen worktrees and several throwaway venvs from the last few days of this loop. Cleaned up, 11 GB reclaimed. Worth mentioning because the failure looked exactly like a code regression for a few minutes.
