### PR TITLE
relay_url in host.yaml has never had any effect

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -374,6 +374,45 @@ def _both(first, second):
     return run_both
 
 
+
+class _Unset:
+    """Distinguishes "the caller said nothing" from "the caller said None"."""
+
+    def __repr__(self):
+        return "UNSET"
+
+    def __bool__(self):
+        return False
+
+
+UNSET = _Unset()
+
+
+def resolve_relay_url(param, config: dict) -> str | None:
+    """Which relay this agent announces on.
+
+    Every other host() parameter defaults to None, which load_host_config reads
+    as "not specified" so the file wins. relay_url defaulted to
+    DEFAULT_RELAY_URL — a real string — so `host(agent)`, which is what every
+    generated agent.py calls, passed it as an explicit override and the file
+    never won.
+
+    That line is in every project's host.yaml, under a header that says "edit
+    these values". Editing it did nothing: an agent pointed at a private relay
+    announced on the public one, with a ✓ in the banner and no error anywhere,
+    because as far as the process was concerned nothing had gone wrong.
+
+    UNSET rather than None as the default, because None already means something
+    here — no relay at all — and the two must not collapse into each other.
+    """
+    if param is not UNSET:
+        return param or None          # explicit, including None for "off"
+
+    from_file = config.get("relay_url", UNSET)
+    if from_file is UNSET:
+        return DEFAULT_RELAY_URL      # nothing said anywhere
+    return from_file or None          # an empty value in the file means off
+
 def _create_relay_lifespan(relay_url: str, addr_data: dict, summary: str, port: int, relay_session_runner, *, profile: dict | None = None):
     """Create relay startup/shutdown callbacks for ASGI lifespan.
 
@@ -484,7 +523,7 @@ def host(
     workers: int = None,
     reload: bool = None,
     *,
-    relay_url: str = DEFAULT_RELAY_URL,
+    relay_url: str | None = UNSET,
     blacklist: list | None = None,
     whitelist: list | None = None,
     co_dir: Path = None,
@@ -572,10 +611,12 @@ def host(
         port = int(os.environ["AGENT_PORT"])
 
     # Load config: host.yaml (optional) → code param overrides
+    # relay_url is resolved separately: load_host_config drops a None code
+    # param as "not specified", and None is a meaningful answer here.
     config = load_host_config(
         co_dir,
         port=port, trust=trust, result_ttl=result_ttl,
-        workers=workers, reload=reload, relay_url=relay_url,
+        workers=workers, reload=reload,
         summary=summary, examples=examples,
     )
 
@@ -585,7 +626,7 @@ def host(
     result_ttl = config.get('result_ttl', 86400)
     workers = config.get('workers', 1)
     reload = config.get('reload', False)
-    relay_url = config.get('relay_url')
+    relay_url = resolve_relay_url(relay_url, config)
     summary = config.get('summary')
     examples = config.get('examples')
 

--- a/tests/unit/test_host_yaml_relay_url_is_honoured.py
+++ b/tests/unit/test_host_yaml_relay_url_is_honoured.py
@@ -1,0 +1,113 @@
+"""`relay_url` in host.yaml decides which relay the agent announces on.
+
+Every project's `.co/host.yaml` carries the line, under a header that says
+"Host configuration — edit these values":
+
+    relay_url: wss://oo.openonion.ai
+
+Editing it does nothing. `load_host_config` applies code parameters over the
+file "only if not None", and `host()` alone among them defaults to a real
+string:
+
+    port: int = None                        file wins
+    trust: … = None                         file wins
+    workers: int = None                     file wins
+    relay_url: str = DEFAULT_RELAY_URL      file never wins
+
+`python agent.py` calls `host(agent)` without naming a relay, so the default
+string is passed as an explicit code parameter and overrides the file every
+time.
+
+Measured. A project whose host.yaml said `relay_url: wss://127.0.0.1:9/ws` —
+a port that refuses instantly, confirmed with a direct connect
+(`ConnectionRefusedError` in 0.0s):
+
+    banner              ✓ relay
+    relay errors        none, over 75 seconds
+    co call <address>   returned the agent's pwd
+
+It was announcing on the public relay. Nothing said otherwise, because as far
+as the process was concerned nothing was wrong.
+
+Whoever points an agent at their own relay this way is on the public one
+instead, and the first symptom is whatever they were trying to keep off it.
+
+Passing `relay_url=` to `host()` still wins over the file, and
+`relay_url=None` still means no relay at all — kept apart from "not specified"
+by a sentinel, because the two used to be the same value and only one of them
+should reach the file.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host.config import load_host_config
+from connectonion.network.host.server import DEFAULT_RELAY_URL, UNSET, resolve_relay_url
+
+
+PRIVATE = "wss://relay.example.internal/ws"
+
+
+@pytest.fixture
+def co_dir(tmp_path):
+    co = tmp_path / ".co"
+    co.mkdir()
+    (co / "host.yaml").write_text(
+        f"name: billing\nentrypoint: agent.py\nrelay_url: {PRIVATE}\n")
+    return co
+
+
+class TestTheFileIsRead:
+
+    def test_the_relay_in_host_yaml_is_used(self, co_dir):
+        config = load_host_config(co_dir)
+
+        assert resolve_relay_url(UNSET, config) == PRIVATE
+
+    def test_the_other_keys_still_behave(self, co_dir):
+        """port and trust already worked this way; this must not change them."""
+        (co_dir / "host.yaml").write_text(
+            f"name: billing\nport: 9001\ntrust: strict\nrelay_url: {PRIVATE}\n")
+
+        config = load_host_config(co_dir, port=None, trust=None)
+
+        assert config["port"] == 9001
+        assert config["trust"] == "strict"
+
+
+class TestCodeStillWins:
+
+    def test_an_explicit_url_overrides_the_file(self, co_dir):
+        config = load_host_config(co_dir)
+
+        assert resolve_relay_url("wss://from-code/ws", config) == "wss://from-code/ws"
+
+
+class TestTheDefaultStillApplies:
+
+    def test_a_project_with_no_relay_line_gets_the_public_one(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "host.yaml").write_text("name: billing\n")
+
+        assert resolve_relay_url(UNSET, load_host_config(co)) == DEFAULT_RELAY_URL
+
+    def test_no_config_file_at_all(self, tmp_path):
+        assert resolve_relay_url(UNSET, load_host_config(tmp_path / ".co")) == DEFAULT_RELAY_URL
+
+
+class TestTurningItOffStillWorks:
+    """`host(agent, relay_url=None)` is how an agent stays off the relay, and it
+    has to stay distinguishable from "not specified" — which is what the default
+    now means."""
+
+    def test_none_means_no_relay_even_when_the_file_names_one(self, co_dir):
+        assert not resolve_relay_url(None, load_host_config(co_dir))
+
+    def test_an_empty_string_in_the_file_also_means_off(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        (co / "host.yaml").write_text('name: billing\nrelay_url: ""\n')
+
+        assert not resolve_relay_url(UNSET, load_host_config(co))


### PR DESCRIPTION
Found by failure injection — pointing an agent at a dead relay to see whether it degrades cleanly. It did not degrade at all, because it was not using that relay.

Every project's `.co/host.yaml` carries the line, under a header that reads "Host configuration — edit these values":

```yaml
relay_url: wss://oo.openonion.ai
```

`load_host_config` applies code parameters over the file "only if not None". `relay_url` is the one parameter that defaults to a real string:

| parameter | default | result |
|---|---|---|
| `port` | `None` | file wins |
| `trust` | `None` | file wins |
| `workers` | `None` | file wins |
| `relay_url` | `DEFAULT_RELAY_URL` | **file never wins** |

Every generated `agent.py` calls `host(agent)` without naming a relay, so that default was passed as an explicit override on every start.

## Measured

`.co/host.yaml` set to `relay_url: wss://127.0.0.1:9/ws` — a port that refuses instantly (confirmed directly: `ConnectionRefusedError` in 0.0s):

```
banner              ✓ relay
relay errors        none, over 75 seconds
co call <address>   returned the agent's pwd
```

The agent was announcing on the **public** relay. Nothing said otherwise, because as far as the process was concerned nothing had gone wrong.

Anyone pointing an agent at their own relay this way is on the public one instead, and the first symptom is whatever they were trying to keep off it.

## The fix

`resolve_relay_url(param, config)`: an explicit argument wins, then the file, then the default. An empty value in the file means off.

The default is `UNSET`, not `None`, because `None` already means something here — `host(agent, relay_url=None)` is how an agent stays off the relay entirely — and collapsing the two would silently turn "off" into "use the public one".

## After

Same project, same host.yaml:

```
[host] relay connection error (ConnectionRefusedError(61, 'Connection refused')); reconnecting in 1s
[host] relay connection error (ConnectionRefusedError(61, 'Connection refused')); reconnecting in 2s
```

which is what the supervisor loop was written to do all along.

## Tests

`tests/unit/test_host_yaml_relay_url_is_honoured.py` — the file is read; an explicit argument still overrides it; a project with no relay line still gets the public one; `None` still means no relay even when the file names one; an empty value in the file means off; and `port`/`trust` are unchanged. Red first (the resolver did not exist).

## Not fixed here

The banner's `✓ relay` means "a relay URL is configured", not "connected" — it printed a green tick for the unreachable one. Now that the URL is honoured the tick is at least about the right relay, but it still asserts more than it knows. Worth a separate look.