### PR TITLE
feat(host): 新增以受眾分區的 HTTP 路由

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -88,7 +88,8 @@ _FROM = {
     )},
     **{name: ".network" for name in (
         "connect", "RemoteAgent", "Response", "ExecResult", "host", "create_app",
-        "IO", "relay", "announce",
+        "IO", "relay", "announce", "HTTPRequest", "HTTPResponse", "HTTPRoute",
+        "HTTPRouter",
     )},
 }
 
@@ -197,6 +198,10 @@ __all__ = [
     "IO",
     "relay",
     "announce",
+    "HTTPRequest",
+    "HTTPResponse",
+    "HTTPRoute",
+    "HTTPRouter",
     "address",
     # Event decorators
     "on_agent_ready",

--- a/connectonion/network/__init__.py
+++ b/connectonion/network/__init__.py
@@ -19,7 +19,10 @@ This module contains:
 - trust: Trust verification system (TrustAgent is the single interface)
 """
 
-from .host import host, create_app, SessionStorage, Session
+from .host import (
+    host, create_app, SessionStorage, Session,
+    HTTPRequest, HTTPResponse, HTTPRoute, HTTPRouter,
+)
 from .io import IO, WebSocketIO
 from .connect import connect, RemoteAgent, Response, ExecResult
 from .relay import connect as relay_connect, serve_loop
@@ -38,6 +41,10 @@ __all__ = [
     "RemoteAgent",
     "Response",
     "ExecResult",
+    "HTTPRequest",
+    "HTTPResponse",
+    "HTTPRoute",
+    "HTTPRouter",
     "relay_connect",
     "serve_loop",
     "create_announce_message",

--- a/connectonion/network/asgi/__init__.py
+++ b/connectonion/network/asgi/__init__.py
@@ -30,6 +30,7 @@ def create_app(
     trust_config: dict | None = None,
     blacklist: list | None = None,
     whitelist: list | None = None,
+    http=None,
     on_startup: Callable[[], Awaitable[None]] | None = None,
     on_shutdown: Callable[[], Awaitable[None]] | None = None,
 ):
@@ -88,6 +89,7 @@ def create_app(
                 start_time=start_time,
                 blacklist=blacklist,
                 whitelist=whitelist,
+                http=http,
             )
         elif scope["type"] == "websocket":
             await handle_websocket(

--- a/connectonion/network/asgi/http.py
+++ b/connectonion/network/asgi/http.py
@@ -53,7 +53,7 @@ CORS_HEADERS = [
     [b"access-control-allow-methods", b"GET, POST, OPTIONS"],
     [
         b"access-control-allow-headers",
-        b"authorization, content-type, x-co-from, x-co-signature, x-co-timestamp",
+        b"authorization, content-type, x-co-from, x-co-signature, x-co-timestamp, x-co-to, x-co-request-id",
     ],
 ]
 

--- a/connectonion/network/host/__init__.py
+++ b/connectonion/network/host/__init__.py
@@ -39,6 +39,7 @@ from .server import (
     host,
     create_app,
 )
+from .http_routes import HTTPRequest, HTTPResponse, HTTPRoute, HTTPRouter
 
 __all__ = [
     # Main entry point
@@ -67,4 +68,8 @@ __all__ = [
     "admin_sessions_handler",
     # Helpers
     "create_app",
+    "HTTPRequest",
+    "HTTPResponse",
+    "HTTPRoute",
+    "HTTPRouter",
 ]

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -18,10 +18,10 @@ Trust evaluation (via TrustAgent.should_allow()):
 import hashlib
 import json
 import time
+import uuid
 from typing import Dict
 
-from ..trust import TrustAgent, TRUST_LEVELS
-
+from ..trust import TRUST_LEVELS, TrustAgent
 
 # Signature expiry window (5 minutes)
 SIGNATURE_EXPIRY_SECONDS = 300
@@ -38,8 +38,8 @@ def verify_signature(payload: dict, signature: str, public_key: str) -> bool:
     Returns:
         True if signature is valid, False otherwise
     """
-    from nacl.signing import VerifyKey
     from nacl.exceptions import BadSignatureError
+    from nacl.signing import VerifyKey
 
     # Remove 0x prefix if present
     sig_hex = signature[2:] if signature.startswith("0x") else signature
@@ -186,11 +186,88 @@ def extract_and_authenticate(data: dict, trust, *, blacklist=None, whitelist=Non
 FROM_HEADER = "x-co-from"
 SIGNATURE_HEADER = "x-co-signature"
 TIMESTAMP_HEADER = "x-co-timestamp"
+TO_HEADER = "x-co-to"
+REQUEST_ID_HEADER = "x-co-request-id"
 
 
 def _canonical(payload: dict) -> bytes:
     """The bytes that get signed. Same shape as connect.py's."""
     return json.dumps(payload, sort_keys=True, separators=(',', ':')).encode()
+
+
+def canonical_query(query: str | bytes = "") -> str:
+    """Stable query-string form used by both HTTP signer and host."""
+    from urllib.parse import parse_qsl, urlencode
+
+    if isinstance(query, bytes):
+        query = query.decode()
+    return urlencode(sorted(parse_qsl(query, keep_blank_values=True)))
+
+
+def sign_http_request(
+    keys: dict,
+    method: str,
+    path: str,
+    *,
+    recipient_address: str,
+    query: str | bytes = "",
+    body: bytes | str = b"",
+    timestamp=None,
+    request_id: str | None = None,
+) -> dict:
+    """Sign an ordinary publisher HTTP request and return its X-Co headers.
+
+    ``body`` must be the exact bytes sent on the wire.  The signature binds the
+    method, route, canonical query, body digest, timestamp, one-use request id,
+    and recipient without wrapping application JSON in a protocol envelope.
+    """
+    from ... import address as _address
+
+    if isinstance(body, str):
+        body = body.encode()
+    request_id = request_id or uuid.uuid4().hex
+    payload = {
+        "method": method.upper(),
+        "path": path,
+        "query": canonical_query(query),
+        "body_sha256": hashlib.sha256(body).hexdigest(),
+        "timestamp": int(timestamp if timestamp is not None else time.time()),
+        "request_id": request_id,
+        "to": recipient_address,
+    }
+    return {
+        FROM_HEADER: keys["address"],
+        SIGNATURE_HEADER: _address.sign(keys, _canonical(payload)).hex(),
+        TIMESTAMP_HEADER: str(payload["timestamp"]),
+        TO_HEADER: recipient_address,
+        REQUEST_ID_HEADER: request_id,
+    }
+
+
+def request_from_http_headers(
+    headers: dict,
+    method: str,
+    path: str,
+    *,
+    query: str | bytes = "",
+    body: bytes = b"",
+) -> dict:
+    """Rebuild the signed publisher-request payload from actual wire data."""
+    lowered = {str(key).lower(): value for key, value in (headers or {}).items()}
+    timestamp = lowered.get(TIMESTAMP_HEADER)
+    return {
+        "payload": {
+            "method": method.upper(),
+            "path": path,
+            "query": canonical_query(query),
+            "body_sha256": hashlib.sha256(body).hexdigest(),
+            "timestamp": int(timestamp) if timestamp is not None else None,
+            "request_id": lowered.get(REQUEST_ID_HEADER),
+            "to": lowered.get(TO_HEADER),
+        },
+        "from": lowered.get(FROM_HEADER),
+        "signature": lowered.get(SIGNATURE_HEADER),
+    }
 
 
 def sign_request(keys: dict, method: str, path: str, timestamp=None) -> dict:

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -406,6 +406,7 @@ async def handle_http(
     start_time: float,
     blacklist: list | None = None,
     whitelist: list | None = None,
+    http=None,
 ):
     """Route HTTP requests to handler functions."""
     method, path = scope["method"], scope["path"]
@@ -415,6 +416,21 @@ async def handle_http(
         await send({"type": "http.response.start", "status": 204, "headers": headers})
         await send({"type": "http.response.body", "body": b""})
         return
+
+    if http is not None:
+        matched = http.match(method, path)
+        if matched:
+            from .http_routes import dispatch_http_route
+
+            route, path_params = matched
+            await dispatch_http_route(
+                route, path_params, scope, receive, send,
+                trust_agent=trust,
+                recipient_address=route_handlers["agent_metadata"]["address"],
+                blacklist=blacklist,
+                whitelist=whitelist,
+            )
+            return
 
     if path.startswith("/admin") or path.startswith("/superadmin"):
         await handle_admin_routes(

--- a/connectonion/network/host/http_routes.py
+++ b/connectonion/network/host/http_routes.py
@@ -1,0 +1,405 @@
+"""Publisher-defined HTTP resources with audience-scoped route groups.
+
+The group is the security boundary.  Its prefix is deliberately visible in the
+URL, but authorization reads the route's immutable audience metadata rather
+than trying to recover policy from a request string.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+from urllib.parse import parse_qs
+
+from ..asgi.http import CORS_HEADERS, pydantic_json_encoder, read_body
+
+AUDIENCE_PREFIXES = {
+    "public": "/public",
+    "contacts": "/contacts",
+    "admin": "/admin",
+}
+
+# Exact legacy paths remain contracts until their canonical replacements can
+# live under /_co.  A publisher route must not depend on registration order to
+# steal one of them.
+_RESERVED_PATHS = {
+    "/input", "/sessions", "/health", "/info", "/docs", "/ws",
+    "/admin/logs", "/admin/sessions",
+}
+_RESERVED_PREFIXES = ("/_co", "/admin/trust", "/superadmin")
+_PARAMETER = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _validate_relative_path(path: str) -> list[str]:
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise ValueError("HTTP route path must start with '/'")
+    if path.startswith("//") or "//" in path or "?" in path or "#" in path:
+        raise ValueError("HTTP route path must be a clean path without query or fragment")
+    segments = path.split("/")[1:]
+    if any(segment in ("", ".", "..") for segment in segments):
+        raise ValueError("HTTP route path cannot contain empty, '.' or '..' segments")
+
+    names = []
+    for segment in segments:
+        if "{" in segment or "}" in segment:
+            matches = list(_PARAMETER.finditer(segment))
+            remainder = _PARAMETER.sub("", segment)
+            if not matches or "{" in remainder or "}" in remainder:
+                raise ValueError(f"invalid HTTP path parameter segment: {segment!r}")
+            for match in matches:
+                name = match.group(1)
+                if name in names:
+                    raise ValueError(f"duplicate HTTP path parameter: {name}")
+                names.append(name)
+    return names
+
+
+def _reserved(path: str) -> bool:
+    if path in _RESERVED_PATHS:
+        return True
+    return any(path == prefix or path.startswith(prefix + "/")
+               for prefix in _RESERVED_PREFIXES)
+
+
+def _pattern(path: str):
+    names = []
+    pieces = []
+    static_segments = 0
+    for segment in path.split("/")[1:]:
+        matches = list(_PARAMETER.finditer(segment))
+        if not matches:
+            static_segments += 1
+            pieces.append(re.escape(segment))
+            continue
+        cursor = 0
+        segment_pattern = []
+        for match in matches:
+            segment_pattern.append(re.escape(segment[cursor:match.start()]))
+            segment_pattern.append(r"([^/]+)")
+            names.append(match.group(1))
+            cursor = match.end()
+        segment_pattern.append(re.escape(segment[cursor:]))
+        pieces.append("".join(segment_pattern))
+    return re.compile("^/" + "/".join(pieces) + "$"), names, static_segments
+
+
+def _shape(path: str) -> str:
+    return _PARAMETER.sub("{}", path)
+
+
+@dataclass(frozen=True)
+class HTTPRequest:
+    """The request a publisher handler receives when it declares `request`."""
+
+    method: str
+    path: str
+    headers: Mapping[str, str]
+    query: Mapping[str, list[str]]
+    path_params: Mapping[str, str]
+    body: bytes = b""
+    identity: str | None = None
+
+    @property
+    def text(self) -> str:
+        return self.body.decode("utf-8")
+
+    def json(self) -> Any:
+        return json.loads(self.body)
+
+
+@dataclass(frozen=True)
+class HTTPResponse:
+    """Explicit status, headers, media type, and body for an HTTP resource."""
+
+    body: str | bytes = b""
+    status: int = 200
+    media_type: str = "text/plain; charset=utf-8"
+    headers: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if not 100 <= self.status <= 599:
+            raise ValueError("HTTP response status must be between 100 and 599")
+        if not isinstance(self.body, (str, bytes)):
+            raise TypeError("HTTP response body must be str or bytes")
+        if not isinstance(self.media_type, str) or any(
+            char in self.media_type for char in "\r\n"
+        ):
+            raise ValueError("HTTP response media type must be a string without newlines")
+        if not isinstance(self.headers, Mapping):
+            raise TypeError("HTTP response headers must be a mapping")
+        for name, value in self.headers.items():
+            if any(char in str(name) + str(value) for char in "\r\n"):
+                raise ValueError("HTTP response header names and values cannot contain newlines")
+
+
+@dataclass(frozen=True)
+class HTTPRoute:
+    method: str
+    relative_path: str
+    path: str
+    audience: str
+    handler: Callable
+    pattern: Any = field(repr=False)
+    parameter_names: tuple[str, ...] = ()
+    static_segments: int = 0
+
+    async def invoke(self, request: HTTPRequest, params: dict[str, str]):
+        signature = inspect.signature(self.handler)
+        kwargs = {name: params[name] for name in self.parameter_names}
+        if "request" in signature.parameters:
+            kwargs["request"] = request
+        result = self.handler(**kwargs)
+        return await result if inspect.isawaitable(result) else result
+
+
+class _AudienceGroup:
+    def __init__(self, router: "HTTPRouter", audience: str):
+        self._router = router
+        self._audience = audience
+
+    def get(self, path: str):
+        return self._router._decorator("GET", self._audience, path)
+
+    def post(self, path: str):
+        return self._router._decorator("POST", self._audience, path)
+
+
+class HTTPRouter:
+    """Routes grouped by who may call them: public, contacts, or admin."""
+
+    def __init__(self):
+        self._routes: list[HTTPRoute] = []
+        self.public = _AudienceGroup(self, "public")
+        self.contacts = _AudienceGroup(self, "contacts")
+        self.admin = _AudienceGroup(self, "admin")
+
+    @property
+    def routes(self) -> tuple[HTTPRoute, ...]:
+        return tuple(self._routes)
+
+    def _decorator(self, method: str, audience: str, relative_path: str):
+        parameter_names = _validate_relative_path(relative_path)
+        full_path = AUDIENCE_PREFIXES[audience] + relative_path
+        if _reserved(full_path):
+            raise ValueError(f"HTTP path {full_path!r} is reserved by Connectonion")
+
+        def register(handler: Callable):
+            shape = _shape(full_path)
+            for existing in self._routes:
+                if existing.method == method and _shape(existing.path) == shape:
+                    raise ValueError(
+                        f"duplicate HTTP route {method} {full_path}: "
+                        f"already registered by {existing.handler.__name__}"
+                    )
+
+            signature = inspect.signature(handler)
+            accepts_kwargs = any(
+                value.kind is inspect.Parameter.VAR_KEYWORD
+                for value in signature.parameters.values()
+            )
+            missing_path_parameters = [
+                name for name in parameter_names
+                if name not in signature.parameters and not accepts_kwargs
+            ]
+            if missing_path_parameters:
+                raise ValueError(
+                    f"HTTP handler {handler.__name__} does not accept path parameters: "
+                    f"{', '.join(missing_path_parameters)}"
+                )
+            positional_only = [
+                name for name, value in signature.parameters.items()
+                if value.kind is inspect.Parameter.POSITIONAL_ONLY
+                and name in set(parameter_names) | {"request"}
+            ]
+            if positional_only:
+                raise ValueError(
+                    f"HTTP handler parameters must accept keyword values: "
+                    f"{', '.join(positional_only)}"
+                )
+            unsupported = [
+                name for name, value in signature.parameters.items()
+                if value.default is inspect.Parameter.empty
+                and value.kind in (value.POSITIONAL_ONLY, value.POSITIONAL_OR_KEYWORD,
+                                   value.KEYWORD_ONLY)
+                and name not in set(parameter_names) | {"request"}
+            ]
+            if unsupported:
+                raise ValueError(
+                    f"HTTP handler {handler.__name__} has parameters not supplied by "
+                    f"its route: {', '.join(unsupported)}"
+                )
+
+            pattern, names, static_segments = _pattern(full_path)
+            self._routes.append(HTTPRoute(
+                method, relative_path, full_path, audience, handler, pattern,
+                tuple(names), static_segments,
+            ))
+            return handler
+
+        return register
+
+    def match(self, method: str, path: str):
+        candidates = sorted(
+            (route for route in self._routes if route.method == method.upper()),
+            key=lambda route: route.static_segments,
+            reverse=True,
+        )
+        for route in candidates:
+            match = route.pattern.fullmatch(path)
+            if match:
+                return route, dict(zip(route.parameter_names, match.groups()))
+        return None
+
+
+def _scope_headers(scope) -> dict[str, str]:
+    return {key.decode().lower(): value.decode()
+            for key, value in scope.get("headers", [])}
+
+
+def _request_query(scope) -> dict[str, list[str]]:
+    return parse_qs(
+        (scope.get("query_string") or b"").decode(),
+        keep_blank_values=True,
+    )
+
+
+async def _send(send, result):
+    if isinstance(result, HTTPResponse):
+        body = result.body.encode() if isinstance(result.body, str) else result.body
+        headers = {
+            "content-type": result.media_type,
+            **{str(key).lower(): str(value) for key, value in result.headers.items()},
+        }
+        raw_headers = [[key.encode(), value.encode()] for key, value in headers.items()]
+        cors_names = {key for key, _ in raw_headers}
+        raw_headers += [header for header in CORS_HEADERS if header[0] not in cors_names]
+        await send({"type": "http.response.start", "status": result.status,
+                    "headers": raw_headers})
+        await send({"type": "http.response.body", "body": body})
+        return
+
+    if result is None:
+        await send({"type": "http.response.start", "status": 204,
+                    "headers": CORS_HEADERS})
+        await send({"type": "http.response.body", "body": b""})
+        return
+
+    if isinstance(result, (dict, list)):
+        body = json.dumps(result, default=pydantic_json_encoder).encode()
+        media_type = b"application/json"
+    elif isinstance(result, bytes):
+        body, media_type = result, b"application/octet-stream"
+    elif isinstance(result, str):
+        body, media_type = result.encode(), b"text/plain; charset=utf-8"
+    else:
+        raise TypeError(
+            "HTTP handlers must return dict, list, str, bytes, None, or HTTPResponse"
+        )
+
+    await send({"type": "http.response.start", "status": 200,
+                "headers": [[b"content-type", media_type]] + CORS_HEADERS})
+    await send({"type": "http.response.body", "body": body})
+
+
+async def dispatch_http_route(
+    route: HTTPRoute,
+    path_params: dict[str, str],
+    scope,
+    receive,
+    send,
+    *,
+    trust_agent,
+    recipient_address: str,
+    blacklist=None,
+    whitelist=None,
+):
+    """Authenticate, invoke, and serialize one already-matched route."""
+    body = await read_body(receive)
+    headers = _scope_headers(scope)
+    identity = None
+
+    if route.audience != "public":
+        from .auth import (
+            _authenticate_signed,
+            request_from_http_headers,
+            signature_already_used,
+        )
+
+        try:
+            data = request_from_http_headers(
+                headers,
+                scope["method"],
+                scope["path"],
+                query=scope.get("query_string") or b"",
+                body=body,
+            )
+        except (TypeError, ValueError, UnicodeDecodeError):
+            await _send(send, HTTPResponse(
+                json.dumps({"error": "unauthorized: malformed signature headers"}),
+                status=401, media_type="application/json",
+            ))
+            return
+        if not data["payload"].get("request_id"):
+            await _send(send, HTTPResponse(
+                json.dumps({"error": "unauthorized: request id required"}),
+                status=401, media_type="application/json",
+            ))
+            return
+        _, identity, error = _authenticate_signed(
+            data, blacklist=blacklist, recipient_address=recipient_address,
+        )
+        if error:
+            await _send(send, HTTPResponse(
+                json.dumps({"error": error}),
+                status=403 if error.startswith("forbidden") else 401,
+                media_type="application/json",
+            ))
+            return
+        if signature_already_used(data):
+            await _send(send, HTTPResponse(
+                json.dumps({"error": "unauthorized: signature already used"}),
+                status=401, media_type="application/json",
+            ))
+            return
+
+        is_admin = trust_agent.is_admin(identity)
+        level = None if is_admin else trust_agent.get_level(identity)
+        if route.audience == "contacts":
+            allowed = is_admin or (
+                level != "blocked" and (
+                    identity in (whitelist or [])
+                    or level in ("contact", "whitelist")
+                )
+            )
+        else:
+            allowed = is_admin
+        if not allowed:
+            await _send(send, HTTPResponse(
+                json.dumps({"error": f"forbidden: {route.audience} only"}),
+                status=403, media_type="application/json",
+            ))
+            return
+
+    request = HTTPRequest(
+        method=scope["method"],
+        path=scope["path"],
+        headers=headers,
+        query=_request_query(scope),
+        path_params=path_params,
+        body=body,
+        identity=identity,
+    )
+    try:
+        result = await route.invoke(request, path_params)
+        await _send(send, result)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        await _send(send, HTTPResponse(
+            json.dumps({"error": f"invalid request body: {exc}"}),
+            status=400, media_type="application/json",
+        ))
+
+
+__all__ = ["HTTPRequest", "HTTPResponse", "HTTPRoute", "HTTPRouter"]

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -783,6 +783,7 @@ def host(
     co_dir: Path = None,
     summary: str = None,
     examples: list = None,
+    http=None,
 ):
     """
     Host an agent over HTTP/WebSocket with P2P relay discovery (enabled by default).
@@ -828,6 +829,7 @@ def host(
         co_dir: Path to .co directory for agent identity (default: ~/.co/)
         summary: Agent description (default: from config or agent.system_prompt)
         examples: Example prompts (default: from config or auto-generated)
+        http: Optional HTTPRouter with publisher-defined resource routes
 
     Direct execution (WS EXEC):
         Clients can run a tool directly, bypassing the LLM, via
@@ -845,6 +847,11 @@ def host(
         GET  /admin/logs     - Activity log (requires OPENONION_API_KEY)
         GET  /admin/sessions - Activity sessions (requires OPENONION_API_KEY)
     """
+    if http is not None:
+        from .http_routes import HTTPRouter
+        if not isinstance(http, HTTPRouter):
+            raise TypeError("http must be an HTTPRouter")
+
     # Accept the documented simple path directly: host(agent). A factory remains
     # available when per-request isolation is worth its construction cost.
     if not callable(create_agent):
@@ -1016,6 +1023,7 @@ def host(
         whitelist=whitelist,
         on_startup=on_startup,
         on_shutdown=on_shutdown,
+        http=http,
     )
 
     # Display host startup banner (agent info shown separately by Agent class)
@@ -1032,7 +1040,7 @@ def host(
     uvicorn.run(app, host="0.0.0.0", port=port, workers=workers, reload=reload, log_level="warning")
 
 
-def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None, name=None):
+def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl=86400, *, blacklist=None, whitelist=None, name=None, http=None):
     """Create ASGI app for external uvicorn/gunicorn usage.
 
     Each request calls create_agent() to get a fresh Agent instance.
@@ -1047,6 +1055,10 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
         # uvicorn myagent:app --workers 4
     """
     from .auth import get_agent_address
+    from .http_routes import HTTPRouter
+
+    if http is not None and not isinstance(http, HTTPRouter):
+        raise TypeError("http must be an HTTPRouter")
 
     if storage is None:
         storage = SessionStorage()
@@ -1088,4 +1100,5 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
         whitelist=whitelist,
         on_startup=balance_startup,
         on_shutdown=balance_shutdown,
+        http=http,
     )

--- a/docs/design-decisions/023-expose-decorator.md
+++ b/docs/design-decisions/023-expose-decorator.md
@@ -2,6 +2,11 @@
 
 *March 2026*
 
+> **Scope note (August 2026):** `HTTPRouter` now handles publisher-defined HTTP
+> resources with explicit methods, paths, response types, and audience groups.
+> This proposal remains the separate RPC/remote-tool abstraction. See
+> [Custom HTTP routes](../network/http-routes.md).
+
 Hosted agents expose one interface: `INPUT → LLM → tools → OUTPUT`. Every request goes through the LLM. This document proposes `@expose` — a decorator that makes agent functions directly callable over HTTP and WebSocket, bypassing the LLM.
 
 ---

--- a/docs/network/README.md
+++ b/docs/network/README.md
@@ -5,6 +5,7 @@ Connect and collaborate between agents with automatic reliability and recovery.
 ## Core Concepts
 
 - [host.md](host.md) - Make agents network-accessible with `host()`
+- [http-routes.md](http-routes.md) - Publish public, contacts, and admin HTTP resources
 - [connect.md](connect.md) - Connect to remote agents with `connect()`
 - [remote-call.md](remote-call.md) - Run a remote agent's tools directly with `remote.call()`, gated by the host.yaml whitelist
 - [io.md](io.md) - Stream events and communicate with clients

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -4,6 +4,8 @@
 
 **Looking to deploy?** See [Deploy Your Agent](deploy.md) for production deployment options.
 
+**Need an `.ics` feed or H5 API?** See [Custom HTTP routes](http-routes.md).
+
 ---
 
 ## Quick Start (60 Seconds)
@@ -91,6 +93,9 @@ def host(
     # File Upload Limits
     max_file_size: int = 10,               # MB per file
     max_files_per_request: int = 10,       # Max files in one request
+
+    # Deterministic HTTP resources (optional)
+    http: HTTPRouter = None,
 ) -> None:
 ```
 

--- a/docs/network/http-routes.md
+++ b/docs/network/http-routes.md
@@ -1,0 +1,155 @@
+# Custom HTTP routes
+
+Publish deterministic HTTP resources from the same process as your agent. No
+LLM round trip is involved.
+
+```python
+from connectonion import Agent, HTTPResponse, HTTPRouter, host
+
+http = HTTPRouter()
+
+
+@http.public.get("/feeds/{category}.ics")
+def calendar_feed(category: str):
+    return HTTPResponse(
+        build_ics(category),
+        media_type="text/calendar; charset=utf-8",
+        headers={"cache-control": "public, max-age=300"},
+    )
+
+
+@http.contacts.post("/preferences")
+def save_preferences(request):
+    return {"saved": request.json(), "for": request.identity}
+
+
+@http.admin.post("/refresh")
+def refresh(request):
+    return {"started": True, "by": request.identity}
+
+
+host(Agent("sydney-events"), http=http)
+```
+
+The resulting paths say who can call them:
+
+| Python group | URL prefix | Audience |
+|---|---|---|
+| `http.public` | `/public` | Anyone; no signature |
+| `http.contacts` | `/contacts` | Contacts, whitelisted callers, and admins |
+| `http.admin` | `/admin` | Admins, including the agent owner |
+
+The group owns both the prefix and the authorization rule. Connectonion stores
+the audience on the route and checks that metadata before the handler runs; it
+does not infer permission by splitting the incoming URL.
+
+## Methods and parameters
+
+The first release supports `GET` and `POST`. A path parameter is passed to a
+handler by name:
+
+```python
+@http.public.get("/events/{event_id}")
+def event(event_id: str):
+    return {"id": event_id}
+```
+
+Declare `request` only when you need request details:
+
+```python
+@http.public.post("/subscribe")
+def subscribe(request):
+    email = request.json()["email"]
+    source = request.query.get("source", [None])[0]
+    return {"email": email, "source": source}
+```
+
+`HTTPRequest` provides:
+
+- `method`, `path`, `headers`
+- `query`: a mapping from each name to a list of values
+- `path_params`
+- `body`, `text`, and `json()`
+- `identity`: the verified caller address on protected routes, otherwise `None`
+
+Handlers may be synchronous or asynchronous.
+
+## Responses
+
+Return a `dict` or `list` for JSON, `str` for text, `bytes` for binary data, or
+`None` for `204 No Content`. Use `HTTPResponse` when status, headers, or media
+type matters:
+
+```python
+return HTTPResponse(
+    body="BEGIN:VCALENDAR\n...",
+    status=200,
+    media_type="text/calendar; charset=utf-8",
+    headers={"content-disposition": 'inline; filename="events.ics"'},
+)
+```
+
+CORS headers are included on publisher responses and `OPTIONS` preflight
+requests. Header values containing newlines are rejected.
+
+## Calling protected routes
+
+Protected requests use normal HTTP bodies plus `X-Co-*` signature headers. The
+signature binds the method, path, canonical query, exact body digest,
+timestamp, one-use request ID, and recipient agent address.
+
+```python
+import json
+import httpx
+from pathlib import Path
+
+from connectonion import address
+from connectonion.network.host.auth import sign_http_request
+
+body = json.dumps({"topics": ["ai"]}, separators=(",", ":")).encode()
+headers = sign_http_request(
+    address.load(Path(".co")),
+    "POST",
+    "/contacts/preferences",
+    body=body,
+    recipient_address="0xAgentAddress",
+)
+
+response = httpx.post(
+    "https://agent.example/contacts/preferences",
+    content=body,
+    headers={**headers, "content-type": "application/json"},
+)
+```
+
+Pass the exact bytes sent on the wire to `sign_http_request`; changing the body
+or query after signing is refused. A signature is one-use and cannot be replayed.
+
+Never put an admin private key in browser JavaScript. An H5 admin application
+needs a trusted backend or a future short-lived capability flow. Calendar apps
+normally cannot add signature headers, so ordinary `.ics` subscriptions should
+be public URLs.
+
+## Route ownership
+
+Publisher routes cannot replace framework endpoints. Duplicate route shapes,
+current built-in paths, `/admin/trust/*`, `/superadmin/*`, and the permanent
+framework namespace `/_co/*` fail during registration.
+
+This is intentional: `/input`, `/ws`, `/health`, `/info`, sessions, and trust
+management are SDK, deployment, and security contracts. Presentation routes
+can gain explicit replacement options later without making silent shadowing an
+extension mechanism.
+
+## ASGI deployment
+
+The same router works with `create_app`:
+
+```python
+from connectonion import create_app
+
+app = create_app(create_agent, http=http)
+```
+
+`host()` and `create_app()` share the same raw-ASGI dispatcher, so local,
+managed, and external uvicorn deployments behave the same way.

--- a/tests/e2e/test_custom_http_routes.py
+++ b/tests/e2e/test_custom_http_routes.py
@@ -1,0 +1,330 @@
+"""Run publisher routes through the complete raw-ASGI host stack (#772)."""
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+from connectonion import address
+from connectonion.network.trust import TrustAgent
+
+
+class ASGIResponse:
+    def __init__(self):
+        self.status_code = 0
+        self.headers = {}
+        self.body = b""
+
+    def json(self):
+        return json.loads(self.body)
+
+
+def request(app, method, target, *, body=b"", headers=None):
+    path, _, query = target.partition("?")
+
+    async def call():
+        response = ASGIResponse()
+        sent = False
+
+        async def receive():
+            nonlocal sent
+            if sent:
+                return {"type": "http.disconnect"}
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                response.status_code = message["status"]
+                response.headers = {
+                    key.decode().lower(): value.decode()
+                    for key, value in message.get("headers", [])
+                }
+            elif message["type"] == "http.response.body":
+                response.body += message.get("body", b"")
+
+        scope = {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "query_string": query.encode(),
+            "headers": [
+                [key.lower().encode(), str(value).encode()]
+                for key, value in (headers or {}).items()
+            ],
+        }
+        await app(scope, receive, send)
+        return response
+
+    return asyncio.run(call())
+
+
+def agent_factory():
+    agent = MagicMock()
+    agent.name = "route-test-agent"
+    agent.tools.names.return_value = []
+    agent.current_session = {"messages": [], "trace": [], "turn": 1}
+    return agent
+
+
+class FixedTrust(TrustAgent):
+    trust = "careful"
+
+    def __init__(self, levels=None, admins=None):
+        self.levels = levels or {}
+        self.admins = set(admins or [])
+
+    def get_level(self, identity):
+        return self.levels.get(identity, "stranger")
+
+    def is_admin(self, identity):
+        return identity in self.admins
+
+    def get_self_address(self):
+        return None
+
+
+def make_app(tmp_path, monkeypatch, http, trust="open"):
+    from connectonion.network.host import SessionStorage, create_app
+
+    monkeypatch.chdir(tmp_path)
+    storage = SessionStorage(tmp_path / ".co" / "sessions.jsonl")
+    return create_app(agent_factory, storage=storage, trust=trust, http=http)
+
+
+def test_public_calendar_feed_is_anonymous_and_keeps_its_media_type(tmp_path, monkeypatch):
+    from connectonion import HTTPRequest, HTTPResponse, HTTPRouter
+
+    http = HTTPRouter()
+
+    @http.public.get("/feeds/{category}.ics")
+    def feed(category: str, request: HTTPRequest):
+        assert request.query == {"city": ["Sydney"]}
+        return HTTPResponse(
+            f"BEGIN:VCALENDAR\nX-WR-CALNAME:{category}\nEND:VCALENDAR\n",
+            media_type="text/calendar; charset=utf-8",
+            headers={"cache-control": "public, max-age=300"},
+        )
+
+    app = make_app(tmp_path, monkeypatch, http)
+    response = request(app, "GET", "/public/feeds/ai.ics?city=Sydney")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/calendar; charset=utf-8"
+    assert response.headers["cache-control"] == "public, max-age=300"
+    assert response.headers["access-control-allow-origin"] == "*"
+    assert b"X-WR-CALNAME:ai" in response.body
+
+
+def test_public_post_receives_the_original_json_body(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+
+    @http.public.post("/subscribe")
+    def subscribe(request):
+        return {"email": request.json()["email"], "path": request.path}
+
+    app = make_app(tmp_path, monkeypatch, http)
+    body = json.dumps({"email": "reader@example.com"}).encode()
+    response = request(app, "POST", "/public/subscribe", body=body)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "email": "reader@example.com",
+        "path": "/public/subscribe",
+    }
+
+
+def test_contacts_route_requires_a_signed_contact_and_rejects_replay(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    stranger = address.generate()
+    recipient = get_agent_address(agent_factory())
+    trust = FixedTrust(levels={caller["address"]: "contact"})
+    http = HTTPRouter()
+
+    @http.contacts.post("/preferences")
+    def preferences(request):
+        return {"identity": request.identity, "data": request.json()}
+
+    app = make_app(tmp_path, monkeypatch, http, trust=trust)
+    body = b'{"topics":["ai"]}'
+
+    unsigned = request(app, "POST", "/contacts/preferences", body=body)
+    assert unsigned.status_code == 401
+
+    stranger_headers = sign_http_request(
+        stranger, "POST", "/contacts/preferences", body=body,
+        recipient_address=recipient,
+    )
+    refused = request(
+        app, "POST", "/contacts/preferences", body=body, headers=stranger_headers,
+    )
+    assert refused.status_code == 403
+
+    headers = sign_http_request(
+        caller, "POST", "/contacts/preferences", body=body,
+        recipient_address=recipient,
+    )
+    accepted = request(app, "POST", "/contacts/preferences", body=body, headers=headers)
+    assert accepted.status_code == 200
+    assert accepted.json() == {
+        "identity": caller["address"],
+        "data": {"topics": ["ai"]},
+    }
+
+    replay = request(app, "POST", "/contacts/preferences", body=body, headers=headers)
+    assert replay.status_code == 401
+    assert "already used" in replay.json()["error"]
+
+
+def test_admin_route_checks_admin_and_binds_query_and_body(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    recipient = get_agent_address(agent_factory())
+    trust = FixedTrust(admins={caller["address"]})
+    http = HTTPRouter()
+
+    @http.admin.post("/refresh")
+    async def refresh(request):
+        return {
+            "by": request.identity,
+            "scope": request.query["scope"][0],
+            "force": request.json()["force"],
+        }
+
+    app = make_app(tmp_path, monkeypatch, http, trust=trust)
+    body = b'{"force":true}'
+    headers = sign_http_request(
+        caller, "POST", "/admin/refresh", query="scope=all", body=body,
+        recipient_address=recipient,
+    )
+    response = request(
+        app, "POST", "/admin/refresh?scope=all", body=body, headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "by": caller["address"],
+        "scope": "all",
+        "force": True,
+    }
+
+    reordered_headers = sign_http_request(
+        caller, "POST", "/admin/refresh", query="scope=all&b=2&a=1", body=body,
+        recipient_address=recipient,
+    )
+    reordered = request(
+        app, "POST", "/admin/refresh?a=1&scope=all&b=2", body=body,
+        headers=reordered_headers,
+    )
+    assert reordered.status_code == 200
+
+    wrong_body = request(
+        app, "POST", "/admin/refresh?scope=all", body=b'{"force":false}',
+        headers=sign_http_request(
+            caller, "POST", "/admin/refresh", query="scope=all", body=body,
+            recipient_address=recipient,
+        ),
+    )
+    assert wrong_body.status_code == 401
+
+    wrong_query = request(
+        app, "POST", "/admin/refresh?scope=one", body=body,
+        headers=sign_http_request(
+            caller, "POST", "/admin/refresh", query="scope=all", body=body,
+            recipient_address=recipient,
+        ),
+    )
+    assert wrong_query.status_code == 401
+
+
+def test_malformed_or_incomplete_auth_headers_fail_closed(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    recipient = get_agent_address(agent_factory())
+    trust = FixedTrust(levels={caller["address"]: "contact"})
+    http = HTTPRouter()
+    http.contacts.get("/profile")(lambda: {"ok": True})
+    app = make_app(tmp_path, monkeypatch, http, trust=trust)
+
+    malformed = sign_http_request(
+        caller, "GET", "/contacts/profile", recipient_address=recipient,
+    )
+    malformed["x-co-timestamp"] = "tomorrow"
+    response = request(app, "GET", "/contacts/profile", headers=malformed)
+    assert response.status_code == 401
+
+    incomplete = sign_http_request(
+        caller, "GET", "/contacts/profile", recipient_address=recipient,
+    )
+    del incomplete["x-co-request-id"]
+    response = request(app, "GET", "/contacts/profile", headers=incomplete)
+    assert response.status_code == 401
+
+
+def test_blocked_contact_is_not_restored_by_the_parameter_whitelist(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+    from connectonion.network.host import SessionStorage, create_app
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    recipient = get_agent_address(agent_factory())
+    trust = FixedTrust(levels={caller["address"]: "blocked"})
+    http = HTTPRouter()
+    http.contacts.get("/profile")(lambda: {"ok": True})
+    monkeypatch.chdir(tmp_path)
+    app = create_app(
+        agent_factory,
+        storage=SessionStorage(tmp_path / ".co" / "sessions.jsonl"),
+        trust=trust,
+        whitelist=[caller["address"]],
+        http=http,
+    )
+    headers = sign_http_request(
+        caller, "GET", "/contacts/profile", recipient_address=recipient,
+    )
+
+    assert request(app, "GET", "/contacts/profile", headers=headers).status_code == 403
+
+
+def test_parameter_whitelist_grants_a_signed_caller_contact_access(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+    from connectonion.network.host import SessionStorage, create_app
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    recipient = get_agent_address(agent_factory())
+    http = HTTPRouter()
+    http.contacts.get("/profile")(lambda request: {"identity": request.identity})
+    monkeypatch.chdir(tmp_path)
+    app = create_app(
+        agent_factory,
+        storage=SessionStorage(tmp_path / ".co" / "sessions.jsonl"),
+        trust=FixedTrust(),
+        whitelist=[caller["address"]],
+        http=http,
+    )
+    headers = sign_http_request(
+        caller, "GET", "/contacts/profile", recipient_address=recipient,
+    )
+
+    response = request(app, "GET", "/contacts/profile", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"identity": caller["address"]}
+
+
+def test_existing_framework_routes_still_work_with_a_custom_router(tmp_path, monkeypatch):
+    from connectonion import HTTPRouter
+
+    app = make_app(tmp_path, monkeypatch, HTTPRouter())
+
+    assert request(app, "GET", "/health").status_code == 200
+    assert request(app, "GET", "/info").status_code == 200
+    assert request(app, "GET", "/not-a-route").status_code == 404

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -227,6 +227,8 @@ class TestCorsHeaders:
         assert b"x-co-from" in allowed
         assert b"x-co-signature" in allowed
         assert b"x-co-timestamp" in allowed
+        assert b"x-co-to" in allowed
+        assert b"x-co-request-id" in allowed
 
 
 def signed_scope(method: str, path: str) -> dict:

--- a/tests/unit/test_http_routes.py
+++ b/tests/unit/test_http_routes.py
@@ -1,0 +1,121 @@
+"""Audience-scoped publisher HTTP routes (#772)."""
+
+import pytest
+
+
+def test_groups_own_the_audience_and_visible_prefix():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+
+    @http.public.get("/events/{category}.ics")
+    def events(category):
+        return category
+
+    @http.contacts.post("/preferences")
+    def preferences(request):
+        return request.json()
+
+    @http.admin.post("/refresh")
+    def refresh():
+        return {"started": True}
+
+    assert [(route.method, route.path, route.audience) for route in http.routes] == [
+        ("GET", "/public/events/{category}.ics", "public"),
+        ("POST", "/contacts/preferences", "contacts"),
+        ("POST", "/admin/refresh", "admin"),
+    ]
+
+
+def test_same_effective_path_cannot_be_registered_twice():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+
+    @http.public.get("/events/{category}")
+    def first(category):
+        return category
+
+    with pytest.raises(ValueError, match="duplicate HTTP route"):
+        @http.public.get("/events/{name}")
+        def second(name):
+            return name
+
+
+@pytest.mark.parametrize("path", ["events", "//events", "/../_co/info", "/events?city=sydney"])
+def test_relative_route_paths_fail_loudly(path):
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    with pytest.raises(ValueError):
+        http.public.get(path)(lambda: None)
+
+
+def test_framework_routes_cannot_be_shadowed():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    with pytest.raises(ValueError, match="reserved by Connectonion"):
+        http.admin.get("/logs")(lambda: None)
+
+
+def test_static_route_wins_over_a_parameter_route():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    http.public.get("/people/{name}")(lambda name: name)
+    http.public.get("/people/me")(lambda: "me")
+
+    route, params = http.match("GET", "/public/people/me")
+
+    assert route.relative_path == "/people/me"
+    assert params == {}
+
+
+def test_method_mismatch_is_not_a_route_match():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    http.public.get("/feed")(lambda: "feed")
+
+    assert http.match("POST", "/public/feed") is None
+
+
+def test_http_response_rejects_header_injection():
+    from connectonion import HTTPResponse
+
+    with pytest.raises(ValueError, match="header"):
+        HTTPResponse("no", headers={"x-test": "ok\r\nx-admin: yes"})
+
+    with pytest.raises(ValueError, match="media type"):
+        HTTPResponse("no", media_type="text/plain\r\nx-admin: yes")
+
+    with pytest.raises(TypeError, match="body"):
+        HTTPResponse({"use": "a plain dict return for JSON"})
+
+
+def test_create_app_rejects_an_object_that_is_not_an_http_router(tmp_path, monkeypatch):
+    from unittest.mock import MagicMock
+
+    from connectonion.network.host import SessionStorage, create_app
+
+    monkeypatch.chdir(tmp_path)
+    agent = MagicMock(name="agent")
+    agent.name = "test"
+    agent.tools.names.return_value = []
+
+    with pytest.raises(TypeError, match="HTTPRouter"):
+        create_app(
+            lambda: agent,
+            storage=SessionStorage(tmp_path / ".co" / "sessions.jsonl"),
+            trust="open",
+            http={},
+        )
+
+
+def test_handler_must_accept_every_path_parameter():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    with pytest.raises(ValueError, match="does not accept path parameters"):
+        http.public.get("/events/{category}")(lambda: "all")


### PR DESCRIPTION
## 提案摘要

讓 Agent 發布者用一個小而明確的 `HTTPRouter`，直接發布一般 HTTP 資源，例如行事曆 feed、webhook 或訂閱端點：

```python
http = HTTPRouter()

@http.public.get("/feeds/{category}.ics")
def feed(category):
    return HTTPResponse(calendar(category), media_type="text/calendar")

host(agent, http=http)
```

路徑與權限分組保持一致：

- `/public/*`：匿名可讀
- `/contacts/*`：需有效簽章，且呼叫者為 contact、whitelist 或 admin
- `/admin/*`：需有效簽章，且呼叫者為 admin

## 核心設計

- 權限以不可變的 route audience metadata 為唯一事實來源；URL 前綴只負責讓開發者與使用者一眼看懂。
- 不允許靜默覆蓋；重複路由與框架保留路由會在啟動時明確失敗。
- 保留 `/_co/*` 作為未來框架內建路由的命名空間。
- 保護路由使用 Ed25519；簽章綁定 method、path、canonical query、原始 body hash、timestamp、request id 與 recipient，並拒絕 replay。
- MVP 只提供 GET、POST、sync/async handler、path parameter 與明確的 `HTTPResponse`。

## 為什麼這個方案能持久

它沒有新增權限 DSL、middleware 設定或第二套 server。既有 ASGI host 仍是唯一傳輸層；發布者只宣告資源與受眾。未來若新增 PUT、DELETE 或更細緻的 policy，可沿用同一個 route metadata 模型，不必改掉 URL 契約。

## 驗證

- 20 個新 unit/E2E 測試，使用真實 raw-ASGI request/response stack
- 196 個 HTTP、ASGI、host、auth、安全與 public API 回歸測試通過
- calendar media type、CORS、JSON body、contact、parameter whitelist、admin、blocked、malformed auth、query/body binding、replay 均有覆蓋
- `ruff`、`compileall`、wheel 與 sdist build 通過
- 文檔站 lint 無 error，118 個靜態頁 production build 通過

完整全套測試在本機跑到 4,346 項通過後，因既有 Playwright／asyncio 全域事件迴圈污染產生級聯錯誤；受影響測試拆開執行均通過，最終以 CI 的乾淨環境結果為合併門檻。

Closes #772