### PR TITLE
The only account that may grant admin is refused before it gets there

### DIFF
--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -361,22 +361,22 @@ def load_admins(co_dir: Path = None) -> set:
     Returns:
         Set of admin addresses
     """
-    import json
-
     admins = set()
 
-    # Self address is always admin (from project's .co/address.json)
     if co_dir is None:
         co_dir = Path.cwd() / ".co"
 
-    addr_file = co_dir / "address.json"
-    if addr_file.exists():
-        try:
-            addr_data = json.loads(addr_file.read_text(encoding='utf-8'))
-            if addr_data.get('address'):
-                admins.add(addr_data['address'])
-        except Exception:
-            pass
+    # Self address is always admin. Through get_self_address, which reads
+    # `.co/keys/` and falls back to the older `.co/address.json` — this used to
+    # read address.json alone, a file nothing has written since keys moved. So
+    # is_super_admin(self) was True while is_admin(self) was False, and
+    # ws_admin gates on is_admin *before* it reaches the super-admin check:
+    # ADMIN_ADD and ADMIN_REMOVE were unreachable by the one account they exist
+    # for. Same shape as #579 and #614 — a gate compared against a value the
+    # resolver never produces for that identity.
+    self_address = get_self_address(co_dir)
+    if self_address:
+        admins.add(self_address)
 
     # Additional admins from this agent's own admins.txt
     # Same reasoning as _check_list, and the cost is higher since #579: the

--- a/tests/unit/test_the_agent_is_its_own_admin.py
+++ b/tests/unit/test_the_agent_is_its_own_admin.py
@@ -1,0 +1,116 @@
+"""The one identity that may grant admin can reach the command that grants it.
+
+`load_admins()` says what it intends:
+
+    # Self address is always admin (from project's .co/address.json)
+
+and then reads `.co/address.json` — a file nothing writes any more. Identity
+lives in `.co/keys/`. `get_self_address()` was corrected for exactly this
+(openonion/oo-chat#28, where paid onboarding could not succeed because the
+payment address came back None); `load_admins` was not, so the two disagree
+about who the agent is.
+
+Measured on a project that has been run once, so its keys exist:
+
+    self address    0x530c85d3641cff867d
+    is_super_admin  True
+    is_admin        False
+
+The admin socket gates in that order:
+
+    if not trust_agent.is_admin(agent_address):        # ws_admin.py:103
+        forbidden: admin only
+    ...
+    elif msg_type == "ADMIN_ADD":
+        if not trust_agent.is_super_admin(...):        # ws_admin.py:147
+
+So the only super-admin is refused at the outer gate, and ADMIN_ADD and
+ADMIN_REMOVE are unreachable by anyone at all — including the account they
+were written for.
+
+Third time this shape has turned up in this release: a gate compared against a
+value the resolver never produces for that identity (#579 for the approval
+dialog, #614 for CONNECT). The fix is the same each time — ask the resolver
+everyone else asks.
+
+No access widens. Signing as the agent's own address requires its private key,
+which lives with the agent; anyone holding it already controls the process.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+from connectonion.network.trust import tools
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A project whose agent has run once, so `.co/keys/` exists."""
+    co = tmp_path / ".co"
+    co.mkdir()
+    data = address.generate()
+    address.save(data, co)
+    monkeypatch.chdir(tmp_path)
+    return co, data["address"]
+
+
+class TestTheAgentCountsAsItsOwnAdmin:
+
+    def test_is_admin_agrees_with_is_super_admin(self, project):
+        co, me = project
+
+        assert tools.is_super_admin(me, co), "the fixture is not what it claims"
+        assert tools.is_admin(me, co), (
+            "the only super-admin is not an admin, so ws_admin's outer gate "
+            "refuses it before ADMIN_ADD is ever reached"
+        )
+
+    def test_the_self_address_is_in_the_loaded_set(self, project):
+        co, me = project
+
+        assert me in tools.load_admins(co)
+
+
+class TestNobodyElseIsLetIn:
+
+    def test_a_stranger_is_still_not_an_admin(self, project):
+        co, _ = project
+
+        assert not tools.is_admin("0x" + "c" * 64, co)
+
+    def test_the_file_still_decides_for_everyone_else(self, project):
+        co, me = project
+        colleague = "0x" + "d" * 64
+        (co / "admins.txt").write_text(colleague + "\n")
+
+        admins = tools.load_admins(co)
+        assert colleague in admins
+        assert me in admins
+
+
+class TestTheOldFileStillWorks:
+    """A project made before keys moved has address.json and nothing else."""
+
+    def test_address_json_is_still_honoured(self, tmp_path, monkeypatch):
+        import json
+
+        co = tmp_path / ".co"
+        co.mkdir()
+        legacy = "0x" + "e" * 64
+        (co / "address.json").write_text(json.dumps({"address": legacy}))
+        monkeypatch.chdir(tmp_path)
+
+        assert legacy in tools.load_admins(co)
+
+
+class TestNoIdentityAtAll:
+
+    def test_an_unrun_project_has_no_self_admin(self, tmp_path, monkeypatch):
+        """`.co/keys/` appears on first run; before that there is nobody to add."""
+        co = tmp_path / ".co"
+        co.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        assert tools.load_admins(co) == set()


### PR DESCRIPTION
Found by checking the strong claims in the trust module against what the code does.

`load_admins()` states its intent and then does something else:

```python
# Self address is always admin (from project's .co/address.json)
addr_file = co_dir / "address.json"
```

Nothing writes `address.json` any more — identity lives in `.co/keys/`. `get_self_address()` was corrected for exactly this (openonion/oo-chat#28: paid onboarding could not succeed because the payment address came back `None`). `load_admins` was not, so the two functions disagree about who the agent is.

Measured on a project that has been run once, so its keys exist:

```
self address    0x530c85d3641cff867d
is_super_admin  True
is_admin        False
```

## What that costs

`ws_admin.py` gates in this order:

```python
if not trust_agent.is_admin(agent_address):        # line 103, outer
    forbidden: admin only
...
elif msg_type == "ADMIN_ADD":
    if not trust_agent.is_super_admin(...):        # line 147, inner
```

The only super-admin fails the outer gate. **`ADMIN_ADD` and `ADMIN_REMOVE` are unreachable by anyone**, including the one account they exist for — which is why `co deploy` writes `admins.txt` directly over ssh and #614 needed `co create` to do the same.

This is the third appearance of one shape in this release: a gate compared against a value the resolver never produces for that identity. #579 was the approval dialog (`get_level() == 'admin'`, which it never returns), #614 was CONNECT. Each time the fix is the same — ask the resolver everyone else asks.

## The change

`load_admins` calls `get_self_address(co_dir)`, which reads `.co/keys/` and still falls back to `address.json` for a project made before the move.

No access widens. Signing as the agent's own address requires its private key, which lives with the agent; anyone holding it already controls the process.

## Tests

`tests/unit/test_the_agent_is_its_own_admin.py` — the two functions agree, the self address is in the loaded set, a stranger still is not an admin, `admins.txt` still decides for everyone else, a legacy `address.json` project still works, and a project whose agent has never run has no self-admin (the keys do not exist yet). Red first: 3 failed.

Verified on a real project afterwards — `is_super_admin` and `is_admin` both True, and the loaded set holds the agent plus the creator from #615.