### PR TITLE
Recover Google tool sessions after token expiry

### DIFF
--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -244,9 +244,16 @@ def handle_google_auth():
     api_url = "https://oo.openonion.ai/api/v1/oauth"
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    # Clear any existing connection first - this ensures we wait for NEW OAuth to complete
-    # (otherwise /google/status returns connected=true immediately from old credentials)
-    requests.delete(f"{api_url}/google/revoke", headers=headers)
+    # Keep the existing refresh token alive while re-authenticating. Deleting it
+    # here breaks deployed agents immediately. Remember the old expiry instead,
+    # then wait until the callback writes a newer credential row.
+    previous_expiry = None
+    previously_connected = False
+    previous_status = requests.get(f"{api_url}/google/status", headers=headers)
+    if previous_status.status_code == 200:
+        previous = previous_status.json()
+        previously_connected = bool(previous.get("connected"))
+        previous_expiry = previous.get("expires_at")
 
     # Get OAuth URL
     console.print("🔑 Initializing Google OAuth...", style="cyan")
@@ -275,7 +282,9 @@ def handle_google_auth():
         status_response = requests.get(f"{api_url}/google/status", headers=headers)
         if status_response.status_code == 200:
             status = status_response.json()
-            if status.get('connected'):
+            if status.get('connected') and (
+                not previously_connected or status.get('expires_at') != previous_expiry
+            ):
                 console.print("✓ Authorization successful!", style="green")
                 break
     else:
@@ -404,4 +413,3 @@ def handle_microsoft_auth():
     console.print(f"\n📧 You can now use Microsoft tools in your agents:")
     console.print(f"   [dim]from connectonion import Outlook, MicrosoftCalendar[/dim]")
     console.print(f"   [dim]agent = Agent('assistant', tools=[Outlook()])[/dim]\n")
-

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -3,7 +3,7 @@ Purpose: Gmail integration tool for reading, sending, and managing emails via Go
 LLM-Note:
   Dependencies: imports from [os, base64, google.oauth2.credentials, googleapiclient.discovery, googleapiclient.errors] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gmail.py]
   Data flow: Agent calls Gmail methods → _get_credentials() loads tokens from env → builds Gmail API service → API calls to Gmail REST endpoints → returns formatted results (email summaries, bodies, send confirmations)
-  State/Effects: reads GOOGLE_* env vars for OAuth tokens | makes HTTP calls to Gmail API | can modify mailbox state (mark read/unread, archive, star, send emails) | no local file persistence
+  State/Effects: reads GOOGLE_* env vars and OPENONION_API_KEY | persists refreshed tokens to ~/.co/keys.env | makes HTTP calls to Gmail API | can modify mailbox state (mark read/unread, archive, star, send emails)
   Integration: exposes Gmail class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), send(), reply(), mark_read(), mark_unread(), archive_email(), star_email(), get_labels(), add_label(), count_unread(), get_all_contacts(), analyze_contact(), get_unanswered_emails(), update_contact() | used as agent tool via Agent(tools=[Gmail()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately (lazy loading)
   Errors: raises ValueError if OAuth not configured | HttpError from Google API propagates | returns error strings for display to user
@@ -53,6 +53,7 @@ Example:
 """
 
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import base64
 from google.oauth2.credentials import Credentials
@@ -107,37 +108,49 @@ class Gmail:
         if self._service:
             return self._service
 
-        refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
-
-        if not os.getenv("GOOGLE_ACCESS_TOKEN") or not refresh_token:
+        if not os.getenv("OPENONION_API_KEY"):
             raise ValueError(
-                "Google OAuth credentials not found.\n"
-                "Run: co auth google"
+                "OPENONION_API_KEY not found.\n"
+                "Run: co auth"
             )
 
-        access_token = self._refresh_via_backend(refresh_token)
+        access_token = self._refresh_via_backend(None)
+        expiry = self._token_expiry()
 
-        # Create credentials without client_id/client_secret
-        # Backend handles token refresh, so we don't need auto-refresh
+        # Backend owns client_id/client_secret. google-auth invokes our broker
+        # handler when a cached long-running Gmail service receives a 401.
         creds = Credentials(
             token=access_token,
-            refresh_token=refresh_token,
-            token_uri="https://oauth2.googleapis.com/token",
-            client_id=None,
-            client_secret=None,
+            refresh_token=None,
             scopes=["https://www.googleapis.com/auth/gmail.readonly",
                    "https://www.googleapis.com/auth/gmail.modify",
-                   "https://www.googleapis.com/auth/gmail.send"]
+                   "https://www.googleapis.com/auth/gmail.send"],
+            expiry=expiry,
+            refresh_handler=self._refresh_handler,
         )
 
         self._service = build('gmail', 'v1', credentials=creds)
         return self._service
 
-    def _refresh_via_backend(self, refresh_token: str) -> str:
-        """Refresh access token via backend API.
+    def _token_expiry(self) -> datetime:
+        """Return google-auth's naive UTC expiry value."""
+        value = os.getenv("GOOGLE_TOKEN_EXPIRES_AT")
+        if not value:
+            return datetime.utcnow() + timedelta(minutes=55)
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
+
+    def _refresh_handler(self, request, scopes=None):
+        """Let google-auth recover a long-running Gmail client after a 401."""
+        return self._refresh_via_backend(None), self._token_expiry()
+
+    def _refresh_via_backend(self, refresh_token: str | None) -> str:
+        """Ask the backend to refresh its stored Google credentials.
 
         Args:
-            refresh_token: The refresh token
+            refresh_token: Ignored; retained for compatibility with copied tools.
 
         Returns:
             New access token
@@ -158,32 +171,42 @@ class Gmail:
         response = httpx.post(
             f"{backend_url}/api/v1/oauth/google/refresh",
             headers={"Authorization": f"Bearer {api_key}"},
-            json={"refresh_token": refresh_token}
+            timeout=15.0,
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Failed to refresh token via backend: {response.text}"
-            )
+            try:
+                detail = response.json().get("detail")
+            except (TypeError, ValueError):
+                detail = None
+            if response.status_code == 401 and isinstance(detail, dict) \
+                    and detail.get("error") == "reauth_required":
+                raise ValueError("Google authorization expired. Run: co auth google")
+            raise ValueError("Failed to refresh Google authorization via backend")
 
         data = response.json()
         new_access_token = data["access_token"]
         expires_at = data["expires_at"]
+        new_refresh_token = data.get("refresh_token")
 
         # Update environment variables for this session
         os.environ["GOOGLE_ACCESS_TOKEN"] = new_access_token
         os.environ["GOOGLE_TOKEN_EXPIRES_AT"] = expires_at
+        if new_refresh_token:
+            os.environ["GOOGLE_REFRESH_TOKEN"] = new_refresh_token
 
         # Persist to global keys.env so the refreshed token survives this
-        # process. Google refresh tokens don't rotate, so the next process can
-        # always re-derive an access token — only keys.env needs updating.
+        # process. Persist a rotated refresh token if Google issued one.
         from ..cli.commands.project_cmd_lib import upsert_env
         env_file = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
         env_file.parent.mkdir(parents=True, exist_ok=True)
-        upsert_env(env_file, {
+        values = {
             "GOOGLE_ACCESS_TOKEN": new_access_token,
             "GOOGLE_TOKEN_EXPIRES_AT": expires_at,
-        })
+        }
+        if new_refresh_token:
+            values["GOOGLE_REFRESH_TOKEN"] = new_refresh_token
+        upsert_env(env_file, values)
 
         return new_access_token
 

--- a/connectonion/useful_tools/google_calendar.py
+++ b/connectonion/useful_tools/google_calendar.py
@@ -3,7 +3,7 @@ Purpose: Google Calendar integration tool for managing events and meetings via G
 LLM-Note:
   Dependencies: imports from [os, datetime, google.oauth2.credentials, googleapiclient.discovery] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_google_calendar.py]
   Data flow: Agent calls GoogleCalendar methods → _get_credentials() loads tokens from env → builds Calendar API service → API calls to Calendar REST endpoints → returns formatted results (event lists, confirmations, free slots)
-  State/Effects: reads GOOGLE_* env vars for OAuth tokens | makes HTTP calls to Google Calendar API | can create/update/delete events | no local file persistence
+  State/Effects: reads GOOGLE_* env vars and OPENONION_API_KEY | persists refreshed tokens to ~/.co/keys.env | makes HTTP calls to Google Calendar API | can create/update/delete events
   Integration: exposes GoogleCalendar class with list_events(), get_today_events(), get_event(), create_event(), update_event(), delete_event(), create_meet(), get_upcoming_meetings(), find_free_slots() | used as agent tool via Agent(tools=[GoogleCalendar()])
   Performance: network I/O per API call | batch fetching for list operations | date parsing for queries
   Errors: raises ValueError if OAuth not configured | Google API errors propagate | returns error strings for display
@@ -42,7 +42,8 @@ Example:
 """
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 
@@ -68,49 +69,44 @@ class GoogleCalendar:
         self._service = None
 
     def _get_service(self):
-        """Get Google Calendar API service (lazy load with auto-refresh)."""
-        access_token = os.getenv("GOOGLE_ACCESS_TOKEN")
-        refresh_token = os.getenv("GOOGLE_REFRESH_TOKEN")
-        expires_at_str = os.getenv("GOOGLE_TOKEN_EXPIRES_AT")
-
-        if not access_token or not refresh_token:
-            raise ValueError(
-                "Google OAuth credentials not found.\n"
-                "Run: co auth google"
-            )
-
-        # Check if token is expired or about to expire (within 5 minutes)
-        # Always check before returning cached service
-        if expires_at_str:
-            from datetime import datetime, timedelta
-            expires_at = datetime.fromisoformat(expires_at_str.replace('Z', '+00:00'))
-            now = datetime.utcnow().replace(tzinfo=expires_at.tzinfo) if expires_at.tzinfo else datetime.utcnow()
-
-            if now >= expires_at - timedelta(minutes=5):
-                # Token expired or about to expire, refresh via backend
-                access_token = self._refresh_via_backend(refresh_token)
-                # Clear cached service to use new token
-                self._service = None
-
-        # Return cached service if available
+        """Build a Calendar service backed by the server-owned token broker."""
         if self._service:
             return self._service
 
-        # Create credentials
+        if not os.getenv("OPENONION_API_KEY"):
+            raise ValueError(
+                "OPENONION_API_KEY not found.\n"
+                "Run: co auth"
+            )
+
+        access_token = self._refresh_via_backend(None)
         creds = Credentials(
             token=access_token,
-            refresh_token=refresh_token,
-            token_uri="https://oauth2.googleapis.com/token",
-            client_id=None,
-            client_secret=None,
-            scopes=["https://www.googleapis.com/auth/calendar"]
+            refresh_token=None,
+            scopes=["https://www.googleapis.com/auth/calendar"],
+            expiry=self._token_expiry(),
+            refresh_handler=self._refresh_handler,
         )
 
         self._service = build('calendar', 'v3', credentials=creds)
         return self._service
 
-    def _refresh_via_backend(self, refresh_token: str) -> str:
-        """Refresh access token via backend API.
+    def _token_expiry(self) -> datetime:
+        """Return google-auth's naive UTC expiry value."""
+        value = os.getenv("GOOGLE_TOKEN_EXPIRES_AT")
+        if not value:
+            return datetime.utcnow() + timedelta(minutes=55)
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo:
+            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return parsed
+
+    def _refresh_handler(self, request, scopes=None):
+        """Recover a long-running cached Calendar service after a 401."""
+        return self._refresh_via_backend(None), self._token_expiry()
+
+    def _refresh_via_backend(self, refresh_token: str | None) -> str:
+        """Ask the backend to refresh its stored Google credentials.
 
         Args:
             refresh_token: The refresh token
@@ -134,36 +130,40 @@ class GoogleCalendar:
         response = httpx.post(
             f"{backend_url}/api/v1/oauth/google/refresh",
             headers={"Authorization": f"Bearer {api_key}"},
-            json={"refresh_token": refresh_token}
+            timeout=15.0,
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Failed to refresh token via backend: {response.text}"
-            )
+            try:
+                detail = response.json().get("detail")
+            except (TypeError, ValueError):
+                detail = None
+            if response.status_code == 401 and isinstance(detail, dict) \
+                    and detail.get("error") == "reauth_required":
+                raise ValueError("Google authorization expired. Run: co auth google")
+            raise ValueError("Failed to refresh Google authorization via backend")
 
         data = response.json()
         new_access_token = data["access_token"]
         expires_at = data["expires_at"]
+        new_refresh_token = data.get("refresh_token")
 
         # Update environment variables for this session
         os.environ["GOOGLE_ACCESS_TOKEN"] = new_access_token
         os.environ["GOOGLE_TOKEN_EXPIRES_AT"] = expires_at
+        if new_refresh_token:
+            os.environ["GOOGLE_REFRESH_TOKEN"] = new_refresh_token
 
-        # Update .env file if it exists
-        env_file = os.path.join(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co")), "keys.env")
-        if os.path.exists(env_file):
-            with open(env_file, 'r', encoding="utf-8") as f:
-                lines = f.readlines()
-
-            with open(env_file, 'w', encoding="utf-8") as f:
-                for line in lines:
-                    if line.startswith("GOOGLE_ACCESS_TOKEN="):
-                        f.write(f"GOOGLE_ACCESS_TOKEN={new_access_token}\n")
-                    elif line.startswith("GOOGLE_TOKEN_EXPIRES_AT="):
-                        f.write(f"GOOGLE_TOKEN_EXPIRES_AT={expires_at}\n")
-                    else:
-                        f.write(line)
+        from ..cli.commands.project_cmd_lib import upsert_env
+        env_file = Path(os.getenv("AGENT_CONFIG_PATH", os.path.expanduser("~/.co"))) / "keys.env"
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        values = {
+            "GOOGLE_ACCESS_TOKEN": new_access_token,
+            "GOOGLE_TOKEN_EXPIRES_AT": expires_at,
+        }
+        if new_refresh_token:
+            values["GOOGLE_REFRESH_TOKEN"] = new_refresh_token
+        upsert_env(env_file, values)
 
         return new_access_token
 

--- a/docs/integrations/google.md
+++ b/docs/integrations/google.md
@@ -98,58 +98,21 @@ agent.input("Send an email to alice@example.com saying hello")
 ### Read Calendar Events
 
 ```python
-from connectonion import Agent
-import os
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
-from datetime import datetime, timedelta
+from connectonion import Agent, GoogleCalendar
 
-def check_calendar(days_ahead: int = 7) -> str:
-    """Check Google Calendar for upcoming events."""
-    # Load credentials from environment
-    creds = Credentials(
-        token=os.getenv("GOOGLE_ACCESS_TOKEN"),
-        refresh_token=os.getenv("GOOGLE_REFRESH_TOKEN"),
-        token_uri="https://oauth2.googleapis.com/token",
-        client_id=os.getenv("GOOGLE_CLIENT_ID"),  # From backend
-        client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
-        scopes=["https://www.googleapis.com/auth/calendar.readonly"]
-    )
-
-    service = build('calendar', 'v3', credentials=creds)
-
-    # Get events from now to days_ahead
-    now = datetime.utcnow().isoformat() + 'Z'
-    end = (datetime.utcnow() + timedelta(days=days_ahead)).isoformat() + 'Z'
-
-    events_result = service.events().list(
-        calendarId='primary',
-        timeMin=now,
-        timeMax=end,
-        maxResults=10,
-        singleEvents=True,
-        orderBy='startTime'
-    ).execute()
-
-    events = events_result.get('items', [])
-
-    if not events:
-        return f"No events in the next {days_ahead} days"
-
-    summary = f"Upcoming events ({len(events)}):\n"
-    for event in events:
-        start = event['start'].get('dateTime', event['start'].get('date'))
-        summary += f"- {start}: {event['summary']}\n"
-
-    return summary
+calendar = GoogleCalendar()
 
 agent = Agent(
     "Calendar Assistant",
-    tools=[check_calendar]
+    tools=[calendar]
 )
 
 agent.input("What's on my calendar this week?")
 ```
+
+Use the built-in tool instead of constructing `Credentials` with a Google
+client ID or secret. Those secrets stay on the OpenOnion backend, which also
+refreshes short-lived access tokens.
 
 ---
 
@@ -158,80 +121,14 @@ agent.input("What's on my calendar this week?")
 Here's a full agent that can check your calendar and send meeting invites:
 
 ```python
-from connectonion import Agent, send_email
-import os
-from google.oauth2.credentials import Credentials
-from googleapiclient.discovery import build
-from datetime import datetime, timedelta
+from connectonion import Agent, Gmail, GoogleCalendar
 
-class SchedulingAssistant:
-    """AI assistant that manages your calendar and sends meeting emails."""
-
-    def __init__(self):
-        # Initialize Google Calendar API
-        creds = Credentials(
-            token=os.getenv("GOOGLE_ACCESS_TOKEN"),
-            refresh_token=os.getenv("GOOGLE_REFRESH_TOKEN"),
-            token_uri="https://oauth2.googleapis.com/token",
-            client_id=os.getenv("GOOGLE_CLIENT_ID"),
-            client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
-            scopes=["https://www.googleapis.com/auth/calendar.readonly"]
-        )
-        self.calendar = build('calendar', 'v3', credentials=creds)
-
-    def check_availability(self, date_str: str) -> str:
-        """Check if a specific date/time is free on calendar."""
-        # Parse date and check calendar
-        target_date = datetime.fromisoformat(date_str)
-
-        events_result = self.calendar.events().list(
-            calendarId='primary',
-            timeMin=target_date.isoformat() + 'Z',
-            timeMax=(target_date + timedelta(hours=1)).isoformat() + 'Z',
-            singleEvents=True
-        ).execute()
-
-        events = events_result.get('items', [])
-
-        if events:
-            return f"Not available - {len(events)} event(s) scheduled"
-        return "Available"
-
-    def send_meeting_invite(
-        self,
-        to: str,
-        subject: str,
-        datetime_str: str,
-        duration_hours: int = 1
-    ) -> str:
-        """Send meeting invitation email."""
-        meeting_time = datetime.fromisoformat(datetime_str)
-
-        body = f"""
-Hi,
-
-I'd like to schedule a meeting with you.
-
-Date & Time: {meeting_time.strftime('%A, %B %d, %Y at %I:%M %p')}
-Duration: {duration_hours} hour(s)
-
-Please let me know if this works for you.
-
-Best regards
-"""
-
-        result = send_email(to, subject, body)
-        return f"Meeting invite sent to {to}"
-
-# Create tools from methods
-assistant = SchedulingAssistant()
+gmail = Gmail()
+calendar = GoogleCalendar()
 
 agent = Agent(
     "Scheduling Agent",
-    tools=[
-        assistant.check_availability,
-        assistant.send_meeting_invite
-    ],
+    tools=[calendar, gmail],
     system_prompt="""You are a scheduling assistant.
 
 You can:
@@ -245,7 +142,6 @@ When asked to schedule a meeting:
 """
 )
 
-# Use it
 agent.input("""
 Schedule a 1-hour meeting with bob@example.com
 for tomorrow at 2pm. Subject: Q4 Planning Discussion
@@ -274,7 +170,7 @@ If the browser window doesn't complete authorization within 5 minutes:
 co auth google
 ```
 
-The command polls the backend every 2 seconds waiting for your authorization.
+The command polls the backend every 5 seconds waiting for your authorization.
 
 ### Access Denied / User Cancelled
 
@@ -303,7 +199,8 @@ If credentials exist but don't work, re-authenticate:
 co auth google
 ```
 
-This will clear old credentials and set up fresh ones.
+This replaces the credentials only after the new authorization succeeds, so
+running deployments keep working while the browser flow is in progress.
 
 ### Switch Google Account
 
@@ -313,7 +210,8 @@ To use a different Google account:
 co auth google
 ```
 
-This automatically clears the old connection before starting a new OAuth flow. Pick your desired account in the browser.
+Pick your desired account in the browser. The old connection remains usable
+until the new OAuth callback completes.
 
 ### Revoke Access
 
@@ -365,10 +263,10 @@ To disconnect your Google account:
 
 Behind the scenes, `co auth google`:
 
-1. **Clears existing connection**: Calls `/api/v1/oauth/google/revoke` to remove old credentials (allows switching accounts)
+1. **Keeps the current connection alive** while re-authorization is in progress
 2. **Initiates OAuth flow**: Calls `/api/v1/oauth/google/init` with your `OPENONION_API_KEY`
 3. **Opens browser**: Launches Google's OAuth consent screen with required scopes
-4. **Polls for completion**: Checks `/api/v1/oauth/google/status` every 5 seconds
+4. **Polls for completion**: Checks `/api/v1/oauth/google/status` for a newly written credential
 5. **Retrieves credentials**: Gets tokens from `/api/v1/oauth/google/credentials`
 6. **Saves locally**: Writes credentials to `.env` files with secure permissions
 

--- a/tests/e2e/cli/test_cli_auth_google.py
+++ b/tests/e2e/cli/test_cli_auth_google.py
@@ -237,10 +237,6 @@ class TestAuthGoogleFlow:
             # Setup: Create .env with API key
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
-            # Mock API responses
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404  # No existing connection to revoke
-
             mock_init_response = Mock()
             mock_init_response.status_code = 200
             mock_init_response.json.return_value = {
@@ -249,7 +245,17 @@ class TestAuthGoogleFlow:
 
             mock_status_response = Mock()
             mock_status_response.status_code = 200
-            mock_status_response.json.return_value = {'connected': True}
+            mock_status_response.json.return_value = {
+                'connected': True,
+                'expires_at': '2025-12-31T23:59:59',
+            }
+
+            mock_previous_status = Mock()
+            mock_previous_status.status_code = 200
+            mock_previous_status.json.return_value = {
+                'connected': True,
+                'expires_at': '2025-12-31T22:59:59',
+            }
 
             mock_creds_response = Mock()
             mock_creds_response.status_code = 200
@@ -262,8 +268,8 @@ class TestAuthGoogleFlow:
             }
 
             # Setup mock to return different responses
-            mock_requests.delete.return_value = mock_revoke_response  # /google/revoke
             mock_requests.get.side_effect = [
+                mock_previous_status,  # existing /google/status baseline
                 mock_init_response,  # /google/init
                 mock_status_response,  # /google/status
                 mock_creds_response  # /google/credentials
@@ -277,8 +283,8 @@ class TestAuthGoogleFlow:
                 from connectonion.cli.main import cli
                 result = self.runner.invoke(cli, ['auth', 'google'])
 
-            # Verify revoke was called first (to clear any existing connection)
-            mock_requests.delete.assert_called_once()
+            # Re-auth must not revoke credentials used by running deployments.
+            mock_requests.delete.assert_not_called()
 
             # Verify browser was opened
             mock_webbrowser.open.assert_called_once()
@@ -296,16 +302,14 @@ class TestAuthGoogleFlow:
             # Setup: Create .env with API key
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
-            # Mock revoke (always called first)
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404
-            mock_requests.delete.return_value = mock_revoke_response
-
             # Mock failed init response
             mock_response = Mock()
             mock_response.status_code = 500
             mock_response.text = 'Internal Server Error'
-            mock_requests.get.return_value = mock_response
+            mock_previous_status = Mock()
+            mock_previous_status.status_code = 200
+            mock_previous_status.json.return_value = {'connected': False}
+            mock_requests.get.side_effect = [mock_previous_status, mock_response]
 
             from connectonion.cli.main import cli
             result = self.runner.invoke(cli, ['auth', 'google'])
@@ -322,11 +326,6 @@ class TestAuthGoogleFlow:
             # Setup: Create .env with API key
             Path('.env').write_text('OPENONION_API_KEY=test-key\n')
 
-            # Mock revoke (always called first)
-            mock_revoke_response = Mock()
-            mock_revoke_response.status_code = 404
-            mock_requests.delete.return_value = mock_revoke_response
-
             # Mock init response
             mock_init_response = Mock()
             mock_init_response.status_code = 200
@@ -340,6 +339,7 @@ class TestAuthGoogleFlow:
             mock_status_response.json.return_value = {'connected': False}
 
             mock_requests.get.side_effect = [
+                mock_status_response,  # existing /google/status baseline
                 mock_init_response,
                 *[mock_status_response] * 60  # Never becomes connected
             ]
@@ -349,5 +349,3 @@ class TestAuthGoogleFlow:
 
             # Should timeout and show error
             assert 'timed out' in result.output.lower() or result.exit_code != 0
-
-

--- a/tests/e2e/cli/test_cli_auth_google.py
+++ b/tests/e2e/cli/test_cli_auth_google.py
@@ -77,52 +77,49 @@ class TestLoadApiKey:
             key = load_api_key()
             assert key == 'test-key-123'
 
-    def test_load_api_key_from_local_env(self):
+    def test_load_api_key_from_local_env(self, tmp_path, monkeypatch):
         """Test loading API key from local .env file."""
         from connectonion.cli.commands.project_cmd_lib import load_api_key
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
+        monkeypatch.chdir(tmp_path)
 
-            # Create .env with API key
-            Path('.env').write_text('OPENONION_API_KEY=local-key-456\n')
+        # Create .env with API key
+        Path('.env').write_text('OPENONION_API_KEY=local-key-456\n')
 
-            # Clear environment variable
-            with patch.dict(os.environ, {}, clear=True):
-                key = load_api_key()
-                assert key == 'local-key-456'
+        # Clear environment variable
+        with patch.dict(os.environ, {}, clear=True):
+            key = load_api_key()
+            assert key == 'local-key-456'
 
-    def test_load_api_key_from_global_keys_env(self):
+    def test_load_api_key_from_global_keys_env(self, tmp_path, monkeypatch):
         """Test loading API key from global ~/.co/keys.env."""
         from connectonion.cli.commands.project_cmd_lib import load_api_key
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
+        monkeypatch.chdir(tmp_path)
 
-            # Create mock ~/.co/keys.env
-            co_dir = Path(tmpdir) / '.co'
-            co_dir.mkdir()
-            keys_env = co_dir / 'keys.env'
-            keys_env.write_text('OPENONION_API_KEY=global-key-789\n')
+        # Create mock ~/.co/keys.env
+        co_dir = tmp_path / '.co'
+        co_dir.mkdir()
+        keys_env = co_dir / 'keys.env'
+        keys_env.write_text('OPENONION_API_KEY=global-key-789\n')
 
-            # Mock Path.home() to return tmpdir
-            with patch('pathlib.Path.home', return_value=Path(tmpdir)):
-                with patch.dict(os.environ, {}, clear=True):
-                    key = load_api_key()
-                    assert key == 'global-key-789'
+        # Mock Path.home() to return the isolated home.
+        with patch('pathlib.Path.home', return_value=tmp_path):
+            with patch.dict(os.environ, {}, clear=True):
+                key = load_api_key()
+                assert key == 'global-key-789'
 
-    def test_load_api_key_returns_none_when_not_found(self):
+    def test_load_api_key_returns_none_when_not_found(self, tmp_path, monkeypatch):
         """Test that _load_api_key returns None when no key found."""
         from connectonion.cli.commands.project_cmd_lib import load_api_key
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
+        monkeypatch.chdir(tmp_path)
 
-            # Mock Path.home() to return tmpdir (no keys.env)
-            with patch('pathlib.Path.home', return_value=Path(tmpdir)):
-                with patch.dict(os.environ, {}, clear=True):
-                    key = load_api_key()
-                    assert key is None
+        # Mock Path.home() to return the isolated home (no keys.env).
+        with patch('pathlib.Path.home', return_value=tmp_path):
+            with patch.dict(os.environ, {}, clear=True):
+                key = load_api_key()
+                assert key is None
 
 
 class TestSaveGoogleToEnv:

--- a/tests/e2e/cli/test_cli_trust.py
+++ b/tests/e2e/cli/test_cli_trust.py
@@ -18,11 +18,25 @@ Components under test:
 - Trust list display with full addresses for copying
 """
 
+import pytest
+
 from .argparse_runner import ArgparseCliRunner
 
 
 class TestTrustCommand:
     """Test the trust command for managing trust lists."""
+
+    @pytest.fixture(autouse=True)
+    def _agent_project(self, tmp_path, monkeypatch):
+        """Every trust command runs inside an explicit agent project.
+
+        These tests used to inherit whichever temporary ``.co`` another CLI
+        test happened to leave behind. Once Google auth stopped leaking its
+        deleted cwd, they correctly saw that the repository itself is not an
+        agent and failed for an unrelated reason.
+        """
+        (tmp_path / ".co").mkdir()
+        monkeypatch.chdir(tmp_path)
 
     def setup_method(self):
         """Setup test environment."""

--- a/tests/unit/test_auth_survives_a_non_json_error.py
+++ b/tests/unit/test_auth_survives_a_non_json_error.py
@@ -106,6 +106,11 @@ class TestSendEmailToo:
     instead unwinds the turn.
     """
 
+    @pytest.fixture(autouse=True)
+    def _email_identity(self, monkeypatch):
+        """Reach the HTTP error branch without borrowing a developer's .env."""
+        monkeypatch.setenv("AGENT_EMAIL", "agent@example.com")
+
     def test_a_gateway_page_becomes_an_error_result(self, monkeypatch):
         import importlib
         send_email_mod = importlib.import_module('connectonion.useful_tools.send_email')

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -99,7 +99,8 @@ class TestGmailGetService:
         "GOOGLE_SCOPES": "gmail.readonly gmail.send",
         "GOOGLE_ACCESS_TOKEN": "test_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
-        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+        "OPENONION_API_KEY": "api-key",
     })
     @patch('connectonion.useful_tools.gmail.build')
     def test_get_service_creates_service(self, mock_build):
@@ -118,7 +119,8 @@ class TestGmailGetService:
         "GOOGLE_SCOPES": "gmail.readonly gmail.send",
         "GOOGLE_ACCESS_TOKEN": "test_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
-        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+        "OPENONION_API_KEY": "api-key",
     })
     @patch('connectonion.useful_tools.gmail.build')
     def test_get_service_caches_service(self, mock_build):
@@ -140,6 +142,7 @@ class TestGmailGetService:
         "GOOGLE_ACCESS_TOKEN": "stale_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
         "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+        "OPENONION_API_KEY": "api-key",
     })
     @patch('connectonion.useful_tools.gmail.build')
     def test_get_service_refreshes_even_when_expiry_looks_fresh(self, mock_build, monkeypatch):
@@ -153,7 +156,7 @@ class TestGmailGetService:
 
         Gmail()._get_service()
 
-        assert calls == ["test_refresh"]
+        assert calls == [None]
         assert mock_build.call_args.kwargs["credentials"].token == "fresh_token"
 
     @pytest.mark.real_refresh
@@ -161,6 +164,7 @@ class TestGmailGetService:
         "GOOGLE_SCOPES": "gmail.readonly gmail.send",
         "GOOGLE_ACCESS_TOKEN": "stale_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
+        "OPENONION_API_KEY": "api-key",
     }, clear=True)
     @patch('connectonion.useful_tools.gmail.build')
     def test_get_service_refreshes_without_expiry_variable(self, mock_build, monkeypatch):
@@ -181,7 +185,76 @@ class TestGmailGetService:
 
         with pytest.raises(ValueError) as exc_info:
             gmail._get_service()
-        assert "Google OAuth credentials not found" in str(exc_info.value)
+        assert "OPENONION_API_KEY not found" in str(exc_info.value)
+
+    @pytest.mark.real_refresh
+    @patch.dict(os.environ, {
+        "GOOGLE_SCOPES": "gmail.readonly gmail.send",
+        "OPENONION_API_KEY": "api-key",
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+    }, clear=True)
+    @patch('connectonion.useful_tools.gmail.build')
+    def test_google_auth_can_refresh_a_cached_service_after_401(
+        self, mock_build, monkeypatch
+    ):
+        from connectonion.useful_tools.gmail import Gmail
+
+        tokens = iter(["initial", "after-401"])
+        monkeypatch.setattr(
+            Gmail, "_refresh_via_backend", lambda self, _rt: next(tokens)
+        )
+        gmail = Gmail()
+        gmail._get_service()
+        credentials = mock_build.call_args.kwargs["credentials"]
+
+        credentials.refresh(None)
+
+        assert credentials.token == "after-401"
+        assert credentials.expiry.tzinfo is None
+
+    @pytest.mark.real_refresh
+    def test_backend_refresh_uses_server_token_and_persists_rotation(
+        self, monkeypatch, tmp_path
+    ):
+        from connectonion.useful_tools.gmail import Gmail
+
+        monkeypatch.setenv("OPENONION_API_KEY", "api-key")
+        monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path))
+        response = Mock(status_code=200)
+        response.json.return_value = {
+            "access_token": "fresh-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at": "2026-08-08T12:00:00+00:00",
+        }
+
+        with patch("httpx.post", return_value=response) as post:
+            token = Gmail.__new__(Gmail)._refresh_via_backend("stale-local-token")
+
+        assert token == "fresh-access"
+        assert "json" not in post.call_args.kwargs
+        assert post.call_args.kwargs["timeout"] == 15.0
+        assert os.environ["GOOGLE_REFRESH_TOKEN"] == "rotated-refresh"
+        saved = (tmp_path / "keys.env").read_text()
+        assert "GOOGLE_REFRESH_TOKEN=rotated-refresh" in saved
+
+    @pytest.mark.real_refresh
+    def test_backend_reauth_error_is_actionable_without_leaking_provider_body(
+        self, monkeypatch
+    ):
+        from connectonion.useful_tools.gmail import Gmail
+
+        monkeypatch.setenv("OPENONION_API_KEY", "api-key")
+        response = Mock(status_code=401)
+        response.json.return_value = {
+            "detail": {"error": "reauth_required"},
+            "provider_secret": "must-not-appear",
+        }
+        with patch("httpx.post", return_value=response):
+            with pytest.raises(ValueError) as error:
+                Gmail.__new__(Gmail)._refresh_via_backend(None)
+
+        assert "co auth google" in str(error.value)
+        assert "must-not-appear" not in str(error.value)
 
 
 class TestReadEmails:

--- a/tests/unit/test_google_calendar.py
+++ b/tests/unit/test_google_calendar.py
@@ -60,7 +60,8 @@ class TestGetService:
         "GOOGLE_SCOPES": "calendar",
         "GOOGLE_ACCESS_TOKEN": "test_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
-        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+        "OPENONION_API_KEY": "api-key",
     })
     @patch('connectonion.useful_tools.google_calendar.build')
     def test_get_service_creates_service(self, mock_build):
@@ -70,6 +71,7 @@ class TestGetService:
         mock_build.return_value = mock_service
 
         calendar = GoogleCalendar()
+        calendar._refresh_via_backend = Mock(return_value="fresh_token")
         service = calendar._get_service()
 
         assert service == mock_service
@@ -79,7 +81,8 @@ class TestGetService:
         "GOOGLE_SCOPES": "calendar",
         "GOOGLE_ACCESS_TOKEN": "test_token",
         "GOOGLE_REFRESH_TOKEN": "test_refresh",
-        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+        "OPENONION_API_KEY": "api-key",
     })
     @patch('connectonion.useful_tools.google_calendar.build')
     def test_get_service_caches_service(self, mock_build):
@@ -89,6 +92,7 @@ class TestGetService:
         mock_build.return_value = mock_service
 
         calendar = GoogleCalendar()
+        calendar._refresh_via_backend = Mock(return_value="fresh_token")
         service1 = calendar._get_service()
         service2 = calendar._get_service()
 
@@ -104,7 +108,69 @@ class TestGetService:
 
         with pytest.raises(ValueError) as exc_info:
             calendar._get_service()
-        assert "Google OAuth credentials not found" in str(exc_info.value)
+        assert "OPENONION_API_KEY not found" in str(exc_info.value)
+
+    @patch.dict(os.environ, {
+        "GOOGLE_SCOPES": "calendar",
+        "OPENONION_API_KEY": "api-key",
+        "GOOGLE_TOKEN_EXPIRES_AT": FUTURE_EXPIRY,
+    }, clear=True)
+    @patch('connectonion.useful_tools.google_calendar.build')
+    def test_calendar_can_refresh_a_cached_service_after_401(
+        self, mock_build
+    ):
+        from connectonion.useful_tools.google_calendar import GoogleCalendar
+
+        tokens = iter(["initial", "after-401"])
+        calendar = GoogleCalendar()
+        calendar._refresh_via_backend = Mock(side_effect=lambda _rt: next(tokens))
+        calendar._get_service()
+        credentials = mock_build.call_args.kwargs["credentials"]
+
+        credentials.refresh(None)
+
+        assert credentials.token == "after-401"
+        assert credentials.expiry.tzinfo is None
+
+    def test_calendar_backend_refresh_uses_server_token_and_persists_rotation(
+        self, monkeypatch, tmp_path
+    ):
+        from connectonion.useful_tools.google_calendar import GoogleCalendar
+
+        monkeypatch.setenv("OPENONION_API_KEY", "api-key")
+        monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path))
+        response = Mock(status_code=200)
+        response.json.return_value = {
+            "access_token": "fresh-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at": "2026-08-08T12:00:00+00:00",
+        }
+
+        with patch("httpx.post", return_value=response) as post:
+            token = GoogleCalendar.__new__(GoogleCalendar)._refresh_via_backend(
+                "stale-local-token"
+            )
+
+        assert token == "fresh-access"
+        assert "json" not in post.call_args.kwargs
+        assert post.call_args.kwargs["timeout"] == 15.0
+        assert os.environ["GOOGLE_REFRESH_TOKEN"] == "rotated-refresh"
+        saved = (tmp_path / "keys.env").read_text()
+        assert "GOOGLE_REFRESH_TOKEN=rotated-refresh" in saved
+
+    def test_calendar_backend_error_does_not_leak_provider_body(self, monkeypatch):
+        from connectonion.useful_tools.google_calendar import GoogleCalendar
+
+        monkeypatch.setenv("OPENONION_API_KEY", "api-key")
+        response = Mock(status_code=502, text="provider-secret-debug-page")
+        response.json.side_effect = ValueError("not json")
+
+        with patch("httpx.post", return_value=response):
+            with pytest.raises(ValueError) as error:
+                GoogleCalendar.__new__(GoogleCalendar)._refresh_via_backend(None)
+
+        assert "provider-secret" not in str(error.value)
+        assert str(error.value) == "Failed to refresh Google authorization via backend"
 
 
 class TestListEvents:


### PR DESCRIPTION
Client half of #180. Depends on openonion/oo-api#121 being deployed first.

## What changed

- Gmail and Google Calendar get their first token from the authenticated backend account without depending on a locally baked expiry or refresh token
- google-auth now has a backend refresh handler, so cached Gmail and Calendar services recover and retry after an access-token 401
- neither tool sends its locally stored refresh token back to the backend; the authenticated backend account owns refresh
- rotated refresh tokens are persisted when the backend returns one
- `reauth_required` becomes an actionable `co auth google` message without exposing provider response bodies
- backend calls have an explicit 15-second timeout
- `co auth google` no longer deletes the existing database credential before opening the browser; it watches for a changed expiry instead, so running deployments keep working during reauthorization
- Google integration docs no longer tell users to construct `Credentials` with client secrets they never receive

## Verification

- combined Gmail + Google Calendar + CLI auth regression: 98 passed
- `git diff --check`
- all 8 GitHub jobs green on `361d280`

## Release note

Ready for external review. No merge, deployment, or release performed. Rollout order is oo-api #121 first, then this client change.
