### PR TITLE
The person who made the agent cannot command it

### DIFF
--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -27,6 +27,7 @@ from .project_cmd_lib import (
     ensure_global_config,
     copy_docs,
     create_host_yaml,
+    record_creator_as_admin,
     setup_gitignore,
     print_resources,
     LoadingAnimation,
@@ -336,6 +337,10 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     # Create host.yaml from template (unified config for host() and co deploy)
     if create_host_yaml(co_dir, name):
         files_created.append(".co/host.yaml")
+
+    # Who may command this agent — see record_creator_as_admin. `co deploy`
+    # writes the deployer in for the same reason.
+    record_creator_as_admin(project_dir)
 
     # Create .env file - copy from global keys.env
     env_path = project_dir / ".env"

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -27,6 +27,7 @@ from .project_cmd_lib import (
     ensure_global_config,
     copy_docs,
     create_host_yaml,
+    record_creator_as_admin,
     setup_gitignore,
     print_resources,
     get_special_directory_warning,
@@ -307,6 +308,10 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     host_name = os.path.basename(current_dir) or "connectonion-agent"
     if create_host_yaml(co_dir, host_name):
         files_created.append(".co/host.yaml")
+
+    # Who may command this agent. `co deploy` writes the deployer in for the
+    # same reason; without it `co call` from this very machine is refused.
+    record_creator_as_admin(Path(current_dir))
 
     # Handle .gitignore if in git repo
     gi_result = setup_gitignore(Path(current_dir))

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -33,6 +33,43 @@ from ... import address
 console = Console()
 
 
+def record_creator_as_admin(project_dir: Path) -> None:
+    """Let whoever made this agent command it.
+
+    `co deploy` already writes the deployer's address into the agent's
+    .co/admins.txt, with the reason spelled out there: admins.txt is who may
+    command the agent, and without it nobody can — ADMIN_ADD is gated on
+    super-admin, super-admin is the agent's own address, and that private key
+    lives only with the agent. The one account that could grant admin is the
+    one nobody can sign as.
+
+    The same is true of an agent run locally, and neither `co create` nor
+    `co init` did it, so `co call` against an agent you had just made on your
+    own machine answered "agent requires onboarding" (#614).
+
+    The address is read from the keypair, not from keys.env's AGENT_ADDRESS:
+    the file has to name the key that will actually be presented at CONNECT,
+    and those two are not always the same value.
+
+    Appended and only when absent — the file may already name other admins, and
+    a second `co init` must not add the same line twice.
+    """
+    from ... import address
+
+    data = address.load(Path.home() / ".co")
+    if not data or not data.get("address"):
+        return
+
+    admins = project_dir / ".co" / "admins.txt"
+    admins.parent.mkdir(parents=True, exist_ok=True)
+    existing = admins.read_text(encoding="utf-8").splitlines() if admins.exists() else []
+    if data["address"] in (l.strip() for l in existing):
+        return
+
+    with open(admins, "a", encoding="utf-8") as f:
+        f.write(data["address"] + "\n")
+
+
 def mint_invite_code() -> str:
     """One code, for one agent, generated once.
 

--- a/tests/unit/test_the_creator_can_command_their_agent.py
+++ b/tests/unit/test_the_creator_can_command_their_agent.py
@@ -1,0 +1,140 @@
+"""The person who made the agent can talk to it.
+
+`co deploy` writes the deployer's address into the agent's `.co/admins.txt`,
+and says why:
+
+    admins.txt is who may command the agent. Without this nobody can —
+    ADMIN_ADD is gated on super-admin, super-admin is the agent's OWN address,
+    and that private key exists only on the server. The one account that could
+    grant admin is the one nobody can sign as.
+
+`co create` and `co init` never learned it, so an agent run from the machine
+that made it treats its own author as a stranger:
+
+    $ co create calltest --template co-ai
+    $ python agent.py &
+    $ co call 0x900d7723… "co status"
+    agent requires onboarding — run input() once to onboard, then call() works
+
+Confirmed both directions on a live agent. With `.co/admins.txt` absent the
+CONNECT is refused; with the caller's address in it the same command connects
+and runs — the 127 below is the remote shell's own answer, so the trust gate
+and the exec path both worked:
+
+    $ co call 0x900d7723… "co status"
+    STDERR:
+    /bin/bash: co status: command not found
+    Exit code: 127
+
+The advice in that error is not something a CLI user can act on either —
+`input()` is the Python API and `co call` has no way to submit an invite code —
+but that is #614's second half and a separate decision. This is the half with a
+precedent to follow: write it the way deploy already does.
+
+Appended rather than written, and only when absent: the file may already name
+other admins, and re-running init must not mint a second copy of the same line.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def _seed_global_keys() -> str:
+    """conftest's autouse fixture already points HOME at a tmp dir."""
+    from connectonion import address
+
+    home = Path.home()
+    (home / ".co").mkdir(parents=True, exist_ok=True)
+    data = address.generate()
+    address.save(data, home / ".co")
+    (home / ".co" / "keys.env").write_text(
+        f"OPENONION_API_KEY=token\nAGENT_ADDRESS={data['address']}\n"
+    )
+    return data["address"]
+
+
+def _admins(project: Path) -> list:
+    path = project / ".co" / "admins.txt"
+    if not path.exists():
+        return []
+    return [l.strip() for l in path.read_text().splitlines() if l.strip()]
+
+
+class TestCoCreate:
+
+    def _create(self, tmp_path, monkeypatch, name="mine") -> Path:
+        creator = _seed_global_keys()
+        monkeypatch.chdir(tmp_path)
+
+        from connectonion.cli.commands.create import handle_create
+
+        handle_create(name=name, ai=False, key=None, template="co-ai",
+                      description=None, yes=True, parent_dir=tmp_path)
+        self.creator = creator
+        return tmp_path / name
+
+    def test_the_creator_is_an_admin(self, tmp_path, monkeypatch):
+        project = self._create(tmp_path, monkeypatch)
+
+        assert self.creator in _admins(project), _admins(project)
+
+    def test_the_address_is_the_one_that_signs(self, tmp_path, monkeypatch):
+        """Not the one in keys.env — an agent has to trust the key that will
+        actually be presented to it."""
+        from connectonion import address
+
+        project = self._create(tmp_path, monkeypatch)
+        signing = address.load(Path.home() / ".co")["address"]
+
+        assert _admins(project) == [signing]
+
+
+class TestCoInit:
+
+    def _init(self, tmp_path, monkeypatch) -> Path:
+        creator = _seed_global_keys()
+        project = tmp_path / "here"
+        project.mkdir()
+        monkeypatch.chdir(project)
+
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=False, key=None, template="none", description=None,
+                    yes=True, force=True)
+        self.creator = creator
+        return project
+
+    def test_the_creator_is_an_admin(self, tmp_path, monkeypatch):
+        project = self._init(tmp_path, monkeypatch)
+
+        assert self.creator in _admins(project), _admins(project)
+
+    def test_running_it_twice_does_not_duplicate_the_line(self, tmp_path, monkeypatch):
+        """A duplicate in the file that says who may command the agent is how
+        people stop trusting the file."""
+        project = self._init(tmp_path, monkeypatch)
+
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=False, key=None, template="none", description=None,
+                    yes=True, force=True)
+
+        assert _admins(project).count(self.creator) == 1
+
+    def test_an_existing_admin_is_kept(self, tmp_path, monkeypatch):
+        """The file may already name someone else."""
+        creator = _seed_global_keys()
+        project = tmp_path / "shared"
+        (project / ".co").mkdir(parents=True)
+        someone_else = "0x" + "b" * 64
+        (project / ".co" / "admins.txt").write_text(someone_else + "\n")
+        monkeypatch.chdir(project)
+
+        from connectonion.cli.commands.init import handle_init
+
+        handle_init(ai=False, key=None, template="none", description=None,
+                    yes=True, force=True)
+
+        assert someone_else in _admins(project)
+        assert creator in _admins(project)


### PR DESCRIPTION
First half of #614.

```
$ co create calltest --template co-ai
$ python agent.py &
$ co call 0x900d7723… "co status"
agent requires onboarding — run input() once to onboard, then call() works
```

`co deploy` writes the deployer's address into `.co/admins.txt`, and the comment there says why:

> admins.txt is who may command the agent. Without this **nobody can** — ADMIN_ADD is gated on super-admin, super-admin is the agent's OWN address, and that private key exists only on the server. The one account that could grant admin is the one nobody can sign as.

`co create` and `co init` never learned it. The same argument applies to an agent you run locally, and the consequence is that the first thing anyone tries — make an agent, talk to it from the CLI — ends in an instruction to write Python.

## Verified end to end

Not only against the tests. `co create`, `python agent.py`, then a real `co call`:

```
$ cat adminsmoke/.co/admins.txt
0x10e68f6dff39ab1c50cc48ea1c74e7fd6ce7269aa6e8123829b344e57d005508

$ co call 0xfdfa8cd3… ls
Dockerfile
agent.py
requirements.txt
```

Before the change the same call answered `agent requires onboarding`.

## Details worth review

**The address is read from the keypair, not from `keys.env`.** The file has to name the key that will actually be presented at CONNECT. On this machine `~/.co/keys/` derives `0x10e6…` while `keys.env` says `AGENT_ADDRESS=0x5616…` — see #614's third point; I have not reproduced how they diverge, so this change simply uses the one that signs.

**The server is untouched.** `.co/admins.txt` is in the rsync exclude list, with a comment that a stale local copy would silently change who is in charge. Deploy still writes the deployer's address server-side; nothing here reaches it.

**It will be committed.** `.gitignore` covers `.co/keys/`, `logs/`, `cache/`, `history/`, `docs/` — not `admins.txt`. So a project pushed to git carries its author's address, and whoever clones and runs it trusts that address. That mirrors `host.yaml`, which is also committed and also carries trust settings, but it is a consequence rather than an accident and worth a second opinion. Say the word and I will add it to the ignore list instead.

## Tests

`tests/unit/test_the_creator_can_command_their_agent.py` — through both commands: the creator is an admin, the address is the signing one rather than keys.env's, a second run does not duplicate the line, and an admin already in the file is kept. Red first: 5 failed.