### PR TITLE
A keyless project knows its own address, and can take payment

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -288,13 +288,18 @@ def handle_doctor():
         else:
             connectivity_table.add_row("Backend", f"[yellow]⚠[/yellow] Status {response.status_code}")
 
-        # Check authentication (if keys exist)
-        if local_keys.exists() or global_keys.exists():
+        # Signed as whoever this project acts as. This worked the same rule
+        # out a second time, in the same file -- so the identity the panel
+        # names above and the identity it authenticates as here were decided
+        # independently, and doctor could report on an account that is not the
+        # one in question.
+        from ...project import project_identity
+
+        addr_data = project_identity()
+        if addr_data:
             from ... import address
             import time
 
-            co_dir = project_co_dir() if local_keys.exists() else Path.home() / ".co"
-            addr_data = address.load(co_dir)
 
             public_key = addr_data["address"]
             timestamp = int(time.time())

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -434,9 +434,13 @@ def get_self_address(co_dir: Path = None) -> str | None:
     if co_dir is None:
         co_dir = _project_co_dir()
 
-    from ... import address
+    # The identity this project acts as -- its own key, else the machine's,
+    # which is what the host serves under. Loading the directory alone came
+    # back empty for a project with no key of its own, so the payment door had
+    # no address to send a stranger to (#716).
+    from ...project import project_identity
 
-    keys = address.load(co_dir)
+    keys = project_identity(co_dir)
     if keys and keys.get("address"):
         return keys["address"]
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -326,11 +326,15 @@ justify admitting them, it is not enough."""
             # direction this check must never fail in.
             return False
 
-        # Load agent's keys for signing the request
+        # The identity this project acts as, for signing the request. Loading
+        # the project directory alone returned None for a project with no key
+        # of its own, so this gave up before calling oo-api and a stranger who
+        # really had transferred the money was refused (#716). That is the
+        # configuration both `co init` and `co create` produce.
         from ... import address as addr
+        from ...project import project_identity
 
-        co_dir = project_co_dir()
-        keys = addr.load(co_dir)
+        keys = project_identity()
         if not keys:
             return False
 

--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -39,3 +39,24 @@ def project_root(start: Optional[Union[str, Path]] = None) -> Path:
 def project_co_dir(start: Optional[Union[str, Path]] = None) -> Path:
     """The project's ``.co/``. Does not create it."""
     return project_root(start) / CO_DIR
+
+
+def project_identity(co_dir=None):
+    """The identity this project acts as: its own key, else the machine's.
+
+    The same rule `resolve_agent_identity` applies on the host side, in one
+    place so the trust layer, the host and `co doctor` cannot answer it
+    differently. Loading only the project directory came back empty for a
+    project with no key of its own -- which is what both `co init` and
+    `co create` produce -- so the payment door had no address to advertise and
+    payment verification gave up before calling oo-api (#716).
+
+    Deliberately *not* a per-project derived identity. An address is what an
+    OpenOnion account is keyed on: `authenticate()` signs with it and the
+    backend issues the token for that public key, so a new address is a new
+    account with an empty balance. #715 tried that and Aaron stopped it.
+    """
+    from . import address
+
+    co_dir = Path(co_dir) if co_dir else project_co_dir()
+    return address.load(co_dir) or address.load(Path.home() / CO_DIR)

--- a/tests/unit/test_doctor_signs_as_the_agent_it_reports_on.py
+++ b/tests/unit/test_doctor_signs_as_the_agent_it_reports_on.py
@@ -1,0 +1,111 @@
+"""`co doctor` picks its own key to sign the backend probe with.
+
+The keys row and the connectivity check each work the resolution out
+separately, in the same file:
+
+    local_keys = project_co_dir() / "keys" / "agent.key"
+    global_keys = Path.home() / ".co" / "keys" / "agent.key"
+    ...
+    if local_keys.exists() or global_keys.exists():
+        co_dir = project_co_dir() if local_keys.exists() else Path.home() / ".co"
+        addr_data = address.load(co_dir)
+
+Two copies of one rule, in the command an operator runs *to find out what is
+wrong*. They agree today, and nothing makes them agree — the identity the panel
+names and the identity it authenticates as are decided independently, so a
+change to one is a doctor that reports on an account that is not the one in
+question.
+
+Both ask `project_identity` now: its own key, else the machine's. Same answer,
+one place.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def machine(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    keys = address.generate()
+    address.save(keys, home / ".co")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home, keys
+
+
+class TestOneRuleNotTwo:
+
+    def test_the_file_has_no_second_copy(self):
+        import inspect
+
+        from connectonion.cli.commands import doctor_commands
+
+        source = inspect.getsource(doctor_commands)
+
+        assert 'co_dir = project_co_dir() if local_keys.exists()' not in source, (
+            "the connectivity check still resolves the identity on its own"
+        )
+
+    def test_both_paths_use_the_resolver(self):
+        import inspect
+
+        from connectonion.cli.commands import doctor_commands
+
+        source = inspect.getsource(doctor_commands)
+
+        assert source.count("project_identity") >= 1
+
+
+class TestTheRowAndTheAuthAgree:
+    """The keys row names a *file*, which is a different question from *which
+    identity* — but the two answers have to match, or doctor names one key and
+    authenticates with another. Pinned rather than merged: which file holds it
+    is worth printing, and the row cannot say that from an identity alone."""
+
+    def test_the_named_file_holds_the_identity_it_authenticates_as(self, machine, tmp_path, monkeypatch):
+        from connectonion import address
+        from connectonion.project import project_identity
+
+        home, machine_keys = machine
+        project = tmp_path / "keyless"
+        (project / ".co").mkdir(parents=True)
+        monkeypatch.chdir(project)
+
+        named = home / ".co" / "keys" / "agent.key"
+        assert named.exists()
+        assert address.load(home / ".co")["address"] == project_identity()["address"]
+
+    def test_a_project_key_is_named_and_used(self, machine, tmp_path, monkeypatch):
+        from connectonion import address
+        from connectonion.project import project_identity
+
+        project = tmp_path / "haskey"
+        (project / ".co").mkdir(parents=True)
+        own = address.generate()
+        address.save(own, project / ".co")
+        monkeypatch.chdir(project)
+
+        assert (project / ".co" / "keys" / "agent.key").exists()
+        assert project_identity()["address"] == own["address"]
+
+
+class TestItReportsTheIdentityItWouldUse:
+
+    def test_a_keyless_project_names_the_machine_key(self, machine, tmp_path, monkeypatch, capsys):
+        """Unchanged behaviour, pinned: the machine key is what a keyless
+        project uses, and what doctor should name."""
+        from connectonion.cli.commands import doctor_commands
+
+        home, _ = machine
+        project = tmp_path / "keyless"
+        (project / ".co").mkdir(parents=True)
+        monkeypatch.chdir(project)
+        monkeypatch.setenv("COLUMNS", "300")
+
+        doctor_commands.handle_doctor()
+
+        assert "agent.key" in capsys.readouterr().out

--- a/tests/unit/test_the_trust_layer_knows_who_it_is.py
+++ b/tests/unit/test_the_trust_layer_knows_who_it_is.py
@@ -1,0 +1,139 @@
+"""A project without its own key cannot take payment, and does not know its address.
+
+Two places in the trust layer load the agent's key straight from the project
+directory. For the projects `co init` and `co create` produce — neither writes a
+project key — both come back empty.
+
+**Paid onboarding could never succeed.** `_verify_transfer_via_api` loads keys
+to sign the request to oo-api:
+
+    co_dir = project_co_dir()
+    keys = addr.load(co_dir)
+    if not keys:
+        return False
+
+Measured on `main`, in a keyless project:
+
+    project_co_dir(): …/keyless/.co
+    address.load(...): None
+    => verify_payment returns False before any oo-api call
+
+So a stranger who really did transfer the money was refused, on the agent
+configuration that is the common one — and the refusal is indistinguishable
+from "you did not pay".
+
+**And the address to pay was not the agent's.** `get_self_address` has the same
+shape, so `doors_that_open` advertised either no payment door at all (nothing to
+send to) or a stale one from `address.json`.
+
+The answer is the machine identity — the same one `resolve_agent_identity` falls
+back to and the host serves under. Not a per-project derived one: an address is
+what an OpenOnion account is keyed on (`authenticate` signs with it and the
+backend issues the token for that public key), so minting one per project would
+give every project an empty balance. That was #715, and Aaron stopped it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion import address
+
+
+@pytest.fixture
+def keyless_project(tmp_path, monkeypatch):
+    """What `co init` leaves: a `.co/` with no keys, beside a machine identity."""
+    home = tmp_path / "home"
+    (home / ".co").mkdir(parents=True)
+    machine = address.generate()
+    address.save(machine, home / ".co")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    project = tmp_path / "keyless"
+    (project / ".co").mkdir(parents=True)
+    monkeypatch.chdir(project)
+    return project, machine
+
+
+class TestItKnowsItsOwnAddress:
+
+    def test_get_self_address_is_not_empty(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        assert get_self_address()
+
+    def test_it_is_the_machine_identity(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        _, machine = keyless_project
+
+        assert get_self_address() == machine["address"]
+
+    def test_it_is_the_address_the_host_serves(self, keyless_project):
+        """The property that matters: what a stranger is told to pay is the
+        agent they are paying."""
+        from connectonion.network.host.server import resolve_agent_identity
+        from connectonion.network.trust.tools import get_self_address
+
+        project, _ = keyless_project
+
+        assert get_self_address() == resolve_agent_identity(project / ".co")["address"]
+
+
+class TestItCanSignForPaymentVerification:
+
+    def test_a_transfer_check_reaches_the_api(self, keyless_project, monkeypatch):
+        """It returned False before making the call at all, so a stranger who
+        really had paid was refused."""
+        # httpx, not requests — _verify_transfer_via_api imports httpx and
+        # fails closed if it is missing. Patching the wrong library made this
+        # look like the code still gave up early when it was my fake that was
+        # never called.
+        import httpx
+
+        from connectonion.network.trust.trust_agent import TrustAgent
+
+        asked = {}
+
+        class FakeResponse:
+            status_code = 200
+
+            @staticmethod
+            def json():
+                return {"verified": True}
+
+        def fake_post(url, **kwargs):
+            asked["url"] = url
+            return FakeResponse()
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        agent = TrustAgent("careful")
+        agent._config = {"onboard": {"payment": 10}}
+        monkeypatch.setattr(TrustAgent, "promote_to_contact", lambda self, c: None)
+
+        agent.verify_payment("0x" + "c" * 64, 10)
+
+        assert asked, "no request was made — it gave up before asking oo-api"
+
+
+class TestAProjectWithItsOwnKeyIsUnchanged:
+
+    def test_its_own_address_wins(self, keyless_project):
+        from connectonion.network.trust.tools import get_self_address
+
+        project, _ = keyless_project
+        own = address.generate()
+        address.save(own, project / ".co")
+
+        assert get_self_address() == own["address"]
+
+    def test_nothing_anywhere_is_not_a_crash(self, tmp_path, monkeypatch):
+        from connectonion.network.trust.tools import get_self_address
+
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "empty"))
+        project = tmp_path / "bare"
+        (project / ".co").mkdir(parents=True)
+        monkeypatch.chdir(project)
+
+        assert get_self_address() in (None, "")


### PR DESCRIPTION
Two places in the trust layer loaded the agent's key straight from the project directory. Neither `co init` nor `co create` writes one, so both came back empty.

## Paid onboarding could never succeed

`_verify_transfer_via_api` loads keys to sign its request to oo-api and gives up when there are none — **before making the call**:

```
project_co_dir(): …/keyless/.co
address.load(...): None
=> verify_payment returns False before any oo-api call
```

Measured on `main`. A stranger who really had transferred the money was refused, and the refusal is indistinguishable from "you did not pay".

## And the address to pay was not the agent's

`get_self_address` has the same shape, so `doors_that_open` advertised either **no payment door at all** — nothing to send to — or a stale one from `address.json`.

Together: on the common configuration, an agent could not say where to pay and could not confirm a payment that arrived.

## The answer is the machine identity

Both ask `project_identity()` now — the project's own key, else the machine's, which is what `resolve_agent_identity` already falls back to and the host already serves under.

**Deliberately not a per-project derived identity.** An address is what an OpenOnion account is keyed on: `authenticate()` signs with it and the backend issues the token for that public key, so minting one per project would give every project an empty balance. That was #715, which Aaron stopped — correctly, and I have closed it.

## `co doctor` had the rule twice

The keys row and the connectivity check each worked it out separately, in the same file, and the second one picks the key it signs the backend probe with. They agreed by luck; nothing made them. The probe asks the resolver now.

The row still names a *file* — a different question, and worth printing — with a test that the file it names holds the identity it authenticates as.

## Tests

11 cases, 6 red first.

One of mine was wrong and is fixed rather than worked around: it patched `requests.post` while `_verify_transfer_via_api` uses `httpx`, so the fake was never called and the code looked like it still gave up early.

Closes #716.
