### PR TITLE
A scheduled entry runs once, not once per uvicorn worker

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -257,6 +257,60 @@ def is_due(entry: Entry, last_run: Optional[datetime], now: datetime) -> bool:
     return False
 
 
+TICK_LOCK_FILE = "schedule.tick.lock"
+
+
+def _tick_lock(co_dir: Path):
+    """Take the tick for this minute, or return None because someone else has it.
+
+    `create_app`'s docstring tells people to run `uvicorn myagent:app
+    --workers 4`, so the lifespan — and this scheduler — runs once per forked
+    process. The overlap guard above it is a module-level set, which is per
+    process, and `last_run` is not written until the turn returns. So every
+    worker saw the same due entry and started its own copy: four workers, four
+    runs of a pipeline that was written expecting one.
+
+    Elected per tick rather than for the life of the process. A worker that
+    dies holding this costs one tick — the OS drops the flock — where a leader
+    chosen at startup would leave the schedule stopped until someone noticed.
+
+    Refusal is the answer here, not a retry: _lock() below waits and then
+    proceeds anyway, which is right for a short write to the state file and
+    exactly wrong for this, where proceeding is the duplicate run.
+    """
+    handle = open(co_dir / TICK_LOCK_FILE, "a+", encoding="utf-8")
+    try:
+        if os.name == "nt":
+            import msvcrt
+            # seek(0) so lock and unlock name the same byte. "a+" leaves the
+            # position at the end, and this only works by accident while the
+            # file stays empty. _lock() below already does this.
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return handle
+    except OSError:
+        handle.close()
+        return None
+
+
+def _release_tick_lock(handle) -> None:
+    if handle is None:
+        return
+    try:
+        if os.name == "nt":
+            import msvcrt
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
 def _lock(path: Path, attempts: int = 50, pause: float = 0.02):
     """Exclusive, released by the OS on death, and worth waiting a moment for.
 
@@ -411,6 +465,19 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
         entries = load_entries(co_dir)
         if not entries:
             return
+
+        holder = _tick_lock(co_dir)
+        if holder is None:
+            # Another worker is running this tick. Not worth a line of output:
+            # under --workers 4 it is the normal case three times over, every
+            # minute, and it would bury what the running worker says.
+            return
+        try:
+            await _run_due(entries, now)
+        finally:
+            _release_tick_lock(holder)
+
+    async def _run_due(entries, now: datetime) -> None:
         state = load_state(co_dir)
 
         for entry in entries:

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -305,17 +305,20 @@ def usable_uvicorn_options(workers, reload) -> tuple:
     "POST /input" -- and then exit, leaving one uvicorn warning underneath and
     nothing listening on the port the banner named.
 
-    Serving them properly is a larger question than this one. Each worker
-    process would run its own scheduler loop and its own in_flight set, so a
-    schedule that overruns its interval gets one copy per worker: the race #537
-    is about. Until that is answered, keep the agent running and say what was
-    not honoured -- silently running one worker is a smaller lie than dying
-    behind a banner that says otherwise.
+    What blocks it now is only the app object. The scheduler no longer is: it
+    takes one lock per tick, so under several processes exactly one of them
+    runs a due entry (#640). This paragraph used to name that as the second
+    reason, and the message below said so out loud -- kept in sync here because
+    a stale reason in an operator-facing line is how someone concludes the
+    limitation is bigger than it is.
+
+    Keep the agent running and say what was not honoured -- silently running
+    one worker is a smaller lie than dying behind a banner that says otherwise.
     """
     if workers and workers > 1:
         print(f"[host] workers: {workers} not honoured — running one worker "
-              f"(uvicorn needs an import string to fork, and the scheduler is "
-              f"per process)")
+              f"(uvicorn needs an import string to fork; `co host` hands it an "
+              f"app object)")
     if reload:
         print("[host] reload: true not honoured — running without reload "
               "(uvicorn needs an import string to watch files)")

--- a/tests/unit/test_one_scheduler_across_workers.py
+++ b/tests/unit/test_one_scheduler_across_workers.py
@@ -1,0 +1,222 @@
+"""`uvicorn --workers 4` runs a scheduled entry four times.
+
+`create_app`'s own docstring tells people to do it:
+
+    app = create_app(create_agent)
+    # uvicorn myagent:app --workers 4
+
+That is a real import string, so uvicorn forks four processes and each runs the
+lifespan — including the scheduler loop. The overlap guard does not reach across
+them:
+
+    if entry.name in in_flight:
+        _say(f"{entry.name} still running, skipping this tick")
+        continue
+
+`in_flight` is a module-level set, so it is per process. The state file cannot
+close the gap either, and the code says why:
+
+    record_run only happens after the turn returns, so last_run is stale for
+    the whole duration
+
+So every worker sees the same due entry and starts its own copy. #537 is what
+that costs when the entry is not idempotent: two copies of a pipeline that
+downloads, extracts and writes to one table racing into the same rows.
+
+#639 fixed the other half — `workers: 2` in host.yaml killing the agent. This is
+the path where forking *does* work.
+
+The fix is the smallest thing that spans processes: one lock, taken per tick.
+Whichever worker gets it runs that tick; the others skip. Nothing is elected for
+the life of the process, so a worker that dies holding it costs one tick — the
+OS releases the lock and the next tick has a new winner. `schedule.py` already
+locks the state file this way, cross-platform, for the same reason.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host import schedule
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _router():
+    """The module, not the function of the same name.
+
+    `connectonion.network.host` re-exports a function called `http_router`, so
+    the dotted path in monkeypatch.setattr resolves to that and the patch lands
+    nowhere. importlib asks for the module.
+    """
+    import importlib
+
+    return importlib.import_module("connectonion.network.host.http_router")
+
+
+@pytest.fixture
+def co_dir(tmp_path):
+    co = tmp_path / ".co"
+    co.mkdir()
+    (co / "schedule.yaml").write_text(
+        '- name: nightly\n  run: "do the thing"\n  every: 1m\n'
+    )
+    return co
+
+
+class TestTheTickGuardSpansProcesses:
+
+    def test_only_one_holder_at_a_time(self, co_dir):
+        """Two callers, one lock: the second must be refused, not queued."""
+        first = schedule._tick_lock(co_dir)
+        assert first is not None, "the first caller should hold it"
+
+        assert schedule._tick_lock(co_dir) is None, \
+            "a second caller took the lock while the first held it"
+
+        schedule._release_tick_lock(first)
+
+    def test_it_is_available_again_once_released(self, co_dir):
+        handle = schedule._tick_lock(co_dir)
+        schedule._release_tick_lock(handle)
+
+        second = schedule._tick_lock(co_dir)
+        assert second is not None, "the lock was not released"
+        schedule._release_tick_lock(second)
+
+    def test_a_dead_holder_does_not_keep_it(self, co_dir):
+        """The OS releases a flock when the process dies — that is the property
+        that makes per-tick election self-healing rather than a leader that has
+        to be reaped.
+
+        A real second process, because that is the whole claim. `fork` is not
+        available on Windows and a spawned child cannot pickle a local, so this
+        goes through the interpreter directly.
+        """
+        code = ("from pathlib import Path;"
+                "from connectonion.network.host import schedule as s;"
+                f"s._tick_lock(Path({str(co_dir)!r}));"
+                "import os; os._exit(0)")
+        proc = subprocess.run([sys.executable, "-c", code], cwd=str(REPO),
+                              capture_output=True, text=True, timeout=120)
+        assert proc.returncode == 0, proc.stderr[-300:]
+
+        handle = schedule._tick_lock(co_dir)
+        assert handle is not None, "a dead worker's lock outlived it"
+        schedule._release_tick_lock(handle)
+
+
+class TestATickDoesNotRunTwice:
+
+    @pytest.mark.asyncio
+    async def test_the_second_worker_skips_while_the_first_holds_it(self, co_dir, monkeypatch):
+        """The behaviour the whole issue is about, at the tick boundary."""
+        ran = []
+
+        def fake_input_handler(create_agent, storage, prompt, result_ttl, session=None, **kw):
+            ran.append(prompt)
+            return {"status": "done", "session_id": session["session_id"]}
+
+        monkeypatch.setattr(_router(), "input_handler", fake_input_handler)
+
+        on_startup, _ = schedule.create_schedule_lifespan(
+            co_dir, lambda: None, storage=None, result_ttl=60)
+
+        held = schedule._tick_lock(co_dir)          # another worker is mid-tick
+        try:
+            await on_startup.tick_once()
+        finally:
+            schedule._release_tick_lock(held)
+
+        assert ran == [], f"a second worker ran the entry anyway: {ran}"
+
+    @pytest.mark.asyncio
+    async def test_the_entry_still_runs_when_nobody_else_holds_it(self, co_dir, monkeypatch):
+        """The other half: a lock that refuses everyone stops the schedule dead."""
+        ran = []
+
+        def fake_input_handler(create_agent, storage, prompt, result_ttl, session=None, **kw):
+            ran.append(prompt)
+            return {"status": "done", "session_id": session["session_id"]}
+
+        monkeypatch.setattr(_router(), "input_handler", fake_input_handler)
+
+        on_startup, _ = schedule.create_schedule_lifespan(
+            co_dir, lambda: None, storage=None, result_ttl=60)
+        await on_startup.tick_once()
+
+        assert ran == ["do the thing"], f"the only worker did not run it: {ran}"
+
+    @pytest.mark.asyncio
+    async def test_the_lock_is_released_for_the_next_tick(self, co_dir, monkeypatch):
+        """Held for the tick, not for the process — else worker 2 never wins again."""
+        monkeypatch.setattr(_router(), "input_handler",
+                            lambda *a, **kw: {"status": "done", "session_id": "s"})
+
+        on_startup, _ = schedule.create_schedule_lifespan(
+            co_dir, lambda: None, storage=None, result_ttl=60)
+        await on_startup.tick_once()
+
+        handle = schedule._tick_lock(co_dir)
+        assert handle is not None, "tick_once kept the lock after it finished"
+        schedule._release_tick_lock(handle)
+
+    @pytest.mark.asyncio
+    async def test_a_failing_entry_still_releases_it(self, co_dir, monkeypatch):
+        def boom(*a, **kw):
+            raise RuntimeError("the turn died")
+
+        monkeypatch.setattr(_router(), "input_handler", boom)
+
+        on_startup, _ = schedule.create_schedule_lifespan(
+            co_dir, lambda: None, storage=None, result_ttl=60)
+        await on_startup.tick_once()
+
+        handle = schedule._tick_lock(co_dir)
+        assert handle is not None, "a failed entry left the schedule locked forever"
+        schedule._release_tick_lock(handle)
+
+
+class TestFourWorkersLikeUvicornForks:
+    """The issue's actual claim, with four real processes.
+
+    Everything above drives one process holding a lock on behalf of another.
+    That is a fake of the situation, and a fake that agrees with the fix is how
+    the last several of these survived. So: four interpreters, started together,
+    each running one tick against one `.co/` — the shape `uvicorn --workers 4`
+    produces — and one line in the log per run.
+    """
+
+    WORKER = (
+        "import asyncio, sys\n"
+        "from pathlib import Path\n"
+        "from connectonion.network.host import schedule\n"
+        "import importlib\n"
+        "router = importlib.import_module('connectonion.network.host.http_router')\n"
+        "co = Path(sys.argv[1])\n"
+        "def handler(create_agent, storage, prompt, result_ttl, session=None, **kw):\n"
+        "    with open(co / 'runs.log', 'a') as fh:\n"
+        "        fh.write(prompt + '\\n')\n"
+        "    return {'status': 'done', 'session_id': session['session_id']}\n"
+        "router.input_handler = handler\n"
+        "on_startup, _ = schedule.create_schedule_lifespan(co, lambda: None, None, 60)\n"
+        "asyncio.run(on_startup.tick_once())\n"
+    )
+
+    def test_the_entry_runs_once_not_four_times(self, co_dir):
+        workers = [
+            subprocess.Popen([sys.executable, "-c", self.WORKER, str(co_dir)],
+                             cwd=str(REPO), stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, text=True)
+            for _ in range(4)
+        ]
+        for worker in workers:
+            out, err = worker.communicate(timeout=300)
+            assert worker.returncode == 0, err[-400:]
+
+        log = co_dir / "runs.log"
+        runs = log.read_text().splitlines() if log.exists() else []
+
+        assert runs == ["do the thing"], f"{len(runs)} workers ran it: {runs}"


### PR DESCRIPTION
`create_app`'s own docstring tells people to use it:

```python
app = create_app(create_agent)
# uvicorn myagent:app --workers 4
```

That is a real import string, so uvicorn forks four processes and each runs the lifespan — including the scheduler loop. The overlap guard does not reach across them (`in_flight` is a module-level set, so it is per process), and `last_run` is not written until the turn returns. Every worker saw the same due entry and started its own copy.

## Measured

Four real interpreters, started together, ticking one `.co/`:

```
before   4 workers ran it: ['do the thing', 'do the thing', 'do the thing', 'do the thing']
after    ['do the thing']
```

## The fix

One lock, taken per tick. Whichever worker gets it runs that tick; the others return silently — under `--workers 4` a skip is the normal case three times every minute, and logging it would bury what the running worker says.

Elected **per tick**, not for the life of the process: a worker that dies holding it costs one tick, because the OS drops the flock. A leader chosen at startup would leave the schedule stopped until someone noticed.

Refusal, not retry — the existing `_lock()` waits and then proceeds anyway, which is right for a short write to the state file and exactly wrong here, where proceeding *is* the duplicate run.

## Tests

8 cases, proven red on unpatched code first (6 of 7 in the unit classes, and the four-worker test failed with the exact 4-runs output above). The last one — `test_the_entry_still_runs_when_nobody_else_holds_it` — passes before and after by design: it is the guard against a lock that refuses everyone and stops the schedule dead.

The four-worker case runs real subprocesses rather than one process holding a lock on behalf of another. A fake that agrees with the fix is how several of these survived this long.

Also fixed while reviewing my own change: the Windows branch was missing the `seek(0)` that the sibling `_lock()` does, so lock and unlock named the same byte only by accident, while the file happened to stay empty.

Full suite: 4567 passed.

Closes #640.