### PR TITLE
Make `co email send` retries safe and traceable

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -109,7 +109,22 @@ def handle_email_sent(last: int = 10, to: str = None):
         return
 
     from ...useful_tools.get_emails import get_sent
-    emails = get_sent(last=last, to=to)
+    try:
+        emails = get_sent(last=last, to=to)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None and response.status_code == 404:
+            console.print(
+                "\n[yellow]Sent mail is not available on this backend yet.[/yellow] "
+                "The oo-api Sent endpoint must be deployed before this command can be used.\n"
+            )
+        else:
+            status = response.status_code if response is not None else "unknown"
+            console.print(f"\n[red]✗ Could not load sent mail (HTTP {status}).[/red]\n")
+        return
+    except requests.RequestException:
+        console.print("\n[red]✗ Could not reach the email service.[/red] Try again later.\n")
+        return
 
     if not emails:
         scope = f" to {to}" if to else ""
@@ -143,7 +158,22 @@ def handle_email_sent_read(email_id: str):
         return
 
     from ...useful_tools.get_emails import get_sent
-    emails = get_sent(last=100)
+    try:
+        emails = get_sent(last=100)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None and response.status_code == 404:
+            console.print(
+                "\n[yellow]Sent mail is not available on this backend yet.[/yellow] "
+                "The oo-api Sent endpoint must be deployed before this command can be used.\n"
+            )
+        else:
+            status = response.status_code if response is not None else "unknown"
+            console.print(f"\n[red]✗ Could not load sent mail (HTTP {status}).[/red]\n")
+        return
+    except requests.RequestException:
+        console.print("\n[red]✗ Could not reach the email service.[/red] Try again later.\n")
+        return
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
     if not match:

--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -45,20 +45,26 @@ def _err(response) -> str:
     return response.text.strip() or f"HTTP {response.status_code}"
 
 
-def handle_email_send(to: str, subject: str, message: str):
+def handle_email_send(to: str, subject: str, message: str, idempotency_key: str = None):
     """Send an email from the agent's address."""
     if not _require_auth():
         return
 
     from ...useful_tools.send_email import send_email
-    result = send_email(to, subject, message)
+    result = send_email(to, subject, message, idempotency_key=idempotency_key)
 
     if result.get("success"):
         console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
         console.print(f"  From:       {result.get('from', '')}")
         console.print(f"  Message ID: {result.get('message_id', '')}\n")
     else:
-        console.print(f"\n❌ [bold red]Failed:[/bold red] {result.get('error', 'Unknown error')}\n")
+        console.print(f"\n❌ [bold red]Failed:[/bold red] {result.get('error', 'Unknown error')}")
+        if result.get("request_id"):
+            console.print(f"  Request ID: {result['request_id']}")
+        if result.get("idempotency_key"):
+            console.print(f"  Safe retry key: {result['idempotency_key']}")
+            console.print("  [dim]Retry the same command with --idempotency-key <key>[/dim]")
+        console.print()
 
 
 def handle_email_inbox(last: int = 10, unread: bool = False):

--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -61,7 +61,7 @@ def handle_email_send(to: str, subject: str, message: str, idempotency_key: str 
         console.print(f"\n❌ [bold red]Failed:[/bold red] {result.get('error', 'Unknown error')}")
         if result.get("request_id"):
             console.print(f"  Request ID: {result['request_id']}")
-        if result.get("idempotency_key"):
+        if result.get("retryable") and result.get("idempotency_key"):
             console.print(f"  Safe retry key: {result['idempotency_key']}")
             console.print("  [dim]Retry the same command with --idempotency-key <key>[/dim]")
         console.print()

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -668,10 +668,15 @@ def email_send(
     to: str = typer.Argument(..., help="Recipient email address"),
     subject: str = typer.Argument(..., help="Subject line"),
     message: str = typer.Argument(..., help="Body (plain text or HTML)"),
+    idempotency_key: Optional[str] = typer.Option(
+        None,
+        "--idempotency-key",
+        help="Reuse a failed send's key to retry without sending twice",
+    ),
 ):
     """Send an email from the agent's address."""
     from .commands.email_commands import handle_email_send
-    handle_email_send(to, subject, message)
+    handle_email_send(to, subject, message, idempotency_key=idempotency_key)
 
 
 @email_app.command("inbox")

--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -33,7 +33,8 @@ def send_email(
         subject: Email subject line
         message: Email body (plain text or HTML)
         idempotency_key: Reuse the key from a failed result to retry without
-            sending the same email twice. A new key is generated when omitted.
+            sending the same email twice while the provider retry window is
+            still active. A new key is generated when omitted.
 
     Returns:
         dict: Success status and details
@@ -42,7 +43,8 @@ def send_email(
             - from (str): Sender email address
             - error (str): Error message if failed
             - request_id (str): Correlation ID for support and server logs
-            - idempotency_key (str): Key to reuse for a safe retry
+            - idempotency_key (str): Correlation key for this send attempt
+            - retryable (bool): Whether retrying this key is currently safe
     """
     send_key = idempotency_key or str(uuid.uuid4())
     # Credentials come from the environment. A .env file is a convenience fallback,
@@ -82,6 +84,7 @@ def send_email(
             "error": "OPENONION_API_KEY not set. Run 'co auth' to authenticate.",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": False,
         }
 
     if not from_email:
@@ -90,6 +93,7 @@ def send_email(
             "error": "AGENT_EMAIL not set. Run 'co auth' to set up email.",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": False,
         }
     
     # Validate recipient email
@@ -99,6 +103,7 @@ def send_email(
             "error": f"Invalid email address: {to}",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": False,
         }
     
     # Prepare email payload
@@ -142,20 +147,26 @@ def send_email(
                 "idempotency_key": data.get("idempotency_key", send_key),
             }
         elif response.status_code == 429:
-            error_msg, request_id, returned_key = _email_error(response, "Rate limit exceeded", send_key)
+            error_msg, request_id, returned_key, retryable = _email_error(
+                response, "Rate limit exceeded", send_key, default_retryable=False
+            )
             return {
                 "success": False,
                 "error": error_msg,
                 "request_id": request_id,
                 "idempotency_key": returned_key,
+                "retryable": retryable,
             }
         elif response.status_code == 401:
-            _, request_id, returned_key = _email_error(response, "Authentication failed", send_key)
+            _, request_id, returned_key, retryable = _email_error(
+                response, "Authentication failed", send_key, default_retryable=False
+            )
             return {
                 "success": False,
                 "error": "Authentication failed. Run 'co auth' to re-authenticate.",
                 "request_id": request_id,
                 "idempotency_key": returned_key,
+                "retryable": retryable,
             }
         else:
             # The backend answers errors in JSON; the gateway in front of it
@@ -167,16 +178,18 @@ def send_email(
             # deploy_commands._error_text and server_commands._report_failure
             # already guard the same call; auth (fixed above) and this were the
             # two that were missed.
-            error_msg, request_id, returned_key = _email_error(
+            error_msg, request_id, returned_key, retryable = _email_error(
                 response,
                 f"HTTP {response.status_code} (the reply was not JSON)",
                 send_key,
+                default_retryable=response.status_code >= 500,
             )
             return {
                 "success": False,
                 "error": error_msg,
                 "request_id": request_id,
                 "idempotency_key": returned_key,
+                "retryable": retryable,
             }
             
     except requests.exceptions.Timeout:
@@ -185,6 +198,7 @@ def send_email(
             "error": "Request timed out. Retry with the same idempotency key.",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": True,
         }
     except requests.exceptions.ConnectionError:
         return {
@@ -192,6 +206,7 @@ def send_email(
             "error": "Cannot connect to email service. Retry with the same idempotency key when it is reachable.",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": True,
         }
     except Exception as e:
         return {
@@ -199,28 +214,38 @@ def send_email(
             "error": f"Failed to send email: {str(e)}",
             "request_id": send_key,
             "idempotency_key": send_key,
+            "retryable": False,
         }
 
 
-def _email_error(response, fallback: str, send_key: str):
+def _email_error(
+    response,
+    fallback: str,
+    send_key: str,
+    *,
+    default_retryable: bool,
+):
     """Read the stable API error shape, with a gateway-safe fallback."""
     request_id = _response_header(response, "X-Request-ID", send_key)
     returned_key = send_key
+    retryable = default_retryable
     try:
         data = response.json()
         if not isinstance(data, dict):
-            return fallback, request_id, returned_key
+            return fallback, request_id, returned_key, retryable
         request_id = data.get("request_id", request_id)
         returned_key = data.get("idempotency_key", returned_key)
+        error = data.get("error")
+        if isinstance(error, dict) and isinstance(error.get("retryable"), bool):
+            retryable = error["retryable"]
         detail = data.get("detail")
         if detail:
-            return str(detail), request_id, returned_key
-        error = data.get("error")
+            return str(detail), request_id, returned_key, retryable
         if isinstance(error, dict) and error.get("message"):
-            return str(error["message"]), request_id, returned_key
+            return str(error["message"]), request_id, returned_key, retryable
     except (ValueError, AttributeError):
         pass
-    return fallback, request_id, returned_key
+    return fallback, request_id, returned_key, retryable
 
 
 def _response_header(response, name: str, fallback: str) -> str:

--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -13,19 +13,27 @@ import os
 import json
 import yaml
 import requests
+import uuid
 from pathlib import Path
 from ..project import project_co_dir
 from typing import Dict, Optional
 from dotenv import load_dotenv
 
 
-def send_email(to: str, subject: str, message: str) -> Dict:
+def send_email(
+    to: str,
+    subject: str,
+    message: str,
+    idempotency_key: Optional[str] = None,
+) -> Dict:
     """Send an email using the agent's email address.
 
     Args:
         to: Recipient email address
         subject: Email subject line
         message: Email body (plain text or HTML)
+        idempotency_key: Reuse the key from a failed result to retry without
+            sending the same email twice. A new key is generated when omitted.
 
     Returns:
         dict: Success status and details
@@ -33,7 +41,10 @@ def send_email(to: str, subject: str, message: str) -> Dict:
             - message_id (str): ID of sent message
             - from (str): Sender email address
             - error (str): Error message if failed
+            - request_id (str): Correlation ID for support and server logs
+            - idempotency_key (str): Key to reuse for a safe retry
     """
+    send_key = idempotency_key or str(uuid.uuid4())
     # Credentials come from the environment. A .env file is a convenience fallback,
     # NOT a precondition: env vars set directly (container / CI / systemd, or already
     # loaded by the `co` CLI) are equally valid. Load a .env if we can find one to
@@ -68,20 +79,26 @@ def send_email(to: str, subject: str, message: str) -> Dict:
     if not token:
         return {
             "success": False,
-            "error": "OPENONION_API_KEY not set. Run 'co auth' to authenticate."
+            "error": "OPENONION_API_KEY not set. Run 'co auth' to authenticate.",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
 
     if not from_email:
         return {
             "success": False,
-            "error": "AGENT_EMAIL not set. Run 'co auth' to set up email."
+            "error": "AGENT_EMAIL not set. Run 'co auth' to set up email.",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
     
     # Validate recipient email
     if not "@" in to or not "." in to.split("@")[-1]:
         return {
             "success": False,
-            "error": f"Invalid email address: {to}"
+            "error": f"Invalid email address: {to}",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
     
     # Prepare email payload
@@ -102,7 +119,9 @@ def send_email(to: str, subject: str, message: str) -> Dict:
     
     headers = {
         "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "X-Request-ID": send_key,
+        "Idempotency-Key": send_key,
     }
     
     try:
@@ -118,17 +137,25 @@ def send_email(to: str, subject: str, message: str) -> Dict:
             return {
                 "success": True,
                 "message_id": data.get("message_id", "msg_unknown"),
-                "from": data.get("from", from_email)  # actual server-side sender (reflects custom name)
+                "from": data.get("from", from_email),
+                "request_id": data.get("request_id", _response_header(response, "X-Request-ID", send_key)),
+                "idempotency_key": data.get("idempotency_key", send_key),
             }
         elif response.status_code == 429:
+            error_msg, request_id, returned_key = _email_error(response, "Rate limit exceeded", send_key)
             return {
                 "success": False,
-                "error": "Rate limit exceeded"
+                "error": error_msg,
+                "request_id": request_id,
+                "idempotency_key": returned_key,
             }
         elif response.status_code == 401:
+            _, request_id, returned_key = _email_error(response, "Authentication failed", send_key)
             return {
                 "success": False,
-                "error": "Authentication failed. Run 'co auth' to re-authenticate."
+                "error": "Authentication failed. Run 'co auth' to re-authenticate.",
+                "request_id": request_id,
+                "idempotency_key": returned_key,
             }
         else:
             # The backend answers errors in JSON; the gateway in front of it
@@ -140,30 +167,69 @@ def send_email(to: str, subject: str, message: str) -> Dict:
             # deploy_commands._error_text and server_commands._report_failure
             # already guard the same call; auth (fixed above) and this were the
             # two that were missed.
-            try:
-                error_msg = response.json().get("detail", "Unknown error")
-            except ValueError:
-                error_msg = f"HTTP {response.status_code} (the reply was not JSON)"
+            error_msg, request_id, returned_key = _email_error(
+                response,
+                f"HTTP {response.status_code} (the reply was not JSON)",
+                send_key,
+            )
             return {
                 "success": False,
-                "error": error_msg
+                "error": error_msg,
+                "request_id": request_id,
+                "idempotency_key": returned_key,
             }
             
     except requests.exceptions.Timeout:
         return {
             "success": False,
-            "error": "Request timed out. Please try again."
+            "error": "Request timed out. Retry with the same idempotency key.",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
     except requests.exceptions.ConnectionError:
         return {
             "success": False,
-            "error": "Cannot connect to email service. Check your internet connection."
+            "error": "Cannot connect to email service. Retry with the same idempotency key when it is reachable.",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
     except Exception as e:
         return {
             "success": False,
-            "error": f"Failed to send email: {str(e)}"
+            "error": f"Failed to send email: {str(e)}",
+            "request_id": send_key,
+            "idempotency_key": send_key,
         }
+
+
+def _email_error(response, fallback: str, send_key: str):
+    """Read the stable API error shape, with a gateway-safe fallback."""
+    request_id = _response_header(response, "X-Request-ID", send_key)
+    returned_key = send_key
+    try:
+        data = response.json()
+        if not isinstance(data, dict):
+            return fallback, request_id, returned_key
+        request_id = data.get("request_id", request_id)
+        returned_key = data.get("idempotency_key", returned_key)
+        detail = data.get("detail")
+        if detail:
+            return str(detail), request_id, returned_key
+        error = data.get("error")
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"]), request_id, returned_key
+    except (ValueError, AttributeError):
+        pass
+    return fallback, request_id, returned_key
+
+
+def _response_header(response, name: str, fallback: str) -> str:
+    """Read a response header without requiring test doubles to provide it."""
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return fallback
+    value = headers.get(name, fallback)
+    return value if isinstance(value, str) else fallback
 
 
 def get_agent_email() -> Optional[str]:

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -77,14 +77,14 @@ co email send bob@example.com "Subject line" "Body text" \
 
 The same key must only be reused with the same recipient, subject, and body.
 
-All three arguments are positional and required. HTML is auto-detected: if the
-body contains tags (`<...>`), it's sent as HTML, otherwise as plain text.
+All three arguments are positional and required. The message body is sent as
+provided; HTML markup is supported, and ordinary text can be passed directly.
 
 ```bash
 # Plain text
 co email send bob@example.com "Hi" "Just checking in."
 
-# HTML (auto-detected)
+# HTML
 co email send bob@example.com "Receipt" "<h1>Paid</h1><p>Thanks!</p>"
 ```
 

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -66,6 +66,17 @@ Prints the sender, subject, date, and body, then marks the message read.
 co email send bob@example.com "Subject line" "Body text"
 ```
 
+Every send carries a request ID and an idempotency key. If the result is
+uncertain (for example, a timeout after the provider accepted the message),
+the failure prints the key. Reuse it to retry without sending a duplicate:
+
+```bash
+co email send bob@example.com "Subject line" "Body text" \
+  --idempotency-key 4f07d5b4-9d8e-4e58-a889-11bb14cc70ab
+```
+
+The same key must only be reused with the same recipient, subject, and body.
+
 All three arguments are positional and required. HTML is auto-detected: if the
 body contains tags (`<...>`), it's sent as HTML, otherwise as plain text.
 

--- a/tests/unit/test_email_cli_errors.py
+++ b/tests/unit/test_email_cli_errors.py
@@ -8,6 +8,7 @@ import requests
 from connectonion.cli.commands import email_commands
 
 get_emails = importlib.import_module("connectonion.useful_tools.get_emails")
+send_email = importlib.import_module("connectonion.useful_tools.send_email")
 
 
 def _http_error(status):
@@ -42,3 +43,22 @@ def test_sent_read_hides_transport_tracebacks(monkeypatch, capsys):
     output = capsys.readouterr().out
     assert "Could not reach the email service" in output
     assert "secret host detail" not in output
+
+
+def test_send_does_not_call_a_non_retryable_key_safe(monkeypatch, capsys):
+    monkeypatch.setattr(email_commands, "_require_auth", lambda: True)
+    monkeypatch.setattr(send_email, "send_email", lambda *args, **kwargs: {
+        "success": False,
+        "error": "The provider retry window expired.",
+        "request_id": "req-old",
+        "idempotency_key": "send-old",
+        "retryable": False,
+    })
+
+    email_commands.handle_email_send("to@example.com", "subject", "body")
+
+    output = capsys.readouterr().out
+    assert "provider retry window expired" in output
+    assert "Request ID: req-old" in output
+    assert "Safe retry key" not in output
+    assert "--idempotency-key" not in output

--- a/tests/unit/test_email_cli_errors.py
+++ b/tests/unit/test_email_cli_errors.py
@@ -1,0 +1,44 @@
+"""The Sent CLI explains backend version skew instead of dumping a traceback."""
+
+import importlib
+from unittest.mock import MagicMock
+
+import requests
+
+from connectonion.cli.commands import email_commands
+
+get_emails = importlib.import_module("connectonion.useful_tools.get_emails")
+
+
+def _http_error(status):
+    response = MagicMock(status_code=status)
+    return requests.HTTPError(f"HTTP {status}", response=response)
+
+
+def test_sent_list_explains_an_old_backend(monkeypatch, capsys):
+    monkeypatch.setattr(email_commands, "_require_auth", lambda: True)
+    monkeypatch.setattr(
+        get_emails, "get_sent", lambda **kwargs: (_ for _ in ()).throw(_http_error(404))
+    )
+
+    email_commands.handle_email_sent(last=0)
+
+    output = capsys.readouterr().out
+    assert "not available on this backend yet" in output
+    assert "oo-api Sent endpoint" in output
+    assert "deployed before this command" in output
+
+
+def test_sent_read_hides_transport_tracebacks(monkeypatch, capsys):
+    monkeypatch.setattr(email_commands, "_require_auth", lambda: True)
+    monkeypatch.setattr(
+        get_emails,
+        "get_sent",
+        lambda **kwargs: (_ for _ in ()).throw(requests.ConnectionError("secret host detail")),
+    )
+
+    email_commands.handle_email_sent_read("7")
+
+    output = capsys.readouterr().out
+    assert "Could not reach the email service" in output
+    assert "secret host detail" not in output

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -141,7 +141,35 @@ def test_send_email_keeps_server_ids_on_a_stable_json_error(mock_post):
         "error": "Retry with the same idempotency key.",
         "request_id": "server-request",
         "idempotency_key": "send-original",
+        "retryable": True,
     }
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})
+@patch('requests.post')
+def test_send_email_preserves_a_non_retryable_backend_verdict(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 409
+    mock_response.headers = {"X-Request-ID": "req-old"}
+    mock_response.json.return_value = {
+        "detail": "The safe-retry window expired; the email was not resent.",
+        "error": {
+            "code": "idempotency_window_expired",
+            "message": "The safe-retry window expired; the email was not resent.",
+            "retryable": False,
+        },
+        "request_id": "req-old",
+        "idempotency_key": "send-old",
+    }
+    mock_post.return_value = mock_response
+
+    result = send_email(
+        "test@example.com", "Test", "Message", idempotency_key="send-old"
+    )
+
+    assert result["success"] is False
+    assert result["retryable"] is False
+    assert result["idempotency_key"] == "send-old"
 
 
 @patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})
@@ -155,6 +183,7 @@ def test_send_email_timeout_returns_the_key_for_a_safe_retry(mock_post):
     assert result["success"] is False
     assert result["request_id"] == "send-timeout"
     assert result["idempotency_key"] == "send-timeout"
+    assert result["retryable"] is True
     assert "same idempotency key" in result["error"]
 
 

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -49,16 +49,23 @@ def test_send_email_success(mock_post):
     mock_response.json.return_value = {"message_id": "msg_123"}
     mock_post.return_value = mock_response
 
-    result = send_email("test@example.com", "Test Subject", "Test Message")
+    result = send_email(
+        "test@example.com", "Test Subject", "Test Message",
+        idempotency_key="send-test-123",
+    )
 
     assert result["success"] is True
     assert result["message_id"] == "msg_123"
     assert result["from"] == TEST_ACCOUNT["email"]
+    assert result["request_id"] == "send-test-123"
+    assert result["idempotency_key"] == "send-test-123"
 
     mock_post.assert_called_once()
     call_args = mock_post.call_args
     assert "Authorization" in call_args[1]["headers"]
     assert call_args[1]["headers"]["Authorization"] == f"Bearer {TEST_JWT_TOKEN}"
+    assert call_args[1]["headers"]["X-Request-ID"] == "send-test-123"
+    assert call_args[1]["headers"]["Idempotency-Key"] == "send-test-123"
 
 
 @patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})
@@ -109,6 +116,46 @@ def test_send_email_rate_limit(mock_post):
 
     assert result["success"] is False
     assert result["error"] == "Rate limit exceeded"
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})
+@patch('requests.post')
+def test_send_email_keeps_server_ids_on_a_stable_json_error(mock_post):
+    mock_response = MagicMock()
+    mock_response.status_code = 502
+    mock_response.headers = {"X-Request-ID": "header-id"}
+    mock_response.json.return_value = {
+        "detail": "Retry with the same idempotency key.",
+        "request_id": "server-request",
+        "idempotency_key": "send-original",
+    }
+    mock_post.return_value = mock_response
+
+    result = send_email(
+        "test@example.com", "Test", "Message",
+        idempotency_key="send-original",
+    )
+
+    assert result == {
+        "success": False,
+        "error": "Retry with the same idempotency key.",
+        "request_id": "server-request",
+        "idempotency_key": "send-original",
+    }
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})
+@patch('requests.post', side_effect=requests.exceptions.Timeout)
+def test_send_email_timeout_returns_the_key_for_a_safe_retry(mock_post):
+    result = send_email(
+        "test@example.com", "Test", "Message",
+        idempotency_key="send-timeout",
+    )
+
+    assert result["success"] is False
+    assert result["request_id"] == "send-timeout"
+    assert result["idempotency_key"] == "send-timeout"
+    assert "same idempotency key" in result["error"]
 
 
 # -------- get_emails tests -------- #


### PR DESCRIPTION
## What changed

- generate a request/idempotency UUID for every `send_email()` call
- send it as both `X-Request-ID` and `Idempotency-Key`
- return request and idempotency IDs on success, HTTP errors, timeouts, and connection failures
- preserve the backend's `retryable` verdict and label a key “Safe retry” only when retrying is actually safe
- understand oo-api's stable JSON error shape while retaining the non-JSON gateway fallback from 1.5.12
- add optional `idempotency_key=` to the Python tool
- add `co email send --idempotency-key <key>` and print the retry command only for retryable failures
- explain Sent mailbox backend-version skew without a traceback
- document the retry contract

## Why

oo-api can only deduplicate a retry if the client reuses the original key. Previously `send_email` had no request identity, so a timeout left users choosing between freezing a batch and risking duplicate emails. The returned key now gives people and agents an explicit retry path, while a backend `retryable: false` response (including an expired provider window) is never mislabelled as safe.

This is the client half of openonion/oo-api#115 and pairs with oo-api PR #117.

## Compatibility and rollout

The fourth Python argument is optional, and older backends ignore the two new headers. Existing three-argument calls remain valid. Deploy oo-api #117 and its migration before shipping this client; production currently lacks the Sent endpoint.

## Validation

- email tool/CLI suite: **27 passed**
- red regression proved that the old CLI advertised a non-retryable expired key as safe
- full stacked 1.6 candidate: **6037 passed, 18 skipped, 174 deselected, 0 failed** (`--randomly-seed=1320842036`)
- compileall and `git diff --check` pass
- the change is included in the local 1.6 artifact; `twine check` and installed-wheel tests 8/8 pass

This PR is Ready for independent review. It does not deploy or publish anything, and oo-api #115 remains open through production acceptance.
