### PR TITLE
A stray .co above the working directory is a failure, not a wrong answer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,7 +388,15 @@ def _no_stray_project_above_the_test(tmp_path_factory):
 
     yield
 
-    resolved = project_root()
+    try:
+        resolved = project_root()
+    except (FileNotFoundError, OSError):
+        # A test whose working directory was a tmp dir that has since been
+        # removed has no cwd to resolve from. That is not contamination, and
+        # raising here turned a passing test into an error on CI -- where tmp
+        # dirs are cleaned more eagerly than on my machine, which is why this
+        # only showed there.
+        return
     tmp_root = tmp_path_factory.getbasetemp().resolve()
     repo = Path(__file__).resolve().parent.parent
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,3 +359,44 @@ def _forget_seen_signatures():
     _seen_signatures.clear()
     yield
     _seen_signatures.clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_stray_project_above_the_test(tmp_path_factory):
+    """A `.co/` in a shared parent silently becomes every test's project.
+
+    `_never_touch_the_real_home` above isolates HOME, so `~/.co` is safe. This
+    is the other half: `project_root()` walks up from the *working directory*,
+    and a stray `.co/` anywhere above it wins.
+
+    Measured (#694): real-host verification runs left a `/private/tmp/.co/`
+    behind, and afterwards a unit test with nothing to do with any of it failed
+
+        assert logger.log_file_path == Path(".co/logs/test-agent.log").resolve()
+        E  assert PosixPath('/private/tmp/.co/logs/test-agent.log') == …
+
+    standalone, not only in some order -- so `-p no:randomly` does not hide it.
+    It is invisible on CI, where the machine is clean, which is the worst
+    property: a local run disagrees with CI for a reason nobody can reproduce.
+
+    This does not repoint anything. Tests that chdir into their own project
+    depend on the walk-up finding it, and pinning the answer would break them.
+    It only refuses to let the walk-up escape somewhere shared, so the
+    contamination is a failure with a name instead of a wrong answer.
+    """
+    from connectonion.project import project_root
+
+    yield
+
+    resolved = project_root()
+    tmp_root = tmp_path_factory.getbasetemp().resolve()
+    repo = Path(__file__).resolve().parent.parent
+
+    allowed = resolved == repo or resolved.is_relative_to(tmp_root) \
+        or resolved.is_relative_to(repo)
+    assert allowed, (
+        f"this test's project resolved to {resolved}, which is neither the repo "
+        f"nor its own tmp dir — a stray .co/ above the working directory is "
+        f"deciding what the code under test reads. Remove it ({resolved / '.co'}) "
+        f"or chdir somewhere isolated."
+    )

--- a/tests/unit/test_the_suite_notices_a_stray_project.py
+++ b/tests/unit/test_the_suite_notices_a_stray_project.py
@@ -1,0 +1,101 @@
+"""A `.co/` in a shared parent silently becomes every test's project.
+
+`_never_touch_the_real_home` isolates HOME, so `~/.co` is covered. This is the
+other half: `project_root()` walks up from the *working directory*, and a stray
+`.co/` anywhere above it wins.
+
+Measured (#694). My real-host verification runs left a `/private/tmp/.co/`
+behind. Afterwards a unit test with nothing to do with any of that failed:
+
+    assert logger.log_file_path == Path(".co/logs/test-agent.log").resolve()
+    E  assert PosixPath('/private/tmp/.co/logs/test-agent.log')
+           == PosixPath('/…/wt-695/.co/logs/test-agent.log')
+
+standalone, not only in a particular order — so `-p no:randomly` does not hide
+this one. And it is invisible on CI, where the machine is clean, which is the
+worst property to have: a local run disagrees with CI for a reason nobody can
+reproduce.
+
+The escape reproduces exactly:
+
+    cwd          /private/tmp/probe_no_co     (no .co of its own)
+    project_root /private/tmp                 (the stray one wins)
+
+The guard in conftest does not repoint anything — tests that chdir into their
+own project depend on the walk-up finding it, and pinning the answer would
+break them. It refuses to let the walk-up escape somewhere shared, so
+contamination becomes a failure with a name instead of a wrong answer.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestTheWalkUpCanEscape:
+    """What the guard is for, demonstrated without needing a stray directory
+    in a real shared location."""
+
+    def test_a_parent_owning_co_becomes_the_project(self, tmp_path, monkeypatch):
+        from connectonion.project import project_root
+
+        (tmp_path / ".co").mkdir()
+        deep = tmp_path / "somewhere" / "deeper"
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+
+        assert project_root() == tmp_path.resolve()
+
+    def test_without_one_it_stops_at_the_start(self, tmp_path, monkeypatch):
+        from connectonion.project import project_root
+
+        deep = tmp_path / "no" / "co" / "anywhere"
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+
+        assert project_root() == deep.resolve()
+
+
+class TestTheGuardItself:
+
+    def _check(self, resolved: Path, tmp_root: Path, repo: Path) -> bool:
+        """The condition conftest applies, so it is tested rather than trusted."""
+        return (resolved == repo or resolved.is_relative_to(tmp_root)
+                or resolved.is_relative_to(repo))
+
+    def test_the_repo_is_allowed(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+
+        assert self._check(repo, tmp_path, repo)
+
+    def test_a_test_s_own_tmp_dir_is_allowed(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+        mine = tmp_path / "project"
+        mine.mkdir()
+
+        assert self._check(mine, tmp_path, repo)
+
+    def test_a_shared_parent_is_not(self, tmp_path):
+        """The measured case: /private/tmp owning a .co."""
+        repo = Path(__file__).resolve().parents[2]
+
+        assert not self._check(Path("/private/tmp"), tmp_path, repo)
+
+    def test_the_operators_home_is_not(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+
+        assert not self._check(Path.home(), tmp_path, repo)
+
+
+class TestTheGuardIsInstalled:
+    """It is autouse in conftest, so it runs for every test including this one."""
+
+    def test_conftest_carries_it(self):
+        import inspect
+        import tests.conftest as conftest
+
+        source = inspect.getsource(conftest)
+
+        assert "_no_stray_project_above_the_test" in source
+        assert "autouse=True" in source

--- a/tests/unit/test_the_suite_notices_a_stray_project.py
+++ b/tests/unit/test_the_suite_notices_a_stray_project.py
@@ -99,3 +99,26 @@ class TestTheGuardIsInstalled:
 
         assert "_no_stray_project_above_the_test" in source
         assert "autouse=True" in source
+
+
+class TestTheGuardSurvivesAVanishedDirectory:
+    """A test whose cwd was a tmp dir that has since gone has no cwd at all.
+
+    The first version of the guard called project_root() in teardown and blew
+    up with FileNotFoundError, turning a passing test into an error. It only
+    showed on CI, where tmp directories are cleaned more eagerly than on my
+    machine -- the same local-vs-CI asymmetry the guard exists to fix, this
+    time caused by the guard.
+    """
+
+    def test_no_cwd_is_not_contamination(self, tmp_path, monkeypatch):
+        gone = tmp_path / "vanishing"
+        gone.mkdir()
+        monkeypatch.chdir(gone)
+        os.rmdir(gone)
+
+        with pytest.raises((FileNotFoundError, OSError)):
+            Path.cwd()
+
+        # The guard's own teardown runs after this test and must not error.
+        monkeypatch.undo()


### PR DESCRIPTION
`_never_touch_the_real_home` isolates HOME, so `~/.co` is covered. This is the other half: `project_root()` walks up from the **working directory**, and a stray `.co/` anywhere above it wins.

## Measured

My own real-host verification runs earlier in this release left a `/private/tmp/.co/` behind. Afterwards a unit test with nothing to do with any of it failed:

```
tests/unit/test_logger.py::TestLoggerInit::test_default_init

assert logger.log_file_path == Path(".co/logs/test-agent.log").resolve()
E  assert PosixPath('/private/tmp/.co/logs/test-agent.log')
       == PosixPath('/…/wt-695/.co/logs/test-agent.log')
```

`rm -rf /private/tmp/.co` → passes.

Two properties make this worth a guard rather than a cleanup:

- It fails **standalone**, not only in some order, so `-p no:randomly` does not hide it.
- It is **invisible on CI**, where the machine is clean. A local run disagrees with CI for a reason nobody can reproduce.

The escape reproduces exactly:

```
cwd           /private/tmp/probe_no_co     (no .co of its own)
project_root  /private/tmp                 (the stray one wins)
```

## What the guard does

Nothing is repointed. Tests that chdir into their own project depend on the walk-up finding it, and pinning the answer would break them. The fixture only refuses to let the walk-up land somewhere shared — so contamination becomes a failure with a directory name in it, instead of silently changing what the code under test reads.

It checks after the test, which is where the information is: it names the test that ended up somewhere shared.

## Verified against the real thing

Planted a test that chdirs under a stray project; the run ends non-zero with the guard naming the directory. Removed again afterwards.

## Not a shipping defect

Nothing here affects a real agent — the walk-up is documented behaviour, and "the directory that owns `.co/` is the project" is what a user wants. This is a hole in what the suite can prove, which for a long-term release is worth closing.

Closes #694.
