### PR TITLE
workers or reload in host.yaml stops the agent from starting

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -250,6 +250,38 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
     }
 
 
+def usable_uvicorn_options(workers, reload) -> tuple:
+    """What uvicorn can actually be given, and a word about the difference.
+
+    `host()` hands uvicorn an app *object*. Uvicorn can only fork workers or
+    watch files when it is given an import string, and handed an object it
+    refuses both and returns without ever serving. Both values are written into
+    every generated host.yaml, under a header that says to edit them:
+
+        workers: 1
+        reload: false
+
+    Changing either one used to print the whole startup banner -- address, URL,
+    "POST /input" -- and then exit, leaving one uvicorn warning underneath and
+    nothing listening on the port the banner named.
+
+    Serving them properly is a larger question than this one. Each worker
+    process would run its own scheduler loop and its own in_flight set, so a
+    schedule that overruns its interval gets one copy per worker: the race #537
+    is about. Until that is answered, keep the agent running and say what was
+    not honoured -- silently running one worker is a smaller lie than dying
+    behind a banner that says otherwise.
+    """
+    if workers and workers > 1:
+        print(f"[host] workers: {workers} not honoured — running one worker "
+              f"(uvicorn needs an import string to fork, and the scheduler is "
+              f"per process)")
+    if reload:
+        print("[host] reload: true not honoured — running without reload "
+              "(uvicorn needs an import string to watch files)")
+    return 1, False
+
+
 def _print_host_banner(
     port: int,
     address: str,
@@ -775,6 +807,7 @@ def host(
         co_dir=co_dir,
     )
 
+    workers, reload = usable_uvicorn_options(workers, reload)
     uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, log_level="warning")
 
 

--- a/tests/unit/test_workers_and_reload_do_not_kill_the_agent.py
+++ b/tests/unit/test_workers_and_reload_do_not_kill_the_agent.py
@@ -1,0 +1,130 @@
+"""Two keys in every host.yaml stop the agent from starting.
+
+`.co/host.yaml` is generated with nine keys under "Host configuration — edit
+these values". Two of them kill the agent:
+
+    workers: 1     ->  2
+    reload: false  ->  true
+
+`host()` ends at
+
+    uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, ...)
+
+and uvicorn can only fork workers or watch files if it is given an *import
+string*. Handed an app object it refuses both, and `uvicorn.run` returns
+without ever serving.
+
+Measured, both through the code parameter and through host.yaml:
+
+    [host] ───────────────────────────────────
+           http://localhost:8794
+           POST /input · WS /ws · GET /docs
+           0xe8eab6d…
+    WARNING:  You must pass the application as an import string to enable 'reload' or 'workers'.
+    $ curl http://localhost:8794/info
+    (nothing — the process is gone)
+
+So the banner announces an address that answers nothing, and the only sign is
+one uvicorn warning under it. Editing a documented value in the documented file
+turns the agent off.
+
+Serving them properly is a larger question than this: each worker process runs
+its own scheduler loop and its own `in_flight` set, so a schedule that overruns
+its interval gets one copy per worker — the race #537 is about. Until that is
+answered, the honest thing is to keep the agent running and say what was not
+honoured, rather than to exit behind a banner that says otherwise.
+"""
+
+import pytest
+
+from connectonion.network.host.server import usable_uvicorn_options
+
+
+class TestWhatUvicornCanActuallyBeGiven:
+
+    def test_the_defaults_pass_through(self):
+        assert usable_uvicorn_options(1, False) == (1, False)
+
+    def test_more_than_one_worker_becomes_one(self):
+        workers, _ = usable_uvicorn_options(4, False)
+
+        assert workers == 1
+
+    def test_reload_becomes_off(self):
+        _, reload = usable_uvicorn_options(1, True)
+
+        assert reload is False
+
+    def test_both_at_once(self):
+        assert usable_uvicorn_options(4, True) == (1, False)
+
+    def test_zero_or_none_workers_is_one(self):
+        """host.yaml is hand-edited; `workers:` with nothing after it is None."""
+        assert usable_uvicorn_options(None, False)[0] == 1
+
+
+class TestItSaysWhatItDidNotHonour:
+    """Silently running one worker is a smaller lie than dying, but still a lie."""
+
+    def test_dropping_workers_is_reported(self, capsys):
+        usable_uvicorn_options(4, False)
+
+        assert "workers" in capsys.readouterr().out
+
+    def test_the_message_names_the_number_asked_for(self, capsys):
+        usable_uvicorn_options(4, False)
+
+        assert "4" in capsys.readouterr().out
+
+    def test_dropping_reload_is_reported(self, capsys):
+        usable_uvicorn_options(1, True)
+
+        assert "reload" in capsys.readouterr().out
+
+    def test_nothing_is_said_when_nothing_is_dropped(self, capsys):
+        usable_uvicorn_options(1, False)
+
+        assert capsys.readouterr().out == ""
+
+
+class TestHostActuallyUsesIt:
+    """A helper nothing calls is the bug, not the fix.
+
+    This is the assertion that would have caught the original defect: it drives
+    `host()` with the config that killed the agent and looks at what reaches
+    uvicorn.
+    """
+
+    @pytest.fixture
+    def project(self, tmp_path, monkeypatch):
+        from connectonion import Agent, address
+
+        co = tmp_path / ".co"
+        co.mkdir()
+        address.save(address.generate(), co)
+        (co / "host.yaml").write_text(
+            "name: t\nentrypoint: agent.py\nport: 8123\nworkers: 4\nreload: true\n")
+        monkeypatch.chdir(tmp_path)
+        return tmp_path
+
+    def _run_host_capturing_uvicorn(self, monkeypatch):
+        from connectonion import Agent
+        from connectonion.network.host import server as server_module
+
+        seen = {}
+        monkeypatch.setattr(server_module.uvicorn, "run",
+                            lambda app, **kw: seen.update(kw))
+
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+                           relay_url=None)
+        return seen
+
+    def test_uvicorn_is_asked_for_one_worker(self, project, monkeypatch):
+        assert self._run_host_capturing_uvicorn(monkeypatch)["workers"] == 1
+
+    def test_uvicorn_is_asked_for_no_reload(self, project, monkeypatch):
+        assert self._run_host_capturing_uvicorn(monkeypatch)["reload"] is False
+
+    def test_it_still_serves_the_configured_port(self, project, monkeypatch):
+        """The rest of host.yaml must keep working."""
+        assert self._run_host_capturing_uvicorn(monkeypatch)["port"] == 8123


### PR DESCRIPTION
Two of the nine keys in every generated `.co/host.yaml` stop the agent from starting.

```yaml
# Host configuration — edit these values
workers: 1      ->  2
reload: false   ->  true
```

`host()` ends at

```python
uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, ...)
```

and uvicorn can only fork workers or watch files when it is given an **import string**. Handed an app object it refuses both and returns without ever serving.

## Measured — through the code parameter and through host.yaml

```
[host] ───────────────────────────────────
       http://localhost:8794
       POST /input · WS /ws · GET /docs
       0xe8eab6d…
WARNING:  You must pass the application as an import string to enable 'reload' or 'workers'.

$ curl http://localhost:8794/info
(nothing — the process is gone)
```

The banner announces an address that answers nothing. The only sign is one uvicorn warning printed under it. **Editing a documented value in the documented file turns the agent off**, and it looks like it started.

`host(agent, workers=2)` and `.co/host.yaml` with `workers: 2` both do it, and so does `reload: true` on its own.

## Why not just make them work

Each worker process would run its own scheduler loop and its own `in_flight` set, so a schedule that overruns its interval gets one copy per worker — the race #537 is about — and `record_run` only writes `last_run` after the turn returns, so the guard that exists cannot span processes. That is a design question, not a bug fix.

Until it is answered, keep the agent running and say what was not honoured. Silently running one worker is a smaller lie than dying behind a banner that says otherwise:

```
[host] workers: 4 not honoured — running one worker (uvicorn needs an import string to fork, and the scheduler is per process)
[host] reload: true not honoured — running without reload (uvicorn needs an import string to watch files)
```

This touches only `host()`'s own call. The `uvicorn myagent:app --workers 4` path in `create_app`'s docstring is a real import string and is unaffected — filed separately, because that path does fork and does duplicate scheduled runs.

## Verified on a real server

`workers: 4` + `reload: true` in host.yaml:

| | before | after |
|---|---|---|
| processes | 0 | 2 |
| `GET /info` | no answer | 200 |

## Tests

12 tests, red first. Three of them drive `host()` itself with the killing config and assert what reaches `uvicorn.run` — a helper nothing calls is the bug, not the fix, and that is the assertion that would have caught this one.
