### PR TITLE
The real-world examples in docs/README.md raise TypeError on both lines

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1271,11 +1271,11 @@ from connectonion import Agent, send_email
 agent = Agent(
     "customer_support",
     tools=[send_email],
-    instructions="You help users and send them email confirmations"
+    system_prompt="You help users and send them email confirmations"
 )
 
 # The agent can now send emails autonomously
-response = agent("Send a welcome email to alice@example.com")
+response = agent.input("Send a welcome email to alice@example.com")
 # Agent sends: send_email("alice@example.com", "Welcome!", "Thanks for joining...")
 ```
 
@@ -1293,11 +1293,11 @@ def check_system_status() -> dict:
 monitor = Agent(
     "system_monitor",
     tools=[check_system_status, send_email],
-    instructions="Monitor system health and alert admin@example.com if issues"
+    system_prompt="Monitor system health and alert admin@example.com if issues"
 )
 
 # Agent checks system and sends alerts
-monitor("Check the system and alert if there are problems")
+monitor.input("Check the system and alert if there are problems")
 # Agent will:
 # 1. Call check_system_status() 
 # 2. See high CPU (95%)

--- a/tests/unit/test_the_documented_calls_are_real_calls.py
+++ b/tests/unit/test_the_documented_calls_are_real_calls.py
@@ -1,0 +1,90 @@
+"""The examples in the READMEs call the API the package actually has.
+
+Two shapes in `docs/README.md`'s "Real-World" section, both of which raise
+before doing anything:
+
+    agent = Agent("customer_support", tools=[send_email],
+                  instructions="You help users …")
+    response = agent("Send a welcome email to alice@example.com")
+
+`Agent.__init__` takes `system_prompt`, not `instructions`, and it has no
+`**kwargs` to absorb the difference:
+
+    TypeError: Agent.__init__() got an unexpected keyword argument 'instructions'
+
+And `Agent` defines no `__call__`, so the second line raises too. The method is
+`agent.input(...)`.
+
+Someone reading the README meets these in the section that promises real-world
+usage. They are the first thing a person runs, and neither line survives.
+
+The tests below are the general rule rather than these two fixes: every keyword
+a documented call passes must exist on the callable, and no example may call an
+agent instance. Both are cheap to check and neither can drift silently again.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+import connectonion as co
+
+
+REPO = Path(__file__).resolve().parents[2]
+DOCS = [REPO / "README.md", REPO / "docs" / "README.md"]
+SOURCES = {p: p.read_text(encoding="utf-8") for p in DOCS if p.exists()}
+
+
+def _kwargs_passed_to(name: str, text: str) -> set:
+    """Keyword names used in `name(...)` calls in a markdown file."""
+    used = set()
+    for call in re.findall(rf"\b{name}\(([^)]*)\)", text, re.S):
+        used.update(re.findall(r"(\w+)\s*=", call))
+    return used
+
+
+CALLABLES = {
+    "Agent": co.Agent.__init__,
+    "llm_do": co.llm_do,
+    "host": co.host,
+}
+
+
+@pytest.mark.parametrize("path", list(SOURCES))
+@pytest.mark.parametrize("name", sorted(CALLABLES))
+def test_every_documented_keyword_exists(name, path):
+    fn = CALLABLES[name]
+    signature = inspect.signature(fn)
+    accepts_anything = any(p.kind is inspect.Parameter.VAR_KEYWORD
+                           for p in signature.parameters.values())
+    if accepts_anything:
+        pytest.skip(f"{name} takes **kwargs — any keyword is forwarded")
+
+    unknown = sorted(_kwargs_passed_to(name, SOURCES[path]) - set(signature.parameters))
+
+    assert not unknown, (
+        f"{path.relative_to(REPO)} passes {unknown} to {name}(), which takes "
+        f"{sorted(signature.parameters)} and has no **kwargs — the example "
+        f"raises TypeError before it does anything"
+    )
+
+
+@pytest.mark.parametrize("path", list(SOURCES))
+def test_no_example_calls_an_agent_instance(path):
+    """`Agent` has no __call__; the method is .input()."""
+    assert "__call__" not in co.Agent.__dict__, (
+        "Agent became callable — this test and the examples can be relaxed"
+    )
+
+    # `agent("…")` / `monitor("…")` at the start of a line, with a string
+    # argument. Lower-case only: `Agent("name", …)` is the constructor, and a
+    # capitalised name is a class rather than an instance.
+    offenders = re.findall(r"^\s*(?:\w+\s*=\s*)?([a-z_]*(?:agent|monitor|assistant))\(\s*[\"']",
+                           SOURCES[path], re.M)
+
+    assert not offenders, (
+        f"{path.relative_to(REPO)} calls {sorted(set(offenders))} directly; Agent instances "
+        f"are not callable — the example raises TypeError"
+    )


### PR DESCRIPTION
Found by checking documented keyword arguments against the real signatures — the same class as #612, one layer out.

```python
agent = Agent(
    "customer_support",
    tools=[send_email],
    instructions="You help users and send them email confirmations"
)
response = agent("Send a welcome email to alice@example.com")
```

```
TypeError: Agent.__init__() got an unexpected keyword argument 'instructions'
```

The parameter is `system_prompt`, and `Agent.__init__` has no `**kwargs` to absorb the difference. The second line raises as well: `Agent` defines no `__call__`, so an instance is not callable — the method is `agent.input(...)`.

The monitoring example immediately below repeats both mistakes. This is the section headed "Real-World", which is where someone goes to copy something that works.

## The test

The rule rather than the two fixes: every keyword a documented call passes must exist on the callable, and no example may call an agent instance.

The keyword check skips callables that take `**kwargs` — `llm_do(..., temperature=0.3)` appears throughout the docs and is correct, because `llm_do` forwards unknown keywords to the provider. Flagging it would have been a false positive that made the test worth deleting.

Red first: 2 failed, naming `['instructions']` and `['agent', 'monitor']`.

Verified the corrected shape constructs against the real class, not only the regex:

```
constructed: customer_support | tools: ['send_email']
has .input: True
```