### PR TITLE
Automate verified PyPI and GitHub releases

### DIFF
--- a/.github/scripts/verify_published_artifacts.py
+++ b/.github/scripts/verify_published_artifacts.py
@@ -42,16 +42,28 @@ def _archive_contents(path: Path) -> dict[str, tuple[str, bytes]]:
 
     if path.suffix == ".whl":
         with zipfile.ZipFile(path) as archive:
-            return {
-                item.filename: ("file", archive.read(item))
-                for item in archive.infolist()
-                if not item.is_dir()
-            }
+            contents: dict[str, tuple[str, bytes]] = {}
+            seen: set[str] = set()
+            for item in archive.infolist():
+                if item.filename in seen:
+                    raise ArtifactError(
+                        f"duplicate archive member {item.filename!r} in {path}"
+                    )
+                seen.add(item.filename)
+                if not item.is_dir():
+                    contents[item.filename] = ("file", archive.read(item))
+            return contents
 
     if path.name.endswith(".tar.gz"):
         contents: dict[str, tuple[str, bytes]] = {}
         with tarfile.open(path, "r:gz") as archive:
+            seen: set[str] = set()
             for item in archive.getmembers():
+                if item.name in seen:
+                    raise ArtifactError(
+                        f"duplicate archive member {item.name!r} in {path}"
+                    )
+                seen.add(item.name)
                 if item.isfile():
                     extracted = archive.extractfile(item)
                     if extracted is None:

--- a/.github/scripts/verify_published_artifacts.py
+++ b/.github/scripts/verify_published_artifacts.py
@@ -1,0 +1,152 @@
+"""Recover the exact PyPI files and prove they match the reviewed local build."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+MAX_ARTIFACT_BYTES = 100 * 1024 * 1024
+PYPI_HOST = "files.pythonhosted.org"
+
+
+class ArtifactError(RuntimeError):
+    """The published artifacts are unsafe or disagree with the reviewed build."""
+
+
+def _read_url(
+    url: str,
+    *,
+    opener: Callable[..., object] = urllib.request.urlopen,
+) -> bytes:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != "https":
+        raise ArtifactError(f"refusing non-HTTPS artifact URL: {url}")
+
+    with opener(url, timeout=30) as response:  # type: ignore[attr-defined]
+        data = response.read(MAX_ARTIFACT_BYTES + 1)
+    if len(data) > MAX_ARTIFACT_BYTES:
+        raise ArtifactError(f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {url}")
+    return data
+
+
+def _archive_contents(path: Path) -> dict[str, tuple[str, bytes]]:
+    """Compare logical archive contents while ignoring zip/tar timestamps."""
+
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            return {
+                item.filename: ("file", archive.read(item))
+                for item in archive.infolist()
+                if not item.is_dir()
+            }
+
+    if path.name.endswith(".tar.gz"):
+        contents: dict[str, tuple[str, bytes]] = {}
+        with tarfile.open(path, "r:gz") as archive:
+            for item in archive.getmembers():
+                if item.isfile():
+                    extracted = archive.extractfile(item)
+                    if extracted is None:
+                        raise ArtifactError(f"cannot read {item.name} from {path}")
+                    contents[item.name] = ("file", extracted.read())
+                elif item.issym() or item.islnk():
+                    contents[item.name] = (f"link:{item.linkname}", b"")
+        return contents
+
+    raise ArtifactError(f"unsupported release artifact: {path.name}")
+
+
+def assert_same_archive_contents(local: Path, published: Path) -> None:
+    local_contents = _archive_contents(local)
+    published_contents = _archive_contents(published)
+    if local_contents == published_contents:
+        return
+
+    local_names = set(local_contents)
+    published_names = set(published_contents)
+    added = sorted(published_names - local_names)
+    removed = sorted(local_names - published_names)
+    changed = sorted(
+        name
+        for name in local_names & published_names
+        if local_contents[name] != published_contents[name]
+    )
+    raise ArtifactError(
+        f"published {published.name} differs from the reviewed build "
+        f"(added={added[:5]}, removed={removed[:5]}, changed={changed[:5]})"
+    )
+
+
+def recover_published_artifacts(
+    version: str,
+    local_dir: Path,
+    output_dir: Path,
+    *,
+    opener: Callable[..., object] = urllib.request.urlopen,
+) -> list[Path]:
+    wheel = f"connectonion-{version}-py3-none-any.whl"
+    sdist = f"connectonion-{version}.tar.gz"
+    expected = {wheel, sdist}
+
+    metadata_url = f"https://pypi.org/pypi/connectonion/{version}/json"
+    try:
+        metadata = json.loads(_read_url(metadata_url, opener=opener))
+    except (json.JSONDecodeError, urllib.error.URLError) as exc:
+        raise ArtifactError(f"cannot read PyPI metadata for {version}: {exc}") from exc
+
+    entries = {entry.get("filename"): entry for entry in metadata.get("urls", [])}
+    available = {name for name in entries if isinstance(name, str)}
+    if available != expected:
+        raise ArtifactError(
+            f"PyPI files for {version} are not the expected wheel/sdist pair: {sorted(available)}"
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    recovered: list[Path] = []
+    for name in sorted(expected):
+        entry = entries[name]
+        url = entry.get("url", "")
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme != "https" or parsed.hostname != PYPI_HOST:
+            raise ArtifactError(f"unexpected PyPI file host for {name}: {url}")
+
+        data = _read_url(url, opener=opener)
+        expected_digest = entry.get("digests", {}).get("sha256")
+        actual_digest = hashlib.sha256(data).hexdigest()
+        if not expected_digest or actual_digest != expected_digest:
+            raise ArtifactError(f"PyPI SHA256 mismatch for {name}")
+
+        destination = output_dir / name
+        destination.write_bytes(data)
+        assert_same_archive_contents(local_dir / name, destination)
+        recovered.append(destination)
+
+    return recovered
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--local-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    recovered = recover_published_artifacts(
+        args.version,
+        args.local_dir,
+        args.output_dir,
+    )
+    for path in recovered:
+        print(f"verified published artifact: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,154 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (for example 1.6.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.ref }}-${{ inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+
+  release:
+    needs: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the exact release commit
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve and validate the release version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TAG_NAME: ${{ github.ref_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            raw="$MANUAL_VERSION"
+          else
+            raw="$TAG_NAME"
+          fi
+          version="${raw#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.-]+)?$ ]]; then
+            echo "Invalid release version: $raw" >&2
+            exit 1
+          fi
+          python - "$version" <<'PY'
+          import pathlib
+          import re
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          project = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          source = pathlib.Path("connectonion/_version.py").read_text()
+          match = re.search(r'^__version__ = "([^"]+)"$', source, re.MULTILINE)
+          versioning = pathlib.Path("VERSIONING.md").read_text()
+          values = {
+              "pyproject.toml": project["project"]["version"],
+              "connectonion/_version.py": match.group(1) if match else None,
+              "VERSIONING.md": (
+                  re.search(r"^## Current Version: (\S+)$", versioning, re.MULTILINE).group(1)
+                  if re.search(r"^## Current Version: (\S+)$", versioning, re.MULTILINE)
+                  else None
+              ),
+          }
+          wrong = {name: value for name, value in values.items() if value != expected}
+          if wrong:
+              raise SystemExit(f"release {expected} disagrees with version files: {wrong}")
+          PY
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build and validate only this version's artifacts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python -m pip install --upgrade pip build twine
+          rm -rf dist
+          python -m build
+          wheel="dist/connectonion-${VERSION}-py3-none-any.whl"
+          sdist="dist/connectonion-${VERSION}.tar.gz"
+          test -f "$wheel"
+          test -f "$sdist"
+          test "$(find dist -maxdepth 1 -type f | wc -l | tr -d ' ')" = "2"
+          python -m twine check "$wheel" "$sdist"
+
+      - name: Exercise the built wheel like an installed package
+        run: pytest tests/e2e/test_the_wheel_works_when_installed.py -m slow -v --tb=short
+
+      - name: Preserve the reviewed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: connectonion-${{ steps.version.outputs.version }}
+          path: |
+            dist/connectonion-${{ steps.version.outputs.version }}-py3-none-any.whl
+            dist/connectonion-${{ steps.version.outputs.version }}.tar.gz
+          if-no-files-found: error
+
+      - name: Publish to PyPI with trusted publishing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true
+
+      - name: Verify the published package in a clean environment
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          for attempt in {1..12}; do
+            check="$RUNNER_TEMP/published-check-$attempt"
+            python -m venv "$check"
+            if "$check/bin/python" -m pip install --no-cache-dir "connectonion==$VERSION"; then
+              if "$check/bin/python" -c "import connectonion; assert connectonion.__version__ == '$VERSION'"; then
+                exit 0
+              fi
+            fi
+            sleep 10
+          done
+          echo "PyPI never served an importable connectonion==$VERSION" >&2
+          exit 1
+
+      - name: Create or repair the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          wheel="dist/connectonion-${VERSION}-py3-none-any.whl"
+          sdist="dist/connectonion-${VERSION}.tar.gz"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "$wheel" "$sdist" --clobber
+          else
+            gh release create "$TAG" "$wheel" "$sdist" \
+              --target "$GITHUB_SHA" \
+              --generate-notes \
+              --title "$TAG"
+          fi
+
+      # Public announcements deliberately live outside this workflow. A broken
+      # Discord/LinkedIn integration must be visible, but must never roll back or
+      # mark a verified package release as failed (#300).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,17 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
-    secrets: inherit
     permissions:
       contents: read
 
-  release:
+  build:
     needs: tests
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
     permissions:
-      contents: write
-      id-token: write
+      contents: read
 
     steps:
       - name: Checkout the exact release commit
@@ -85,12 +86,14 @@ jobs:
               raise SystemExit(f"release {expected} disagrees with version files: {wrong}")
           PY
           tag="v$version"
-          if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
-            tagged_commit="$(git rev-list -n 1 "$tag")"
-            if [[ "$tagged_commit" != "$GITHUB_SHA" ]]; then
-              echo "$tag points to $tagged_commit, not this workflow commit $GITHUB_SHA" >&2
-              exit 1
-            fi
+          if ! git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+            echo "Release tag $tag does not exist; manual runs may only retry a reviewed tag" >&2
+            exit 1
+          fi
+          tagged_commit="$(git rev-list -n 1 "$tag")"
+          if [[ "$tagged_commit" != "$GITHUB_SHA" ]]; then
+            echo "$tag points to $tagged_commit, not this workflow commit $GITHUB_SHA" >&2
+            exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
@@ -121,15 +124,53 @@ jobs:
             dist/connectonion-${{ steps.version.outputs.version }}.tar.gz
           if-no-files-found: error
 
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/connectonion/${{ needs.build.outputs.version }}/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Recover the reviewed artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: connectonion-${{ needs.build.outputs.version }}
+          path: dist
+
       - name: Publish to PyPI with trusted publishing
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist/
           skip-existing: true
 
+  finalize:
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout the exact release commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Recover the reviewed artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: connectonion-${{ needs.build.outputs.version }}
+          path: dist
+
       - name: Verify the published package in a clean environment
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           for attempt in {1..12}; do
             check="$RUNNER_TEMP/published-check-$attempt"
@@ -146,7 +187,7 @@ jobs:
 
       - name: Recover and verify the exact PyPI artifacts
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           python .github/scripts/verify_published_artifacts.py \
             --version "$VERSION" \
@@ -156,8 +197,8 @@ jobs:
       - name: Create or repair the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
-          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ needs.build.outputs.version }}
+          TAG: ${{ needs.build.outputs.tag }}
         run: |
           # Always attach the exact bytes PyPI serves. On a retry,
           # skip-existing must never let a new local build replace the assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,26 +16,30 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
     secrets: inherit
+    permissions:
+      contents: read
 
   release:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout the exact release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -80,8 +84,16 @@ jobs:
           if wrong:
               raise SystemExit(f"release {expected} disagrees with version files: {wrong}")
           PY
+          tag="v$version"
+          if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$tag")"
+            if [[ "$tagged_commit" != "$GITHUB_SHA" ]]; then
+              echo "$tag points to $tagged_commit, not this workflow commit $GITHUB_SHA" >&2
+              exit 1
+            fi
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Build and validate only this version's artifacts
         env:
@@ -101,7 +113,7 @@ jobs:
         run: pytest tests/e2e/test_the_wheel_works_when_installed.py -m slow -v --tb=short
 
       - name: Preserve the reviewed artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: connectonion-${{ steps.version.outputs.version }}
           path: |
@@ -110,7 +122,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish to PyPI with trusted publishing
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist/
           skip-existing: true
@@ -132,14 +144,26 @@ jobs:
           echo "PyPI never served an importable connectonion==$VERSION" >&2
           exit 1
 
+      - name: Recover and verify the exact PyPI artifacts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python .github/scripts/verify_published_artifacts.py \
+            --version "$VERSION" \
+            --local-dir dist \
+            --output-dir published
+
       - name: Create or repair the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          wheel="dist/connectonion-${VERSION}-py3-none-any.whl"
-          sdist="dist/connectonion-${VERSION}.tar.gz"
+          # Always attach the exact bytes PyPI serves. On a retry,
+          # skip-existing must never let a new local build replace the assets
+          # for an already-published version.
+          wheel="published/connectonion-${VERSION}-py3-none-any.whl"
+          sdist="published/connectonion-${VERSION}.tar.gz"
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "$wheel" "$sdist" --clobber
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -56,10 +56,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/tests/unit/test_release_published_artifacts.py
+++ b/tests/unit/test_release_published_artifacts.py
@@ -1,0 +1,120 @@
+"""The release retry cannot make GitHub assets disagree with PyPI."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_published_artifacts",
+    ROOT / ".github/scripts/verify_published_artifacts.py",
+)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class Response(io.BytesIO):
+    pass
+
+
+def _wheel(path: Path, content: bytes, timestamp=(2024, 1, 1, 0, 0, 0)) -> bytes:
+    with zipfile.ZipFile(path, "w") as archive:
+        item = zipfile.ZipInfo("connectonion/example.py", timestamp)
+        archive.writestr(item, content)
+    return path.read_bytes()
+
+
+def _sdist(path: Path, content: bytes, mtime: int = 1) -> bytes:
+    with tarfile.open(path, "w:gz") as archive:
+        item = tarfile.TarInfo("connectonion-1.6.0/connectonion/example.py")
+        item.size = len(content)
+        item.mtime = mtime
+        archive.addfile(item, io.BytesIO(content))
+    return path.read_bytes()
+
+
+def test_logical_archive_comparison_ignores_container_timestamps(tmp_path):
+    local_wheel = tmp_path / "local.whl"
+    remote_wheel = tmp_path / "remote.whl"
+    _wheel(local_wheel, b"same", (2024, 1, 1, 0, 0, 0))
+    _wheel(remote_wheel, b"same", (2025, 2, 2, 0, 0, 0))
+
+    MODULE.assert_same_archive_contents(local_wheel, remote_wheel)
+
+
+def test_logical_archive_comparison_rejects_changed_code(tmp_path):
+    local_wheel = tmp_path / "local.whl"
+    remote_wheel = tmp_path / "remote.whl"
+    _wheel(local_wheel, b"reviewed")
+    _wheel(remote_wheel, b"different")
+
+    with pytest.raises(MODULE.ArtifactError, match="differs from the reviewed build"):
+        MODULE.assert_same_archive_contents(local_wheel, remote_wheel)
+
+
+def test_recovery_downloads_exact_verified_pypi_bytes(tmp_path):
+    version = "1.6.0"
+    local_dir = tmp_path / "dist"
+    output_dir = tmp_path / "published"
+    local_dir.mkdir()
+    wheel_name = f"connectonion-{version}-py3-none-any.whl"
+    sdist_name = f"connectonion-{version}.tar.gz"
+    wheel_bytes = _wheel(local_dir / wheel_name, b"reviewed")
+    sdist_bytes = _sdist(local_dir / sdist_name, b"reviewed")
+    file_urls = {
+        wheel_name: f"https://files.pythonhosted.org/packages/{wheel_name}",
+        sdist_name: f"https://files.pythonhosted.org/packages/{sdist_name}",
+    }
+    blobs = {file_urls[wheel_name]: wheel_bytes, file_urls[sdist_name]: sdist_bytes}
+    metadata = {
+        "urls": [
+            {
+                "filename": name,
+                "url": url,
+                "digests": {"sha256": hashlib.sha256(blobs[url]).hexdigest()},
+            }
+            for name, url in file_urls.items()
+        ]
+    }
+
+    def opener(url, timeout):
+        del timeout
+        if url.endswith("/json"):
+            return Response(json.dumps(metadata).encode())
+        return Response(blobs[url])
+
+    recovered = MODULE.recover_published_artifacts(
+        version,
+        local_dir,
+        output_dir,
+        opener=opener,
+    )
+
+    assert {path.name for path in recovered} == {wheel_name, sdist_name}
+    assert (output_dir / wheel_name).read_bytes() == wheel_bytes
+    assert (output_dir / sdist_name).read_bytes() == sdist_bytes
+
+
+def test_recovery_rejects_an_extra_or_missing_pypi_file(tmp_path):
+    metadata = {"urls": []}
+
+    def opener(url, timeout):
+        del url, timeout
+        return Response(json.dumps(metadata).encode())
+
+    with pytest.raises(MODULE.ArtifactError, match="expected wheel/sdist pair"):
+        MODULE.recover_published_artifacts(
+            "1.6.0",
+            tmp_path / "dist",
+            tmp_path / "published",
+            opener=opener,
+        )

--- a/tests/unit/test_release_published_artifacts.py
+++ b/tests/unit/test_release_published_artifacts.py
@@ -61,6 +61,33 @@ def test_logical_archive_comparison_rejects_changed_code(tmp_path):
         MODULE.assert_same_archive_contents(local_wheel, remote_wheel)
 
 
+def test_logical_archive_comparison_rejects_duplicate_wheel_paths(tmp_path):
+    local_wheel = tmp_path / "local.whl"
+    remote_wheel = tmp_path / "remote.whl"
+    _wheel(local_wheel, b"reviewed")
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        with zipfile.ZipFile(remote_wheel, "w") as archive:
+            archive.writestr("connectonion/example.py", b"hidden")
+            archive.writestr("connectonion/example.py", b"reviewed")
+
+    with pytest.raises(MODULE.ArtifactError, match="duplicate archive member"):
+        MODULE.assert_same_archive_contents(local_wheel, remote_wheel)
+
+
+def test_logical_archive_comparison_rejects_duplicate_sdist_paths(tmp_path):
+    local_sdist = tmp_path / "local.tar.gz"
+    remote_sdist = tmp_path / "remote.tar.gz"
+    _sdist(local_sdist, b"reviewed")
+    with tarfile.open(remote_sdist, "w:gz") as archive:
+        for content in (b"hidden", b"reviewed"):
+            item = tarfile.TarInfo("connectonion-1.6.0/connectonion/example.py")
+            item.size = len(content)
+            archive.addfile(item, io.BytesIO(content))
+
+    with pytest.raises(MODULE.ArtifactError, match="duplicate archive member"):
+        MODULE.assert_same_archive_contents(local_sdist, remote_sdist)
+
+
 def test_recovery_downloads_exact_verified_pypi_bytes(tmp_path):
     version = "1.6.0"
     local_dir = tmp_path / "dist"

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -22,6 +22,15 @@ def test_tag_and_emergency_manual_release_paths_exist():
     assert '"$tagged_commit" != "$GITHUB_SHA"' in RELEASE
 
 
+def test_manual_release_is_only_a_retry_for_an_existing_reviewed_tag():
+    assert "Release tag $tag does not exist" in RELEASE
+    assert 'git rev-list -n 1 "$tag"' in RELEASE
+
+
+def test_test_job_does_not_inherit_repository_secrets():
+    assert "secrets: inherit" not in RELEASE
+
+
 def test_release_uses_trusted_publishing_and_verifies_pypi():
     assert "id-token: write" in RELEASE
     assert "pypa/gh-action-pypi-publish@" in RELEASE
@@ -29,16 +38,25 @@ def test_release_uses_trusted_publishing_and_verifies_pypi():
     assert "connectonion.__version__ == '$VERSION'" in RELEASE
 
 
-def test_publish_permissions_are_scoped_to_the_release_job():
-    before_jobs, release_job = RELEASE.split("jobs:", 1)[0], RELEASE.split("  release:", 1)[1]
-    tests_job = RELEASE.split("  tests:", 1)[1].split("  release:", 1)[0]
+def test_build_publish_and_finalize_permissions_are_separated():
+    before_jobs = RELEASE.split("jobs:", 1)[0]
+    tests_job = RELEASE.split("  tests:", 1)[1].split("  build:", 1)[0]
+    build_job = RELEASE.split("  build:", 1)[1].split("  publish:", 1)[0]
+    publish_job = RELEASE.split("  publish:", 1)[1].split("  finalize:", 1)[0]
+    finalize_job = RELEASE.split("  finalize:", 1)[1]
 
     assert "contents: read" in before_jobs
     assert "contents: write" not in before_jobs
     assert "id-token: write" not in before_jobs
     assert "contents: read" in tests_job
-    assert "contents: write" in release_job
-    assert "id-token: write" in release_job
+    assert "contents: read" in build_job
+    assert "contents: write" not in build_job
+    assert "id-token: write" not in build_job
+    assert "id-token: write" in publish_job
+    assert "contents: write" not in publish_job
+    assert "environment:" in publish_job
+    assert "contents: write" in finalize_job
+    assert "id-token: write" not in finalize_job
 
 
 def test_only_the_current_pair_is_built_and_attached():

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -1,0 +1,39 @@
+"""The release path is automated, gated, and separate from announcements."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = (ROOT / ".github/workflows/release.yml").read_text()
+TESTS = (ROOT / ".github/workflows/tests.yml").read_text()
+
+
+def test_release_reuses_the_full_test_workflow():
+    assert "workflow_call:" in TESTS
+    assert "uses: ./.github/workflows/tests.yml" in RELEASE
+    assert "needs: tests" in RELEASE
+
+
+def test_tag_and_emergency_manual_release_paths_exist():
+    assert 'tags:\n      - "v*"' in RELEASE
+    assert "workflow_dispatch:" in RELEASE
+    assert "MANUAL_VERSION" in RELEASE
+
+
+def test_release_uses_trusted_publishing_and_verifies_pypi():
+    assert "id-token: write" in RELEASE
+    assert "pypa/gh-action-pypi-publish@release/v1" in RELEASE
+    assert "--no-cache-dir \"connectonion==$VERSION\"" in RELEASE
+    assert "connectonion.__version__ == '$VERSION'" in RELEASE
+
+
+def test_only_the_current_pair_is_built_and_attached():
+    assert "rm -rf dist" in RELEASE
+    assert 'wheel="dist/connectonion-${VERSION}-py3-none-any.whl"' in RELEASE
+    assert 'sdist="dist/connectonion-${VERSION}.tar.gz"' in RELEASE
+    assert "gh release create" in RELEASE
+
+
+def test_announcements_cannot_fail_a_package_release():
+    assert "Discord/LinkedIn integration" in RELEASE
+    assert "discord.com/api/webhooks" not in RELEASE.lower()

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 RELEASE = (ROOT / ".github/workflows/release.yml").read_text()
 TESTS = (ROOT / ".github/workflows/tests.yml").read_text()
@@ -18,22 +17,55 @@ def test_tag_and_emergency_manual_release_paths_exist():
     assert 'tags:\n      - "v*"' in RELEASE
     assert "workflow_dispatch:" in RELEASE
     assert "MANUAL_VERSION" in RELEASE
+    assert 'git rev-parse --verify --quiet "refs/tags/$tag"' in RELEASE
+    assert 'tagged_commit="$(git rev-list -n 1 "$tag")"' in RELEASE
+    assert '"$tagged_commit" != "$GITHUB_SHA"' in RELEASE
 
 
 def test_release_uses_trusted_publishing_and_verifies_pypi():
     assert "id-token: write" in RELEASE
-    assert "pypa/gh-action-pypi-publish@release/v1" in RELEASE
+    assert "pypa/gh-action-pypi-publish@" in RELEASE
     assert "--no-cache-dir \"connectonion==$VERSION\"" in RELEASE
     assert "connectonion.__version__ == '$VERSION'" in RELEASE
+
+
+def test_publish_permissions_are_scoped_to_the_release_job():
+    before_jobs, release_job = RELEASE.split("jobs:", 1)[0], RELEASE.split("  release:", 1)[1]
+    tests_job = RELEASE.split("  tests:", 1)[1].split("  release:", 1)[0]
+
+    assert "contents: read" in before_jobs
+    assert "contents: write" not in before_jobs
+    assert "id-token: write" not in before_jobs
+    assert "contents: read" in tests_job
+    assert "contents: write" in release_job
+    assert "id-token: write" in release_job
 
 
 def test_only_the_current_pair_is_built_and_attached():
     assert "rm -rf dist" in RELEASE
     assert 'wheel="dist/connectonion-${VERSION}-py3-none-any.whl"' in RELEASE
     assert 'sdist="dist/connectonion-${VERSION}.tar.gz"' in RELEASE
+    assert "verify_published_artifacts.py" in RELEASE
+    assert 'wheel="published/connectonion-${VERSION}-py3-none-any.whl"' in RELEASE
+    assert 'sdist="published/connectonion-${VERSION}.tar.gz"' in RELEASE
     assert "gh release create" in RELEASE
 
 
 def test_announcements_cannot_fail_a_package_release():
     assert "Discord/LinkedIn integration" in RELEASE
     assert "discord.com/api/webhooks" not in RELEASE.lower()
+
+
+def test_external_actions_are_pinned_to_immutable_commits():
+    workflows = RELEASE + TESTS
+    external_uses = [
+        line.strip()
+        for line in workflows.splitlines()
+        if line.strip().startswith("uses:") and "uses: ./" not in line
+    ]
+
+    assert external_uses
+    for line in external_uses:
+        reference = line.split("@", 1)[1].split()[0]
+        assert len(reference) == 40
+        assert all(character in "0123456789abcdef" for character in reference)


### PR DESCRIPTION
Closes #298.

Adds a tag-triggered release workflow plus a manual **retry** path for an already-reviewed tag. It:

- reuses the full Linux/Windows test workflow before building
- requires `vX.Y.Z` to exist and resolve to the exact workflow commit, including manual runs
- validates the requested version against every source of truth
- removes stale artifacts, builds exactly one wheel and one sdist, runs `twine check`, and exercises the installed wheel
- keeps the build job read-only and gives it no repository secrets or OIDC permission
- publishes only the preserved build artifact from a separate `pypi` environment job with `id-token: write`
- finalizes the GitHub release in a third job with `contents: write` but no OIDC permission
- pins every external GitHub Action to an immutable commit
- installs the published version in a clean venv and verifies its imported version
- downloads the exact PyPI files, verifies their SHA-256 values, rejects duplicate archive members, and compares logical contents with the reviewed build
- creates or repairs the GitHub release using the exact bytes served by PyPI, so `skip-existing` retries cannot replace assets with a different build

Announcements remain deliberately separate so an integration failure cannot fail a verified package release (#300).

## Validation

- focused release/version/packaging/installed-wheel group: **80 passed**
- all 8 GitHub jobs green on `cbe545d` (Linux Python 3.10–3.13 and all Windows jobs)
- combined 1.6 candidate: **6035 passed, 18 skipped, 174 deselected, 0 failed** (`--randomly-seed=3541708264`)
- Ruff, workflow YAML parsing, and `git diff --check` pass
- local-only 1.6.0 wheel/sdist rebuilt and `twine check` passed; installed-wheel suite 8/8

## Required repository configuration

Before release, create and protect the GitHub environment named `pypi`, require an independent reviewer with self-review disabled, decide the admin-bypass policy, and bind the PyPI trusted publisher to that exact environment. The 2026-08-09 read-only audit found that `pypi` does not exist, the existing environments have no protection rules, and the repository has no ruleset or `main` branch protection.

This PR is Ready for independent review. It does not publish, tag, merge, or deploy a version.
