### PR TITLE
EXEC asks who is calling, not only what they ask for

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -66,6 +66,48 @@ from .http_router import (
 )
 
 
+EXEC_REQUIRES = ("admin", "whitelist")
+
+
+def _make_ws_exec(create_agent, exec_permissions, trust_agent):
+    """Direct tool execution, gated on who is asking as well as what they ask.
+
+    EXEC used to take neither the caller's address nor their level:
+
+        def handle_ws_exec(tool_name, args):
+            return exec_handler(create_agent, exec_permissions, tool_name, args)
+
+    while the INPUT handler beside it resolved both and carried them down. So
+    the permission whitelist was the only gate, and any authenticated
+    connection could run any whitelisted tool. #653 measured what that costs on
+    default settings: a stranger submits an invite code, becomes a contact, and
+    runs `whoami` as the operator. The session loop's comment said "Auth is the
+    same gate as INPUT" -- the authentication was; the authorisation was not.
+
+    Admin or whitelisted, because EXEC is the terminal-style fast path: no LLM,
+    no session, and no approval hook. `before_each_tool` does not fire here, so
+    a tool invoked this way skips everything that normally sits between the
+    model deciding to call something and it running. A contact can still talk
+    to the agent through INPUT, where those checks are in the way. Driving the
+    operator's tools directly is a different act and was never gated as one.
+    """
+    def handle_ws_exec(tool_name, args, requester_address=None):
+        if not requester_address:
+            return {"status": "error",
+                    "error": "forbidden: exec requires an authenticated caller"}
+
+        level = ('admin' if trust_agent.is_admin(requester_address)
+                 else trust_agent.get_level(requester_address))
+        if level not in EXEC_REQUIRES:
+            return {"status": "error",
+                    "error": f"forbidden: exec requires admin or whitelist, "
+                             f"you are {level}"}
+
+        return exec_handler(create_agent, exec_permissions, tool_name, args)
+
+    return handle_ws_exec
+
+
 def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
     """Parse trust config from trust parameter.
 
@@ -210,8 +252,7 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         return input_handler(create_agent, storage, prompt, result_ttl, session,
                              connection, images, files, requester=requester)
 
-    def handle_ws_exec(tool_name, args):
-        return exec_handler(create_agent, exec_permissions, tool_name, args)
+    handle_ws_exec = _make_ws_exec(create_agent, exec_permissions, trust_agent)
 
     def handle_health(start_time):
         return health_handler(agent_name, start_time)

--- a/connectonion/network/host/ws_router/exec.py
+++ b/connectonion/network/host/ws_router/exec.py
@@ -15,8 +15,13 @@ from rich.console import Console
 console = Console()
 
 
-async def run_exec(data, send_msg, route_handlers):
-    """Run one EXEC request in a worker thread, reply with EXEC_RESULT."""
+async def run_exec(data, send_msg, route_handlers, requester_address=None):
+    """Run one EXEC request in a worker thread, reply with EXEC_RESULT.
+
+    `requester_address` is the connection's authenticated caller. It used not
+    to be passed at all, so the gate below it could only ask what was being
+    run, never by whom (#653).
+    """
     exec_id = data.get("exec_id")
     tool_name = data.get("tool")
     args = data.get("args") or {}
@@ -28,7 +33,8 @@ async def run_exec(data, send_msg, route_handlers):
 
     console.print(f"[green]✓ EXEC[/green] tool={tool_name} args={str(args)[:80]}")
     try:
-        result = await asyncio.to_thread(route_handlers["ws_exec"], tool_name, args)
+        result = await asyncio.to_thread(route_handlers["ws_exec"], tool_name, args,
+                                         requester_address)
     except Exception as e:
         result = {"status": "error", "error": f"{type(e).__name__}: {e}"}
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -120,7 +120,11 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 if not conn["authenticated"]:
                     await send_msg({"type": "ERROR", "message": "authenticate first (send CONNECT)"})
                 else:
-                    task = asyncio.create_task(run_exec(data, send_msg, route_handlers))
+                    # conn has held the caller's address since CONNECT. Nothing
+                    # asked it, so any authenticated connection could run any
+                    # whitelisted tool (#653).
+                    task = asyncio.create_task(
+                        run_exec(data, send_msg, route_handlers, conn["agent_address"]))
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
 

--- a/tests/unit/test_exec_asks_who_is_calling.py
+++ b/tests/unit/test_exec_asks_who_is_calling.py
@@ -1,0 +1,198 @@
+"""A contact runs the operator's shell, and the gate never learns who asked.
+
+#653 measured the chain end to end against agents made by today's `co create`,
+on default settings — no capture, no replay, no attack on the protocol:
+
+    1. connect                  -> ONBOARD_REQUIRED ['invite_code']
+    2. submit the invite code   -> CONNECTED           (a stranger is now a contact)
+    3. the contact ran  whoami  -> changxing           (the operator's account)
+
+Step 3 works because EXEC is gated by the permission whitelist alone. The two
+handlers sit next to each other:
+
+    def handle_ws_input(storage, prompt, connection, session=None, images=None,
+                        files=None, requester_address=None):
+        ...
+        requester = {'address': requester_address, 'level': level}
+
+    def handle_ws_exec(tool_name, args):
+        return exec_handler(create_agent, exec_permissions, tool_name, args)
+
+INPUT resolves the caller's level and carries it down. EXEC is handed neither
+the address nor the level, so *any* authenticated connection may run *any*
+whitelisted tool. The session loop's comment says "Auth is the same gate as
+INPUT", and the authentication is — the authorisation is not.
+
+`conn["agent_address"]` has held the authenticated caller's address all along.
+Nothing asked it.
+
+## What this changes
+
+EXEC now requires admin or whitelisted. It is the terminal-style fast path: no
+LLM, no session, and no approval hook — `before_each_tool` does not fire, so a
+tool invoked this way skips every check that exists between the model deciding
+to call something and it running. A contact can still talk to the agent
+(INPUT), where the model and the approval flow are in the way. Driving the
+operator's tools directly is not the same act, and it was never gated as if it
+were.
+
+The remaining half of #653 is the *scope* of what is whitelisted --
+`Bash(co *)` is auto-approved, and `co` is not a read-only tool -- which is
+#652 and a decision about defaults rather than a missing check.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from connectonion.network.host.ws_router.exec import run_exec
+
+
+ADMIN = "0x" + "1" * 64
+WHITELISTED = "0x" + "2" * 64
+CONTACT = "0x" + "3" * 64
+STRANGER = "0x" + "4" * 64
+
+
+@pytest.fixture
+def ran():
+    """What actually reached the tool runner."""
+    return []
+
+
+@pytest.fixture
+def handlers(ran):
+    """route_handlers whose ws_exec records the call it was asked to make."""
+    def ws_exec(tool_name, args, requester_address=None):
+        ran.append((tool_name, requester_address))
+        return {"status": "success", "result": "changxing"}
+
+    return {"ws_exec": ws_exec}
+
+
+def _exec_as(address, handlers):
+    """One EXEC frame from this caller, returning the reply frames."""
+    sent = []
+
+    async def send_msg(msg):
+        sent.append(msg)
+
+    asyncio.run(run_exec({"exec_id": "e1", "tool": "bash", "args": {"command": "whoami"}},
+                         send_msg, handlers, requester_address=address))
+    return sent
+
+
+class TestTheCallerReachesTheGate:
+
+    def test_exec_is_told_who_asked(self, handlers, ran):
+        _exec_as(ADMIN, handlers)
+
+        assert ran == [("bash", ADMIN)], (
+            "the tool ran without the gate ever learning who asked"
+        )
+
+    def test_it_forwards_exactly_what_the_connection_had(self, handlers, ran):
+        """Including nothing, so the gate can refuse it.
+
+        run_exec does not decide anything -- deciding in two places is how the
+        advertised and enforced halves of the payment gate drifted apart
+        (#690). It carries the address; TestWhoMayDriveToolsDirectly below
+        checks what the real handler does with None.
+        """
+        _exec_as(None, handlers)
+
+        assert ran == [("bash", None)]
+
+    def test_the_result_reaches_the_client(self, handlers):
+        sent = _exec_as(ADMIN, handlers)
+
+        assert sent[0]["type"] == "EXEC_RESULT"
+        assert sent[0]["status"] == "success"
+
+
+class TestWhoMayDriveToolsDirectly:
+    """Against the real handler, not the fake above."""
+
+    def _handler(self, levels, admins):
+        from connectonion.network.host import server
+
+        trust = MagicMock()
+        trust.is_admin.side_effect = lambda a: a in admins
+        trust.get_level.side_effect = lambda a: levels.get(a, "stranger")
+        return trust
+
+    @pytest.fixture
+    def ws_exec(self):
+        """The real handle_ws_exec, with a trust agent that knows four callers."""
+        from connectonion.network.host import server
+
+        trust = self._handler(
+            {WHITELISTED: "whitelist", CONTACT: "contact", STRANGER: "stranger"},
+            {ADMIN},
+        )
+        calls = []
+
+        def exec_handler(create_agent, permissions, tool_name, args):
+            calls.append(tool_name)
+            return {"status": "success", "result": "ok"}
+
+        with patch.object(server, "exec_handler", exec_handler):
+            yield server._make_ws_exec(lambda: None, {}, trust), calls
+
+    def test_the_operator_may(self, ws_exec):
+        handler, calls = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=ADMIN)
+
+        assert result["status"] == "success"
+        assert calls == ["bash"]
+
+    def test_a_whitelisted_caller_may(self, ws_exec):
+        handler, calls = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=WHITELISTED)
+
+        assert result["status"] == "success"
+
+    def test_a_contact_may_not(self, ws_exec):
+        """The one the issue measured: an invite code bought this level."""
+        handler, calls = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=CONTACT)
+
+        assert result["status"] == "error"
+        assert calls == [], "the tool ran for a contact"
+
+    def test_a_stranger_may_not(self, ws_exec):
+        handler, calls = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=STRANGER)
+
+        assert result["status"] == "error"
+        assert calls == []
+
+    def test_the_refusal_says_what_is_needed(self, ws_exec):
+        handler, _ = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=CONTACT)
+
+        assert "whitelist" in result["error"].lower(), result["error"]
+
+    def test_no_address_is_refused(self, ws_exec):
+        handler, calls = ws_exec
+        result = handler("bash", {"command": "whoami"}, requester_address=None)
+
+        assert result["status"] == "error"
+        assert calls == []
+
+
+class TestInputIsUnaffected:
+    """A contact can still talk to the agent — the model and the approval flow
+    are in the way there, which is the whole difference."""
+
+    def test_input_still_carries_a_contacts_level(self):
+        import inspect
+
+        from connectonion.network.host import server
+
+        source = inspect.getsource(server._create_route_handlers)
+
+        assert "requester = {'address': requester_address, 'level': level}" in source, (
+            "the INPUT path stopped resolving the caller's level"
+        )

--- a/tests/unit/test_ws_exec.py
+++ b/tests/unit/test_ws_exec.py
@@ -176,7 +176,7 @@ class TestRunExec:
         async def send(msg):
             sent.append(msg)
 
-        def ws_exec(tool, args):
+        def ws_exec(tool, args, requester_address=None):
             assert tool == "_echo"
             return {"status": "success", "result": "echo: hey", "duration_ms": 1}
 
@@ -209,7 +209,7 @@ class TestRunExec:
         async def send(msg):
             sent.append(msg)
 
-        def ws_exec(tool, args):
+        def ws_exec(tool, args, requester_address=None):
             raise RuntimeError("handler blew up")
 
         await run_exec({"type": "EXEC", "exec_id": "e3", "tool": "_echo"},


### PR DESCRIPTION
## What #653 measured

On agents made by today's `co create`, default settings, no capture, no replay, no attack on the protocol — this is the intended way to let someone in:

```
1. connect                  -> ONBOARD_REQUIRED ['invite_code']
2. submit the invite code   -> CONNECTED           (a stranger is now a contact)
3. the contact ran  whoami  -> changxing           (the operator's account)
```

## Why step 3 worked

The two handlers sat next to each other and were not written to the same standard:

```python
def handle_ws_input(storage, prompt, connection, session=None, images=None,
                    files=None, requester_address=None):
    ...
    requester = {'address': requester_address, 'level': level}

def handle_ws_exec(tool_name, args):
    return exec_handler(create_agent, exec_permissions, tool_name, args)
```

INPUT resolves the caller's level and carries it down. EXEC was handed **neither the address nor the level**, so the permission whitelist was the entire gate and any authenticated connection could run any whitelisted tool.

The session loop's comment says *"Auth is the same gate as INPUT"*. The authentication was. The authorisation was not — and `conn["agent_address"]` has held the authenticated caller since CONNECT. Nothing asked it.

## What changes

EXEC requires **admin or whitelist**.

EXEC is the terminal-style fast path: no LLM, no session, and no approval hook. `before_each_tool` does not fire, so a tool invoked this way skips everything that normally sits between the model deciding to call something and it running. A contact can still talk to the agent through INPUT, where the model and the approval flow are in the way. Driving the operator's tools directly is a different act and was never gated as one.

**This is a behaviour change.** A caller who is a contact rather than whitelisted stops being able to drive tools directly over `remote.call` / `co call`. The threshold is one constant (`EXEC_REQUIRES`) if that is too strict.

## Not in this PR

The other half of #653 is the **scope** of what is whitelisted: `Bash(co *)` is auto-approved as "safe - connectonion CLI", and `co` is not a read-only tool — `co ai` runs headless and acts, `co server destroy` and `co keys --ssh --write` are in there too. That is #652, and a decision about defaults rather than a missing check, so I have not narrowed it unilaterally.

With this merged, the chain still needs the caller to be whitelisted rather than merely admitted, which is what the invite code was buying.

## Found while making the change

Two existing fakes declared `def ws_exec(tool, args)` — the signature without the caller. They passed before and would have gone on certifying exactly the gap this fixes. Updated to the real signature.

One of my own tests asserted `run_exec` refuses an anonymous call; it does not, and should not — deciding in two places is how the advertised and enforced halves of the payment gate drifted apart (#690). `run_exec` carries the address; the handler decides. Rewritten to check that contract, with the refusal checked against the real handler.

## Tests

10 new cases, red first. Suite running.