### PR TITLE
An agent offers doors that cannot open, and one that opens for a single letter

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -243,13 +243,20 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
     # connectonion-react already documents — "the public /info answer is
     # deliberately narrower".
 
-    if trust_config:
-        onboard = trust_config.get("onboard", {})
-        if onboard:
-            result["onboard"] = {
-                "invite_code": "invite_code" in onboard,
-                "payment": onboard.get("payment"),
-            }
+    # The same rule the CONNECT path applies, on this handler's own input.
+    # Deciding it separately is how this came to publish an invite code that no
+    # value opens: `trust_config` holds the *unexpanded* `$CO_INVITE_CODE`, so
+    # `"invite_code" in onboard` was true on an agent with none set. /info needs
+    # no credentials, so that answer went to the whole internet.
+    from ..trust.ws_admin import doors_that_open
+
+    offered = doors_that_open((trust_config or {}).get("onboard", {}),
+                              trust.get_self_address()) if trust_config else None
+    if offered:
+        result["onboard"] = {
+            "invite_code": "invite_code" in offered["methods"],
+            "payment": offered.get("payment_amount"),
+        }
 
     return result
 

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -75,6 +75,17 @@ def _resolve_codes(codes) -> list:
     door, not an open one.
     """
     import os as _os
+    # One value written plainly is one code, not one per letter. The shipped
+    # policies write a list, so iterating a bare string never showed here -- but
+    # `invite_code: mycode` is the natural way to write a single code in YAML,
+    # and iterating it makes every character a code that opens the door.
+    # One value written plainly is one code, not one per letter. The shipped
+    # policies write a list, so iterating a bare string never showed here -- but
+    # `invite_code: mycode` is the natural way to write a single code in YAML,
+    # and iterating it makes every character a code that opens the door while
+    # the code the operator actually chose is refused.
+    if isinstance(codes, str):
+        codes = [codes]
     out = []
     for code in codes or []:
         text = str(code)

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -19,21 +19,33 @@ console = Console()
 
 
 def get_onboard_requirements(trust_agent) -> dict | None:
-    """Extract onboard requirements from trust config."""
+    """The ways in that can actually be taken, or None if there are none.
+
+    Not what the policy mentions — what a stranger can complete. An agent with
+    no way in says so, rather than offering a menu whose every item fails.
+    """
     config = trust_agent.config
     onboard = config.get("onboard", {})
     if not onboard:
         return None
 
+    # Only doors that open. This listed a method whenever the policy *mentioned*
+    # it, while verify_invite resolves the list first -- and an unset $CO_INVITE_CODE
+    # resolves to nothing, deliberately (#561: "a missing code is a closed door,
+    # not an open one"). Every agent without a code set therefore offered strangers
+    # an invite code that no value could satisfy. Same for a payment with no address
+    # to send it to: told to pay, not told where.
+    from .fast_rules import _resolve_codes
+
     result = {"methods": []}
-    if "invite_code" in onboard:
+    if _resolve_codes(onboard.get("invite_code", [])):
         result["methods"].append("invite_code")
-    if "payment" in onboard:
+
+    payment_address = trust_agent.get_self_address() if "payment" in onboard else None
+    if payment_address:
         result["methods"].append("payment")
         result["payment_amount"] = onboard["payment"]
-        payment_address = trust_agent.get_self_address()
-        if payment_address:
-            result["payment_address"] = payment_address
+        result["payment_address"] = payment_address
 
     return result if result["methods"] else None
 

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -2,9 +2,10 @@
 
 Purpose: Verify signed websocket frames for ONBOARD_SUBMIT and ADMIN_* actions, then mutate trust state (verify invite/payment, promote/demote/block/unblock, super-admin add/remove) and stream back ONBOARD_SUCCESS / ADMIN_RESULT / ERROR responses. handle_onboard_submit returns the verified agent_address so the session loop can finish the trust-gated CONNECT.
 LLM-Note:
-  Dependencies: imports from [rich.console] | imported by [network/host/ws_router/session.py (handle_admin_message, handle_onboard_submit), network/host/ws_router/connect.py (get_onboard_requirements during CONNECT)] | tested by [no direct test file]
+  Dependencies: imports from [rich.console, .fast_rules (_resolve_codes, lazily)] | imported by [network/host/ws_router/session.py (handle_admin_message, handle_onboard_submit), network/host/ws_router/connect.py (get_onboard_requirements during CONNECT), network/host/http_router.py (doors_that_open for /info)] | tested by [tests/unit/test_an_agent_only_offers_a_door_that_opens.py]
   Data flow:
-    • get_onboard_requirements(trust_agent) — read trust_agent.config.onboard → {methods: ["invite_code"|"payment"], payment_amount, payment_address (from trust_agent.get_self_address())} or None
+    • doors_that_open(onboard, self_address) — the single rule: an invite code counts only if _resolve_codes yields one (an unset $CO_INVITE_CODE yields nothing, #561), a payment counts only if there is an address to send it to → {methods, payment_amount, payment_address} or None
+    • get_onboard_requirements(trust_agent) — read trust_agent.config.onboard → doors_that_open(…, trust_agent.get_self_address()) or None
     • handle_onboard_submit(data, send_msg, route_handlers) — auth via route_handlers["auth"](data, "open") → check trust_agent.is_blocked → verify_invite or verify_payment → reply ONBOARD_SUCCESS with new level or ERROR
     • handle_admin_message(data, send_msg, route_handlers) — auth + is_admin gate → ADMIN_PROMOTE/DEMOTE/BLOCK/UNBLOCK/GET_LEVEL routed to route_handlers admin_trust_* callbacks → ADMIN_ADD/REMOVE additionally gated on is_super_admin → reply ADMIN_RESULT
   State/Effects: mutates trust agent state via trust_agent.verify_invite/verify_payment and admin_trust_* / admin_admins_* callbacks | prints colored audit lines to stdout via rich.Console (✓/✗ with truncated agent_address) | sends frames to client via injected send_msg
@@ -18,36 +19,44 @@ from rich.console import Console
 console = Console()
 
 
-def get_onboard_requirements(trust_agent) -> dict | None:
-    """The ways in that can actually be taken, or None if there are none.
+def doors_that_open(onboard: dict, self_address) -> dict | None:
+    """Which onboarding methods a stranger could actually complete, or None.
 
-    Not what the policy mentions — what a stranger can complete. An agent with
-    no way in says so, rather than offering a menu whose every item fails.
+    One rule, so that every place which tells a stranger how to get in reaches
+    the same verdict. Deciding it twice is how the agent came to publish an
+    invite code that no value opens: the raw policy holds the unexpanded
+    `$CO_INVITE_CODE`, so `"invite_code" in onboard` is true on an agent with
+    none set, while verify_invite -- which resolves it -- lets nobody in.
+    #561 fixed two such places; the advertiser and /info were the third and
+    fourth.
     """
-    config = trust_agent.config
-    onboard = config.get("onboard", {})
-    if not onboard:
-        return None
-
-    # Only doors that open. This listed a method whenever the policy *mentioned*
-    # it, while verify_invite resolves the list first -- and an unset $CO_INVITE_CODE
-    # resolves to nothing, deliberately (#561: "a missing code is a closed door,
-    # not an open one"). Every agent without a code set therefore offered strangers
-    # an invite code that no value could satisfy. Same for a payment with no address
-    # to send it to: told to pay, not told where.
     from .fast_rules import _resolve_codes
 
     result = {"methods": []}
     if _resolve_codes(onboard.get("invite_code", [])):
         result["methods"].append("invite_code")
 
-    payment_address = trust_agent.get_self_address() if "payment" in onboard else None
-    if payment_address:
+    # A payment with nowhere to send it is not a way in: the client would be
+    # told to pay and not told where, and verify_payment refuses without an
+    # address anyway.
+    if "payment" in onboard and self_address:
         result["methods"].append("payment")
         result["payment_amount"] = onboard["payment"]
-        result["payment_address"] = payment_address
+        result["payment_address"] = self_address
 
     return result if result["methods"] else None
+
+
+def get_onboard_requirements(trust_agent) -> dict | None:
+    """The ways in that can actually be taken, or None if there are none.
+
+    Not what the policy mentions — what a stranger can complete. An agent with
+    no way in says so, rather than offering a menu whose every item fails.
+    """
+    onboard = trust_agent.config.get("onboard", {})
+    if not onboard:
+        return None
+    return doors_that_open(onboard, trust_agent.get_self_address())
 
 
 async def handle_onboard_submit(data, send_msg, route_handlers):

--- a/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
+++ b/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
@@ -19,8 +19,14 @@ resolver is explicit about what an unset variable means (#561):
     An unset variable resolves to *nothing*, never to the placeholder and never
     to a default. … A missing code is a closed door, not an open one.
 
-So with `CO_INVITE_CODE` unset — which is every agent that has not set one —
-the two disagree. Measured against a real hosted agent on default trust:
+So with `CO_INVITE_CODE` unset the two disagree. `co init` does mint a code into
+the project's `.env`, and importing connectonion loads it — so a laptop project
+usually has one. Where it is missing is the deployed agent: the resolver's own
+docstring notes that the env file is "the one thing `co deploy` neither rsyncs
+nor overwrites", so a server whose env file was never populated runs with no
+code, and so does any `host()` in a project that never ran `co init`.
+
+Measured against a real hosted agent with no code in its environment:
 
     GET /info          "onboard": {"invite_code": true, "payment": 10}
     co call <address>  agent requires onboarding (invite_code, payment)
@@ -53,7 +59,7 @@ import pytest
 
 @pytest.fixture
 def careful(monkeypatch):
-    """A default-trust agent with no invite code set — the common case."""
+    """A default-trust agent with no invite code set — the deployed case."""
     from connectonion.network.trust.trust_agent import TrustAgent
 
     monkeypatch.delenv("CO_INVITE_CODE", raising=False)
@@ -199,3 +205,76 @@ class TestAnAgentWithNoDoorAtAll:
         monkeypatch.delenv("CO_INVITE_CODE", raising=False)
 
         assert get_onboard_requirements(TrustAgent("strict")) is None
+
+
+class TestInfoSaysTheSameThing:
+    """`/info` built its own answer and reached the opposite conclusion.
+
+        onboard = trust_config.get("onboard", {})
+        if onboard:
+            result["onboard"] = {
+                "invite_code": "invite_code" in onboard,
+                ...
+
+    `trust_config` is the *raw* policy, so with no code set this is the
+    unexpanded placeholder and the test is still true:
+
+        /info path  (_parse_trust_config)  {'onboard': {'invite_code': ['$CO_INVITE_CODE'], 'payment': 10}}
+        CONNECT path (get_onboard_requirements)  None
+
+    That makes four places deciding what onboarding exists — #561 fixed two,
+    the advertiser above was the third, and this is the fourth. It is also the
+    worst placed of them: `/info` needs no credentials, so a deployed agent
+    publishes this answer to the whole internet.
+
+    So `/info` asks the same function the CONNECT path asks, rather than
+    reaching its own verdict from a different input.
+    """
+
+    @staticmethod
+    def _info(trust_agent):
+        from connectonion.network.host.http_router import info_handler
+
+        return info_handler(
+            {"name": "a", "address": "0x" + "1" * 64, "tools": []},
+            trust_agent,
+            trust_agent.config,
+        )
+
+    def test_an_unusable_invite_code_is_not_announced(self, careful, monkeypatch):
+        monkeypatch.setattr(careful, "get_self_address", lambda: "0x" + "a" * 64)
+
+        assert self._info(careful)["onboard"]["invite_code"] is False
+
+    def test_a_usable_one_is(self, monkeypatch):
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        monkeypatch.setenv("CO_INVITE_CODE", "let-me-in")
+        agent = TrustAgent("careful")
+        monkeypatch.setattr(agent, "get_self_address", lambda: "0x" + "a" * 64)
+
+        assert self._info(agent)["onboard"]["invite_code"] is True
+
+    def test_payment_with_nowhere_to_send_it_is_not_announced(self, careful, monkeypatch):
+        monkeypatch.setattr(careful, "get_self_address", lambda: None)
+
+        assert "onboard" not in self._info(careful)
+
+    def test_the_amount_is_still_published_when_it_can_be_paid(self, careful, monkeypatch):
+        monkeypatch.setattr(careful, "get_self_address", lambda: "0x" + "a" * 64)
+
+        assert self._info(careful)["onboard"]["payment"] == 10
+
+    def test_the_two_paths_agree(self, careful, monkeypatch):
+        """The property that makes a fifth path impossible to introduce quietly."""
+        from connectonion.network.trust.ws_admin import get_onboard_requirements
+
+        for address in [None, "0x" + "a" * 64]:
+            monkeypatch.setattr(careful, "get_self_address", lambda: address)
+            offered = get_onboard_requirements(careful)
+            info = self._info(careful).get("onboard")
+
+            if offered is None:
+                assert info is None
+            else:
+                assert info["invite_code"] == ("invite_code" in offered["methods"])

--- a/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
+++ b/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
@@ -1,0 +1,201 @@
+"""A stranger is offered an invite code that cannot open anything.
+
+`get_onboard_requirements` advertises a method whenever the policy *mentions*
+it:
+
+    if "invite_code" in onboard:
+        result["methods"].append("invite_code")
+
+The shipped `careful` policy — the default for every agent — mentions it as an
+environment reference:
+
+    onboard:
+      invite_code: [$CO_INVITE_CODE]
+      payment: 10
+
+`verify_invite` does not use that list directly. It resolves it, and the
+resolver is explicit about what an unset variable means (#561):
+
+    An unset variable resolves to *nothing*, never to the placeholder and never
+    to a default. … A missing code is a closed door, not an open one.
+
+So with `CO_INVITE_CODE` unset — which is every agent that has not set one —
+the two disagree. Measured against a real hosted agent on default trust:
+
+    GET /info          "onboard": {"invite_code": true, "payment": 10}
+    co call <address>  agent requires onboarding (invite_code, payment)
+    verify_invite('')            -> False
+    verify_invite('anything')    -> False
+    verify_invite('$CO_INVITE_CODE') -> False
+
+The stranger is told to enter a code, and no code exists that works.
+
+This is the third path of #561. That fix changed `evaluate_request` and
+`verify_invite`, and the comment left on the second one says why both were
+needed — "fixing only the other one would have left the real door open". The
+advertiser was never compared against the resolver at all.
+
+Payment has the same shape for a different reason: the amount is advertised
+whether or not there is an address to send it to. `get_self_address()` returns
+None for an agent with no key of its own, and the method is still offered, so a
+client is told to pay and not told where.
+
+What is deliberately *not* changed here: `payment: 10` sitting in the default
+policy at all. Every agent from `co init` advertises "transfer 10 to my address
+and become a contact" without its operator configuring anything, and the door
+is wired end to end — ONBOARD_SUBMIT → verify_payment → oo-api → promote to
+contact. Whether that default should exist is a product decision, filed
+separately. This change only stops the agent offering doors that cannot open.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def careful(monkeypatch):
+    """A default-trust agent with no invite code set — the common case."""
+    from connectonion.network.trust.trust_agent import TrustAgent
+
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    return TrustAgent("careful")
+
+
+class TestAnInviteCodeThatCannotWork:
+
+    def test_it_is_not_offered(self, careful):
+        from connectonion.network.trust.ws_admin import get_onboard_requirements
+
+        offered = get_onboard_requirements(careful) or {"methods": []}
+
+        assert "invite_code" not in offered["methods"]
+
+    def test_the_resolver_agrees_nothing_opens_it(self, careful):
+        """The measurement the advertisement should have matched."""
+        for attempt in ["", "anything", "$CO_INVITE_CODE"]:
+            assert careful.verify_invite("0x" + "f" * 64, attempt) is False
+
+
+class TestAnInviteCodeThatDoesWork:
+    """The point of the feature — it must still be offered."""
+
+    def test_it_is_offered(self, monkeypatch):
+        from connectonion.network.trust.trust_agent import TrustAgent
+        from connectonion.network.trust.ws_admin import get_onboard_requirements
+
+        monkeypatch.setenv("CO_INVITE_CODE", "let-me-in")
+        offered = get_onboard_requirements(TrustAgent("careful"))
+
+        assert "invite_code" in offered["methods"]
+
+    def test_and_the_code_opens_it(self, monkeypatch, tmp_path):
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        monkeypatch.setenv("CO_INVITE_CODE", "let-me-in")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".co").mkdir()
+
+        assert TrustAgent("careful").verify_invite("0x" + "f" * 64, "let-me-in")
+
+
+class TestPaymentWithNowhereToSendIt:
+
+    def test_it_is_not_offered_without_an_address(self, careful, monkeypatch):
+        from connectonion.network.trust import ws_admin
+
+        monkeypatch.setattr(careful, "get_self_address", lambda: None)
+        offered = ws_admin.get_onboard_requirements(careful) or {"methods": []}
+
+        assert "payment" not in offered["methods"]
+
+    def test_it_is_offered_with_one(self, careful, monkeypatch):
+        from connectonion.network.trust import ws_admin
+
+        monkeypatch.setattr(careful, "get_self_address", lambda: "0x" + "a" * 64)
+        offered = ws_admin.get_onboard_requirements(careful)
+
+        assert "payment" in offered["methods"]
+        assert offered["payment_address"] == "0x" + "a" * 64
+        assert offered["payment_amount"] == 10
+
+
+class TestAnInviteCodeWrittenAsAScalar:
+    """`invite_code: mycode` admits anyone who types one letter of it.
+
+    The resolver iterates what it is given:
+
+        for code in codes or []:
+
+    The shipped policies write a list, so this never showed. A hand-written
+    policy that says `invite_code: mycode` -- the natural way to write one value
+    in YAML -- iterates the *string*, and every character becomes a code that
+    opens the door. A stranger typing `m` is promoted to contact.
+
+    Same family as #561, which removed a published constant from the shipped
+    policy. This is the other way to end up with a code nobody chose.
+    """
+
+    def test_a_scalar_is_one_code_not_one_per_letter(self):
+        from connectonion.network.trust.fast_rules import _resolve_codes
+
+        assert _resolve_codes("mycode") == ["mycode"]
+
+    def test_a_letter_of_it_does_not_open_the_door(self, tmp_path, monkeypatch):
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".co").mkdir()
+        agent = TrustAgent("careful")
+        agent._config["onboard"] = {"invite_code": "mycode"}
+
+        assert agent.verify_invite("0x" + "f" * 64, "m") is False
+
+    def test_the_whole_code_still_does(self, tmp_path, monkeypatch):
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".co").mkdir()
+        agent = TrustAgent("careful")
+        agent._config["onboard"] = {"invite_code": "mycode"}
+
+        assert agent.verify_invite("0x" + "f" * 64, "mycode") is True
+
+    def test_a_scalar_environment_reference_still_resolves(self, monkeypatch):
+        from connectonion.network.trust.fast_rules import _resolve_codes
+
+        monkeypatch.setenv("CO_INVITE_CODE", "from-the-env")
+
+        assert _resolve_codes("$CO_INVITE_CODE") == ["from-the-env"]
+
+    def test_a_list_is_unchanged(self, monkeypatch):
+        from connectonion.network.trust.fast_rules import _resolve_codes
+
+        monkeypatch.setenv("CO_INVITE_CODE", "from-the-env")
+
+        assert _resolve_codes(["one", "$CO_INVITE_CODE"]) == ["one", "from-the-env"]
+
+    def test_nothing_is_still_nothing(self):
+        from connectonion.network.trust.fast_rules import _resolve_codes
+
+        assert _resolve_codes(None) == []
+        assert _resolve_codes([]) == []
+        assert _resolve_codes("") == []
+
+
+class TestAnAgentWithNoDoorAtAll:
+
+    def test_nothing_is_offered(self, careful, monkeypatch):
+        """Neither method usable — the client should be told there is no way in,
+        not handed a menu of two that both fail."""
+        from connectonion.network.trust import ws_admin
+
+        monkeypatch.setattr(careful, "get_self_address", lambda: None)
+
+        assert ws_admin.get_onboard_requirements(careful) is None
+
+    def test_a_policy_without_onboarding_is_unchanged(self, monkeypatch):
+        from connectonion.network.trust.trust_agent import TrustAgent
+        from connectonion.network.trust.ws_admin import get_onboard_requirements
+
+        monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+
+        assert get_onboard_requirements(TrustAgent("strict")) is None


### PR DESCRIPTION
Found by driving a real hosted agent over the relay with `co call`, not by reading code.

## 1. Four places decided what onboarding exists, and they disagreed

`get_onboard_requirements` (the CONNECT path) and `info_handler` (`/info`) each listed a method whenever the policy **mentioned** it:

```python
if "invite_code" in onboard:
    result["methods"].append("invite_code")
```

`verify_invite` does not use that list directly. It resolves it, and the resolver is explicit about what an unset variable means (#561):

> An unset variable resolves to *nothing*, never to the placeholder and never to a default. … **A missing code is a closed door, not an open one.**

Measured with `CO_INVITE_CODE` absent:

```
/info path   (_parse_trust_config)        {'invite_code': ['$CO_INVITE_CODE'], 'payment': 10}
CONNECT path (get_onboard_requirements)   invite_code offered
verify_invite('anything')                 -> False
```

So a stranger is told to enter a code and no code opens it. `/info` is the worse of the two: it needs no credentials, so a deployed agent publishes that answer to the whole internet.

This is **#561's third and fourth paths**. That fix changed `evaluate_request` and `verify_invite`; the comment on the second says why both were needed — *"fixing only the other one would have left the real door open"*. Neither advertiser was checked against either.

Payment had the same shape for a different reason: the amount was advertised whether or not `get_self_address()` gave anywhere to send it. Told to pay, not told where.

**Both now apply one rule** — `doors_that_open(onboard, self_address)` — each on its own input, so `trust_config` stays `/info`'s data rather than becoming a flag, and a fifth caller cannot reach a different verdict by accident.

## 2. A scalar invite code opens for any one of its letters — and refuses itself

`_resolve_codes` iterates what it is given. The shipped policies write a list, so a bare string never showed here. `invite_code: mycode` — the natural way to write one value in YAML — iterates the **string**:

| | result |
|---|---|
| `_resolve_codes("mycode")` | `['m','y','c','o','d','e']` |
| `verify_invite(addr, "m")` | **True** — promoted to contact |
| `verify_invite(addr, "mycode")` | **False** — the operator's real code refused |

A scalar `$CO_INVITE_CODE` splits the same way. Measured, not inferred: every row is a test that fails on `main`.

## Where the missing code actually happens

An earlier draft of this PR said "every agent without a code set, which is the default". **That was wrong** and is corrected here: `co init` mints a `CO_INVITE_CODE` into the project's `.env`, and importing connectonion loads it, so a laptop project usually has a working code.

Where it is missing is the **deployed** agent — the resolver's own docstring notes the env file is *"the one thing `co deploy` neither rsyncs nor overwrites"*, so a server whose env file was never populated runs without one. Same for any `host()` in a project that never ran `co init`.

## What a `None` menu does now

`get_onboard_requirements` can now return `None` where it used to return a menu. Checked the one caller — `ws_router/connect.py:28` has `if onboard_info:` and falls through to the plain `forbidden` error. A stranger is told there is no way in, instead of being handed a menu whose every item fails.

## Not changed here

`payment: 10` in the shipped `careful` policy — every agent gets it without configuring anything, and the door is wired end to end (ONBOARD_SUBMIT → verify_payment → oo-api → promote to contact). That is a product decision; filed as #672.

## Tests

`tests/unit/test_an_agent_only_offers_a_door_that_opens.py`, 19 cases, all proven to fail first. Full suite **4424 passed**.

The two existing Mock-based `/info` tests keep passing untouched — which is the point of giving each caller its own input. A `Mock` trust that never had a real config is exactly why neither of them caught this.