### PR TITLE
A copied skill leaves its secrets behind

### DIFF
--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -148,6 +148,34 @@ def _load_index() -> Optional[dict]:
 SOURCE_PRIORITY = {src: i for i, (src, _, _) in enumerate(SOURCES)}
 
 
+# What a skill must not carry with it. VERSIONING.md put it plainly when the
+# command was introduced -- "skills carry their own files but never their
+# secrets" -- and nothing implemented it: the copy took the directory whole,
+# .env, credentials.json, keys/ and all.
+#
+# It matters most where the command points. `--to-project` puts the skill where
+# `co deploy` will find it, and a deploy rsyncs the project tree to a server, so
+# a credential a skill kept beside itself on a laptop lands on the box.
+#
+# Matched on the name, not the contents: guessing at contents gets both false
+# positives and false negatives, and a name like `.env` or `id_rsa` is what
+# people actually use. `.env.example` is deliberately not caught -- it is the
+# file you commit.
+SECRET_NAMES = {".env", "credentials.json", "id_rsa", "id_ed25519", ".netrc",
+                ".npmrc", ".pypirc", "keys.env", "service-account.json"}
+SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
+
+
+def _is_secret(path: Path) -> bool:
+    name = path.name
+    if name in SECRET_NAMES:
+        return True
+    if name.endswith(SECRET_SUFFIXES):
+        return True
+    # `.env.local`, `.env.production` -- but not `.env.example`
+    return name.startswith(".env.") and not name.endswith((".example", ".sample", ".template"))
+
+
 def _copy_entry(entry: dict, force: bool, skills_dir: Optional[Path] = None) -> bool:
     """Copy a single index entry into <skills_dir>/<name>/. Returns True if copied."""
     name = entry["name"]
@@ -164,17 +192,40 @@ def _copy_entry(entry: dict, force: bool, skills_dir: Optional[Path] = None) -> 
         return False
 
     dest_dir.mkdir(parents=True, exist_ok=True)
+    left_behind = []
     if src_path.name == "SKILL.md" and src_path.parent.is_dir():
+        def skip_secrets(directory, names):
+            # copytree's ignore hook, so a credential nested in a subdirectory is
+            # left behind too -- keys/id_rsa was the one that made this obvious.
+            dropped = [n for n in names if _is_secret(Path(directory) / n)]
+            left_behind.extend(str(Path(directory).joinpath(n)) for n in dropped)
+            return set(dropped)
+
         for item in src_path.parent.iterdir():
             target = dest_dir / item.name
+            if _is_secret(item):
+                left_behind.append(str(item))
+                continue
             if item.is_dir():
                 if target.exists() and force:
                     shutil.rmtree(target)
-                shutil.copytree(item, target)
+                shutil.copytree(item, target, ignore=skip_secrets)
             else:
                 shutil.copy2(item, target)
     else:
         shutil.copy2(src_path, dest_file)
+
+    # A directory whose whole contents were secrets arrives empty, which reads as
+    # "the keys came along". Remove it rather than leave that impression.
+    for directory in sorted((d for d in dest_dir.rglob("*") if d.is_dir()),
+                            key=lambda d: len(d.parts), reverse=True):
+        if not any(directory.iterdir()):
+            directory.rmdir()
+
+    # Said out loud: a skill that really did keep something here would otherwise
+    # lose it without a word, and finding that out later is worse.
+    for path in left_behind:
+        console.print(f"[yellow]  skipped {Path(path).name} (a secret stays where it is)[/yellow]")
 
     console.print(f"[green]✓ Copied {name} ({entry['source']}) → {dest_dir}[/green]")
     return True

--- a/tests/unit/test_a_copied_skill_leaves_its_secrets_behind.py
+++ b/tests/unit/test_a_copied_skill_leaves_its_secrets_behind.py
@@ -1,0 +1,138 @@
+"""`co skills copy` takes the skill's files and leaves its credentials.
+
+VERSIONING.md says so, in the entry that introduced the command:
+
+    skills carry their own files but never their secrets, and
+    `co skills copy --to-project` puts one where a deploy will find it
+
+`_copy_entry` copies the directory whole:
+
+    for item in src_path.parent.iterdir():
+        if item.is_dir():
+            shutil.copytree(item, target)
+        else:
+            shutil.copy2(item, target)
+
+Measured on a skill directory holding a credential:
+
+    src/leaky/.env                 ->  copied
+    src/leaky/credentials.json     ->  copied
+    src/leaky/keys/id_rsa          ->  copied
+
+Nothing in skills_commands.py, useful_plugins/skills.py, the co_ai loader or the
+fanout mentions `.env` or a secret at all, so the sentence was never true of any
+skills path.
+
+It matters most where the command is pointed: `--to-project` puts the skill
+where `co deploy` will find it, and a deploy rsyncs the project tree to a server.
+A credential that a skill kept beside itself on a laptop then lands on the box.
+
+Skipping is not silent. A skill that really did keep something here would
+otherwise lose it without a word, and finding that out later is worse than being
+told now.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands.skills_commands import _copy_entry
+
+
+@pytest.fixture
+def a_skill_with_secrets(tmp_path):
+    src = tmp_path / "src" / "leaky"
+    src.mkdir(parents=True)
+    (src / "SKILL.md").write_text("---\nname: leaky\ndescription: d\n---\n\nDo it.\n")
+
+    # what a skill legitimately carries
+    (src / "helper.py").write_text("print('hi')\n")
+    (src / "reference.md").write_text("notes\n")
+    (src / "data").mkdir()
+    (src / "data" / "table.csv").write_text("a,b\n1,2\n")
+    (src / ".env.example").write_text("API_TOKEN=\n")
+
+    # what it must not
+    (src / ".env").write_text("API_TOKEN=super-secret\n")
+    (src / "credentials.json").write_text('{"aws": "key"}')
+    (src / "server.pem").write_text("-----BEGIN PRIVATE KEY-----\n")
+    (src / "keys").mkdir()
+    (src / "keys" / "id_rsa").write_text("PRIVATE\n")
+
+    return src, tmp_path / "dest"
+
+
+def _copy(a_skill_with_secrets):
+    src, dest_root = a_skill_with_secrets
+    entry = {"name": "leaky", "path": str(src / "SKILL.md"), "source": "test"}
+    _copy_entry(entry, force=True, skills_dir=dest_root)
+    return dest_root / "leaky"
+
+
+class TestTheSecretsStayBehind:
+
+    @pytest.mark.parametrize("secret", [
+        ".env",
+        "credentials.json",
+        "server.pem",
+        "keys/id_rsa",
+    ])
+    def test_it_is_not_copied(self, a_skill_with_secrets, secret):
+        dest = _copy(a_skill_with_secrets)
+
+        assert not (dest / secret).exists(), f"{secret} travelled with the skill"
+
+
+class TestTheSkillStillArrives:
+    """Filtering that eats the skill is worse than the leak."""
+
+    @pytest.mark.parametrize("kept", [
+        "SKILL.md",
+        "helper.py",
+        "reference.md",
+        "data/table.csv",
+        ".env.example",
+    ])
+    def test_it_is_copied(self, a_skill_with_secrets, kept):
+        dest = _copy(a_skill_with_secrets)
+
+        assert (dest / kept).exists(), f"{kept} was dropped; it is not a secret"
+
+    def test_the_body_is_intact(self, a_skill_with_secrets):
+        dest = _copy(a_skill_with_secrets)
+
+        assert "Do it." in (dest / "SKILL.md").read_text()
+
+
+class TestItSaysWhatItLeft:
+    """A skill that really did keep something here loses it otherwise, silently."""
+
+    def test_the_skipped_files_are_named(self, a_skill_with_secrets, capsys):
+        _copy(a_skill_with_secrets)
+
+        printed = capsys.readouterr().out
+        assert ".env" in printed
+
+    def test_a_skill_with_no_secrets_says_nothing_about_them(self, tmp_path, capsys):
+        src = tmp_path / "src" / "clean"
+        src.mkdir(parents=True)
+        (src / "SKILL.md").write_text("---\nname: clean\n---\n\nGo.\n")
+
+        _copy_entry({"name": "clean", "path": str(src / "SKILL.md"), "source": "t"},
+                    force=True, skills_dir=tmp_path / "dest")
+
+        assert "skipped" not in capsys.readouterr().out.lower()
+
+
+class TestASingleFileSkill:
+    """`<name>.md` with no directory of its own — the other shape."""
+
+    def test_it_still_copies(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "solo.md").write_text("---\nname: solo\n---\n\nGo.\n")
+
+        _copy_entry({"name": "solo", "path": str(src / "solo.md"), "source": "t"},
+                    force=True, skills_dir=tmp_path / "dest")
+
+        assert (tmp_path / "dest" / "solo" / "SKILL.md").exists()


### PR DESCRIPTION
`VERSIONING.md` said so in the entry that introduced the command:

> skills carry their own files **but never their secrets**, and `co skills copy --to-project` puts one where a deploy will find it

Nothing implemented it. `_copy_entry` copies the directory whole:

```python
for item in src_path.parent.iterdir():
    if item.is_dir():
        shutil.copytree(item, target)
    else:
        shutil.copy2(item, target)
```

Measured on a skill that kept a credential beside itself:

| file | before | after |
|---|---|---|
| `.env` | copied | skipped |
| `credentials.json` | copied | skipped |
| `keys/id_rsa` | copied | skipped |
| `SKILL.md`, `helper.py`, `data/table.csv`, `.env.example` | copied | copied |

Nothing in `skills_commands.py`, `useful_plugins/skills.py`, the co_ai loader or the fanout mentions `.env` or a secret at all — the sentence was never true of any skills path.

## Why it is worth closing

`--to-project` puts the skill where `co deploy` will find it, and a deploy rsyncs the project tree to a server. A credential that lived beside a skill on a laptop lands on the box.

## Choices in it

**Matched on the name, not the contents.** Guessing at contents produces both false positives and false negatives, and `.env` / `id_rsa` / `*.pem` is what people actually use. `.env.example` is deliberately *not* caught — that is the file you commit.

**Nothing is dropped silently.** Each skipped file is named:

```
skipped .env (a secret stays where it is)
skipped credentials.json (a secret stays where it is)
skipped id_rsa (a secret stays where it is)
```

A skill that really did keep something here would otherwise lose it without a word, and finding that out later is worse.

**An emptied directory is removed.** `keys/` arriving empty reads as "the keys came along".

## Tests

13, red first (5 failed). Five of them are the other half — `SKILL.md`, a helper script, a data file and `.env.example` must still arrive, because filtering that eats the skill is worse than the leak.

Full suite: 4271 passed.