### PR TITLE
Images bypass the upload size limit that files obey

### DIFF
--- a/connectonion/network/host/config.py
+++ b/connectonion/network/host/config.py
@@ -151,3 +151,48 @@ def validate_files(files: list, config: dict) -> None:
             )
 
     logger.info(f"File upload validated: {len(files)} file(s) accepted")
+
+
+def validate_images(images, config: dict) -> None:
+    """Hold images to the same limit as files.
+
+    `max_file_size` says "MB per file (both WebSocket and HTTP)" and
+    validate_files enforces it — for `files`. The same two handlers take
+    `images` beside it, a list of base64 strings that goes straight to
+    agent.input() and on to the model, and nothing measured it. uvicorn sets no
+    request-size cap of its own, so an authenticated client could hand the host
+    a body of any size and the agent would hold it in memory.
+
+    Not a new limit: the one already advertised in /info as max_file_size_mb.
+
+    The decoded size is what matters, and base64 is 4 characters per 3 bytes.
+    Measured from the string rather than decoded, so a large image is refused
+    without first allocating it — decoding to find out how big it is would be
+    the same problem one step later.
+    """
+    if not images:
+        return
+
+    max_count = config.get("max_files_per_request", DEFAULT_FILE_LIMITS["max_files_per_request"])
+    max_size_mb = config.get("max_file_size", DEFAULT_FILE_LIMITS["max_file_size"])
+    max_size_bytes = max_size_mb * 1024 * 1024
+
+    if len(images) > max_count:
+        logger.warning(f"Image upload rejected: too many images ({len(images)} > {max_count})")
+        raise ValueError(
+            f"Too many images: {len(images)} (max: {max_count}). "
+            f"Increase max_files_per_request in host.yaml"
+        )
+
+    for index, image in enumerate(images):
+        if not isinstance(image, str):
+            continue
+        payload = image.split(",", 1)[1] if image.startswith("data:") else image
+        size = len(payload) * 3 // 4
+        if size > max_size_bytes:
+            mb = size / 1024 / 1024
+            logger.warning(f"Image upload rejected: image {index} too large ({mb:.1f}MB > {max_size_mb}MB)")
+            raise ValueError(
+                f"Image too large: image {index} ({mb:.1f}MB, max: {max_size_mb}MB). "
+                f"Increase max_file_size in host.yaml"
+            )

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -44,7 +44,7 @@ from .schedule import create_schedule_lifespan
 from ..trust import TrustAgent, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
 from .auth import extract_and_authenticate
-from .config import load_host_config, load_list_file, validate_files, DEFAULT_FILE_LIMITS
+from .config import load_host_config, load_list_file, validate_files, validate_images, DEFAULT_FILE_LIMITS
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
 from .http_router import (
     input_handler,
@@ -189,11 +189,13 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
 
     def handle_input(storage, prompt, session=None, connection=None, images=None, files=None):
         validate_files(files, config)
+        validate_images(images, config)
         return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
 
     def handle_ws_input(storage, prompt, connection, session=None, images=None,
                         files=None, requester_address=None):
         validate_files(files, config)
+        validate_images(images, config)
         # Resolved here, not carried in the session — see input_handler.
         # `admin` is not one of get_level's answers — it returns stranger /
         # contact / whitelist / blocked. The operator is whoever is in

--- a/tests/unit/test_an_image_counts_against_the_upload_limit.py
+++ b/tests/unit/test_an_image_counts_against_the_upload_limit.py
@@ -1,0 +1,94 @@
+"""An image is an upload, and the upload limit applies to it.
+
+`host.yaml` states the rule and where it applies:
+
+    max_file_size: 10          # MB per file (both WebSocket and HTTP)
+
+`validate_files()` enforces it, and both input paths call it — for `files`.
+The same handlers take `images` beside `files`:
+
+    def handle_input(storage, prompt, session=None, connection=None,
+                     images=None, files=None):
+        validate_files(files, config)
+        return input_handler(..., images, files)
+
+`images` is a list of base64 strings that goes straight to `agent.input()` and
+on to the model. Nothing measures it — not here, not in `input_handler`, and
+uvicorn sets no request-size cap of its own. A client that has passed the trust
+gate can hand the host a body of any size, and the agent holds it in memory and
+forwards it.
+
+That is a smaller hole than it first looks — it needs an authenticated caller,
+so the trust gate is doing its job — but "authenticated" includes contact level,
+which onboarding with an invite code grants. On the 1-2GB VPS `co server new`
+provisions, one large image is enough to end the process, and the operator sees
+an agent that died with no explanation.
+
+The fix is not a new limit. It is applying the one that already exists and is
+already advertised in `/info` as `max_file_size_mb`.
+"""
+
+import base64
+
+import pytest
+
+from connectonion.network.host.config import validate_files, validate_images
+
+
+CONFIG = {"max_file_size": 1, "max_files_per_request": 3}
+
+
+def _image_of(mb: float) -> str:
+    """A base64 data URL of roughly the given decoded size."""
+    return "data:image/png;base64," + base64.b64encode(b"x" * int(mb * 1024 * 1024)).decode()
+
+
+class TestAnImageTooLarge:
+
+    def test_is_refused(self):
+        with pytest.raises(ValueError):
+            validate_images([_image_of(2)], CONFIG)
+
+    def test_the_error_says_which_limit(self):
+        with pytest.raises(ValueError, match="max_file_size"):
+            validate_images([_image_of(2)], CONFIG)
+
+    def test_the_error_says_the_size_in_mb(self):
+        with pytest.raises(ValueError, match=r"2\.\d ?MB"):
+            validate_images([_image_of(2)], CONFIG)
+
+
+class TestWhatIsStillAccepted:
+
+    def test_an_image_under_the_limit(self):
+        validate_images([_image_of(0.5)], CONFIG)
+
+    def test_no_images_at_all(self):
+        validate_images(None, CONFIG)
+        validate_images([], CONFIG)
+
+    def test_a_raw_base64_string_without_the_data_url_prefix(self):
+        """Clients send both shapes."""
+        validate_images([base64.b64encode(b"x" * 1024).decode()], CONFIG)
+
+    def test_something_that_is_not_base64_is_not_a_crash(self):
+        """A malformed image is the model's problem to report, not a traceback
+        out of the size check."""
+        validate_images(["not base64 at all !!!"], CONFIG)
+
+
+class TestTheCountLimitToo:
+
+    def test_too_many_images_is_refused(self):
+        with pytest.raises(ValueError, match="max_files_per_request"):
+            validate_images([_image_of(0.1)] * 4, CONFIG)
+
+
+class TestFilesAreUnaffected:
+
+    def test_a_file_under_the_limit_still_passes(self):
+        validate_files([{"name": "a.txt", "data": b"x" * 1024}], CONFIG)
+
+    def test_a_file_over_the_limit_still_fails(self):
+        with pytest.raises(ValueError, match="File too large"):
+            validate_files([{"name": "big.bin", "data": b"x" * 2 * 1024 * 1024}], CONFIG)


### PR DESCRIPTION
`host.yaml` states the rule and where it applies:

```yaml
max_file_size: 10          # MB per file (both WebSocket and HTTP)
```

`validate_files()` enforces it, and both input paths call it — for `files`. The same handlers take `images` beside it:

```python
def handle_input(storage, prompt, session=None, connection=None, images=None, files=None):
    validate_files(files, config)
    return input_handler(..., images, files)
```

`images` is a list of base64 strings that goes straight to `agent.input()` and on to the model. Nothing measures it — not there, not in `input_handler` — and uvicorn sets no request-size cap of its own.

## How much this matters

Less than it first looks, and I want to be accurate about it: `/input` is authenticated (a raw POST gets 401), so this sits behind the trust gate in exactly the place the existing file check does. Nobody off the street can do it.

But "authenticated" includes contact level, which onboarding with an invite code grants. On the 1–2 GB VPS `co server new` provisions, one large image is enough to end the process, and the operator is left with an agent that died and no explanation.

## The change

`validate_images()` beside `validate_files()`, applying the limit that already exists and is already advertised in `/info` as `max_file_size_mb`. Called from both handlers.

Size is computed from the base64 string (4 characters per 3 bytes) rather than by decoding — decoding a 500 MB image to discover it is 500 MB would be the same problem one step later.

## Tests

`tests/unit/test_an_image_counts_against_the_upload_limit.py` — an oversized image is refused and the error names both the limit and the size; an image under it, no images, a raw base64 string with no `data:` prefix, and something that is not base64 at all all pass; too many images is refused by the count limit; and files still behave exactly as before. Red first (the function did not exist).

Both call sites are wired — checked by grep after writing them, because a validator nobody calls is the failure mode this release has produced four times.