### PR TITLE
fix(session): the session log stops growing forever

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -631,6 +631,11 @@ def host(
     # this one just started and owns none. Left alone they are permanent, since
     # `running` is exempt from TTL, and every mid-turn restart adds one (#545).
     storage.reconcile_interrupted()
+    # And drop what no reader can see: superseded records, and sessions past
+    # their TTL that are not running. The file is append-only otherwise, and a
+    # live agent was at 17 MB for 222 sessions — every dashboard open reparses
+    # all of it.
+    storage.compact()
 
     # Create Active Session Registry for WebSocket reconnection
     registry = ActiveSessionRegistry()
@@ -734,6 +739,7 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     if storage is None:
         storage = SessionStorage()
     storage.reconcile_interrupted()      # see the note at the other call site
+    storage.compact()
 
     # Create Active Session Registry for WebSocket reconnection
     registry = ActiveSessionRegistry()

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -10,6 +10,7 @@ LLM-Note:
 """
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Optional
@@ -121,6 +122,38 @@ class SessionStorage:
     # had a question outstanding, and the thread that would have finished either
     # one no longer exists.
     UNFINISHED = ('running', 'waiting_approval')
+
+    def compact(self) -> None:
+        """Drop what no reader can see any more, and rewrite the file.
+
+        `save()` appends and nothing removed. `expires` was honoured on read —
+        list() and get() skip records past their TTL — but they stayed in the
+        file and list() parsed all of them to answer. Measured on a live agent:
+        17 MB for 222 sessions. One running a schedule every fifteen minutes
+        writes 96 a day, so about 7 MB a day and 2.5 GB a year, and a dashboard
+        that reparses the lot each time it is opened.
+
+        Safe for one specific reason: it removes only what list() and get()
+        already refuse to return — superseded records for a session, and
+        sessions past their TTL that are not `running`. Every one of those was
+        invisible to every reader before it was removed, so nothing observable
+        changes except the size.
+
+        Written to a temporary file and moved into place, so a crash in the
+        middle leaves the old file rather than half a new one.
+        """
+        if not self.path.exists():
+            return
+
+        now = time.time()
+        keep = [s for s in self._latest_by_id().values()
+                if s.status == "running" or not s.expires or s.expires > now]
+
+        tmp = self.path.with_suffix(f"{self.path.suffix}.compact.{os.getpid()}")
+        with open(tmp, "w", encoding="utf-8") as f:
+            for session in sorted(keep, key=lambda s: s.created or 0):
+                f.write(session.model_dump_json() + "\n")
+        tmp.replace(self.path)
 
     def reconcile_interrupted(self):
         """Close out sessions this process cannot possibly finish.

--- a/tests/unit/test_the_session_log_does_not_grow_forever.py
+++ b/tests/unit/test_the_session_log_does_not_grow_forever.py
@@ -1,0 +1,150 @@
+"""What a long-running agent's session log costs after a few months.
+
+`save()` appends and nothing ever removes. `expires` is honoured on *read* —
+`list()` and `get()` skip records past their TTL — but the records stay in the
+file, and `list()` parses all of them to answer.
+
+Measured on a live agent: 17 MB for 222 sessions, about 77 KB each. One running
+a schedule every 15 minutes writes 96 a day:
+
+    ~7 MB a day     ~2.5 GB a year
+
+Two costs, and the second is the one people feel. The disk fills, and the
+dashboard — which calls `list()` — parses the whole file every time it is
+opened, forever.
+
+Compaction is safe here for a specific reason: it drops only what `list()` and
+`get()` already refuse to return. An expired record is invisible to every
+reader before it is removed, so removing it changes nothing anyone can observe
+except the size of the file.
+"""
+
+import json
+import time
+
+import pytest
+
+from connectonion.network.host.session import Session, SessionStorage
+
+
+def _write(storage, **kw):
+    storage.save(Session(**kw))
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SessionStorage(tmp_path / '.co' / 'sessions.jsonl')
+
+
+class TestExpiredRecordsLeave:
+
+    def test_the_file_shrinks(self, storage):
+        past = time.time() - 100
+        for i in range(20):
+            _write(storage, session_id=f"old-{i}", status="done", prompt="x" * 500,
+                   created=past - 1000, expires=past)
+        before = storage.path.stat().st_size
+
+        storage.compact()
+
+        assert storage.path.stat().st_size < before / 2, (
+            f"{before} → {storage.path.stat().st_size}"
+        )
+
+    def test_what_readers_can_see_is_unchanged(self, storage):
+        now = time.time()
+        _write(storage, session_id="live", status="done", prompt="keep",
+               created=now, expires=now + 3600)
+        _write(storage, session_id="gone", status="done", prompt="drop",
+               created=now - 1000, expires=now - 100)
+
+        before = {s.session_id for s in storage.list()}
+        storage.compact()
+        after = {s.session_id for s in storage.list()}
+
+        assert before == after == {"live"}
+
+    def test_a_running_session_survives_whatever_its_ttl_says(self, storage):
+        """`running` is exempt from the TTL on read, so it is exempt here."""
+        past = time.time() - 100
+        _write(storage, session_id="busy", status="running", prompt="working",
+               created=past - 1000, expires=past)
+
+        storage.compact()
+
+        assert storage.get("busy") is not None
+
+    def test_only_the_newest_record_per_session_is_kept(self, storage):
+        """Every turn appends a fresh record for the same id; readers use the
+        last one, so the earlier ones are already invisible."""
+        now = time.time()
+        for turn in range(5):
+            _write(storage, session_id="s1", status="done", prompt=f"turn {turn}",
+                   created=now, expires=now + 3600)
+
+        storage.compact()
+
+        assert storage.path.read_text().count('"session_id"') == 1
+        assert storage.get("s1").prompt == "turn 4"
+
+
+class TestItIsSafeToRunAtStartup:
+
+    def test_an_empty_file_is_fine(self, storage):
+        storage.compact()          # must not raise
+
+    def test_a_torn_line_does_not_stop_it(self, storage):
+        """Same rule as _records: one unreadable record is not an unreadable
+        file, and startup must not hinge on it."""
+        now = time.time()
+        _write(storage, session_id="ok", status="done", prompt="p",
+               created=now, expires=now + 3600)
+        with open(storage.path, 'a', encoding='utf-8') as f:
+            f.write('{"session_id": "torn", "stat\n')
+
+        storage.compact()
+
+        assert storage.get("ok") is not None
+
+    def test_nothing_is_lost_when_nothing_has_expired(self, storage):
+        now = time.time()
+        for i in range(5):
+            _write(storage, session_id=f"s{i}", status="done", prompt="p",
+                   created=now, expires=now + 3600)
+
+        storage.compact()
+
+        assert len(storage.list()) == 5
+
+
+class TestItIsActuallyCalled:
+    """A compaction nothing invokes is a function, not a fix.
+
+    `get_default_trust()` in this repo was exactly that for seven months —
+    correct, tested in isolation, never called — so the check here is that the
+    startup path names it, not that it works in a vacuum.
+    """
+
+    def test_the_host_compacts_on_startup(self):
+        import importlib
+        import inspect
+
+        server = importlib.import_module('connectonion.network.host.server')
+        source = inspect.getsource(server)
+
+        assert source.count("storage.compact()") >= 1, (
+            "nothing calls compact(), so the file still grows forever"
+        )
+
+    def test_it_runs_beside_the_other_startup_reconciliation(self):
+        """Both walk the same file; doing them apart means reading it twice."""
+        import importlib
+        import inspect
+
+        server = importlib.import_module('connectonion.network.host.server')
+        lines = inspect.getsource(server).splitlines()
+        reconcile = [i for i, l in enumerate(lines) if "reconcile_interrupted()" in l]
+        compact = [i for i, l in enumerate(lines) if "storage.compact()" in l]
+
+        assert compact, "compact() is not in the startup path"
+        assert min(abs(c - r) for c in compact for r in reconcile) <= 3


### PR DESCRIPTION
`save()` appends and nothing ever removed. `expires` was honoured on **read** — `list()` and `get()` skip records past their TTL — but the records stayed in the file, and `list()` parses all of them to answer.

Measured on a live agent: **17 MB for 222 sessions**, about 77 KB each. One running a schedule every fifteen minutes writes 96 a day:

```
~7 MB a day        ~2.5 GB a year
```

The disk is the obvious cost. The one people feel is the dashboard, which calls `list()` and reparses the whole file every time it is opened — forever.

## Why compaction is safe here

It drops only what `list()` and `get()` **already refuse to return**: superseded records for a session, and sessions past their TTL that are not `running`. Same predicate, so every record removed was invisible to every reader before it went. Nothing observable changes except the size.

Written to a temp file and moved into place, so a crash mid-way leaves the old file rather than half a new one.

## Measured, not asserted

A simulated year at fifteen-minute intervals — 2000 records with realistic session bodies:

| | before | after |
|---|---|---|
| file | 5.6 MB | 0.3 MB |
| sessions `list()` returns | 95 | **95** |
| `list()` | 70 ms | 3 ms |
| `compact()` itself | — | 129 ms, once, at startup |

The middle row is the important one.

## It is actually called

From both startup paths, beside `reconcile_interrupted()`, which already walks the same file — and there is a test asserting that, because `get_default_trust()` in this repo was correct, tested in isolation, and **never called for seven months** (#366). A compaction nothing invokes is a function, not a fix.

3188 unit tests pass.
