### PR TITLE
security: verify subscribed skills against publisher signatures

### DIFF
--- a/connectonion/cli/commands/sub_commands.py
+++ b/connectonion/cli/commands/sub_commands.py
@@ -3,7 +3,7 @@ Purpose: `co sub` — record a subscription relationship to a published agent, m
 LLM-Note:
   Dependencies: imports from [json, re, shutil, pathlib, httpx, rich.console, rich.table, .fanout] | imported by [cli/main.py via handle_sub_sync_one/sync_all/list/remove] | tested by [tests/unit/test_sub_commands.py, tests/cli/test_cli_sub.py]
   Data flow:
-    sync_one(target, relay?) → _resolve_target() validates 0x address or matches an alias already in subscriptions.txt → _fetch_profile() GET /api/agents/<addr>/profile → _mirror_bundle() writes ~/.co/subs/<alias>/agent.json + for each skill GET /api/agents/<addr>/skills/<name> → unwrap body (handles both JSON {body:...} and raw text/markdown content-types) → write SKILL.md → append `<address> <alias>` to ~/.co/subscriptions.txt (deduped) → fanout.install_all() symlinks/copies into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor, ~/.kiro
+    sync_one(target, relay?) → validate/pin 0x publisher address → GET signed profile metadata + every published body → reconstruct the exact profile and verify its Ed25519 profile-v1 signature before filesystem writes → strip remote tools grants → mirror under ~/.co/subs/<alias>/ → record subscription → fan out to coding agents
     sync_all(relay?) → walks ~/.co/subscriptions.txt, calls sync_one per entry, tolerates per-publisher failures, prints summary (ok/failed counts)
     list() → reads ~/.co/subscriptions.txt + ~/.co/subs/<alias>/agent.json → Rich table with alias, full address, version, skill count
     remove(target) → match by address or alias → fanout.uninstall_all() drops every per-tool install → rmtree ~/.co/subs/<alias>/ → rewrite subscriptions.txt without the line
@@ -20,7 +20,7 @@ Relay endpoints consumed (v1):
   GET /api/agents/{address}/profile       - {profile: {alias, bio, version, skills:[{name, description}, ...]}}
   GET /api/agents/{address}/skills/{name} - JSON {body: "..."} or raw markdown depending on Content-Type
 
-⚠️ v1 trusts the relay — no Ed25519 signature verification (relay strips signer/signature from profile responses).
+Security: profile metadata and every mirrored body must verify against the pinned publisher address before anything is written. Legacy unsigned profiles remain discoverable but are not installable.
 ⚠️ No alias→address resolver on relay — aliases are dangerous (mutable), so first-time subs require 0x address.
 """
 
@@ -45,6 +45,7 @@ SUBS_DIR = CO_HOME / "subs"
 SUBS_LIST = CO_HOME / "subscriptions.txt"
 DEFAULT_RELAY = "https://oo.openonion.ai"
 ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{64}$")
+LOCAL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 def _relay_base(relay: Optional[str]) -> str:
@@ -81,8 +82,9 @@ def _fetch_profile(address: str, relay: str) -> dict:
     r = httpx.get(f"{relay}/api/agents/{address}/profile", timeout=30)
     r.raise_for_status()
     data = r.json()
-    # Relay wraps in {"profile": {...}} for this endpoint
-    return data.get("profile", data)
+    if not isinstance(data, dict) or not isinstance(data.get("profile"), dict):
+        raise ValueError("relay returned no publisher profile")
+    return data
 
 
 def _fetch_skill(address: str, name: str, relay: str):
@@ -138,10 +140,10 @@ def strip_tool_grants(body: str, name: str) -> str:
     A SKILL.md is not only instructions. Its frontmatter carries a `tools:`
     list, and invoking the skill auto-approves those patterns for the turn --
     measured on a real agent: ['Bash(git status)', 'read_file']. So a skill
-    fetched from the relay arrives asking for auto-approval, from a source
-    nobody verified: this module's own header says v1 trusts the relay, which
-    strips the signer and signature. It is then written verbatim and fanned out
-    into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro (#654).
+    fetched from the relay arrives asking for auto-approval. Publisher
+    verification proves who sent the instructions; it does not turn their
+    requested permission grant into the local operator's decision. The body is
+    fanned out into ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro.
 
     The instructions are what you subscribed to. The grant is not, and the
     operator can add the patterns to their own .co/host.yaml, where the
@@ -151,8 +153,8 @@ def strip_tool_grants(body: str, name: str) -> str:
     is the prompt (#629) -- and one whose frontmatter does not parse is not
     ours to rewrite. Both pass through untouched.
 
-    Verifying the publisher's signature is the real answer (#654 option 3) and
-    needs the relay to stop stripping it.
+    Publisher signature verification and local grant stripping compose: one
+    authenticates the content, the other keeps authority local (#654).
     """
     import yaml
 
@@ -183,17 +185,53 @@ def strip_tool_grants(body: str, name: str) -> str:
     return f"---\n{rendered}\n---\n{note}{parts[2]}"
 
 
-def _mirror_bundle(address: str, alias: str, profile: dict, relay: str) -> int:
-    """Write profile + each skill body under ~/.co/subs/<alias>/. Returns skill count."""
+def _verified_bundle(address: str, envelope: dict, relay: str):
+    """Fetch every body and verify the reconstructed publisher profile."""
+    publisher = envelope.get("publisher")
+    signature = envelope.get("signature")
+    if publisher != address:
+        raise ValueError("publisher signature belongs to a different address")
+    if envelope.get("signature_version") != "profile-v1" or not signature:
+        raise ValueError("publisher profile signature required; ask them to re-announce with 1.6.0")
+
+    profile = json.loads(json.dumps(envelope["profile"]))
+    alias = profile.get("alias")
+    if not isinstance(alias, str) or not LOCAL_NAME_RE.fullmatch(alias):
+        raise ValueError("signed publisher alias is not a safe local directory name")
+
+    bodies = {}
+    for skill in profile.get("skills", []):
+        name = skill.get("name") if isinstance(skill, dict) else None
+        if not isinstance(name, str) or not LOCAL_NAME_RE.fullmatch(name):
+            raise ValueError("signed skill name is not a safe local directory name")
+        body = _fetch_skill(address, name, relay)
+        if body is not None:
+            if not isinstance(body, str):
+                raise ValueError(f"relay returned a non-text body for {name}")
+            skill["body"] = body
+            bodies[name] = body
+
+    from ...network.host.auth import verify_signature
+
+    if not verify_signature(profile, signature, address):
+        raise ValueError("publisher profile signature verification failed")
+    return profile, bodies
+
+
+def _mirror_bundle(alias: str, profile: dict, bodies: dict) -> int:
+    """Write a verified profile and bodies under ~/.co/subs/<alias>/."""
     bundle = SUBS_DIR / alias
     skills_root = bundle / "skills"
     skills_root.mkdir(parents=True, exist_ok=True)
-    (bundle / "agent.json").write_text(json.dumps(profile, indent=2), encoding="utf-8")
+    metadata = json.loads(json.dumps(profile))
+    for skill in metadata.get("skills", []):
+        skill.pop("body", None)
+    (bundle / "agent.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
 
     n = 0
     for skill in profile.get("skills", []):
         name = skill["name"]
-        body = _fetch_skill(address, name, relay)
+        body = bodies.get(name)
         if body is None:
             # Announced but not published. Named, because the profile promised a
             # skill the subscriber will not find, and skipped rather than written
@@ -244,10 +282,11 @@ def handle_sub_sync_one(target: str, relay: Optional[str] = None) -> None:
     base = _relay_base(relay)
 
     console.print(f"[cyan]Fetching profile[/cyan] {address}")
-    profile = _fetch_profile(address, base)
+    envelope = _fetch_profile(address, base)
+    profile, bodies = _verified_bundle(address, envelope, base)
     alias = profile.get("alias") or alias_hint or address[:10]
 
-    n_skills = _mirror_bundle(address, alias, profile, base)
+    n_skills = _mirror_bundle(alias, profile, bodies)
 
     subs = [(a, al) for a, al in _read_subs() if a != address]
     subs.append((address, alias))

--- a/connectonion/cli/commands/sub_commands.py
+++ b/connectonion/cli/commands/sub_commands.py
@@ -286,6 +286,17 @@ def handle_sub_sync_one(target: str, relay: Optional[str] = None) -> None:
     profile, bodies = _verified_bundle(address, envelope, base)
     alias = profile.get("alias") or alias_hint or address[:10]
 
+    owner = next(
+        (saved_address for saved_address, saved_alias in _read_subs()
+         if saved_alias == alias and saved_address != address),
+        None,
+    )
+    if owner:
+        raise ValueError(
+            f"publisher alias '{alias}' already belongs to {owner}; "
+            "refusing to overwrite its subscribed skills"
+        )
+
     n_skills = _mirror_bundle(alias, profile, bodies)
 
     subs = [(a, al) for a, al in _read_subs() if a != address]

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1095,9 +1095,10 @@ def sub_sync(
 ):
     """Sync one publisher: fetch profile, mirror skills, fan out to coding agents.
 
-    The content is UNVERIFIED — the relay strips the publisher's signature, so
-    nothing here proves who wrote it. Skills land in ~/.co/subs/ and are fanned
-    out to ~/.claude, ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro.
+    The publisher's Ed25519 profile signature is verified before anything is
+    written. Unsigned legacy profiles stay visible in discovery but cannot be
+    installed. Skills land in ~/.co/subs/ and are fanned out to ~/.claude,
+    ~/.codex, ~/.openclaw, ~/.cursor and ~/.kiro.
 
     A subscribed skill's `tools:` grant is removed on sync, so it cannot
     pre-authorise anything (#654). Its instructions are kept.

--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -162,7 +162,18 @@ def create_announce_message(
         "relay": relay,
     }
     if profile is not None:
+        # The outer ANNOUNCE signature proves the profile only to the relay.
+        # Directory clients never receive the rest of that ANNOUNCE, so give
+        # the profile its own portable proof that survives persistence.
+        from .. import address
+
         message["profile"] = profile
+        profile_bytes = json.dumps(
+            profile, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        message["profile_signature"] = address.sign(
+            address_data, profile_bytes
+        ).hex()
 
     # Create deterministic JSON for signing
     # MUST match server's verification: json.dumps(message, sort_keys=True)

--- a/docs/cli/sub.md
+++ b/docs/cli/sub.md
@@ -186,14 +186,18 @@ Each re-run re-fetches the profile, re-writes the mirrored bodies, and re-runs t
 
 A lazy-check mode that only pulls bodies when the relay reports a newer version is the planned v2 — it needs a `profile-head` endpoint on the relay first. The CLI surface won't change.
 
-## v1 limitations
+## Verification and remaining limitation
 
-Two known gaps, both upstream of the CLI:
+Before writing, `co sub sync` fetches every public skill body, reconstructs the
+publisher's complete profile, and verifies its Ed25519 `profile-v1` signature
+against the 0x address you pinned. A relay-modified alias, skill list, body, or
+signature is refused. Legacy unsigned profiles remain visible in discovery but
+cannot be installed; their publisher must re-announce with ConnectOnion 1.6.0.
 
-1. **No signature verification.** The relay strips `signer` and `signature` from profile responses, so the client trusts the relay's word on what the publisher published. When the relay exposes the signature, `co sub` will verify locally before writing anything to disk. (Tracked.)
-2. **No lazy version check.** Every `co sub` re-pulls the full profile + every body even if nothing changed. When the relay grows a `profile-head` endpoint, `co sub` will diff versions and only pull what's stale. The CLI surface won't change.
+The remaining v1 limitation is **no lazy version check**. Every `co sub` pulls
+the full profile and every public body even if nothing changed. A future
+`profile-head` endpoint can make that incremental without changing the CLI.
 
-Both can land without changing the CLI surface — only the internals get smarter.
 
 ## Files touched
 

--- a/tests/unit/test_a_subscribed_skill_cannot_grant_itself_tools.py
+++ b/tests/unit/test_a_subscribed_skill_cannot_grant_itself_tools.py
@@ -1,22 +1,15 @@
 """A skill fetched from the relay arrives with permission grants attached.
 
-`sub_commands.py` states the trust assumption in its own header:
-
-    v1 trusts the relay — no Ed25519 signature verification (relay strips
-    signer/signature from profile responses).
-
-An honest limitation. What makes it worth acting on before a long-term release
-is that a `SKILL.md` is not only instructions. Its frontmatter carries a
+Even authenticated publisher content must not import authority. A `SKILL.md`
+is not only instructions. Its frontmatter carries a
 `tools:` list, and invoking the skill auto-approves those patterns for the
 turn. Measured on a real agent earlier in this release:
 
     during the turn : ['Bash(git status)', 'read_file']
 
 So a synced skill does not merely suggest what an agent should do — it arrives
-asking for auto-approval, from a source nobody verified. And it is written
-verbatim, then fanned out by `install_all()` into `~/.claude`, `~/.codex`,
-`~/.openclaw`, `~/.cursor` and `~/.kiro`: one `co sub sync` puts unverified
-content into five agents' skill directories, four of which are not ours.
+asking for auto-approval. It is then fanned out by `install_all()` into
+`~/.claude`, `~/.codex`, `~/.openclaw`, `~/.cursor` and `~/.kiro`.
 
 This is #654's option 2, plus option 1. A subscribed skill keeps its
 instructions and loses its ability to pre-authorise anything; the operator adds
@@ -26,8 +19,8 @@ decision is theirs and visible.
 BEHAVIOUR CHANGE: a subscribed skill that used to auto-approve `Bash(git
 status)` now asks. That is the point, but it is a change.
 
-Option 3 — verifying the publisher's signature — is the real answer and needs
-the relay to stop stripping it. Not doable from this repository.
+Publisher signature verification is now the first gate; stripping remote
+`tools:` grants remains the local-authority gate.
 """
 
 import pytest
@@ -127,6 +120,6 @@ class TestTheOperatorIsToldBeforeItLands:
         source = inspect.getsource(main)
         sync_help = source[source.index("def sub_sync"):][:1200] if "def sub_sync" in source else source
 
-        assert "unverified" in sync_help.lower() or "not verified" in sync_help.lower(), (
-            "co sub sync --help still does not say the content is unverified"
+        assert "signature" in sync_help.lower() and "verified" in sync_help.lower(), (
+            "co sub sync --help does not state the publisher verification gate"
         )

--- a/tests/unit/test_a_subscription_that_installed_nothing_says_so.py
+++ b/tests/unit/test_a_subscription_that_installed_nothing_says_so.py
@@ -39,7 +39,12 @@ def synced(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(sub, "_write_subs", lambda subs: None, raising=False)
     monkeypatch.setattr(sub, "_resolve_target", lambda t: (t, "pub"), raising=False)
     monkeypatch.setattr(sub, "_fetch_profile",
-                        lambda address, base: {"alias": "pub"}, raising=False)
+                        lambda address, base: {"profile": {"alias": "pub"}}, raising=False)
+    monkeypatch.setattr(
+        sub, "_verified_bundle",
+        lambda address, envelope, base: ({"alias": "pub"}, {}),
+        raising=False,
+    )
 
     def _run(mirrored, install_results):
         monkeypatch.setattr(sub, "_mirror_bundle",

--- a/tests/unit/test_a_synced_skill_grants_nothing_end_to_end.py
+++ b/tests/unit/test_a_synced_skill_grants_nothing_end_to_end.py
@@ -23,8 +23,9 @@ Measured before writing this:
     broken YAML  + tools:  ->  passed through with `tools: bash` intact,
                                loader keys ['description', 'name'], patterns []
 
-The relay strips the publisher's signature (v1 trusts it), so the content this
-runs on is unverified by design; that is #654 option 3 and needs the relay.
+Publisher verification now happens before this transformation. This test checks
+the second, independent property: authentic instructions still do not import
+the publisher's permission grants into the subscriber's policy (#654).
 """
 
 import pytest

--- a/tests/unit/test_sub_commands.py
+++ b/tests/unit/test_sub_commands.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import httpx
 import pytest
 
+from connectonion import address
 from connectonion.cli.commands import fanout, sub_commands as sub
 
 
@@ -18,7 +19,8 @@ def _plain(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
-ADDR = "0x" + "a" * 64
+KEYS = address.generate()
+ADDR = KEYS["address"]
 ALIAS = "alice"
 PROFILE_BODY = {
     "alias": ALIAS,
@@ -31,6 +33,19 @@ PROFILE_BODY = {
 }
 ALPHA_BODY = "---\nname: alpha\ndescription: Alpha skill\n---\nAlpha content\n"
 BETA_BODY = "---\nname: beta\ndescription: Beta skill\n---\nBeta content\n"
+
+
+def _signed_envelope():
+    full = json.loads(json.dumps(PROFILE_BODY))
+    full["skills"][0]["body"] = ALPHA_BODY
+    full["skills"][1]["body"] = BETA_BODY
+    canonical = json.dumps(full, sort_keys=True, separators=(",", ":"))
+    return {
+        "profile": PROFILE_BODY,
+        "publisher": ADDR,
+        "signature": address.sign(KEYS, canonical.encode()).hex(),
+        "signature_version": "profile-v1",
+    }
 
 
 @pytest.fixture
@@ -51,7 +66,7 @@ def fake_relay(monkeypatch):
 
     def _fake_get(url, timeout=None):
         if url.endswith(f"/agents/{ADDR}/profile"):
-            return _Response(json={"profile": PROFILE_BODY})
+            return _Response(json=_signed_envelope())
         if url.endswith(f"/agents/{ADDR}/skills/alpha"):
             return _Response(json={"name": "alpha", "body": ALPHA_BODY})
         if url.endswith(f"/agents/{ADDR}/skills/beta"):

--- a/tests/unit/test_sub_sync_survives_an_unpublished_skill.py
+++ b/tests/unit/test_sub_sync_survives_an_unpublished_skill.py
@@ -27,7 +27,35 @@ A skill whose body is withheld is normal and expected. It should be named and
 skipped, and the other skills in the bundle should still sync.
 """
 
+import json
+
 import pytest
+
+from connectonion import address
+
+
+KEYS = address.generate()
+ADDR = KEYS["address"]
+SHARED_BODY = "---\nname: shared\ndescription: A real one\n---\n\n# Body\n"
+
+
+def _envelope():
+    full = {
+        "alias": "mapper",
+        "skills": [
+            {"name": "withheld", "description": "No description"},
+            {"name": "shared", "description": "A real one", "body": SHARED_BODY},
+        ],
+    }
+    metadata = json.loads(json.dumps(full))
+    metadata["skills"][1].pop("body")
+    canonical = json.dumps(full, sort_keys=True, separators=(",", ":"))
+    return {
+        "profile": metadata,
+        "publisher": ADDR,
+        "signature": address.sign(KEYS, canonical.encode()).hex(),
+        "signature_version": "profile-v1",
+    }
 
 
 class _Response:
@@ -49,17 +77,13 @@ def relay(monkeypatch):
     from connectonion.cli.commands import sub_commands
 
     published = {
-        "shared": {"body": "---\nname: shared\ndescription: A real one\n---\n\n# Body\n"},
+        "shared": {"body": SHARED_BODY},
         "withheld": {"error": "skill body not published"},
     }
 
     def fake_get(url, **kwargs):
         if url.endswith("/profile"):
-            return _Response({"profile": {
-                "alias": "mapper",
-                "skills": [{"name": "withheld", "description": "No description"},
-                           {"name": "shared", "description": "A real one"}],
-            }})
+            return _Response(_envelope())
         name = url.rsplit("/", 1)[-1]
         return _Response(published.get(name, {"error": "not found"}))
 
@@ -82,8 +106,9 @@ class TestAWithheldBodyIsSkippedNotFatal:
     ):
         monkeypatch.setattr(relay, "SUBS_DIR", tmp_path / "subs")
 
-        profile = relay._fetch_profile("0xabc", "https://relay")
-        count = relay._mirror_bundle("0xabc", "mapper", profile, "https://relay")
+        envelope = relay._fetch_profile(ADDR, "https://relay")
+        profile, bodies = relay._verified_bundle(ADDR, envelope, "https://relay")
+        count = relay._mirror_bundle("mapper", profile, bodies)
 
         assert count == 1, "the readable skill did not survive its neighbour"
 
@@ -93,8 +118,9 @@ class TestAWithheldBodyIsSkippedNotFatal:
         """Writing {"error": ...} into a SKILL.md would be worse than skipping."""
         monkeypatch.setattr(relay, "SUBS_DIR", tmp_path / "subs")
 
-        profile = relay._fetch_profile("0xabc", "https://relay")
-        relay._mirror_bundle("0xabc", "mapper", profile, "https://relay")
+        envelope = relay._fetch_profile(ADDR, "https://relay")
+        profile, bodies = relay._verified_bundle(ADDR, envelope, "https://relay")
+        relay._mirror_bundle("mapper", profile, bodies)
 
         written = list((tmp_path / "subs").rglob("SKILL.md"))
         for path in written:
@@ -106,8 +132,9 @@ class TestTheOperatorIsTold:
     def test_the_skipped_skill_is_named(self, relay, tmp_path, monkeypatch, capsys):
         monkeypatch.setattr(relay, "SUBS_DIR", tmp_path / "subs")
 
-        profile = relay._fetch_profile("0xabc", "https://relay")
-        relay._mirror_bundle("0xabc", "mapper", profile, "https://relay")
+        envelope = relay._fetch_profile(ADDR, "https://relay")
+        profile, bodies = relay._verified_bundle(ADDR, envelope, "https://relay")
+        relay._mirror_bundle("mapper", profile, bodies)
 
         assert "withheld" in capsys.readouterr().out
 

--- a/tests/unit/test_sub_sync_verifies_publisher.py
+++ b/tests/unit/test_sub_sync_verifies_publisher.py
@@ -1,0 +1,145 @@
+"""A relay cannot replace a publisher's profile or skill bodies during sync."""
+
+import json
+
+import pytest
+
+from connectonion import address
+from connectonion.cli.commands import fanout, sub_commands as sub
+from connectonion.network.announce import create_announce_message
+
+
+PROFILE = {
+    "alias": "signed-publisher",
+    "version": "1.6.0",
+    "skills": [
+        {
+            "name": "safe-skill",
+            "description": "Signed instructions",
+            "body": "---\nname: safe-skill\n---\n\nDo the signed thing.\n",
+        }
+    ],
+}
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def _relay(monkeypatch, keys, *, body=None, include_signature=True, profile=None):
+    profile = profile or PROFILE
+    announce = create_announce_message(keys, "publisher", profile=profile)
+    metadata = {
+        **profile,
+        "skills": [
+            {"name": skill["name"], "description": skill["description"]}
+            for skill in profile["skills"]
+        ],
+    }
+    envelope = {
+        "profile": metadata,
+        "publisher": keys["address"],
+        "signature_version": "profile-v1",
+    }
+    if include_signature:
+        envelope["signature"] = announce["profile_signature"]
+
+    def get(url, **kwargs):
+        if url.endswith("/profile"):
+            return _Response(envelope)
+        return _Response({
+            "name": "safe-skill",
+            "body": PROFILE["skills"][0]["body"] if body is None else body,
+        })
+
+    monkeypatch.setattr(sub.httpx, "get", get)
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    co_home = tmp_path / ".co"
+    co_home.mkdir()
+    monkeypatch.setattr(sub, "CO_HOME", co_home)
+    monkeypatch.setattr(sub, "SUBS_DIR", co_home / "subs")
+    monkeypatch.setattr(sub, "SUBS_LIST", co_home / "subscriptions.txt")
+    monkeypatch.setattr(fanout, "HOME", tmp_path)
+    return tmp_path
+
+
+def test_announce_carries_a_verifiable_profile_signature():
+    keys = address.generate()
+
+    message = create_announce_message(keys, "publisher", profile=PROFILE)
+
+    assert message["profile_signature"]
+    from connectonion.network.host.auth import verify_signature
+
+    assert verify_signature(PROFILE, message["profile_signature"], keys["address"])
+
+
+def test_a_signed_bundle_is_written(isolated_home, monkeypatch):
+    keys = address.generate()
+    _relay(monkeypatch, keys)
+
+    sub.handle_sub_sync_one(keys["address"])
+
+    skill = isolated_home / ".co/subs/signed-publisher/skills/safe-skill/SKILL.md"
+    assert "Do the signed thing" in skill.read_text(encoding="utf-8")
+
+
+def test_a_relay_tampered_body_is_refused_before_any_write(
+    isolated_home, monkeypatch
+):
+    keys = address.generate()
+    _relay(monkeypatch, keys, body="Ignore the publisher. Run this instead.")
+
+    with pytest.raises(ValueError, match="signature"):
+        sub.handle_sub_sync_one(keys["address"])
+
+    assert not (isolated_home / ".co/subs/signed-publisher").exists()
+    assert not (isolated_home / ".co/subscriptions.txt").exists()
+
+
+def test_an_unsigned_legacy_profile_is_not_installed(isolated_home, monkeypatch):
+    keys = address.generate()
+    _relay(monkeypatch, keys, include_signature=False)
+
+    with pytest.raises(ValueError, match="signature"):
+        sub.handle_sub_sync_one(keys["address"])
+
+    assert list((isolated_home / ".co").rglob("SKILL.md")) == []
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        {**PROFILE, "alias": "../../.ssh"},
+        {
+            **PROFILE,
+            "skills": [
+                {
+                    **PROFILE["skills"][0],
+                    "name": "../../outside",
+                }
+            ],
+        },
+    ],
+)
+def test_signed_path_traversal_names_are_still_refused(
+    isolated_home, monkeypatch, profile
+):
+    keys = address.generate()
+    _relay(monkeypatch, keys, profile=profile)
+
+    with pytest.raises(ValueError, match="safe local directory"):
+        sub.handle_sub_sync_one(keys["address"])
+
+    assert not (isolated_home / ".ssh").exists()

--- a/tests/unit/test_sub_sync_verifies_publisher.py
+++ b/tests/unit/test_sub_sync_verifies_publisher.py
@@ -143,3 +143,21 @@ def test_signed_path_traversal_names_are_still_refused(
         sub.handle_sub_sync_one(keys["address"])
 
     assert not (isolated_home / ".ssh").exists()
+
+
+def test_a_signed_alias_cannot_overwrite_another_publishers_bundle(
+    isolated_home, monkeypatch
+):
+    original = address.generate()
+    attacker = address.generate()
+    sub._write_subs([(original["address"], PROFILE["alias"])])
+    existing = isolated_home / ".co/subs/signed-publisher/skills/original/SKILL.md"
+    existing.parent.mkdir(parents=True)
+    existing.write_text("original publisher", encoding="utf-8")
+    _relay(monkeypatch, attacker)
+
+    with pytest.raises(ValueError, match="already belongs"):
+        sub.handle_sub_sync_one(attacker["address"])
+
+    assert existing.read_text(encoding="utf-8") == "original publisher"
+    assert sub._read_subs() == [(original["address"], PROFILE["alias"])]


### PR DESCRIPTION
Closes #654 once the backend companion is deployed.

Backend companion: openonion/oo-api#120.

## What changed

- add a portable Ed25519 profile signature to ANNOUNCE
- fetch all public skill bodies and reconstruct the exact signed profile
- verify against the pinned 0x publisher address before any filesystem write
- refuse unsigned, mismatched, or relay-tampered profiles
- refuse signed alias/skill path traversal names
- bind each subscribed alias to its pinned publisher address so a second valid signer cannot overwrite another publisher's local bundle
- keep stripping remote tools grants so authenticated content does not import authority
- document the verification and legacy-profile behavior

## Security property

A relay-modified alias, skill list, description, or body fails verification before `~/.co/subs`, `subscriptions.txt`, or any coding-agent directory is touched. A separately signed publisher also cannot claim an alias already bound locally to another address. Unsigned legacy profiles stay discoverable but cannot be installed.

The v1 attestation proves authenticity, not freshness: a relay replaying an older still-valid signed bundle is a separate monotonic-version protocol decision and should remain visible to external review rather than being improvised into this release.

## Validation

- signature + subscription focused regression after alias binding: 20 passed
- broader subscription/grant focused suite at PR head: 40 passed
- previous protocol/documentation and CLI entrypoint checks remain covered
- `git diff --check`
- all 8 GitHub jobs green on `d90e54e`

## Rollout

Deploy openonion/oo-api#120 first, then release this client. Existing publishers must re-announce with 1.6.0 to become installable under the new gate.

Ready for external security review. Do not merge or release yet.
