### PR TITLE
Refuse browser do across billing accounts

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -2,7 +2,7 @@
 Purpose: Thin client for the browser daemon — wraps one command as a JSON envelope, sends it over the platform transport (POSIX Unix socket / Windows named pipe), and maps the reply to stdout/stderr/exit code.
 LLM-Note:
   Dependencies: imports from [socket, os, json, sys, time, pathlib, browser_agent.daemon (default_sock_path, _owner_alive), browser_agent.transport] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: send(line, headless, tab) → _caller() derives identity (CO_WHO, else claude-<CLAUDE_JOB_DIR>, else "") → build wire-v1 envelope json{v:1, caller, tab, line} (structured caller/tab means any character in a name is safe — nothing is spliced into the shlex-parsed command line) → _connect(default_sock_path()) or _spawn_daemon() → POSIX: send, half-close, read reply to EOF over raw AF_UNIX | Windows: send_bytes/recv_bytes one framed message each way over an HMAC-authenticated named pipe (transport.win_connect + load_or_create_authkey) → header "OK" prints payload to stdout & returns 0 | header "ERR"/"ERR <n>" prints payload to stderr & returns the int (1 default, else 2/3/4) → a pre-upgrade daemon's "unknown command: {…" reply is rewritten to a restart hint
+  Data flow: send(line, headless, tab) → derive caller label and public billing address → build wire-v1 JSON {v,caller,account,tab,line} (no API key crosses the transport) → connect/spawn daemon → print reply and mirror its exit code
   State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log | writes to stdout/stderr
   Integration: exposes _caller() -> str, send(line, headless=False, tab=None) -> int | FIRST-RUN AUTO-INSTALL: on the cold-start path (no daemon yet) AND when a warm daemon answers "No browser is installed for this user" (send retries once), a page-driving verb with no system Chrome triggers `python -m patchright install chromium` right in the user's terminal (chromium: per-user dir, never needs admin — the branded chrome channel runs a system installer) (_ensure_browser_ready) — `co browser` just works with zero setup commands; PAGELESS_VERBS (status/tab/close/...) never provision
   Performance: one connect + request/response | daemon spawn adds browser launch latency on first call
@@ -128,6 +128,20 @@ def _caller() -> str:
     return who.strip()
 
 
+def _caller_account() -> str:
+    """Public address of the account this invocation expects `do` to bill."""
+    from connectonion import address
+
+    try:
+        data = address.load(Path.cwd() / ".co") or address.load(Path.home() / ".co")
+    except Exception:
+        # Page-only commands and `status` must remain usable while diagnosing a
+        # broken local identity. An empty account keeps compatibility; the
+        # daemon still names its payer in status.
+        return ""
+    return str((data or {}).get("address") or "")
+
+
 # Verbs that never launch Chrome: no point provisioning a browser for them.
 PAGELESS_VERBS = {"status", "tab", "help", "use", "switch", "close", "closetab"}
 
@@ -171,10 +185,23 @@ def send(line: str, headless: bool = False, tab: str = None,
          _provisioned: bool = False) -> int:
     """Send one request; print the reply; return the process exit code.
 
-    Wire v1 is a JSON envelope {caller, tab, line} — caller identity and tab
-    targeting are structured fields, so any character in a name is safe (nothing
-    is spliced into the shlex-parsed command line)."""
-    request = json.dumps({"v": 1, "caller": _caller(), "tab": tab, "line": line})
+    Wire v1 is a JSON envelope {caller, account, tab, line}. `account` is the
+    public address only; an API key never crosses the daemon transport."""
+    account = _caller_account()
+    if line.split()[:1] == ["do"] and not account:
+        print(
+            "cannot determine which OpenOnion account should pay for `do`; "
+            "run `co status` or `co auth` first",
+            file=sys.stderr,
+        )
+        return 5
+    request = json.dumps({
+        "v": 1,
+        "caller": _caller(),
+        "account": account,
+        "tab": tab,
+        "line": line,
+    })
     sock_path = default_sock_path()
     try:
         conn = _connect(sock_path)

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -2,7 +2,7 @@
 Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI requests to it over the platform transport (POSIX Unix socket / Windows named pipe), arbitrating concurrent agents through per-tab ownership.
 LLM-Note:
   Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.agent (resolve_api_key, build_browser_agent), browser_agent.transport] | imported by [browser_agent/client.py (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: client sends ONE request = wire-v1 JSON envelope {v, caller, tab, line} (a bare string is accepted as an anonymous main-tab request) → _parse_envelope → shlex.split(line) → dispatch: `tab`/`status`/`use`/`newtab`/`closetab` route first; a -t target that is not `main`/registered is exit 3 unless the verb is READONLY → an unknown verb is rejected BEFORE any claim → page-driving verbs and a targeted `close` pass _register_tab + _held_by_other (exit-4-busy if a DIFFERENT identity holds the tab within GUARD_WINDOW, 120s) then _stamp_claim → `do` hands the parsed instruction to the NL Agent on the same live browser; a matched method is called via getattr(browser, verb)(*coerced args); an unmatched verb returns "unknown command" (it is NOT auto-run as NL — only `do` is) → reply "OK\n<payload>" | "ERR\n<msg>" | "ERR <code>\n<msg>" (code ∈ {2 usage,3 unknown tab,4 busy}) written back, connection closed
+  Data flow: client sends wire-v1 JSON {v,caller,account,tab,line} (or a legacy plain line) → page verbs stay shared; model-backed `do` refuses when the caller's public account address differs from the daemon payer → reply includes process exit code (2 usage, 3 unknown tab, 4 busy, 5 payer mismatch)
   State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | the tab REGISTRY + claims live on browser._tab_meta[key] (key None = shared 'main'): who/purpose/opened_at/caller/claim_at/last_line/last_at | tracks last_command for `status` | binds the endpoint at default_sock_path() via `transport` — POSIX: a raw AF_UNIX socket (unchanged); Windows: a native named pipe (multiprocessing.connection) with an HMAC authkey — under a lifetime OS lock (transport.lock_path: fcntl.flock POSIX / msvcrt Windows, released by the OS on any death, so simultaneous cold-starts can't both bind) and records its owner pid in transport.pid_path so a refused probe can tell busy from stale; 120s per-connection recv timeout | _cleanup closes the listener (POSIX also unlinks the socket) + pidfile only while the pidfile still names this process (browser teardown is the driver pipe closing on process death — the executor is already gone when atexit runs) | serve() exits (releasing the endpoint) when browser._context_is_alive() goes false or _launch_failed()
   Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]` | module helpers _key()/_tab_label()/_held_by_other()/_owner_alive() define the None↔main aliasing, the shared claim-expiry predicate (dispatch, _tab_open, _closetab), and the socket-owner liveness check (client + _bind)
   Performance: one request at a time | browser launch overhead on first page verb (1-3s) | `do` builds a fresh Agent per call | tab lifecycle/status verbs never launch Chrome
@@ -243,14 +243,19 @@ class BrowserDaemon:
         self._next_tab = 1        # id allocator for auto-named tabs
 
     def _parse_envelope(self, raw: str) -> tuple:
-        """Wire v1: one JSON object {"caller","tab","line"} — quote-safe by construction
+        """Wire v1: JSON {caller,account,tab,line} — quote-safe by construction
         (a caller or tab name can hold any character without breaking shlex). A plain
         line (old client) is accepted as an anonymous request for the main tab."""
         if not raw.startswith("{"):
-            return "", None, raw
+            return "", "", None, raw
         req = json.loads(raw)
         tab = req.get("tab")
-        return str(req.get("caller") or ""), (str(tab) if tab is not None else None), str(req.get("line") or "")
+        return (
+            str(req.get("caller") or ""),
+            str(req.get("account") or ""),
+            (str(tab) if tab is not None else None),
+            str(req.get("line") or ""),
+        )
 
     # Verbs that neither drive nor destroy a page: never guarded, and a not-yet-registered
     # -t target is fine (you may inspect or create it). `help` never reaches the daemon —
@@ -261,7 +266,7 @@ class BrowserDaemon:
         """Run one request. Returns (ok, payload); ok is True, False, or an int error
         code the client mirrors into its exit (2 usage · 3 unknown tab · 4 tab busy)."""
         try:
-            caller, tab, line = self._parse_envelope(raw)
+            caller, caller_account, tab, line = self._parse_envelope(raw)
             tokens = shlex.split(line)
         except (ValueError, TypeError) as exc:  # malformed envelope/quoting is the CLIENT's error
             return 2, f"unparseable request: {exc}"
@@ -313,6 +318,14 @@ class BrowserDaemon:
         self._stamp_claim(meta, caller, line)
         self.last_command = {"line": line, "at": time.time()}
         if verb == "do":  # explicit natural-language agent — use the PARSED remainder,
+            daemon_account = _daemon_account() or ""
+            if caller_account and daemon_account and caller_account != daemon_account:
+                return 5, (
+                    "refusing `do`: this browser daemon bills "
+                    f"{daemon_account[:10]}…, but this command came from "
+                    f"{caller_account[:10]}…. Page commands remain available. "
+                    "Stop the daemon and retry from this project so the payer matches."
+                )
             command = " ".join(tokens[1:])  # not the still-quoted raw line
             return self._run_nl(command)
         return self._call_verb(verb, tokens[1:])

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -2,7 +2,7 @@
 Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI requests to it over the platform transport (POSIX Unix socket / Windows named pipe), arbitrating concurrent agents through per-tab ownership.
 LLM-Note:
   Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.agent (resolve_api_key, build_browser_agent), browser_agent.transport] | imported by [browser_agent/client.py (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: client sends wire-v1 JSON {v,caller,account,tab,line} (or a legacy plain line) → page verbs stay shared; model-backed `do` refuses when the caller's public account address differs from the daemon payer → reply includes process exit code (2 usage, 3 unknown tab, 4 busy, 5 payer mismatch)
+  Data flow: client sends wire-v1 JSON {v,caller,account,tab,line} (or a legacy plain line) → page verbs stay shared; model-backed `do` runs only when both public account addresses are present and equal (legacy/missing/mismatched payer data fails closed) → reply includes process exit code (2 usage, 3 unknown tab, 4 busy, 5 payer mismatch)
   State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | the tab REGISTRY + claims live on browser._tab_meta[key] (key None = shared 'main'): who/purpose/opened_at/caller/claim_at/last_line/last_at | tracks last_command for `status` | binds the endpoint at default_sock_path() via `transport` — POSIX: a raw AF_UNIX socket (unchanged); Windows: a native named pipe (multiprocessing.connection) with an HMAC authkey — under a lifetime OS lock (transport.lock_path: fcntl.flock POSIX / msvcrt Windows, released by the OS on any death, so simultaneous cold-starts can't both bind) and records its owner pid in transport.pid_path so a refused probe can tell busy from stale; 120s per-connection recv timeout | _cleanup closes the listener (POSIX also unlinks the socket) + pidfile only while the pidfile still names this process (browser teardown is the driver pipe closing on process death — the executor is already gone when atexit runs) | serve() exits (releasing the endpoint) when browser._context_is_alive() goes false or _launch_failed()
   Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]` | module helpers _key()/_tab_label()/_held_by_other()/_owner_alive() define the None↔main aliasing, the shared claim-expiry predicate (dispatch, _tab_open, _closetab), and the socket-owner liveness check (client + _bind)
   Performance: one request at a time | browser launch overhead on first page verb (1-3s) | `do` builds a fresh Agent per call | tab lifecycle/status verbs never launch Chrome
@@ -309,6 +309,31 @@ class BrowserDaemon:
                 f"'co browser do \"<instruction>\"' for natural language."
             )
 
+        # `do` spends credits in this long-lived process. Old clients have no
+        # account field, and a broken daemon identity cannot prove whose credits
+        # would be spent, so both cases must fail closed. Do this before claiming
+        # the tab: a rejected billing attempt must not make the page look busy.
+        if verb == "do":
+            try:
+                daemon_account = str(_daemon_account() or "").strip()
+            except Exception:
+                daemon_account = ""
+            caller_account = caller_account.strip()
+            if not caller_account or not daemon_account:
+                return 5, (
+                    "refusing `do`: cannot verify that the caller and browser "
+                    "daemon use the same OpenOnion billing account. Upgrade the "
+                    "client, then run `co status` or `co auth`; page commands "
+                    "remain available."
+                )
+            if caller_account.casefold() != daemon_account.casefold():
+                return 5, (
+                    "refusing `do`: this browser daemon bills "
+                    f"{daemon_account[:10]}…, but this command came from "
+                    f"{caller_account[:10]}…. Page commands remain available. "
+                    "Stop the daemon and retry from this project so the payer matches."
+                )
+
         # Every page-driving command (and a targeted close) claims its tab: a DIFFERENT
         # agent mid-task there fails loudly (exit 4) and is taught the tab lifecycle —
         # never silent interleaving on one page.
@@ -318,14 +343,6 @@ class BrowserDaemon:
         self._stamp_claim(meta, caller, line)
         self.last_command = {"line": line, "at": time.time()}
         if verb == "do":  # explicit natural-language agent — use the PARSED remainder,
-            daemon_account = _daemon_account() or ""
-            if caller_account and daemon_account and caller_account != daemon_account:
-                return 5, (
-                    "refusing `do`: this browser daemon bills "
-                    f"{daemon_account[:10]}…, but this command came from "
-                    f"{caller_account[:10]}…. Page commands remain available. "
-                    "Stop the daemon and retry from this project so the payer matches."
-                )
             command = " ".join(tokens[1:])  # not the still-quoted raw line
             return self._run_nl(command)
         return self._call_verb(verb, tokens[1:])

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -249,9 +249,12 @@ def test_dispatch_do_routes_to_nl(tmp_path, monkeypatch):
 
     monkeypatch.setattr(d, "resolve_api_key", lambda: "key")
     monkeypatch.setattr(d, "build_browser_agent", lambda browser, key: FakeAgent())
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xsame-account")
 
     daemon = make_daemon(str(tmp_path / "s.sock"))
-    ok, payload = daemon.dispatch('do find the cheapest flight')
+    ok, payload = daemon.dispatch(_env(
+        "do find the cheapest flight", account="0xsame-account"
+    ))
     assert ok is True
     assert payload == "agent says hi"
     assert captured["command"] == "find the cheapest flight"
@@ -585,6 +588,50 @@ def test_do_runs_when_caller_and_daemon_accounts_match(tmp_path, monkeypatch):
     daemon._run_nl.assert_called_once_with("send the form")
 
 
+@pytest.mark.parametrize("raw", [
+    "do send the form",
+    _env("do send the form"),
+])
+def test_do_from_legacy_or_accountless_client_fails_closed(
+    tmp_path, monkeypatch, raw
+):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    daemon._run_nl = Mock(side_effect=AssertionError("must not spend"))
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xdaemon-account")
+
+    code, payload = daemon.dispatch(raw)
+
+    assert code == 5
+    assert "cannot verify" in payload
+    daemon._run_nl.assert_not_called()
+    assert daemon.browser._tab_meta == {}
+
+
+def test_do_fails_closed_when_daemon_account_is_unavailable(tmp_path, monkeypatch):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    daemon._run_nl = Mock(side_effect=AssertionError("must not spend"))
+    monkeypatch.setattr(d, "_daemon_account", Mock(side_effect=OSError("bad identity")))
+
+    code, payload = daemon.dispatch(
+        _env("do send the form", caller="agent", account="0xcaller-account")
+    )
+
+    assert code == 5
+    assert "cannot verify" in payload
+    daemon._run_nl.assert_not_called()
+    assert daemon.browser._tab_meta == {}
+
+
+def test_do_compares_hex_addresses_case_insensitively(tmp_path, monkeypatch):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    daemon._run_nl = Mock(return_value=(True, "done"))
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xAbCd")
+
+    result = daemon.dispatch(_env("do work", account="0xaBcD"))
+
+    assert result == (True, "done")
+
+
 def test_client_derives_only_the_public_billing_address(tmp_path, monkeypatch):
     from connectonion import address
 
@@ -806,15 +853,16 @@ def test_targeted_close_of_own_tab_is_allowed_bare_close_is_whole_browser(tmp_pa
     assert "closed" in payload.lower()
 
 
-def test_do_instruction_is_not_quote_mangled(tmp_path):
+def test_do_instruction_is_not_quote_mangled(tmp_path, monkeypatch):
     """Fix: the NL instruction was re-derived from the shlex-joined line, leaking quotes.
     A multi-word instruction must reach the agent as clean text."""
     import shlex as _shlex
     captured = {}
     daemon = make_daemon(str(tmp_path / "s.sock"))
     daemon._run_nl = lambda cmd: captured.setdefault("cmd", cmd) or (True, "ok")
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xsame-account")
     line = _shlex.join(["do", "log in and download my invoices"])   # what client.send builds
-    daemon.dispatch(_env(line, caller="a"))
+    daemon.dispatch(_env(line, caller="a", account="0xsame-account"))
     assert captured["cmd"] == "log in and download my invoices"
 
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -21,6 +21,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -537,9 +538,72 @@ def test_launch_failure_message_is_actionable(short_sock, monkeypatch, capsys):
 import json as _json
 
 
-def _env(line, caller="", tab=None):
+def _env(line, caller="", tab=None, account=""):
     """Build the v1 wire envelope the way client.send does."""
-    return _json.dumps({"v": 1, "caller": caller, "tab": tab, "line": line})
+    return _json.dumps({
+        "v": 1, "caller": caller, "account": account, "tab": tab, "line": line
+    })
+
+
+def test_do_refuses_to_bill_a_different_daemon_account(tmp_path, monkeypatch):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    daemon._run_nl = Mock(side_effect=AssertionError("must not spend"))
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xdaemon-account")
+
+    code, payload = daemon.dispatch(
+        _env("do send the form", caller="agent", account="0xcaller-account")
+    )
+
+    assert code == 5
+    assert "refusing `do`" in payload
+    assert "0xdaemon" in payload and "0xcaller" in payload
+    daemon._run_nl.assert_not_called()
+
+
+def test_page_commands_remain_shared_across_billing_accounts(tmp_path, monkeypatch):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xdaemon-account")
+
+    ok, _ = daemon.dispatch(
+        _env("go_to example.com", caller="agent", account="0xcaller-account")
+    )
+
+    assert ok is True
+    assert daemon.browser.calls == [("go_to", "example.com")]
+
+
+def test_do_runs_when_caller_and_daemon_accounts_match(tmp_path, monkeypatch):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+    daemon._run_nl = Mock(return_value=(True, "done"))
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xsame-account")
+
+    result = daemon.dispatch(
+        _env("do send the form", caller="agent", account="0xsame-account")
+    )
+
+    assert result == (True, "done")
+    daemon._run_nl.assert_called_once_with("send the form")
+
+
+def test_client_derives_only_the_public_billing_address(tmp_path, monkeypatch):
+    from connectonion import address
+
+    monkeypatch.setattr(Path, "cwd", lambda: tmp_path)
+    monkeypatch.setattr(
+        address,
+        "load",
+        lambda path: {"address": "0xpublic", "private_key": "never-sent"},
+    )
+
+    assert c._caller_account() == "0xpublic"
+
+
+def test_client_refuses_do_when_it_cannot_name_the_payer(monkeypatch, capsys):
+    monkeypatch.setattr(c, "_caller_account", lambda: "")
+    monkeypatch.setattr(c, "_connect", Mock(side_effect=AssertionError("no socket")))
+
+    assert c.send("do submit the form") == 5
+    assert "cannot determine" in capsys.readouterr().err
 
 
 def test_tab_open_prints_only_the_name(tmp_path):


### PR DESCRIPTION
Fixes #728 using the issue's option 2: refuse model-backed `do` unless the caller and daemon billing accounts are both known and match.

## What changed

- the client adds its public OpenOnion account address to the existing per-user local envelope; no API key/private key crosses the transport
- before `do` claims a tab, constructs an Agent, or spends tokens, the daemon compares that address with the account in its own environment
- mismatch exits with code 5 and names both shortened public addresses plus the restart action
- legacy/accountless clients and an unreadable daemon identity fail closed instead of silently spending from an unverifiable account
- hex addresses compare case-insensitively
- inability to identify the caller's payer also fails before connecting for `do`
- page-only browser commands remain shared across accounts because they do not invoke a model
- legacy plain page requests remain readable by an upgraded daemon

## Verification

- 10 focused billing-boundary tests passed
- complete daemon/transport suite passed outside the managed socket sandbox: **105 passed**
- `git diff --check` passed

Ready for external release review. No merge or release performed.
