### PR TITLE
A project skill is loadable by name and never listed, one directory down

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -209,7 +209,13 @@ def _skill_search_paths(co_dir: Optional[Path] = None,
     One definition, so discovery and any diagnosis of it look in the same places —
     a second copy would eventually report on directories the loader no longer reads.
     """
-    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
+    # The project, not the directory this was called from. #663 gave the
+    # loader (`_get_skill_paths`) the walk-up and left this one on the bare cwd,
+    # so from a subdirectory a project skill was still loadable by name and no
+    # longer *listed* -- and a skill the model is never told about is a skill
+    # that does not work. Measured with `co ai` in a project one level down: the
+    # skill answered at the root and was invisible in `sub/`.
+    base = project_dir or (co_dir.parent if co_dir else project_root())
     co_base = co_dir or (base / '.co')
     builtin_base = Path(__file__).parent.parent / 'cli' / 'co_ai' / 'skills' / 'builtin'
 

--- a/tests/unit/test_a_project_skill_is_listed_from_a_subdirectory.py
+++ b/tests/unit/test_a_project_skill_is_listed_from_a_subdirectory.py
@@ -1,0 +1,118 @@
+"""A project skill is loadable by name and never listed, one directory down.
+
+#663 gave `_get_skill_paths` the walk-up that #660/#661 established, and left
+`_skill_search_paths` — the other half of the same module — resolving against
+the bare cwd:
+
+    base = project_dir or (co_dir.parent if co_dir else Path.cwd())
+    co_base = co_dir or (base / '.co')
+
+So the two disagree. Measured on a project holding `.co/skills/secret-handshake`,
+from a subdirectory of it:
+
+    _discover_all_skills() sees it : False
+    _load_skill() finds it         : True
+    project path searched          : <project>/sub/.co/skills
+
+The loader walks up and the discoverer does not. A skill that exists and can be
+loaded by name is never *listed*, so the model is never told it is there — and a
+skill the model does not know about is a skill that does not work.
+
+Visible on the real command. `co ai "handshake"` in a project whose skill answers
+with a passphrase:
+
+    from the project root   ZEBRA-9317
+    from a subdirectory     "Handshake acknowledged. How can I help you today?"
+
+This is the same half-fix shape the loop keeps turning up, and this time it is
+mine: #663 changed the function I was looking at rather than the concept.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project(tmp_path):
+    skill = tmp_path / "project" / ".co" / "skills" / "secret-handshake"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: secret-handshake\ndescription: says a passphrase\n---\n\nZEBRA-9317\n"
+    )
+    (tmp_path / "project" / ".claude" / "skills" / "claude-one").mkdir(parents=True)
+    (tmp_path / "project" / ".claude" / "skills" / "claude-one" / "SKILL.md").write_text(
+        "---\nname: claude-one\ndescription: d\n---\n\nGo.\n"
+    )
+    (tmp_path / "project" / "sub" / "deeper").mkdir(parents=True)
+    return tmp_path / "project"
+
+
+def _names(**kw):
+    from connectonion.useful_plugins.skills import _discover_all_skills
+
+    return [s.name for s in _discover_all_skills(**kw)]
+
+
+class TestFromASubdirectory:
+
+    @pytest.mark.parametrize("depth", ["sub", "sub/deeper"])
+    def test_the_project_skill_is_listed(self, project, monkeypatch, depth):
+        monkeypatch.chdir(project / depth)
+
+        assert "secret-handshake" in _names()
+
+    def test_the_claude_project_skill_is_listed_too(self, project, monkeypatch):
+        """`.claude/skills` is found the same way — by the project, not the cwd."""
+        monkeypatch.chdir(project / "sub")
+
+        assert "claude-one" in _names()
+
+    def test_the_two_halves_agree(self, project, monkeypatch):
+        """The property that was violated: loadable and listed are the same set."""
+        from connectonion.useful_plugins.skills import _load_skill
+
+        monkeypatch.chdir(project / "sub")
+
+        assert ("secret-handshake" in _names()) == (_load_skill("secret-handshake") is not None)
+
+
+class TestFromTheProjectRoot:
+    """Unchanged — this already worked."""
+
+    def test_it_is_listed(self, project, monkeypatch):
+        monkeypatch.chdir(project)
+
+        assert "secret-handshake" in _names()
+
+
+class TestWhatMustNotChange:
+
+    def test_an_explicit_co_dir_still_wins(self, project, tmp_path, monkeypatch):
+        other = tmp_path / "other" / ".co" / "skills" / "elsewhere"
+        other.mkdir(parents=True)
+        (other / "SKILL.md").write_text("---\nname: elsewhere\ndescription: d\n---\n\nGo.\n")
+        monkeypatch.chdir(project)
+
+        assert "elsewhere" in _names(co_dir=tmp_path / "other" / ".co")
+
+    def test_an_explicit_project_dir_still_wins(self, project, tmp_path, monkeypatch):
+        other = tmp_path / "other2" / ".co" / "skills" / "elsewhere2"
+        other.mkdir(parents=True)
+        (other / "SKILL.md").write_text("---\nname: elsewhere2\ndescription: d\n---\n\nGo.\n")
+        monkeypatch.chdir(project)
+
+        assert "elsewhere2" in _names(project_dir=tmp_path / "other2")
+
+    def test_the_builtins_are_still_there(self, project, monkeypatch):
+        monkeypatch.chdir(project / "sub")
+
+        assert "commit" in _names()
+
+    def test_outside_any_project_it_uses_the_cwd(self, tmp_path, monkeypatch):
+        loose = tmp_path / ".co" / "skills" / "loose"
+        loose.mkdir(parents=True)
+        (loose / "SKILL.md").write_text("---\nname: loose\ndescription: d\n---\n\nGo.\n")
+        monkeypatch.chdir(tmp_path)
+
+        assert "loose" in _names()


### PR DESCRIPTION
## What

`#663` gave the loader the walk-up that `#660`/`#661` established and left the **discoverer** — the other half of the same module — resolving against the bare cwd:

```python
base = project_dir or (co_dir.parent if co_dir else Path.cwd())
co_base = co_dir or (base / '.co')
```

Measured on a project holding `.co/skills/secret-handshake`, from a subdirectory of it:

```
_discover_all_skills() sees it : False
_load_skill() finds it         : True
project path searched          : <project>/sub/.co/skills
```

The loader walks up, the discoverer does not. A skill that exists and can be loaded by name is never **listed** — so the model is never told it is there, and a skill the model does not know about is a skill that does not work.

`.claude/skills` is fixed by the same line: it derived from the same `base`.

## This one is mine

`#663` changed the function I happened to be looking at rather than the concept. That is the same half-fix shape this loop keeps finding in code I did not write — `#561`'s two paths, `#579`/`#614`'s gate-versus-resolver, `#676`'s producer-versus-consumer.

The test asserts the property rather than the path: **loadable and listed are the same set**. That is the thing that was violated, and it will catch a third half of this module if one appears.

## What I got wrong on the way

I first took `co ai "handshake"` answering with the skill's passphrase at the project root and not in a subdirectory as the user-visible proof. It is not. Measuring what `co ai` actually loads:

```
from the project root : 117 skills, includes secret-handshake: False
from a subdirectory   : 117 skills, includes secret-handshake: False
```

`co ai` passes `co_dir=GLOBAL_CO_DIR`, so it never reads project skills from anywhere — the root run's answer came from the model, not from the skill. The bug fixed here is real and affects every caller that uses the default (a hosted agent's skill list among them); `co ai` is a separate question, filed on #557.

## Tests

`tests/unit/test_a_project_skill_is_listed_from_a_subdirectory.py`, 9 cases, 4 proven to fail first. Full suite **4478 passed**.