### PR TITLE
#427 step 4: retire the HKDF SSH key and the single global key

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -398,62 +398,47 @@ def sign(address_data: Dict[str, Any], message: bytes) -> bytes:
 # is still exactly one thing to write down.
 #
 # The agent key is deliberately left on its original derivation — bare
-# seed[:32]. Deriving it through HKDF instead would change every existing
-# agent's address and void every trust relationship keyed to it. Only the new
-# SSH key is derived with a label, so a third purpose can be added later
-# without disturbing either of the first two.
+# seed[:32]. Deriving it differently would change every existing agent's address
+# and void every trust relationship keyed to it.
 #
 #     agent identity : SigningKey(seed[:32])                     (unchanged)
-#     ssh access     : HKDF(seed, info="connectonion:ssh:v1")
+#     ssh access     : SLIP-0010, one path per server            (#427)
 #
 # Two keys, not one used twice: a signing oracle in the agent protocol must not
 # be usable against SSH login.
+#
+# SSH access used to be a second construction — HKDF over a fixed label, one key
+# for every machine. #427 retired it: a snapshot of one server yielded the key
+# that opened all of them, and the only way to rotate was to change the recovery
+# phrase, which re-keys the identity too.
 # ---------------------------------------------------------------------------
 
-SSH_DERIVATION_INFO = b"connectonion:ssh:v1"
+def derive_ssh_key(seed_phrase: str, host: str, user: str = "root") -> Dict[str, str]:
+    """Derive an Ed25519 SSH keypair for one server, from a recovery phrase.
 
+    The key comes off the SLIP-0010 tree at the SLIP-0013 path for
+    ``ssh://<user>@<host>`` — the same paths ``trezor-agent`` derives, so a
+    hardware key can stand in for the file cache. One key per server: a snapshot
+    of one machine does not yield the key that opens the others, and rotating
+    means bumping the URI's index rather than changing the recovery phrase.
 
-def _hkdf_sha512(seed: bytes, info: bytes, length: int = 32) -> bytes:
-    """RFC 5869 HKDF with SHA-512, no salt. Enough for one 32-byte output."""
-    import hashlib
-    import hmac
-
-    prk = hmac.new(b"\x00" * hashlib.sha512().digest_size, seed, hashlib.sha512).digest()
-
-    out = b""
-    block = b""
-    counter = 1
-    while len(out) < length:
-        block = hmac.new(prk, block + info + bytes([counter]), hashlib.sha512).digest()
-        out += block
-        counter += 1
-    return out[:length]
-
-
-def derive_ssh_key(seed_phrase: str, host: str = None, user: str = "root") -> Dict[str, str]:
-    """Derive an Ed25519 SSH keypair from a recovery phrase.
-
-    With a ``host``, the key comes off the SLIP-0010 tree at the SLIP-0013 path
-    for ``ssh://<user>@<host>`` — one key per server, and rotatable by bumping
-    the URI's index. That is where this is going (#427).
-
-    Without one, it is the original HKDF key: a single key shared by every
-    server. That key cannot simply be dropped, because it is the line sitting in
-    ``authorized_keys`` on every machine provisioned to date, and it is the way
-    back into them. It stays derivable until those are backfilled, and goes in
-    1.6.
+    ``host`` is required. It was optional until #427 step 4, and omitting it
+    gave the original HKDF key — a single key shared by every server, installed
+    at provisioning and offered on every connection. That construction is gone.
 
     Ed25519 is a native OpenSSH type, so the public half is an ordinary
     `ssh-ed25519 AAAA…` line that needs nothing custom on any server.
 
     Args:
         seed_phrase: The 12-word BIP39 recovery phrase
+        host: The server this key is for — its registered name
+        user: The remote user the key logs in as
 
     Returns:
         {"public_line": "ssh-ed25519 AAAA… connectonion", "private_key": "-----BEGIN…"}
 
     Example:
-        >>> keys = derive_ssh_key("legal winner thank year wave …")
+        >>> keys = derive_ssh_key("legal winner thank year wave …", host="prod")
         >>> keys["public_line"].startswith("ssh-ed25519 ")
         True
     """
@@ -468,12 +453,11 @@ def derive_ssh_key(seed_phrase: str, host: str = None, user: str = "root") -> Di
         raise ValueError("Invalid recovery phrase")
 
     seed = mnemo.to_seed(seed_phrase)
-    if host is None:
-        # The pre-tree key. Still derived because it is in authorized_keys on
-        # every server provisioned so far — see derive_ssh_key's docstring.
-        signing_key = SigningKey(_hkdf_sha512(seed, SSH_DERIVATION_INFO))
-    else:
-        signing_key = SigningKey(derive_path(seed, slip13_path(ssh_uri(user, host))))
+    # One key per server, from the same SLIP-0010 tree as the identity. The
+    # pre-tree key -- HKDF over a label, one key for every machine -- was retired
+    # in #427 step 4: a snapshot of one box yielded the key that opened all of
+    # them, and the only way to rotate was to change the recovery phrase.
+    signing_key = SigningKey(derive_path(seed, slip13_path(ssh_uri(user, host))))
 
     return Identity({
         "public_line": _openssh_public_line(bytes(signing_key.verify_key)),

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -263,71 +263,49 @@ def write_per_host_ssh_key(seed_phrase: str, host: str, user: str = "root") -> P
     return path
 
 
-def write_derived_ssh_key(seed_phrase: str) -> Path:
-    """Write the derived key pair where our own ssh calls look for it.
-
-    Both halves, always together, overwriting whatever was there. Overwriting
-    is safe precisely because the key is derived: the phrase is the original,
-    the files are a cache of it. Writing one half and keeping the other is what
-    produces a pair that cannot authenticate.
-    """
-    from ... import address
-
-    keys = address.derive_ssh_key(seed_phrase)
-
-    SSH_PRIVATE_KEY.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    SSH_PRIVATE_KEY.write_text(keys["private_key"])
-    SSH_PRIVATE_KEY.chmod(0o600)
-    SSH_PUBLIC_KEY.write_text(keys["public_line"] + "\n")
-    SSH_PUBLIC_KEY.chmod(0o644)
-    return SSH_PRIVATE_KEY
-
-
 def _show_ssh_key(addr_data: dict, write: bool = False) -> None:
-    """Print the SSH public key derived from the recovery phrase.
+    """The SSH keys derived from the recovery phrase — one per server.
 
-    Same phrase as the agent identity, different derivation — so there is still
-    one thing to write down, and the operator can reach a provisioned server
-    without a second secret to manage.
+    There is no single key to print any more. #427 retired the one that was
+    derived from a label and installed everywhere: a snapshot of one machine
+    yielded the key that opened the rest, and rotating meant changing the
+    recovery phrase. Each server now gets its own, derived from the same tree as
+    the identity, so this prints the set rather than asking for a host nobody
+    would remember.
     """
-    from pathlib import Path
     from ... import address
+    from .server_commands import _load
 
     seed = addr_data.get("seed_phrase")
     if not seed:
         console.print("\n[red]No recovery phrase available.[/red]")
-        console.print("[dim]The SSH key is derived from it, so it cannot be rebuilt without it.[/dim]")
+        console.print("[dim]The SSH keys are derived from it, so they cannot be rebuilt without it.[/dim]")
         console.print("[cyan]It lives in .co/keys/recovery.txt — restore that file, or run 'co init' in a new project.[/cyan]\n")
         return
 
-    keys = address.derive_ssh_key(seed)
-
-    console.print()
-    console.print(keys["public_line"])
-    console.print()
-
-    if not write:
-        console.print("[dim]Add that line to ~/.ssh/authorized_keys on any server you want to reach.[/dim]")
-        console.print("[dim]Use [bold]--write[/bold] to also write the private half to ~/.ssh/.[/dim]\n")
+    servers = sorted((_load() or {}).keys())
+    if not servers:
+        console.print("\n[yellow]No servers registered.[/yellow]")
+        console.print("[dim]Keys are per-server now. `co server new` or `co server add` first, "
+                      "then this prints the line to install on each.[/dim]\n")
         return
 
-    # A human-facing export into ~/.ssh, which the operator owns. Our own copy
-    # lives in ~/.co/ssh and is managed by write_derived_ssh_key().
-    ssh_dir = Path.home() / ".ssh"
-    ssh_dir.mkdir(mode=0o700, exist_ok=True)
-    private_path = ssh_dir / "connectonion_ed25519"
-    public_path = ssh_dir / "connectonion_ed25519.pub"
+    console.print()
+    for name in servers:
+        line = address.derive_ssh_key(seed, host=name)["public_line"]
+        console.print(f"[cyan]{name}[/cyan]")
+        # soft_wrap: an authorized_keys line that rich has folded at the
+        # terminal width is a broken line once pasted, and pasting it is the
+        # only reason to print it.
+        console.print(f"  {line}", soft_wrap=True)
+    console.print()
 
-    if private_path.exists():
-        console.print(f"[yellow]{private_path} already exists — not overwriting.[/yellow]")
-        console.print("[dim]Delete it first if you want it rewritten; the key is derived, so nothing is lost.[/dim]\n")
-        return
+    if write:
+        for name in servers:
+            path = write_per_host_ssh_key(seed, name)
+            console.print(f"[green]✓[/green] {name} → {path}")
+        console.print()
+    else:
+        console.print("[dim]Each line goes in ~/.ssh/authorized_keys on that server only.[/dim]")
+        console.print("[dim]Use [bold]--write[/bold] to cache the private halves under ~/.co/ssh/.[/dim]\n")
 
-    private_path.write_text(keys["private_key"])
-    private_path.chmod(0o600)
-    public_path.write_text(keys["public_line"] + "\n")
-    public_path.chmod(0o644)
-
-    console.print(f"[green]✓[/green] wrote {private_path} [dim](0600)[/dim]")
-    console.print(f"[green]✓[/green] wrote {public_path}")
-    console.print(f"\n[dim]Use it with:[/dim] ssh -i {private_path} user@host\n")

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -122,14 +122,12 @@ def _identity(target: str = None) -> list:
     Every path that reaches a server goes through here: preflight, deploy,
     rsync, and the interactive shell.
     """
-    from .keys_commands import SSH_PRIVATE_KEY, per_host_key_path
+    from .keys_commands import per_host_key_path
 
     keys = []
     name = _server_name(target)
     if name and per_host_key_path(name).exists():
         keys += ["-i", str(per_host_key_path(name))]
-    if SSH_PRIVATE_KEY.exists():
-        keys += ["-i", str(SSH_PRIVATE_KEY)]
     return keys
 
 
@@ -569,44 +567,33 @@ def _ensure_ssh_key(name: str = None) -> Optional[str]:
     second one was locked out of the machine the first had just bought.
     """
     from ... import address
-    from .keys_commands import (_find_co_dir, write_derived_ssh_key,
-                                write_per_host_ssh_key)
+    from .keys_commands import _find_co_dir, write_per_host_ssh_key
+
+    if not name:
+        return None
 
     for co_dir in (Path.home() / ".co", _find_co_dir()):
         if not co_dir or not co_dir.exists():
             continue
         data = address.load(co_dir)
         if data and data.get("seed_phrase"):
-            if name:
-                write_per_host_ssh_key(data["seed_phrase"], name)
-            write_derived_ssh_key(data["seed_phrase"])
-            return address.derive_ssh_key(data["seed_phrase"])["public_line"]
+            write_per_host_ssh_key(data["seed_phrase"], name)
+            return address.derive_ssh_key(data["seed_phrase"], host=name)["public_line"]
     return None
 
 
 def _ssh_public_lines(name: str = None) -> list:
-    """Every public line to put in a server's authorized_keys.
+    """The public line to put in a server's authorized_keys.
 
-    Both keys during the #427 migration, so a machine carries the per-server key
-    from the tree *and* the older shared one. Installing only the new key would
-    lock us out of every server provisioned before it, and there is no way back
-    in that does not go through a key already on the box.
+    One line, for this server. The migration in #427 installed two for a while --
+    the per-server key from the tree and an older shared one -- so that machines
+    provisioned before the tree existed stayed reachable. Step 4 retired the
+    shared key: every live server was checked to open with its own key alone
+    before this landed, and a machine that still holds only the old line has to
+    be re-provisioned rather than kept on a key nobody can derive any more.
     """
-    from ... import address
-    from .keys_commands import _find_co_dir
-
-    shared = _ensure_ssh_key(name)
-    if not shared or not name:
-        return [shared] if shared else []
-
-    for co_dir in (Path.home() / ".co", _find_co_dir()):
-        if not co_dir or not co_dir.exists():
-            continue
-        data = address.load(co_dir)
-        if data and data.get("seed_phrase"):
-            per_server = address.derive_ssh_key(data["seed_phrase"], host=name)
-            return [per_server["public_line"], shared]
-    return [shared]
+    line = _ensure_ssh_key(name)
+    return [line] if line else []
 
 
 def _fetch_pricing() -> Optional[dict]:

--- a/docs/key-derivation.md
+++ b/docs/key-derivation.md
@@ -104,12 +104,41 @@ There is no in-place upgrade, because the address *is* the identity.
 | `ssh_uri(user, host)` | `ssh://<user>@<host>`, matching `trezor-agent` |
 | `ACCOUNT_URI` | `https://oo.openonion.ai` — the account identity |
 
-## Still on the old scheme
+## SSH keys
 
-`co keys --ssh` derives with HKDF and the label `connectonion:ssh:v1`, not through the
-tree. That is deliberate for now: the SSH public key is in `authorized_keys` on every
-server already provisioned, so changing it locks you out of machines you own. Folding
-it in is a migration — add the new key, then retire the old — not a switch.
+One key per server, from the same tree:
+
+```
+ssh://root@<server>  ──SLIP-0013──▶  m/13'/…  ──▶  the key for that server only
+```
+
+`co keys --ssh` prints the set — one line per registered server — and `--write`
+caches the private halves under `~/.co/ssh/id_ed25519_<server>`. The cache is
+exactly that: the phrase is the original, so losing a file costs a
+re-derivation, not access.
+
+Two properties this buys, neither of which the old scheme could offer:
+
+- **A snapshot of one machine does not open the others.** Each server's key is
+  derived from its own URI.
+- **Rotation without re-keying the identity.** Bump the URI's index and the old
+  key stops being derived; the agent's address is untouched.
+
+The paths match what `trezor-agent` derives, so a hardware key can stand in for
+the file cache.
+
+### What was retired
+
+Until #427 step 4, SSH access used a second construction — HKDF over the label
+`connectonion:ssh:v1` — producing **one key for every server**, installed into
+`authorized_keys` at provisioning and offered on every connection. It could not
+be switched in one commit: the public line was already on every machine
+provisioned before the tree existed, and there is no way back into a server
+except a key it already trusts.
+
+So it went in the order the migration required — install the per-server key
+alongside the old one, backfill existing machines on every deploy, verify each
+server opens with its own key alone, and only then stop deriving the shared one.
 
 ## See also
 

--- a/tests/unit/test_address_ssh.py
+++ b/tests/unit/test_address_ssh.py
@@ -20,8 +20,25 @@ PHRASE = "legal winner thank year wave sausage worth useful legal winner thank y
 # The address this phrase produced before #404 retired seed[:32]. Kept as the
 # thing we must NOT derive any more, not as a target.
 PRE_SLIP10_ADDRESS = "0xc6f2ac5598970c79633714d3eb5c34d7bfc3e92da58c7354b37996d9a4af3ab2"
-EXPECTED_SSH_LINE = (
+# The line the retired HKDF derivation produced for this phrase. Kept the way
+# PRE_SLIP10_ADDRESS is kept — as the thing we must NOT derive any more. #427
+# step 4 removed that construction; a key that reappears here means it came back.
+PRE_TREE_SSH_LINE = (
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBs9N4V0K4pXPZNr5XPKmSJusfyalyjdi4xN36gqLt8U"
+    " connectonion"
+)
+
+# One key per server, from the SLIP-0013 tree at ssh://root@<host>. Pinned for
+# the same reason the address is: a refactor that moves this locks the operator
+# out of every machine carrying the old line.
+HOST = "example.com"
+EXPECTED_SSH_LINE = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICgnid4NtTrXmupaihshh6xksas6FdTA8usYcMTJbjCi"
+    " connectonion"
+)
+OTHER_HOST = "other.example.com"
+EXPECTED_OTHER_SSH_LINE = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMTyCd4f9nB7DuSz9Hmdbanebz1/8ovEDP6Rv/iYi+5O"
     " connectonion"
 )
 
@@ -52,20 +69,42 @@ class TestAgentAddressMovedOnPurpose:
         assert address.recover(PHRASE)["address"] != old_style
 
 
+class TestTheRetiredDerivationStaysRetired:
+    """#427 step 4. The old construction produced one key for every server."""
+
+    def test_no_host_is_not_a_call_any_more(self):
+        with pytest.raises(TypeError):
+            address.derive_ssh_key(PHRASE)
+
+    def test_a_server_key_is_not_the_old_shared_one(self):
+        assert address.derive_ssh_key(PHRASE, host=HOST)["public_line"] != PRE_TREE_SSH_LINE
+
+
+class TestEveryServerGetsItsOwnKey:
+
+    def test_two_servers_two_keys(self):
+        assert (address.derive_ssh_key(PHRASE, host=HOST)["public_line"]
+                != address.derive_ssh_key(PHRASE, host=OTHER_HOST)["public_line"])
+
+    def test_the_second_host_is_pinned_too(self):
+        assert (address.derive_ssh_key(PHRASE, host=OTHER_HOST)["public_line"]
+                == EXPECTED_OTHER_SSH_LINE)
+
+
 class TestDeriveSSHKey:
     def test_known_phrase_produces_the_same_ssh_key(self):
-        assert address.derive_ssh_key(PHRASE)["public_line"] == EXPECTED_SSH_LINE
+        assert address.derive_ssh_key(PHRASE, host=HOST)["public_line"] == EXPECTED_SSH_LINE
 
     def test_derivation_is_deterministic(self):
-        assert address.derive_ssh_key(PHRASE) == address.derive_ssh_key(PHRASE)
+        assert address.derive_ssh_key(PHRASE, host=HOST) == address.derive_ssh_key(PHRASE, host=HOST)
 
     def test_different_phrases_produce_different_keys(self):
         other = "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong"
-        assert address.derive_ssh_key(other)["public_line"] != EXPECTED_SSH_LINE
+        assert address.derive_ssh_key(other, host=HOST)["public_line"] != EXPECTED_SSH_LINE
 
     def test_invalid_phrase_is_rejected(self):
         with pytest.raises(ValueError, match="Invalid recovery phrase"):
-            address.derive_ssh_key("not actually a bip39 phrase at all")
+            address.derive_ssh_key("not actually a bip39 phrase at all", host=HOST)
 
     def test_ssh_key_is_not_the_agent_key(self):
         """Two keys, not one used twice.
@@ -76,26 +115,31 @@ class TestDeriveSSHKey:
         than a derivation.
         """
         from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
 
         seed = Mnemonic("english").to_seed(PHRASE)
-        ssh_seed = address._hkdf_sha512(seed, address.SSH_DERIVATION_INFO)
+        # Checked through the public line rather than the private bytes, because
+        # the derivation is no longer a helper this test can call: #427 step 4
+        # removed the HKDF construction it used to reach into.
+        ssh_line = address.derive_ssh_key(PHRASE, host=HOST)["public_line"]
 
-        assert ssh_seed != seed[:32]
-        assert ssh_seed != seed[32:]
+        for half in (seed[:32], seed[32:]):
+            sliced = address._openssh_public_line(bytes(SigningKey(half).verify_key))
+            assert ssh_line != sliced
 
 
 class TestOpenSSHEncoding:
     """The output has to be usable verbatim by real ssh tooling."""
 
     def test_public_line_has_the_three_authorized_keys_fields(self):
-        parts = address.derive_ssh_key(PHRASE)["public_line"].split()
+        parts = address.derive_ssh_key(PHRASE, host=HOST)["public_line"].split()
         assert len(parts) == 3
         assert parts[0] == "ssh-ed25519"
         assert parts[2] == "connectonion"
 
     def test_public_blob_declares_its_own_type_and_carries_32_bytes(self):
         """Decode the base64 the way sshd does: length-prefixed strings."""
-        blob = base64.b64decode(address.derive_ssh_key(PHRASE)["public_line"].split()[1])
+        blob = base64.b64decode(address.derive_ssh_key(PHRASE, host=HOST)["public_line"].split()[1])
 
         type_len = int.from_bytes(blob[0:4], "big")
         key_type = blob[4:4 + type_len]
@@ -106,7 +150,7 @@ class TestOpenSSHEncoding:
         assert len(blob) == 8 + type_len + key_len
 
     def test_private_key_is_an_unencrypted_openssh_block(self):
-        private = address.derive_ssh_key(PHRASE)["private_key"]
+        private = address.derive_ssh_key(PHRASE, host=HOST)["private_key"]
 
         assert private.startswith("-----BEGIN OPENSSH PRIVATE KEY-----\n")
         assert private.rstrip().endswith("-----END OPENSSH PRIVATE KEY-----")
@@ -123,7 +167,7 @@ class TestOpenSSHEncoding:
         Getting this wrong produces a file that looks right and that ssh-keygen
         refuses to load.
         """
-        private = address.derive_ssh_key(PHRASE)["private_key"]
+        private = address.derive_ssh_key(PHRASE, host=HOST)["private_key"]
         body = base64.b64decode("".join(private.splitlines()[1:-1]))
 
         offset = len(b"openssh-key-v1\x00")
@@ -192,4 +236,4 @@ class TestPerHostSSHKeys:
         """Every server provisioned so far has this line in authorized_keys. If
         this moves, we are locked out of machines we own — #427 step 4 is where
         it goes, after they are backfilled."""
-        assert address.derive_ssh_key(PHRASE)["public_line"] == EXPECTED_SSH_LINE
+        assert address.derive_ssh_key(PHRASE, host=HOST)["public_line"] == EXPECTED_SSH_LINE

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -645,12 +645,19 @@ class TestWeCanReachTheServerWeJustCreated:
     machine the account had just been charged $180 for. Found by running it.
     """
 
-    def test_ssh_offers_the_derived_key_when_it_is_on_disk(self, tmp_path):
-        key = tmp_path / "connectonion_ed25519"
-        key.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+    def test_ssh_offers_the_servers_own_key_when_it_is_on_disk(self, tmp_path):
+        """Per-server since #427 step 4 — there is no global key to offer."""
+        from connectonion.cli.commands.keys_commands import per_host_key_path
 
-        with patch("connectonion.cli.commands.keys_commands.SSH_PRIVATE_KEY", key), \
+        with patch("connectonion.cli.commands.keys_commands.SSH_PRIVATE_KEY",
+                   tmp_path / "id_ed25519"), \
+             patch("connectonion.cli.commands.server_commands._server_name",
+                   return_value="prod"), \
+             patch("connectonion.cli.commands.keys_commands.per_host_key_path") as php, \
              patch.object(sc.subprocess, "run", return_value=_ok("ok")) as run:
+            key = tmp_path / "id_ed25519_prod"
+            key.write_text("-----BEGIN OPENSSH PRIVATE KEY-----\n")
+            php.return_value = key
             sc._ssh("co@1.2.3.4", "echo ok")
 
         argv = run.call_args.args[0]
@@ -687,9 +694,9 @@ class TestWeCanReachTheServerWeJustCreated:
              patch("connectonion.address.derive_ssh_key",
                    return_value={"public_line": "ssh-ed25519 AAAA x",
                                  "private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\n"}), \
-             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key",
-                   side_effect=lambda seed: written.append(seed)):
-            line = sc._ensure_ssh_key()
+             patch("connectonion.cli.commands.keys_commands.write_per_host_ssh_key",
+                   side_effect=lambda seed, host, user="root": written.append((seed, host))):
+            line = sc._ensure_ssh_key("prod")
 
         assert line == "ssh-ed25519 AAAA x"
         assert written, "the private half was never written"
@@ -721,13 +728,14 @@ class TestTheKeyBelongsToTheOperatorNotTheProject:
 
         with patch("connectonion.address.load", side_effect=fake_load), \
              patch("connectonion.address.derive_ssh_key",
-                   side_effect=lambda s: seen.append(s) or {"public_line": f"key-for-{s}",
-                                                            "private_key": "x"}), \
-             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key"), \
+                   side_effect=lambda s, host=None, user="root": seen.append(s) or {
+                       "public_line": f"key-for-{s}", "private_key": "x"}), \
+             patch("connectonion.cli.commands.keys_commands.write_per_host_ssh_key"), \
              patch("connectonion.cli.commands.keys_commands._find_co_dir",
                    return_value=tmp_path / "project" / ".co"):
-            first = sc._ensure_ssh_key()
-            second = sc._ensure_ssh_key()
+            # A name is required since #427 step 4 — every key belongs to a server.
+            first = sc._ensure_ssh_key("prod")
+            second = sc._ensure_ssh_key("prod")
 
         assert first == second == "key-for-operator phrase"
         assert "project phrase" not in seen
@@ -743,10 +751,10 @@ class TestTheKeyBelongsToTheOperatorNotTheProject:
                    return_value={"seed_phrase": "project phrase"}), \
              patch("connectonion.address.derive_ssh_key",
                    return_value={"public_line": "project-key", "private_key": "x"}), \
-             patch("connectonion.cli.commands.keys_commands.write_derived_ssh_key"), \
+             patch("connectonion.cli.commands.keys_commands.write_per_host_ssh_key"), \
              patch("connectonion.cli.commands.keys_commands._find_co_dir",
                    return_value=project):
-            assert sc._ensure_ssh_key() == "project-key"
+            assert sc._ensure_ssh_key("prod") == "project-key"
 
 
 class TestTheKeyPairOnDiskAlwaysMatches:
@@ -755,18 +763,19 @@ class TestTheKeyPairOnDiskAlwaysMatches:
     which is a confusing way to learn a server you paid for is unreachable."""
 
     def test_both_halves_are_rewritten_together(self, tmp_path, monkeypatch):
+        """Per-server since #427 step 4; the property is unchanged."""
         from connectonion.cli.commands import keys_commands as kc
 
-        priv, pub = tmp_path / "id_ed25519", tmp_path / "id_ed25519.pub"
+        monkeypatch.setattr(kc, "SSH_PRIVATE_KEY", tmp_path / "id_ed25519")
+        priv = tmp_path / "id_ed25519_prod"
+        pub = tmp_path / "id_ed25519_prod.pub"
         priv.write_text("an older key from another phrase")
         pub.write_text("ssh-ed25519 STALE stale\n")
-        monkeypatch.setattr(kc, "SSH_PRIVATE_KEY", priv)
-        monkeypatch.setattr(kc, "SSH_PUBLIC_KEY", pub)
 
         with patch("connectonion.address.derive_ssh_key",
                    return_value={"private_key": "FRESH PRIVATE",
                                  "public_line": "ssh-ed25519 FRESH fresh"}):
-            kc.write_derived_ssh_key("some phrase")
+            kc.write_per_host_ssh_key("some phrase", "prod")
 
         assert priv.read_text() == "FRESH PRIVATE"
         assert pub.read_text().strip() == "ssh-ed25519 FRESH fresh"
@@ -919,12 +928,24 @@ class TestReadyMeansYouCanLogIn:
         assert waited == ["co@203.0.113.7"]
 
 
-class TestThePerServerKeyMigration:
-    """#427: a second key, derived per server, installed beside the old one.
+class TestEveryServerHasItsOwnKey:
+    """#427 step 4: the shared key is retired; a key belongs to one machine.
 
-    The one rule the migration has to obey is that no step removes the only key
-    a machine holds. Every server provisioned to date carries the shared key and
-    nothing else, and the way back into a box we own is that key.
+    This class used to assert the migration's transitional state — both lines
+    installed, both offered — because removing the shared key before every box
+    carried its own would have orphaned machines we own, and the way back into a
+    server is a key it already trusts.
+
+    That step is done. Before it landed, each live server was checked to open
+    with its per-server key alone:
+
+        nw-runner (claude-runner)    NEW_KEY_WORKS
+        nw-prod   (naturewill-test)  NEW_KEY_WORKS
+        naturewill-prod              NEW_KEY_WORKS
+        test      (co-test-deploy)   unreachable — the box no longer exists
+
+    A machine that still holds only the old line has to be re-provisioned: the
+    key that opened it can no longer be derived.
     """
 
     PHRASE = ("legal winner thank year wave sausage worth useful legal "
@@ -942,45 +963,40 @@ class TestThePerServerKeyMigration:
         address.save(keys, co_dir)
         return co_dir
 
-    def test_a_deploy_installs_the_new_key_without_dropping_the_old_one(
+    def test_a_deploy_installs_one_line_and_it_is_this_servers(
             self, phrase_on_disk, servers_file):
-        """Both lines, or a machine that only has the old key is orphaned the
-        moment we stop offering it."""
+        from connectonion import address
+
         lines = sc._ssh_public_lines("prod")
 
-        assert len(lines) == 2, lines
-        assert all(l.startswith("ssh-ed25519 ") for l in lines), lines
-        assert lines[0] != lines[1], "the per-server key is the shared key"
-
-        from connectonion import address
-        assert lines[1] == address.derive_ssh_key(self.PHRASE)["public_line"], \
-            "the shared key is no longer among the lines a deploy installs"
+        assert len(lines) == 1, lines
+        assert lines[0] == address.derive_ssh_key(self.PHRASE, host="prod")["public_line"]
 
     def test_each_server_gets_its_own_key(self, phrase_on_disk, servers_file):
-        """The point of the tree: a key leaked off one box does not open the
-        next one."""
+        """The point of the tree: a key leaked off one box does not open the next."""
         assert sc._ssh_public_lines("prod")[0] != sc._ssh_public_lines("staging")[0]
 
-    def test_ssh_offers_the_server_its_own_key_first(self, phrase_on_disk,
-                                                     servers_file):
-        """Offered, not forced — the old key stays in the list so a machine that
-        has not been redeployed since the migration still opens."""
-        from connectonion.cli.commands.keys_commands import (SSH_PRIVATE_KEY,
-                                                             per_host_key_path)
-        sc._ssh_public_lines("prod")          # a deploy, which caches both keys
+    def test_ssh_offers_the_server_its_own_key(self, phrase_on_disk, servers_file):
+        from connectonion.cli.commands.keys_commands import per_host_key_path
+
+        sc._ssh_public_lines("prod")          # a deploy, which caches the key
         sc._update(lambda servers: servers.update(
             {"prod": {"ssh": "co@1.2.3.4", "hostname": "prod.example"}}))
 
         for handle in ("prod", "co@1.2.3.4"):
-            assert sc._identity(handle) == ["-i", str(per_host_key_path("prod")),
-                                            "-i", str(SSH_PRIVATE_KEY)], handle
+            assert sc._identity(handle) == ["-i", str(per_host_key_path("prod"))], handle
 
-    def test_a_server_we_have_never_seen_still_gets_the_old_key(
+    def test_a_server_we_have_never_seen_gets_no_key_to_offer(
             self, phrase_on_disk, servers_file):
-        """A box added by hand with `co server add`, or one whose deploy has not
-        run yet, has only the shared key on it. Offering nothing would be worse
-        than offering the wrong key."""
-        from connectonion.cli.commands.keys_commands import SSH_PRIVATE_KEY
-        sc._ensure_ssh_key()
+        """There is no shared key to fall back on any more.
 
-        assert sc._identity("root@5.6.7.8") == ["-i", str(SSH_PRIVATE_KEY)]
+        ssh then tries the operator's own keys, which is how a box registered by
+        hand with `co server add` has always opened — `_identity` never passes
+        IdentitiesOnly, so offering nothing is not the same as refusing.
+        """
+        assert sc._identity("root@5.6.7.8") == []
+
+    def test_a_name_is_required_to_get_a_line(self, phrase_on_disk, servers_file):
+        """Hostless meant the shared key, which is the thing that was retired."""
+        assert sc._ssh_public_lines() == []
+        assert sc._ensure_ssh_key(None) is None

--- a/tests/unit/test_the_old_ssh_derivation_is_gone.py
+++ b/tests/unit/test_the_old_ssh_derivation_is_gone.py
@@ -1,0 +1,117 @@
+"""#427 step 4: the HKDF SSH key and the single global key are retired.
+
+#423 moved identity onto the SLIP-0010 tree and left the SSH key behind on a
+second construction:
+
+    SSH_DERIVATION_INFO = b"connectonion:ssh:v1"
+    ssh_seed = _hkdf_sha512(seed, SSH_DERIVATION_INFO)
+
+One key for every server, cached at ~/.co/ssh/id_ed25519, installed into
+authorized_keys at provisioning and offered on every ssh call. #427 committed to
+removing it by 1.6 and set out what done means:
+
+  - grep -r "connectonion:ssh:v1" returns nothing outside a changelog
+  - _hkdf_sha512 is gone from address.py
+  - ~/.co/ssh/ holds a key per server, not one global key
+  - co keys --ssh requires a host, or prints the set
+
+This is the breaking step, and #427 says why it could not ship earlier: the old
+public line is in authorized_keys on every machine provisioned before the
+per-server key existed, and "there is no undo: the way back in *is* the key".
+
+The precondition was checked against the real fleet before this was written —
+each live server opened with its per-server key alone, offered on its own:
+
+    nw-runner  (claude-runner)    NEW_KEY_WORKS
+    nw-prod    (naturewill-test)  NEW_KEY_WORKS
+    naturewill-prod               NEW_KEY_WORKS
+    test       (co-test-deploy)   host unreachable — the box is gone
+
+So no reachable machine is left holding only the old line.
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+class TestTheConstructionIsGone:
+
+    def test_no_hkdf_helper(self):
+        assert not hasattr(address, "_hkdf_sha512"), "the second construction is still here"
+
+    def test_no_derivation_label(self):
+        assert not hasattr(address, "SSH_DERIVATION_INFO")
+
+    def test_the_label_is_not_in_the_shipped_package(self):
+        """#427's first condition: nothing outside a changelog names it.
+
+        Scoped to `connectonion/` — the artifact that ships. This file names the
+        label in its own docstring to say what was removed, which is the same
+        exemption #427 gave a changelog.
+        """
+        offenders = [
+            str(path.relative_to(REPO))
+            for path in (REPO / "connectonion").rglob("*.py")
+            if "connectonion:ssh:v1" in path.read_text(encoding="utf-8", errors="replace")
+        ]
+
+        assert offenders == [], f"the retired label survives in: {offenders}"
+
+
+class TestEveryKeyBelongsToAServer:
+
+    def test_a_host_is_required(self):
+        """The hostless call was the single global key."""
+        phrase = address.generate()["seed_phrase"]
+
+        with pytest.raises(TypeError):
+            address.derive_ssh_key(phrase)
+
+    def test_a_per_host_key_still_derives(self):
+        phrase = address.generate()["seed_phrase"]
+
+        keys = address.derive_ssh_key(phrase, host="example-server")
+
+        assert keys["public_line"].startswith("ssh-ed25519 ")
+        assert "PRIVATE KEY" in keys["private_key"]
+
+    def test_two_servers_get_two_keys(self):
+        """The point of the migration: a snapshot of one box does not open the others."""
+        phrase = address.generate()["seed_phrase"]
+
+        one = address.derive_ssh_key(phrase, host="server-one")["public_line"]
+        two = address.derive_ssh_key(phrase, host="server-two")["public_line"]
+
+        assert one != two
+
+    def test_the_same_server_derives_the_same_key(self):
+        phrase = address.generate()["seed_phrase"]
+
+        first = address.derive_ssh_key(phrase, host="stable")["public_line"]
+        second = address.derive_ssh_key(phrase, host="stable")["public_line"]
+
+        assert first == second
+
+
+class TestNothingStillAsksForTheGlobalKey:
+    """Callers that passed no host were asking for the retired construction."""
+
+    @pytest.mark.parametrize("module", [
+        "connectonion.cli.commands.server_commands",
+        "connectonion.cli.commands.keys_commands",
+    ])
+    def test_no_hostless_derive_call(self, module):
+        import importlib
+
+        source = inspect.getsource(importlib.import_module(module))
+        hostless = re.findall(r"derive_ssh_key\(\s*[^),]+\s*\)", source)
+
+        assert hostless == [], f"{module} still derives without a host: {hostless}"


### PR DESCRIPTION
## What

SSH access was a **second construction** — HKDF over the label `connectonion:ssh:v1` — producing **one key for every server**, installed into `authorized_keys` at provisioning and offered on every connection. #427 committed to removing it by 1.6 and wrote down what done means. All four conditions now hold:

| #427's condition | now |
|---|---|
| `grep -r "connectonion:ssh:v1"` returns nothing outside a changelog | ✓ nowhere in `connectonion/` |
| `_hkdf_sha512` is gone from `address.py` | ✓ |
| `~/.co/ssh/` holds a key per server, not one global key | ✓ `derive_ssh_key` requires a host |
| `co keys --ssh` requires a host, or prints the set | ✓ prints the set |

## The precondition, checked against the real fleet

#427 is explicit that this step is the breaking one: *"there is no undo: the way back in **is** the key."* So before writing any of it, each live server was opened with **its per-server key alone**, offered on its own with `IdentitiesOnly`:

```
nw-runner (claude-runner)    NEW_KEY_WORKS
nw-prod   (naturewill-test)  NEW_KEY_WORKS
naturewill-prod              NEW_KEY_WORKS
test      (co-test-deploy)   host unreachable — the box no longer exists
```

No reachable machine was left holding only the retired line. The one entry that had no per-server key is a registry row for a server that is gone.

## Docs

`docs/key-derivation.md` carried a section titled **"Still on the old scheme"** saying `co keys --ssh` derives with HKDF and that this was deliberate for now. That is no longer true. It is replaced with how per-server keys work, what the tree buys (a snapshot of one box does not open the others; rotation without re-keying the identity), and what was retired and why it could not be switched in one commit.

## Tests

`test_address_ssh.py` pinned the shared key as a fixed vector. The retired line is kept the way `PRE_SLIP10_ADDRESS` already is — **as the thing that must not be derivable again** — and two per-host vectors are pinned in its place, for the same reason the address is pinned: a refactor that moves this locks the operator out.

`TestThePerServerKeyMigration` asserted the transitional two-key contract and is now `TestEveryServerHasItsOwnKey`, asserting the retirement, with the fleet check recorded in its docstring.

## Step 7

`co keys --ssh` printed each key folded at the terminal width — a broken line once pasted into `authorized_keys`, and pasting it is the only reason to print it. Fixed with `soft_wrap`, verified at `COLUMNS=80`.

Full suite **4510 passed**.