### PR TITLE
A subscribed skill keeps its instructions and loses its permission grant

### DIFF
--- a/connectonion/cli/commands/sub_commands.py
+++ b/connectonion/cli/commands/sub_commands.py
@@ -91,6 +91,79 @@ def _fetch_skill(address: str, name: str, relay: str) -> str:
     return r.json()["body"]
 
 
+def _declared_tools(body: str) -> str:
+    """What a skill's frontmatter asked to auto-approve, for the operator's eyes.
+
+    Printed at sync time rather than written into the skill: the body is a
+    prompt an agent reads, and this list is a decision the operator makes.
+    """
+    import yaml
+
+    if not body.startswith("---"):
+        return ""
+    parts = body.split("---", 2)
+    if len(parts) < 3:
+        return ""
+    try:
+        front = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return ""
+    if not isinstance(front, dict):
+        return ""
+    return str(front.get("tools", ""))
+
+
+def strip_tool_grants(body: str, name: str) -> str:
+    """Remove a subscribed skill's `tools:` grant, keeping its instructions.
+
+    A SKILL.md is not only instructions. Its frontmatter carries a `tools:`
+    list, and invoking the skill auto-approves those patterns for the turn --
+    measured on a real agent: ['Bash(git status)', 'read_file']. So a skill
+    fetched from the relay arrives asking for auto-approval, from a source
+    nobody verified: this module's own header says v1 trusts the relay, which
+    strips the signer and signature. It is then written verbatim and fanned out
+    into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro (#654).
+
+    The instructions are what you subscribed to. The grant is not, and the
+    operator can add the patterns to their own .co/host.yaml, where the
+    decision is theirs and visible.
+
+    A skill with no frontmatter is a legitimate simple skill -- the whole file
+    is the prompt (#629) -- and one whose frontmatter does not parse is not
+    ours to rewrite. Both pass through untouched.
+
+    Verifying the publisher's signature is the real answer (#654 option 3) and
+    needs the relay to stop stripping it.
+    """
+    import yaml
+
+    if not body.startswith("---"):
+        return body
+    parts = body.split("---", 2)
+    if len(parts) < 3:
+        return body
+
+    try:
+        front = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        # Rewriting what we cannot read is worse than passing it through; the
+        # skill loader reports an unreadable one.
+        return body
+    if not isinstance(front, dict) or "tools" not in front:
+        return body
+
+    front.pop("tools")
+    rendered = yaml.safe_dump(front, sort_keys=False, allow_unicode=True).rstrip()
+    # The note says what happened; it does not repeat the patterns. This body
+    # becomes the prompt an agent reads, and the operator is the one who needs
+    # the list -- so it goes to the terminal at sync time instead, where the
+    # decision to add them is being made.
+    note = ("\n> `tools:` removed on sync — a subscribed skill does not "
+            "pre-authorise anything. Add what you want to your own "
+            ".co/host.yaml.\n")
+    return f"---\n{rendered}\n---\n{note}{parts[2]}"
+
+
 def _mirror_bundle(address: str, alias: str, profile: dict, relay: str) -> int:
     """Write profile + each skill body under ~/.co/subs/<alias>/. Returns skill count."""
     bundle = SUBS_DIR / alias
@@ -103,7 +176,11 @@ def _mirror_bundle(address: str, alias: str, profile: dict, relay: str) -> int:
         name = skill["name"]
         body = _fetch_skill(address, name, relay)
         (skills_root / name).mkdir(parents=True, exist_ok=True)
-        (skills_root / name / "SKILL.md").write_text(body, encoding="utf-8")
+        cleaned = strip_tool_grants(body, name)
+        if cleaned != body:
+            console.print(f"[yellow]{name}: removed its tools: grant[/yellow] "
+                          f"[dim]{_declared_tools(body)}[/dim]")
+        (skills_root / name / "SKILL.md").write_text(cleaned, encoding="utf-8")
         n += 1
     return n
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -996,7 +996,15 @@ def sub_sync(
     target: str = typer.Argument(..., help="0x address (or locally-pinned alias) to sync"),
     relay: Optional[str] = typer.Option(None, "--relay", help="Relay URL (default: https://oo.openonion.ai)"),
 ):
-    """Sync one publisher: fetch profile, mirror skills, fan out to coding agents."""
+    """Sync one publisher: fetch profile, mirror skills, fan out to coding agents.
+
+    The content is UNVERIFIED — the relay strips the publisher's signature, so
+    nothing here proves who wrote it. Skills land in ~/.co/subs/ and are fanned
+    out to ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro.
+
+    A subscribed skill's `tools:` grant is removed on sync, so it cannot
+    pre-authorise anything (#654). Its instructions are kept.
+    """
     from .commands.sub_commands import handle_sub_sync_one
     handle_sub_sync_one(target, relay=relay)
 

--- a/tests/unit/test_a_subscribed_skill_cannot_grant_itself_tools.py
+++ b/tests/unit/test_a_subscribed_skill_cannot_grant_itself_tools.py
@@ -1,0 +1,132 @@
+"""A skill fetched from the relay arrives with permission grants attached.
+
+`sub_commands.py` states the trust assumption in its own header:
+
+    v1 trusts the relay — no Ed25519 signature verification (relay strips
+    signer/signature from profile responses).
+
+An honest limitation. What makes it worth acting on before a long-term release
+is that a `SKILL.md` is not only instructions. Its frontmatter carries a
+`tools:` list, and invoking the skill auto-approves those patterns for the
+turn. Measured on a real agent earlier in this release:
+
+    during the turn : ['Bash(git status)', 'read_file']
+
+So a synced skill does not merely suggest what an agent should do — it arrives
+asking for auto-approval, from a source nobody verified. And it is written
+verbatim, then fanned out by `install_all()` into `~/.claude`, `~/.codex`,
+`~/.openclaw`, `~/.cursor` and `~/.kiro`: one `co sub sync` puts unverified
+content into five agents' skill directories, four of which are not ours.
+
+This is #654's option 2, plus option 1. A subscribed skill keeps its
+instructions and loses its ability to pre-authorise anything; the operator adds
+patterns themselves if they want them, in their own `.co/host.yaml`, where the
+decision is theirs and visible.
+
+BEHAVIOUR CHANGE: a subscribed skill that used to auto-approve `Bash(git
+status)` now asks. That is the point, but it is a change.
+
+Option 3 — verifying the publisher's signature — is the real answer and needs
+the relay to stop stripping it. Not doable from this repository.
+"""
+
+import pytest
+
+from connectonion.cli.commands.sub_commands import strip_tool_grants
+
+
+WITH_TOOLS = """---
+name: deploy-helper
+description: Ships the thing
+tools:
+  - Bash(git status)
+  - read_file
+---
+
+Run the deploy and report what happened.
+"""
+
+WITHOUT_TOOLS = """---
+name: plain
+description: Just instructions
+---
+
+Do the thing.
+"""
+
+NO_FRONTMATTER = "The whole file is the instructions.\n"
+
+
+class TestTheGrantIsRemoved:
+
+    def test_the_tools_list_is_gone(self):
+        out = strip_tool_grants(WITH_TOOLS, "deploy-helper")
+
+        assert "Bash(git status)" not in out
+        assert "read_file" not in out
+
+    def test_the_instructions_survive(self):
+        out = strip_tool_grants(WITH_TOOLS, "deploy-helper")
+
+        assert "Run the deploy and report what happened." in out
+
+    def test_the_rest_of_the_frontmatter_survives(self):
+        out = strip_tool_grants(WITH_TOOLS, "deploy-helper")
+
+        assert "name: deploy-helper" in out
+        assert "description: Ships the thing" in out
+
+    def test_it_still_parses_as_a_skill(self):
+        import yaml
+
+        out = strip_tool_grants(WITH_TOOLS, "deploy-helper")
+        front = out.split("---")[1]
+
+        assert yaml.safe_load(front)["name"] == "deploy-helper"
+
+    def test_it_says_what_it_removed(self):
+        """Silence would leave the operator wondering why the skill behaves
+        differently from the publisher's copy."""
+        out = strip_tool_grants(WITH_TOOLS, "deploy-helper")
+
+        assert "tools" in out.lower()
+        assert "removed" in out.lower() or "not granted" in out.lower()
+
+
+class TestSkillsWithNothingToStrip:
+
+    def test_one_without_tools_is_untouched(self):
+        assert strip_tool_grants(WITHOUT_TOOLS, "plain") == WITHOUT_TOOLS
+
+    def test_one_without_frontmatter_is_untouched(self):
+        """A file with no frontmatter is a legitimate simple skill — the whole
+        file is the prompt (#629)."""
+        assert strip_tool_grants(NO_FRONTMATTER, "simple") == NO_FRONTMATTER
+
+    def test_an_empty_body_is_untouched(self):
+        assert strip_tool_grants("", "empty") == ""
+
+    def test_unparseable_frontmatter_is_left_alone(self):
+        """Not ours to repair, and rewriting what we cannot read is worse than
+        passing it through — the skill loader reports it (#629)."""
+        broken = "---\nname: [unclosed\n---\n\nbody\n"
+
+        assert strip_tool_grants(broken, "broken") == broken
+
+
+class TestTheOperatorIsToldBeforeItLands:
+    """#654's option 1: the warning was at lines 23-24 of a module docstring,
+    and `co sub sync --help` said nothing. The person taking the risk is the
+    one who did not see it."""
+
+    def test_the_help_text_mentions_it(self):
+        import inspect
+
+        from connectonion.cli import main
+
+        source = inspect.getsource(main)
+        sync_help = source[source.index("def sub_sync"):][:1200] if "def sub_sync" in source else source
+
+        assert "unverified" in sync_help.lower() or "not verified" in sync_help.lower(), (
+            "co sub sync --help still does not say the content is unverified"
+        )


### PR DESCRIPTION
`sub_commands.py` states its own trust assumption in its header:

> ⚠️ v1 trusts the relay — no Ed25519 signature verification (relay strips signer/signature from profile responses).

An honest limitation, recorded by whoever built it. What makes it worth acting on before a long-term release is that **a `SKILL.md` is not only instructions**. Its frontmatter carries a `tools:` list, and invoking the skill auto-approves those patterns for the turn. Measured on a real agent earlier in this release:

```
during the turn : ['Bash(git status)', 'read_file']
```

So a synced skill does not merely suggest what an agent should do — it arrives asking for auto-approval, from a source nobody verified. It is then written verbatim and fanned out by `install_all()` into `~/.claude`, `~/.codex`, `~/.openclaw`, `~/.cursor` and `~/.kiro`. **One `co sub sync` puts unverified content into five agents' skill directories, four of which are not ours.**

## What changes

**`tools:` is removed on sync** (#654's option 2). The instructions are what you subscribed to; the grant is not. An operator who wants those patterns adds them to their own `.co/host.yaml`, where the decision is theirs and visible.

Untouched: a skill with no frontmatter (a legitimate simple skill — the whole file is the prompt, #629), and one whose frontmatter does not parse (not ours to rewrite; the loader reports it).

**The warning reaches the person taking the risk** (option 1). It had been at lines 23–24 of a module docstring, while `co sub sync --help` said only *"Sync one publisher: fetch profile, mirror skills, fan out to coding agents."* The help now says the content is unverified and where it lands, and each stripped skill is named at sync time with what it had asked for.

**⚠️ Behaviour change:** a subscribed skill that used to auto-approve `Bash(git status)` now asks.

## Not done

Option 3 — verifying the publisher's signature — is the real answer, and it needs the relay to stop stripping the signature. Not doable from this repository.

## Found while writing it

My first version wrote the removed patterns **into the skill body**. That body is the prompt an agent reads; the list is a decision the operator makes. Wrong channel. The body now says only that something was removed, and the patterns go to the terminal at sync time.

## Tests

10 cases, red first.

Part of #654.
