### PR TITLE
Handle managed provider failures without tracebacks

### DIFF
--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -1,10 +1,16 @@
 """
-Purpose: AI coding agent CLI command
+Purpose: AI coding agent CLI command with concise provider-failure reporting
 LLM-Note:
   Dependencies: imports from [cli/co_ai/main.py, cli/co_ai/agent.py] | imported by [cli/main.py] | no direct tests
   Data flow: CLI args → start_server() or agent.input() for one-shot
   Integration: exposes handle_ai() | called from main.py as 'co ai' command
+  Errors: known LLM provider failures print one actionable message and exit 1; programmer errors still propagate with their traceback
 """
+
+import typer
+from rich.console import Console
+
+console = Console()
 
 
 def handle_ai(
@@ -38,7 +44,12 @@ def handle_ai(
     )
 
     if prompt:
-        result = agent.input(prompt)
+        from ...core.exceptions import LLMProviderError
+        try:
+            result = agent.input(prompt)
+        except LLMProviderError as exc:
+            console.print(f"\n[red]✗ Model request failed:[/red] {exc}\n")
+            raise typer.Exit(1) from None
         # Print the agent's response for one-shot mode
         print("\n" + result)
     else:

--- a/connectonion/core/exceptions.py
+++ b/connectonion/core/exceptions.py
@@ -32,11 +32,19 @@ class LLMAuthenticationError(LLMProviderError):
     def __init__(self, original_error, model: str = "unknown"):
         self.model = model
         self.status_code = getattr(original_error, "status_code", None)
-        super().__init__(
-            f"Authentication failed for {model}. Check the API key for this "
-            f"provider — the key that works for one provider is not the key for "
-            f"another. Original: {type(original_error).__name__}: {original_error}"
-        )
+        if model.startswith("co/"):
+            message = (
+                f"The managed provider credential for {model} was rejected. "
+                "This is a service-side configuration problem; retry later or "
+                "contact OpenOnion support."
+            )
+        else:
+            message = (
+                f"Authentication failed for {model}. Check the API key for this "
+                "provider — the key that works for one provider is not the key for "
+                "another."
+            )
+        super().__init__(message)
         self.__cause__ = original_error
 
 

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1182,6 +1182,12 @@ class OpenOnionLLM(LLM):
                 # 403 can mean other things, and guessing from the status alone
                 # would tell a suspended account to go buy credits.
                 raise PaidModelRequiredError(e) from e
+            elif e.status_code == 401:
+                # Managed-provider credentials live on oo-api, not on the
+                # caller's machine. Still use the shared provider-error family
+                # so library and CLI callers can handle this without depending
+                # on an OpenAI-compatible transport implementation.
+                raise LLMAuthenticationError(e, model=f"co/{self.model}") from e
             logger.error(f"APIStatusError: status={e.status_code}, message={e.message}, body={getattr(e, 'body', None)}")
             raise
         except (openai.APITimeoutError, openai.APIConnectionError) as e:

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -12,7 +12,10 @@ Components under test:
 
 import connectonion.cli.commands.ai_commands as ai_mod
 import connectonion.cli.commands.trust_commands as trust_mod
+import pytest
+import typer
 from connectonion.cli.co_ai.agent import GLOBAL_CO_DIR
+from connectonion.core.exceptions import LLMAuthenticationError
 
 
 def test_handle_ai_calls_start_server(monkeypatch):
@@ -70,6 +73,41 @@ def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
     assert created["prompt"] == "task"
     assert created["yolo_turns"] is None
     assert capsys.readouterr().out.endswith("done\n")
+
+
+def test_handle_ai_reports_a_provider_failure_without_a_traceback(monkeypatch, capsys):
+    class FakeAgent:
+        def input(self, prompt):
+            raise LLMAuthenticationError(
+                RuntimeError("raw upstream implementation detail"),
+                model="co/claude-sonnet-4",
+            )
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent", lambda **kwargs: FakeAgent()
+    )
+
+    with pytest.raises(typer.Exit) as caught:
+        ai_mod.handle_ai(prompt="task")
+
+    output = capsys.readouterr().out
+    assert caught.value.exit_code == 1
+    assert "Model request failed" in output
+    assert "service-side configuration" in output
+    assert "raw upstream implementation detail" not in output
+
+
+def test_handle_ai_does_not_hide_programmer_errors(monkeypatch):
+    class FakeAgent:
+        def input(self, prompt):
+            raise TypeError("our bug")
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent", lambda **kwargs: FakeAgent()
+    )
+
+    with pytest.raises(TypeError, match="our bug"):
+        ai_mod.handle_ai(prompt="task")
 
 
 def test_trust_commands_list_and_actions(tmp_path, monkeypatch):

--- a/tests/unit/test_uniform_provider_errors.py
+++ b/tests/unit/test_uniform_provider_errors.py
@@ -76,6 +76,19 @@ class TestAuthFailsTheSameWayEverywhere:
         with pytest.raises(LLMAuthenticationError):
             llm.complete([{"role": "user", "content": "hi"}])
 
+    def test_managed_provider_auth_is_a_service_error_for_the_user(self):
+        llm = create_llm("co/claude-sonnet-4", api_key="caller-token")
+        original = _openai_error(openai.AuthenticationError, 401)
+        _make_fail(llm, original)
+
+        with pytest.raises(LLMAuthenticationError) as caught:
+            llm.complete([{"role": "user", "content": "hi"}])
+
+        assert caught.value.model == "co/claude-sonnet-4"
+        assert "service-side configuration" in str(caught.value)
+        assert "caller-token" not in str(caught.value)
+        assert caught.value.__cause__ is original
+
 
 class TestRateLimit:
     def test_openai(self, monkeypatch):


### PR DESCRIPTION
Related to openonion/oo-api#110.

A production probe on 2026-08-08 confirmed that `co/claude-sonnet-4` still receives an upstream 401 because the deployed Anthropic credential is invalid. That credential must be fixed in oo-api; this PR fixes the client behavior when a provider fails.

## Changes

- translates managed-route 401s into the shared `LLMAuthenticationError` family
- tells users that a `co/*` credential rejection is service-side, rather than asking them to change a key they do not own
- catches known provider failures at the one-shot `co ai` boundary, prints one actionable message, and exits 1
- preserves original exceptions as `__cause__` for library/debug callers
- deliberately lets programmer errors such as `TypeError` keep their traceback

## Verification

- 50 focused provider/CLI/error tests passed
- 115 broader OpenOnion/Anthropic/Groq/Agent tests passed
- compileall and diff check passed

Ready for external review before 1.6.0. This does not fix or rotate the production Anthropic credential and does not publish anything.
