### PR TITLE
feat(skills): define versioned runtime requirements schema

### DIFF
--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -34,10 +34,12 @@ Usage:
 """
 
 import re
-from pathlib import Path
-from typing import Any, Dict, Optional, List
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
 from ....project import project_co_dir
+from ....skill_requirements import SkillRequirements, parse_skill_requirements
 
 
 @dataclass
@@ -46,6 +48,7 @@ class SkillInfo:
     name: str
     description: str
     path: Path
+    requirements: Optional[SkillRequirements] = None
 
     def load_content(self) -> str:
         """Load the full SKILL.md content."""
@@ -199,7 +202,8 @@ def _parse_skill_file(path: Path) -> Optional[SkillInfo]:
     if not description:
         description = f"Skill: {name}"
 
-    return SkillInfo(name=name, description=description, path=path)
+    requirements = parse_skill_requirements(frontmatter, name)
+    return SkillInfo(name=name, description=description, path=path, requirements=requirements)
 
 
 def load_skills(base_path: Optional[Path] = None) -> Dict[str, SkillInfo]:

--- a/connectonion/skill_requirements.py
+++ b/connectonion/skill_requirements.py
@@ -1,0 +1,179 @@
+"""Versioned runtime requirement manifests for SKILL.md files.
+
+This module only parses the declaration.  Checking the current machine and
+installing supported dependencies are deliberately separate concerns.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+
+SCHEMA_VERSION = 1
+_SECTIONS = ("required", "optional")
+_CATEGORIES = ("python", "executables", "environment", "oauth", "capabilities")
+_IDENTIFIERS = {
+    "python": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+    "executables": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$"),
+    "environment": re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$"),
+    "oauth": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+    "capabilities": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+}
+
+
+class SkillManifestError(ValueError):
+    """A requirement manifest is invalid and identifies its exact location."""
+
+    def __init__(self, skill_name: str, field: str, problem: str):
+        self.skill_name = skill_name
+        self.field = field
+        self.problem = problem
+        super().__init__(f"Skill {skill_name!r}: {field}: {problem}")
+
+
+@dataclass(frozen=True)
+class SkillRequirement:
+    """One normalized runtime requirement."""
+
+    category: str
+    name: str
+    version: Optional[str] = None
+    setup: Optional[str] = None
+    scopes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SkillRequirements:
+    """A validated version of a skill's runtime requirement manifest."""
+
+    version: int
+    required: tuple[SkillRequirement, ...] = ()
+    optional: tuple[SkillRequirement, ...] = ()
+
+
+def parse_skill_requirements(
+    frontmatter: Mapping[str, Any], skill_name: str
+) -> Optional[SkillRequirements]:
+    """Validate and normalize ``frontmatter.requirements``.
+
+    Skills which do not declare requirements remain fully compatible and
+    return ``None``. Invalid declarations raise :class:`SkillManifestError`.
+    """
+    if "requirements" not in frontmatter:
+        return None
+
+    root = frontmatter["requirements"]
+    _mapping(root, skill_name, "requirements")
+    _known_fields(root, {"version", *_SECTIONS}, skill_name, "requirements")
+
+    if "version" not in root:
+        _fail(skill_name, "requirements.version", "is required")
+    version = root["version"]
+    if isinstance(version, bool) or not isinstance(version, int):
+        _fail(skill_name, "requirements.version", "must be the integer 1")
+    if version != SCHEMA_VERSION:
+        _fail(
+            skill_name,
+            "requirements.version",
+            f"unsupported schema version {version}; supported version is {SCHEMA_VERSION}",
+        )
+
+    parsed = {
+        section: _parse_section(root.get(section, {}), skill_name, section)
+        for section in _SECTIONS
+    }
+    return SkillRequirements(version=version, **parsed)
+
+
+def _parse_section(value: Any, skill_name: str, section: str) -> tuple[SkillRequirement, ...]:
+    path = f"requirements.{section}"
+    _mapping(value, skill_name, path)
+    _known_fields(value, set(_CATEGORIES), skill_name, path)
+
+    requirements = []
+    for category in _CATEGORIES:
+        entries = value.get(category, [])
+        category_path = f"{path}.{category}"
+        if not isinstance(entries, list):
+            _fail(skill_name, category_path, "must be a list")
+        for index, entry in enumerate(entries):
+            requirements.append(
+                _parse_entry(entry, skill_name, category, f"{category_path}[{index}]")
+            )
+    return tuple(requirements)
+
+
+def _parse_entry(value: Any, skill_name: str, category: str, path: str) -> SkillRequirement:
+    _mapping(value, skill_name, path)
+    name_field = "provider" if category == "oauth" else "name"
+    allowed = {name_field, "setup"}
+    if category in {"python", "executables", "capabilities"}:
+        allowed.add("version")
+    if category == "oauth":
+        allowed.add("scopes")
+    _known_fields(value, allowed, skill_name, path)
+
+    if name_field not in value:
+        _fail(skill_name, f"{path}.{name_field}", "is required")
+    name = _nonempty_string(value[name_field], skill_name, f"{path}.{name_field}")
+    if not _IDENTIFIERS[category].fullmatch(name):
+        _fail(skill_name, f"{path}.{name_field}", f"is not a valid {category} identifier")
+
+    version = None
+    if "version" in value:
+        version = _nonempty_string(value["version"], skill_name, f"{path}.version")
+        try:
+            SpecifierSet(version)
+        except InvalidSpecifier:
+            _fail(skill_name, f"{path}.version", "must be a valid PEP 440 constraint")
+
+    setup = None
+    if "setup" in value:
+        setup = _nonempty_string(value["setup"], skill_name, f"{path}.setup")
+
+    scopes: tuple[str, ...] = ()
+    if "scopes" in value:
+        raw_scopes = value["scopes"]
+        if not isinstance(raw_scopes, list):
+            _fail(skill_name, f"{path}.scopes", "must be a list")
+        parsed_scopes = []
+        for index, scope in enumerate(raw_scopes):
+            parsed_scopes.append(
+                _nonempty_string(scope, skill_name, f"{path}.scopes[{index}]")
+            )
+        scopes = tuple(parsed_scopes)
+
+    return SkillRequirement(
+        category=category, name=name, version=version, setup=setup, scopes=scopes
+    )
+
+
+def _mapping(value: Any, skill_name: str, path: str) -> None:
+    if not isinstance(value, Mapping):
+        _fail(skill_name, path, "must be a mapping")
+
+
+def _known_fields(value: Mapping[str, Any], allowed: set[str], skill_name: str, path: str) -> None:
+    for field in value:
+        if not isinstance(field, str) or field not in allowed:
+            _fail(skill_name, f"{path}.{field}", "is not a supported field")
+
+
+def _nonempty_string(value: Any, skill_name: str, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _fail(skill_name, path, "must be a non-empty string")
+    return value.strip()
+
+
+def _fail(skill_name: str, field: str, problem: str) -> None:
+    raise SkillManifestError(skill_name, field, problem)
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SkillManifestError",
+    "SkillRequirement",
+    "SkillRequirements",
+    "parse_skill_requirements",
+]

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -74,6 +74,7 @@ from copy import deepcopy
 
 from ..core.events import after_user_input, on_complete, before_each_tool, on_agent_ready
 from ..project import project_co_dir, project_root
+from ..skill_requirements import SkillManifestError, parse_skill_requirements
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -160,10 +161,13 @@ def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
         if path.exists():
             content = path.read_text(encoding="utf-8")
             frontmatter, instructions = _parse_skill_content(content)
+            manifest_name = frontmatter.get('name') or skill_name
+            requirements = parse_skill_requirements(frontmatter, str(manifest_name))
             return {
                 'path': str(path),
                 'frontmatter': frontmatter,
-                'instructions': instructions
+                'instructions': instructions,
+                'requirements': requirements,
             }
 
     return None
@@ -428,6 +432,13 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— name and description were still read')
         return f'SKILL.md frontmatter is not valid YAML{where}: {detail}'
+
+    frontmatter = _read_frontmatter(yaml_text)
+    skill_name = frontmatter.get('name') or skill_md.parent.name
+    try:
+        parse_skill_requirements(frontmatter, str(skill_name))
+    except SkillManifestError as exc:
+        return str(exc)
 
     return None
 

--- a/docs/features/skill-requirements.md
+++ b/docs/features/skill-requirements.md
@@ -1,0 +1,67 @@
+# Skill Runtime Requirements
+
+A skill can declare what must already exist on the machine before it runs. The
+manifest lives in `SKILL.md` frontmatter and is optional, so existing skills do
+not need to change.
+
+```yaml
+---
+name: send-report
+description: Build and email the weekly report
+requirements:
+  version: 1
+  required:
+    python:
+      - name: pandas
+        version: ">=2.2,<3"
+        setup: "Install with: pip install 'pandas>=2.2,<3'"
+    executables:
+      - name: wkhtmltopdf
+        version: ">=0.12"
+        setup: "Install wkhtmltopdf with your system package manager"
+    environment:
+      - name: REPORT_FROM_ADDRESS
+        setup: "Set REPORT_FROM_ADDRESS in .env"
+    oauth:
+      - provider: google
+        scopes: [gmail.send]
+        setup: "Connect Google in co auth"
+    capabilities:
+      - name: outbound-network
+        setup: "Allow HTTPS access to the mail provider"
+  optional:
+    python:
+      - name: pyarrow
+        version: ">=16"
+        setup: "Install pyarrow for faster exports"
+---
+
+Build the report and send it.
+```
+
+`required` entries prevent safe execution when they are unavailable. `optional`
+entries enable enhancements and never prevent the skill from running. Both
+sections support these categories:
+
+| Category | Identity field | Other fields |
+| --- | --- | --- |
+| `python` | `name` | `version`, `setup` |
+| `executables` | `name` | `version`, `setup` |
+| `environment` | `name` | `setup` |
+| `oauth` | `provider` | `scopes`, `setup` |
+| `capabilities` | `name` | `version`, `setup` |
+
+`version` is a non-empty [PEP 440](https://packaging.python.org/en/latest/specifications/version-specifiers/)
+constraint interpreted by the validator for that category. `setup` is an
+actionable message shown to a human when the requirement is missing. OAuth
+`scopes` is a list of non-empty scope names.
+
+The manifest is strict. Unknown fields, wrong types, and unsupported schema
+versions fail with the skill name and exact field, for example:
+
+```text
+Skill 'send-report': requirements.required.python[0].version: must be a non-empty string
+```
+
+Schema version `1` describes requirements only. It never installs packages,
+starts an OAuth flow, probes the network, or changes the machine.

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -235,6 +235,10 @@ Markdown content after frontmatter - instructions for the agent.
 
 ## Creating Skills
 
+Skills that rely on Python packages, executables, credentials, OAuth, or
+platform features can declare a versioned, required/optional runtime contract.
+See [Skill Runtime Requirements](skill-requirements.md) for the complete schema.
+
 ### 1. Project-Level Skill (Specific to one project)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pypdf>=4.0.0",
     "python-pptx>=1.0.0",
     "python-docx>=1.1.0",
+    "packaging>=23.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_skill_requirements.py
+++ b/tests/unit/test_skill_requirements.py
@@ -1,0 +1,146 @@
+"""The versioned SKILL.md runtime requirements contract."""
+
+import pytest
+
+from connectonion.skill_requirements import (
+    SkillManifestError,
+    parse_skill_requirements,
+)
+
+
+def _manifest(**overrides):
+    requirements = {"version": 1, "required": {}, "optional": {}}
+    requirements.update(overrides)
+    return {"requirements": requirements}
+
+
+class TestCompatibility:
+    def test_a_skill_without_requirements_still_loads(self):
+        assert parse_skill_requirements({"name": "old-skill"}, "old-skill") is None
+
+    def test_empty_sections_are_valid(self):
+        parsed = parse_skill_requirements(_manifest(), "simple")
+
+        assert parsed.version == 1
+        assert parsed.required == ()
+        assert parsed.optional == ()
+
+
+class TestSchema:
+    def test_every_requirement_kind_is_normalized(self):
+        frontmatter = _manifest(required={
+            "python": [{"name": "httpx", "version": ">=0.27,<1", "setup": "pip install httpx"}],
+            "executables": [{"name": "ffmpeg", "version": ">=6"}],
+            "environment": [{"name": "OPENAI_API_KEY", "setup": "Set it in .env"}],
+            "oauth": [{"provider": "google", "scopes": ["gmail.send", "drive.readonly"]}],
+            "capabilities": [{"name": "browser", "version": ">=1"}],
+        })
+
+        parsed = parse_skill_requirements(frontmatter, "media-mail")
+
+        assert [item.category for item in parsed.required] == [
+            "python", "executables", "environment", "oauth", "capabilities"
+        ]
+        assert parsed.required[0].name == "httpx"
+        assert parsed.required[0].version == ">=0.27,<1"
+        assert parsed.required[0].setup == "pip install httpx"
+        assert parsed.required[3].name == "google"
+        assert parsed.required[3].scopes == ("gmail.send", "drive.readonly")
+
+    def test_required_and_optional_stay_separate(self):
+        parsed = parse_skill_requirements(_manifest(
+            required={"python": [{"name": "core"}]},
+            optional={"python": [{"name": "faster"}]},
+        ), "split")
+
+        assert [item.name for item in parsed.required] == ["core"]
+        assert [item.name for item in parsed.optional] == ["faster"]
+
+
+class TestPreciseFailures:
+    @pytest.mark.parametrize(
+        ("frontmatter", "field"),
+        [
+            ({"requirements": []}, "requirements"),
+            ({"requirements": {}}, "requirements.version"),
+            (_manifest(version="1"), "requirements.version"),
+            (_manifest(version=2), "requirements.version"),
+            (_manifest(required=[]), "requirements.required"),
+            (_manifest(required={"python": {}}), "requirements.required.python"),
+            (_manifest(required={"python": [{}]}), "requirements.required.python[0].name"),
+            (_manifest(required={"python": [{"name": "--extra-index-url"}]}),
+             "requirements.required.python[0].name"),
+            (_manifest(required={"environment": [{"name": "NOT-AN-ENV-VAR"}]}),
+             "requirements.required.environment[0].name"),
+            (_manifest(required={"python": [{"name": "x", "version": ""}]}),
+             "requirements.required.python[0].version"),
+            (_manifest(required={"python": [{"name": "x", "version": "version two"}]}),
+             "requirements.required.python[0].version"),
+            (_manifest(required={"oauth": [{"provider": "google", "scopes": "gmail.send"}]}),
+             "requirements.required.oauth[0].scopes"),
+            (_manifest(required={"oauth": [{"provider": "google", "scopes": [""]}]}),
+             "requirements.required.oauth[0].scopes[0]"),
+            (_manifest(required={"python": [{"name": "x", "scopes": []}]}),
+             "requirements.required.python[0].scopes"),
+            (_manifest(required={"containers": []}), "requirements.required.containers"),
+            ({"requirements": {"version": 1, "future": {}}}, "requirements.future"),
+        ],
+    )
+    def test_error_names_the_skill_and_exact_field(self, frontmatter, field):
+        with pytest.raises(SkillManifestError) as caught:
+            parse_skill_requirements(frontmatter, "send-report")
+
+        assert caught.value.skill_name == "send-report"
+        assert caught.value.field == field
+        assert "Skill 'send-report'" in str(caught.value)
+        assert field in str(caught.value)
+
+
+class TestLoaderIntegration:
+    def test_plugin_loader_returns_the_validated_contract(self, tmp_path, monkeypatch):
+        import importlib
+
+        skills = importlib.import_module("connectonion.useful_plugins.skills")
+
+        skill_dir = tmp_path / ".co" / "skills" / "mailer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  required:\n    environment:\n      - name: MAIL_FROM\n---\n\nSend it.\n"
+        )
+        monkeypatch.setattr(skills, "_get_skill_paths", lambda name: [skill_dir / "SKILL.md"])
+
+        loaded = skills._load_skill("mailer")
+
+        assert loaded["requirements"].required[0].name == "MAIL_FROM"
+
+    def test_co_ai_loader_keeps_the_same_contract(self, tmp_path):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        skill_dir = tmp_path / "mailer"
+        skill_dir.mkdir()
+        path = skill_dir / "SKILL.md"
+        path.write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  optional:\n    capabilities:\n      - name: browser\n---\n\nSend it.\n"
+        )
+
+        info = _parse_skill_file(path)
+
+        assert info.requirements.optional[0].name == "browser"
+
+    def test_doctor_reports_an_invalid_manifest(self, tmp_path):
+        from connectonion.useful_plugins.skills import find_skill_problems
+
+        skill_dir = tmp_path / ".co" / "skills" / "mailer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  required:\n    python:\n      - name: httpx\n        version: 3\n---\n\nSend it.\n"
+        )
+
+        problems = find_skill_problems(co_dir=tmp_path / ".co")
+
+        assert len(problems) == 1
+        assert "Skill 'mailer'" in problems[0][2]
+        assert "requirements.required.python[0].version" in problems[0][2]


### PR DESCRIPTION
Closes #470

## Summary
- add a strict, versioned `requirements` contract for Python packages, executables, environment variables, OAuth connections, and platform capabilities
- separate required and optional requirements while keeping skills without a manifest fully compatible
- wire the same parser into both skill loaders and doctor diagnostics, with skill name plus exact field errors
- document the complete schema and human setup hints

## Validation
- `pytest -q tests/unit/test_skill_requirements.py tests/unit/test_one_reader_for_skill_frontmatter.py tests/unit/test_a_skill_that_cannot_be_read_is_reported.py tests/unit/test_co_ai_skills.py tests/unit/test_skills.py` (79 passed)
- `ruff check connectonion/skill_requirements.py connectonion/cli/co_ai/skills/loader.py tests/unit/test_skill_requirements.py`
- broader local unit run reached 2196 passed before interruption; its 6 failures were sandbox-only socket, home-directory write, and network restrictions, outside the changed code