### PR TITLE
co syno login: a candidate answering HTML is a miss, not a crash

### DIFF
--- a/connectonion/useful_tools/synology.py
+++ b/connectonion/useful_tools/synology.py
@@ -142,7 +142,15 @@ def pick_reachable(candidates: list, timeout: float = 3.0) -> str:
             )
         except httpx.RequestError:
             continue
-        if reply.status_code == 200 and reply.json().get("success"):
+        if reply.status_code != 200:
+            continue
+        # A portal or reverse proxy can answer 200 with an HTML page. That is
+        # "not DSM", the same as no answer — move on to the next candidate.
+        try:
+            body = reply.json()
+        except ValueError:
+            continue
+        if body.get("success"):
             return base
 
     raise ValueError(

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -111,6 +111,25 @@ def test_pick_reachable_falls_past_unreachable_candidates():
         assert pick_reachable(["https://192.168.1.50:5001", "https://relay"]) == "https://relay"
 
 
+def test_pick_reachable_falls_past_a_200_that_is_not_dsm():
+    """A portal or proxy answering 200 with HTML is "not DSM", same as no answer.
+
+    Seen for real: `co syno login openonion-nas` resolved four candidates and
+    died with a JSONDecodeError on the first one instead of probing the rest.
+    """
+    from connectonion.useful_tools.synology import pick_reachable
+
+    def get(url, **kwargs):
+        if "portal" in url:
+            reply = MagicMock(status_code=200)
+            reply.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+            return reply
+        return MagicMock(status_code=200, json=lambda: {"success": True})
+
+    with patch("httpx.get", side_effect=get):
+        assert pick_reachable(["https://portal", "https://relay"]) == "https://relay"
+
+
 def test_pick_reachable_raises_when_nothing_answers():
     from connectonion.useful_tools.synology import pick_reachable
 


### PR DESCRIPTION
`co syno login openonion-nas` resolved 4 QuickConnect candidates and died with a raw JSONDecodeError on the first one that answered 200 with a non-JSON body, instead of probing the rest. `pick_reachable` already skips candidates that refuse the connection; this makes a 200-with-HTML (portal / proxy / router page) skip the same way.

Same family as f0bf157 (#628) — that sweep fixed the error branches in auth and send_email; this probe loop was missed because the non-JSON reply arrives with status 200.

Regression test added and proven red on unpatched code first.