### PR TITLE
After upgrading, a 1.5-era project shows costs 6x too high and nothing says why

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -45,6 +45,33 @@ def verdict(problems: list) -> int:
     return 1
 
 
+def model_pricing_note(model) -> "str | None":
+    """What to say about a model 1.6.0 no longer prices, or None.
+
+    #603 dropped thirty pre-2025 models from the price table and deliberately
+    left routing alone, so a project that still names `gpt-4o-mini` keeps
+    working — but every cost shown for it is DEFAULT_PRICING now, six times the
+    real figure in that example, marked only by a `~`.
+
+    The `~` says the number is a guess. It does not say why, and `co doctor` —
+    which is what people run after an upgrade when something looks off — said
+    nothing at all.
+
+    Not a problem row: the agent runs. A note, next to the model.
+    """
+    if not model or not model.strip():
+        return None
+
+    from ...core.usage import is_estimated_price
+
+    model = model.strip()
+    if not is_estimated_price(model):
+        return None
+
+    return (f"{model} is no longer in the price table — it still runs, "
+            f"and costs shown for it are estimates")
+
+
 def handle_doctor():
     """Run comprehensive diagnostics on ConnectOnion installation.
 
@@ -105,6 +132,7 @@ def handle_doctor():
 
     # Check for host.yaml (project config)
     local_config = Path(".co") / "host.yaml"
+    config = {}
 
     if local_config.exists():
         config_table.add_row("Config", f"[green]✓[/green] {local_config}")
@@ -113,6 +141,21 @@ def handle_doctor():
             config = yaml.safe_load(f) or {}
         agent_name = config.get("name", "Not set")
         config_table.add_row("Agent Name", f"[dim]{agent_name}[/dim]")
+
+    # The model this project would use, and whether 1.6.0 still prices it.
+    #
+    # MODEL comes from the environment because connectonion/__init__.py loads
+    # the project .env at import and cli/main.py loads it again — both happen
+    # before this runs. The explicit load_dotenv further down is for the API
+    # key and comes later; do not reorder this above it expecting to find the
+    # value there.
+    model = os.getenv("MODEL") or config.get("model")
+    if model:
+        note = model_pricing_note(model)
+        if note:
+            config_table.add_row("Model", f"[yellow]○[/yellow] {note}")
+        else:
+            config_table.add_row("Model", f"[green]✓[/green] {model}")
     else:
         config_table.add_row("Config", "[yellow]○[/yellow] Not found (optional)")
 

--- a/tests/unit/test_doctor_mentions_a_model_it_no_longer_prices.py
+++ b/tests/unit/test_doctor_mentions_a_model_it_no_longer_prices.py
@@ -1,0 +1,70 @@
+"""After the upgrade, `co doctor` says whether your model is still priced.
+
+1.6.0 dropped thirty models released before 2025 (#603). Routing was left
+alone on purpose — code that still names `gpt-4o-mini` reaches OpenAI exactly
+as before — but the price table no longer has an entry, so every figure shown
+for it is `DEFAULT_PRICING`, flagged with a `~`:
+
+    MODEL from .env      gpt-4o-mini
+    is_estimated_price   True
+    cost for 1M/100k     $1.30        (the real price is $0.21)
+
+Six times too high, on a project that upgraded and changed nothing. The `~`
+says the number is a guess; it does not say why, and nothing else does either.
+
+`co doctor` is the command people run after an upgrade when something looks
+off. On a 1.5-era project it reported "1 problem" about an unrelated symlink
+and said nothing about the model — the one thing that had actually changed
+underneath them.
+
+This is not a `✗`. The agent works; only the accounting is approximate. It is
+an `○`, next to the model, saying what happened and what to do about it.
+"""
+
+import pytest
+
+from connectonion.cli.commands.doctor_commands import model_pricing_note
+
+
+class TestARetiredModel:
+
+    @pytest.mark.parametrize("model", ["gpt-4o-mini", "gpt-4o", "claude-3-5-sonnet-20241022"])
+    def test_is_reported(self, model):
+        note = model_pricing_note(model)
+
+        assert note, f"{model} is unpriced since 1.6.0 and nothing said so"
+
+    def test_the_note_names_the_model(self):
+        assert "gpt-4o-mini" in model_pricing_note("gpt-4o-mini")
+
+    def test_the_note_says_costs_are_estimates(self):
+        note = model_pricing_note("gpt-4o-mini").lower()
+
+        assert "estimate" in note
+
+    def test_it_does_not_claim_the_agent_is_broken(self):
+        """Routing still works — this is about the figure, not the run."""
+        note = model_pricing_note("gpt-4o-mini").lower()
+
+        assert "fail" not in note and "error" not in note
+
+
+class TestASupportedModel:
+
+    @pytest.mark.parametrize("model", [
+        "co/gemini-3.6-flash", "gemini-2.5-pro", "o4-mini",
+        "claude-sonnet-4-20250514",
+    ])
+    def test_is_not_reported(self, model):
+        assert model_pricing_note(model) is None
+
+    def test_a_dated_variant_is_not_reported(self):
+        """Prefix matching prices these; the note must not fire on them."""
+        assert model_pricing_note("gemini-2.5-pro-preview-05-06") is None
+
+
+class TestNoModel:
+
+    @pytest.mark.parametrize("model", [None, "", "   "])
+    def test_nothing_to_say(self, model):
+        assert model_pricing_note(model) is None


### PR DESCRIPTION
#603 dropped thirty pre-2025 models from the price table and deliberately left routing alone — a project that still names `gpt-4o-mini` reaches OpenAI exactly as before. What it does not do any more is price it:

```
MODEL from .env      gpt-4o-mini
is_estimated_price   True
cost for 1M/100k     $1.30        (the real price is $0.21)
```

Six times too high, on a project that upgraded and changed nothing. The `~` marks the figure as an estimate — that is #601's work and it is doing its job — but it does not say why, and nothing else did either.

`co doctor` is the command people run after an upgrade when something looks off. Run against a 1.5-era project it reported "1 problem" about an unrelated broken symlink and said nothing at all about the model.

## The change

```
Model   ○ gpt-4o-mini is no longer in the price table — it still runs,
          and costs shown for it are estimates
```

and for a model that is priced:

```
Model   ✓ co/gemini-3.6-flash
```

An `○`, not a `✗`. The agent works; only the accounting is approximate, and a red cross would send people looking for a breakage that is not there. A test pins that the note does not use the words fail or error.

## Review note

`MODEL` is read from the environment, which works because `connectonion/__init__.py` and `cli/main.py` both load the project `.env` at import — before this runs. The explicit `load_dotenv` further down in `handle_doctor` is for the API key and comes later. That ordering is now written down next to the line, because moving it would silently stop the check finding anything.

## Tests

`tests/unit/test_doctor_mentions_a_model_it_no_longer_prices.py` — retired models are reported by name and described as estimates, supported ones and their dated variants are not, an absent or blank model says nothing. Red first (the function did not exist).

Verified against the real command on three projects: a retired model, another retired model, and a supported one.