### PR TITLE
fix(usage): the default model was priced by guesswork, and said nothing

### DIFF
--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -527,8 +527,14 @@ class Console:
         if cached:
             tokens_str = f"{tokens_str} ({cached} cached)"
 
-        # Format cost
-        cost_str = f"${usage.cost:.4f}" if usage.cost < 0.01 else f"${usage.cost:.2f}"
+        # Format cost. A `~` when the model is not in the pricing table, because
+        # the figure is then a generic fallback rather than a looked-up price —
+        # and printing a guess in the same shape as a fact is how the default
+        # model stayed mispriced without anyone noticing.
+        from .core.usage import is_estimated_price
+
+        amount = f"${usage.cost:.4f}" if usage.cost < 0.01 else f"${usage.cost:.2f}"
+        cost_str = f"~{amount}" if is_estimated_price(model) else amount
 
         # Format timing
         time_str = f"{duration_ms/1000:.1f}s" if duration_ms >= 100 else f"{duration_ms/1000:.2f}s"

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -102,18 +102,46 @@ DEFAULT_PRICING = {"input": 1.00, "output": 3.00, "cached": 0.50}
 DEFAULT_CONTEXT_LIMIT = 128000
 
 
+def _priced_name(model: str) -> str:
+    """The name this model is listed under, if it is listed at all.
+
+    `co/` is the managed route to a model, not a different model — and not one
+    of the priced entries carries the prefix, so every agent on the default
+    setup (which is a `co/` model) had its tokens costed from the generic
+    fallback. For co/gemini-3.6-flash that is 3.00 an output megatoken against
+    the model's own 7.50.
+    """
+    return model[len("co/"):] if model.startswith("co/") else model
+
+
 def get_pricing(model: str) -> dict:
     """Get pricing for a model, with fallback to default."""
+    name = _priced_name(model)
+
     # Try exact match
-    if model in MODEL_PRICING:
-        return MODEL_PRICING[model]
+    if name in MODEL_PRICING:
+        return MODEL_PRICING[name]
 
     # Try prefix match (e.g., "gpt-4o-2024-08-06" -> "gpt-4o")
     for known_model in MODEL_PRICING:
-        if model.startswith(known_model):
+        if name.startswith(known_model):
             return MODEL_PRICING[known_model]
 
     return DEFAULT_PRICING
+
+
+def is_estimated_price(model: str) -> bool:
+    """Whether this model's cost is a guess rather than a looked-up price.
+
+    DEFAULT_PRICING is returned exactly like a real entry, so a fabricated
+    number reaches a display with the same confidence as a known one. That is
+    how the default model went mispriced without anyone noticing: the figure
+    looked like every other figure.
+
+    Callers that show money should say when it is an estimate. The next model
+    the world ships is unknown here again.
+    """
+    return get_pricing(model) is DEFAULT_PRICING
 
 
 def get_context_limit(model: str) -> int:

--- a/tests/unit/test_a_guessed_price_says_so.py
+++ b/tests/unit/test_a_guessed_price_says_so.py
@@ -1,0 +1,108 @@
+"""What a cost figure means when the model is not in the table.
+
+`get_pricing` falls back to DEFAULT_PRICING for anything it does not know, and
+returns it exactly like a real entry. Nothing downstream can tell the
+difference, so a fabricated number is displayed with the same confidence as a
+looked-up one.
+
+Two things that makes wrong today:
+
+    gemini-3.6-flash      {'input': 1.5, 'output': 7.5, 'cached': 0.15}
+    co/gemini-3.6-flash   {'input': 1.0, 'output': 3.0, 'cached': 0.5}   ← default
+
+`co/` is the managed route — the default path, the one with the free credits —
+and **not one of the 26 priced models carries that prefix**. Every agent on the
+default setup has its output tokens costed at 3.00 when the model's own price
+is 7.50.
+
+The prefix fix is the easy half. The half that lasts is saying when the number
+is a guess: the next model added to the world is unknown again, and a silent
+default is how this went unnoticed while it was the default.
+"""
+
+import pytest
+
+from connectonion.core.usage import (
+    DEFAULT_PRICING,
+    calculate_cost,
+    get_pricing,
+    is_estimated_price,
+)
+
+
+class TestTheManagedRouteFindsItsModel:
+
+    @pytest.mark.parametrize("model", [
+        "co/gemini-3.6-flash", "co/gpt-4o", "co/claude-sonnet-4-5",
+    ])
+    def test_a_co_model_is_priced_like_the_model_it_is(self, model):
+        bare = model[len("co/"):]
+
+        if get_pricing(bare) is DEFAULT_PRICING:
+            pytest.skip(f"{bare} is not priced either — nothing to compare")
+
+        assert get_pricing(model) == get_pricing(bare)
+
+    def test_the_default_model_is_not_costed_by_guesswork(self):
+        assert not is_estimated_price("co/gemini-3.6-flash"), (
+            "the default path prices its tokens from a generic fallback"
+        )
+
+    def test_the_output_price_actually_changes(self):
+        """3.00 vs 7.50 is not a rounding difference."""
+        guessed = 1_000_000 / 1_000_000 * DEFAULT_PRICING["output"]
+        real = calculate_cost("co/gemini-3.6-flash", 0, 1_000_000)
+
+        assert real != pytest.approx(guessed)
+
+
+class TestAGuessAnnouncesItself:
+    """The durable half. The next model the world ships is unknown again."""
+
+    def test_an_unknown_model_is_flagged(self):
+        assert is_estimated_price("some-model-nobody-has-heard-of")
+
+    def test_a_known_model_is_not(self):
+        assert not is_estimated_price("gpt-4o")
+
+    def test_a_dated_variant_is_not(self):
+        """Prefix matching already handles gpt-4o-2024-08-06."""
+        assert not is_estimated_price("gpt-4o-2024-08-06")
+
+
+class TestNothingElseMoves:
+
+    def test_known_models_cost_what_they_did(self):
+        assert calculate_cost("gpt-4o", 1_000_000, 100_000) == pytest.approx(3.5)
+
+    def test_an_unknown_model_still_returns_a_number(self):
+        """A guess is better than a crash in a display path — it just has to
+        be labelled."""
+        assert calculate_cost("nobody-has-heard-of-this", 1_000_000, 0) > 0
+
+
+class TestTheDisplaySaysWhichItIs:
+    """A guess printed in the same shape as a fact is the whole problem."""
+
+    def _line(self, model, capsys):
+        """The console writes to stderr, not to a console object one can swap —
+        which is why the first version of this test failed while the code was
+        already right."""
+        from connectonion.console import Console
+        from connectonion.core.usage import TokenUsage
+
+        Console().log_llm_response(model, 120.0, 0,
+                                   TokenUsage(input_tokens=1000, output_tokens=100,
+                                              cost=0.0042))
+        return capsys.readouterr().err
+
+    def test_a_known_model_prints_a_plain_figure(self, capsys):
+        line = self._line("gpt-4o", capsys)
+
+        assert "$0.0042" in line
+        assert "~$" not in line, line
+
+    def test_an_unknown_model_is_marked(self, capsys):
+        line = self._line("some-model-nobody-has-heard-of", capsys)
+
+        assert "~$0.0042" in line, line


### PR DESCRIPTION
`get_pricing` falls back to `DEFAULT_PRICING` for anything it does not know, and returns it **exactly like a real entry**. Nothing downstream can tell the difference, so a fabricated number reaches the display with the same confidence as a looked-up one.

```
gemini-3.6-flash      {'input': 1.5, 'output': 7.5, 'cached': 0.15}
co/gemini-3.6-flash   {'input': 1.0, 'output': 3.0, 'cached': 0.5}   ← the default
```

`co/` is the managed *route* to a model, not a different model — and **not one of the 26 priced entries carries the prefix**.

So every agent on the default setup — a `co/` model, the path with the free credits — had its output tokens costed at 3.00 a megatoken against the model's own 7.50. Two and a half times off, on the figure people use to decide whether to keep going.

## The half that lasts

Stripping the prefix is easy. The durable part is saying when the number is a guess — the next model the world ships is unknown here again, and a silent fallback is exactly how this went unnoticed *while it was the default*:

```
is_estimated_price(model)   → True when the price came from the fallback
console                     → ~$0.0042   instead of   $0.0042
```

A `~` because a guess printed in the shape of a fact is the whole problem, and because a display path should degrade to an approximation rather than a crash.

## For whoever owns the price table

`co/` models are billed by the backend, which may not charge the underlying provider's rate. Mapping them to the model they proxy is the best information available locally and strictly better than a generic default — but if the managed route has its own prices, they belong in the table under their own names, and then this mapping should go.

## One test-writing note

The display tests failed while the code was already correct: the console writes to **stderr**, not through a console object one can swap out. The fixture now reads `capsys.readouterr().err`, and says why.

3238 unit tests pass.
