### PR TITLE
A container deploy silently drops every admin but the deployer

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -194,8 +194,8 @@ def _add_directory_to_tarball(
         tar.add(path, arcname=str(rel), recursive=False)
 
 
-def _add_deployer_as_admin(tar: tarfile.TarFile) -> None:
-    """Ship the deployer's address as the agent's one admin.
+def _add_deployer_as_admin(tar: tarfile.TarFile, project_dir: Path) -> None:
+    """Ship the admin list: whoever the project names, plus the deployer.
 
     A deployed agent generates its own keypair on first boot, and ADMIN_ADD is gated
     on super-admin — which is that same address, whose private key never leaves the
@@ -206,8 +206,14 @@ def _add_deployer_as_admin(tar: tarfile.TarFile) -> None:
     list and grants the role to whoever signs as it. Nothing secret travels, and
     revoking is deleting a line. Same idea as ssh-copy-id, one layer up.
 
-    Written into the package on every deploy so the list self-heals, and synthesized
-    here rather than read from disk because .co/ is excluded from the package.
+    Written into the package on every deploy so the list self-heals.
+
+    Merged with the project's own .co/admins.txt rather than replacing it. That
+    file is packed with the rest of the project — only some of .co/ is excluded,
+    not all of it — so this used to add a *second* member with the same path,
+    and extraction took the last one. Anyone the operator had added was dropped,
+    silently, and the loss surfaced later as a colleague who could not command an
+    agent they had been given access to. One entry now, and it contains both.
 
     The identity resolved is the one `co call` signs with — project .co/ first, then
     ~/.co/ — and deliberately not `project_dir/.co`: a --template deploy builds a
@@ -224,7 +230,15 @@ def _add_deployer_as_admin(tar: tarfile.TarFile) -> None:
     if not data or not data.get("address"):
         return
 
-    payload = f"{data['address']}\n".encode()
+    admins = []
+    configured = project_dir / ".co" / "admins.txt"
+    if configured.exists():
+        admins = [l.strip() for l in configured.read_text(encoding="utf-8").splitlines()
+                  if l.strip()]
+    if data["address"] not in admins:
+        admins.append(data["address"])
+
+    payload = ("\n".join(admins) + "\n").encode()
     info = tarfile.TarInfo(name=".co/admins.txt")
     info.size = len(payload)
     info.mode = 0o600
@@ -267,6 +281,10 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
     External --skills directories are copied into .co/skills/.
     """
     ignore_patterns = _load_deploy_ignore_patterns(project_dir)
+    # _add_deployer_as_admin writes this path itself, having merged the
+    # project's copy with the deployer. Packing the file here as well would put
+    # two members under one name and let write order decide which survives.
+    ignore_patterns.append(".co/admins.txt")
     tarball = Path(tempfile.mkdtemp()) / "agent.tar.gz"
     with tarfile.open(tarball, "w:gz") as tar:
         if _is_git_repo(project_dir):
@@ -295,7 +313,7 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                 arc_prefix,
                 _load_skill_ignore_patterns(skills_path),
             )
-        _add_deployer_as_admin(tar)
+        _add_deployer_as_admin(tar, project_dir)
     return tarball
 
 

--- a/tests/unit/test_deploy_keeps_the_admins_you_configured.py
+++ b/tests/unit/test_deploy_keeps_the_admins_you_configured.py
@@ -1,0 +1,110 @@
+"""A container deploy keeps the admins the project names.
+
+`_build_tarball()` packs the project — including `.co/admins.txt` — and then
+calls `_add_deployer_as_admin()`, which appends a second entry of the same name
+holding only the deployer. Two members, one path; extraction takes the last.
+
+Measured on a real tarball, with a colleague added to the project's file:
+
+    project .co/admins.txt      0x10e6…  (the deployer)
+                                0xbbbb…  (a colleague)
+
+    entries named admins.txt    2
+    winning content             ['0x10e6…']
+
+So anyone the operator added is dropped on deploy, silently, and the loss shows
+up later as a person who cannot command an agent they were given access to.
+
+The deployer must always end up in the file — that is what
+`_add_deployer_as_admin` is for, and #614 is what happens without it. But
+"always present" and "the only one" are different guarantees, and the second
+one was never intended: the docstring says it seeds the deployer, not that it
+replaces the list.
+
+The two are merged, and the tarball carries one entry for the path.
+"""
+
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from connectonion.cli.commands.deploy_commands import _build_tarball
+
+
+COLLEAGUE = "0x" + "b" * 64
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project with a .co/, as `co create` leaves one."""
+    from connectonion import address
+
+    home = Path.home()
+    (home / ".co").mkdir(parents=True, exist_ok=True)
+    data = address.generate()
+    address.save(data, home / ".co")
+
+    p = tmp_path / "shipme"
+    (p / ".co").mkdir(parents=True)
+    (p / "agent.py").write_text("from connectonion import host\n")
+    (p / ".co" / "host.yaml").write_text("name: shipme\nentrypoint: agent.py\n")
+    return SimpleNamespace(dir=p, deployer=data["address"])
+
+
+def _admins_in(tarball: Path) -> list:
+    with tarfile.open(tarball) as tar:
+        members = [m for m in tar.getmembers() if m.name == ".co/admins.txt"]
+        assert members, "no admins.txt in the tarball"
+        # What extraction leaves behind.
+        text = tar.extractfile(members[-1]).read().decode()
+    return [l.strip() for l in text.splitlines() if l.strip()]
+
+
+def _entry_count(tarball: Path) -> int:
+    with tarfile.open(tarball) as tar:
+        return len([m for m in tar.getmembers() if m.name == ".co/admins.txt"])
+
+
+class TestAnAdminTheProjectNames:
+
+    def test_survives_the_deploy(self, project):
+        (project.dir / ".co" / "admins.txt").write_text(
+            f"{project.deployer}\n{COLLEAGUE}\n")
+
+        assert COLLEAGUE in _admins_in(_build_tarball(project.dir, []))
+
+    def test_survives_even_when_the_deployer_is_not_listed(self, project):
+        """The operator may have written only their colleague's address."""
+        (project.dir / ".co" / "admins.txt").write_text(COLLEAGUE + "\n")
+
+        assert COLLEAGUE in _admins_in(_build_tarball(project.dir, []))
+
+
+class TestTheDeployerIsStillAlwaysThere:
+    """#614: without this, nobody can command the agent."""
+
+    def test_added_when_the_project_has_no_file(self, project):
+        assert _admins_in(_build_tarball(project.dir, [])) == [project.deployer]
+
+    def test_added_when_the_project_names_only_someone_else(self, project):
+        (project.dir / ".co" / "admins.txt").write_text(COLLEAGUE + "\n")
+
+        assert project.deployer in _admins_in(_build_tarball(project.dir, []))
+
+    def test_not_listed_twice(self, project):
+        (project.dir / ".co" / "admins.txt").write_text(project.deployer + "\n")
+
+        admins = _admins_in(_build_tarball(project.dir, []))
+        assert admins.count(project.deployer) == 1, admins
+
+
+class TestTheArchiveIsTidy:
+
+    def test_one_entry_for_the_path(self, project):
+        """Two members with one name is a coin toss decided by write order."""
+        (project.dir / ".co" / "admins.txt").write_text(
+            f"{project.deployer}\n{COLLEAGUE}\n")
+
+        assert _entry_count(_build_tarball(project.dir, [])) == 1


### PR DESCRIPTION
Found by step 7 of the release loop — checking whether the previous fix (#615, which made `co create` write `.co/admins.txt`) had consequences elsewhere. It did, and it uncovered behaviour that predates it.

`_build_tarball()` packs the project, `.co/admins.txt` included — only *parts* of `.co/` are excluded, not all of it — and then `_add_deployer_as_admin()` appends a second member with the same path holding only the deployer. Extraction takes the last one.

Measured on a real tarball with a colleague added to the project's file:

```
project .co/admins.txt      0x10e6…  (the deployer)
                            0xbbbb…  (a colleague)

entries named admins.txt    2
winning content             ['0x10e6…']
```

The colleague is gone, nothing says so, and the loss surfaces much later as a person who cannot command an agent they were given access to.

## Why it was invisible

Before #615 a project usually had no `.co/admins.txt` at all, so there was nothing to lose — only someone who had hand-written the file was affected, and they would have had no reason to look. The function's docstring also states that `.co/` is excluded from the package, which stopped being true when `host.yaml` started travelling. Corrected here.

## The change

The two lists are merged: the project's file plus the deployer, deduplicated, written as one member. The project's copy is excluded from the file walk so the archive carries a single entry for the path — two members under one name is a coin toss decided by write order.

The deployer still always ends up in the file. That is what this function is for, and #614 is what happens without it. But "always present" and "the only one" are different guarantees, and only the first was ever intended; the tests pin them separately.

## Tests

`tests/unit/test_deploy_keeps_the_admins_you_configured.py` — an admin the project names survives (with and without the deployer also listed), the deployer is added when absent and not duplicated when present, and the archive has one entry for the path. Red first: 3 failed, one per way of losing someone.

Verified on a real tarball afterwards: one entry, both addresses.