### PR TITLE
open trust allows everyone in; it does not let anyone in unsigned

### DIFF
--- a/connectonion/network/trust/policies/open.md
+++ b/connectonion/network/trust/policies/open.md
@@ -1,12 +1,25 @@
 ---
 # Open Trust (Development)
-# Allow everyone - no verification needed
+# Every caller is allowed — the signature is still required
 
 default: allow
 ---
 
 # Open Trust
 
-For development and testing. Everyone is allowed.
+For development and testing. Every identity is allowed: no whitelist, no
+onboarding, nobody to ask.
 
-**WARNING:** Never use in production.
+Requests are still signed. The levels decide *who may act* — `open` says anyone,
+`careful` says admin, whitelisted and contacts, `strict` says the whitelist only.
+None of them decides whether a request is authenticated at all:
+`extract_and_authenticate` refuses an unsigned one before it reads the level.
+
+    POST /input  (no signature)  ->  401 unauthorized: signed request required
+
+So `curl` on its own will not reach an agent on this level. Use `co call`,
+`connect()`, or any client that signs — `address.generate()` is enough of an
+identity, because this level does not care which one it is.
+
+**WARNING:** Never use in production. Anyone who can sign anything can run this
+agent's tools.

--- a/tests/unit/test_open_trust_still_needs_a_signature.py
+++ b/tests/unit/test_open_trust_still_needs_a_signature.py
@@ -1,0 +1,107 @@
+"""`open` trust allows everyone in. It does not let anyone in unsigned.
+
+The shipped policy says the second thing:
+
+    connectonion/network/trust/policies/open.md
+
+        # Open Trust (Development)
+        # Allow everyone - no verification needed
+        default: allow
+
+Verification is exactly what is still needed. `extract_and_authenticate` refuses
+an unsigned request before any trust level is consulted:
+
+    # Protocol requirement: ALL requests must be signed
+    if "payload" not in data or "signature" not in data:
+        return None, None, False, "unauthorized: signed request required"
+
+Measured against a real agent started with `trust: open` in host.yaml:
+
+    GET  /info    ->  {"trust": "open"}
+    POST /input   ->  401 {"error": "unauthorized: signed request required"}
+
+The levels decide *authorisation* — which signed identity may act. `open` means
+any identity, `careful` means admin/whitelisted/contact, `strict` means the
+whitelist. None of them decides *authentication*, which is the signature and is
+not optional.
+
+`careful.md` and `strict.md` describe themselves in exactly those terms — "Who
+has access", "Only whitelisted users". `open.md` was the one that conflated the
+two, and it is the level a developer picks precisely when they want to curl the
+thing. What they get instead looks like a bug in the framework.
+
+The behavioural assertions here matter more than the wording one: they pin a
+security property. An `open` that skipped signatures would let an unauthenticated
+caller run an agent's tools, and it would look like it was doing what its own
+documentation said.
+"""
+
+import pytest
+
+from connectonion.network.host.auth import extract_and_authenticate
+from connectonion.network.trust.factory import PROMPTS_DIR
+
+
+UNSIGNED = {"prompt": "run something"}
+
+
+def _authenticate(data, trust="open"):
+    return extract_and_authenticate(data, trust)
+
+
+class TestOpenStillRequiresASignature:
+
+    def test_an_unsigned_request_is_refused(self):
+        _, _, valid, error = _authenticate(UNSIGNED)
+
+        assert not valid
+        assert "signed" in error
+
+    def test_a_payload_without_a_signature_is_refused(self):
+        _, _, valid, error = _authenticate({"payload": {"prompt": "hi"}})
+
+        assert not valid
+        assert "signed" in error
+
+    def test_a_signature_without_a_payload_is_refused(self):
+        _, _, valid, _ = _authenticate({"signature": "0xdeadbeef"})
+
+        assert not valid
+
+    @pytest.mark.parametrize("level", ["open", "careful", "strict"])
+    def test_no_level_makes_the_signature_optional(self, level):
+        """Authentication is not what the levels decide."""
+        _, _, valid, error = _authenticate(UNSIGNED, trust=level)
+
+        assert not valid, f"{level} accepted an unsigned request"
+        assert "signed" in error
+
+
+class TestThePolicySaysWhatItDoes:
+    """The wording is what sent a reader to curl an agent that will refuse them."""
+
+    def test_open_does_not_claim_verification_is_unnecessary(self):
+        text = (PROMPTS_DIR / "open.md").read_text(encoding="utf-8")
+
+        assert "no verification needed" not in text.lower(), (
+            "open.md still says verification is not needed; a request without a "
+            "signature is refused before the trust level is read"
+        )
+
+    def test_open_still_allows_by_default(self):
+        """The functional half must not change while the wording does."""
+        import yaml
+
+        from connectonion.network.trust import parse_policy
+
+        config, _ = parse_policy((PROMPTS_DIR / "open.md").read_text(encoding="utf-8"))
+
+        assert config.get("default") == "allow"
+
+    @pytest.mark.parametrize("name", ["open", "careful", "strict"])
+    def test_every_level_still_parses(self, name):
+        from connectonion.network.trust import parse_policy
+
+        config, _ = parse_policy((PROMPTS_DIR / f"{name}.md").read_text(encoding="utf-8"))
+
+        assert config, f"{name}.md stopped parsing"


### PR DESCRIPTION
Found while checking, one by one, whether the nine keys in a generated `host.yaml` are actually honoured — after #639 turned up two that killed the agent.

The shipped policy for `trust: open` says verification is not needed:

```
connectonion/network/trust/policies/open.md

    # Open Trust (Development)
    # Allow everyone - no verification needed
    default: allow
```

Verification is exactly what is still needed. `extract_and_authenticate` refuses an unsigned request *before* any trust level is consulted:

```python
# Protocol requirement: ALL requests must be signed
if "payload" not in data or "signature" not in data:
    return None, None, False, "unauthorized: signed request required"
```

## Measured against a real agent, `trust: open` in host.yaml

| request | result |
|---|---|
| `GET /info` | `{"trust": "open"}` |
| `POST /input`, unsigned | `401 unauthorized: signed request required` |
| `POST /input`, signed by a brand-new `address.generate()` | `200` — agent replies `OK` |

The levels decide **authorisation** — which signed identity may act. `open` says any, `careful` says admin/whitelisted/contact, `strict` says the whitelist. None of them decides **authentication**. `careful.md` and `strict.md` already describe themselves in exactly those terms ("Who has access", "Only whitelisted users"); `open.md` was the one that conflated the two — and it is the level a developer picks precisely when they want to curl the thing. What they get instead looks like a bug in the framework.

## The tests are mostly not about the wording

Ten of the eleven pin the security property across all three levels: no level makes the signature optional. An `open` that skipped signatures would let an unauthenticated caller run the agent's tools *while looking like it did what its own documentation said*. Those pass today and are the reason to have them.

One asserts the file no longer claims otherwise — that is the red one.

Everything the rewritten file claims was run first, including that a freshly generated identity is enough to be let in.

## The rest of the sweep

All nine keys now check out: `port`, `name`, `trust`, `result_ttl` (111 in host.yaml → `expires - created = 111s` in the session record) honoured; `relay_url` fixed in #626; `workers` and `reload` in #639; `permissions` observed refusing a non-whitelisted tool; `entrypoint` is for the deploy tooling, not `host()`.