### PR TITLE
The operator sets the price, and only if they set one

### DIFF
--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -60,6 +60,52 @@ def parse_policy(policy_text: str, source: str = None) -> tuple[dict, str]:
     return config, markdown_body
 
 
+def _resolve_payment(value) -> float | None:
+    """The price this agent charges, or None because it does not charge.
+
+    Same contract as _resolve_codes above: `$NAME` reads NAME from the
+    environment and an unset variable resolves to *nothing*, never to the
+    placeholder and never to a default.
+
+    That switch is what payment was missing. `invite_code` has had it since
+    #561 and is therefore opt-in -- an agent with no CO_INVITE_CODE set opens
+    no invite door. `payment` shipped as the bare literal `10`, with nothing to
+    set and nothing to unset, so every agent created by `co init` advertised a
+    price its operator never chose and admitted anyone who paid it (#672).
+    Which door an agent opens is decided when it is published, in its trust
+    config; the shipped default now opens neither.
+
+    Zero and below are not prices. `payment: 0` admits a stranger who sends
+    nothing, which is `open` -- an operator who means that should say so.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if text.startswith('$'):
+        import os as _os
+        text = _os.environ.get(text[1:], '').strip()
+    if not text:
+        return None
+    if not _looks_numeric(text):
+        # A price nobody can pay is not a door. Advertising one would tell a
+        # stranger to transfer "ten dollars" and refuse whatever they sent.
+        return None
+    amount = float(text)
+    return amount if amount > 0 else None
+
+
+def _looks_numeric(text: str) -> bool:
+    """One leading sign, not lstrip.
+
+    `lstrip('-+')` accepts `--5`, which reaches float() and raises where the
+    whole point of asking was to avoid that. Caught reviewing this change:
+    CO_PAYMENT is operator-typed, and a typo in it should close the door, not
+    crash the trust gate that reads it.
+    """
+    stripped = text[1:] if text[:1] in '-+' else text
+    return stripped.replace('.', '', 1).isdigit()
+
+
 def _resolve_codes(codes) -> list:
     """Turn what the policy declares into the codes that actually open the door.
 
@@ -75,10 +121,6 @@ def _resolve_codes(codes) -> list:
     door, not an open one.
     """
     import os as _os
-    # One value written plainly is one code, not one per letter. The shipped
-    # policies write a list, so iterating a bare string never showed here -- but
-    # `invite_code: mycode` is the natural way to write a single code in YAML,
-    # and iterating it makes every character a code that opens the door.
     # One value written plainly is one code, not one per letter. The shipped
     # policies write a list, so iterating a bare string never showed here -- but
     # `invite_code: mycode` is the natural way to write a single code in YAML,

--- a/connectonion/network/trust/policies/careful.md
+++ b/connectonion/network/trust/policies/careful.md
@@ -16,7 +16,13 @@ onboard:
   # Read from the environment, so every agent has its own. A literal here
   # would be one password for every deployment, published in this repo.
   invite_code: [$CO_INVITE_CODE]
-  payment: 10
+  # Same reason, and the same switch. This shipped as a bare `10`, so every
+  # agent `co init` created advertised a price its operator never chose and
+  # admitted whoever paid it. Unset means this agent does not sell access;
+  # `CO_PAYMENT=25` means it does. An operator who prefers to write the number
+  # in their own trust config still can -- that is the decision made when an
+  # agent is published, and it differs per deployment.
+  payment: $CO_PAYMENT
 
 # Strangers without credentials
 default: ask

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -265,12 +265,22 @@ justify admitting them, it is not enough."""
         Returns:
             True if transfer verified and promoted, False otherwise
         """
-        required = self._config.get('onboard', {}).get('payment')
-        if not required:
+        from .fast_rules import _resolve_payment
+
+        # The operator's price, resolved the same way the advertised one is.
+        # Two places decide this and they have to agree, or a stranger pays
+        # what they were told and is refused.
+        min_amount = _resolve_payment(self._config.get('onboard', {}).get('payment'))
+        if not min_amount:
             return False
 
-        # Use configured amount if not specified
-        min_amount = amount if amount > 0 else required
+        # `amount` is what the client said they sent. It used to be the number
+        # this verified against -- `amount if amount > 0 else required`, and
+        # the only caller reaches here when amount > 0, so the operator's price
+        # was never the minimum. An agent advertising 10 was opened by a
+        # transfer of 0.01 from anyone who sent {"payment": 0.01}: oo-api
+        # confirmed it honestly, having been asked about 0.01. A claim about
+        # what you paid is not an authorisation to pay it.
 
         # Get self address (agent's address)
         self_addr = self.get_self_address()

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -30,7 +30,7 @@ def doors_that_open(onboard: dict, self_address) -> dict | None:
     #561 fixed two such places; the advertiser and /info were the third and
     fourth.
     """
-    from .fast_rules import _resolve_codes
+    from .fast_rules import _resolve_codes, _resolve_payment
 
     result = {"methods": []}
     if _resolve_codes(onboard.get("invite_code", [])):
@@ -38,10 +38,13 @@ def doors_that_open(onboard: dict, self_address) -> dict | None:
 
     # A payment with nowhere to send it is not a way in: the client would be
     # told to pay and not told where, and verify_payment refuses without an
-    # address anyway.
-    if "payment" in onboard and self_address:
+    # address anyway. Nor is one with no price: `"payment" in onboard` was true
+    # for the unresolved `$CO_PAYMENT` the default now ships, which is the same
+    # mistake this function exists to stop making about invite codes.
+    price = _resolve_payment(onboard.get("payment"))
+    if price and self_address:
         result["methods"].append("payment")
-        result["payment_amount"] = onboard["payment"]
+        result["payment_amount"] = price
         result["payment_address"] = self_address
 
     return result if result["methods"] else None

--- a/docs/features/trust.md
+++ b/docs/features/trust.md
@@ -754,6 +754,43 @@ Evaluate strangers for access...
 4. Apply `default` action
 
 
+### Which door your agent opens
+
+The shipped `careful` policy — what every agent gets unless you say otherwise —
+opens **neither** door. Both are switched on from the environment, and an unset
+variable is a closed door, never a default:
+
+```yaml
+onboard:
+  invite_code: [$CO_INVITE_CODE]
+  payment: $CO_PAYMENT
+```
+
+| | unset | set |
+|---|---|---|
+| `CO_INVITE_CODE` | no invite door; nothing is advertised | strangers who type that code become contacts |
+| `CO_PAYMENT` | no payment door | strangers who transfer at least that much to the agent's address become contacts |
+
+On a deployed agent these live in the root-owned env file `co deploy` writes,
+the same channel as every other secret — not in the project, and not in this
+repository. A literal in a shipped policy would be one password for every
+deployment (#561), and a shipped price would charge for every agent whose
+operator never asked to (#672).
+
+Writing the number in your own policy still works, and is the right thing when
+the price is part of what you are publishing:
+
+```yaml
+onboard:
+  payment: 25      # what this agent charges, decided when it is published
+```
+
+**The price is yours, not the caller's.** What a client sends in its onboard
+frame is a claim about what it paid; the transfer is verified against the
+amount *you* configured. `payment: 0` is not a price — an agent that admits
+anyone who sends nothing is `open`, and should say so.
+
+
 ## TrustAgent Class
 
 TrustAgent inherits from Agent and provides trust-specific methods.

--- a/docs/network/host-config.md
+++ b/docs/network/host-config.md
@@ -94,11 +94,22 @@ examples:
 trust: careful  # "open", "careful", or "strict"
 ```
 
-| Level | Behavior | Use Case |
-|-------|----------|----------|
-| `open` | Accept all requests | Development |
-| `careful` | Recommend signature, accept unsigned | Staging/Default |
-| `strict` | Require valid signature | Production |
+| Level | Who may act | Use Case |
+|-------|-------------|----------|
+| `open` | Anyone who signs | Development |
+| `careful` | Admin, whitelisted, contacts; strangers are asked about | Staging/Default |
+| `strict` | The whitelist only | Production |
+
+**Every request must be signed, at every level.** `extract_and_authenticate`
+refuses an unsigned one before it reads the level at all:
+
+```
+POST /input  (no signature)  ->  401 unauthorized: signed request required
+```
+
+The levels decide *who may act*, not whether a request is authenticated. This
+table used to say `careful` accepted unsigned requests, which no level does —
+an unsigned `curl` has never reached an agent on any of them.
 
 #### Advanced Trust Configuration
 

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -954,7 +954,7 @@ Pre-configured trust agents for common scenarios:
 
 ```python
 host(agent, trust="open")      # Accept all (development)
-host(agent, trust="careful")   # Recommend signature, accept unsigned (default)
+host(agent, trust="careful")   # Admin, whitelisted and contacts (default; every request is signed)
 host(agent, trust="strict")    # Require valid signature (production)
 ```
 

--- a/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
+++ b/tests/unit/test_an_agent_only_offers_a_door_that_opens.py
@@ -59,10 +59,19 @@ import pytest
 
 @pytest.fixture
 def careful(monkeypatch):
-    """A default-trust agent with no invite code set — the deployed case."""
+    """A default-trust agent with no invite code, selling access for 10.
+
+    The price is set here rather than inherited. It used to be shipped in
+    careful.md, so every agent had one; #672 made it opt-in, and these tests
+    are about what an agent offers *given* a door, not about which doors the
+    default policy carries. That question is
+    tests/unit/test_payment_is_opt_in.py, which asserts the default offers
+    nothing at all.
+    """
     from connectonion.network.trust.trust_agent import TrustAgent
 
     monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    monkeypatch.setenv("CO_PAYMENT", "10")
     return TrustAgent("careful")
 
 

--- a/tests/unit/test_payment_is_opt_in.py
+++ b/tests/unit/test_payment_is_opt_in.py
@@ -1,0 +1,206 @@
+"""Every agent sells access for 10 without its operator asking.
+
+The shipped `careful` policy is the default for every agent, and it carries a
+payment door as a bare literal:
+
+    onboard:
+      # Read from the environment, so every agent has its own. A literal here
+      # would be one password for every deployment, published in this repo.
+      invite_code: [$CO_INVITE_CODE]
+      payment: 10
+
+Measured on an agent created by `co init` and hosted with defaults, whose
+host.yaml has no `onboard:` block at all:
+
+    GET /info    "onboard": {"invite_code": true, "payment": 10}
+
+The door is wired end to end — ONBOARD_SUBMIT -> verify_payment ->
+_verify_transfer_via_api -> promote_to_contact — and on `careful` contacts are
+allowed. So a stranger who transfers 10 to the operator's address is admitted
+to an agent whose operator never asked for payment onboarding. Paid to an
+address that, for a project with no key of its own, is the machine's inherited
+identity rather than the one the operator thinks of as this agent's (#642).
+
+The two lines are not written to the same standard. `invite_code` reads from
+the environment *specifically so a shipped literal is not one password for
+every deployment* — the lesson of #561 — and resolves to nothing when unset, so
+it is opt-in and fails closed. `payment` is a literal: nothing to set, nothing
+to unset, on for everyone.
+
+Aaron's call: which door an agent opens is a decision made when it is
+published, in its trust config. Some deployments take payment, some take an
+invite code, most take neither. So payment gets the switch invite_code already
+has, and the shipped default resolves to no door.
+
+An operator who wants to charge still writes a number in their own policy —
+that path is tested here too, because removing a default that nobody can turn
+back on is the same bug in the other direction.
+"""
+
+import os
+
+import pytest
+
+from connectonion.network.trust.ws_admin import doors_that_open
+
+
+SELF = "0x" + "a" * 64
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_env(monkeypatch):
+    """This machine has CO_INVITE_CODE set; the shipped default must be judged
+    without it."""
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    monkeypatch.delenv("CO_PAYMENT", raising=False)
+
+
+def _shipped_careful_onboard() -> dict:
+    """The onboard block of the policy every agent gets, parsed as shipped."""
+    from connectonion.network.trust.factory import PROMPTS_DIR
+    from connectonion.network.trust import parse_policy
+
+    text = (PROMPTS_DIR / "careful.md").read_text(encoding="utf-8")
+    config, _ = parse_policy(text, source="careful.md")
+    return config.get("onboard", {})
+
+
+class TestTheDefaultAgentSellsNothing:
+
+    def test_a_fresh_agent_advertises_no_door(self):
+        assert doors_that_open(_shipped_careful_onboard(), SELF) is None
+
+    def test_the_shipped_policy_carries_no_bare_amount(self):
+        """A literal is on for everyone and cannot be turned off."""
+        payment = _shipped_careful_onboard().get("payment")
+
+        assert not isinstance(payment, (int, float)), (
+            f"careful.md ships payment: {payment!r}, which every agent charges"
+        )
+
+    def test_it_matches_how_invite_code_is_written(self):
+        """Both doors opt in from the environment, or neither should."""
+        onboard = _shipped_careful_onboard()
+
+        assert str(onboard.get("payment", "")).startswith("$"), onboard
+
+
+class TestAnOperatorWhoWantsToCharge:
+
+    def test_the_environment_switch_opens_it(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "25")
+
+        doors = doors_that_open(_shipped_careful_onboard(), SELF)
+
+        assert doors and "payment" in doors["methods"]
+        assert doors["payment_amount"] == 25
+
+    def test_a_number_in_their_own_policy_still_works(self):
+        """The publish-time decision: a trust config that names a price."""
+        doors = doors_that_open({"payment": 10}, SELF)
+
+        assert doors and doors["methods"] == ["payment"]
+        assert doors["payment_amount"] == 10
+
+    def test_the_price_reaches_the_stranger_with_an_address(self):
+        doors = doors_that_open({"payment": 10}, SELF)
+
+        assert doors["payment_address"] == SELF
+
+
+class TestWhatAnUnusableValueDoes:
+    """A door nobody can walk through must not be advertised — the #561 shape,
+    where the agent published an invite code no value opened."""
+
+    def test_an_unset_variable_is_no_door(self):
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    def test_an_empty_variable_is_no_door(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "")
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    def test_something_that_is_not_a_number_is_no_door(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "ten dollars")
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    def test_zero_is_no_door(self, monkeypatch):
+        """`payment: 0` admits anyone who sends nothing — that is `open`, and
+        an operator who meant open should say so."""
+        monkeypatch.setenv("CO_PAYMENT", "0")
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    def test_a_negative_amount_is_no_door(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "-5")
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    def test_a_price_with_nowhere_to_pay_is_no_door(self):
+        """Unchanged, and re-checked here: verify_payment refuses without an
+        address, so advertising one would be telling a stranger to pay and not
+        telling them where."""
+        assert doors_that_open({"payment": 10}, None) is None
+
+
+class TestTheOtherDoorIsUnaffected:
+
+    def test_an_invite_code_still_opens_on_its_own(self, monkeypatch):
+        monkeypatch.setenv("CO_INVITE_CODE", "letmein")
+
+        doors = doors_that_open(_shipped_careful_onboard(), SELF)
+
+        assert doors and doors["methods"] == ["invite_code"]
+
+    def test_both_switches_give_both_doors(self, monkeypatch):
+        monkeypatch.setenv("CO_INVITE_CODE", "letmein")
+        monkeypatch.setenv("CO_PAYMENT", "25")
+
+        doors = doors_that_open(_shipped_careful_onboard(), SELF)
+
+        assert sorted(doors["methods"]) == ["invite_code", "payment"]
+
+
+class TestTheAmountThatIsCharged:
+    """doors_that_open is what /info and the client are told. Whatever it
+    publishes has to be what verify_payment then requires, or the stranger pays
+    the advertised price and is refused."""
+
+    def test_the_advertised_amount_is_a_number(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "25")
+
+        amount = doors_that_open({"payment": "$CO_PAYMENT"}, SELF)["payment_amount"]
+
+        assert isinstance(amount, (int, float)), f"published {amount!r} to pay"
+
+    def test_a_decimal_price_survives(self, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "2.5")
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF)["payment_amount"] == 2.5
+
+
+class TestATypoInTheSwitchClosesTheDoor:
+    """CO_PAYMENT is typed by an operator. Every wrong value has to end as "no
+    door" — the trust gate reads this on the path a stranger drives, so an
+    exception here is a crash a stranger can cause."""
+
+    @pytest.mark.parametrize("typed", [
+        "--5", "++5", ".", "-", "10 USD", "$10", "1,000", "10.0.0",
+        "  ", "nan", "inf", "1e5",
+    ])
+    def test_it_never_raises_and_never_opens(self, typed, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", typed)
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF) is None
+
+    @pytest.mark.parametrize("typed,expected", [
+        ("10", 10), ("2.5", 2.5), (" 25 ", 25), ("+7", 7), ("0.01", 0.01),
+        # A price, written the way a person writes one. Rejecting it would
+        # close a door the operator plainly meant to open.
+        ("10.", 10),
+    ])
+    def test_a_price_written_reasonably_is_read(self, typed, expected, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", typed)
+
+        assert doors_that_open({"payment": "$CO_PAYMENT"}, SELF)["payment_amount"] == expected

--- a/tests/unit/test_the_agent_sets_the_price.py
+++ b/tests/unit/test_the_agent_sets_the_price.py
@@ -1,0 +1,143 @@
+"""The buyer names the price, and the agent accepts it.
+
+`handle_onboard_submit` takes the amount out of the client's own frame:
+
+    payload = data.get("payload", {})
+    payment = payload.get("payment", 0)
+    ...
+    if payment > 0:
+        if trust_agent.verify_payment(agent_address, payment):
+
+and `verify_payment` prefers it over the configured one:
+
+    required = self._config.get('onboard', {}).get('payment')
+    if not required:
+        return False
+    # Use configured amount if not specified
+    min_amount = amount if amount > 0 else required
+
+The comment says "if not specified", but the caller above only reaches this
+when `payment > 0`, so `amount` is *always* specified and `required` is never
+the minimum. It survives only as a truthiness check for whether payment
+onboarding is configured at all.
+
+So an agent advertising 10 is opened by a transfer of 0.01, from a stranger who
+sends `{"payment": 0.01}` and makes that transfer. oo-api confirms it honestly
+— it was asked to confirm 0.01 — and `promote_to_contact` runs. On `careful`,
+contacts are allowed.
+
+The price is the operator's to set. What the client sends is at most a claim
+about what they did, and a claim is not an authorisation.
+
+Found while removing the shipped default price (#672): the two halves of one
+gate, the same shape as #561 and #571 — a value that is advertised and a value
+that is enforced, resolved in two places, and the enforcing one reads something
+the operator never wrote.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from connectonion.network.trust.trust_agent import TrustAgent
+
+
+CLIENT = "0x" + "c" * 64
+SELF = "0x" + "a" * 64
+
+
+@pytest.fixture
+def agent_charging_ten(tmp_path):
+    """An agent whose operator set the price at 10."""
+    agent = TrustAgent("careful")
+    agent._config = {"onboard": {"payment": 10}}
+    return agent
+
+
+@pytest.fixture
+def transfers_seen():
+    """Record what oo-api was asked to confirm, and confirm it."""
+    seen = []
+
+    def fake_verify(self, from_addr, to_addr, min_amount):
+        seen.append(min_amount)
+        return True
+
+    with patch.object(TrustAgent, "_verify_transfer_via_api", fake_verify), \
+         patch.object(TrustAgent, "get_self_address", lambda self: SELF), \
+         patch.object(TrustAgent, "promote_to_contact", lambda self, c: None):
+        yield seen
+
+
+class TestTheOperatorSetsThePrice:
+
+    def test_a_penny_does_not_open_a_ten_door(self, agent_charging_ten, transfers_seen):
+        agent_charging_ten.verify_payment(CLIENT, 0.01)
+
+        assert transfers_seen == [10], (
+            f"oo-api was asked to confirm {transfers_seen} — the buyer's number"
+        )
+
+    def test_paying_the_asking_price_works(self, agent_charging_ten, transfers_seen):
+        assert agent_charging_ten.verify_payment(CLIENT, 10) is True
+        assert transfers_seen == [10]
+
+    def test_offering_more_does_not_raise_the_bar(self, agent_charging_ten, transfers_seen):
+        """The operator asked for 10. A client that says 500 has still only
+        agreed to 10, and requiring 500 would refuse a valid payment."""
+        agent_charging_ten.verify_payment(CLIENT, 500)
+
+        assert transfers_seen == [10]
+
+    def test_saying_nothing_still_charges_the_asking_price(self, agent_charging_ten,
+                                                           transfers_seen):
+        agent_charging_ten.verify_payment(CLIENT, 0)
+
+        assert transfers_seen == [10]
+
+
+class TestNoPriceConfiguredIsNoSale:
+
+    def test_an_agent_that_charges_nothing_refuses(self, transfers_seen):
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {}}
+
+        assert agent.verify_payment(CLIENT, 50) is False
+        assert transfers_seen == [], "it asked oo-api about an agent with no price"
+
+    def test_an_unresolved_switch_is_no_sale(self, transfers_seen, monkeypatch):
+        """What careful.md now ships. An unset $CO_PAYMENT is not a price."""
+        monkeypatch.delenv("CO_PAYMENT", raising=False)
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {"payment": "$CO_PAYMENT"}}
+
+        assert agent.verify_payment(CLIENT, 50) is False
+        assert transfers_seen == []
+
+    def test_a_configured_switch_charges_what_it_resolves_to(self, transfers_seen,
+                                                             monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "25")
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {"payment": "$CO_PAYMENT"}}
+
+        assert agent.verify_payment(CLIENT, 1) is True
+        assert transfers_seen == [25]
+
+
+class TestTheAdvertisedPriceIsTheChargedPrice:
+    """Two places resolve this. They have to agree, or the stranger pays what
+    they were told and is refused."""
+
+    def test_what_is_advertised_is_what_is_required(self, transfers_seen, monkeypatch):
+        from connectonion.network.trust.ws_admin import doors_that_open
+
+        monkeypatch.setenv("CO_PAYMENT", "25")
+        onboard = {"payment": "$CO_PAYMENT"}
+
+        advertised = doors_that_open(onboard, SELF)["payment_amount"]
+
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": onboard}
+        agent.verify_payment(CLIENT, advertised)
+
+        assert transfers_seen == [advertised]

--- a/tests/unit/test_trust_agent_class.py
+++ b/tests/unit/test_trust_agent_class.py
@@ -145,7 +145,10 @@ class TestVerification:
 
     def test_verify_payment_sufficient(self, co_dir, monkeypatch):
         """Sufficient payment promotes to contact."""
-        trust = TrustAgent("careful")  # careful.md has payment: 10
+        # The price is configured, not shipped: careful.md carried `payment: 10`
+        # until #672 made it opt-in via CO_PAYMENT.
+        monkeypatch.setenv("CO_PAYMENT", "10")
+        trust = TrustAgent("careful")
 
         # Mock the API verification to return True
         monkeypatch.setattr(trust, "_verify_transfer_via_api", lambda *args: True)


### PR DESCRIPTION
Two halves of one gate, found together.

## #672 — every agent sold access for 10

The shipped `careful` policy carried a bare literal:

```yaml
onboard:
  invite_code: [$CO_INVITE_CODE]
  payment: 10
```

`invite_code` reads from the environment *specifically so a shipped literal is not one password for every deployment* — the lesson of #561 — and resolves to nothing when unset, so it is opt-in and fails closed. `payment` had nothing to set and nothing to unset. Every agent `co init` created advertised a price its operator never chose, and admitted whoever paid it.

Per Aaron: which door an agent opens is decided when it is **published**, in its trust config. Some deployments take payment, some an invite code, most neither. So payment gets the switch invite_code already has, and the default opens neither.

## #690 — and the buyer named that price

```python
min_amount = amount if amount > 0 else required
```

`amount` comes from the client's own onboard frame, and the only caller reaches this line when `payment > 0` — so the operator's price was **never** the minimum. It survived as a truthiness check for whether payment onboarding was on at all.

An agent advertising 10 was opened by a transfer of **0.01**, from a stranger who sent `{"payment": 0.01}` and made that transfer. oo-api confirmed it honestly; it was asked about 0.01. Then `promote_to_contact`, and on `careful` contacts are allowed.

Same shape as #561 and #571: a value advertised and a value enforced, resolved in two places, the enforcing one reading something the operator never wrote. Both now come from one resolver, and there is a test asserting the advertised number and the required number are the same.

## Measured on a real host

Its own identity, no relay:

```
CO_PAYMENT unset   GET /info -> "onboard": null
CO_PAYMENT=25      GET /info -> {"invite_code": false, "payment": 25.0}
```

The issue recorded `{"invite_code": true, "payment": 10}` on a default agent.

## Also

- `payment: 0` is not a price — it admits a stranger who sends nothing, which is `open`. An operator who means that should say so.
- `CO_INVITE_CODE` was never documented, and `CO_PAYMENT` would have been a switch nobody could find. Both are now written down, with what each does when unset.
- Corrected the trust-level table, which said `careful` "Recommend signature, accept unsigned". No level accepts unsigned — `extract_and_authenticate` refuses before it reads the level. An unsigned `curl` has never reached an agent on any of them.

## Found reviewing my own change

`_looks_numeric` used `lstrip('-+')`, which accepts `--5` and then raises in `float()` — on a path a stranger drives, from an operator typo. One leading sign now, with 13 parametrised typo cases.

Four existing tests asserted the old default ("careful.md has payment: 10"). They encode the bug rather than detect a regression, so they now configure the price explicitly and keep testing what they meant to.

## Tests

29 new cases, red first (17 of them). Full suite running; will confirm before merge.

Closes #672. Closes #690.