### PR TITLE
from connectonion.logger import Logger raises ImportError

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -53,8 +53,14 @@ for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
 # effect. `tui` and `useful_plugins` are re-exported by nobody, which is exactly
 # why they are listed: removing a name that used to resolve is not something a
 # startup-time change should do quietly. Naming one here does not import it.
-_SUBMODULES = ("address", "core", "debug", "logger", "network", "prompts",
-               "tui", "useful_plugins", "useful_tools")
+# Every submodule that resolved as an attribute before the package went lazy.
+# The eager imports set these as a side effect; nothing does now, so each one
+# has to be named. #632 named most of them and missed console, derive and
+# useful_events_handlers -- each measured, one interpreter per attribute,
+# because accessing any one of them imports the others and hides the gap.
+_SUBMODULES = ("address", "console", "core", "debug", "derive", "logger",
+               "network", "prompts", "tui", "useful_events_handlers",
+               "useful_plugins", "useful_tools")
 
 _FROM = {
     **{name: ".core" for name in (

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -19,7 +19,6 @@ from typing import Optional, Union, Dict, Any, List
 import yaml
 
 from .console import Console
-from .core.usage import totals_from_trace
 
 # How many run_N.yaml files to keep per eval. They hold the full message array
 # of one turn, nothing in the code reads them back, and an agent on a schedule
@@ -272,6 +271,13 @@ class Logger:
         # Aggregate from trace
         trace = session.get('trace', [])
         tool_calls = [t for t in trace if t.get('type') == 'tool_result']
+        # Imported here, not at module level: `.core.usage` runs
+        # `connectonion.core.__init__`, which imports Agent, which imports
+        # Logger from this module -- so `import connectonion.logger` in a
+        # process that has not already loaded core died on the cycle. The
+        # eager imports used to hide it; #631 removed them.
+        from .core.usage import totals_from_trace
+
         total_tokens, total_cost = totals_from_trace(trace)
 
         # Build metadata as compact JSON string

--- a/tests/unit/test_a_submodule_can_be_imported_on_its_own.py
+++ b/tests/unit/test_a_submodule_can_be_imported_on_its_own.py
@@ -1,0 +1,123 @@
+"""`from connectonion.logger import Logger` raises ImportError.
+
+A regression from #631, which stopped `connectonion/__init__.py` importing the
+framework eagerly so that `co --version` did not have to pay for it. The eager
+imports had been hiding a cycle:
+
+    connectonion.logger
+      -> from .core.usage import totals_from_trace     (line 22)
+      -> connectonion.core.__init__
+      -> from .agent import Agent
+      -> from ..logger import Logger                   -- logger is on line 22
+
+Before #631 something always pulled `connectonion.core` in first, so the cycle
+was never entered from this side. Now nothing does. Measured at 6863e45~1 (the
+commit before #631) against today's main:
+
+    import connectonion.logger                        worked  -> ImportError
+    from connectonion.logger import Logger            worked  -> ImportError
+    import connectonion; connectonion.logger          worked  -> ImportError
+
+The third is the lazy package's own attribute access, so the failure is reached
+through `connectonion.logger` as well as through a direct import.
+
+It only shows in a process that has not already imported `connectonion.core`,
+which is why nothing caught it: `from connectonion import Agent` imports core on
+the way, and every test and every entry point does that first. A user who writes
+`from connectonion.logger import Logger` in a fresh script does not.
+
+Each case therefore runs in its own interpreter. Asserting this inside the test
+process proves nothing — by then core is long since imported.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _in_a_fresh_interpreter(code: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO, capture_output=True, text=True, timeout=120,
+    )
+
+
+# Every submodule the package promises as an attribute. logger is the one that
+# broke; the rest are here so the next import added to one of them is caught.
+# Real top-level modules of the package.
+SUBMODULES = [
+    "address", "console", "core", "debug", "derive", "logger",
+    "network", "prompts", "tui", "useful_events_handlers", "useful_plugins",
+    "useful_tools",
+]
+
+# Everything that resolved as `connectonion.<name>` before the package went
+# lazy, measured at 6863e45~1. `announce` and `relay` live under
+# `connectonion.network` and were only ever attributes, never importable paths.
+ATTRIBUTES = SUBMODULES + ["announce", "relay"]
+
+
+class TestImportedFirstInACleanProcess:
+
+    @pytest.mark.parametrize("module", SUBMODULES)
+    def test_the_submodule_imports(self, module):
+        result = _in_a_fresh_interpreter(f"import connectonion.{module}")
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]
+
+    def test_the_logger_class_can_be_imported_directly(self):
+        """The shape a user actually writes."""
+        result = _in_a_fresh_interpreter(
+            "from connectonion.logger import Logger; print(Logger.__name__)"
+        )
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]
+        assert "Logger" in result.stdout
+
+    @pytest.mark.parametrize("module", ATTRIBUTES)
+    def test_the_lazy_attribute_resolves(self, module):
+        """`import connectonion` then `connectonion.<name>` — the path #631 added."""
+        result = _in_a_fresh_interpreter(
+            f"import connectonion; assert connectonion.{module}.__name__"
+        )
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]
+
+
+class TestTheUsualOrderStillWorks:
+    """What every entry point does today — must not regress while fixing the above."""
+
+    def test_agent_first(self):
+        result = _in_a_fresh_interpreter(
+            "from connectonion import Agent; from connectonion.logger import Logger"
+        )
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]
+
+    def test_core_first(self):
+        result = _in_a_fresh_interpreter(
+            "import connectonion.core; import connectonion.logger"
+        )
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]
+
+
+class TestTheLoggerStillCountsTokens:
+    """The import being moved is the one that does the counting."""
+
+    def test_totals_from_trace_is_reachable_from_the_logger(self):
+        """It moved into the function; it must still be the same one."""
+        result = _in_a_fresh_interpreter(
+            "import connectonion.logger as l\n"
+            "from connectonion.core.usage import totals_from_trace as t\n"
+            "import inspect; src = inspect.getsource(l)\n"
+            "assert 'totals_from_trace' in src\n"
+            "print(t([]))"
+        )
+
+        assert result.returncode == 0, result.stderr.strip().splitlines()[-1:]


### PR DESCRIPTION
## What

Four attributes that resolved before the package went lazy do not any more. Measured at `6863e45~1` (the commit before #631) against today's `main`, **one interpreter per case** — accessing any one of them imports the others and hides the gap, which is why the earlier sweep saw nothing:

| | before #631 | main |
|---|---|---|
| `import connectonion.logger` | ok | **ImportError** |
| `from connectonion.logger import Logger` | ok | **ImportError** |
| `connectonion.logger` | ok | **ImportError** |
| `connectonion.console` | ok | **AttributeError** |
| `connectonion.derive` | ok | **AttributeError** |
| `connectonion.useful_events_handlers` | ok | **AttributeError** |

## The cycle

```
connectonion.logger
  -> from .core.usage import totals_from_trace     (line 22)
  -> connectonion.core.__init__ -> from .agent import Agent
  -> from ..logger import Logger                   <- logger is still on line 22
```

`#631` removed the eager imports in `__init__.py` that used to guarantee `core` went first. Every test and entry point still does `from connectonion import Agent`, which imports core on the way — so nothing in the suite reaches the broken order. A user writing `from connectonion.logger import Logger` in a fresh script does.

Closed by importing `.core.usage` inside the one function that uses it (`totals_from_trace`, one call site).

## The three attributes

`#632` was titled "keeps every submodule attribute that used to resolve" and missed three. This time the list came from measuring what actually resolved at `6863e45~1`, not from reading imports: `announce` and `relay` turned out to be attributes only, never importable paths, so the test keeps two lists rather than assuming they match.

## Tests

`tests/unit/test_a_submodule_can_be_imported_on_its_own.py`, 30 cases in subprocesses. All six failures reproduced first (the three attributes re-proven by reverting `_SUBMODULES`). Full suite **4338 passed**. `co --version` measured at 0.45s, unchanged.