### PR TITLE
Document Gemini 3.6 cached input pricing

### DIFF
--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -81,22 +81,17 @@ MODEL_PRICING = {
     "claude-opus-4": {"input": 15.00, "output": 75.00, "cached": 1.50, "cache_write": 18.75},
     "claude-3-7-sonnet": {"input": 3.00, "output": 15.00, "cached": 0.30, "cache_write": 3.75},
 
-    # Google Gemini models - cached = 25% of input (75% discount), except where
-    # a row says otherwise. input/output for gemini-3.6-flash are confirmed
+    # Google Gemini cached-input discounts vary by model. Most rows below are
+    # 75% discounts; Gemini 3.6 Flash is a provider-published 90% discount:
+    # https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash
+    # input/output for gemini-3.6-flash are also confirmed
     # against real charges: input_tokens x 1.50/1M + (total - input) x 7.50/1M
     # reproduced what the backend billed to a ratio of 1.0000 and 1.0009 on two
     # calls — so the server bills every non-input token, reasoning included, at
     # the output rate. See test_the_cached_rate_follows_its_stated_rule.py.
-    "gemini-3.6-flash": {"input": 1.50, "output": 7.50,
-                         # unverified: 10% of input, not the 25% every other row
-                         # uses, and 0.15 is exactly gemini-2.5-flash's INPUT
-                         # price one line down. Left as found rather than
-                         # "corrected" to 0.375, which would be a made-up price —
-                         # the thing this release removed. Unreachable on the co/
-                         # path (the server states the cost, and cached_tokens
-                         # came back 0 even on a repeated 6k-token prefix); it
-                         # applies to a direct Gemini API call.
-                         "cached": 0.15},
+    # Standard paid tier, per million tokens: input $1.50, output $7.50,
+    # context-cached input $0.15 (Google pricing page, checked 2026-08-08).
+    "gemini-3.6-flash": {"input": 1.50, "output": 7.50, "cached": 0.15},
     "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cached": 0.375},
     # Solved from real charges, two calls: (in=4, total=28, $0.000074) and
     # (in=2006, total=2101, $0.001288) give input 0.50 / output 3.00 and both

--- a/tests/unit/test_the_cached_rate_follows_its_stated_rule.py
+++ b/tests/unit/test_the_cached_rate_follows_its_stated_rule.py
@@ -1,39 +1,4 @@
-"""The Gemini rows state a rule for cached tokens; one of them breaks it.
-
-MODEL_PRICING says, two lines above the data:
-
-    # Google Gemini models - cached = 25% of input (75% discount)
-
-Every row honours it except one:
-
-    gemini-3.6-flash   input 1.50   cached 0.15     10%   ← and 0.15 is exactly
-    gemini-3.5-flash   input 1.50   cached 0.375    25%      the row below's INPUT
-    gemini-3-pro-preview  2.00      cached 0.50     25%
-    gemini-2.5-pro        1.25      cached 0.3125   25%
-    gemini-2.5-flash      0.15      cached 0.0375   25%
-    gemini-2.0-flash      0.10      cached 0.025    25%
-
-The input price is not the thing in doubt. Reconciled against what the backend
-actually charged, twice:
-
-    in=   4  total=  75   charged=$0.000539  predicted=$0.000539  ratio 1.0009
-    in=2006  total=2092   charged=$0.003654  predicted=$0.003654  ratio 1.0000
-
-where predicted = input_tokens x $1.50/1M + (total - input) x $7.50/1M. So 1.50
-and 7.50 are exactly right for this model, and the billing model is: input at the
-input rate, every remaining token — completion and reasoning both — at the output
-rate. Which leaves cached at 10% of a confirmed input price, against a rule the
-file states for itself.
-
-It is NOT changed here. 0.375 would be a number I made up, and a made-up price is
-what this release exists to remove — the `co/` path never reaches it either
-(the server states the cost, and cached_tokens came back 0 even on an identical
-6k-token prefix). It bites only a direct Gemini API call, where calculate_cost
-uses this table and Gemini does report cached tokens.
-
-So the discrepancy is recorded here, where a run will show it, instead of sitting
-behind a comment that says the opposite. Filed for the authoritative figure.
-"""
+"""Pin Gemini cached-input pricing, including the published 3.6 exception."""
 
 import pytest
 
@@ -43,13 +8,12 @@ from connectonion.core.usage import MODEL_PRICING
 GOOGLE_ROWS = {name: row for name, row in MODEL_PRICING.items()
                if name.startswith("gemini")}
 
-# The one row that does not follow the stated rule, and why it is still here.
-UNRESOLVED = {"gemini-3.6-flash"}
+PUBLISHED_EXCEPTIONS = {"gemini-3.6-flash"}
 
 
-class TestEveryGoogleRowFollowsTheStatedRule:
+class TestTheCommonGoogleRowsUseTheSeventyFivePercentDiscount:
 
-    @pytest.mark.parametrize("name", sorted(set(GOOGLE_ROWS) - UNRESOLVED))
+    @pytest.mark.parametrize("name", sorted(set(GOOGLE_ROWS) - PUBLISHED_EXCEPTIONS))
     def test_cached_is_a_quarter_of_input(self, name):
         row = GOOGLE_ROWS[name]
         if "cached" not in row:
@@ -57,8 +21,7 @@ class TestEveryGoogleRowFollowsTheStatedRule:
 
         assert row["cached"] == pytest.approx(row["input"] * 0.25), (
             f"{name}: cached {row['cached']} is "
-            f"{row['cached'] / row['input']:.0%} of input {row['input']}, and the "
-            f"comment above this table says 25%"
+            f"{row['cached'] / row['input']:.0%} of input {row['input']}"
         )
 
     def test_the_rows_were_actually_found(self):
@@ -66,38 +29,13 @@ class TestEveryGoogleRowFollowsTheStatedRule:
         assert len(GOOGLE_ROWS) >= 6
 
 
-class TestTheUnresolvedRowIsStillUnresolved:
-    """When someone supplies the real figure, this fails and says what to do."""
+class TestTheProviderPublishedException:
+    """Google lists 3.6 Flash cached input at $0.15/M, a 90% discount."""
 
-    def test_gemini_3_6_flash_still_breaks_the_rule(self):
+    def test_gemini_3_6_flash_is_ten_percent_of_input(self):
         row = MODEL_PRICING["gemini-3.6-flash"]
-
-        assert row["cached"] != pytest.approx(row["input"] * 0.25), (
-            "gemini-3.6-flash's cached price now follows the 25% rule. If that "
-            "came from the provider's published figure, delete this test and "
-            "drop the row from UNRESOLVED above — the rule now holds everywhere."
-        )
-
-    def test_it_is_flagged_where_the_price_is_written(self):
-        """The table must say so too, or the next reader trusts the comment."""
-        import inspect
-
-        from connectonion.core import usage
-
-        # The row spans several lines, so read from its key to its closing
-        # brace. A same-line check passed only while the row was one line.
-        lines = inspect.getsource(usage).splitlines()
-        start = next(i for i, l in enumerate(lines) if '"gemini-3.6-flash": {' in l)
-        row = []
-        for line in lines[start:]:
-            row.append(line)
-            if "}" in line:
-                break
-
-        assert "unverified" in "\n".join(row).lower(), (
-            "the row that breaks the documented rule carries no note saying so:\n"
-            + "\n".join(row)
-        )
+        assert row["cached"] == pytest.approx(row["input"] * 0.10)
+        assert row["cached"] == 0.15
 
 
 class TestTheConfirmedRatesStay:


### PR DESCRIPTION
Resolves the uncertainty in #731 without changing the price.

Google's official Gemini API pricing page currently lists the Gemini 3.6 Flash standard paid tier at:

- input: $1.50 / 1M tokens
- output (including thinking): $7.50 / 1M tokens
- context-cached input: $0.15 / 1M tokens

Source: https://ai.google.dev/gemini-api/docs/pricing#gemini-3.6-flash

The existing `0.15` value was correct. This PR replaces the misleading blanket 25% rule/unverified warning with the provider-published 90% discount exception, and changes the regression test to pin that exact exception while retaining the 25% checks for the other rows.

Verification: 32 passed, 1 expected skip across the cached-pricing and usage suites; `git diff --check` passed.

Ready for external release review. No release performed.

