### PR TITLE
fix: add keep-address email quota upgrade (1.5.20)

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -38,7 +38,7 @@ patch releases; the minor is the statement that it no longer needs to be.
 - Reserved for breaking changes, or for a stable release worth naming
 - Same rule as any whole number: earned, not reached
 
-## Current Version: 1.5.19
+## Current Version: 1.5.20
 
 ### Version History
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
@@ -62,6 +62,7 @@ patch releases; the minor is the statement that it no longer needs to be.
 - 1.5.8 (**paid onboarding could not succeed, and failed open when it could not run** — the two halves of the same gate; a token that names another account is refreshed rather than reused; the deploy stamp follows what was installed rather than what was asked for; and the pin test asserts the real version instead of one it hardcoded)
 - 1.5.9 (**Home becomes a control panel**: the page says what the agent has been doing, shows its address and trust, and is the starter itself rather than a copy that drifts from it; **an agent keeps its own schedule** in `.co/schedule.yaml`, run by the host every minute; and `<co-table>` is documented for agents that write their own Home)
 - 1.5.10 (**a schedule that will never fire says so** — a hand-written file reaches production, and a dropped entry is otherwise indistinguishable from one that is not due yet; Recent stops saying the same sentence three times. Released as 1.5.10 rather than the 1.6.0 that was prepared: see the rule at the top of this file)
+- 1.5.20 (**paid quota without an address change**: `co email upgrade plus --keep-address` raises an existing `@mail.openonion.ai` mailbox to the Plus monthly quota while preserving the exact sender address, so a mailbox that has reached the free limit does not have to abandon the address its users already know.)
 - 1.5.19 (**OAuth and status calls cannot wait forever on a broken network**: every Google and Microsoft authorization request, including polling and credential retrieval, now has a bounded timeout; `co status` likewise stops waiting after 15 seconds instead of hanging indefinitely. This patch is cut directly from the exercised 1.5.18 release and does not include the unreviewed 1.6.0 candidate.)
   Published on [PyPI](https://pypi.org/project/connectonion/1.5.19/) and as [GitHub release `v1.5.19`](https://github.com/openonion/connectonion/releases/tag/v1.5.19); both carry the exact artifacts preserved by the release build.
 - 1.5.18 (**the wheel acceptance test installs the wheel it was given**: the build environment already contains ConnectOnion while it runs the artifact test, so pip must force-reinstall the candidate into the child virtualenv instead of treating the outer copy as satisfying it; this carries the same email retry fix through the corrected release gate)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.5.19"
+__version__ = "1.5.20"

--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -251,7 +251,12 @@ def handle_email_name(name: str, buy: bool = False):
     console.print(f"  Your address: [cyan]{data['email']}[/cyan]\n")
 
 
-def handle_email_upgrade(tier: str, domain: str = None, alias: str = None):
+def handle_email_upgrade(
+    tier: str,
+    domain: str = None,
+    alias: str = None,
+    keep_address: bool = False,
+):
     """Upgrade email tier (plus/pro), deducting the monthly price from credits."""
     token = load_api_key()
     if not token:
@@ -264,6 +269,8 @@ def handle_email_upgrade(tier: str, domain: str = None, alias: str = None):
         payload["domain"] = domain
     if alias:
         payload["alias"] = alias
+    if keep_address:
+        payload["keep_address"] = True
 
     r = requests.post(f"{backend_url()}/api/v1/email/upgrade", json=payload, headers=headers, timeout=15)
     if not r.ok:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -741,10 +741,15 @@ def email_upgrade(
     tier: str = typer.Argument(..., help="Tier: plus or pro"),
     domain: Optional[str] = typer.Option(None, "--domain", "-d", help="Sending domain (plus/pro)"),
     alias: Optional[str] = typer.Option(None, "--alias", "-a", help="Mailbox alias, e.g. 'aaron'"),
+    keep_address: bool = typer.Option(
+        False,
+        "--keep-address",
+        help="Increase quota while preserving an existing @mail.openonion.ai address (plus only)",
+    ),
 ):
     """Upgrade email tier — deducts the monthly price from your credits."""
     from .commands.email_commands import handle_email_upgrade
-    handle_email_upgrade(tier, domain=domain, alias=alias)
+    handle_email_upgrade(tier, domain=domain, alias=alias, keep_address=keep_address)
 
 
 # Gmail command group. `co gmail` (no args) shows the Gmail inbox.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -218,7 +218,7 @@ co email send bob@example.com "Hi" "Body text"    # send (HTML auto-detected)
 - `co email sent` - list sent email (`--last/-n`, `--to`)
 - `co email sent read <#>` - print one sent message's body and status
 - `co email name <name> [--buy]` - check or claim a readable address (e.g. `aaron@openonion.ai`), paid from credits
-- `co email upgrade <tier>` - raise your monthly send quota on your own domain (`plus`/`pro`, `--domain` required, `--alias` optional), paid from credits
+- `co email upgrade <tier>` - raise your monthly send quota (`plus --keep-address` preserves an existing hosted address; `--domain`/`--alias` selects a new one), paid from credits
 
 The same `send_email` / `get_emails` functions also work as agent tools, so
 your agent can do everything `co email` does. See [email.md](email.md) for

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -149,19 +149,23 @@ $ co email name aaron --buy
 
 ### `co email upgrade <tier>` — Raise your sending quota
 
-The paid tiers (`plus`, `pro`) send from **your own domain** and lift the
-monthly quota, billed from your credits. A sending domain is **required**:
+The paid tiers (`plus`, `pro`) lift the monthly quota and are billed from your
+credits. An existing `@mail.openonion.ai` mailbox can keep its exact address;
+otherwise select the domain and alias offered by the tier:
 
 ```bash
-co email upgrade plus --domain mail.acme.com                  # plus, on your domain
+co email upgrade plus --keep-address                          # keep the current hosted address
+co email upgrade plus --domain steadmail.com --alias support  # plus, new hosted address
 co email upgrade pro  --domain mail.acme.com --alias support  # pro + a mailbox alias
 ```
 
 **Options**
-- `--domain, -d` — sending domain (**required** for plus/pro)
+- `--keep-address` — preserve the current `@mail.openonion.ai` address (plus only)
+- `--domain, -d` — sending domain (required unless `--keep-address` is used)
 - `--alias, -a` — mailbox alias, e.g. `support` → `support@mail.acme.com`
 
-Leave out the domain and the upgrade is rejected before anything is charged:
+Leave out both the domain and `--keep-address` and the upgrade is rejected
+before anything is charged:
 
 ```bash
 $ co email upgrade plus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.19"
+version = "1.5.20"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_email_upgrade.py
+++ b/tests/unit/test_email_upgrade.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+
+def test_keep_address_upgrade_sends_quota_only_request(monkeypatch):
+    response = Mock()
+    response.ok = True
+    response.json.return_value = {
+        "message": "Email upgraded to plus tier",
+        "email_address": "rental@mail.openonion.ai",
+        "emails_per_month": 10000,
+        "balance": 0.0,
+    }
+    post = Mock(return_value=response)
+    monkeypatch.setattr(
+        "connectonion.cli.commands.email_commands.load_api_key",
+        lambda: "test-token",
+    )
+    monkeypatch.setattr(
+        "connectonion.cli.commands.email_commands.requests.post",
+        post,
+    )
+
+    result = CliRunner().invoke(
+        app,
+        ["email", "upgrade", "plus", "--keep-address"],
+    )
+
+    assert result.exit_code == 0
+    assert "rental@mail.openonion.ai" in result.stdout
+    assert post.call_args.kwargs["json"] == {
+        "tier": "plus",
+        "keep_address": True,
+    }


### PR DESCRIPTION
## What changed

- add `co email upgrade plus --keep-address`
- send the explicit `keep_address` API field without a replacement domain or alias
- document both keep-address and replacement-address upgrade modes
- bump the patch release to 1.5.20

## Why

A paid mailbox at the free 100-email monthly limit could only upgrade by replacing its established `@mail.openonion.ai` address. The server now supports quota-only upgrades, and this client exposes that capability.

## Validation

- focused CLI, help, release-history and version-consistency suite — 30 passed
- server email suite — 40 passed in `openonion/oo-api`