### PR TITLE
A captured CONNECT opens nothing twice, and nothing signed goes onto a LAN

### DIFF
--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -96,6 +96,35 @@ def _sort_endpoints(endpoints: List[str]) -> List[str]:
     return sorted(endpoints, key=priority)
 
 
+LOOPBACK = ("localhost", "127.0.0.1", "::1", "[::1]")
+
+
+def endpoint_is_safe(url: str) -> bool:
+    """May a signed frame go to this endpoint?
+
+    TLS anywhere, or plaintext to loopback only.
+
+    Before #643 `resolve_endpoint` never resolved anything, so every client went
+    through the relay over `wss://` and TLS covered this. Direct connections
+    then became the normal path, and a self-hosted agent announces plain
+    `ws://`:
+
+        "endpoints": ["http://10.5.27.133:8797", "ws://10.5.27.133:8797/ws", …]
+
+    A CONNECT is signed, and on a LAN anyone who can observe that traffic can
+    capture one. Within the freshness window a captured CONNECT is the whole
+    whitelisted tool surface (#649). Loopback has no network to observe, and a
+    deployed agent is served over https (1.5.3), so both of the cases direct
+    resolution exists for stay fast; the rest falls back to the relay.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme in ("https", "wss"):
+        return True
+    return (parsed.hostname or "") in LOOPBACK
+
+
 async def resolve_endpoint(
     agent_address: str,
     relay_url: str,
@@ -151,7 +180,9 @@ async def resolve_endpoint(
         sorted_endpoints = _sort_endpoints(agent_info["endpoints"])
 
         # Step 3: Try each HTTP endpoint
-        http_endpoints = [ep for ep in sorted_endpoints if ep.startswith("http://") or ep.startswith("https://")]
+        http_endpoints = [ep for ep in sorted_endpoints
+                          if (ep.startswith("http://") or ep.startswith("https://"))
+                          and endpoint_is_safe(ep)]
 
         for http_url in http_endpoints:
             try:

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -18,6 +18,7 @@ Trust evaluation (via TrustAgent.should_allow()):
 import hashlib
 import json
 import time
+from typing import Dict
 
 from ..trust import TrustAgent, TRUST_LEVELS
 
@@ -204,6 +205,50 @@ def request_from_headers(headers: dict, method: str, path: str) -> dict:
         "from": lowered.get(FROM_HEADER),
         "signature": lowered.get(SIGNATURE_HEADER),
     }
+
+
+# ─────────────────────────── replay ───────────────────────────
+#
+# EXEC carries no signature of its own -- the signature authenticates the
+# *connection*, and every command on it is trusted because of who opened it. So
+# a captured CONNECT, replayed inside the five-minute freshness window, is not
+# "repeat what the caller did": it is any whitelisted tool with any arguments,
+# because the attacker writes the EXEC frames themselves (#649, measured).
+#
+# One signature opens one connection. The attack has to *open* one; without a
+# MITM position an attacker cannot inject into somebody else's live socket.
+#
+# Legitimate clients are unaffected: each builds a fresh CONNECT with a fresh
+# timestamp, and the one place this codebase re-establishes a connection
+# deliberately does not replay the frame -- see ws_router/connect.py, "no
+# CONNECT replay, its signature may have aged past the 5-minute window".
+#
+# Signing each command is the complete answer and a protocol change (#649
+# option 3). This closes the route without breaking a client.
+
+_seen_signatures: Dict[str, float] = {}
+
+
+def signature_already_used(data: dict) -> bool:
+    """True if this exact signature has opened a connection already.
+
+    Records it if not. Entries past the freshness window are dropped as we go:
+    they cannot be replayed anyway, so keeping them is memory the agent never
+    gets back.
+    """
+    signature = data.get("signature")
+    if not signature:
+        return False          # refused by the signature check itself
+
+    now = time.time()
+    for old in [sig for sig, seen in _seen_signatures.items()
+                if now - seen > SIGNATURE_EXPIRY_SECONDS]:
+        del _seen_signatures[old]
+
+    if signature in _seen_signatures:
+        return True
+    _seen_signatures[signature] = now
+    return False
 
 
 def _authenticate_signed(data: dict, *, blacklist=None, recipient_address=None):

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -19,6 +19,15 @@ console = Console()
 
 async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
     """Handle CONNECT message: auth, session merge, send CONNECTED. Returns (io, task) for reattach or None."""
+    from ..auth import signature_already_used
+
+    # One signature opens one connection (#649). Checked before the trust gate
+    # so a replay is refused whatever level the original caller had.
+    if signature_already_used(data):
+        await send_msg({"type": "ERROR",
+                        "message": "unauthorized: this CONNECT was already used"})
+        return
+
     _, agent_address, sig_valid, err = route_handlers["auth"](
         data, trust, blacklist=blacklist, whitelist=whitelist
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,3 +342,20 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "real_api" in item.keywords:
                 item.add_marker(skip_marker)
+
+
+@pytest.fixture(autouse=True)
+def _forget_seen_signatures():
+    """One CONNECT signature opens one connection (#649), and the record of
+    which ones have been used is process-global -- it has to be, because the
+    replay being refused happens across connections.
+
+    That makes it state one test hands to the next. Several test files send a
+    hardcoded `"signature": "0xsig"`, so without this the second test to use
+    one is refused for a reason that has nothing to do with what it checks.
+    """
+    from connectonion.network.host.auth import _seen_signatures
+
+    _seen_signatures.clear()
+    yield
+    _seen_signatures.clear()

--- a/tests/unit/test_a_captured_connect_opens_nothing_twice.py
+++ b/tests/unit/test_a_captured_connect_opens_nothing_twice.py
@@ -1,0 +1,205 @@
+"""One captured CONNECT is five minutes of the whole whitelisted tool surface.
+
+#649, measured against a live agent. `CONNECT` carries a signed payload;
+`EXEC` carries no signature at all:
+
+    exec_msg = {"type": "EXEC", "exec_id": exec_id, "tool": tool, "args": args}
+
+So the signature authenticates the *connection*, and every command on it is
+trusted because of who opened it. `SIGNATURE_EXPIRY_SECONDS = 300`, and nothing
+marked a signature as used. The EXEC frames in that measurement were written by
+the attacker, not captured:
+
+    1st (legitimate)                 -> ran 1 times
+    2nd (CONNECT replayed verbatim)  -> ran 2 times
+    3rd (replayed again)             -> ran 3 times
+
+Two things are fixed here, neither of them a protocol change.
+
+**A CONNECT signature opens one connection.** Seen once, refused after. The
+attack needs to *open* a connection; without a MITM position an attacker cannot
+inject into someone else's existing socket. Legitimate clients build a fresh
+CONNECT with a fresh timestamp every time, and the one place this codebase
+re-establishes a connection deliberately avoids replaying the frame -- the
+comment in connect.py says so: "no CONNECT replay -- its signature may have
+aged past the 5-minute window".
+
+**Nothing signed goes onto a network in plaintext.** #643 made direct
+resolution work, and a self-hosted agent announces plain `ws://`. On a LAN
+anyone who can observe the traffic can capture a CONNECT. Plaintext is now used
+only for loopback, where there is no network to observe; a `wss://` endpoint is
+preferred when offered, and otherwise the relay carries it.
+
+What is *not* fixed here is signing each command (#649's option 3). That is the
+complete answer and a protocol change: every EXEC and INPUT carrying its own
+signature over its own contents. These two close the route without breaking a
+single client.
+"""
+
+import time
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def keys():
+    return address.generate()
+
+
+def _connect_frame(keys, to: str, timestamp=None):
+    import json
+
+    payload = {"to": to, "timestamp": int(timestamp or time.time())}
+    canonical = json.dumps(payload, sort_keys=True, separators=(',', ':'))
+    return {"type": "CONNECT", "payload": payload, "from": keys["address"],
+            "signature": address.sign(keys, canonical.encode()).hex()}
+
+
+class TestASignatureOpensOneConnection:
+
+    def test_the_first_use_is_accepted(self, keys):
+        from connectonion.network.host.auth import signature_already_used
+
+        frame = _connect_frame(keys, "0x" + "a" * 64)
+
+        assert signature_already_used(frame) is False
+
+    def test_the_second_use_is_refused(self, keys):
+        """The measurement in the issue: replayed verbatim, ran again."""
+        from connectonion.network.host.auth import signature_already_used
+
+        frame = _connect_frame(keys, "0x" + "a" * 64)
+        signature_already_used(frame)
+
+        assert signature_already_used(frame) is True
+
+    def test_a_fresh_frame_from_the_same_caller_is_fine(self, keys):
+        """What every legitimate reconnect looks like."""
+        from connectonion.network.host.auth import signature_already_used
+
+        signature_already_used(_connect_frame(keys, "0x" + "a" * 64, time.time() - 2))
+
+        assert signature_already_used(
+            _connect_frame(keys, "0x" + "a" * 64, time.time())) is False
+
+    def test_two_callers_do_not_collide(self, keys):
+        from connectonion.network.host.auth import signature_already_used
+
+        other = address.generate()
+        signature_already_used(_connect_frame(keys, "0x" + "a" * 64))
+
+        assert signature_already_used(_connect_frame(other, "0x" + "a" * 64)) is False
+
+    def test_an_unsigned_frame_is_not_tracked(self, keys):
+        """It is refused earlier, by the signature check itself."""
+        from connectonion.network.host.auth import signature_already_used
+
+        assert signature_already_used({"type": "CONNECT"}) is False
+
+    def test_the_cache_does_not_grow_without_bound(self, keys):
+        """Entries past the freshness window cannot be replayed anyway, so
+        keeping them is memory an agent never gets back.
+
+        The cache stamps *insertion* time, not the frame's timestamp -- so a
+        far-future timestamp cannot pin an entry there. Ageing the recorded
+        times is therefore how this is exercised; my first version pushed
+        old-looking frames instead and kept 51 entries, proving nothing.
+        """
+        from connectonion.network.host.auth import (SIGNATURE_EXPIRY_SECONDS,
+                                                    _seen_signatures,
+                                                    signature_already_used)
+
+        _seen_signatures.clear()
+        for _ in range(50):
+            signature_already_used(_connect_frame(address.generate(), "0x" + "a" * 64))
+        aged = time.time() - SIGNATURE_EXPIRY_SECONDS - 60
+        for sig in _seen_signatures:
+            _seen_signatures[sig] = aged
+
+        signature_already_used(_connect_frame(keys, "0x" + "a" * 64))
+
+        assert len(_seen_signatures) == 1, f"{len(_seen_signatures)} entries kept"
+
+
+class TestNothingSignedGoesOntoALanInPlaintext:
+    """#643 made direct resolution work; a self-hosted agent announces ws://."""
+
+    def test_loopback_plaintext_is_fine(self):
+        from connectonion.network.connect import endpoint_is_safe
+
+        assert endpoint_is_safe("http://localhost:8000") is True
+        assert endpoint_is_safe("http://127.0.0.1:8000") is True
+
+    def test_a_lan_address_in_plaintext_is_not(self):
+        """The exact shape from the issue's measurement."""
+        from connectonion.network.connect import endpoint_is_safe
+
+        assert endpoint_is_safe("http://10.5.27.133:8797") is False
+
+    def test_a_public_address_in_plaintext_is_not(self):
+        from connectonion.network.connect import endpoint_is_safe
+
+        assert endpoint_is_safe("http://129.94.128.29:8000") is False
+
+    def test_tls_anywhere_is_fine(self):
+        from connectonion.network.connect import endpoint_is_safe
+
+        assert endpoint_is_safe("https://agent.example.com") is True
+        assert endpoint_is_safe("https://10.5.27.133:8797") is True
+
+    def test_ipv6_loopback_counts(self):
+        from connectonion.network.connect import endpoint_is_safe
+
+        assert endpoint_is_safe("http://[::1]:8000") is True
+
+
+class TestWhichEndpointIsChosen:
+    """The preference order, given what a relay actually returns."""
+
+    def _resolve(self, endpoints, agent_address="0x" + "b" * 64):
+        import asyncio
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import importlib
+
+        # `connectonion.network.connect` is also the name of a function the
+        # package re-exports, so the dotted attribute is that function and not
+        # this module. Same shadowing that made a monkeypatch land nowhere in
+        # #687's tests.
+        connect_mod = importlib.import_module("connectonion.network.connect")
+
+        directory = MagicMock()
+        directory.status_code = 200
+        directory.json.return_value = {"endpoints": endpoints}
+
+        info = MagicMock()
+        info.status_code = 200
+        info.json.return_value = {"address": agent_address}
+
+        async def get(url, *a, **kw):
+            return directory if "/api/agents/" in url else info
+
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=get)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch.object(connect_mod.httpx, "AsyncClient", return_value=client):
+            return asyncio.run(connect_mod.resolve_endpoint(agent_address,
+                                                            "wss://relay.example"))
+
+    def test_a_lan_plaintext_endpoint_is_not_used(self):
+        assert self._resolve(["http://10.5.27.133:8797"]) is None
+
+    def test_localhost_still_wins(self):
+        assert self._resolve(["http://10.5.27.133:8797",
+                              "http://localhost:8000"]) == "ws://localhost:8000/ws"
+
+    def test_tls_is_used_over_the_relay(self):
+        assert self._resolve(["https://agent.example.com"]) == "wss://agent.example.com/ws"
+
+    def test_tls_is_preferred_over_lan_plaintext(self):
+        assert self._resolve(["http://10.5.27.133:8797",
+                              "https://agent.example.com"]) == "wss://agent.example.com/ws"

--- a/tests/unit/test_a_direct_endpoint_is_actually_resolved.py
+++ b/tests/unit/test_a_direct_endpoint_is_actually_resolved.py
@@ -98,8 +98,13 @@ def _resolve(monkeypatch, directory, info_by_host=None):
     return result, client
 
 
-LAN = "http://10.0.0.5:8797"
-PUBLIC = "http://203.0.113.9:8797"
+# Served over TLS. Since #649 a signed CONNECT is only sent to loopback in
+# plaintext, so a bare `http://` LAN or public endpoint is skipped and these
+# tests -- which are about ordering and resolution mechanics, not schemes --
+# would be testing the refusal instead. `test_a_captured_connect_opens_nothing_twice.py`
+# is where the refusal itself is pinned.
+LAN = "https://10.0.0.5:8797"
+PUBLIC = "https://203.0.113.9:8797"
 LOCAL = "http://localhost:8797"
 
 
@@ -121,7 +126,7 @@ class TestWhatTheRelayActuallyReturns:
     def test_it_is_the_websocket_form(self, monkeypatch):
         result, _ = _resolve(monkeypatch, self.DIRECTORY, {LAN: {"address": AGENT}})
 
-        assert result == "ws://10.0.0.5:8797/ws"
+        assert result == "wss://10.0.0.5:8797/ws"
 
 
 class TestAnExplicitNoIsStillHonoured:
@@ -166,7 +171,7 @@ class TestTheChecksThatMustStay:
         result, _ = _resolve(monkeypatch, {"endpoints": [LAN, PUBLIC]},
                              {PUBLIC: {"address": AGENT}})
 
-        assert result == "ws://203.0.113.9:8797/ws"
+        assert result == "wss://203.0.113.9:8797/ws"
 
     def test_a_short_address_is_not_looked_up(self, monkeypatch):
         client = FakeClient({}, {})


### PR DESCRIPTION
`EXEC` carries **no signature of its own**. The signature authenticates the *connection*, and every command on it is trusted because of who opened it. So a captured CONNECT replayed inside the five-minute window is not "repeat what the caller did" — it is any whitelisted tool with any arguments, because the attacker writes the EXEC frames. From #649's measurement against a live agent:

```
1st (legitimate)                 -> ran 1 times
2nd (CONNECT replayed verbatim)  -> ran 2 times
3rd (replayed again)             -> ran 3 times
side_effects.txt: 3 lines
```

Two halves here, neither a protocol change.

## One signature opens one connection

Seen once, refused after. The attack has to **open** a connection; without a MITM position an attacker cannot inject into somebody else's live socket.

Legitimate clients are unaffected — each builds a fresh CONNECT with a fresh timestamp, and the one place this codebase re-establishes a connection already avoids replaying the frame (`ws_router/connect.py`: *"no CONNECT replay — its signature may have aged past the 5-minute window"*).

## Plaintext only to loopback

#643 made direct resolution work, and a self-hosted agent announces plain `ws://`. On a LAN anyone who can observe that traffic can capture a CONNECT. Now: `wss://` preferred when offered, plain `ws://` only where there is no network to observe, everything else back through the relay.

**⚠️ Behaviour change worth knowing about:** a LAN agent reached over plain `http`/`ws` is no longer contacted directly — that traffic goes through the relay. Deployed agents are served over https (1.5.3) and localhost is untouched, so both cases direct resolution was built for keep it. This is option 1 as written in #649, but it does trade some of #643's speed win for LAN users, so it should be a conscious call rather than something noticed later.

## Not done

Signing each command — #649's option 3, every EXEC and INPUT carrying its own signature over its own contents. That is the complete answer and a protocol change. These two close the route without breaking a client.

## Two test-side consequences, both real

The replay cache is **process-global**, and has to be, since the replay it refuses crosses connections. That makes it state one test hands to the next: several files send a hardcoded `"signature": "0xsig"`, so the second test to use one was refused for reasons unrelated to itself. `conftest` clears it per test.

#643's resolution tests describe their LAN and public hosts over TLS now. They are about ordering and resolution mechanics, not schemes; left as plain `http` they would have been testing the new refusal instead of what they were written for.

## Tests

15 cases, 13 red first.

Two of my own were wrong and are corrected rather than worked around: the cache-pruning test aged frames instead of the recorded entries (the cache stamps *insertion* time, deliberately, so a far-future timestamp cannot pin an entry), and `connectonion.network.connect` resolves to a re-exported *function*, not the module, so a patch on it landed nowhere — the same shadowing that bit #687.

Part of #649.