### PR TITLE
Reading sessions needs an identity

### DIFF
--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -149,6 +149,63 @@ def extract_and_authenticate(data: dict, trust, *, blacklist=None, whitelist=Non
         return None, agent_address, True, f"forbidden: {decision.reason}"
 
 
+# ─────────────────────────── signed GETs ───────────────────────────
+#
+# A GET has no body to sign, so `curl http://agent/sessions` returned every
+# conversation on the agent -- prompts, answers and full message history -- to
+# anyone who could reach the port (#683). It is also where #696's attack got
+# its session ids.
+#
+# The signature travels in headers over {method, path, timestamp}, canonicalised
+# exactly as CONNECT and INPUT already are, and is then verified by the same
+# _authenticate_signed below. One canonicalisation, one freshness window, one
+# blacklist check -- a second implementation of any of those is how the halves
+# of a gate drift apart, which is most of what this release has been about.
+
+FROM_HEADER = "x-co-from"
+SIGNATURE_HEADER = "x-co-signature"
+TIMESTAMP_HEADER = "x-co-timestamp"
+
+
+def _canonical(payload: dict) -> bytes:
+    """The bytes that get signed. Same shape as connect.py's."""
+    return json.dumps(payload, sort_keys=True, separators=(',', ':')).encode()
+
+
+def sign_request(keys: dict, method: str, path: str, timestamp=None) -> dict:
+    """Headers a client sends with a signed GET.
+
+    Exported so a client does not have to reconstruct the format -- and so the
+    tests drive the real one rather than certifying their own idea of it.
+    """
+    from ... import address as _address
+
+    payload = {"method": method.upper(), "path": path,
+               "timestamp": int(timestamp if timestamp is not None else time.time())}
+    return {
+        FROM_HEADER: keys["address"],
+        SIGNATURE_HEADER: _address.sign(keys, _canonical(payload)).hex(),
+        TIMESTAMP_HEADER: str(payload["timestamp"]),
+    }
+
+
+def request_from_headers(headers: dict, method: str, path: str) -> dict:
+    """Turn a signed GET into the dict every other authenticated frame is.
+
+    The payload is rebuilt from the *actual* method and path, not from anything
+    the client sent, so a signature made for one path does not verify against
+    another.
+    """
+    lowered = {str(k).lower(): v for k, v in (headers or {}).items()}
+    timestamp = lowered.get(TIMESTAMP_HEADER)
+    return {
+        "payload": {"method": method.upper(), "path": path,
+                    "timestamp": int(timestamp) if timestamp is not None else None},
+        "from": lowered.get(FROM_HEADER),
+        "signature": lowered.get(SIGNATURE_HEADER),
+    }
+
+
 def _authenticate_signed(data: dict, *, blacklist=None, recipient_address=None):
     """Authenticate signed request with Ed25519 - ALWAYS REQUIRED.
 

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -192,15 +192,34 @@ def exec_handler(create_agent: Callable, permissions: dict, tool_name: str, args
             "duration_ms": int((time.time() - start) * 1000)}
 
 
-def session_handler(storage: SessionStorage, session_id: str) -> dict | None:
-    """GET /sessions/{id}"""
+def session_handler(storage: SessionStorage, session_id: str,
+                    caller: str | None = None) -> dict | None:
+    """GET /sessions/{id} — the caller's own, or nothing.
+
+    Owner recorded by #698. A session stored before that has none and stays
+    readable: silently orphaning existing history on upgrade is a worse
+    surprise than the status quo for data that predates the check.
+    """
+    from .session import session_owner
+
     session = storage.get(session_id)
+    owner = session_owner(session)
+    if owner and owner != caller:
+        return None
     return session.model_dump() if session else None
 
 
-def sessions_handler(storage: SessionStorage) -> dict:
-    """GET /sessions"""
-    return {"sessions": [s.model_dump() for s in storage.list()]}
+def sessions_handler(storage: SessionStorage, caller: str | None = None) -> dict:
+    """GET /sessions — the caller's own.
+
+    This returned every conversation on the agent, to anyone who could reach
+    the port (#683), and was where #696's attack got its session ids.
+    """
+    from .session import session_owner
+
+    mine = [s for s in storage.list()
+            if (session_owner(s) or caller) == caller]
+    return {"sessions": [s.model_dump() for s in mine]}
 
 
 def health_handler(agent_name: str, start_time: float) -> dict:
@@ -434,12 +453,27 @@ async def handle_http(
             return
         await send_json(send, result)
 
-    elif method == "GET" and path.startswith("/sessions/"):
-        result = route_handlers["session"](storage, path[10:])
-        await send_json(send, result or {"error": "not found"}, 404 if not result else 200)
+    elif method == "GET" and (path == "/sessions" or path.startswith("/sessions/")):
+        # Signed, like everything else that reads conversation content. A GET
+        # has no body, so the signature is in headers over {method, path,
+        # timestamp} and is verified by the same _authenticate_signed as every
+        # other frame -- same freshness window, same blacklist (#683).
+        from .auth import request_from_headers, _authenticate_signed
 
-    elif method == "GET" and path == "/sessions":
-        await send_json(send, route_handlers["sessions"](storage))
+        headers = {k.decode(): v.decode() for k, v in scope.get("headers") or []}
+        _, caller, err = _authenticate_signed(
+            request_from_headers(headers, method, path), blacklist=blacklist)
+        if err:
+            await send_json(send, {"error": err},
+                            401 if err.startswith("unauthorized") else 403)
+            return
+
+        if path == "/sessions":
+            await send_json(send, route_handlers["sessions"](storage, caller))
+        else:
+            result = route_handlers["session"](storage, path[10:], caller)
+            await send_json(send, result or {"error": "not found"},
+                            404 if not result else 200)
 
     elif method == "GET" and path == "/health":
         await send_json(send, route_handlers["health"](start_time))

--- a/connectonion/network/static/docs.html
+++ b/connectonion/network/static/docs.html
@@ -273,14 +273,7 @@
         <div class="endpoint-section">
           <h4>Curl</h4>
           <div class="curl-box">
-            <pre id="sessions-curl">co call &lt;address&gt; sessions
-
-# or sign it yourself — a GET has no body, so the signature is in headers
-# over {"method","path","timestamp"}, same canonical form as CONNECT:
-#   x-co-from:      your agent address
-#   x-co-signature: sign(canonical(payload))
-#   x-co-timestamp: unix seconds
-python -c "from connectonion.network.host.auth import sign_request; print(sign_request(keys,'GET','/sessions'))"</pre>
+            <pre id="sessions-curl">curl -X GET "http://localhost:8000/sessions"</pre>
             <button class="copy-btn" onclick="copyCurl('sessions-curl')">Copy</button>
           </div>
         </div>
@@ -547,6 +540,23 @@ python -c "from connectonion.network.host.auth import sign_request; print(sign_r
       } catch(e) { console.error(e); }
     }
 
+    // Reading sessions needs an identity (#683). A GET has no body, so the
+    // signature is in headers over {method, path, timestamp} -- the same
+    // canonical form CONNECT uses. This page has no key and must not have one,
+    // so it shows the call rather than making it.
+    function signedCurl(base, path){
+      return `# The signature covers {"method","path","timestamp"} — same canonical
+# form as CONNECT. Print the three headers for this path:
+python -c "import pathlib, connectonion.address as a; \\
+from connectonion.network.host.auth import sign_request; \\
+print(sign_request(a.load(pathlib.Path('.co')), 'GET', '${path}'))"
+
+curl -X GET "${base}${path}" \\
+  -H "x-co-from: <address>" \\
+  -H "x-co-signature: <signature>" \\
+  -H "x-co-timestamp: <unix seconds>"`;
+    }
+
     async function fetchInfo(){
       const res = await fetch(buildUrl('/info'));
       const data = await res.json();
@@ -559,9 +569,9 @@ python -c "from connectonion.network.host.auth import sign_request; print(sign_r
         $('session-result').textContent = '{"error": "Please enter a session ID"}';
         return;
       }
-      const res = await fetch(buildUrl('/sessions/' + sessionId));
-      const data = await res.json();
-      $('session-result').textContent = JSON.stringify(data, null, 2);
+      $('session-result').textContent = JSON.stringify({
+        note: "Signed request required — see the curl above. This page has no key.",
+      }, null, 2);
     }
 
     async function fetchHealth(){
@@ -600,11 +610,11 @@ python -c "from connectonion.network.host.auth import sign_request; print(sign_r
   -d '${inputBody}'`;
 
       // GET /sessions curl
-      $('sessions-curl').textContent = `curl -X GET "${base}/sessions"`;
+      $('sessions-curl').textContent = signedCurl(base, '/sessions');
 
       // GET /sessions/{session_id} curl
       const sessionId = $('session-id').value.trim() || '{session_id}';
-      $('session-curl').textContent = `curl -X GET "${base}/sessions/${sessionId}"`;
+      $('session-curl').textContent = signedCurl(base, '/sessions/' + sessionId);
 
       // GET /info curl
       $('info-curl').textContent = `curl -X GET "${base}/info"`;
@@ -678,9 +688,9 @@ python -c "from connectonion.network.host.auth import sign_request; print(sign_r
     async function sendWs(){ if(!ws) return; const { images, files } = await getAttachments(); const msg = { type:'INPUT', prompt: $('ws-prompt').value }; if(images) msg.images=images; if(files) msg.files=files; ws.send(JSON.stringify(msg)); log('→ ' + JSON.stringify(msg)); }
 
     async function refreshSessions(){
-      const res = await fetch(buildUrl('/sessions'));
-      const data = await res.json();
-      $('sessions').textContent = JSON.stringify(data, null, 2);
+      $('sessions').textContent = JSON.stringify({
+        note: "Signed request required — see the curl above. This page has no key.",
+      }, null, 2);
     }
     function toggleAuto(){ if($('auto').checked){ autoTimer=setInterval(refreshSessions, 5000); } else { clearInterval(autoTimer); } }
 

--- a/connectonion/network/static/docs.html
+++ b/connectonion/network/static/docs.html
@@ -260,7 +260,7 @@
       <summary class="endpoint-header">
         <span class="method get">GET</span>
         <span class="endpoint-path">/sessions</span>
-        <span class="endpoint-desc">List all sessions</span>
+        <span class="endpoint-desc">List your own sessions (signed)</span>
         <span class="endpoint-expand">▾</span>
       </summary>
       <div class="endpoint-body">
@@ -273,7 +273,14 @@
         <div class="endpoint-section">
           <h4>Curl</h4>
           <div class="curl-box">
-            <pre id="sessions-curl">curl -X GET "http://localhost:8000/sessions"</pre>
+            <pre id="sessions-curl">co call &lt;address&gt; sessions
+
+# or sign it yourself — a GET has no body, so the signature is in headers
+# over {"method","path","timestamp"}, same canonical form as CONNECT:
+#   x-co-from:      your agent address
+#   x-co-signature: sign(canonical(payload))
+#   x-co-timestamp: unix seconds
+python -c "from connectonion.network.host.auth import sign_request; print(sign_request(keys,'GET','/sessions'))"</pre>
             <button class="copy-btn" onclick="copyCurl('sessions-curl')">Copy</button>
           </div>
         </div>

--- a/tests/e2e/test_host.py
+++ b/tests/e2e/test_host.py
@@ -39,11 +39,17 @@ def run_async(coro):
 
 # === Simple ASGI Test Client ===
 
-def create_signed_request(prompt: str, timestamp: float = None) -> dict:
-    """Create a properly signed request for testing."""
+def create_signed_request(prompt: str, timestamp: float = None, signing_key=None) -> dict:
+    """Create a properly signed request for testing.
+
+    `signing_key` lets a caller keep one identity across requests. Since #683
+    reading a session needs a signature and returns only the caller's own, a
+    test that creates a session with one key and reads it with another sees
+    nothing -- correctly, and uselessly.
+    """
     from nacl.signing import SigningKey
 
-    signing_key = SigningKey.generate()
+    signing_key = signing_key or SigningKey.generate()
     public_key = f"0x{signing_key.verify_key.encode().hex()}"
 
     payload = {"prompt": prompt, "timestamp": timestamp or time.time()}
@@ -61,7 +67,13 @@ class ASGITestClient:
     """Minimal ASGI test client - no external dependencies."""
 
     def __init__(self, app):
+        from nacl.signing import SigningKey
+
         self.app = app
+        # One identity per client. Sessions are owned by whoever created them
+        # (#698) and reading one needs a signature (#683), so a client that
+        # generated a new key per request could never read back what it wrote.
+        self.signing_key = SigningKey.generate()
 
     def _run(self, coro):
         # Use new_event_loop to avoid "no current event loop" error in Python 3.10+
@@ -75,21 +87,36 @@ class ASGITestClient:
     def get(self, path: str) -> "Response":
         return self._run(self._request("GET", path))
 
+    def get_signed(self, path: str) -> "Response":
+        """GET with the headers #683 requires, as this client's identity."""
+        from connectonion.network.host.auth import sign_request
+
+        keys = {"address": f"0x{self.signing_key.verify_key.encode().hex()}",
+                "signing_key": self.signing_key}
+        return self._run(self._request("GET", path,
+                                       headers=sign_request(keys, "GET", path)))
+
     def post(self, path: str, json_data: dict = None) -> "Response":
         return self._run(self._request("POST", path, json_data))
 
     def post_signed(self, path: str, prompt: str) -> "Response":
-        """POST with a signed request (protocol requirement)."""
-        signed_data = create_signed_request(prompt)
+        """POST with a signed request (protocol requirement).
+
+        One identity for the life of the client, so a session this creates can
+        be read back by get_signed -- see create_signed_request.
+        """
+        signed_data = create_signed_request(prompt, signing_key=self.signing_key)
         return self._run(self._request("POST", path, signed_data))
 
-    async def _request(self, method: str, path: str, body: dict = None) -> "Response":
+    async def _request(self, method: str, path: str, body: dict = None,
+                       headers: dict = None) -> "Response":
         scope = {
             "type": "http",
             "method": method,
             "path": path,
             "query_string": b"",
-            "headers": [[b"content-type", b"application/json"]],
+            "headers": [[b"content-type", b"application/json"]]
+                       + [[k.encode(), str(v).encode()] for k, v in (headers or {}).items()],
         }
 
         body_bytes = json.dumps(body).encode() if body else b""
@@ -232,7 +259,7 @@ class TestHostEndpoints:
         create_response = client.post_signed("/input", "Hello")
         session_id = create_response.json()["session_id"]
 
-        response = client.get(f"/sessions/{session_id}")
+        response = client.get_signed(f"/sessions/{session_id}")
 
         assert response.status_code == 200
         data = response.json()
@@ -244,14 +271,14 @@ class TestHostEndpoints:
         session_id = create_response.json()["session_id"]
         partial_id = session_id[:8]
 
-        response = client.get(f"/sessions/{partial_id}")
+        response = client.get_signed(f"/sessions/{partial_id}")
 
         # Partial ID should return 404 - exact match required
         assert response.status_code == 404
 
     def test_get_session_not_found(self, client):
         """GET /sessions/{session_id} should return 404 for unknown session."""
-        response = client.get("/sessions/nonexistent")
+        response = client.get_signed("/sessions/nonexistent")
 
         assert response.status_code == 404
 
@@ -260,7 +287,7 @@ class TestHostEndpoints:
         create_response = client.post_signed("/input", "Hello")
         session_id = create_response.json()["session_id"]
 
-        response = client.get(f"/sessions/{session_id}")
+        response = client.get_signed(f"/sessions/{session_id}")
 
         data = response.json()
         assert "expires" in data
@@ -271,7 +298,7 @@ class TestHostEndpoints:
         create_response = client.post_signed("/input", "Hello")
         session_id = create_response.json()["session_id"]
 
-        response = client.get(f"/sessions/{session_id}")
+        response = client.get_signed(f"/sessions/{session_id}")
 
         data = response.json()
         assert "duration_ms" in data
@@ -283,7 +310,7 @@ class TestHostEndpoints:
         client.post_signed("/input", "Session 1")
         client.post_signed("/input", "Session 2")
 
-        response = client.get("/sessions")
+        response = client.get_signed("/sessions")
 
         assert response.status_code == 200
         data = response.json()
@@ -292,7 +319,7 @@ class TestHostEndpoints:
 
     def test_get_sessions_empty(self, client):
         """GET /sessions should return empty list if no sessions."""
-        response = client.get("/sessions")
+        response = client.get_signed("/sessions")
 
         assert response.status_code == 200
         assert response.json()["sessions"] == []
@@ -303,7 +330,7 @@ class TestHostEndpoints:
         time.sleep(0.01)  # Ensure different timestamps
         client.post_signed("/input", "Second")
 
-        response = client.get("/sessions")
+        response = client.get_signed("/sessions")
 
         sessions = response.json()["sessions"]
         assert len(sessions) >= 2

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -227,6 +227,23 @@ class TestCorsHeaders:
 
 
 @pytest.mark.asyncio
+def signed_scope(method: str, path: str) -> dict:
+    """A scope carrying the headers a signed GET needs (#683).
+
+    Reading a session needs an identity, so a routing test that sends no
+    headers now exercises the 401 branch and never reaches the route it is
+    about. The headers come from the real `sign_request`, not a hand-rolled
+    imitation of it.
+    """
+    from connectonion import address
+    from connectonion.network.host.auth import sign_request
+
+    keys = address.generate()
+    headers = sign_request(keys, method, path)
+    return {"method": method, "path": path,
+            "headers": [[k.encode(), v.encode()] for k, v in headers.items()]}
+
+
 class TestHandleHttpRouting:
     """Test handle_http routing logic."""
 
@@ -310,7 +327,7 @@ class TestHandleHttpRouting:
 
     async def test_sessions_list_endpoint(self):
         """GET /sessions returns session list."""
-        scope = {"method": "GET", "path": "/sessions", "headers": []}
+        scope = signed_scope("GET", "/sessions")
         sent = []
 
         async def receive():
@@ -320,7 +337,7 @@ class TestHandleHttpRouting:
             sent.append(msg)
 
         handlers = {
-            "sessions": lambda storage: {"sessions": [{"id": "1"}, {"id": "2"}]},
+            "sessions": lambda storage, caller: {"sessions": [{"id": "1"}, {"id": "2"}]},
         }
 
         await handle_http(
@@ -336,7 +353,7 @@ class TestHandleHttpRouting:
 
     async def test_session_by_id_found(self):
         """GET /sessions/{id} returns session when found."""
-        scope = {"method": "GET", "path": "/sessions/abc123", "headers": []}
+        scope = signed_scope("GET", "/sessions/abc123")
         sent = []
 
         async def receive():
@@ -346,7 +363,7 @@ class TestHandleHttpRouting:
             sent.append(msg)
 
         handlers = {
-            "session": lambda storage, id: {"session_id": id, "status": "done"},
+            "session": lambda storage, id, caller: {"session_id": id, "status": "done"},
         }
 
         await handle_http(
@@ -363,7 +380,7 @@ class TestHandleHttpRouting:
 
     async def test_session_by_id_not_found(self):
         """GET /sessions/{id} returns 404 when not found."""
-        scope = {"method": "GET", "path": "/sessions/unknown", "headers": []}
+        scope = signed_scope("GET", "/sessions/unknown")
         sent = []
 
         async def receive():
@@ -373,7 +390,7 @@ class TestHandleHttpRouting:
             sent.append(msg)
 
         handlers = {
-            "session": lambda storage, id: None,
+            "session": lambda storage, id, caller: None,
         }
 
         await handle_http(

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -226,7 +226,6 @@ class TestCorsHeaders:
         assert b"content-type" in allowed
 
 
-@pytest.mark.asyncio
 def signed_scope(method: str, path: str) -> dict:
     """A scope carrying the headers a signed GET needs (#683).
 
@@ -244,6 +243,7 @@ def signed_scope(method: str, path: str) -> dict:
             "headers": [[k.encode(), v.encode()] for k, v in headers.items()]}
 
 
+@pytest.mark.asyncio
 class TestHandleHttpRouting:
     """Test handle_http routing logic."""
 

--- a/tests/unit/test_reading_sessions_needs_an_identity.py
+++ b/tests/unit/test_reading_sessions_needs_an_identity.py
@@ -1,0 +1,192 @@
+"""`curl http://agent/sessions` returns every conversation on the agent.
+
+No signature, no identity, no key. Measured against a real host on default
+trust:
+
+    GET /sessions -> {"sessions": [{"session_id": "9fd5d3fc-…",
+                                    "status": "done",
+                                    "prompt": "What codeword did I give you earlier?",
+                                    "result": "PURPLE-OTTER-42",
+                                    "session": {…every message…}}]}
+
+The prompt, the answer and the full message history. `POST /input` immediately
+above it in the same dispatch goes through `route_handlers["auth"]`; these two
+never did:
+
+    elif method == "GET" and path.startswith("/sessions/"):
+        result = route_handlers["session"](storage, path[10:])
+
+    elif method == "GET" and path == "/sessions":
+        await send_json(send, route_handlers["sessions"](storage))
+
+It is also where #696's attack got its ids. That one needed a session id to
+read somebody else's conversation; this hands out every id on the agent to
+anyone who can reach the port.
+
+A GET has no body to sign, so the signature travels in headers over
+`{"method", "path", "timestamp"}` -- canonicalised exactly as CONNECT and INPUT
+already are, and verified through the same `extract_and_authenticate`, so the
+trust level, the blacklist and the five-minute freshness window all apply
+without a second implementation of any of them.
+
+Aaron chose this over gating on OPENONION_API_KEY (#670 is about that key being
+over-powered) and over deleting the endpoints.
+
+Scoping comes from #698: a session records who started it, so `/sessions`
+returns the caller's own and `/sessions/{id}` returns one only if they own it.
+"""
+
+import json
+import time
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def caller():
+    return address.generate()
+
+
+@pytest.fixture
+def other():
+    return address.generate()
+
+
+def signed_headers(keys, method: str, path: str, timestamp=None) -> dict:
+    """What a client sends. Imported from the module under test on purpose --
+    a test that builds these by hand certifies its own idea of the format."""
+    from connectonion.network.host.auth import sign_request
+
+    return sign_request(keys, method, path, timestamp=timestamp)
+
+
+class TestTheHeadersAreTheSameProtocol:
+    """One canonicalisation in the codebase, not two."""
+
+    def test_the_payload_is_method_path_and_timestamp(self, caller):
+        from connectonion.network.host.auth import request_from_headers
+
+        headers = signed_headers(caller, "GET", "/sessions")
+        data = request_from_headers(headers, "GET", "/sessions")
+
+        assert data["payload"]["method"] == "GET"
+        assert data["payload"]["path"] == "/sessions"
+        assert isinstance(data["payload"]["timestamp"], (int, float))
+
+    def test_it_verifies(self, caller):
+        from connectonion.network.host.auth import request_from_headers, verify_signature
+
+        headers = signed_headers(caller, "GET", "/sessions")
+        data = request_from_headers(headers, "GET", "/sessions")
+
+        assert verify_signature(data["payload"], data["signature"], data["from"])
+
+    def test_the_signer_is_carried(self, caller):
+        from connectonion.network.host.auth import request_from_headers
+
+        data = request_from_headers(signed_headers(caller, "GET", "/sessions"),
+                                    "GET", "/sessions")
+
+        assert data["from"] == caller["address"]
+
+
+class TestASignatureIsBoundToTheRequest:
+    """Otherwise one captured header set reads anything."""
+
+    def test_a_signature_for_another_path_does_not_verify(self, caller):
+        from connectonion.network.host.auth import request_from_headers, verify_signature
+
+        headers = signed_headers(caller, "GET", "/sessions/mine")
+        data = request_from_headers(headers, "GET", "/sessions/yours")
+
+        assert not verify_signature(data["payload"], data["signature"], data["from"])
+
+    def test_a_signature_for_another_method_does_not_verify(self, caller):
+        from connectonion.network.host.auth import request_from_headers, verify_signature
+
+        headers = signed_headers(caller, "GET", "/sessions")
+        data = request_from_headers(headers, "DELETE", "/sessions")
+
+        assert not verify_signature(data["payload"], data["signature"], data["from"])
+
+    def test_an_old_signature_is_refused(self, caller):
+        """The same five-minute window every other frame gets."""
+        from connectonion.network.host.auth import (SIGNATURE_EXPIRY_SECONDS,
+                                                    _authenticate_signed,
+                                                    request_from_headers)
+
+        stale = time.time() - SIGNATURE_EXPIRY_SECONDS - 60
+        data = request_from_headers(signed_headers(caller, "GET", "/sessions", stale),
+                                    "GET", "/sessions")
+
+        _, _, err = _authenticate_signed(data)
+        assert err and "expired" in err
+
+    def test_no_headers_at_all_is_refused(self):
+        from connectonion.network.host.auth import _authenticate_signed, request_from_headers
+
+        data = request_from_headers({}, "GET", "/sessions")
+
+        _, _, err = _authenticate_signed(data)
+        assert err, "an unsigned GET authenticated"
+
+
+class TestWhatTheCallerSees:
+    """Scoped by the owner #698 records."""
+
+    def _storage(self, tmp_path, *owners):
+        from connectonion.network.host.session import SessionStorage
+        from connectonion.network.host.session.storage import Session
+
+        storage = SessionStorage(path=tmp_path / "s.jsonl")
+        for index, owner in enumerate(owners):
+            storage.save(Session(
+                session_id=f"s{index}", status="done", prompt="p", result="r",
+                session={"messages": [], "iteration": 1, "updated": 1.0,
+                         "requester": {"address": owner, "level": "whitelist"}},
+            ))
+        return storage
+
+    def test_only_their_own_are_listed(self, tmp_path, caller, other):
+        from connectonion.network.host.http_router import sessions_handler
+
+        storage = self._storage(tmp_path, caller["address"], other["address"])
+        listed = sessions_handler(storage, caller["address"])["sessions"]
+
+        assert [s["session_id"] for s in listed] == ["s0"], listed
+
+    def test_somebody_elses_is_not_readable_by_id(self, tmp_path, caller, other):
+        from connectonion.network.host.http_router import session_handler
+
+        storage = self._storage(tmp_path, other["address"])
+
+        assert session_handler(storage, "s0", caller["address"]) is None
+
+    def test_their_own_is(self, tmp_path, caller):
+        from connectonion.network.host.http_router import session_handler
+
+        storage = self._storage(tmp_path, caller["address"])
+
+        assert session_handler(storage, "s0", caller["address"])["result"] == "r"
+
+    def test_an_unowned_session_is_still_readable(self, tmp_path, caller):
+        """Stored before any owner was recorded. Same rule as #698: nobody is
+        evicted from those on upgrade."""
+        from connectonion.network.host.http_router import session_handler
+        from connectonion.network.host.session import SessionStorage
+        from connectonion.network.host.session.storage import Session
+
+        storage = SessionStorage(path=tmp_path / "s.jsonl")
+        storage.save(Session(session_id="old", status="done", prompt="p", result="r"))
+
+        assert session_handler(storage, "old", caller["address"])["result"] == "r"
+
+    def test_nothing_is_listed_for_nobody(self, tmp_path, caller, other):
+        """No caller address means the request was not authenticated."""
+        from connectonion.network.host.http_router import sessions_handler
+
+        storage = self._storage(tmp_path, caller["address"], other["address"])
+
+        assert sessions_handler(storage, None)["sessions"] == []


### PR DESCRIPTION
`curl http://agent/sessions` returned **every conversation on the agent** to anyone who could reach the port. Measured on a real host — no signature, no identity, no key:

```
GET /sessions -> {"sessions": [{"session_id": "9fd5d3fc-…",
                                "status": "done",
                                "prompt": "What codeword did I give you earlier?",
                                "result": "PURPLE-OTTER-42",
                                "session": {…every message…}}]}
```

`POST /input` immediately above it in the same dispatch went through `route_handlers["auth"]`. These two never did. It is also where #696's attack got its session ids — that one needed an id to read somebody's conversation; this handed out every id on the agent.

## Approach

Aaron picked signed GETs over gating on `OPENONION_API_KEY` (#670 is about that key being over-powered) and over deleting the endpoints.

A GET has no body, so the signature is in headers over `{method, path, timestamp}`:

```
x-co-from:      the caller's agent address
x-co-signature: sign(canonical(payload))
x-co-timestamp: unix seconds
```

Canonicalised **exactly** as CONNECT and INPUT already are, and verified by the same `_authenticate_signed` — same five-minute freshness window, same blacklist check. No second implementation of any of it. Most of what this release has been fixing is one decision made in two places and drifting; this deliberately does not add another.

The payload is rebuilt from the server's **own** method and path, never from anything the client sent, so a signature made for `/sessions/mine` does not verify against `/sessions/yours`. Tested both ways.

`sign_request()` is exported so a client does not reconstruct the format by hand — and so these tests drive the real one instead of certifying their own idea of it.

## Scope

From the owner #698 records: `/sessions` returns the caller's own, `/sessions/{id}` returns one only if they own it. Sessions stored before an owner existed stay readable — same rule as #698, since silently orphaning existing history on upgrade is a worse surprise than the status quo.

## Measured after

```
unauthenticated curl      -> {"error": "unauthorized: 'from' field required"}
signed as A               -> 1 session; result: PURPLE-OTTER-42.
signed as B (new to it)   -> 0 sessions
```

## Also

The agent's own `/docs` page advertised `curl -X GET "http://localhost:8000/sessions"` as the way to call this. Left alone it becomes a documented call that always 401s — the shape this release keeps running into. Updated to show `co call` and the header form.

## Tests

12 cases, red first.

Closes #683.