### PR TITLE
feat(doctor): deterministic repair plans and JSON

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -11,6 +11,7 @@ LLM-Note:
 
 import sys
 import os
+import shlex
 import shutil
 from pathlib import Path
 
@@ -22,6 +23,49 @@ from rich.table import Table
 from rich import box
 
 console = Console()
+
+
+def _repair_runtime(*, yes: bool) -> None:
+    """Show the complete plan, apply approved mutations, and print outcomes."""
+    import typer
+
+    from .doctor_runtime import repair_runtime, runtime_checks
+
+    checks = runtime_checks()
+    unhealthy = [check for check in checks if check.status not in {"ok", "idle"}]
+    plan = Table(show_header=True, box=box.SIMPLE, padding=(0, 1))
+    plan.add_column("Check", style="cyan")
+    plan.add_column("State")
+    plan.add_column("Proposed change")
+    for check in unhealthy:
+        change = shlex.join(check.repair) if check.repair else "no safe automatic repair"
+        plan.add_row(check.label, check.status, change)
+    if not unhealthy:
+        plan.add_row("Runtime", "healthy", "nothing to change")
+    console.print(Panel(plan, title="[bold]Repair plan[/bold]", border_style="yellow"))
+
+    def approve(check):
+        if yes:
+            return True
+        return typer.confirm(f"Apply repair for {check.label}: {shlex.join(check.repair)}?", default=False)
+
+    outcomes = repair_runtime(checks, approve=approve)
+    result = Table(show_header=True, box=box.SIMPLE, padding=(0, 1))
+    result.add_column("Check", style="cyan")
+    result.add_column("Outcome")
+    result.add_column("Detail")
+    if outcomes:
+        for outcome in outcomes:
+            style = {"repaired": "green", "still-blocked": "red"}.get(outcome.outcome, "yellow")
+            result.add_row(
+                outcome.label,
+                f"[{style}]{outcome.outcome}[/{style}]",
+                outcome.detail,
+            )
+    else:
+        result.add_row("Runtime", "[green]healthy[/green]", "no repair needed")
+    console.print(Panel(result, title="[bold]Repair results[/bold]", border_style="cyan"))
+    console.print()
 
 
 def verdict(problems: list) -> int:
@@ -171,19 +215,25 @@ def _shown(path: Path) -> str:
         return os.path.relpath(path, Path.cwd())
 
 
-def handle_doctor():
+def handle_doctor(*, fix: bool = False, yes: bool = False):
     """Run comprehensive diagnostics on ConnectOnion installation.
 
     TODO: Replace manual checks with `co ai` powered diagnosis —
     let an LLM agent inspect the environment, interpret errors,
     and suggest fixes conversationally.
     """
+    if fix:
+        _repair_runtime(yes=yes)
+
     # `found`, not `problems`: find_skill_problems() already puts a list of
     # (location, name, reason) tuples in a local called `problems`, and
     # shadowing it made the loop below unpack my strings into three names.
     # The real CLI caught that; the unit tests could not see it.
     found: list[str] = []
     from ... import __version__
+    from .doctor_runtime import runtime_checks
+
+    runtime = {check.id: check for check in runtime_checks()}
 
     console.print("\n[bold cyan]🔍 ConnectOnion Diagnostics[/bold cyan]\n")
 
@@ -196,10 +246,20 @@ def handle_doctor():
     system_table.add_row("Version", f"[green]✓[/green] {__version__}")
 
     # Python
+    python_check = runtime["python"]
     python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     python_path = sys.executable
-    system_table.add_row("Python", f"[green]✓[/green] {python_version}")
+    python_mark = "[green]✓[/green]" if python_check.status == "ok" else "[red]✗[/red]"
+    system_table.add_row("Python", f"{python_mark} {python_check.detail}")
+    if python_check.status != "ok":
+        found.append(python_check.detail)
     system_table.add_row("Python Path", f"[dim]{python_path}[/dim]")
+
+    platform_check = runtime["platform"]
+    platform_mark = "[green]✓[/green]" if platform_check.status == "ok" else "[red]✗[/red]"
+    system_table.add_row("Operating system", f"{platform_mark} {platform_check.detail}")
+    if platform_check.status != "ok":
+        found.append(platform_check.detail)
 
     # Virtual environment
     in_venv = hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix)
@@ -339,6 +399,15 @@ def handle_doctor():
     from ...useful_tools.browser_tools.browser import (
         driver_stealth_status, installed_browser_path,
     )
+    daemon = runtime["browser-daemon"]
+    daemon_mark = "[green]✓[/green]" if daemon.status == "ok" else "[yellow]○[/yellow]"
+    browser_table.add_row("Browser daemon", f"{daemon_mark} {daemon.detail}")
+    os_prerequisites = runtime["os-prerequisites"]
+    prereq_mark = "[green]✓[/green]" if os_prerequisites.status == "ok" else "[yellow]○[/yellow]"
+    if os_prerequisites.status == "blocked":
+        prereq_mark = "[red]✗[/red]"
+        found.append(f"browser OS prerequisites: {os_prerequisites.detail}")
+    browser_table.add_row("OS prerequisites", f"{prereq_mark} {os_prerequisites.detail}")
     status, browser_version, detail = driver_stealth_status()
     # The package being healthy says nothing about there being a browser to
     # launch. A deployed agent reported "Patchright ✓ / Stealth driver ✓ /

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -47,6 +47,8 @@ def _repair_runtime(*, yes: bool) -> None:
     def approve(check):
         if yes:
             return True
+        if not sys.stdin.isatty():
+            return False
         return typer.confirm(f"Apply repair for {check.label}: {shlex.join(check.repair)}?", default=False)
 
     outcomes = repair_runtime(checks, approve=approve)
@@ -215,13 +217,33 @@ def _shown(path: Path) -> str:
         return os.path.relpath(path, Path.cwd())
 
 
-def handle_doctor(*, fix: bool = False, yes: bool = False):
+def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = False):
     """Run comprehensive diagnostics on ConnectOnion installation.
 
     TODO: Replace manual checks with `co ai` powered diagnosis —
     let an LLM agent inspect the environment, interpret errors,
     and suggest fixes conversationally.
     """
+    if json_output:
+        import json
+        import subprocess
+
+        from .doctor_runtime import runtime_json_report
+
+        def quiet_run(command, **kwargs):
+            return subprocess.run(
+                command,
+                **kwargs,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+        report, code = runtime_json_report(fix=fix, approved=yes, run=quiet_run)
+        # stdout.write, not Rich: wrapping or styling would make the document
+        # invalid JSON for the CI/support-bundle consumer this mode exists for.
+        sys.stdout.write(json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n")
+        return code
+
     if fix:
         _repair_runtime(yes=yes)
 

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -278,32 +278,55 @@ def handle_doctor():
     else:
         config_table.add_row("Keys", "[yellow]○[/yellow] Not found (run 'co auth' to create)")
 
-    # Check for API key
-    api_key = os.getenv("OPENONION_API_KEY")
-    if api_key:
-        api_key_display = f"{api_key[:20]}..." if len(api_key) > 20 else api_key
-        config_table.add_row("API Key", f"[green]✓[/green] Found in environment")
-        config_table.add_row("Key Preview", f"[dim]{api_key_display}[/dim]")
-    else:
-        # Check .env files
-        from dotenv import load_dotenv
-        local_env = Path(".env")
-        global_env = Path.home() / ".co" / "keys.env"
+    # The same redacted discovery `co status` uses. Doctor used to print the
+    # first 20 characters of OPENONION_API_KEY as a "preview" in normal output;
+    # that is enough credential material to leak into support logs and has no
+    # diagnostic value.
+    from .status_commands import _credential_rows, _oauth_rows
 
-        if local_env.exists():
-            load_dotenv(local_env)
+    credential_actions = {
+        "OPENONION_API_KEY": "co auth",
+        "OPENAI_API_KEY": "set OPENAI_API_KEY in <project>/.env",
+        "ANTHROPIC_API_KEY": "set ANTHROPIC_API_KEY in <project>/.env",
+        "GEMINI_API_KEY": "set GEMINI_API_KEY in <project>/.env",
+        "GOOGLE_API_KEY": "set GOOGLE_API_KEY in <project>/.env",
+        "GROQ_API_KEY": "set GROQ_API_KEY in <project>/.env",
+        "XAI_API_KEY": "set XAI_API_KEY in <project>/.env",
+        "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in <project>/.env",
+        "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
+    }
+    api_key = None
+    for row in _credential_rows(project_dir=project_co_dir().parent):
+        status = row["status"]
+        action = credential_actions[row["credential"]]
+        if status == "configured":
+            mark, style = "✓", "green"
+        elif status == "conflict":
+            mark, style = "✗", "red"
+            found.append(f"credential {row['credential']} is shadowed — {action}")
+        else:
+            mark, style = "○", "yellow"
+        config_table.add_row(
+            row["provider"],
+            f"[{style}]{mark}[/{style}] {status} · {row['source']} · {action}",
+        )
+        if row["credential"] == "OPENONION_API_KEY" and status == "configured":
+            # Presence gates the probe; the secret itself is never rendered.
+            # Normal CLI startup has already loaded the selected project env.
             api_key = os.getenv("OPENONION_API_KEY")
-            if api_key:
-                config_table.add_row("API Key", f"[green]✓[/green] Found in .env")
-
-        if not api_key and global_env.exists():
-            load_dotenv(global_env)
-            api_key = os.getenv("OPENONION_API_KEY")
-            if api_key:
-                config_table.add_row("API Key", f"[green]✓[/green] Found in ~/.co/keys.env")
-
-        if not api_key:
-            config_table.add_row("API Key", "[yellow]○[/yellow] Not configured (run 'co auth')")
+    for row in _oauth_rows(project_dir=project_co_dir().parent):
+        status = row["status"]
+        if status == "connected":
+            mark, style = "✓", "green"
+        elif status in {"conflict", "expired", "invalid expiry", "incomplete (scopes missing)"}:
+            mark, style = "✗", "red"
+            found.append(f"{row['provider']} is {status} — {row['action']}")
+        else:
+            mark, style = "○", "yellow"
+        config_table.add_row(
+            row["provider"],
+            f"[{style}]{mark}[/{style}] {status} · {row['source']} · {row['action']}",
+        )
 
     console.print(Panel(config_table, title="[bold]Configuration[/bold]", border_style="green"))
     console.print()

--- a/connectonion/cli/commands/doctor_runtime.py
+++ b/connectonion/cli/commands/doctor_runtime.py
@@ -1,0 +1,210 @@
+"""Deterministic browser/runtime checks and narrowly-scoped repairs for doctor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import platform
+import subprocess
+import sys
+from typing import Callable, Iterable
+
+
+PATCHRIGHT_VERSION = "1.61.2"
+SUPPORTED_SYSTEMS = {"Darwin", "Linux", "Windows"}
+
+
+@dataclass(frozen=True)
+class RuntimeCheck:
+    id: str
+    label: str
+    status: str
+    detail: str
+    repair: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class RepairOutcome:
+    id: str
+    label: str
+    outcome: str
+    detail: str
+
+
+def _linux_prerequisites(browser_path: str | None) -> RuntimeCheck:
+    if platform.system() != "Linux":
+        return RuntimeCheck("os-prerequisites", "OS prerequisites", "ok", "managed by the platform")
+    if not browser_path:
+        return RuntimeCheck(
+            "os-prerequisites",
+            "OS prerequisites",
+            "pending",
+            "checked after a browser is installed",
+        )
+    try:
+        result = subprocess.run(
+            ["ldd", browser_path], capture_output=True, text=True, timeout=10, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return RuntimeCheck(
+            "os-prerequisites",
+            "OS prerequisites",
+            "blocked",
+            "could not inspect browser libraries; run: python -m patchright install --with-deps chromium",
+        )
+    missing = sorted(
+        line.split("=>", 1)[0].strip()
+        for line in result.stdout.splitlines()
+        if "=> not found" in line
+    )
+    if missing:
+        return RuntimeCheck(
+            "os-prerequisites",
+            "OS prerequisites",
+            "blocked",
+            "missing libraries: " + ", ".join(missing)
+            + "; run: python -m patchright install --with-deps chromium",
+        )
+    if result.returncode:
+        return RuntimeCheck(
+            "os-prerequisites", "OS prerequisites", "blocked", "ldd could not inspect the browser"
+        )
+    return RuntimeCheck("os-prerequisites", "OS prerequisites", "ok", "browser libraries resolved")
+
+
+def runtime_checks() -> list[RuntimeCheck]:
+    """Inspect supported Python, package, platform, daemon, driver, and browser state."""
+    from ... import __version__
+    from ..browser_agent.daemon import _owner_alive, default_sock_path
+    from ...useful_tools.browser_tools.browser import (
+        driver_stealth_status,
+        installed_browser_path,
+    )
+
+    checks: list[RuntimeCheck] = []
+    python_ok = sys.version_info >= (3, 10)
+    checks.append(
+        RuntimeCheck(
+            "python",
+            "Python",
+            "ok" if python_ok else "unsupported",
+            f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+            + ("" if python_ok else "; ConnectOnion requires Python >=3.10"),
+        )
+    )
+    checks.append(RuntimeCheck("package", "ConnectOnion package", "ok", __version__))
+
+    system = platform.system() or "unknown"
+    system_supported = system in SUPPORTED_SYSTEMS
+    checks.append(
+        RuntimeCheck(
+            "platform",
+            "Operating system",
+            "ok" if system_supported else "unsupported",
+            system if system_supported else f"{system}; supported: Darwin, Linux, Windows",
+        )
+    )
+    safe_to_repair = python_ok and system_supported
+
+    driver_status, version, detail = driver_stealth_status()
+    if driver_status == "ok":
+        checks.append(RuntimeCheck("patchright", "Patchright", "ok", f"{version} · {detail}"))
+    else:
+        pip_command = [sys.executable, "-m", "pip", "install"]
+        if driver_status == "broken":
+            pip_command.extend(["--force-reinstall", "--no-cache-dir"])
+        pip_command.append(f"patchright=={PATCHRIGHT_VERSION}")
+        repair = tuple(pip_command) if safe_to_repair else None
+        checks.append(RuntimeCheck("patchright", "Patchright", driver_status, detail, repair))
+
+    browser_path = installed_browser_path() if driver_status != "missing" else None
+    checks.append(
+        RuntimeCheck("browser", "Browser binary", "ok", browser_path)
+        if browser_path
+        else RuntimeCheck(
+            "browser",
+            "Browser binary",
+            "missing",
+            "none installed for this user",
+            (sys.executable, "-m", "patchright", "install", "chromium")
+            if safe_to_repair
+            else None,
+        )
+    )
+
+    daemon_running = _owner_alive(default_sock_path())
+    checks.append(
+        RuntimeCheck(
+            "browser-daemon",
+            "Browser daemon",
+            "ok" if daemon_running else "idle",
+            "running" if daemon_running else "stopped; starts on demand",
+        )
+    )
+    checks.append(_linux_prerequisites(browser_path))
+    return checks
+
+
+def repair_runtime(
+    checks: Iterable[RuntimeCheck],
+    *,
+    approve: Callable[[RuntimeCheck], bool],
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    recheck: Callable[[], list[RuntimeCheck]] = runtime_checks,
+) -> list[RepairOutcome]:
+    """Apply approved known repairs, then classify every unhealthy item."""
+    checks = list(checks)
+    attempted: dict[str, str | None] = {}
+    declined: set[str] = set()
+
+    for check in checks:
+        if check.status in {"ok", "idle"}:
+            continue
+        if not check.repair:
+            continue
+        if not approve(check):
+            declined.add(check.id)
+            continue
+        try:
+            result = run(list(check.repair), check=False)
+            attempted[check.id] = None if result.returncode == 0 else f"command exited {result.returncode}"
+        except PermissionError:
+            attempted[check.id] = "permission denied"
+        except OSError as exc:
+            attempted[check.id] = f"could not start repair: {exc.strerror or type(exc).__name__}"
+
+    if attempted:
+        importlib.invalidate_caches()
+        try:
+            from ...useful_tools.browser_tools.browser import forget_browser_path
+
+            forget_browser_path()
+        except ImportError:
+            pass
+
+    after = {check.id: check for check in recheck()} if attempted else {check.id: check for check in checks}
+    outcomes: list[RepairOutcome] = []
+    for check in checks:
+        if check.status in {"ok", "idle"}:
+            continue
+        current = after.get(check.id)
+        if check.id in declined:
+            outcomes.append(RepairOutcome(check.id, check.label, "skipped", "not approved"))
+            continue
+        if check.id not in attempted:
+            if current and current.status in {"ok", "idle"}:
+                outcomes.append(RepairOutcome(check.id, check.label, "repaired", current.detail))
+            else:
+                outcomes.append(RepairOutcome(check.id, check.label, "skipped", check.detail))
+            continue
+        error = attempted[check.id]
+        if not error and current and current.status in {"ok", "idle"}:
+            outcomes.append(RepairOutcome(check.id, check.label, "repaired", current.detail))
+        else:
+            detail = error or (current.detail if current else "check did not return a result")
+            outcomes.append(RepairOutcome(check.id, check.label, "still-blocked", detail))
+    return outcomes
+
+
+def repairable_checks(checks: Iterable[RuntimeCheck]) -> list[RuntimeCheck]:
+    return [check for check in checks if check.repair]

--- a/connectonion/cli/commands/doctor_runtime.py
+++ b/connectonion/cli/commands/doctor_runtime.py
@@ -208,3 +208,82 @@ def repair_runtime(
 
 def repairable_checks(checks: Iterable[RuntimeCheck]) -> list[RuntimeCheck]:
     return [check for check in checks if check.repair]
+
+
+def _check_json(check: RuntimeCheck) -> dict:
+    return {
+        "id": check.id,
+        "label": check.label,
+        "status": check.status,
+        "detail": check.detail,
+    }
+
+
+def runtime_json_report(
+    *,
+    fix: bool,
+    approved: bool,
+    probe: Callable[[], list[RuntimeCheck]] | None = None,
+    run: Callable[..., subprocess.CompletedProcess] | None = None,
+) -> tuple[dict, int]:
+    """Return schema-v1 runtime diagnostics with no timestamps or secret values."""
+    probe = runtime_checks if probe is None else probe
+    run = subprocess.run if run is None else run
+    initial = probe()
+    plan = [
+        {
+            "check_id": check.id,
+            "label": check.label,
+            "command": list(check.repair),
+            "requires_approval": True,
+        }
+        for check in initial
+        if check.status not in {"ok", "idle"} and check.repair
+    ]
+    final = initial
+
+    def capture_recheck():
+        nonlocal final
+        final = probe()
+        return final
+
+    outcomes: list[RepairOutcome] = []
+    if fix:
+        outcomes = repair_runtime(
+            initial,
+            approve=lambda _check: approved,
+            run=run,
+            recheck=capture_recheck,
+        )
+
+    approval_required = bool(fix and plan and not approved)
+    blocked = [
+        check.id
+        for check in final
+        if check.status not in {"ok", "idle", "pending"}
+    ]
+    code = 1 if blocked or approval_required else 0
+    report = {
+        "schema_version": 1,
+        "command": "co doctor",
+        "fix_requested": fix,
+        "approved_noninteractive": approved,
+        "approval_required": approval_required,
+        "checks": [_check_json(check) for check in final],
+        "plan": plan,
+        "outcomes": [
+            {
+                "check_id": outcome.id,
+                "label": outcome.label,
+                "outcome": outcome.outcome,
+                "detail": outcome.detail,
+            }
+            for outcome in outcomes
+        ],
+        "summary": {
+            "status": "blocked" if code else "healthy",
+            "exit_code": code,
+            "blocked_check_ids": blocked,
+        },
+    }
+    return report, code

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -38,6 +38,17 @@ CREDENTIAL_ENV_VARS = (
     ("MISTRAL_API_KEY", "Mistral"),
 )
 
+OAUTH_CONNECTIONS = (
+    ("Google OAuth", "GOOGLE", "co auth google"),
+    ("Microsoft OAuth", "MICROSOFT", "co auth microsoft"),
+)
+
+_OAUTH_ENV_VARS = {
+    f"{prefix}_{suffix}"
+    for _provider, prefix, _action in OAUTH_CONNECTIONS
+    for suffix in ("ACCESS_TOKEN", "REFRESH_TOKEN", "TOKEN_EXPIRES_AT", "SCOPES", "EMAIL")
+}
+
 _PLACEHOLDER_VALUES = {
     "changeme",
     "replace-me",
@@ -74,7 +85,7 @@ def _read_credential_file(path: Path) -> dict[str, str]:
         values = dotenv_values(path, interpolate=False)
     except (OSError, UnicodeError):
         return {}
-    supported = {name for name, _provider in CREDENTIAL_ENV_VARS}
+    supported = {name for name, _provider in CREDENTIAL_ENV_VARS} | _OAUTH_ENV_VARS
     return {
         name: str(value)
         for name, value in values.items()
@@ -187,6 +198,76 @@ def _revealed_credential_rows(
                         "value": str(value),
                     }
                 )
+    return rows
+
+
+def _oauth_rows(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    now: float | None = None,
+) -> list[dict[str, str]]:
+    """Return redacted OAuth connection state using the same source precedence."""
+    import datetime
+    import time
+
+    sources = _credential_sources(project_dir=project_dir, home=home, environ=environ)
+    now = time.time() if now is None else now
+    rows = []
+    for provider, prefix, action in OAUTH_CONNECTIONS:
+        found = []
+        for source, values in sources:
+            access = values.get(f"{prefix}_ACCESS_TOKEN")
+            refresh = values.get(f"{prefix}_REFRESH_TOKEN")
+            if _is_configured(access) or _is_configured(refresh):
+                state = tuple(
+                    str(values.get(f"{prefix}_{suffix}") or "")
+                    for suffix in ("ACCESS_TOKEN", "REFRESH_TOKEN", "TOKEN_EXPIRES_AT", "SCOPES", "EMAIL")
+                )
+                found.append((source, state, values))
+
+        if not found:
+            rows.append({"provider": provider, "status": "missing", "source": "—", "action": action})
+            continue
+
+        unique_states = {state for _source, state, _values in found}
+        source_names = [source for source, *_rest in found]
+        if len(unique_states) > 1:
+            source = " + ".join(
+                f"{name} (used)" if index == 0 else name
+                for index, name in enumerate(source_names)
+            )
+            rows.append({"provider": provider, "status": "conflict", "source": source,
+                         "action": f"remove or update the shadowed value; then {action}"})
+            continue
+
+        source, state, values = found[0]
+        _access, refresh, _expires, scopes, _email = state
+        expires = values.get(f"{prefix}_TOKEN_EXPIRES_AT")
+        expired = False
+        invalid_expiry = False
+        if _is_configured(expires):
+            try:
+                expired = float(str(expires)) <= now
+            except ValueError:
+                try:
+                    parsed = datetime.datetime.fromisoformat(str(expires).replace("Z", "+00:00"))
+                    expired = parsed.timestamp() <= now
+                except ValueError:
+                    invalid_expiry = True
+
+        if not _is_configured(scopes):
+            status = "incomplete (scopes missing)"
+        elif invalid_expiry:
+            status = "invalid expiry"
+        elif expired and not _is_configured(refresh):
+            status = "expired"
+        elif expired:
+            status = "refresh available"
+        else:
+            status = "connected"
+        rows.append({"provider": provider, "status": status, "source": source, "action": action})
     return rows
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -295,6 +295,7 @@ def reset():
 def doctor(
     fix: bool = typer.Option(False, "--fix", help="Offer safe browser/runtime repairs"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Approve every offered repair"),
+    json_output: bool = typer.Option(False, "--json", help="Emit stable machine-readable output"),
 ):
     """Diagnose installation."""
     if yes and not fix:
@@ -303,7 +304,7 @@ def doctor(
     from .commands.doctor_commands import handle_doctor
     # The exit code is the whole point of running this in a script: it used to
     # be 0 even under its own `✗ broken symlink`.
-    if handle_doctor(fix=fix, yes=yes):
+    if handle_doctor(fix=fix, yes=yes, json_output=json_output):
         raise typer.Exit(1)
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -292,12 +292,18 @@ def reset():
 
 
 @app.command()
-def doctor():
+def doctor(
+    fix: bool = typer.Option(False, "--fix", help="Offer safe browser/runtime repairs"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Approve every offered repair"),
+):
     """Diagnose installation."""
+    if yes and not fix:
+        console.print("[red]--yes requires --fix.[/red]")
+        raise typer.Exit(2)
     from .commands.doctor_commands import handle_doctor
     # The exit code is the whole point of running this in a script: it used to
     # be 0 even under its own `✗ broken symlink`.
-    if handle_doctor():
+    if handle_doctor(fix=fix, yes=yes):
         raise typer.Exit(1)
 
 

--- a/tests/unit/test_doctor_credentials_are_redacted.py
+++ b/tests/unit/test_doctor_credentials_are_redacted.py
@@ -1,0 +1,127 @@
+"""Credential diagnostics must be useful without becoming a secret leak."""
+
+from types import SimpleNamespace
+
+from connectonion.cli.commands.status_commands import _oauth_rows
+
+
+def _oauth(rows, provider):
+    return next(row for row in rows if row["provider"] == provider)
+
+
+def test_oauth_reports_missing_connected_expired_and_refreshable(tmp_path):
+    missing = _oauth_rows(project_dir=tmp_path, home=tmp_path, environ={}, now=100)
+    assert _oauth(missing, "Google OAuth")["status"] == "missing"
+
+    connected = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "access-secret",
+            "GOOGLE_TOKEN_EXPIRES_AT": "200",
+            "GOOGLE_SCOPES": "gmail.send",
+        },
+        now=100,
+    )
+    assert _oauth(connected, "Google OAuth")["status"] == "connected"
+
+    expired = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "MICROSOFT_ACCESS_TOKEN": "expired-secret",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "50",
+            "MICROSOFT_SCOPES": "Mail.Send",
+        },
+        now=100,
+    )
+    assert _oauth(expired, "Microsoft OAuth")["status"] == "expired"
+
+    refreshable = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "MICROSOFT_ACCESS_TOKEN": "expired-secret",
+            "MICROSOFT_REFRESH_TOKEN": "refresh-secret",
+            "MICROSOFT_TOKEN_EXPIRES_AT": "50",
+            "MICROSOFT_SCOPES": "Mail.Send",
+        },
+        now=100,
+    )
+    assert _oauth(refreshable, "Microsoft OAuth")["status"] == "refresh available"
+
+    incomplete = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={"GOOGLE_ACCESS_TOKEN": "access-without-scopes"},
+        now=100,
+    )
+    assert _oauth(incomplete, "Google OAuth")["status"] == "incomplete (scopes missing)"
+
+    invalid = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path,
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "access-secret",
+            "GOOGLE_SCOPES": "gmail.send",
+            "GOOGLE_TOKEN_EXPIRES_AT": "not-a-date",
+        },
+        now=100,
+    )
+    assert _oauth(invalid, "Google OAuth")["status"] == "invalid expiry"
+
+
+def test_oauth_reports_which_source_shadows_another_without_values(tmp_path):
+    (tmp_path / ".env").write_text(
+        "GOOGLE_ACCESS_TOKEN=project-secret\n"
+        "GOOGLE_REFRESH_TOKEN=project-refresh\n",
+        encoding="utf-8",
+    )
+
+    rows = _oauth_rows(
+        project_dir=tmp_path,
+        home=tmp_path / "home",
+        environ={
+            "GOOGLE_ACCESS_TOKEN": "process-secret",
+            "GOOGLE_REFRESH_TOKEN": "process-refresh",
+            "GOOGLE_SCOPES": "gmail.send",
+        },
+        now=100,
+    )
+    row = _oauth(rows, "Google OAuth")
+
+    assert row["status"] == "conflict"
+    assert "process environment (used)" in row["source"]
+    assert "<project>/.env" in row["source"]
+    rendered = repr(rows)
+    for secret in ("process-secret", "process-refresh", "project-secret", "project-refresh"):
+        assert secret not in rendered
+
+
+def test_doctor_never_renders_an_api_key_preview(tmp_path, monkeypatch, capsys):
+    from connectonion.cli.commands import doctor_commands
+    from connectonion.useful_tools.browser_tools import browser as browser_module
+
+    secret = "oo_live_abcdefghijklmnopqrstuvwxyz0123456789"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("OPENONION_API_KEY", secret)
+    monkeypatch.setattr(
+        browser_module,
+        "driver_stealth_status",
+        lambda: ("missing", None, "patchright not installed"),
+    )
+    monkeypatch.setattr(
+        doctor_commands.requests,
+        "get",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=200),
+    )
+
+    doctor_commands.handle_doctor()
+    output = capsys.readouterr().out
+
+    assert "OpenOnion" in output
+    assert "configured" in output
+    assert "Key Preview" not in output
+    assert secret not in output
+    assert secret[:20] not in output

--- a/tests/unit/test_doctor_fix_cli.py
+++ b/tests/unit/test_doctor_fix_cli.py
@@ -1,5 +1,6 @@
 """CLI contract for the explicit doctor repair mode."""
 
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from connectonion.cli.main import app
@@ -9,7 +10,7 @@ runner = CliRunner()
 
 
 def test_help_exposes_fix_and_explicit_noninteractive_approval():
-    output = runner.invoke(app, ["doctor", "--help"]).output
+    output = strip_ansi(runner.invoke(app, ["doctor", "--help"]).output)
 
     assert "--fix" in output
     assert "--yes" in output

--- a/tests/unit/test_doctor_fix_cli.py
+++ b/tests/unit/test_doctor_fix_cli.py
@@ -1,0 +1,22 @@
+"""CLI contract for the explicit doctor repair mode."""
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+
+runner = CliRunner()
+
+
+def test_help_exposes_fix_and_explicit_noninteractive_approval():
+    output = runner.invoke(app, ["doctor", "--help"]).output
+
+    assert "--fix" in output
+    assert "--yes" in output
+
+
+def test_yes_without_fix_fails_closed():
+    result = runner.invoke(app, ["doctor", "--yes"])
+
+    assert result.exit_code == 2
+    assert "--yes requires --fix" in result.output

--- a/tests/unit/test_doctor_fix_cli.py
+++ b/tests/unit/test_doctor_fix_cli.py
@@ -13,6 +13,7 @@ def test_help_exposes_fix_and_explicit_noninteractive_approval():
 
     assert "--fix" in output
     assert "--yes" in output
+    assert "--json" in output
 
 
 def test_yes_without_fix_fails_closed():

--- a/tests/unit/test_doctor_json.py
+++ b/tests/unit/test_doctor_json.py
@@ -1,0 +1,106 @@
+"""Stable JSON and fail-closed semantics for scriptable doctor repairs."""
+
+import json
+import subprocess
+
+from typer.testing import CliRunner
+
+from connectonion.cli.commands.doctor_runtime import RuntimeCheck, runtime_json_report
+from connectonion.cli.main import app
+
+
+def _missing():
+    return [
+        RuntimeCheck("python", "Python", "ok", "3.10.13"),
+        RuntimeCheck(
+            "browser",
+            "Browser binary",
+            "missing",
+            "none installed",
+            ("python", "-m", "patchright", "install", "chromium"),
+        ),
+        RuntimeCheck("platform", "Operating system", "ok", "Linux"),
+    ]
+
+
+def test_same_state_produces_the_same_ordered_schema():
+    first, first_code = runtime_json_report(fix=False, approved=False, probe=_missing)
+    second, second_code = runtime_json_report(fix=False, approved=False, probe=_missing)
+
+    assert first == second
+    assert first_code == second_code == 1
+    assert list(first) == [
+        "schema_version",
+        "command",
+        "fix_requested",
+        "approved_noninteractive",
+        "approval_required",
+        "checks",
+        "plan",
+        "outcomes",
+        "summary",
+    ]
+    assert [check["id"] for check in first["checks"]] == ["python", "browser", "platform"]
+    assert first["schema_version"] == 1
+    assert "generated_at" not in first
+
+
+def test_noninteractive_fix_without_yes_fails_closed():
+    calls = []
+    report, code = runtime_json_report(
+        fix=True,
+        approved=False,
+        probe=_missing,
+        run=lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+
+    assert code == 1
+    assert calls == []
+    assert report["approval_required"] is True
+    assert report["outcomes"][0]["outcome"] == "skipped"
+    assert report["outcomes"][0]["detail"] == "not approved"
+
+
+def test_explicit_yes_records_the_command_and_repair_result():
+    states = [_missing(), [
+        RuntimeCheck("python", "Python", "ok", "3.10.13"),
+        RuntimeCheck("browser", "Browser binary", "ok", "/user/chromium"),
+        RuntimeCheck("platform", "Operating system", "ok", "Linux"),
+    ]]
+    calls = []
+
+    def probe():
+        return states.pop(0)
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    report, code = runtime_json_report(fix=True, approved=True, probe=probe, run=run)
+
+    assert code == 0
+    assert calls == [["python", "-m", "patchright", "install", "chromium"]]
+    assert report["plan"][0]["command"] == calls[0]
+    assert report["outcomes"][0]["outcome"] == "repaired"
+    assert report["summary"] == {
+        "status": "healthy",
+        "exit_code": 0,
+        "blocked_check_ids": [],
+    }
+
+
+def test_cli_json_is_one_parseable_document(monkeypatch):
+    from connectonion.cli.commands import doctor_runtime
+
+    healthy = lambda: [RuntimeCheck("python", "Python", "ok", "3.10.13")]
+    monkeypatch.setattr(doctor_runtime, "runtime_checks", healthy)
+    secret = "oo_live_must_never_enter_the_support_bundle"
+    monkeypatch.setenv("OPENONION_API_KEY", secret)
+
+    result = CliRunner().invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 0
+    document = json.loads(result.output)
+    assert document["schema_version"] == 1
+    assert result.output.count("\n") == 1
+    assert secret not in result.output

--- a/tests/unit/test_doctor_runtime_repair.py
+++ b/tests/unit/test_doctor_runtime_repair.py
@@ -1,0 +1,141 @@
+"""`co doctor --fix` only applies approved, deterministic runtime repairs."""
+
+import subprocess
+
+from connectonion.cli.commands.doctor_runtime import (
+    PATCHRIGHT_VERSION,
+    RuntimeCheck,
+    repair_runtime,
+)
+
+
+def _completed(_command, **_kwargs):
+    return subprocess.CompletedProcess([], 0)
+
+
+def test_a_fresh_runtime_is_repaired_in_one_invocation():
+    missing = [
+        RuntimeCheck(
+            "patchright",
+            "Patchright",
+            "missing",
+            "not installed",
+            ("python", "-m", "pip", "install", f"patchright=={PATCHRIGHT_VERSION}"),
+        ),
+        RuntimeCheck(
+            "browser",
+            "Browser binary",
+            "missing",
+            "not installed",
+            ("python", "-m", "patchright", "install", "chromium"),
+        ),
+    ]
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return _completed(command, **kwargs)
+
+    healthy = lambda: [
+        RuntimeCheck("patchright", "Patchright", "ok", PATCHRIGHT_VERSION),
+        RuntimeCheck("browser", "Browser binary", "ok", "/user/chromium"),
+    ]
+    outcomes = repair_runtime(missing, approve=lambda _check: True, run=run, recheck=healthy)
+
+    assert calls == [list(check.repair) for check in missing]
+    assert [outcome.outcome for outcome in outcomes] == ["repaired", "repaired"]
+
+
+def test_repeated_runs_are_idempotent():
+    calls = []
+    checks = [RuntimeCheck("browser", "Browser binary", "ok", "/user/chromium")]
+
+    outcomes = repair_runtime(
+        checks,
+        approve=lambda _check: True,
+        run=lambda *args, **kwargs: calls.append((args, kwargs)),
+        recheck=lambda: checks,
+    )
+
+    assert calls == []
+    assert outcomes == []
+
+
+def test_unsupported_items_are_skipped_without_a_command():
+    calls = []
+    check = RuntimeCheck("platform", "Operating system", "unsupported", "Plan 9")
+
+    outcomes = repair_runtime(
+        [check],
+        approve=lambda _check: True,
+        run=lambda *args, **kwargs: calls.append((args, kwargs)),
+        recheck=lambda: [check],
+    )
+
+    assert calls == []
+    assert outcomes[0].outcome == "skipped"
+    assert "Plan 9" in outcomes[0].detail
+
+
+def test_permission_denied_is_still_blocked_without_a_traceback():
+    check = RuntimeCheck(
+        "browser",
+        "Browser binary",
+        "missing",
+        "not installed",
+        ("python", "-m", "patchright", "install", "chromium"),
+    )
+
+    def denied(*_args, **_kwargs):
+        raise PermissionError("secret local path must not be rendered")
+
+    outcomes = repair_runtime(
+        [check], approve=lambda _check: True, run=denied, recheck=lambda: [check]
+    )
+
+    assert outcomes[0].outcome == "still-blocked"
+    assert outcomes[0].detail == "permission denied"
+    assert "secret local path" not in outcomes[0].detail
+
+
+def test_declined_repairs_are_skipped():
+    check = RuntimeCheck(
+        "browser",
+        "Browser binary",
+        "missing",
+        "not installed",
+        ("python", "-m", "patchright", "install", "chromium"),
+    )
+
+    outcomes = repair_runtime(
+        [check], approve=lambda _check: False, run=_completed, recheck=lambda: [check]
+    )
+
+    assert outcomes[0].outcome == "skipped"
+    assert outcomes[0].detail == "not approved"
+
+
+def test_a_dependent_check_is_reclassified_after_repair():
+    browser = RuntimeCheck(
+        "browser",
+        "Browser binary",
+        "missing",
+        "not installed",
+        ("python", "-m", "patchright", "install", "chromium"),
+    )
+    prerequisites = RuntimeCheck(
+        "os-prerequisites", "OS prerequisites", "pending", "checked after install"
+    )
+    after = [
+        RuntimeCheck("browser", "Browser binary", "ok", "/user/chromium"),
+        RuntimeCheck("os-prerequisites", "OS prerequisites", "ok", "libraries resolved"),
+    ]
+
+    outcomes = repair_runtime(
+        [browser, prerequisites],
+        approve=lambda _check: True,
+        run=_completed,
+        recheck=lambda: after,
+    )
+
+    assert [outcome.outcome for outcome in outcomes] == ["repaired", "repaired"]


### PR DESCRIPTION
Implements #469 as the third doctor stack layer. Merge order: #758 (redacted credential diagnostics), then #759 (runtime checks/repairs), then this PR.

Adds `co doctor --json` schema v1 with deterministic ordered checks and repair plan, recorded outcomes, blocked IDs, and no timestamps. JSON mode writes exactly one compact JSON document; repair subprocess output is suppressed so it cannot corrupt the document or leak into a support bundle.

Safety:
- `--json --fix` never prompts; without `--yes` it executes nothing, records `approval_required`/`skipped`, and exits nonzero
- normal `--fix` requires approval for each mutation and treats non-TTY stdin as denial
- `--yes` without `--fix` exits 2
- environment credentials are excluded from the runtime JSON report

Validation:
- 24 focused JSON/repair tests passed
- 185 doctor/status/browser-related unit tests passed with isolated HOME
- deterministic schema/order, idempotency, fail-closed approval, recorded command/result, one-document parsing, and secret exclusion covered
- `py_compile` and `git diff --check` passed

Closes #469 after #758 and #759 are merged.