### PR TITLE
A deploy reports success and the agent does not survive a reboot

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -369,6 +369,21 @@ def _remote_user(target: str) -> str:
     return target.split("@")[0]
 
 
+def _enable(target: str, agent: str) -> bool:
+    """Set the unit to start at boot.
+
+    Separate from writing it: the unit's contents and whether systemd will
+    start it after a reboot are two different facts, and only one of them is
+    visible in the file.
+    """
+    result = _ssh(target, f"sudo systemctl enable {agent} >/dev/null 2>&1", timeout=60)
+    if result.returncode != 0:
+        console.print(f"[yellow]  {agent} will not start after a reboot: "
+                      f"systemctl enable failed[/yellow]")
+        return False
+    return True
+
+
 def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
                            hostname: Optional[str] = None,
                            user: Optional[str] = None,
@@ -389,7 +404,14 @@ def _write_unit_if_changed(target: str, agent: str, entrypoint: str,
 
     current = _ssh(target, f"cat {unit_path} 2>/dev/null", timeout=60)
     if current.returncode == 0 and current.stdout == wanted:
-        return True
+        # The unit is right, but being enabled is a separate fact about the
+        # machine and this branch used to skip it — so enablement was decided
+        # by whatever the first deploy did and never looked at again. A box
+        # that had been disabled by hand stayed disabled through every later
+        # deploy, each one printing the green success line, until a reboot
+        # turned it into an outage nobody connected to a deploy weeks earlier
+        # (#574). enable is idempotent and one round trip.
+        return _enable(target, agent)
 
     console.print("[dim]  writing systemd unit …[/dim]")
     script = f"""

--- a/tests/unit/test_a_deploy_survives_a_reboot.py
+++ b/tests/unit/test_a_deploy_survives_a_reboot.py
@@ -1,0 +1,97 @@
+"""A deploy that reports success leaves the agent set to start at boot.
+
+`systemctl enable` lives inside `_write_unit_if_changed()`, after the early
+return that skips the write when the unit text is unchanged:
+
+    current = _ssh(target, f"cat {unit_path} …")
+    if current.returncode == 0 and current.stdout == wanted:
+        return True                    # ← enable never runs
+
+The unit text is unchanged on every deploy after the first. So enablement is
+decided once, by whatever the first deploy happened to do, and never revisited.
+Observed on a real box — `naturewill: active/disabled` after a clean deploy that
+printed the green success line:
+
+    ssh <server> 'sudo systemctl disable naturewill'
+    co deploy --to <server>          # ✓ naturewill is running on <server>
+    ssh <server> 'systemctl is-enabled naturewill'
+    disabled
+
+The machine reboots, the agent does not come back, and nothing said so. That is
+the worst shape a failure can take: it is invisible until an unrelated event —
+a kernel update, a power cut — turns it into an outage nobody connects to a
+deploy weeks earlier. #574.
+
+`systemctl enable` is idempotent and costs one ssh round trip, so it belongs on
+the deploy path unconditionally, not inside a branch about file contents.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+def run(stdout="", returncode=0):
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def commands_for(unit_on_server: str):
+    """Run the unit step against a fake server; return every command it sent."""
+    sent = []
+
+    def fake_ssh(tgt, command, timeout=None, **kwargs):
+        sent.append(command)
+        if command.strip() == "id -un":
+            return run("deployer\n")
+        if command.startswith("cat /etc/systemd/system/"):
+            if unit_on_server is None:
+                return run("", returncode=1)
+            return run(unit_on_server)
+        return run()
+
+    with patch.object(dts, "_ssh", side_effect=fake_ssh):
+        dts._write_unit_if_changed("nw-e2e", "billing", "agent.py")
+
+    return sent
+
+
+def _wanted_unit() -> str:
+    return dts._unit_text("billing", "agent.py", None, user="deployer", port=None)
+
+
+class TestTheUnitIsAlreadyThere:
+    """The common case: every deploy after the first."""
+
+    def test_it_is_still_enabled(self):
+        sent = commands_for(unit_on_server=_wanted_unit())
+
+        assert any("systemctl enable billing" in c for c in sent), sent
+
+    def test_the_unit_is_not_rewritten_for_nothing(self):
+        """The early return was there for a reason — a daemon-reload on every
+        deploy hides whether a restart came from new code or a new unit."""
+        sent = commands_for(unit_on_server=_wanted_unit())
+
+        assert not any("UNITEOF" in c for c in sent), sent
+        assert not any("daemon-reload" in c for c in sent), sent
+
+
+class TestTheUnitIsNew:
+
+    def test_it_is_written_and_enabled(self):
+        sent = commands_for(unit_on_server=None)
+
+        assert any("UNITEOF" in c for c in sent), sent
+        assert any("systemctl enable billing" in c for c in sent), sent
+
+
+class TestTheUnitChanged:
+
+    def test_it_is_rewritten_and_enabled(self):
+        sent = commands_for(unit_on_server="[Unit]\nDescription=something else\n")
+
+        assert any("UNITEOF" in c for c in sent), sent
+        assert any("systemctl enable billing" in c for c in sent), sent

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -239,17 +239,25 @@ class TestSystemdUnit:
         assert "/srv/myagent/.venv/bin/python agent.py" in unit
 
     def test_an_unchanged_unit_is_not_rewritten(self):
-        """Rewriting every deploy would mean a daemon-reload for no reason."""
+        """Rewriting every deploy would mean a daemon-reload for no reason.
+
+        Asserted as "no write and no reload" rather than "exactly one ssh
+        call": the count also covered `systemctl enable`, and enabling is a
+        separate fact from the file's contents — skipping it is #574, where a
+        deploy reported success and the agent did not come back from a reboot.
+        """
         # Same user the target implies — the unit runs as whoever owns the files.
         wanted = dts._unit_text("myagent", "agent.py", user="user")
         with patch.object(dts, "_ssh", return_value=_ok(wanted)) as ssh:
             # The deploy flow resolves the account once and passes it down, so
-            # this call counts only the ssh the unit write itself does.
+            # these calls are only the ones the unit step itself does.
             assert dts._write_unit_if_changed(
                 "user@host", "myagent", "agent.py", user="user"
             ) is True
 
-        assert ssh.call_count == 1  # the read only
+        sent = [c.args[1] for c in ssh.call_args_list]
+        assert not any("UNITEOF" in c for c in sent), sent
+        assert not any("daemon-reload" in c for c in sent), sent
 
     def test_a_changed_unit_is_written_and_reloaded(self):
         with patch.object(dts, "_ssh", side_effect=[_ok("old content"), _ok()]) as ssh:


### PR DESCRIPTION
Closes #574.

`systemctl enable` lives inside `_write_unit_if_changed()`, after the early return that skips the write when the unit text is unchanged:

```python
current = _ssh(target, f"cat {unit_path} …")
if current.returncode == 0 and current.stdout == wanted:
    return True                    # ← enable never runs
```

The unit text is unchanged on every deploy after the first. So enablement was decided once, by whatever the first deploy happened to do, and never looked at again.

On a real box:

```
ssh <server> 'sudo systemctl disable naturewill'
co deploy --to <server>          # ✓ naturewill is running on <server>
ssh <server> 'systemctl is-enabled naturewill'
disabled
```

The failure takes the worst possible shape: nothing is wrong until the machine reboots for an unrelated reason — a kernel update, a power cut — and then the agent is simply gone, weeks after the deploy that caused it.

## The fix

`_enable()` is its own step, called on both paths. The contents of the unit file and whether systemd will start it after a reboot are two different facts, and only one of them is visible in the file.

It warns rather than failing the deploy when enable fails: the agent is running either way, and a deploy that succeeded should not be reported as failed.

## Tests

`tests/unit/test_a_deploy_survives_a_reboot.py` — three cases (unit absent, unit changed, unit unchanged) all end enabled, and the unchanged case still does not rewrite or daemon-reload. Confirmed red on unpatched code: exactly one failure, the unchanged case.

One existing test needed a change. `test_an_unchanged_unit_is_not_rewritten` asserted `ssh.call_count == 1`, which also counted the enable; its docstring says what it means — "rewriting every deploy would mean a daemon-reload for no reason" — so it now asserts no unit write and no daemon-reload.