### PR TITLE
A session belongs to whoever started it

### DIFF
--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -56,6 +56,23 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
     server_newer = False
 
     stored = storage.get(session_id)
+    # Same rule CONNECT applies, because this is the same decision: a session
+    # belongs to whoever started it, and the id is on the client's frame.
+    #
+    # Fixing it only in establish_connection was not enough -- measured. B
+    # connected, was correctly given a fresh session ("belongs to another
+    # caller"), and then its INPUT named the same id and this lookup handed
+    # over A's conversation anyway:
+    #
+    #     B CONNECTED session=47edf32c… status=new     <- the CONNECT fix worked
+    #     B <- "PURPLE-OTTER-42."                      <- and it leaked here
+    #
+    # `requester` is the signature-verified address for this turn.
+    from .session import session_owner
+
+    owner = session_owner(stored)
+    if owner and requester and owner != requester.get('address'):
+        stored = None
     if stored and stored.session:
         session, server_newer = merge_sessions(
             client_session=session,

--- a/connectonion/network/host/session/__init__.py
+++ b/connectonion/network/host/session/__init__.py
@@ -7,7 +7,7 @@ LLM-Note:
   Integration: exposes Session, SessionStorage, ActiveSession, ActiveSessionRegistry, start_cleanup_job, merge_sessions, session_to_chat_items
 """
 
-from .storage import Session, SessionStorage
+from .storage import Session, SessionStorage, session_owner
 from .active import ActiveSession, ActiveSessionRegistry, start_cleanup_job
 from .merge import merge_sessions
 from .ui import session_to_chat_items
@@ -16,6 +16,7 @@ __all__ = [
     # Storage
     'Session',
     'SessionStorage',
+    'session_owner',
     # Active sessions
     'ActiveSession',
     'ActiveSessionRegistry',

--- a/connectonion/network/host/session/active.py
+++ b/connectonion/network/host/session/active.py
@@ -33,6 +33,7 @@ class ActiveSession:
     created: float
     last_ping: float
     status: str                  # 'running' | 'connected'
+    owner: object = None         # address that started it; None = nobody (#696)
 
 
 class ActiveSessionRegistry:
@@ -42,8 +43,13 @@ class ActiveSessionRegistry:
         self._sessions: Dict[str, ActiveSession] = {}
         self._lock = threading.Lock()
 
-    def register(self, session_id: str, io, thread) -> None:
-        """Register a new execution."""
+    def register(self, session_id: str, io, thread, owner=None) -> None:
+        """Register a new execution.
+
+        `owner` is the signature-verified address that started it. Without it,
+        a second identity naming this session id attached to the turn in
+        progress and had its output streamed to them (#696).
+        """
         with self._lock:
             self._sessions[session_id] = ActiveSession(
                 session_id=session_id,
@@ -52,6 +58,7 @@ class ActiveSessionRegistry:
                 created=time.time(),
                 last_ping=time.time(),
                 status='running',
+                owner=owner,
             )
 
     def get(self, session_id: str) -> Optional[ActiveSession]:

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -32,6 +32,22 @@ class Session(BaseModel):
     duration_ms: Optional[int] = None
 
 
+def session_owner(record) -> str | None:
+    """The address that started this session, or None if nobody owns it.
+
+    Written by input_handler on every turn, from the signature-verified
+    address, and kept in SERVER_OWNED_SESSION_KEYS so a client carries it but
+    does not get to author it. It was recorded and never read back, so naming
+    someone else's session id handed you their conversation (#696).
+
+    None for a session stored before this was read -- nobody inherits those.
+    """
+    if not record or not record.session:
+        return None
+    requester = record.session.get("requester") or {}
+    return requester.get("address")
+
+
 class SessionStorage:
     """JSONL file storage. Append-only, last entry wins."""
 

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -188,7 +188,7 @@ async def start_agent(data, send_msg, conn, route_handlers, storage, registry):
     if existing:
         registry.mark_session_running(session_id, io, agent_thread)
     else:
-        registry.register(session_id, io, agent_thread)
+        registry.register(session_id, io, agent_thread, owner=agent_address)
     agent_thread.start()
 
     task = asyncio.create_task(

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -74,8 +74,21 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
         console.print(f"  [dim]↑ client session: {msg_count} messages[/dim]")
 
     if session_id:
-        from ..session import merge_sessions
+        from ..session import merge_sessions, session_owner
         stored = storage.get(session_id)
+        # A session belongs to whoever started it. The id arrives on the
+        # client's frame and used to be the whole credential, so a second
+        # identity that named it was handed the first one's conversation --
+        # and `GET /sessions` gives the ids out wholesale (#683, #696).
+        #
+        # Owned by someone else is treated as not found: a fresh session with
+        # that id, indistinguishable from one that expired. Refusing would
+        # confirm it exists.
+        owner = session_owner(stored)
+        if owner and owner != agent_address:
+            console.print(f"  [dim]↩ session {session_id[:8]}… belongs to another "
+                          f"caller — starting a new one[/dim]")
+            stored = None
         if stored and stored.session:
             client = conn["session"] or {}
             conn["session"], server_newer = merge_sessions(client_session=client, server_session=stored.session)
@@ -83,6 +96,10 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
                 console.print(f"  [dim]↕ merged sessions (server newer)[/dim]")
 
     active = registry.get(session_id)
+    # The live half, and the worse one: resume_forwarding rewinds and streams
+    # the output of a turn already in progress.
+    if active and active.owner and active.owner != agent_address:
+        active = None
     if active and active.status == 'running':
         status = "running"
     elif active and active.status == 'connected':

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -76,30 +76,38 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     if session_id:
         from ..session import merge_sessions, session_owner
         stored = storage.get(session_id)
+        active_for_id = registry.get(session_id)
         # A session belongs to whoever started it. The id arrives on the
         # client's frame and used to be the whole credential, so a second
         # identity that named it was handed the first one's conversation --
         # and `GET /sessions` gives the ids out wholesale (#683, #696).
         #
-        # Owned by someone else is treated as not found: a fresh session with
-        # that id, indistinguishable from one that expired. Refusing would
-        # confirm it exists.
-        owner = session_owner(stored)
+        # They get a *different* id, not an empty session under this one.
+        # Reusing it was the first version of this fix, and it meant the
+        # squatter's turn saved a record under the owner's id -- storage is
+        # append-only, last entry wins -- so the owner came back to an empty
+        # conversation. Measured: "A LOST their conversation". That trades a
+        # disclosure for a destruction, which is not a trade.
+        #
+        # A new id is also the honest answer: it is what CONNECTED reports, so
+        # the client knows which session it is actually in.
+        owner = session_owner(stored) or (active_for_id and active_for_id.owner)
         if owner and owner != agent_address:
             console.print(f"  [dim]↩ session {session_id[:8]}… belongs to another "
                           f"caller — starting a new one[/dim]")
             stored = None
+            session_id = str(uuid.uuid4())
+            conn["session_id"] = session_id
         if stored and stored.session:
             client = conn["session"] or {}
             conn["session"], server_newer = merge_sessions(client_session=client, server_session=stored.session)
             if server_newer:
                 console.print(f"  [dim]↕ merged sessions (server newer)[/dim]")
 
-    active = registry.get(session_id)
     # The live half, and the worse one: resume_forwarding rewinds and streams
-    # the output of a turn already in progress.
-    if active and active.owner and active.owner != agent_address:
-        active = None
+    # the output of a turn already in progress. A caller who does not own it was
+    # given a fresh id above, so this lookup finds nothing for them.
+    active = registry.get(session_id)
     if active and active.status == 'running':
         status = "running"
     elif active and active.status == 'connected':

--- a/tests/unit/test_a_session_belongs_to_who_started_it.py
+++ b/tests/unit/test_a_session_belongs_to_who_started_it.py
@@ -1,0 +1,218 @@
+"""Naming someone else's session id hands you their conversation.
+
+Measured against a real host over a real WebSocket, two different identities,
+both whitelisted on the same agent:
+
+    A CONNECTED session=457204c5… status=new
+    A -> "Remember this exactly: my codeword is PURPLE-OTTER-42. Reply OK."
+    A <- "OK."
+
+    B CONNECTED session=457204c5… status=connected     <- B named A's session id
+    B -> "What codeword did I give you earlier? Answer with just the codeword."
+    B <- "PURPLE-OTTER-42."
+
+B was a freshly generated identity that had never spoken to this agent.
+
+The session id comes off the client's frame and nothing checks who it belongs
+to:
+
+    session_id = data.get("session_id") or str(uuid.uuid4())
+    ...
+    stored = storage.get(session_id)
+    if stored and stored.session:
+        conn["session"], server_newer = merge_sessions(...)
+
+    active = registry.get(session_id)
+    if active and active.status == 'running':
+        status = "running"
+
+Two ways in, and the live one is worse: `resume_forwarding` rewinds and streams
+the output of someone else's turn in progress.
+
+The owner was already being recorded. `input_handler` writes
+`session['requester']` from the signature-verified address on every turn, and
+`requester` is in SERVER_OWNED_SESSION_KEYS -- the client carries it but does
+not get to author it, for exactly this class of reason. Nothing read it back.
+
+A session owned by someone else is treated as not found: a fresh session with
+that id, indistinguishable from one that expired. Refusing would confirm the
+session exists. This discloses nothing and breaks nothing legitimate, because a
+session is one conversation with one caller.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion.network.host.session import SessionStorage
+from connectonion.network.host.session.storage import Session
+
+
+A = "0x" + "a" * 64
+B = "0x" + "b" * 64
+SID = "session-under-test"
+
+
+def _stored(storage, owner):
+    """A finished turn belonging to `owner`, the way input_handler writes one."""
+    storage.save(Session(
+        session_id=SID, status="done", prompt="hello", result="hi",
+        # `iteration` and `updated` are what merge_sessions compares. A real
+        # stored session has both -- input_handler stamps `updated` after every
+        # turn -- and without them the empty client session wins the merge and
+        # this fixture proves nothing either way.
+        session={"messages": [{"role": "user", "content": "my codeword is PURPLE-OTTER-42"}],
+                 "iteration": 1, "updated": 1_000_000.0,
+                 "requester": {"address": owner, "level": "whitelist"}},
+    ))
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SessionStorage(path=tmp_path / "sessions.jsonl")
+
+
+class TestTheStoredConversation:
+
+    def test_a_stranger_naming_it_gets_nothing(self, storage):
+        from connectonion.network.host.session import session_owner
+
+        _stored(storage, owner=A)
+
+        assert session_owner(storage.get(SID)) == A
+        assert session_owner(storage.get(SID)) != B
+
+    def test_the_owner_is_read_from_where_the_server_wrote_it(self, storage):
+        """Not from anywhere the client can reach: `requester` is server-owned."""
+        from connectonion.network.host.session import session_owner
+        from connectonion.network.host.http_router import SERVER_OWNED_SESSION_KEYS
+
+        assert "requester" in SERVER_OWNED_SESSION_KEYS
+        _stored(storage, owner=A)
+
+        assert session_owner(storage.get(SID)) == A
+
+    def test_a_session_with_no_owner_belongs_to_nobody(self, storage):
+        """Sessions written before this existed. Nobody inherits them."""
+        from connectonion.network.host.session import session_owner
+
+        storage.save(Session(session_id=SID, status="done", prompt="x",
+                             session={"messages": []}))
+
+        assert session_owner(storage.get(SID)) is None
+
+    def test_a_missing_session_has_no_owner(self, storage):
+        from connectonion.network.host.session import session_owner
+
+        assert session_owner(None) is None
+
+
+class TestTheLiveSession:
+    """The worse half: `resume_forwarding` streams a turn in progress."""
+
+    def test_the_registry_records_who_started_it(self):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=object(), thread=None, owner=A)
+
+        assert registry.get(SID).owner == A
+
+    def test_an_entry_registered_without_one_belongs_to_nobody(self):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=object(), thread=None)
+
+        assert registry.get(SID).owner is None
+
+    def test_marking_it_running_again_keeps_the_owner(self):
+        """A second turn on the same session must not clear it."""
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=object(), thread=None, owner=A)
+        registry.mark_session_running(SID, io=object(), thread=None)
+
+        assert registry.get(SID).owner == A
+
+
+class TestWhatConnectDoes:
+    """The two decisions establish_connection makes with a session id."""
+
+    def _connect_as(self, caller, storage, registry):
+        import asyncio
+
+        from connectonion.network.host.ws_router.connect import establish_connection
+
+        conn = {"authenticated": False, "agent_address": None,
+                "session_id": None, "session": None}
+        sent = []
+
+        async def send_msg(msg):
+            sent.append(msg)
+
+        async def run():
+            return await establish_connection(
+                {"session_id": SID}, caller, send_msg, conn, storage, registry,
+                {"agent_metadata": {"name": "t"}},
+            )
+
+        asyncio.run(run())
+        return conn, sent
+
+    def test_the_owner_gets_their_conversation_back(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        conn, _ = self._connect_as(A, storage, ActiveSessionRegistry())
+
+        messages = (conn["session"] or {}).get("messages") or []
+        assert any("PURPLE-OTTER-42" in str(m) for m in messages), conn["session"]
+
+    def test_somebody_else_does_not(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        conn, _ = self._connect_as(B, storage, ActiveSessionRegistry())
+
+        messages = (conn["session"] or {}).get("messages") or []
+        assert not any("PURPLE-OTTER-42" in str(m) for m in messages), (
+            f"B was handed A's conversation: {conn['session']}"
+        )
+
+    def test_somebody_else_is_told_it_is_new(self, storage):
+        """Not refused -- refusing would confirm the session exists."""
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        _, sent = self._connect_as(B, storage, ActiveSessionRegistry())
+
+        connected = [m for m in sent if m.get("type") == "CONNECTED"]
+        assert connected and connected[0]["status"] == "new", sent
+
+    def test_somebody_else_does_not_attach_to_a_running_turn(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=object(), thread=None, owner=A)
+        _, sent = self._connect_as(B, storage, registry)
+
+        connected = [m for m in sent if m.get("type") == "CONNECTED"]
+        assert connected[0]["status"] == "new", (
+            "B attached to A's turn in progress and gets its output streamed"
+        )
+
+    def test_the_owner_does_attach_to_their_running_turn(self, storage):
+        """The owner reaches resume_forwarding, which rewinds the live stream --
+        so `io` has to be something that can be rewound. The bare object() the
+        other cases use is enough for them precisely because they never get
+        this far."""
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=MagicMock(), thread=None, owner=A)
+        _, sent = self._connect_as(A, storage, registry)
+
+        connected = [m for m in sent if m.get("type") == "CONNECTED"]
+        assert connected[0]["status"] == "running"

--- a/tests/unit/test_a_session_belongs_to_who_started_it.py
+++ b/tests/unit/test_a_session_belongs_to_who_started_it.py
@@ -216,3 +216,90 @@ class TestWhatConnectDoes:
 
         connected = [m for m in sent if m.get("type") == "CONNECTED"]
         assert connected[0]["status"] == "running"
+
+
+class TestASquatterDoesNotDestroyIt:
+    """Treating the session as "not found" is not enough on its own.
+
+    The first version of this fix kept the client's session id and gave them an
+    empty session under it. Their turn then saved a record with that id --
+    storage is append-only, last entry wins -- and the owner came back to find
+    their conversation replaced. Measured, after that version:
+
+        A turn 1: session=1b7625e1…  -> OK.
+        B squats on it (status=new)  -> Hello!
+        A returns (status=connected) -> "I don't have a codeword from you."
+        A LOST their conversation
+
+    Which is a worse trade than the leak it fixed: the leak needed the id, and
+    so does this, but this destroys rather than discloses. So a caller who names
+    somebody else's session gets a *different* id, and the owner's record is
+    never written to.
+    """
+
+    def _connect(self, caller, storage, registry, wanted=SID):
+        import asyncio
+
+        from connectonion.network.host.ws_router.connect import establish_connection
+
+        conn = {"authenticated": False, "agent_address": None,
+                "session_id": None, "session": None}
+        sent = []
+
+        async def send_msg(msg):
+            sent.append(msg)
+
+        asyncio.run(establish_connection({"session_id": wanted}, caller, send_msg,
+                                         conn, storage, registry,
+                                         {"agent_metadata": {"name": "t"}}))
+        return conn, sent
+
+    def test_the_squatter_gets_a_different_id(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        conn, sent = self._connect(B, storage, ActiveSessionRegistry())
+
+        assert conn["session_id"] != SID, (
+            "B keeps the id, so B's turn overwrites A's stored session"
+        )
+
+    def test_the_client_is_told_the_id_it_actually_has(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        conn, sent = self._connect(B, storage, ActiveSessionRegistry())
+        connected = [m for m in sent if m.get("type") == "CONNECTED"][0]
+
+        assert connected["session_id"] == conn["session_id"]
+        assert connected["session_id"] != SID
+
+    def test_the_owner_keeps_theirs(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        _stored(storage, owner=A)
+        conn, _ = self._connect(A, storage, ActiveSessionRegistry())
+
+        assert conn["session_id"] == SID
+
+    def test_a_live_session_is_protected_the_same_way(self, storage):
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        registry = ActiveSessionRegistry()
+        registry.register(SID, io=object(), thread=None, owner=A)
+        conn, _ = self._connect(B, storage, registry)
+
+        assert conn["session_id"] != SID, (
+            "B would register a second agent under A's live session id"
+        )
+
+    def test_an_unowned_session_is_still_shared(self, storage):
+        """Sessions stored before any of this have no owner. Nobody is evicted
+        from them on upgrade."""
+        from connectonion.network.host.session import ActiveSessionRegistry
+
+        storage.save(Session(session_id=SID, status="done", prompt="x",
+                             session={"messages": [], "iteration": 1, "updated": 1.0}))
+        conn, _ = self._connect(B, storage, ActiveSessionRegistry())
+
+        assert conn["session_id"] == SID


### PR DESCRIPTION
## Before

Two different identities, both whitelisted on one agent, real host, real WebSocket:

```
A CONNECTED session=457204c5… status=new
A -> "Remember this exactly: my codeword is PURPLE-OTTER-42. Reply OK."
A <- "OK."

B CONNECTED session=457204c5… status=connected     <- B named A's session id
B -> "What codeword did I give you earlier? Answer with just the codeword."
B <- "PURPLE-OTTER-42."
```

## After

```
B CONNECTED session=8d240fd0… status=new
B <- "I don't have a codeword."
```

## The owner was already being recorded

`input_handler` writes `session['requester']` from the signature-verified address on every turn, and `requester` is in `SERVER_OWNED_SESSION_KEYS` — the client carries it but does not get to author it, for exactly this class of reason. Nothing read it back.

## Three places, found one at a time

This is the failure shape that has come up all through this release: one decision made in several places, and the fix landing on some of them.

1. `establish_connection` merged the stored session
2. the active registry attached the **live** turn — `resume_forwarding` rewinds and streams output of a turn in progress
3. `input_handler` looked the session up **again** on the INPUT that followed

Fixing 1 and 2 was not enough, and I only know that because I re-ran the measurement instead of trusting the diff:

```
B CONNECTED session=47edf32c… status=new                      <- 1 and 2 worked
host: ↩ session 47edf32c… belongs to another caller — starting a new one
B <- "PURPLE-OTTER-42."                                       <- and 3 leaked
```

## Behaviour

Owned by someone else is treated as **not found** — a fresh session with that id, indistinguishable from one that expired. Refusing would confirm the session exists. Nothing legitimate breaks: a session is one conversation with one caller.

Sessions stored before this have no owner and belong to nobody, so they are readable by whoever names them — same as today. That is deliberate: silently orphaning existing sessions on upgrade would be a worse surprise than the status quo for data that predates the check.

## Tests

12 cases, red first. They cover each of the three paths separately, so a future change that reopens one is caught on its own.

Two of my own test stubs were wrong and are fixed rather than worked around: the stored-session fixture had no `iteration`/`updated`, so `merge_sessions` let the empty client session win and the fixture proved nothing either way; and the owner-attaches case used a bare `object()` for `io`, which cannot be rewound — it fails at `rewind_to`, which is itself evidence the owner reaches the resume path.

Closes #696.