### PR TITLE
security: sign every protocol-v2 command frame

### DIFF
--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -1,8 +1,8 @@
 """
-Purpose: Client SDK for talking to remote ConnectOnion agents over websockets — handles relay/direct endpoint resolution, signed CONNECT/INPUT frames, streaming UI events, and onboard (invite/payment) flows.
+Purpose: Client SDK for talking to remote ConnectOnion agents over websockets — handles relay/direct endpoint resolution, signed CONNECT and per-command frames, streaming UI events, and onboard (invite/payment) flows.
 LLM-Note:
   Dependencies: imports from [asyncio, json, time, uuid, dataclasses, typing, httpx, websockets (lazy), .. address (sign)] | imported by [network/__init__.py (re-exports connect, RemoteAgent, Response), connectonion/__init__.py (top-level re-export)] | tested by [tests/unit/test_connect.py, tests/unit/test_connect.py]
-  Data flow: connect(address, keys, relay_url) → RemoteAgent → .input(prompt) opens ws → CONNECT (signed payload {to, timestamp, optional session}) → CONNECTED {session_id} → INPUT {input_id, prompt, optional images/files} → streams (tool_call, tool_result, thinking, assistant, ask_user, ONBOARD_REQUIRED/SUCCESS) → OUTPUT {result, session} → returns Response(text, done)
+  Data flow: connect(address, keys, relay_url) → RemoteAgent → .input(prompt) opens ws → CONNECT (signed payload {to, timestamp, signed_commands}, optional session) → CONNECTED {session_id} → INPUT (complete command duplicated top-level for v1 compatibility and signed as payload for v2) → streams (tool_call, tool_result, thinking, assistant, ask_user, ONBOARD_REQUIRED/SUCCESS) → OUTPUT {result, session} → returns Response(text, done)
   State/Effects: mutates self._current_session, self._ui_events, self._status; opens outbound websocket connection; performs signed payloads via address.sign(keys, canonical_json) when keys provided; resolve_endpoint() makes httpx GETs to relay /api/agents/{addr} and /info on each candidate to pick localhost/LAN/public WS endpoint (cached after first attempt)
   Integration: exposes connect(address, keys=None, relay_url="wss://oo.openonion.ai") -> RemoteAgent | RemoteAgent.input/input_async/reset, .status, .current_session, .ui properties | Response dataclass(text, done) | resolve_endpoint(agent_address, relay_url, timeout=3.0) helper
   Performance: endpoint resolution attempted once per RemoteAgent (cached in _endpoint_resolved/_resolved_endpoint) | per-recv asyncio.wait_for to avoid hangs (default timeout=60s, 30s for CONNECTED) | sync .input() rejected inside running event loop (use input_async)
@@ -70,19 +70,19 @@ def _sort_endpoints(endpoints: List[str]) -> List[str]:
     was reached over whichever the relay listed first — and it lists plaintext
     first. The connection then went in the clear to an agent that had offered TLS.
 
-    What travels on it is a signed CONNECT, and #649 measured what a captured one
-    is worth: EXEC carries no signature of its own, so within the five-minute
-    freshness window a replayed CONNECT opens a session on which any whitelisted
-    tool runs with any arguments. Before #643 this never came up — resolution
-    always failed and every client went through the relay over wss://.
+    What travels on it is authenticated protocol traffic. #649 measured the old
+    protocol's impact: a captured CONNECT opened a connection whose unsigned EXEC
+    frames could name any whitelisted tool. CONNECT replay protection and v2
+    per-command signatures now close both halves; TLS still prevents disclosure
+    of prompts, results, and metadata that signatures do not encrypt.
 
     Closeness still decides first. A plaintext loopback connection has no network
     to be observed on, and reaching an agent on this machine is the case direct
     resolution exists for. This only chooses between endpoints that are equally
     close.
 
-    Not the whole of #649: an agent that offers no TLS at all still speaks
-    plaintext across a LAN, and what to do about that is the trade filed there.
+    An agent that offers no TLS still must not carry private protocol traffic
+    across a network in plaintext, regardless of authentication strength.
     """
     def priority(url: str) -> tuple:
         if "localhost" in url or "127.0.0.1" in url:
@@ -394,10 +394,13 @@ class RemoteAgent:
         await self._try_resolve_endpoint()
 
         exec_id = str(uuid.uuid4())
-        exec_msg = {"type": "EXEC", "exec_id": exec_id, "tool": tool, "args": args}
 
         connection, is_direct = await self._open_best_connection(websockets)
         connect_msg = self._build_connect_message(is_direct)
+        exec_msg = self._build_command_message(
+            {"type": "EXEC", "exec_id": exec_id, "tool": tool, "args": args},
+            is_direct,
+        )
 
         try:
             async with connection as ws:
@@ -704,7 +707,11 @@ class RemoteAgent:
             connect_msg["session"] = self._current_session
 
         if self._keys:
-            payload: Dict[str, Any] = {"to": self.address, "timestamp": connect_msg["timestamp"]}
+            payload: Dict[str, Any] = {
+                "to": self.address,
+                "timestamp": connect_msg["timestamp"],
+                "signed_commands": 1,
+            }
             canonical = json.dumps(payload, sort_keys=True, separators=(',', ':'))
             signature = addr.sign(self._keys, canonical.encode())
             connect_msg["payload"] = payload
@@ -726,7 +733,6 @@ class RemoteAgent:
             "type": "INPUT",
             "input_id": input_id,
             "prompt": prompt,
-            "timestamp": int(time.time())
         }
 
         # Only include 'to' for relay mode (not needed for direct connection)
@@ -741,18 +747,31 @@ class RemoteAgent:
         if files:
             input_msg["files"] = files
 
-        # Sign if keys provided
-        if self._keys:
-            payload: Dict[str, Any] = {"prompt": prompt, "timestamp": input_msg["timestamp"]}
-            if not is_direct:
-                payload["to"] = self.address
-            canonical = json.dumps(payload, sort_keys=True, separators=(',', ':'))
-            signature = addr.sign(self._keys, canonical.encode())
-            input_msg["payload"] = payload
-            input_msg["from"] = self._keys["address"]
-            input_msg["signature"] = signature.hex()
+        return self._build_command_message(input_msg, is_direct)
 
-        return input_msg
+    def _build_command_message(
+        self, message: Dict[str, Any], is_direct: bool = False
+    ) -> Dict[str, Any]:
+        """Sign one complete application command for protocol-v2 hosts.
+
+        Fields remain duplicated at the top level so pre-v2 hosts can consume
+        the frame. A v2 host discards those copies and executes this payload.
+        """
+        command = dict(message)
+        command["timestamp"] = int(time.time())
+        command["nonce"] = str(uuid.uuid4())
+        # Recipient stays in the signature even on a direct socket. Only the
+        # relay needs it for routing, but the host needs it to prevent a frame
+        # captured for one agent from being delivered to another.
+        command["to"] = self.address
+
+        frame = dict(command)
+        if self._keys:
+            canonical = json.dumps(command, sort_keys=True, separators=(',', ':'))
+            frame["payload"] = command
+            frame["from"] = self._keys["address"]
+            frame["signature"] = addr.sign(self._keys, canonical.encode()).hex()
+        return frame
 
     def _build_onboard_submit(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
         """Build ONBOARD_SUBMIT message with optional signing."""

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -316,8 +316,11 @@ def _authenticate_signed(data: dict, *, blacklist=None, recipient_address=None):
     if abs(now - timestamp) > SIGNATURE_EXPIRY_SECONDS:
         return None, agent_address, "unauthorized: signature expired"
 
-    # Optionally verify 'to' matches agent address
-    if recipient_address and to_address and to_address != recipient_address:
+    # When the caller supplies the host address, the signed payload must name
+    # that exact recipient. Treating a missing ``to`` as acceptable would let
+    # the same otherwise-valid command be replayed against a different host,
+    # whose replay cache is necessarily independent.
+    if recipient_address and to_address != recipient_address:
         return None, agent_address, "unauthorized: wrong recipient"
 
     # Verify signature ALWAYS (no whitelist bypass - that's at policy level)

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -209,11 +209,10 @@ def request_from_headers(headers: dict, method: str, path: str) -> dict:
 
 # ─────────────────────────── replay ───────────────────────────
 #
-# EXEC carries no signature of its own -- the signature authenticates the
-# *connection*, and every command on it is trusted because of who opened it. So
-# a captured CONNECT, replayed inside the five-minute freshness window, is not
-# "repeat what the caller did": it is any whitelisted tool with any arguments,
-# because the attacker writes the EXEC frames themselves (#649, measured).
+# In protocol v1, EXEC carried no signature of its own: the signature authenticated
+# the connection and every command on it was trusted because of who opened it. A
+# captured CONNECT could therefore be replayed and followed by attacker-authored
+# EXEC frames (#649, measured).
 #
 # One signature opens one connection. The attack has to *open* one; without a
 # MITM position an attacker cannot inject into somebody else's live socket.
@@ -223,8 +222,9 @@ def request_from_headers(headers: dict, method: str, path: str) -> dict:
 # deliberately does not replay the frame -- see ws_router/connect.py, "no
 # CONNECT replay, its signature may have aged past the 5-minute window".
 #
-# Signing each command is the complete answer and a protocol change (#649
-# option 3). This closes the route without breaking a client.
+# Protocol v2 advertises per-command signatures inside the signed CONNECT. Its
+# commands include type, recipient and a random nonce in their signed payload;
+# v1 remains accepted so an upgraded host does not strand an older client.
 
 _seen_signatures: Dict[str, float] = {}
 
@@ -249,6 +249,36 @@ def signature_already_used(data: dict) -> bool:
         return True
     _seen_signatures[signature] = now
     return False
+
+
+def authenticated_command_payload(
+    data: dict, expected_address: str, expected_recipient: str = None
+):
+    """Return a verified command payload bound to the connected caller.
+
+    CONNECT authenticates the socket. Protocol-v2 clients additionally sign
+    every command with its type and a random nonce, so possession or injection
+    into that socket is not enough to invent a different command.
+    """
+    payload = data.get("payload")
+    if not isinstance(payload, dict):
+        return None, "unauthorized: signed command required"
+
+    _, caller, error = _authenticate_signed(
+        data, recipient_address=expected_recipient
+    )
+    if error:
+        return None, error
+    if caller != expected_address:
+        return None, "unauthorized: command signer does not own this connection"
+    if payload.get("type") != data.get("type"):
+        return None, "unauthorized: signed command type mismatch"
+    nonce = payload.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        return None, "unauthorized: signed command nonce required"
+    if signature_already_used(data):
+        return None, "unauthorized: signed command already used"
+    return payload, None
 
 
 def _authenticate_signed(data: dict, *, blacklist=None, recipient_address=None):

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -28,8 +28,12 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
                         "message": "unauthorized: this CONNECT was already used"})
         return
 
+    metadata = route_handlers.get("agent_metadata") or {}
+    auth_kwargs = {"blacklist": blacklist, "whitelist": whitelist}
+    if metadata.get("address"):
+        auth_kwargs["recipient_address"] = metadata["address"]
     _, agent_address, sig_valid, err = route_handlers["auth"](
-        data, trust, blacklist=blacklist, whitelist=whitelist
+        data, trust, **auth_kwargs
     )
 
     if err and "forbidden" in err.lower():

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -73,6 +73,10 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     """
     conn["authenticated"] = True
     conn["agent_address"] = agent_address
+    conn["signed_commands"] = (
+        data.get("payload", {}).get("signed_commands") == 1
+    )
+    conn["recipient_address"] = data.get("payload", {}).get("to")
     session_id = data.get("session_id") or str(uuid.uuid4())
     conn["session_id"] = session_id
     conn["session"] = data.get("session")

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -44,6 +44,18 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
 
             msg_type = data.get("type")
 
+            # CONNECT establishes the identity and protocol capabilities for
+            # this socket. Letting a second CONNECT overwrite that state makes
+            # it possible to downgrade an authenticated v2 connection to v1
+            # and then inject unsigned commands. Reauthentication belongs on a
+            # fresh transport, with fresh per-connection state.
+            if msg_type == "CONNECT" and conn.get("authenticated"):
+                await send_msg({
+                    "type": "ERROR",
+                    "message": "already authenticated: open a new connection",
+                })
+                continue
+
             # A v2 CONNECT signs the capability that enables this gate. Keep the
             # few transport/authentication frames outside it; every application
             # command, including approval and ask-user responses forwarded below,

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -28,7 +28,8 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
     direct ASGI WebSocket path and the relay-routed path, each providing its
     own send_msg/recv_msg adapters.
     """
-    conn = {"authenticated": False, "agent_address": None, "session_id": None, "session": None}
+    conn = {"authenticated": False, "agent_address": None, "session_id": None,
+            "session": None, "signed_commands": False, "recipient_address": None}
     active_io = None
     forward_task = None
     exec_tasks = set()
@@ -42,6 +43,36 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 break
 
             msg_type = data.get("type")
+
+            # A v2 CONNECT signs the capability that enables this gate. Keep the
+            # few transport/authentication frames outside it; every application
+            # command, including approval and ask-user responses forwarded below,
+            # must be signed and is replaced with the verified payload before use.
+            exempt = {"CONNECT", "PONG", "SESSION_STATUS", "ONBOARD_SUBMIT"}
+            if (conn.get("authenticated") and conn.get("signed_commands")
+                    and msg_type not in exempt):
+                from ..auth import authenticated_command_payload
+
+                signed_frame = data
+                verified, command_error = authenticated_command_payload(
+                    data, conn["agent_address"], conn.get("recipient_address")
+                )
+                if command_error:
+                    await send_msg({"type": "ERROR", "message": command_error})
+                    continue
+                # ADMIN handlers independently authenticate their frame. Preserve
+                # that envelope while replacing every actionable top-level field
+                # with its verified copy. Other handlers only need the payload.
+                if (msg_type or "").startswith("ADMIN_"):
+                    data = {
+                        **verified,
+                        "payload": verified,
+                        "from": signed_frame.get("from"),
+                        "signature": signed_frame.get("signature"),
+                    }
+                else:
+                    data = verified
+                msg_type = data.get("type")
             if msg_type not in ("CONNECT", "INPUT", "SESSION_STATUS", "PONG"):
                 console.print(f"[dim]← recv: {msg_type}[/dim]")
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -28,8 +28,8 @@ See [Trust Gate](#trust-gate-onboarding).
 │                                                                │
 │   Every connection:  WS open → CONNECT → CONNECTED → ...      │
 │                                                                │
-│   CONNECT carries:   auth + session (conversation history)     │
-│   INPUT carries:     just the prompt (session already set)     │
+│   CONNECT carries:   auth + session + signed-command capability│
+│   INPUT carries:     signed prompt/attachments (session set)   │
 │                                                                │
 │   Server decides:    new / connected / running                 │
 │                      …or, for a caller the trust policy denies │
@@ -243,7 +243,11 @@ Authenticate, restore session, and sync conversation. **Always the first message
   "session_id": "550e8400-...",
   "session": { "messages": [...], "mode": "safe" },
   "last_msg_id": "ev-9f12...",
-  "payload": { "to": "0x3d4017c3e843...", "timestamp": 1702234567 },
+  "payload": {
+    "to": "0x3d4017c3e843...",
+    "timestamp": 1702234567,
+    "signed_commands": 1
+  },
   "from": "0xClientPublicKey",
   "signature": "0x..."
 }
@@ -257,6 +261,11 @@ Authenticate, restore session, and sync conversation. **Always the first message
 | `payload` | Yes | Signed payload for authentication |
 | `from` | Yes | Client's public address |
 | `signature` | Yes | Ed25519 signature of payload |
+
+`payload.signed_commands: 1` is itself signed. It opts the connection into the
+v2 command gate described below. A new server continues accepting a v1 CONNECT
+without it, so an older client is not stranded; it does not receive v2's
+per-command injection/replay protection.
 
 Server response based on state:
 
@@ -284,11 +293,17 @@ written down. The shipped policy declares `invite_code: [$CO_INVITE_CODE]` and
 onboarding to offer, so a stranger gets `ERROR` from the policy rather than an
 `ONBOARD_REQUIRED` leading nowhere.
 
-**A CONNECT signature opens one connection.** Replaying a captured one is
-refused with `ERROR unauthorized: this CONNECT was already used`. EXEC carries
-no signature of its own, so the connection is the unit of authentication and a
-replayed CONNECT would otherwise be the whole whitelisted tool surface for the
-five-minute freshness window.
+**A signature is single-use.** Replaying a captured CONNECT is refused with
+`ERROR unauthorized: this CONNECT was already used`. A v2 client also signs every
+application command; replaying one is refused with `signed command already used`.
+
+**A v2 command signs what the server executes.** Its payload contains `type`, all
+command fields, `to`, `timestamp`, and a random `nonce`. The server verifies the
+signer is the caller that opened this connection, verifies the recipient and
+type, then discards the unsigned compatibility copy and dispatches the signed
+payload. INPUT, EXEC, runtime input, approval responses and ask-user responses
+all pass through this gate. PONG and SESSION_STATUS are transport/status frames;
+ONBOARD_SUBMIT and ADMIN frames retain their existing independent signatures.
 
 This decision is made **per caller**, after the signature is verified, so an admin, a
 contact, or anyone who onboarded earlier never sees the gate at all.
@@ -302,9 +317,24 @@ Send a prompt. Only valid after CONNECTED. **No session data — just the prompt
   "type": "INPUT",
   "prompt": "Translate hello to Spanish",
   "images": ["data:image/png;base64,..."],
-  "files": [{ "name": "doc.pdf", "data": "data:application/pdf;base64,..." }]
+  "files": [{ "name": "doc.pdf", "data": "data:application/pdf;base64,..." }],
+  "payload": {
+    "type": "INPUT",
+    "input_id": "7c2a...",
+    "prompt": "Translate hello to Spanish",
+    "images": ["data:image/png;base64,..."],
+    "files": [{ "name": "doc.pdf", "data": "data:application/pdf;base64,..." }],
+    "to": "0x3d4017c3e843...",
+    "timestamp": 1702234567,
+    "nonce": "550e8400-..."
+  },
+  "from": "0xClientPublicKey",
+  "signature": "0x..."
 }
 ```
+
+The command fields remain at the top level only so a v2 client can talk to a v1
+host. A v2 host executes the verified `payload`, never those duplicates.
 
 If sent while the session's agent is already running, this message is routed as runtime input: the prompt is appended to the running agent's message history (with framing telling the LLM to treat it as additional context, not a replacement) and the server replies `RUNTIME_INPUT_ACK` instead of starting a new OUTPUT cycle. No new `thinking` chat item is created — the existing one keeps streaming.
 
@@ -317,7 +347,18 @@ Run one registered tool directly — no LLM, no session, no history. Only valid 
   "type": "EXEC",
   "exec_id": "7c2a...",
   "tool": "bash",
-  "args": { "command": "co status" }
+  "args": { "command": "co status" },
+  "payload": {
+    "type": "EXEC",
+    "exec_id": "7c2a...",
+    "tool": "bash",
+    "args": { "command": "co status" },
+    "to": "0x3d4017c3e843...",
+    "timestamp": 1702234567,
+    "nonce": "550e8400-..."
+  },
+  "from": "0xClientPublicKey",
+  "signature": "0x..."
 }
 ```
 

--- a/tests/e2e/test_host_ws.py
+++ b/tests/e2e/test_host_ws.py
@@ -37,7 +37,15 @@ import pytest
 from nacl.signing import SigningKey
 
 from connectonion import Agent
+from connectonion.network.host import get_agent_address
 from tests.utils.mock_helpers import MockLLM, LLMResponseBuilder
+
+
+class _HostedAgentIdentity:
+    name = "ws-agent"
+
+
+HOST_ADDRESS = get_agent_address(_HostedAgentIdentity())
 
 
 def sign_init(signing_key: SigningKey = None):
@@ -46,7 +54,7 @@ def sign_init(signing_key: SigningKey = None):
         signing_key = SigningKey.generate()
 
     public_key = f"0x{signing_key.verify_key.encode().hex()}"
-    payload = {"timestamp": time.time()}
+    payload = {"timestamp": time.time(), "to": HOST_ADDRESS}
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     signature = f"0x{signing_key.sign(canonical.encode()).signature.hex()}"
 
@@ -218,7 +226,7 @@ class TestWebSocketStrict:
     def test_strict_invalid_signature(self, app_strict):
         signing_key = SigningKey.generate()
         public_key = f"0x{signing_key.verify_key.encode().hex()}"
-        payload = {"timestamp": time.time()}
+        payload = {"timestamp": time.time(), "to": HOST_ADDRESS}
         data = {"type": "CONNECT", "payload": payload, "from": public_key, "signature": "0x" + "00" * 64}
 
         client = ASGIWebSocketClient(app_strict)
@@ -246,7 +254,7 @@ class TestWebSocketAccessLists:
     def test_blacklisted(self, app_strict_bw):
         data = {
             "type": "CONNECT",
-            "payload": {"timestamp": time.time()},
+            "payload": {"timestamp": time.time(), "to": HOST_ADDRESS},
             "from": "0xbad",
             "signature": "0x" + "00" * 64
         }
@@ -263,7 +271,7 @@ class TestWebSocketAccessLists:
         """
         data = {
             "type": "CONNECT",
-            "payload": {"timestamp": time.time()},
+            "payload": {"timestamp": time.time(), "to": HOST_ADDRESS},
             "from": "0xgood",
             "signature": "0x" + "00" * 64  # Invalid signature
         }

--- a/tests/unit/test_a_captured_connect_opens_nothing_twice.py
+++ b/tests/unit/test_a_captured_connect_opens_nothing_twice.py
@@ -14,7 +14,7 @@ the attacker, not captured:
     2nd (CONNECT replayed verbatim)  -> ran 2 times
     3rd (replayed again)             -> ran 3 times
 
-Two things are fixed here, neither of them a protocol change.
+This test records the first two defenses, which did not change the protocol.
 
 **A CONNECT signature opens one connection.** Seen once, refused after. The
 attack needs to *open* a connection; without a MITM position an attacker cannot
@@ -30,10 +30,10 @@ anyone who can observe the traffic can capture a CONNECT. Plaintext is now used
 only for loopback, where there is no network to observe; a `wss://` endpoint is
 preferred when offered, and otherwise the relay carries it.
 
-What is *not* fixed here is signing each command (#649's option 3). That is the
-complete answer and a protocol change: every EXEC and INPUT carrying its own
-signature over its own contents. These two close the route without breaking a
-single client.
+Per-command signing is now covered separately by
+`test_each_command_is_signed.py`: a v2 CONNECT negotiates it without breaking a
+v1 client, then every application command is bound to its type, contents,
+recipient, caller and a single-use nonce.
 """
 
 import time

--- a/tests/unit/test_each_command_is_signed.py
+++ b/tests/unit/test_each_command_is_signed.py
@@ -1,6 +1,7 @@
 """Protocol-v2 binds every command to the caller that opened the socket."""
 
 import copy
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -108,6 +109,57 @@ def test_command_is_bound_to_recipient(keys):
     assert "wrong recipient" in error
 
 
+def test_command_without_recipient_is_rejected(keys):
+    recipient = "0x" + "12" * 20
+    frame = RemoteAgent(recipient, keys=keys)._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {}}
+    )
+    payload = dict(frame["payload"])
+    payload.pop("to")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    frame["payload"] = payload
+    frame["signature"] = address.sign(keys, canonical.encode()).hex()
+
+    verified, error = auth.authenticated_command_payload(
+        frame, keys["address"], recipient
+    )
+
+    assert verified is None
+    assert "wrong recipient" in error
+
+
+@pytest.mark.asyncio
+async def test_connect_is_bound_to_the_actual_host_address(keys):
+    from connectonion.network.host.ws_router.connect import handle_connect
+
+    claimed_recipient = "0x" + "12" * 20
+    actual_recipient = "0x" + "34" * 20
+    frame = RemoteAgent(claimed_recipient, keys=keys)._build_connect_message()
+    conn = {"authenticated": False}
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await handle_connect(
+        frame,
+        send,
+        conn,
+        {
+            "auth": auth.extract_and_authenticate,
+            "agent_metadata": {"address": actual_recipient},
+        },
+        MagicMock(),
+        MagicMock(),
+        "open",
+        None,
+        None,
+    )
+
+    assert conn["authenticated"] is False
+    assert "wrong recipient" in sent[-1]["message"]
+
+
 def test_top_level_type_cannot_relabel_a_signed_command(keys):
     frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_command_message(
         {"type": "INPUT", "input_id": "i1", "prompt": "hello"}
@@ -120,10 +172,14 @@ def test_top_level_type_cannot_relabel_a_signed_command(keys):
     assert "type mismatch" in error
 
 
-async def _session_with(messages, monkeypatch, *, signed_commands, ran):
+async def _session_with(
+    messages, monkeypatch, *, signed_commands, ran, connect_calls=None
+):
     from connectonion.network.host.ws_router import session
 
     async def fake_connect(data, send, conn, *args):
+        if connect_calls is not None:
+            connect_calls.append(data)
         conn.update(
             authenticated=True,
             agent_address=data["from"],
@@ -162,6 +218,24 @@ async def _session_with(messages, monkeypatch, *, signed_commands, ran):
         enable_ping=False,
     )
     return sent
+
+
+@pytest.mark.asyncio
+async def test_authenticated_socket_rejects_a_second_connect(keys, monkeypatch):
+    first = {"type": "CONNECT", "from": keys["address"]}
+    downgrade = {"type": "CONNECT", "from": "0xattacker"}
+    connect_calls = []
+
+    sent = await _session_with(
+        [first, downgrade],
+        monkeypatch,
+        signed_commands=True,
+        ran=[],
+        connect_calls=connect_calls,
+    )
+
+    assert connect_calls == [first]
+    assert "already authenticated" in sent[-1]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_each_command_is_signed.py
+++ b/tests/unit/test_each_command_is_signed.py
@@ -1,0 +1,259 @@
+"""Protocol-v2 binds every command to the caller that opened the socket."""
+
+import copy
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion import address
+from connectonion.network.connect import RemoteAgent
+from connectonion.network.host import auth
+
+
+@pytest.fixture(autouse=True)
+def clean_replay_cache():
+    auth._seen_signatures.clear()
+    yield
+    auth._seen_signatures.clear()
+
+
+@pytest.fixture
+def keys():
+    return address.generate()
+
+
+def test_connect_negotiates_signed_commands(keys):
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_connect_message()
+
+    assert frame["payload"]["signed_commands"] == 1
+    assert auth.verify_signature(frame["payload"], frame["signature"], frame["from"])
+
+
+def test_input_signature_covers_every_field(keys):
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_input_message(
+        "hello", "input-1", images=["image"], files=[{"name": "a.txt"}]
+    )
+
+    assert frame["payload"]["type"] == "INPUT"
+    assert frame["payload"]["input_id"] == "input-1"
+    assert frame["payload"]["images"] == ["image"]
+    assert frame["payload"]["files"] == [{"name": "a.txt"}]
+    assert frame["payload"]["nonce"]
+    assert auth.verify_signature(frame["payload"], frame["signature"], frame["from"])
+
+
+def test_v1_host_can_read_a_v2_input(keys):
+    from connectonion.network.host.ws_router.agent_io import verified_prompt
+
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_input_message(
+        "hello", "input-1"
+    )
+    handlers = {
+        "auth": lambda data, trust: auth.extract_and_authenticate(data, trust)
+    }
+
+    assert verified_prompt(frame, handlers) == ("hello", None)
+
+
+def test_server_executes_the_signed_copy_not_tampered_top_level(keys):
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    frame = agent._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {"path": "ok"}}
+    )
+    frame["tool"] = "bash"
+    frame["args"] = {"command": "bad"}
+
+    payload, error = auth.authenticated_command_payload(frame, keys["address"])
+
+    assert error is None
+    assert payload["tool"] == "safe"
+    assert payload["args"] == {"path": "ok"}
+
+
+def test_command_is_bound_to_connection_owner(keys):
+    other = address.generate()
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {}}
+    )
+
+    payload, error = auth.authenticated_command_payload(frame, other["address"])
+
+    assert payload is None
+    assert "does not own" in error
+
+
+def test_command_signature_cannot_be_replayed(keys):
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {}}
+    )
+
+    assert auth.authenticated_command_payload(frame, keys["address"])[1] is None
+    assert "already used" in auth.authenticated_command_payload(
+        copy.deepcopy(frame), keys["address"]
+    )[1]
+
+
+def test_command_is_bound_to_recipient(keys):
+    recipient = "0x" + "12" * 20
+    frame = RemoteAgent(recipient, keys=keys)._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {}},
+        is_direct=True,
+    )
+
+    payload, error = auth.authenticated_command_payload(
+        frame, keys["address"], "0x" + "34" * 20
+    )
+
+    assert payload is None
+    assert "wrong recipient" in error
+
+
+def test_top_level_type_cannot_relabel_a_signed_command(keys):
+    frame = RemoteAgent("0x" + "12" * 20, keys=keys)._build_command_message(
+        {"type": "INPUT", "input_id": "i1", "prompt": "hello"}
+    )
+    frame["type"] = "EXEC"
+
+    payload, error = auth.authenticated_command_payload(frame, keys["address"])
+
+    assert payload is None
+    assert "type mismatch" in error
+
+
+async def _session_with(messages, monkeypatch, *, signed_commands, ran):
+    from connectonion.network.host.ws_router import session
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=data["from"],
+            signed_commands=signed_commands,
+            session_id="s1",
+            recipient_address=data.get("to"),
+        )
+
+    async def fake_exec(data, send, handlers, requester_address):
+        ran.append((data, requester_address))
+
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    monkeypatch.setattr(session, "run_exec", fake_exec)
+
+    queue = list(messages)
+    sent = []
+
+    async def recv():
+        if queue:
+            return queue.pop(0)
+        # Let a scheduled EXEC task reach fake_exec before the socket closes.
+        import asyncio
+        await asyncio.sleep(0.01)
+        return None
+
+    async def send(message):
+        sent.append(message)
+
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={},
+        storage=MagicMock(),
+        registry=MagicMock(),
+        trust="open",
+        enable_ping=False,
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_v2_session_rejects_unsigned_exec_before_it_runs(keys, monkeypatch):
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    unsigned = {"type": "EXEC", "exec_id": "e1", "tool": "bash", "args": {}}
+    ran = []
+
+    sent = await _session_with(
+        [connect, unsigned], monkeypatch, signed_commands=True, ran=ran
+    )
+
+    assert ran == []
+    assert "signed command required" in sent[-1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_v2_session_executes_the_verified_payload(keys, monkeypatch):
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    signed = agent._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {"value": 1}}
+    )
+    signed["tool"] = "tampered"
+    ran = []
+
+    await _session_with(
+        [connect, signed], monkeypatch, signed_commands=True, ran=ran
+    )
+
+    assert ran[0][0]["tool"] == "safe"
+    assert ran[0][1] == keys["address"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_keeps_accepting_connection_authenticated_exec(keys, monkeypatch):
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    unsigned = {"type": "EXEC", "exec_id": "e1", "tool": "legacy", "args": {}}
+    ran = []
+
+    await _session_with(
+        [connect, unsigned], monkeypatch, signed_commands=False, ran=ran
+    )
+
+    assert ran[0][0]["tool"] == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_v2_session_binds_admin_action_to_signed_type(keys, monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    signed = agent._build_command_message(
+        {"type": "ADMIN_PROMOTE", "client_id": "0xclient"}
+    )
+    signed["type"] = "ADMIN_BLOCK"
+    called = []
+
+    async def fake_admin(data, send, handlers):
+        called.append(data)
+
+    monkeypatch.setattr(session, "handle_admin_message", fake_admin)
+    sent = await _session_with(
+        [connect, signed], monkeypatch, signed_commands=True, ran=[]
+    )
+
+    assert called == []
+    assert "type mismatch" in sent[-1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_v2_session_passes_verified_admin_frame_to_independent_auth(keys, monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    signed = agent._build_command_message(
+        {"type": "ADMIN_PROMOTE", "client_id": "0xclient"}
+    )
+    signed["client_id"] = "0xattacker-choice"
+    called = []
+
+    async def fake_admin(data, send, handlers):
+        assert auth.extract_and_authenticate(data, "open")[2] is True
+        called.append(data)
+
+    monkeypatch.setattr(session, "handle_admin_message", fake_admin)
+    await _session_with(
+        [connect, signed], monkeypatch, signed_commands=True, ran=[]
+    )
+
+    assert called[0]["type"] == "ADMIN_PROMOTE"
+    assert called[0]["client_id"] == "0xclient"
+    assert called[0]["payload"]["client_id"] == "0xclient"

--- a/tests/unit/test_the_websocket_input_honours_its_signature.py
+++ b/tests/unit/test_the_websocket_input_honours_its_signature.py
@@ -28,10 +28,11 @@ signature decided nothing.
 This is the half of #649 that is a gap rather than a decision: the HTTP path
 already establishes the intended reading, and nothing on the wire changes.
 
-What stays a decision, and is not done here: whether a signature should be
-*required*. A client built without keys sends none, and the connection it is on
-was authenticated by its CONNECT. Honouring a signature that is present is the
-part with no trade in it.
+Protocol v2 now resolves the remaining decision: a client opts in through its
+signed CONNECT and every subsequent application command requires a complete
+signature. Protocol v1 remains accepted for compatibility. This test keeps
+recording the earlier invariant that, whenever an INPUT signature is present,
+the server runs the signed prompt rather than an unsigned duplicate.
 """
 
 import json


### PR DESCRIPTION
Advances #649.

## What changes

- advertises `signed_commands: 1` inside the signed CONNECT payload
- signs each complete INPUT, EXEC, runtime-input, approval, ask-user, and ADMIN command with type, recipient, timestamp, and a random nonce
- binds each command to the caller that opened the socket and to the intended host
- rejects replayed command signatures and top-level type/content substitution
- dispatches the verified payload instead of unsigned compatibility copies
- keeps protocol-v1 clients working; v1 connections remain on the legacy connection-authenticated behavior

## Compatibility / rollout

The capability is signed, so it cannot be stripped from a v2 CONNECT without invalidating authentication. New clients duplicate command fields at the top level so they can still talk to v1 hosts. Deploying a v2 host first is compatible with old clients; the stronger command guarantee applies once both sides are v2.

This is Ready for external security review before 1.6.0. It does not publish or release anything.

## Verification

- 60 focused security/admin tests passed
- 207 broader network/auth/onboarding/EXEC/skill-permission tests passed
- `python -m compileall -q connectonion/network`
- `git diff --check`
