### PR TITLE
A new project arrives with bytecode compiled on the installer's machine

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -43,6 +43,44 @@ console = Console()
 TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
 
 
+def copy_template_files(template: str, project_dir: Path, files_created: list) -> None:
+    """Copy one template into a new project, source only.
+
+    `pip install` byte-compiles every .py in the wheel, and the template's
+    agent.py is a .py under the package even though nothing imports it — so an
+    installed copy carries
+    `templates/co-ai/__pycache__/agent.cpython-3xx.pyc`, compiled by whichever
+    interpreter did the installing. Copying the directory as found handed that
+    to every new project: a `__pycache__` for code the user has not run yet.
+
+    Nothing breaks — a mismatched magic number is ignored, and .gitignore covers
+    the directory — but the first thing someone sees in their first project
+    should not need explaining.
+    """
+    for item in template_dir_for(template).iterdir():
+        if item.name.startswith('.') and item.name != '.env.example':
+            continue
+        if item.name == '.env.example':
+            continue
+        # The installer's leftovers, at this level and every level below.
+        if item.name == '__pycache__' or item.suffix in ('.pyc', '.pyo'):
+            continue
+
+        dest_path = project_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, dest_path,
+                            ignore=shutil.ignore_patterns('__pycache__', '*.py[cod]'))
+            files_created.append(f"{item.name}/")
+        else:
+            shutil.copy2(item, dest_path)
+            files_created.append(item.name)
+
+
+def template_dir_for(template: str) -> Path:
+    """Where a template lives. Read through TEMPLATES_DIR so a test can move it."""
+    return TEMPLATES_DIR / template
+
+
 def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
                   template: Optional[str], description: Optional[str], yes: bool,
                   parent_dir: Optional[Path] = None):
@@ -278,19 +316,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     files_created = []
 
     if template != 'custom' and template_dir.exists():
-        for item in template_dir.iterdir():
-            if item.name.startswith('.') and item.name != '.env.example':
-                continue
-
-            dest_path = project_dir / item.name
-
-            if item.is_dir():
-                shutil.copytree(item, dest_path)
-                files_created.append(f"{item.name}/")
-            else:
-                if item.name != '.env.example':
-                    shutil.copy2(item, dest_path)
-                    files_created.append(item.name)
+        copy_template_files(template, project_dir, files_created)
 
     # Create custom agent.py if custom template
     if custom_code:

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -131,6 +131,12 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
             # Skip hidden files except .env.example
             if item.name.startswith('.') and item.name != '.env.example':
                 continue
+            # The installer's leftovers: pip byte-compiles the template's
+            # agent.py because it is a .py under the package, and copying that
+            # hands a new project bytecode for code nobody has run. Same reason
+            # as in create.py's copy_template_files.
+            if item.name == '__pycache__' or item.suffix in ('.pyc', '.pyo'):
+                continue
 
             dest_path = Path(current_dir) / item.name
 
@@ -141,7 +147,8 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
                 else:
                     if dest_path.exists():
                         shutil.rmtree(dest_path)
-                    shutil.copytree(item, dest_path)
+                    shutil.copytree(item, dest_path,
+                                    ignore=shutil.ignore_patterns('__pycache__', '*.py[cod]'))
                     files_created.append(f"{item.name}/")
             else:
                 # Skip .env.example, we'll create .env directly

--- a/tests/unit/test_a_new_project_has_no_installer_bytecode.py
+++ b/tests/unit/test_a_new_project_has_no_installer_bytecode.py
@@ -1,0 +1,109 @@
+"""A brand-new project contains only what the user is meant to read.
+
+`pip install` byte-compiles every `.py` in the wheel. `cli/templates/co-ai/
+agent.py` is a template rather than a module, but it is a `.py` under the
+package, so installation leaves:
+
+    site-packages/connectonion/cli/templates/co-ai/__pycache__/agent.cpython-310.pyc
+
+`co create` copies the template directory as it finds it, so every new project
+arrives with a `__pycache__` holding bytecode compiled on the installing
+machine, for whatever interpreter did the installing. Observed from a real
+wheel install:
+
+    $ co create wheeltest --template co-ai
+    $ ls -a wheeltest
+    .co  .env  .gitignore  Dockerfile  __pycache__  agent.py  requirements.txt
+
+Nothing breaks — a mismatched magic number is ignored and .gitignore covers the
+directory. But a person opening their first ConnectOnion project should not
+have to work out why there is compiled output for code they have not run, and
+"is that mine?" is a question the template is supposed to prevent.
+
+Only source is copied; the interpreter makes its own bytecode when the user
+runs the thing.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import create as create_cmd
+
+
+@pytest.fixture
+def template_with_bytecode(tmp_path, monkeypatch):
+    """A template directory as pip leaves it: source plus a __pycache__."""
+    templates = tmp_path / "templates"
+    co_ai = templates / "co-ai"
+    co_ai.mkdir(parents=True)
+    (co_ai / "agent.py").write_text("from connectonion import host\n")
+    (co_ai / "requirements.txt").write_text("connectonion\n")
+    cache = co_ai / "__pycache__"
+    cache.mkdir()
+    (cache / "agent.cpython-310.pyc").write_bytes(b"\x6f\x0d\x0d\x0a stale")
+
+    monkeypatch.setattr(create_cmd, "TEMPLATES_DIR", templates)
+    return templates
+
+
+def _copy(template_with_bytecode, tmp_path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    create_cmd.copy_template_files("co-ai", project, [])
+    return project
+
+
+class TestWhatArrivesInTheProject:
+
+    def test_the_source_is_there(self, template_with_bytecode, tmp_path):
+        project = _copy(template_with_bytecode, tmp_path)
+
+        assert (project / "agent.py").exists()
+        assert (project / "requirements.txt").exists()
+
+    def test_the_installers_bytecode_is_not(self, template_with_bytecode, tmp_path):
+        project = _copy(template_with_bytecode, tmp_path)
+
+        assert not (project / "__pycache__").exists(), list(project.iterdir())
+
+
+class TestNestedDirectoriesToo:
+    """A template with a subdirectory gets the same treatment — copytree would
+    otherwise carry a __pycache__ from any depth."""
+
+    def test_a_nested_pycache_is_left_behind(self, template_with_bytecode, tmp_path):
+        nested = template_with_bytecode / "co-ai" / "tools"
+        nested.mkdir()
+        (nested / "search.py").write_text("def search(): ...\n")
+        (nested / "__pycache__").mkdir()
+        (nested / "__pycache__" / "search.cpython-310.pyc").write_bytes(b"stale")
+
+        project = _copy(template_with_bytecode, tmp_path)
+
+        assert (project / "tools" / "search.py").exists()
+        assert not (project / "tools" / "__pycache__").exists()
+
+
+class TestCoInitToo:
+    """`co init --template co-ai` copies the same directory by its own loop."""
+
+    def test_init_leaves_the_bytecode_behind(self, template_with_bytecode, tmp_path, monkeypatch):
+        from connectonion.cli.commands import init as init_cmd
+
+        home = Path.home()
+        (home / ".co").mkdir(parents=True, exist_ok=True)
+        (home / ".co" / "keys.env").write_text("OPENONION_API_KEY=token\n")
+
+        project = tmp_path / "into"
+        project.mkdir()
+        monkeypatch.chdir(project)
+        monkeypatch.setattr(init_cmd, "TEMPLATES_DIR", template_with_bytecode,
+                            raising=False)
+
+        init_cmd.handle_init(ai=False, key=None, template="co-ai",
+                             description=None, yes=True, force=True)
+
+        assert (project / "agent.py").exists()
+        assert not (project / "__pycache__").exists(), list(project.iterdir())


### PR DESCRIPTION
Found by building the wheel, installing it into a fresh venv, and running `co create` from it — the only place this shows up. A checkout has no such file.

```
$ co create wheeltest --template co-ai
$ ls -a wheeltest
.co  .env  .gitignore  Dockerfile  __pycache__  agent.py  requirements.txt
$ ls wheeltest/__pycache__
agent.cpython-310.pyc
```

`pip install` byte-compiles every `.py` in the wheel. `cli/templates/co-ai/agent.py` is a template — nothing imports it — but it is a `.py` under the package, so installation leaves `templates/co-ai/__pycache__/agent.cpython-3xx.pyc` in site-packages, compiled by whichever interpreter did the installing. The template directory is then copied as found.

## How much this matters

Not much, and I want to be plain about that: a mismatched magic number is ignored, `.gitignore` covers `__pycache__/`, and nothing misbehaves. What it costs is an explanation — someone opening their first ConnectOnion project finds compiled output for code they have not run, and "is that mine?" is a question a template exists to prevent.

## The change

The copy loop moved out of `handle_create` into `copy_template_files()` so it can be tested without running the whole command. `co init` has its own copy loop with the same gap; it got the same guard.

## Tests

`tests/unit/test_a_new_project_has_no_installer_bytecode.py` — a template fixture shaped the way pip leaves one (source plus `__pycache__`), asserting the source arrives and the bytecode does not, at the top level and nested, through both `co create` and `co init`. Red first: 3 failed.