### PR TITLE
A schedule entry can run a command, not only a prompt

### DIFF
--- a/connectonion/network/host/schedule.py
+++ b/connectonion/network/host/schedule.py
@@ -58,9 +58,21 @@ def running_entries() -> set:
 
 @dataclass
 class Entry:
-    """One line of the schedule: what to run, and how often or when."""
+    """One line of the schedule: what to run, and how often or when.
+
+    `run` is a prompt, executed through the same path as POST /input. `exec` is
+    a command, executed directly. Exactly one of them.
+
+    The second exists because the first cannot be trusted for deterministic
+    work: a task whose whole job was running one script logged "successfully
+    executed the script and updated…" on several consecutive runs while the
+    output file's mtime never moved (#709). The log line is the model's own
+    account and nothing compared it against the filesystem. An exec entry is
+    recorded by its exit code, which nothing has an opinion about.
+    """
     name: str
-    run: str
+    run: Optional[str] = None
+    exec: Optional[str] = None
     interval: Optional[timedelta] = None
     at: Optional[str] = None
     tz: Optional[str] = None
@@ -109,8 +121,16 @@ def load_entries(co_dir, report=False):
             problems.append(f"{where}: not a mapping")
             continue
         run = item.get("run")
-        if not isinstance(run, str) or not run.strip():
-            problems.append(f"{where}: no run")
+        command = item.get("exec")
+        has_run = isinstance(run, str) and run.strip()
+        has_exec = isinstance(command, str) and command.strip()
+        if has_run and has_exec:
+            # Two answers to "what does this entry do" is a question, not a
+            # default, and picking one silently is how the wrong half runs.
+            problems.append(f"{where}: has both run and exec — pick one")
+            continue
+        if not has_run and not has_exec:
+            problems.append(f"{where}: no run or exec")
             continue
 
         interval = at = None
@@ -130,8 +150,13 @@ def load_entries(co_dir, report=False):
             problems.append(f"{where}: needs every or at")
             continue
 
-        name = str(item.get("name") or run).strip()
-        entry = Entry(name=name, run=run.strip(), interval=interval, at=at,
+        # `or run` alone names an unnamed exec entry "None", since run is
+        # None for those.
+        name = str(item.get("name") or run or command).strip()
+        entry = Entry(name=name,
+                      run=run.strip() if has_run else None,
+                      exec=command.strip() if has_exec else None,
+                      interval=interval, at=at,
                       tz=str(item["tz"]).strip() if item.get("tz") else None)
 
         if at is not None and _parse_at(entry) is None:
@@ -445,6 +470,27 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
         if console:
             console.print(f"[dim][schedule][/dim] {message}")
 
+    def _run_command(entry: Entry) -> tuple:
+        """Run the entry's command and report its exit code.
+
+        Nothing is asked whether it succeeded — that is the whole point of the
+        exec form. A task whose job was running one script reported success on
+        several consecutive runs while the file it writes never changed (#709),
+        because the only account of what happened was the model's own.
+
+        stderr is kept on failure: a non-zero exit with nothing to read is a
+        mystery at 3am, and the schedule state is where someone will look.
+        """
+        import subprocess
+
+        result = subprocess.run(entry.exec, shell=True, cwd=co_dir.parent,
+                                capture_output=True, text=True, timeout=600)
+        if result.returncode == 0:
+            return "done", None
+        detail = (result.stderr or result.stdout or "").strip()
+        return "failed", f"exit {result.returncode}: {detail[-400:]}" if detail else \
+            f"exit {result.returncode}"
+
     def _run_entry(entry: Entry) -> tuple:
         """One turn, through the same path as POST /input.
 
@@ -503,7 +549,12 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
                 # A turn takes as long as it takes — four minutes is normal for
                 # real work. In a thread, so the heartbeat keeps going and the
                 # agent stays reachable while it runs.
-                status, session_id = await asyncio.to_thread(_run_entry, entry)
+                if entry.exec:
+                    status, reason = await asyncio.to_thread(_run_command, entry)
+                    session_id = None
+                else:
+                    status, session_id = await asyncio.to_thread(_run_entry, entry)
+                    reason = None
             except Exception as exc:
                 # One entry failing is not the scheduler failing. Record it and
                 # keep the others on time.
@@ -516,7 +567,8 @@ def create_schedule_lifespan(co_dir: Path, create_agent, storage, result_ttl: in
                 # mean the entry never runs again, which is worse than the
                 # overlap it prevents.
                 in_flight.discard(entry.name)
-            record_run(co_dir, entry.name, when=now, status=status, session_id=session_id)
+            record_run(co_dir, entry.name, when=now, status=status,
+                       session_id=session_id, reason=reason)
 
     def _compact_sessions() -> None:
         """Housekeeping on the tick, because startup may never come again.

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -496,7 +496,9 @@ def scheduled_entries():
         when = last_run(state, e.name)
         out.append({
             "name": e.name,
-            "run": e.run,
+            # An exec entry has no prompt, and a blank here is a scheduled
+            # task that looks like it does nothing (#709).
+            "run": e.run or e.exec,
             "cadence": f"every {_cadence(e)}" if e.interval else str(e.at or ""),
             "status": st.get("status"),
             "last_run": when,

--- a/tests/unit/test_a_scheduled_command_actually_runs.py
+++ b/tests/unit/test_a_scheduled_command_actually_runs.py
@@ -1,0 +1,171 @@
+"""A scheduled task can report success without doing the work.
+
+From #709, measured on a real agent. The task's whole job was running one
+script:
+
+    - name: refresh dashboard numbers
+      every: 30m
+      run: |
+        Run .co/skills/<skill>/scripts/stats.py to recompute stats.json.
+
+and the log said, on several consecutive runs:
+
+    [co] ✓ The agent successfully executed the `stats.py` script and updated …
+
+The output file's mtime never changed. Running the same script by hand, on the
+same box as the same user, updated it immediately. So the schedule reported
+success for about a day while the dashboard served day-old numbers.
+
+Structural, not a one-off: `run` is a prompt executed through the same path as
+`POST /input`, and there was no way to say "just execute this command". Even
+fully deterministic maintenance went through a model that can claim completion,
+and the log line is that model's own account — nothing compares it against the
+filesystem.
+
+So an entry may say `exec:` instead of `run:`. The command runs, and what is
+recorded is its exit code. There is no room for it to be reported as done
+without having run, because nothing is asked for an opinion.
+
+Same family as #535 and #682, which this release has spent itself on: `done`
+must not mean "something said done".
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from connectonion.network.host.schedule import load_entries
+
+
+def _write(co_dir, text):
+    co_dir.mkdir(parents=True, exist_ok=True)
+    (co_dir / "schedule.yaml").write_text(text, encoding="utf-8")
+    return co_dir
+
+
+@pytest.fixture
+def co_dir(tmp_path):
+    return tmp_path / ".co"
+
+
+class TestAnEntryMaySayExec:
+
+    def test_it_loads(self, co_dir):
+        _write(co_dir, '- name: stats\n  every: 30m\n  exec: python scripts/stats.py\n')
+
+        entries, problems = load_entries(co_dir, report=True)
+
+        assert problems == []
+        assert [e.name for e in entries] == ["stats"]
+
+    def test_the_command_is_kept(self, co_dir):
+        _write(co_dir, '- name: stats\n  every: 30m\n  exec: python scripts/stats.py\n')
+
+        assert load_entries(co_dir)[0].exec == "python scripts/stats.py"
+
+    def test_a_prompt_entry_still_works(self, co_dir):
+        _write(co_dir, '- name: think\n  every: 30m\n  run: consider the numbers\n')
+        entry = load_entries(co_dir)[0]
+
+        assert entry.run == "consider the numbers"
+        assert entry.exec is None
+
+    def test_neither_is_a_problem(self, co_dir):
+        _write(co_dir, '- name: empty\n  every: 30m\n')
+
+        _entries, problems = load_entries(co_dir, report=True)
+
+        assert problems and "run" in problems[0].lower()
+
+    def test_both_is_a_problem(self, co_dir):
+        """Two answers to "what does this entry do" is a question, not a
+        default — and picking one silently is how the wrong half runs."""
+        _write(co_dir, '- name: two\n  every: 30m\n  run: think\n  exec: echo hi\n')
+
+        _entries, problems = load_entries(co_dir, report=True)
+
+        assert problems, "an entry with both run and exec was accepted"
+
+
+class TestItRunsTheCommandForReal:
+
+    def _tick(self, co_dir, monkeypatch):
+        import asyncio
+        import importlib
+
+        from connectonion.network.host.schedule import create_schedule_lifespan
+
+        router = importlib.import_module("connectonion.network.host.http_router")
+        monkeypatch.setattr(router, "input_handler",
+                            lambda *a, **kw: pytest.fail("a prompt path ran for an exec entry"))
+        on_startup, _ = create_schedule_lifespan(co_dir, lambda: None, None, result_ttl=60)
+        asyncio.run(on_startup.tick_once())
+
+    def test_the_side_effect_happens(self, co_dir, monkeypatch, tmp_path):
+        marker = tmp_path / "ran.txt"
+        _write(co_dir, f'- name: touch\n  every: 1m\n  exec: /usr/bin/touch {marker}\n')
+
+        self._tick(co_dir, monkeypatch)
+
+        assert marker.exists(), "the scheduled command did not run"
+
+    def test_a_failing_command_is_recorded_as_failed(self, co_dir, monkeypatch):
+        from connectonion.network.host.schedule import load_state
+
+        _write(co_dir, '- name: broken\n  every: 1m\n  exec: /usr/bin/false\n')
+
+        self._tick(co_dir, monkeypatch)
+        state = load_state(co_dir)
+
+        assert state["broken"]["status"] == "failed", state
+
+    def test_a_working_command_is_recorded_as_done(self, co_dir, monkeypatch):
+        from connectonion.network.host.schedule import load_state
+
+        _write(co_dir, '- name: fine\n  every: 1m\n  exec: /usr/bin/true\n')
+
+        self._tick(co_dir, monkeypatch)
+        state = load_state(co_dir)
+
+        assert state["fine"]["status"] == "done", state
+
+    def test_the_failure_says_what_the_command_said(self, co_dir, monkeypatch):
+        """A non-zero exit with nothing to read is a mystery at 3am."""
+        from connectonion.network.host.schedule import load_state
+
+        _write(co_dir, '- name: noisy\n  every: 1m\n  exec: sh -c "echo the-real-reason >&2; exit 3"\n')
+
+        self._tick(co_dir, monkeypatch)
+        reason = load_state(co_dir)["noisy"].get("reason", "")
+
+        assert "the-real-reason" in reason, reason
+
+
+class TestHomeShowsWhatTheEntryDoes:
+    """The dashboard sends `run` for each entry. An exec entry has none, so Home
+    would list a scheduled task with a blank where its work should be — an
+    operator looking at the panel to see what runs would see nothing."""
+
+    def _rows(self, co_dir, monkeypatch):
+        """Through the real `scheduled_entries`, which reads the schedule module
+        rather than reparsing the file — so the page and the scheduler cannot
+        disagree about what an entry means."""
+        from connectonion.network.host.ws_router import dashboard
+
+        monkeypatch.setattr(dashboard, "_co", lambda: co_dir)
+        entries, _problems = dashboard.scheduled_entries()
+        return entries
+
+    def test_an_exec_entry_is_not_blank(self, co_dir, monkeypatch):
+        _write(co_dir, '- name: stats\n  every: 30m\n  exec: python scripts/stats.py\n')
+
+        row = self._rows(co_dir, monkeypatch)[0]
+
+        assert row["run"], row
+        assert "stats.py" in row["run"]
+
+    def test_a_prompt_entry_is_unchanged(self, co_dir, monkeypatch):
+        _write(co_dir, '- name: think\n  every: 30m\n  run: consider the numbers\n')
+
+        assert self._rows(co_dir, monkeypatch)[0]["run"] == "consider the numbers"


### PR DESCRIPTION
From #709, measured on a real agent. A task whose whole job was running one script logged, on several consecutive runs:

```
[co] ✓ The agent successfully executed the `stats.py` script and updated …
```

The output file's mtime never changed. Running the script by hand on the same box, as the same user, updated it immediately. **The schedule reported success for about a day while the dashboard served day-old numbers.**

Structural, not a one-off: `run` is a prompt executed through the same path as `POST /input`, and there was no way to say *"just execute this command"*. Deterministic maintenance went through a model that can claim completion, and the log line was that model's own account — nothing compared it against the filesystem.

Same family as #535 and #682, which this release has spent itself on: **`done` must not mean "something said done".**

## What changes

```yaml
- name: refresh dashboard numbers
  every: 30m
  exec: python scripts/stats.py
```

The command runs and what is recorded is its **exit code**, which nothing has an opinion about. On failure the command's own stderr is kept — a non-zero exit with nothing to read is a mystery at 3am, and the schedule state is where someone will look.

`run:` is untouched. An entry with **both** is a problem rather than a default: two answers to "what does this do" is a question, and picking one silently is how the wrong half runs.

## Verified on a real host

```
command ran: YES
stamp    status=done    reason=
broken   status=failed  reason=exit 3: real-reason
```

## Found reviewing my own change

- An **unnamed** exec entry would have been called `"None"` — the name falls back to `run`, which is now `None` for those.
- **Home would have shown a blank.** The dashboard takes `run` for each row, so an exec entry would have listed a scheduled task with nothing under what it does — an operator checking the panel to see what runs would have seen an empty cell.

## Tests

11 cases, 9 red first. The execution ones assert the side effect on disk and fail the test if the prompt path is entered at all.

Closes #709.
