### PR TITLE
A skill's permissions do not outlive a turn that ended by raising

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -485,6 +485,35 @@ def setup_skills(agent: 'Agent') -> None:
     agent.skills = _discover_all_skills(co_dir=co_dir)
 
 
+def _close_out_a_turn_that_never_finished(agent: 'Agent') -> None:
+    """Undo a skill's grants when the turn that made them died before restoring.
+
+    `cleanup_scope` is @on_complete, and on_complete is a plain statement after
+    the loop in Agent.input -- no finally. A turn that raises never reaches it,
+    and the grant stays:
+
+        turn 1, during        ['Bash(rm -rf *)', 'write']
+          ... the turn raises
+        turn 2, at the start  ['Bash(rm -rf *)', 'write']
+
+    The permission record even carries expires={'type': 'turn_end'}; nothing was
+    enforcing it. The ordinary way to get here is the operator answering "no" to
+    an approval, which raises -- so a refusal left the skill's permissions alive
+    for the rest of the session.
+
+    A snapshot tagged with an earlier turn is exactly the evidence that its
+    restore never ran, so this runs at the start of every turn rather than
+    wrapping the turn in try/finally: on_complete keeps meaning "the turn
+    finished", which the logger and the eval writer both read it as.
+    """
+    snapshot = agent.current_session.get('_permission_snapshot')
+    if not snapshot:
+        return
+    if snapshot.get('turn') == agent.current_session.get('turn', 0):
+        return          # this turn's own scope, still running
+    _restore_permissions(agent)
+
+
 @after_user_input
 def handle_skill_invocation(agent: 'Agent') -> None:
     """Detect /command and load skill with permission scope.
@@ -492,6 +521,8 @@ def handle_skill_invocation(agent: 'Agent') -> None:
     Intercepts messages starting with / and loads corresponding skill.
     Sets permission_scope in session and replaces user message with skill instructions.
     """
+    _close_out_a_turn_that_never_finished(agent)
+
     messages = agent.current_session.get('messages', [])
     if not messages:
         return

--- a/tests/unit/test_a_skills_permissions_do_not_outlive_a_failed_turn.py
+++ b/tests/unit/test_a_skills_permissions_do_not_outlive_a_failed_turn.py
@@ -1,0 +1,142 @@
+"""A skill's permissions end with the turn, including a turn that ends badly.
+
+The module says so in its own docstring:
+
+    Permission Scope:
+    - Set when skill invoked (tied to turn number)
+    - Auto-clears when turn ends (security)
+    - Only affects current turn (no permission escalation)
+
+`cleanup_scope` is `@on_complete`, and `on_complete` is a plain statement after
+the loop in `Agent.input`:
+
+    result = self._run_iteration_loop(max_iterations or self.max_iterations)
+    ...
+    self._invoke_events('on_complete')
+
+No `finally`. A turn that raises never reaches it, and the grant stays:
+
+    turn 1, during      ['Bash(rm -rf *)', 'write']
+      ... the turn raises
+    turn 2, at the start['Bash(rm -rf *)', 'write']      <- still there
+
+The comment in `_grant_skill_permissions` names the trigger: "on_complete is not
+in a finally block, so a turn that raises — a rejected approval does exactly
+that — never restores and leaves its snapshot behind". So the most ordinary way
+to reach it is the operator answering "no" to a dialog. They refuse, and the
+skill's permissions survive their refusal for the rest of the session.
+
+Restoring at the *start* of a turn is what fixes it: the plugin's own
+`@after_user_input` runs on every turn, before anything is granted, and a
+snapshot left by an earlier turn is exactly the evidence that its restore never
+ran. Doing it there rather than wrapping the turn in `try/finally` keeps
+`on_complete` meaning "the turn finished", which the logger and the eval writer
+both rely on.
+"""
+
+import pytest
+
+from connectonion.useful_plugins.skills import (
+    _grant_skill_permissions,
+    _restore_permissions,
+    handle_skill_invocation,
+)
+
+
+class FakeAgent:
+    """Enough of an Agent for the permission bookkeeping."""
+
+    def __init__(self, turn=1):
+        self.current_session = {"turn": turn, "permissions": {}, "messages": []}
+        self.logger = None
+
+
+def _a_turn_that_raised(turn=1):
+    """An agent left as a turn that died mid-flight leaves it."""
+    agent = FakeAgent(turn=turn)
+    _grant_skill_permissions(agent, "risky", ["Bash(rm -rf *)", "write"])
+    return agent                       # no _restore_permissions: the turn raised
+
+
+class TestTheNextTurnStartsClean:
+
+    def test_the_grant_does_not_survive(self):
+        agent = _a_turn_that_raised()
+
+        agent.current_session["turn"] = 2
+        handle_skill_invocation(agent)
+
+        assert "Bash(rm -rf *)" not in agent.current_session["permissions"]
+
+    def test_nothing_of_the_skill_survives(self):
+        agent = _a_turn_that_raised()
+
+        agent.current_session["turn"] = 2
+        handle_skill_invocation(agent)
+
+        assert agent.current_session["permissions"] == {}
+
+    def test_the_stale_snapshot_is_gone(self):
+        """Left behind, it becomes the baseline the next skill restores to."""
+        agent = _a_turn_that_raised()
+
+        agent.current_session["turn"] = 2
+        handle_skill_invocation(agent)
+
+        assert "_permission_snapshot" not in agent.current_session
+
+    def test_an_operator_approval_from_the_failed_turn_is_kept(self):
+        """Theirs, not the skill's — the same rule `_restore_permissions` follows."""
+        agent = _a_turn_that_raised()
+        agent.current_session["permissions"]["read_file"] = {
+            "allowed": True, "source": "user",
+        }
+
+        agent.current_session["turn"] = 2
+        handle_skill_invocation(agent)
+
+        assert "read_file" in agent.current_session["permissions"]
+
+
+class TestTheTurnThatIsStillRunning:
+    """Only a snapshot from an *earlier* turn is evidence of a failed restore."""
+
+    def test_the_current_turn_keeps_its_grant(self):
+        agent = _a_turn_that_raised()
+
+        handle_skill_invocation(agent)          # same turn, still going
+
+        assert "Bash(rm -rf *)" in agent.current_session["permissions"]
+
+    def test_and_keeps_its_snapshot(self):
+        agent = _a_turn_that_raised()
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session["_permission_snapshot"]["turn"] == 1
+
+
+class TestWhatMustNotChange:
+
+    def test_a_turn_that_ended_properly_is_unaffected(self):
+        agent = _a_turn_that_raised()
+        _restore_permissions(agent)             # on_complete did run
+
+        agent.current_session["turn"] = 2
+        handle_skill_invocation(agent)
+
+        assert agent.current_session["permissions"] == {}
+
+    def test_an_agent_that_never_ran_a_skill(self):
+        agent = FakeAgent(turn=3)
+
+        handle_skill_invocation(agent)
+
+        assert agent.current_session["permissions"] == {}
+
+    def test_restore_still_clears_within_one_turn(self):
+        agent = _a_turn_that_raised()
+
+        _restore_permissions(agent)
+
+        assert agent.current_session["permissions"] == {}


### PR DESCRIPTION
A skill's permissions outlive the turn when that turn ends by raising — and the ordinary way to make a turn raise is the operator refusing an approval.

The module docstring states the guarantee:

```
Permission Scope:
- Set when skill invoked (tied to turn number)
- Auto-clears when turn ends (security)
- Only affects current turn (no permission escalation)
```

`cleanup_scope` is `@on_complete`, and `on_complete` is a plain statement after the loop in `Agent.input` — no `finally`:

```python
result = self._run_iteration_loop(max_iterations or self.max_iterations)
...
self._invoke_events('on_complete')
```

A turn that raises never reaches it. `_grant_skill_permissions` even says so in a comment; what was missing is anything that acts on it.

## Measured on a real agent

Sampled at `after_user_input` — *during* the turn, which is when a permission decides anything:

| at the start of turn 2 | permissions | snapshot |
|---|---|---|
| **before** | `['Bash(git status)', 'read_file']` | `turn=1` |
| **after** | `[]` | none |

Turn 1 invoked a skill and then raised. Without the fix, **the whole of turn 2 runs with the previous turn's grants active** — a tool matching `Bash(git status)` or `read_file` is auto-approved and the operator is never asked. They are cleared only at the *end* of turn 2, by the stale snapshot finally being restored.

The permission record even carries `expires: {'type': 'turn_end'}`. Nothing was enforcing it.

## The fix

Restore at the *start* of a turn. The plugin's own `@after_user_input` runs on every turn before anything is granted, and a snapshot tagged with an earlier turn is exactly the evidence that its restore never ran.

Not `try/finally` around the turn: that would make `on_complete` fire on failures too, and both the logger and the eval writer read it as "the turn finished".

An approval the operator gave during the failed turn is still kept — the same rule `_restore_permissions` already follows.

## A note on how this was verified

The first real-agent probe measured permissions *after* `input()` returned and showed `[]` on unfixed code — it looked clean, and I nearly wrote this up as a non-finding. The leak is only visible while turn 2 is running, which is the only time it matters. Moving the sample into `after_user_input` is what showed it.

## Tests

9 tests, red first (3 failed). They include what must not change: a turn still running keeps its own grant and its own snapshot, a turn that ended properly is unaffected, and an operator's approval survives.
