### PR TITLE
The release checklist names files that are not there

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -68,34 +68,37 @@ patch releases; the minor is the statement that it no longer needs to be.
 
 ## Files to Update When Versioning
 
-When updating version, these files must be changed:
+Three files carry the version, and `test_the_version_agrees_with_itself.py`
+fails if they disagree — so a release that misses one is caught rather than
+shipped.
 
-### Python Package Files
-1. `/connectonion/__init__.py` - `__version__` variable
-2. `/setup.py` - `version` parameter
+1. `connectonion/_version.py` — `__version__ = "X.Y.Z"`. **The only literal.**
+   `connectonion/__init__.py` reads it (`from ._version import __version__`)
+   so that `co --version` need not import the package; there is nothing to edit
+   there.
+2. `pyproject.toml` — the `version` field. This is what the wheel carries.
+3. `## Current Version:` at the top of this file.
 
-### Documentation Files
-3. `/docs-site/app/page.tsx` - Version badge
-4. `/README.md` - Any version references
-5. `/docs-site/README.md` - Any version references
+And one in the sibling docs repo, checked by the same test when it is beside
+this one: `docs-site/lib/version.ts` — `VERSION = 'X.Y.Z'`.
 
-### Configuration Files (if present)
-6. `/pyproject.toml` - version field (if exists)
-7. `/package.json` - version field (if exists)
+The entry in the release list below is not optional either: a version with no
+entry fails `test_every_release_has_an_entry.py`.
 
 ## Version Update Checklist
 
 When releasing a new version:
 
-- [ ] Update `__version__` in `/connectonion/__init__.py`
-- [ ] Update `version` in `/setup.py`
-- [ ] Update version badge in `/docs-site/app/page.tsx` (if exists)
-- [ ] Update any version references in README files
+- [ ] Update `__version__` in `connectonion/_version.py`
+- [ ] Update `version` in `pyproject.toml`
+- [ ] Update `## Current Version:` and add the release line in this file
+- [ ] Update `VERSION` in the docs site's `lib/version.ts`
+- [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
 - [ ] Commit changes: `git commit -m "Release vX.Y.Z: Description"`
 - [ ] Create git tag: `git tag vX.Y.Z`
 - [ ] Push commits: `git push`
 - [ ] Push tag: `git push origin vX.Y.Z`
-- [ ] Build package: `python setup.py sdist bdist_wheel`
+- [ ] Build package: `python -m build`
 - [ ] Upload to PyPI: `twine upload dist/*`
 
 ## What Triggers Each Version Type

--- a/tests/unit/test_the_release_checklist_names_real_files.py
+++ b/tests/unit/test_the_release_checklist_names_real_files.py
@@ -1,0 +1,130 @@
+"""The release procedure names files that are not there.
+
+VERSIONING.md's "Files to Update When Versioning" and "Version Update Checklist"
+are what someone follows on the day a release is cut. Every entry is wrong:
+
+    1. /connectonion/__init__.py - `__version__` variable
+         it reads `from ._version import __version__` — there is no literal to edit
+    2. /setup.py - version parameter
+         does not exist
+    3. /docs-site/app/page.tsx - Version badge
+         does not exist
+    6. /pyproject.toml - version field (if exists)
+         it exists, and is one of the two places that must change
+    -  connectonion/_version.py
+         the actual home of the version string, named nowhere
+
+and the build step cannot run:
+
+    python setup.py sdist bdist_wheel
+
+Following it produces a release where nothing that matters was edited, and then
+a command that fails. The version *consistency* is guarded —
+test_the_version_agrees_with_itself.py compares pyproject, the package,
+VERSIONING.md and the docs site — so the release would be caught. The
+instructions for getting there were not guarded by anything.
+
+Same shape as #636: a documented thing that is not real. Checked here rather
+than trusted, so the procedure cannot rot again while the code moves under it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+VERSIONING = REPO / "VERSIONING.md"
+
+
+def _release_sections() -> str:
+    """The two sections a releaser actually follows."""
+    text = VERSIONING.read_text(encoding="utf-8")
+    start = text.index("## Files to Update When Versioning")
+    end = text.index("## What Triggers Each Version Type")
+    return text[start:end]
+
+
+def _paths_named() -> list:
+    """Backticked things that name a file in this repo.
+
+    The sibling docs site is skipped on purpose: it lives beside this checkout,
+    not inside it, and test_the_version_agrees_with_itself.py is what locates
+    and checks it. Asserting on it from here would fail in a clone that does not
+    have it, which is a different thing from the procedure being wrong.
+    """
+    found = []
+    for line in _release_sections().split("\n"):
+        if "if exists" in line or "if present" in line:
+            continue
+        for token in re.findall(r"`([^`]+)`", line):
+            token = token.strip().lstrip("/")
+            if " " in token:                              # a command, not a path
+                continue
+            if token.startswith(("docs-site/", "lib/")):  # the sibling repo
+                continue
+            if "/" in token or token.endswith((".py", ".md", ".toml", ".json", ".tsx")):
+                found.append(token)
+    return found
+
+
+def _is_in_the_repo(name: str) -> bool:
+    """A path relative to the root, or a bare filename found anywhere in it."""
+    if (REPO / name).exists():
+        return True
+    return "/" not in name and any(REPO.rglob(name))
+
+
+class TestEveryFileItNamesExists:
+
+    def test_at_least_one_path_is_named(self):
+        """If the parser stops finding anything, this test stops meaning anything."""
+        assert _paths_named(), "no paths found — the sections moved or were renamed"
+
+    def test_they_all_exist(self):
+        missing = sorted({p for p in _paths_named() if not _is_in_the_repo(p)})
+
+        assert missing == [], (
+            f"VERSIONING.md tells a releaser to edit files that are not here: {missing}"
+        )
+
+
+class TestItNamesTheFileTheVersionIsActuallyIn:
+    """`connectonion/__init__.py` has no version literal — it imports one."""
+
+    def test_the_version_lives_where_this_test_thinks(self):
+        source = (REPO / "connectonion" / "_version.py").read_text(encoding="utf-8")
+
+        assert re.search(r'^__version__ = "', source, re.M), "the version moved again"
+
+    def test_the_init_has_no_literal_to_edit(self):
+        source = (REPO / "connectonion" / "__init__.py").read_text(encoding="utf-8")
+
+        assert not re.search(r'^__version__ = "', source, re.M)
+
+    def test_the_checklist_names_the_real_file(self):
+        assert "_version.py" in _release_sections(), (
+            "the release checklist does not mention connectonion/_version.py, "
+            "which is the only place the version string exists"
+        )
+
+
+class TestTheBuildCommandCanRun:
+
+    def test_it_does_not_call_a_setup_py_that_is_not_there(self):
+        sections = _release_sections()
+
+        if "setup.py" in sections:
+            assert (REPO / "setup.py").exists(), (
+                "the release step runs setup.py, and there is no setup.py"
+            )
+
+    def test_the_build_backend_it_names_is_the_one_configured(self):
+        """pyproject declares the backend; the checklist should drive that one."""
+        pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+
+        assert "build-backend" in pyproject, "pyproject has no build backend"
+        assert "python -m build" in _release_sections(), (
+            "the checklist does not use the PEP 517 build this project is set up for"
+        )


### PR DESCRIPTION
`VERSIONING.md`'s **Files to Update When Versioning** and **Version Update Checklist** are what someone follows on the day a release is cut. Every entry was wrong:

| the checklist said | reality |
|---|---|
| `/connectonion/__init__.py` — `__version__` variable | reads `from ._version import __version__` — **there is no literal to edit** |
| `/setup.py` — `version` parameter | **does not exist** |
| `/docs-site/app/page.tsx` — version badge | does not exist; the real one is `docs-site/lib/version.ts` |
| `/pyproject.toml` — "(if exists)" | it exists, and is one of the files that must change |
| — | `connectonion/_version.py`, the only literal, **named nowhere** |

and the build step could not run:

```
python setup.py sdist bdist_wheel
```

## What was and was not guarded

Version *consistency* is guarded — `test_the_version_agrees_with_itself.py` compares pyproject, the package, this file and the docs site, so a release that edited the wrong things gets caught. **The instructions for getting there were guarded by nothing**, which is why they could drift this far: `setup.py` was removed, the version moved into `_version.py` for #588, and the docs site changed shape, all without the procedure noticing.

Now checked, in the same shape as #636 (a documented thing must be real): every file the procedure names must exist, the file the version actually lives in must be named, and the build command must be the one `pyproject.toml` is set up for.

The sibling docs site is deliberately not asserted from here — it lives beside the checkout, not inside it, and the version test is what locates it. Failing in a clone that does not have it would be a different thing from the procedure being wrong.

## Verified by following it

On a copy, bumped to a fake 9.9.9:

```
guards                 5 passed
python -m build        connectonion-9.9.9-py3-none-any.whl
co --version           9.9.9        (installed from that wheel)
```

The old procedure could not have produced that — its build command has no `setup.py` to run.

7 tests, red first (4 failed).