### PR TITLE
One reader for SKILL.md frontmatter

### DIFF
--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -35,7 +35,7 @@ Usage:
 
 import re
 from pathlib import Path
-from typing import Dict, Optional, List
+from typing import Any, Dict, Optional, List
 from dataclasses import dataclass
 
 
@@ -55,19 +55,23 @@ class SkillInfo:
 SKILLS_REGISTRY: Dict[str, SkillInfo] = {}
 
 
-def parse_skill_frontmatter(content: str) -> Dict[str, str]:
-    """Parse YAML frontmatter from SKILL.md content."""
-    # Match --- ... --- at start of file
-    match = re.match(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
-    if not match:
-        return {}
+def parse_skill_frontmatter(content: str) -> Dict[str, Any]:
+    """Parse YAML frontmatter from SKILL.md content.
 
-    frontmatter = {}
-    for line in match.group(1).split('\n'):
-        if ':' in line:
-            key, value = line.split(':', 1)
-            frontmatter[key.strip()] = value.strip()
+    Defers to the parser the skills plugin uses, because SKILL.md is one format
+    and two readers of it disagreed. This one used to split each line on the
+    first colon, which accepted frontmatter YAML rejects (an unquoted colon in a
+    description) and mangled what YAML handles (`tools: [a, b]` came back as the
+    string "[a, b]"). Whether a skill worked depended on which entry point
+    loaded it.
 
+    A file whose frontmatter does not parse now reads as empty here too, and the
+    fallbacks below take over — `co doctor` names the file and the line (#629),
+    which is what makes converging on the stricter reader safe.
+    """
+    from ....useful_plugins.skills import _parse_skill_content
+
+    frontmatter, _ = _parse_skill_content(content)
     return frontmatter
 
 
@@ -161,8 +165,17 @@ def _parse_skill_file(path: Path) -> Optional[SkillInfo]:
     content = path.read_text(encoding="utf-8")
     frontmatter = parse_skill_frontmatter(content)
 
+    # YAML types its values, and these two are labels for humans: the registry is
+    # keyed by name and the description goes into a prompt. `name: no` is a bool
+    # in YAML — `no`, `on`, `yes` and `off` all are — and a skill keyed by False
+    # cannot be looked up by any name a user can type. Structured values like
+    # `tools:` keep their real type; that is what the YAML reader is for.
     name = frontmatter.get("name")
     description = frontmatter.get("description")
+    if name is not None and not isinstance(name, str):
+        name = str(name)
+    if description is not None and not isinstance(description, str):
+        description = str(description)
 
     # If no name, use directory/file name
     if not name:

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -380,7 +380,12 @@ def _tool_patterns(frontmatter: dict) -> list:
     Nothing was granted that should not have been -- no single character matches
     a tool name -- but the author's declaration did nothing at all.
     """
-    declared = frontmatter.get('tools', [])
+    declared = frontmatter.get('tools')
+    if declared is None:
+        # No key at all, or `tools:` with nothing after it -- a null in YAML,
+        # which the caller's `for pattern in patterns` used to trip over. That
+        # runs when the skill is invoked, so it took the user's turn with it.
+        return []
     if isinstance(declared, str):
         return [declared]
     return list(declared)

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -371,6 +371,21 @@ def skills_that_will_not_travel(co_dir: Optional[Path] = None,
 # UNIFIED PERMISSIONS WITH SNAPSHOT/RESTORE
 # =============================================================================
 
+def _tool_patterns(frontmatter: dict) -> list:
+    """The `tools:` declaration as a list of patterns.
+
+    YAML gives a string for `tools: read_file` and a list for `tools: [a, b]`.
+    The caller does `for pattern in patterns`, so the scalar form walked the
+    characters and registered `r`, `e`, `a`, `d`... as permission patterns.
+    Nothing was granted that should not have been -- no single character matches
+    a tool name -- but the author's declaration did nothing at all.
+    """
+    declared = frontmatter.get('tools', [])
+    if isinstance(declared, str):
+        return [declared]
+    return list(declared)
+
+
 def _grant_skill_permissions(agent: 'Agent', skill_name: str, patterns: List[str]) -> None:
     """Grant skill permissions using unified permission structure with 'when' field.
 
@@ -501,7 +516,7 @@ def handle_skill_invocation(agent: 'Agent') -> None:
     instructions = skill['instructions']
 
     # Grant skill permissions (with snapshot)
-    patterns = frontmatter.get('tools', [])
+    patterns = _tool_patterns(frontmatter)
     _grant_skill_permissions(agent, skill_name, patterns)
 
     # Replace user message with skill instructions, preserving slash-command args.
@@ -548,7 +563,7 @@ def skill(agent: 'Agent', name: str) -> str:
     instructions = skill_data['instructions']
 
     # Grant skill permissions (with snapshot)
-    patterns = frontmatter.get('tools', [])
+    patterns = _tool_patterns(frontmatter)
     _grant_skill_permissions(agent, name, patterns)
 
     return instructions

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -188,6 +188,25 @@ def _clear_stale_singleton_lock(profile_dir: Path) -> None:
         (profile_dir / name).unlink(missing_ok=True)
 
 
+def _profile_lock_holder(profile_dir: Path) -> Optional[int]:
+    """PID of the LIVE process holding this profile's SingletonLock, or None.
+
+    The mirror of _clear_stale_singleton_lock: that one removes a DEAD owner's lock,
+    this one reports a LIVE owner. Run right after it, so a lock that remains means a
+    real Chrome still owns the persistent profile — a second launch on it aborts with
+    Chrome's cryptic ProcessSingleton error (or hangs to timeout). Returning the pid
+    lets open_browser fail fast with an actionable message instead.
+    """
+    lock = profile_dir / "SingletonLock"
+    if not lock.is_symlink():
+        return None
+    tail = os.readlink(lock).rsplit("-", 1)[-1]
+    if not tail.isdigit():
+        return None
+    pid = int(tail)
+    return pid if _pid_alive(pid) else None
+
+
 def driver_stealth_status():
     """Report whether the installed Patchright driver still has its stealth patches.
 
@@ -575,16 +594,34 @@ class BrowserAutomation:
             if had_previous_browser_state:
                 self._teardown()   # context is dead/unusable — full cleanup before relaunch
 
-        self.playwright = sync_playwright().start()
-
         # Dedicated persistent profile owned by co
         # First run: fresh profile, user logs in once. All later runs reuse saved cookies.
+        # Resolve and unlock it BEFORE starting the driver: the profile can be driven by
+        # only one browser at a time, so if a live one already owns it we fail fast here —
+        # no driver started, nothing to leak.
         profile_dir = Path.home() / ".co" / "browser_profile"
         profile_dir.mkdir(parents=True, exist_ok=True)
 
         # A previous Chrome that died uncleanly can leave a SingletonLock that blocks this
         # launch. Clear it if its owner is dead, so the persistent profile can't get bricked.
         _clear_stale_singleton_lock(profile_dir)
+
+        # A lock that survives the stale-clear means a LIVE browser still owns the profile.
+        # Launching anyway aborts with Chrome's cryptic ProcessSingleton error (or hangs to
+        # the 120s timeout), so surface the holder and the fix instead.
+        holder = _profile_lock_holder(profile_dir)
+        if holder is not None:
+            raise RuntimeError(
+                f"Browser profile is already in use by another process (PID {holder}).\n"
+                f"The persistent profile at {profile_dir} can be driven by only one browser "
+                f"at a time — usually another `co browser` daemon or a Chrome window you "
+                f"opened on this profile.\n"
+                f"Fix: quit that browser, or stop the process:  kill {holder}\n"
+                f"Then retry. (If you're sure nothing is using it, the lock is stale — "
+                f"remove {profile_dir / 'SingletonLock'} and retry.)"
+            )
+
+        self.playwright = sync_playwright().start()
 
         # Remove --no-sandbox from args since Playwright adds it by default
         # Just keep the flags we actually need

--- a/tests/unit/test_one_reader_for_skill_frontmatter.py
+++ b/tests/unit/test_one_reader_for_skill_frontmatter.py
@@ -201,3 +201,26 @@ class TestTheBundledSkillsStillRead:
         for path in bundled:
             info = _parse_skill_file(path)
             assert info.description, f"{path} lost its description"
+
+
+class TestAToolsKeyWithNothingAfterIt:
+    """`tools:` and then nothing is a null in YAML, and the caller iterates it.
+
+    Pre-existing — it crashed the same way before the readers were unified —
+    but it lands in the function that now owns reading that key. It fires when
+    the skill is *invoked*, and `_grant_skill_permissions` is not in a try
+    block, so the exception unwinds the turn the user was in the middle of.
+    """
+
+    def test_it_is_no_patterns_rather_than_a_crash(self):
+        from connectonion.useful_plugins.skills import _tool_patterns, _parse_skill_content
+
+        frontmatter, _ = _parse_skill_content("---\nname: n\ntools:\n---\n\nBody.\n")
+
+        assert frontmatter["tools"] is None, "the shape this is about changed"
+        assert _tool_patterns(frontmatter) == []
+
+    def test_an_explicit_empty_list_is_still_no_patterns(self):
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        assert _tool_patterns({"tools": []}) == []

--- a/tests/unit/test_one_reader_for_skill_frontmatter.py
+++ b/tests/unit/test_one_reader_for_skill_frontmatter.py
@@ -1,0 +1,203 @@
+"""SKILL.md has one meaning, whichever part of the code reads it.
+
+It had two readers. `useful_plugins/skills.py` parses YAML; `co_ai/skills/loader.py`
+split each line on the first colon:
+
+    for line in match.group(1).split('\\n'):
+        if ':' in line:
+            key, value = line.split(':', 1)
+            frontmatter[key.strip()] = value.strip()
+
+They disagree in both directions, measured on real skills installed on this
+machine:
+
+    feishu-data-analysis   YAML: {}                 line-split: name, description, …
+    outline-plan           YAML: {}                 line-split: allowed-tools, description, …
+    tools: [read_file, write_file]
+                           YAML: ['read_file', 'write_file']
+                           line-split: '[read_file, write_file]'   (a string)
+
+So the same skill behaved differently depending on whether the agent's skills
+plugin or `co ai` loaded it, and neither said anything. The line splitter also
+cannot represent what YAML can — block scalars and multi-line values arrive
+truncated or as a stray key.
+
+YAML is the documented format and the one the bundled skills are written in
+(all 9 parse cleanly), so it is the reader that stays. #629 made `co doctor`
+name the file and line of a frontmatter that does not parse, which is what
+makes converging on the stricter reader safe to do: the skills that stop
+being read silently are now the skills that get reported loudly.
+
+Second half of the same issue: `tools:` is fed straight to
+`_grant_skill_permissions`, which does `for pattern in patterns`. YAML returns
+a *string* for `tools: read_file`, so the loop walked the characters and
+registered `r`, `e`, `a`, `d`… as permission patterns. Fail-safe — no single
+character matches a real tool — but the author's declaration did nothing.
+"""
+
+import pytest
+
+from connectonion.cli.co_ai.skills.loader import parse_skill_frontmatter
+from connectonion.useful_plugins.skills import _parse_skill_content
+
+
+GOOD = """---
+name: deploy
+description: Ship the thing
+tools: [read_file, write]
+---
+
+# Deploy
+
+Do the deploy.
+"""
+
+
+class TestBothReadersAgree:
+
+    @pytest.mark.parametrize("key", ["name", "description"])
+    def test_on_the_keys_co_ai_uses(self, key):
+        yaml_side, _ = _parse_skill_content(GOOD)
+
+        assert parse_skill_frontmatter(GOOD)[key] == yaml_side[key]
+
+    def test_on_a_list_being_a_list(self):
+        """The line splitter handed back the string '[read_file, write]'."""
+        assert parse_skill_frontmatter(GOOD)["tools"] == ["read_file", "write"]
+
+    def test_on_a_frontmatter_that_does_not_parse(self):
+        """One reader accepted what the other rejected. Now neither invents a
+        reading of a file that has a syntax error in it."""
+        broken = "---\nname: x\nargument-hint: [a] | [b]\n---\n\nBody.\n"
+
+        yaml_side, _ = _parse_skill_content(broken)
+
+        assert parse_skill_frontmatter(broken) == yaml_side == {}
+
+
+class TestScalarToolsIsOnePattern:
+    """`tools: read_file` is a pattern, not nine of them."""
+
+    def test_a_scalar_becomes_a_one_element_list(self):
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        assert _tool_patterns({"tools": "read_file"}) == ["read_file"]
+
+    def test_a_list_is_left_alone(self):
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        assert _tool_patterns({"tools": ["read_file", "write"]}) == ["read_file", "write"]
+
+    def test_no_tools_key_is_empty(self):
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        assert _tool_patterns({}) == []
+
+    def test_the_characters_are_not_patterns(self):
+        """What the bug produced, named so it cannot come back quietly."""
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        assert "r" not in _tool_patterns({"tools": "read_file"})
+
+
+class TestWhatCoAiStillDoesOnItsOwn:
+    """Its fallbacks are its own and must survive the reader changing."""
+
+    def test_the_name_falls_back_to_the_directory(self, tmp_path):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        d = tmp_path / "my-skill"
+        d.mkdir()
+        (d / "SKILL.md").write_text("---\ndescription: no name key\n---\n\nBody.\n")
+
+        assert _parse_skill_file(d / "SKILL.md").name == "my-skill"
+
+    def test_the_description_falls_back_to_the_first_paragraph(self, tmp_path):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        d = tmp_path / "s"
+        d.mkdir()
+        (d / "SKILL.md").write_text("---\nname: s\n---\n\n# Title\n\nWhat it does.\n")
+
+        assert "What it does." in _parse_skill_file(d / "SKILL.md").description
+
+    def test_a_file_with_no_frontmatter_still_loads(self, tmp_path):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        d = tmp_path / "plain"
+        d.mkdir()
+        (d / "SKILL.md").write_text("Just the instructions.\n")
+
+        info = _parse_skill_file(d / "SKILL.md")
+        assert info.name == "plain"
+
+
+class TestYamlTypesDoNotEscapeIntoTheName:
+    """The reader changed; what the callers get must not.
+
+    The line splitter always handed back strings. YAML types its values, so
+    switching to it made `name: 123` an int and `name: no` a bool — YAML reads
+    `no`, `on`, `yes` and `off` as booleans. The registry is built with
+    `{s.name: s for s in skills}`, so a skill keyed by `False` cannot be looked
+    up by any name a user can type, and it fails that way silently.
+
+    Structured values like `tools: [a, b]` still arrive as a list — that is the
+    reason to use YAML. It is the two human-facing labels that are pinned.
+    """
+
+    def _skill(self, tmp_path, folder, content):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        d = tmp_path / folder
+        d.mkdir()
+        (d / "SKILL.md").write_text(content)
+        return _parse_skill_file(d / "SKILL.md")
+
+    def test_a_numeric_name_is_a_string(self, tmp_path):
+        info = self._skill(tmp_path, "numeric", "---\nname: 123\ndescription: d\n---\n\nB.\n")
+
+        assert info.name == "123"
+
+    @pytest.mark.parametrize("written", ["no", "yes", "true", "off"])
+    def test_a_name_yaml_reads_as_a_boolean_stays_a_string(self, tmp_path, written):
+        info = self._skill(tmp_path, f"b-{written}", f"---\nname: {written}\ndescription: d\n---\n\nB.\n")
+
+        assert isinstance(info.name, str), f"`name: {written}` became {type(info.name).__name__}"
+
+    def test_the_skill_can_be_found_by_the_name_it_declares(self, tmp_path):
+        """The consequence, not just the type: registry lookups are by string."""
+        info = self._skill(tmp_path, "numeric", "---\nname: 123\ndescription: d\n---\n\nB.\n")
+        registry = {info.name: info}
+
+        assert registry.get("123") is info
+
+    def test_a_non_string_description_is_a_string(self, tmp_path):
+        info = self._skill(tmp_path, "listy", "---\nname: n\ndescription: [a, b]\n---\n\nB.\n")
+
+        assert isinstance(info.description, str)
+
+    def test_a_block_scalar_description_keeps_all_of_its_text(self, tmp_path):
+        """What the line splitter could not do: it kept only `>`."""
+        info = self._skill(tmp_path, "blocky",
+                           "---\nname: n\ndescription: >\n  line one\n  line two\n---\n\nB.\n")
+
+        assert "line one" in info.description and "line two" in info.description
+
+
+class TestTheBundledSkillsStillRead:
+    """Converging on the stricter reader must not lose our own skills."""
+
+    def test_every_bundled_skill_has_a_description(self):
+        from pathlib import Path
+
+        import connectonion
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        root = Path(connectonion.__file__).parent
+        bundled = sorted(root.rglob("SKILL.md"))
+
+        assert bundled, "no bundled skills found — the glob is wrong"
+
+        for path in bundled:
+            info = _parse_skill_file(path)
+            assert info.description, f"{path} lost its description"


### PR DESCRIPTION
Closes #630.

`SKILL.md` had two parsers. `useful_plugins/skills.py` parses YAML; `co_ai/skills/loader.py` split each line on the first colon. They disagreed **in both directions**, measured on real skills installed on this machine:

| | YAML reader | line splitter |
|---|---|---|
| `feishu-data-analysis` | `{}` — no description | 4 keys |
| `outline-plan` | `{}` — no description | 3 keys |
| `tools: [read_file, write_file]` | `['read_file', 'write_file']` | `'[read_file, write_file]'` (a string) |

A skill behaved differently depending on whether the agent's skills plugin or `co ai` loaded it, and neither path said anything. The line splitter also cannot represent what YAML can — block scalars and multi-line values arrived truncated or as a stray key.

YAML is the documented format, and all 9 bundled skills parse cleanly under it (checked before switching), so it is the reader that stays.

**#629 is what makes this safe.** A frontmatter that does not parse is now reported by `co doctor` with its file and line, so skills that were being silently misread become skills that are loudly named. `co ai`'s own fallbacks are untouched — such a skill gets its name from the directory and its description from the first paragraph of the body, not "No description".

## Second half: a scalar `tools:`

`tools:` went straight into `for pattern in patterns`. YAML returns a *string* for `tools: read_file`, so the loop walked the characters and registered `r`, `e`, `a`, `d`… as permission patterns. Fail-safe — no single character matches a real tool name, so nothing extra was granted — but the author's declaration did nothing at all. `_tool_patterns()` normalises the scalar form.

## The bug this change introduced

Found by probing the change, not by reading it. YAML types its values, so switching to it made `name: 123` an **int** and `name: no` a **bool** — YAML reads `no`, `on`, `yes` and `off` as booleans. The registry is built with `{s.name: s for s in skills}`, so a skill keyed by `False` cannot be looked up by any name a user can type, and it fails that way silently.

The two human-facing labels are coerced back to `str`. `tools:` keeps its real type, which is the whole point of using YAML.

## Tests

20 tests, red first — 6 failed on the parser divergence, then 5 more once the type escape was found. They cover: both readers agreeing on the same file, a list staying a list, bundled skills all keeping their descriptions, and `co ai`'s directory-name and first-paragraph fallbacks still working.
