### PR TITLE
What the agent serves comes from the directory it was started in

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -20,6 +20,7 @@ import uuid
 from functools import partial
 from pathlib import Path
 from typing import Callable
+from ...project import project_co_dir
 
 from ..asgi.http import read_body, send_json, send_html, send_text, CORS_HEADERS
 from ..trust.http_admin import handle_admin_routes
@@ -255,7 +256,7 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
 
 def admin_logs_handler(agent_name: str) -> dict:
     """GET /admin/logs"""
-    log_path = Path(f".co/logs/{agent_name}.log")
+    log_path = project_co_dir() / "logs" / f"{agent_name}.log"
     if log_path.exists():
         return {"content": log_path.read_text(encoding="utf-8")}
     return {"error": "No logs found"}
@@ -264,7 +265,7 @@ def admin_logs_handler(agent_name: str) -> dict:
 def admin_sessions_handler() -> dict:
     """GET /admin/sessions"""
     import yaml
-    sessions_dir = Path(".co/evals")
+    sessions_dir = project_co_dir() / "evals"
     if not sessions_dir.exists():
         return {"sessions": []}
 

--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -14,6 +14,7 @@ import json
 import yaml
 import requests
 from pathlib import Path
+from ..project import project_co_dir
 from typing import Dict, Optional
 from dotenv import load_dotenv
 
@@ -169,11 +170,12 @@ def get_agent_email() -> Optional[str]:
     Returns:
         str: Agent's email address or None if not configured
     """
-    co_dir = Path(".co")
+    # The project's `.co/`. This walked up exactly one level by hand --
+    # `Path("../.co")` -- so it survived one subdirectory and returned None
+    # from two. project.py does the same walk for any depth.
+    co_dir = project_co_dir()
     if not co_dir.exists():
-        co_dir = Path("../.co")
-        if not co_dir.exists():
-            return None
+        return None
     
     config_path = co_dir / "host.yaml"
     if not config_path.exists():

--- a/connectonion/useful_tools/slash_command.py
+++ b/connectonion/useful_tools/slash_command.py
@@ -37,6 +37,7 @@ Your command prompt here...
 
 import yaml
 from pathlib import Path
+from ..project import project_co_dir, project_root
 from typing import Dict, Optional, List
 
 
@@ -70,12 +71,12 @@ class SlashCommand:
             SlashCommand instance or None if not found
         """
         # Check user custom first
-        custom_path = Path(".co/commands") / f"{command_name}.md"
+        custom_path = project_co_dir() / "commands" / f"{command_name}.md"
         if custom_path.exists():
             return cls._parse_file(custom_path, is_custom=True)
 
         # Check built-in
-        builtin_path = Path("commands") / f"{command_name}.md"
+        builtin_path = project_root() / "commands" / f"{command_name}.md"
         if builtin_path.exists():
             return cls._parse_file(builtin_path, is_custom=False)
 
@@ -172,14 +173,14 @@ class SlashCommand:
         commands = {}
 
         # Load built-ins first
-        builtin_dir = Path("commands")
+        builtin_dir = project_root() / "commands"
         if builtin_dir.exists():
             for filepath in builtin_dir.glob("*.md"):
                 cmd = cls._parse_file(filepath, is_custom=False)
                 commands[cmd.name] = cmd
 
         # Load customs (override built-ins)
-        custom_dir = Path(".co/commands")
+        custom_dir = project_co_dir() / "commands"
         if custom_dir.exists():
             for filepath in custom_dir.glob("*.md"):
                 cmd = cls._parse_file(filepath, is_custom=True)
@@ -197,5 +198,5 @@ class SlashCommand:
         Returns:
             True if custom command exists in .co/commands/
         """
-        custom_path = Path(".co/commands") / f"{command_name}.md"
+        custom_path = project_co_dir() / "commands" / f"{command_name}.md"
         return custom_path.exists()

--- a/tests/unit/test_what_the_agent_serves_comes_from_the_project.py
+++ b/tests/unit/test_what_the_agent_serves_comes_from_the_project.py
@@ -1,0 +1,191 @@
+"""The admin routes, the slash commands and the agent's own email address
+answer for the directory the process was started in.
+
+Four readers left on a bare relative path after #660, #661, #663 and #666:
+
+    http_router.admin_logs_handler       Path(f".co/logs/{agent_name}.log")
+    http_router.admin_sessions_handler   Path(".co/evals")
+    slash_command.SlashCommand           Path(".co/commands"), Path("commands")
+    send_email.get_agent_email           Path(".co") or Path("../.co")
+
+Measured on a project holding one of each, from the project root and from two
+depths below it:
+
+                        root    sub     sub/deeper
+    /admin/sessions     1       0       0
+    logs found          True    False   False
+    agent email         set     set     None
+    slash cmd found     True    False   False
+
+The first two are served over HTTP by the hosted agent: an operator looking at
+Home sees no sessions and "No logs found" for an agent that has both.
+
+`get_agent_email` is the interesting row. Someone already knew the walk was
+needed and wrote one level of it:
+
+    co_dir = Path(".co")
+    if not co_dir.exists():
+        co_dir = Path("../.co")
+
+So it survives one subdirectory and fails at two — which is why the table above
+measures two depths rather than one. That is the same walk `connectonion/project.py`
+now does properly, for any depth.
+
+All four fail in the visible direction — nothing is served from the wrong
+project, it is simply absent — which is why they are being fixed rather than
+filed: 1.6.0 is long-term support, and these are the last of the family.
+
+Not changed here: `Path("commands")` for built-in commands. No `commands/`
+directory ships in the package and there is none at the repo root, so "built-in"
+in this class means a directory in the project rather than one in the install.
+That reading is preserved — the directory is now found from a subdirectory like
+everything else — but whether built-ins were meant to ship with the package is a
+question this test cannot answer.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project with a log, an eval, a custom command and an email configured."""
+    root = tmp_path / "project"
+    co = root / ".co"
+    (co / "logs").mkdir(parents=True)
+    (co / "evals").mkdir()
+    (co / "commands").mkdir()
+    (root / "commands").mkdir()
+    (co / "host.yaml").write_text("agent:\n  email: a@mail.openonion.ai\n")
+    (co / "logs" / "myagent.log").write_text("a log line\n")
+    (co / "evals" / "s1.yaml").write_text("session_id: s1\n")
+    (co / "commands" / "mycmd.md").write_text(
+        "---\nname: mycmd\ndescription: mine\n---\n\ndo the thing\n")
+    (root / "commands" / "builtin.md").write_text(
+        "---\nname: builtin\ndescription: theirs\n---\n\nbuilt in\n")
+    (root / "sub" / "deeper").mkdir(parents=True)
+    return root
+
+
+DEPTHS = ["sub", "sub/deeper"]
+
+
+class TestTheAdminRoutes:
+    """Served over HTTP by the hosted agent."""
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_the_sessions_are_listed(self, project, monkeypatch, depth):
+        from connectonion.network.host.http_router import admin_sessions_handler
+
+        monkeypatch.chdir(project / depth)
+
+        assert len(admin_sessions_handler().get("sessions", [])) == 1
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_the_log_is_found(self, project, monkeypatch, depth):
+        from connectonion.network.host.http_router import admin_logs_handler
+
+        monkeypatch.chdir(project / depth)
+
+        assert "a log line" in admin_logs_handler("myagent").get("content", "")
+
+
+class TestTheAgentsOwnEmail:
+    """One level of the walk was written by hand; this needs all of it."""
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_it_is_configured(self, project, monkeypatch, depth):
+        from connectonion.useful_tools.send_email import get_agent_email
+
+        monkeypatch.chdir(project / depth)
+
+        assert get_agent_email() == "a@mail.openonion.ai"
+
+
+class TestTheSlashCommands:
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_a_custom_command_loads(self, project, monkeypatch, depth):
+        from connectonion.useful_tools.slash_command import SlashCommand
+
+        monkeypatch.chdir(project / depth)
+
+        assert SlashCommand.load("mycmd") is not None
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_it_is_reported_as_custom(self, project, monkeypatch, depth):
+        from connectonion.useful_tools.slash_command import SlashCommand
+
+        monkeypatch.chdir(project / depth)
+
+        assert SlashCommand.is_custom("mycmd")
+
+    @pytest.mark.parametrize("depth", DEPTHS)
+    def test_all_of_them_are_listed(self, project, monkeypatch, depth):
+        from connectonion.useful_tools.slash_command import SlashCommand
+
+        monkeypatch.chdir(project / depth)
+        names = SlashCommand.list_all()
+
+        assert "mycmd" in names and "builtin" in names
+
+
+class TestFromTheProjectRoot:
+    """Unchanged — all of this already worked."""
+
+    def test_the_sessions_are_still_listed(self, project, monkeypatch):
+        from connectonion.network.host.http_router import admin_sessions_handler
+
+        monkeypatch.chdir(project)
+
+        assert len(admin_sessions_handler().get("sessions", [])) == 1
+
+    def test_the_email_is_still_read(self, project, monkeypatch):
+        from connectonion.useful_tools.send_email import get_agent_email
+
+        monkeypatch.chdir(project)
+
+        assert get_agent_email() == "a@mail.openonion.ai"
+
+    def test_a_custom_command_still_overrides_a_built_in(self, project, monkeypatch):
+        """The precedence the class exists to express."""
+        from connectonion.useful_tools.slash_command import SlashCommand
+
+        (project / "commands" / "mycmd.md").write_text(
+            "---\nname: mycmd\ndescription: theirs\n---\n\nthe built-in one\n")
+        monkeypatch.chdir(project)
+
+        assert SlashCommand.is_custom("mycmd")
+
+
+class TestOutsideAnyProject:
+    """No `.co/` above — each must still behave, not raise."""
+
+    def test_no_sessions_rather_than_an_error(self, tmp_path, monkeypatch):
+        from connectonion.network.host.http_router import admin_sessions_handler
+
+        monkeypatch.chdir(tmp_path)
+
+        assert admin_sessions_handler() == {"sessions": []}
+
+    def test_no_logs_rather_than_an_error(self, tmp_path, monkeypatch):
+        from connectonion.network.host.http_router import admin_logs_handler
+
+        monkeypatch.chdir(tmp_path)
+
+        assert "error" in admin_logs_handler("myagent")
+
+    def test_no_email_rather_than_an_error(self, tmp_path, monkeypatch):
+        from connectonion.useful_tools.send_email import get_agent_email
+
+        monkeypatch.chdir(tmp_path)
+
+        assert get_agent_email() is None
+
+    def test_no_commands_rather_than_an_error(self, tmp_path, monkeypatch):
+        from connectonion.useful_tools.slash_command import SlashCommand
+
+        monkeypatch.chdir(tmp_path)
+
+        assert SlashCommand.load("mycmd") is None


### PR DESCRIPTION
## What

Four readers still on a bare relative path after #660, #661, #663 and #666:

```
http_router.admin_logs_handler       Path(f".co/logs/{agent_name}.log")
http_router.admin_sessions_handler   Path(".co/evals")
slash_command.SlashCommand           Path(".co/commands"), Path("commands")
send_email.get_agent_email           Path(".co") or Path("../.co")
```

Measured on a project holding one of each, at two depths:

| | root | sub | sub/deeper |
|---|---|---|---|
| `/admin/sessions` | 1 | **0** | **0** |
| logs found | True | **False** | **False** |
| agent email | set | set | **None** |
| slash cmd found | True | **False** | **False** |

The first two are **served over HTTP by the hosted agent** — an operator on Home sees no sessions and `No logs found` for an agent that has both.

## The interesting row

`get_agent_email` is why the table measures two depths and not one:

```python
co_dir = Path(".co")
if not co_dir.exists():
    co_dir = Path("../.co")
```

Someone already knew the walk was needed and wrote **one level of it by hand**. So it survives one subdirectory and returns `None` from two. That is the same walk `connectonion/project.py` now does for any depth.

## Preserved, not redefined

`Path("commands")` for built-in commands. No `commands/` directory ships in the package and there is none at the repo root, so "built-in" in this class means *a directory in the project*, not one in the install. That reading is kept — the directory is simply now found from a subdirectory like everything else. Whether built-ins were meant to ship with the package is a separate question this change does not answer.

## Tests

`tests/unit/test_what_the_agent_serves_comes_from_the_project.py`, 19 cases, each proven to fail first. The slash-command cases were re-proven after correcting the fixture: the first red came from command files with no YAML frontmatter, which is a real requirement — the fix had actually started *finding* the files, and the parse then failed. Red for the wrong reason is not red.

Full suite **4379 passed**.