### PR TITLE
security(doctor): redact and diagnose credentials

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -278,32 +278,55 @@ def handle_doctor():
     else:
         config_table.add_row("Keys", "[yellow]○[/yellow] Not found (run 'co auth' to create)")
 
-    # Check for API key
-    api_key = os.getenv("OPENONION_API_KEY")
-    if api_key:
-        api_key_display = f"{api_key[:20]}..." if len(api_key) > 20 else api_key
-        config_table.add_row("API Key", f"[green]✓[/green] Found in environment")
-        config_table.add_row("Key Preview", f"[dim]{api_key_display}[/dim]")
-    else:
-        # Check .env files
-        from dotenv import load_dotenv
-        local_env = Path(".env")
-        global_env = Path.home() / ".co" / "keys.env"
+    # The same redacted discovery `co status` uses. Doctor used to print the
+    # first 20 characters of OPENONION_API_KEY as a "preview" in normal output;
+    # that is enough credential material to leak into support logs and has no
+    # diagnostic value.
+    from .status_commands import _credential_rows, _oauth_rows
 
-        if local_env.exists():
-            load_dotenv(local_env)
+    credential_actions = {
+        "OPENONION_API_KEY": "co auth",
+        "OPENAI_API_KEY": "set OPENAI_API_KEY in <project>/.env",
+        "ANTHROPIC_API_KEY": "set ANTHROPIC_API_KEY in <project>/.env",
+        "GEMINI_API_KEY": "set GEMINI_API_KEY in <project>/.env",
+        "GOOGLE_API_KEY": "set GOOGLE_API_KEY in <project>/.env",
+        "GROQ_API_KEY": "set GROQ_API_KEY in <project>/.env",
+        "XAI_API_KEY": "set XAI_API_KEY in <project>/.env",
+        "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in <project>/.env",
+        "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
+    }
+    api_key = None
+    for row in _credential_rows(project_dir=project_co_dir().parent):
+        status = row["status"]
+        action = credential_actions[row["credential"]]
+        if status == "configured":
+            mark, style = "✓", "green"
+        elif status == "conflict":
+            mark, style = "✗", "red"
+            found.append(f"credential {row['credential']} is shadowed — {action}")
+        else:
+            mark, style = "○", "yellow"
+        config_table.add_row(
+            row["provider"],
+            f"[{style}]{mark}[/{style}] {status} · {row['source']} · {action}",
+        )
+        if row["credential"] == "OPENONION_API_KEY" and status == "configured":
+            # Presence gates the probe; the secret itself is never rendered.
+            # Normal CLI startup has already loaded the selected project env.
             api_key = os.getenv("OPENONION_API_KEY")
-            if api_key:
-                config_table.add_row("API Key", f"[green]✓[/green] Found in .env")
-
-        if not api_key and global_env.exists():
-            load_dotenv(global_env)
-            api_key = os.getenv("OPENONION_API_KEY")
-            if api_key:
-                config_table.add_row("API Key", f"[green]✓[/green] Found in ~/.co/keys.env")
-
-        if not api_key:
-            config_table.add_row("API Key", "[yellow]○[/yellow] Not configured (run 'co auth')")
+    for row in _oauth_rows(project_dir=project_co_dir().parent):
+        status = row["status"]
+        if status == "connected":
+            mark, style = "✓", "green"
+        elif status in {"conflict", "expired", "invalid expiry", "incomplete (scopes missing)"}:
+            mark, style = "✗", "red"
+            found.append(f"{row['provider']} is {status} — {row['action']}")
+        else:
+            mark, style = "○", "yellow"
+        config_table.add_row(
+            row["provider"],
+            f"[{style}]{mark}[/{style}] {status} · {row['source']} · {row['action']}",
+        )
 
     console.print(Panel(config_table, title="[bold]Configuration[/bold]", border_style="green"))
     console.print()

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -38,6 +38,17 @@ CREDENTIAL_ENV_VARS = (
     ("MISTRAL_API_KEY", "Mistral"),
 )
 
+OAUTH_CONNECTIONS = (
+    ("Google OAuth", "GOOGLE", "co auth google"),
+    ("Microsoft OAuth", "MICROSOFT", "co auth microsoft"),
+)
+
+_OAUTH_ENV_VARS = {
+    f"{prefix}_{suffix}"
+    for _provider, prefix, _action in OAUTH_CONNECTIONS
+    for suffix in ("ACCESS_TOKEN", "REFRESH_TOKEN", "TOKEN_EXPIRES_AT", "SCOPES", "EMAIL")
+}
+
 _PLACEHOLDER_VALUES = {
     "changeme",
     "replace-me",
@@ -74,7 +85,7 @@ def _read_credential_file(path: Path) -> dict[str, str]:
         values = dotenv_values(path, interpolate=False)
     except (OSError, UnicodeError):
         return {}
-    supported = {name for name, _provider in CREDENTIAL_ENV_VARS}
+    supported = {name for name, _provider in CREDENTIAL_ENV_VARS} | _OAUTH_ENV_VARS
     return {
         name: str(value)
         for name, value in values.items()
@@ -187,6 +198,76 @@ def _revealed_credential_rows(
                         "value": str(value),
                     }
                 )
+    return rows
+
+
+def _oauth_rows(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    now: float | None = None,
+) -> list[dict[str, str]]:
+    """Return redacted OAuth connection state using the same source precedence."""
+    import datetime
+    import time
+
+    sources = _credential_sources(project_dir=project_dir, home=home, environ=environ)
+    now = time.time() if now is None else now
+    rows = []
+    for provider, prefix, action in OAUTH_CONNECTIONS:
+        found = []
+        for source, values in sources:
+            access = values.get(f"{prefix}_ACCESS_TOKEN")
+            refresh = values.get(f"{prefix}_REFRESH_TOKEN")
+            if _is_configured(access) or _is_configured(refresh):
+                state = tuple(
+                    str(values.get(f"{prefix}_{suffix}") or "")
+                    for suffix in ("ACCESS_TOKEN", "REFRESH_TOKEN", "TOKEN_EXPIRES_AT", "SCOPES", "EMAIL")
+                )
+                found.append((source, state, values))
+
+        if not found:
+            rows.append({"provider": provider, "status": "missing", "source": "—", "action": action})
+            continue
+
+        unique_states = {state for _source, state, _values in found}
+        source_names = [source for source, *_rest in found]
+        if len(unique_states) > 1:
+            source = " + ".join(
+                f"{name} (used)" if index == 0 else name
+                for index, name in enumerate(source_names)
+            )
+            rows.append({"provider": provider, "status": "conflict", "source": source,
+                         "action": f"remove or update the shadowed value; then {action}"})
+            continue
+
+        source, state, values = found[0]
+        _access, refresh, _expires, scopes, _email = state
+        expires = values.get(f"{prefix}_TOKEN_EXPIRES_AT")
+        expired = False
+        invalid_expiry = False
+        if _is_configured(expires):
+            try:
+                expired = float(str(expires)) <= now
+            except ValueError:
+                try:
+                    parsed = datetime.datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
+                    expired = parsed.timestamp() <= now
+                except ValueError:
+                    invalid_expiry = True
+
+        if not _is_configured(scopes):
+            status = "incomplete (scopes missing)"
+        elif invalid_expiry:
+            status = "invalid expiry"
+        elif expired and not _is_configured(refresh):
+            status = "expired"
+        elif expired:
+            status = "refresh available"
+        else:
+            status = "connected"
+        rows.append({"provider": provider, "status": status, "source": source, "action": action})
     return rows
 
 

--- a/tests/unit/test_doctor_credentials_are_redacted.py
+++ b/tests/unit/test_doctor_credentials_are_redacted.py
@@ -1,0 +1,127 @@
+"""Credential diagnostics must be useful without becoming a secret leak."""
+
+from types import SimpleNamespace
+
+from connectonion.cli.commands.status_commands import _oauth_rows
+
+
+def _oauth(rows, provider):
+    return next(row for row in rows if row["provider"] == provider)
+
+
+def test_oauth_reports_missing_connected_expired_and_refreshable(tmp_path):
+    missing = _oauth_rows(project_dir=tmp_path, home=tmp_path, environ={}, now=100)
+    assert _oauth(missing, "Google OAuth")["status"] == "missing"
+
+    connected = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "access-secret",
+            "GOOGLE_TOKEN_EXPIRES_AT": "200",
+            "GOOGLE_SCOPES": "gmail.send",
+        },
+        now=100,
+    )
+    assert _oauth(connected, "Google OAuth")["status"] == "connected"
+
+    expired = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "MICROSOFT_ACCESS_TOKEN": "expired-secret",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "50",
+            "MICROSOFT_SCOPES": "Mail.Send",
+        },
+        now=100,
+    )
+    assert _oauth(expired, "Microsoft OAuth")["status"] == "expired"
+
+    refreshable = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "MICROSOFT_ACCESS_TOKEN": "expired-secret",
+            "MICROSOFT_REFRESH_TOKEN": "refresh-secret",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "50",
+            "MICROSOFT_SCOPES": "Mail.Send",
+        },
+        now=100,
+    )
+    assert _oauth(refreshable, "Microsoft OAuth")["status"] == "refresh available"
+
+    incomplete = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={"GOOGLE_ACCESS_TOKEN": "access-without-scopes"},
+        now=100,
+    )
+    assert _oauth(incomplete, "Google OAuth")["status"] == "incomplete (scopes missing)"
+
+    invalid = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "access-secret",
+            "GOOGLE_SCOPES": "gmail.send",
+            "GOOGLE_TOKEN_EXPIRES_AT": "not-a-date",
+        },
+        now=100,
+    )
+    assert _oauth(invalid, "Google OAuth")["status"] == "invalid expiry"
+
+
+def test_oauth_reports_which_source_shadows_another_without_values(tmp_path):
+    (tmp_path / ".env").write_text(
+        "GOOGLE_ACCESS_TOKEN=project-secret\n"
+        "GOOGLE_REFRESH_TOKEN=project-refresh\n",
+        encoding="utf-8",
+    )
+
+    rows = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path / "home",
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "process-secret",
+            "GOOGLE_REFRESH_TOKEN": "process-refresh",
+            "GOOGLE_SCOPES": "gmail.send",
+        },
+        now=100,
+    )
+    row = _oauth(rows, "Google OAuth")
+
+    assert row["status"] == "conflict"
+    assert "process environment (used)" in row["source"]
+    assert "<project>/.env" in row["source"]
+    rendered = repr(rows)
+    for secret in ("process-secret", "process-refresh", "project-secret", "project-refresh"):
+        assert secret not in rendered
+
+
+def test_doctor_never_renders_an_api_key_preview(tmp_path, monkeypatch, capsys):
+    from connectonion.cli.commands import doctor_commands
+    from connectonion.useful_tools.browser_tools import browser as browser_module
+
+    secret = "oo_live_abcdefghijklmnopqrstuvwxyz0123456789"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("OPENONION_API_KEY", secret)
+    monkeypatch.setattr(
+        browser_module,
+        "driver_stealth_status",
+        lambda: ("missing", None, "patchright not installed"),
+    )
+    monkeypatch.setattr(
+        doctor_commands.requests,
+        "get",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=200),
+    )
+
+    doctor_commands.handle_doctor()
+    output = capsys.readouterr().out
+
+    assert "OpenOnion" in output
+    assert "configured" in output
+    assert "Key Preview" not in output
+    assert secret not in output
+    assert secret[:20] not in output


### PR DESCRIPTION
Implements #468 with an explicit credential-safety boundary.

This removes the API-key prefix preview from normal `co doctor` output and adds redacted diagnostics for OpenOnion/model-provider keys plus Google and Microsoft OAuth. It reports source precedence, the value source that wins when another is shadowed, missing scopes, malformed/expired tokens, and the exact reconnect/configuration command without returning secret values. Running `co doctor` again re-reads every source and verifies the resulting state.

Credential repair remains manual by design: `co auth google` and `co auth microsoft` revoke the existing provider connection before starting a new browser login, so they are not attached to the broad `doctor --fix --yes` approval in #759/#760. Doctor names the exact command; the user explicitly runs that provider-specific mutation, then reruns doctor.

Validation:
- 9 focused credential tests passed, covering missing, connected, expired, refreshable, malformed, missing-scope, and shadowed states
- 158 doctor/status-related unit tests passed with an isolated HOME
- output tests prove neither full secrets nor the former 20-character preview appear
- `py_compile` and `git diff --check` passed

Closes #468 after merge.