### PR TITLE
The secret filter covers the shapes the first pass missed

### DIFF
--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -161,16 +161,28 @@ SOURCE_PRIORITY = {src: i for i, (src, _, _) in enumerate(SOURCES)}
 # positives and false negatives, and a name like `.env` or `id_rsa` is what
 # people actually use. `.env.example` is deliberately not caught -- it is the
 # file you commit.
-SECRET_NAMES = {".env", "credentials.json", "id_rsa", "id_ed25519", ".netrc",
-                ".npmrc", ".pypirc", "keys.env", "service-account.json"}
+SECRET_NAMES = {".env", ".netrc", ".npmrc", ".pypirc", "keys.env",
+                "credentials.json", "service-account.json", "service_account.json",
+                "token.json", "auth.json", "secrets.json", "secrets.yaml", "secrets.yml",
+                ".git-credentials"}
 SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx")
+
+# Whole directories that exist to hold credentials. Listed as directories on
+# purpose: the first pass named `id_rsa` and `id_ed25519` and `.ssh/id_ecdsa`
+# walked straight past, because guessing every key filename is the wrong shape
+# of rule. Nothing inside one of these travels.
+SECRET_DIRS = {".ssh", ".aws", ".gnupg", ".kube", ".docker", ".azure"}
 
 
 def _is_secret(path: Path) -> bool:
     name = path.name
-    if name in SECRET_NAMES:
+    if name in SECRET_DIRS:
         return True
-    if name.endswith(SECRET_SUFFIXES):
+    if name in SECRET_NAMES or name.endswith(SECRET_SUFFIXES):
+        return True
+    # An SSH private key is `id_<type>`; its `.pub` half is not a secret, and
+    # nor is anything else that merely starts with those two letters.
+    if name.startswith("id_") and not name.endswith(".pub"):
         return True
     # `.env.local`, `.env.production` -- but not `.env.example`
     return name.startswith(".env.") and not name.endswith((".example", ".sample", ".template"))

--- a/tests/unit/test_a_copied_skill_leaves_its_secrets_behind.py
+++ b/tests/unit/test_a_copied_skill_leaves_its_secrets_behind.py
@@ -136,3 +136,58 @@ class TestASingleFileSkill:
                     force=True, skills_dir=tmp_path / "dest")
 
         assert (tmp_path / "dest" / "solo" / "SKILL.md").exists()
+
+
+class TestTheShapesTheFirstPassMissed:
+    """Step 7 on #657: assume the fix was incomplete, and it was.
+
+    Matching one filename at a time missed two kinds of thing —
+
+        token.json, auth.json, service_account.json, .git-credentials,
+        secrets.yaml                      common names that were simply not listed
+
+        .ssh/id_ecdsa, .aws/credentials   a credential *directory*, where guessing
+                                          each filename is the wrong shape of rule
+
+    The second is why the directory rule exists: a skill carrying `.ssh/` should
+    leave all of it, not the two key names someone thought of.
+    """
+
+    @pytest.mark.parametrize("name", [
+        "token.json", "auth.json", "service_account.json",
+        ".git-credentials", "secrets.yaml", "secrets.yml",
+    ])
+    def test_a_credential_file_is_skipped(self, tmp_path, name):
+        from connectonion.cli.commands.skills_commands import _is_secret
+
+        assert _is_secret(tmp_path / name), f"{name} would travel"
+
+    @pytest.mark.parametrize("directory", [".ssh", ".aws", ".gnupg", ".kube"])
+    def test_a_credential_directory_is_skipped_whole(self, tmp_path, directory):
+        from connectonion.cli.commands.skills_commands import _is_secret
+
+        assert _is_secret(tmp_path / directory)
+
+    def test_everything_inside_such_a_directory_stays(self, tmp_path):
+        """The point of the directory rule: no guessing at the names inside."""
+        src = tmp_path / "src" / "s"
+        (src / ".ssh").mkdir(parents=True)
+        (src / "SKILL.md").write_text("---\nname: s\n---\n\nGo.\n")
+        (src / ".ssh" / "id_ecdsa").write_text("PRIVATE\n")
+        (src / ".ssh" / "known_hosts").write_text("host\n")
+
+        _copy_entry({"name": "s", "path": str(src / "SKILL.md"), "source": "t"},
+                    force=True, skills_dir=tmp_path / "dest")
+
+        assert not (tmp_path / "dest" / "s" / ".ssh").exists()
+        assert (tmp_path / "dest" / "s" / "SKILL.md").exists()
+
+    @pytest.mark.parametrize("innocent", [
+        "config.json", "package.json", "data.yaml", "README.md",
+        "tokens.md", "secrets.md",
+    ])
+    def test_an_ordinary_file_is_not_mistaken_for_one(self, tmp_path, innocent):
+        """A rule that eats documentation is a rule nobody keeps."""
+        from connectonion.cli.commands.skills_commands import _is_secret
+
+        assert not _is_secret(tmp_path / innocent)


### PR DESCRIPTION
Step 7 of the loop on #657 — assume my own fix was incomplete. It was.

Run against a list of things people actually keep beside a skill:

| missed before | why |
|---|---|
| `token.json`, `auth.json`, `service_account.json`, `.git-credentials`, `secrets.yaml`, `secrets.yml` | names simply not in the list |
| `.ssh/id_ecdsa`, `.aws/credentials` | a credential **directory** — naming each file inside is the wrong shape of rule |

The second is the structural one. The first pass named `id_rsa` and `id_ed25519`; `id_ecdsa` walked straight past. Guessing every key filename was never going to hold.

## What changed

**Credential directories are skipped whole**: `.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`. Nothing inside one travels, and nobody has to have thought of the filenames.

**An SSH private key is `id_<type>`**, so that is the rule rather than two examples. `id_rsa.pub` is not a secret and still travels.

## What must not be caught, and is not

`config.json`, `package.json`, `data.yaml`, `README.md`, `tokens.md`, `secrets.md` — documentation *about* secrets is not a secret, and a rule that eats it is a rule nobody keeps. Six tests pin that side.

```
SKIP  .env              SKIP  token.json          config.json
      .env.example      SKIP  secrets.yaml        README.md
SKIP  credentials.json  SKIP  .aws                tokens.md
SKIP  id_rsa            SKIP  .ssh                helper.py
      id_rsa.pub        SKIP  .git-credentials
```

30 tests in the file now, red first (11 failed). Full suite: 4288 passed.