### PR TITLE
keys.env keeps naming an identity the machine no longer has

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1147,6 +1147,48 @@ def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> No
         env_path.chmod(0o600)
 
 
+def _state_the_address_the_key_has(global_dir: Path) -> None:
+    """Keep keys.env's AGENT_ADDRESS equal to the key it claims to describe.
+
+    The line is a copy of the keypair, not a fact of its own, and it was written
+    once at first setup and never revisited. ensure_global_config() does have the
+    reconcile — but only inside the branch that regenerates a *missing* key, and
+    a key that merely *changed* returns above it. So after a `co reset`, or a
+    restore from a different recovery phrase, the file kept naming the previous
+    identity, every project made afterwards copied that line into its .env, and
+    every deploy shipped it to a server.
+
+    An address is what other agents whitelist, what goes in admins.txt, and what
+    someone pastes to a colleague. One whose private key nobody holds is worse
+    than none.
+
+    Rewritten every time rather than once — the same self-healing rule `co deploy`
+    applies to authorized_keys and admins.txt. A no-op when they already agree.
+    """
+    keys_env = global_dir / "keys.env"
+    if not keys_env.exists():
+        return
+
+    data = address.load(global_dir)
+    if not data or not data.get("address"):
+        return
+
+    lines = keys_env.read_text(encoding="utf-8").splitlines(keepends=True)
+    wanted = f"AGENT_ADDRESS={data['address']}\n"
+    out, found = [], False
+    for line in lines:
+        if line.startswith("AGENT_ADDRESS="):
+            found = True
+            out.append(wanted)
+        else:
+            out.append(line)
+    if not found:
+        out.append(wanted)
+
+    if out != lines:
+        keys_env.write_text("".join(out), encoding="utf-8")
+
+
 def ensure_global_config() -> None:
     """Ensure ~/.co/ exists with global identity (keys + keys.env).
 
@@ -1157,8 +1199,10 @@ def ensure_global_config() -> None:
     global_dir = Path.home() / ".co"
     key_file = global_dir / "keys" / "agent.key"
 
-    # If keys exist, already initialized
+    # If keys exist, already initialized — except for one line, which is a copy
+    # of the key rather than a fact of its own.
     if key_file.exists():
+        _state_the_address_the_key_has(global_dir)
         return
 
     # First time - create global config

--- a/tests/unit/test_the_stated_address_follows_the_key.py
+++ b/tests/unit/test_the_stated_address_follows_the_key.py
@@ -1,0 +1,113 @@
+"""What `keys.env` says the address is, and what the key says it is.
+
+`AGENT_ADDRESS` in `~/.co/keys.env` is written once, at first setup, and never
+reconciled. `ensure_global_config()` has the reconcile — it rewrites the line
+from the keypair — but only inside the branch that regenerates a *missing* key.
+An existing key that has *changed* returns at the top:
+
+    if key_file.exists():
+        return
+
+So after a `co reset`, or a restore from a different recovery phrase, the file
+keeps naming the old identity. Reproduced from a clean HOME:
+
+    keypair  0x8a6c70b01453      stated  0x8a6c70b01453     fresh: agree
+    keypair  0x2cc36d08f71a      stated  0x8a6c70b01453     after the key changed
+
+Every project made afterwards copies that line into its `.env`, and every deploy
+ships it to a server. Observed in three places on this operator's machines:
+
+    ~/.co/keys.env         token bills 0x10e6…   AGENT_ADDRESS 0x5616…
+    /etc/…/dash-e2e.env    token bills 0x10e6…   AGENT_ADDRESS 0x5616…
+    /etc/…/naturewill.env  token bills 0x5616…   AGENT_ADDRESS 0x5616…
+
+An address is what other agents whitelist, what goes in `admins.txt`, and what
+someone pastes to a colleague. Publishing one whose private key you do not hold
+is worse than publishing none: everything downstream trusts a name nobody can
+answer to.
+
+The keypair is the source of truth. The line in keys.env is a copy of it, so it
+is written every time rather than once — the same self-healing rule `co deploy`
+already applies to `authorized_keys` and `admins.txt`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+from connectonion.cli.commands.project_cmd_lib import ensure_global_config
+
+
+def _stated() -> str:
+    keys_env = Path.home() / ".co" / "keys.env"
+    for line in keys_env.read_text(encoding="utf-8").splitlines():
+        if line.startswith("AGENT_ADDRESS="):
+            return line.split("=", 1)[1].strip()
+    return ""
+
+
+def _keypair() -> str:
+    return address.load(Path.home() / ".co")["address"]
+
+
+class TestAFreshMachine:
+
+    def test_they_agree(self):
+        ensure_global_config()
+
+        assert _stated() == _keypair()
+
+
+class TestAfterTheKeyChanges:
+    """What `co reset` does, and what restoring a different phrase does."""
+
+    def test_the_stated_address_follows(self):
+        ensure_global_config()
+        before = _keypair()
+
+        address.save(address.generate(), Path.home() / ".co")
+        ensure_global_config()
+
+        assert _keypair() != before, "the fixture did not change the key"
+        assert _stated() == _keypair(), (
+            f"keys.env still names {_stated()[:14]} while the key is "
+            f"{_keypair()[:14]} — every project made from here inherits it"
+        )
+
+
+class TestNothingElseIsDisturbed:
+
+    def test_the_other_lines_survive(self):
+        ensure_global_config()
+        keys_env = Path.home() / ".co" / "keys.env"
+        keys_env.write_text(keys_env.read_text() + "OPENONION_API_KEY=token\n"
+                            "GEMINI_API_KEY=key\n", encoding="utf-8")
+
+        address.save(address.generate(), Path.home() / ".co")
+        ensure_global_config()
+
+        text = keys_env.read_text()
+        assert "OPENONION_API_KEY=token" in text
+        assert "GEMINI_API_KEY=key" in text
+
+    def test_the_address_is_not_written_twice(self):
+        ensure_global_config()
+        address.save(address.generate(), Path.home() / ".co")
+        ensure_global_config()
+
+        keys_env = Path.home() / ".co" / "keys.env"
+        lines = [l for l in keys_env.read_text().splitlines()
+                 if l.startswith("AGENT_ADDRESS=")]
+
+        assert len(lines) == 1, lines
+
+    def test_an_unchanged_key_leaves_the_file_alone(self):
+        """The common case is a no-op, and must stay one."""
+        ensure_global_config()
+        keys_env = Path.home() / ".co" / "keys.env"
+        before = keys_env.read_text()
+
+        ensure_global_config()
+
+        assert keys_env.read_text() == before


### PR DESCRIPTION
Closes #616. Traced from #614's third point.

`AGENT_ADDRESS` in `~/.co/keys.env` is a copy of the keypair, written once at first setup. `ensure_global_config()` **does** contain the reconcile — it rewrites the line from the key — but only inside the branch that regenerates a *missing* key. A key that merely *changed* returns above it:

```python
if key_file.exists():
    return
```

Reproduced from a clean HOME:

```
keypair  0x8a6c70b01453      stated  0x8a6c70b01453     fresh: they agree
keypair  0x2cc36d08f71a      stated  0x8a6c70b01453     after the key changed
```

## Where it ends up

Every project made afterwards copies that line into its `.env`, and every deploy ships it to a server. On this operator's machines:

| file | token bills | AGENT_ADDRESS |
|---|---|---|
| `~/.co/keys.env` (laptop) | `0x10e6…` | `0x5616…` |
| `/etc/connectonion/dash-e2e.env` | `0x10e6…` | `0x5616…` |
| `/etc/connectonion/naturewill.env` | `0x5616…` | `0x5616…` |

(Read via the JWT's `public_key` claim; no token values printed.)

An address is what other agents whitelist, what goes in `admins.txt`, and what someone pastes to a colleague. Publishing one whose private key nobody holds is worse than publishing none — everything downstream trusts a name that cannot answer. It is also why #614 could only be fixed by reading the agent's debug log: the one place a project records an address was recording the wrong one.

## The change

The line is a copy, so it is written every time rather than once — the same self-healing rule `co deploy` already applies to `authorized_keys` and `admins.txt`. A no-op when they already agree, so the common path does not touch the file at all (pinned by a test).

## Verified

Beyond the unit tests — after changing the key, `keys.env` follows, and a project created next carries the right address:

```
A key/stated: 0xbaa525154e34 0xbaa525154e34
B key/stated: 0xc328cf5a2d72 0xc328cf5a2d72
project .env: AGENT_ADDRESS=0xc328cf5a2d725e
keypair     : 0xc328cf5a2d725efd67133c
```

CI command locally: 3768 passed, 11 skipped. Rebased onto #615.

## Not fixed here, for the operator

`naturewill` holds a token for `0x5616…` ($0.0005) while the funded account is `0x10e6…` ($1245) — which is why `co status` looks healthy while that agent cannot pay. This PR stops new projects inheriting a wrong address; it does not re-issue a token that was already delivered.