### PR TITLE
An agent started one directory down is still the agent host.yaml describes

### DIFF
--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -27,6 +27,27 @@ from .core.usage import totals_from_trace
 KEEP_RUNS_PER_EVAL = 20
 
 
+def _project_co_dir(start=None) -> Path:
+    """The project's `.co/`, found by walking up -- not `Path(".co")`.
+
+    A bare `.co` is created wherever the Agent happens to be constructed, so a
+    script run from a subdirectory of its own project got a second `.co/logs/`
+    there. That is untidy on its own, and it defeats the rule the rest of the
+    agent follows: host.yaml and the trust lists are located by walking up
+    (#660), and a scattered `.co` stops that walk at the wrong directory. The
+    scaffold builds the Agent before calling host(), so the scatter happens
+    first and the walk finds it.
+
+    Falls back to the starting directory when there is no `.co/` above, which is
+    a fresh project's first run -- the logs land where it was started, as before.
+    """
+    start = Path(start or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        if (directory / ".co").is_dir():
+            return directory / ".co"
+    return start / ".co"
+
+
 def _slugify(text: str, max_length: int = 50) -> str:
     """Convert text to URL-friendly slug for filenames.
 
@@ -86,7 +107,7 @@ class Logger:
     ):
         self.agent_name = agent_name
         # Base .co directory (default: current directory's .co/)
-        self.co_dir = Path(co_dir) if co_dir else Path(".co")
+        self.co_dir = Path(co_dir) if co_dir else _project_co_dir()
 
         # Determine what to enable
         self.enable_console = not quiet

--- a/connectonion/network/host/config.py
+++ b/connectonion/network/host/config.py
@@ -28,6 +28,39 @@ DEFAULT_FILE_LIMITS = {
 }
 
 
+def project_co_dir(start=None) -> Path:
+    """The `.co/` that belongs to this agent -- the project's, not the one beside
+    wherever the process was started.
+
+    This resolved against the bare cwd, so an agent started one directory down
+    found no host.yaml and every value in it fell back to a default. Measured on
+    a project whose file says trust: careful, port: 8806, 88 permission entries:
+
+        from the project root      port 8806   trust careful   permissions 88
+        from a subdirectory of it  port None   trust None      permissions 0
+
+    They fall back in different directions. The port lands on 8000, so the agent
+    listens somewhere else. The permissions land on none, so everything asks --
+    safe. Trust lands on "careful" (server.py), so a project that says `strict`
+    runs as `careful` instead: it admits contacts and accepts an invite code,
+    while its configuration says whitelist only.
+
+    Walking up is how the rest of the agent is found, and the rule is written
+    down in dashboard.py -- "the project, not wherever you ran from" -- after the
+    same bug hit the Home page. #660 did the trust lists.
+
+    There is a second copy of this in network/trust/tools.py rather than one
+    shared definition: host imports trust (server.py -> TrustAgent), so a shared
+    home in either package would close a cycle. Eight lines duplicated beats an
+    import loop; if a third caller appears, that is the time to find it a home.
+    """
+    start = Path(start or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        if (directory / '.co').is_dir():
+            return directory / '.co'
+    return start / '.co'
+
+
 def load_host_config(co_dir: Path = None, **code_params) -> dict:
     """
     Load host configuration from .co/host.yaml.
@@ -49,7 +82,7 @@ def load_host_config(co_dir: Path = None, **code_params) -> dict:
         Includes 'permissions' field if defined in host.yaml
     """
     if co_dir is None:
-        co_dir = Path.cwd() / '.co'
+        co_dir = project_co_dir()
 
     # Start with defaults
     config = DEFAULT_FILE_LIMITS.copy()

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -44,7 +44,7 @@ from .schedule import create_schedule_lifespan
 from ..trust import TrustAgent, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
 from .auth import extract_and_authenticate
-from .config import load_host_config, load_list_file, validate_files, validate_images, DEFAULT_FILE_LIMITS
+from .config import load_host_config, load_list_file, validate_files, validate_images, project_co_dir, DEFAULT_FILE_LIMITS
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
 from .http_router import (
     input_handler,
@@ -351,8 +351,9 @@ def _print_host_banner(
         relay_status = "[dim]no relay[/dim]"
 
     # Get absolute paths for config and logs
-    config_file = (co_dir / "host.yaml").resolve() if co_dir else (Path.cwd() / ".co" / "host.yaml").resolve()
-    logs_dir = (co_dir / "logs").resolve() if co_dir else (Path.cwd() / ".co" / "logs").resolve()
+    base = co_dir or project_co_dir()
+    config_file = (base / "host.yaml").resolve()
+    logs_dir = (base / "logs").resolve()
 
     # Header with [host] prefix
     console.print()
@@ -680,9 +681,13 @@ def host(
             "host(lambda: Agent(...)) for per-request isolation.[/yellow]"
         )
 
-    # Resolve co_dir: explicit > cwd/.co (project default)
+    # Resolve co_dir: explicit > the project's .co, found by walking up.
+    # Not `Path.cwd() / '.co'`: an agent started one directory down found no
+    # host.yaml and ran on defaults -- a project that says `trust: strict` came
+    # up as `careful`, admitting contacts and accepting an invite code while its
+    # configuration said whitelist only.
     if co_dir is None:
-        co_dir = Path.cwd() / '.co'
+        co_dir = project_co_dir()
 
     # A server can host more than one agent, and only the port stops it: two of
     # them defaulting to 8000 means the second dies on "address already in use"

--- a/tests/unit/test_host_yaml_is_found_from_a_subdirectory.py
+++ b/tests/unit/test_host_yaml_is_found_from_a_subdirectory.py
@@ -1,0 +1,147 @@
+"""An agent started one directory down is still the agent host.yaml describes.
+
+`load_host_config` resolved against the bare cwd:
+
+    co_dir = Path.cwd() / '.co'
+
+so starting the agent from a subdirectory found no `host.yaml` and every value
+in it fell back to a default. Measured on a project whose file says
+`trust: careful` and `port: 8806`, with 88 permission entries:
+
+    from the project root       port 8806   trust careful   permissions 88
+    from a subdirectory of it   port None   trust None      permissions 0
+
+The three fall back in different directions:
+
+    port          -> 8000, so the agent listens somewhere else than configured
+    permissions   -> none auto-approved, so everything asks: safe
+    trust         -> "careful", the default in server.py
+
+The last one is the reason this is not merely untidy. A project that says
+`trust: strict` — whitelist only, no onboarding — runs as `careful` instead,
+which admits contacts and accepts an invite code. The configuration says one
+thing and the running agent enforces something looser, with nothing said.
+
+Same shape as #660, and the same rule applies: the directory that owns `.co/` is
+the project, not wherever the process was started. dashboard.py settled it for
+the Home page and wrote it down; #660 did the trust lists.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host.config import load_host_config
+
+
+@pytest.fixture
+def project(tmp_path):
+    co = tmp_path / "project" / ".co"
+    co.mkdir(parents=True)
+    (co / "host.yaml").write_text(
+        "name: configured\n"
+        "port: 8806\n"
+        "trust: strict\n"
+        "permissions:\n"
+        "  read_file:\n"
+        "    allowed: true\n"
+    )
+    (tmp_path / "project" / "subdir" / "deeper").mkdir(parents=True)
+    return tmp_path / "project"
+
+
+class TestFromASubdirectory:
+
+    def test_the_configured_port_is_used(self, project, monkeypatch):
+        monkeypatch.chdir(project / "subdir")
+
+        assert load_host_config(None).get("port") == 8806
+
+    def test_the_configured_trust_is_used(self, project, monkeypatch):
+        """The direction that matters: strict must not become careful."""
+        monkeypatch.chdir(project / "subdir")
+
+        assert load_host_config(None).get("trust") == "strict"
+
+    def test_the_permissions_come_with_it(self, project, monkeypatch):
+        monkeypatch.chdir(project / "subdir")
+
+        assert "read_file" in (load_host_config(None).get("permissions") or {})
+
+    def test_two_levels_down_as_well(self, project, monkeypatch):
+        monkeypatch.chdir(project / "subdir" / "deeper")
+
+        assert load_host_config(None).get("name") == "configured"
+
+
+class TestFromTheProjectRoot:
+    """Unchanged — this already worked."""
+
+    def test_it_still_reads_the_file(self, project, monkeypatch):
+        monkeypatch.chdir(project)
+
+        config = load_host_config(None)
+        assert config.get("port") == 8806
+        assert config.get("trust") == "strict"
+
+
+class TestWhatMustNotChange:
+
+    def test_an_explicit_co_dir_still_wins(self, project, tmp_path, monkeypatch):
+        other = tmp_path / "other" / ".co"
+        other.mkdir(parents=True)
+        (other / "host.yaml").write_text("name: explicit\nport: 9999\n")
+        monkeypatch.chdir(project)
+
+        assert load_host_config(other).get("port") == 9999
+
+    def test_code_parameters_still_override_the_file(self, project, monkeypatch):
+        monkeypatch.chdir(project / "subdir")
+
+        assert load_host_config(None, port=7777).get("port") == 7777
+
+    def test_outside_any_project_there_is_simply_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        assert load_host_config(None).get("port") is None
+
+
+class TestHostItselfUsesIt:
+    """A resolver the real path does not reach is the bug, not the fix.
+
+    `host()` computed `co_dir = Path.cwd() / '.co'` before calling
+    load_host_config, so fixing only the loader would have changed nothing for
+    an actual agent.
+    """
+
+    def test_the_configured_port_reaches_uvicorn(self, project, monkeypatch):
+        from connectonion import Agent, address
+        from connectonion.network.host import server as server_module
+
+        address.save(address.generate(), project / ".co")
+        monkeypatch.chdir(project / "subdir")
+
+        seen = {}
+        monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: seen.update(kw))
+        monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: None)
+
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+                           relay_url=None)
+
+        assert seen.get("port") == 8806
+
+    def test_the_configured_trust_is_what_it_serves(self, project, monkeypatch):
+        from connectonion import Agent, address
+        from connectonion.network.host import server as server_module
+
+        address.save(address.generate(), project / ".co")
+        monkeypatch.chdir(project / "subdir")
+
+        seen = {}
+        monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: None)
+        monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: seen.update(kw))
+
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+                           relay_url=None)
+
+        assert seen.get("trust") == "strict", "the agent served a looser trust than configured"

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -58,7 +58,9 @@ class TestLoggerInit:
         assert logger.enable_console is True
         assert logger.enable_sessions is True
         assert logger.enable_file is True
-        assert logger.log_file_path == Path(".co/logs/test-agent.log")
+        # Resolved, not relative: the Logger locates the project's .co by walking
+        # up, so a chdir after construction cannot move where it writes.
+        assert logger.log_file_path == Path(".co/logs/test-agent.log").resolve()
         assert logger.console is not None
 
     def test_quiet_mode(self):
@@ -291,7 +293,7 @@ class TestEvalLogging:
         logger.log_turn("Say hello to Alice", "Hello, Alice!", 1000, session, "gpt-4")
 
         # File should be created with slugified input name
-        assert logger.eval_file == Path(".co/evals/say_hello_to_alice.yaml")
+        assert logger.eval_file == Path(".co/evals/say_hello_to_alice.yaml").resolve()
         assert logger.eval_file.exists()
 
     def test_log_turn_creates_run_yaml_for_messages(self, tmp_path, monkeypatch):


### PR DESCRIPTION
`load_host_config` resolved against the bare cwd, so starting the agent from a subdirectory found no `host.yaml` and every value in it fell back to a default.

## Measured

A project whose file says `port: 8806`, `trust: careful`, 88 permission entries:

| run from | port | trust | permissions |
|---|---|---|---|
| the project root | 8806 | careful | 88 |
| a subdirectory of it | **None** | **None** | **0** |

They fall back in different directions:

- **port** → 8000, so the agent listens somewhere other than configured
- **permissions** → none auto-approved, so everything asks — safe
- **trust** → `"careful"`, the default in server.py

The last is why this is not merely untidy. A project that says **`trust: strict`** — whitelist only, no onboarding — runs as **`careful`** instead, admitting contacts and accepting an invite code, while its configuration says otherwise and nothing is printed.

## Two things had to change

**1. `host()` computed `co_dir = Path.cwd() / '.co'` itself** before calling the loader, so fixing only `load_host_config` would have left the real path untouched. Two tests drive `host()` and assert what reaches `uvicorn.run` and the banner — a resolver the real path does not reach is the bug, not the fix.

**2. `Logger` defaulted to `Path(".co")`, which *creates* one.** Constructing an Agent in a subdirectory made a `.co/logs/` there — and the scaffold builds the Agent *before* calling `host()`, so the scatter happened first and the walk-up then found that new `.co`. The fix would have defeated itself in exactly the standard layout. Measured before and after.

Same rule as #660, and as `dashboard.py` before it: the directory that owns `.co/` is the project, not wherever the process was started.

## Note on the duplicate resolver

There are now two small copies of the walk-up — one in `host/config.py`, one in `trust/tools.py` (#660) — rather than one shared definition. `host` imports `trust` (`server.py → TrustAgent`), so a shared home in either package closes an import cycle. Eight lines duplicated beats that; each names the other.

## Tests

10 tests, red first (4 failed, then 2 more once `host()` itself was driven). Two assertions in `test_logger.py` compared a relative path — same location, now resolved, and resolved is the point: a `chdir` after construction can no longer move where the logs go.

Full suite: 4308 passed.