### PR TITLE
A stranger is not sent to a door that is not there

### DIFF
--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -177,12 +177,30 @@ class TrustAgent:
         elif result == 'deny':
             return Decision(allow=False, reason="Denied by fast rules")
 
-        # result is None -> default: ask triggered
-        # Check if onboard methods are available
-        onboard = self._config.get('onboard', {})
-        if onboard and (onboard.get('invite_code') or onboard.get('payment')):
-            # Onboard methods available - return special decision for browser to collect credentials
-            self.logger.info(f"[ONBOARD] Stranger {client_id[:10]}... needs to onboard (methods: {list(onboard.keys())})")
+        # result is None -> default: ask triggered.
+        #
+        # Which doors actually open, asked of the one rule that decides it.
+        # This used to read the raw config:
+        #
+        #     if onboard and (onboard.get('invite_code') or onboard.get('payment')):
+        #
+        # and both shipped values are unexpanded placeholders -- `[$CO_INVITE_CODE]`
+        # and `$CO_PAYMENT` -- so both were truthy on an agent with neither set.
+        # Every stranger was sent to onboard through nothing, while /info
+        # correctly published no way in, and `_llm_decide` below was
+        # unreachable: `careful` is the default level, and `default: ask`
+        # evaluated by the LLM policy is its whole documented behaviour for
+        # strangers.
+        #
+        # #561 fixed two places that decided this separately; #671 found the
+        # advertiser and /info as the third and fourth. This was the fifth.
+        from .ws_admin import doors_that_open
+
+        offered = doors_that_open(self._config.get('onboard', {}),
+                                  self.get_self_address())
+        if offered:
+            self.logger.info(f"[ONBOARD] Stranger {client_id[:10]}... needs to onboard "
+                             f"(methods: {offered['methods']})")
             return Decision(allow=False, reason="Onboard required")
 
         # No onboard methods - use LLM to evaluate

--- a/tests/unit/test_a_stranger_is_not_sent_to_a_door_that_is_not_there.py
+++ b/tests/unit/test_a_stranger_is_not_sent_to_a_door_that_is_not_there.py
@@ -1,0 +1,158 @@
+"""A default agent tells every stranger to onboard, through no door at all.
+
+`should_allow` decides what happens once the fast rules have deferred:
+
+    onboard = self._config.get('onboard', {})
+    if onboard and (onboard.get('invite_code') or onboard.get('payment')):
+        return Decision(allow=False, reason="Onboard required")
+
+    return self._llm_decide(client_id, request)
+
+Both values in the shipped policy are unexpanded placeholders --
+`[$CO_INVITE_CODE]` and `$CO_PAYMENT` -- so both are truthy on an agent with
+neither set, and every stranger is sent to onboard.
+
+This is the shape #671 exists to prevent. `doors_that_open` is the single rule:
+an invite code counts only if `_resolve_codes` yields one, a payment only if it
+resolves to an amount and there is an address to send it to. #561 fixed two
+places that decided it separately; #671 found the advertiser and `/info` as the
+third and fourth. This is the fifth, and it was still asking the raw config.
+
+Measured against a real host on default trust, no CO_INVITE_CODE, no
+CO_PAYMENT, from a client that had never connected:
+
+    GET /info                 "onboard": null
+    CONNECT (stranger)   ->   {"type": "ERROR", "message": "forbidden: Onboard required"}
+
+    host log:  [FAST_RULES] Returning None (needs LLM)
+               ✗ CONNECT auth error: forbidden: Onboard required
+
+Two things are wrong at once.
+
+The stranger is told to onboard while `/info` -- correctly, since #671 --
+publishes no way to. Whatever they do next, nothing admits them.
+
+And `_llm_decide` never runs. `careful` is the default trust level and its
+whole documented behaviour for strangers is `default: ask`, evaluated by the
+LLM policy. On a default agent that evaluation is unreachable: the branch above
+it always wins.
+"""
+
+import pytest
+
+from connectonion.network.trust.trust_agent import TrustAgent
+
+
+STRANGER = "0x" + "f" * 64
+
+
+@pytest.fixture(autouse=True)
+def isolated(monkeypatch, tmp_path):
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    monkeypatch.delenv("CO_PAYMENT", raising=False)
+
+    # Promotions are durable and land in one directory shared by the session
+    # (#694), so a test that promotes changes later tests' answers.
+    from connectonion.network.trust import tools
+
+    co = tmp_path / ".co"
+    co.mkdir()
+    monkeypatch.setattr(tools, "_project_co_dir", lambda: co)
+
+
+@pytest.fixture
+def careful(monkeypatch):
+    """A default agent, and a record of whether the LLM was consulted."""
+    agent = TrustAgent("careful")
+    asked = []
+    monkeypatch.setattr(
+        TrustAgent, "_llm_decide",
+        lambda self, client_id, request: asked.append(client_id) or _ALLOW)
+    monkeypatch.setattr(TrustAgent, "get_self_address", lambda self: "0x" + "a" * 64)
+    return agent, asked
+
+
+class _Decision:
+    def __init__(self, allow, reason):
+        self.allow, self.reason = allow, reason
+
+
+_ALLOW = _Decision(True, "the LLM said so")
+
+
+class TestWithNoDoorConfigured:
+
+    def test_the_stranger_is_not_told_to_onboard(self, careful):
+        agent, _ = careful
+
+        decision = agent.should_allow(STRANGER, {})
+
+        assert "onboard" not in decision.reason.lower(), decision.reason
+
+    def test_the_llm_policy_actually_runs(self, careful):
+        """`careful` is the default level and `default: ask` is its documented
+        behaviour. It was unreachable."""
+        agent, asked = careful
+
+        agent.should_allow(STRANGER, {})
+
+        assert asked == [STRANGER], "default: ask never reached the LLM"
+
+
+class TestWithADoorThatOpens:
+    """Unchanged: an operator who configured one still gets onboarding."""
+
+    def test_an_invite_code_sends_them_to_onboard(self, careful, monkeypatch):
+        monkeypatch.setenv("CO_INVITE_CODE", "letmein")
+        agent, asked = careful
+
+        decision = agent.should_allow(STRANGER, {})
+
+        assert decision.allow is False
+        assert "onboard" in decision.reason.lower()
+        assert asked == [], "the LLM was consulted even though a door was open"
+
+    def test_a_price_sends_them_to_onboard(self, careful, monkeypatch):
+        monkeypatch.setenv("CO_PAYMENT", "25")
+        agent, asked = careful
+
+        decision = agent.should_allow(STRANGER, {})
+
+        assert "onboard" in decision.reason.lower()
+        assert asked == []
+
+    def test_a_price_with_nowhere_to_pay_is_not_a_door(self, careful, monkeypatch):
+        """Same rule doors_that_open applies: verify_payment refuses without an
+        address, so telling a stranger to pay would be telling them nothing."""
+        monkeypatch.setenv("CO_PAYMENT", "25")
+        agent, asked = careful
+        monkeypatch.setattr(TrustAgent, "get_self_address", lambda self: None)
+
+        agent.should_allow(STRANGER, {})
+
+        assert asked == [STRANGER]
+
+
+class TestTheTwoHalvesAgree:
+    """What /info publishes and what CONNECT demands come from one rule."""
+
+    @pytest.mark.parametrize("env", [
+        {},
+        {"CO_INVITE_CODE": "letmein"},
+        {"CO_PAYMENT": "25"},
+        {"CO_INVITE_CODE": "letmein", "CO_PAYMENT": "25"},
+    ])
+    def test_onboard_is_demanded_exactly_when_a_door_opens(self, careful, monkeypatch, env):
+        from connectonion.network.trust.ws_admin import doors_that_open
+
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        agent, _ = careful
+
+        offered = doors_that_open(agent._config.get("onboard", {}),
+                                  agent.get_self_address())
+        demanded = "onboard" in agent.should_allow(STRANGER, {}).reason.lower()
+
+        assert demanded == (offered is not None), (
+            f"{env}: /info offers {offered}, CONNECT demands onboard={demanded}"
+        )


### PR DESCRIPTION
The fifth place that decided which onboarding doors exist by reading the raw config.

```python
onboard = self._config.get('onboard', {})
if onboard and (onboard.get('invite_code') or onboard.get('payment')):
    return Decision(allow=False, reason="Onboard required")

return self._llm_decide(client_id, request)
```

Both shipped values are unexpanded placeholders — `[$CO_INVITE_CODE]` and `$CO_PAYMENT` — so both are truthy on an agent with neither set.

## Two things wrong at once

**The stranger is told to onboard through nothing.** `/info` correctly publishes no way in (since #671), and CONNECT demands one anyway. Whatever they do next, nothing admits them.

**`_llm_decide` never runs.** `careful` is the default trust level, and `default: ask` evaluated by the LLM policy is its whole documented behaviour for strangers. On a default agent that evaluation was unreachable — the branch above it always won.

## Measured

Real host, default trust, no `CO_INVITE_CODE`, no `CO_PAYMENT`, client that had never connected:

```
before   {"type": "ERROR", "message": "forbidden: Onboard required"}
         host log: [FAST_RULES] Returning None (needs LLM)     <- and then it did not

after    {"type": "ERROR", "message": "forbidden: The client has a current level of
         'stranger' and lacks an invite code or verified payment, so admission is
         not justified from identity and level alone."}
```

The refusal now comes from the policy the operator chose, and says why.

## The rule

`doors_that_open` decides this once: an invite code counts only if `_resolve_codes` yields one, a payment only if it resolves to an amount **and** there is an address to send it to. #561 fixed two places deciding it separately; #671 found the advertiser and `/info` as the third and fourth. This was the fifth.

A parametrised test now asserts the property directly — CONNECT demands onboarding **exactly** when `/info` offers it — across all four combinations of the two switches. That is the check that makes a sixth place hard to add quietly.

## Tests

9 cases, 4 red first (the rest are the guards: an operator who *has* configured a door still gets onboarding, and the LLM is not consulted then).

Tests pin the trust-list directory per test (#694): promotions are durable and land in one directory shared by the whole session, so a test that promotes changes later tests' answers.