### PR TITLE
co keys shows a different identity depending on where you stand

### DIFF
--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -20,8 +20,26 @@ console = Console()
 
 
 def _find_co_dir() -> Path:
-    """Find the .co directory (local first, then global)."""
-    local = Path(".co")
+    """The identity this project uses: its own key, else the machine's.
+
+    The project half is found by walking up, the way everything else has since
+    #660. As a bare `Path(".co")` it was invisible one directory down, and the
+    `~/.co` fallback then answered instead -- so `co keys` printed a different
+    address depending on where in the project you stood:
+
+        from the project root   Address 0xd72fbbd5…   Source .co (project)
+        from a subdirectory     Address 0x10e68f6d…   Source ~/.co (global)
+
+    Both stated as confidently as the other, and an operator reads one off this
+    panel and hands it out.
+
+    The fallback itself stays: a project with no key of its own is a real
+    configuration -- `co init` usually produces one -- and it is what
+    resolve_agent_identity does on the host side.
+    """
+    from ...project import project_co_dir
+
+    local = project_co_dir()
     if local.exists() and (local / "keys" / "agent.key").exists():
         return local
 
@@ -75,10 +93,21 @@ def _short_path(p: Path) -> str:
 
 
 def _source_label(co_dir: Path) -> str:
-    """Return human-readable source label for where keys are loaded from."""
+    """Return human-readable source label for where keys are loaded from.
+
+    Relative to where you are standing, so it stays short and says which way the
+    project lies: `.co` at the root, `../.co` from a subdirectory. It used to
+    interpolate `co_dir` directly, which read fine only because that value was
+    the relative `Path(".co")`; once it became the resolved project path the
+    panel printed the machine's whole directory tree.
+    """
     if co_dir.resolve() == (Path.home() / ".co").resolve():
         return "~/.co (global)"
-    return f"{co_dir} (project)"
+    try:
+        shown = co_dir.relative_to(Path.cwd())
+    except ValueError:
+        shown = Path(os.path.relpath(co_dir, Path.cwd()))
+    return f"{shown} (project)"
 
 
 def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):

--- a/tests/e2e/cli/test_cli_keys.py
+++ b/tests/e2e/cli/test_cli_keys.py
@@ -114,7 +114,10 @@ class TestFindCoDir:
                 from connectonion.cli.commands.keys_commands import _find_co_dir
                 result = _find_co_dir()
                 assert result is not None
-                assert result == Path(".co")
+                # Resolved, not the relative `Path(".co")` it used to return:
+                # the project is now found by walking up, so the answer has to
+                # name a directory rather than depend on the cwd.
+                assert result == (Path(tmpdir) / ".co").resolve()
             finally:
                 os.chdir(original_cwd)
 

--- a/tests/unit/test_co_keys_shows_this_projects_identity.py
+++ b/tests/unit/test_co_keys_shows_this_projects_identity.py
@@ -1,0 +1,118 @@
+"""`co keys` shows a different identity depending on where you stand.
+
+`_find_co_dir` looks in the bare cwd, then falls back to the machine's:
+
+    local = Path(".co")
+    if local.exists() and (local / "keys" / "agent.key").exists():
+        return local
+    global_dir = Path.home() / ".co"
+    ...
+
+so one directory down the project's own key is invisible and the global one
+answers instead. Measured on a project with its own keypair:
+
+    from the project root   Address 0xd72fbbd5…   Source .co (project)
+    from a subdirectory     Address 0x10e68f6d…   Source ~/.co (global)
+
+Two different addresses for the same agent, and the panel states the wrong one
+as confidently as the right one.
+
+This is the shape I got wrong when filing #665. I wrote there that these
+commands "fail in the visible direction — the command says it found nothing,
+rather than silently acting on the wrong thing". That is true of `co status` and
+`co doctor`; it is not true here, because the `~/.co` fallback always finds
+*something*. An operator reads an address off this panel and hands it out, and
+from a subdirectory it is the machine's rather than the agent's.
+
+The fallback itself is right and stays: a project with no key of its own is a
+real configuration — `co init` produces one — and `resolve_agent_identity` on
+the host side does exactly this, own key then `~/.co`. What changes is that
+"own key" is found by walking up, the way everything else since #660 is.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project_with_its_own_key(tmp_path, monkeypatch):
+    from connectonion import address
+
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    machine = address.generate()
+    address.save(machine, home / ".co")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    project = tmp_path / "project"
+    (project / ".co").mkdir(parents=True)
+    own = address.generate()
+    address.save(own, project / ".co")
+    (project / "sub" / "deeper").mkdir(parents=True)
+    return project, own, machine
+
+
+class TestFromASubdirectory:
+
+    @pytest.mark.parametrize("depth", ["sub", "sub/deeper"])
+    def test_it_finds_the_projects_co(self, project_with_its_own_key, monkeypatch, depth):
+        from connectonion.cli.commands.keys_commands import _find_co_dir
+
+        project, _, _ = project_with_its_own_key
+        monkeypatch.chdir(project / depth)
+
+        assert _find_co_dir() == project / ".co"
+
+    def test_the_address_is_the_projects(self, project_with_its_own_key, monkeypatch):
+        from connectonion import address
+        from connectonion.cli.commands.keys_commands import _find_co_dir
+
+        project, own, machine = project_with_its_own_key
+        monkeypatch.chdir(project / "sub")
+        loaded = address.load(_find_co_dir())
+
+        assert loaded["address"] == own["address"]
+        assert loaded["address"] != machine["address"]
+
+
+class TestFromTheProjectRoot:
+    """Unchanged."""
+
+    def test_it_still_finds_the_project(self, project_with_its_own_key, monkeypatch):
+        from connectonion.cli.commands.keys_commands import _find_co_dir
+
+        project, _, _ = project_with_its_own_key
+        monkeypatch.chdir(project)
+
+        assert _find_co_dir() == project / ".co"
+
+
+class TestTheGlobalFallbackStays:
+    """A project with no key of its own is what `co init` usually produces."""
+
+    def test_a_keyless_project_uses_the_machine_identity(self, tmp_path, monkeypatch):
+        from connectonion import address
+        from connectonion.cli.commands.keys_commands import _find_co_dir
+
+        home = tmp_path / "home2"
+        (home / ".co").mkdir(parents=True)
+        address.save(address.generate(), home / ".co")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        keyless = tmp_path / "keyless"
+        (keyless / ".co").mkdir(parents=True)
+        (keyless / "sub").mkdir()
+        monkeypatch.chdir(keyless / "sub")
+
+        assert _find_co_dir() == home / ".co"
+
+    def test_no_identity_anywhere_is_still_None(self, tmp_path, monkeypatch):
+        from connectonion.cli.commands.keys_commands import _find_co_dir
+
+        home = tmp_path / "empty"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.chdir(tmp_path)
+
+        assert _find_co_dir() is None


### PR DESCRIPTION
## What

`_find_co_dir` looked in the bare cwd and fell back to the machine's identity, so one directory down the project's own key was invisible and `~/.co` answered instead.

Measured on a project with its own keypair:

| | Address | Source |
|---|---|---|
| from the project root | `0xd72fbbd5…` | `.co (project)` |
| from a subdirectory | `0x10e68f6d…` | `~/.co (global)` |

**Two addresses for one agent**, each stated as confidently as the other. An operator reads one off this panel and hands it out.

## This corrects something I wrote

When I filed #665 I said these commands "fail in the visible direction — the command says it found nothing, rather than silently acting on the wrong thing." That is true of `co status` and `co doctor`. It is **not** true here: the `~/.co` fallback always finds *something*, so the failure is silent and plausible rather than visible.

## What stays

The fallback. A project without its own key is a real configuration — `co init` usually produces one — and it is exactly what `resolve_agent_identity` does on the host side: own key, then `~/.co`. What changes is that "own key" is found by walking up, as everything else has since #660.

## Step 7 caught two things this introduced

**The Source label.** It interpolated `co_dir` directly, which read as `.co (project)` only because that value used to be the relative `Path(".co")`. With a resolved path the panel printed the machine's whole directory tree. Now shown relative to where you stand, which also says which way the project lies:

```
from keytest        .co (project)
from keytest/sub    ../.co (project)
```

**An existing test** asserted the old relative contract (`result == Path(".co")`). Updated to the resolved path with the reason recorded, rather than deleted.

## Tests

`tests/unit/test_co_keys_shows_this_projects_identity.py`, 6 cases, 4 proven to fail first. Full suite **4491 passed**. Verified on the real command from both directories.