### PR TITLE
fix(relay): the heartbeat is for a terminal, not for a journal

### DIFF
--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -163,6 +163,33 @@ async def _run_session(session_id, first_msg, sessions, relay_ws, session_handle
         del sessions[session_id]
 
 
+def heartbeat_is_worth_printing() -> bool:
+    """Whether anyone is watching the pulse.
+
+    The relay loop refreshes its ANNOUNCE every sixty seconds — the relay drops
+    a registration after about 120 — and printed a `♥` each time. In a terminal
+    that is a pulse you can watch. Under systemd it is 1400 lines a day that say
+    nothing, on every deployed agent, drowning the ones that do. Measured on a
+    live one: 3656 log lines over 11 hours, roughly 660 of them heartbeats.
+
+    "Is it running" is already answered by `systemctl status`.
+
+    Same test connectonion/__init__.py already applies to its env diagnostic —
+    a redirected stream is a different audience — with the same escape hatch for
+    someone debugging a piped run.
+
+    Only the heartbeat is affected. `♥ cannot refresh`, `Relay error` and
+    `Relay disconnected` print either way: silence means healthy, which is what
+    a log is for.
+    """
+    import os
+    import sys
+
+    if os.getenv("CO_HEARTBEAT") == "1":
+        return True
+    return bool(getattr(sys.stderr, "isatty", lambda: False)())
+
+
 async def serve_once(
     relay_url: str,
     make_announce,
@@ -271,7 +298,8 @@ async def serve_loop(
                     addr_data, summary, endpoints=endpoints, relay=relay_url
                 )
                 await send_announce(websocket, fresh_announce)
-                console.print(f"{prefix} [red]♥[/red]")
+                if heartbeat_is_worth_printing():
+                    console.print(f"{prefix} [red]♥[/red]")
             else:
                 # Nothing is sent. The fallback used to re-stamp the original
                 # frame and send it again, which could only ever be rejected:

--- a/tests/unit/test_the_heartbeat_is_for_a_terminal.py
+++ b/tests/unit/test_the_heartbeat_is_for_a_terminal.py
@@ -1,0 +1,70 @@
+"""Who the relay heartbeat is talking to.
+
+Every sixty seconds the relay loop refreshes its ANNOUNCE — the relay drops a
+registration after about 120 seconds of silence — and prints a `♥`. In a
+terminal that is a pulse you can watch. Under systemd it is a line in the
+journal, and measured on a live agent it is most of the journal:
+
+    11 hours of logs      3656 lines
+    heartbeats            ~660 of them
+    the rest              mostly one repeated failure banner
+
+1400 lines a day that say nothing, on every deployed agent, drowning the ones
+that do. "Is it running" is already answered by `systemctl status`.
+
+This repo already draws the line where it belongs — connectonion/__init__.py:
+
+    _show_env = _sys.stderr.isatty() or _os.getenv("CO_DEBUG_ENV") == "1"
+
+with the reasoning that a redirected stream is a different audience. The
+heartbeat is the same shape: decoration for a person watching, noise in a file.
+
+Everything that is not a heartbeat still prints either way — `♥ cannot refresh`,
+`Relay error`, `Relay disconnected`. Silence means healthy, which is what a log
+is for.
+"""
+
+import inspect
+
+import pytest
+
+from connectonion.network import relay
+from connectonion.network.relay import heartbeat_is_worth_printing
+
+
+class TestATerminalSeesIt:
+
+    def test_an_attached_terminal_gets_the_pulse(self, monkeypatch):
+        monkeypatch.setattr('sys.stderr.isatty', lambda: True, raising=False)
+
+        assert heartbeat_is_worth_printing() is True
+
+
+class TestAJournalDoesNot:
+
+    def test_a_redirected_stream_stays_quiet(self, monkeypatch):
+        monkeypatch.setattr('sys.stderr.isatty', lambda: False, raising=False)
+
+        assert heartbeat_is_worth_printing() is False
+
+    def test_it_can_be_turned_back_on(self, monkeypatch):
+        """The same escape hatch as CO_DEBUG_ENV: someone debugging a piped run
+        should be able to ask for it."""
+        monkeypatch.setattr('sys.stderr.isatty', lambda: False, raising=False)
+        monkeypatch.setenv('CO_HEARTBEAT', '1')
+
+        assert heartbeat_is_worth_printing() is True
+
+
+class TestOnlyTheHeartbeatIsAffected:
+    """The failure lines are the reason the log exists at all."""
+
+    def _line_containing(self, text: str) -> str:
+        source = inspect.getsource(relay)
+        return next(l for l in source.splitlines() if text in l)
+
+    def test_the_lapse_warning_is_unconditional(self):
+        assert 'heartbeat_is_worth_printing' not in self._line_containing('cannot refresh')
+
+    def test_relay_errors_are_unconditional(self):
+        assert 'heartbeat_is_worth_printing' not in self._line_containing('Relay error:')


### PR DESCRIPTION
Measured on the deployed client agent, which is what prompted this:

```
11 hours of logs      3656 lines
heartbeats            ~660
the rest              mostly one repeated failure banner
```

The relay loop refreshes its ANNOUNCE every sixty seconds — the relay drops a registration after about 120 — and printed a `♥` each time. In a terminal that is a pulse you can watch. Under systemd it is **1400 lines a day that say nothing**, on every deployed agent, drowning the ones that do.

"Is it running" is already answered by `systemctl status`.

## The line this repo already draws

`connectonion/__init__.py`:

```python
_show_env = _sys.stderr.isatty() or _os.getenv("CO_DEBUG_ENV") == "1"
```

with the reasoning that a redirected stream is a different audience. The heartbeat is the same shape, and gets the same escape hatch — `CO_HEARTBEAT=1` — for someone debugging a piped run.

## Only the heartbeat

`♥ cannot refresh`, `Relay error` and `Relay disconnected` print either way, and two tests read the source to hold them to it. Silence means healthy, which is what a log is for.

## The tradeoff, stated

A heartbeat that stops is a signal, and on a server that signal is now gone. It was a poor one — nobody watches for the absence of a line — and every failure path that matters announces itself. Recording it so the next person weighing this has the argument rather than just the diff.

3216 unit tests pass.
