### PR TITLE
Say so when two agents answer to one address

### DIFF
--- a/connectonion/address.py
+++ b/connectonion/address.py
@@ -311,6 +311,11 @@ def load(co_dir: Path) -> Optional[Dict[str, Any]]:
             "email": email,
             "email_active": email_active,
             "legacy_derivation": legacy_derivation,
+            # Which directory this key came from. A project with no key of its
+            # own falls back to the global ~/.co, so anything recorded *about*
+            # the key -- which agent is serving under it (#642) -- has to be
+            # written beside the key, not in whichever project loaded it.
+            "source": str(co_dir),
             "signing_key": signing_key
         })
         

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -611,6 +611,11 @@ RSYNC_FILTERS = [
     "--exclude", ".co/keys/",
     "--exclude", ".co/address.json",
     "--exclude", ".co/admins.txt",
+    # Which agent is serving under this key, and from which directory on
+    # the operator's machine (#642). Shipping it puts a local absolute path
+    # on the server and makes the deployed agent read the laptop's claim as
+    # a collision on every start.
+    "--exclude", ".co/served_by.json",
     "--exclude", ".co/provision.json",
     "--exclude", ".co/requirements.sha256",
     "--exclude", ".co/logs/",

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -30,6 +30,7 @@ import random
 from functools import partial
 import os
 from pathlib import Path
+import json
 from typing import Callable, Optional, Union
 
 import uvicorn
@@ -288,6 +289,68 @@ def resolve_agent_identity(co_dir: Path) -> dict:
     fresh = address.generate()
     address.save(fresh, co_dir)
     return fresh
+
+
+SERVED_BY_FILE = "served_by.json"
+
+
+def claim_identity(co_dir: Path, identity: dict, name: str) -> Optional[str]:
+    """Record that this agent serves under this key, or say who already does.
+
+    One address, one agent. #642 caught two of them sharing `0x10e68f6d…` —
+    `oo` on this laptop with bash and write, and `naturewill` on the deployed
+    box with the contract-ledger tools — because every 1.5.x `co init` wrote
+    `AGENT_CONFIG_PATH=~/.co` and a project with no key of its own inherits the
+    global one on purpose. Since #643 a client resolves an endpoint directly
+    and picks by proximity, so a call meant for the deployed agent reaches the
+    local coding agent instead. `/info` verification cannot catch that: the
+    address genuinely matches.
+
+    The record goes beside the key rather than in the project, because the
+    whole problem is several projects sharing one identity directory.
+
+    Returns a warning, not a refusal. The agent whose address this is may be
+    the one restarting, and an operator who cannot start their agent because of
+    a stale claim is worse off than one who is told the truth. `co deploy` is
+    where refusing belongs — that is the moment a second permanent copy is
+    made.
+    """
+    source = Path(identity.get("source") or co_dir)
+    if not source.is_dir():
+        # A freshly generated identity is saved into a directory that may not
+        # exist yet, and a hint about who is serving is not worth failing a
+        # start over. No directory, no claim, no warning.
+        return None
+    record = source / SERVED_BY_FILE
+    mine = {"name": name, "project": str(co_dir.parent), "address": identity["address"]}
+
+    existing = None
+    if record.exists():
+        try:
+            existing = json.loads(record.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            # A warning aid, not a gate. An unreadable record costs a warning,
+            # not a start.
+            existing = None
+
+    record.write_text(json.dumps(mine, indent=2), encoding="utf-8")
+
+    if not existing or existing.get("project") == mine["project"]:
+        return None       # nobody else, or the same project restarting/renamed
+
+    # Only advice that works. Saying "point AGENT_CONFIG_PATH at this project's
+    # .co" would be wrong for the case that produces this warning: the project
+    # has no key there, which is why it inherited one. Nothing today mints a
+    # local identity for a project that already exists — that gap is what makes
+    # this a warning rather than a refusal, and it is filed separately.
+    return (
+        f"{identity['address'][:10]}… is already served by "
+        f"'{existing.get('name')}' in {existing.get('project')}, using the same "
+        f"key from {source}. Two agents on one address means whichever is "
+        f"nearest answers the call, and the tools they answer with differ. A "
+        f"project created by `co create` gets its own identity and does not "
+        f"share."
+    )
 
 
 def usable_uvicorn_options(workers, reload) -> tuple:
@@ -746,6 +809,12 @@ def host(
 
     # Load or generate agent identity -- the one `co status` reports, not a new one
     addr_data = resolve_agent_identity(co_dir)
+
+    # Said before the banner, where the address is about to be printed as if it
+    # belonged to this agent alone.
+    collision = claim_identity(co_dir, addr_data, agent_metadata["name"])
+    if collision:
+        print(f"[host] {collision}")
 
     agent_metadata["address"] = addr_data['address']
     agent_metadata["trust"] = trust if isinstance(trust, str) else "custom"

--- a/tests/unit/test_one_agent_one_address.py
+++ b/tests/unit/test_one_agent_one_address.py
@@ -1,0 +1,218 @@
+"""Two agents answer to one address and nobody is told.
+
+#642, measured on this laptop: `0x10e68f6dff39ab…` was announced by two
+different agents at once —
+
+    this laptop, localhost:8000   name `oo`          bash, write, edit, … (24 tools)
+    the deployed box              name `naturewill`  the contract-ledger tools
+
+— because both loaded the same keypair. Every 1.5.x project's `co init` wrote
+`AGENT_CONFIG_PATH=~/.co`, and a project with no key of its own falls back to
+the global one on purpose (that fallback fixed a worse bug: the host used to
+mint a third address and serve under it while `co status` reported the
+configured one).
+
+After #643 a client resolves an endpoint directly and picks by network
+proximity, so a call meant for the deployed agent lands on the local coding
+agent instead — one holding `bash` and `write` on the caller's machine. `/info`
+verification cannot catch it: the address genuinely matches. That is the point.
+
+The rule is one agent, one address. This is the part that can be proven without
+asking anything of the network: the identity directory records which project
+and name is serving under it, and a second, different agent starting on the
+same keypair is told it is a collision rather than silently joining it.
+
+What it deliberately does not do is refuse to start. The agent whose address
+this is may be the one restarting, and an operator who cannot start their agent
+because of a stale claim is worse off than one who is told the truth. `co
+deploy` is where refusing belongs — a deploy is the moment a second permanent
+copy is created.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+from connectonion.network.host.server import claim_identity, resolve_agent_identity
+
+
+@pytest.fixture
+def shared(tmp_path):
+    """One global ~/.co holding the only keypair, and two projects with none."""
+    home_co = tmp_path / "home" / ".co"
+    home_co.mkdir(parents=True)
+    address.save(address.generate(), home_co)
+
+    first = tmp_path / "oo" / ".co"
+    second = tmp_path / "naturewill" / ".co"
+    for co in (first, second):
+        co.mkdir(parents=True)
+    return home_co, first, second
+
+
+class TestTheSecondAgentIsTold:
+
+    def test_a_different_name_on_the_same_key_is_a_collision(self, shared, monkeypatch):
+        home_co, first, second = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        assert claim_identity(first, resolve_agent_identity(first), "oo") is None
+
+        warning = claim_identity(second, resolve_agent_identity(second), "naturewill")
+
+        assert warning, "the second agent joined the first one's address silently"
+        assert "oo" in warning, warning
+
+    def test_the_warning_names_the_other_project(self, shared, monkeypatch):
+        home_co, first, second = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        claim_identity(first, resolve_agent_identity(first), "oo")
+        warning = claim_identity(second, resolve_agent_identity(second), "naturewill")
+
+        assert str(first.parent) in warning, warning
+
+    def test_the_same_agent_restarting_is_not_a_collision(self, shared, monkeypatch):
+        """The common case. An operator who cannot restart is worse off."""
+        home_co, first, _ = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        claim_identity(first, resolve_agent_identity(first), "oo")
+
+        assert claim_identity(first, resolve_agent_identity(first), "oo") is None
+
+    def test_a_rename_in_place_is_not_a_collision(self, shared, monkeypatch):
+        """One project, one key — renaming the agent is allowed, and the claim
+        follows it rather than warning forever."""
+        home_co, first, _ = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        claim_identity(first, resolve_agent_identity(first), "oo")
+        assert claim_identity(first, resolve_agent_identity(first), "oo-renamed") is None
+        assert claim_identity(first, resolve_agent_identity(first), "oo-renamed") is None
+
+
+class TestAProjectWithItsOwnKey:
+    """What `co create` produces now, and what the fix for this is: no sharing,
+    so nothing to warn about."""
+
+    def test_two_projects_with_their_own_keys_never_collide(self, tmp_path, monkeypatch):
+        home_co = tmp_path / "home" / ".co"
+        home_co.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        first, second = tmp_path / "a" / ".co", tmp_path / "b" / ".co"
+        for co in (first, second):
+            co.mkdir(parents=True)
+            address.save(address.generate(), co)
+
+        assert claim_identity(first, resolve_agent_identity(first), "a") is None
+        assert claim_identity(second, resolve_agent_identity(second), "b") is None
+
+    def test_the_claim_lands_beside_the_key_it_is_about(self, tmp_path, monkeypatch):
+        """Not in the project — the whole point is that several projects share
+        one identity directory, so the record has to live with the key."""
+        home_co = tmp_path / "home" / ".co"
+        home_co.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+        project = tmp_path / "p" / ".co"
+        project.mkdir(parents=True)
+        address.save(address.generate(), project)
+
+        claim_identity(project, resolve_agent_identity(project), "p")
+
+        assert (project / "served_by.json").exists()
+        assert not (home_co / "served_by.json").exists()
+
+
+class TestWhereTheIdentityCameFrom:
+    """claim_identity has to record against the key's own directory, so the
+    loaded identity has to say which one that was."""
+
+    def test_an_inherited_identity_says_it_is_the_global_one(self, shared, monkeypatch):
+        home_co, first, _ = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        assert resolve_agent_identity(first)["source"] == str(home_co)
+
+    def test_a_local_identity_says_the_project(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "nowhere")
+        co = tmp_path / "p" / ".co"
+        co.mkdir(parents=True)
+        address.save(address.generate(), co)
+
+        assert resolve_agent_identity(co)["source"] == str(co)
+
+
+class TestTheRecordItself:
+
+    def test_it_is_readable_json(self, shared, monkeypatch):
+        home_co, first, _ = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+
+        claim_identity(first, resolve_agent_identity(first), "oo")
+        record = json.loads((home_co / "served_by.json").read_text())
+
+        assert record["name"] == "oo"
+        assert record["project"] == str(first.parent)
+
+    def test_a_corrupt_record_does_not_stop_the_agent(self, shared, monkeypatch):
+        """It is a warning aid, not a gate. Losing it costs a warning."""
+        home_co, first, _ = shared
+        monkeypatch.setattr(Path, "home", lambda: home_co.parent)
+        (home_co / "served_by.json").write_text("{not json")
+
+        assert claim_identity(first, resolve_agent_identity(first), "oo") is None
+
+
+class TestTheClaimStaysOnThisMachine:
+    """It names a directory on the operator's laptop.
+
+    Shipped, it would put that path on the server and make the deployed agent
+    read the laptop's claim as a collision every time it starts — the warning
+    firing on the one agent that is not the problem.
+
+    Driven through real rsync rather than asserting against the exclude list.
+    #686 found `.env.example` silently not travelling that way: what the list
+    says and what rsync does are two different questions.
+    """
+
+    def test_it_does_not_travel(self, tmp_path):
+        import shutil
+        import subprocess
+
+        if not shutil.which("rsync"):
+            pytest.skip("no rsync here")
+
+        from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+
+        project = tmp_path / "project"
+        (project / ".co").mkdir(parents=True)
+        (project / "agent.py").write_text("# the agent")
+        (project / ".co" / "served_by.json").write_text('{"name": "oo"}')
+        (project / ".co" / "host.yaml").write_text("workers: 1\n")
+
+        out = subprocess.run(
+            ["rsync", "-an", "--out-format=%n", *RSYNC_FILTERS,
+             f"{project}/", str(tmp_path / "server")],
+            capture_output=True, text=True, timeout=300,
+        )
+        assert out.returncode == 0, out.stderr[-300:]
+        sent = out.stdout.split()
+
+        assert ".co/served_by.json" not in sent, sent
+        assert "agent.py" in sent, f"the exclude took the project with it: {sent}"
+        assert ".co/host.yaml" in sent, f"the rest of .co stopped travelling: {sent}"
+
+
+class TestItNeverStopsTheAgentStarting:
+
+    def test_a_missing_directory_costs_a_warning_not_a_start(self, tmp_path):
+        """Recording who serves an identity is a hint. Nine host tests died on
+        the first draft of this, which wrote the record without asking whether
+        the directory was there."""
+        identity = {"address": "0x" + "b" * 64, "source": str(tmp_path / "gone")}
+
+        assert claim_identity(tmp_path / "p" / ".co", identity, "p") is None


### PR DESCRIPTION
## What #642 measured

`0x10e68f6dff39ab…` was announced by two different agents at once:

| where | name | tools |
|---|---|---|
| this laptop, `localhost:8000` | `oo` | `bash`, `write`, `edit`, … (24) |
| the deployed box | `naturewill` | the contract-ledger tools |

Both load the same keypair, because every 1.5.x `co init` wrote `AGENT_CONFIG_PATH=~/.co` and a project with no key of its own inherits the global one **on purpose** — that fallback fixed a worse bug, where the host minted a third address and served under it while `co status` reported the configured one.

Since #643 a client resolves an endpoint directly and picks by proximity, so a call meant for the deployed agent lands on the local coding agent — one holding `bash` and `write` on the caller's machine. `/info` verification cannot catch this in principle: the address genuinely matches.

## What this does

The identity directory records which project and name serves under it. A different agent starting on the same keypair is told, by name and directory:

```
[host] 0x10e68f6d… is already served by 'oo' in /Users/…/oo, using the same
key from /Users/…/.co. Two agents on one address means whichever is nearest
answers the call, and the tools they answer with differ. A project created by
`co create` gets its own identity and does not share.
```

The record lives **beside the key**, not in the project — the whole problem is several projects sharing one identity directory. `address.load()` now reports which directory the key came from, so there is one answer to that rather than a rule restated at each caller.

## Why a warning and not a refusal

Aaron's rule is one agent, one address, and `co deploy` refusing is the right place for it. I did not add that here, and this is the half that is missing: **nothing today mints a local identity for a project that already exists.** Refusing a deploy would strand every 1.5.x project with no command to run. Filed separately rather than shipped as a dead end.

The host warning is also deliberately not fatal — the agent whose address this is may be the one restarting, and an operator who cannot start their agent because of a stale claim is worse off than one who is told the truth.

## Found while reviewing this change

- The first draft of the warning advised "point AGENT_CONFIG_PATH at this project's .co" — which does not work for the case that produces the warning, because the project has no key there. That is why it inherited one.
- The record would have **rsynced to the server**, putting a local absolute path on the box and making the deployed agent read the laptop's claim as a collision on every start. Excluded, and verified through real rsync rather than by reading the exclude list — the way #686 found `.env.example` silently not travelling.
- The first draft wrote the record without asking whether the directory existed, which killed nine host tests. A hint about who is serving is not worth failing a start over.

## Tests

12 cases, red first. Full suite 4571 passed.

Part of #642.