### PR TITLE
connect(address).input(...) cannot talk to a default agent

### DIFF
--- a/connectonion/cli/commands/call_commands.py
+++ b/connectonion/cli/commands/call_commands.py
@@ -39,13 +39,16 @@ USAGE = (
 
 
 def _load_keys():
-    """This machine's identity, to sign the request (required for strict-trust
-    remotes, harmless otherwise). Project .co first, then ~/.co; None if absent."""
-    from connectonion import address
-    co_dir = Path(".co")
-    if not (co_dir.exists() and (co_dir / "keys" / "agent.key").exists()):
-        co_dir = Path.home() / ".co"
-    return address.load(co_dir)
+    """This caller's identity, to sign the request.
+
+    Every trust level above `open` refuses an unsigned request -- `careful`, the
+    default, included. This was a second copy of the resolver that used a bare
+    `Path(".co")`, so running `co call` from a subdirectory signed as the machine
+    rather than as the project.
+    """
+    from connectonion.network.connect import _this_callers_identity
+
+    return _this_callers_identity()
 
 
 def handle_call(args) -> int:

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -33,6 +33,36 @@ import httpx
 from .. import address as addr
 
 
+def _this_callers_identity():
+    """The keys a client signs with: this project's, else this machine's.
+
+    `connect()` took `keys=None` and passed it straight through, so the
+    documented one-liner -- `connect(addr).input(...)` -- sent unsigned frames
+    and a `careful` agent refused them:
+
+        ConnectionError: Auth error: unauthorized: signed request required
+
+    `careful` is what `co init` writes, so that was the default server. What
+    `careful` adds over `strict` is a way *in* for a signed stranger, not
+    permission to stay anonymous.
+
+    `co call` never hit this because it loaded the keys itself, in a second copy
+    of this logic that resolved `.co` against the bare cwd. The host side had
+    already settled the question -- resolve_agent_identity: the project's key
+    when it has one, the machine's ~/.co when it does not -- so a client gets
+    the same answer, with the walk-up #661 gave the project half.
+
+    Never generates. An agent must have an address; a caller without one is a
+    caller the remote is entitled to refuse.
+    """
+    from pathlib import Path
+
+    from .. import address
+    from ..project import project_co_dir
+
+    return address.load(project_co_dir()) or address.load(Path.home() / ".co")
+
+
 def _sort_endpoints(endpoints: List[str]) -> List[str]:
     """Closest first, and among equally close ones, the encrypted one.
 
@@ -196,7 +226,10 @@ class RemoteAgent:
         relay_url: str = "wss://oo.openonion.ai"
     ):
         self.address = agent_address
-        self._keys = keys
+        # None means "I did not choose" -- find the caller's identity, because
+        # an unsigned client cannot talk to a default agent. False means "no
+        # keys, deliberately", which trust: open accepts and people use in dev.
+        self._keys = _this_callers_identity() if keys is None else (keys or None)
         self._relay_url = relay_url.rstrip("/")
         self._status = "idle"
         self._current_session: Optional[Dict[str, Any]] = None
@@ -778,7 +811,10 @@ def connect(
 
     Args:
         address: Agent's public key address (0x...)
-        keys: Signing keys from address.load() - required for strict trust agents
+        keys: Signing keys. Omit them and this project's identity is used
+              (then this machine's ~/.co). Every trust level above `open`
+              refuses an unsigned request, `careful` included. Pass
+              keys=False to connect anonymously to a `trust: open` agent.
         relay_url: Relay server base URL (default: production)
 
     Returns:

--- a/tests/unit/test_the_documented_way_to_call_an_agent_works.py
+++ b/tests/unit/test_the_documented_way_to_call_an_agent_works.py
@@ -1,0 +1,167 @@
+"""`connect(address).input(...)` — the documented one-liner — cannot talk to a
+default agent.
+
+`connect` takes `keys=None` and passes it straight through:
+
+    def connect(address, keys=None, relay_url=...):
+        keys: Signing keys from address.load() - required for strict trust agents
+        ...
+        >>> agent = connect("0x3d4017c3...")
+        >>> response = agent.input("Book a flight")
+
+The example is the shape a user copies, and the parameter doc says signing is a
+`strict` concern. Both are wrong about the default. Measured against a real
+hosted agent on `trust: careful` — the default from `co init` — using exactly
+that example:
+
+    ConnectionError: Auth error: unauthorized: signed request required
+
+`careful` refuses an unsigned frame just as `strict` does; what `careful` adds is
+a way *in* for a signed stranger (onboarding), not permission to stay anonymous.
+
+The CLI does not have this problem, because it loads the keys itself:
+
+    # cli/commands/call_commands.py
+    def _load_keys():
+        co_dir = Path(".co")
+        if not (co_dir.exists() and (co_dir / "keys" / "agent.key").exists()):
+            co_dir = Path.home() / ".co"
+        return address.load(co_dir)
+
+    kwargs = {"keys": _load_keys()}
+
+So `co call` reaches the agent and `connect()` does not — the same two-places
+shape as #669 and #671, with only one of the two places doing the work.
+
+The host side already settled what the answer is. `resolve_agent_identity` uses
+the project's key when it has one and the machine's `~/.co` identity when it does
+not, and #661 gave the project half of that a proper walk-up. A client is the
+same question from the other end, so it gets the same answer here, and
+`_load_keys` becomes one call into it rather than a second copy with a bare
+`Path(".co")` that reads the wrong project from a subdirectory.
+
+Passing `keys=` explicitly still wins, and an unsigned client is still possible
+by asking for one — `connect(addr, keys=False)` — because `trust: open` accepts
+anonymous callers and that is a thing people do in development.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def a_project_with_an_identity(tmp_path, monkeypatch):
+    from connectonion import address
+
+    co = tmp_path / "project" / ".co"
+    co.mkdir(parents=True)
+    keys = address.generate()
+    address.save(keys, co)
+    (tmp_path / "project" / "sub").mkdir()
+    monkeypatch.chdir(tmp_path / "project")
+    return tmp_path / "project", keys
+
+
+class TestTheDocumentedOneLiner:
+
+    def test_it_signs(self, a_project_with_an_identity):
+        from connectonion.network import connect
+
+        _, keys = a_project_with_an_identity
+
+        assert connect("0x" + "a" * 64)._keys["address"] == keys["address"]
+
+    def test_from_a_subdirectory_it_is_still_this_project(self, a_project_with_an_identity, monkeypatch):
+        """`co call`'s copy used a bare `Path(".co")`, so a subdirectory silently
+        fell through to the machine identity instead."""
+        project, keys = a_project_with_an_identity
+        monkeypatch.chdir(project / "sub")
+
+        assert connect_keys("0x" + "a" * 64)["address"] == keys["address"]
+
+
+def connect_keys(address_str):
+    from connectonion.network import connect
+
+    return connect(address_str)._keys
+
+
+class TestTheMachineIdentityIsTheFallback:
+    """What the host side does — `resolve_agent_identity`: own key, else ~/.co."""
+
+    def test_a_project_without_keys_uses_the_home_identity(self, tmp_path, monkeypatch):
+        from connectonion import address
+        from connectonion.network import connect
+
+        home = tmp_path / "home"
+        (home / ".co").mkdir(parents=True)
+        machine = address.generate()
+        address.save(machine, home / ".co")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        project = tmp_path / "keyless"
+        (project / ".co").mkdir(parents=True)
+        monkeypatch.chdir(project)
+
+        assert connect("0x" + "a" * 64)._keys["address"] == machine["address"]
+
+    def test_no_identity_anywhere_is_not_an_error(self, tmp_path, monkeypatch):
+        """A caller with no key at all still constructs; the agent decides."""
+        from connectonion.network import connect
+
+        home = tmp_path / "empty-home"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.chdir(tmp_path)
+
+        assert connect("0x" + "a" * 64)._keys is None
+
+
+class TestWhatMustNotChange:
+
+    def test_explicit_keys_still_win(self, a_project_with_an_identity):
+        from connectonion import address
+        from connectonion.network import connect
+
+        chosen = address.generate()
+
+        assert connect("0x" + "a" * 64, keys=chosen)._keys["address"] == chosen["address"]
+
+    def test_an_unsigned_client_can_still_be_asked_for(self, a_project_with_an_identity):
+        """`trust: open` accepts anonymous callers, and that is a real workflow."""
+        from connectonion.network import connect
+
+        assert connect("0x" + "a" * 64, keys=False)._keys is None
+
+
+class TestTheCliUsesTheSameOne:
+    """One resolver, not two — `_load_keys` was the copy that worked."""
+
+    def test_it_finds_the_projects_identity(self, a_project_with_an_identity):
+        from connectonion.cli.commands.call_commands import _load_keys
+
+        _, keys = a_project_with_an_identity
+
+        assert _load_keys()["address"] == keys["address"]
+
+    def test_from_a_subdirectory_too(self, a_project_with_an_identity, monkeypatch):
+        from connectonion.cli.commands.call_commands import _load_keys
+
+        project, keys = a_project_with_an_identity
+        monkeypatch.chdir(project / "sub")
+
+        assert _load_keys()["address"] == keys["address"]
+
+
+class TestTheDocstringSaysWhatIsTrue:
+    """The claim that sent a user down this path in the first place."""
+
+    def test_it_does_not_say_signing_is_only_for_strict(self):
+        import inspect
+
+        from connectonion.network import connect
+
+        text = (inspect.getdoc(connect) or "").lower()
+
+        assert "required for strict trust agents" not in text


### PR DESCRIPTION
## What

`connect` takes `keys=None` and passes it straight through, so the documented one-liner sends **unsigned** frames. Measured against a real hosted agent on `trust: careful` — what `co init` writes — using the example from `connect`'s own docstring:

```python
>>> agent = connect("0x3d4017c3...")
>>> response = agent.input("Book a flight")
ConnectionError: Auth error: unauthorized: signed request required
```

The parameter doc said signing is *"required for strict trust agents"*. It is required by `careful` too. What `careful` adds over `strict` is a way **in** for a signed stranger (onboarding), not permission to stay anonymous.

So the primary client entry point, exactly as documented, does not work against the default server configuration.

## Why `co call` was fine

It loaded the keys itself:

```python
def _load_keys():
    co_dir = Path(".co")
    if not (co_dir.exists() and (co_dir / "keys" / "agent.key").exists()):
        co_dir = Path.home() / ".co"
    return address.load(co_dir)
```

The same two-places shape as #669 and #671, with only one of the two doing the work — and that copy resolves `.co` against the bare cwd, so `co call` from a subdirectory signs as the machine rather than as the project.

## The answer was already settled on the host side

`resolve_agent_identity` uses the project's key when it has one and the machine's `~/.co` when it does not; #661 gave the project half a proper walk-up. A client is the same question from the other end, so it gets the same answer, and `_load_keys` becomes one call into it.

It never generates: an agent must have an address, but a caller without one is a caller the remote is entitled to refuse.

## Verified end to end

Against a live agent, after the change — the documented one-liner with no `keys=`:

```
signed as: 0x10e68f6dff39ab1c50…
endpoint:  ws://10.5.27.133:8931/ws     -> reply: Pong
forced relay path                        -> reply: Pong
```

Both paths, and the agent's own log confirms it served them.

## What must not change

- `keys=` passed explicitly still wins.
- `keys=False` still connects anonymously — `trust: open` accepts that and people use it in development. `None` now means "I did not choose", which is not the same thing.

## Tests

`tests/unit/test_the_documented_way_to_call_an_agent_works.py`, 9 cases, proven to fail first. Full suite **4433 passed**.