### PR TITLE
co doctor puts a green tick beside the wrong key file

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -13,6 +13,8 @@ import sys
 import os
 import shutil
 from pathlib import Path
+
+from ...project import project_co_dir
 import requests
 from rich.console import Console
 from rich.panel import Panel
@@ -70,6 +72,23 @@ def model_pricing_note(model) -> "str | None":
 
     return (f"{model} is no longer in the price table — it still runs, "
             f"and costs shown for it are estimates")
+
+
+def _shown(path: Path) -> str:
+    """A path relative to where you are standing, so the panel stays readable.
+
+    These rows used to interpolate a bare `Path(".co")/…`, which read as
+    `.co/keys/agent.key` only because it was relative to begin with. Resolving
+    the project properly made them absolute, and the panel started printing the
+    machine's whole directory tree. Relative to the cwd it also says which way
+    the project lies: `.co/…` at the root, `../.co/…` below it.
+    """
+    import os
+
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return os.path.relpath(path, Path.cwd())
 
 
 def handle_doctor():
@@ -131,11 +150,16 @@ def handle_doctor():
     config_table.add_column("Status")
 
     # Check for host.yaml (project config)
-    local_config = Path(".co") / "host.yaml"
+    # The project's, found by walking up -- the rule since #660. As a bare
+    # Path(".co") every one of these answered for whatever directory `co doctor`
+    # was run from, so a subdirectory of a project was diagnosed as a different
+    # project: no config, and the machine's key reported as this agent's with a
+    # green tick beside it.
+    local_config = project_co_dir() / "host.yaml"
     config = {}
 
     if local_config.exists():
-        config_table.add_row("Config", f"[green]✓[/green] {local_config}")
+        config_table.add_row("Config", f"[green]✓[/green] {_shown(local_config)}")
         import yaml
         with open(local_config, 'r', encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
@@ -160,11 +184,11 @@ def handle_doctor():
         config_table.add_row("Config", "[yellow]○[/yellow] Not found (optional)")
 
     # Check for keys
-    local_keys = Path(".co") / "keys" / "agent.key"
+    local_keys = project_co_dir() / "keys" / "agent.key"
     global_keys = Path.home() / ".co" / "keys" / "agent.key"
 
     if local_keys.exists():
-        config_table.add_row("Keys", f"[green]✓[/green] {local_keys}")
+        config_table.add_row("Keys", f"[green]✓[/green] {_shown(local_keys)}")
     elif global_keys.exists():
         config_table.add_row("Keys", f"[green]✓[/green] {global_keys}")
     else:
@@ -269,7 +293,7 @@ def handle_doctor():
             from ... import address
             import time
 
-            co_dir = Path(".co") if local_keys.exists() else Path.home() / ".co"
+            co_dir = project_co_dir() if local_keys.exists() else Path.home() / ".co"
             addr_data = address.load(co_dir)
 
             public_key = addr_data["address"]

--- a/tests/e2e/cli/test_doctor_checks_this_projects_keys.py
+++ b/tests/e2e/cli/test_doctor_checks_this_projects_keys.py
@@ -1,0 +1,115 @@
+"""`co doctor` puts a green tick beside the wrong key file.
+
+The check resolves the project's key against the bare cwd:
+
+    local_keys = Path(".co") / "keys" / "agent.key"
+    global_keys = Path.home() / ".co" / "keys" / "agent.key"
+    if local_keys.exists(): ... else global_keys ...
+
+so one directory down the project's own key is invisible and the machine's is
+reported in its place. Diffing the whole `co doctor` output between a project
+root and a subdirectory of it, on a project that has its own keypair:
+
+    project      Keys ✓ .co/keys/agent.key
+    project/sub  Keys ✓ <home>/.co/keys/agent.key
+
+One line differs, and it is the one that says which identity this project uses.
+Both carry a green tick.
+
+Same shape as `co keys` (#680), and the same correction to #665: I wrote there
+that these commands "fail in the visible direction — the command says it found
+nothing". `co doctor` does not fail. It reports success against the wrong file.
+
+## Why this runs the real command
+
+The first version of this test called `handle_doctor()` in-process and passed
+while the bug was present: rich renders the table to the terminal width, and at
+pytest's default the path was truncated away entirely, leaving `Keys ✓` with
+nothing to assert against. The row only carries its path at a width that shows
+it. So this drives the CLI in a subprocess with `COLUMNS` set, which is how the
+bug was measured in the first place.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def project_with_its_own_key(tmp_path):
+    from connectonion import address
+
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    address.save(address.generate(), home / ".co")
+
+    project = tmp_path / "project"
+    (project / ".co").mkdir(parents=True)
+    own = address.generate()
+    address.save(own, project / ".co")
+    (project / "sub" / "deeper").mkdir(parents=True)
+    return project, home, own
+
+
+def _doctor(cwd: Path, home: Path) -> str:
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["COLUMNS"] = "200"
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[3]) + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-m", "connectonion.cli.main", "doctor"],
+        cwd=str(cwd), env=env, capture_output=True, text=True, timeout=300,
+    )
+    return result.stdout
+
+
+def _keys_row(output: str) -> str:
+    return next((l for l in output.splitlines() if "Keys" in l), "")
+
+
+class TestFromASubdirectory:
+
+    @pytest.mark.parametrize("depth", ["sub", "sub/deeper"])
+    def test_it_does_not_report_the_machine_key(self, project_with_its_own_key, depth):
+        project, home, _ = project_with_its_own_key
+
+        row = _keys_row(_doctor(project / depth, home))
+
+        assert str(home) not in row, f"doctor reported the machine's key: {row.strip()}"
+
+    def test_it_reports_a_key_at_all(self, project_with_its_own_key):
+        """A tick against nothing would pass the test above and help nobody."""
+        project, home, _ = project_with_its_own_key
+
+        assert "agent.key" in _keys_row(_doctor(project / "sub", home))
+
+
+class TestFromTheProjectRoot:
+    """Unchanged — this already worked."""
+
+    def test_it_reports_the_projects_key(self, project_with_its_own_key):
+        project, home, _ = project_with_its_own_key
+
+        row = _keys_row(_doctor(project, home))
+
+        assert "agent.key" in row and str(home) not in row
+
+
+class TestTheGlobalFallbackStays:
+    """A project with no key of its own is what `co init` usually produces."""
+
+    def test_a_keyless_project_reports_the_machine_key(self, tmp_path):
+        from connectonion import address
+
+        home = tmp_path / "home2"
+        (home / ".co").mkdir(parents=True)
+        address.save(address.generate(), home / ".co")
+
+        keyless = tmp_path / "keyless"
+        (keyless / ".co").mkdir(parents=True)
+        (keyless / "sub").mkdir()
+
+        assert "agent.key" in _keys_row(_doctor(keyless / "sub", home))


### PR DESCRIPTION
## What

Three lookups in `doctor_commands.py` resolved the project against the bare cwd, so one directory down a project is diagnosed as a *different* project.

Diffing the whole `co doctor` output between a project root and a subdirectory of it, on a project with its own keypair — **one line differs**, and it is the one that says which identity this project uses:

```
project      Keys ✓ .co/keys/agent.key
project/sub  Keys ✓ <home>/.co/keys/agent.key
```

Both carry a green tick.

Same shape as `co keys` (#680), and the same correction to #665: I wrote there that these commands *"fail in the visible direction — the command says it found nothing"*. `co doctor` does not fail. It reports success against the wrong file.

## The test I threw away

The first version called `handle_doctor()` in-process and **passed while the bug was present**. rich renders the table to the terminal width, and at pytest's default the path was truncated away entirely — the row was `Keys ✓` with nothing to assert against.

I stopped there rather than change the code behind a test that could not fail, and rewrote it to drive the real CLI in a subprocess with `COLUMNS` set — which is how the bug was measured in the first place. The file records why, so the next person does not simplify it back into the version that proves nothing.

## Step 7

The same cosmetic regression #680 had: with the project resolved properly, these rows became absolute and printed the machine's whole directory tree. They are shown relative to where you stand now, which also says which way the project lies:

```
project      Keys ✓ .co/keys/agent.key
project/sub  Keys ✓ ../.co/keys/agent.key
```

The Config row had it too.

## Tests

`tests/e2e/cli/test_doctor_checks_this_projects_keys.py`, 5 cases, 2 proven to fail first — including one asserting the row still names *a* key, because a tick against nothing would satisfy the other test and help nobody.

Full suite **4496 passed**.