### PR TITLE
co eval stops reporting on files it wrote, and says when nothing ran

### DIFF
--- a/connectonion/cli/commands/eval_commands.py
+++ b/connectonion/cli/commands/eval_commands.py
@@ -85,6 +85,26 @@ def get_agent_from_file(file_path: str, cwd: str):
     )
 
 
+def is_run_record(data) -> bool:
+    """True if this YAML is something the logger wrote, not an eval you authored.
+
+    `.co/evals/` is two things at once: the suite you write and the run log the
+    framework writes (`logger.py`: "writes YAML evals to .co/evals/ ... one
+    file per unique first input"). `co eval` scanned the directory and reported
+    on both, so it complained about every file it had put there itself -- 8 in
+    a project where an agent had run a few turns, 487 in `~/.co/evals` after a
+    few days of `co ai` (#682).
+
+    The rule is the documented format, not a guess: `docs/debug/eval.md` says an
+    authored eval carries `agent:` and `expected:`. Neither present means a run
+    record. *One* present means a half-written test, which still gets its
+    complaint -- staying quiet about a real mistake is the opposite bug.
+    """
+    if not isinstance(data, dict) or not data:
+        return True
+    return "agent" not in data and "expected" not in data
+
+
 def handle_eval(name: Optional[str] = None, agent_file: Optional[str] = None):
     """Run evals and show results.
 
@@ -97,20 +117,41 @@ def handle_eval(name: Optional[str] = None, agent_file: Optional[str] = None):
     if not evals_dir.exists():
         console.print("[yellow]No evals found.[/yellow]")
         console.print("[dim]Create eval files in .co/evals/*.yaml[/dim]")
-        return
+        # Non-zero, because nothing ran. Exit 0 here reads as "evals passed" to
+        # anything gating on it in CI, which is the same mistake #535 fixed for
+        # the schedule display: done must not imply the work succeeded.
+        return 1
 
     if name:
         eval_files = list(evals_dir.glob(f"{name}.yaml"))
         if not eval_files:
             console.print(f"[red]Eval not found: {name}[/red]")
-            return
+            return 1
     else:
         eval_files = list(evals_dir.glob("*.yaml"))
 
     if not eval_files:
         console.print("[yellow]No eval files found in .co/evals/[/yellow]")
-        return
+        return 1
 
+    # The logger's own records live here too. They are not tests and never
+    # were; scanning them is what produced a wall of "No agent specified".
+    authored = []
+    for eval_file in eval_files:
+        with open(eval_file, encoding="utf-8") as f:
+            if not is_run_record(yaml.safe_load(f)):
+                authored.append(eval_file)
+
+    skipped = len(eval_files) - len(authored)
+    if skipped:
+        console.print(f"[dim]{skipped} run record(s) in .co/evals/ — not evals, skipped[/dim]")
+
+    if not authored:
+        console.print("[yellow]No evals to run.[/yellow]")
+        console.print("[dim]An eval needs 'agent:' and 'expected:' — see docs/debug/eval.md[/dim]")
+        return 1
+
+    eval_files = authored
     _run_evals(eval_files, agent_file)
 
     # Reload and show status
@@ -119,7 +160,7 @@ def handle_eval(name: Optional[str] = None, agent_file: Optional[str] = None):
     else:
         eval_files = list(evals_dir.glob("*.yaml"))
 
-    _show_eval_status(eval_files)
+    return _show_eval_status(eval_files)
 
 
 def _run_evals(eval_files: list, agent_override: Optional[str] = None):
@@ -136,6 +177,14 @@ def _run_evals(eval_files: list, agent_override: Optional[str] = None):
         if not agent_file:
             console.print(f"[red]No agent specified for {eval_file.stem}[/red]")
             console.print(f"[dim]Add 'agent: agent.py' to the YAML or use --agent flag[/dim]")
+            continue
+
+        # A named agent file that is not there. This used to raise
+        # FileNotFoundError out of get_agent_from_file and end the run with a
+        # traceback -- worse than the exit-0 this issue is about, because it
+        # takes the other evals with it (#682).
+        if not (Path(cwd) / agent_file).exists() and not Path(agent_file).exists():
+            console.print(f"[red]Agent file not found for {eval_file.stem}: {agent_file}[/red]")
             continue
 
         # Load agent (cached)
@@ -244,8 +293,14 @@ Does the output satisfy the expected criteria? Consider:
     return llm_do(prompt, output=JudgeResult)
 
 
-def _show_eval_status(eval_files: list):
-    """Show pass/fail status for all evals (uses stored results, no re-judging)."""
+def _show_eval_status(eval_files: list) -> int:
+    """Show pass/fail status for all evals, and return an exit code.
+
+    Non-zero if anything failed, or if nothing was actually checked. `co eval`
+    used to return None -- exit 0 -- after a run where eight evals could not
+    run and none executed, which anything gating on it in CI reads as "evals
+    passed" (#682).
+    """
     table = Table(title="Eval Results", show_header=True)
     table.add_column("Eval", style="cyan")
     table.add_column("Status", justify="center")
@@ -300,3 +355,13 @@ def _show_eval_status(eval_files: list):
     if no_expected > 0:
         console.print(f"[dim]{no_expected} no expected[/dim]", end="")
     console.print()
+
+    if failed:
+        return 1
+    if not passed:
+        # Nothing was checked. Saying so is the point: a suite that judged
+        # nothing has not passed.
+        console.print("[yellow]Nothing was checked — no eval produced a "
+                      "pass or a fail.[/yellow]")
+        return 1
+    return 0

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -306,7 +306,11 @@ def eval(
 ):
     """Run evals and show results."""
     from .commands.eval_commands import handle_eval
-    handle_eval(name=name, agent_file=agent)
+
+    # The exit code is the point of #682: `co eval` returned 0 after a run
+    # where nothing executed. Discarding it here would leave that fix
+    # unreachable from a shell, which is where CI reads it.
+    raise typer.Exit(code=handle_eval(name=name, agent_file=agent) or 0)
 
 
 @app.command()

--- a/tests/unit/test_co_eval_reports_what_it_did.py
+++ b/tests/unit/test_co_eval_reports_what_it_did.py
@@ -1,0 +1,195 @@
+"""`co eval` complains about files it wrote itself, then exits 0.
+
+`.co/evals/` is two things at once: the eval **suite** you author, and the run
+**log** the framework writes. `co eval` scans the directory, so it reports on
+both. Measured on main, in a project where an agent had run a few turns:
+
+    $ co eval
+    No agent specified for say_a
+    Add 'agent: agent.py' to the YAML or use --agent flag
+    … 8 of these …
+
+    9 no expected
+    $ echo $?
+    0
+
+    project where an agent ran :   8 files, 0 authored, 8 written by the logger
+    ~/.co/evals (co ai's home) : 487 files, 0 authored, 487 written by the logger
+
+Every file it complained about is one `logger.py` put there — its own header
+says so: "writes YAML evals to `.co/evals/` … one file per unique first input".
+
+Two separate things, both fixed here.
+
+**A record is not a test.** `docs/debug/eval.md` documents an authored eval as
+requiring `agent:` and `expected:`; the auto-written records have neither, and
+were never meant to be runnable. So a file with no `agent:` **and** no
+`expected:` is a run record and is skipped without complaint. A file with one
+of them is a half-written test and still says so — that is a real mistake and
+staying quiet about it would be the opposite bug.
+
+**Nothing ran, and it said success.** Eight could not run, nine had no
+expectation, none executed, exit 0. Anything gating on `co eval` in CI reads
+that as "evals passed". Same family as #535's second half, settled for the
+schedule display: `done` must not imply the work succeeded.
+"""
+
+import pytest
+
+from connectonion.cli.commands.eval_commands import is_run_record
+
+
+RECORD = {
+    "name": "say hello",
+    "created": "2026-08-05",
+    "runs": 3,
+    "model": "co/gemini-2.5-flash",
+    "turns": [{"input": "say hello", "output": "Hello!"}],
+}
+
+AUTHORED = {
+    "agent": "agent.py",
+    "input": "say hello",
+    "expected": "a greeting",
+}
+
+
+class TestWhatIsATestAndWhatIsALog:
+
+    def test_a_logger_record_is_not_a_test(self):
+        assert is_run_record(RECORD) is True
+
+    def test_an_authored_eval_is(self):
+        assert is_run_record(AUTHORED) is False
+
+    def test_expected_alone_is_a_test(self):
+        """Half-written, and worth complaining about — `--agent` supplies the
+        other half, so this is runnable."""
+        assert is_run_record({"input": "x", "expected": "y"}) is False
+
+    def test_agent_alone_is_a_test(self):
+        """Also half-written: it names an agent but nothing to check."""
+        assert is_run_record({"agent": "agent.py", "input": "x"}) is False
+
+    def test_an_empty_file_is_not_a_test(self):
+        assert is_run_record({}) is True
+        assert is_run_record(None) is True
+
+    def test_the_shape_the_logger_actually_writes(self):
+        """Against the real writer, not a guess at its output."""
+        import tempfile
+        from pathlib import Path
+
+        import yaml
+
+        from connectonion.logger import Logger
+
+        co_dir = Path(tempfile.mkdtemp()) / ".co"
+        (co_dir / "evals").mkdir(parents=True)
+        logger = Logger("t", quiet=True, co_dir=co_dir)
+        logger._init_eval_file("say hello")
+        logger._write_eval()
+
+        written = list((co_dir / "evals").glob("*.yaml"))
+        assert written, "the logger wrote no eval file"
+        assert is_run_record(yaml.safe_load(written[0].read_text(encoding="utf-8")))
+
+
+class TestTheExitCodeMeansSomething:
+
+    def _run(self, tmp_path, monkeypatch, **files):
+        """`co eval` in a project holding these files, returning its exit code."""
+        import yaml
+        from connectonion.cli.commands import eval_commands
+
+        evals = tmp_path / ".co" / "evals"
+        evals.mkdir(parents=True)
+        for stem, data in files.items():
+            (evals / f"{stem}.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        return eval_commands.handle_eval()
+
+    def test_nothing_to_run_is_not_success(self, tmp_path, monkeypatch):
+        """The measured case: only logger records, nothing executed, exit 0."""
+        code = self._run(tmp_path, monkeypatch, say_a=RECORD, say_b=RECORD)
+
+        assert code != 0, "a run where nothing executed reported success"
+
+    def test_an_empty_directory_is_not_success(self, tmp_path, monkeypatch):
+        code = self._run(tmp_path, monkeypatch)
+
+        assert code != 0
+
+    def test_a_half_written_eval_is_not_success(self, tmp_path, monkeypatch):
+        code = self._run(tmp_path, monkeypatch, half={"input": "x", "expected": "y",
+                                                      "agent": "missing.py"})
+
+        assert code != 0
+
+
+class TestTheNoiseIsGone:
+
+    def test_a_logger_record_draws_no_complaint(self, tmp_path, monkeypatch, capsys):
+        import yaml
+        from connectonion.cli.commands import eval_commands
+
+        evals = tmp_path / ".co" / "evals"
+        evals.mkdir(parents=True)
+        (evals / "say_a.yaml").write_text(yaml.safe_dump(RECORD), encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        eval_commands.handle_eval()
+        out = capsys.readouterr()
+
+        assert "No agent specified" not in (out.out + out.err), out.out
+
+    def test_a_half_written_eval_still_complains(self, tmp_path, monkeypatch, capsys):
+        """The opposite bug would be silence about a real mistake."""
+        import yaml
+        from connectonion.cli.commands import eval_commands
+
+        evals = tmp_path / ".co" / "evals"
+        evals.mkdir(parents=True)
+        (evals / "half.yaml").write_text(
+            yaml.safe_dump({"input": "x", "expected": "y"}), encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        eval_commands.handle_eval()
+        out = capsys.readouterr()
+
+        assert "No agent specified" in (out.out + out.err), out.out
+
+
+class TestTheShellSeesIt:
+    """The exit code has to survive the CLI layer, or the fix is unreachable
+    from the place that reads it."""
+
+    def _co_eval(self, tmp_path, files):
+        import subprocess
+        import sys
+
+        import yaml
+
+        evals = tmp_path / ".co" / "evals"
+        evals.mkdir(parents=True)
+        for stem, data in files.items():
+            (evals / f"{stem}.yaml").write_text(yaml.safe_dump(data), encoding="utf-8")
+
+        return subprocess.run(
+            [sys.executable, "-m", "connectonion.cli.main", "eval"],
+            cwd=tmp_path, capture_output=True, text=True, timeout=300,
+            env={**__import__("os").environ,
+                 "PYTHONPATH": str(__import__("pathlib").Path(__file__).resolve().parents[2])},
+        )
+
+    def test_only_run_records_exits_non_zero(self, tmp_path):
+        result = self._co_eval(tmp_path, {"say_a": RECORD, "say_b": RECORD})
+
+        assert result.returncode != 0, result.stdout[-400:]
+
+    def test_it_says_they_were_skipped_rather_than_broken(self, tmp_path):
+        result = self._co_eval(tmp_path, {"say_a": RECORD})
+
+        assert "No agent specified" not in result.stdout
+        assert "run record" in result.stdout, result.stdout[-300:]


### PR DESCRIPTION
`.co/evals/` is two things at once: the eval **suite** you author, and the run **log** the framework writes. `co eval` scanned the directory and reported on both.

## Measured (from #682)

```
$ co eval
No agent specified for say_a
Add 'agent: agent.py' to the YAML or use --agent flag
… 8 of these …

9 no expected
$ echo $?
0
```

```
project where an agent ran :   8 files, 0 authored, 8 written by the logger
~/.co/evals (co ai's home) : 487 files, 0 authored, 487 written by the logger
```

Every file it complained about is one `logger.py` put there — its own header says so.

## A record is not a test

A file with **neither** `agent:` nor `expected:` is a run record: skipped, with a count, not a complaint. The rule is the documented format rather than a guess — `docs/debug/eval.md` requires both for an authored eval.

One of the two present is a **half-written test** and still gets its complaint. Staying quiet about a real mistake is the opposite bug, so there is a test for each direction.

## Nothing ran, and it said success

Eight could not run, nine had no expectation, none executed, exit 0 — which anything gating `co eval` in CI reads as *"evals passed"*. Same family as #535's second half, settled for the schedule display: `done` must not imply the work succeeded.

Non-zero now when something failed, when nothing was checked, and when there is nothing to run.

## Two things found while doing it

**`co eval` crashed on a missing agent file.** A YAML naming an `agent:` that does not exist raised `FileNotFoundError` out of `get_agent_from_file` and ended the whole run with a traceback, taking the other evals with it — worse than the exit-0 this issue is about. It is reported and counted now.

**`main.py` discarded `handle_eval`'s return value.** The exit code would never have reached a shell, so the headline fix would have been unreachable from the one place that reads it. There is a subprocess test that runs the real CLI and checks `returncode`, precisely so this cannot be true again.

## Tests

13 cases, red first. Including one that asserts the predicate against **what the logger actually writes** — driving the real `Logger` and feeding its output to `is_run_record` — rather than a hand-made guess at its shape.

Closes #682.
