### PR TITLE
fix(announce): the truncation notice is said once, not on every reconnect

### DIFF
--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -28,6 +28,9 @@ import httpx
 # one gets ANNOUNCE_OK.
 ANNOUNCE_SUMMARY_LIMIT = 1000
 
+# The summary we last mentioned cutting, so a reconnect does not repeat it.
+_summary_already_mentioned = None
+
 
 def fit_summary(summary):
     """Cut a summary to what the relay will accept, and say so when it does.
@@ -45,9 +48,19 @@ def fit_summary(summary):
     """
     if not summary or len(summary) <= ANNOUNCE_SUMMARY_LIMIT:
         return summary
-    print(f"[announce] summary is {len(summary)} characters and the relay takes "
-          f"{ANNOUNCE_SUMMARY_LIMIT}; announcing the first {ANNOUNCE_SUMMARY_LIMIT}. "
-          f"Shorten `summary:` in .co/host.yaml to choose what goes.")
+
+    # Said once per summary, not once per announce. This function is the relay
+    # loop's callback — the message is rebuilt on every reconnect, deliberately,
+    # because it is signed and has to be fresh for the socket it announces on
+    # (#548). Printing here on every network blip fills the log with one line
+    # and teaches the operator to stop reading it. A changed summary is news
+    # again: host.yaml was edited.
+    global _summary_already_mentioned
+    if _summary_already_mentioned != summary:
+        _summary_already_mentioned = summary
+        print(f"[announce] summary is {len(summary)} characters and the relay takes "
+              f"{ANNOUNCE_SUMMARY_LIMIT}; announcing the first {ANNOUNCE_SUMMARY_LIMIT}. "
+              f"Shorten `summary:` in .co/host.yaml to choose what goes.")
     return summary[:ANNOUNCE_SUMMARY_LIMIT]
 
 

--- a/tests/unit/test_a_summary_that_cannot_be_announced.py
+++ b/tests/unit/test_a_summary_that_cannot_be_announced.py
@@ -28,6 +28,21 @@ import pytest
 from connectonion.network.announce import ANNOUNCE_SUMMARY_LIMIT, fit_summary
 
 
+@pytest.fixture(autouse=True)
+def _forget_what_was_already_said():
+    """The notice is deduplicated by module-level state, so it leaks between
+    tests: two of these use the same 5,000-character summary, and without this
+    the second one sees nothing and fails for the wrong reason.
+
+    Stated as a fixture rather than fixed by giving each test its own string,
+    because the coupling is real and the next test added here would hit it too.
+    """
+    import connectonion.network.announce as ann
+    ann._summary_already_mentioned = None
+    yield
+    ann._summary_already_mentioned = None
+
+
 class TestASummaryIsCutToWhatCanBeSent:
 
     def test_a_long_one_is_shortened(self, capsys):
@@ -69,3 +84,50 @@ class TestAnOrdinarySummaryIsUntouched:
     def test_an_empty_summary_is_left_alone(self):
         assert fit_summary("") == ""
         assert fit_summary(None) is None
+
+
+class TestItIsSaidOnceNotOnEveryReconnect:
+    """`create_announce_message` is the relay loop's callback, not a one-off.
+
+        while True:
+            await relay.serve_once(
+                relay_url,
+                lambda: announce.create_announce_message(…),
+
+    It is rebuilt on every reconnect — deliberately, because the message is
+    signed and has to be fresh for the socket it announces on (#548). So a
+    notice printed here is printed on every network blip, and an agent with a
+    long summary and a flaky link fills its log with one repeated line.
+
+    Same rule this repo already applies to the legacy trust-list notice: a
+    warning nobody sees is useless, and one that fires on every event is noise
+    that trains people to stop reading the log.
+    """
+
+    def test_a_reconnect_does_not_repeat_it(self, capsys, monkeypatch):
+        import connectonion.network.announce as ann
+        monkeypatch.setattr(ann, '_summary_already_mentioned', None, raising=False)
+
+        for _ in range(5):
+            ann.fit_summary("x" * 5000)
+
+        assert capsys.readouterr().out.count('[announce]') == 1
+
+    def test_a_different_summary_is_still_worth_saying(self, capsys, monkeypatch):
+        """host.yaml edited and the loop restarted is new information."""
+        import connectonion.network.announce as ann
+        monkeypatch.setattr(ann, '_summary_already_mentioned', None, raising=False)
+
+        ann.fit_summary("x" * 5000)
+        capsys.readouterr()
+        ann.fit_summary("y" * 9000)
+
+        assert '[announce]' in capsys.readouterr().out
+
+    def test_it_still_cuts_every_time(self, capsys, monkeypatch):
+        """Quiet is about the notice, not about the behaviour."""
+        import connectonion.network.announce as ann
+        monkeypatch.setattr(ann, '_summary_already_mentioned', None, raising=False)
+
+        for _ in range(3):
+            assert len(ann.fit_summary("x" * 5000)) == ann.ANNOUNCE_SUMMARY_LIMIT


### PR DESCRIPTION
Step 7 on #595, merged an hour ago.

The notice it prints lives in `create_announce_message`, which is the relay loop's **callback**:

```python
while True:
    await relay.serve_once(
        relay_url,
        lambda: announce.create_announce_message(…),
```

The message is rebuilt on every reconnect — deliberately, because it is signed and has to be fresh for the socket it announces on (#548). So an agent with a long summary and a flaky link printed the same line on every blip. Measured before fixing:

```
assert 5 == 1     # five reconnects, five copies
```

This repo has written the rule down twice already this week — on the legacy trust-list notice and on the unlocked-write warning:

> a warning nobody sees is useless, and one everybody sees on every event is noise that trains people to ignore it

Said **once per summary** rather than once per process, so editing `host.yaml` and restarting the loop is news again.

## The dedup is module state, and it leaked

Two existing tests use the same 5,000-character summary; with the dedup in place the second saw nothing and failed for the wrong reason. An autouse fixture resets it and says so — giving each test its own string would have hidden a coupling that the next test added there would have hit anyway.

3211 unit tests pass.
