### PR TITLE
co --version: 3.4s → 0.9s, by not importing the whole framework to print it

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -16,6 +16,7 @@ from ._version import __version__
 # Auto-load .env files for the entire framework
 import os as _os
 import sys as _sys
+from types import ModuleType as _ModuleType
 from dotenv import load_dotenv
 from pathlib import Path as _Path
 
@@ -37,38 +38,95 @@ for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
         if _show_env:
             print(f"[env] {_env_file.resolve()}", file=_sys.stderr)
 
-from .core import Agent, LLM, create_tool_from_function
-from .core import (
-    on_agent_ready,
-    after_user_input,
-    before_iteration,
-    after_iteration,
-    before_llm,
-    after_llm,
-    before_each_tool,
-    before_tools,
-    after_each_tool,
-    after_tools,
-    on_error,
-    on_complete,
-    on_stop_signal,
-)
-from .logger import Logger
-from .llm_do import llm_do
-from .transcribe import transcribe
-from .prompts import load_system_prompt
-from .debug import xray, auto_debug_exception, replay, xray_replay
-from .useful_tools import (
-    send_email, get_emails, mark_read, mark_unread,
-    Memory, Gmail, GDrive, Synology, GoogleCalendar, Outlook, MicrosoftCalendar,
-    WebFetch, Shell, bash, codex, DiffWriter, MODE_NORMAL, MODE_AUTO, MODE_PLAN,
-    pick, yes_no, autocomplete, TodoList, SlashCommand,
-    # Claude Code-style file tools
-    read_file, edit, multi_edit, glob, grep, write,
-)
-from .network import connect, RemoteAgent, Response, ExecResult, host, create_app, IO
-from .network import relay, announce
-from . import address
+# The public names are resolved on first use, not on import (PEP 562).
+#
+# These used to be plain `from .core import Agent` lines, which meant importing
+# anything from this package imported all of it: the model SDKs, Gmail's Google
+# credentials, the TUI and the whole network stack. `import connectonion.cli.main`
+# runs this file first — Python offers no way around that — so `co --version`
+# paid 3.4s to print six characters, and every `co` call paid it again.
+#
+# Only the lookup moves. `from connectonion import Agent` still works, still
+# returns the same object, and the second read is a plain global: __getattr__
+# writes what it resolved into globals(), so it runs once per name.
+_SUBMODULES = ("address", "core", "debug", "logger", "network", "prompts", "useful_tools")
+
+_FROM = {
+    **{name: ".core" for name in (
+        "Agent", "LLM", "create_tool_from_function",
+        "on_agent_ready", "after_user_input", "before_iteration", "after_iteration",
+        "before_llm", "after_llm", "before_each_tool", "before_tools",
+        "after_each_tool", "after_tools", "on_error", "on_complete", "on_stop_signal",
+    )},
+    "Logger": ".logger",
+    # Both of these name a module *and* the function inside it. The eager
+    # `from .llm_do import llm_do` bound the function over the module, and code
+    # calls `connectonion.llm_do(...)` — so the function is what this must return.
+    "llm_do": ".llm_do",
+    "transcribe": ".transcribe",
+    "load_system_prompt": ".prompts",
+    **{name: ".debug" for name in ("xray", "auto_debug_exception", "replay", "xray_replay")},
+    **{name: ".useful_tools" for name in (
+        "send_email", "get_emails", "mark_read", "mark_unread",
+        "Memory", "Gmail", "GDrive", "Synology", "GoogleCalendar", "Outlook",
+        "MicrosoftCalendar", "WebFetch", "Shell", "bash", "codex", "DiffWriter",
+        "MODE_NORMAL", "MODE_AUTO", "MODE_PLAN",
+        "pick", "yes_no", "autocomplete", "TodoList", "SlashCommand",
+        # Claude Code-style file tools
+        "read_file", "edit", "multi_edit", "glob", "grep", "write",
+    )},
+    **{name: ".network" for name in (
+        "connect", "RemoteAgent", "Response", "ExecResult", "host", "create_app",
+        "IO", "relay", "announce",
+    )},
+}
+
+
+def __getattr__(name):
+    from importlib import import_module
+
+    if name in _SUBMODULES:
+        # `from .core import Agent` also set `connectonion.core`, and code reads it.
+        value = import_module(f".{name}", __name__)
+    elif name in _FROM:
+        value = getattr(import_module(_FROM[name], __name__), name)
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(__all__) | set(_SUBMODULES) | set(globals()))
+
+
+class _Package(_ModuleType):
+    """Keeps `llm_do` and `transcribe` meaning the function, not the module.
+
+    Each of those names belongs to both a module and the function inside it.
+    Importing `connectonion.llm_do` — which docs/README.md tells people to do,
+    and which web_fetch.py and gmail.py do internally — makes the import system
+    bind the *module* onto this package, shadowing the function. Then
+    `connectonion.llm_do(...)` raises "'module' object is not callable".
+
+    The eager version won that race by accident: `__init__` ran before anything
+    else could import the submodule, and its last act was to rebind the name to
+    the function. Lazy resolution gives up that ordering, so the tie is settled
+    here instead — where it does not depend on who imported what first.
+
+    Overriding __getattribute__ rather than __getattr__ is the point: by the
+    time this matters the attribute *exists*, so __getattr__ would never run.
+    """
+
+    _SHADOWED = frozenset({"llm_do", "transcribe"})
+
+    def __getattribute__(self, name):
+        value = _ModuleType.__getattribute__(self, name)
+        if name in _Package._SHADOWED and isinstance(value, _ModuleType):
+            return getattr(value, name)
+        return value
+
 
 __all__ = [
     # Core
@@ -144,3 +202,6 @@ __all__ = [
     "on_complete",
     "on_stop_signal",
 ]
+
+# The module's last act: everything above must exist before the class changes.
+_sys.modules[__name__].__class__ = _Package

--- a/tests/unit/test_importing_connectonion_stays_cheap.py
+++ b/tests/unit/test_importing_connectonion_stays_cheap.py
@@ -1,0 +1,227 @@
+"""`import connectonion` loads what you asked for, not everything.
+
+#588 removed the OpenAI and Anthropic SDKs from the startup path and `co --version`
+went from 9.5s to 3.4s. The other 3.4s is still there, and it is the same bug:
+
+    connectonion.cli.main       3.36s
+      connectonion              3.30s        <- importing the CLI runs this
+        connectonion.core         1.39s
+        connectonion.useful_tools 1.16s
+          connectonion.useful_tools.gmail  0.53s   -> google.oauth2, google.auth
+        connectonion.tui          0.59s
+        connectonion.network      0.54s
+
+`connectonion/__init__.py` imports every subsystem eagerly to re-export its
+names. Importing `connectonion.cli.main` runs the package `__init__` first —
+Python has no way around that — so `co --version` pays for Gmail's Google
+credentials, the TUI, and the whole network stack in order to print six
+characters.
+
+The test that was guarding this could not see it:
+
+    HEAVY = ("openai", "anthropic")
+
+It named two SDKs instead of the property, so `google.oauth2` walked past a
+green suite. The list here is the subsystems the package pulls, not a list of
+vendors to keep adding to.
+
+The cost is paid by every `co` invocation, and Claude Code and codex drive `co`
+in a loop — which is what makes three seconds worth removing rather than
+tolerating.
+
+Lazy re-export (PEP 562) keeps `from connectonion import Agent` working and
+defers the import to the first use of a name. What must not change is the
+public surface, so most of this file is about that: every name in `__all__`
+still resolves, and to the same object it resolved to before.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _in_a_fresh_interpreter(code: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, PYTHONPATH=str(REPO))
+    return subprocess.run([sys.executable, "-c", code],
+                          capture_output=True, text=True, cwd=REPO, env=env)
+
+
+def _top_level_modules_added_by(statement: str) -> set:
+    """What the statement pulls in — measured against the interpreter it started
+    with, not against an empty one.
+
+    The difference matters. `google` is already in `sys.modules` before a bare
+    interpreter runs a single line of user code: a `.pth` file in site-packages
+    registers the namespace package at startup, and it disappears under `-S`.
+    A test that asserted `"google" not in sys.modules` was therefore asserting
+    something about this machine's site-packages, and could not have passed
+    whatever the framework did.
+
+    Subtracting the baseline asks the question that is actually about us: did
+    importing connectonion pull in anything under `google.*`? An empty namespace
+    entry costs nothing; `google.auth` and `google.oauth2` cost half a second.
+    """
+    code = ("import sys, json\n"
+            "_before = set(sys.modules)\n"
+            f"{statement}\n"
+            "_added = set(sys.modules) - _before\n"
+            "print(json.dumps(sorted({m.split('.')[0] for m in _added})))")
+    out = _in_a_fresh_interpreter(code)
+    assert out.returncode == 0, out.stderr
+    import json
+    return set(json.loads(out.stdout))
+
+
+# Third-party packages the framework only needs once you use the thing that
+# needs them. Named by what drags them in, so a new vendor does not need a new
+# entry here to be caught.
+NOT_NEEDED_TO_START = {
+    "openai": "the OpenAI SDK",
+    "anthropic": "the Anthropic SDK",
+    "google": "Gmail's Google credentials",
+}
+
+
+class TestStartingTheCLI:
+
+    @pytest.mark.parametrize("module,why", sorted(NOT_NEEDED_TO_START.items()))
+    def test_the_cli_entry_point_does_not_load_it(self, module, why):
+        loaded = _top_level_modules_added_by("import connectonion.cli.main")
+
+        assert module not in loaded, f"co pays for {why} before parsing an argument"
+
+    @pytest.mark.parametrize("module,why", sorted(NOT_NEEDED_TO_START.items()))
+    def test_importing_the_package_does_not_load_it(self, module, why):
+        loaded = _top_level_modules_added_by("import connectonion")
+
+        assert module not in loaded, f"importing connectonion pays for {why}"
+
+    def test_version_still_prints(self):
+        out = _in_a_fresh_interpreter(
+            "import runpy, sys;"
+            " sys.argv = ['co', '--version'];"
+            " runpy.run_module('connectonion.cli.main', run_name='__main__')")
+
+        from connectonion._version import __version__
+
+        assert __version__ in out.stdout, out.stdout + out.stderr
+
+
+class TestThePublicSurfaceIsUnchanged:
+    """The reason to be careful: this changes how every name in the package is
+    reached. A name that stops resolving is a worse bug than a slow start."""
+
+    def test_every_exported_name_resolves(self):
+        import connectonion
+
+        missing = [n for n in connectonion.__all__ if not hasattr(connectonion, n)]
+
+        assert not missing, f"__all__ promises names that cannot be reached: {missing}"
+
+    def test_every_exported_name_is_importable_by_from_import(self):
+        names = ", ".join(__import__("connectonion").__all__)
+        out = _in_a_fresh_interpreter(f"from connectonion import {names}")
+
+        assert out.returncode == 0, out.stderr
+
+    def test_a_star_import_still_works(self):
+        out = _in_a_fresh_interpreter(
+            "exec('from connectonion import *'); assert Agent and host and llm_do")
+
+        assert out.returncode == 0, out.stderr
+
+    def test_the_submodules_are_still_attributes(self):
+        """`from .core import Agent` used to set `connectonion.core` as a side
+        effect, and code reads it. Lazy loading has to keep that true."""
+        import connectonion
+
+        for sub in ("core", "network", "useful_tools", "debug", "address", "logger"):
+            assert hasattr(connectonion, sub), f"connectonion.{sub} disappeared"
+
+    def test_an_unknown_name_still_raises_attribute_error(self):
+        import connectonion
+
+        with pytest.raises(AttributeError):
+            connectonion.no_such_thing
+
+    def test_dir_lists_the_public_names(self):
+        import connectonion
+
+        assert set(connectonion.__all__) <= set(dir(connectonion))
+
+    def test_a_name_is_the_same_object_every_time(self):
+        """Resolved once and cached — two reads must not build two classes, or
+        `isinstance` against the second one fails."""
+        import connectonion
+
+        assert connectonion.Agent is connectonion.Agent
+
+
+class TestANameThatIsAlsoAModule:
+    """`llm_do` and `transcribe` name both a module and the function inside it.
+
+    Importing `connectonion.llm_do` makes the import system bind the *module*
+    onto the package, shadowing the function. The eager version won that race
+    by accident — `__init__` always ran first and rebound the function last —
+    and lazy loading loses it: `connectonion.llm_do(...)` raises
+
+        TypeError: 'module' object is not callable
+
+    as soon as anything has imported the submodule. Which ordinary use does:
+    `from connectonion.llm_do import llm_do` is in docs/README.md and in
+    web_fetch.py and gmail.py.
+    """
+
+    @pytest.mark.parametrize("name", ["llm_do", "transcribe"])
+    def test_it_is_the_function_even_after_the_module_is_imported(self, name):
+        out = _in_a_fresh_interpreter(
+            f"import connectonion.{name}\n"
+            "import connectonion\n"
+            f"assert callable(connectonion.{name}), type(connectonion.{name})\n"
+            f"from connectonion import {name}\n"
+            f"assert callable({name}), type({name})\n")
+
+        assert out.returncode == 0, out.stderr
+
+    @pytest.mark.parametrize("name", ["llm_do", "transcribe"])
+    def test_it_is_the_function_when_nothing_imported_the_module(self, name):
+        out = _in_a_fresh_interpreter(
+            f"import connectonion; assert callable(connectonion.{name})")
+
+        assert out.returncode == 0, out.stderr
+
+    def test_the_module_is_still_reachable_by_its_own_path(self):
+        """`from connectonion.llm_do import llm_do` is documented — README:1676."""
+        out = _in_a_fresh_interpreter(
+            "from connectonion.llm_do import llm_do; assert callable(llm_do)")
+
+        assert out.returncode == 0, out.stderr
+
+
+class TestWhatMustStayEager:
+
+    def test_the_env_files_are_still_loaded_at_import(self, tmp_path):
+        """A documented side effect: importing the package loads .env and
+        ~/.co/keys.env. Deferring that would change when credentials appear."""
+        env = tmp_path / ".env"
+        env.write_text("CO_TEST_EAGER_ENV=loaded\n")
+
+        out = subprocess.run(
+            [sys.executable, "-c",
+             "import connectonion, os; print(os.getenv('CO_TEST_EAGER_ENV'))"],
+            capture_output=True, text=True, cwd=tmp_path,
+            env=dict(os.environ, PYTHONPATH=str(REPO)))
+
+        assert "loaded" in out.stdout, out.stdout + out.stderr
+
+    def test_the_version_is_still_an_attribute(self):
+        import connectonion
+        from connectonion._version import __version__
+
+        assert connectonion.__version__ == __version__


### PR DESCRIPTION
Closes the second half of #588.

The first half removed the OpenAI and Anthropic SDKs from the startup path (9.5s → 3.4s). The rest was the same bug one level up: `connectonion/__init__.py` imports every subsystem eagerly in order to re-export its names, and `import connectonion.cli.main` runs the package `__init__` first — Python offers no way around that.

```
connectonion.cli.main       3.36s
  connectonion              3.30s     <- importing the CLI runs this
    connectonion.core         1.39s
    connectonion.useful_tools 1.16s   (gmail -> google.auth, google.oauth2)
    connectonion.tui          0.59s
    connectonion.network      0.54s
```

Names are now resolved on first use (PEP 562). Only the lookup moves — `from connectonion import Agent` still works and still returns the same object.

| | before | after |
|---|---|---|
| `co --version` | 3.5s | **0.92s** |
| test suite | 616s | **358s** |

## Two things this had to get right

**A name that is also a module.** `llm_do` and `transcribe` each name a module *and* the function inside it. Importing `connectonion.llm_do` makes the import system bind the *module* onto the package, shadowing the function:

```
TypeError: 'module' object is not callable
```

The eager version won that race by accident — `__init__` ran first and rebound the function last. Ordinary code loses it: `from connectonion.llm_do import llm_do` appears in docs/README.md:1676, `web_fetch.py` and `gmail.py`. Settled in `__getattribute__`, where it does not depend on who imported what first. Found by the suite (3 failures), not by reading the code.

**The old guard could not have caught this.** It asserted `"google" not in sys.modules`, but a `.pth` file in site-packages registers the `google` namespace package before user code runs — it is there under a bare `python -c pass`, and gone under `-S`. That assertion was about this machine's site-packages and could not have failed for a code reason. It now measures what importing connectonion *adds* to `sys.modules`, which is the question that is actually about us.

## Tests

Red first. 16 tests, of which 12 are about the public surface staying identical — every name in `__all__` resolves, `from connectonion import *`, submodules still reachable as attributes, `.env` still loaded eagerly at import, `Agent is Agent`. Cold-imported each module that imports back from the top-level package (`read_file`, `browser`, `tui.chat`, `co_ai.main`) to check for cycles: none — lazy `__init__` finishes before any submodule loads, which makes those imports safer than they were.

Full suite: 3884 passed.