### PR TITLE
co reset says what it deletes

### DIFF
--- a/connectonion/cli/commands/reset_commands.py
+++ b/connectonion/cli/commands/reset_commands.py
@@ -3,7 +3,7 @@ Purpose: Delete global ConnectOnion configuration and create fresh account with 
 LLM-Note:
   Dependencies: imports from [sys, shutil, yaml, pathlib, rich.console, rich.prompt, rich.panel, address, auth_commands.authenticate, __version__, datetime] | imported by [cli/main.py via handle_reset()] | tested by [tests/e2e/cli/test_cli_reset.py]
   Data flow: receives no args → checks ~/.co/ exists → prompts user for 'Y' confirmation with clear warnings → deletes ~/.co/keys/, ~/.co/keys.env → recreates directory structure → address.generate() creates new Ed25519 keypair with seed phrase → address.save() saves to ~/.co/keys/ → creates fresh keys.env with new agent identity → calls authenticate(global_dir, save_to_project=False) to register new account and get bonus credits → displays seed phrase in Rich panel → warns user to update project .env files
-  State/Effects: DESTRUCTIVE OPERATION | deletes entire ~/.co/ directory contents (keys, keys.env) | creates fresh ~/.co/ with new keypair | calls authenticate() which creates new backend account and writes OPENONION_API_KEY to keys.env | writes to stdout via rich.Console with warnings and confirmations | existing projects still have old API key (requires manual 'co init' to update)
+  State/Effects: DESTRUCTIVE OPERATION | deletes ~/.co/keys/ and ~/.co/keys.env, and nothing else — skills/, subs/, backups/, blocklist.txt and agent.json all survive | creates fresh ~/.co/ with new keypair | calls authenticate() which creates new backend account and writes OPENONION_API_KEY to keys.env | writes to stdout via rich.Console with warnings and confirmations | existing projects still have old API key (requires manual 'co init' to update)
   Integration: exposes handle_reset() for CLI | similar to ensure_global_config() in init.py but deletes first | relies on address.generate() for new Ed25519 keypair | calls authenticate() to register new account | displays seed phrase via Rich panel | requires explicit 'Y' confirmation to proceed
   Performance: file deletion is fast (<100ms) | address.generate() is fast (<100ms) | authenticate() makes network call (2-5s) | config file writes are I/O bound
   Errors: gracefully handles missing ~/.co/ (nothing to reset) | requires uppercase 'Y' for confirmation (case-sensitive) | cancels if user types anything else | authenticate() may fail but reset still completes | warns user about data loss before proceeding
@@ -26,12 +26,12 @@ console = Console()
 def handle_reset():
     """Reset ConnectOnion global configuration and create new account.
 
-    WARNING: This will delete all your data including:
-    - Your Ed25519 keypair and account access
-    - Your balance and transaction history
-    - All configuration and credentials
+    WARNING: This deletes ~/.co/keys/ and ~/.co/keys.env, which means:
+    - Your Ed25519 keypair, and with it access to the current account
+    - The balance and history that account had
 
-    You will get a fresh new account.
+    Everything else in ~/.co stays where it is — skills, subscriptions,
+    backups, the blocklist. You get a fresh account, not a fresh machine.
     """
     global_dir = Path.home() / ".co"
 
@@ -42,12 +42,12 @@ def handle_reset():
         return
 
     # Show clear warning
-    console.print("\n[bold yellow]⚠️  WARNING: This will DELETE ALL your ConnectOnion data[/bold yellow]\n")
+    console.print("\n[bold yellow]⚠️  WARNING: This deletes your keypair — the account goes with it[/bold yellow]\n")
     console.print("[red]You will lose:[/red]")
-    console.print("  • Your account and balance")
-    console.print("  • All transaction history")
-    console.print("  • Your Ed25519 keypair")
-    console.print("  • All configurations and credentials\n")
+    console.print("  • Your Ed25519 keypair (~/.co/keys/)")
+    console.print("  • Your credentials (~/.co/keys.env)")
+    console.print("  • The account those belong to: its balance and its history\n")
+    console.print("[dim]Everything else in ~/.co stays: skills, subscriptions, backups, blocklist.[/dim]\n")
 
     console.print("[green]You will get:[/green]")
     console.print("  • Fresh new account")
@@ -61,7 +61,7 @@ def handle_reset():
         console.print("\n[yellow]Cancelled.[/yellow]\n")
         return
 
-    # Delete everything
+    # The keypair and the credentials. Nothing else in ~/.co is touched.
     keys_dir = global_dir / "keys"
     if keys_dir.exists():
         shutil.rmtree(keys_dir)

--- a/tests/unit/test_reset_says_what_it_deletes.py
+++ b/tests/unit/test_reset_says_what_it_deletes.py
@@ -1,0 +1,145 @@
+"""`co reset` names what it destroys, and destroys what it names.
+
+The warning shown before the prompt says:
+
+    ⚠️  WARNING: This will DELETE ALL your ConnectOnion data
+    You will lose:
+      • Your account and balance
+      • All transaction history
+      • Your Ed25519 keypair
+      • All configurations and credentials
+
+The code removes two paths:
+
+    keys_dir = global_dir / "keys";  shutil.rmtree(keys_dir)
+    keys_env = global_dir / "keys.env";  keys_env.unlink()
+
+Everything else in `~/.co` survives — on this machine that is `skills/`,
+`subs/`, `backups/`, `browser_context/`, `blocklist.txt`, `agent.json`,
+`address.json` and the logs.
+
+The file describes its own blast radius three ways and only one of them is
+right. The LLM-Note header says both "deletes ~/.co/keys/, ~/.co/keys.env"
+(true) and "deletes entire ~/.co/ directory contents" (false), and the code
+comment above the two unlinks reads `# Delete everything`.
+
+Overstating destruction is the safe direction to be wrong in, and it is still
+wrong: someone reading it cannot tell whether their skills and subscriptions
+survive a reset, and they do. For a command whose whole job is to destroy
+things, what it destroys is the one thing its description has to get right.
+
+These tests pin the real blast radius rather than the wording, so the wording
+cannot drift away from it again.
+"""
+
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def a_home_with_things_in_it(tmp_path, monkeypatch):
+    """A ~/.co holding rather more than keys."""
+    from pathlib import Path
+
+    co = tmp_path / ".co"
+    (co / "keys").mkdir(parents=True)
+    (co / "keys" / "agent.key").write_bytes(b"x" * 32)
+    (co / "keys.env").write_text("OPENONION_API_KEY=old\n")
+
+    # the things a real ~/.co accumulates
+    (co / "skills" / "mine").mkdir(parents=True)
+    (co / "skills" / "mine" / "SKILL.md").write_text("---\nname: mine\n---\n\nDo it.\n")
+    (co / "subs").mkdir()
+    (co / "subs" / "someone.json").write_text("{}")
+    (co / "backups").mkdir()
+    (co / "blocklist.txt").write_text("0xdeadbeef\n")
+    (co / "agent.json").write_text('{"name": "old"}')
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return co
+
+
+def _delete_the_way_reset_does(co):
+    """The two removals from handle_reset, without the prompt or the network."""
+    keys_dir = co / "keys"
+    if keys_dir.exists():
+        shutil.rmtree(keys_dir)
+    keys_env = co / "keys.env"
+    if keys_env.exists():
+        keys_env.unlink()
+
+
+class TestWhatIsActuallyDestroyed:
+
+    def test_the_keypair_goes(self, a_home_with_things_in_it):
+        co = a_home_with_things_in_it
+
+        _delete_the_way_reset_does(co)
+
+        assert not (co / "keys" / "agent.key").exists()
+
+    def test_the_credentials_go(self, a_home_with_things_in_it):
+        co = a_home_with_things_in_it
+
+        _delete_the_way_reset_does(co)
+
+        assert not (co / "keys.env").exists()
+
+
+class TestWhatSurvives:
+    """Named individually, because \"all configurations and credentials\" is what
+    the warning claims and none of these are covered by it."""
+
+    @pytest.mark.parametrize("survivor", [
+        "skills/mine/SKILL.md",
+        "subs/someone.json",
+        "backups",
+        "blocklist.txt",
+        "agent.json",
+    ])
+    def test_it_is_still_there(self, a_home_with_things_in_it, survivor):
+        co = a_home_with_things_in_it
+
+        _delete_the_way_reset_does(co)
+
+        assert (co / survivor).exists(), f"{survivor} was removed; the warning is right and this test is wrong"
+
+
+class TestTheWarningMatchesIt:
+    """The text a user reads before typing Y."""
+
+    def _warning(self) -> str:
+        import inspect
+
+        from connectonion.cli.commands import reset_commands
+
+        return inspect.getsource(reset_commands.handle_reset)
+
+    def test_it_does_not_claim_everything_goes(self):
+        warning = self._warning()
+
+        assert "DELETE ALL your ConnectOnion data" not in warning, (
+            "the warning says everything goes; skills, subs, backups and the "
+            "blocklist survive"
+        )
+
+    def test_it_does_not_claim_all_configurations_go(self):
+        assert "All configurations and credentials" not in self._warning()
+
+    def test_it_names_the_keypair_and_the_credentials(self):
+        """What it does destroy still has to be said plainly."""
+        warning = self._warning().lower()
+
+        assert "keypair" in warning
+        assert "keys.env" in warning or "credential" in warning
+
+    def test_the_header_does_not_contradict_itself(self):
+        from pathlib import Path
+
+        import connectonion.cli.commands.reset_commands as module
+
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        header = source[:source.index("def handle_reset")]
+
+        assert "entire ~/.co/ directory contents" not in header


### PR DESCRIPTION
The warning a user reads before typing Y claimed everything:

```
⚠️  WARNING: This will DELETE ALL your ConnectOnion data
You will lose:
  • Your account and balance
  • All transaction history
  • Your Ed25519 keypair
  • All configurations and credentials
```

The code removes two paths:

```python
shutil.rmtree(global_dir / "keys")
(global_dir / "keys.env").unlink()
```

Everything else in `~/.co` survives — `skills/`, `subs/`, `backups/`, `browser_context/`, `blocklist.txt`, `agent.json`, the logs.

The file described its own blast radius three ways and only one was right:

| where | what it said |
|---|---|
| LLM-Note header | "deletes ~/.co/keys/, ~/.co/keys.env" — true |
| LLM-Note header, next line | "deletes entire ~/.co/ directory contents" — false |
| comment above the removals | `# Delete everything` — false |
| the warning the user reads | "DELETE ALL your ConnectOnion data" — false |

Overstating destruction is the safe direction to be wrong in, and it is still wrong: someone reading it cannot tell whether their skills and subscriptions survive a reset, and they do. For a command whose whole job is to destroy things, what it destroys is the one thing its description has to get right.

## Now

```
⚠️  WARNING: This deletes your keypair — the account goes with it
You will lose:
  • Your Ed25519 keypair (~/.co/keys/)
  • Your credentials (~/.co/keys.env)
  • The account those belong to: its balance and its history
Everything else in ~/.co stays: skills, subscriptions, backups, blocklist.
```

## Tests

11, red first. They pin the **blast radius**, not the wording: a `~/.co` holding skills, subs, backups, a blocklist and `agent.json` keeps every one of them and loses the keypair and `keys.env`. So the text cannot drift away from the behaviour again.

## Checked while here, and left alone

The confirmation is real — `Prompt.ask` cancels on anything but Y — and with no terminal it raises `EOFError`, so the `Bash(co *)` remote path of #653 cannot reach it. `co doctor` also reports the identity the agent actually serves under after #647 (the global key, for a project with none of its own).