### PR TITLE
Deliver runtime input before a turn closes

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -449,10 +449,9 @@ class Agent:
             if not response.tool_calls:
                 content = response.content or ""
                 self.current_session['messages'].append({"role": "assistant", "content": content})
-                return content
-
-            # Process tool calls
-            self._execute_and_record_tools(response.tool_calls)
+            else:
+                # Process tool calls
+                self._execute_and_record_tools(response.tool_calls)
 
             # Fire after_iteration
             self._invoke_events('after_iteration')
@@ -461,6 +460,14 @@ class Agent:
             if self.current_session.pop('stop_signal', None):
                 self._invoke_events('on_stop_signal')
                 return "What would you like me to do?"
+
+            if not response.tool_calls:
+                if self.current_session.pop('_continue_iteration', False):
+                    # An accepted follow-up is new work. Give it the LLM call it
+                    # needs even when the original request used its full budget.
+                    max_iterations += 1
+                    continue
+                return content
 
         # Hit max iterations
         return f"Task incomplete: Maximum iterations ({max_iterations}) reached."

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -2,7 +2,7 @@
 Purpose: Agent thread orchestration + io → client streaming — the bridge between the sync agent and the async transport
 LLM-Note:
   Dependencies: imports from [...io (WebSocketIO), ..session (session_to_chat_items via lazy import), asyncio, threading, rich.console] | imported by [.session (start_agent), .connect (resume_forwarding)]
-  Data flow: start_agent: validate INPUT → create WebSocketIO → register in registry BEFORE thread.start (race-safe) → spawn _agent_thread_body (thread target running route_handlers["ws_input"]) → spawn forward_task = forward_agent_msgs_to_client → return (io, task) | resume_forwarding: same forward_task spawn but on existing active.io | forward_agent_msgs_to_client: read_msgs_from_agent → send_msg loop → on agent finish read result_holder → emit OUTPUT (success) / ERROR (exception)
+  Data flow: start_agent: validate INPUT → create WebSocketIO → register in registry BEFORE thread.start (race-safe) → spawn _agent_thread_body (thread target running route_handlers["ws_input"]) → success or exception always returns registry to connected → spawn forward_task = forward_agent_msgs_to_client → return (io, task) | resume_forwarding: same forward_task spawn but on existing active.io | forward_agent_msgs_to_client: read_msgs_from_agent → send_msg loop → on agent finish read result_holder → emit OUTPUT (success) / ERROR (exception)
   State/Effects: spawns daemon Thread + asyncio.Task | mutates registry (register / mark_session_running) | calls io.mark_agent_done() in finally
   Integration: start_agent(data, send_msg, conn, route_handlers, storage, registry) → (io, forward_task) | None | resume_forwarding(send_msg, active, registry, session_id, storage, conn) → (io, forward_task) | forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder, conn, storage) — async, runs until io marked done
   Performance: thread-per-INPUT (worker isolation) | one forward_task per WS connection
@@ -22,10 +22,12 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
     try:
         result_holder[0] = route_handlers["ws_input"](storage, prompt, io, session, images, files,
                                                       requester_address=requester_address)
-        registry.mark_session_connected(session_id)
     except Exception as e:
         result_holder[0] = e
     finally:
+        # A failed run is finished too. Leaving it marked "running" routes the
+        # next INPUT into a dead IO queue and creates another false ACK.
+        registry.mark_session_connected(session_id)
         io.mark_agent_done()
 
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -105,9 +105,20 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                         await send_msg({"type": "ERROR", "message": "prompt required"})
                     else:
                         rid = str(uuid.uuid4())
-                        existing.io.push_runtime_input({"type": "RUNTIME_INPUT", "id": rid, "prompt": prompt})
-                        console.print(f"[yellow]↳ RUNTIME_INPUT[/yellow] session={sid[:8]}... prompt={prompt[:50]}...")
-                        await send_msg({"type": "RUNTIME_INPUT_ACK", "session_id": sid, "id": rid})
+                        accepted = existing.io.push_runtime_input({
+                            "type": "RUNTIME_INPUT", "id": rid, "prompt": prompt,
+                        })
+                        if accepted is not False:
+                            console.print(f"[yellow]↳ RUNTIME_INPUT[/yellow] session={sid[:8]}... prompt={prompt[:50]}...")
+                            await send_msg({"type": "RUNTIME_INPUT_ACK", "session_id": sid, "id": rid})
+                        else:
+                            await send_msg({
+                                "type": "ERROR",
+                                "code": "RUNTIME_INPUT_REJECTED",
+                                "message": "running turn is not accepting runtime input; retry after OUTPUT",
+                                "session_id": sid,
+                                "retryable": True,
+                            })
                 else:
                     result = await start_agent(data, send_msg, conn, route_handlers, storage, registry)
                     if result:

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [network/io/base.IO, asyncio, threading, time, uuid] | imported by [network/host/ws_router/agent_io.py] | tested by [tests/unit/test_io.py, tests/unit/test_io_image_support.py]
   Data flow: agent calls io.send(event) → auto-stamps id (UUID) and ts if missing → enqueues for async forwarder | client message → enqueued for agent | read_msgs_from_agent() async-iterates outgoing for forwarding to client | send_to_agent() pushes incoming messages to agent
   State/Effects: maintains incoming + outgoing channels (async-safe) | finished flag prevents sends after close | unblocks agent's blocking receive on close
-  Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs for mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
+  Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs/finish_runtime_inputs for lossless mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
   Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread | _wait_for_msgs_from_agent waits at most ~1s so idle-session forwarders don't pin executor-pool threads
   Errors: closed IO unblocks pending receive() so agent thread doesn't hang | no exceptions raised — channel coordination handled internally
 """
@@ -40,6 +40,9 @@ class WebSocketIO(IO):
         # ── Runtime input (client→agent, separate from receive()) ──
         self._runtime_inputs: list[Dict[str, Any]] = []
         self._runtime_input_lock = threading.Lock()
+        # Runtime input is opt-in. The plugin opens this at each turn boundary;
+        # without it, the host must reject rather than ACK a queue nobody drains.
+        self._accepting_runtime_inputs = False
 
         self._closed = False
 
@@ -105,10 +108,13 @@ class WebSocketIO(IO):
             self._msgs_from_client.append(msg)
             self._client_condition.notify_all()
 
-    def push_runtime_input(self, msg: Dict[str, Any]) -> None:
-        """Queue a mid-execution user message; agent drains at next iteration."""
+    def push_runtime_input(self, msg: Dict[str, Any]) -> bool:
+        """Queue mid-execution input only while the current turn can consume it."""
         with self._runtime_input_lock:
+            if not self._accepting_runtime_inputs:
+                return False
             self._runtime_inputs.append(msg)
+            return True
 
     def pop_runtime_inputs(self) -> list[Dict[str, Any]]:
         """Drain queued runtime inputs (agent calls at iteration start)."""
@@ -116,6 +122,25 @@ class WebSocketIO(IO):
             result = list(self._runtime_inputs)
             self._runtime_inputs.clear()
             return result
+
+    def finish_runtime_inputs(self) -> list[Dict[str, Any]]:
+        """Atomically drain pending input or seal a turn that has none left.
+
+        A non-empty result keeps acceptance open because the agent will run
+        another iteration. An empty result seals the window, so transport code
+        rejects rather than falsely acknowledges a too-late message.
+        """
+        with self._runtime_input_lock:
+            result = list(self._runtime_inputs)
+            self._runtime_inputs.clear()
+            if not result:
+                self._accepting_runtime_inputs = False
+            return result
+
+    def open_runtime_inputs(self) -> None:
+        """Open a fresh turn's runtime-input window on a reused IO instance."""
+        with self._runtime_input_lock:
+            self._accepting_runtime_inputs = True
 
     def rewind_to(self, last_msg_id=None):
         """Rewind cursor for replay on reconnect. None or unknown id → replay all."""

--- a/connectonion/useful_plugins/no_progress_guard.py
+++ b/connectonion/useful_plugins/no_progress_guard.py
@@ -42,13 +42,16 @@ def _last_tool_signature(messages):
     tool_executor), which makes a repeated identical call serialize byte-for-byte.
     """
     for message in reversed(messages):
-        if message.get('role') == 'assistant' and message.get('tool_calls'):
-            return json.dumps(
-                [
-                    [tc['function']['name'], tc['function'].get('arguments', '')]
-                    for tc in message['tool_calls']
-                ]
-            )
+        if message.get('role') != 'assistant':
+            continue
+        if not message.get('tool_calls'):
+            return None
+        return json.dumps(
+            [
+                [tc['function']['name'], tc['function'].get('arguments', '')]
+                for tc in message['tool_calls']
+            ]
+        )
     return None
 
 

--- a/connectonion/useful_plugins/runtime_input.py
+++ b/connectonion/useful_plugins/runtime_input.py
@@ -1,16 +1,16 @@
 """
-Purpose: Apply mid-execution user input from io to message history at iteration boundaries
+Purpose: Apply mid-execution user input without losing final-iteration arrivals
 LLM-Note:
-  Dependencies: imports from [core/events (before_iteration)] | imported by [useful_plugins/__init__.py] | tested by [tests/unit/test_runtime_input.py]
-  Data flow: ws_router pushes runtime input to agent.io._runtime_inputs via push_runtime_input() → @before_iteration handler pulls them at iteration start → wrapped in RUNTIME_INPUT_FRAME_PREFIX (additive framing for LLM) → appended to messages as user role → user_input trace emitted with runtime_input: true → session_to_chat_items strips prefix when rendering user bubble
+  Dependencies: imports from [core/events (after_user_input, before_iteration, after_iteration)] | imported by [useful_plugins/__init__.py] | tested by [tests/unit/test_runtime_input.py]
+  Data flow: ws_router pushes accepted runtime input to agent.io → @before_iteration drains ordinary arrivals; @after_iteration atomically drains-or-seals a final no-tool response → pending final input sets _continue_iteration so the LLM answers it → framed user message + trace → session_to_chat_items strips the frame prefix
   State/Effects: mutates agent.current_session['messages'] | emits user_input trace events
-  Integration: exports runtime_input plugin (single before_iteration handler) + RUNTIME_INPUT_FRAME_PREFIX constant | plugin opt-in via Agent(plugins=[runtime_input]) for hosted agents that should accept mid-execution user input
+  Integration: exports runtime_input plugin (turn-open, iteration-start, final-boundary handlers) + RUNTIME_INPUT_FRAME_PREFIX constant | plugin opt-in via Agent(plugins=[runtime_input]) for hosted agents that should accept mid-execution user input
   Errors: silent no-op when agent.io is None or doesn't support pop_runtime_inputs
 """
 
 from typing import TYPE_CHECKING
 
-from ..core.events import before_iteration
+from ..core.events import after_iteration, after_user_input, before_iteration
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -24,15 +24,14 @@ RUNTIME_INPUT_FRAME_PREFIX = (
 )
 
 
-@before_iteration
-def apply_runtime_input(agent: "Agent") -> None:
-    """Pull mid-execution user messages from io and append to message history."""
-    if not agent.io or not hasattr(agent.io, 'pop_runtime_inputs'):
-        return
-    for msg in agent.io.pop_runtime_inputs():
+def _append_runtime_inputs(agent: "Agent", messages: list[dict]) -> bool:
+    """Append a drained batch and report whether it contained usable input."""
+    appended = False
+    for msg in messages:
         prompt = msg.get('prompt')
         if not prompt:
             continue
+        appended = True
         framed = RUNTIME_INPUT_FRAME_PREFIX + prompt
         agent.current_session['messages'].append({"role": "user", "content": framed})
         agent._record_trace({
@@ -43,6 +42,44 @@ def apply_runtime_input(agent: "Agent") -> None:
             'iteration': agent.current_session['iteration'],
             'runtime_input': True,
         })
+    return appended
 
 
-runtime_input = [apply_runtime_input]
+@after_user_input
+def open_runtime_input_window(agent: "Agent") -> None:
+    """Re-open acceptance when a reused IO starts another agent turn."""
+    opener = getattr(agent.io, 'open_runtime_inputs', None) if agent.io else None
+    if opener:
+        opener()
+
+
+@before_iteration
+def apply_runtime_input(agent: "Agent") -> None:
+    """Pull input queued before an iteration starts."""
+    if not agent.io or not hasattr(agent.io, 'pop_runtime_inputs'):
+        return
+    _append_runtime_inputs(agent, agent.io.pop_runtime_inputs())
+
+
+@after_iteration
+def apply_runtime_input_before_completion(agent: "Agent") -> None:
+    """Drain input that arrived during a final no-tool LLM call."""
+    messages = agent.current_session.get('messages', [])
+    if not messages or messages[-1].get('role') != 'assistant':
+        return
+    if messages[-1].get('tool_calls'):
+        return
+    if not agent.io or not hasattr(agent.io, 'pop_runtime_inputs'):
+        return
+
+    finish = getattr(agent.io, 'finish_runtime_inputs', None)
+    pending = finish() if finish else agent.io.pop_runtime_inputs()
+    if _append_runtime_inputs(agent, pending):
+        agent.current_session['_continue_iteration'] = True
+
+
+runtime_input = [
+    open_runtime_input_window,
+    apply_runtime_input,
+    apply_runtime_input_before_completion,
+]

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -478,14 +478,20 @@ The hosted IO implementation (`WebSocketIO`) bridges sync agent code to async We
 Agent Thread (sync)              Async forwarder / router
   io.send(event)   ──►  _msgs_from_agent (append-only log) ──► forward_task ──► ws.send()
   io.receive()     ◄──  _msgs_from_client (mailbox)        ◄── send_to_agent (router)
-  io.pop_runtime_inputs() ◄── _runtime_inputs (drain queue) ◄── push_runtime_input (router)
+  pop/finish_runtime_inputs() ◄── _runtime_inputs (drain queue) ◄── push_runtime_input (router)
 ```
 
 | Channel | Direction | Storage | Reader / Writer |
 |---|---|---|---|
 | `_msgs_from_agent` | agent → client | append-only list, cursor-indexed for replay on reconnect | written by `io.send`, read by `forward_task` via `read_msgs_from_agent` |
 | `_msgs_from_client` | client → agent | mailbox, consumed on read (e.g. `ASK_USER_RESPONSE`) | written by `send_to_agent`, read by blocking `io.receive` |
-| `_runtime_inputs` | client → agent | drain-all queue, separate from receive() so ask_user pops don't eat them | written by `push_runtime_input`, drained by `apply_runtime_input` plugin at iteration boundary |
+| `_runtime_inputs` | client → agent | drain-all queue, separate from `receive()`, with an atomic acceptance boundary | written by `push_runtime_input`; drained by the `runtime_input` plugin at iteration start and immediately before a final no-tool response completes |
+
+The runtime-input window is opt-in. The plugin opens it for a turn, and the
+router acknowledges an input only if `push_runtime_input()` accepts it. At a
+final no-tool response, `finish_runtime_inputs()` either drains pending input
+and keeps the turn alive for another LLM call, or seals the empty queue so a
+late sender receives retryable `RUNTIME_INPUT_REJECTED` rather than a false ACK.
 
 ### Cursor-based replay
 

--- a/docs/network/protocol.md
+++ b/docs/network/protocol.md
@@ -177,9 +177,9 @@ Two paths depending on whether an agent is already running:
 6. Spawn `forward_task = asyncio.create_task(forward_agent_msgs_to_client(...))` to pipe `io.read_msgs_from_agent()` events out via `send_msg`. On agent completion, sends `OUTPUT` (or `ERROR` on exception).
 
 **Runtime input (inline in `session.py`)** when `existing.status == 'running'`:
-1. Push `{type: RUNTIME_INPUT, id, prompt}` onto `existing.io._runtime_inputs` (separate queue from `receive()`'s mailbox to avoid being eaten by ask_user/approval pops).
-2. Reply `RUNTIME_INPUT_ACK`. No new agent thread, no new OUTPUT cycle.
-3. The agent's `apply_runtime_input` plugin (in `useful_plugins/runtime_input.py`) drains the queue at the next iteration boundary and appends each prompt to message history with an additive framing prefix.
+1. Atomically offer `{type: RUNTIME_INPUT, id, prompt}` to `existing.io._runtime_inputs` (separate from `receive()`'s mailbox so ask-user/approval reads cannot consume it).
+2. Reply `RUNTIME_INPUT_ACK` only when the running turn is still accepting input. A sealed turn, or an agent without the `runtime_input` plugin, receives retryable `RUNTIME_INPUT_REJECTED` instead.
+3. The `runtime_input` plugin drains ordinary arrivals at the next iteration boundary. Before a no-tool response completes, it performs one final atomic drain-or-seal; pending input extends the same turn for another LLM answer.
 
 See [websocket-protocol.md](websocket-protocol.md) for full message reference.
 
@@ -200,9 +200,9 @@ Agent thread                          Async event loop                 Client
      │  (block until client sends, e.g.      │  (per-message dispatch     │
      │   ASK_USER_RESPONSE)                  │   in run_ws_session)          │
      │                                       │                            │
-     │  io.pop_runtime_inputs() (separate    │   push_runtime_input from  │
-     │  queue, drained at iteration start    │   INPUT-during-running     │
-     │  by apply_runtime_input plugin)       │   inline branch            │
+     │  pop/finish_runtime_inputs()          │   push_runtime_input from  │
+     │  (drained at iteration start and      │   INPUT-during-running;    │
+     │   atomically before completion)       │   ACK only when accepted   │
 ```
 
 Three independent channels on one `WebSocketIO`:
@@ -211,7 +211,7 @@ Three independent channels on one `WebSocketIO`:
 |---|---|---|---|
 | `_msgs_from_agent` | agent → client | append-only list, cursor-indexed for replay | written by `io.send`, read by `forward_task` via `read_msgs_from_agent` |
 | `_msgs_from_client` | client → agent | mailbox (consumed on read) | written by `send_to_agent`, read by `io.receive` (blocking) |
-| `_runtime_inputs` | client → agent | drain-all queue | written by `push_runtime_input`, drained by `apply_runtime_input` plugin |
+| `_runtime_inputs` | client → agent | drain-all queue with an atomic acceptance boundary | written by `push_runtime_input`; drained at iteration start and before final completion by the `runtime_input` plugin |
 
 ---
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -101,6 +101,28 @@ class TestWebSocketIO:
         assert not thread.is_alive()
         assert result_holder[0] == {"approved": True}
 
+    def test_runtime_input_completion_boundary_is_atomic(self):
+        """A message is either accepted for this turn or explicitly rejected."""
+        io = WebSocketIO()
+
+        # Agents without the runtime_input plugin never open the window.
+        assert io.push_runtime_input({'id': 'disabled', 'prompt': 'zero'}) is False
+        io.open_runtime_inputs()
+        assert io.push_runtime_input({'id': 'first', 'prompt': 'one'}) is True
+        assert io.finish_runtime_inputs() == [
+            {'id': 'first', 'prompt': 'one'}
+        ]
+
+        # Pending work kept the turn open. Once an empty final check seals it,
+        # no later caller can receive a false-positive acknowledgement.
+        assert io.push_runtime_input({'id': 'second', 'prompt': 'two'}) is True
+        assert io.finish_runtime_inputs() == [
+            {'id': 'second', 'prompt': 'two'}
+        ]
+        assert io.finish_runtime_inputs() == []
+        assert io.push_runtime_input({'id': 'too-late', 'prompt': 'three'}) is False
+        assert io.pop_runtime_inputs() == []
+
 
 class TestReceiveAll:
     """Test receive_all() non-blocking message retrieval."""

--- a/tests/unit/test_no_progress_guard.py
+++ b/tests/unit/test_no_progress_guard.py
@@ -50,6 +50,14 @@ class TestLastToolSignature:
     def test_none_when_no_tool_calls(self):
         assert _last_tool_signature([{'role': 'user', 'content': 'hi'}]) is None
 
+    def test_final_assistant_answer_does_not_repeat_an_old_tool(self):
+        messages = [
+            _assistant_call('search', '{}'),
+            {'role': 'tool', 'content': 'result'},
+            {'role': 'assistant', 'content': 'done'},
+        ]
+        assert _last_tool_signature(messages) is None
+
 
 class TestNoProgressGuard:
     def test_stops_after_repeated_identical_calls(self):

--- a/tests/unit/test_runtime_input.py
+++ b/tests/unit/test_runtime_input.py
@@ -2,10 +2,16 @@
 
 from unittest.mock import Mock
 
+from connectonion import Agent
+from connectonion.core.llm import LLMResponse
+from connectonion.core.usage import TokenUsage
+from connectonion.network.io import WebSocketIO
 from connectonion.useful_plugins.runtime_input import (
     RUNTIME_INPUT_FRAME_PREFIX,
     apply_runtime_input,
+    runtime_input,
 )
+from tests.utils.mock_helpers import MockLLM
 
 
 class FakeAgent:
@@ -113,3 +119,50 @@ def test_turn_defaults_to_zero_when_missing():
     del agent.current_session['turn']  # simulate older session
     apply_runtime_input(agent)
     assert agent.current_session['trace'][0]['turn'] == 0
+
+
+def test_input_arriving_during_a_final_llm_call_gets_an_answer():
+    """An ACK-able follow-up must survive a one-iteration, no-tool turn."""
+    io = WebSocketIO()
+    calls = 0
+
+    def answer(messages, tools):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert io.push_runtime_input({'id': 'late', 'prompt': 'and TCP too'})
+            return LLMResponse(
+                content='HTTP is an application protocol.',
+                tool_calls=[],
+                raw_response=None,
+                usage=TokenUsage(),
+            )
+        return LLMResponse(
+            content='TCP is a transport protocol.',
+            tool_calls=[],
+            raw_response=None,
+            usage=TokenUsage(),
+        )
+
+    agent = Agent(
+        'runtime-input',
+        llm=MockLLM(on_complete=answer),
+        plugins=[runtime_input],
+        max_iterations=1,
+        quiet=True,
+        log=False,
+    )
+    agent.io = io
+
+    result = agent.input('what is HTTP?')
+
+    assert result == 'TCP is a transport protocol.'
+    assert calls == 2
+    assert any(
+        message.get('content') == RUNTIME_INPUT_FRAME_PREFIX + 'and TCP too'
+        for message in agent.current_session['messages']
+    )
+    assert any(
+        entry.get('id') == 'late' and entry.get('runtime_input') is True
+        for entry in agent.current_session['trace']
+    )

--- a/tests/unit/test_runtime_input_ack_is_truthful.py
+++ b/tests/unit/test_runtime_input_ack_is_truthful.py
@@ -1,0 +1,103 @@
+"""Runtime-input ACKs promise that the running turn accepted the message."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+def _run_runtime_input(push_result):
+    from connectonion.network.host.ws_router import session as ws_session
+
+    sent = []
+    frames = [
+        {'type': 'CONNECT'},
+        {'type': 'INPUT', 'prompt': 'follow up'},
+    ]
+    io = Mock()
+    io.push_runtime_input.return_value = push_result
+    active = SimpleNamespace(status='running', io=io)
+    registry = Mock()
+    registry.get.return_value = active
+
+    async def send_msg(data):
+        sent.append(data)
+
+    async def recv_msg():
+        return frames.pop(0) if frames else None
+
+    async def connect(data, send_msg, conn, *args, **kwargs):
+        conn.update({
+            'authenticated': True,
+            'agent_address': '0xclient',
+            'session_id': 'session-1',
+            'session': {},
+        })
+        return None
+
+    original = ws_session.handle_connect
+    ws_session.handle_connect = connect
+    try:
+        asyncio.run(ws_session.run_ws_session(
+            send_msg,
+            recv_msg,
+            route_handlers={},
+            storage=None,
+            registry=registry,
+            trust=None,
+            enable_ping=False,
+        ))
+    finally:
+        ws_session.handle_connect = original
+
+    return sent, io
+
+
+def test_an_accepted_runtime_input_is_acknowledged():
+    sent, io = _run_runtime_input(True)
+
+    io.push_runtime_input.assert_called_once()
+    assert [frame['type'] for frame in sent] == ['RUNTIME_INPUT_ACK']
+
+
+def test_a_sealed_turn_does_not_send_a_false_ack():
+    sent, io = _run_runtime_input(False)
+
+    io.push_runtime_input.assert_called_once()
+    assert not any(frame['type'] == 'RUNTIME_INPUT_ACK' for frame in sent)
+    assert sent == [{
+        'type': 'ERROR',
+        'code': 'RUNTIME_INPUT_REJECTED',
+        'message': 'running turn is not accepting runtime input; retry after OUTPUT',
+        'session_id': 'session-1',
+        'retryable': True,
+    }]
+
+
+def test_a_failed_agent_turn_is_not_left_running():
+    from connectonion.network.host.ws_router.agent_io import _agent_thread_body
+
+    error = RuntimeError('model failed')
+
+    def fail(*args, **kwargs):
+        raise error
+
+    io = Mock()
+    registry = Mock()
+    result_holder = [None]
+
+    _agent_thread_body(
+        {'ws_input': fail},
+        storage=None,
+        prompt='hello',
+        io=io,
+        session={},
+        images=None,
+        files=None,
+        registry=registry,
+        session_id='session-1',
+        result_holder=result_holder,
+    )
+
+    assert result_holder[0] is error
+    registry.mark_session_connected.assert_called_once_with('session-1')
+    io.mark_agent_done.assert_called_once_with()


### PR DESCRIPTION
## What changed

- drain runtime input once more at the final no-tool iteration boundary and run another LLM iteration when a follow-up arrived
- make the WebSocket runtime-input window explicit and atomic, so a message is either queued or rejected instead of receiving a false ACK
- reject runtime input for agents that did not opt into the `runtime_input` plugin
- return failed agent threads from `running` to `connected`, preventing later input from being queued to a dead worker
- make `after_iteration` fire for final no-tool iterations while keeping the no-progress guard from counting an old tool call twice

## Root cause

`runtime_input` only drained its queue in `before_iteration`. A normal answer with no tool calls returned immediately, so input received during that LLM call remained queued forever even though the host had sent `RUNTIME_INPUT_ACK`. The same false-ACK state occurred after an agent exception because the active-session registry stayed `running`.

## User impact

A follow-up sent while a plain answer is being generated is now visible in session history and receives another LLM answer. If the turn has already closed its acceptance window, the client gets a retryable `RUNTIME_INPUT_REJECTED` error rather than a success acknowledgement. Agents without the plugin also fail explicitly.

## Validation

- focused agent/event/IO/host regression suite: **122 passed**
- full randomized non-paid suite (seed `762`): **5873 passed, 18 skipped, 174 deselected**, 0 failed
- `ruff` on the new runtime-input implementation/tests: clean
- `git diff --check`: clean

Closes #762.

Ready for human review before inclusion in the 1.6.0 release candidate. No release, tag, merge, or deployment was performed.

