### PR TITLE
Stop warning against documented host usage

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -731,14 +731,19 @@ def host(
     Configuration: .co/host.yaml (required) with code param overrides.
     Run 'co init' to generate the config file.
 
-    Each request calls create_agent() to get a fresh Agent instance.
-    This ensures complete isolation between concurrent requests.
+    Passing an Agent instance is the simple path and shares that instance.
+    Passing a factory creates a fresh Agent for each request.
 
-    State Control via Closure:
-        # Isolated state (default, safest) - create inside:
+    State Control:
+        # Simple/default: share one configured agent and expensive tool setup:
+        agent = Agent("assistant", tools=[BrowserTool()])
+        host(agent)
+
+        # Per-request isolation: create everything inside a factory:
         def create_agent():
             browser = BrowserTool()  # Fresh per request
             return Agent("assistant", tools=[browser])
+        host(create_agent)
 
         # Shared state (advanced) - create outside, capture via closure:
         browser = BrowserTool()  # Shared across all requests
@@ -746,9 +751,9 @@ def host(
             return Agent("assistant", tools=[browser])
 
     Args:
-        create_agent: Function that returns a fresh Agent instance.
-                      Called once per request. Define tools inside for isolation,
-                      or outside for shared state.
+        create_agent: Agent instance for shared state, or a function that returns
+                      a fresh Agent per request. A factory isolates state but also
+                      pays the full construction cost on every request.
         port: HTTP port (default: 8000 or from .co/host.yaml)
         trust: Trust level, policy, or Agent (default: from .co/host.yaml or "careful")
             - Level: "open", "careful", "strict"
@@ -781,16 +786,11 @@ def host(
         GET  /admin/logs     - Activity log (requires OPENONION_API_KEY)
         GET  /admin/sessions - Activity sessions (requires OPENONION_API_KEY)
     """
-    # Accept agent instance directly: host(agent) → wrap in factory
-    # Warning: shared state across all requests (not isolated per request)
+    # Accept the documented simple path directly: host(agent). A factory remains
+    # available when per-request isolation is worth its construction cost.
     if not callable(create_agent):
         _agent_instance = create_agent
         create_agent = lambda: _agent_instance
-        console = Console()
-        console.print(
-            "[yellow]Warning: host(agent) — pass a factory function instead: "
-            "host(lambda: Agent(...)) for per-request isolation.[/yellow]"
-        )
 
     # Resolve co_dir: explicit > the project's .co, found by walking up.
     # Not `Path.cwd() / '.co'`: an agent started one directory down found no

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -107,6 +107,25 @@ class TestHostRelayKeyManagement:
 class TestHostRelayConnection:
     """Test relay connection handling in host()."""
 
+    def test_documented_host_agent_path_does_not_warn_against_itself(
+        self, tmp_path, create_mock_agent
+    ):
+        agent = create_mock_agent()
+        mock_addr = {'address': '0xtest', 'short_address': 'co/test', 'signing_key': Mock()}
+
+        with patch.object(Path, 'cwd', return_value=tmp_path), \
+             patch('connectonion.address.load', return_value=mock_addr), \
+             patch.object(host_module, '_create_relay_lifespan', return_value=(AsyncMock(), AsyncMock())), \
+             patch.object(host_module, 'create_schedule_lifespan', return_value=(None, None)), \
+             patch('uvicorn.run'), \
+             patch.object(host_module, '_print_host_banner'), \
+             patch.object(host_module.Console, 'print') as console_print:
+            host_module.host(agent, port=8080)
+
+        warnings = "\n".join(str(call) for call in console_print.call_args_list)
+        assert "pass a factory" not in warnings
+        assert "Warning: host(agent)" not in warnings
+
     def test_profile_publishes_project_scoped_skills_only(self):
         """Published profile carries display fields only. Both project-tree skill
         categories are advertised (project = .co/skills, claude-project = .claude/skills);


### PR DESCRIPTION
Fixes #727.

`host(agent)` is the generated template, the documented beginner path, and an explicit design decision across the repository. The runtime alone warned users that this supported path was wrong and suggested a factory that costs roughly a full agent/skill construction on every request.

This change:

- stops warning against `host(agent)`
- documents the actual contract: an instance shares configured state/resources; a factory creates a fresh Agent per request and pays that construction cost
- keeps factory behavior unchanged for users who need per-request isolation
- adds a regression test that exercises the documented instance path and ensures the contradictory warning stays gone

Verification: host relay + `co init` + `co create` suites, 73 passed; `git diff --check` passed.

Ready for external release review. No release performed.

