### PR TITLE
A browser daemon that is shutting down exits; it does not abort the process

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -741,6 +741,19 @@ class BrowserDaemon:
 
     def _cleanup(self):
         self._closing = True   # read by serve() -- see the accept loop
+        # Wake a thread already blocked in accept(). Closing the listener raises
+        # out of accept() on macOS, which is where the abort was seen -- but not
+        # on Linux, where accept() simply keeps blocking and serve() never
+        # notices the flag. CI caught that: this file's own test failed on all
+        # four Linux jobs and passed on macOS and Windows.
+        #
+        # One throwaway connection is enough; connect_ex reports failure as a
+        # return value rather than an exception, and a failure here means the
+        # socket is already gone, which is the outcome we wanted anyway.
+        if self._srv and not transport.IS_WINDOWS and os.path.exists(self.sock_path):
+            waker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            waker.connect_ex(self.sock_path)
+            waker.close()
         # Stop accepting FIRST: closing/unlinking the socket before anything slow
         # means a client connecting during shutdown fails immediately and spawns
         # a fresh daemon, instead of reaching a daemon that will never accept its request.

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -199,6 +199,9 @@ class BrowserDaemon:
         self.sock_path = sock_path
         self.browser = BrowserAutomation(headless=headless)
         self._srv = None
+        # Set by _cleanup before it closes the listener, so serve() can tell "we are
+        # stopping" from "the socket broke while we were meant to be serving".
+        self._closing = False
         self._had_browser = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
         self._next_tab = 1        # id allocator for auto-named tabs
@@ -567,7 +570,25 @@ class BrowserDaemon:
             signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 
         while True:
-            conn = self._accept()
+            try:
+                conn = self._accept()
+            except OSError:
+                # Closing the listener is how this daemon is told to stop, and
+                # _accept's docstring says the raise is the mechanism. Letting it
+                # escape is the part that hurt: each serve() thread printed a
+                # traceback on the way out, and several doing that at once while
+                # the interpreter finalised aborted the process --
+                #   Fatal Python error: _enter_buffered_busy: could not acquire
+                #   lock for <_io.BufferedWriter name='<stderr>'> at interpreter
+                #   shutdown, possibly due to daemon threads
+                # -- taking whatever was still buffered with it. Seen at the end
+                # of a full test run: everything passed, exit code 134.
+                #
+                # Only when it is us doing the closing. A listener that breaks
+                # while this is supposed to be serving is a real failure.
+                if self._closing:
+                    return
+                raise
             if conn is None:
                 continue  # a client that failed the auth handshake (Windows) — keep serving
             request = ""
@@ -719,6 +740,7 @@ class BrowserDaemon:
             conn.sendall(data)
 
     def _cleanup(self):
+        self._closing = True   # read by serve() -- see the accept loop
         # Stop accepting FIRST: closing/unlinking the socket before anything slow
         # means a client connecting during shutdown fails immediately and spawns
         # a fresh daemon, instead of reaching a daemon that will never accept its request.

--- a/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
+++ b/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
@@ -1,0 +1,112 @@
+"""A browser daemon that is shutting down exits; it does not abort the process.
+
+Closing the listener is how a daemon is told to stop — `_cleanup` closes the
+socket first, and `_accept`'s docstring says so:
+
+    A dead listener still raises out on both platforms so a dying daemon exits.
+
+Raising is the intended mechanism. Escaping as an unhandled thread exception is
+not. Each `serve()` thread prints a full traceback to stderr on its way out, and
+with several of them going at once while the interpreter finalises, one holds
+the stderr buffer lock when finalisation starts:
+
+    ConnectionAbortedError: [Errno 53] Software caused connection abort
+      File ".../browser_agent/daemon.py", line 694, in _accept
+        conn, _ = self._srv.accept()
+    ...
+    Fatal Python error: _enter_buffered_busy: could not acquire lock for
+    <_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly due
+    to daemon threads
+
+Observed at the end of a full local test run: 4181 tests passed and the process
+then died with SIGABRT (exit 134). An abort at shutdown discards whatever was
+still buffered, and what a user sees when they stop `co browser` is a wall of
+tracebacks under a fatal error.
+
+So: a listener closed by our own shutdown ends the loop quietly. A socket error
+at any other time still raises — a daemon whose listener breaks while it is
+supposed to be serving is a real failure and must not be swallowed.
+"""
+
+import shutil
+import socket
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.browser_agent import daemon as d
+
+
+@pytest.fixture
+def server():
+    """A daemon on its own socket path, no browser launched.
+
+    Not bound here: serve() binds for itself, and binding twice on one path is
+    a different failure than the one under test.
+
+    Its own short directory rather than pytest's tmp_path, because an AF_UNIX
+    path is capped near 104 bytes and pytest's includes the test's own name —
+    long test names in a deep checkout produce "AF_UNIX path too long", which
+    looks like a daemon failure and is not one.
+    """
+    directory = tempfile.mkdtemp(prefix="cod")
+    server = d.BrowserDaemon(str(Path(directory) / "s.sock"), headless=True)
+    yield server
+    if server._srv:
+        server._srv.close()
+    shutil.rmtree(directory, ignore_errors=True)
+
+
+class TestClosingTheListenerStopsIt:
+
+    def test_serve_returns_instead_of_raising(self, server):
+        error = {}
+
+        def run():
+            try:
+                server.serve()
+            except BaseException as exc:      # SystemExit included
+                error["exc"] = exc
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        threading.Event().wait(0.3)
+
+        server._cleanup()
+        thread.join(timeout=5)
+
+        assert not thread.is_alive(), "serve() did not stop when the listener closed"
+        assert "exc" not in error, f"serve() raised on shutdown: {error.get('exc')!r}"
+
+    def test_it_is_marked_as_closing(self, server):
+        server._bind()
+        server._cleanup()
+
+        assert server._closing is True
+
+    def test_a_fresh_daemon_is_not_closing(self, server):
+        assert server._closing is False
+
+
+class TestARealFailureStillRaises:
+    """Swallowing every socket error would hide a daemon that broke while serving."""
+
+    def test_an_accept_error_while_serving_is_not_swallowed(self, server):
+        def explode():
+            raise OSError("the listener broke while we were serving")
+
+        server._accept = explode
+
+        with pytest.raises(OSError):
+            server.serve()
+
+    def test_a_non_socket_error_is_untouched(self, server):
+        def explode():
+            raise ValueError("something else entirely")
+
+        server._accept = explode
+
+        with pytest.raises(ValueError):
+            server.serve()


### PR DESCRIPTION
Found by the exit code of a full local test run: **4181 passed, then exit 134** — SIGABRT after every test had already succeeded.

```
ConnectionAbortedError: [Errno 53] Software caused connection abort
  File ".../browser_agent/daemon.py", line 694, in _accept
    conn, _ = self._srv.accept()
...
Fatal Python error: _enter_buffered_busy: could not acquire lock for
<_io.BufferedWriter name='<stderr>'> at interpreter shutdown, possibly due to
daemon threads
```

Closing the listener is how the daemon is told to stop, and `_accept`'s own docstring says the raise is the mechanism:

> A dead listener still raises out on both platforms so a dying daemon exits.

**Raising is intended. Escaping as an unhandled thread exception is not.** Each `serve()` thread prints a full traceback on its way out; several doing that at once while the interpreter finalises means one holds the stderr buffer lock when finalisation starts, and the process aborts — discarding whatever was still buffered.

It is not only a test artefact: the same shutdown path runs when a user stops `co browser`, and what they see is a wall of tracebacks under a fatal error.

## The fix

`_cleanup` marks the daemon as closing *before* it closes the socket. The accept loop returns quietly only in that case.

A listener that breaks while the daemon is supposed to be serving still raises — that is a real failure and must not be swallowed. Two of the five tests are about that, not about the shutdown.

## Note on the test fixture

The socket lives in its own short directory rather than pytest's `tmp_path`. An AF_UNIX path is capped near 104 bytes and pytest's includes the test's own name, so long names in a deep checkout produce `OSError: AF_UNIX path too long` — which looks like a daemon failure and is not one. It cost me one wrong red before I read it properly.

Red-then-green re-proven against the corrected fixture: 3 failed without the change, 5 pass with it.