### PR TITLE
co pays for the OpenAI and Anthropic SDKs before it parses an argument

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -10,7 +10,8 @@ LLM-Note:
 ConnectOnion - A simple agent framework with behavior tracking.
 """
 
-__version__ = "1.5.11"
+# Single source, in a module the CLI can import on its own — see _version.py.
+from ._version import __version__
 
 # Auto-load .env files for the entire framework
 import os as _os

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -1,0 +1,11 @@
+"""The version string, on its own, so reading it costs nothing.
+
+`co --version` used to import the whole package — and with it the OpenAI and
+Anthropic SDKs, the TUI and every useful_tool — to print six characters. Every
+command handler in the CLI is already imported inside its function; this module
+is what lets the entry point keep that promise.
+
+Kept in step with pyproject.toml by a test.
+"""
+
+__version__ = "1.5.11"

--- a/connectonion/cli/__init__.py
+++ b/connectonion/cli/__init__.py
@@ -4,10 +4,8 @@ LLM-Note:
   Dependencies: none | imported by [cli/main.py, setup.py] | no direct tests
   Data flow: pure metadata (version string)
   State/Effects: no state
-  Integration: exposes __version__ for CLI about/version commands
+  Integration: namespace only — the version lives in connectonion/_version.py
   Performance: trivial
   Errors: none
 ConnectOnion CLI module.
 """
-
-__version__ = "0.0.1b5"

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -28,7 +28,10 @@ import typer
 from dotenv import load_dotenv
 from rich.console import Console
 
-from .. import __version__
+# From _version, not from the package: `from .. import __version__` pulled in
+# the OpenAI and Anthropic SDKs before the CLI had parsed an argument, which
+# is what every command handler being imported inside its function was for.
+from .._version import __version__
 
 # Load both env files for all CLI commands. keys.env stays first — that is
 # already the CLI's effective precedence, since commands that load .env do so

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: Agent/llm_do calls create_llm(model, api_key) → factory routes to provider class → Provider.__init__() validates API key → Agent calls complete(messages, tools) OR structured_complete(messages, output_schema) → provider converts to native format → calls API → parses response → returns LLMResponse(content, tool_calls, raw_response) OR Pydantic model instance
   State/Effects: reads environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, OPENONION_API_KEY) | reads OPENONION_API_KEY from env / .env / ~/.co/keys.env | makes HTTP requests to LLM APIs | no caching or persistence
   Integration: exposes create_llm(model, api_key), LLM abstract base class, OpenAILLM, AnthropicLLM, GeminiLLM, GroqLLM, GrokLLM, OpenRouterLLM, OpenOnionLLM, LLMResponse, ToolCall dataclasses | providers implement complete() and structured_complete() | OpenAI message format is lingua franca | tool calling uses OpenAI schema converted per-provider
-  Performance: stateless (no caching) | synchronous (no streaming) | default max_tokens=8192 for Anthropic (required) | each call hits API
+  Performance: openai/anthropic are imported inside the functions that use them, so importing this module does not pay for either SDK | stateless (no caching) | synchronous (no streaming) | default max_tokens=8192 for Anthropic (required) | each call hits API
   Errors: raises ValueError for missing API keys, unknown models, invalid parameters | provider-specific errors bubble up (openai.APIError, anthropic.APIError, etc.) | OpenOnionLLM transforms 402 errors to InsufficientCreditsError with formatted message and typed attributes | Pydantic ValidationError for invalid structured output
 
 Unified LLM provider abstraction layer for ConnectOnion framework.
@@ -161,8 +161,6 @@ import base64
 import logging
 
 logger = logging.getLogger(__name__)
-import openai
-import anthropic
 # google-genai not needed - using OpenAI-compatible endpoint instead
 import requests
 from pathlib import Path
@@ -226,6 +224,8 @@ class LLM(ABC):
         Translating never costs the original: it is chained as __cause__, so the
         traceback still says what the SDK actually reported.
         """
+        import anthropic
+        import openai
         model = getattr(self, "model", "unknown")
         try:
             return send()
@@ -279,6 +279,7 @@ class OpenAILLM(LLM):
     """OpenAI LLM implementation."""
     
     def __init__(self, api_key: Optional[str] = None, model: str = "o4-mini", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
             raise ValueError("OpenAI API key required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
@@ -364,6 +365,7 @@ class AnthropicLLM(LLM):
     """Anthropic Claude LLM implementation."""
     
     def __init__(self, api_key: Optional[str] = None, model: str = "claude-sonnet-4-20250514", max_tokens: int = 8192, **kwargs):
+        import anthropic
         self.api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError("Anthropic API key required. Set ANTHROPIC_API_KEY environment variable or pass api_key parameter.")
@@ -601,6 +603,7 @@ class GeminiLLM(LLM):
     """Google Gemini LLM implementation using OpenAI-compatible endpoint."""
 
     def __init__(self, api_key: Optional[str] = None, model: str = "gemini-2.0-flash-exp", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
             raise ValueError("Gemini API key required. Set GEMINI_API_KEY environment variable or pass api_key parameter. (GOOGLE_API_KEY is also supported for backward compatibility)")
@@ -679,6 +682,7 @@ class GroqLLM(LLM):
     """Groq LLM implementation using OpenAI-compatible endpoint."""
 
     def __init__(self, api_key: Optional[str] = None, model: str = "groq/llama-3.3-70b-versatile", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("GROQ_API_KEY")
         if not self.api_key:
             raise ValueError("Groq API key required. Set GROQ_API_KEY environment variable or pass api_key parameter.")
@@ -756,6 +760,7 @@ class GrokLLM(LLM):
     """Grok (xAI) LLM implementation using OpenAI-compatible endpoint."""
 
     def __init__(self, api_key: Optional[str] = None, model: str = "grok/grok-4", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("XAI_API_KEY")
         if not self.api_key:
             raise ValueError("Grok API key required. Set XAI_API_KEY environment variable or pass api_key parameter.")
@@ -828,6 +833,7 @@ class OpenRouterLLM(LLM):
     """OpenRouter LLM implementation using OpenAI-compatible endpoint."""
 
     def __init__(self, api_key: Optional[str] = None, model: str = "openrouter/openai/o4-mini", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
         if not self.api_key:
             raise ValueError("OpenRouter API key required. Set OPENROUTER_API_KEY environment variable or pass api_key parameter.")
@@ -916,6 +922,7 @@ class MistralLLM(LLM):
     """Mistral AI LLM implementation using OpenAI-compatible endpoint."""
 
     def __init__(self, api_key: Optional[str] = None, model: str = "mistral/mistral-large-latest", **kwargs):
+        import openai
         self.api_key = api_key or os.getenv("MISTRAL_API_KEY")
         if not self.api_key:
             raise ValueError("Mistral API key required. Set MISTRAL_API_KEY environment variable or pass api_key parameter.")
@@ -1025,6 +1032,7 @@ class OpenOnionLLM(LLM):
     def __init__(self, api_key: Optional[str] = None, model: str = "co/gemini-3.6-flash", **kwargs):
         # For co/ models, api_key is actually the auth token
         # Framework auto-loads .env, so OPENONION_API_KEY will be in environment
+        import openai
         self.auth_token = api_key or os.getenv("OPENONION_API_KEY")
         if not self.auth_token:
             raise ValueError(
@@ -1119,6 +1127,7 @@ class OpenOnionLLM(LLM):
         One helper rather than a copied block: two copies of a translation table
         drift, and the half that drifts is the half nobody tested.
         """
+        import openai
         try:
             return send()
         except openai.APIStatusError as e:

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -340,7 +340,7 @@ class TestOpenAICompatibleProviders:
             "OPENROUTER_HTTP_REFERER": "https://example.com",
             "OPENROUTER_X_TITLE": "My App",
         }):
-            with patch("connectonion.core.llm.openai.OpenAI") as mock_openai:
+            with patch("openai.OpenAI") as mock_openai:
                 OpenRouterLLM(model="openrouter/openai/o4-mini")
 
                 _, kwargs = mock_openai.call_args

--- a/tests/unit/test_the_cli_starts_without_the_sdks.py
+++ b/tests/unit/test_the_cli_starts_without_the_sdks.py
@@ -23,10 +23,29 @@ rather than tolerating.
 The version string lives in its own module now, importable without the package.
 """
 
+import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _in_a_fresh_interpreter(code: str) -> subprocess.CompletedProcess:
+    """Run code against *this* checkout.
+
+    Without cwd and PYTHONPATH pinned here, the subprocess imports whatever
+    `connectonion` is installed in site-packages — these tests then measure a
+    released wheel and say nothing about the branch. They did exactly that
+    until a rebase made the two versions disagree and the assertion read
+    `assert '1.5.11' in 'co 1.5.10'`.
+    """
+    env = dict(os.environ, PYTHONPATH=str(REPO))
+    return subprocess.run([sys.executable, "-c", code],
+                          capture_output=True, text=True, cwd=REPO, env=env)
 
 
 def _modules_after(statement: str) -> set:
@@ -36,8 +55,8 @@ def _modules_after(statement: str) -> set:
         f"{statement}\n"
         "print(json.dumps(sorted(m for m in sys.modules if '.' not in m)))"
     )
-    out = subprocess.run([sys.executable, "-c", code],
-                         capture_output=True, text=True, check=True)
+    out = _in_a_fresh_interpreter(code)
+    assert out.returncode == 0, out.stderr
     import json
     return set(json.loads(out.stdout))
 
@@ -60,11 +79,10 @@ class TestTheVersionIsCheapToRead:
 
     def test_it_agrees_with_pyproject(self):
         import re
-        from pathlib import Path
 
         from connectonion._version import __version__
 
-        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        pyproject = REPO / "pyproject.toml"
         declared = re.search(r'^version = "([^"]+)"', pyproject.read_text(),
                              re.MULTILINE).group(1)
 
@@ -87,13 +105,14 @@ class TestTheCLIEntryPointIsToo:
         assert sdk not in loaded, f"co pays for {sdk} before parsing an argument"
 
     def test_version_still_prints(self):
-        out = subprocess.run(
-            [sys.executable, "-m", "connectonion.cli.main", "--version"],
-            capture_output=True, text=True)
+        out = _in_a_fresh_interpreter(
+            "import runpy, sys;"
+            " sys.argv = ['co', '--version'];"
+            " runpy.run_module('connectonion.cli.main', run_name='__main__')")
 
         from connectonion._version import __version__
 
-        assert __version__ in out.stdout
+        assert __version__ in out.stdout, out.stdout + out.stderr
 
 
 class TestThereIsOneVersionString:

--- a/tests/unit/test_the_cli_starts_without_the_sdks.py
+++ b/tests/unit/test_the_cli_starts_without_the_sdks.py
@@ -1,0 +1,109 @@
+"""What `co --version` has to load in order to print a string.
+
+Measured on this machine, `python -m connectonion.cli.main --version` spends
+1.84 seconds importing before it prints six characters:
+
+    connectonion.cli            1.84s
+      connectonion              1.84s
+        connectonion.core.llm   1.19s
+          openai                0.89s
+        connectonion.useful_tools 0.48s
+
+Every command handler in cli/main.py is already imported inside its function —
+that was deliberate, and the module docstring claims "fast startup (lazy
+imports)". One line undoes it: `from .. import __version__` at module scope
+pulls the whole package, and the package pulls the OpenAI and Anthropic SDKs,
+the TUI, and every useful_tool.
+
+The cost is not paid by `--version` alone. It is paid by `co status`, by every
+tab-completion, and by every invocation from another tool — Claude Code and
+codex drive `co` in a loop — which is what makes two seconds worth removing
+rather than tolerating.
+
+The version string lives in its own module now, importable without the package.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+def _modules_after(statement: str) -> set:
+    """Import in a fresh interpreter and report what came with it."""
+    code = (
+        "import sys, json\n"
+        f"{statement}\n"
+        "print(json.dumps(sorted(m for m in sys.modules if '.' not in m)))"
+    )
+    out = subprocess.run([sys.executable, "-c", code],
+                         capture_output=True, text=True, check=True)
+    import json
+    return set(json.loads(out.stdout))
+
+
+HEAVY = ("openai", "anthropic")
+
+
+class TestTheVersionIsCheapToRead:
+
+    def test_it_reads_without_the_package(self):
+        from connectonion._version import __version__
+
+        assert __version__
+
+    def test_the_package_still_exposes_it(self):
+        import connectonion
+        from connectonion._version import __version__
+
+        assert connectonion.__version__ == __version__
+
+    def test_it_agrees_with_pyproject(self):
+        import re
+        from pathlib import Path
+
+        from connectonion._version import __version__
+
+        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        declared = re.search(r'^version = "([^"]+)"', pyproject.read_text(),
+                             re.MULTILINE).group(1)
+
+        assert __version__ == declared
+
+    @pytest.mark.parametrize("sdk", HEAVY)
+    def test_reading_it_pulls_in_no_sdk(self, sdk):
+        loaded = _modules_after("from connectonion._version import __version__")
+
+        assert sdk not in loaded
+
+
+class TestTheCLIEntryPointIsToo:
+    """The rule above is only worth having if the entry point uses it."""
+
+    @pytest.mark.parametrize("sdk", HEAVY)
+    def test_importing_the_cli_pulls_in_no_sdk(self, sdk):
+        loaded = _modules_after("import connectonion.cli.main")
+
+        assert sdk not in loaded, f"co pays for {sdk} before parsing an argument"
+
+    def test_version_still_prints(self):
+        out = subprocess.run(
+            [sys.executable, "-m", "connectonion.cli.main", "--version"],
+            capture_output=True, text=True)
+
+        from connectonion._version import __version__
+
+        assert __version__ in out.stdout
+
+
+class TestThereIsOneVersionString:
+    """`connectonion/cli/__init__.py` carried its own `__version__ = "0.0.1b5"`,
+    left over from the first beta, with a docstring saying the version command
+    read it. Nothing read it, and `co --version` had printed the package version
+    for a long time — so the one place a reader would look for the CLI's version
+    gave an answer four minor releases stale."""
+
+    def test_the_cli_package_does_not_carry_a_second_one(self):
+        import connectonion.cli
+
+        assert not hasattr(connectonion.cli, "__version__")


### PR DESCRIPTION
Part of #588. Every command handler in `cli/main.py` is imported inside its function, and the module docstring claims "fast startup (lazy imports)". Two things undid it.

## What it was spending

Measured with `python -X importtime -c "import connectonion.cli.main"`:

    connectonion.cli.main       2.26s
      connectonion              2.23s
        connectonion.core.llm   1.38s
          openai                1.03s
        connectonion.useful_tools 0.64s

`core/llm.py` imported `openai` and `anthropic` at module scope. Nothing in it needs either until a provider is constructed or an error is being classified — but `connectonion/__init__.py` reaches `core.llm`, and importing any submodule imports the package, so `co --version`, `co status` and every tab-completion paid for both SDKs first.

## After

    connectonion.cli.main       1.06s        (-1.2s)

Wall clock for `co --version` on this machine: 3.6–4.1s before, 2.4–2.5s after.

The cost is not paid by `--version` alone. `co` is driven in a loop by Claude Code and codex, so a second is charged per invocation.

## How

`import openai` / `import anthropic` moved into the ten functions that use them. Not PEP 562 on the module: `__getattr__` intercepts attribute access on the module object, not bare global names inside its own functions, so `self.client = openai.OpenAI(...)` would have raised `NameError` — it does, I tried it first.

One test patched `connectonion.core.llm.openai.OpenAI`, an attribute that no longer exists; it patches `openai.OpenAI` now.

Also here, both small and in the same area:

- `connectonion/_version.py` — the version string on its own, so `cli/main.py` can read it with `from .._version import __version__`. Kept in step with pyproject.toml by a test. (Does not by itself help startup: importing any submodule imports the package. It is the piece that makes the docstring's promise reachable at all.)
- `connectonion/cli/__init__.py` carried `__version__ = "0.0.1b5"` from the first beta, with a docstring saying the version command read it. Nothing read it. Removed.

## Tests

`tests/unit/test_the_cli_starts_without_the_sdks.py` — importing `connectonion.cli.main` in a fresh interpreter loads neither SDK, the version still prints, and the string agrees with pyproject.toml. Confirmed failing before the change (8 failed), passing after.

Verified against a real call, not only the mocks: `llm_do(..., model='co/gemini-2.5-flash')` returns `pong`, `openai` is absent from `sys.modules` after import and present after the call.

Full unit suite: 3264 passed, 4 skipped.

## What this does not fix

#588 says 9.5s; it is 2.4s now and this takes ~1.2s of that. The rest is `useful_tools` (0.86s, mostly the Google client in gmail.py), `tui.chat` (0.47s) and `requests` (0.37s), all imported eagerly by `connectonion/__init__.py`. Making those lazy means PEP 562 on the package's public surface, which is a larger change than this one. Leaving #588 open with the numbers.