### PR TITLE
Declining an invite code is an error result, not a traceback

### DIFF
--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -331,7 +331,16 @@ class RemoteAgent:
                                 text="", status="error",
                                 error=f"agent requires onboarding ({', '.join(methods) or 'no methods offered'})"
                                       " — run this from a terminal to enter an invite code")
-                        credentials = self._prompt_onboard(methods, event.get("payment_amount"))
+                        try:
+                            credentials = self._prompt_onboard(methods, event.get("payment_amount"))
+                        except ValueError as declined:
+                            # Entering nothing is an answer, and a normal one.
+                            # _prompt_onboard raises for it, and every other refusal
+                            # call() can meet — a blacklist, a bad code, a tool that
+                            # is not whitelisted — comes back as an ExecResult. This
+                            # is that same channel, not a swallowed error.
+                            return ExecResult(text="", status="error",
+                                              error=f"onboarding not completed: {declined}")
                         await ws.send(json.dumps(self._build_onboard_submit(credentials)))
                         continue
                     if etype == "ERROR":

--- a/tests/unit/test_co_call_can_onboard.py
+++ b/tests/unit/test_co_call_can_onboard.py
@@ -209,3 +209,40 @@ class TestACodeThatIsWrong:
         agent.call("bash", command="pwd")
 
         assert not [m for m in socket.sent if m.get("type") == "EXEC"]
+
+
+class TestDecliningThePrompt:
+    """Pressing Enter is an answer, and it is a normal one.
+
+    `_prompt_onboard` raises ValueError when nothing is entered. `call()` never
+    reached it before, and every other refusal it can meet — a blacklist, a bad
+    invite code, a tool that is not whitelisted — comes back as
+    `ExecResult(status="error")`. Declining should not be the one that prints a
+    stack trace at somebody who just typed `co call`.
+
+    Confirmed through a pty against a real host before fixing:
+
+        Enter invite code:
+        Traceback (most recent call last):
+          ...
+        ValueError: No valid onboard credentials provided
+    """
+
+    def test_it_is_an_error_result_not_an_exception(self, monkeypatch):
+        agent, _ = _agent_that(monkeypatch, ONBOARD_THEN_IN, invite="")
+
+        result = agent.call("bash", command="pwd")
+
+        assert not result.ok
+
+    def test_the_error_says_what_happened(self, monkeypatch):
+        agent, _ = _agent_that(monkeypatch, ONBOARD_THEN_IN, invite="")
+
+        assert "onboard" in agent.call("bash", command="pwd").error.lower()
+
+    def test_no_command_is_run(self, monkeypatch):
+        agent, socket = _agent_that(monkeypatch, ONBOARD_THEN_IN, invite="")
+
+        agent.call("bash", command="pwd")
+
+        assert not [m for m in socket.sent if m.get("type") == "EXEC"]


### PR DESCRIPTION
Found by probing #634 against a real host through a pty — the path that PR opened, exercised the way a user would.

Pressing Enter at the prompt printed a stack trace:

```
   Enter invite code:
Traceback (most recent call last):
  ...
ValueError: No valid onboard credentials provided
```

`_prompt_onboard` raises when nothing is entered. `call()` never reached it before #634, and every other refusal it can meet — a blacklist, a bad invite code, a tool that is not whitelisted — comes back as `ExecResult(status="error")`. Entering nothing is an answer, and a normal one; it should not be the single case that throws at somebody who just typed `co call`.

This puts it on that same channel. It is the function's error contract, not a swallowed exception — `input()` keeps raising, as its module docstring says it does.

Verified on the real host, same pty:

```
STATUS: error
ERROR: onboarding not completed: No valid onboard credentials provided
```

3 tests, red first.