### PR TITLE
security: bind admin signatures to request routes

### DIFF
--- a/connectonion/network/asgi/http.py
+++ b/connectonion/network/asgi/http.py
@@ -51,7 +51,10 @@ def pydantic_json_encoder(obj):
 CORS_HEADERS = [
     [b"access-control-allow-origin", b"*"],
     [b"access-control-allow-methods", b"GET, POST, OPTIONS"],
-    [b"access-control-allow-headers", b"authorization, content-type"],
+    [
+        b"access-control-allow-headers",
+        b"authorization, content-type, x-co-from, x-co-signature, x-co-timestamp",
+    ],
 ]
 
 

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -190,6 +190,29 @@ def sign_request(keys: dict, method: str, path: str, timestamp=None) -> dict:
     }
 
 
+def sign_request_body(keys: dict, method: str, path: str, payload=None,
+                      timestamp=None) -> dict:
+    """Build a signed JSON request whose authority is bound to its route.
+
+    POST admin calls carry arguments as well as the method and path. Keeping
+    all of them in one signed payload prevents a captured promote request from
+    being submitted to block, or to any other admin endpoint.
+    """
+    from ... import address as _address
+
+    signed_payload = dict(payload or {})
+    signed_payload.update(
+        method=method.upper(),
+        path=path,
+        timestamp=int(timestamp if timestamp is not None else time.time()),
+    )
+    return {
+        "payload": signed_payload,
+        "from": keys["address"],
+        "signature": _address.sign(keys, _canonical(signed_payload)).hex(),
+    }
+
+
 def request_from_headers(headers: dict, method: str, path: str) -> dict:
     """Turn a signed GET into the dict every other authenticated frame is.
 

--- a/connectonion/network/static/docs.html
+++ b/connectonion/network/static/docs.html
@@ -497,7 +497,7 @@
         <li><code>strict</code> - Signature required (production)</li>
       </ul>
       <p style="margin:12px 0 0;font-size:12px;color:var(--muted);">
-        For signed requests: <code>payload.to</code> should match agent address, <code>payload.timestamp</code> should be within 5 minutes.
+        For signed input requests: <code>payload.to</code> should match agent address. Admin requests also bind <code>payload.method</code> and <code>payload.path</code> to the route. All signatures must be within 5 minutes.
       </p>
     </div>
   </main>

--- a/connectonion/network/trust/http_admin.py
+++ b/connectonion/network/trust/http_admin.py
@@ -2,11 +2,11 @@
 
 Purpose: Authenticate and dispatch /admin/* and /superadmin/* HTTP requests for the hosted agent's trust controls (promote/demote/block/unblock, level lookup, super-admin add/remove, and legacy admin logs/sessions).
 LLM-Note:
-  Dependencies: imports from [hmac, json, os] | imported by [network/host/http_router.py (handle_admin_routes called for paths starting with /admin or /superadmin)] | tested by [no direct test file]
-  Data flow: receives ASGI scope/receive + parsed method/path from http_router → /admin/logs and /admin/sessions accept EITHER Bearer OPENONION_API_KEY (hmac.compare_digest) or a signed admin request; /admin/trust/* and /superadmin/* require the signed one. Both go through _admin_signature — one implementation, so the check guarding the trust routes cannot drift from the check guarding the logs. GETs may sign via X-From/X-Signature/X-Timestamp headers (proxies often strip GET bodies). A route_handlers without "auth" or "trust_agent" has no signed path and answers 401 rather than raising → calls into route_handlers callbacks (admin_logs, admin_sessions, admin_trust_promote/demote/block/unblock/level, admin_admins_add/remove) → responds via send_json/send_text
+  Dependencies: imports from [hmac, json, os, network/host/auth.py] | imported by [network/host/http_router.py (handle_admin_routes called for paths starting with /admin or /superadmin)] | tested by [tests/unit/test_admin_signatures_are_route_bound.py, tests/unit/test_an_admin_signature_is_used_once.py, tests/unit/test_reading_logs_does_not_need_the_billing_key.py]
+  Data flow: receives ASGI scope/receive + parsed method/path from http_router → /admin/logs and /admin/sessions accept EITHER Bearer OPENONION_API_KEY (hmac.compare_digest) or a signed admin request; /admin/trust/* and /superadmin/* require a signature over payload + actual method/path. GETs use the shared X-Co-From/X-Co-Signature/X-Co-Timestamp scheme; legacy X-From headers remain read-only for 1.6 compatibility → calls into route_handlers callbacks (admin_logs, admin_sessions, admin_trust_promote/demote/block/unblock/level, admin_admins_add/remove) → responds via send_json/send_text
   State/Effects: invokes route_handlers (which mutate trust agent state, file logs, sessions) | reads OPENONION_API_KEY from env for legacy auth | logs nothing directly
   Integration: exposes async handle_admin_routes(method, path, scope, receive, route_handlers, *, send_json, send_text, read_body) -> bool (always True after this function — it owns the response for /admin/* and /superadmin/*) | route_handlers dict must include "trust_agent", "auth", and the admin_* callbacks
-  Errors: returns 401 unauthorized on bad bearer/signature or a route_handlers with no verifier wired, 403 forbidden when not admin/superadmin, 400 on missing client_id/admin_id or invalid X-Timestamp/JSON, 404 catch-all for unknown admin paths — never raises
+  Errors: returns 401 unauthorized on bad/unbound bearer/signature or a route_handlers with no verifier wired, 403 forbidden when not admin/superadmin, 400 on missing client_id/admin_id or invalid signature timestamp/JSON, 404 catch-all for unknown admin paths — never raises
   Security: ⚠️ bearer comparison uses hmac.compare_digest to avoid timing leaks | signature verification delegated to route_handlers["auth"] | the bearer key is the model billing credential, which is why signing is now an alternative (#670)
 """
 
@@ -15,7 +15,7 @@ import json
 import os
 
 
-async def _admin_signature(method, scope, receive, route_handlers, *, read_body,
+async def _admin_signature(method, path, scope, receive, route_handlers, *, read_body,
                            require_super=False):
     """Verify a signed admin request. -> (ok, status, error, data).
 
@@ -28,18 +28,40 @@ async def _admin_signature(method, scope, receive, route_handlers, *, read_body,
     that spends its money (#670). A second copy of a signature check is the
     thing most likely to drift out of step with the one that guards more.
 
-    GETs may carry the signature in X-From / X-Signature / X-Timestamp, because
-    proxies strip GET bodies.
+    GETs carry the shared X-Co-* headers because proxies strip GET bodies.
+    Legacy X-* headers remain accepted only for the two read-only activity
+    routes. A legacy signature can therefore still read what it was designed
+    to read, but cannot be redirected to a trust mutation.
     """
-    headers_dict = dict(scope.get("headers", []))
-    header_from = headers_dict.get(b"x-from", b"").decode()
-    header_sig = headers_dict.get(b"x-signature", b"").decode()
-    header_ts = headers_dict.get(b"x-timestamp", b"").decode()
+    headers = {
+        key.decode().lower(): value.decode()
+        for key, value in scope.get("headers", [])
+    }
+    from ..host.auth import (
+        FROM_HEADER,
+        SIGNATURE_HEADER,
+        TIMESTAMP_HEADER,
+        request_from_headers,
+    )
 
-    if method == "GET" and header_from and header_sig and header_ts:
+    bound_header_present = any(
+        headers.get(name)
+        for name in (FROM_HEADER, SIGNATURE_HEADER, TIMESTAMP_HEADER)
+    )
+    legacy_from = headers.get("x-from")
+    legacy_sig = headers.get("x-signature")
+    legacy_ts = headers.get("x-timestamp")
+
+    if method == "GET" and bound_header_present:
         try:
-            data = {"payload": {"timestamp": float(header_ts)},
-                    "from": header_from, "signature": header_sig}
+            data = request_from_headers(headers, method, path)
+        except (TypeError, ValueError):
+            return False, 400, "Invalid X-Co-Timestamp header", {}
+    elif (method == "GET" and legacy_from and legacy_sig and legacy_ts
+          and path in ("/admin/logs", "/admin/sessions")):
+        try:
+            data = {"payload": {"timestamp": float(legacy_ts)},
+                    "from": legacy_from, "signature": legacy_sig}
         except ValueError:
             return False, 400, "Invalid X-Timestamp header", {}
     else:
@@ -48,6 +70,20 @@ async def _admin_signature(method, scope, receive, route_handlers, *, read_body,
             data = json.loads(body) if body else {}
         except json.JSONDecodeError:
             return False, 400, "Invalid JSON", {}
+
+    payload = data.get("payload", {})
+    is_bound = (
+        payload.get("method") == method.upper()
+        and payload.get("path") == path
+    )
+    legacy_read_only = (
+        method == "GET"
+        and path in ("/admin/logs", "/admin/sessions")
+        and "method" not in payload
+        and "path" not in payload
+    )
+    if not is_bound and not legacy_read_only:
+        return False, 401, "unauthorized: route-bound method and path required", data
 
     # A caller that wires no signature verifier has no signed path — say so
     # rather than raising KeyError. The legacy routes reach here now, and they
@@ -69,11 +105,6 @@ async def _admin_signature(method, scope, receive, route_handlers, *, read_body,
     # signature_already_used() is auth.py's, the same record CONNECT uses against
     # the replay in #649, called here rather than reimplemented.
     #
-    # What this does not fix: the payload is {timestamp} alone, so a signature is
-    # still not bound to the route it was made for. Binding it to method and path
-    # — which auth.py's own signed-GET scheme does, over {method, path,
-    # timestamp} with x-co-* headers — is a protocol change for any client
-    # already signing admin calls, so it is filed rather than slipped in here.
     from ..host.auth import signature_already_used
 
     if signature_already_used(data):
@@ -113,7 +144,7 @@ async def handle_admin_routes(method, path, scope, receive, route_handlers, *, s
 
         if not by_key:
             signed, status, error, _ = await _admin_signature(
-                method, scope, receive, route_handlers, read_body=read_body
+                method, path, scope, receive, route_handlers, read_body=read_body
             )
             if not signed:
                 await send_json({"error": error}, status)
@@ -134,7 +165,7 @@ async def handle_admin_routes(method, path, scope, receive, route_handlers, *, s
     # Admin trust routes (signed request + admin check)
     if path.startswith("/admin/trust/") or path.startswith("/superadmin/"):
         ok, status, error, data = await _admin_signature(
-            method, scope, receive, route_handlers, read_body=read_body,
+            method, path, scope, receive, route_handlers, read_body=read_body,
             require_super=path.startswith("/superadmin/"),
         )
         if not ok:

--- a/docs/features/trust.md
+++ b/docs/features/trust.md
@@ -670,7 +670,9 @@ Host provides these routes:
 
 ### Admin Routes (Requires Admin)
 
-Admin routes use **signed requests** (same as `/input`). The signer's address must be in the admins list.
+Admin routes use **route-bound signed requests**. The signed payload includes
+the actual HTTP `method` and `path`, so a signature made for one admin action
+cannot authorise another. The signer's address must be in the admins list.
 
 **Admins list = self address (default) + ~/.co/admins.txt**
 
@@ -694,10 +696,16 @@ Only the agent's own address (super admin) can manage the admins list.
 | `/superadmin/remove` | POST | Remove an admin |
 
 **Example admin request:**
+
+Build this body with `connectonion.network.host.auth.sign_request_body` so the
+canonical JSON and signature format stay consistent with the server.
+
 ```json
 {
     "payload": {
         "client_id": "0xclient123...",
+        "method": "POST",
+        "path": "/admin/trust/promote",
         "timestamp": 1699999999
     },
     "from": "0xAdminPublicKey",
@@ -710,6 +718,8 @@ Only the agent's own address (super admin) can manage the admins list.
 {
     "payload": {
         "admin_id": "0xnewadmin...",
+        "method": "POST",
+        "path": "/superadmin/add",
         "timestamp": 1699999999
     },
     "from": "0xSelfAddress",

--- a/tests/unit/test_admin_signatures_are_route_bound.py
+++ b/tests/unit/test_admin_signatures_are_route_bound.py
@@ -1,0 +1,147 @@
+"""Admin signatures authorise one HTTP method and path, not any admin call."""
+
+import pytest
+
+from connectonion import address
+from connectonion.network.host.auth import extract_and_authenticate
+from connectonion.network.trust import http_admin
+
+
+class _TrustAgent:
+    def __init__(self, admin):
+        self.admin = admin
+
+    def is_admin(self, candidate):
+        return candidate == self.admin
+
+    def is_super_admin(self, candidate):
+        return candidate == self.admin
+
+
+async def _call(keys, method, path, *, signed_body=None, signed_headers=None):
+    sent = {}
+
+    async def send_json(body, status=200):
+        sent.update(body=body, status=status)
+
+    async def send_text(text, status=200):
+        sent.update(body=text, status=status)
+
+    async def read_body(receive):
+        import json
+
+        return json.dumps(signed_body).encode() if signed_body else b""
+
+    def authenticate(data, mode):
+        return extract_and_authenticate(data, mode)
+
+    handlers = {
+        "auth": authenticate,
+        "trust_agent": _TrustAgent(keys["address"]),
+        "admin_logs": lambda: {"content": "logs"},
+        "admin_sessions": lambda: {"sessions": []},
+        "admin_trust_promote": lambda client_id: {"promoted": client_id},
+        "admin_trust_block": lambda client_id, reason: {"blocked": client_id},
+        "admin_trust_level": lambda client_id: {"level": "contact"},
+    }
+    raw_headers = [
+        (name.encode(), value.encode())
+        for name, value in (signed_headers or {}).items()
+    ]
+    await http_admin.handle_admin_routes(
+        method,
+        path,
+        {"headers": raw_headers},
+        None,
+        handlers,
+        send_json=send_json,
+        send_text=send_text,
+        read_body=read_body,
+    )
+    return sent
+
+
+@pytest.fixture(autouse=True)
+def clean_replay_cache():
+    from connectonion.network.host import auth
+
+    auth._seen_signatures.clear()
+    yield
+    auth._seen_signatures.clear()
+
+
+@pytest.mark.asyncio
+async def test_route_bound_get_is_accepted():
+    from connectonion.network.host.auth import sign_request
+
+    keys = address.generate()
+    headers = sign_request(keys, "GET", "/admin/logs")
+
+    sent = await _call(keys, "GET", "/admin/logs", signed_headers=headers)
+
+    assert sent["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_get_signature_cannot_be_moved_to_another_route():
+    from connectonion.network.host.auth import sign_request
+
+    keys = address.generate()
+    headers = sign_request(keys, "GET", "/admin/logs")
+
+    sent = await _call(keys, "GET", "/admin/sessions", signed_headers=headers)
+
+    assert sent["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_route_bound_post_is_accepted():
+    from connectonion.network.host.auth import sign_request_body
+
+    keys = address.generate()
+    body = sign_request_body(
+        keys,
+        "POST",
+        "/admin/trust/promote",
+        {"client_id": "0xclient"},
+    )
+
+    sent = await _call(keys, "POST", "/admin/trust/promote", signed_body=body)
+
+    assert sent["status"] == 200
+
+
+@pytest.mark.asyncio
+async def test_post_signature_cannot_authorise_a_different_mutation():
+    from connectonion.network.host.auth import sign_request_body
+
+    keys = address.generate()
+    body = sign_request_body(
+        keys,
+        "POST",
+        "/admin/trust/promote",
+        {"client_id": "0xclient"},
+    )
+
+    sent = await _call(keys, "POST", "/admin/trust/block", signed_body=body)
+
+    assert sent["status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_legacy_unbound_body_cannot_mutate_trust():
+    import json
+    import time
+
+    keys = address.generate()
+    payload = {"client_id": "0xclient", "timestamp": time.time()}
+    signature = address.sign(
+        keys,
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(),
+    ).hex()
+    body = {"payload": payload, "from": keys["address"], "signature": signature}
+
+    sent = await _call(keys, "POST", "/admin/trust/block", signed_body=body)
+
+    assert sent["status"] == 401
+    assert "method" in sent["body"]["error"] or "route" in sent["body"]["error"]

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -219,11 +219,14 @@ class TestCorsHeaders:
         assert b"OPTIONS" in methods
 
     def test_allows_common_headers(self):
-        """CORS allows authorization and content-type headers."""
+        """CORS allows auth plus the route-bound signature headers."""
         headers_dict = {k: v for k, v in CORS_HEADERS}
         allowed = headers_dict[b"access-control-allow-headers"]
         assert b"authorization" in allowed
         assert b"content-type" in allowed
+        assert b"x-co-from" in allowed
+        assert b"x-co-signature" in allowed
+        assert b"x-co-timestamp" in allowed
 
 
 def signed_scope(method: str, path: str) -> dict:


### PR DESCRIPTION
Closes #729.

## What changed

- bind signed admin requests to the actual HTTP method and path
- add `sign_request_body()` for POST admin clients
- use the existing `x-co-*` signed-GET scheme instead of a second header format
- preserve legacy Bearer access and legacy signed reads for `/admin/logs` and `/admin/sessions`
- refuse unbound signatures on trust and super-admin mutations
- allow the `x-co-*` headers through CORS
- document the route-bound payload format

## Security property

A signature created for `POST /admin/trust/promote` cannot be submitted to
`POST /admin/trust/block`, and a GET signature cannot be moved to another
admin route. Legacy unbound signatures remain usable only on the two read-only
activity routes, so they cannot be redirected into a mutation.

## Verification

- 156 focused auth/ASGI/host tests passed
- compileall passed
- diff check passed
- broader unit run reached 1,606 passed before being stopped; its failures were existing sandbox-dependent socket/browser/event-loop tests, not touched paths

Ready for external security review before 1.6.0. Do not merge or release yet.

