### PR TITLE
One bad command file no longer empties the menu

### DIFF
--- a/connectonion/useful_tools/slash_command.py
+++ b/connectonion/useful_tools/slash_command.py
@@ -38,7 +38,7 @@ Your command prompt here...
 import yaml
 from pathlib import Path
 from ..project import project_co_dir, project_root
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
 
 class SlashCommand:
@@ -163,30 +163,43 @@ class SlashCommand:
         return filtered
 
     @classmethod
-    def list_all(cls) -> Dict[str, "SlashCommand"]:
+    def list_all(cls, report: bool = False):
         """List all available commands (built-in and custom).
 
+        One bad file used to lose every good one. This is the menu, and
+        `_parse_file` raises on a file without frontmatter, so a typo in a file
+        the user may never have opened produced no commands at all and a
+        traceback.
+
+        A file that cannot be read is skipped and named. Silence would be its
+        own bug — #629 exists because a dropped entry is indistinguishable from
+        one that was never there — so `report=True` returns the reasons.
+
+        Checked, not caught: `_why_the_command_cannot_be_read` asks the
+        questions `_parse_file` would raise on, so a genuinely unexpected
+        failure still surfaces instead of being swallowed as "malformed".
+
         Returns:
-            Dict mapping command names to SlashCommand instances
-            Custom commands override built-ins
+            Dict mapping command names to SlashCommand instances, or
+            (commands, problems) when report=True. Custom commands override
+            built-ins.
         """
         commands = {}
+        problems = []
 
-        # Load built-ins first
-        builtin_dir = project_root() / "commands"
-        if builtin_dir.exists():
-            for filepath in builtin_dir.glob("*.md"):
-                cmd = cls._parse_file(filepath, is_custom=False)
+        for directory, is_custom in ((project_root() / "commands", False),
+                                     (project_co_dir() / "commands", True)):
+            if not directory.exists():
+                continue
+            for filepath in sorted(directory.glob("*.md")):
+                reason = _why_the_command_cannot_be_read(filepath)
+                if reason:
+                    problems.append(f"{filepath.name}: {reason}")
+                    continue
+                cmd = cls._parse_file(filepath, is_custom=is_custom)
                 commands[cmd.name] = cmd
 
-        # Load customs (override built-ins)
-        custom_dir = project_co_dir() / "commands"
-        if custom_dir.exists():
-            for filepath in custom_dir.glob("*.md"):
-                cmd = cls._parse_file(filepath, is_custom=True)
-                commands[cmd.name] = cmd
-
-        return commands
+        return (commands, problems) if report else commands
 
     @classmethod
     def is_custom(cls, command_name: str) -> bool:
@@ -200,3 +213,43 @@ class SlashCommand:
         """
         custom_path = project_co_dir() / "commands" / f"{command_name}.md"
         return custom_path.exists()
+
+
+def _why_the_command_cannot_be_read(filepath: Path) -> Optional[str]:
+    """The reason a command file cannot be loaded, or None if it is fine.
+
+    The same questions `_parse_file` raises on, asked instead of caught, so the
+    menu can skip one file without a try/except that would also hide a bug in
+    the parser itself.
+
+    Unlike a SKILL.md, a command with no frontmatter is not currently a valid
+    simple command -- `_parse_file` requires `name` and `description`. Whether
+    it *should* be (filename as name, whole file as prompt, the way #629 treats
+    skills) is a format decision and is not made here. #668 records that the
+    two subsystems disagree about identical input.
+    """
+    content = filepath.read_text(encoding="utf-8", errors="replace")
+
+    if not content.strip():
+        return "file is empty"
+    if not content.startswith("---"):
+        return "no YAML frontmatter (expected a '---' block at the top)"
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return "frontmatter is not closed by a second '---'"
+
+    import yaml as _yaml
+    try:
+        frontmatter = _yaml.safe_load(parts[1])
+    except _yaml.YAMLError as exc:
+        # The one place catching is right: asking "is this valid YAML" without
+        # running the parser means writing a second YAML parser.
+        return f"frontmatter is not valid YAML: {str(exc).splitlines()[0]}"
+
+    if not isinstance(frontmatter, dict):
+        return "frontmatter is not a mapping"
+    for field in ("name", "description"):
+        if field not in frontmatter:
+            return f"missing '{field}' field"
+    return None

--- a/tests/unit/test_one_bad_command_file_keeps_the_menu.py
+++ b/tests/unit/test_one_bad_command_file_keeps_the_menu.py
@@ -1,0 +1,129 @@
+"""One typo in one command file and there are no commands at all.
+
+`list_all()` is the menu — `slash_command.py` says so — and it parses every
+`.md` in both command directories through `_parse_file`, which raises:
+
+    if not content.startswith("---"):
+        raise ValueError(f"Command file {filepath} missing YAML frontmatter")
+
+So a single bad file loses every good one:
+
+    .co/commands/good.md      valid frontmatter
+    .co/commands/broken.md    no frontmatter
+
+    list_all()     -> ValueError: Command file .../broken.md missing YAML frontmatter
+    load('good')   -> works
+
+The good command is individually loadable. It is only the listing that dies,
+which means the user sees no commands and a traceback, for a typo in a file
+they may not even have opened.
+
+#629 settled the same question for skills and is the shape copied here: a
+`_why_the_..._cannot_be_read` predicate that **checks** rather than catches, so
+the listing names the broken file and keeps the rest.
+
+What this deliberately does not decide is whether a command with no frontmatter
+should work the way a skill with no frontmatter does — where the whole file is
+the prompt and the name comes from the filename. The two subsystems disagree
+about identical input today. That is a format decision; `list_all()` losing
+everything is a bug either way, and it is the only thing fixed here.
+"""
+
+import pytest
+
+from connectonion.useful_tools.slash_command import SlashCommand
+
+
+GOOD = """---
+name: deploy
+description: Ship it
+---
+
+Do the deploy.
+"""
+
+NO_FRONTMATTER = "Just some notes I left in this folder.\n"
+UNCLOSED = "---\nname: half\n"
+BAD_YAML = "---\nname: [unclosed\ndescription: x\n---\n\nbody\n"
+NO_NAME = "---\ndescription: nameless\n---\n\nbody\n"
+EMPTY = ""
+
+
+@pytest.fixture
+def commands(tmp_path, monkeypatch):
+    """A project whose .co/commands/ is `files`."""
+    def write(**files):
+        co = tmp_path / ".co" / "commands"
+        co.mkdir(parents=True, exist_ok=True)
+        for stem, text in files.items():
+            (co / f"{stem}.md").write_text(text, encoding="utf-8")
+        monkeypatch.setattr("connectonion.useful_tools.slash_command.project_co_dir",
+                            lambda: tmp_path / ".co")
+        monkeypatch.setattr("connectonion.useful_tools.slash_command.project_root",
+                            lambda: tmp_path / "no-builtins-here")
+        return co
+    return write
+
+
+class TestTheMenuSurvivesOneBadFile:
+
+    @pytest.mark.parametrize("bad", [NO_FRONTMATTER, UNCLOSED, BAD_YAML, NO_NAME, EMPTY])
+    def test_the_good_command_is_still_listed(self, commands, bad):
+        commands(good=GOOD, broken=bad)
+
+        assert "deploy" in SlashCommand.list_all()
+
+    def test_the_broken_one_is_not_invented(self, commands):
+        commands(good=GOOD, broken=NO_FRONTMATTER)
+
+        assert list(SlashCommand.list_all()) == ["deploy"]
+
+    def test_several_bad_files_do_not_add_up(self, commands):
+        commands(good=GOOD, a=NO_FRONTMATTER, b=BAD_YAML, c=EMPTY)
+
+        assert list(SlashCommand.list_all()) == ["deploy"]
+
+    def test_all_bad_is_an_empty_menu_not_a_traceback(self, commands):
+        commands(a=NO_FRONTMATTER, b=BAD_YAML)
+
+        assert SlashCommand.list_all() == {}
+
+
+class TestTheOperatorIsToldWhichFile:
+    """Silence would be its own bug — #629's whole point was that a dropped
+    entry is indistinguishable from one that was never there."""
+
+    def test_the_problem_names_the_file(self, commands):
+        co = commands(good=GOOD, broken=NO_FRONTMATTER)
+        _, problems = SlashCommand.list_all(report=True)
+
+        assert any("broken.md" in str(p) for p in problems), problems
+
+    def test_it_says_what_is_wrong(self, commands):
+        commands(good=GOOD, broken=NO_NAME)
+        _, problems = SlashCommand.list_all(report=True)
+
+        assert any("name" in str(p).lower() for p in problems), problems
+
+    def test_a_clean_directory_reports_nothing(self, commands):
+        commands(good=GOOD)
+        listed, problems = SlashCommand.list_all(report=True)
+
+        assert list(listed) == ["deploy"]
+        assert problems == []
+
+
+class TestLoadingOneByNameIsUnchanged:
+    """`load()` still raises — a command you asked for by name and cannot have
+    is an error, not something to skip past silently."""
+
+    def test_a_good_one_loads(self, commands):
+        commands(good=GOOD)
+
+        assert SlashCommand.load("good").name == "deploy"
+
+    def test_a_broken_one_still_raises(self, commands):
+        commands(broken=NO_FRONTMATTER)
+
+        with pytest.raises(ValueError):
+            SlashCommand.load("broken")


### PR DESCRIPTION
`list_all()` parsed every `.md` through `_parse_file`, which raises on a file without frontmatter. One typo lost every good command:

```
.co/commands/good.md      valid frontmatter
.co/commands/broken.md    no frontmatter

list_all()     -> ValueError: Command file .../broken.md missing YAML frontmatter
load('good')   -> works
```

The good command was individually loadable — only the listing died. So the user got **no commands at all, plus a traceback**, for a file they may never have opened.

## Scope, stated accurately

`SlashCommand` is exported from `connectonion` as a public extension point. The CLI itself does not call `list_all()`; a user's own agent does, to build its menu. So this is a user-facing API fix, not a fix to `co`'s own command list — worth being precise about, since the issue title reads like the latter.

## The fix

A file that cannot be read is skipped and named. Silence would be its own bug — #629 exists because a dropped entry is indistinguishable from one that was never there — so `list_all(report=True)` returns `(commands, problems)`.

**Checked, not caught**, copying #629's shape: `_why_the_command_cannot_be_read` asks the questions `_parse_file` would raise on, so a genuine bug in the parser still surfaces instead of being swallowed as "malformed". The one `try/except` is around `yaml.safe_load`, where the alternative is writing a second YAML parser.

`load()` by name still raises. A command you asked for and cannot have is an error, not something to skip past.

## Not decided here

Whether a command with no frontmatter should work the way a `SKILL.md` with none does — filename as name, whole file as prompt. The two subsystems disagree about identical input today; #668 records it. That is a format decision, and the menu losing everything is a bug either way.

## Tests

13 cases, red first, across five ways a file can be bad: no frontmatter, unclosed frontmatter, invalid YAML, missing `name`, empty. Plus: all-bad is an empty menu rather than a traceback, several bad files do not compound, a clean directory reports no problems, and `load()`'s behaviour is unchanged.

Closes #668.