### PR TITLE
co deploy one directory down tells you to break your project

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -366,7 +366,10 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
     """Deploy the current ConnectOnion project."""
     console.print("\n[cyan]Deploying to ConnectOnion Cloud...[/cyan]\n")
 
-    project_dir = Path.cwd() if project_dir is None else project_dir
+    # The project, not the directory you ran from -- see _read_project.
+    from ...project import project_root
+
+    project_dir = project_root() if project_dir is None else project_dir
 
     # Must be a ConnectOnion project
     host_yaml_path = project_dir / ".co" / "host.yaml"

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -81,12 +81,23 @@ def _ssh(target: str, command: str, timeout: int = 300) -> subprocess.CompletedP
         )
 
 
-def _read_project(project_dir: Path) -> Optional[dict]:
+def _read_project(project_dir: Optional[Path] = None) -> Optional[dict]:
     """Read the agent name and entrypoint from .co/host.yaml.
 
     Same contract as the cloud deploy, so a project does not need a second
     config to be deployable both ways.
+
+    The project is the directory that owns `.co/`, found by walking up -- the
+    rule the rest of the codebase settled on in #660/#661/#663. Resolved against
+    the bare cwd, `co deploy` from a subdirectory said "Not a ConnectOnion
+    project. Run 'co init' first." while `load_host_config` from the same place
+    read the project's own `trust: strict`. Following that advice created a
+    second `.co` there, which downgraded the real project to `careful` and made
+    deploy report success against the subdirectory.
     """
+    from ...project import project_root
+
+    project_dir = Path(project_dir) if project_dir else project_root()
     host_yaml = project_dir / ".co" / "host.yaml"
     if not host_yaml.exists():
         console.print("[red]Not a ConnectOnion project. Run 'co init' first.[/red]")
@@ -883,7 +894,9 @@ def _mark_provisioned(target: str, agent: str) -> None:
 def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
                      own_identity: bool = False) -> bool:
     """co deploy --to <server>:  ensure(setup) → sync code → restart."""
-    project_dir = (project_dir or Path.cwd()).resolve()
+    from ...project import project_root
+
+    project_dir = Path(project_dir).resolve() if project_dir else project_root()
 
     # Checked here rather than discovered inside subprocess.run, which raises
     # FileNotFoundError and prints a traceback — for the one failure a person can

--- a/tests/unit/test_deploy_finds_the_project_from_a_subdirectory.py
+++ b/tests/unit/test_deploy_finds_the_project_from_a_subdirectory.py
@@ -1,0 +1,109 @@
+"""`co deploy` one directory down tells you to break your project.
+
+Deploy resolves the project against the bare cwd:
+
+    project_dir = (project_dir or Path.cwd()).resolve()     # deploy_to_server.py
+    project_dir = Path.cwd() if project_dir is None else …  # deploy_commands.py
+
+so from a subdirectory `_read_project` finds no `.co/host.yaml` and says:
+
+    Not a ConnectOnion project. Run 'co init' first.
+
+You are in one. The framework knows it — `load_host_config(None)` from the same
+directory returns the project's `trust: strict`, because #661 taught it to walk
+up. Only deploy cannot see it.
+
+Following the advice is what makes this a bug rather than a wrong message.
+Measured end to end, in a subdirectory of a project configured `trust: strict`:
+
+    co init here
+    a decoy .co now exists here : True
+    trust now reads             : careful      (was strict)
+    _read_project               : name=sub, entrypoint=agent.py
+
+Three things at once. The project's trust is silently downgraded — a whitelist-
+only agent now admits contacts and accepts an invite code — because the decoy
+`.co` shadows the real one, which is the hazard #663 spent a change removing.
+Deploy then reports success against the **subdirectory**, so what ships is the
+wrong tree with the wrong name.
+
+The fix is the one the rest of the codebase already made: the project is the
+directory that owns `.co/`, found by walking up. Then deploy works from a
+subdirectory and nobody is told to plant a decoy.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project(tmp_path):
+    co = tmp_path / "project" / ".co"
+    co.mkdir(parents=True)
+    (co / "host.yaml").write_text("name: realagent\nentrypoint: main.py\ntrust: strict\nport: 8123\n")
+    (tmp_path / "project" / "main.py").write_text("# the entrypoint\n")
+    (tmp_path / "project" / "sub" / "deeper").mkdir(parents=True)
+    return tmp_path / "project"
+
+
+class TestFromASubdirectory:
+
+    @pytest.mark.parametrize("depth", ["sub", "sub/deeper"])
+    def test_the_project_is_found(self, project, monkeypatch, depth):
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        monkeypatch.chdir(project / depth)
+
+        assert (_read_project(None) or {}).get("name") == "realagent"
+
+    def test_the_entrypoint_comes_with_it(self, project, monkeypatch):
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        monkeypatch.chdir(project / "sub")
+
+        assert (_read_project(None) or {}).get("entrypoint") == "main.py"
+
+    def test_nobody_is_told_to_run_co_init(self, project, monkeypatch, capsys):
+        """The advice that plants a decoy `.co` and downgrades the project."""
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        monkeypatch.chdir(project / "sub")
+        _read_project(None)
+
+        assert "co init" not in capsys.readouterr().out
+
+
+class TestFromTheProjectRoot:
+    """Unchanged."""
+
+    def test_it_still_reads_the_project(self, project, monkeypatch):
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        monkeypatch.chdir(project)
+
+        assert (_read_project(None) or {}).get("name") == "realagent"
+
+
+class TestOutsideAnyProject:
+
+    def test_it_still_says_so(self, tmp_path, monkeypatch, capsys):
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        monkeypatch.chdir(tmp_path)
+
+        assert _read_project(None) is None
+        assert "co init" in capsys.readouterr().out
+
+
+class TestWhatMustNotChange:
+
+    def test_an_explicit_directory_still_wins(self, project, tmp_path, monkeypatch):
+        from connectonion.cli.commands.deploy_to_server import _read_project
+
+        other = tmp_path / "other"
+        (other / ".co").mkdir(parents=True)
+        (other / ".co" / "host.yaml").write_text("name: otheragent\n")
+        monkeypatch.chdir(project)
+
+        assert (_read_project(other) or {}).get("name") == "otheragent"


### PR DESCRIPTION
## What

Deploy resolved the project against the bare cwd:

```python
project_dir = (project_dir or Path.cwd()).resolve()      # deploy_to_server.py
project_dir = Path.cwd() if project_dir is None else …   # deploy_commands.py
```

so from a subdirectory `_read_project` finds no `.co/host.yaml` and says:

> Not a ConnectOnion project. Run 'co init' first.

**You are in one.** `load_host_config(None)` from the same directory returns the project's `trust: strict`, because #661 taught it to walk up. Only deploy could not see it.

## Following the advice is the bug

Measured end to end, in a subdirectory of a project configured `trust: strict`:

```
co init here
a decoy .co now exists here : True
trust now reads             : careful      (was strict)
_read_project               : name=sub, entrypoint=agent.py
```

Three things at once:

1. **The project's trust is silently downgraded.** A whitelist-only agent now admits contacts and accepts an invite code — the decoy `.co` shadows the real one, which is the hazard #663 spent a change removing.
2. **Deploy then reports success against the subdirectory** — wrong tree, wrong name.
3. It looks like it worked.

So the tool's own error message leads the user into breaking the thing they were trying to deploy.

## The fix

The rule the rest of the codebase already settled on: the project is the directory that owns `.co/`, found by walking up. Both entry points — the server deploy and the cloud deploy — resolve it that way now, and `_read_project` takes `None` and does it itself rather than leaving each caller to decide.

Verified on the real path from a subdirectory afterwards:

```
project found : deploy2
entrypoint    : agent.py
trust intact  : strict
no .co was created in the subdirectory
```

## What must not change

An explicitly passed directory still wins, and outside any project the message is still the right one — there is a test for each.

## Tests

`tests/unit/test_deploy_finds_the_project_from_a_subdirectory.py`, 7 cases, 4 proven to fail first. Full suite **4485 passed**.