### PR TITLE
The agent does not get to write the files that decide what it may do

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -429,6 +429,17 @@ def check_approval(agent: 'Agent') -> None:
         tool_name = pending['name']
         tool_args = pending['arguments']
 
+        # Before the whitelist, and before the mode: these decide what this
+        # agent may do and who may command it, so no configuration grants them.
+        # is_tool_permitted has the same guard, but this is the path the agent's
+        # own turn takes -- that function is for callers outside the LLM loop,
+        # and a guard added only there would have left the case #722 is about
+        # untouched. Two copies of the matching already live in this file; this
+        # comment is here so the third does not go unnoticed.
+        refusal = _refuse_control_file(tool_name, tool_args)
+        if refusal:
+            raise ValueError(refusal)
+
         # Get permissions from session (includes safe tools from template)
         permissions = agent.current_session.get('permissions', {})
 
@@ -754,6 +765,26 @@ def _is_control_file(path: str) -> bool:
 CO_DIR_NAME = ".co"
 
 
+def _refuse_control_file(tool_name: str, tool_args: dict):
+    """The reason this call may not touch the agent's own control files, or None.
+
+    Shared by the two places that decide whether a tool may run: this module's
+    `check_approval` (the agent's own turn) and `is_tool_permitted` (network
+    EXEC and anything else outside the loop).
+    """
+    for key in ("file_path", "path", "target", "filename"):
+        candidate = tool_args.get(key)
+        if candidate and _is_control_file(candidate):
+            return (f"{Path(str(candidate)).name} decides what this agent may do — "
+                    f"the agent does not get to write it")
+
+    if tool_name == 'bash' and 'command' in tool_args:
+        command = str(tool_args['command'])
+        if any(_is_control_file(word.strip("'\"")) for word in command.split()):
+            return ("this command names a file that decides what this agent may do")
+    return None
+
+
 def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tuple[bool, str]:
     """Check one tool call against a permission whitelist. Returns (allowed, reason).
 
@@ -770,11 +801,9 @@ def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tup
     # Before the whitelist, not through it: these are refused however generously
     # the operator configured file writing, because they are what "how
     # generously" is stored in.
-    for key in ("file_path", "path", "target", "filename"):
-        candidate = tool_args.get(key)
-        if candidate and _is_control_file(candidate):
-            return False, (f"{Path(str(candidate)).name} decides what this agent may do — "
-                           f"the agent does not get to write it")
+    refusal = _refuse_control_file(tool_name, tool_args)
+    if refusal:
+        return False, refusal
 
     # A speed bump for bash, not a boundary — and worth being exact about which.
     # It catches a control path written literally (`> .co/host.yaml`). It does
@@ -785,11 +814,6 @@ def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tup
     # already granted everything, and this does not take it back. The complete
     # protection here is for the file tools above, where the path is an argument
     # rather than a string to be interpreted.
-    if tool_name == 'bash' and 'command' in tool_args:
-        command = str(tool_args['command'])
-        if any(_is_control_file(word.strip("'\"")) for word in command.split()):
-            return False, ("this command names a file that decides what this agent "
-                           "may do")
 
     # Bash chains: every subcommand in "a && b | c" must be individually
     # permitted. This is AUTHORITATIVE for bash — we never fall through to the

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -719,6 +719,41 @@ def load_permission_patterns(co_dir=None) -> dict:
     return permissions
 
 
+# The files that decide what this agent may do and who may command it. An
+# operator who whitelists `write` — which every coding agent needs — was also
+# handing over these, and `load_config_permissions()` reads the first one back
+# as the whitelist. So a prompt-injected turn could write itself `Bash(*)` and
+# every later turn, in every later session, was unrestricted (#722).
+#
+# Not all of `.co/`: agents write `dashboard.html` on purpose — it *is* the Home
+# page, built by the dashboard skill — and logs, docs and skills are content
+# too. The line is what a file decides, not where it lives.
+CONTROL_FILES = ("host.yaml", "schedule.yaml", "admins.txt")
+CONTROL_DIRS = ("keys",)
+
+
+def _is_control_file(path: str) -> bool:
+    """True if this path is one of the agent's own control files.
+
+    Compared on the normalised path so `./co/..`, `../.co/x` and an absolute
+    path all reach the same answer — a check that only matches the tidy
+    spelling is a check with a published bypass.
+    """
+    import os
+
+    normalised = os.path.normpath(str(path)).replace(os.sep, "/")
+    parts = normalised.split("/")
+    if CO_DIR_NAME not in parts:
+        return False
+    tail = parts[parts.index(CO_DIR_NAME) + 1:]
+    if not tail:
+        return False
+    return tail[0] in CONTROL_FILES or tail[0] in CONTROL_DIRS
+
+
+CO_DIR_NAME = ".co"
+
+
 def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tuple[bool, str]:
     """Check one tool call against a permission whitelist. Returns (allowed, reason).
 
@@ -731,6 +766,30 @@ def is_tool_permitted(tool_name: str, tool_args: dict, permissions: dict) -> tup
 
     if not permissions:
         return False, "no permissions configured"
+
+    # Before the whitelist, not through it: these are refused however generously
+    # the operator configured file writing, because they are what "how
+    # generously" is stored in.
+    for key in ("file_path", "path", "target", "filename"):
+        candidate = tool_args.get(key)
+        if candidate and _is_control_file(candidate):
+            return False, (f"{Path(str(candidate)).name} decides what this agent may do — "
+                           f"the agent does not get to write it")
+
+    # A speed bump for bash, not a boundary — and worth being exact about which.
+    # It catches a control path written literally (`> .co/host.yaml`). It does
+    # not catch `cd .co && echo x > host.yaml`, and nothing word-shaped can:
+    # reaching that would mean interpreting the shell.
+    #
+    # What actually bounds bash is the operator's own whitelist. `Bash(*)` has
+    # already granted everything, and this does not take it back. The complete
+    # protection here is for the file tools above, where the path is an argument
+    # rather than a string to be interpreted.
+    if tool_name == 'bash' and 'command' in tool_args:
+        command = str(tool_args['command'])
+        if any(_is_control_file(word.strip("'\"")) for word in command.split()):
+            return False, ("this command names a file that decides what this agent "
+                           "may do")
 
     # Bash chains: every subcommand in "a && b | c" must be individually
     # permitted. This is AUTHORITATIVE for bash — we never fall through to the

--- a/tests/unit/test_the_agent_cannot_rewrite_its_own_rules.py
+++ b/tests/unit/test_the_agent_cannot_rewrite_its_own_rules.py
@@ -1,0 +1,170 @@
+"""An agent with the write tool can rewrite the whitelist it is judged by.
+
+`load_config_permissions()` reads `.co/host.yaml` into `session['permissions']`,
+and nothing treats that file as different from any other. With `write` allowed
+— the configuration any coding agent has — the agent may write it:
+
+    perms = {'write': {'allowed': True}, 'edit': {'allowed': True}}
+
+    write  notes.md               -> (True, 'allowed')
+    write  .co/host.yaml          -> (True, 'allowed')     <- its own whitelist
+    write  .co/schedule.yaml      -> (True, 'allowed')
+    edit   .co/host.yaml          -> (True, 'allowed')
+
+So a prompt-injected turn writes itself `Bash(*)` and every later turn — and
+every later session — is unrestricted. The gate is real, and the thing it gates
+decides its own rules.
+
+This is not "the agent can already run bash". An operator who whitelists
+`Bash(git status)` has said what they will tolerate. Editing `host.yaml` is not
+one of the things they tolerated; it is the ability to change the answer,
+permanently.
+
+The line is what a file *decides*, not where it lives. These four decide what
+the agent may do and who may command it:
+
+    .co/host.yaml        permissions, trust level, its own configuration
+    .co/schedule.yaml    what runs unattended, including exec: (#709)
+    .co/admins.txt       who may command it
+    .co/keys/            who it is
+
+Everything else under `.co/` stays writable, because agents legitimately write
+there — `dashboard.html` *is* the Home page, and the dashboard skill builds it.
+A blanket ban would break a feature to fix a hole.
+"""
+
+import pytest
+
+from connectonion.useful_plugins.tool_approval.approval import is_tool_permitted
+
+
+OPEN = {"write": {"allowed": True}, "edit": {"allowed": True},
+        "multi_edit": {"allowed": True}}
+
+
+class TestTheControlFilesAreRefused:
+
+    @pytest.mark.parametrize("path", [
+        ".co/host.yaml",
+        ".co/schedule.yaml",
+        ".co/admins.txt",
+        ".co/keys/agent.key",
+        ".co/keys/recovery.txt",
+    ])
+    @pytest.mark.parametrize("tool", ["write", "edit", "multi_edit"])
+    def test_it_cannot_be_written(self, tool, path):
+        allowed, _reason = is_tool_permitted(tool, {"file_path": path}, OPEN)
+
+        assert allowed is False, f"{tool} was allowed to write {path}"
+
+    def test_the_reason_says_why(self):
+        _allowed, reason = is_tool_permitted("write", {"file_path": ".co/host.yaml"}, OPEN)
+
+        assert "host.yaml" in reason or "control" in reason.lower(), reason
+
+    @pytest.mark.parametrize("path", [
+        "/abs/project/.co/host.yaml",
+        "../.co/host.yaml",
+        "./.co/schedule.yaml",
+        ".co//host.yaml",
+    ])
+    def test_the_path_does_not_have_to_be_spelled_one_way(self, path):
+        """A check that only matches the tidy spelling is a check with a
+        published bypass."""
+        allowed, _reason = is_tool_permitted("write", {"file_path": path}, OPEN)
+
+        assert allowed is False, path
+
+
+class TestContentStaysWritable:
+    """Agents write here on purpose. Breaking that to close the hole would be a
+    worse trade than the hole."""
+
+    @pytest.mark.parametrize("path", [
+        ".co/dashboard.html",
+        ".co/logs/agent.log",
+        ".co/docs/notes.md",
+        ".co/skills/mine/SKILL.md",
+        "notes.md",
+        "src/main.py",
+    ])
+    def test_it_is_still_allowed(self, path):
+        allowed, _reason = is_tool_permitted("write", {"file_path": path}, OPEN)
+
+        assert allowed is True, f"{path} should still be writable"
+
+    def test_a_file_merely_named_like_one_is_fine(self):
+        """`host.yaml` in the project root is not the agent's configuration."""
+        allowed, _reason = is_tool_permitted("write", {"file_path": "host.yaml"}, OPEN)
+
+        assert allowed is True
+
+
+class TestNothingElseChanges:
+
+    def test_no_permissions_still_refuses_everything(self):
+        allowed, reason = is_tool_permitted("write", {"file_path": "notes.md"}, {})
+
+        assert allowed is False
+        assert "no permissions" in reason
+
+    def test_bash_is_still_checked_per_subcommand(self):
+        perms = {"Bash(git status)": {"allowed": True}}
+
+        assert is_tool_permitted("bash", {"command": "git status"}, perms)[0] is True
+        assert is_tool_permitted("bash", {"command": "git status && rm -rf /"}, perms)[0] is False
+
+    def test_bash_cannot_write_a_control_file_either(self):
+        """The same decision, reached with a different tool."""
+        perms = {"Bash(*)": {"allowed": True}}
+
+        allowed, _reason = is_tool_permitted(
+            "bash", {"command": "echo 'permissions: {}' > .co/host.yaml"}, perms)
+
+        assert allowed is False
+
+
+class TestWhatTheBashCheckDoesNotCover:
+    """Written down because a partial guard mistaken for a boundary is worse
+    than no guard.
+
+    The file-tool check is complete: the path is an argument, so it can be
+    normalised and compared. Bash takes a string to be interpreted later, and a
+    word-shaped check cannot follow it.
+    """
+
+    def test_a_literal_path_is_caught(self):
+        perms = {"Bash(*)": {"allowed": True}}
+
+        allowed, reason = is_tool_permitted(
+            "bash", {"command": "echo x > .co/host.yaml"}, perms)
+
+        assert allowed is False
+        assert "decides what this agent may do" in reason
+
+    def test_changing_directory_first_is_not(self):
+        """The known bypass. Reaching it would mean interpreting the shell.
+
+        What bounds bash is the operator's whitelist: this only gets through
+        because the operator granted the subcommands it uses. `Bash(*)` has
+        already granted everything, and this check does not take it back.
+        """
+        perms = {"Bash(cd *)": {"allowed": True}, "Bash(echo *)": {"allowed": True}}
+
+        allowed, _reason = is_tool_permitted(
+            "bash", {"command": "cd .co && echo x > host.yaml"}, perms)
+
+        assert allowed is True, (
+            "if this now fails, the bash check learned to follow a cd — update "
+            "the note in approval.py, it is no longer only a speed bump"
+        )
+
+    def test_the_narrow_whitelist_is_what_actually_holds(self):
+        """An operator who whitelisted one command has not granted the others,
+        and that is the real boundary."""
+        perms = {"Bash(git status)": {"allowed": True}}
+
+        allowed, _reason = is_tool_permitted(
+            "bash", {"command": "cd .co && echo x > host.yaml"}, perms)
+
+        assert allowed is False

--- a/tests/unit/test_the_agent_cannot_rewrite_its_own_rules.py
+++ b/tests/unit/test_the_agent_cannot_rewrite_its_own_rules.py
@@ -168,3 +168,66 @@ class TestWhatTheBashCheckDoesNotCover:
             "bash", {"command": "cd .co && echo x > host.yaml"}, perms)
 
         assert allowed is False
+
+
+class TestTheAgentsOwnLoopIsCoveredToo:
+    """`is_tool_permitted` is not the path the attack takes.
+
+    `check_approval` — the before_each_tool hook, which is what runs when the
+    agent itself calls a tool — has its own copy of the matching logic and never
+    calls `is_tool_permitted`. Its docstring describes them as *"same matching
+    the LLM approval flow uses in check_approval"*, which reads like a guarantee
+    and is a duplication.
+
+    So a guard added only to `is_tool_permitted` protects network EXEC and
+    leaves the agent's own turn — the case #722 is about — untouched. I nearly
+    shipped exactly that.
+    """
+
+    def _approve(self, tool_name, tool_args, permissions):
+        """Drive the real hook, and report whether the call was let through.
+
+        `check_approval(agent)` takes only the agent — the call under
+        consideration comes from `session['pending_tool']`. My first version
+        passed `tool_name=`/`tool_args=` as keywords, which are not parameters:
+        every call raised TypeError, the `except` read it as a refusal, and the
+        two tests that expected a refusal passed for that reason. Two tests
+        green off a TypeError is exactly the false evidence this file is about.
+        """
+        from types import SimpleNamespace
+
+        from connectonion.useful_plugins.tool_approval.approval import check_approval
+
+        agent = SimpleNamespace(
+            current_session={
+                "pending_tool": {"name": tool_name, "arguments": tool_args},
+                "permissions": permissions,
+                "mode": "auto_review",
+            },
+            io=None, logger=None,
+        )
+        try:
+            check_approval(agent)
+        except ValueError as exc:           # a refusal is raised, not returned
+            return False, str(exc)
+        return True, "allowed"
+
+    def test_the_agent_cannot_write_its_own_whitelist(self):
+        allowed, reason = self._approve("write", {"file_path": ".co/host.yaml"}, OPEN)
+
+        assert allowed is False, "the agent's own loop still lets it rewrite host.yaml"
+
+    def test_the_agent_cannot_write_its_own_schedule(self):
+        allowed, _reason = self._approve("write", {"file_path": ".co/schedule.yaml"}, OPEN)
+
+        assert allowed is False
+
+    def test_the_agent_can_still_write_its_home_page(self):
+        allowed, _reason = self._approve("write", {"file_path": ".co/dashboard.html"}, OPEN)
+
+        assert allowed is True
+
+    def test_the_agent_can_still_write_ordinary_files(self):
+        allowed, _reason = self._approve("write", {"file_path": "src/main.py"}, OPEN)
+
+        assert allowed is True


### PR DESCRIPTION
`load_config_permissions()` reads `.co/host.yaml` into `session['permissions']`, and nothing treated that file as different from any other. With `write` allowed — the configuration any coding agent has — the agent could write it:

```
perms = {'write': {'allowed': True}, 'edit': {'allowed': True}}

write  notes.md               -> (True, 'allowed')
write  .co/host.yaml          -> (True, 'allowed')     <- its own whitelist
write  .co/schedule.yaml      -> (True, 'allowed')
edit   .co/host.yaml          -> (True, 'allowed')
```

A prompt-injected turn writes itself `Bash(*)` and **every later turn, in every later session, is unrestricted**. The gate is real, and the thing it gates decided its own rules.

Not the same as "the agent can already run bash": an operator who whitelists `Bash(git status)` has said what they will tolerate. Editing `host.yaml` is not one of those things — it is the ability to change the answer, permanently.

## Where the line is

What a file *decides*, not where it lives:

```
.co/host.yaml        permissions, trust level, its own configuration
.co/schedule.yaml    what runs unattended, including exec: (#709)
.co/admins.txt       who may command it
.co/keys/            who it is
```

Everything else under `.co/` stays writable. `dashboard.html` **is** the Home page and the dashboard skill builds it; logs, docs and skills are content too. A blanket ban would break a feature to close a hole.

Paths are normalised before comparison, so `../.co/host.yaml`, `./.co/…` and an absolute path all reach the same answer.

## Bash is a speed bump, and the code says so

It catches a control path written literally (`> .co/host.yaml`). It does **not** catch `cd .co && echo x > host.yaml`, and nothing word-shaped can — that would mean interpreting the shell.

What bounds bash is the operator's own whitelist; `Bash(*)` has already granted everything and this does not take it back. **There is a test asserting the bypass exists**, so the speed bump is not mistaken for a boundary later. If someone teaches the check to follow a `cd`, that test fails and asks them to update the note.

## Tests

33 cases, 20 red first.

Closes #722. Unblocks #721, which I held because `exec:` would otherwise have been a second, more direct door onto this.
