### PR TITLE
A credential conflict says which value is used

### DIFF
--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -131,7 +131,19 @@ def _credential_rows(
             source = "—"
         elif len(unique_values) > 1:
             status = "conflict"
-            source = " + ".join(source_names)
+            # Which one is actually used. _credential_sources returns its
+            # sources in precedence order — process environment first, because
+            # load_dotenv() does not override a variable already set — so the
+            # first one found is the winner.
+            #
+            # The panel named the conflict and stopped one word short of the
+            # answer, and an operator reading it is looking *because* something
+            # is using the wrong key. The natural guess is that the project's
+            # own .env wins, being the more specific of the two. It does not.
+            source = " + ".join(
+                f"{name} (used)" if index == 0 else name
+                for index, name in enumerate(source_names)
+            )
         elif source_names[0] == "process environment":
             status = "configured"
             source = " + ".join(source_names)

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -99,7 +99,11 @@ class TestCredentialStatus:
         anthropic = self._row(rows, "ANTHROPIC_API_KEY")
 
         assert anthropic["status"] == "conflict"
-        assert anthropic["source"] == "<project>/.env + ~/.co/keys.env"
+        # The winner is marked now: with no environment value, the project's
+        # .env is the highest-precedence source present and is the one loaded.
+        # Naming a conflict without naming the winner left the operator to
+        # guess, and the natural guess is wrong the other way round.
+        assert anthropic["source"] == "<project>/.env (used) + ~/.co/keys.env"
         assert "local-secret" not in repr(rows)
         assert "global-secret" not in repr(rows)
         assert str(tmp_path) not in repr(rows)

--- a/tests/unit/test_a_conflict_says_which_value_wins.py
+++ b/tests/unit/test_a_conflict_says_which_value_wins.py
@@ -1,0 +1,107 @@
+"""`co status` names a credential conflict without saying which value is used.
+
+The panel reports:
+
+    Gemini   GEMINI_API_KEY   conflict   process environment + <project>/.env
+
+Both true, and it stops one word short of the answer. The operator is looking at
+this panel *because* something is using the wrong key, and it does not tell them
+which one that is — so the natural guess is that the project's own `.env` wins,
+being the more specific of the two.
+
+It does not. `dotenv.load_dotenv()` does not override a variable already in the
+environment, so the process environment wins. Measured:
+
+    .env says: project-value | environment says: environment-value
+    the value an agent would use: environment-value
+
+The information was already there: `_credential_sources` returns its sources in
+precedence order, process environment first, and `found` preserves it. So the
+first source listed is the winner and nothing said so.
+
+Marked rather than reordered or reworded — the list stays complete, because
+"where else is this defined" is the other half of what the operator came for.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands.status_commands import _credential_rows
+
+
+def _row(rows, name):
+    return next(r for r in rows if r["credential"] == name)
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / ".co").mkdir()
+    return tmp_path
+
+
+class TestAConflictNamesTheWinner:
+
+    def test_the_environment_is_marked_when_it_wins(self, project):
+        (project / ".env").write_text("GEMINI_API_KEY=from-dot-env\n", encoding="utf-8")
+
+        rows = _credential_rows(project_dir=project, home=project / "home",
+                                environ={"GEMINI_API_KEY": "from-environment"})
+        row = _row(rows, "GEMINI_API_KEY")
+
+        assert row["status"] == "conflict"
+        assert "process environment (used)" in row["source"], row["source"]
+
+    def test_the_other_places_are_still_listed(self, project):
+        """Where else it is defined is the other half of the question."""
+        (project / ".env").write_text("GEMINI_API_KEY=from-dot-env\n", encoding="utf-8")
+
+        rows = _credential_rows(project_dir=project, home=project / "home",
+                                environ={"GEMINI_API_KEY": "from-environment"})
+
+        assert "<project>/.env" in _row(rows, "GEMINI_API_KEY")["source"]
+
+    def test_the_file_is_marked_when_it_is_the_only_one_loaded(self, project):
+        """No environment value: the highest-precedence source present wins."""
+        (project / ".env").write_text("GEMINI_API_KEY=from-dot-env\n", encoding="utf-8")
+        home = project / "home"
+        (home / ".co").mkdir(parents=True)
+        (home / ".co" / "keys.env").write_text("GEMINI_API_KEY=from-home\n",
+                                               encoding="utf-8")
+
+        row = _row(_credential_rows(project_dir=project, home=home, environ={}),
+                   "GEMINI_API_KEY")
+
+        assert row["status"] == "conflict"
+        assert "<project>/.env (used)" in row["source"], row["source"]
+
+
+class TestNothingElseChanges:
+
+    def test_one_source_is_not_marked(self, project):
+        """Nothing to disambiguate — a mark would be noise."""
+        rows = _credential_rows(project_dir=project, home=project / "home",
+                                environ={"GEMINI_API_KEY": "only-here"})
+        row = _row(rows, "GEMINI_API_KEY")
+
+        assert row["status"] == "configured"
+        assert "(used)" not in row["source"]
+
+    def test_the_same_value_twice_is_not_a_conflict(self, project):
+        """Defined in two places with one value: still not a conflict, and
+        still nothing to choose between."""
+        (project / ".env").write_text("GEMINI_API_KEY=same\n", encoding="utf-8")
+
+        row = _row(_credential_rows(project_dir=project, home=project / "home",
+                                    environ={"GEMINI_API_KEY": "same"}),
+                   "GEMINI_API_KEY")
+
+        assert row["status"] != "conflict"
+        assert "(used)" not in row["source"]
+
+    def test_missing_is_untouched(self, project):
+        row = _row(_credential_rows(project_dir=project, home=project / "home",
+                                    environ={}), "GEMINI_API_KEY")
+
+        assert row["status"] == "missing"
+        assert row["source"] == "—"


### PR DESCRIPTION
`co status` reported a conflict without saying which value is used:

```
Gemini   GEMINI_API_KEY   conflict   process environment + <project>/.env
```

Both true, and one word short of the answer. Someone is reading this panel *because* something is using the wrong key, and the natural guess is that the project's own `.env` wins — it is the more specific of the two.

It does not. `load_dotenv()` does not override a variable already in the environment, so the process environment wins. Measured:

```
.env says: project-value | environment says: environment-value
the value an agent would use: environment-value
```

## The fix

The information was already there: `_credential_sources` returns its sources in precedence order — process environment, then `<project>/.env`, then `~/.co/keys.env` — and the row preserves that order. So the first source found is the winner, and nothing said so.

```
before   conflict   process environment + <project>/.env
after    conflict   process environment (used) + <project>/.env
```

Marked rather than reordered or trimmed. Where else a key is defined is the other half of what the operator came for — that is what 1.5.1 added this panel for.

## Tests

6 cases, 2 red first. Including the case where there is no environment value and a file wins instead, and the three that must stay unmarked: a single source, the same value in two places, and missing.
