### PR TITLE
Make release artifact uploads version-safe

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -100,9 +100,16 @@ When releasing a new version:
 - [ ] Create git tag: `git tag vX.Y.Z`
 - [ ] Push commits: `git push`
 - [ ] Push tag: `git push origin vX.Y.Z`
+- [ ] Remove artifacts from older releases: `rm -rf dist/`
 - [ ] Build package: `python -m build`
+- [ ] Validate both current-version artifacts: `python -m twine check dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`
 - [ ] Check what you built: `pytest tests/e2e/test_the_wheel_works_when_installed.py -m slow`
-- [ ] Upload to PyPI: `twine upload dist/*`
+- [ ] Upload only the two artifacts just validated: `python -m twine upload dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`
+
+Replace `X.Y.Z` with the version being released. Do not upload the whole dist
+directory with a wildcard: build does not remove older artifacts, so that can
+mix a previous release into the current upload. PyPI uploads are not an atomic
+transaction; one file can succeed before a stale or duplicate file fails.
 
 The suite above it runs against the source tree, where every file is present
 whether or not it is packaged. Nothing else looks at the artifact that goes to

--- a/tests/unit/test_the_release_checklist_names_real_files.py
+++ b/tests/unit/test_the_release_checklist_names_real_files.py
@@ -128,3 +128,22 @@ class TestTheBuildCommandCanRun:
         assert "python -m build" in _release_sections(), (
             "the checklist does not use the PEP 517 build this project is set up for"
         )
+
+
+class TestReleaseArtifactsCannotMixVersions:
+    def test_old_artifacts_are_removed_before_building(self):
+        sections = _release_sections()
+
+        assert sections.index("rm -rf dist/") < sections.index("python -m build")
+
+    def test_artifacts_are_checked_before_upload(self):
+        sections = _release_sections()
+
+        assert sections.index("python -m twine check") < sections.index("python -m twine upload")
+
+    def test_upload_is_limited_to_the_current_version(self):
+        sections = _release_sections()
+
+        assert "twine upload dist/*" not in sections
+        assert "dist/connectonion-X.Y.Z.tar.gz" in sections
+        assert "dist/connectonion-X.Y.Z-py3-none-any.whl" in sections


### PR DESCRIPTION
## Summary

- require removing old `dist/` artifacts before building a release
- run `twine check` against the exact current-version wheel and sdist
- upload only those two explicit files instead of `dist/*`
- add release-procedure regression tests for ordering and version scoping

`python -m build` does not clean `dist/`. During the 1.5.13 → 1.6.0 transition, the old artifacts otherwise remain beside the new files. PyPI uploads are not atomic, so a broad glob can partially upload before failing on a stale/duplicate artifact.

## Verification

- release checklist/version/release-history tests: 20 passed
- `git diff --check` clean

Ready for external review. This PR does not build 1.6.0, upload to PyPI, create a tag, or create a GitHub release.
