### PR TITLE
Hosting from a subdirectory plants a .co/ and loses the session history

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -752,7 +752,8 @@ def host(
     from .ws_router.dashboard import ensure_dashboard
     ensure_dashboard(agent_metadata)
 
-    storage = SessionStorage()
+    # co_dir, not the default: host(co_dir=...) must put the sessions there too.
+    storage = SessionStorage(co_dir / "session_results.jsonl")
 
     # Any session still marked `running` belongs to a process that is gone —
     # this one just started and owns none. Left alone they are permanent, since

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -17,6 +17,8 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+from ....project import project_co_dir
+
 
 class Session(BaseModel):
     """Session record for agent requests."""
@@ -33,8 +35,15 @@ class Session(BaseModel):
 class SessionStorage:
     """JSONL file storage. Append-only, last entry wins."""
 
-    def __init__(self, path: str = ".co/session_results.jsonl"):
-        self.path = Path(path)
+    def __init__(self, path=None):
+        # The project's `.co/`, not a bare relative path. `host()` builds this
+        # with no argument, so an agent hosted from a subdirectory wrote its
+        # sessions to `sub/.co/` -- invisible to any later run, and the `.co/`
+        # created here is a decoy that the walk-up in #660/#661/#663 stops at,
+        # so the project's own host.yaml and trust lists stop being found.
+        # Absolute, because a relative path is re-resolved on every use and a
+        # tool calling os.chdir would move the history mid-run.
+        self.path = Path(path) if path else project_co_dir() / "session_results.jsonl"
         self.path.parent.mkdir(exist_ok=True)
 
     def save(self, session: Session):

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -87,11 +87,18 @@ class TestSessionStorageInit:
     """Test SessionStorage initialization."""
 
     def test_default_path(self, tmp_path, monkeypatch):
-        """Default path is .co/session_results.jsonl."""
+        """Default path is `.co/session_results.jsonl` in the project.
+
+        Same directory as before when the cwd *is* the project, which is what
+        this asserted. It is now resolved rather than relative: the bare relative
+        path was re-read against the cwd on every use, and constructing it from a
+        subdirectory both lost the history and planted a `.co/` that shadowed the
+        project's own — see test_the_session_history_belongs_to_the_project.py.
+        """
         monkeypatch.chdir(tmp_path)
         storage = SessionStorage()
 
-        assert storage.path == Path(".co/session_results.jsonl")
+        assert storage.path == tmp_path.resolve() / ".co" / "session_results.jsonl"
 
     def test_custom_path(self, tmp_path):
         """Custom path is used when provided."""

--- a/tests/unit/test_the_session_history_belongs_to_the_project.py
+++ b/tests/unit/test_the_session_history_belongs_to_the_project.py
@@ -1,0 +1,198 @@
+"""Hosting an agent from a subdirectory plants a `.co/` and loses its sessions.
+
+`SessionStorage` defaults to a bare relative path, and its constructor creates
+the directory:
+
+    def __init__(self, path: str = ".co/session_results.jsonl"):
+        self.path = Path(path)
+        self.path.parent.mkdir(exist_ok=True)
+
+`host()` constructs it with no argument, so this runs on the hosting path.
+Measured on a project whose `.co/host.yaml` says `trust: strict`, from a
+subdirectory of it, on main after #663:
+
+    storage path      : .co/session_results.jsonl   (i.e. sub/.co/, not the project's)
+    decoy .co created : True
+    trust now reads   : None
+
+Two costs. The session history is written somewhere no later run will look, so
+an agent restarted from the project root does not see the turns it just served.
+And the created `.co/` is a decoy: #660 and #661 made everything walk *up* to
+the project, and the walk stops at the nearest `.co/`, so from then on the
+subdirectory's empty one answers for `host.yaml` and the trust lists. A project
+configured whitelist-only runs as `careful` — admitting contacts and accepting
+invite codes — because of where the process was started.
+
+#663 fixed the same shape in plan mode and in `co skills copy --to-project`.
+This one was missed there: every test constructs `SessionStorage` with an
+explicit path, so nothing exercised the default.
+
+The path is also relative, so it is resolved afresh against the cwd on every
+use — a tool that calls `os.chdir` moves the session history mid-run.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host.session.storage import SessionStorage, Session
+
+
+@pytest.fixture
+def project(tmp_path):
+    co = tmp_path / "project" / ".co"
+    co.mkdir(parents=True)
+    (co / "host.yaml").write_text("name: real\ntrust: strict\n")
+    (tmp_path / "project" / "sub" / "deeper").mkdir(parents=True)
+    return tmp_path / "project"
+
+
+class TestFromASubdirectory:
+
+    def test_no_decoy_is_created(self, project, monkeypatch):
+        monkeypatch.chdir(project / "sub")
+
+        SessionStorage()
+
+        assert not (project / "sub" / ".co").exists(), "a decoy .co/ was planted"
+
+    def test_the_history_goes_to_the_projects_co(self, project, monkeypatch):
+        monkeypatch.chdir(project / "sub")
+
+        assert Path(SessionStorage().path).parent == project / ".co"
+
+    def test_the_configured_trust_still_reads(self, project, monkeypatch):
+        """What the decoy costs: the project's own host.yaml stops being found."""
+        from connectonion.network.host.config import load_host_config
+
+        monkeypatch.chdir(project / "sub")
+        SessionStorage()
+
+        assert load_host_config(None).get("trust") == "strict"
+
+    def test_a_saved_session_is_read_back_from_the_project_root(self, project, monkeypatch):
+        """The other cost: a restart from the root must see what was served."""
+        monkeypatch.chdir(project / "sub")
+        SessionStorage().save(Session(session_id="s1", status="done", prompt="p"))
+
+        monkeypatch.chdir(project)
+
+        assert any(s.session_id == "s1" for s in SessionStorage().list())
+
+    def test_two_levels_down_as_well(self, project, monkeypatch):
+        monkeypatch.chdir(project / "sub" / "deeper")
+
+        assert Path(SessionStorage().path).parent == project / ".co"
+
+
+class TestThePathIsSettled(object):
+    """A relative path is re-resolved on every use; a chdir moves the history."""
+
+    def test_it_is_absolute(self, project, monkeypatch):
+        monkeypatch.chdir(project)
+
+        assert Path(SessionStorage().path).is_absolute()
+
+    def test_a_chdir_after_construction_does_not_move_it(self, project, tmp_path, monkeypatch):
+        monkeypatch.chdir(project)
+        storage = SessionStorage()
+        storage.save(Session(session_id="before", status="done", prompt="p"))
+
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+        storage.save(Session(session_id="after", status="done", prompt="p"))
+
+        ids = {s.session_id for s in storage.list()}
+        assert ids == {"before", "after"}
+        assert not (elsewhere / ".co").exists()
+
+
+class TestWhatMustNotChange:
+
+    def test_an_explicit_path_still_wins(self, project, tmp_path, monkeypatch):
+        monkeypatch.chdir(project)
+        chosen = tmp_path / "chosen" / "sessions.jsonl"
+        chosen.parent.mkdir()
+
+        assert Path(SessionStorage(chosen).path) == chosen
+
+    def test_a_string_path_still_works(self, project, tmp_path, monkeypatch):
+        monkeypatch.chdir(project)
+        chosen = tmp_path / "chosen2"
+        chosen.mkdir()
+
+        SessionStorage(str(chosen / "s.jsonl")).save(Session(session_id="x", status="done", prompt="p"))
+
+        assert (chosen / "s.jsonl").exists()
+
+    def test_outside_any_project_it_still_works(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        storage = SessionStorage()
+        storage.save(Session(session_id="loose", status="done", prompt="p"))
+
+        assert (tmp_path / ".co").is_dir()
+        assert any(s.session_id == "loose" for s in storage.list())
+
+
+class TestHostUsesIt:
+    """A default the hosting path does not reach would not be the bug."""
+
+    def test_host_stores_sessions_in_the_projects_co(self, project, monkeypatch):
+        from connectonion import Agent, address
+        from connectonion.network.host import server as server_module
+
+        address.save(address.generate(), project / ".co")
+        monkeypatch.chdir(project / "sub")
+
+        monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: None)
+        monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: None)
+
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+                           relay_url=None)
+
+        assert not (project / "sub" / ".co").exists()
+
+
+# Every entry point that a hosted agent touches early. This is the guard that
+# catches the *next* one: #663 fixed two creators, this file is the third, and
+# each was found only after the previous fix made the walk-up matter more.
+# Subprocesses, because a decoy planted by one probe would hide the next.
+IN_A_SUBDIRECTORY_OF_A_PROJECT = [
+    ("session storage",
+     "from connectonion.network.host.session.storage import SessionStorage; SessionStorage()"),
+    ("an agent",
+     "from connectonion import Agent; Agent('a', tools=[], model='co/gemini-2.5-flash')"),
+    ("a logger",
+     "from connectonion.logger import Logger; Logger(agent_name='a', quiet=True)"),
+    ("a skill lookup",
+     "from connectonion.useful_plugins.skills import _load_skill; _load_skill('x')"),
+    ("a trust check",
+     "from connectonion.network.trust.tools import get_level; get_level('0x'+'a'*64)"),
+    ("plan mode",
+     "from connectonion.cli.co_ai.tools.plan_mode import get_plan_file_path; get_plan_file_path('s')"),
+    ("the permission whitelist",
+     "from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns;"
+     " load_permission_patterns(None)"),
+]
+
+
+class TestNothingPlantsADecoy:
+
+    @pytest.mark.parametrize("what,probe",
+                             IN_A_SUBDIRECTORY_OF_A_PROJECT,
+                             ids=[w for w, _ in IN_A_SUBDIRECTORY_OF_A_PROJECT])
+    def test_it_leaves_the_subdirectory_alone(self, what, probe, project):
+        import os, subprocess, sys
+
+        here = project / "sub"
+        # This repo, not whatever `connectonion` happens to be installed. Without
+        # it the probes import the released package and the test reports on that.
+        env = dict(os.environ)
+        repo = str(Path(__file__).resolve().parents[2])
+        env["PYTHONPATH"] = repo + os.pathsep + env.get("PYTHONPATH", "")
+        subprocess.run([sys.executable, "-c", probe], cwd=here, env=env,
+                       capture_output=True, text=True, timeout=180)
+
+        assert not (here / ".co").exists(), f"{what} planted a .co/ in {here}"


### PR DESCRIPTION
## What

`SessionStorage` defaults to a bare relative path **and creates the directory**:

```python
def __init__(self, path: str = ".co/session_results.jsonl"):
    self.path = Path(path)
    self.path.parent.mkdir(exist_ok=True)
```

`host()` builds it with no argument, so this is on the hosting path. Measured on a project whose `host.yaml` says `trust: strict`, from a subdirectory, on `main` after #663:

```
storage path      : .co/session_results.jsonl   <- sub/.co, not the project's
decoy .co created : True
trust now reads   : None
```

Two costs:

1. **The session history goes where no later run looks.** An agent restarted from the project root does not see the turns it just served.
2. **The created `.co/` is a decoy.** `#660`/`#661`/`#663` made everything walk *up* to the project, and the walk stops at the nearest `.co/`. From then on the subdirectory's empty one answers for `host.yaml` and the trust lists — a project configured whitelist-only runs as `careful`, admitting contacts and accepting invite codes.

`#663` fixed this shape in plan mode and in `co skills copy --to-project` and missed this one: **every test constructed `SessionStorage` with an explicit path**, so nothing exercised the default.

## The guard

Rather than fixing the third creator and assuming it is the last, this adds a standing check: each entry point a hosted agent touches early — session storage, an Agent, a Logger, a skill lookup, a trust check, plan mode, the permission whitelist — run in a subdirectory of a real project, in its own interpreter, asserting no `.co/` appears.

Two things were verified about the guard itself:

- it **fails** when the fix in this PR is reverted (otherwise it is decoration)
- its subprocesses import **this repo**, not the installed `connectonion`. Without that they imported the released 1.5.11 and reported three creators that are already fixed here — a green-looking measurement of the wrong package.

## Also

The path is now resolved rather than relative, so a tool calling `os.chdir` cannot move the history mid-run. `host(co_dir=...)` passes its own `co_dir` so an explicit one still wins.

`test_host_session.py::test_default_path` asserted the relative path; updated to the resolved one, same directory, with the reason recorded.

## Tests

`tests/unit/test_the_session_history_belongs_to_the_project.py`, 18 cases, proven to fail first. Full suite **4348 passed**.