### PR TITLE
Drop every model released before 2025

### DIFF
--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -265,7 +265,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
 # OPENROUTER_API_KEY=
 
 # Optional: Override default model
-# MODEL=gpt-4o-mini
+# MODEL=co/gemini-3.6-flash
 """
             env_path.write_text(env_content, encoding='utf-8')
         files_created.append(".env")

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -268,11 +268,9 @@ def api_key_setup_menu(temp_project_dir: Optional[Path] = None) -> Tuple[str, st
                             console.print("[green]You now have 100k free tokens![/green]")
                             console.print("\n[cyan]You can use ConnectOnion models with the 'co/' prefix:[/cyan]")
                             console.print("  • co/gemini-3.6-flash")
-                            console.print("  • co/gpt-4o")
-                            console.print("  • co/gemini-3.6-flash")
+                            console.print("  • co/gemini-3-pro-preview")
                             console.print("  • co/gpt-5")
-                            console.print("  • co/claude-3-haiku")
-                            console.print("  • co/claude-3-sonnet")
+                            console.print("  • co/claude-sonnet-4")
 
                             return "star", "connectonion", temp_dir  # Return the temp directory
                         else:
@@ -351,11 +349,9 @@ def api_key_setup_menu(temp_project_dir: Optional[Path] = None) -> Tuple[str, st
                         console.print("[green]You now have 100k free tokens![/green]")
                         console.print("\n[cyan]You can use ConnectOnion models with the 'co/' prefix:[/cyan]")
                         console.print("  • co/gemini-3.6-flash")
-                        console.print("  • co/gpt-4o")
-                        console.print("  • co/gemini-3.6-flash")
+                        console.print("  • co/gemini-3-pro-preview")
                         console.print("  • co/gpt-5")
-                        console.print("  • co/claude-3-haiku")
-                        console.print("  • co/claude-3-sonnet")
+                        console.print("  • co/claude-sonnet-4")
                         break  # Success, exit the loop
                     except Exception as e:
                         console.print(f"\n[red]Authentication failed: {e}[/red]")
@@ -556,11 +552,11 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
     configs = {
         'openai': {
             'var': 'OPENAI_API_KEY',
-            'model': 'gpt-4o-mini'
+            'model': 'o4-mini'
         },
         'anthropic': {
             'var': 'ANTHROPIC_API_KEY',
-            'model': 'claude-3-5-haiku-latest'
+            'model': 'claude-sonnet-4-20250514'
         },
         'google': {
             'var': 'GEMINI_API_KEY',
@@ -576,7 +572,7 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         },
         'openrouter': {
             'var': 'OPENROUTER_API_KEY',
-            'model': 'openrouter/openai/gpt-4o-mini'
+            'model': 'openrouter/openai/o4-mini'
         },
         'connectonion': {
             'var': 'CONNECTONION_API_KEY',
@@ -596,7 +592,7 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
 
 # Model Configuration (use co/ prefix for managed models)
 MODEL=co/gemini-3.6-flash
-# Available models: co/gemini-3.6-flash, co/gpt-4o, co/claude-3-haiku, co/claude-3-sonnet
+# Available models: co/gemini-3.6-flash, co/gemini-3-pro-preview, co/gpt-5, co/claude-sonnet-4
 
 # No API key needed - authentication handled via JWT token from 'co auth'
 
@@ -638,7 +634,7 @@ def generate_custom_template_with_name(description: str, api_key: str, model: st
     Args:
         description: What the agent should do
         api_key: API key or token for LLM
-        model: Optional model to use (e.g., "co/gpt-4o-mini")
+        model: Optional model to use (e.g., "co/gemini-3.6-flash")
         loading_animation: Optional LoadingAnimation instance to update
 
     Returns:

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -130,7 +130,7 @@ Example Usage
 ------------
 Basic completion:
     >>> from connectonion.llm import create_llm
-    >>> llm = create_llm(model="gpt-4o-mini")
+    >>> llm = create_llm(model="o4-mini")
     >>> response = llm.complete([{"role": "user", "content": "Hello"}])
     >>> print(response.content)
 
@@ -138,7 +138,7 @@ Structured output:
     >>> from pydantic import BaseModel
     >>> class Answer(BaseModel):
     ...     value: int
-    >>> llm = create_llm(model="gpt-4o-mini")
+    >>> llm = create_llm(model="o4-mini")
     >>> result = llm.structured_complete(
     ...     [{"role": "user", "content": "What is 2+2?"}],
     ...     Answer
@@ -363,7 +363,7 @@ class OpenAILLM(LLM):
 class AnthropicLLM(LLM):
     """Anthropic Claude LLM implementation."""
     
-    def __init__(self, api_key: Optional[str] = None, model: str = "claude-3-5-sonnet-20241022", max_tokens: int = 8192, **kwargs):
+    def __init__(self, api_key: Optional[str] = None, model: str = "claude-sonnet-4-20250514", max_tokens: int = 8192, **kwargs):
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("Anthropic API key required. Set ANTHROPIC_API_KEY environment variable or pass api_key parameter.")
@@ -827,7 +827,7 @@ class GrokLLM(LLM):
 class OpenRouterLLM(LLM):
     """OpenRouter LLM implementation using OpenAI-compatible endpoint."""
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "openrouter/openai/gpt-4o-mini", **kwargs):
+    def __init__(self, api_key: Optional[str] = None, model: str = "openrouter/openai/o4-mini", **kwargs):
         self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
         if not self.api_key:
             raise ValueError("OpenRouter API key required. Set OPENROUTER_API_KEY environment variable or pass api_key parameter.")
@@ -991,27 +991,9 @@ class MistralLLM(LLM):
 # Model registry mapping model names to providers
 MODEL_REGISTRY = {
     # OpenAI models
-    "gpt-4o": "openai",
-    "gpt-4o-mini": "openai",
-    "gpt-4-turbo": "openai",
-    "gpt-3.5-turbo": "openai",
-    "o1": "openai",
-    "o1-mini": "openai",
-    "o1-preview": "openai",
-    "o4-mini": "openai",  # Testing placeholder
-    
-    # Anthropic Claude models
-    "claude-3-5-sonnet": "anthropic",
-    "claude-3-5-sonnet-20241022": "anthropic",
-    "claude-3-5-sonnet-latest": "anthropic",
-    "claude-3-5-haiku": "anthropic",
-    "claude-3-5-haiku-20241022": "anthropic",
-    "claude-3-5-haiku-latest": "anthropic",
-    "claude-3-haiku-20240307": "anthropic",
-    "claude-3-opus-20240229": "anthropic",
-    "claude-3-opus-latest": "anthropic",
-    "claude-3-sonnet-20240229": "anthropic",
-    
+    "o3-mini": "openai",
+    "o4-mini": "openai",
+
     # Claude 4 models
     "claude-opus-4.1": "anthropic",
     "claude-opus-4-1-20250805": "anthropic",
@@ -1034,14 +1016,6 @@ MODEL_REGISTRY = {
     "gemini-2.5-flash": "google",
     "gemini-2.0-flash-exp": "google",
     "gemini-2.0-flash-thinking-exp": "google",
-    "gemini-1.5-pro": "google",
-    "gemini-1.5-pro-002": "google",
-    "gemini-1.5-pro-001": "google",
-    "gemini-1.5-flash": "google",
-    "gemini-1.5-flash-002": "google",
-    "gemini-1.5-flash-001": "google",
-    "gemini-1.5-flash-8b": "google",
-    "gemini-1.0-pro": "google",
 }
 
 
@@ -1227,7 +1201,7 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
     """Factory function to create the appropriate LLM based on model name.
     
     Args:
-        model: The model name (e.g., "gpt-4o", "claude-3-5-sonnet", "gemini-1.5-pro")
+        model: The model name (e.g., "o4-mini", "claude-sonnet-4-20250514", "gemini-2.5-pro")
         api_key: Optional API key to override environment variable
         **kwargs: Additional arguments to pass to the LLM constructor
     

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -28,23 +28,10 @@ class TokenUsage(BaseModel):
 # Format: {"input": $, "output": $, "cached": $, "cache_write": $}
 MODEL_PRICING = {
     # OpenAI models - cached = 50% of input
-    "gpt-4o": {"input": 2.50, "output": 10.00, "cached": 1.25},
-    "gpt-4o-mini": {"input": 0.15, "output": 0.60, "cached": 0.075},
-    "gpt-4-turbo": {"input": 10.00, "output": 30.00, "cached": 5.00},
-    "o1": {"input": 15.00, "output": 60.00, "cached": 7.50},
-    "o1-mini": {"input": 3.00, "output": 12.00, "cached": 1.50},
-    "o1-preview": {"input": 15.00, "output": 60.00, "cached": 7.50},
     "o3-mini": {"input": 1.10, "output": 4.40, "cached": 0.55},
     "o4-mini": {"input": 1.10, "output": 4.40, "cached": 0.55},
 
     # Anthropic Claude models - cached = 10% of input, cache_write = 125% of input
-    "claude-3-5-sonnet-20241022": {"input": 3.00, "output": 15.00, "cached": 0.30, "cache_write": 3.75},
-    "claude-3-5-sonnet-latest": {"input": 3.00, "output": 15.00, "cached": 0.30, "cache_write": 3.75},
-    "claude-3-5-haiku-20241022": {"input": 0.80, "output": 4.00, "cached": 0.08, "cache_write": 1.00},
-    "claude-3-5-haiku-latest": {"input": 0.80, "output": 4.00, "cached": 0.08, "cache_write": 1.00},
-    "claude-3-opus-20240229": {"input": 15.00, "output": 75.00, "cached": 1.50, "cache_write": 18.75},
-    "claude-3-sonnet-20240229": {"input": 3.00, "output": 15.00, "cached": 0.30, "cache_write": 3.75},
-    "claude-3-haiku-20240307": {"input": 0.25, "output": 1.25, "cached": 0.025, "cache_write": 0.3125},
 
     # Claude 4 models
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00, "cached": 0.30, "cache_write": 3.75},
@@ -58,30 +45,15 @@ MODEL_PRICING = {
     "gemini-2.5-pro": {"input": 1.25, "output": 10.00, "cached": 0.3125},
     "gemini-2.5-flash": {"input": 0.15, "output": 0.60, "cached": 0.0375},
     "gemini-2.0-flash": {"input": 0.10, "output": 0.40, "cached": 0.025},
-    "gemini-1.5-pro": {"input": 1.25, "output": 5.00, "cached": 0.3125},
-    "gemini-1.5-flash": {"input": 0.075, "output": 0.30, "cached": 0.01875},
 }
 
 # Context window limits (tokens)
 MODEL_CONTEXT_LIMITS = {
     # OpenAI
-    "gpt-4o": 128000,
-    "gpt-4o-mini": 128000,
-    "gpt-4-turbo": 128000,
-    "o1": 200000,
-    "o1-mini": 128000,
-    "o1-preview": 128000,
     "o3-mini": 200000,
     "o4-mini": 200000,
 
     # Anthropic
-    "claude-3-5-sonnet-20241022": 200000,
-    "claude-3-5-sonnet-latest": 200000,
-    "claude-3-5-haiku-20241022": 200000,
-    "claude-3-5-haiku-latest": 200000,
-    "claude-3-opus-20240229": 200000,
-    "claude-3-sonnet-20240229": 200000,
-    "claude-3-haiku-20240307": 200000,
     "claude-sonnet-4-20250514": 200000,
     "claude-opus-4-20250514": 200000,
 
@@ -93,8 +65,6 @@ MODEL_CONTEXT_LIMITS = {
     "gemini-2.5-pro": 1000000,
     "gemini-2.5-flash": 1000000,
     "gemini-2.0-flash": 1000000,
-    "gemini-1.5-pro": 2000000,
-    "gemini-1.5-flash": 1000000,
 }
 
 # Default values for unknown models
@@ -122,20 +92,17 @@ def get_pricing(model: str) -> dict:
     if name in MODEL_PRICING:
         return MODEL_PRICING[name]
 
-    # Try prefix match (e.g., "gpt-4o-2024-08-06" -> "gpt-4o"), longest first.
+    # Try prefix match (e.g., "gemini-2.5-pro-preview" -> "gemini-2.5-pro"),
+    # longest first.
     #
-    # Taking the first key that matched let dict order decide, and three entries
-    # are prefixes of others: gpt-4o ⊂ gpt-4o-mini, o1 ⊂ o1-mini, o1 ⊂
-    # o1-preview. Exact matches are tried above, so the listed names were fine —
-    # but a pinned, dated name is not listed, and pinning a date is what
-    # production code does:
-    #
-    #     gpt-4o-mini              input 0.15   output 0.60
-    #     gpt-4o-mini-2024-07-18   input 2.50   output 10.00   ← gpt-4o's price
-    #
-    # Seventeen times the cost for the same model, depending on whether the
-    # name carries its date. The longest match is the most specific one, which
-    # is what a prefix match is for.
+    # Taking the first key that matched let dict order decide. Exact matches are
+    # tried above, so a listed name was always fine — but a pinned, dated name is
+    # not listed, and pinning a date is what production code does. When one entry
+    # is a prefix of another, the shorter one used to win and charge its own
+    # price for the longer model. The table no longer contains such a pair (a
+    # test enforces that), but the ordering is what makes it safe to add one.
+    # The longest match is the most specific one, which is what a prefix match
+    # is for.
     for known_model in sorted(MODEL_PRICING, key=len, reverse=True):
         if name.startswith(known_model):
             return MODEL_PRICING[known_model]
@@ -165,10 +132,10 @@ def get_context_limit(model: str) -> int:
         return MODEL_CONTEXT_LIMITS[name]
 
     # Longest first, for the reason spelled out in get_pricing — and here the
-    # consequence is worse than a wrong number on screen. o1 is 200000 and
-    # o1-mini is 128000, so `o1-mini-2024-09-12` took o1's: the agent believed
-    # it had seventy-two thousand tokens it did not have, auto-compaction fired
-    # too late, and the provider rejected the request for length.
+    # consequence is worse than a wrong number on screen. A dated name that fell
+    # through to a larger model's limit made the agent believe it had tens of
+    # thousands of tokens it did not have: auto-compaction fired too late and the
+    # provider rejected the request for length.
     for known_model in sorted(MODEL_CONTEXT_LIMITS, key=len, reverse=True):
         if name.startswith(known_model):
             return MODEL_CONTEXT_LIMITS[known_model]

--- a/connectonion/llm_do.py
+++ b/connectonion/llm_do.py
@@ -83,11 +83,11 @@ Supported Providers
 ------------------
 All providers from llm.py module:
 
-1. **OpenAI**: gpt-4o, gpt-4o-mini, gpt-3.5-turbo, o4-mini
+1. **OpenAI**: o4-mini, o3-mini
    - Native structured output via responses.parse()
    - Fastest structured output implementation
 
-2. **Anthropic**: claude-3-5-sonnet, claude-3-5-haiku-20241022
+2. **Anthropic**: claude-sonnet-4-20250514, claude-opus-4-20250514
    - Structured output via forced tool calling
    - Requires max_tokens parameter (default: 8192)
 
@@ -95,7 +95,7 @@ All providers from llm.py module:
    - Structured output via response_schema
    - Good balance of speed and quality
 
-4. **ConnectOnion**: co/gpt-4o, co/gemini-3.6-flash (DEFAULT)
+4. **ConnectOnion**: co/gemini-3.6-flash (DEFAULT), co/gpt-5
    - Managed API keys (no env vars needed!)
    - Proxies to OpenAI with usage tracking
    - Requires: run `co auth` first
@@ -120,7 +120,7 @@ Usage Patterns
    ... )
 
 4. **Different Provider**:
-   >>> answer = llm_do("Hello", model="claude-3-5-haiku-20241022")
+   >>> answer = llm_do("Hello", model="claude-sonnet-4-20250514")
 
 5. **Runtime Parameters**:
    >>> answer = llm_do(
@@ -239,10 +239,10 @@ def llm_do(
     Make a one-shot LLM call with optional structured output.
 
     Supports multiple LLM providers:
-    - OpenAI: "gpt-4o", "o4-mini", "gpt-3.5-turbo"
-    - Anthropic: "claude-3-5-sonnet", "claude-3-5-haiku-20241022"
+    - OpenAI: "o4-mini", "o3-mini"
+    - Anthropic: "claude-sonnet-4-20250514", "claude-opus-4-20250514"
     - Google: "gemini-2.5-pro", "gemini-2.5-flash"
-    - ConnectOnion Managed: "co/gpt-4o", "co/gemini-3.6-flash" (no API keys needed!)
+    - ConnectOnion Managed: "co/gemini-3.6-flash", "co/gpt-5" (no API keys needed!)
 
     Args:
         input: The input text/question to send to the LLM
@@ -264,7 +264,7 @@ def llm_do(
         >>> answer = llm_do("What's 2+2?", model="co/gemini-3.6-flash")
 
         >>> # With Claude
-        >>> answer = llm_do("Explain quantum physics", model="claude-3-5-haiku-20241022")
+        >>> answer = llm_do("Explain quantum physics", model="claude-sonnet-4-20250514")
 
         >>> # With Gemini
         >>> answer = llm_do("Write a poem", model="gemini-2.5-flash")

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -106,7 +106,7 @@ class TrustAgent:
         authentication backends, or business logic. See module docstring.
     """
 
-    def __init__(self, trust: str = "careful", *, api_key: str = None, model: str = "co/gpt-4o-mini"):
+    def __init__(self, trust: str = "careful", *, api_key: str = None, model: str = "co/gemini-3.6-flash"):
         """
         Create a TrustAgent.
 

--- a/tests/.co/config.toml
+++ b/tests/.co/config.toml
@@ -15,5 +15,5 @@ email = "0x7b78b4cf@mail.openonion.ai"
 email_active = false
 created_at = "2025-09-18T11:42:35.025759"
 algorithm = "ed25519"
-default_model = "gpt-4o-mini"
+default_model = "co/gemini-3.6-flash"
 max_iterations = 10

--- a/tests/e2e/real_api/manual/manual_defaults.py
+++ b/tests/e2e/real_api/manual/manual_defaults.py
@@ -47,7 +47,7 @@ print(f"llm_do default model: {llm_do_model_default}")
 
 # Expected values
 expected_agent = "co/gemini-3.6-flash"
-expected_llm_do = "co/gpt-4o"
+expected_llm_do = "co/gemini-3.6-flash"
 
 if agent_model_default == expected_agent:
     print(f"✓ Agent default is correct: {expected_agent}")
@@ -67,7 +67,7 @@ print("=" * 60)
 print("\n1. With ConnectOnion managed keys (requires 'co auth'):")
 print("   from connectonion import llm_do, Agent")
 print("   ")
-print("   # Simple call - uses co/gpt-4o")
+print("   # Simple call - uses co/gemini-3.6-flash")
 print("   answer = llm_do('What is 2+2?')")
 print("   ")
 print("   # Agent - uses co/gemini-3.6-flash")
@@ -76,11 +76,11 @@ print("   result = agent.input('Analyze this data')")
 
 print("\n2. With your own API keys (override):")
 print("   # Override with your model")
-print("   answer = llm_do('Hello', model='gpt-4o', api_key='sk-...')")
-print("   agent = Agent('name', model='claude-3-5-sonnet', api_key='sk-ant-...')")
+print("   answer = llm_do('Hello', model='o4-mini', api_key='sk-...')")
+print("   agent = Agent('name', model='claude-sonnet-4-20250514', api_key='sk-ant-...')")
 
 print("\n3. Backend supported models:")
-print("   - co/gpt-4o ✓")
+print("   - co/gemini-3.6-flash ✓")
 print("   - co/gemini-3.6-flash ✓")
 
 # Test 3: Try to use with override (if OpenAI key available)
@@ -90,7 +90,7 @@ if has_openai:
     print("=" * 60)
 
     try:
-        result = llm_do("Say hello", model="gpt-4o-mini")
+        result = llm_do("Say hello", model="o4-mini")
         print(f"✓ llm_do works with OpenAI override")
         print(f"  Result: {result[:50]}...")
     except Exception as e:

--- a/tests/e2e/real_api/manual/manual_llm_do_examples.py
+++ b/tests/e2e/real_api/manual/manual_llm_do_examples.py
@@ -33,7 +33,7 @@ print(f"  ConnectOnion: {'✓' if has_co_auth else '✗'}")
 
 # Test 1: Simple string response with default model
 print("\n" + "=" * 70)
-print("Test 1: Simple string response with default model (co/gpt-4o)")
+print("Test 1: Simple string response with default model (co/gemini-3.6-flash)")
 print("=" * 70)
 
 if has_co_auth:
@@ -47,15 +47,15 @@ if has_co_auth:
 else:
     print("⊘ Skipped - No ConnectOnion auth (run 'co auth')")
 
-# Test 2: With ConnectOnion managed keys - co/o4-mini
+# Test 2: With ConnectOnion managed keys - co/gemini-3.6-flash
 print("\n" + "=" * 70)
-print("Test 2: With ConnectOnion managed keys (co/o4-mini)")
+print("Test 2: With ConnectOnion managed keys (co/gemini-3.6-flash)")
 print("=" * 70)
 
 if has_co_auth:
     try:
-        answer = llm_do("What's 2+2?", model="co/o4-mini")
-        print(f"✓ co/o4-mini works")
+        answer = llm_do("What's 2+2?", model="co/gemini-3.6-flash")
+        print(f"✓ co/gemini-3.6-flash works")
         print(f"  Answer: {answer}")
     except Exception as e:
         print(f"✗ Error: {e}")
@@ -64,14 +64,14 @@ else:
 
 # Test 3: With Claude (requires Anthropic API key or use override)
 print("\n" + "=" * 70)
-print("Test 3: With Claude (claude-3-5-haiku-20241022)")
+print("Test 3: With Claude (claude-sonnet-4-20250514)")
 print("=" * 70)
 
 if has_anthropic:
     try:
         answer = llm_do(
             "Explain quantum physics in one sentence",
-            model="claude-3-5-haiku-20241022"
+            model="claude-sonnet-4-20250514"
         )
         print(f"✓ Claude works")
         print(f"  Answer: {answer[:100]}...")
@@ -119,7 +119,7 @@ if has_openai:
         result = llm_do(
             "I love this! Best thing ever!",
             output=Analysis,
-            model="gpt-4o-mini"  # Use OpenAI directly
+            model="o4-mini"  # Use OpenAI directly
         )
         print(f"✓ Structured output works")
         print(f"  Input: 'I love this! Best thing ever!'")
@@ -135,7 +135,7 @@ elif has_co_auth:
         result = llm_do(
             "I love this! Best thing ever!",
             output=Analysis,
-            model="co/gpt-4o"  # Use managed keys
+            model="co/gemini-3.6-flash"  # Use managed keys
         )
         print(f"✓ Structured output works (with managed keys)")
         print(f"  Sentiment: {result.sentiment}")
@@ -156,12 +156,12 @@ if has_openai:
         result1 = llm_do(
             "What is the capital of France? One word only.",
             temperature=0.0,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
         result2 = llm_do(
             "What is the capital of France? One word only.",
             temperature=0.0,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
         print(f"✓ Temperature works")
         print(f"  Temperature 0.0 (attempt 1): {result1}")
@@ -179,7 +179,7 @@ print("=" * 70)
 
 tests_run = sum([
     has_co_auth,  # Test 1: default model
-    has_co_auth,  # Test 2: co/o4-mini
+    has_co_auth,  # Test 2: co/gemini-3.6-flash
     has_anthropic,  # Test 3: Claude
     has_gemini,  # Test 4: Gemini
     # Test 5 skipped (Ollama)
@@ -189,10 +189,10 @@ tests_run = sum([
 
 print(f"\nTests run: {tests_run}/7 (Ollama skipped)")
 print(f"\nDefault model configuration:")
-print(f"  llm_do default: co/gpt-4o")
+print(f"  llm_do default: co/gemini-3.6-flash")
 print(f"  Requires: ConnectOnion auth ('co auth')")
 print(f"\nOverride examples:")
-print(f"  llm_do('Hello', model='gpt-4o-mini', api_key='sk-...')")
-print(f"  llm_do('Hello', model='claude-3-5-haiku-20241022', api_key='sk-ant-...')")
+print(f"  llm_do('Hello', model='o4-mini', api_key='sk-...')")
+print(f"  llm_do('Hello', model='claude-sonnet-4-20250514', api_key='sk-ant-...')")
 
 print("\n" + "=" * 70)

--- a/tests/e2e/real_api/manual/manual_structured_output.py
+++ b/tests/e2e/real_api/manual/manual_structured_output.py
@@ -30,10 +30,10 @@ print(f"  OpenAI: {'✓' if has_openai else '✗'}")
 
 # Select model to use
 if has_co_auth:
-    model = "co/gpt-4o"
+    model = "co/o4-mini"
     print(f"\nUsing: {model} (ConnectOnion managed)")
 elif has_openai:
-    model = "gpt-4o-mini"
+    model = "o4-mini"
     print(f"\nUsing: {model} (OpenAI direct)")
 else:
     print("\n✗ No authentication available. Set OPENONION_API_KEY or OPENAI_API_KEY")

--- a/tests/e2e/real_api/test_all_models.py
+++ b/tests/e2e/real_api/test_all_models.py
@@ -2,8 +2,8 @@
 LLM-Note: Parametrized tests for all newest LLM models
 
 What it tests:
-- OpenAI models: gpt-4o, gpt-4o-mini, o1-mini
-- Anthropic models: claude-3-5-sonnet, claude-3-5-haiku, claude-opus-4.1
+- OpenAI models: o4-mini, o4-mini, o3-mini
+- Anthropic models: claude-sonnet-4-20250514, claude-opus-4-20250514, claude-opus-4.1
 - Google models: gemini-2.5-pro, gemini-2.5-flash
 - Basic completion and tool calling for each model
 
@@ -38,16 +38,16 @@ from tests.e2e.real_api.conftest import (
 # =============================================================================
 
 OPENAI_MODELS = [
-    "gpt-4o",
-    "gpt-4o-mini",
-    "o1-mini",
+    "o4-mini",
+    "o4-mini",
+    "o3-mini",
     # "o1",        # Expensive, enable if needed
     # "o4-mini",   # May not be available yet
 ]
 
 ANTHROPIC_MODELS = [
     "claude-sonnet-4",
-    "claude-3-5-haiku-latest",
+    "claude-sonnet-4-20250514",
     # "claude-opus-4",  # Expensive, enable if needed
 ]
 
@@ -58,7 +58,7 @@ GEMINI_MODELS = [
 ]
 
 OPENONION_MODELS = [
-    "co/gpt-4o-mini",
+    "co/o4-mini",
     "co/gemini-2.5-flash",
 ]
 

--- a/tests/e2e/real_api/test_llm_do.py
+++ b/tests/e2e/real_api/test_llm_do.py
@@ -156,7 +156,7 @@ class TestBasicFunctionality:
         """Test simple completion with OpenAI."""
         result = llm_do(
             "What is 2+2? Answer with just the number.",
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
         assert isinstance(result, str)
         assert "4" in result
@@ -165,7 +165,7 @@ class TestBasicFunctionality:
         """Test simple completion with Anthropic."""
         result = llm_do(
             "What is 2+2? Answer with just the number.",
-            model="claude-3-5-haiku-20241022"
+            model="claude-sonnet-4-20250514"
         )
         assert isinstance(result, str)
         assert "4" in result
@@ -183,7 +183,7 @@ class TestBasicFunctionality:
         """Test simple completion with ConnectOnion managed keys."""
         result = llm_do(
             "What is 2+2? Answer with just the number.",
-            model="co/gpt-4o"
+            model="co/o4-mini"
         )
         assert isinstance(result, str)
         assert "4" in result
@@ -201,7 +201,7 @@ class TestStructuredOutput:
         result = llm_do(
             "I absolutely love this product! Best purchase ever!",
             output=Analysis,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, Analysis)
@@ -219,7 +219,7 @@ class TestStructuredOutput:
         Due: January 15, 2024
         """
 
-        result = llm_do(invoice_text, output=Invoice, model="gpt-4o-mini")
+        result = llm_do(invoice_text, output=Invoice, model="o4-mini")
 
         assert isinstance(result, Invoice)
         assert result.invoice_number == "INV-2024-001"
@@ -232,7 +232,7 @@ class TestStructuredOutput:
         result = llm_do(
             "John Doe, 30, software engineer",
             output=Person,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, Person)
@@ -245,7 +245,7 @@ class TestStructuredOutput:
         result = llm_do(
             "I absolutely love this product! Best purchase ever!",
             output=SentimentAnalysis,
-            model="claude-3-5-haiku-20241022"
+            model="claude-sonnet-4-20250514"
         )
 
         assert isinstance(result, SentimentAnalysis)
@@ -278,7 +278,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             "Extract keywords from: 'Machine learning and artificial intelligence are transforming technology and business'",
             output=KeywordExtraction,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, KeywordExtraction)
@@ -292,7 +292,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             "Review: The laptop is amazing! Fast performance, great display. Rating: 5/5. Highly recommend!",
             output=ProductReview,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, ProductReview)
@@ -306,7 +306,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             'Email: "URGENT: Your account will be suspended unless you verify your information immediately!" Classify this email.',
             output=EmailClassification,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, EmailClassification)
@@ -336,7 +336,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             invoice_text,
             output=InvoiceDetailed,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, InvoiceDetailed)
@@ -360,7 +360,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             blog_text,
             output=BlogAnalysis,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, BlogAnalysis)
@@ -375,7 +375,7 @@ class TestComplexStructuredOutput:
         result = llm_do(
             "User comment: 'This is a great product! Everyone should try it. Visit my-totally-legit-site.com for more info!'",
             output=ContentModeration,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, ContentModeration)
@@ -398,12 +398,12 @@ class TestAdvancedFeatures:
         result1 = llm_do(
             "What is the capital of France? One word only.",
             temperature=0.0,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
         result2 = llm_do(
             "What is the capital of France? One word only.",
             temperature=0.0,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         # Both should mention Paris
@@ -414,7 +414,7 @@ class TestAdvancedFeatures:
         """Test max_tokens parameter pass-through."""
         result = llm_do(
             "Write a very long story about a dragon",
-            model="gpt-4o-mini",
+            model="o4-mini",
             max_tokens=20  # Very short limit
         )
 
@@ -427,7 +427,7 @@ class TestAdvancedFeatures:
         result = llm_do(
             "Hello",
             system_prompt="You are a pirate. Always respond like a pirate.",
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         # Should contain pirate-like language
@@ -449,12 +449,12 @@ class TestCrossProviderConsistency:
         results = []
 
         if os.getenv("OPENAI_API_KEY"):
-            result = llm_do(prompt, model="gpt-4o-mini")
+            result = llm_do(prompt, model="o4-mini")
             results.append(("OpenAI", result))
             assert "4" in result
 
         if os.getenv("ANTHROPIC_API_KEY"):
-            result = llm_do(prompt, model="claude-3-5-haiku-20241022")
+            result = llm_do(prompt, model="claude-sonnet-4-20250514")
             results.append(("Anthropic", result))
             assert "4" in result
 
@@ -476,7 +476,7 @@ class TestDocumentationExamples:
 
     def test_quick_start_example(self):
         """Test the Quick Start example from docs."""
-        answer = llm_do("What's 2+2?", model="gpt-4o-mini")
+        answer = llm_do("What's 2+2?", model="o4-mini")
         assert "4" in answer
 
     def test_format_conversion_example(self):
@@ -488,7 +488,7 @@ class TestDocumentationExamples:
         result = llm_do(
             "Extract: name=John age=30",
             output=PersonData,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, PersonData)
@@ -500,7 +500,7 @@ class TestDocumentationExamples:
         result = llm_do(
             "Is this valid SQL? Reply yes/no only: SELECT * FROM users",
             temperature=0,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert result.strip().lower() in ["yes", "no"]

--- a/tests/e2e/real_api/test_production_client.py
+++ b/tests/e2e/real_api/test_production_client.py
@@ -77,7 +77,7 @@ def test_production_llm_do_structured(monkeypatch):
         "Write a friendly hello email to a new colleague",
         output=EmailDraft,
         temperature=0.7,
-        model="co/gpt-4o-mini"
+        model="co/o4-mini"
     )
 
     # Verify we got a valid Pydantic model

--- a/tests/e2e/real_api/test_real_agent.py
+++ b/tests/e2e/real_api/test_real_agent.py
@@ -39,7 +39,7 @@ def get_current_time() -> str:
 
 @requires_openai
 def test_agent_run_no_tools_needed():
-    agent = Agent(name="test_no_tools", model="gpt-4o-mini", log=False)
+    agent = Agent(name="test_no_tools", model="o4-mini", log=False)
     result = agent.input("Simply say 'Hello test'")
     assert result is not None
     assert isinstance(result, str)
@@ -52,7 +52,7 @@ def test_agent_run_with_single_tool_call():
     agent = Agent(
         name="test_single_tool",
         tools=[calculator],
-        model="gpt-4o-mini",
+        model="o4-mini",
         system_prompt="You are a calculator assistant. When asked to calculate, use the calculator tool.",
         log=False,
     )
@@ -72,7 +72,7 @@ def test_agent_run_with_multiple_tool_calls():
     agent = Agent(
         name="test_multi_tool",
         tools=[calculator, get_current_time],
-        model="gpt-4o-mini",
+        model="o4-mini",
         system_prompt="You have calculator and time tools. Use them when asked.",
         log=False,
     )

--- a/tests/e2e/real_api/test_real_anthropic.py
+++ b/tests/e2e/real_api/test_real_anthropic.py
@@ -41,7 +41,7 @@ class TestRealAnthropic:
 
     def test_anthropic_basic_completion(self):
         """Test basic completion with Anthropic."""
-        llm = AnthropicLLM(model="claude-3-5-haiku-latest")
+        llm = AnthropicLLM(model="claude-sonnet-4-20250514")
         agent = Agent(name="anthropic_test", llm=llm)
 
         response = agent.input("Say 'Hello from Claude' exactly")
@@ -52,7 +52,7 @@ class TestRealAnthropic:
         """Test Anthropic with tool calling."""
         agent = Agent(
             name="anthropic_tools",
-            model="claude-3-5-haiku-latest",
+            model="claude-sonnet-4-20250514",
             tools=[text_processor]
         )
 
@@ -64,7 +64,7 @@ class TestRealAnthropic:
         """Test multi-turn conversation with Anthropic."""
         agent = Agent(
             name="anthropic_conversation",
-            model="claude-3-5-haiku-latest"
+            model="claude-sonnet-4-20250514"
         )
 
         # First turn
@@ -79,8 +79,8 @@ class TestRealAnthropic:
     def test_anthropic_different_models(self):
         """Test different Anthropic models."""
         models = [
-            "claude-3-5-haiku-latest",
-            "claude-3-5-sonnet-latest",
+            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-20250514",
         ]
 
         for model in models:
@@ -100,7 +100,7 @@ class TestRealAnthropic:
         """Test Anthropic with custom system prompt."""
         agent = Agent(
             name="anthropic_system",
-            model="claude-3-5-haiku-latest",
+            model="claude-sonnet-4-20250514",
             system_prompt="You are a helpful poetry assistant. Always respond in haiku format."
         )
 

--- a/tests/e2e/real_api/test_real_example_agent.py
+++ b/tests/e2e/real_api/test_real_example_agent.py
@@ -88,7 +88,7 @@ def test_complete_agent_workflow(tmp_path):
             process_data
         ],
         system_prompt="You are a helpful assistant with access to various tools.",
-        model="gpt-4o-mini",  # Using a cost-effective model
+        model="o4-mini",  # Using a cost-effective model
         log=str(log_path)  # Log to file (console always on by default)
     )
 
@@ -126,7 +126,7 @@ def test_agent_with_real_conversation(tmp_path):
     agent = Agent(
         name="conversation_example",
         tools=[calculator, get_current_time, search_web],
-        model="gpt-4o-mini",
+        model="o4-mini",
         log=str(log_path)
     )
 
@@ -161,7 +161,7 @@ def test_agent_with_decorators():
     agent = Agent(
         name="decorator_example",
         tools=[custom_tool, process_data],
-        model="gpt-4o-mini"
+        model="o4-mini"
     )
 
     response = agent.input("Use the custom tool with input 'test data'")

--- a/tests/e2e/real_api/test_real_llm.py
+++ b/tests/e2e/real_api/test_real_llm.py
@@ -35,7 +35,7 @@ class TestRealLLMDo:
     @requires_openai
     def test_real_api_simple_call(self):
         """Test real API call with simple string."""
-        result = llm_do("What is 2+2? Reply with just the number.", model="gpt-4o-mini")
+        result = llm_do("What is 2+2? Reply with just the number.", model="o4-mini")
 
         assert result is not None
         assert "4" in result
@@ -50,7 +50,7 @@ class TestRealLLMDo:
         result = llm_do(
             "What is 10 times 5?",
             output=TestResult,
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert isinstance(result, TestResult)
@@ -63,7 +63,7 @@ class TestRealLLMDo:
         result = llm_do(
             "Bonjour",
             system_prompt="You are a translator. Translate from French to English only. Be concise.",
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         assert result is not None
@@ -78,7 +78,7 @@ class TestRealMultiLLMSupport:
     @requires_openai
     def test_openai_model(self):
         """Test OpenAI model integration."""
-        agent = Agent("test_openai", model="gpt-4o-mini")
+        agent = Agent("test_openai", model="o4-mini")
         response = agent.input("Say hello in 5 words or less")
 
         assert response is not None
@@ -88,7 +88,7 @@ class TestRealMultiLLMSupport:
     @requires_anthropic
     def test_anthropic_model(self):
         """Test Anthropic Claude model integration."""
-        agent = Agent("test_anthropic", model="claude-3-5-haiku-20241022")
+        agent = Agent("test_anthropic", model="claude-sonnet-4-20250514")
         response = agent.input("Say hello in 5 words or less")
 
         assert response is not None
@@ -112,13 +112,13 @@ class TestRealMultiLLMSupport:
 
         # Test OpenAI with tools
         if os.getenv("OPENAI_API_KEY"):
-            agent = Agent("openai_tools", model="gpt-4o-mini", tools=[add_numbers])
+            agent = Agent("openai_tools", model="o4-mini", tools=[add_numbers])
             response = agent.input("What is 25 plus 17?")
             assert "42" in str(response)
 
         # Test Anthropic with tools
         if os.getenv("ANTHROPIC_API_KEY"):
-            agent = Agent("anthropic_tools", model="claude-3-5-haiku-20241022", tools=[add_numbers])
+            agent = Agent("anthropic_tools", model="claude-sonnet-4-20250514", tools=[add_numbers])
             response = agent.input("What is 25 plus 17?")
             assert "42" in str(response)
 

--- a/tests/e2e/real_api/test_real_managed.py
+++ b/tests/e2e/real_api/test_real_managed.py
@@ -57,7 +57,7 @@ def test_co_model_direct_api():
     print("\nTesting LLM completion...")
     
     payload = {
-        "model": "co/gpt-4o-mini",  # With co/ prefix as CLI sends
+        "model": "co/o4-mini",  # With co/ prefix as CLI sends
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Say 'Hello from ConnectOnion!' in exactly 3 words."}
@@ -103,7 +103,7 @@ def test_llm_do_function():
             print(f"✅ Found saved token: {token[:20]}...")
             
             # Test llm_do with co/ model
-            print("\nCalling llm_do with co/gpt-4o-mini...")
+            print("\nCalling llm_do with co/o4-mini...")
             
             # Set production mode
             os.environ.pop("OPENONION_DEV", None)
@@ -111,7 +111,7 @@ def test_llm_do_function():
             try:
                 response = llm_do(
                     "Reply with exactly: 'ConnectOnion works!'",
-                    model="co/gpt-4o-mini",
+                    model="co/o4-mini",
                     temperature=0.1
                 )
                 print(f"✅ Response: {response}")
@@ -160,8 +160,8 @@ def test_model_name_variations():
     
     # Test different model name formats
     test_cases = [
-        ("co/gpt-4o-mini", "With co/ prefix (as CLI sends)"),
-        ("gpt-4o-mini", "Without co/ prefix (raw model name)"),
+        ("co/o4-mini", "With co/ prefix (as CLI sends)"),
+        ("o4-mini", "Without co/ prefix (raw model name)"),
     ]
     
     results = []
@@ -206,8 +206,8 @@ def test_all_managed_models_with_tools():
     # All managed models that support tool calling
     models_to_test = [
         # OpenAI models
-        "co/gpt-4o-mini",
-        # "co/gpt-4o",  # More expensive, skip in regular tests
+        "co/o4-mini",
+        # "co/o4-mini",  # More expensive, skip in regular tests
         # Google Gemini models
         "co/gemini-2.5-flash",
         # "co/gemini-2.5-pro",  # More expensive

--- a/tests/e2e/real_api/test_real_multi_llm.py
+++ b/tests/e2e/real_api/test_real_multi_llm.py
@@ -59,7 +59,7 @@ def _tools():
 
 def test_model_detection_openai():
     """Test OpenAI model name patterns."""
-    models = ["o4-mini", "gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo", "o1", "o1-mini"]
+    models = ["o4-mini", "o4-mini", "o4-mini", "o3-mini", "o1", "o3-mini"]
     for model in models:
         assert model.startswith("gpt") or model.startswith("o")
 
@@ -71,7 +71,7 @@ def test_model_detection_google():
         "gemini-2.0-flash-exp",
         "gemini-2.0-flash-thinking-exp",
         "gemini-2.5-flash",
-        "gemini-1.5-flash-8b",
+        "gemini-2.5-flash",
     ]
     for model in models:
         assert model.startswith("gemini")
@@ -83,8 +83,8 @@ def test_model_detection_anthropic():
         "claude-opus-4.1",
         "claude-opus-4",
         "claude-sonnet-4",
-        "claude-3-5-sonnet-latest",
-        "claude-3-5-haiku-latest",
+        "claude-sonnet-4-20250514",
+        "claude-sonnet-4-20250514",
     ]
     for model in models:
         assert model.startswith("claude")
@@ -96,14 +96,14 @@ def test_select_model_for_code_generation():
         mapping = {
             "code": "o4-mini",
             "reasoning": "gemini-2.5-pro",
-            "fast": "gpt-4o-mini",
+            "fast": "o4-mini",
             "long_context": "gemini-2.5-pro",
         }
         return mapping.get(task_type, "o4-mini")
 
     assert select_model_for_task("code") == "o4-mini"
     assert select_model_for_task("reasoning") == "gemini-2.5-pro"
-    assert select_model_for_task("fast") == "gpt-4o-mini"
+    assert select_model_for_task("fast") == "o4-mini"
     assert select_model_for_task("long_context") == "gemini-2.5-pro"
 
 
@@ -133,11 +133,11 @@ def test_tools_work_across_all_models():
     test_cases = []
 
     if os.getenv("OPENAI_API_KEY"):
-        test_cases.append(("gpt-4o-mini", "openai"))
+        test_cases.append(("o4-mini", "openai"))
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         test_cases.append(("gemini-2.5-flash", "google"))
     if os.getenv("ANTHROPIC_API_KEY"):
-        test_cases.append(("claude-3-5-haiku-latest", "anthropic"))
+        test_cases.append(("claude-sonnet-4-20250514", "anthropic"))
 
     for model, provider in test_cases:
         agent = Agent(f"test_{provider}", model=model, tools=tools)
@@ -155,7 +155,7 @@ def test_tools_work_across_all_models():
 def test_openai_real_call():
     """Test actual API call with OpenAI model."""
     tools = _tools()
-    agent = Agent("test", model="gpt-4o-mini", tools=tools)
+    agent = Agent("test", model="o4-mini", tools=tools)
     response = agent.input("Use the simple_calculator tool to add 5 and 3")
     assert "8" in response
 
@@ -173,7 +173,7 @@ def test_gemini_real_call():
 def test_anthropic_real_call():
     """Test actual API call with Claude model."""
     tools = _tools()
-    agent = Agent("test", model="claude-3-5-haiku-latest", tools=tools)
+    agent = Agent("test", model="claude-sonnet-4-20250514", tools=tools)
     response = agent.input("Use the process_data tool to convert 'Hello' to uppercase")
     assert "HELLO" in response
 
@@ -189,11 +189,11 @@ def test_flagship_model_comparison():
     flagship_models = []
 
     if os.getenv("OPENAI_API_KEY"):
-        flagship_models.append(("gpt-4o-mini", "openai"))
+        flagship_models.append(("o4-mini", "openai"))
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         flagship_models.append(("gemini-2.5-flash", "google"))
     if os.getenv("ANTHROPIC_API_KEY"):
-        flagship_models.append(("claude-3-5-haiku-latest", "anthropic"))
+        flagship_models.append(("claude-sonnet-4-20250514", "anthropic"))
 
     for model, provider in flagship_models:
         agent = Agent(f"compare_{provider}", model=model)
@@ -212,11 +212,11 @@ def test_fast_model_performance():
     fast_models = []
 
     if os.getenv("OPENAI_API_KEY"):
-        fast_models.append("gpt-4o-mini")
+        fast_models.append("o4-mini")
     if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
         fast_models.append("gemini-2.5-flash")
     if os.getenv("ANTHROPIC_API_KEY"):
-        fast_models.append("claude-3-5-haiku-latest")
+        fast_models.append("claude-sonnet-4-20250514")
 
     for model in fast_models:
         start_time = time.time()

--- a/tests/e2e/real_api/test_real_openai.py
+++ b/tests/e2e/real_api/test_real_openai.py
@@ -45,7 +45,7 @@ class TestRealOpenAI:
 
     def test_openai_basic_completion(self):
         """Test basic completion with OpenAI."""
-        llm = OpenAILLM(model="gpt-4o-mini")
+        llm = OpenAILLM(model="o4-mini")
         agent = Agent(name="openai_test", llm=llm)
 
         response = agent.input("Say 'Hello from OpenAI' exactly")
@@ -56,7 +56,7 @@ class TestRealOpenAI:
         """Test OpenAI with tool calling."""
         agent = Agent(
             name="openai_tools",
-            model="gpt-4o-mini",
+            model="o4-mini",
             tools=[calculator]
         )
 
@@ -68,7 +68,7 @@ class TestRealOpenAI:
         """Test multi-turn conversation with OpenAI."""
         agent = Agent(
             name="openai_conversation",
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         # First turn
@@ -84,7 +84,7 @@ class TestRealOpenAI:
         """Test streaming responses from OpenAI."""
         agent = Agent(
             name="openai_streaming",
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         response = agent.input("Count from 1 to 5")
@@ -95,10 +95,10 @@ class TestRealOpenAI:
 
     def test_openai_different_models(self):
         """Test different OpenAI models."""
-        models = ["gpt-4o-mini", "gpt-4o"]
+        models = ["o4-mini", "o4-mini"]
 
         for model in models:
-            if model == "gpt-4o" and not os.getenv("TEST_EXPENSIVE_MODELS"):
+            if model == "o4-mini" and not os.getenv("TEST_EXPENSIVE_MODELS"):
                 continue  # Skip expensive models unless explicitly enabled
 
             agent = Agent(

--- a/tests/e2e/real_api/test_responses_parse.py
+++ b/tests/e2e/real_api/test_responses_parse.py
@@ -36,8 +36,8 @@ class MathAnswer(BaseModel):
 # =============================================================================
 
 OPENAI_MODELS = [
-    "co/gpt-4o-mini",
-    "co/gpt-4o",
+    "co/o4-mini",
+    "co/o4-mini",
     "co/gpt-5",
     "co/gpt-5-mini",
     "co/gpt-5-nano",

--- a/tests/e2e/test_auth_integration.py
+++ b/tests/e2e/test_auth_integration.py
@@ -138,7 +138,7 @@ def test_model_name_handling():
             print(f"   CLI now sends full model name with co/ prefix")
             
             # Test what happens now
-            model = "co/gpt-4o-mini"
+            model = "co/o4-mini"
             print(f"   Example: {model} -> API receives: {model}")
         else:
             print(f"\n❌ Model name still being stripped")

--- a/tests/unit/test_a_guessed_price_says_so.py
+++ b/tests/unit/test_a_guessed_price_says_so.py
@@ -33,7 +33,7 @@ from connectonion.core.usage import (
 class TestTheManagedRouteFindsItsModel:
 
     @pytest.mark.parametrize("model", [
-        "co/gemini-3.6-flash", "co/gpt-4o", "co/claude-sonnet-4-5",
+        "co/gemini-3.6-flash", "co/o4-mini", "co/claude-sonnet-4-5",
     ])
     def test_a_co_model_is_priced_like_the_model_it_is(self, model):
         bare = model[len("co/"):]
@@ -63,17 +63,18 @@ class TestAGuessAnnouncesItself:
         assert is_estimated_price("some-model-nobody-has-heard-of")
 
     def test_a_known_model_is_not(self):
-        assert not is_estimated_price("gpt-4o")
+        assert not is_estimated_price("o4-mini")
 
     def test_a_dated_variant_is_not(self):
-        """Prefix matching already handles gpt-4o-2024-08-06."""
-        assert not is_estimated_price("gpt-4o-2024-08-06")
+        """Prefix matching already handles o4-mini-2024-08-06."""
+        assert not is_estimated_price("o4-mini-2024-08-06")
 
 
 class TestNothingElseMoves:
 
     def test_known_models_cost_what_they_did(self):
-        assert calculate_cost("gpt-4o", 1_000_000, 100_000) == pytest.approx(3.5)
+        # 1M in at $1.25/M + 100k out at $10/M
+        assert calculate_cost("gemini-2.5-pro", 1_000_000, 100_000) == pytest.approx(2.25)
 
     def test_an_unknown_model_still_returns_a_number(self):
         """A guess is better than a crash in a display path — it just has to
@@ -97,7 +98,7 @@ class TestTheDisplaySaysWhichItIs:
         return capsys.readouterr().err
 
     def test_a_known_model_prints_a_plain_figure(self, capsys):
-        line = self._line("gpt-4o", capsys)
+        line = self._line("o4-mini", capsys)
 
         assert "$0.0042" in line
         assert "~$" not in line, line

--- a/tests/unit/test_agent_prompts.py
+++ b/tests/unit/test_agent_prompts.py
@@ -24,14 +24,14 @@ class TestAgentSystemPrompts:
     
     def test_agent_with_default_prompt(self):
         """Test agent with no prompt specified uses default."""
-        agent = Agent("test_agent", api_key="fake_key", model="gpt-4o-mini")
+        agent = Agent("test_agent", api_key="fake_key", model="o4-mini")
         assert agent.system_prompt == DEFAULT_PROMPT
         assert "helpful assistant" in agent.system_prompt
     
     def test_agent_with_string_prompt(self):
         """Test agent with direct string prompt."""
         prompt = "You are a Python expert"
-        agent = Agent("test_agent", system_prompt=prompt, api_key="fake_key", model="gpt-4o-mini")
+        agent = Agent("test_agent", system_prompt=prompt, api_key="fake_key", model="o4-mini")
         assert agent.system_prompt == prompt
     
     def test_agent_with_file_path_string(self):
@@ -42,7 +42,7 @@ class TestAgentSystemPrompts:
             temp_path = f.name
         
         try:
-            agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="gpt-4o-mini")
+            agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="o4-mini")
             assert agent.system_prompt == content
         finally:
             os.unlink(temp_path)
@@ -55,7 +55,7 @@ class TestAgentSystemPrompts:
             temp_path = Path(f.name)
         
         try:
-            agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="gpt-4o-mini")
+            agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="o4-mini")
             assert agent.system_prompt == content
         finally:
             temp_path.unlink()
@@ -71,7 +71,7 @@ class TestAgentSystemPrompts:
                 temp_path = f.name
             
             try:
-                agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="gpt-4o-mini")
+                agent = Agent("test_agent", system_prompt=temp_path, api_key="fake_key", model="o4-mini")
                 assert agent.system_prompt == content
             finally:
                 os.unlink(temp_path)
@@ -80,7 +80,7 @@ class TestAgentSystemPrompts:
         """Test agent with Path object to nonexistent file raises error."""
         path = Path("/nonexistent/prompt.md")
         with pytest.raises(FileNotFoundError):
-            Agent("test_agent", system_prompt=path, api_key="fake_key", model="gpt-4o-mini")
+            Agent("test_agent", system_prompt=path, api_key="fake_key", model="o4-mini")
     
     def test_agent_with_string_that_looks_like_path(self):
         """Test agent with string that looks like path but isn't a file."""
@@ -92,7 +92,7 @@ class TestAgentSystemPrompts:
         ]
         
         for prompt in prompts:
-            agent = Agent("test_agent", system_prompt=prompt, api_key="fake_key", model="gpt-4o-mini")
+            agent = Agent("test_agent", system_prompt=prompt, api_key="fake_key", model="o4-mini")
             assert agent.system_prompt == prompt
     
     def test_agent_prompt_with_tools(self):
@@ -111,7 +111,7 @@ class TestAgentSystemPrompts:
                 "math_agent",
                 system_prompt=temp_path,
                 tools=[calculator],
-                api_key="fake_key", model="gpt-4o-mini"
+                api_key="fake_key", model="o4-mini"
             )
             assert agent.system_prompt == content
             assert len(agent.tools) == 1
@@ -139,7 +139,7 @@ Professional yet friendly and approachable."""
             temp_path = f.name
         
         try:
-            agent = Agent("support_agent", system_prompt=temp_path, api_key="fake_key", model="gpt-4o-mini")
+            agent = Agent("support_agent", system_prompt=temp_path, api_key="fake_key", model="o4-mini")
             assert "customer support specialist" in agent.system_prompt
             assert "empathize" in agent.system_prompt
             assert "Professional yet friendly" in agent.system_prompt

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -84,7 +84,7 @@ class TestEventSystem:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_user_input(track_user_input)]
         )
 
@@ -103,7 +103,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[before_llm(track_before_llm)]
         )
 
@@ -127,7 +127,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_llm(track_after_llm)]
         )
 
@@ -154,7 +154,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[before_each_tool(track_before_tool)]
         )
 
@@ -180,7 +180,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_tools(track_after_tools)]
         )
 
@@ -207,7 +207,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[failing_tool],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[on_error(track_error)]
         )
 
@@ -232,7 +232,7 @@ class TestEventSystem:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_user_input(handler1),
                 after_user_input(handler2),
@@ -256,7 +256,7 @@ class TestEventSystem:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_user_input(add_system_message)]
         )
 
@@ -275,7 +275,7 @@ class TestEventSystem:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_user_input(failing_event)]
         )
 
@@ -299,7 +299,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_user_input(track_user),
                 after_llm(track_llm),
@@ -322,7 +322,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini"
+            model="o4-mini"
         )
 
         result = agent.input("Search for Python")
@@ -344,7 +344,7 @@ class TestEventSystem:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_user_input(verify_agent_access)]
         )
 
@@ -384,7 +384,7 @@ class TestEventSystem:
         with pytest.raises(TypeError, match="Event must be callable"):
             Agent(
                 "test",
-                model="gpt-4o-mini",
+                model="o4-mini",
                 on_events=["not a function"]  # String instead of callable
             )
 
@@ -397,7 +397,7 @@ class TestEventSystem:
         with pytest.raises(ValueError, match="missing _event_type.*Did you forget to wrap it"):
             Agent(
                 "test",
-                model="gpt-4o-mini",
+                model="o4-mini",
                 on_events=[my_handler]  # Not wrapped with after_llm(), etc.
             )
 
@@ -412,7 +412,7 @@ class TestEventSystem:
         with pytest.raises(ValueError, match="Invalid event type"):
             Agent(
                 "test",
-                model="gpt-4o-mini",
+                model="o4-mini",
                 on_events=[my_handler]
             )
 
@@ -434,7 +434,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],  # Only has 'search' tool
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[on_error(track_error)]
         )
 
@@ -457,7 +457,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[on_complete(track_complete)]
         )
 
@@ -482,7 +482,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(track_after_tools),
                 on_complete(track_complete)
@@ -511,7 +511,7 @@ class TestEventSystem:
         agent = Agent(
             "test",
             tools=[search, failing_tool],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[after_tools(track_after_tools), on_error(track_error)]
         )
 
@@ -649,7 +649,7 @@ class TestNewEventSyntax:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[check_tool, log_tool],
             log=False
         )
@@ -671,7 +671,7 @@ class TestNewEventSyntax:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 before_each_tool(handler1, handler2),  # returns [fn, fn]
                 after_tools(handler3),                 # returns fn
@@ -698,7 +698,7 @@ class TestNewEventSyntax:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 decorated_handler,                                # @decorator
                 before_each_tool(wrapper_handler1, wrapper_handler2),  # wrapper(fn1, fn2)
@@ -725,7 +725,7 @@ class TestNewEventSyntax:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 handler1,                              # decorated
                 after_user_input(handler2, handler3),  # wrapper with multiple
@@ -757,7 +757,7 @@ class TestOnStopSignalEvent:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(set_stop),
                 on_stop_signal(track_stop)
@@ -794,7 +794,7 @@ class TestOnStopSignalEvent:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(set_stop),
                 on_stop_signal(check_agent)
@@ -847,7 +847,7 @@ class TestOnStopSignalEvent:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(set_stop),
                 on_stop_signal(handler1),
@@ -870,7 +870,7 @@ class TestOnStopSignalEvent:
 
         agent = Agent(
             "test",
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[on_stop_signal(track_stop)]
         )
 
@@ -892,7 +892,7 @@ class TestOnStopSignalEvent:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(set_stop),
                 on_stop_signal(failing_handler)
@@ -916,7 +916,7 @@ class TestOnStopSignalEvent:
         agent = Agent(
             "test",
             tools=[search],
-            model="gpt-4o-mini",
+            model="o4-mini",
             on_events=[
                 after_tools(set_stop),
                 on_stop_signal(save_checkpoint)

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -75,10 +75,10 @@ def test_insufficient_credits_handles_missing_body_attribute():
 def test_llm_connection_captures_model_and_base_url():
     err = LLMConnectionError(
         TimeoutError("connect timed out"),
-        model="gpt-4o",
+        model="o4-mini",
         base_url="https://api.openai.com",
     )
-    assert err.model == "gpt-4o"
+    assert err.model == "o4-mini"
     assert err.base_url == "https://api.openai.com"
     assert err.error_type == "TimeoutError"
 
@@ -86,12 +86,12 @@ def test_llm_connection_captures_model_and_base_url():
 def test_llm_connection_message_includes_model_and_diagnostics():
     err = LLMConnectionError(
         ConnectionRefusedError("nope"),
-        model="claude-3-5-sonnet-latest",
+        model="claude-sonnet-4-20250514",
         base_url="https://api.anthropic.com",
     )
     msg = str(err)
     assert 'Connection Failed' in msg
-    assert 'claude-3-5-sonnet-latest' in msg
+    assert 'claude-sonnet-4-20250514' in msg
     assert 'api.anthropic.com' in msg
     assert 'ConnectionRefusedError' in msg
 

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -153,7 +153,7 @@ class TestHostRelayConnection:
         field is simply left out rather than sent as null/zero."""
         profile = host_module._build_agent_profile({
             "name": "byo_key_agent",
-            "model": "gpt-4o",
+            "model": "o4-mini",
             "skills": [],
         })
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -44,14 +44,12 @@ class TestMultiLLMSupport:
         from connectonion.core.llm import MODEL_REGISTRY
 
         # Test OpenAI models
-        assert MODEL_REGISTRY["gpt-4o"] == "openai"
-        assert MODEL_REGISTRY["gpt-4o-mini"] == "openai"
-        assert MODEL_REGISTRY["o1"] == "openai"
+        assert MODEL_REGISTRY["o3-mini"] == "openai"
         assert MODEL_REGISTRY["o4-mini"] == "openai"
 
         # Test Anthropic models
-        assert MODEL_REGISTRY["claude-3-5-sonnet-20241022"] == "anthropic"
-        assert MODEL_REGISTRY["claude-3-5-haiku-20241022"] == "anthropic"
+        assert MODEL_REGISTRY["claude-sonnet-4-20250514"] == "anthropic"
+        assert MODEL_REGISTRY["claude-sonnet-4-20250514"] == "anthropic"
         assert MODEL_REGISTRY["claude-opus-4.1"] == "anthropic"
 
         # Test Google models
@@ -66,12 +64,12 @@ class TestMultiLLMSupport:
 
         # Test OpenAI model creation
         if self.has_openai:
-            llm = create_llm("gpt-4o-mini")
+            llm = create_llm("o4-mini")
             assert isinstance(llm, OpenAILLM)
 
         # Test Anthropic model creation
         if self.has_anthropic:
-            llm = create_llm("claude-3-5-haiku-20241022")
+            llm = create_llm("claude-sonnet-4-20250514")
             assert isinstance(llm, AnthropicLLM)
 
         # Test Google model creation

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -57,7 +57,7 @@ class TestMissingAPIKeys:
         """Test OpenAI raises ValueError when API key missing from environment."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                OpenAILLM(model="gpt-4o-mini")
+                OpenAILLM(model="o4-mini")
 
             assert "OpenAI API key required" in str(exc_info.value)
             assert "OPENAI_API_KEY" in str(exc_info.value)
@@ -66,7 +66,7 @@ class TestMissingAPIKeys:
         """Test OpenAI raises ValueError when api_key parameter is None."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                OpenAILLM(api_key=None, model="gpt-4o-mini")
+                OpenAILLM(api_key=None, model="o4-mini")
 
             assert "OpenAI API key required" in str(exc_info.value)
 
@@ -74,7 +74,7 @@ class TestMissingAPIKeys:
         """Test Anthropic raises ValueError when API key missing from environment."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                AnthropicLLM(model="claude-3-5-sonnet-20241022")
+                AnthropicLLM(model="claude-sonnet-4-20250514")
 
             assert "Anthropic API key required" in str(exc_info.value)
             assert "ANTHROPIC_API_KEY" in str(exc_info.value)
@@ -102,7 +102,7 @@ class TestMissingAPIKeys:
         """Test OpenRouter raises ValueError when API key missing from environment."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                OpenRouterLLM(model="openrouter/openai/gpt-4o-mini")
+                OpenRouterLLM(model="openrouter/openai/o4-mini")
 
             assert "OpenRouter API key required" in str(exc_info.value)
             assert "OPENROUTER_API_KEY" in str(exc_info.value)
@@ -120,7 +120,7 @@ class TestMissingAPIKeys:
         """Test OpenOnion raises ValueError with helpful message about co init."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                OpenOnionLLM(model="co/gpt-4o")
+                OpenOnionLLM(model="co/o4-mini")
 
             error_msg = str(exc_info.value)
             assert "OPENONION_API_KEY not found" in error_msg
@@ -155,7 +155,7 @@ class TestStructuredOutputErrors:
     def test_openai_structured_max_tokens_exceeded(self):
         """Test handling when OpenAI structured response exceeds max tokens."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = OpenAILLM(model="gpt-4o-mini")
+            llm = OpenAILLM(model="o4-mini")
 
             # Mock incomplete response due to max tokens
             mock_response = Mock()
@@ -172,7 +172,7 @@ class TestStructuredOutputErrors:
     def test_openai_structured_content_filter(self):
         """Test handling when OpenAI filters content in structured response."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = OpenAILLM(model="gpt-4o-mini")
+            llm = OpenAILLM(model="o4-mini")
 
             # Mock incomplete response due to content filter
             mock_response = Mock()
@@ -189,7 +189,7 @@ class TestStructuredOutputErrors:
     def test_openai_structured_refusal(self):
         """Test handling when OpenAI model refuses to generate structured output."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = OpenAILLM(model="gpt-4o-mini")
+            llm = OpenAILLM(model="o4-mini")
 
             # Mock refusal response
             mock_content = Mock()
@@ -214,7 +214,7 @@ class TestStructuredOutputErrors:
     def test_anthropic_structured_no_output(self):
         """Test Anthropic structured_complete raises error when no tool output received."""
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
-            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            llm = AnthropicLLM(model="claude-sonnet-4-20250514")
 
             # Mock response with no tool_use blocks
             mock_content_block = Mock()
@@ -238,7 +238,7 @@ class TestJSONParsingErrors:
     def test_openai_malformed_tool_arguments(self):
         """Test handling when OpenAI returns malformed JSON in tool arguments."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = OpenAILLM(model="gpt-4o-mini")
+            llm = OpenAILLM(model="o4-mini")
 
             # Mock response with malformed JSON
             mock_tool_call = Mock()
@@ -302,7 +302,7 @@ class TestProviderErrorBubbling:
     def test_openai_api_error_bubbles_up(self):
         """Test that OpenAI API errors are not caught and bubble up."""
         with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
-            llm = OpenAILLM(model="gpt-4o-mini")
+            llm = OpenAILLM(model="o4-mini")
 
             # Mock generic Exception (provider errors bubble up as-is)
             llm.client.chat.completions.create = Mock(
@@ -318,7 +318,7 @@ class TestProviderErrorBubbling:
     def test_anthropic_api_error_bubbles_up(self):
         """Test that Anthropic API errors are not caught and bubble up."""
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
-            llm = AnthropicLLM(model="claude-3-5-sonnet-20241022")
+            llm = AnthropicLLM(model="claude-sonnet-4-20250514")
 
             # Mock generic Exception (provider errors bubble up as-is)
             llm.client.messages.create = Mock(
@@ -341,7 +341,7 @@ class TestOpenAICompatibleProviders:
             "OPENROUTER_X_TITLE": "My App",
         }):
             with patch("connectonion.core.llm.openai.OpenAI") as mock_openai:
-                OpenRouterLLM(model="openrouter/openai/gpt-4o-mini")
+                OpenRouterLLM(model="openrouter/openai/o4-mini")
 
                 _, kwargs = mock_openai.call_args
                 assert kwargs["base_url"] == "https://openrouter.ai/api/v1"
@@ -395,7 +395,7 @@ class TestOpenAICompatibleProviders:
     def test_openrouter_structured_complete_json_mode(self):
         """OpenRouter structured output should use JSON mode and validate with Pydantic."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
-            llm = OpenRouterLLM(model="openrouter/openai/gpt-4o-mini")
+            llm = OpenRouterLLM(model="openrouter/openai/o4-mini")
 
             mock_message = Mock()
             mock_message.content = '{"value": 9, "message": "great"}'
@@ -428,7 +428,7 @@ class TestModelInference:
     def test_infer_openrouter_from_prefix(self):
         """Test that openrouter/* models are routed to OpenRouterLLM."""
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
-            llm = create_llm("openrouter/openai/gpt-4o-mini")
+            llm = create_llm("openrouter/openai/o4-mini")
             assert isinstance(llm, OpenRouterLLM)
 
     def test_infer_grok_from_prefix(self):
@@ -477,28 +477,28 @@ class TestOpenOnionAuthentication:
         """Test that OPENONION_API_KEY from environment is used first."""
         with patch.dict(os.environ, {"OPENONION_API_KEY": "env-token"}):
             with patch('builtins.print'):  # Suppress warning message
-                llm = OpenOnionLLM(model="co/gpt-4o")
+                llm = OpenOnionLLM(model="co/o4-mini")
                 assert llm.auth_token == "env-token"
 
     def test_openonion_strips_co_prefix(self):
         """Test that co/ prefix is stripped from model name."""
         with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
             with patch('builtins.print'):  # Suppress warning
-                llm = OpenOnionLLM(model="co/gpt-4o-mini")
-                assert llm.model == "gpt-4o-mini"  # Prefix stripped
+                llm = OpenOnionLLM(model="co/o4-mini")
+                assert llm.model == "o4-mini"  # Prefix stripped
 
     def test_openonion_dev_mode_uses_localhost(self):
         """Test that OPENONION_DEV env var uses localhost."""
         with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token", "OPENONION_DEV": "1"}):
             with patch('builtins.print'):  # Suppress warning
-                llm = OpenOnionLLM(model="co/gpt-4o")
+                llm = OpenOnionLLM(model="co/o4-mini")
                 assert "localhost" in str(llm.client.base_url)
 
     def test_openonion_production_uses_oo_url(self):
         """Test that production mode uses oo.openonion.ai."""
         with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}, clear=True):
             with patch('builtins.print'):  # Suppress warning
-                llm = OpenOnionLLM(model="co/gpt-4o")
+                llm = OpenOnionLLM(model="co/o4-mini")
                 assert "oo.openonion.ai" in str(llm.client.base_url)
 
 
@@ -508,13 +508,13 @@ class TestAPIKeyFromParameter:
     def test_openai_api_key_from_parameter(self):
         """Test OpenAI accepts API key via parameter."""
         with patch.dict(os.environ, {}, clear=True):
-            llm = OpenAILLM(api_key="param-key", model="gpt-4o-mini")
+            llm = OpenAILLM(api_key="param-key", model="o4-mini")
             assert llm.api_key == "param-key"
 
     def test_anthropic_api_key_from_parameter(self):
         """Test Anthropic accepts API key via parameter."""
         with patch.dict(os.environ, {}, clear=True):
-            llm = AnthropicLLM(api_key="param-key", model="claude-3-5-sonnet-20241022")
+            llm = AnthropicLLM(api_key="param-key", model="claude-sonnet-4-20250514")
             assert llm.api_key == "param-key"
 
     def test_gemini_api_key_from_parameter(self):
@@ -526,7 +526,7 @@ class TestAPIKeyFromParameter:
     def test_create_llm_passes_api_key_to_provider(self):
         """Test that create_llm passes api_key parameter to provider."""
         with patch.dict(os.environ, {}, clear=True):
-            llm = create_llm("gpt-4o-mini", api_key="test-key")
+            llm = create_llm("o4-mini", api_key="test-key")
             assert isinstance(llm, OpenAILLM)
             assert llm.api_key == "test-key"
 
@@ -538,12 +538,12 @@ class TestCoModelRouting:
         """Test that co/* models are routed to OpenOnionLLM."""
         with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
             with patch('builtins.print'):  # Suppress warning
-                llm = create_llm("co/gpt-4o")
+                llm = create_llm("co/o4-mini")
                 assert isinstance(llm, OpenOnionLLM)
 
     def test_co_prefix_with_various_models(self):
         """Test that various co/* models all route to OpenOnion."""
-        models = ["co/gpt-4o", "co/claude-3-5-sonnet", "co/gemini-2.0-flash-exp", "co/o4-mini"]
+        models = ["co/o4-mini", "co/claude-sonnet-4-20250514", "co/gemini-2.0-flash-exp", "co/o4-mini"]
 
         with patch.dict(os.environ, {"OPENONION_API_KEY": "test-token"}):
             with patch('builtins.print'):  # Suppress warning

--- a/tests/unit/test_model_routing_o_prefix.py
+++ b/tests/unit/test_model_routing_o_prefix.py
@@ -36,25 +36,28 @@ class TestUnknownModelsSaySo:
 class TestKnownModelsStillRoute:
     """The tightening must not strand the models it was protecting."""
 
-    @pytest.mark.parametrize("model", ["o1", "o1-mini", "o1-preview", "o4-mini"])
+    @pytest.mark.parametrize("model", ["o1", "o3-mini", "o3-mini", "o4-mini"])
     def test_registered_o_series_models_still_reach_openai(self, model):
         assert isinstance(create_llm(model, api_key="test-key"), OpenAILLM)
 
-    @pytest.mark.parametrize("model", ["o3-mini", "o4-turbo"])
+    @pytest.mark.parametrize("model", ["o3-pro", "o4-turbo"])
     def test_unregistered_but_real_o_series_families_still_infer(self, model):
         """The registry cannot list every variant OpenAI ships, so inference by
         family prefix has to keep working — that is what the allowlist is for."""
         assert isinstance(create_llm(model, api_key="test-key"), OpenAILLM)
 
-    def test_gpt_models_are_untouched(self):
+    def test_a_retired_name_still_routes_rather_than_crashing(self):
+        """1.6.0 stops pricing and listing the gpt-4 family, but someone whose
+        code still names one is calling a live OpenAI endpoint. Dropping it from
+        the registry must not turn that into "Unknown model"."""
         assert isinstance(create_llm("gpt-4o", api_key="test-key"), OpenAILLM)
 
     def test_other_providers_are_untouched(self):
-        assert isinstance(create_llm("claude-3-5-sonnet-20241022", api_key="k"), AnthropicLLM)
-        assert isinstance(create_llm("gemini-1.5-pro", api_key="k"), GeminiLLM)
+        assert isinstance(create_llm("claude-sonnet-4-20250514", api_key="k"), AnthropicLLM)
+        assert isinstance(create_llm("gemini-2.5-pro", api_key="k"), GeminiLLM)
 
     def test_the_allowlist_is_prefixes_not_whole_names(self):
-        """o1-mini must match on "o1" — listing whole names would need an entry
+        """o3-mini must match on "o1" — listing whole names would need an entry
         per variant and go stale on the next OpenAI release."""
-        assert "o1-mini".startswith(OPENAI_REASONING_PREFIXES)
+        assert "o3-mini".startswith(OPENAI_REASONING_PREFIXES)
         assert not "olmo-7b".startswith(OPENAI_REASONING_PREFIXES)

--- a/tests/unit/test_no_models_from_before_2025.py
+++ b/tests/unit/test_no_models_from_before_2025.py
@@ -1,0 +1,75 @@
+"""Which models this release still claims to support.
+
+Anything released before 2025 is dropped: the price tables, the context
+limits, the defaults built into the provider classes, and the names shown in
+docs and templates. A version meant to be supported long-term should not carry
+a price for a model nobody can call any more, and a default that names one is
+worse than no default at all.
+
+The tables are the enforceable part — a name in them is a claim that using it
+will be costed correctly.
+"""
+
+import re
+
+import pytest
+
+from connectonion.core.usage import MODEL_CONTEXT_LIMITS, MODEL_PRICING
+
+# Families the world shipped before 2025. Kept as prefixes rather than exact
+# names because the dated variants are the ones that end up pinned in code.
+BEFORE_2025 = (
+    "gpt-4", "gpt-3.5",
+    "o1-",
+    "claude-3-5-", "claude-3-opus", "claude-3-sonnet", "claude-3-haiku",
+    "gemini-1.5",
+)
+
+
+def _stale(names) -> list:
+    return sorted(n for n in names
+                  if any(n.startswith(p) for p in BEFORE_2025))
+
+
+class TestTheTablesCarryNothingRetired:
+
+    def test_pricing_has_no_pre_2025_model(self):
+        assert _stale(MODEL_PRICING) == []
+
+    def test_context_limits_have_no_pre_2025_model(self):
+        assert _stale(MODEL_CONTEXT_LIMITS) == []
+
+    def test_the_two_tables_still_agree(self):
+        """A model priced but not sized, or the reverse, is a gap either way."""
+        assert set(MODEL_PRICING) == set(MODEL_CONTEXT_LIMITS)
+
+
+class TestNoDefaultNamesARetiredModel:
+    """A default that names an unsupported model is worse than none: it is
+    chosen for people who did not choose."""
+
+    def _defaults_in(self, module_path: str) -> list:
+        import inspect, importlib
+
+        source = inspect.getsource(importlib.import_module(module_path))
+        return re.findall(r'model:\s*str\s*=\s*"([^"]+)"', source)
+
+    @pytest.mark.parametrize("module", [
+        "connectonion.core.llm",
+        "connectonion.network.trust.trust_agent",
+    ])
+    def test_no_constructor_defaults_to_one(self, module):
+        stale = _stale(self._defaults_in(module))
+
+        assert stale == [], f"{module} defaults to {stale}"
+
+
+class TestWhatIsLeftIsStillUsable:
+
+    def test_the_tables_are_not_empty(self):
+        assert len(MODEL_PRICING) >= 8
+
+    def test_the_project_default_is_priced(self):
+        from connectonion.core.usage import is_estimated_price
+
+        assert not is_estimated_price("co/gemini-3.6-flash")

--- a/tests/unit/test_openonion_llm.py
+++ b/tests/unit/test_openonion_llm.py
@@ -28,13 +28,13 @@ class TestOpenOnionLLM:
     def test_initialization_production(self):
         """Test OpenOnionLLM initializes with production URL."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             assert hasattr(llm, 'client'), "Should have OpenAI client"
             assert llm.client.base_url == "https://oo.openonion.ai/v1/"
             assert llm.client.api_key == "mock-jwt-token"
             assert llm.auth_token == "mock-jwt-token"
-            assert llm.model == "gpt-4o"  # co/ prefix stripped by implementation
+            assert llm.model == "o4-mini"  # co/ prefix stripped by implementation
 
     def test_initialization_development(self):
         """Test OpenOnionLLM initializes with development URL."""
@@ -45,7 +45,7 @@ class TestOpenOnionLLM:
             assert llm.model == "o4-mini"  # co/ prefix stripped
 
     def test_complete_gpt4o(self):
-        """Test complete method with co/gpt-4o model."""
+        """Test complete method with co/o4-mini model."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
             # Create mock response
             mock_response = MagicMock()
@@ -57,14 +57,14 @@ class TestOpenOnionLLM:
             mock_response.usage.completion_tokens = 20
             mock_response.usage.prompt_tokens_details = None
 
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             with patch.object(llm.client.chat.completions, 'create', return_value=mock_response) as mock_create:
                 result = llm.complete([{"role": "user", "content": "test"}])
 
                 # Check call parameters
                 call_kwargs = mock_create.call_args[1]
-                assert call_kwargs['model'] == "gpt-4o"  # Sent to server without prefix
+                assert call_kwargs['model'] == "o4-mini"  # Sent to server without prefix
 
                 # Check response
                 assert result.content == "Test response"
@@ -114,7 +114,7 @@ class TestOpenOnionLLM:
             mock_tool_call.id = "call_123"
             mock_response.choices[0].message.tool_calls = [mock_tool_call]
 
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             tools = [{
                 "name": "test_tool",
@@ -143,7 +143,7 @@ class TestOpenOnionLLM:
         """Test create_llm function with co/ models."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
             # Test various co/ models
-            models = ["co/gpt-4o", "co/o4-mini", "co/claude-3-haiku", "co/gemini-2.0-flash-exp"]
+            models = ["co/o4-mini", "co/o3-mini", "co/claude-sonnet-4-20250514", "co/gemini-2.0-flash-exp"]
 
             for model in models:
                 llm = create_llm(model)
@@ -155,7 +155,7 @@ class TestOpenOnionLLM:
         """Test error when no auth token is found."""
         with patch.dict('os.environ', {}, clear=True):
             with pytest.raises(ValueError) as exc_info:
-                OpenOnionLLM(model="co/gpt-4o")
+                OpenOnionLLM(model="co/o4-mini")
 
             assert "OPENONION_API_KEY not found" in str(exc_info.value)
             assert "Run 'co init'" in str(exc_info.value)
@@ -163,7 +163,7 @@ class TestOpenOnionLLM:
     def test_get_balance_success(self):
         """Test get_balance returns balance on successful request."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             # Mock successful response
             mock_response = MagicMock()
@@ -191,7 +191,7 @@ class TestOpenOnionLLM:
     def test_get_balance_network_error(self):
         """Test get_balance raises on network error (let it crash philosophy)."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             # Mock network error
             with patch('requests.get', side_effect=Exception("Network error")):
@@ -202,7 +202,7 @@ class TestOpenOnionLLM:
     def test_get_balance_auth_error(self):
         """Test get_balance returns None on 401 auth error."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             # Mock auth error response
             mock_response = MagicMock()
@@ -217,7 +217,7 @@ class TestOpenOnionLLM:
     def test_get_balance_invalid_response(self):
         """Test get_balance returns None when balance_usd missing."""
         with patch.dict(os.environ, {'OPENONION_API_KEY': 'mock-jwt-token'}, clear=True):
-            llm = OpenOnionLLM(model="co/gpt-4o")
+            llm = OpenOnionLLM(model="co/o4-mini")
 
             # Mock response without balance_usd
             mock_response = MagicMock()

--- a/tests/unit/test_the_longest_price_match_wins.py
+++ b/tests/unit/test_the_longest_price_match_wins.py
@@ -1,102 +1,67 @@
 """Which entry a model name falls back to when it is not listed exactly.
 
-`get_pricing` walks MODEL_PRICING and takes the first key the name starts
-with. Dict order therefore decides, and three entries are prefixes of others:
+`get_pricing` and `get_context_limit` walk their table and take a key the name
+starts with. Taking the *first* one let dict order decide, and that was wrong
+whenever one entry was a prefix of another:
 
-    'gpt-4o'  ⊂  'gpt-4o-mini'
-    'o1'      ⊂  'o1-mini'
-    'o1'      ⊂  'o1-preview'
+    gpt-4o  ⊂  gpt-4o-mini          gpt-4o-mini-2024-07-18 → gpt-4o's price
+    o1      ⊂  o1-mini              o1-mini-2024-09-12     → o1's 200000 limit
 
-Exact matches are tried first, so the listed names are safe. The pinned,
-dated forms are not — and pinning a date is what production code does:
+Seventeen times the cost, and seventy-two thousand tokens of context the model
+did not have. Exact matches are tried first, so listed names were safe; a
+pinned, dated name is not listed, and pinning a date is what production does.
 
-    gpt-4o-mini              input 0.15   output 0.60
-    gpt-4o-mini-2024-07-18   input 2.50   output 10.00     ← gpt-4o's price
-    o1-mini                  input 3.00   output 12.00
-    o1-mini-2024-09-12       input 15.00  output 60.00     ← o1's price
-
-Seventeen times the cost for the same model, depending on whether the name
-carries its date.
-
-The longest matching name is the most specific one, and specificity is what a
-prefix match is for.
+Those two pairs are gone — every pre-2025 model was dropped — so this asserts
+the rule against a table built for the purpose. The rule is what has to
+survive: the next time two entries share a prefix, nobody will be looking.
 """
 
 import pytest
 
-from connectonion.core.usage import calculate_cost, get_pricing
+from connectonion.core import usage
 
 
-class TestADatedNameKeepsItsOwnPrice:
-
-    @pytest.mark.parametrize("pinned,plain", [
-        ("gpt-4o-mini-2024-07-18", "gpt-4o-mini"),
-        ("o1-mini-2024-09-12", "o1-mini"),
-        ("o1-preview-2024-09-12", "o1-preview"),
-    ])
-    def test_it_matches_the_model_it_names(self, pinned, plain):
-        assert get_pricing(pinned) == get_pricing(plain), (
-            f"{pinned} is priced as something else"
-        )
-
-    def test_the_difference_was_seventeenfold(self):
-        plain = calculate_cost("gpt-4o-mini", 1_000_000, 100_000)
-        pinned = calculate_cost("gpt-4o-mini-2024-07-18", 1_000_000, 100_000)
-
-        assert pinned == pytest.approx(plain)
-
-    def test_the_managed_route_gets_it_too(self):
-        assert get_pricing("co/gpt-4o-mini-2024-07-18") == get_pricing("gpt-4o-mini")
+SHADOWED = {
+    "aurora":        {"input": 10.0, "output": 30.0, "cached": 5.0},
+    "aurora-mini":   {"input": 0.5,  "output": 1.5,  "cached": 0.25},
+}
+SHADOWED_LIMITS = {"aurora": 200_000, "aurora-mini": 128_000}
 
 
-class TestNothingElseMoves:
-
-    @pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "o1", "o1-mini",
-                                       "gemini-3.6-flash"])
-    def test_an_exactly_listed_model_is_unchanged(self, model):
-        from connectonion.core.usage import MODEL_PRICING
-
-        assert get_pricing(model) == MODEL_PRICING[model]
-
-    def test_a_dated_variant_of_a_leaf_still_works(self):
-        """gpt-4o-2024-08-06 has no longer competitor; it still finds gpt-4o."""
-        assert get_pricing("gpt-4o-2024-08-06") == get_pricing("gpt-4o")
-
-    def test_something_unknown_is_still_a_guess(self):
-        from connectonion.core.usage import is_estimated_price
-
-        assert is_estimated_price("a-model-from-next-year")
+@pytest.fixture
+def shadowed(monkeypatch):
+    monkeypatch.setattr(usage, "MODEL_PRICING", SHADOWED)
+    monkeypatch.setattr(usage, "MODEL_CONTEXT_LIMITS", SHADOWED_LIMITS)
 
 
-class TestTheContextLimitHasTheSameHazard:
-    """Same loop, same three collisions, and a worse failure than a wrong
-    number on screen.
+class TestTheMoreSpecificNameWins:
 
-        o1          200000
-        o1-mini     128000
+    def test_a_dated_variant_takes_its_own_price(self, shadowed):
+        assert usage.get_pricing("aurora-mini-2025-06-01") == SHADOWED["aurora-mini"]
 
-    `o1-mini-2024-09-12` took o1's 200000, so the agent believed it had
-    seventy-two thousand tokens it did not have: auto-compaction fires too
-    late and the provider rejects the request for length.
-    """
+    def test_not_the_shorter_entry_it_also_starts_with(self, shadowed):
+        assert usage.get_pricing("aurora-mini-2025-06-01") != SHADOWED["aurora"]
 
-    @pytest.mark.parametrize("pinned,plain", [
-        ("o1-mini-2024-09-12", "o1-mini"),
-        ("o1-preview-2024-09-12", "o1-preview"),
-        ("gpt-4o-mini-2024-07-18", "gpt-4o-mini"),
-    ])
-    def test_a_dated_name_keeps_its_own_limit(self, pinned, plain):
-        from connectonion.core.usage import get_context_limit
+    def test_the_same_holds_for_the_context_limit(self, shadowed):
+        assert usage.get_context_limit("aurora-mini-2025-06-01") == 128_000
 
-        assert get_context_limit(pinned) == get_context_limit(plain)
+    def test_the_shorter_name_still_matches_its_own_variants(self, shadowed):
+        assert usage.get_pricing("aurora-2025-06-01") == SHADOWED["aurora"]
 
-    def test_the_listed_names_are_unchanged(self):
-        from connectonion.core.usage import MODEL_CONTEXT_LIMITS, get_context_limit
+    def test_the_managed_route_resolves_the_same_way(self, shadowed):
+        assert usage.get_pricing("co/aurora-mini-2025-06-01") == SHADOWED["aurora-mini"]
 
-        for model, limit in MODEL_CONTEXT_LIMITS.items():
-            assert get_context_limit(model) == limit
 
-    def test_the_managed_route_finds_it(self):
-        from connectonion.core.usage import get_context_limit
+class TestTheRealTableHasNoneOfThis:
+    """Kept as a check rather than an assumption: if a prefix pair is ever
+    added back, the rule above is what stands between it and a wrong bill."""
 
-        assert get_context_limit("co/o1-mini") == get_context_limit("o1-mini")
+    def test_no_entry_shadows_another(self):
+        names = list(usage.MODEL_PRICING)
+        pairs = [(a, b) for a in names for b in names
+                 if a != b and b.startswith(a)]
+
+        assert pairs == [], f"prefix pairs are back: {pairs}"
+
+    def test_the_two_tables_cover_the_same_models(self):
+        assert set(usage.MODEL_PRICING) == set(usage.MODEL_CONTEXT_LIMITS)

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -96,7 +96,7 @@ class TestIsCustomTrust:
     def test_agent_is_custom(self):
         """Test that Agent instances are custom."""
         from connectonion import Agent
-        agent = Agent(name="guardian", tools=[], model="gpt-4o-mini")
+        agent = Agent(name="guardian", tools=[], model="o4-mini")
         assert is_custom_trust(agent) is True
 
 

--- a/tests/unit/test_uniform_provider_errors.py
+++ b/tests/unit/test_uniform_provider_errors.py
@@ -41,7 +41,7 @@ def _make_fail(llm, exc):
         llm.client.chat.completions.create = raiser
 
 
-OPENAI_LIKE = ["gpt-4o", "groq/llama-3.3-70b-versatile", "grok/grok-4",
+OPENAI_LIKE = ["o4-mini", "groq/llama-3.3-70b-versatile", "grok/grok-4",
                "openrouter/meta-llama/llama-3-8b", "mistral/mistral-small"]
 
 
@@ -59,7 +59,7 @@ class TestAuthFailsTheSameWayEverywhere:
 
     def test_anthropic(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
-        llm = create_llm("claude-3-5-sonnet-20241022", api_key="k")
+        llm = create_llm("claude-sonnet-4-20250514", api_key="k")
         _make_fail(llm, _anthropic_error(anthropic.AuthenticationError, 401))
 
         with pytest.raises(LLMAuthenticationError):
@@ -80,7 +80,7 @@ class TestAuthFailsTheSameWayEverywhere:
 class TestRateLimit:
     def test_openai(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        llm = create_llm("gpt-4o", api_key="k")
+        llm = create_llm("o4-mini", api_key="k")
         _make_fail(llm, _openai_error(openai.RateLimitError, 429))
 
         with pytest.raises(LLMRateLimitError):
@@ -88,7 +88,7 @@ class TestRateLimit:
 
     def test_anthropic(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
-        llm = create_llm("claude-3-5-sonnet-20241022", api_key="k")
+        llm = create_llm("claude-sonnet-4-20250514", api_key="k")
         _make_fail(llm, _anthropic_error(anthropic.RateLimitError, 429))
 
         with pytest.raises(LLMRateLimitError):
@@ -109,7 +109,7 @@ class TestOneBaseCatchesThemAll:
     def test_the_original_error_is_still_reachable(self, monkeypatch):
         """Translating must not cost the traceback that says what happened."""
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        llm = create_llm("gpt-4o", api_key="k")
+        llm = create_llm("o4-mini", api_key="k")
         original = _openai_error(openai.AuthenticationError, 401)
         _make_fail(llm, original)
 
@@ -122,7 +122,7 @@ class TestOneBaseCatchesThemAll:
         """A 400 is a bad request, not an auth failure. Inventing a category for
         it would make the shared types mean less, not more."""
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        llm = create_llm("gpt-4o", api_key="k")
+        llm = create_llm("o4-mini", api_key="k")
         _make_fail(llm, _openai_error(openai.BadRequestError, 400))
 
         with pytest.raises(openai.BadRequestError):

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -56,16 +56,16 @@ class TestGetPricing:
 
     def test_exact_match(self):
         """Test pricing lookup with exact model name."""
-        pricing = get_pricing("gpt-4o")
-        assert pricing["input"] == 2.50
-        assert pricing["output"] == 10.00
-        assert pricing["cached"] == 1.25
+        pricing = get_pricing("o4-mini")
+        assert pricing["input"] == 1.10
+        assert pricing["output"] == 4.40
+        assert pricing["cached"] == 0.55
 
     def test_prefix_match(self):
         """Test pricing lookup with model name prefix."""
-        # e.g., "gpt-4o-2024-08-06" should match "gpt-4o"
-        pricing = get_pricing("gpt-4o-2024-08-06")
-        assert pricing["input"] == 2.50
+        # e.g., "o4-mini-2025-04-16" should match "o4-mini"
+        pricing = get_pricing("o4-mini-2025-04-16")
+        assert pricing["input"] == 1.10
 
     def test_unknown_model_returns_default(self):
         """Test unknown model returns default pricing."""
@@ -74,7 +74,7 @@ class TestGetPricing:
 
     def test_anthropic_model_has_cache_write(self):
         """Test Anthropic models include cache_write pricing."""
-        pricing = get_pricing("claude-3-5-sonnet-20241022")
+        pricing = get_pricing("claude-sonnet-4-20250514")
         assert "cache_write" in pricing
         assert pricing["cache_write"] == 3.75
 
@@ -84,13 +84,13 @@ class TestGetContextLimit:
 
     def test_exact_match(self):
         """Test context limit lookup with exact model name."""
-        limit = get_context_limit("gpt-4o")
-        assert limit == 128000
+        limit = get_context_limit("o4-mini")
+        assert limit == 200000
 
     def test_prefix_match(self):
         """Test context limit lookup with model name prefix."""
-        limit = get_context_limit("gpt-4o-mini-2024")
-        assert limit == 128000
+        limit = get_context_limit("o4-mini-2025-04-16")
+        assert limit == 200000
 
     def test_unknown_model_returns_default(self):
         """Test unknown model returns default context limit."""
@@ -106,7 +106,7 @@ class TestGetContextLimit:
 
     def test_claude_context(self):
         """Test Claude models have 200k context."""
-        limit = get_context_limit("claude-3-5-sonnet-20241022")
+        limit = get_context_limit("claude-sonnet-4-20250514")
         assert limit == 200000
 
 
@@ -116,11 +116,11 @@ class TestCalculateCost:
     def test_basic_cost_no_cache(self):
         """Test cost calculation without caching."""
         cost = calculate_cost(
-            model="gpt-4o-mini",
+            model="gemini-2.5-flash",
             input_tokens=1000,
             output_tokens=500,
         )
-        # gpt-4o-mini: input=$0.15/1M, output=$0.60/1M
+        # gemini-2.5-flash: input=$0.15/1M, output=$0.60/1M
         # 1000 * 0.15 / 1M + 500 * 0.60 / 1M = 0.00015 + 0.0003 = 0.00045
         expected = (1000 / 1_000_000) * 0.15 + (500 / 1_000_000) * 0.60
         assert abs(cost - expected) < 0.0001
@@ -128,32 +128,32 @@ class TestCalculateCost:
     def test_cost_with_cached_tokens(self):
         """Test cost calculation with cached tokens."""
         cost = calculate_cost(
-            model="gpt-4o-mini",
+            model="gemini-2.5-flash",
             input_tokens=1000,
             output_tokens=500,
             cached_tokens=300,
         )
-        # gpt-4o-mini: input=$0.15/1M, output=$0.60/1M, cached=$0.075/1M
+        # gemini-2.5-flash: input=$0.15/1M, output=$0.60/1M, cached=$0.0375/1M
         # Non-cached: 700 input, 500 output
         # Cached: 300
         non_cached_input = 1000 - 300
         expected = (
             (non_cached_input / 1_000_000) * 0.15 +
             (500 / 1_000_000) * 0.60 +
-            (300 / 1_000_000) * 0.075
+            (300 / 1_000_000) * 0.0375
         )
         assert abs(cost - expected) < 0.0001
 
     def test_anthropic_cache_write_cost(self):
         """Test Anthropic cache write cost."""
         cost = calculate_cost(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-sonnet-4-20250514",
             input_tokens=1000,
             output_tokens=500,
             cached_tokens=0,
             cache_write_tokens=200,
         )
-        # claude-3-5-sonnet: input=$3/1M, output=$15/1M, cache_write=$3.75/1M
+        # claude-sonnet-4: input=$3/1M, output=$15/1M, cache_write=$3.75/1M
         expected = (
             (1000 / 1_000_000) * 3.00 +
             (500 / 1_000_000) * 15.00 +
@@ -175,7 +175,7 @@ class TestCalculateCost:
     def test_zero_tokens_returns_zero(self):
         """Test zero tokens returns zero cost."""
         cost = calculate_cost(
-            model="gpt-4o",
+            model="o4-mini",
             input_tokens=0,
             output_tokens=0,
         )
@@ -187,14 +187,13 @@ class TestModelPricing:
 
     def test_openai_models_exist(self):
         """Test OpenAI models are in pricing."""
-        assert "gpt-4o" in MODEL_PRICING
-        assert "gpt-4o-mini" in MODEL_PRICING
+        assert "o3-mini" in MODEL_PRICING
         assert "o4-mini" in MODEL_PRICING
 
     def test_anthropic_models_exist(self):
         """Test Anthropic models are in pricing."""
-        assert "claude-3-5-sonnet-20241022" in MODEL_PRICING
-        assert "claude-3-5-haiku-20241022" in MODEL_PRICING
+        assert "claude-sonnet-4-20250514" in MODEL_PRICING
+        assert "claude-opus-4-20250514" in MODEL_PRICING
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in pricing."""
@@ -210,13 +209,13 @@ class TestModelContextLimits:
 
     def test_openai_models_exist(self):
         """Test OpenAI models are in context limits."""
-        assert "gpt-4o" in MODEL_CONTEXT_LIMITS
-        assert MODEL_CONTEXT_LIMITS["gpt-4o"] == 128000
+        assert "o4-mini" in MODEL_CONTEXT_LIMITS
+        assert MODEL_CONTEXT_LIMITS["o4-mini"] == 200000
 
     def test_anthropic_models_exist(self):
         """Test Anthropic models are in context limits."""
-        assert "claude-3-5-sonnet-20241022" in MODEL_CONTEXT_LIMITS
-        assert MODEL_CONTEXT_LIMITS["claude-3-5-sonnet-20241022"] == 200000
+        assert "claude-sonnet-4-20250514" in MODEL_CONTEXT_LIMITS
+        assert MODEL_CONTEXT_LIMITS["claude-sonnet-4-20250514"] == 200000
 
     def test_gemini_models_exist(self):
         """Test Gemini models are in context limits."""

--- a/tests/utils/config_helpers.py
+++ b/tests/utils/config_helpers.py
@@ -49,7 +49,7 @@ TEST_CONFIG_TOML = {
         "email_active": TEST_ACCOUNT["email_active"],
         "created_at": "2024-01-01T00:00:00",
         "algorithm": "ed25519",
-        "default_model": "gpt-4o-mini",
+        "default_model": "o4-mini",
         "max_iterations": 10,
     },
     "auth": {
@@ -136,7 +136,7 @@ def main():
     agent = Agent(
         "test-agent",
         tools=[send_email, get_emails, mark_read],
-        model="gpt-4o-mini"
+        model="o4-mini"
     )
     
     # Test email functionality

--- a/tests/utils/mock_helpers.py
+++ b/tests/utils/mock_helpers.py
@@ -38,7 +38,7 @@ class MockLLM(LLM):
         ])
 
         # With custom model name
-        mock_llm = MockLLM(responses=[...], model="gpt-4o-mini")
+        mock_llm = MockLLM(responses=[...], model="o4-mini")
     """
 
     def __init__(
@@ -135,7 +135,7 @@ class OpenAIMockBuilder:
     """Builder for creating OpenAI API mocks."""
 
     @staticmethod
-    def simple_response(content: str, model: str = "gpt-3.5-turbo") -> Mock:
+    def simple_response(content: str, model: str = "o4-mini") -> Mock:
         """Create mock for text-only responses."""
         mock_response = MagicMock()
         mock_response.id = "chatcmpl-test123"


### PR DESCRIPTION
1.6.0 is meant to be supported for a long time. Two things in this repo are promises rather than data:

- an entry in `MODEL_PRICING` says using that model will be costed correctly
- a constructor default picks a model for everyone who did not pick one

Neither should name a model nobody should be calling any more.

## What was removed

30 entries from `MODEL_PRICING` and `MODEL_CONTEXT_LIMITS`, and the same families from `MODEL_REGISTRY`: the gpt-4 and gpt-3.5 families, o1, claude-3 and claude-3.5, gemini-1.5 and gemini-1.0.

Eleven models remain — `o3-mini`, `o4-mini`, `claude-sonnet-4-20250514`, `claude-opus-4-20250514`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3-pro-preview`, `gemini-3-pro-image-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.0-flash` — and the two tables agree entry for entry.

## Defaults that named one

| | before | after |
|---|---|---|
| `AnthropicLLM` | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-20250514` |
| `OpenRouterLLM` | `openrouter/openai/gpt-4o-mini` | `openrouter/openai/o4-mini` |
| `TrustAgent` | `co/gpt-4o-mini` | `co/gemini-3.6-flash` |
| `co init` .env comment | `gpt-4o-mini` | `co/gemini-3.6-flash` |

Docstrings, the `co init` provider templates and the model lists printed after `co auth` moved with them.

## What deliberately did not change

Routing. `create_llm` still infers a provider from a `gpt-` or `claude-` prefix, so someone whose code names a retired model keeps reaching the live endpoint instead of getting `Unknown model`. Dropping a name from our tables is us withdrawing a claim, not breaking their call.

What they do get is honesty about the number: `is_estimated_price()` returns True for those names now, and the console prints the cost as `~$…`.

## Tests

`tests/unit/test_no_models_from_before_2025.py` is the guard — the tables carry nothing retired, the two tables agree, no constructor default names one, and what is left is still usable. Verified it fails on the pre-change tables (3 failures) and passes after.

`tests/unit/test_model_routing_o_prefix.py` gains a test that a retired name still routes rather than crashing.

Full unit suite: 3252 passed, 4 skipped.