### PR TITLE
The events API's examples describe a trace the agent does not write

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ from connectonion import Agent, after_tools, llm_do
 # Define a reflection plugin
 def add_reflection(agent):
     trace = agent.current_session['trace'][-1]
-    if trace['type'] == 'tool_execution' and trace['status'] == 'success':
+    if trace['type'] == 'tool_result' and trace['status'] == 'success':
         result = trace['result']
         reflection = llm_do(
             f"Result: {result[:200]}\n\nWhat did we learn?",

--- a/connectonion/core/events.py
+++ b/connectonion/core/events.py
@@ -194,8 +194,8 @@ def after_each_tool(*funcs: EventHandler) -> Union[EventHandler, List[EventHandl
         @after_each_tool
         def log_tool(agent):
             trace = agent.current_session['trace'][-1]
-            if trace['type'] == 'tool_execution':
-                print(f"Tool: {trace['tool_name']} in {trace['timing']:.0f}ms")
+            if trace['type'] == 'tool_result':
+                print(f"Tool: {trace['name']} in {trace['timing_ms']:.0f}ms")
 
         on_events=[after_each_tool(handler1, handler2)]
     """
@@ -235,7 +235,7 @@ def after_tools(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]
         @after_tools
         def add_reflection(agent):
             trace = agent.current_session['trace']
-            recent = [t for t in trace if t['type'] == 'tool_execution'][-3:]
+            recent = [t for t in trace if t['type'] == 'tool_result'][-3:]
             agent.current_session['messages'].append({
                 'role': 'assistant',
                 'content': f"Completed {len(recent)} tools"
@@ -307,7 +307,7 @@ def on_complete(*funcs: EventHandler) -> Union[EventHandler, List[EventHandler]]
         @on_complete
         def log_done(agent):
             trace = agent.current_session['trace']
-            tools_used = [t['tool_name'] for t in trace if t['type'] == 'tool_execution']
+            tools_used = [t['name'] for t in trace if t['type'] == 'tool_result']
             print(f"Task done. Tools: {tools_used}")
 
         on_events=[on_complete(handler1, handler2)]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1679,11 +1679,11 @@ def _add_reflection(agent) -> None:
     """Reflect on tool execution result"""
     trace = agent.current_session['trace'][-1]
 
-    if trace['type'] == 'tool_execution' and trace['status'] == 'success':
+    if trace['type'] == 'tool_result' and trace['status'] == 'success':
         # Extract current tool execution
         user_prompt = agent.current_session.get('user_prompt', '')
-        tool_name = trace['tool_name']
-        tool_args = trace['arguments']
+        tool_name = trace['name']
+        tool_args = trace['args']
         tool_result = trace['result']
 
         # Compress conversation messages
@@ -1746,7 +1746,7 @@ from connectonion import Agent, after_each_tool
 
 def log_tool(agent):
     trace = agent.current_session['trace'][-1]
-    print(f"✓ {trace['tool_name']} completed in {trace['timing']}ms")
+    print(f"✓ {trace['name']} completed in {trace['timing_ms']}ms")
 
 # Plugin is an event list
 logger = [after_each_tool(log_tool)]  # after_each_tool for per-tool logging
@@ -1901,7 +1901,7 @@ if "Maximum iterations" in result:
     # Look at the execution trace to see what went wrong
     for entry in agent.current_session['trace']:
         if entry.get('status') == 'error':
-            print(f"Tool {entry['tool_name']} failed: {entry['result']}")
+            print(f"Tool {entry['name']} failed: {entry['result']}")
 
 # Solutions:
 # 1. Increase iterations

--- a/tests/unit/test_the_events_examples_match_the_trace.py
+++ b/tests/unit/test_the_events_examples_match_the_trace.py
@@ -1,0 +1,99 @@
+"""The examples in the events API describe a trace the agent does not write.
+
+`core/events.py` is where someone learns to hook into a run. Three of its
+docstrings — the code people copy — filter the trace like this:
+
+    trace = agent.current_session['trace'][-1]
+    if trace['type'] == 'tool_execution':
+        print(f"Tool: {trace['tool_name']} in {trace['timing']:.0f}ms")
+
+Nothing writes `tool_execution`. The entries are `tool_call` and `tool_result`,
+their name field is `name`, and their timing field is `timing_ms`. A handler
+written from these examples never fires: the `if` is never true, the list
+comprehension is always empty, and there is no error to notice — the run
+completes and the hook simply had nothing to say.
+
+`tool_execution` came from `core/tool_executor.py`'s module note, which claimed
+to write it and did not. The note has since been corrected; these examples had
+not been.
+
+An example in a public API is the contract most people actually read. This test
+holds the docstrings to the trace: every type they compare against must be a
+type something writes, and every field they read must exist on that entry.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from connectonion.core import events
+
+
+SOURCE = Path(events.__file__).read_text()
+PACKAGE = Path(events.__file__).resolve().parents[2] / "connectonion"
+
+
+def _types_written() -> set:
+    """Every 'type' literal the package puts into a trace entry."""
+    written = set()
+    for path in PACKAGE.rglob("*.py"):
+        for m in re.finditer(r"""['"]type['"]\s*:\s*['"]([a-z_]+)['"]""", path.read_text()):
+            written.add(m.group(1))
+    return written
+
+
+def _types_compared_in_docstrings() -> set:
+    """Every type literal an events.py docstring tells a reader to match."""
+    compared = set()
+    tree = ast.parse(SOURCE)
+    for node in ast.walk(tree):
+        doc = ast.get_docstring(node) if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)) else None
+        if not doc:
+            continue
+        compared.update(re.findall(r"""\['type'\]\s*==\s*'([a-z_]+)'""", doc))
+    return compared
+
+
+class TestTheTypesExist:
+
+    def test_the_examples_name_types_something_writes(self):
+        written = _types_written()
+        compared = _types_compared_in_docstrings()
+
+        assert compared, "no example filters the trace — has this file changed shape?"
+        assert compared <= written, (
+            f"events.py teaches readers to match {sorted(compared - written)}, "
+            f"which nothing writes"
+        )
+
+    def test_tool_execution_is_gone(self):
+        """The specific name that was wrong, so a revert is loud."""
+        assert "tool_execution" not in SOURCE
+
+
+class TestTheFieldsExist:
+    """A type that exists is not enough — the examples also read fields off it."""
+
+    TOOL_RESULT_FIELDS = {"args", "id", "name", "result", "status",
+                          "timing_ms", "tool_id", "ts", "type"}
+
+    def test_every_field_the_examples_read_is_on_the_entry(self):
+        fields = set()
+        tree = ast.parse(SOURCE)
+        for node in ast.walk(tree):
+            doc = ast.get_docstring(node) if isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)) else None
+            if not doc or "tool_result" not in doc:
+                continue
+            # t['field'] / trace['field'] on the lines that talk about tools
+            fields.update(re.findall(r"""\b(?:t|trace)\['([a-z_]+)'\]""", doc))
+
+        unknown = fields - self.TOOL_RESULT_FIELDS
+        assert not unknown, f"the examples read {sorted(unknown)}, which a tool entry has not"
+
+    def test_the_old_field_names_are_gone(self):
+        assert "tool_name" not in SOURCE, "tool entries carry `name`, not `tool_name`"
+        assert "['timing']" not in SOURCE, "tool entries carry `timing_ms`"


### PR DESCRIPTION
`core/events.py` is where someone learns to hook into a run. Three of its docstrings — the code people copy — say this:

```python
trace = agent.current_session['trace'][-1]
if trace['type'] == 'tool_execution':
    print(f"Tool: {trace['tool_name']} in {trace['timing']:.0f}ms")
```

Nothing writes `tool_execution`. The entries are `tool_call` and `tool_result`; the name field is `name`; the timing field is `timing_ms`.

So a handler written from the documentation never fires. The `if` is never true, the list comprehension is always empty, and there is no error to notice — the run completes and the hook had nothing to say. For a hook API that is the worst failure mode available: it looks like the agent never used a tool.

`tool_execution` came from `core/tool_executor.py`'s module note, which claimed to write it and did not. That note was corrected when `co eval`'s copy of the same mistake was fixed (#606); these examples had not been.

## Where else

`README.md` and `docs/README.md` carry the same shape (plus `trace['arguments']`, which is `args`). Fixed.

`docs/design-decisions/019-agent-lifecycle-design.md` also uses it. Left alone on purpose: it is a dated record of what was proposed, not instructions to follow. If the implementation diverged from the design, the design note is the history of that.

## Tests

`tests/unit/test_the_events_examples_match_the_trace.py` parses the docstrings and holds them to the code: every type literal they compare against must be a type something in the package writes, and every field they read off a tool entry must exist on one. Red first: 4 failed.

Verified against a real `Agent`, not only the parser — handlers written exactly like the corrected examples:

```
after_each_tool saw: ['add in 0ms']
on_complete saw: ['add']
```

Unit suite: 3311 passed, 4 skipped.