### PR TITLE
security: authenticate session status queries

### DIFF
--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -94,10 +94,27 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     registry.update_ping(conn["session_id"])
 
             elif msg_type == "SESSION_STATUS":
-                # SESSION_STATUS query: lookup by sid, reply with current registry status.
+                # A live connection already has a verified identity. A temporary
+                # status-only socket must independently sign the query as a v2
+                # command. In either case, a caller only sees its own active
+                # session; every other case has the same not_found answer so the
+                # endpoint is not an existence oracle (#766).
+                requester = conn.get("agent_address") if conn.get("authenticated") else None
                 sid = (data.get("session") or {}).get("session_id")
-                active = registry.get(sid) if sid else None
-                status = active.status if active else "not_found"
+                if requester is None:
+                    from ..auth import authenticated_command_payload
+
+                    metadata = route_handlers.get("agent_metadata") or {}
+                    verified, status_error = authenticated_command_payload(
+                        data, data.get("from"), metadata.get("address")
+                    )
+                    if status_error is None:
+                        requester = data.get("from")
+                        sid = verified.get("session_id")
+
+                active = registry.get(sid) if requester and sid else None
+                owner = getattr(active, "owner", None) if active else None
+                status = active.status if active and owner == requester else "not_found"
                 await send_msg({"type": "SESSION_STATUS", "session_id": sid, "status": status})
 
             elif msg_type == "ONBOARD_SUBMIT":

--- a/docs/network/client-reconnection.md
+++ b/docs/network/client-reconnection.md
@@ -160,11 +160,15 @@ checkSessionStatus(sessionId)
   │
   └─ no active WS:
        Open temporary WS just for status check
-       Send SESSION_STATUS
+       Send signed SESSION_STATUS (type + session id + recipient + timestamp + nonce)
        Wait for response
        Close temporary WS
        Return status
 ```
+
+The host returns a real status only when the verified caller owns the active
+session. An unsigned, replayed, wrong-recipient, or foreign-owner probe receives
+the same `not_found` result as a missing session.
 
 ---
 

--- a/docs/network/protocol.md
+++ b/docs/network/protocol.md
@@ -140,7 +140,10 @@ match data["type"]:
 
 `CONNECT` must come first — it authenticates and populates `conn`. `INPUT` and most others require `conn["authenticated"] == True`.
 
-`SESSION_STATUS`, `ONBOARD_SUBMIT`, `ADMIN_*` carry their own auth and don't require prior CONNECT.
+`SESSION_STATUS` uses the verified connection identity after CONNECT. On a
+temporary status-only socket it carries its own protocol-v2 signature and is
+bound to the session owner. `ONBOARD_SUBMIT` and `ADMIN_*` carry their own auth
+and don't require prior CONNECT.
 
 ---
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -302,7 +302,9 @@ command fields, `to`, `timestamp`, and a random `nonce`. The server verifies the
 signer is the caller that opened this connection, verifies the recipient and
 type, then discards the unsigned compatibility copy and dispatches the signed
 payload. INPUT, EXEC, runtime input, approval responses and ask-user responses
-all pass through this gate. PONG and SESSION_STATUS are transport/status frames;
+all pass through this gate. PONG is a transport frame. SESSION_STATUS uses the
+verified CONNECT identity on a live socket, or an independently signed v2 frame
+on a temporary socket, and only reveals a session owned by that identity.
 ONBOARD_SUBMIT and ADMIN frames retain their existing independent signatures.
 
 This decision is made **per caller**, after the signature is verified, so an admin, a

--- a/tests/unit/test_session_status_needs_identity.py
+++ b/tests/unit/test_session_status_needs_identity.py
@@ -1,0 +1,137 @@
+"""SESSION_STATUS reveals state only to the session owner (#766)."""
+
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion import address
+from connectonion.network.connect import RemoteAgent
+from connectonion.network.host import auth
+
+
+@pytest.fixture(autouse=True)
+def clean_replay_cache():
+    auth._seen_signatures.clear()
+    yield
+    auth._seen_signatures.clear()
+
+
+async def _run(messages, *, owner, monkeypatch=None, connect_as=None):
+    from connectonion.network.host.ws_router import session
+
+    if connect_as is not None:
+        async def fake_connect(data, send, conn, *args):
+            conn.update(authenticated=True, agent_address=connect_as,
+                        signed_commands=False, session_id="connected-session")
+
+        monkeypatch.setattr(session, "handle_connect", fake_connect)
+        messages = [{"type": "CONNECT", "from": connect_as}, *messages]
+
+    queue = list(messages)
+    sent = []
+
+    async def recv():
+        return queue.pop(0) if queue else None
+
+    async def send(message):
+        sent.append(message)
+
+    registry = MagicMock()
+    registry.get.side_effect = lambda sid: (
+        SimpleNamespace(status="running", owner=owner) if sid == "s1" else None
+    )
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={"agent_metadata": {"address": "0x" + "12" * 20}},
+        storage=MagicMock(),
+        registry=registry,
+        trust="open",
+        enable_ping=False,
+    )
+    return [message for message in sent if message["type"] == "SESSION_STATUS"]
+
+
+@pytest.mark.asyncio
+async def test_unsigned_temporary_probe_fails_closed():
+    replies = await _run(
+        [{"type": "SESSION_STATUS", "session": {"session_id": "s1"}}],
+        owner="0xowner",
+    )
+
+    assert replies == [
+        {"type": "SESSION_STATUS", "session_id": "s1", "status": "not_found"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_owner_can_read_status(monkeypatch):
+    replies = await _run(
+        [{"type": "SESSION_STATUS", "session": {"session_id": "s1"}}],
+        owner="0xowner",
+        monkeypatch=monkeypatch,
+        connect_as="0xowner",
+    )
+
+    assert replies[-1]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_authenticated_non_owner_cannot_distinguish_the_session(monkeypatch):
+    replies = await _run(
+        [{"type": "SESSION_STATUS", "session": {"session_id": "s1"}}],
+        owner="0xowner",
+        monkeypatch=monkeypatch,
+        connect_as="0xstranger",
+    )
+
+    assert replies[-1]["status"] == "not_found"
+
+
+def _signed_status(keys, recipient):
+    return RemoteAgent(recipient, keys=keys)._build_command_message(
+        {"type": "SESSION_STATUS", "session_id": "s1"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_temporary_probe_is_bound_to_owner():
+    keys = address.generate()
+    replies = await _run(
+        [_signed_status(keys, "0x" + "12" * 20)], owner=keys["address"]
+    )
+
+    assert replies[-1]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_signed_non_owner_gets_the_same_not_found_answer():
+    keys = address.generate()
+    replies = await _run(
+        [_signed_status(keys, "0x" + "12" * 20)], owner="0xowner"
+    )
+
+    assert replies[-1]["status"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_temporary_probe_replay_fails_closed():
+    keys = address.generate()
+    frame = _signed_status(keys, "0x" + "12" * 20)
+    replies = await _run(
+        [frame, copy.deepcopy(frame)], owner=keys["address"]
+    )
+
+    assert [reply["status"] for reply in replies] == ["running", "not_found"]
+
+
+@pytest.mark.asyncio
+async def test_temporary_probe_for_another_host_fails_closed():
+    keys = address.generate()
+    replies = await _run(
+        [_signed_status(keys, "0x" + "34" * 20)], owner=keys["address"]
+    )
+
+    assert replies[-1]["status"] == "not_found"


### PR DESCRIPTION
## What changed

- reuse the verified CONNECT identity for status checks on a live socket
- require a protocol-v2 signed envelope on a temporary status-only socket
- bind every real status to `ActiveSession.owner`
- return the same `not_found` result for unsigned, replayed, wrong-recipient, foreign-owner, and missing-session probes
- document the authenticated reconnection protocol

## Why this is stacked

This PR uses the signed-command validation introduced by PR #750, so its base is `fix/signed-command-frames-649`. Rebase/retarget it to `main` after #750 merges.

## Evidence

- 7 new adversarial tests cover unsigned probing, authenticated owner/non-owner, signed temporary owner/non-owner, replay, and wrong recipient
- focused protocol/host suite: **35 passed**
- full stacked 1.6 candidate, including the later release-workflow and email-retryability hardening: **6037 passed, 18 skipped, 174 deselected, 0 failed** (`--randomly-seed=1320842036`)

## Coordination

The matching temporary-probe signing change is in openonion/connectonion-ts#33 (Ready for review, CI green). Make that client available before shipping this host behavior. Existing authenticated live-socket checks remain compatible; old unsigned temporary probes fail closed as `not_found`.

Keep #766 open until both PRs are accepted and the client-first rollout is complete.

Refs #766

This PR is Ready for independent security review. No release or deployment is part of it.
