### PR TITLE
test: the tag check says when it cannot run instead of passing

### DIFF
--- a/tests/unit/test_every_release_has_an_entry.py
+++ b/tests/unit/test_every_release_has_an_entry.py
@@ -28,6 +28,14 @@ import connectonion
 REPO = Path(__file__).resolve().parents[2]
 VERSIONING = REPO / 'VERSIONING.md'
 
+# Where VERSIONING.md starts recording every release rather than milestones.
+# Before this it lists 0.0.1, 0.1.0, 1.0.0, 1.2.0 … — eleven entries covering
+# eighty-odd tags — and the rest of that history is in CHANGELOG.md. Demanding
+# an entry for each of those would mean writing a past nobody here checked.
+#
+# A floor, so 1.6 and everything after is covered without touching this line.
+DENSE_HISTORY_FROM = (1, 5, 0)
+
 
 def _documented_versions() -> set:
     return set(re.findall(r'^- (\d+\.\d+\.\d+)', VERSIONING.read_text(encoding='utf-8'),
@@ -49,14 +57,35 @@ class TestNoReleaseIsSkipped:
     def test_every_released_tag_is_documented(self):
         import subprocess
 
-        tags = subprocess.run(['git', 'tag', '-l', 'v1.5.*'], cwd=REPO,
+        tags = subprocess.run(['git', 'tag', '-l', 'v*'], cwd=REPO,
                               capture_output=True, text=True).stdout.split()
-        released = {t.lstrip('v') for t in tags}
+        if not tags:
+            # actions/checkout@v4 does not fetch tags unless asked, so on CI
+            # this has nothing to compare against — and passing on an empty set
+            # is how a check ends up reporting nothing in exactly the
+            # environment it was written to guard. Say so instead; -rs in
+            # addopts makes the skip visible.
+            #
+            # It runs where a release is actually cut, which is a working
+            # checkout. `fetch-tags: true` in the workflow would make it run
+            # everywhere and is the better answer, once someone with the
+            # `workflow` token scope can push that file (#584).
+            pytest.skip("no tags in this checkout — nothing to compare "
+                        "VERSIONING.md against (CI does not fetch them)")
+
+        def parts(v):
+            return [int(x) for x in v.split('.')]
+
         documented = _documented_versions()
 
-        missing = sorted(released - documented,
-                         key=lambda v: [int(p) for p in v.split('.')])
-        assert missing == [], f"released with no entry: {missing}"
+        released = {t.lstrip('v') for t in tags
+                    if re.fullmatch(r'v\d+\.\d+\.\d+', t)}
+        in_scope = {v for v in released if parts(v) >= list(DENSE_HISTORY_FROM)}
+
+        missing = sorted(in_scope - documented, key=parts)
+        assert missing == [], (
+            f"released with no entry in VERSIONING.md: {missing}"
+        )
 
 
 class TestOneHistoryNotTwo:
@@ -69,3 +98,29 @@ class TestOneHistoryNotTwo:
         assert 'VERSIONING.md' in text, (
             "CHANGELOG.md does not say where the current history lives"
         )
+
+
+class TestACheckThatCannotRunSaysSo:
+    """The tag comparison is the one that found the six missing entries, and
+    it is the one that cannot run on CI: `actions/checkout@v4` does not fetch
+    tags unless asked, so `git tag -l` comes back empty there.
+
+    Passing on an empty set is how a check ends up reporting nothing in exactly
+    the environment it was written to guard — the same shape as the Windows
+    clipboard tests that skipped everywhere (#584) and the docs-site check that
+    skipped inside a worktree (#583). Third time this week, so it gets a test
+    of its own rather than a comment.
+    """
+
+    def test_no_tags_skips_rather_than_passes(self, monkeypatch):
+        import subprocess as sp_mod
+
+        class Empty:
+            stdout = ""
+
+        monkeypatch.setattr(sp_mod, 'run', lambda *a, **k: Empty())
+
+        with pytest.raises(pytest.skip.Exception) as skipped:
+            TestNoReleaseIsSkipped().test_every_released_tag_is_documented()
+
+        assert 'tags' in str(skipped.value)


### PR DESCRIPTION
Step 7 on #598, merged an hour ago.

That PR added a check that every released tag has an entry in VERSIONING.md. It is the one that found the six missing ones — and it is the one that **cannot run on CI**:

```yaml
- uses: actions/checkout@v4      # does not fetch tags unless asked
```

`git tag -l` comes back empty there, and comparing against an empty set passes. Reporting nothing, in exactly the environment it was written to guard.

**Third time this week.** The Windows clipboard tests skipped everywhere because no job named their file (#584); the docs-site version check skipped inside a worktree because it resolved a sibling directory from the wrong root (#583). So this one gets a test of its own rather than a comment — the skip path is asserted, not assumed:

```python
with pytest.raises(pytest.skip.Exception) as skipped:
    TestNoReleaseIsSkipped().test_every_released_tag_is_documented()
assert 'tags' in str(skipped.value)
```

`fetch-tags: true` in the workflow is the better answer. It needs the `workflow` token scope, which is what is still blocking #584. Until then the check runs where a release is actually cut — a working checkout — and says out loud when it cannot.

## The other half, found by widening the glob

Changing `v1.5.*` to `v*` so 1.6 would be covered turned up **eighty-one tags back to 0.0.4**, none of them in VERSIONING.md.

Before 1.5.0 that file records milestones — 0.0.1, 0.1.0, 1.0.0, 1.2.0 — and the rest of that history belongs to CHANGELOG.md. Demanding an entry for each would mean writing a past nobody here checked. The comparison starts at 1.5.0, expressed as a floor so 1.6 and later need no edit to this file.

3220 unit tests pass.
