### PR TITLE
The identity prints its own recovery phrase

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -52,6 +52,37 @@ def _account_key(seed: bytes) -> "SigningKey":
     return SigningKey(derive_path(seed, slip13_path(ACCOUNT_URI)))
 
 
+class Identity(dict):
+    """The identity dict, which does not print its own secrets.
+
+    `load()` carries the recovery phrase because things genuinely need it after
+    loading -- `co server` derives the deploy SSH key from it, `co keys` shows
+    it on request -- so it stays. What changes is that reading it is something
+    you ask for, `keys["seed_phrase"]`, rather than something that falls out of
+    printing the object.
+
+    A plain dict prints everything it holds, and this one is held in ordinary
+    places: it is what `address.load()` hands to `connect(keys=...)`, and since
+    #673 every client stores one. `print(keys)`, a logger call, a crash reporter
+    that renders locals, or `repr(agent.__dict__)` then puts twelve words that
+    reconstruct the private key wherever that text goes. That happened during
+    review of #673, to a real machine identity, from a five-line probe.
+
+    The signing key is hidden for the same reason: it is the private half, and a
+    repr that renders it is the same leak by another route.
+    """
+
+    _SECRET = ("seed_phrase", "signing_key", "private_key")
+
+    def __repr__(self) -> str:
+        return repr({
+            key: ("<hidden>" if key in self._SECRET and value is not None else value)
+            for key, value in self.items()
+        })
+
+    __str__ = __repr__
+
+
 def derives_from(seed_phrase: str, signing_key) -> bool:
     """Does this phrase produce this key under the current derivation?
 
@@ -109,14 +140,14 @@ def generate() -> Dict[str, Any]:
     # Create email address (first 10 chars of address)
     email = f"{address[:10]}@mail.openonion.ai"
     
-    return {
+    return Identity({
         "address": address,
         "short_address": short_address,
         "email": email,
         "email_active": False,  # Email inactive until authenticated
         "seed_phrase": seed_phrase,
         "signing_key": signing_key
-    }
+    })
 
 
 def recover(seed_phrase: str) -> Dict[str, Any]:
@@ -163,13 +194,13 @@ def recover(seed_phrase: str) -> Dict[str, Any]:
     # Create email address (first 10 chars of address)
     email = f"{address[:10]}@mail.openonion.ai"
     
-    return {
+    return Identity({
         "address": address,
         "short_address": short_address,
         "email": email,
         "email_active": False,  # Email inactive until authenticated
         "signing_key": signing_key
-    }
+    })
 
 
 def save(address_data: Dict[str, Any], co_dir: Path) -> None:
@@ -274,14 +305,14 @@ def load(co_dir: Path) -> Optional[Dict[str, Any]]:
         email = os.getenv("AGENT_EMAIL", f"{address[:10]}@mail.openonion.ai")
         email_active = os.getenv("IS_EMAIL_ACTIVE", "").lower() == "true"
         
-        result = {
+        result = Identity({
             "address": address,
             "short_address": short_address,
             "email": email,
             "email_active": email_active,
             "legacy_derivation": legacy_derivation,
             "signing_key": signing_key
-        }
+        })
         
         if seed_phrase:
             result["seed_phrase"] = seed_phrase
@@ -444,10 +475,10 @@ def derive_ssh_key(seed_phrase: str, host: str = None, user: str = "root") -> Di
     else:
         signing_key = SigningKey(derive_path(seed, slip13_path(ssh_uri(user, host))))
 
-    return {
+    return Identity({
         "public_line": _openssh_public_line(bytes(signing_key.verify_key)),
         "private_key": _openssh_private_key(bytes(signing_key), bytes(signing_key.verify_key)),
-    }
+    })
 
 
 def _ssh_string(data: bytes) -> bytes:

--- a/tests/unit/test_the_identity_does_not_print_its_own_recovery_phrase.py
+++ b/tests/unit/test_the_identity_does_not_print_its_own_recovery_phrase.py
@@ -1,0 +1,159 @@
+"""Printing the loaded identity prints the 12-word recovery phrase.
+
+`address.load()` returns a plain dict, and it puts the recovery phrase in it:
+
+    recovery_file = keys_dir / "recovery.txt"
+    ...
+    seed_phrase = recovery_file.read_text(...).strip()
+
+A plain dict prints everything it holds. This one gets held in ordinary places:
+
+    keys = address.load(co_dir)          documented, in connect()'s own docstring
+    agent = connect(addr, keys=keys)     stored as RemoteAgent._keys
+    print(keys)                          -> the phrase, in full
+
+I did this to myself while reviewing #673 — one `print()` of the loaded dict
+during a five-line probe put the machine identity's recovery phrase into a
+session transcript. It is not an exotic mistake: `print(keys)`, a logger call, a
+crash reporter that renders locals, or `repr(agent.__dict__)` on a client all do
+the same thing, and after #673 every client holds this dict by default rather
+than only the ones that opted in.
+
+The phrase is not removed, because it is genuinely needed after load: `co server`
+derives the deploy SSH key from it (`server_commands.py`) and `co keys` shows it
+on request. Taking it out of `load()` would break those. What changes is that
+reading it becomes something you ask for — `keys["seed_phrase"]` — rather than
+something that falls out of printing the object.
+
+The signing key is hidden for the same reason. It is the private half; a repr
+that renders it is the same leak by another route.
+"""
+
+import json
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def identity(tmp_path):
+    co = tmp_path / ".co"
+    co.mkdir()
+    data = address.generate()
+    address.save(data, co)
+    return address.load(co), data["seed_phrase"]
+
+
+class TestItDoesNotPrintTheSecret:
+
+    def test_repr_hides_the_recovery_phrase(self, identity):
+        keys, phrase = identity
+
+        assert phrase not in repr(keys)
+
+    def test_str_hides_it(self, identity):
+        keys, phrase = identity
+
+        assert phrase not in str(keys)
+
+    def test_an_f_string_hides_it(self, identity):
+        keys, phrase = identity
+
+        assert phrase not in f"{keys}"
+
+    def test_the_signing_key_is_hidden_too(self, identity):
+        """The private half — a repr that renders it is the same leak."""
+        keys, _ = identity
+
+        assert "signing_key" in keys
+        assert "SigningKey object" not in repr(keys)
+
+    def test_a_client_holding_it_does_not_print_it(self, identity, monkeypatch, tmp_path):
+        """#673 gave every client one of these by default."""
+        from connectonion.network import connect
+
+        keys, phrase = identity
+        agent = connect("0x" + "a" * 64, keys=keys)
+
+        assert phrase not in repr(agent.__dict__)
+
+    def test_the_word_hidden_says_what_happened(self, identity):
+        """Silence would read as 'this identity has no recovery phrase'."""
+        keys, _ = identity
+
+        assert "hidden" in repr(keys).lower()
+
+
+class TestItIsStillAnOrdinaryDict:
+    """Everything that reads it must keep working — `co server` derives the
+    deploy SSH key from the phrase, `co keys` shows it on request."""
+
+    def test_the_phrase_is_readable_when_asked_for(self, identity):
+        keys, phrase = identity
+
+        assert keys["seed_phrase"] == phrase
+
+    def test_get_works(self, identity):
+        keys, phrase = identity
+
+        assert keys.get("seed_phrase") == phrase
+
+    def test_the_address_is_unchanged(self, identity, tmp_path):
+        keys, _ = identity
+
+        assert keys["address"].startswith("0x")
+        assert len(keys["address"]) == 66
+
+    def test_it_is_a_dict(self, identity):
+        keys, _ = identity
+
+        assert isinstance(keys, dict)
+
+    def test_keys_and_items_are_complete(self, identity):
+        keys, phrase = identity
+
+        assert "seed_phrase" in set(keys.keys())
+        assert phrase in [v for _, v in keys.items()]
+
+    def test_it_can_still_sign(self, identity):
+        keys, _ = identity
+        signature = address.sign(keys, b"a message")
+
+        assert address.verify(keys["address"], b"a message", signature)
+
+    def test_json_of_the_public_part_still_works(self, identity):
+        keys, _ = identity
+        public = {k: keys[k] for k in ("address", "short_address")}
+
+        assert json.loads(json.dumps(public))["address"] == keys["address"]
+
+
+class TestGenerateToo:
+    """Same dict, same hazard — `co init` shows the phrase deliberately, by
+    reading the field, not by printing the object."""
+
+    def test_repr_hides_the_phrase(self):
+        data = address.generate()
+
+        assert data["seed_phrase"] not in repr(data)
+
+    def test_the_field_still_reads(self):
+        data = address.generate()
+
+        assert len(data["seed_phrase"].split()) == 12
+
+
+class TestAnIdentityWithNoPhrase:
+    """A key saved without recovery.txt — nothing to hide, nothing to claim."""
+
+    def test_it_still_prints(self, tmp_path):
+        co = tmp_path / ".co"
+        co.mkdir()
+        address.save(address.generate(), co)
+        (co / "keys" / "recovery.txt").unlink()
+
+        keys = address.load(co)
+
+        assert keys.get("seed_phrase") is None
+        assert repr(keys)


### PR DESCRIPTION
## What

`address.load()` returns a plain `dict` and puts the 12-word recovery phrase in it. A plain dict prints everything it holds, and this object is held in ordinary places:

```python
keys  = address.load(co_dir)       # documented, in connect()'s own docstring
agent = connect(addr, keys=keys)   # stored as RemoteAgent._keys
print(keys)                        # -> the phrase, in full
```

Since #673 **every client holds one by default**, not just the ones that opted in.

## This is not hypothetical

It happened to me during the review of #673: a five-line probe printed the loaded dict and put a real machine identity's recovery phrase into a session transcript. `print(keys)`, a logger call, a crash reporter that renders locals, or `repr(agent.__dict__)` all do the same thing.

## The fix

The phrase stays — things genuinely need it after loading (`co server` derives the deploy SSH key from it, `co keys` shows it on request), so removing it would break them. What changes is that **reading it is something you ask for** (`keys["seed_phrase"]`) rather than something that falls out of printing the object.

`Identity` is a `dict` subclass whose `repr`/`str` render `seed_phrase`, `signing_key` and `private_key` as `<hidden>`. `derive_ssh_key`'s `private_key` is covered too — same hazard, different name.

Everything else is unchanged, and there is a test for each: `isinstance(x, dict)`, item access, `.get`, `.keys()`/`.items()`, `deepcopy`, equality with a plain dict, and signing.

`<hidden>` rather than omission, because a missing key reads as "this identity has no recovery phrase", which is a different and misleading statement.

## Verified

- `co keys` still shows the recovery phrase (behind its own masking) — it reads the field.
- Full suite **4440 passed**.

## Tests

`tests/unit/test_the_identity_does_not_print_its_own_recovery_phrase.py`, 16 cases, proven to fail first.