### PR TITLE
release: ConnectOnion 1.6.0

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -38,9 +38,10 @@ patch releases; the minor is the statement that it no longer needs to be.
 - Reserved for breaking changes, or for a stable release worth naming
 - Same rule as any whole number: earned, not reached
 
-## Current Version: 1.5.20
+## Current Version: 1.6.0
 
 ### Version History
+- 1.6.0 (**safer remote agents and a cleaner credential boundary**: host identity and temporary session-status probes are signed consistently; relay profile updates reject stale or conflicting state; Microsoft OAuth credentials and refresh-token rotation stay on the CLI machine instead of being stored by the backend; project invite credentials are private and no shared default invite code is documented; email sending has traceable, tenant-scoped idempotency and resilient provider-error handling; paid mailbox upgrades can preserve the existing address and are charged atomically; portable skills, dependency floors, cross-platform tests, and exact-artifact release verification are hardened for a stable release.)
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
 - 0.0.2 → 0.0.9 (Early production releases)
 - 0.1.0 → 0.1.9 (Added multi-model support, CLI improvements)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.5.20"
+__version__ = "1.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.5.20"
+version = "1.6.0"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.5.20"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- bump package, CLI, lockfile, and release-history versions to 1.6.0
- document the reviewed security, email, OAuth, skill portability, and release-hardening changes

## Release validation
- post-merge main matrix passed on Python 3.10–3.13 and native Windows E2E
- release/version tests: 22 passed
- exact wheel acceptance: 8 passed
- built connectonion-1.6.0 wheel and sdist
- twine check passed for both artifacts
- docs-site 1.6.0 PR #34 merged after Quality and Vercel passed