### PR TITLE
fix(session): compaction does not eat a write that lands while it runs

### DIFF
--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -146,6 +146,7 @@ class SessionStorage:
             return
 
         now = time.time()
+        size_when_read = self.path.stat().st_size
         keep = [s for s in self._latest_by_id().values()
                 if s.status == "running" or not s.expires or s.expires > now]
 
@@ -153,6 +154,31 @@ class SessionStorage:
         with open(tmp, "w", encoding="utf-8") as f:
             for session in sorted(keep, key=lambda s: s.created or 0):
                 f.write(session.model_dump_json() + "\n")
+
+        # Someone appended while we were reading and writing, and their record
+        # is only in the file we are about to replace. A lost session record is
+        # a turn that happened and left no trace — absent from the dashboard,
+        # uncounted by `co status`, with nothing anywhere saying one was
+        # dropped.
+        #
+        # The window is small: this runs at startup, before this process serves
+        # anything. Not zero — `host()` can run workers > 1, so another process
+        # may already be serving, and the relay announce and the schedule's
+        # first tick both begin within milliseconds.
+        #
+        # Skipping costs nothing; the next startup compacts. So notice, and
+        # leave the file alone.
+        # A missing file counts as changed. Compaction is housekeeping and must
+        # not be able to stop the agent — the same rule _records already states
+        # for a torn line: refusing to boot over it costs the agent.
+        try:
+            unchanged = self.path.stat().st_size == size_when_read
+        except OSError:
+            unchanged = False
+        if not unchanged:
+            tmp.unlink(missing_ok=True)
+            return
+
         tmp.replace(self.path)
 
     def reconcile_interrupted(self):

--- a/tests/unit/test_compaction_does_not_eat_a_write.py
+++ b/tests/unit/test_compaction_does_not_eat_a_write.py
@@ -1,0 +1,134 @@
+"""What happens to a session saved while the log is being compacted.
+
+compact() reads every record, writes a temp file, and moves it into place. A
+save() landing between the read and the move is written to the file that is
+about to be replaced — and vanishes.
+
+The window is small and the placement makes it smaller: compaction runs at
+startup, before this process serves anything. It is not zero. `host()` can run
+with workers > 1, so a second process may already be serving while this one
+starts; the relay announce and the schedule's first tick both begin within
+milliseconds of it; and `reconcile_interrupted()` immediately before it writes
+to the same file.
+
+A lost session record is a turn that happened and left no trace — the dashboard
+never shows it, `co status` never counts it, and nothing anywhere says a record
+was dropped. The schedule's state file settled this shape of problem with a
+lock; here it is enough to notice, because skipping a compaction costs nothing:
+the next startup does it.
+"""
+
+import time
+
+import pytest
+
+from connectonion.network.host.session import Session, SessionStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SessionStorage(tmp_path / '.co' / 'sessions.jsonl')
+
+
+def _expired(storage, n=10):
+    past = time.time() - 100
+    for i in range(n):
+        storage.save(Session(session_id=f"old-{i}", status="done", prompt="x" * 200,
+                             created=past - 1000, expires=past))
+
+
+class TestAWriteDuringCompactionSurvives:
+
+    def test_a_session_saved_mid_compaction_is_not_lost(self, storage, monkeypatch):
+        _expired(storage)
+        now = time.time()
+
+        # A save that lands after compact() has read the file and before it
+        # replaces it — which is exactly what a worker serving a request does.
+        original = storage._latest_by_id
+
+        def read_then_someone_writes():
+            records = original()
+            storage.save(Session(session_id="mid", status="done", prompt="a real turn",
+                                 created=now, expires=now + 3600))
+            return records
+
+        monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)
+        storage.compact()
+
+        assert storage.get("mid") is not None, (
+            "a turn happened and left no trace: the dashboard will never show "
+            "it and nothing said a record was dropped"
+        )
+
+    def test_compaction_is_skipped_rather_than_half_done(self, storage, monkeypatch):
+        """Skipping costs nothing — the next startup compacts."""
+        _expired(storage)
+        size_before = storage.path.stat().st_size
+        now = time.time()
+        original = storage._latest_by_id
+
+        def read_then_someone_writes():
+            records = original()
+            storage.save(Session(session_id="mid", status="done", prompt="p",
+                                 created=now, expires=now + 3600))
+            return records
+
+        monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)
+        storage.compact()
+
+        assert storage.path.stat().st_size > size_before
+
+
+class TestTheQuietPathIsUnchanged:
+
+    def test_compaction_still_happens_when_nobody_writes(self, storage):
+        _expired(storage, 20)
+        before = storage.path.stat().st_size
+
+        storage.compact()
+
+        assert storage.path.stat().st_size < before / 2
+
+    def test_an_empty_file_is_still_fine(self, storage):
+        storage.compact()
+
+
+class TestStartupDoesNotHingeOnIt:
+    """Compaction is housekeeping. It must not be able to stop the agent.
+
+    The same rule `_records` already states for a torn line: "Refusing to boot
+    over it costs the agent, so a truncated write or a hand edit is not allowed
+    to be fatal."
+    """
+
+    def test_the_file_disappearing_mid_compaction_is_not_fatal(self, storage,
+                                                               monkeypatch):
+        _expired(storage)
+        original = storage._latest_by_id
+
+        def read_then_someone_deletes():
+            records = original()
+            storage.path.unlink()
+            return records
+
+        monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_deletes)
+
+        storage.compact()          # must not raise
+
+    def test_no_temp_file_is_left_behind_when_it_skips(self, storage, monkeypatch):
+        _expired(storage)
+        now = time.time()
+        original = storage._latest_by_id
+
+        def read_then_someone_writes():
+            records = original()
+            storage.save(Session(session_id="mid", status="done", prompt="p",
+                                 created=now, expires=now + 3600))
+            return records
+
+        monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)
+        storage.compact()
+
+        leftovers = list(storage.path.parent.glob("*.compact.*"))
+        assert leftovers == [], leftovers


### PR DESCRIPTION
Step 7 on #592, which I merged an hour ago.

`compact()` reads every record, writes a temp file, and moves it into place. **A `save()` landing between the read and the move goes into the file that is about to be replaced — and vanishes.**

A lost session record is a turn that happened and left no trace: absent from the dashboard, uncounted by `co status`, with nothing anywhere saying one was dropped. Proven before fixing:

```
AssertionError: a turn happened and left no trace: the dashboard will never
show it and nothing said a record was dropped
```

## How small the window is, honestly

Compaction runs at startup, before this process serves anything. That makes it small. It does not make it zero:

- `host()` can run with `workers > 1`, so another process may already be serving
- the relay announce and the schedule's first tick both begin within milliseconds
- `reconcile_interrupted()` writes to the same file immediately before

## The fix

Compare the file to what it was when read; leave it alone if it moved. **Skipping costs nothing** — the next startup compacts — so the cheap answer is also the safe one and no lock is needed. The schedule's state file needed a lock because its writes are the point; here the write is housekeeping.

A file that vanished mid-compaction counts as changed rather than raising. It raised `FileNotFoundError` until a test asked, and compaction must not be able to stop the agent — the rule `_records` already states for a torn line:

> Refusing to boot over it costs the agent, so a truncated write or a hand edit is not allowed to be fatal.

Two more tests cover that and check no `.compact.<pid>` temp file is left behind on the skip path.

3194 unit tests pass.
