### PR TITLE
co browser status starts a browser to find out whether a browser is running

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -172,6 +172,17 @@ def send(line: str, headless: bool = False, tab: str = None) -> int:
     try:
         conn = _connect(sock_path)
         if conn is None:
+            if line.split()[:1] == ["status"]:
+                # Asking whether the browser is running must not start it. With
+                # nobody listening the answer is already known, and obtaining it
+                # by launching a Chrome — and creating ~/.co/browser.log to do
+                # so — is both backwards and the thing that broke in a managed
+                # sandbox: $HOME readable, writes only in the workspace, so the
+                # open raised PermissionError, which the RuntimeError below does
+                # not catch, and the CLI printed a traceback instead of a status
+                # (#356).
+                print("Browser daemon: not running — the next page command starts one")
+                return 0
             _ensure_browser_ready(line)  # cold start: provision the browser first
             conn = _spawn_daemon(sock_path, headless)
     except RuntimeError as exc:

--- a/tests/unit/test_browser_status_is_read_only.py
+++ b/tests/unit/test_browser_status_is_read_only.py
@@ -119,30 +119,35 @@ class TestAWarmDaemonIsUnaffected:
 
     def test_status_reaches_a_running_daemon(self, monkeypatch, capsys):
         """When one is up, status must still ask it — the local answer is only
-        for the case where there is nobody to ask."""
-        asked = []
+        for the case where there is nobody to ask.
+
+        The fake reply is delivered once and then the socket reports EOF. An
+        earlier version of this returned the same bytes on every recv, so
+        send()'s read-to-EOF loop never ended: green here, and a job killed at
+        five minutes on CI. A fake that cannot end is not a fake of a socket.
+        """
+        sent = []
 
         class FakeConn:
+            def __init__(self):
+                self._reply = [b"OK\nBrowser: open, headless=false\n"]
+
             def sendall(self, data):
-                asked.append(data)
+                sent.append(data)
 
             def shutdown(self, how):
                 pass
 
             def recv(self, n):
-                return b"OK\nBrowser: open\n" if len(asked) == 1 and not getattr(self, "_done", False) else b""
+                return self._reply.pop(0) if self._reply else b""
 
             def close(self):
                 pass
 
-        conn = FakeConn()
-
-        def once(data):
-            asked.append(data)
-
-        monkeypatch.setattr(client, "_connect", lambda *a, **k: conn)
+        monkeypatch.setattr(client, "_connect", lambda *a, **k: FakeConn())
 
         code = client.send("status")
 
-        assert asked, "status did not reach the running daemon"
+        assert sent, "status did not reach the running daemon"
         assert code == 0
+        assert "Browser: open" in capsys.readouterr().out

--- a/tests/unit/test_browser_status_is_read_only.py
+++ b/tests/unit/test_browser_status_is_read_only.py
@@ -1,0 +1,148 @@
+"""Asking whether the browser is running does not start it.
+
+`co browser status` goes through the same cold-start path as every other verb:
+
+    conn = _connect(sock_path)
+    if conn is None:
+        _ensure_browser_ready(line)      # skipped for pageless verbs
+        conn = _spawn_daemon(sock_path, headless)
+
+`_spawn_daemon` creates `~/.co/` and opens `~/.co/browser.log` for append before
+launching a detached daemon. So the answer to "is the browser running?" is
+obtained by starting a browser — which makes the answer yes, and costs a Chrome
+process to learn nothing.
+
+Where it stops being merely backwards: a sandbox that can read `$HOME` but write
+only to the workspace and temp. The `mkdir`/`open` raise `PermissionError`,
+`send()` catches only `RuntimeError`, and the CLI prints a Typer traceback
+instead of a status. Reported from a real managed sandbox in #356:
+
+    CO_WHO=codex-root co browser status
+
+With no daemon there is nothing to report but "not running", and that answer
+needs no process, no home directory and no log.
+
+The other pageless verbs — `tab`, `use`, `close` — read a registry that lives
+inside the daemon, so they are left alone here: they have a reason to want one.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.cli.browser_agent import client
+
+
+@pytest.fixture
+def no_daemon(monkeypatch, tmp_path):
+    """A cold start: nothing listening, and a home nobody may write to."""
+    monkeypatch.setattr(client, "_connect", lambda *a, **k: None)
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("status spawned a daemon")
+
+    monkeypatch.setattr(client, "_spawn_daemon", refuse)
+    return tmp_path
+
+
+class TestNothingIsStarted:
+
+    def test_status_does_not_spawn_a_daemon(self, no_daemon, capsys):
+        code = client.send("status")
+
+        assert code == 0, capsys.readouterr()
+
+    def test_it_says_the_daemon_is_not_running(self, no_daemon, capsys):
+        client.send("status")
+
+        out = capsys.readouterr().out
+        assert "not running" in out.lower(), out
+
+    def test_it_writes_nothing_under_the_home_directory(self, no_daemon, monkeypatch, tmp_path):
+        """The sandbox case: $HOME is readable and not writable."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        client.send("status")
+
+        assert not (home / ".co").exists(), list(home.iterdir())
+
+    def test_a_read_only_home_does_not_raise(self, no_daemon, monkeypatch, tmp_path):
+        """What #356 actually saw — a traceback, not an error line."""
+        home = tmp_path / "locked"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        home.chmod(0o500)
+        try:
+            assert client.send("status") == 0
+        finally:
+            home.chmod(0o700)
+
+
+class TestEverythingElseStillStarts:
+
+    def test_a_page_verb_still_spawns(self, monkeypatch):
+        """The fix must not turn the daemon off for the verbs that need it."""
+        monkeypatch.setattr(client, "_connect", lambda *a, **k: None)
+        monkeypatch.setattr(client, "_ensure_browser_ready", lambda line: None)
+        spawned = []
+
+        def record(sock_path, headless):
+            spawned.append(sock_path)
+            raise RuntimeError("stop here — spawning is what we wanted to see")
+
+        monkeypatch.setattr(client, "_spawn_daemon", record)
+
+        client.send("go_to https://example.com")
+
+        assert spawned, "a page-driving verb no longer starts the daemon"
+
+    def test_tab_still_spawns(self, monkeypatch):
+        """`tab` reads a registry that lives in the daemon process."""
+        monkeypatch.setattr(client, "_connect", lambda *a, **k: None)
+        monkeypatch.setattr(client, "_ensure_browser_ready", lambda line: None)
+        spawned = []
+        monkeypatch.setattr(client, "_spawn_daemon",
+                            lambda s, h: (spawned.append(s), _raise())[0])
+
+        def _raise():
+            raise RuntimeError("stop")
+
+        client.send("tab")
+
+        assert spawned
+
+
+class TestAWarmDaemonIsUnaffected:
+
+    def test_status_reaches_a_running_daemon(self, monkeypatch, capsys):
+        """When one is up, status must still ask it — the local answer is only
+        for the case where there is nobody to ask."""
+        asked = []
+
+        class FakeConn:
+            def sendall(self, data):
+                asked.append(data)
+
+            def shutdown(self, how):
+                pass
+
+            def recv(self, n):
+                return b"OK\nBrowser: open\n" if len(asked) == 1 and not getattr(self, "_done", False) else b""
+
+            def close(self):
+                pass
+
+        conn = FakeConn()
+
+        def once(data):
+            asked.append(data)
+
+        monkeypatch.setattr(client, "_connect", lambda *a, **k: conn)
+
+        code = client.send("status")
+
+        assert asked, "status did not reach the running daemon"
+        assert code == 0


### PR DESCRIPTION
Closes #356.

`send()` treats every verb the same on a cold start:

```python
conn = _connect(sock_path)
if conn is None:
    _ensure_browser_ready(line)      # skipped for pageless verbs
    conn = _spawn_daemon(sock_path, headless)
```

`_spawn_daemon` creates `~/.co/` and opens `~/.co/browser.log` for append before launching a detached daemon. So `co browser status` answers "is the browser running?" by starting one — which makes the answer yes, and costs a Chrome process to learn nothing.

Where it stops being merely backwards is the environment #356 reported from: a managed sandbox where $HOME is readable and writes are allowed only in the workspace and temp. The `mkdir` raises `PermissionError`, `send()` catches only `RuntimeError`, and the user gets a Typer traceback.

## Reproduced

`HOME` at a 0500 directory, `CO_BROWSER_SOCK` at a path with nothing listening:

```
before:
  PermissionError: [Errno 13] Permission denied: '.../fakehome/.co'
  (under the full traceback)

after:
  Browser daemon: not running — the next page command starts one
```

Worth noting how nearly this one got away: my first "real" check passed because this machine already had a daemon running, so `status` connected to it and never reached the branch I had changed. Pointing the socket at nothing was what actually exercised it.

## Scope

`status` only. `tab`, `use` and `close` read a registry that lives inside the daemon process, so they have a reason to start one; a test pins that page verbs and `tab` still spawn, and another that a warm daemon is still asked rather than answered locally.

## Tests

`tests/unit/test_browser_status_is_read_only.py` — 7 cases: nothing is spawned, the answer says not running, nothing is written under $HOME, a 0500 home does not raise, page verbs and `tab` still spawn, and a running daemon is still consulted. Red first: 4 failed.