### PR TITLE
fix(doctor): the verdict agrees with what the diagnosis found

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -22,6 +22,29 @@ from rich import box
 console = Console()
 
 
+def verdict(problems: list) -> int:
+    """The last line, and the exit code, saying what the body already said.
+
+    `co doctor` printed `✅ Diagnostics complete!` and exited 0 whatever it
+    found — including, on a real project, right under its own
+    `user/email-outreach ✗ broken symlink`. People read the last line, and a
+    deploy script reads the exit code; both were told everything was fine.
+
+    Five places add a `✗` row. They now record what they found, and this says
+    it back.
+    """
+    if not problems:
+        console.print("[bold green]✅ Diagnostics complete — nothing wrong[/bold green]\n")
+        return 0
+
+    console.print(f"[bold red]✗ Diagnostics complete — {len(problems)} problem"
+                  f"{'s' if len(problems) > 1 else ''}[/bold red]")
+    for problem in problems:
+        console.print(f"  [red]•[/red] {problem}")
+    console.print()
+    return 1
+
+
 def handle_doctor():
     """Run comprehensive diagnostics on ConnectOnion installation.
 
@@ -29,6 +52,11 @@ def handle_doctor():
     let an LLM agent inspect the environment, interpret errors,
     and suggest fixes conversationally.
     """
+    # `found`, not `problems`: find_skill_problems() already puts a list of
+    # (location, name, reason) tuples in a local called `problems`, and
+    # shadowing it made the loop below unpack my strings into three names.
+    # The real CLI caught that; the unit tests could not see it.
+    found: list[str] = []
     from ... import __version__
 
     console.print("\n[bold cyan]🔍 ConnectOnion Diagnostics[/bold cyan]\n")
@@ -60,6 +88,7 @@ def handle_doctor():
         system_table.add_row("Command", f"[green]✓[/green] {co_path}")
     else:
         system_table.add_row("Command", "[red]✗[/red] 'co' not found in PATH")
+        found.append("'co' is not on PATH")
 
     # Package location
     import connectonion
@@ -141,6 +170,7 @@ def handle_doctor():
     elif status == "broken":
         browser_table.add_row("Patchright", f"[yellow]○[/yellow] {browser_version}")
         browser_table.add_row("Stealth driver", f"[red]✗[/red] {detail}")
+        found.append(f"stealth driver: {detail}")
     else:  # missing
         browser_table.add_row("Patchright", f"[yellow]○[/yellow] {detail}")
 
@@ -173,6 +203,7 @@ def handle_doctor():
 
     for location, name, reason in problems:
         skills_table.add_row(f"{location}/{name}", f"[red]✗[/red] {reason}")
+        found.append(f"skill {location}/{name}: {reason}")
 
     console.print(Panel(skills_table, title="[bold]Skills[/bold]", border_style="yellow"))
     console.print()
@@ -217,9 +248,11 @@ def handle_doctor():
                 connectivity_table.add_row("Authentication", "[green]✓[/green] Valid credentials")
             else:
                 connectivity_table.add_row("Authentication", f"[red]✗[/red] Failed (status {response.status_code})")
+                found.append(f"authentication failed (status {response.status_code})")
 
         console.print(Panel(connectivity_table, title="[bold]Connectivity[/bold]", border_style="magenta"))
         console.print()
 
-    console.print("[bold green]✅ Diagnostics complete![/bold green]\n")
+    code = verdict(found)
     console.print("[dim]Run 'co auth' if you need to authenticate[/dim]\n")
+    return code

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -225,7 +225,10 @@ def reset():
 def doctor():
     """Diagnose installation."""
     from .commands.doctor_commands import handle_doctor
-    handle_doctor()
+    # The exit code is the whole point of running this in a script: it used to
+    # be 0 even under its own `✗ broken symlink`.
+    if handle_doctor():
+        raise typer.Exit(1)
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})

--- a/tests/unit/test_doctor_says_what_it_found.py
+++ b/tests/unit/test_doctor_says_what_it_found.py
@@ -1,0 +1,79 @@
+"""What `co doctor` concludes after finding something wrong.
+
+Run on a real project from a clean install of the wheel:
+
+    user/email-outreach   ✗ broken symlink
+    …
+    ✅ Diagnostics complete!
+
+    $ echo $?
+    0
+
+It found the problem, printed it, and then said everything was fine — in the
+one command whose entire job is to tell you whether anything is wrong. People
+read the last line, and any script using it as a gate reads the exit code.
+
+Five places add a `✗` row and nothing counted them. So they are counted, the
+last line says what was found, and the exit code agrees with the last line.
+"""
+
+import pytest
+
+from connectonion.cli.commands.doctor_commands import verdict
+
+
+class TestTheLastLineAgreesWithTheBody:
+
+    def test_nothing_found_still_says_so(self, capsys):
+        assert verdict([]) == 0
+
+        out = capsys.readouterr().out
+        assert '✅' in out
+
+    def test_one_problem_is_named_in_the_summary(self, capsys):
+        verdict(["user/email-outreach: broken symlink"])
+
+        out = capsys.readouterr().out
+        assert 'email-outreach' in out
+        assert '✅' not in out, "the summary claimed success over its own finding"
+
+    def test_several_are_all_named(self, capsys):
+        verdict(["a: broken symlink", "b: not on PATH", "c: auth failed"])
+
+        out = capsys.readouterr().out
+        for name in ('a', 'b', 'c'):
+            assert name in out
+
+    def test_the_count_is_stated(self, capsys):
+        verdict(["a: x", "b: y"])
+
+        assert '2' in capsys.readouterr().out
+
+
+class TestAScriptCanUseIt:
+    """`co doctor` in a deploy script is the obvious use, and it was useless
+    for that: it exits 0 whatever it finds."""
+
+    def test_a_clean_run_exits_zero(self, capsys):
+        assert verdict([]) == 0
+
+    def test_a_problem_exits_non_zero(self, capsys):
+        assert verdict(["something: wrong"]) == 1
+
+
+class TestTheExitCodeIsWiredUp:
+    """A verdict nothing acts on is a print statement.
+
+    `get_default_trust()` was correct, tested and never called for seven months
+    (#366), and this session has already shipped a compaction that nothing
+    invoked. So the wiring gets asserted, not assumed.
+    """
+
+    def test_the_cli_exits_non_zero_on_problems(self):
+        import inspect
+        from connectonion.cli import main
+
+        source = inspect.getsource(main.doctor)
+        assert 'typer.Exit(1)' in source, (
+            "co doctor cannot fail, so a script cannot use it as a gate"
+        )


### PR DESCRIPTION
`co doctor` on a real project, from a clean install of the built wheel:

```
user/email-outreach   ✗ broken symlink
…
✅ Diagnostics complete!

$ echo $?
0
```

It found the problem, printed it, and concluded that everything was fine — in **the one command whose entire job is to say whether anything is wrong**. People read the last line; a script using it as a gate reads the exit code. Both were told the opposite of the body.

Five places add a `✗` row and nothing counted them.

## After

```
✗ Diagnostics complete — 1 problem
  • skill user/email-outreach: broken symlink

$ echo $?
1
```

## Two things worth recording about how this went

**The accumulator was first called `problems`** — which is already a local in that function, holding `(location, name, reason)` tuples from `find_skill_problems()`. Shadowing it made the loop below unpack my strings into three names:

```
ValueError: too many values to unpack (expected 3)
```

**Seven unit tests were green** while the real CLI crashed on the very project I had used to reproduce the original bug. Fourth time this session the built wheel caught what the tests could not, so the rename carries that reason in a comment rather than just a better name.

**The exit code is asserted, not assumed.** A verdict nothing acts on is a print statement — which is what `get_default_trust()` was for seven months (#366), and what the compaction in #592 nearly was.

3227 unit tests pass.
