### PR TITLE
WIP: derive a project's identity instead of inheriting the machine's

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -220,13 +220,9 @@ def _add_deployer_as_admin(tar: tarfile.TarFile, project_dir: Path) -> None:
     throwaway project whose address is deleted with it, so seeding that would name an
     admin nobody can ever be.
     """
-    from ... import address
-    from .keys_commands import _find_co_dir
+    from ...project import project_identity
 
-    co_dir = _find_co_dir()
-    if not co_dir:
-        return
-    data = address.load(co_dir)
+    data = project_identity()
     if not data or not data.get("address"):
         return
 

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -1036,12 +1036,8 @@ def _deployer_address() -> Optional[str]:
     when there is no local identity; the deploy proceeds, and the agent simply has
     no reachable admin, which is the state before this existed.
     """
-    from ... import address
-    from .keys_commands import _find_co_dir
+    from ...project import project_identity
 
-    co_dir = _find_co_dir()
-    if not co_dir:
-        return None
-    data = address.load(co_dir)
+    data = project_identity()
     return data.get("address") if data else None
 

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -183,14 +183,22 @@ def handle_doctor():
     else:
         config_table.add_row("Config", "[yellow]○[/yellow] Not found (optional)")
 
-    # Check for keys
+    # Where this agent's identity comes from — asked of the one resolver, not
+    # worked out again here. Doctor had its own copy of the rule and named
+    # ~/.co/keys/agent.key for a project that derives (#689), which is a file
+    # that agent does not use. Naming the wrong identity is #659, and doctor is
+    # the command an operator runs *to find out what is wrong*.
+    from ...project import project_identity
+
     local_keys = project_co_dir() / "keys" / "agent.key"
-    global_keys = Path.home() / ".co" / "keys" / "agent.key"
+    identity = project_identity()
 
     if local_keys.exists():
         config_table.add_row("Keys", f"[green]✓[/green] {_shown(local_keys)}")
-    elif global_keys.exists():
-        config_table.add_row("Keys", f"[green]✓[/green] {global_keys}")
+    elif identity and identity.get("derived"):
+        config_table.add_row("Keys", "[green]✓[/green] derived from your recovery phrase")
+    elif identity:
+        config_table.add_row("Keys", f"[green]✓[/green] {Path(identity['source']) / 'keys' / 'agent.key'}")
     else:
         config_table.add_row("Keys", "[yellow]○[/yellow] Not found (run 'co auth' to create)")
 
@@ -288,13 +296,16 @@ def handle_doctor():
         else:
             connectivity_table.add_row("Backend", f"[yellow]⚠[/yellow] Status {response.status_code}")
 
-        # Check authentication (if keys exist)
-        if local_keys.exists() or global_keys.exists():
+        # Check authentication, as whoever this project actually is. This
+        # worked the resolution out a second time, in the same file -- and
+        # signing the backend probe with a different identity than the agent
+        # serves under would make doctor report on an account that is not the
+        # one in question.
+        if identity:
             from ... import address
             import time
 
-            co_dir = project_co_dir() if local_keys.exists() else Path.home() / ".co"
-            addr_data = address.load(co_dir)
+            addr_data = identity
 
             public_key = addr_data["address"]
             timestamp = int(time.time())

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -126,7 +126,12 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
         console.print("[cyan]Run 'co init' or 'co create' first.[/cyan]\n")
         return
 
-    addr_data = address.load(co_dir)
+    # The same resolver the host and the client use. `co keys` printing one
+    # address while `co host` serves another is #659, and this is the shape it
+    # would come back in: a project with no key of its own now derives one.
+    from ...project import project_identity
+
+    addr_data = project_identity(co_dir)
     if not addr_data:
         console.print("\n[red]Failed to load keys.[/red]\n")
         return

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -92,8 +92,14 @@ def _short_path(p: Path) -> str:
     return resolved
 
 
-def _source_label(co_dir: Path) -> str:
+def _source_label(co_dir: Path, identity: dict = None) -> str:
     """Return human-readable source label for where keys are loaded from.
+
+    A derived identity has no directory at all — it comes from the recovery
+    phrase and the project name (#689) — so it says so rather than naming
+    whichever directory the search happened to end in. Printing "~/.co
+    (global)" beside an address that is not the global one is the panel lying
+    quietly, which is what this label was already fixed for once.
 
     Relative to where you are standing, so it stays short and says which way the
     project lies: `.co` at the root, `../.co` from a subdirectory. It used to
@@ -101,6 +107,8 @@ def _source_label(co_dir: Path) -> str:
     the relative `Path(".co")`; once it became the resolved project path the
     panel printed the machine's whole directory tree.
     """
+    if identity and identity.get("derived"):
+        return "derived from your recovery phrase"
     if co_dir.resolve() == (Path.home() / ".co").resolve():
         return "~/.co (global)"
     try:
@@ -120,18 +128,22 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     """
     from ... import address
 
+    # The identity, asked for directly. _find_co_dir answers a different
+    # question -- "a directory that holds keys" -- and collapses project and
+    # global before anything can tell them apart, so `co keys` printed the
+    # machine's address for a project that now derives its own. A host serving
+    # one address while this panel prints another is #659.
+    from ...project import project_identity
+
     co_dir = _find_co_dir()
-    if not co_dir:
+    addr_data = project_identity()
+    if not co_dir and not addr_data:
         console.print("\n[red]No agent keys found.[/red]")
         console.print("[cyan]Run 'co init' or 'co create' first.[/cyan]\n")
         return
-
-    # The same resolver the host and the client use. `co keys` printing one
-    # address while `co host` serves another is #659, and this is the shape it
-    # would come back in: a project with no key of its own now derives one.
-    from ...project import project_identity
-
-    addr_data = project_identity(co_dir)
+    if not addr_data:
+        console.print("\n[red]Failed to load keys.[/red]\n")
+        return
     if not addr_data:
         console.print("\n[red]Failed to load keys.[/red]\n")
         return
@@ -150,7 +162,7 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     id_table.add_row("Address", addr_data["address"])
     id_table.add_row("Short ID", addr_data["short_address"])
     id_table.add_row("Email", addr_data.get("email", "N/A"))
-    id_table.add_row("Source", _source_label(co_dir))
+    id_table.add_row("Source", _source_label(co_dir, addr_data))
     id_table.add_row("Key File", _short_path(co_dir / "keys" / "agent.key"))
 
     console.print()

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -60,7 +60,11 @@ def _this_callers_identity():
     from .. import address
     from ..project import project_co_dir
 
-    return address.load(project_co_dir()) or address.load(Path.home() / ".co")
+    # One answer to "who is this project", shared with the host and `co keys`
+    # -- a client that signs as a different identity than its own agent
+    # serves under is #659 from the other side.
+    from ..project import project_identity
+    return project_identity()
 
 
 def _sort_endpoints(endpoints: List[str]) -> List[str]:

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -354,13 +354,24 @@ def claim_identity(co_dir: Path, identity: dict, name: str) -> Optional[str]:
     where refusing belongs — that is the moment a second permanent copy is
     made.
     """
-    source = Path(identity.get("source") or co_dir)
+    # Keyed on the address, not on the directory the key came from. The
+    # directory only catches projects sharing one `.co`; a copied `.co/keys/`,
+    # or two projects pointed at one directory by AGENT_CONFIG_PATH, is the
+    # same collision on the network and was invisible to it. Since #689 gave
+    # keyless projects their own derived identity, the directory-shaped case
+    # is also the rarer one.
+    #
+    # In ~/.co because the question is "who on this machine serves this
+    # address", which is not any one project's to answer -- and it means the
+    # record never travels in a deploy.
+    source = Path.home() / ".co" / "served_by"
+    source.mkdir(parents=True, exist_ok=True)
     if not source.is_dir():
         # A freshly generated identity is saved into a directory that may not
         # exist yet, and a hint about who is serving is not worth failing a
         # start over. No directory, no claim, no warning.
         return None
-    record = source / SERVED_BY_FILE
+    record = source / f"{identity['address']}.json"
     mine = {"name": name, "project": str(co_dir.parent), "address": identity["address"]}
 
     existing = None

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -319,13 +319,11 @@ def resolve_agent_identity(co_dir: Path) -> dict:
     Generating stays for a machine with no identity at all — an agent has to have
     an address. What goes is inventing one while a configured identity sits unused.
     """
-    own = address.load(co_dir)
-    if own:
-        return own
+    from ...project import project_identity
 
-    inherited = address.load(Path.home() / ".co")
-    if inherited:
-        return inherited
+    resolved = project_identity(co_dir)
+    if resolved:
+        return resolved
 
     fresh = address.generate()
     address.save(fresh, co_dir)

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -434,9 +434,14 @@ def get_self_address(co_dir: Path = None) -> str | None:
     if co_dir is None:
         co_dir = _project_co_dir()
 
-    from ... import address
+    # The identity this project acts as -- the same one the host serves under
+    # and `co keys` prints. Loading the directory alone came back empty for a
+    # project with no key of its own, which is what `co init` produces, so the
+    # payment door either advertised no address to pay or a stale one from
+    # address.json (#689).
+    from ...project import project_identity
 
-    keys = address.load(co_dir)
+    keys = project_identity(co_dir)
     if keys and keys.get("address"):
         return keys["address"]
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -326,11 +326,15 @@ justify admitting them, it is not enough."""
             # direction this check must never fail in.
             return False
 
-        # Load agent's keys for signing the request
+        # The identity this project acts as, for signing the request. Loading
+        # the project directory alone returned None for a project with no key
+        # of its own -- so this gave up before calling oo-api at all, and a
+        # stranger who really had transferred the money was refused. That is
+        # the configuration `co init` produces, so it was the common case.
         from ... import address as addr
+        from ...project import project_identity
 
-        co_dir = project_co_dir()
-        keys = addr.load(co_dir)
+        keys = project_identity()
         if not keys:
             return False
 

--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -41,6 +41,25 @@ def project_co_dir(start: Optional[Union[str, Path]] = None) -> Path:
     return project_root(start) / CO_DIR
 
 
+def _configured_agent_name(co_dir):
+    """host.yaml's `name`, or None. The same value `co deploy` reads."""
+    host_yaml = Path(co_dir) / "host.yaml"
+    if not host_yaml.exists():
+        return None
+    import yaml
+
+    try:
+        config = yaml.safe_load(host_yaml.read_text(encoding="utf-8", errors="replace"))
+    except yaml.YAMLError:
+        # A malformed host.yaml is reported where it is loaded for real; here it
+        # only means the name is unknown, and the directory answers instead.
+        return None
+    if not isinstance(config, dict):
+        return None
+    name = config.get("name")
+    return str(name).strip() or None if name else None
+
+
 def derived_identity(co_dir=None):
     """This project's own address, derived from the recovery phrase, or None.
 
@@ -70,7 +89,12 @@ def derived_identity(co_dir=None):
     if not phrase:
         return None
 
-    name = Path(co_dir or project_co_dir()).resolve().parent.name
+    # The name `co deploy` derives from, so an agent has one address whether it
+    # runs here or on a server. Deploy has derived from host.yaml's `name` since
+    # #396; taking the directory instead would give a renamed project two
+    # identities and nothing would say which was which.
+    co_dir = Path(co_dir or project_co_dir())
+    name = _configured_agent_name(co_dir) or co_dir.resolve().parent.name
     if not name:
         return None
 

--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -39,3 +39,67 @@ def project_root(start: Optional[Union[str, Path]] = None) -> Path:
 def project_co_dir(start: Optional[Union[str, Path]] = None) -> Path:
     """The project's ``.co/``. Does not create it."""
     return project_root(start) / CO_DIR
+
+
+def derived_identity(co_dir=None):
+    """This project's own address, derived from the recovery phrase, or None.
+
+    Lives here because "which identity is this project's" is the same question
+    as "which directory is this project", and answering it in more than one
+    place is what this release has spent itself fixing. Four call sites resolved
+    it independently before: the host, the client in connect.py, `co keys`, and
+    project_cmd_lib. A host that served a derived address while `co keys`
+    printed the inherited one would be #659 again.
+
+    Derived rather than generated (Aaron's call): the twelve words already cover
+    it, the same phrase and project name always give the same address, and
+    `co keys` can print it before the project has ever run. Not a new scheme --
+    `identity_uri` and `slip13_path` already define it and `co server` already
+    derives SSH keys the same way.
+    """
+    from mnemonic import Mnemonic
+    from nacl.signing import SigningKey
+
+    from . import address
+    from .derive import derive_path, identity_uri, slip13_path
+
+    phrase_file = Path.home() / CO_DIR / "keys" / "recovery.txt"
+    if not phrase_file.exists():
+        return None
+    phrase = phrase_file.read_text(encoding="utf-8", errors="replace").strip()
+    if not phrase:
+        return None
+
+    name = Path(co_dir or project_co_dir()).resolve().parent.name
+    if not name:
+        return None
+
+    signing_key = SigningKey(
+        derive_path(Mnemonic("english").to_seed(phrase), slip13_path(identity_uri(name))))
+    hex_address = "0x" + bytes(signing_key.verify_key).hex()
+    return address.Identity({
+        "address": hex_address,
+        "short_address": f"{hex_address[:6]}...{hex_address[-4:]}",
+        "email": f"{hex_address[:10]}@mail.openonion.ai",
+        "email_active": False,
+        "source": "derived",
+        "signing_key": signing_key,
+    })
+
+
+def project_identity(co_dir=None):
+    """The identity this project acts as: its own key, else derived, else the
+    global one, else nothing.
+
+    The single answer every caller should use.
+    """
+    from . import address
+
+    co_dir = Path(co_dir) if co_dir else project_co_dir()
+    own = address.load(co_dir)
+    if own:
+        return own
+    derived = derived_identity(co_dir)
+    if derived:
+        return derived
+    return address.load(Path.home() / CO_DIR)

--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -82,7 +82,16 @@ def derived_identity(co_dir=None):
         "short_address": f"{hex_address[:6]}...{hex_address[-4:]}",
         "email": f"{hex_address[:10]}@mail.openonion.ai",
         "email_active": False,
-        "source": "derived",
+        # `source` means "the directory this key belongs to", and #688 writes
+        # the served-by record into it. A derived key belongs to the project it
+        # was derived for -- so that stays a real directory rather than a
+        # marker string, which would have made claim_identity silently do
+        # nothing and taken #688's collision warning with it.
+        #
+        # Nothing collides here anyway: two projects deriving from one phrase
+        # get two addresses. The record still says who is serving.
+        "source": str(Path(co_dir or project_co_dir())),
+        "derived": True,
         "signing_key": signing_key,
     })
 

--- a/tests/e2e/cli/test_cli_deploy.py
+++ b/tests/e2e/cli/test_cli_deploy.py
@@ -807,13 +807,15 @@ class TestDeployerSeededAsAdmin:
 
         # A real identity, not a mock: the point of the test is that the address
         # the operator actually signs with is the one that lands in the package.
-        identity = tmp_path / "identity" / ".co"
-        identity.mkdir(parents=True)
+        #
+        # And found the way the code finds it, rather than by patching a seam.
+        # This used to patch `_find_co_dir`, which the deploy path stopped
+        # calling when identity resolution moved into project_identity (#689) --
+        # so the patch landed nowhere and the test would have passed for the
+        # wrong reason if the assertion had been weaker.
         keys = address.generate()
-        address.save(keys, identity)
-        monkeypatch.setattr(
-            "connectonion.cli.commands.keys_commands._find_co_dir", lambda: identity
-        )
+        address.save(keys, repo / ".co")
+        monkeypatch.chdir(repo)
 
         tarball = _build_tarball(repo, [])
         with tarfile.open(tarball) as tar:

--- a/tests/e2e/cli/test_doctor_checks_this_projects_keys.py
+++ b/tests/e2e/cli/test_doctor_checks_this_projects_keys.py
@@ -98,17 +98,43 @@ class TestFromTheProjectRoot:
         assert "agent.key" in row and str(home) not in row
 
 
-class TestTheGlobalFallbackStays:
-    """A project with no key of its own is what `co init` usually produces."""
+class TestAKeylessProjectSaysWhereItsIdentityComesFrom:
+    """A project with no key of its own is what `co init` usually produces.
 
-    def test_a_keyless_project_reports_the_machine_key(self, tmp_path):
+    It used to report the machine's key file. Since #689 it derives its own
+    identity from the recovery phrase, so naming a file at all would name one
+    this agent does not use — which is the mistake this whole file exists to
+    catch, one release later.
+    """
+
+    def test_it_says_derived_rather_than_naming_a_file(self, tmp_path):
         from connectonion import address
 
         home = tmp_path / "home2"
-        (home / ".co").mkdir(parents=True)
-        address.save(address.generate(), home / ".co")
+        (home / ".co" / "keys").mkdir(parents=True)
+        identity = address.generate()
+        address.save(identity, home / ".co")
+        (home / ".co" / "keys" / "recovery.txt").write_text(
+            identity["seed_phrase"], encoding="utf-8")
 
         keyless = tmp_path / "keyless"
+        (keyless / ".co").mkdir(parents=True)
+        (keyless / "sub").mkdir()
+
+        row = _keys_row(_doctor(keyless / "sub", home))
+        assert "derived" in row.lower(), row
+
+    def test_with_no_phrase_it_still_falls_back(self, tmp_path):
+        """Nothing to derive from — the machine key is still better than
+        claiming there is no identity."""
+        from connectonion import address
+
+        home = tmp_path / "home3"
+        (home / ".co").mkdir(parents=True)
+        address.save(address.generate(), home / ".co")
+        (home / ".co" / "keys" / "recovery.txt").unlink(missing_ok=True)
+
+        keyless = tmp_path / "keyless3"
         (keyless / ".co").mkdir(parents=True)
         (keyless / "sub").mkdir()
 

--- a/tests/unit/test_a_project_derives_its_own_identity.py
+++ b/tests/unit/test_a_project_derives_its_own_identity.py
@@ -222,3 +222,58 @@ class TestEveryPlaceThatReportsTheIdentityAgrees:
         doctor_commands.handle_doctor()
 
         assert "agent.key" in capsys.readouterr().out
+
+
+class TestItIsTheNameDeployUses:
+    """`co deploy` has derived the agent's identity since #396, from
+    `host.yaml`'s name:
+
+        agent_identity = derived_agent_identity(agent)   # agent = config["name"]
+
+    Deriving locally from the *directory* instead would give the same project
+    two addresses — one when it runs here, another when it is deployed — for any
+    operator who renamed either. `co init` writes the directory name into
+    host.yaml, so they agree until someone edits one, which is exactly the kind
+    of divergence nobody notices until an address stops matching.
+    """
+
+    def test_host_yaml_name_wins_over_the_directory(self, machine):
+        _, global_identity, project = machine
+        co = project("on-disk")
+        (co / "host.yaml").write_text("name: the-real-name\n", encoding="utf-8")
+
+        from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
+
+        from connectonion.derive import derive_path, identity_uri, slip13_path
+
+        seed = Mnemonic("english").to_seed(global_identity["seed_phrase"])
+        expected = SigningKey(derive_path(seed, slip13_path(identity_uri("the-real-name"))))
+
+        assert resolve_agent_identity(co)["address"] == \
+            "0x" + bytes(expected.verify_key).hex()
+
+    def test_it_matches_what_deploy_would_ship(self, machine):
+        from connectonion.cli.commands.server_commands import derived_agent_identity
+
+        _, _, project = machine
+        co = project("shipme")
+        (co / "host.yaml").write_text("name: shipme\n", encoding="utf-8")
+
+        assert resolve_agent_identity(co)["address"] == \
+            derived_agent_identity("shipme")["address"]
+
+    def test_the_directory_is_the_fallback(self, machine):
+        """No host.yaml, or no name in it — the directory is still the answer."""
+        _, _, project = machine
+        co = project("nameless")
+
+        assert resolve_agent_identity(co)["address"] == \
+            resolve_agent_identity(project("nameless"))["address"]
+
+    def test_a_host_yaml_without_a_name_falls_back(self, machine):
+        _, _, project = machine
+        co = project("no-name-key")
+        (co / "host.yaml").write_text("port: 8000\n", encoding="utf-8")
+
+        assert resolve_agent_identity(co)["derived"] is True

--- a/tests/unit/test_a_project_derives_its_own_identity.py
+++ b/tests/unit/test_a_project_derives_its_own_identity.py
@@ -1,0 +1,165 @@
+"""Every project on this machine answers to the same address.
+
+Confirmed on `main`, in a directory `co init --yes` had just created:
+
+    $ ls .co/keys/
+    (nothing — no key of its own)
+    $ co keys
+    Address   0x10e68f6dff39ab1c50cc48ea1c74e7fd6ce7269aa6e8123829b…
+    Source    ~/.co (global)
+
+That is #642: `oo` on this laptop and `naturewill` on the deployed box announced
+the same address, because a project with no key of its own inherits the global
+one. #688 made the collision visible; this is the half that stops it happening.
+
+Aaron's call, and it is better than minting a random keypair per project, which
+is what I had proposed: **derive it**. `derive.py` already exports what is
+needed, and `server_commands.py` already uses it:
+
+    signing_key = SigningKey(derive_path(seed, slip13_path(identity_uri(name))))
+
+`slip13_path`'s docstring says why that shape was chosen:
+
+    The name *is* the path, which is what lets `co keys` print an agent's
+    address before anything is deployed, and makes the same name always return
+    the same key. `index` is the rotation counter.
+
+So a project's identity costs nothing to back up — the twelve words already
+cover it — is recoverable from the phrase and the project name alone, and is
+knowable before the project has ever run. A random per-project key had none of
+those properties.
+
+BEHAVIOUR CHANGE: a 1.5.x project with no key of its own moves from the global
+address to a derived one. That is the point of the issue, and it means whatever
+was whitelisted or paid to the old address does not follow. Inheriting stays
+for a project that cannot derive — no phrase on the machine — because an agent
+has to have an address.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+from connectonion.network.host.server import resolve_agent_identity
+
+
+@pytest.fixture
+def machine(tmp_path, monkeypatch):
+    """A global ~/.co holding a recovery phrase, and two projects with no keys."""
+    home = tmp_path / "home"
+    home_co = home / ".co"
+    (home_co / "keys").mkdir(parents=True)
+    identity = address.generate()
+    address.save(identity, home_co)
+    (home_co / "keys" / "recovery.txt").write_text(identity["seed_phrase"],
+                                                   encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    def project(name):
+        """Idempotent: the same name is the same directory, so a test can ask
+        for it twice and compare."""
+        co = tmp_path / name / ".co"
+        co.mkdir(parents=True, exist_ok=True)
+        return co
+
+    return home_co, identity, project
+
+
+class TestTwoProjectsAreTwoAgents:
+
+    def test_they_do_not_share_an_address(self, machine):
+        _, _, project = machine
+
+        first = resolve_agent_identity(project("oo"))
+        second = resolve_agent_identity(project("naturewill"))
+
+        assert first["address"] != second["address"]
+
+    def test_neither_is_the_global_one(self, machine):
+        home_co, global_identity, project = machine
+
+        derived = resolve_agent_identity(project("oo"))
+
+        assert derived["address"] != global_identity["address"]
+
+    def test_the_same_project_is_the_same_agent_every_time(self, machine):
+        _, _, project = machine
+
+        first = resolve_agent_identity(project("oo"))
+        again = resolve_agent_identity(project("oo"))
+
+        assert first["address"] == again["address"]
+
+    def test_it_says_where_it_came_from(self, machine):
+        _, _, project = machine
+
+        assert resolve_agent_identity(project("oo"))["source"] == "derived"
+
+
+class TestItIsTheDocumentedDerivation:
+    """Not a new scheme: the one `identity_uri` and `slip13_path` already define."""
+
+    def test_it_matches_deriving_by_hand(self, machine):
+        from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
+
+        from connectonion.derive import derive_path, identity_uri, slip13_path
+
+        _, global_identity, project = machine
+        seed = Mnemonic("english").to_seed(global_identity["seed_phrase"])
+        expected = SigningKey(derive_path(seed, slip13_path(identity_uri("oo"))))
+
+        resolved = resolve_agent_identity(project("oo"))
+
+        assert resolved["address"] == "0x" + bytes(expected.verify_key).hex()
+
+    def test_the_name_is_the_directory(self, machine):
+        """`co deploy` and the relay already key on the project directory's
+        name, so the identity keys on the same thing."""
+        from mnemonic import Mnemonic
+        from nacl.signing import SigningKey
+
+        from connectonion.derive import derive_path, identity_uri, slip13_path
+
+        _, global_identity, project = machine
+        seed = Mnemonic("english").to_seed(global_identity["seed_phrase"])
+
+        for name in ("alpha", "beta"):
+            expected = SigningKey(derive_path(seed, slip13_path(identity_uri(name))))
+            assert resolve_agent_identity(project(name))["address"] == \
+                "0x" + bytes(expected.verify_key).hex()
+
+
+class TestWhatMustNotChange:
+
+    def test_a_project_with_its_own_key_keeps_it(self, machine):
+        _, _, project = machine
+        co = project("has-its-own")
+        mine = address.generate()
+        address.save(mine, co)
+
+        assert resolve_agent_identity(co)["address"] == mine["address"]
+
+    def test_no_phrase_still_inherits(self, tmp_path, monkeypatch):
+        """Nothing to derive from. Inheriting beats inventing — that is what
+        resolve_agent_identity was fixed to do, and it stays."""
+        home = tmp_path / "home"
+        home_co = home / ".co"
+        home_co.mkdir(parents=True)
+        global_identity = address.generate()
+        address.save(global_identity, home_co)
+        (home_co / "keys" / "recovery.txt").unlink(missing_ok=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        co = tmp_path / "p" / ".co"
+        co.mkdir(parents=True)
+
+        assert resolve_agent_identity(co)["address"] == global_identity["address"]
+
+    def test_nothing_at_all_still_generates(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "empty"))
+        co = tmp_path / "p" / ".co"
+        co.mkdir(parents=True)
+
+        assert resolve_agent_identity(co)["address"].startswith("0x")

--- a/tests/unit/test_a_project_derives_its_own_identity.py
+++ b/tests/unit/test_a_project_derives_its_own_identity.py
@@ -91,10 +91,15 @@ class TestTwoProjectsAreTwoAgents:
 
         assert first["address"] == again["address"]
 
-    def test_it_says_where_it_came_from(self, machine):
+    def test_it_says_it_was_derived(self, machine):
+        """A flag, not a marker in `source`. `source` means "the directory this
+        key belongs to" and #688 writes its served-by record there — overloading
+        it made claim_identity silently do nothing."""
         _, _, project = machine
+        resolved = resolve_agent_identity(project("oo"))
 
-        assert resolve_agent_identity(project("oo"))["source"] == "derived"
+        assert resolved["derived"] is True
+        assert Path(resolved["source"]).name == ".co"
 
 
 class TestItIsTheDocumentedDerivation:

--- a/tests/unit/test_a_project_derives_its_own_identity.py
+++ b/tests/unit/test_a_project_derives_its_own_identity.py
@@ -168,3 +168,57 @@ class TestWhatMustNotChange:
         co.mkdir(parents=True)
 
         assert resolve_agent_identity(co)["address"].startswith("0x")
+
+
+class TestEveryPlaceThatReportsTheIdentityAgrees:
+    """The point of one resolver is that nothing gets to keep its own copy.
+
+    `co doctor` had one. It printed
+
+        Keys  ✓ /Users/changxing/.co/keys/agent.key
+
+    for a project that derives — naming a file that is not this agent's
+    identity, which is #659 in the one command an operator runs *to find out
+    what is wrong*. Found by running it, after I had written "all four callers"
+    in the PR: doctor was a fifth.
+    """
+
+    def test_doctor_does_not_name_the_global_key_for_a_derived_project(self, machine, capsys, monkeypatch):
+        """Wide, because rich wraps a long path across table cells and the
+        exact string then is not in the output — so this passed for the wrong
+        reason first time, the same way #681's did."""
+        from connectonion.cli.commands import doctor_commands
+
+        home_co, _, project = machine
+        co = project("oo")
+        monkeypatch.chdir(co.parent)
+        monkeypatch.setenv("COLUMNS", "300")
+
+        doctor_commands.handle_doctor()
+        out = capsys.readouterr().out
+
+        assert str(home_co / "keys" / "agent.key") not in out, out[:800]
+
+    def test_doctor_says_it_is_derived(self, machine, capsys, monkeypatch):
+        from connectonion.cli.commands import doctor_commands
+
+        _, _, project = machine
+        co = project("oo")
+        monkeypatch.chdir(co.parent)
+
+        doctor_commands.handle_doctor()
+
+        assert "derived" in capsys.readouterr().out.lower()
+
+    def test_a_project_with_its_own_key_still_names_the_file(self, machine, capsys, monkeypatch):
+        from connectonion import address
+        from connectonion.cli.commands import doctor_commands
+
+        _, _, project = machine
+        co = project("has-its-own")
+        address.save(address.generate(), co)
+        monkeypatch.chdir(co.parent)
+
+        doctor_commands.handle_doctor()
+
+        assert "agent.key" in capsys.readouterr().out

--- a/tests/unit/test_deploy_keeps_the_admins_you_configured.py
+++ b/tests/unit/test_deploy_keeps_the_admins_you_configured.py
@@ -37,20 +37,32 @@ COLLEAGUE = "0x" + "b" * 64
 
 
 @pytest.fixture
-def project(tmp_path):
-    """A project with a .co/, as `co create` leaves one."""
+def project(tmp_path, monkeypatch):
+    """A project with a .co/, as `co create` leaves one, and the operator
+    standing in it.
+
+    `deployer` is whatever the resolver says this project is, not the machine
+    key. Since #689 a project with no key of its own derives its own identity,
+    so hardcoding the global address here would be asserting the old rule
+    rather than the thing this file is about — which is that the admins the
+    operator configured survive a deploy.
+    """
     from connectonion import address
+    from connectonion.project import project_identity
 
     home = Path.home()
-    (home / ".co").mkdir(parents=True, exist_ok=True)
+    (home / ".co" / "keys").mkdir(parents=True, exist_ok=True)
     data = address.generate()
     address.save(data, home / ".co")
+    (home / ".co" / "keys" / "recovery.txt").write_text(data["seed_phrase"],
+                                                       encoding="utf-8")
 
     p = tmp_path / "shipme"
     (p / ".co").mkdir(parents=True)
     (p / "agent.py").write_text("from connectonion import host\n")
     (p / ".co" / "host.yaml").write_text("name: shipme\nentrypoint: agent.py\n")
-    return SimpleNamespace(dir=p, deployer=data["address"])
+    monkeypatch.chdir(p)
+    return SimpleNamespace(dir=p, deployer=project_identity()["address"])
 
 
 def _admins_in(tarball: Path) -> list:

--- a/tests/unit/test_one_agent_one_address.py
+++ b/tests/unit/test_one_agent_one_address.py
@@ -40,15 +40,28 @@ from connectonion.network.host.server import claim_identity, resolve_agent_ident
 
 @pytest.fixture
 def shared(tmp_path):
-    """One global ~/.co holding the only keypair, and two projects with none."""
+    """Two projects that really do share one keypair.
+
+    They used to share it by *both having none* and inheriting the global
+    ~/.co. Since #689 that no longer collides — a project with no key of its
+    own derives `agent://<name>`, so two of them are two agents, which is the
+    whole point of that change.
+
+    The collision this file is about still exists: it needs the same key file
+    in both places, which is what AGENT_CONFIG_PATH pointing two projects at
+    one directory produces, and what copying a `.co/keys/` produces. So the
+    fixture plants the same key in both rather than relying on inheritance.
+    """
     home_co = tmp_path / "home" / ".co"
     home_co.mkdir(parents=True)
-    address.save(address.generate(), home_co)
+    identity = address.generate()
+    address.save(identity, home_co)
 
     first = tmp_path / "oo" / ".co"
     second = tmp_path / "naturewill" / ".co"
     for co in (first, second):
         co.mkdir(parents=True)
+        address.save(identity, co)
     return home_co, first, second
 
 
@@ -111,9 +124,17 @@ class TestAProjectWithItsOwnKey:
         assert claim_identity(first, resolve_agent_identity(first), "a") is None
         assert claim_identity(second, resolve_agent_identity(second), "b") is None
 
-    def test_the_claim_lands_beside_the_key_it_is_about(self, tmp_path, monkeypatch):
-        """Not in the project — the whole point is that several projects share
-        one identity directory, so the record has to live with the key."""
+    def test_the_claim_is_keyed_on_the_address(self, tmp_path, monkeypatch):
+        """Not in the project, and not beside the key either.
+
+        Beside the key only catches projects sharing one `.co`. A copied
+        `.co/keys/`, or AGENT_CONFIG_PATH pointing two projects at one
+        directory, is the same collision on the network and was invisible to
+        that. The address is what actually collides, so it is what the record
+        is filed under — in ~/.co, because "who on this machine serves this
+        address" is not any one project's question, and because a record there
+        never travels in a deploy.
+        """
         home_co = tmp_path / "home" / ".co"
         home_co.mkdir(parents=True)
         monkeypatch.setattr(Path, "home", lambda: home_co.parent)
@@ -123,19 +144,23 @@ class TestAProjectWithItsOwnKey:
 
         claim_identity(project, resolve_agent_identity(project), "p")
 
-        assert (project / "served_by.json").exists()
-        assert not (home_co / "served_by.json").exists()
+        identity = resolve_agent_identity(project)
+        assert (home_co / "served_by" / f"{identity['address']}.json").exists()
+        assert not (project / "served_by.json").exists()
 
 
 class TestWhereTheIdentityCameFrom:
     """claim_identity has to record against the key's own directory, so the
     loaded identity has to say which one that was."""
 
-    def test_an_inherited_identity_says_it_is_the_global_one(self, shared, monkeypatch):
+    def test_a_loaded_identity_says_which_directory_it_came_from(self, shared, monkeypatch):
+        """It used to be the global one for a keyless project. Since #689 a
+        keyless project derives instead, so what this checks is the surviving
+        case: a key on disk reports its own directory."""
         home_co, first, _ = shared
         monkeypatch.setattr(Path, "home", lambda: home_co.parent)
 
-        assert resolve_agent_identity(first)["source"] == str(home_co)
+        assert resolve_agent_identity(first)["source"] == str(first)
 
     def test_a_local_identity_says_the_project(self, tmp_path, monkeypatch):
         monkeypatch.setattr(Path, "home", lambda: tmp_path / "nowhere")
@@ -152,8 +177,10 @@ class TestTheRecordItself:
         home_co, first, _ = shared
         monkeypatch.setattr(Path, "home", lambda: home_co.parent)
 
-        claim_identity(first, resolve_agent_identity(first), "oo")
-        record = json.loads((home_co / "served_by.json").read_text())
+        identity = resolve_agent_identity(first)
+        claim_identity(first, identity, "oo")
+        record = json.loads(
+            (home_co / "served_by" / f"{identity['address']}.json").read_text())
 
         assert record["name"] == "oo"
         assert record["project"] == str(first.parent)

--- a/tests/unit/test_the_documented_way_to_call_an_agent_works.py
+++ b/tests/unit/test_the_documented_way_to_call_an_agent_works.py
@@ -87,24 +87,34 @@ def connect_keys(address_str):
     return connect(address_str)._keys
 
 
-class TestTheMachineIdentityIsTheFallback:
-    """What the host side does — `resolve_agent_identity`: own key, else ~/.co."""
+class TestTheClientIsTheSameAgentAsTheHost:
+    """A client signs as whatever this project *is* — the same answer
+    `resolve_agent_identity` gives the host. Signing as one identity while your
+    own agent serves under another is #659 from the other side."""
 
-    def test_a_project_without_keys_uses_the_home_identity(self, tmp_path, monkeypatch):
+    def test_a_project_without_keys_derives_its_own(self, tmp_path, monkeypatch):
+        """It used to sign as the machine identity, which is what made every
+        project on a laptop one agent (#642). Since #689 it derives."""
         from connectonion import address
         from connectonion.network import connect
+        from connectonion.project import project_identity
 
         home = tmp_path / "home"
         (home / ".co").mkdir(parents=True)
         machine = address.generate()
         address.save(machine, home / ".co")
+        (home / ".co" / "keys" / "recovery.txt").write_text(
+            machine["seed_phrase"], encoding="utf-8")
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
 
         project = tmp_path / "keyless"
         (project / ".co").mkdir(parents=True)
         monkeypatch.chdir(project)
 
-        assert connect("0x" + "a" * 64)._keys["address"] == machine["address"]
+        signing_as = connect("0x" + "a" * 64)._keys["address"]
+
+        assert signing_as != machine["address"]
+        assert signing_as == project_identity(project / ".co")["address"]
 
     def test_no_identity_anywhere_is_not_an_error(self, tmp_path, monkeypatch):
         """A caller with no key at all still constructs; the agent decides."""

--- a/tests/unit/test_the_host_serves_the_address_you_were_told.py
+++ b/tests/unit/test_the_host_serves_the_address_you_were_told.py
@@ -51,6 +51,10 @@ def machine(tmp_path, monkeypatch):
     (home / ".co").mkdir(parents=True)
     machine_keys = address.generate()
     address.save(machine_keys, home / ".co")
+    # The phrase, so a keyless project can derive its own identity (#689).
+    # Without it the fixture only ever exercises the inherit fallback.
+    (home / ".co" / "keys" / "recovery.txt").write_text(
+        machine_keys["seed_phrase"], encoding="utf-8")
 
     project = tmp_path / "project"
     (project / ".co").mkdir(parents=True)
@@ -61,20 +65,27 @@ def machine(tmp_path, monkeypatch):
 
 class TestAProjectWithNoKeyOfItsOwn:
 
-    def test_it_uses_the_machine_identity(self, machine):
+    def test_it_derives_its_own(self, machine):
+        """It used to take the machine's, which made every project on a laptop
+        one agent (#642). Since #689 it derives `agent://<project-name>` from
+        the same recovery phrase — its own address, and one the phrase can
+        reproduce."""
         machine_keys, project = machine
 
         resolved = resolve_agent_identity(project / ".co")
 
-        assert resolved["address"] == machine_keys["address"]
+        assert resolved["address"] != machine_keys["address"]
+        assert resolved["derived"] is True
 
     def test_it_does_not_invent_one(self, machine):
+        """Still the property this class was written for: whatever it resolves
+        to must be reproducible, not a fresh random key."""
         machine_keys, project = machine
 
-        resolved = resolve_agent_identity(project / ".co")
+        first = resolve_agent_identity(project / ".co")
+        again = resolve_agent_identity(project / ".co")
 
-        assert resolved["address"] != address.generate()["address"]  # sanity
-        assert resolved["address"] == machine_keys["address"]
+        assert first["address"] == again["address"]
 
     def test_it_writes_no_key_into_the_project(self, machine):
         _, project = machine
@@ -84,15 +95,20 @@ class TestAProjectWithNoKeyOfItsOwn:
         assert not (project / ".co" / "keys" / "agent.key").exists()
 
     def test_it_agrees_with_what_co_status_would_report(self, machine):
-        """The same resolution `co status` does, spelled out here so the two
-        cannot drift apart again."""
+        """The property this whole file exists for, and it matters more now.
+
+        This used to re-implement the resolution rule inline — which is the
+        drift it was written to prevent, one copy later. Both sides now ask
+        `project_identity`, so there is one rule and this asserts they share
+        it.
+        """
+        from connectonion.project import project_identity
+
         machine_keys, project = machine
-
         co_dir = project / ".co"
-        status_dir = co_dir if (co_dir / "keys" / "agent.key").exists() else Path.home() / ".co"
-        status_says = address.load(status_dir)["address"]
 
-        assert resolve_agent_identity(co_dir)["address"] == status_says
+        assert resolve_agent_identity(co_dir)["address"] == \
+            project_identity(co_dir)["address"]
 
 
 class TestAProjectWithItsOwnKey:
@@ -159,6 +175,8 @@ class TestHostActuallyUsesIt:
         server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
                            relay_url=None)
 
-        assert seen.get("address") == machine_keys["address"], (
+        from connectonion.project import project_identity
+
+        assert seen.get("address") == project_identity(project / ".co")["address"], (
             "host() served an address the operator was never told"
         )

--- a/tests/unit/test_the_trust_layer_knows_who_it_is.py
+++ b/tests/unit/test_the_trust_layer_knows_who_it_is.py
@@ -1,0 +1,157 @@
+"""A project without its own key cannot take payment, and does not know its address.
+
+Two places in the trust layer load the agent's key straight from the project
+directory. For the projects `co init` produces — which have no key of their own
+— both come back empty.
+
+**Paid onboarding could never succeed.** `_verify_transfer_via_api` loads keys
+to sign the request to oo-api:
+
+    co_dir = project_co_dir()
+    keys = addr.load(co_dir)
+    if not keys:
+        return False
+
+Confirmed on `main`, in a keyless project:
+
+    project_co_dir(): …/keyless/.co
+    address.load(...): None
+    => verify_payment returns False before any oo-api call
+
+So a stranger who really did transfer the money was refused, on the agent
+configuration that is the common one. That predates this change; it is what
+loading the project directory and only the project directory has always done.
+
+**And the address to pay was not the agent's.** `get_self_address` has the same
+shape, so `doors_that_open` either advertised no payment door at all (no
+address to send to) or a stale one from `address.json`.
+
+Both now ask `project_identity`, which is the same answer the host serves
+under. An agent advertising one address, signing as another, and serving as a
+third is the shape this release has spent itself removing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def keyless_project(tmp_path, monkeypatch):
+    """What `co init` leaves: a `.co/` with no keys, and a phrase at home."""
+    home = tmp_path / "home"
+    (home / ".co" / "keys").mkdir(parents=True)
+    machine = address.generate()
+    address.save(machine, home / ".co")
+    (home / ".co" / "keys" / "recovery.txt").write_text(machine["seed_phrase"],
+                                                        encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    project = tmp_path / "keyless"
+    (project / ".co").mkdir(parents=True)
+    monkeypatch.chdir(project)
+    return project, machine
+
+
+class TestItKnowsItsOwnAddress:
+
+    def test_get_self_address_is_not_empty(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        assert get_self_address()
+
+    def test_it_is_the_address_the_host_would_serve(self, keyless_project):
+        from connectonion.network.host.server import resolve_agent_identity
+        from connectonion.network.trust.tools import get_self_address
+
+        project, _ = keyless_project
+
+        assert get_self_address() == resolve_agent_identity(project / ".co")["address"]
+
+    def test_it_is_not_the_machine_identity(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        _, machine = keyless_project
+
+        assert get_self_address() != machine["address"]
+
+
+class TestItCanSignForPaymentVerification:
+
+    def test_a_transfer_check_reaches_the_api(self, keyless_project, monkeypatch):
+        """It used to return False before making the call at all, so a stranger
+        who really had paid was refused."""
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        asked = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"verified": True}
+
+        def fake_post(url, **kwargs):
+            asked["url"] = url
+            asked["json"] = kwargs.get("json")
+            return FakeResponse()
+
+        import httpx
+        monkeypatch.setattr(httpx, "post", fake_post, raising=False)
+        import requests
+        monkeypatch.setattr(requests, "post", fake_post, raising=False)
+
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {"payment": 10}}
+        monkeypatch.setattr(TrustAgent, "promote_to_contact", lambda self, c: None)
+
+        agent.verify_payment("0x" + "c" * 64, 10)
+
+        assert asked, "no request was made — it gave up before asking oo-api"
+
+    def test_it_signs_as_the_identity_the_host_serves(self, keyless_project, monkeypatch):
+        from connectonion.network.host.server import resolve_agent_identity
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        project, _ = keyless_project
+        sent = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"verified": True}
+
+        def fake_post(url, **kwargs):
+            sent.update(kwargs.get("json") or {})
+            return FakeResponse()
+
+        import requests
+        monkeypatch.setattr(requests, "post", fake_post, raising=False)
+        import httpx
+        monkeypatch.setattr(httpx, "post", fake_post, raising=False)
+
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {"payment": 10}}
+        monkeypatch.setattr(TrustAgent, "promote_to_contact", lambda self, c: None)
+        agent.verify_payment("0x" + "c" * 64, 10)
+
+        served = resolve_agent_identity(project / ".co")["address"]
+        signed_as = sent.get("to_address") or sent.get("public_key") or sent.get("agent_address")
+        assert signed_as is None or signed_as == served, (sent, served)
+
+
+class TestAProjectWithItsOwnKeyIsUnchanged:
+
+    def test_its_own_address_wins(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        project, _ = keyless_project
+        own = address.generate()
+        address.save(own, project / ".co")
+
+        assert get_self_address() == own["address"]


### PR DESCRIPTION
**Not ready to merge.** Pushing so the validated part is not lost and so the remaining shape is written down.

## The design, and that it works

Aaron's call on #689, and better than what I had proposed (minting a random keypair per project): **derive** the identity. `derive.py` already exports `identity_uri`, and `co server` already derives SSH keys the same way.

```
same phrase + same name, twice : 0x082bdef09814d1e5 == 0x082bdef09814d1e5
a different project            : 0xabaf329446ac763f   differs
rotation (index=1)             : 0xe89f0227cad87165   differs
```

Nothing new to back up, recoverable from the phrase and the project name alone, and knowable before the project has ever run.

## What is done

`project.py` owns one `project_identity()` — own key, else derived, else the machine's. The **host** and the **client** both go through it. 9 new tests pass.

## What is not, and why I stopped

**`co keys` still reports the old address.** I verified against two real freshly-`co init`ed projects rather than trusting the unit tests:

```
project 'newuser'   Address 0x10e68f6d…   Source ~/.co (global)
project 'newuser2'  Address 0x10e68f6d…   Source ~/.co (global)
```

`_find_co_dir()` collapses "project" and "global" *before* `project_identity` sees a directory, so passing it a `co_dir` cannot help. Its own docstring says its fallback exists to mirror `resolve_agent_identity` — which this PR changes, so the two are now out of step by construction. It has **ten callers** whose contract is "a directory that has keys".

A host serving a derived address while `co keys` prints the inherited one is #659 exactly, and that is the bug class this whole release has been about. Shipping it half-done would be doing the thing I have spent twenty PRs undoing.

**10 existing tests encode the old contract** — `test_a_project_without_keys_uses_the_home_identity`, `test_it_uses_the_machine_identity`, `test_it_agrees_with_what_co_status_would_report`. They are not regressions; they are the behaviour being deliberately changed. Each needs restating with the new rule, which is careful work, not a find-and-replace.

## The remaining shape

1. `_find_co_dir()` returns the project directory when there is one, keys or not; `project_identity` decides what identity that means. Ten call sites re-checked against that.
2. The 10 tests restated.
3. `co deploy` refuses a project whose identity is claimed by another (#642's other half), pointing at the derived one.

## Worth flagging before it lands

Every existing 1.5.x project with no key of its own **changes address**. That is the point of #642, and it means whatever was whitelisted, announced or paid to the old address does not follow. Deserves a release note, not a footnote.
