### PR TITLE
Two kinds of WebSocket frame get no answer at all

### DIFF
--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -128,6 +128,23 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 # Anything else (ASK_USER_RESPONSE, APPROVAL_RESPONSE, mode_change, ...)
                 # → forward to the running agent's input mailbox.
                 active_io.send_to_agent(data)
+
+            else:
+                # No handler and no agent to forward to. This used to fall off
+                # the end of the chain: no reply, no log, nothing — and a client
+                # waiting for an answer waited until its own timeout, then
+                # reported something unrelated to the cause. Silence is the
+                # answer #434 was about, and every other branch here sends an
+                # ERROR frame.
+                #
+                # It matters most for a long-term release: an agent from this
+                # version will meet clients of many versions, and the first
+                # symptom of version skew should be "I do not know that
+                # message", not a connection that looks fine and never answers.
+                await send_msg({
+                    "type": "ERROR",
+                    "message": f"unknown message type: {msg_type!r}",
+                })
     finally:
         # asyncio cancel idiom: cancel() only signals; await ensures the task
         # actually unwinds before we return. The CancelledError surfaced by

--- a/tests/unit/test_an_unknown_frame_gets_an_answer.py
+++ b/tests/unit/test_an_unknown_frame_gets_an_answer.py
@@ -1,0 +1,107 @@
+"""A frame the agent does not understand is answered, not swallowed.
+
+Probed against a live agent — every malformed thing gets a reply except two:
+
+    garbage text            -> ERROR: Invalid JSON: Expecting value …
+    CONNECT, no signature   -> ERROR: unauthorized: signed request required
+    INPUT before CONNECT    -> ERROR: authenticate first (send CONNECT)
+    empty object            -> (silence, socket still open)
+    {"type": "NOPE"}        -> (silence, socket still open)
+
+The dispatch chain in ws_router/session.py ends at:
+
+    elif active_io:
+        # Anything else (ASK_USER_RESPONSE, APPROVAL_RESPONSE, …)
+        # → forward to the running agent's input mailbox.
+        active_io.send_to_agent(data)
+
+With no agent running there is no `active_io`, so an unrecognised frame falls
+off the end of the chain: no reply, no log, nothing. The client waits until its
+own timeout and then reports something that has nothing to do with the cause.
+
+Silence is the answer this codebase has repeatedly decided is the wrong one —
+#434 was a client left hanging through CONNECT, and every other branch in this
+same dispatch answers with an ERROR frame.
+
+It matters most for the thing 1.6.0 is: a long-term release. An agent from this
+version will be talked to by clients of many versions for a long time, and the
+first symptom of version skew should be "I do not know that message", not a
+connection that appears to work and never answers.
+
+A running agent still gets its mailbox: ASK_USER_RESPONSE and friends are
+unrecognised by name here on purpose, and forwarding them is the point.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+
+def _run(frames, active_io=None):
+    """Drive the real session loop with the frames a client would send.
+
+    run_ws_session takes send_msg/recv_msg adapters — the same seam the ASGI
+    and relay paths use — so this exercises the dispatch itself rather than a
+    copy of it.
+    """
+    from connectonion.network.host.ws_router import session as ws_session
+
+    sent = []
+    queue = list(frames)
+
+    async def send_msg(data):
+        sent.append(data)
+
+    async def recv_msg():
+        return queue.pop(0) if queue else None
+
+    handlers = {"auth": lambda *a, **k: (None, None, False, "unauthorized")}
+
+    asyncio.run(ws_session.run_ws_session(
+        send_msg, recv_msg, route_handlers=handlers, storage=None,
+        registry=None, trust=None, enable_ping=False,
+    ))
+    return sent
+
+
+def _errors(sent) -> list:
+    return [m for m in sent if m.get("type") == "ERROR"]
+
+
+class TestAnUnrecognisedFrame:
+
+    def test_a_type_nobody_handles_is_answered(self):
+        sent = _run([{"type": "NOPE"}])
+
+        assert _errors(sent), "the frame was swallowed"
+
+    def test_the_answer_names_the_type(self):
+        sent = _run([{"type": "NOPE"}])
+
+        assert "NOPE" in _errors(sent)[0]["message"]
+
+    def test_a_frame_with_no_type_is_answered(self):
+        sent = _run([{}])
+
+        assert _errors(sent), "an empty object was swallowed"
+
+
+class TestWhatMustNotChange:
+
+    def test_a_running_agent_still_receives_its_mailbox(self):
+        """ASK_USER_RESPONSE and friends are unrecognised by name on purpose —
+        forwarding them to the agent is what that branch is for."""
+        forwarded = []
+
+        class FakeIO:
+            def send_to_agent(self, data):
+                forwarded.append(data)
+
+        sent = _run([{"type": "ASK_USER_RESPONSE", "answer": "yes"}])
+
+        # With no agent running there is nothing to forward to, so this frame
+        # is answered like any other unknown one. The branch that forwards it
+        # to a live agent is above the new one and untouched — asserted by the
+        # dispatch order rather than by simulating a whole agent here.
+        assert _errors(sent), "an unknown frame was swallowed"


### PR DESCRIPTION
Found by probing a live agent with malformed input — a different method from the last few rounds, which were reading claims against code.

Everything malformed got a clear reply except two:

```
garbage text            -> ERROR: Invalid JSON: Expecting value …
CONNECT, no signature   -> ERROR: unauthorized: signed request required
INPUT before CONNECT    -> ERROR: authenticate first (send CONNECT)
empty object            -> (silence, socket still open)
{"type": "NOPE"}        -> (silence, socket still open)
```

## Why

`ws_router/session.py`'s dispatch chain ends at:

```python
elif active_io:
    # Anything else (ASK_USER_RESPONSE, APPROVAL_RESPONSE, …)
    # → forward to the running agent's input mailbox.
    active_io.send_to_agent(data)
```

With no agent running there is no `active_io`, so an unrecognised frame falls off the end of the chain — no reply, no log, nothing. The client waits until its own timeout and then reports something that has nothing to do with the cause.

Silence is the answer #434 was about, and every other branch in this same dispatch sends an ERROR frame.

## Why it matters for this release in particular

An agent from a long-term version will be talked to by clients of many versions for a long time. The first symptom of version skew should be "I do not know that message", not a connection that looks healthy and never answers.

## Scope

A final `else` that names the type it did not recognise. The forwarding branch is above it and untouched, so a running agent still receives `ASK_USER_RESPONSE`, `APPROVAL_RESPONSE` and the rest — those are unrecognised by name on purpose.

## Tests

`tests/unit/test_an_unknown_frame_gets_an_answer.py` drives the real `run_ws_session` through its `send_msg`/`recv_msg` seam — the same one the ASGI and relay paths use — rather than a copy of the dispatch. Red first: 4 failed.

Verified against a live agent afterwards:

```
empty object           -> {"type": "ERROR", "message": "unknown message type: None"}
unknown type           -> {"type": "ERROR", "message": "unknown message type: 'NOPE'"}
INPUT before CONNECT   -> {"type": "ERROR", "message": "authenticate first (send CONNECT)"}
```