### PR TITLE
Lazy package keeps every submodule attribute that used to resolve

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -49,7 +49,12 @@ for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
 # Only the lookup moves. `from connectonion import Agent` still works, still
 # returns the same object, and the second read is a plain global: __getattr__
 # writes what it resolved into globals(), so it runs once per name.
-_SUBMODULES = ("address", "core", "debug", "logger", "network", "prompts", "useful_tools")
+# Every subpackage the eager imports used to bind onto this package as a side
+# effect. `tui` and `useful_plugins` are re-exported by nobody, which is exactly
+# why they are listed: removing a name that used to resolve is not something a
+# startup-time change should do quietly. Naming one here does not import it.
+_SUBMODULES = ("address", "core", "debug", "logger", "network", "prompts",
+               "tui", "useful_plugins", "useful_tools")
 
 _FROM = {
     **{name: ".core" for name in (

--- a/tests/unit/test_importing_connectonion_stays_cheap.py
+++ b/tests/unit/test_importing_connectonion_stays_cheap.py
@@ -225,3 +225,44 @@ class TestWhatMustStayEager:
         from connectonion._version import __version__
 
         assert connectonion.__version__ == __version__
+
+
+class TestEverySubmoduleThatUsedToBeReachableStillIs:
+    """Eager `from .X import Y` also bound `connectonion.X`, for every subpackage
+    the import touched — including ones nobody re-exported from.
+
+    Checked against the commit before lazy loading landed:
+
+        connectonion.tui             module          -> must stay a module
+        connectonion.useful_plugins  module          -> must stay a module
+        connectonion.cli             AttributeError  -> nothing to preserve
+
+    They are undocumented internals, which is exactly why this is worth pinning:
+    nobody would notice removing them until someone's code stopped importing.
+    Listing them costs nothing at startup — a name is only imported when read.
+    """
+
+    @pytest.mark.parametrize("name", ["tui", "useful_plugins"])
+    def test_it_is_still_an_attribute(self, name):
+        import connectonion
+
+        assert hasattr(connectonion, name), f"connectonion.{name} used to resolve"
+
+    @pytest.mark.parametrize("name", ["tui", "useful_plugins"])
+    def test_reading_it_gives_the_module(self, name):
+        import connectonion
+        from types import ModuleType
+
+        assert isinstance(getattr(connectonion, name), ModuleType)
+
+    @pytest.mark.parametrize("name", ["tui", "useful_plugins"])
+    def test_it_is_not_loaded_until_it_is_read(self, name):
+        """The point of the change: listing a name must not import it."""
+        loaded = _top_level_modules_added_by("import connectonion")
+
+        assert "connectonion" in loaded
+        out = _in_a_fresh_interpreter(
+            "import sys, connectonion;"
+            f" assert 'connectonion.{name}' not in sys.modules, 'imported too early'")
+
+        assert out.returncode == 0, out.stderr


### PR DESCRIPTION
Follow-up to #631, from checking its own blast radius.

Making the package lazy dropped two attributes that used to resolve:

| | before #631 | after #631 | now |
|---|---|---|---|
| `connectonion.tui` | module | AttributeError | module |
| `connectonion.useful_plugins` | module | AttributeError | module |
| `connectonion.cli` | AttributeError | AttributeError | unchanged |

Neither is re-exported by anything. They were bound onto the package as a side effect of the eager `from .X import Y` lines, and the lazy version had no reason to know about them — so they were not in the list.

Nothing in this repo reads them that way: every internal user goes through `importlib.import_module("connectonion.useful_plugins.X")`, a module path, which never depended on the parent attribute. **That is the argument for restoring them, not against.** An undocumented attribute that quietly stops resolving is not found by our tests — it is found by somebody else's code, after a long-term release ships.

Measured against the commit before #631 rather than assumed, and listing a name in `_SUBMODULES` does not import it, so `co --version` is unchanged.