### PR TITLE
A project made by co create cannot admit anyone, and does not hide its secrets

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -23,6 +23,7 @@ from .auth_commands import authenticate
 # Import shared functions from project_cmd_lib
 from .project_cmd_lib import (
     PROVIDER_TO_ENV,
+    mint_invite_code,
     ensure_global_config,
     copy_docs,
     create_host_yaml,
@@ -369,6 +370,15 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
             ])
 
         env_content = "\n".join(env_lines) + "\n"
+
+    # The agent's own way in. Without it the host starts up saying "no one can
+    # onboard" and points at `co init` — a different command, for a directory
+    # that is already a project. Minted only when absent: regenerating would
+    # lock out everyone holding the old one.
+    if "CO_INVITE_CODE" not in env_content:
+        if env_content and not env_content.endswith("\n"):
+            env_content += "\n"
+        env_content += f"CO_INVITE_CODE={mint_invite_code()}\n"
 
     env_path.write_text(env_content, encoding='utf-8')
     files_created.append(".env")

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -23,6 +23,7 @@ from .auth_commands import authenticate
 # Import shared functions from project_cmd_lib
 from .project_cmd_lib import (
     PROVIDER_TO_ENV,
+    mint_invite_code,
     ensure_global_config,
     copy_docs,
     create_host_yaml,
@@ -226,9 +227,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # `invite_code: [OpenOnion]` — one password for every deployment, published
     # in this repository and printed by every agent on startup (#561).
     if "CO_INVITE_CODE" not in existing_keys:
-        import secrets as _secrets
-        alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"   # no O/0, no I/1 — it gets typed by hand
-        code = "-".join("".join(_secrets.choice(alphabet) for _ in range(5)) for _ in range(3))
+        code = mint_invite_code()
         keys_to_add.append(f"CO_INVITE_CODE={code}")
         global_keys["CO_INVITE_CODE"] = f"CO_INVITE_CODE={code}"
         # In global_keys so the branch that writes a *fresh* .env includes it,

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -33,6 +33,30 @@ from ... import address
 console = Console()
 
 
+def mint_invite_code() -> str:
+    """One code, for one agent, generated once.
+
+    The alphabet drops O/0 and I/1 because this gets read off a screen and
+    typed on a phone. Three groups of five is enough entropy for a door that
+    also checks trust levels, and short enough to dictate over a call.
+
+    Callers mint it only when the project has none: regenerating would silently
+    lock out everyone already holding the old one.
+
+    It replaced the shipped policy's literal `invite_code: [OpenOnion]` — one
+    password for every deployment, published in this repository and printed by
+    every agent on startup (#561). `co init` minted one from the start and
+    `co create` did not, so the command the docs lead with produced a project
+    that told its operator "no one can onboard" and pointed at the other
+    command for the fix.
+    """
+    import secrets
+
+    alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+    return "-".join("".join(secrets.choice(alphabet) for _ in range(5))
+                    for _ in range(3))
+
+
 def get_docs_source() -> Path:
     """Get the docs directory path - works in both dev and installed package."""
     # After pip install: connectonion/docs/ exists (via force-include)
@@ -928,13 +952,23 @@ entrypoint: agent.py
 
 
 def setup_gitignore(project_dir: Path) -> Optional[str]:
-    """Create or update .gitignore if in a git repo. Returns description of what was done, or None."""
-    git_dir = project_dir / ".git"
-    # Also check parent for `co create` inside a git repo
-    parent_git = Path.cwd() / ".git"
-    if not git_dir.exists() and not parent_git.exists():
-        return None
+    """Write .gitignore. Returns a description of what was done, or None.
 
+    Written whether or not this is a git repo yet, because the ordinary order
+    is the other way round:
+
+        co create my-agent      # .env: OPENONION_API_KEY, CO_INVITE_CODE
+        cd my-agent
+        git init && git add . && git commit
+
+    A project is made first and versioned once it works. Waiting for `.git` to
+    exist meant the file that excludes `.env` was never written, and `git add .`
+    took the agent's API token and the code that lets a stranger onboard.
+
+    An unused .gitignore in a directory that never becomes a repo costs a few
+    bytes. A missing one costs a published token, and the recovery is rotating
+    every key in the file.
+    """
     gitignore_path = project_dir / ".gitignore"
     if gitignore_path.exists():
         existing = gitignore_path.read_text(encoding='utf-8')

--- a/tests/unit/test_a_created_project_can_admit_someone.py
+++ b/tests/unit/test_a_created_project_can_admit_someone.py
@@ -1,0 +1,98 @@
+"""A project made by `co create` can let someone in.
+
+`co init` mints `CO_INVITE_CODE` into the project .env — one code per agent,
+generated once, never regenerated (#561 replaced the shipped
+`invite_code: [OpenOnion]`, which was one password for every deployment,
+published in this repository).
+
+`co create` never learned to. It is the command the docs lead with, and what it
+produces starts up saying:
+
+    Invite: no one can onboard — CO_INVITE_CODE is not set.
+    Add it to .env, or run `co init` to mint one.
+
+The advice is for a different command. `co init` works on a directory that is
+already a project; running it inside a created one to obtain a code is not a
+path anyone would find, and until they do, the agent is unreachable by anyone
+who is not already an admin.
+
+Observed by running the real commands: `co create smoke-agent --template co-ai`
+wrote AGENT_ADDRESS, AGENT_EMAIL, IS_EMAIL_ACTIVE and OPENONION_API_KEY — and
+no code.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+CODE = re.compile(r"^CO_INVITE_CODE=[A-Z2-9]{5}-[A-Z2-9]{5}-[A-Z2-9]{5}$", re.M)
+
+
+def _seed_global_keys() -> None:
+    """conftest's autouse fixture already points HOME at a tmp dir."""
+    home = Path.home()
+    (home / ".co").mkdir(parents=True, exist_ok=True)
+    (home / ".co" / "keys.env").write_text(
+        "OPENONION_API_KEY=token\nAGENT_ADDRESS=0xabc\n"
+    )
+
+
+def _create(tmp_path, monkeypatch, name="admits-people") -> str:
+    _seed_global_keys()
+    monkeypatch.chdir(tmp_path)
+
+    from connectonion.cli.commands.create import handle_create
+
+    handle_create(name=name, ai=False, key=None, template="co-ai",
+                  description=None, yes=True, parent_dir=tmp_path)
+    return (tmp_path / name / ".env").read_text()
+
+
+class TestTheCodeIsThere:
+
+    def test_a_created_project_has_one(self, tmp_path, monkeypatch):
+        env = _create(tmp_path, monkeypatch)
+
+        assert "CO_INVITE_CODE=" in env, env
+
+    def test_it_is_shaped_like_something_a_person_can_type(self, tmp_path, monkeypatch):
+        """Three groups of five, from an alphabet with no O/0 and no I/1 — it
+        gets read off a screen and typed on a phone."""
+        env = _create(tmp_path, monkeypatch)
+
+        assert CODE.search(env), env
+
+    def test_it_appears_exactly_once(self, tmp_path, monkeypatch):
+        """A duplicate in the file holding the agent's way in is how people
+        stop trusting the file (#589)."""
+        env = _create(tmp_path, monkeypatch)
+
+        assert env.count("CO_INVITE_CODE=") == 1, env
+
+
+class TestTwoProjectsAreTwoDoors:
+
+    def test_each_project_gets_its_own(self, tmp_path, monkeypatch):
+        """One code for every deployment is what #561 removed. A second
+        project must not inherit the first one's."""
+        first = _create(tmp_path, monkeypatch, name="one")
+        second = _create(tmp_path, monkeypatch, name="two")
+
+        assert CODE.search(first).group() != CODE.search(second).group()
+
+
+class TestTheRestOfTheEnvIsUnharmed:
+
+    def test_the_credentials_are_still_written(self, tmp_path, monkeypatch):
+        env = _create(tmp_path, monkeypatch)
+
+        assert "OPENONION_API_KEY=" in env
+        assert "AGENT_ADDRESS=" in env
+
+    def test_no_machine_path_travels(self, tmp_path, monkeypatch):
+        """#604's rule holds on this path too."""
+        env = _create(tmp_path, monkeypatch)
+
+        assert "AGENT_CONFIG_PATH" not in env

--- a/tests/unit/test_a_new_project_ignores_its_secrets.py
+++ b/tests/unit/test_a_new_project_ignores_its_secrets.py
@@ -1,0 +1,92 @@
+"""A new project carries a .gitignore before it carries a git repo.
+
+`setup_gitignore()` returns early unless the directory — or the current one —
+is already a git repo:
+
+    git_dir = project_dir / ".git"
+    parent_git = Path.cwd() / ".git"
+    if not git_dir.exists() and not parent_git.exists():
+        return None
+
+So the ordinary way to start a project produces no .gitignore at all:
+
+    co create my-agent          # .env: OPENONION_API_KEY, CO_INVITE_CODE
+    cd my-agent
+    git init && git add . && git commit && git push
+
+`git init` after `co create` is the normal order — the project is made first
+and versioned once it works. By then the file that would have excluded `.env`
+was never written, and `git add .` takes the agent's API token and the code
+that lets a stranger onboard.
+
+An unused .gitignore in a directory that never becomes a repo costs a few
+bytes. A missing one costs a published token, and the recovery is to rotate
+every key in it.
+
+This was already known — the comment in env_inheritance.py describes the same
+window: "with a .gitignore written only when the directory was already a git
+repo — one `git add .` from being published".
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands.project_cmd_lib import setup_gitignore
+
+
+class TestItIsWrittenBeforeThereIsARepo:
+
+    def test_a_plain_directory_gets_one(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        project = tmp_path / "my-agent"
+        project.mkdir()
+
+        setup_gitignore(project)
+
+        assert (project / ".gitignore").exists()
+
+    def test_it_excludes_the_env_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        project = tmp_path / "my-agent"
+        project.mkdir()
+
+        setup_gitignore(project)
+
+        assert ".env" in (project / ".gitignore").read_text()
+
+
+class TestNothingElseChanges:
+
+    def test_an_existing_gitignore_is_appended_to_not_replaced(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        project = tmp_path / "my-agent"
+        project.mkdir()
+        (project / ".gitignore").write_text("node_modules/\n")
+
+        setup_gitignore(project)
+
+        text = (project / ".gitignore").read_text()
+        assert "node_modules/" in text
+        assert ".env" in text
+
+    def test_it_is_not_added_twice(self, tmp_path, monkeypatch):
+        """Running create twice, or create then init, must not stack copies."""
+        monkeypatch.chdir(tmp_path)
+        project = tmp_path / "my-agent"
+        project.mkdir()
+
+        setup_gitignore(project)
+        setup_gitignore(project)
+
+        text = (project / ".gitignore").read_text()
+        assert text.count("# ConnectOnion") == 1, text
+
+    def test_a_real_repo_still_works(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        project = tmp_path / "my-agent"
+        (project / ".git").mkdir(parents=True)
+
+        setup_gitignore(project)
+
+        assert ".env" in (project / ".gitignore").read_text()


### PR DESCRIPTION
Both found by running `co create` and starting what it produced, not by reading code.

## 1. Nobody can onboard

`co init` mints `CO_INVITE_CODE` into the project .env. `co create` never did. So the command the docs lead with produces a project that says, on startup:

```
Invite: no one can onboard — CO_INVITE_CODE is not set.
Add it to .env, or run `co init` to mint one.
```

The advice points at a different command, for a directory that is already a project. Until someone works that out, the agent is unreachable by anyone who is not already an admin.

```
$ co create smoke-agent --template co-ai
$ grep -oE '^[A-Z_]+' smoke-agent/.env
AGENT_ADDRESS AGENT_EMAIL IS_EMAIL_ACTIVE OPENONION_API_KEY
```

#561 replaced the shipped policy's literal `invite_code: [OpenOnion]` — one password for every deployment, published in this repository — with one code per agent. This path never followed.

`mint_invite_code()` now sits in `project_cmd_lib.py`, where both commands already share their helpers, rather than inline in `init.py`.

## 2. The secrets are not ignored

`setup_gitignore()` returned early unless the directory, or the current one, was already a git repo. The ordinary order is the reverse:

```
co create my-agent          # .env: OPENONION_API_KEY, CO_INVITE_CODE
cd my-agent
git init && git add . && git commit && git push
```

A project is made first and versioned once it works. By then the file that excludes `.env` was never written, and `git add .` takes the API token and the code that lets a stranger in.

Written unconditionally now. An unused .gitignore in a directory that never becomes a repo costs a few bytes; a missing one costs a published token and the recovery is rotating every key in the file.

This window was already described in `env_inheritance.py`'s comment — "a .gitignore written only when the directory was already a git repo — one `git add .` from being published" — as a known aggravating factor for the secret-inheritance bug. It was never closed.

## Tests

- `test_a_created_project_can_admit_someone.py` — a code is present, shaped to be typed by hand, exactly once, and different per project. Red first: 4 failed.
- `test_a_new_project_ignores_its_secrets.py` — a plain directory gets a .gitignore that excludes .env, an existing one is appended to rather than replaced, and it is not stacked twice. Red first: 4 failed.

Verified against the real commands, not only the tests: `co create live --template co-ai` wrote one code and a .gitignore, `python agent.py` printed `Invite: set — CO_INVITE_CODE in .env, not printed here`, and `/health` answered `{"status": "healthy"}`.

CI command locally: 3722 passed, 9 skipped.