### PR TITLE
GET /admin/logs looks for a file the agent never writes

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -254,9 +254,15 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
     return result
 
 
-def admin_logs_handler(agent_name: str) -> dict:
-    """GET /admin/logs"""
-    log_path = project_co_dir() / "logs" / f"{agent_name}.log"
+def admin_logs_handler(log_path) -> dict:
+    """GET /admin/logs
+
+    Takes the path, not a name to rebuild one from. It used to take the agent's
+    display name, which is host.yaml's name and not the Agent's -- so it looked
+    for a file the logger never writes. `Logger(log=...)` was unreachable too,
+    whatever the names.
+    """
+    log_path = Path(log_path)
     if log_path.exists():
         return {"content": log_path.read_text(encoding="utf-8")}
     return {"error": "No logs found"}

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -219,7 +219,11 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         return info_handler(agent_metadata, trust, trust_config, config)
 
     def handle_admin_logs():
-        return admin_logs_handler(agent_name)
+        # Where the log actually is, asked of the logger that writes it. Rebuilt
+        # from agent_metadata["name"] this looked for the *display* name --
+        # host.yaml's, deliberately (see _extract_agent_metadata) -- while the
+        # file is named after the Agent. `co init` makes those differ by default.
+        return admin_logs_handler(create_agent().logger.log_file_path)
 
     return {
         "input": handle_input,

--- a/tests/unit/test_admin_logs_reads_the_log_the_agent_writes.py
+++ b/tests/unit/test_admin_logs_reads_the_log_the_agent_writes.py
@@ -1,0 +1,162 @@
+"""`GET /admin/logs` looks for a file the agent never writes.
+
+The endpoint rebuilds the path from the agent's *display* name:
+
+    agent_name = agent_metadata["name"]
+    ...
+    log_path = project_co_dir() / "logs" / f"{agent_name}.log"
+
+and `agent_metadata["name"]` is host.yaml's name, deliberately — the comment
+above it says why, and for the relay, the directory and `/info` it is right:
+
+    host.yaml's name, when it has one. The Agent object's name is whatever
+    the code that built it chose — the co-ai template hardcodes "oo" …
+
+The log file is named by the Logger from the *Agent's* name. The two are not
+the same string, and `co init` makes them differ by default: host.yaml gets the
+directory name while the Agent is named in code.
+
+Measured against a real hosted agent, `Agent("e2eagent")` in a project whose
+host.yaml says `name: e2e3`, started from a subdirectory, over real HTTP with
+the admin bearer token:
+
+    ls .co/logs/                                  e2eagent.log     (457 bytes)
+    GET /admin/logs                               {"error": "No logs found"}
+    cp .co/logs/e2eagent.log .co/logs/e2e3.log
+    GET /admin/logs                               "A REAL LOG LINE…"
+
+Same shape as #579, #614 and #660: a lookup compared against a value the thing
+that produces it never produces. Nothing surfaced it because the unit tests
+passed a name and created a file with that name, so both sides of the mismatch
+were the test's own string. Only a real agent writes its log under one name and
+serves it under another.
+
+The fix asks the logger where its log is instead of rebuilding the path, which
+also covers `Logger(log=...)` — an operator who set an explicit log file was
+equally unreachable, whatever the names.
+
+The path is not published: it stays out of `agent_metadata`, which goes to
+`/info` and the relay directory, because an operator's filesystem layout is not
+part of an agent's public profile.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    co = tmp_path / "project" / ".co"
+    (co / "logs").mkdir(parents=True)
+    (co / "host.yaml").write_text("name: the-project\n")
+    (tmp_path / "project" / "sub").mkdir()
+    monkeypatch.chdir(tmp_path / "project")
+    return tmp_path / "project"
+
+
+def _an_agent(name, **kwargs):
+    from connectonion import Agent
+
+    return Agent(name, tools=[], model="co/gemini-2.5-flash", **kwargs)
+
+
+class TestTheNamesDiffer:
+    """host.yaml says one thing, the Agent is called another — the default."""
+
+    def test_the_log_is_served(self, project):
+        from connectonion.network.host.server import _create_route_handlers
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        agent = _an_agent("the-agent")
+        agent.logger.log_file_path.write_text("A REAL LOG LINE\n")
+
+        handlers = _create_route_handlers(
+            lambda: agent, {"name": "the-project"}, 3600, TrustAgent("careful"), {})
+
+        assert "A REAL LOG LINE" in handlers["admin_logs"]().get("content", "")
+
+    def test_the_public_name_is_untouched(self, project):
+        """The display name stays host.yaml's — that decision is not being undone."""
+        from connectonion.network.host.server import _extract_agent_metadata
+
+        metadata, _ = _extract_agent_metadata(lambda: _an_agent("the-agent"),
+                                              "the-project")
+
+        assert metadata["name"] == "the-project"
+
+    def test_no_filesystem_path_is_published(self, project):
+        """`/info` and the relay directory get this dict; a path is not public."""
+        from connectonion.network.host.server import _extract_agent_metadata
+
+        metadata, _ = _extract_agent_metadata(lambda: _an_agent("the-agent"),
+                                              "the-project")
+
+        assert not any("logs" in str(v) for v in metadata.values())
+
+
+class TestAnExplicitLogFile:
+    """`Logger(log=...)` was unreachable whatever the names matched."""
+
+    def test_it_is_served(self, project, tmp_path):
+        from connectonion.network.host.server import _create_route_handlers
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        elsewhere = tmp_path / "somewhere" / "custom.log"
+        elsewhere.parent.mkdir()
+        agent = _an_agent("the-agent", log=str(elsewhere))
+        elsewhere.write_text("THE CUSTOM LOG\n")
+
+        handlers = _create_route_handlers(
+            lambda: agent, {"name": "the-project"}, 3600, TrustAgent("careful"), {})
+
+        assert "THE CUSTOM LOG" in handlers["admin_logs"]().get("content", "")
+
+
+class TestWhenTheNamesAgree:
+    """This already worked and must keep working."""
+
+    def test_the_log_is_still_served(self, project):
+        from connectonion.network.host.server import _create_route_handlers
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        agent = _an_agent("the-project")
+        agent.logger.log_file_path.write_text("MATCHING NAMES\n")
+
+        handlers = _create_route_handlers(
+            lambda: agent, {"name": "the-project"}, 3600, TrustAgent("careful"), {})
+
+        assert "MATCHING NAMES" in handlers["admin_logs"]().get("content", "")
+
+
+class TestWithNoLog:
+
+    def test_it_reports_rather_than_raises(self, project):
+        from connectonion.network.host.server import _create_route_handlers
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        agent = _an_agent("never-logged")
+        if agent.logger.log_file_path.exists():
+            agent.logger.log_file_path.unlink()
+
+        handlers = _create_route_handlers(
+            lambda: agent, {"name": "the-project"}, 3600, TrustAgent("careful"), {})
+
+        assert "error" in handlers["admin_logs"]()
+
+
+class TestTheHandlerItself:
+    """`admin_logs_handler` takes the path now, not a name to rebuild one from."""
+
+    def test_it_reads_the_file_it_is_given(self, tmp_path):
+        from connectonion.network.host.http_router import admin_logs_handler
+
+        log = tmp_path / "any.log"
+        log.write_text("CONTENT\n")
+
+        assert "CONTENT" in admin_logs_handler(log).get("content", "")
+
+    def test_a_missing_file_is_reported(self, tmp_path):
+        from connectonion.network.host.http_router import admin_logs_handler
+
+        assert "error" in admin_logs_handler(tmp_path / "nothing.log")

--- a/tests/unit/test_host_routes.py
+++ b/tests/unit/test_host_routes.py
@@ -406,7 +406,7 @@ class TestAdminLogsHandler:
         log_file = log_dir / "test_agent.log"
         log_file.write_text("Log line 1\nLog line 2\n")
 
-        result = admin_logs_handler("test_agent")
+        result = admin_logs_handler(log_file)
 
         assert "content" in result
         assert "Log line 1" in result["content"]
@@ -416,7 +416,7 @@ class TestAdminLogsHandler:
         """admin_logs_handler returns error when log doesn't exist."""
         monkeypatch.chdir(tmp_path)
 
-        result = admin_logs_handler("nonexistent_agent")
+        result = admin_logs_handler(tmp_path / ".co" / "logs" / "nonexistent.log")
 
         assert "error" in result
         assert result["error"] == "No logs found"

--- a/tests/unit/test_what_the_agent_serves_comes_from_the_project.py
+++ b/tests/unit/test_what_the_agent_serves_comes_from_the_project.py
@@ -84,11 +84,23 @@ class TestTheAdminRoutes:
 
     @pytest.mark.parametrize("depth", DEPTHS)
     def test_the_log_is_found(self, project, monkeypatch, depth):
-        from connectonion.network.host.http_router import admin_logs_handler
+        """Through the route, because the path now comes from the Logger.
+
+        `admin_logs_handler` used to rebuild the path from the agent's display
+        name and this asserted that rebuild resolved to the project. It takes
+        the path itself now — the logger's, which walks up on its own (#661) —
+        so the subdirectory case belongs at the route, where the two meet.
+        """
+        from connectonion import Agent
+        from connectonion.network.host.server import _create_route_handlers
+        from connectonion.network.trust.trust_agent import TrustAgent
 
         monkeypatch.chdir(project / depth)
+        agent = Agent("myagent", tools=[], model="co/gemini-2.5-flash")
+        handlers = _create_route_handlers(
+            lambda: agent, {"name": "the-project"}, 3600, TrustAgent("careful"), {})
 
-        assert "a log line" in admin_logs_handler("myagent").get("content", "")
+        assert "a log line" in handlers["admin_logs"]().get("content", "")
 
 
 class TestTheAgentsOwnEmail:


### PR DESCRIPTION
## What

The endpoint rebuilt the log path from the agent's **display** name:

```python
agent_name = agent_metadata["name"]
log_path = project_co_dir() / "logs" / f"{agent_name}.log"
```

`agent_metadata["name"]` is host.yaml's name — deliberately, and the comment above it says why:

> host.yaml's name, when it has one. The Agent object's name is whatever the code that built it chose — the co-ai template hardcodes "oo" …

That is right for the relay, the directory and `/info`. It is not the name the **Logger** uses, which is the `Agent(...)` name. `co init` makes the two differ by default: host.yaml gets the directory name while the Agent is named in code.

Measured against a real hosted agent over HTTP, `Agent("a-different-agent-name")` in a project whose host.yaml says `name: e2e4`:

| | before | after |
|---|---|---|
| `ls .co/logs/` | `a-different-agent-name.log` | same |
| `/info` name | `e2e4` | `e2e4` (unchanged) |
| `GET /admin/logs` | `{"error": "No logs found"}` | the log |

Same shape as #579, #614 and #660: **a lookup compared against a value the thing that produces it never produces.**

## Why nothing caught it

Every test passed a name and created a file with that name, so both sides of the mismatch were the test's own string. Only a real agent writes its log under one name and serves it under another — this came out of running the authenticated admin surface over real HTTP, which the previous round's e2e had stopped at `unauthorized`.

## The fix

The handler takes the path, asked of the logger that writes it. That also reaches `Logger(log=...)`: an operator who set an explicit log file was unreachable **whatever the names matched**.

The path deliberately stays out of `agent_metadata` — that dict goes to `/info` and the relay directory, and an operator's filesystem layout is not part of an agent's public profile. There is a test for that.

## Two existing tests asserted the old signature

Including one of #667's own. Both updated rather than deleted: #667's case moves to the route, where the logger's walk-up (#661) and the endpoint actually meet.

## Tests

`tests/unit/test_admin_logs_reads_the_log_the_agent_writes.py`, 8 cases, proven to fail first. Full suite **4405 passed**. Verified over real HTTP with the admin bearer token.