### PR TITLE
AGENT_CONFIG_PATH is still travelling in a project .env

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -316,13 +316,17 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     # Always copy from global keys.env (includes AGENT_ADDRESS, AGENT_EMAIL, and API keys)
     if global_keys_env.exists() and global_keys_env.stat().st_size > 0:
         # Copy global keys to project
-        from .env_inheritance import is_personal_account_credential
+        from .env_inheritance import (
+            describes_this_machine,
+            is_personal_account_credential,
+        )
+
+        def inherited(line: str) -> bool:
+            key = line.strip().split('=', 1)[0]
+            return not (is_personal_account_credential(key) or describes_this_machine(key))
 
         with open(global_keys_env, 'r', encoding='utf-8') as f:
-            env_content = "".join(
-                line for line in f
-                if not is_personal_account_credential(line.strip().split('=', 1)[0])
-            )
+            env_content = "".join(line for line in f if inherited(line))
 
         # AGENT_CONFIG_PATH is deliberately not written here. Every tool that
         # reads it already falls back to ~/.co on the machine it is running on

--- a/connectonion/cli/commands/env_inheritance.py
+++ b/connectonion/cli/commands/env_inheritance.py
@@ -25,3 +25,19 @@ def is_personal_account_credential(key: str) -> bool:
     return key.startswith(PERSONAL_ACCOUNT_PREFIXES)
 
 
+# Values that are true of the machine rather than of the project. A project .env
+# travels — cloned, rsynced, deployed — and an absolute home directory is right
+# in exactly one place.
+#
+# AGENT_CONFIG_PATH is the whole list so far. #438 removed the line that wrote
+# it, and `co deploy` rewrites it for the server, but neither covers the route
+# it actually arrives by: it sits in ~/.co/keys.env on machines where an older
+# release put it there, and keys.env is copied key by key.
+MACHINE_LOCAL_KEYS = ('AGENT_CONFIG_PATH',)
+
+
+def describes_this_machine(key: str) -> bool:
+    """Whether this keys.env entry would be wrong anywhere else."""
+    return key in MACHINE_LOCAL_KEYS
+
+

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -165,7 +165,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # Authenticate to get OPENONION_API_KEY (always, for everyone)
     auth_success = authenticate(global_co_dir, save_to_project=False)
 
-    from .env_inheritance import is_personal_account_credential
+    from .env_inheritance import describes_this_machine, is_personal_account_credential
 
     # Handle .env file - append API keys from global config
     env_path = Path(current_dir) / ".env"
@@ -187,7 +187,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
                 line = line.strip()
                 if line and not line.startswith('#') and '=' in line:
                     key = line.split('=')[0].strip()
-                    if is_personal_account_credential(key):
+                    if is_personal_account_credential(key) or describes_this_machine(key):
                         # Filtered at the source, so both write paths are clean.
                         # Filtering only where keys are appended left the branch
                         # that creates a fresh .env pouring the whole file in —

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -252,8 +252,9 @@ class TestCliCreate:
             assert os.path.exists(f'{base_path}/.co')
             assert os.path.exists(f'{base_path}/.co/host.yaml')
 
-    def test_create_adds_agent_config_path_to_env(self):
-        """Test that create adds AGENT_CONFIG_PATH to project .env file."""
+    def test_create_writes_no_absolute_home_directory(self):
+        """The opposite of what this asserted until 1.6.0 — see the twin in
+        test_cli_init.py, and tests/unit/test_the_machine_path_does_not_travel.py."""
         with self.runner.isolated_filesystem():
             from connectonion.cli.main import cli
 
@@ -267,10 +268,7 @@ class TestCliCreate:
             env_file = 'config-test-agent/.env'
             assert os.path.exists(env_file)
             with open(env_file) as f:
-                content = f.read()
-                assert "AGENT_CONFIG_PATH=" in content
-                # Should point to home directory .co folder
-                assert "/.co" in content
+                assert "AGENT_CONFIG_PATH" not in f.read()
 
     def test_create_adds_default_model_comment_to_env(self):
         """Test that create adds default model comment to project .env file."""

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -296,21 +296,23 @@ class TestCliInit:
             assert (fake_home / ".co" / "keys" / "agent.key").exists()
             assert (fake_home / ".co" / "keys.env").exists()
 
-    def test_init_creates_agent_config_path_in_env(self):
-        """Test that init creates AGENT_CONFIG_PATH in .env file."""
+    def test_init_writes_no_absolute_home_directory(self):
+        """The opposite of what this file asserted until 1.6.0.
+
+        It asked for AGENT_CONFIG_PATH in the project .env and gave no reason.
+        #438 and `co deploy` both say the reason runs the other way: the value
+        is an absolute path to the machine that ran the command, and a project
+        .env travels. See tests/unit/test_the_machine_path_does_not_travel.py.
+        """
         with self.runner.isolated_filesystem():
             from connectonion.cli.main import cli
 
             result = self.runner.invoke(cli, ['init', '--template', 'co-ai'])
             assert result.exit_code == 0
 
-            # Check that .env contains AGENT_CONFIG_PATH
             assert os.path.exists(".env")
             with open(".env") as f:
-                content = f.read()
-                assert "AGENT_CONFIG_PATH=" in content
-                # Should point to home directory .co folder
-                assert "/.co" in content
+                assert "AGENT_CONFIG_PATH" not in f.read()
 
     def test_init_adds_default_model_comment_in_env(self):
         """Test that init adds default model comment to .env file."""

--- a/tests/unit/test_the_machine_path_does_not_travel.py
+++ b/tests/unit/test_the_machine_path_does_not_travel.py
@@ -1,0 +1,109 @@
+"""AGENT_CONFIG_PATH describes the machine, not the project.
+
+#438 removed the line that wrote `AGENT_CONFIG_PATH=/Users/someone/.co` into a
+new project's .env, and `co deploy` learned to rewrite it for the server. The
+value came back by a route neither of those covers: `co init` copies
+~/.co/keys.env into the project .env key by key, and on any machine where
+something once wrote AGENT_CONFIG_PATH into keys.env it is copied along with
+the rest.
+
+The failure is the same one #438 described. A project made on one machine and
+run on another — cloned, rsynced, handed to a colleague — carries an absolute
+path to a home directory that does not exist there, and the agent looks for its
+identity and keys inside it. Unset, the code falls back to ~/.co, which is
+correct everywhere. Set to someone else's home, it is correct in exactly one
+place.
+
+`co deploy` already strips it (tests/unit/test_a_project_travels.py), which is
+the same judgement: the value is not portable. It should not be written in the
+first place.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands.env_inheritance import describes_this_machine
+
+
+class TestWhatIsRefused:
+
+    def test_the_config_path_is(self):
+        assert describes_this_machine("AGENT_CONFIG_PATH")
+
+    @pytest.mark.parametrize("key", [
+        "OPENONION_API_KEY", "AGENT_ADDRESS", "AGENT_EMAIL",
+        "OPENAI_API_KEY", "GEMINI_API_KEY", "CO_INVITE_CODE",
+    ])
+    def test_the_credentials_a_project_needs_are_not(self, key):
+        assert not describes_this_machine(key)
+
+
+class TestARealInitDoesNotWriteIt:
+    """The unit above is the rule; this is the thing the rule protects. The
+    earlier fix here passed its tests and still wrote the value, because the
+    tests checked the source for a template line and the value arrived through
+    keys.env instead."""
+
+    def _seed_keys_env(self) -> Path:
+        """The autouse fixture in conftest already points HOME at a tmp dir."""
+        home = Path.home()
+        (home / ".co").mkdir(parents=True, exist_ok=True)
+        (home / ".co" / "keys.env").write_text(
+            "OPENONION_API_KEY=token\n"
+            "AGENT_ADDRESS=0xabc\n"
+            f"AGENT_CONFIG_PATH={home / '.co'}\n"
+            "GEMINI_API_KEY=key\n"
+        )
+        return home
+
+    def _init_in(self, tmp_path, monkeypatch) -> str:
+        self._seed_keys_env()
+
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.chdir(project)
+
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=False, key=None, template="none", description=None,
+                    yes=True, force=True)
+        return (project / ".env").read_text()
+
+    def test_the_env_carries_no_home_directory(self, tmp_path, monkeypatch):
+        env = self._init_in(tmp_path, monkeypatch)
+
+        assert "AGENT_CONFIG_PATH" not in env, env
+
+    def test_the_keys_the_project_needs_are_still_there(self, tmp_path, monkeypatch):
+        env = self._init_in(tmp_path, monkeypatch)
+
+        assert "OPENONION_API_KEY=" in env
+        assert "GEMINI_API_KEY=" in env
+
+    def test_co_create_does_not_write_it_either(self, tmp_path, monkeypatch):
+        """`co create` builds the .env from the same file by a different loop,
+        and its comment already claimed the value was not written."""
+        self._seed_keys_env()
+        monkeypatch.chdir(tmp_path)
+
+        from connectonion.cli.commands.create import handle_create
+
+        handle_create(name="travelling-agent", ai=False, key=None,
+                      template="co-ai", description=None, yes=True,
+                      parent_dir=tmp_path)
+
+        env = (tmp_path / "travelling-agent" / ".env").read_text()
+        assert "AGENT_CONFIG_PATH" not in env, env
+        assert "OPENONION_API_KEY=" in env
+
+
+class TestTheFallbackIsTheRightOne:
+
+    def test_unset_resolves_to_the_home_of_whoever_runs_it(self, monkeypatch):
+        monkeypatch.delenv("AGENT_CONFIG_PATH", raising=False)
+
+        resolved = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")))
+
+        assert resolved == Path.home() / ".co"


### PR DESCRIPTION
#438 removed the line that wrote `AGENT_CONFIG_PATH=/Users/someone/.co` into a new project's `.env`, and `co deploy` learned to rewrite it for the server. It is still there. A real `co init` on this machine, today, writes:

    AGENT_CONFIG_PATH=/Users/changxing/.co

It arrives by a route neither fix covers. `ensure_global_config()` writes AGENT_CONFIG_PATH into `~/.co/keys.env` — correct, that file never leaves the machine — and both `co init` and `co create` then copy keys.env into the project `.env` key by key.

## Why it matters

The failure is the one #438 described. A project made on one machine and run on another — cloned, rsynced, handed to a colleague — carries an absolute path to a home directory that does not exist there. `gmail.py`, `outlook.py`, `gdrive.py`, `synology.py` and both calendars all resolve `os.getenv("AGENT_CONFIG_PATH", "~/.co")`, so they look for keys.env inside a directory that cannot exist and find nothing. Unset, the fallback is right on every machine.

`co deploy` already strips the value on the way to a server. That is the same judgement — it is not portable — applied one step too late.

## The fix

`describes_this_machine()` alongside the existing `is_personal_account_credential()` in `env_inheritance.py`, applied where each command reads keys.env.

`co create` needed it too. Its comment says "AGENT_CONFIG_PATH is deliberately not written here", and that was true of the block it sits in — the copy loop twelve lines above was writing it anyway.

## Tests

`tests/unit/test_the_machine_path_does_not_travel.py`. The rule is checked as a unit; what the rule protects is checked by running the real `handle_init()` and `handle_create()` and reading the `.env` they produce.

The previous fix here passed its tests and still wrote the value, because those tests checked the source for a template line while the value came through keys.env. So both real-path tests were confirmed to fail on unpatched code (2 failed, 9 passed) and pass after.

Full unit suite: 3266 passed, 4 skipped. A real `co init` now writes AGENT_ADDRESS, AGENT_EMAIL, CO_INVITE_CODE, GEMINI_API_KEY, IS_EMAIL_ACTIVE, OPENONION_API_KEY — and no home directory.