### PR TITLE
feat(deploy): realize skill runtime dependencies

### DIFF
--- a/connectonion/cli/co_ai/context.py
+++ b/connectonion/cli/co_ai/context.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Optional
 
 from connectonion.cli.co_ai.skills.loader import load_skills, get_skills_for_prompt
+from connectonion.skill_preflight import format_preflight_report, preflight_skills
 
 
 def load_project_context(base_path: Optional[Path] = None) -> str:
@@ -80,6 +81,16 @@ def load_project_context(base_path: Optional[Path] = None) -> str:
     skills_prompt = get_skills_for_prompt()
     if skills_prompt:
         parts.append(f"# Available Skills\n\n{skills_prompt}")
+
+    # One local-only preflight for the same skill tiers the runtime plugin sees.
+    from connectonion.useful_plugins.skills import _discover_all_skills
+
+    discovered = _discover_all_skills(project_dir=base)
+    preflight = preflight_skills((s.name, s.requirements) for s in discovered)
+    preflight_text = format_preflight_report(preflight)
+    if preflight_text:
+        print(preflight_text)
+        parts.append(f"# Skill Runtime Preflight\n\n{preflight_text}")
 
     # 5. Git status
     git_info = _get_git_info(base)

--- a/connectonion/cli/co_ai/skills/loader.py
+++ b/connectonion/cli/co_ai/skills/loader.py
@@ -34,10 +34,12 @@ Usage:
 """
 
 import re
-from pathlib import Path
-from typing import Any, Dict, Optional, List
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
 from ....project import project_co_dir
+from ....skill_requirements import SkillRequirements, parse_skill_requirements
 
 
 @dataclass
@@ -46,6 +48,7 @@ class SkillInfo:
     name: str
     description: str
     path: Path
+    requirements: Optional[SkillRequirements] = None
 
     def load_content(self) -> str:
         """Load the full SKILL.md content."""
@@ -199,7 +202,8 @@ def _parse_skill_file(path: Path) -> Optional[SkillInfo]:
     if not description:
         description = f"Skill: {name}"
 
-    return SkillInfo(name=name, description=description, path=path)
+    requirements = parse_skill_requirements(frontmatter, name)
+    return SkillInfo(name=name, description=description, path=path, requirements=requirements)
 
 
 def load_skills(base_path: Optional[Path] = None) -> Dict[str, SkillInfo]:

--- a/connectonion/cli/co_ai/skills/tool.py
+++ b/connectonion/cli/co_ai/skills/tool.py
@@ -33,7 +33,9 @@ Usage:
 """
 
 from typing import Optional
-from connectonion.cli.co_ai.skills.loader import get_skill, load_skills, SKILLS_REGISTRY
+
+from connectonion.cli.co_ai.skills.loader import SKILLS_REGISTRY, get_skill, load_skills
+from connectonion.skill_preflight import format_preflight_report, preflight_skills
 
 
 def skill(name: str, args: Optional[str] = None) -> str:
@@ -67,6 +69,10 @@ def skill(name: str, args: Optional[str] = None) -> str:
             return f"Skill '{name}' not found. Available skills: {', '.join(available)}"
         else:
             return f"Skill '{name}' not found. No skills are currently loaded."
+
+    preflight = preflight_skills([(skill_info.name, skill_info.requirements)])
+    if preflight.missing_required:
+        return format_preflight_report(preflight) + "\nSkill did not start."
 
     # Load the full skill content
     content = skill_info.load_content()

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -285,6 +285,10 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
     # project's copy with the deployer. Packing the file here as well would put
     # two members under one name and let write order decide which survives.
     ignore_patterns.append(".co/admins.txt")
+    ignore_patterns.extend([
+        ".co/skill-requirements.requested.json",
+        ".co/skill-python-requirements.txt",
+    ])
     tarball = Path(tempfile.mkdtemp()) / "agent.tar.gz"
     with tarfile.open(tarball, "w:gz") as tar:
         if _is_git_repo(project_dir):
@@ -313,6 +317,24 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
                 arc_prefix,
                 _load_skill_ignore_patterns(skills_path),
             )
+
+        from ...skill_deploy import collect_deploy_skill_requirements
+
+        skill_requirements = collect_deploy_skill_requirements(project_dir, skills_paths)
+        requested = json.dumps(
+            {**skill_requirements.requested_state, "digest": skill_requirements.digest},
+            indent=2,
+        ).encode()
+        info = tarfile.TarInfo(name=".co/skill-requirements.requested.json")
+        info.size = len(requested)
+        info.mode = 0o644
+        tar.addfile(info, io.BytesIO(requested))
+
+        python_requirements = ("\n".join(skill_requirements.python) + "\n").encode()
+        info = tarfile.TarInfo(name=".co/skill-python-requirements.txt")
+        info.size = len(python_requirements)
+        info.mode = 0o644
+        tar.addfile(info, io.BytesIO(python_requirements))
         _add_deployer_as_admin(tar, project_dir)
     return tarball
 
@@ -385,6 +407,15 @@ def _deploy_current_project(skills: list[str], project_dir: Path | None = None) 
         if not sp.is_dir():
             console.print(f"[red]Skills path not found or not a directory: {sp}[/red]")
             return False
+
+    from ...skill_deploy import collect_deploy_skill_requirements
+
+    skill_requirements = collect_deploy_skill_requirements(project_dir, skills_paths)
+    if skill_requirements.unsupported:
+        console.print("[red]Cloud deploy cannot realize these required skill dependencies:[/red]")
+        for requirement in skill_requirements.unsupported:
+            console.print(f"  [red]✗[/red] {requirement}")
+        return False
 
     # Load config from host.yaml. The project is checked before credentials are:
     # a broken host.yaml is worth reporting whether or not you happen to be

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -765,7 +765,8 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     return True
 
 
-def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool:
+def _install_deps_if_changed(target: str, agent: str, project_dir: Path,
+                             skill_requirements=None) -> bool:
     """pip install when requirements.txt changed, or when this CLI is a new
     version of connectonion than the one that last installed.
 
@@ -783,11 +784,15 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
     from ... import __version__
 
     requirements = project_dir / "requirements.txt"
-    if not requirements.exists():
+    skill_python = tuple(getattr(skill_requirements, "python", ()))
+    if not requirements.exists() and not skill_python:
         return True
 
+    digest_input = requirements.read_bytes() if requirements.exists() else b""
+    if skill_python or getattr(skill_requirements, "skills", ()):
+        digest_input += b"\nskills:" + skill_requirements.digest.encode()
     digest = hashlib.sha256(
-        requirements.read_bytes() + b"\ncli:" + __version__.encode()
+        digest_input + b"\ncli:" + __version__.encode()
     ).hexdigest()
     stamp = f"{SRV}/{agent}/.co/requirements.sha256"
 
@@ -796,8 +801,16 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         return True
 
     console.print("[dim]  installing dependencies …[/dim]")
-    result = _ssh(
-        target,
+    root_install = (
+        f"{SRV}/{agent}/.venv/bin/pip install -q -U -r requirements.txt\n"
+        if requirements.exists() else ""
+    )
+    skill_install = ""
+    if skill_python:
+        quoted = " ".join(shlex.quote(requirement) for requirement in skill_python)
+        skill_install = f"{SRV}/{agent}/.venv/bin/pip install -q -U {quoted}\n"
+
+    install_command = (
         # From the project directory, because a requirements.txt is allowed to
         # name things relative to itself — a local wheel, `-e .`, a nested
         # `-r requirements-dev.txt`. Run from the login shell's home instead and
@@ -809,7 +822,8 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         # Measured: a venv on 1.5.4 with `connectonion` unpinned stayed on 1.5.4
         # through `pip install -r`, and moved to 1.5.6 only with -U. Without it
         # the reinstall this function just decided to do would change nothing.
-        f"{SRV}/{agent}/.venv/bin/pip install -q -U -r requirements.txt\n"
+        + root_install
+        + skill_install
         # Then the runtime, by name and version.
         #
         # -U asks the index for "newest", which is a race with our own release:
@@ -820,16 +834,21 @@ def _install_deps_if_changed(target: str, agent: str, project_dir: Path) -> bool
         # The pin also fixes the reverse skew: an older CLI deploying onto a
         # server that resolves a *newer* connectonion than the one writing the
         # systemd unit and the .co/ layout it will read.
-        f"{SRV}/{agent}/.venv/bin/pip install -q "
+        + f"{SRV}/{agent}/.venv/bin/pip install -q "
         f"{shlex.quote('connectonion==' + __version__)}\n"
+        # This is the realized state, not another copy of what was requested.
+        # It is written only after every install succeeds, so a failed deploy
+        # leaves the old digest in place and the next deploy retries.
+        f"{SRV}/{agent}/.venv/bin/pip freeze --all > "
+        f"{SRV}/{agent}/.co/skill-requirements.realized.txt\n"
         # Last, and only if everything above succeeded — `set -e` is what makes
         # that true. The stamp is the claim "this server is current for this
         # CLI", and a deploy that could not converge must not leave that claim
         # behind: the next deploy would match it, skip the install, and freeze
         # the mismatch for good.
-        f"printf '%s' {shlex.quote(digest)} > {stamp}",
-        timeout=900,
+        f"printf '%s' {shlex.quote(digest)} > {stamp}"
     )
+    result = _ssh(target, install_command, timeout=900)
     if result.returncode != 0:
         console.print("[red]pip install failed.[/red]")
         for line in (result.stderr or result.stdout).strip().splitlines()[-12:]:
@@ -966,6 +985,15 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
         console.print(f"[dim]Set 'entrypoint' in {project_dir / '.co' / 'host.yaml'}[/dim]")
         return False
 
+    from ...skill_deploy import collect_deploy_skill_requirements
+
+    skill_requirements = collect_deploy_skill_requirements(project_dir)
+    if skill_requirements.unsupported:
+        console.print("[red]Required skill dependencies cannot be realized automatically:[/red]")
+        for requirement in skill_requirements.unsupported:
+            console.print(f"  [red]✗[/red] {requirement}")
+        return False
+
     console.print(f"\n[bold]{agent}[/bold] → [cyan]{server}[/cyan] [dim]({target})[/dim]")
     _warn_about_skills_left_behind(project_dir)
 
@@ -995,7 +1023,7 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
         return False
     if not _sync_env(target, agent, project_dir):
         return False
-    if not _install_deps_if_changed(target, agent, project_dir):
+    if not _install_deps_if_changed(target, agent, project_dir, skill_requirements):
         return False
     # Decided on the server, where the answer lives, and recorded so a redeploy
     # keeps it — the Caddyfile points at this number.
@@ -1044,4 +1072,3 @@ def _deployer_address() -> Optional[str]:
         return None
     data = address.load(co_dir)
     return data.get("address") if data else None
-

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -24,6 +24,22 @@ from rich import box
 console = Console()
 
 
+def _add_skill_preflight_rows(skills_table, found: list[str], skills) -> None:
+    """Add local runtime requirement results; optional misses are informational."""
+    from ...skill_preflight import preflight_skills
+
+    preflight = preflight_skills((s.name, s.requirements) for s in skills)
+    for check in preflight.missing_required + preflight.missing_optional:
+        requirement = check.requirement
+        label = f"{check.skill_name}/{requirement.category}/{requirement.name}"
+        setup = f" — {requirement.setup}" if requirement.setup else ""
+        if check.required:
+            skills_table.add_row(label, f"[red]✗[/red] {check.detail}{setup}")
+            found.append(f"skill {label}: {check.detail}{setup}")
+        else:
+            skills_table.add_row(label, f"[yellow]○[/yellow] optional: {check.detail}{setup}")
+
+
 def verdict(problems: list) -> int:
     """The last line, and the exit code, saying what the body already said.
 
@@ -371,6 +387,8 @@ def handle_doctor():
     for location, name, reason in problems:
         skills_table.add_row(f"{location}/{name}", f"[red]✗[/red] {reason}")
         found.append(f"skill {location}/{name}: {reason}")
+
+    _add_skill_preflight_rows(skills_table, found, skills)
 
     console.print(Panel(skills_table, title="[bold]Skills[/bold]", border_style="yellow"))
     console.print()

--- a/connectonion/cli/commands/skills_commands.py
+++ b/connectonion/cli/commands/skills_commands.py
@@ -212,6 +212,13 @@ def _copy_entry(entry: dict, force: bool, skills_dir: Optional[Path] = None) -> 
     """Copy a single index entry into <skills_dir>/<name>/. Returns True if copied."""
     name = entry["name"]
     src_path = Path(entry["path"])
+    from ...skill_preflight import format_preflight_report, preflight_skills
+    from ...skill_requirements import parse_skill_requirements
+    from ...useful_plugins.skills import _parse_skill_content
+
+    frontmatter, _ = _parse_skill_content(src_path.read_text(encoding="utf-8"))
+    manifest_name = str(frontmatter.get("name") or name)
+    requirements = parse_skill_requirements(frontmatter, manifest_name)
     dest_dir = (skills_dir or SKILLS_DIR) / name
     dest_file = dest_dir / "SKILL.md"
 
@@ -260,6 +267,9 @@ def _copy_entry(entry: dict, force: bool, skills_dir: Optional[Path] = None) -> 
         console.print(f"[yellow]  skipped {Path(path).name} (a secret stays where it is)[/yellow]")
 
     console.print(f"[green]✓ Copied {name} ({entry['source']}) → {dest_dir}[/green]")
+    report = format_preflight_report(preflight_skills([(manifest_name, requirements)]))
+    if report:
+        console.print(report)
     return True
 
 

--- a/connectonion/skill_deploy.py
+++ b/connectonion/skill_deploy.py
@@ -1,0 +1,77 @@
+"""Collect the skill dependency state that must travel with a deployment."""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .skill_requirements import parse_skill_requirements
+from .useful_plugins.skills import _parse_skill_content
+
+
+@dataclass(frozen=True)
+class DeploySkillRequirements:
+    python: tuple[str, ...] = ()
+    unsupported: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+
+    @property
+    def requested_state(self) -> dict:
+        return {
+            "schema": 1,
+            "skills": list(self.skills),
+            "python": list(self.python),
+            "unsupported": list(self.unsupported),
+        }
+
+    @property
+    def digest(self) -> str:
+        encoded = json.dumps(
+            self.requested_state, sort_keys=True, separators=(",", ":")
+        ).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+
+def collect_deploy_skill_requirements(
+    project_dir: Path, extra_skill_paths: Iterable[Path] = ()
+) -> DeploySkillRequirements:
+    """Collect required runtime dependencies from skills that will deploy."""
+    files = []
+    for root in (project_dir / ".co" / "skills", project_dir / ".claude" / "skills"):
+        if root.is_dir():
+            files.extend(root.glob("*/SKILL.md"))
+    for path in extra_skill_paths:
+        if (path / "SKILL.md").is_file():
+            files.append(path / "SKILL.md")
+        elif path.is_dir():
+            files.extend(path.glob("*/SKILL.md"))
+
+    python = set()
+    unsupported = set()
+    skills = set()
+    for skill_file in sorted(set(path.resolve() for path in files)):
+        frontmatter, _ = _parse_skill_content(skill_file.read_text(encoding="utf-8"))
+        name = str(frontmatter.get("name") or skill_file.parent.name)
+        manifest = parse_skill_requirements(frontmatter, name)
+        if manifest is None:
+            continue
+        skills.add(name)
+        for requirement in manifest.required:
+            if requirement.category == "python":
+                python.add(requirement.name + (requirement.version or ""))
+            elif requirement.category in {"executables", "capabilities"}:
+                constraint = f" {requirement.version}" if requirement.version else ""
+                hint = f" — {requirement.setup}" if requirement.setup else ""
+                unsupported.add(
+                    f"{name}: {requirement.category}/{requirement.name}{constraint}{hint}"
+                )
+
+    return DeploySkillRequirements(
+        python=tuple(sorted(python)),
+        unsupported=tuple(sorted(unsupported)),
+        skills=tuple(sorted(skills)),
+    )
+
+
+__all__ = ["DeploySkillRequirements", "collect_deploy_skill_requirements"]

--- a/connectonion/skill_preflight.py
+++ b/connectonion/skill_preflight.py
@@ -1,0 +1,185 @@
+"""Purely local preflight checks for versioned skill requirements."""
+
+import importlib.metadata
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Callable, Iterable, Mapping, Optional
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from .skill_requirements import SkillRequirement, SkillRequirements
+
+
+@dataclass(frozen=True)
+class RequirementCheck:
+    skill_name: str
+    required: bool
+    requirement: SkillRequirement
+    available: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class SkillPreflightReport:
+    checks: tuple[RequirementCheck, ...] = ()
+
+    @property
+    def missing_required(self) -> tuple[RequirementCheck, ...]:
+        return tuple(check for check in self.checks if check.required and not check.available)
+
+    @property
+    def missing_optional(self) -> tuple[RequirementCheck, ...]:
+        return tuple(check for check in self.checks if not check.required and not check.available)
+
+    @property
+    def ready(self) -> bool:
+        return not self.missing_required
+
+
+def preflight_skills(
+    skills: Iterable[tuple[str, Optional[SkillRequirements]]],
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    which: Callable[[str], Optional[str]] = shutil.which,
+    package_version: Callable[[str], str] = importlib.metadata.version,
+    executable_version: Optional[Callable[[str], Optional[str]]] = None,
+) -> SkillPreflightReport:
+    """Resolve manifests against this machine without making network calls."""
+    env = os.environ if environ is None else environ
+    executable_version = executable_version or _executable_version
+    checks = []
+    for skill_name, manifest in skills:
+        if manifest is None:
+            continue
+        for required, requirements in ((True, manifest.required), (False, manifest.optional)):
+            for requirement in requirements:
+                available, detail = _check_requirement(
+                    requirement, env, which, package_version, executable_version
+                )
+                checks.append(RequirementCheck(
+                    skill_name, required, requirement, available, detail
+                ))
+    return SkillPreflightReport(tuple(checks))
+
+
+def format_preflight_report(report: SkillPreflightReport) -> str:
+    """One actionable report containing required and optional findings."""
+    findings = report.missing_required + report.missing_optional
+    if not findings:
+        return ""
+    lines = ["Skill runtime preflight:"]
+    for check in findings:
+        level = "required" if check.required else "optional"
+        req = check.requirement
+        constraint = f" {req.version}" if req.version else ""
+        lines.append(
+            f"- {check.skill_name} [{level}/{req.category}] "
+            f"{req.name}{constraint}: {check.detail}"
+        )
+        if req.setup:
+            lines.append(f"  Setup: {req.setup}")
+    return "\n".join(lines)
+
+
+def _check_requirement(requirement, env, which, package_version, executable_version):
+    category = requirement.category
+    if category == "python":
+        try:
+            installed = package_version(requirement.name)
+        except importlib.metadata.PackageNotFoundError:
+            return False, "package is not installed"
+        return _version_result(installed, requirement.version)
+
+    if category == "executables":
+        path = which(requirement.name)
+        if not path:
+            return False, "executable is not on PATH"
+        if not requirement.version:
+            return True, f"found at {path}"
+        installed = executable_version(path)
+        if not installed:
+            return False, "found, but its version could not be determined"
+        return _version_result(installed, requirement.version)
+
+    if category == "environment":
+        return ((True, "set") if env.get(requirement.name)
+                else (False, "environment variable is not set"))
+
+    if category == "oauth":
+        prefix = re.sub(r"[^A-Za-z0-9]", "_", requirement.name).upper()
+        connected = bool(env.get(f"{prefix}_ACCESS_TOKEN") or env.get(f"{prefix}_REFRESH_TOKEN"))
+        if not connected:
+            return False, f"{requirement.name} OAuth is not connected"
+        available_scopes = set(filter(None, re.split(r"[\s,]+", env.get(f"{prefix}_SCOPES", ""))))
+        missing = sorted(scope for scope in requirement.scopes
+                         if not _has_scope(scope, available_scopes))
+        if missing:
+            return False, "missing OAuth scopes: " + ", ".join(missing)
+        return True, "connected"
+
+    if category == "capabilities":
+        available = set(filter(None, re.split(
+            r"[\s,]+", env.get("CONNECTONION_CAPABILITIES", "")
+        )))
+        if requirement.name not in available:
+            return False, "platform capability is not available"
+        versions = _capability_versions(env.get("CONNECTONION_CAPABILITY_VERSIONS", ""))
+        if not requirement.version:
+            return True, "available"
+        installed = versions.get(requirement.name)
+        if not installed:
+            return False, "available, but its version is not declared"
+        return _version_result(installed, requirement.version)
+
+    return False, "unsupported requirement category"
+
+
+def _version_result(installed: str, constraint: Optional[str]) -> tuple[bool, str]:
+    if not constraint:
+        return True, f"installed {installed}"
+    try:
+        matches = Version(installed) in SpecifierSet(constraint)
+    except InvalidVersion:
+        return False, f"installed version {installed!r} is not PEP 440 compatible"
+    if matches:
+        return True, f"installed {installed}"
+    return False, f"installed {installed} does not satisfy {constraint}"
+
+
+def _executable_version(path: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            [path, "--version"], capture_output=True, text=True, timeout=2, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = re.search(r"(?<!\w)(\d+(?:\.\d+)+(?:[-+._][A-Za-z0-9.]+)?)", result.stdout + result.stderr)
+    return match.group(1) if match else None
+
+
+def _capability_versions(value: str) -> dict[str, str]:
+    versions = {}
+    for item in filter(None, re.split(r"[\s,]+", value)):
+        if "=" in item:
+            name, version = item.split("=", 1)
+            if name and version:
+                versions[name] = version
+    return versions
+
+
+def _has_scope(required: str, available: set[str]) -> bool:
+    return required in available or any(
+        scope.endswith("/" + required) for scope in available
+    )
+
+
+__all__ = [
+    "RequirementCheck",
+    "SkillPreflightReport",
+    "format_preflight_report",
+    "preflight_skills",
+]

--- a/connectonion/skill_requirements.py
+++ b/connectonion/skill_requirements.py
@@ -1,0 +1,179 @@
+"""Versioned runtime requirement manifests for SKILL.md files.
+
+This module only parses the declaration.  Checking the current machine and
+installing supported dependencies are deliberately separate concerns.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+
+SCHEMA_VERSION = 1
+_SECTIONS = ("required", "optional")
+_CATEGORIES = ("python", "executables", "environment", "oauth", "capabilities")
+_IDENTIFIERS = {
+    "python": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+    "executables": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]*$"),
+    "environment": re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$"),
+    "oauth": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+    "capabilities": re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$"),
+}
+
+
+class SkillManifestError(ValueError):
+    """A requirement manifest is invalid and identifies its exact location."""
+
+    def __init__(self, skill_name: str, field: str, problem: str):
+        self.skill_name = skill_name
+        self.field = field
+        self.problem = problem
+        super().__init__(f"Skill {skill_name!r}: {field}: {problem}")
+
+
+@dataclass(frozen=True)
+class SkillRequirement:
+    """One normalized runtime requirement."""
+
+    category: str
+    name: str
+    version: Optional[str] = None
+    setup: Optional[str] = None
+    scopes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SkillRequirements:
+    """A validated version of a skill's runtime requirement manifest."""
+
+    version: int
+    required: tuple[SkillRequirement, ...] = ()
+    optional: tuple[SkillRequirement, ...] = ()
+
+
+def parse_skill_requirements(
+    frontmatter: Mapping[str, Any], skill_name: str
+) -> Optional[SkillRequirements]:
+    """Validate and normalize ``frontmatter.requirements``.
+
+    Skills which do not declare requirements remain fully compatible and
+    return ``None``. Invalid declarations raise :class:`SkillManifestError`.
+    """
+    if "requirements" not in frontmatter:
+        return None
+
+    root = frontmatter["requirements"]
+    _mapping(root, skill_name, "requirements")
+    _known_fields(root, {"version", *_SECTIONS}, skill_name, "requirements")
+
+    if "version" not in root:
+        _fail(skill_name, "requirements.version", "is required")
+    version = root["version"]
+    if isinstance(version, bool) or not isinstance(version, int):
+        _fail(skill_name, "requirements.version", "must be the integer 1")
+    if version != SCHEMA_VERSION:
+        _fail(
+            skill_name,
+            "requirements.version",
+            f"unsupported schema version {version}; supported version is {SCHEMA_VERSION}",
+        )
+
+    parsed = {
+        section: _parse_section(root.get(section, {}), skill_name, section)
+        for section in _SECTIONS
+    }
+    return SkillRequirements(version=version, **parsed)
+
+
+def _parse_section(value: Any, skill_name: str, section: str) -> tuple[SkillRequirement, ...]:
+    path = f"requirements.{section}"
+    _mapping(value, skill_name, path)
+    _known_fields(value, set(_CATEGORIES), skill_name, path)
+
+    requirements = []
+    for category in _CATEGORIES:
+        entries = value.get(category, [])
+        category_path = f"{path}.{category}"
+        if not isinstance(entries, list):
+            _fail(skill_name, category_path, "must be a list")
+        for index, entry in enumerate(entries):
+            requirements.append(
+                _parse_entry(entry, skill_name, category, f"{category_path}[{index}]")
+            )
+    return tuple(requirements)
+
+
+def _parse_entry(value: Any, skill_name: str, category: str, path: str) -> SkillRequirement:
+    _mapping(value, skill_name, path)
+    name_field = "provider" if category == "oauth" else "name"
+    allowed = {name_field, "setup"}
+    if category in {"python", "executables", "capabilities"}:
+        allowed.add("version")
+    if category == "oauth":
+        allowed.add("scopes")
+    _known_fields(value, allowed, skill_name, path)
+
+    if name_field not in value:
+        _fail(skill_name, f"{path}.{name_field}", "is required")
+    name = _nonempty_string(value[name_field], skill_name, f"{path}.{name_field}")
+    if not _IDENTIFIERS[category].fullmatch(name):
+        _fail(skill_name, f"{path}.{name_field}", f"is not a valid {category} identifier")
+
+    version = None
+    if "version" in value:
+        version = _nonempty_string(value["version"], skill_name, f"{path}.version")
+        try:
+            SpecifierSet(version)
+        except InvalidSpecifier:
+            _fail(skill_name, f"{path}.version", "must be a valid PEP 440 constraint")
+
+    setup = None
+    if "setup" in value:
+        setup = _nonempty_string(value["setup"], skill_name, f"{path}.setup")
+
+    scopes: tuple[str, ...] = ()
+    if "scopes" in value:
+        raw_scopes = value["scopes"]
+        if not isinstance(raw_scopes, list):
+            _fail(skill_name, f"{path}.scopes", "must be a list")
+        parsed_scopes = []
+        for index, scope in enumerate(raw_scopes):
+            parsed_scopes.append(
+                _nonempty_string(scope, skill_name, f"{path}.scopes[{index}]")
+            )
+        scopes = tuple(parsed_scopes)
+
+    return SkillRequirement(
+        category=category, name=name, version=version, setup=setup, scopes=scopes
+    )
+
+
+def _mapping(value: Any, skill_name: str, path: str) -> None:
+    if not isinstance(value, Mapping):
+        _fail(skill_name, path, "must be a mapping")
+
+
+def _known_fields(value: Mapping[str, Any], allowed: set[str], skill_name: str, path: str) -> None:
+    for field in value:
+        if not isinstance(field, str) or field not in allowed:
+            _fail(skill_name, f"{path}.{field}", "is not a supported field")
+
+
+def _nonempty_string(value: Any, skill_name: str, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _fail(skill_name, path, "must be a non-empty string")
+    return value.strip()
+
+
+def _fail(skill_name: str, field: str, problem: str) -> None:
+    raise SkillManifestError(skill_name, field, problem)
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SkillManifestError",
+    "SkillRequirement",
+    "SkillRequirements",
+    "parse_skill_requirements",
+]

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -74,7 +74,11 @@ from copy import deepcopy
 
 from ..core.events import after_user_input, on_complete, before_each_tool, on_agent_ready
 from ..project import project_co_dir, project_root
-from ..skill_requirements import SkillManifestError, parse_skill_requirements
+from ..skill_requirements import (
+    SkillManifestError,
+    SkillRequirements,
+    parse_skill_requirements,
+)
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -85,6 +89,8 @@ class SkillInfo:
     name: str
     description: str
     location: str  # project | claude-project | user | claude-user | builtin
+    path: Optional[Path] = None
+    requirements: Optional[SkillRequirements] = None
 
 
 # The only locations a hosted agent publishes to clients: the two that ship inside
@@ -324,8 +330,15 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
 
             frontmatter, _ = _parse_skill_content(content)
             description = frontmatter.get('description', 'No description')
+            try:
+                requirements = parse_skill_requirements(frontmatter, name)
+            except SkillManifestError:
+                requirements = None  # find_skill_problems reports the exact field
 
-            result.append(SkillInfo(name=name, description=description, location=location))
+            result.append(SkillInfo(
+                name=name, description=description, location=location,
+                path=skill_file, requirements=requirements,
+            ))
 
     return result
 
@@ -640,6 +653,13 @@ def handle_skill_invocation(agent: 'Agent') -> None:
     frontmatter = skill['frontmatter']
     instructions = skill['instructions']
 
+    from ..skill_preflight import format_preflight_report, preflight_skills
+
+    preflight = preflight_skills([(skill_name, skill.get('requirements'))])
+    if preflight.missing_required:
+        messages[-1]['content'] = format_preflight_report(preflight) + "\nSkill did not start."
+        return
+
     # Grant skill permissions (with snapshot)
     patterns = _tool_patterns(frontmatter)
     _grant_skill_permissions(agent, skill_name, patterns)
@@ -686,6 +706,12 @@ def skill(agent: 'Agent', name: str) -> str:
 
     frontmatter = skill_data['frontmatter']
     instructions = skill_data['instructions']
+
+    from ..skill_preflight import format_preflight_report, preflight_skills
+
+    preflight = preflight_skills([(name, skill_data.get('requirements'))])
+    if preflight.missing_required:
+        return format_preflight_report(preflight) + "\nSkill did not start."
 
     # Grant skill permissions (with snapshot)
     patterns = _tool_patterns(frontmatter)

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -74,6 +74,7 @@ from copy import deepcopy
 
 from ..core.events import after_user_input, on_complete, before_each_tool, on_agent_ready
 from ..project import project_co_dir, project_root
+from ..skill_requirements import SkillManifestError, parse_skill_requirements
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -160,10 +161,13 @@ def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
         if path.exists():
             content = path.read_text(encoding="utf-8")
             frontmatter, instructions = _parse_skill_content(content)
+            manifest_name = frontmatter.get('name') or skill_name
+            requirements = parse_skill_requirements(frontmatter, str(manifest_name))
             return {
                 'path': str(path),
                 'frontmatter': frontmatter,
-                'instructions': instructions
+                'instructions': instructions,
+                'requirements': requirements,
             }
 
     return None
@@ -428,6 +432,13 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— name and description were still read')
         return f'SKILL.md frontmatter is not valid YAML{where}: {detail}'
+
+    frontmatter = _read_frontmatter(yaml_text)
+    skill_name = frontmatter.get('name') or skill_md.parent.name
+    try:
+        parse_skill_requirements(frontmatter, str(skill_name))
+    except SkillManifestError as exc:
+        return str(exc)
 
     return None
 

--- a/docs/features/skill-requirements.md
+++ b/docs/features/skill-requirements.md
@@ -1,0 +1,67 @@
+# Skill Runtime Requirements
+
+A skill can declare what must already exist on the machine before it runs. The
+manifest lives in `SKILL.md` frontmatter and is optional, so existing skills do
+not need to change.
+
+```yaml
+---
+name: send-report
+description: Build and email the weekly report
+requirements:
+  version: 1
+  required:
+    python:
+      - name: pandas
+        version: ">=2.2,<3"
+        setup: "Install with: pip install 'pandas>=2.2,<3'"
+    executables:
+      - name: wkhtmltopdf
+        version: ">=0.12"
+        setup: "Install wkhtmltopdf with your system package manager"
+    environment:
+      - name: REPORT_FROM_ADDRESS
+        setup: "Set REPORT_FROM_ADDRESS in .env"
+    oauth:
+      - provider: google
+        scopes: [gmail.send]
+        setup: "Connect Google in co auth"
+    capabilities:
+      - name: outbound-network
+        setup: "Allow HTTPS access to the mail provider"
+  optional:
+    python:
+      - name: pyarrow
+        version: ">=16"
+        setup: "Install pyarrow for faster exports"
+---
+
+Build the report and send it.
+```
+
+`required` entries prevent safe execution when they are unavailable. `optional`
+entries enable enhancements and never prevent the skill from running. Both
+sections support these categories:
+
+| Category | Identity field | Other fields |
+| --- | --- | --- |
+| `python` | `name` | `version`, `setup` |
+| `executables` | `name` | `version`, `setup` |
+| `environment` | `name` | `setup` |
+| `oauth` | `provider` | `scopes`, `setup` |
+| `capabilities` | `name` | `version`, `setup` |
+
+`version` is a non-empty [PEP 440](https://packaging.python.org/en/latest/specifications/version-specifiers/)
+constraint interpreted by the validator for that category. `setup` is an
+actionable message shown to a human when the requirement is missing. OAuth
+`scopes` is a list of non-empty scope names.
+
+The manifest is strict. Unknown fields, wrong types, and unsupported schema
+versions fail with the skill name and exact field, for example:
+
+```text
+Skill 'send-report': requirements.required.python[0].version: must be a non-empty string
+```
+
+Schema version `1` describes requirements only. It never installs packages,
+starts an OAuth flow, probes the network, or changes the machine.

--- a/docs/features/skill-requirements.md
+++ b/docs/features/skill-requirements.md
@@ -75,3 +75,11 @@ The same local preflight runs after `co skills copy`, in `co doctor`, and when
 `co ai` starts. Missing required entries stop that skill before its instructions
 or temporary permissions are loaded. Missing optional entries are shown as
 informational setup hints and do not stop the skill.
+
+During deploy, required Python constraints from every project or explicitly
+bundled skill are packaged into `.co/skill-python-requirements.txt` and installed
+before the service starts. A successful installation records `pip freeze --all`
+as the realized state; the request digest is advanced only afterwards, so a
+failed installation is retried by the next deploy. Required executables and
+platform capabilities are not installed automatically and stop deploy with the
+skill's setup hint. Optional dependencies remain informational.

--- a/docs/features/skill-requirements.md
+++ b/docs/features/skill-requirements.md
@@ -65,3 +65,13 @@ Skill 'send-report': requirements.required.python[0].version: must be a non-empt
 
 Schema version `1` describes requirements only. It never installs packages,
 starts an OAuth flow, probes the network, or changes the machine.
+
+Platform runtimes advertise capabilities locally through the comma-separated
+`CONNECTONION_CAPABILITIES` environment variable. When a capability has a
+version constraint, its version is read from
+`CONNECTONION_CAPABILITY_VERSIONS` as comma-separated `name=version` pairs.
+
+The same local preflight runs after `co skills copy`, in `co doctor`, and when
+`co ai` starts. Missing required entries stop that skill before its instructions
+or temporary permissions are loaded. Missing optional entries are shown as
+informational setup hints and do not stop the skill.

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -235,6 +235,10 @@ Markdown content after frontmatter - instructions for the agent.
 
 ## Creating Skills
 
+Skills that rely on Python packages, executables, credentials, OAuth, or
+platform features can declare a versioned, required/optional runtime contract.
+See [Skill Runtime Requirements](skill-requirements.md) for the complete schema.
+
 ### 1. Project-Level Skill (Specific to one project)
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "pypdf>=4.0.0",
     "python-pptx>=1.0.0",
     "python-docx>=1.1.0",
+    "packaging>=23.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_deploy_skill_requirements.py
+++ b/tests/unit/test_deploy_skill_requirements.py
@@ -1,0 +1,162 @@
+"""Declared skill dependencies travel and converge before service restart."""
+
+import json
+import tarfile
+from unittest.mock import patch
+
+from connectonion.cli.commands import deploy_commands, deploy_to_server
+from connectonion.skill_deploy import collect_deploy_skill_requirements
+
+SKILL = """---
+name: reporter
+description: Build a report
+requirements:
+  version: 1
+  required:
+    python:
+      - name: pandas
+        version: ">=2.2,<3"
+---
+
+Build it.
+"""
+
+
+def _project(tmp_path, skill=SKILL):
+    project = tmp_path / "project"
+    skill_dir = project / ".co" / "skills" / "reporter"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(skill)
+    (skill_dir / "template.txt").write_text("asset")
+    (project / "agent.py").write_text("print('ok')")
+    return project
+
+
+def _ok(stdout=""):
+    class Result:
+        returncode = 0
+        stderr = ""
+    result = Result()
+    result.stdout = stdout
+    return result
+
+
+def _fail(stderr="failed"):
+    class Result:
+        returncode = 1
+        stdout = ""
+    result = Result()
+    result.stderr = stderr
+    return result
+
+
+class TestCollectionAndPackaging:
+    def test_python_constraints_are_canonical(self, tmp_path):
+        requirements = collect_deploy_skill_requirements(_project(tmp_path))
+
+        assert requirements.python == ("pandas>=2.2,<3",)
+        assert requirements.skills == ("reporter",)
+        assert len(requirements.digest) == 64
+
+    def test_skill_manifest_assets_and_generated_contract_travel(self, tmp_path):
+        project = _project(tmp_path)
+
+        tarball = deploy_commands._build_tarball(project, [])
+
+        with tarfile.open(tarball) as archive:
+            names = archive.getnames()
+            assert ".co/skills/reporter/SKILL.md" in names
+            assert ".co/skills/reporter/template.txt" in names
+            assert ".co/skill-python-requirements.txt" in names
+            assert archive.extractfile(".co/skill-python-requirements.txt").read() == b"pandas>=2.2,<3\n"
+            requested = json.load(archive.extractfile(".co/skill-requirements.requested.json"))
+            assert requested["python"] == ["pandas>=2.2,<3"]
+            assert requested["digest"]
+
+    def test_external_skill_manifest_and_assets_travel_together(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "agent.py").write_text("print('ok')")
+        external = tmp_path / "external"
+        external.mkdir()
+        (external / "SKILL.md").write_text(SKILL)
+        (external / "template.txt").write_text("asset")
+
+        tarball = deploy_commands._build_tarball(project, [external])
+
+        with tarfile.open(tarball) as archive:
+            assert ".co/skills/external/SKILL.md" in archive.getnames()
+            assert ".co/skills/external/template.txt" in archive.getnames()
+            assert archive.extractfile(".co/skill-python-requirements.txt").read() == b"pandas>=2.2,<3\n"
+
+
+class TestServerRealization:
+    def test_changed_manifest_installs_and_stamps_realized_state(self, tmp_path):
+        project = _project(tmp_path)
+        requirements = collect_deploy_skill_requirements(project)
+
+        with patch.object(deploy_to_server, "_ssh", side_effect=[_ok("old"), _ok()]) as ssh:
+            assert deploy_to_server._install_deps_if_changed(
+                "user@host", "agent", project, requirements
+            )
+
+        command = ssh.call_args_list[-1].args[1]
+        assert "pip install -q -U 'pandas>=2.2,<3'" in command
+        assert "pip freeze --all" in command
+        assert command.index("pip freeze --all") < command.index("requirements.sha256")
+
+    def test_unchanged_manifest_skips_install(self, tmp_path):
+        project = _project(tmp_path)
+        requirements = collect_deploy_skill_requirements(project)
+        import hashlib
+
+        from connectonion import __version__
+
+        digest = hashlib.sha256(
+            b"\nskills:" + requirements.digest.encode()
+            + b"\ncli:" + __version__.encode()
+        ).hexdigest()
+
+        with patch.object(deploy_to_server, "_ssh", return_value=_ok(digest)) as ssh:
+            assert deploy_to_server._install_deps_if_changed(
+                "user@host", "agent", project, requirements
+            )
+
+        assert ssh.call_count == 1
+
+    def test_failed_install_is_retried_because_no_stamp_is_written(self, tmp_path):
+        project = _project(tmp_path)
+        requirements = collect_deploy_skill_requirements(project)
+
+        with patch.object(
+            deploy_to_server, "_ssh", side_effect=[_ok("old"), _fail(), _ok("old"), _ok()]
+        ) as ssh:
+            assert not deploy_to_server._install_deps_if_changed(
+                "user@host", "agent", project, requirements
+            )
+            assert deploy_to_server._install_deps_if_changed(
+                "user@host", "agent", project, requirements
+            )
+
+        installs = [call.args[1] for call in ssh.call_args_list if "pip install" in call.args[1]]
+        assert len(installs) == 2
+
+
+class TestUnsupportedRequirements:
+    def test_required_binary_is_named_before_any_server_call(self, tmp_path, capsys):
+        skill = SKILL.replace(
+            "    python:\n      - name: pandas\n        version: \">=2.2,<3\"",
+            "    executables:\n      - name: ffmpeg\n        setup: Install ffmpeg on the server",
+        )
+        project = _project(tmp_path, skill)
+        (project / ".co" / "host.yaml").write_text("name: reporter\nentrypoint: agent.py\n")
+
+        with patch.object(deploy_to_server.shutil, "which", return_value="/usr/bin/tool"), \
+             patch.object(deploy_to_server, "load_server", return_value={"ssh": "user@host"}), \
+             patch.object(deploy_to_server, "_ssh") as ssh:
+            assert not deploy_to_server.handle_deploy_to("prod", project)
+
+        ssh.assert_not_called()
+        output = capsys.readouterr().out
+        assert "ffmpeg" in output
+        assert "Install ffmpeg on the server" in output

--- a/tests/unit/test_skill_preflight.py
+++ b/tests/unit/test_skill_preflight.py
@@ -1,0 +1,241 @@
+"""One local skill preflight shared by doctor, installation, and startup."""
+
+import importlib.metadata
+import socket
+
+from connectonion.skill_preflight import format_preflight_report, preflight_skills
+from connectonion.skill_requirements import parse_skill_requirements
+
+
+def _requirements(required=None, optional=None):
+    return parse_skill_requirements({"requirements": {
+        "version": 1,
+        "required": required or {},
+        "optional": optional or {},
+    }}, "reporter")
+
+
+def _run(requirements, **kwargs):
+    defaults = {
+        "environ": {},
+        "which": lambda name: None,
+        "package_version": lambda name: (_ for _ in ()).throw(
+            importlib.metadata.PackageNotFoundError(name)
+        ),
+        "executable_version": lambda path: None,
+    }
+    defaults.update(kwargs)
+    return preflight_skills([("reporter", requirements)], **defaults)
+
+
+class TestLocalResolvers:
+    def test_validation_has_no_network_side_effects(self, monkeypatch):
+        def network_would_fail(*args, **kwargs):
+            raise AssertionError("preflight attempted a network connection")
+
+        monkeypatch.setattr(socket, "create_connection", network_would_fail)
+        report = _run(_requirements(required={
+            "python": [{"name": "local-package"}],
+            "executables": [{"name": "local-command"}],
+            "environment": [{"name": "LOCAL_VALUE"}],
+            "oauth": [{"provider": "local-provider"}],
+            "capabilities": [{"name": "local-capability"}],
+        }))
+
+        assert len(report.missing_required) == 5
+
+    def test_python_package_version_matches(self):
+        report = _run(
+            _requirements(required={"python": [{"name": "pandas", "version": ">=2,<3"}]}),
+            package_version=lambda name: "2.2.1",
+        )
+
+        assert report.ready
+        assert report.checks[0].available
+
+    def test_wrong_python_version_is_actionable(self):
+        report = _run(
+            _requirements(required={"python": [{
+                "name": "pandas", "version": ">=2", "setup": "pip install -U pandas"
+            }]}),
+            package_version=lambda name: "1.5.0",
+        )
+
+        assert not report.ready
+        assert "does not satisfy >=2" in format_preflight_report(report)
+        assert "Setup: pip install -U pandas" in format_preflight_report(report)
+
+    def test_executable_presence_and_version_are_checked(self):
+        report = _run(
+            _requirements(required={"executables": [{"name": "ffmpeg", "version": ">=6"}]}),
+            which=lambda name: "/usr/bin/ffmpeg",
+            executable_version=lambda path: "6.1",
+        )
+
+        assert report.ready
+
+    def test_environment_variables_are_not_read_by_value(self):
+        report = _run(
+            _requirements(required={"environment": [{"name": "SECRET_TOKEN"}]}),
+            environ={"SECRET_TOKEN": "do-not-print"},
+        )
+
+        assert report.ready
+        assert "do-not-print" not in format_preflight_report(report)
+
+    def test_oauth_requires_a_connection_and_scopes(self):
+        report = _run(
+            _requirements(required={"oauth": [{
+                "provider": "google", "scopes": ["gmail.send", "drive.readonly"]
+            }]}),
+            environ={
+                "GOOGLE_REFRESH_TOKEN": "secret",
+                "GOOGLE_SCOPES": "https://www.googleapis.com/auth/gmail.send",
+            },
+        )
+
+        assert not report.ready
+        assert report.missing_required[0].detail == "missing OAuth scopes: drive.readonly"
+        assert "secret" not in format_preflight_report(report)
+
+    def test_capabilities_are_resolved_from_the_runtime_stamp(self):
+        report = _run(
+            _requirements(required={"capabilities": [{"name": "browser", "version": ">=2"}]}),
+            environ={
+                "CONNECTONION_CAPABILITIES": "browser,filesystem",
+                "CONNECTONION_CAPABILITY_VERSIONS": "browser=2.1",
+            },
+        )
+
+        assert report.ready
+
+
+class TestRequiredAndOptional:
+    def test_optional_findings_do_not_make_the_skill_unready(self):
+        report = _run(_requirements(optional={"python": [{"name": "pyarrow"}]}))
+
+        assert report.ready
+        assert not report.missing_required
+        assert len(report.missing_optional) == 1
+        assert "[optional/python]" in format_preflight_report(report)
+
+    def test_all_findings_are_one_report(self):
+        report = _run(_requirements(
+            required={"environment": [{"name": "MAIL_FROM"}]},
+            optional={"executables": [{"name": "wkhtmltopdf"}]},
+        ))
+
+        rendered = format_preflight_report(report)
+        assert rendered.count("Skill runtime preflight:") == 1
+        assert "[required/environment]" in rendered
+        assert "[optional/executables]" in rendered
+
+    def test_a_skill_without_a_manifest_has_no_checks(self):
+        report = _run(None)
+
+        assert report.ready
+        assert report.checks == ()
+        assert format_preflight_report(report) == ""
+
+
+class TestSharedEntryPoints:
+    SKILL = (
+        "---\nname: reporter\ndescription: Report\nrequirements:\n  version: 1\n"
+        "  required:\n    environment:\n      - name: REPORT_TOKEN\n"
+        "        setup: Set REPORT_TOKEN in .env\n---\n\nRun.\n"
+    )
+
+    def test_co_ai_startup_includes_one_preflight_report(self, tmp_path, monkeypatch, capsys):
+        from connectonion.cli.co_ai.context import load_project_context
+        from connectonion.cli.co_ai.skills import loader
+
+        skill_dir = tmp_path / ".co" / "skills" / "reporter"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(self.SKILL)
+        loader.SKILLS_REGISTRY.clear()
+        monkeypatch.delenv("REPORT_TOKEN", raising=False)
+
+        context = load_project_context(tmp_path)
+
+        assert context.count("Skill runtime preflight:") == 1
+        assert "REPORT_TOKEN" in capsys.readouterr().out
+
+    def test_skill_copy_runs_the_same_preflight(self, tmp_path, monkeypatch, capsys):
+        from connectonion.cli.commands import skills_commands
+
+        source = tmp_path / "source" / "reporter"
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text(self.SKILL)
+        monkeypatch.delenv("REPORT_TOKEN", raising=False)
+
+        copied = skills_commands._copy_entry(
+            {"name": "reporter", "source": "test", "path": str(source / "SKILL.md")},
+            force=False,
+            skills_dir=tmp_path / "installed",
+        )
+
+        assert copied
+        assert "Skill runtime preflight:" in capsys.readouterr().out
+
+    def test_invalid_manifest_is_rejected_before_copy(self, tmp_path):
+        from connectonion.cli.commands import skills_commands
+        from connectonion.skill_requirements import SkillManifestError
+
+        source = tmp_path / "source" / "broken"
+        source.mkdir(parents=True)
+        (source / "SKILL.md").write_text(
+            self.SKILL.replace("version: 1", "version: next")
+        )
+        destination = tmp_path / "installed"
+
+        import pytest
+        with pytest.raises(SkillManifestError):
+            skills_commands._copy_entry(
+                {"name": "broken", "source": "test", "path": str(source / "SKILL.md")},
+                force=False,
+                skills_dir=destination,
+            )
+
+        assert not destination.exists()
+
+    def test_required_missing_stops_the_co_ai_skill_before_instructions(self, tmp_path, monkeypatch):
+        from connectonion.cli.co_ai.skills import loader
+        from connectonion.cli.co_ai.skills.tool import skill
+
+        skill_dir = tmp_path / ".co" / "skills" / "reporter"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(self.SKILL)
+        loader.SKILLS_REGISTRY.clear()
+        loader.load_skills(tmp_path)
+        monkeypatch.delenv("REPORT_TOKEN", raising=False)
+
+        result = skill("reporter")
+
+        assert "Skill did not start." in result
+        assert "Run." not in result
+
+    def test_doctor_uses_the_shared_result_without_failing_optional(self, monkeypatch):
+        from connectonion.cli.commands import doctor_commands
+        from connectonion.useful_plugins.skills import SkillInfo
+
+        rows = []
+
+        class Table:
+            def add_row(self, *values):
+                rows.append(values)
+
+        required = _requirements(required={"environment": [{"name": "MUST_HAVE"}]})
+        optional = _requirements(optional={"environment": [{"name": "NICE_TO_HAVE"}]})
+        skills = [
+            SkillInfo("must", "", "project", requirements=required),
+            SkillInfo("nice", "", "project", requirements=optional),
+        ]
+        monkeypatch.delenv("MUST_HAVE", raising=False)
+        monkeypatch.delenv("NICE_TO_HAVE", raising=False)
+        found = []
+
+        doctor_commands._add_skill_preflight_rows(Table(), found, skills)
+
+        assert any("MUST_HAVE" in problem for problem in found)
+        assert not any("NICE_TO_HAVE" in problem for problem in found)
+        assert any("optional" in status for _, status in rows)

--- a/tests/unit/test_skill_requirements.py
+++ b/tests/unit/test_skill_requirements.py
@@ -1,0 +1,146 @@
+"""The versioned SKILL.md runtime requirements contract."""
+
+import pytest
+
+from connectonion.skill_requirements import (
+    SkillManifestError,
+    parse_skill_requirements,
+)
+
+
+def _manifest(**overrides):
+    requirements = {"version": 1, "required": {}, "optional": {}}
+    requirements.update(overrides)
+    return {"requirements": requirements}
+
+
+class TestCompatibility:
+    def test_a_skill_without_requirements_still_loads(self):
+        assert parse_skill_requirements({"name": "old-skill"}, "old-skill") is None
+
+    def test_empty_sections_are_valid(self):
+        parsed = parse_skill_requirements(_manifest(), "simple")
+
+        assert parsed.version == 1
+        assert parsed.required == ()
+        assert parsed.optional == ()
+
+
+class TestSchema:
+    def test_every_requirement_kind_is_normalized(self):
+        frontmatter = _manifest(required={
+            "python": [{"name": "httpx", "version": ">=0.27,<1", "setup": "pip install httpx"}],
+            "executables": [{"name": "ffmpeg", "version": ">=6"}],
+            "environment": [{"name": "OPENAI_API_KEY", "setup": "Set it in .env"}],
+            "oauth": [{"provider": "google", "scopes": ["gmail.send", "drive.readonly"]}],
+            "capabilities": [{"name": "browser", "version": ">=1"}],
+        })
+
+        parsed = parse_skill_requirements(frontmatter, "media-mail")
+
+        assert [item.category for item in parsed.required] == [
+            "python", "executables", "environment", "oauth", "capabilities"
+        ]
+        assert parsed.required[0].name == "httpx"
+        assert parsed.required[0].version == ">=0.27,<1"
+        assert parsed.required[0].setup == "pip install httpx"
+        assert parsed.required[3].name == "google"
+        assert parsed.required[3].scopes == ("gmail.send", "drive.readonly")
+
+    def test_required_and_optional_stay_separate(self):
+        parsed = parse_skill_requirements(_manifest(
+            required={"python": [{"name": "core"}]},
+            optional={"python": [{"name": "faster"}]},
+        ), "split")
+
+        assert [item.name for item in parsed.required] == ["core"]
+        assert [item.name for item in parsed.optional] == ["faster"]
+
+
+class TestPreciseFailures:
+    @pytest.mark.parametrize(
+        ("frontmatter", "field"),
+        [
+            ({"requirements": []}, "requirements"),
+            ({"requirements": {}}, "requirements.version"),
+            (_manifest(version="1"), "requirements.version"),
+            (_manifest(version=2), "requirements.version"),
+            (_manifest(required=[]), "requirements.required"),
+            (_manifest(required={"python": {}}), "requirements.required.python"),
+            (_manifest(required={"python": [{}]}), "requirements.required.python[0].name"),
+            (_manifest(required={"python": [{"name": "--extra-index-url"}]}),
+             "requirements.required.python[0].name"),
+            (_manifest(required={"environment": [{"name": "NOT-AN-ENV-VAR"}]}),
+             "requirements.required.environment[0].name"),
+            (_manifest(required={"python": [{"name": "x", "version": ""}]}),
+             "requirements.required.python[0].version"),
+            (_manifest(required={"python": [{"name": "x", "version": "version two"}]}),
+             "requirements.required.python[0].version"),
+            (_manifest(required={"oauth": [{"provider": "google", "scopes": "gmail.send"}]}),
+             "requirements.required.oauth[0].scopes"),
+            (_manifest(required={"oauth": [{"provider": "google", "scopes": [""]}]}),
+             "requirements.required.oauth[0].scopes[0]"),
+            (_manifest(required={"python": [{"name": "x", "scopes": []}]}),
+             "requirements.required.python[0].scopes"),
+            (_manifest(required={"containers": []}), "requirements.required.containers"),
+            ({"requirements": {"version": 1, "future": {}}}, "requirements.future"),
+        ],
+    )
+    def test_error_names_the_skill_and_exact_field(self, frontmatter, field):
+        with pytest.raises(SkillManifestError) as caught:
+            parse_skill_requirements(frontmatter, "send-report")
+
+        assert caught.value.skill_name == "send-report"
+        assert caught.value.field == field
+        assert "Skill 'send-report'" in str(caught.value)
+        assert field in str(caught.value)
+
+
+class TestLoaderIntegration:
+    def test_plugin_loader_returns_the_validated_contract(self, tmp_path, monkeypatch):
+        import importlib
+
+        skills = importlib.import_module("connectonion.useful_plugins.skills")
+
+        skill_dir = tmp_path / ".co" / "skills" / "mailer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  required:\n    environment:\n      - name: MAIL_FROM\n---\n\nSend it.\n"
+        )
+        monkeypatch.setattr(skills, "_get_skill_paths", lambda name: [skill_dir / "SKILL.md"])
+
+        loaded = skills._load_skill("mailer")
+
+        assert loaded["requirements"].required[0].name == "MAIL_FROM"
+
+    def test_co_ai_loader_keeps_the_same_contract(self, tmp_path):
+        from connectonion.cli.co_ai.skills.loader import _parse_skill_file
+
+        skill_dir = tmp_path / "mailer"
+        skill_dir.mkdir()
+        path = skill_dir / "SKILL.md"
+        path.write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  optional:\n    capabilities:\n      - name: browser\n---\n\nSend it.\n"
+        )
+
+        info = _parse_skill_file(path)
+
+        assert info.requirements.optional[0].name == "browser"
+
+    def test_doctor_reports_an_invalid_manifest(self, tmp_path):
+        from connectonion.useful_plugins.skills import find_skill_problems
+
+        skill_dir = tmp_path / ".co" / "skills" / "mailer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mailer\ndescription: Mail\nrequirements:\n  version: 1\n"
+            "  required:\n    python:\n      - name: httpx\n        version: 3\n---\n\nSend it.\n"
+        )
+
+        problems = find_skill_problems(co_dir=tmp_path / ".co")
+
+        assert len(problems) == 1
+        assert "Skill 'mailer'" in problems[0][2]
+        assert "requirements.required.python[0].version" in problems[0][2]


### PR DESCRIPTION
Closes #472

Stacked on #755 and #756; review and merge those first. Cloud realization also requires the paired oo-api PR that will be linked here.

## Summary
- package every shipped Skill manifest/asset plus canonical requested-state and Python requirements artifacts
- install required Skill Python constraints in the self-hosted agent venv before restart
- stamp actual `pip freeze --all` state only after successful convergence; failed installs keep the old digest and retry next deploy
- fail before touching/restarting the target when required executables or platform capabilities cannot be realized automatically
- cover changed, unchanged, failed/retried, external asset, and unsupported-requirement paths

## Validation
- 70 focused deploy tests pass
- 205/206 broader deploy-selected tests pass; the sole local failure is an existing sandbox-blocked write to `~/.co/ssh`
- stacked schema/preflight/deploy test set: 45 passed
- Ruff and diff checks pass