### PR TITLE
A direct endpoint that stops answering falls back to the relay

### DIFF
--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -306,19 +306,15 @@ class RemoteAgent:
         import websockets
 
         await self._try_resolve_endpoint()
-        if self._resolved_endpoint:
-            ws_url = self._resolved_endpoint
-            is_direct = True
-        else:
-            ws_url = f"{self._relay_url}/ws/input"
-            is_direct = False
 
         exec_id = str(uuid.uuid4())
-        connect_msg = self._build_connect_message(is_direct)
         exec_msg = {"type": "EXEC", "exec_id": exec_id, "tool": tool, "args": args}
 
+        connection, is_direct = await self._open_best_connection(websockets)
+        connect_msg = self._build_connect_message(is_direct)
+
         try:
-            async with websockets.connect(ws_url) as ws:
+            async with connection as ws:
                 await ws.send(json.dumps(connect_msg))
 
                 # Wait for CONNECTED (EXEC needs the same auth gate as INPUT).
@@ -389,6 +385,44 @@ class RemoteAgent:
         self._ui_events = []
         self._status = "idle"
 
+    def _ways_to_reach(self) -> list:
+        """Where to try, best first: the agent itself, then the relay behind it.
+
+        #643 made direct resolution work, and a resolved endpoint is cached for
+        the life of this object. That is a good trade until the endpoint stops
+        answering -- the agent restarts on another port, or the caller moves off
+        that network -- and then every later call fails over a path that worked
+        before #643, when resolution never succeeded and everything went through
+        the relay.
+
+        The relay is still there and still reaches the agent. One refused
+        connection is a cheaper thing to pay than the conversation.
+        """
+        relay = (f"{self._relay_url}/ws/input", False)
+        if self._resolved_endpoint:
+            return [(self._resolved_endpoint, True), relay]
+        return [relay]
+
+    async def _open_best_connection(self, websockets):
+        """Open the first way that answers, and remember if the direct one did not.
+
+        Only the connection attempt is retried. Once a socket is open, an error
+        on it is the agent's answer and belongs to the caller -- retrying a
+        refused tool call somewhere else would run it twice.
+        """
+        for ws_url, is_direct in self._ways_to_reach():
+            try:
+                return await websockets.connect(ws_url), is_direct
+            except OSError:
+                if not is_direct:
+                    raise          # the relay is the last resort; there is no next
+                self._forget_direct_endpoint()
+
+    def _forget_direct_endpoint(self) -> None:
+        """Stop trying a corpse on every turn; resolve again when next asked."""
+        self._resolved_endpoint = None
+        self._endpoint_resolved = False
+
     async def _try_resolve_endpoint(self) -> None:
         """Try to resolve endpoint for the agent address. Only attempts once."""
         if self._endpoint_resolved:
@@ -418,23 +452,19 @@ class RemoteAgent:
             "content": prompt
         })
 
-        # Choose connection: direct (resolved) or via relay
-        if self._resolved_endpoint:
-            ws_url = self._resolved_endpoint
-            is_direct = True
-        else:
-            ws_url = f"{self._relay_url}/ws/input"
-            is_direct = False
-
         # Generate input_id for routing/response matching
         input_id = str(uuid.uuid4())
 
-        # Build the CONNECT and INPUT messages
+        # The agent itself when it answers, the relay behind it when it does not.
+        connection, is_direct = await self._open_best_connection(websockets)
+
+        # Build the CONNECT and INPUT messages -- after opening, because both are
+        # shaped by which way answered and a relay-bound frame is not a direct one.
         connect_msg = self._build_connect_message(is_direct)
         input_msg = self._build_input_message(prompt, input_id, is_direct, images, files)
 
         try:
-            async with websockets.connect(ws_url) as ws:
+            async with connection as ws:
                 # Authenticate first
                 await ws.send(json.dumps(connect_msg))
 

--- a/tests/unit/test_a_dead_direct_endpoint_falls_back_to_the_relay.py
+++ b/tests/unit/test_a_dead_direct_endpoint_falls_back_to_the_relay.py
@@ -1,0 +1,218 @@
+"""A direct endpoint that stops answering must not take the agent with it.
+
+#643 made `resolve_endpoint` work for the first time, so clients now reach an
+agent on its own address — localhost, LAN, then public — instead of always
+going through the relay. The endpoint is resolved once and cached for the life
+of the RemoteAgent:
+
+    if self._endpoint_resolved:
+        return
+    self._endpoint_resolved = True
+    self._resolved_endpoint = await resolve_endpoint(...)
+
+and then used with no way back:
+
+    if self._resolved_endpoint:
+        ws_url = self._resolved_endpoint
+        is_direct = True
+    else:
+        ws_url = f"{self._relay_url}/ws/input"
+
+So if the agent restarts on another port, or the caller moves off that network,
+every later call on that RemoteAgent fails — over a path that worked before
+#643, because before #643 resolution never succeeded and everything went
+through the relay. That is the regression the change brought with it.
+
+The relay is still there and still reaches the agent. Falling back to it costs
+one failed connection; not falling back costs the conversation.
+
+The cached endpoint is forgotten at the same time, so the next call resolves
+again rather than retrying a corpse every turn.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from connectonion.network.connect import RemoteAgent
+
+
+AGENT = "0x" + "e" * 64
+DEAD = "ws://10.0.0.99:9999/ws"
+RELAY = "wss://relay.test"
+
+
+class FakeWebSocket:
+    def __init__(self, script):
+        self.script = list(script)
+        self.sent = []
+        self._outbox = []
+
+    async def send(self, raw):
+        message = json.loads(raw)
+        self.sent.append(message)
+        for trigger, replies in self.script:
+            if message.get("type") == trigger:
+                for reply in replies:
+                    reply = dict(reply)
+                    if reply.get("type") == "EXEC_RESULT" and "exec_id" in message:
+                        reply["exec_id"] = message["exec_id"]
+                    if reply.get("type") == "OUTPUT" and "input_id" in message:
+                        reply["input_id"] = message["input_id"]
+                    self._outbox.append(reply)
+
+    async def recv(self):
+        if not self._outbox:
+            raise AssertionError(
+                f"waited for a frame nobody sent; sent so far: "
+                f"{[m.get('type') for m in self.sent]}")
+        return json.dumps(self._outbox.pop(0))
+
+    def __await__(self):
+        """`websockets.connect(url)` is awaitable and returns the protocol; the
+        code now awaits it before entering, so the stand-in must be too."""
+        async def _self():
+            return self
+        return _self().__await__()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+EXEC_OK = [
+    ("CONNECT", [{"type": "CONNECTED", "session_id": "s1"}]),
+    ("EXEC", [{"type": "EXEC_RESULT", "status": "success", "result": "FROM-RELAY"}]),
+]
+
+INPUT_OK = [
+    ("CONNECT", [{"type": "CONNECTED", "session_id": "s1"}]),
+    ("INPUT", [{"type": "OUTPUT", "result": "FROM-RELAY", "session": {}}]),
+]
+
+
+def _agent_whose_direct_endpoint_is_dead(monkeypatch, script):
+    """Connecting to DEAD refuses; the relay answers."""
+    import websockets
+
+    relay_socket = FakeWebSocket(script)
+    attempts = []
+
+    def connect(url, *a, **k):
+        attempts.append(url)
+        if url == DEAD:
+            raise ConnectionRefusedError("nothing is listening there any more")
+        return relay_socket
+
+    monkeypatch.setattr(websockets, "connect", connect)
+
+    agent = RemoteAgent(AGENT, keys=None, relay_url=RELAY)
+    agent._endpoint_resolved = True          # already resolved, as after one call
+    agent._resolved_endpoint = DEAD
+    return agent, attempts, relay_socket
+
+
+class TestCallFallsBack:
+
+    def test_it_still_returns_a_result(self, monkeypatch):
+        agent, _, _ = _agent_whose_direct_endpoint_is_dead(monkeypatch, EXEC_OK)
+
+        assert agent.call("bash", command="pwd").ok
+
+    def test_the_result_came_from_the_relay(self, monkeypatch):
+        agent, attempts, _ = _agent_whose_direct_endpoint_is_dead(monkeypatch, EXEC_OK)
+
+        result = agent.call("bash", command="pwd")
+
+        assert "FROM-RELAY" in result.text
+        assert attempts == [DEAD, f"{RELAY}/ws/input"], attempts
+
+    def test_the_dead_endpoint_is_forgotten(self, monkeypatch):
+        """Otherwise every later call pays for the same refusal first."""
+        agent, _, _ = _agent_whose_direct_endpoint_is_dead(monkeypatch, EXEC_OK)
+
+        agent.call("bash", command="pwd")
+
+        assert agent._resolved_endpoint is None
+
+
+class TestInputFallsBackToo:
+
+    def test_it_still_answers(self, monkeypatch):
+        agent, _, _ = _agent_whose_direct_endpoint_is_dead(monkeypatch, INPUT_OK)
+
+        assert "FROM-RELAY" in agent.input("hello").text
+
+    def test_it_tried_direct_first(self, monkeypatch):
+        agent, attempts, _ = _agent_whose_direct_endpoint_is_dead(monkeypatch, INPUT_OK)
+
+        agent.input("hello")
+
+        assert attempts[0] == DEAD
+
+
+class TestTheConnectMessageMatchesThePathItIsSentOn:
+    """`_build_connect_message(is_direct)` differs between the two. A fallback
+    that reused the direct message would be signed for the wrong recipient."""
+
+    def test_the_relay_gets_a_relay_shaped_connect(self, monkeypatch):
+        agent, _, socket = _agent_whose_direct_endpoint_is_dead(monkeypatch, EXEC_OK)
+
+        agent.call("bash", command="pwd")
+
+        sent = [m for m in socket.sent if m.get("type") == "CONNECT"][0]
+        expected = agent._build_connect_message(False)
+        assert set(sent) == set(expected)
+
+
+class TestWhatMustNotChange:
+
+    def test_a_working_direct_endpoint_is_not_second_guessed(self, monkeypatch):
+        import websockets
+
+        socket = FakeWebSocket(EXEC_OK)
+        attempts = []
+        monkeypatch.setattr(websockets, "connect",
+                            lambda url, *a, **k: (attempts.append(url), socket)[1])
+
+        agent = RemoteAgent(AGENT, keys=None, relay_url=RELAY)
+        agent._endpoint_resolved = True
+        agent._resolved_endpoint = "ws://10.0.0.5:8797/ws"
+
+        assert agent.call("bash", command="pwd").ok
+        assert attempts == ["ws://10.0.0.5:8797/ws"]
+        assert agent._resolved_endpoint == "ws://10.0.0.5:8797/ws"
+
+    def test_a_relay_only_agent_is_untouched(self, monkeypatch):
+        import websockets
+
+        socket = FakeWebSocket(EXEC_OK)
+        attempts = []
+        monkeypatch.setattr(websockets, "connect",
+                            lambda url, *a, **k: (attempts.append(url), socket)[1])
+
+        agent = RemoteAgent(AGENT, keys=None, relay_url=RELAY)
+        agent._endpoint_resolved = True
+        agent._resolved_endpoint = None
+
+        assert agent.call("bash", command="pwd").ok
+        assert attempts == [f"{RELAY}/ws/input"]
+
+    def test_a_relay_that_also_refuses_still_raises(self, monkeypatch):
+        """Falling back is not the same as pretending it worked."""
+        import websockets
+
+        def refuse(url, *a, **k):
+            raise ConnectionRefusedError(url)
+
+        monkeypatch.setattr(websockets, "connect", refuse)
+
+        agent = RemoteAgent(AGENT, keys=None, relay_url=RELAY)
+        agent._endpoint_resolved = True
+        agent._resolved_endpoint = DEAD
+
+        with pytest.raises(Exception):
+            agent.call("bash", command="pwd")

--- a/tests/unit/test_co_call_can_onboard.py
+++ b/tests/unit/test_co_call_can_onboard.py
@@ -64,6 +64,14 @@ class FakeWebSocket:
                 f"{[m.get('type') for m in self.sent]}")
         return json.dumps(self._outbox.pop(0))
 
+    def __await__(self):
+        """`websockets.connect(url)` is awaitable as well as a context manager,
+        and connect.py awaits it so a refused connection can be retried
+        elsewhere. A stand-in that is only a context manager is not one."""
+        async def _self():
+            return self
+        return _self().__await__()
+
     async def __aenter__(self):
         return self
 

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -278,6 +278,14 @@ def create_mock_ws(messages: list):
             self.messages = messages
             self.index = 0
 
+        def __await__(self):
+            """`websockets.connect(url)` is awaitable as well as a context
+            manager, and connect.py awaits it so a refused connection can be
+            retried elsewhere."""
+            async def _self():
+                return self
+            return _self().__await__()
+
         async def __aenter__(self):
             return self
 
@@ -398,6 +406,14 @@ class TestStreamInput:
                 self.agent = agent_ref
                 self.status_during_recv = None
                 self.call_count = 0
+
+            def __await__(self):
+                """`websockets.connect(url)` is awaitable as well as a context
+                manager, and connect.py awaits it so a refused connection can be
+                retried elsewhere."""
+                async def _self():
+                    return self
+                return _self().__await__()
 
             async def __aenter__(self):
                 return self


### PR DESCRIPTION
Step 7 of the release loop, on #643: assume the fix brought the next bug. It did.

#643 made `resolve_endpoint` work for the first time, so clients now reach agents directly. The endpoint is resolved once, cached for the life of the `RemoteAgent`, and used with no way back:

```python
if self._resolved_endpoint:
    ws_url = self._resolved_endpoint
else:
    ws_url = f"{self._relay_url}/ws/input"
```

So an agent that restarts on another port, or a caller that moves off that network, breaks **every later call on that object** — over a path that worked before #643, when resolution never succeeded and everything went through the relay.

## The fix

`_open_best_connection` tries the agent first and the relay behind it. **Only the connection attempt is retried**: once a socket is open, an error on it is the agent's answer and belongs to the caller — retrying a refused tool call somewhere else would run it twice.

The dead endpoint is forgotten at the same time, so the next call resolves again instead of paying for the same refusal every turn.

The CONNECT frame is built *after* the connection is opened, because `_build_connect_message(is_direct)` differs between the two paths and a relay-bound frame is not a direct one. A test pins that.

## Proven against a real agent

The fake could not have shown this on its own — the change is to *how the connection is opened*, so it was verified with the real `websockets` library:

| | |
|---|---|
| turn 1 | `ws://10.5.27.133:8798/ws` — answered |
| agent killed, restarted on port 8799 | |
| turn 2, **same client object** | relay — answered |
| `_resolved_endpoint` after turn 2 | `None` — re-resolves next time |

Before this, turn 2 raised `ConnectionRefusedError`.

## Tests

9 tests, red first (6 failed), re-proven red after the fake was made awaitable to match what `websockets.connect` actually returns. Three are "what must not change": a working direct endpoint is not second-guessed, a relay-only agent is untouched, and a relay that also refuses still raises — falling back is not the same as pretending it worked.