### PR TITLE
ci: add a minimal CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# Static analysis for the package users install.
+#
+# Deliberately minimal: default query suite, one language, no build step —
+# Python needs no compilation, so there is nothing to configure and nothing to
+# drift. The weekly schedule is what catches a newly published advisory against
+# code that has not changed; push/PR runs catch what we write.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Monday 03:27 UTC — off the hour so it does not queue with everyone else's.
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Required to upload the SARIF result to the Security tab.
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"


### PR DESCRIPTION
Part of #771.

The 1.6.0 release audit found the repository had **no code-scanning analysis**. Alongside that, Dependabot alerts, secret scanning and push protection are now enabled across the public repos (see the issue for the per-repo result).

This adds the missing third leg for the repo that actually ships to PyPI.

- default query suite, Python only, no build step — nothing to configure, nothing to drift
- runs on push/PR to `main`, plus a weekly schedule so a newly published advisory is caught against code that has not changed
- `security-events: write` scoped to the job, everything else read-only

Verification: the workflow parses as valid YAML; the real check is this PR's own CodeQL run, since the workflow triggers on `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YE2E7YwTvLnPp2qjfcofRq