### PR TITLE
The unauthenticated /info publishes the operator's account balance

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -231,9 +231,16 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
         },
     }
 
-    # Startup balance snapshot for co/* managed-key agents; omitted otherwise.
-    if agent_metadata.get("balance_usd") is not None:
-        result["balance_usd"] = agent_metadata["balance_usd"]
+    # The balance is deliberately not here. /info needs no credentials, so on a
+    # deployed agent this response is readable by the whole internet, and the
+    # operator's account balance is both commercially revealing on its own and a
+    # targeting signal — credits are money, and an agent holding a lot of them is
+    # worth more effort than one holding none.
+    #
+    # It still reaches authenticated clients: AGENT_PROFILE after CONNECT, and
+    # the CONNECTED frame. That is where the chat UI reads it, and what
+    # connectonion-react already documents — "the public /info answer is
+    # deliberately narrower".
 
     if trust_config:
         onboard = trust_config.get("onboard", {})

--- a/tests/unit/test_host_routes.py
+++ b/tests/unit/test_host_routes.py
@@ -270,8 +270,16 @@ class TestInfoHandler:
         assert result["trust"] == "careful"
         assert "version" in result
 
-    def test_includes_balance_when_present(self):
-        """A managed-key agent's balance snapshot is echoed on /info."""
+    def test_never_publishes_the_balance(self):
+        """The opposite of what this asserted until 1.6.0.
+
+        /info takes no credentials, so on a deployed agent this response is
+        readable by the whole internet, and the operator's balance is both
+        commercially revealing and a targeting signal. It still reaches
+        authenticated clients in AGENT_PROFILE and the CONNECTED frame — which
+        is where oo-chat reads it, and what connectonion-react already
+        documented: "the public /info answer is deliberately narrower".
+        """
         metadata = {
             "name": "my_agent",
             "tools": [],
@@ -283,7 +291,8 @@ class TestInfoHandler:
 
         result = info_handler(metadata, mock_trust)
 
-        assert result["balance_usd"] == 4.22
+        assert "balance_usd" not in result
+        assert 4.22 not in result.values()
 
     def test_omits_balance_when_absent(self):
         """Agents without an OpenOnion balance don't get a null/zero field."""

--- a/tests/unit/test_info_does_not_publish_the_balance.py
+++ b/tests/unit/test_info_does_not_publish_the_balance.py
@@ -1,0 +1,86 @@
+"""The unauthenticated `/info` does not say how much money the operator has.
+
+`/info` needs no credentials. Its own comment in http_router.py says what that
+means and draws the line carefully for skills:
+
+    /info is unauthenticated: anyone who can reach the agent can read it, and on
+    a deployed agent that is the whole internet. … The operator's own toolboxes
+    … must not be advertised by it; a full list here leaks which tools, SaaS
+    accounts and internal workflows the operator has on their machine.
+
+Twenty lines below, the same response carries `balance_usd`. Measured against a
+live agent on this machine:
+
+    $ curl -s http://127.0.0.1:8477/info
+    "balance_usd": 1207.1999
+
+That is the operator's real account balance, published to anyone who can reach
+the agent. It is commercially revealing on its own, and it is a targeting
+signal: credits are money, and an agent with a large balance is worth more
+effort than one with none.
+
+The client library already documents the intended boundary — `connectonion-react`
+says of the authenticated profile:
+
+    The agent's full self-description — name, model, tools, every skill, balance
+    — pushed by the Host once the connection is authenticated. … the public
+    `/info` answer is deliberately narrower.
+
+So the contract was already written down; `/info` did not keep it. The balance
+still goes to authenticated clients in AGENT_PROFILE and in the CONNECTED
+frame, which is where the chat UI reads it from.
+"""
+
+import pytest
+
+from connectonion.network.host import http_router
+from connectonion.network.trust.trust_agent import TrustAgent
+
+
+def _info(**metadata) -> dict:
+    base = {
+        "name": "billing",
+        "address": "0x" + "a" * 64,
+        "tools": ["read"],
+        "model": "co/gemini-3.6-flash",
+        "version": "1.6.0",
+    }
+    base.update(metadata)
+    # The real TrustAgent, not a string: info_handler reads .trust off it, and
+    # a stand-in that answers differently is how a test agrees with itself.
+    return http_router.info_handler(base, trust=TrustAgent("careful"), trust_config={})
+
+
+class TestTheBalanceStaysPrivate:
+
+    def test_it_is_absent_when_the_agent_has_one(self):
+        result = _info(balance_usd=1207.1999)
+
+        assert "balance_usd" not in result, result
+
+    def test_no_field_carries_the_number_under_another_name(self):
+        """A rename would be the same leak with a different label."""
+        result = _info(balance_usd=1207.1999)
+
+        assert 1207.1999 not in result.values()
+
+
+class TestWhatInfoStillAnswers:
+    """It is the pre-connection answer: enough to decide whether to connect."""
+
+    def test_the_name_and_address(self):
+        result = _info(balance_usd=1207.1999)
+
+        assert result["name"] == "billing"
+        assert result["address"] == "0x" + "a" * 64
+
+    def test_the_model_and_tools(self):
+        result = _info()
+
+        assert result["model"] == "co/gemini-3.6-flash"
+        assert result["tools"] == ["read"]
+
+    def test_an_agent_without_a_balance_is_unchanged(self):
+        result = _info()
+
+        assert "balance_usd" not in result


### PR DESCRIPTION
Found by checking the strong claims in `http_router.py` against what the endpoint returns.

`/info` takes no credentials. Its own comment says what that means, and draws the line carefully — for skills:

> `/info` is unauthenticated: anyone who can reach the agent can read it, and on a deployed agent that is the whole internet. … The operator's own toolboxes … must not be advertised by it; a full list here leaks which tools, SaaS accounts and internal workflows the operator has on their machine.

Twenty lines below, the same response carries `balance_usd`. Against a live agent on this machine:

```
$ curl -s http://127.0.0.1:8477/info
"balance_usd": 1207.1999
```

That is the operator's real balance, published to anyone who can reach the agent. It is commercially revealing on its own — how much money this operator has with OpenOnion — and it is a targeting signal: credits are money, and an agent holding a lot of them is worth more effort than one holding none.

## The boundary was already documented

`connectonion-react` says of the authenticated profile:

> The agent's full self-description — name, model, tools, every skill, **balance** — pushed by the Host once the connection is authenticated. … the public `/info` answer is **deliberately narrower**.

So the contract existed on the client side. `/info` was not keeping it.

## What changes

The field is dropped from `/info` only. Authenticated clients are unaffected — `AGENT_PROFILE` (server.py:154) and the `CONNECTED` frame (ws_router/connect.py:120) still carry it, and that is where oo-chat reads it: its balance and settings specs feed the value through `PROFILE`, never through `/info`. Nothing in oo-chat or chat-ui fetches `/info` at all.

Verified against a live agent after the change — `/info` has no `balance_usd`, and both authenticated paths still do.

## Tests

`tests/unit/test_info_does_not_publish_the_balance.py` — the field is absent when the agent has a balance, no other field carries the number under a different name, and what `/info` is for (name, address, model, tools) still answers. Red first: 2 failed, the two balance assertions.

The test builds a real `TrustAgent` rather than passing a string — `info_handler` reads `.trust` off it, and my first version passed `"careful"`, which failed with `AttributeError` before it could check anything.