### PR TITLE
A stray .co/ one directory down quietly replaces the project's own

### DIFF
--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -37,6 +37,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, Optional, List
 from dataclasses import dataclass
+from ....project import project_co_dir
 
 
 @dataclass
@@ -97,7 +98,7 @@ def discover_skills(base_path: Optional[Path] = None) -> List[SkillInfo]:
     if base_path:
         search_paths.append(base_path / ".co" / "skills")
     else:
-        search_paths.append(Path.cwd() / ".co" / "skills")
+        search_paths.append(project_co_dir() / "skills")
 
     # User-level skills
     home_skills = Path.home() / ".co" / "skills"

--- a/connectonion/cli/co_ai/tools/plan_mode.py
+++ b/connectonion/cli/co_ai/tools/plan_mode.py
@@ -33,6 +33,7 @@ State management:
 """
 
 from pathlib import Path
+from ....project import project_co_dir
 from rich.console import Console
 from rich.panel import Panel
 from rich.markdown import Markdown
@@ -52,7 +53,10 @@ console = Console()
 
 def get_plan_file_path(session_id: str = None) -> Path:
     """Get the plan file path, scoped by session ID."""
-    co_dir = Path.cwd() / ".co"
+    # The project's `.co/`, not one planted wherever `co ai` was started: the
+    # walk-up stops at the nearest `.co/`, so a stray one shadows the project's
+    # host.yaml and trust lists for everything run there afterwards.
+    co_dir = project_co_dir()
     co_dir.mkdir(exist_ok=True)
     if session_id:
         return co_dir / f"PLAN_{session_id}.md"

--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -18,6 +18,7 @@ import re
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from ...project import project_co_dir
 from typing import List, Optional
 
 from rich.console import Console
@@ -30,17 +31,29 @@ SKILLS_DIR = CO_HOME / "skills"
 INDEX_FILE = SKILLS_DIR / "index.json"
 AGENT_JSON = CO_HOME / "agent.json"
 
+def project_skills_dir() -> Path:
+    """`.co/skills` in the project, wherever `co` was run from.
+
+    Resolved per call. As a module-level constant this was `Path.cwd() / '.co'`
+    evaluated at *import* time, so it named the directory the process started in
+    and nothing could change it afterwards. `--to-project` then mkdir'd it,
+    which plants a `.co/` that shadows the project's own for every later lookup.
+    """
+    return project_co_dir() / "skills"
+
+
 # Sources mirror oo/lib/fanout.py — same agents, read direction.
 # Each entry: (source_id, root_path, layout)
 # layout: "skill-dir" → root/<name>/SKILL.md, "flat-md" → root/<name>.md, "mdc" → root/<name>.mdc
-SOURCES = [
-    ("co-project", Path.cwd() / ".co" / "skills", "skill-dir"),
-    ("co-user",    Path.home() / ".co" / "skills", "skill-dir"),
-    ("claude",     Path.home() / ".claude" / "skills", "skill-dir"),
-    ("codex",      Path.home() / ".codex" / "skills", "skill-dir"),
-    ("cursor",     Path.home() / ".cursor" / "rules", "mdc"),
-    ("kiro",       Path.home() / ".kiro" / "steering", "flat-md"),
-]
+def sources() -> list:
+    return [
+        ("co-project", project_skills_dir(), "skill-dir"),
+        ("co-user",    Path.home() / ".co" / "skills", "skill-dir"),
+        ("claude",     Path.home() / ".claude" / "skills", "skill-dir"),
+        ("codex",      Path.home() / ".codex" / "skills", "skill-dir"),
+        ("cursor",     Path.home() / ".cursor" / "rules", "mdc"),
+        ("kiro",       Path.home() / ".kiro" / "steering", "flat-md"),
+    ]
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
@@ -95,7 +108,7 @@ def _entry(source_id: str, fallback_name: str, path: Path) -> dict:
 def handle_skills_discover(save: bool = True, json_out: bool = False, include_namespaced: bool = False):
     """Scan known agent skill roots and print/save an index."""
     all_skills: list = []
-    for source_id, root, layout in SOURCES:
+    for source_id, root, layout in sources():
         all_skills.extend(scan_source(source_id, root, layout))
 
     if not include_namespaced:
@@ -113,7 +126,7 @@ def handle_skills_discover(save: bool = True, json_out: bool = False, include_na
 
     index = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "sources": [src for src, _, _ in SOURCES],
+        "sources": [src for src, _, _ in sources()],
         "skills": deduped,
     }
 
@@ -145,7 +158,14 @@ def _load_index() -> Optional[dict]:
     return json.loads(INDEX_FILE.read_text(encoding="utf-8"))
 
 
-SOURCE_PRIORITY = {src: i for i, (src, _, _) in enumerate(SOURCES)}
+def source_priority() -> dict:
+    """Priority by source, in the order `sources()` lists them.
+
+    A function, not a constant: as a constant it ran `sources()` at import
+    time, which resolves the project directory — the very thing this module
+    stopped doing at import time.
+    """
+    return {src: i for i, (src, _, _) in enumerate(sources())}
 
 
 # What a skill must not carry with it. VERSIONING.md put it plainly when the
@@ -262,7 +282,7 @@ def handle_skills_copy(
         console.print("[yellow]No index found. Run `co skills discover` first.[/yellow]")
         return
 
-    skills_dir = (Path.cwd() / ".co" / "skills") if to_project else SKILLS_DIR
+    skills_dir = project_skills_dir() if to_project else SKILLS_DIR
     skills_dir.mkdir(parents=True, exist_ok=True)
 
     by_name: dict = {}
@@ -271,11 +291,12 @@ def handle_skills_copy(
 
     if all_:
         candidates = [s for s in index["skills"] if not source or s["source"] == source]
-        # Dedupe by name using SOURCES priority order (co-project > co-user > claude > ...)
+        # Dedupe by name using source priority order (co-project > co-user > claude > ...)
+        priority = source_priority()
         chosen: dict = {}
         for s in candidates:
             existing = chosen.get(s["name"])
-            if existing is None or SOURCE_PRIORITY[s["source"]] < SOURCE_PRIORITY[existing["source"]]:
+            if existing is None or priority[s["source"]] < priority[existing["source"]]:
                 chosen[s["name"]] = s
 
         copied = skipped = 0

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -27,25 +27,9 @@ from .core.usage import totals_from_trace
 KEEP_RUNS_PER_EVAL = 20
 
 
-def _project_co_dir(start=None) -> Path:
-    """The project's `.co/`, found by walking up -- not `Path(".co")`.
-
-    A bare `.co` is created wherever the Agent happens to be constructed, so a
-    script run from a subdirectory of its own project got a second `.co/logs/`
-    there. That is untidy on its own, and it defeats the rule the rest of the
-    agent follows: host.yaml and the trust lists are located by walking up
-    (#660), and a scattered `.co` stops that walk at the wrong directory. The
-    scaffold builds the Agent before calling host(), so the scatter happens
-    first and the walk finds it.
-
-    Falls back to the starting directory when there is no `.co/` above, which is
-    a fresh project's first run -- the logs land where it was started, as before.
-    """
-    start = Path(start or Path.cwd()).resolve()
-    for directory in (start, *start.parents):
-        if (directory / ".co").is_dir():
-            return directory / ".co"
-    return start / ".co"
+# The project's `.co/`, found by walking up -- not `Path(".co")`, which creates
+# one wherever the Agent happens to be constructed. See connectonion/project.py.
+from .project import project_co_dir as _project_co_dir
 
 
 def _slugify(text: str, max_length: int = 50) -> str:

--- a/connectonion/network/host/config.py
+++ b/connectonion/network/host/config.py
@@ -28,37 +28,9 @@ DEFAULT_FILE_LIMITS = {
 }
 
 
-def project_co_dir(start=None) -> Path:
-    """The `.co/` that belongs to this agent -- the project's, not the one beside
-    wherever the process was started.
-
-    This resolved against the bare cwd, so an agent started one directory down
-    found no host.yaml and every value in it fell back to a default. Measured on
-    a project whose file says trust: careful, port: 8806, 88 permission entries:
-
-        from the project root      port 8806   trust careful   permissions 88
-        from a subdirectory of it  port None   trust None      permissions 0
-
-    They fall back in different directions. The port lands on 8000, so the agent
-    listens somewhere else. The permissions land on none, so everything asks --
-    safe. Trust lands on "careful" (server.py), so a project that says `strict`
-    runs as `careful` instead: it admits contacts and accepts an invite code,
-    while its configuration says whitelist only.
-
-    Walking up is how the rest of the agent is found, and the rule is written
-    down in dashboard.py -- "the project, not wherever you ran from" -- after the
-    same bug hit the Home page. #660 did the trust lists.
-
-    There is a second copy of this in network/trust/tools.py rather than one
-    shared definition: host imports trust (server.py -> TrustAgent), so a shared
-    home in either package would close a cycle. Eight lines duplicated beats an
-    import loop; if a third caller appears, that is the time to find it a home.
-    """
-    start = Path(start or Path.cwd()).resolve()
-    for directory in (start, *start.parents):
-        if (directory / '.co').is_dir():
-            return directory / '.co'
-    return start / '.co'
+# The `.co/` that belongs to this agent -- the project's, not the one beside
+# wherever the process was started. See connectonion/project.py.
+from ...project import project_co_dir
 
 
 def load_host_config(co_dir: Path = None, **code_params) -> dict:

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -47,22 +47,8 @@ _project_dir = None
 _agent_metadata = None
 
 
-def project_root(start=None):
-    """The directory that owns ``.co/`` — the project, not wherever you ran from.
-
-    Walks up from ``start``. Everything else the agent is made of is found this way
-    (``.co/skills``, ``.co/host.yaml``), and the Home page had no such notion: it
-    resolved against the bare cwd, so running the agent from a subdirectory created
-    a second dashboard.html there and served that one instead.
-
-    Falls back to ``start`` when there is no ``.co/`` above it — an agent hosted
-    outside a project still gets a Home, it just lives where it was started.
-    """
-    start = Path(start or Path.cwd()).resolve()
-    for directory in (start, *start.parents):
-        if (directory / CO_DIR).is_dir():
-            return directory
-    return start
+# The directory that owns `.co/`. See connectonion/project.py.
+from ....project import project_root
 
 
 def dashboard_path():

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -53,37 +53,9 @@ def _mention_a_legacy_list(list_name: str) -> None:
           f"{list_file(list_name)}.")
 
 
-def _project_co_dir(start=None) -> Path:
-    """The `.co/` that belongs to this agent — the project's, not the one beside
-    wherever the process happens to be standing.
-
-    These resolved against the bare cwd, so running the agent one directory down
-    looked for `subdir/.co/contacts.txt`. Measured on a project with a real
-    contact and a real block in its lists:
-
-        from the project root      -> contact
-        from a subdirectory of it  -> stranger
-
-    The directions are not symmetric. A contact or a whitelisted address demoted
-    to stranger is refused, which is safe. A blocked address demoted to stranger
-    is no longer blocked -- is_blocked() reads the same list -- so someone who
-    was blocked gets back in because of where the process was started.
-
-    Walking up is how everything else the agent is made of is found (.co/skills,
-    .co/host.yaml), and it is what dashboard.py settled on for the Home page
-    after the same bug: "the project, not wherever you ran from". It also closes
-    the other half of the hazard that comment names -- a tool or a plugin calling
-    os.chdir mid-run, after which every later check would read somewhere else.
-
-    Falls back to the starting directory when there is no `.co/` above it, so an
-    agent hosted outside a project still has lists; they just live where it was
-    started.
-    """
-    start = Path(start or Path.cwd()).resolve()
-    for directory in (start, *start.parents):
-        if (directory / ".co").is_dir():
-            return directory / ".co"
-    return start / ".co"
+# The `.co/` that belongs to this agent. A blocked address read from the wrong
+# list comes back a stranger, so this one fails open. See connectonion/project.py.
+from ...project import project_co_dir as _project_co_dir
 
 
 def _admins_file(co_dir: Path = None) -> Path:
@@ -397,7 +369,7 @@ def load_admins(co_dir: Path = None) -> set:
     admins = set()
 
     if co_dir is None:
-        co_dir = Path.cwd() / ".co"
+        co_dir = _project_co_dir()
 
     # Self address is always admin. Through get_self_address, which reads
     # `.co/keys/` and falls back to the older `.co/address.json` — this used to
@@ -460,7 +432,7 @@ def get_self_address(co_dir: Path = None) -> str | None:
     import json
 
     if co_dir is None:
-        co_dir = Path.cwd() / ".co"
+        co_dir = _project_co_dir()
 
     from ... import address
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -53,6 +53,7 @@ Extensibility:
 
 from dataclasses import dataclass
 from pathlib import Path
+from ...project import project_co_dir
 from typing import Optional
 import logging
 
@@ -300,7 +301,7 @@ justify admitting them, it is not enough."""
         # Load agent's keys for signing the request
         from ... import address as addr
 
-        co_dir = Path.cwd() / '.co'
+        co_dir = project_co_dir()
         keys = addr.load(co_dir)
         if not keys:
             return False

--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -1,0 +1,41 @@
+"""Where the project is.
+
+The directory that owns ``.co/`` is the project, not wherever the process was
+started. An agent run from a subdirectory is the same agent, with the same
+skills, the same trust lists and the same ``host.yaml``.
+
+This walk was written five times before it had a home — in the dashboard, the
+logger, the host config, the trust lists — and each copy was added by a separate
+bug where something resolved against the bare cwd instead. Two of those bugs
+failed open: a project configured ``trust: strict`` ran as ``careful``, and an
+address on the blocklist read back as a stranger.
+
+Nothing here creates a directory. Creating ``.co/`` wherever you happen to be
+standing is the other half of the same bug: the walk stops at the *nearest*
+``.co/``, so a stray one shadows the project's own for everything that comes
+after it.
+"""
+
+from pathlib import Path
+from typing import Optional, Union
+
+
+CO_DIR = ".co"
+
+
+def project_root(start: Optional[Union[str, Path]] = None) -> Path:
+    """The directory that owns ``.co/``, found by walking up from ``start``.
+
+    Falls back to ``start`` when there is no ``.co/`` above it — an agent hosted
+    outside a project still works, its files just live where it was started.
+    """
+    start = Path(start or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        if (directory / CO_DIR).is_dir():
+            return directory
+    return start
+
+
+def project_co_dir(start: Optional[Union[str, Path]] = None) -> Path:
+    """The project's ``.co/``. Does not create it."""
+    return project_root(start) / CO_DIR

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -73,6 +73,7 @@ from typing import TYPE_CHECKING, Optional, Dict, Any, List
 from copy import deepcopy
 
 from ..core.events import after_user_input, on_complete, before_each_tool, on_agent_ready
+from ..project import project_co_dir, project_root
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -128,10 +129,10 @@ def _get_skill_paths(skill_name: str) -> List[Path]:
     home = Path.home()
 
     # 1. Project-level ConnectOnion: .co/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.co' / 'skills' / skill_name / 'SKILL.md')
+    paths.append(project_co_dir() / 'skills' / skill_name / 'SKILL.md')
 
     # 2. Project-level Claude Code: .claude/skills/skill-name/SKILL.md
-    paths.append(Path.cwd() / '.claude' / 'skills' / skill_name / 'SKILL.md')
+    paths.append(project_root() / '.claude' / 'skills' / skill_name / 'SKILL.md')
 
     # 3. User-level ConnectOnion: ~/.co/skills/skill-name/SKILL.md
     paths.append(home / '.co' / 'skills' / skill_name / 'SKILL.md')

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Dict, Any, List
 
 from ..core.events import on_agent_ready
+from ..project import project_co_dir
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -49,7 +50,7 @@ def _get_agent_paths(agent_name: str) -> List[Path]:
     paths = []
 
     # 1. Project-level
-    paths.append(Path.cwd() / '.co' / 'agents' / agent_name / 'AGENT.md')
+    paths.append(project_co_dir() / 'agents' / agent_name / 'AGENT.md')
 
     # 2. User-level
     paths.append(Path.home() / '.co' / 'agents' / agent_name / 'AGENT.md')
@@ -100,7 +101,7 @@ def _discover_all_agents() -> List[Dict[str, str]]:
     seen_names = set()
 
     for location, base_path in [
-        ('project', Path.cwd() / '.co' / 'agents'),
+        ('project', project_co_dir() / 'agents'),
         ('user', Path.home() / '.co' / 'agents'),
         ('builtin', Path(__file__).parent / 'builtin_agents')
     ]:

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -204,6 +204,7 @@ from pathlib import Path
 
 from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
 from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
+from ...project import project_co_dir
 from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
 
 if TYPE_CHECKING:
@@ -702,7 +703,7 @@ def load_permission_patterns(co_dir=None) -> dict:
         if template_permissions and isinstance(template_permissions, dict):
             permissions.update(_convert_permission_patterns(template_permissions))
 
-    co_dir = Path(co_dir) if co_dir else (Path.cwd() / '.co')
+    co_dir = Path(co_dir) if co_dir else project_co_dir()
     host_yaml = co_dir / 'host.yaml'
     if host_yaml.exists():
         with open(host_yaml, 'r', encoding='utf-8') as f:
@@ -777,7 +778,7 @@ def load_config_permissions(agent: 'Agent') -> None:
 
     # Reuse the shared loader — template safe defaults + project host.yaml —
     # so the session flow and direct EXEC honor one whitelist.
-    co_dir = Path.cwd() / '.co'
+    co_dir = project_co_dir()
     host_yaml = co_dir / 'host.yaml'
     loaded = load_permission_patterns(co_dir)
 

--- a/tests/unit/test_nothing_scatters_a_decoy_co_directory.py
+++ b/tests/unit/test_nothing_scatters_a_decoy_co_directory.py
@@ -1,0 +1,300 @@
+"""A stray `.co/` one directory down quietly replaces the project's own.
+
+#660 and #661 made the rule: the directory that owns `.co/` is the project, and
+everything walks up to find it. The walk-up stops at the *nearest* `.co/`. That
+makes any code which creates a `.co/` wherever it happens to be standing far more
+dangerous than it was before those two fixes — it does not merely leave a stray
+directory, it plants a decoy that every later lookup finds first.
+
+`plan_mode.get_plan_file_path` does exactly that:
+
+    co_dir = Path.cwd() / ".co"
+    co_dir.mkdir(exist_ok=True)
+
+Measured on a project whose `.co/host.yaml` says `trust: strict` and whose
+`.co/blocklist.txt` holds an address, running `co ai` from a subdirectory:
+
+    BEFORE plan mode: trust=strict  blocked=True
+    plan mode created: True
+    AFTER  plan mode: trust=None    blocked=False
+
+Both flips are fail-open, and both persist: the decoy stays on disk, so every
+later run from that subdirectory reads it. A project configured whitelist-only
+admits contacts and accepts an invite code, and an address the operator blocked
+is no longer blocked — because someone once opened plan mode in a subdirectory.
+
+Logger had the same shape and #661 fixed it. This is the remaining creator, and
+the same round found four readers still resolving against the bare cwd:
+project skills, project subagents, the co_ai skill loader, and the permission
+whitelist the approval plugin reads out of the same `host.yaml` that #661 taught
+`host()` to walk up for — so today one half of that file is found from a
+subdirectory and the other half is not.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+BLOCKED = "0x" + "b" * 64
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """A configured project with a subdirectory to run from."""
+    co = tmp_path / "project" / ".co"
+    (co / "skills" / "mine").mkdir(parents=True)
+    (co / "agents" / "helper").mkdir(parents=True)
+    (co / "host.yaml").write_text(
+        "name: real\n"
+        "port: 8806\n"
+        "trust: strict\n"
+        "permissions:\n"
+        "  my_project_tool:\n"
+        "    allowed: true\n"
+    )
+    (co / "blocklist.txt").write_text(BLOCKED + "\n")
+    (co / "skills" / "mine" / "SKILL.md").write_text(
+        "---\nname: mine\ndescription: d\n---\n\nDo it.\n"
+    )
+    (co / "agents" / "helper" / "AGENT.md").write_text(
+        "---\nname: helper\ndescription: d\n---\n\nHelp.\n"
+    )
+    (tmp_path / "project" / "sub" / "deeper").mkdir(parents=True)
+
+    from connectonion.network.trust import tools
+    monkeypatch.setattr(tools, "_mentioned", set(), raising=False)
+    return tmp_path / "project"
+
+
+class TestPlanModePlantsNoDecoy:
+    """The creator. This is the one that makes the others permanent."""
+
+    def test_no_co_directory_appears_in_the_subdirectory(self, project, monkeypatch):
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+
+        monkeypatch.chdir(project / "sub")
+        get_plan_file_path("s1")
+
+        assert not (project / "sub" / ".co").exists(), "plan mode planted a decoy .co/"
+
+    def test_the_plan_goes_to_the_projects_own_co(self, project, monkeypatch):
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+
+        monkeypatch.chdir(project / "sub")
+
+        assert get_plan_file_path("s1").parent == project / ".co"
+
+    def test_trust_survives_it(self, project, monkeypatch):
+        """The consequence that matters: strict must not become the default."""
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+        from connectonion.network.host.config import load_host_config
+
+        monkeypatch.chdir(project / "sub")
+        get_plan_file_path("s1")
+
+        assert load_host_config(None).get("trust") == "strict"
+
+    def test_a_blocked_address_stays_blocked(self, project, monkeypatch):
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+        from connectonion.network.trust.tools import is_blocked
+
+        monkeypatch.chdir(project / "sub")
+        get_plan_file_path("s1")
+
+        assert is_blocked(BLOCKED), "opening plan mode un-blocked a blocked address"
+
+    def test_outside_any_project_it_still_works(self, tmp_path, monkeypatch):
+        """No project above us — plan mode must still have somewhere to write."""
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+
+        monkeypatch.chdir(tmp_path)
+        path = get_plan_file_path("s1")
+
+        assert path.parent == tmp_path / ".co"
+        assert path.parent.is_dir(), "it must still create one where there is no project"
+
+    def test_the_session_id_still_scopes_the_file(self, project, monkeypatch):
+        from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path
+
+        monkeypatch.chdir(project / "sub")
+
+        assert get_plan_file_path("abc").name == "PLAN_abc.md"
+        assert get_plan_file_path(None).name != "PLAN_abc.md"
+
+
+class TestTheReadersWalkUpToo:
+    """Four lookups that still resolved against the bare cwd."""
+
+    def test_a_project_skill_is_found(self, project, monkeypatch):
+        from connectonion.useful_plugins.skills import _load_skill
+
+        monkeypatch.chdir(project / "sub")
+
+        assert _load_skill("mine") is not None
+
+    def test_the_co_ai_loader_sees_it(self, project, monkeypatch):
+        from connectonion.cli.co_ai.skills.loader import discover_skills
+
+        monkeypatch.chdir(project / "sub")
+
+        assert any(s.name == "mine" for s in discover_skills())
+
+    def test_a_project_subagent_is_found(self, project, monkeypatch):
+        from connectonion.useful_plugins.subagents import _discover_all_agents
+
+        monkeypatch.chdir(project / "sub")
+
+        assert any(a["name"] == "helper" for a in _discover_all_agents())
+
+    def test_the_permission_whitelist_comes_from_the_project(self, project, monkeypatch):
+        """#661 taught `host()` to walk up for host.yaml; the approval plugin
+        reads permissions out of the same file and did not."""
+        from connectonion.useful_plugins.tool_approval.approval import (
+            load_permission_patterns,
+        )
+
+        monkeypatch.chdir(project / "sub")
+
+        assert "my_project_tool" in load_permission_patterns(None)
+
+    def test_two_levels_down_as_well(self, project, monkeypatch):
+        from connectonion.useful_plugins.skills import _load_skill
+
+        monkeypatch.chdir(project / "sub" / "deeper")
+
+        assert _load_skill("mine") is not None
+
+
+class TestFromTheProjectRoot:
+    """Unchanged — all of this already worked."""
+
+    def test_the_skill_is_still_found(self, project, monkeypatch):
+        from connectonion.useful_plugins.skills import _load_skill
+
+        monkeypatch.chdir(project)
+
+        assert _load_skill("mine") is not None
+
+    def test_the_permission_is_still_read(self, project, monkeypatch):
+        from connectonion.useful_plugins.tool_approval.approval import (
+            load_permission_patterns,
+        )
+
+        monkeypatch.chdir(project)
+
+        assert "my_project_tool" in load_permission_patterns(None)
+
+
+class TestWhatMustNotChange:
+
+    def test_user_level_skills_are_still_reached(self, project, monkeypatch, tmp_path):
+        """Walking up must not cost the ~/.co fallback."""
+        from connectonion.useful_plugins.skills import _get_skill_paths
+
+        monkeypatch.chdir(project / "sub")
+        paths = [str(p) for p in _get_skill_paths("anything")]
+
+        assert any(str(Path.home() / ".co") in p for p in paths)
+
+    def test_an_explicit_base_path_still_wins(self, project, tmp_path, monkeypatch):
+        from connectonion.cli.co_ai.skills.loader import discover_skills
+
+        elsewhere = tmp_path / "elsewhere"
+        (elsewhere / ".co" / "skills" / "other").mkdir(parents=True)
+        (elsewhere / ".co" / "skills" / "other" / "SKILL.md").write_text(
+            "---\nname: other\ndescription: d\n---\n\nGo.\n"
+        )
+        monkeypatch.chdir(project)
+
+        assert any(s.name == "other" for s in discover_skills(base_path=elsewhere))
+
+    def test_outside_any_project_the_cwd_is_used(self, tmp_path, monkeypatch):
+        from connectonion.useful_plugins.skills import _load_skill
+
+        (tmp_path / ".co" / "skills" / "loose").mkdir(parents=True)
+        (tmp_path / ".co" / "skills" / "loose" / "SKILL.md").write_text(
+            "---\nname: loose\ndescription: d\n---\n\nGo.\n"
+        )
+        monkeypatch.chdir(tmp_path)
+
+        assert _load_skill("loose") is not None
+
+
+class TestTheSecondCreator:
+    """`co skills copy --to-project` plants one too.
+
+        skills_dir = (Path.cwd() / ".co" / "skills") if to_project else SKILLS_DIR
+        skills_dir.mkdir(parents=True, exist_ok=True)
+
+    The point of `--to-project` is that a deploy will find the skill. Run from a
+    subdirectory it puts the skill somewhere no deploy looks *and* leaves a decoy
+    `.co/` behind that shadows the project's own from then on.
+    """
+
+    def test_no_decoy_appears(self, project, monkeypatch, tmp_path):
+        from connectonion.cli.commands.skills_commands import _copy_entry
+        from connectonion.cli.commands import skills_commands
+
+        src = tmp_path / "src" / "new"
+        src.mkdir(parents=True)
+        (src / "SKILL.md").write_text("---\nname: new\ndescription: d\n---\n\nGo.\n")
+        monkeypatch.chdir(project / "sub")
+
+        _copy_entry({"name": "new", "path": str(src / "SKILL.md"), "source": "t"},
+                    force=True, skills_dir=skills_commands.project_skills_dir())
+
+        assert not (project / "sub" / ".co").exists()
+
+    def test_it_lands_where_a_deploy_looks(self, project, monkeypatch, tmp_path):
+        from connectonion.cli.commands.skills_commands import _copy_entry
+        from connectonion.cli.commands import skills_commands
+
+        src = tmp_path / "src" / "new"
+        src.mkdir(parents=True)
+        (src / "SKILL.md").write_text("---\nname: new\ndescription: d\n---\n\nGo.\n")
+        monkeypatch.chdir(project / "sub")
+
+        _copy_entry({"name": "new", "path": str(src / "SKILL.md"), "source": "t"},
+                    force=True, skills_dir=skills_commands.project_skills_dir())
+
+        assert (project / ".co" / "skills" / "new" / "SKILL.md").exists()
+
+
+class TestTrustIsConsistentWithItself:
+    """`list_file` walks up (#660); two functions in the same file did not.
+
+    Both fail safe on their own — no admins found, no self address — but the
+    split means one half of trust answers for the project and the other half
+    answers for wherever the process was standing. The visible cost: an agent
+    onboarding by payment advertises `methods: ["payment"]` and no
+    `payment_address`, so the client is told to pay and not told where.
+    """
+
+    def test_the_admins_are_the_projects_admins(self, project, monkeypatch):
+        from connectonion.network.trust.tools import load_admins
+
+        (project / ".co" / "admins.txt").write_text("0x" + "a" * 64 + "\n")
+        monkeypatch.chdir(project / "sub")
+
+        assert "0x" + "a" * 64 in load_admins()
+
+    def test_the_self_address_is_the_projects(self, project, monkeypatch):
+        from connectonion import address
+        from connectonion.network.trust.tools import get_self_address
+
+        saved = address.generate()
+        address.save(saved, project / ".co")
+        monkeypatch.chdir(project / "sub")
+
+        assert get_self_address() == saved["address"]
+
+    def test_an_explicit_co_dir_still_wins(self, project, tmp_path, monkeypatch):
+        from connectonion.network.trust.tools import load_admins
+
+        other = tmp_path / "other" / ".co"
+        other.mkdir(parents=True)
+        (other / "admins.txt").write_text("0x" + "c" * 64 + "\n")
+        monkeypatch.chdir(project)
+
+        assert "0x" + "c" * 64 in load_admins(other)


### PR DESCRIPTION
## What

`#660`/`#661` made walking up to the project's `.co/` the rule. The walk stops at the **nearest** `.co/`, so anything that *creates* one where it happens to be standing now plants a decoy that shadows the project's own for everything afterwards.

Measured on a real `co init` project (`trust: strict`, one permission), run from `deep/nested/`:

| | main | this PR |
|---|---|---|
| trust | `strict` | `strict` |
| project permission honoured | **False** | True |
| plan file | `nested/.co/PLAN_s.md` | `<project>/.co/PLAN_s.md` |
| decoy `.co/` planted | **yes** | no |
| trust, read again afterwards | **None** | `strict` |

That last row is the cost: one `co ai` plan-mode run from a subdirectory permanently downgrades a `trust: strict` project to the default (`careful` — admits contacts, accepts invite codes) and un-blocks blocked addresses, because the decoy stays on disk.

## Two creators

- `plan_mode.get_plan_file_path` — `Path.cwd() / ".co"` then `mkdir`
- `co skills copy --to-project` — same, and its `SOURCES` table resolved the cwd at **import** time, so it named the process's starting directory and nothing could change it later

## Six readers still on the bare cwd

project skills, project subagents, the `co_ai` skill loader, the permission whitelist, `load_admins`, `get_self_address`, and the trust agent's own key load.

The whitelist is the sharpest: `#661` taught `host()` to walk up for `host.yaml`, and the approval plugin reads `permissions` out of that same file and did not — one half of the file found from a subdirectory, the other not. `trust/tools.py` had the same split *inside one file*: `list_file` walked up, `load_admins` did not.

All six fail in the safe direction on their own (fewer skills, fewer admins, fewer auto-approvals). They are in here because the split itself is the bug, and because `1.6.0` is long-term support.

## One home for the walk

It had been written five times — dashboard, logger, host config, trust lists — once per bug that needed it. `connectonion/project.py` now holds it and those four point at it.

## Tests

`tests/unit/test_nothing_scatters_a_decoy_co_directory.py`, 21 cases, each proven to fail first (including reverting the trust hunk to re-prove the two that initially errored on a wrong function name). Full suite **4330 passed**.

## Not in scope

`co status`, `co keys`, `co auth`, `co doctor` still resolve `Path(".co")` against the cwd. They report rather than enforce, and no test drove them here — filed separately.