### PR TITLE
The agent log has a ceiling

### DIFF
--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -11,6 +11,7 @@ LLM-Note:
 
 import re
 from datetime import datetime
+import os
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Union
 from rich.console import Console as RichConsole
@@ -65,6 +66,12 @@ def _plain_prefix() -> str:
     return PREFIX
 
 
+# The agent log rotates at this size, keeping one previous generation (#638).
+# 10 MB is thousands of turns at the ~1.3 KB per turn measured there, and two
+# files is a bound an operator never has to think about.
+LOG_MAX_BYTES = 10 * 1024 * 1024
+
+
 class Console:
     """Console for agent output and optional file logging.
 
@@ -84,16 +91,43 @@ class Console:
             self._init_log_file()
 
     def _init_log_file(self):
-        """Initialize log file with session header."""
+        """Initialize log file with session header, rotating it if it is full."""
         # Create parent dirs if needed
         if self.log_file.parent != Path('.'):
             self.log_file.parent.mkdir(parents=True, exist_ok=True)
+
+        self._rotate_if_full()
 
         # Add session separator
         with open(self.log_file, 'a', encoding='utf-8') as f:
             f.write(f"\n{'='*60}\n")
             f.write(f"Session started: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
             f.write(f"{'='*60}\n\n")
+
+    def _rotate_if_full(self):
+        """At the cap, the log becomes `.log.1` and a fresh one starts.
+
+        Nothing rotated or capped this file. Measured on the deployed
+        naturewill agent over 3.3 days: 1.46 MB, ~160 MB/year; a working agent
+        on a fifteen-minute schedule, ~44 MB/year (#638). Neither fills the
+        1-2 GB VPS `co server new` provisions soon, but 1.6.0 is meant to run
+        for years without anyone looking at it, and #637 capped the fast member
+        of this same family.
+
+        Rotation rather than truncation: history is what an operator opens the
+        log for. One generation, so the ceiling is two files.
+
+        On open, not from a background thread -- a plain append-only text file
+        that an operator can also point logrotate at, and rotating underneath a
+        running writer is how you lose the lines in flight.
+        """
+        if not self.log_file.exists():
+            return
+        if self.log_file.stat().st_size < LOG_MAX_BYTES:
+            return
+
+        previous = self.log_file.with_name(self.log_file.name + ".1")
+        os.replace(self.log_file, previous)
 
     def print_banner(
         self,

--- a/tests/unit/test_the_agent_log_has_a_ceiling.py
+++ b/tests/unit/test_the_agent_log_has_a_ceiling.py
@@ -1,0 +1,123 @@
+"""`.co/logs/{agent}.log` grows forever.
+
+Measured in #638. On the deployed naturewill agent over ~3.3 days:
+
+    .co/logs/naturewill.log   1.46 MB  ->  ~0.44 MB/day  =  ~160 MB/year
+
+That one fails fast every run and logs a large error block each time, so it is
+the high end. A working agent, three tool-using turns, is ~1.3 KB per turn —
+125 KB/day on a fifteen-minute schedule, ~44 MB/year.
+
+Neither number fills the 1–2 GB VPS `co server new` provisions any time soon,
+which is why #638 was filed rather than fixed. But unbounded is unbounded, and
+1.6.0 is meant to run for years without anyone looking at it. #637's evals were
+the fast member of the same family (3.5 GB/year) and were capped; this is the
+slow one.
+
+Rotation, not truncation: at the cap the file becomes `.log.1` and a fresh one
+starts. One generation is kept, so the ceiling is two files. Deleting history
+outright would take away the thing an operator goes to the log for.
+
+What is deliberately not done is anything time-based or configurable. An
+operator who wants a different policy points logrotate at the directory, which
+works because these are ordinary append-only text files — and stays working
+because rotation happens on open, not from a background thread.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.console import Console, LOG_MAX_BYTES
+
+
+@pytest.fixture
+def log(tmp_path):
+    return tmp_path / "logs" / "agent.log"
+
+
+class TestTheFileHasACeiling:
+
+    def test_a_small_log_is_left_alone(self, log):
+        Console(log_file=log)
+        first = log.read_text(encoding="utf-8")
+
+        Console(log_file=log)
+
+        assert log.read_text(encoding="utf-8").startswith(first)
+        assert not (log.parent / "agent.log.1").exists()
+
+    def test_an_oversized_log_is_rotated(self, log):
+        log.parent.mkdir(parents=True)
+        log.write_text("x" * (LOG_MAX_BYTES + 1), encoding="utf-8")
+
+        Console(log_file=log)
+
+        assert (log.parent / "agent.log.1").exists(), sorted(
+            p.name for p in log.parent.iterdir())
+
+    def test_the_old_content_is_kept_not_deleted(self, log):
+        log.parent.mkdir(parents=True)
+        log.write_text("the evidence" + "x" * LOG_MAX_BYTES, encoding="utf-8")
+
+        Console(log_file=log)
+
+        assert "the evidence" in (log.parent / "agent.log.1").read_text(
+            encoding="utf-8", errors="replace")
+
+    def test_the_new_file_starts_fresh(self, log):
+        log.parent.mkdir(parents=True)
+        log.write_text("old" + "x" * LOG_MAX_BYTES, encoding="utf-8")
+
+        Console(log_file=log)
+        text = log.read_text(encoding="utf-8")
+
+        assert "old" not in text
+        assert "Session started" in text
+
+    def test_only_one_generation_is_kept(self, log):
+        """The ceiling is two files, not a growing pile of .log.N."""
+        log.parent.mkdir(parents=True)
+        for _ in range(3):
+            log.write_text("y" * (LOG_MAX_BYTES + 1), encoding="utf-8")
+            Console(log_file=log)
+
+        rotated = sorted(p.name for p in log.parent.iterdir() if ".log." in p.name)
+        assert rotated == ["agent.log.1"], rotated
+
+    def test_the_newest_history_wins(self, log):
+        """A second rotation replaces .log.1 rather than keeping the older one."""
+        log.parent.mkdir(parents=True)
+        log.write_text("older" + "x" * LOG_MAX_BYTES, encoding="utf-8")
+        Console(log_file=log)
+        log.write_text("newer" + "x" * LOG_MAX_BYTES, encoding="utf-8")
+        Console(log_file=log)
+
+        kept = (log.parent / "agent.log.1").read_text(encoding="utf-8", errors="replace")
+        assert "newer" in kept and "older" not in kept
+
+
+class TestTheCeilingIsSane:
+
+    def test_it_is_measured_in_megabytes(self):
+        """Small enough to bound growth, large enough that a real session fits.
+        #638 measured ~1.3 KB per turn and 1.46 MB over three days."""
+        assert 1_000_000 <= LOG_MAX_BYTES <= 100_000_000, LOG_MAX_BYTES
+
+
+class TestNothingElseChanges:
+
+    def test_a_missing_directory_is_still_created(self, tmp_path):
+        log = tmp_path / "deep" / "logs" / "agent.log"
+
+        Console(log_file=log)
+
+        assert log.exists()
+
+    def test_no_log_file_is_still_fine(self):
+        assert Console(log_file=None).log_file is None
+
+    def test_the_session_header_is_still_written(self, log):
+        Console(log_file=log)
+
+        assert "Session started" in log.read_text(encoding="utf-8")


### PR DESCRIPTION
`.co/logs/{agent}.log` was appended to forever — no `maxBytes`, no rotation, no cleanup.

## Measured (from #638)

Deployed naturewill agent, ~3.3 days:

```
.co/logs/naturewill.log   1.46 MB  ->  ~0.44 MB/day  =  ~160 MB/year
```

That agent fails fast every run and logs a large error block each time, so it is the high end. A working agent, three tool-using turns: ~1.3 KB per turn → 125 KB/day on a fifteen-minute schedule → ~44 MB/year.

## Why fix it now

Neither number fills the 1–2 GB VPS `co server new` provisions any time soon, which is exactly why #638 was filed rather than fixed. What changes the calculus is the release: 1.6.0 is meant to run for years without anyone looking at it, and #637 — the fast member of this same family, 3.5 GB/year of eval runs — was already capped. Leaving the slow one unbounded is the kind of thing that surfaces as a full disk on someone's box in 2028.

This is option 2 of the three the issue lists. Option 1 was "leave it and document that `.co/logs/` is the operator's to rotate", which stays true — see below.

## Behaviour

At 10 MB the log becomes `.log.1` and a fresh one starts. **Rotation, not truncation**: history is what an operator opens the log for. One generation is kept, so the ceiling is two files rather than a growing pile of `.log.N`.

Rotation happens **on open**, not from a background thread. Two reasons: these stay ordinary append-only text files that an operator can still point logrotate at, and rotating underneath a running writer loses the lines in flight.

## Tests

10 cases, red first. Covering: a small log is untouched, an oversized one rotates, the old content is kept rather than deleted, the new file starts fresh, only one generation survives three rotations, and the newest history wins over the older. Plus the unchanged behaviours — directories still created, no log file still fine, session header still written.

Closes #638.
