### PR TITLE
fix(announce): a summary too long to announce is cut here, not refused there

### DIFF
--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -22,6 +22,35 @@ import ifaddr
 import httpx
 
 
+# The relay's limit, stated here because this is where the message is built.
+# Verified against the live relay: 5,400 characters comes back as
+# {"type": "ERROR", "error": "Summary too long (max 1000 chars)"} while a short
+# one gets ANNOUNCE_OK.
+ANNOUNCE_SUMMARY_LIMIT = 1000
+
+
+def fit_summary(summary):
+    """Cut a summary to what the relay will accept, and say so when it does.
+
+    host() already truncates the summary it derives from the system prompt, but
+    passed a `summary:` from host.yaml through whole — so an operator who wrote
+    a long one got an agent that starts, serves locally, and is never
+    registered: the relay refuses every announce and the reconnect loop retries
+    forever.
+
+    Not silent — the client prints `Relay error: …` — but it scrolls past in
+    startup output beside a banner that still says the relay is on. The number
+    is knowable here, so it is applied here, and the operator is told what was
+    actually sent instead of matching a red line against a config file.
+    """
+    if not summary or len(summary) <= ANNOUNCE_SUMMARY_LIMIT:
+        return summary
+    print(f"[announce] summary is {len(summary)} characters and the relay takes "
+          f"{ANNOUNCE_SUMMARY_LIMIT}; announcing the first {ANNOUNCE_SUMMARY_LIMIT}. "
+          f"Shorten `summary:` in .co/host.yaml to choose what goes.")
+    return summary[:ANNOUNCE_SUMMARY_LIMIT]
+
+
 def get_ips() -> List[str]:
     """Get all IP addresses (localhost, local network, public)."""
     ips = ["localhost"]
@@ -102,7 +131,7 @@ def create_announce_message(
         "type": "ANNOUNCE",
         "address": address_data["address"],
         "timestamp": int(time.time()),
-        "summary": summary,
+        "summary": fit_summary(summary),
         "endpoints": endpoints,
         "relay": relay,
     }

--- a/tests/unit/test_a_summary_that_cannot_be_announced.py
+++ b/tests/unit/test_a_summary_that_cannot_be_announced.py
@@ -1,0 +1,71 @@
+"""A summary the relay will not accept, caught before it is sent.
+
+`create_announce_message` documents "summary: agent capability description
+(max 1000 chars)" and does not apply it. The relay does:
+
+    {"type": "ERROR", "error": "Summary too long (max 1000 chars)"}
+
+verified against the live relay with a 5,400-character summary, while a short
+one got ANNOUNCE_OK.
+
+The code already knows the number. `host()` truncates the summary it derives
+from the system prompt:
+
+    summary = sample.system_prompt[:1000] if sample.system_prompt else …
+
+but passes a `summary:` from host.yaml through whole. So an operator who writes
+a long one gets an agent that starts, serves locally, and is never registered —
+the relay refuses every announce, and the reconnect loop retries forever.
+
+It is not silent: the client prints `Relay error: …` in red. It scrolls past in
+startup output, though, next to a banner that still says the relay is on. The
+limit is knowable here, so it is applied here, and the operator is told what
+was sent rather than left to match a red line against a config file.
+"""
+
+import pytest
+
+from connectonion.network.announce import ANNOUNCE_SUMMARY_LIMIT, fit_summary
+
+
+class TestASummaryIsCutToWhatCanBeSent:
+
+    def test_a_long_one_is_shortened(self, capsys):
+        fitted = fit_summary("很长的摘要。" * 900)
+
+        assert len(fitted) <= ANNOUNCE_SUMMARY_LIMIT
+
+    def test_the_operator_is_told(self, capsys):
+        fit_summary("x" * 5000)
+
+        out = capsys.readouterr().out
+        assert '5000' in out and str(ANNOUNCE_SUMMARY_LIMIT) in out, out
+
+    def test_it_says_where_to_change_it(self, capsys):
+        """The value came from host.yaml; that is where the fix goes."""
+        fit_summary("x" * 5000)
+
+        assert 'host.yaml' in capsys.readouterr().out
+
+
+class TestAnOrdinarySummaryIsUntouched:
+
+    def test_it_is_returned_as_written(self, capsys):
+        text = "把飞书云盘里的合同扫描件整理成结构化台账。"
+
+        assert fit_summary(text) == text
+
+    def test_nothing_is_printed(self, capsys):
+        fit_summary("a short summary")
+
+        assert capsys.readouterr().out == ""
+
+    def test_exactly_at_the_limit_is_fine(self, capsys):
+        text = "x" * ANNOUNCE_SUMMARY_LIMIT
+
+        assert fit_summary(text) == text
+        assert capsys.readouterr().out == ""
+
+    def test_an_empty_summary_is_left_alone(self):
+        assert fit_summary("") == ""
+        assert fit_summary(None) is None


### PR DESCRIPTION
`create_announce_message` documented the limit and did not apply it:

```python
summary: agent capability description (max 1000 chars)
```

The relay applies it. Verified against the live relay with a throwaway identity:

```
5,400 chars  →  {"type": "ERROR", "error": "Summary too long (max 1000 chars)"}
short        →  ANNOUNCE_OK
```

## The code already knew the number

`host()` truncates the summary it derives from the system prompt:

```python
summary = sample.system_prompt[:1000] if sample.system_prompt else …
```

and passed a `summary:` from `host.yaml` through whole. So an operator who wrote a long one got an agent that starts, serves locally, and **is never registered** — the relay refuses every announce and the reconnect loop retries forever.

It is not silent: the client prints `Relay error: …` in red. But it scrolls past in startup output, beside a banner that still says the relay is on, and matching it back to a line in `host.yaml` is left to the operator.

## After

```
[announce] summary is 5400 characters and the relay takes 1000; announcing the
first 1000. Shorten `summary:` in .co/host.yaml to choose what goes.

5,400 chars → ANNOUNCE_OK
```

Same summary, same relay.

**Truncating without saying so would have been worse than the bug** — a registered agent describing itself in a sentence that stops mid-word, and nothing to explain it. So it cuts, and says what went.

3208 unit tests pass.
