### PR TITLE
The startup banner ticks a relay it has not tried and links a site that may not know the agent

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -268,8 +268,19 @@ def _print_host_banner(
     prefix = "[magenta]\\[host][/magenta]"
     indent = "       "  # 7 spaces to align with [host]
 
-    # Build relay status
-    relay_status = "[green]✓[/green] relay" if relay_url else "[dim]no relay[/dim]"
+    # What relay this agent will announce on — a statement of configuration, not
+    # of success. This printed "✓ relay" whenever a URL was set, before any
+    # connection was attempted, so an unreachable relay still got a green tick
+    # and the operator was told their agent was reachable. Whether it connected
+    # is said by the lines that know: `relay connection error …`, `relay
+    # reconnected`, and the ♥ in a terminal.
+    from urllib.parse import urlparse
+
+    if relay_url:
+        relay_host = urlparse(relay_url).netloc or relay_url
+        relay_status = f"[dim]relay:[/dim] {relay_host}"
+    else:
+        relay_status = "[dim]no relay[/dim]"
 
     # Get absolute paths for config and logs
     config_file = (co_dir / "host.yaml").resolve() if co_dir else (Path.cwd() / ".co" / "host.yaml").resolve()
@@ -282,10 +293,14 @@ def _print_host_banner(
     console.print(f"{indent}[bold]POST[/bold] /input · [bold]WS[/bold] /ws · [dim]GET /docs[/dim]")
     console.print()
 
-    # Full address + clickable chat link hint
-    chat_url = f"https://chat.openonion.ai/{address}"
+    # Full address, and the chat site — but only when this agent announces on the
+    # relay that site reads. The link was unconditional, which was accidentally
+    # true while every agent was on the public relay; an agent on a private one
+    # was being sent to a site that has never heard of it.
     console.print(f"{indent}[cyan]{address}[/cyan]")
-    console.print(f"{indent}[link={chat_url}][dim]↳ chat.openonion.ai ↗[/dim][/link]")
+    if relay_url == DEFAULT_RELAY_URL:
+        chat_url = f"https://chat.openonion.ai/{address}"
+        console.print(f"{indent}[link={chat_url}][dim]↳ chat.openonion.ai ↗[/dim][/link]")
     console.print(f"{indent}{relay_status}")
     console.print()
 

--- a/tests/unit/test_the_banner_says_what_it_knows.py
+++ b/tests/unit/test_the_banner_says_what_it_knows.py
@@ -1,0 +1,99 @@
+"""The startup banner states what is configured, not what has succeeded.
+
+Two lines assert more than the process knows at the moment they print:
+
+    ↳ chat.openonion.ai ↗
+    ✓ relay
+
+`✓ relay` is `"✓ relay" if relay_url else "no relay"` — a green tick for
+"a URL is set", printed before any connection is attempted. Against a relay
+that refuses instantly it still printed the tick, and the operator reading it
+has been told their agent is reachable.
+
+`chat_url` is `f"https://chat.openonion.ai/{address}"` regardless of which
+relay the agent announces on. That was accidentally true while every agent was
+on the public relay; #626 made a private `relay_url` in host.yaml actually
+work, so now it can point at a site that has never heard of the agent.
+
+Neither is a lie the code could have caught: the banner prints during startup,
+before the relay loop has connected to anything. So it should say what it has —
+the relay it is about to use — and leave success to the lines that know:
+`relay connection error …`, `relay reconnected`, and the `♥` for a terminal.
+"""
+
+import re
+
+import pytest
+
+from connectonion.network.host.server import DEFAULT_RELAY_URL, _print_host_banner
+
+
+ADDRESS = "0x" + "a" * 64
+PRIVATE = "wss://relay.example.internal/ws"
+
+
+def _banner(capsys, relay_url) -> str:
+    _print_host_banner(port=8000, address=ADDRESS, relay_url=relay_url,
+                       trust="careful", trust_config={}, co_dir=None)
+    out = capsys.readouterr()
+    return out.out + out.err
+
+
+class TestNoTickForSomethingUntried:
+
+    def test_the_public_relay_gets_no_success_mark(self, capsys):
+        banner = _banner(capsys, DEFAULT_RELAY_URL)
+
+        assert "✓ relay" not in banner, banner
+
+    def test_a_private_relay_gets_no_success_mark(self, capsys):
+        banner = _banner(capsys, PRIVATE)
+
+        assert "✓ relay" not in banner, banner
+
+
+class TestItStillSaysWhichRelay:
+
+    def test_the_public_one_is_named(self, capsys):
+        banner = _banner(capsys, DEFAULT_RELAY_URL)
+
+        assert "oo.openonion.ai" in banner
+
+    def test_a_private_one_is_named(self, capsys):
+        banner = _banner(capsys, PRIVATE)
+
+        assert "relay.example.internal" in banner
+
+    def test_no_relay_still_says_so(self, capsys):
+        banner = _banner(capsys, None)
+
+        assert "no relay" in banner
+
+
+class TestTheChatLinkMatchesTheRelay:
+
+    def test_it_is_shown_for_the_public_relay(self, capsys):
+        """That is the site that can find an agent announced there."""
+        banner = _banner(capsys, DEFAULT_RELAY_URL)
+
+        assert "chat.openonion.ai" in banner
+
+    def test_it_is_not_shown_for_a_private_relay(self, capsys):
+        """chat.openonion.ai cannot reach an agent that never announced to it."""
+        banner = _banner(capsys, PRIVATE)
+
+        assert "chat.openonion.ai" not in banner, banner
+
+    def test_it_is_not_shown_without_a_relay(self, capsys):
+        banner = _banner(capsys, None)
+
+        assert "chat.openonion.ai" not in banner, banner
+
+
+class TestWhatTheBannerIsFor:
+
+    def test_the_address_is_still_there(self, capsys):
+        assert ADDRESS in _banner(capsys, DEFAULT_RELAY_URL)
+
+    def test_the_local_url_is_still_there(self, capsys):
+        assert "localhost:8000" in _banner(capsys, DEFAULT_RELAY_URL)


### PR DESCRIPTION
Follow-up to #626, which named this as the thing it did not fix.

Two lines in the startup banner assert more than the process knows when they print:

```
↳ chat.openonion.ai ↗
✓ relay
```

**`✓ relay`** was `"✓ relay" if relay_url else "no relay"` — a green tick meaning "a URL is set", printed before any connection is attempted. Pointed at a relay that refuses instantly, it still printed the tick, and the operator reading it has been told their agent is reachable.

**The chat link** was unconditional. That was accidentally true while every agent announced on the public relay; #626 made a private `relay_url` in host.yaml actually work, so the line can now send someone to a site that has never heard of their agent.

## The change

The banner states the relay it is about to use, and leaves success to the lines that know — `relay connection error …`, `relay reconnected`, and the `♥` a terminal gets:

```
relay: oo.openonion.ai          public — chat link shown
relay: relay.example.internal   private — chat link omitted
no relay                        unchanged
```

## Verified live

Rebased onto #626 first, because without it a private `relay_url` is ignored and the second case cannot be reached at all:

```
=== private relay
       0x96859d2cfde7c10f…
       relay: relay.example.internal

=== public relay
       0x96859d2cfde7c10f…
       ↳ chat.openonion.ai ↗
       relay: oo.openonion.ai
```

## Tests

`tests/unit/test_the_banner_says_what_it_knows.py` — no success mark for either relay, the relay is still named in both cases, `no relay` still says so, the chat link appears only for the public relay, and the address and local URL are still there. Red first: 6 failed.