### PR TITLE
co email sent: the Sent mailbox (#662), plus a relay import fix

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -97,6 +97,68 @@ def handle_email_inbox(last: int = 10, unread: bool = False):
     console.print("\n[dim]Read one with:[/dim] [bold]co email read <#>[/bold]\n")
 
 
+def handle_email_sent(last: int = 10, to: str = None):
+    """List emails the agent has sent."""
+    if not _require_auth():
+        return
+
+    from ...useful_tools.get_emails import get_sent
+    emails = get_sent(last=last, to=to)
+
+    if not emails:
+        scope = f" to {to}" if to else ""
+        console.print(f"\n[cyan]Sent:[/cyan] no emails{scope}\n")
+        return
+
+    table = Table(title="📤 Sent", show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("To")
+    table.add_column("Subject")
+    table.add_column("Status")
+    table.add_column("Sent")
+
+    for email in emails:
+        table.add_row(
+            str(email.get("id", "")),
+            str(email.get("to", "")),
+            str(email.get("subject", "")),
+            str(email.get("status", "")),
+            str(email.get("timestamp", ""))[:19],
+        )
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Read one with:[/dim] [bold]co email sent read <#>[/bold]\n")
+
+
+def handle_email_sent_read(email_id: str):
+    """Show a single sent email's body."""
+    if not _require_auth():
+        return
+
+    from ...useful_tools.get_emails import get_sent
+    emails = get_sent(last=100)
+    match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
+
+    if not match:
+        console.print(f"\n[yellow]No sent email with id {email_id} in your recent sent mail.[/yellow]\n")
+        return
+
+    header = (
+        f"[cyan]To:[/cyan]         {match.get('to', '')}\n"
+        f"[cyan]From:[/cyan]       {match.get('from', '')}\n"
+        f"[cyan]Subject:[/cyan]    {match.get('subject', '')}\n"
+        f"[cyan]Status:[/cyan]     {match.get('status', '')}\n"
+        f"[cyan]Message ID:[/cyan] {match.get('message_id', '')}\n"
+        f"[cyan]Date:[/cyan]       {match.get('timestamp', '')}"
+    )
+    console.print()
+    console.print(Panel.fit(header, title=f"📤 Sent #{email_id}", border_style="cyan"))
+    console.print()
+    console.print(match.get("body", "") or "[dim](empty body)[/dim]")
+    console.print()
+
+
 def handle_email_read(email_id: str):
     """Show a single email's body and mark it read."""
     if not _require_auth():

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -691,6 +691,29 @@ def email_read(email_id: str = typer.Argument(..., help="Email # from the inbox 
     handle_email_read(email_id)
 
 
+sent_app = _typer_app(help="List and read emails the agent has sent")
+email_app.add_typer(sent_app, name="sent")
+
+
+@sent_app.callback(invoke_without_command=True)
+def email_sent(
+    ctx: typer.Context,
+    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    to: str = typer.Option(None, "--to", help="Only emails sent to this address"),
+):
+    """With no subcommand, list recent sent emails."""
+    if ctx.invoked_subcommand is None:
+        from .commands.email_commands import handle_email_sent
+        handle_email_sent(last=last, to=to)
+
+
+@sent_app.command("read")
+def email_sent_read(email_id: str = typer.Argument(..., help="Email # from the sent list")):
+    """Show one sent email's body."""
+    from .commands.email_commands import handle_email_sent_read
+    handle_email_sent_read(email_id)
+
+
 @email_app.command("name")
 def email_name(
     name: str = typer.Argument(..., help="Desired name, e.g. 'aaron' → aaron@openonion.ai"),

--- a/connectonion/network/relay.py
+++ b/connectonion/network/relay.py
@@ -19,6 +19,11 @@ import json
 import asyncio
 from typing import Dict, Any
 import websockets
+# websockets >= 14 stopped re-exporting submodules lazily: `websockets.exceptions`
+# only resolves if some other module already imported it. The except at the
+# bottom of serve_loop needs the explicit import or it raises AttributeError
+# at the exact moment a connection drops.
+import websockets.exceptions
 
 
 async def connect(relay_url: str = "wss://oo.openonion.ai"):

--- a/connectonion/useful_tools/get_emails.py
+++ b/connectonion/useful_tools/get_emails.py
@@ -86,6 +86,60 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
     return formatted_emails
 
 
+def get_sent(last: int = 10, to: str = None) -> List[Dict]:
+    """Get emails the agent has sent (the Sent mailbox).
+
+    Args:
+        last: Number of emails to retrieve (default: 10)
+        to: Only emails sent to this address (default: all)
+
+    Returns:
+        List of email dictionaries containing:
+            - id: Record ID (use with `co email sent read <id>`)
+            - to: Recipient's email address
+            - from: The address it went out as
+            - subject: Email subject
+            - body: What was sent
+            - status: Last known status (e.g. "sent")
+            - message_id: Provider message ID
+            - timestamp: ISO format send time
+    """
+    token = os.getenv("OPENONION_API_KEY")
+
+    if not token:
+        raise ValueError(
+            "OPENONION_API_KEY not found in .env file. "
+            "Agent emails are hosted by OpenOnion and require authentication. "
+            "Check your .env file for OPENONION_API_KEY, or run 'co init' to copy "
+            "OPENONION_API_KEY from ~/.co/keys.env to your project."
+        )
+
+    backend_url = os.getenv("CONNECTONION_BACKEND_URL", "https://oo.openonion.ai")
+
+    params = {"limit": last}
+    if to:
+        params["to"] = to
+
+    response = requests.get(
+        f"{backend_url}/api/v1/email/sent",
+        params=params,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+        timeout=10,
+    )
+    response.raise_for_status()
+
+    return [{
+        "id": email.get("id", ""),
+        "to": email.get("to", ""),
+        "from": email.get("from", ""),
+        "subject": email.get("subject", ""),
+        "body": email.get("body", ""),
+        "status": email.get("status", ""),
+        "message_id": email.get("message_id", ""),
+        "timestamp": email.get("sent_at", ""),
+    } for email in response.json().get("emails", [])]
+
+
 def mark_read(email_ids: Union[str, List[str]]) -> bool:
     """Mark email(s) as read.
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -215,6 +215,8 @@ co email send bob@example.com "Hi" "Body text"    # send (HTML auto-detected)
 - `co email` / `co email inbox` - list received email (`--last/-n`, `--unread/-u`)
 - `co email read <#>` - print one message's body and mark it read
 - `co email send <to> <subject> <message>` - send from your agent address
+- `co email sent` - list sent email (`--last/-n`, `--to`)
+- `co email sent read <#>` - print one sent message's body and status
 - `co email name <name> [--buy]` - check or claim a readable address (e.g. `aaron@openonion.ai`), paid from credits
 - `co email upgrade <tier>` - raise your monthly send quota on your own domain (`plus`/`pro`, `--domain` required, `--alias` optional), paid from credits
 

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -77,6 +77,32 @@ co email send bob@example.com "Hi" "Just checking in."
 co email send bob@example.com "Receipt" "<h1>Paid</h1><p>Thanks!</p>"
 ```
 
+### `co email sent` — List sent email
+
+```bash
+co email sent                        # last 10
+co email sent --last 25              # last 25  (alias: -n 25)
+co email sent --to alice@example.com # only mail sent to alice
+```
+
+What your agent has sent, newest first, with each message's last known status.
+The leftmost `#` is the email's id — pass it to `co email sent read`. Useful
+after a failed batch: if a send is listed here, the server accepted it, and
+retrying would produce a duplicate.
+
+Options:
+- `--last, -n` — how many to show (default 10)
+- `--to` — only messages sent to this address
+
+### `co email sent read <#>` — Read one sent message
+
+```bash
+co email sent read 7
+```
+
+Prints the recipient, sender address, status, provider message id, date, and
+the body that was actually sent.
+
 ## Customizing your address (paid)
 
 The two commands below spend ConnectOnion credits. Each shows you the price or

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -26,7 +26,7 @@ import importlib
 # actual module object via importlib so patch.object targets the module, not the fn.
 send_email_module = importlib.import_module("connectonion.useful_tools.send_email")
 from connectonion.useful_tools.send_email import send_email, get_agent_email, is_email_active
-from connectonion.useful_tools.get_emails import get_emails, mark_read, mark_unread
+from connectonion.useful_tools.get_emails import get_emails, get_sent, mark_read, mark_unread
 
 # Import test configuration
 from tests.utils.config_helpers import (
@@ -181,6 +181,63 @@ def test_get_emails_no_project():
     """Test getting emails without OPENONION_API_KEY."""
     with pytest.raises(ValueError) as exc:
         get_emails()
+    assert "OPENONION_API_KEY not found" in str(exc.value)
+
+
+# === The Sent mailbox (issue #662) ===
+
+A_SENT_ROW = {
+    "id": 7,
+    "to": "alice@example.com",
+    "from": "0xtest@mail.openonion.ai",
+    "subject": "hello",
+    "body": "<p>hi</p>",
+    "status": "sent",
+    "message_id": "re_123",
+    "sent_at": "2026-08-07T03:00:00",
+}
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
+@patch('requests.get')
+def test_get_sent_returns_what_was_sent(mock_get):
+    """A sent email can be read back: recipient, body, status, message id."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"emails": [A_SENT_ROW], "count": 1}
+    mock_get.return_value = mock_response
+
+    emails = get_sent(last=5)
+
+    assert len(emails) == 1
+    assert emails[0]["to"] == "alice@example.com"
+    assert emails[0]["body"] == "<p>hi</p>"
+    assert emails[0]["status"] == "sent"
+    assert emails[0]["message_id"] == "re_123"
+    assert emails[0]["timestamp"] == "2026-08-07T03:00:00"
+
+    call_args = mock_get.call_args
+    assert call_args[0][0].endswith("/api/v1/email/sent")
+    assert call_args[1]["params"] == {"limit": 5}
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
+@patch('requests.get')
+def test_get_sent_filters_by_recipient(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"emails": [], "count": 0}
+    mock_get.return_value = mock_response
+
+    get_sent(to="alice@example.com")
+
+    assert mock_get.call_args[1]["params"] == {"limit": 10, "to": "alice@example.com"}
+
+
+@patch.dict('os.environ', {}, clear=True)
+def test_get_sent_without_auth_says_so():
+    with pytest.raises(ValueError) as exc:
+        get_sent()
     assert "OPENONION_API_KEY not found" in str(exc.value)
 
 

--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -28,6 +28,7 @@ import asyncio
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 from connectonion.network import relay
 import websockets
+import websockets.exceptions  # not re-exported by the package since websockets 14
 
 
 class TestRelayConnection:


### PR DESCRIPTION
Closes #662 (client half; server half is openonion/oo-api#116).

**Sent mailbox**
- `co email sent` — what the agent sent, newest first, with last known status
- `co email sent -n 25 --to alice@example.com` — more, or filtered by recipient
- `co email sent read <#>` — recipient, From address, status, provider message id, and the body that was actually sent
- `get_sent()` in useful_tools/get_emails.py is the engine and doubles as an agent tool; CLI is presentation only (same split as inbox/read)
- docs/cli/email.md and docs/cli/README.md updated

**Relay fix (separate commit)**
websockets >= 14 stopped lazily re-exporting submodules, so `except websockets.exceptions.ConnectionClosed` in serve_loop raises AttributeError at the exact moment a connection drops — unless something else imported the submodule first. Same flakiness hit test_relay.py under pytest-randomly (reproduced on main with --randomly-seed=4086534803). Explicit `import websockets.exceptions` in both.

Until oo-api#116 is deployed, `co email sent` fails with a clean HTTP error rather than lying — ship the server first.