### PR TITLE
browser: choose the engine from the attested tier, and never withhold one

### DIFF
--- a/connectonion/useful_tools/browser_tools/engine.py
+++ b/connectonion/useful_tools/browser_tools/engine.py
@@ -96,10 +96,31 @@ def choose(attestation, onion_present):
     return ONION, None
 
 
-def _cached_attestation():
-    """The licence this machine already holds, or None. Never raises.
+# The paid engine is not reachable from here yet, and this names exactly what
+# is missing rather than leaving a stub that reads as finished.
+#
+# `onionwright.licence.license.load(path, server_key)` needs a cache path and
+# the pinned server key; `onionwright.launcher.resolve_binary(token,
+# server_key, pin)` needs an authenticated token and a Chromium revision.
+# connectonion holds none of those three today. Supplying them is the open
+# work in openonion/connectonion#511 — not something to fake here.
+#
+# Until then the defaults below raise, `resolve()` reads that as "no licence"
+# the same way it reads an offline machine, and everyone gets the free engine.
+# That is the right failure direction and the wrong end state, so
+# test_the_paid_path_is_not_wired_up_yet asserts it out loud: when the wiring
+# lands, that test fails and has to be deleted, which is the point of it.
+PAID_WIRING_PENDING = (
+    "onionwright is installed but connectonion has no licence configuration "
+    "yet (cache path, pinned server key, Chromium revision) — see "
+    "openonion/connectonion#511"
+)
 
-    The import is the point. `onionwright` is not a dependency of
+
+def _cached_attestation():
+    """The licence this machine already holds, or None.
+
+    The import is load-bearing. `onionwright` is not a dependency of
     connectonion, so on a default install this raises ImportError immediately
     and we are done -- no token read, no HTTP, no clock check. A free machine
     reaches the network exactly as often as it did before tiering existed,
@@ -110,19 +131,23 @@ def _cached_attestation():
     refresh belongs to the licence client's own schedule (it renews at the
     12-hour half-life of a 24-hour attestation), not to `co browser go_to`.
     """
-    from onionwright.licence import license as licence_cache  # noqa: F401
+    import onionwright.licence  # noqa: F401
 
-    raise NotImplementedError(
-        "reading the cached attestation is wired up with the onionwright "
-        "install path; see openonion/connectonion#511"
-    )
+    raise NotImplementedError(PAID_WIRING_PENDING)
 
 
 def _onion_path():
-    """Where the paid binary is, or None. Never raises."""
-    from onionwright import launcher
+    """Where the paid binary is, or None.
 
-    return getattr(launcher, "installed_path", lambda: None)()
+    Deliberately no `getattr(..., default)` probe. An earlier version guessed
+    at `launcher.installed_path`, which does not exist, and the default made
+    it answer "absent" on every machine including a paid one -- a silent
+    permanent downgrade that the tests could not see because they inject this
+    function. A name that is wrong should fail loudly enough to notice.
+    """
+    import onionwright.launcher  # noqa: F401
+
+    raise NotImplementedError(PAID_WIRING_PENDING)
 
 
 def resolve(load_attestation=_cached_attestation, onion_path=_onion_path,

--- a/connectonion/useful_tools/browser_tools/engine.py
+++ b/connectonion/useful_tools/browser_tools/engine.py
@@ -94,3 +94,64 @@ def choose(attestation, onion_present):
         )
 
     return ONION, None
+
+
+def _cached_attestation():
+    """The licence this machine already holds, or None. Never raises.
+
+    The import is the point. `onionwright` is not a dependency of
+    connectonion, so on a default install this raises ImportError immediately
+    and we are done -- no token read, no HTTP, no clock check. A free machine
+    reaches the network exactly as often as it did before tiering existed,
+    which is never.
+
+    Reading the *cache* rather than refreshing is also deliberate: a browser
+    command is not the right place to discover that oo-api is slow. The
+    refresh belongs to the licence client's own schedule (it renews at the
+    12-hour half-life of a 24-hour attestation), not to `co browser go_to`.
+    """
+    from onionwright.licence import license as licence_cache  # noqa: F401
+
+    raise NotImplementedError(
+        "reading the cached attestation is wired up with the onionwright "
+        "install path; see openonion/connectonion#511"
+    )
+
+
+def _onion_path():
+    """Where the paid binary is, or None. Never raises."""
+    from onionwright import launcher
+
+    return getattr(launcher, "installed_path", lambda: None)()
+
+
+def resolve(load_attestation=_cached_attestation, onion_path=_onion_path,
+            with_path=False):
+    """Decide the engine against the real machine. Never raises.
+
+    Returns `(engine, note)`, or `(engine, note, path)` when `with_path`.
+
+    Both lookups are injected so the policy above stays testable without a
+    paid install, and both are wrapped: an exception from either means "we
+    could not establish a licence", which `choose()` already treats as free.
+    Every failure mode of asking therefore lands on the branch that works.
+
+    The path is only returned for the paid engine. patchright and system
+    Chrome are already resolved by `installed_browser_path()`, and duplicating
+    that here would give the machine two answers to one question.
+    """
+    try:
+        attestation = load_attestation()
+    except Exception:
+        attestation = None
+
+    try:
+        path = onion_path()
+    except Exception:
+        path = None
+
+    chosen, note = choose(attestation=attestation, onion_present=bool(path))
+
+    if with_path:
+        return chosen, note, (path if chosen == ONION else None)
+    return chosen, note

--- a/connectonion/useful_tools/browser_tools/engine.py
+++ b/connectonion/useful_tools/browser_tools/engine.py
@@ -1,0 +1,96 @@
+"""Which browser binary `co browser` drives: the free one, or the one you paid for.
+
+    free   patchright + the Chrome already on this machine
+    pro    the onion browser, a patched Chromium
+
+The split is decided by the server (`service.entitlement()` in oo-api, keyed on
+cumulative credit) and carried in a signed attestation. This module does not
+decide *whether* someone paid -- it only reads the answer and picks a binary.
+
+One rule runs through all of it, and it is the reason the decision is a pure
+function with no network in it:
+
+**Nothing here may stop a browser from starting.**
+
+A default install drives system Chrome through patchright today, with no licence
+call anywhere on the path -- measured on a clean Ubuntu box, not assumed. So it
+cannot currently be blocked by billing, an expired attestation, or an oo-api
+outage, and adding tiering must not hand a free user a new way to fail. Every
+branch below ends in an engine; the only thing that varies is which one, and
+whether we say something about it.
+
+The `note` exists because the interesting case is not an error either: an
+account holding only the $5 signup grant is not broken, it is not yet enough.
+That deserves one line saying what unlocks the other engine, not a traceback and
+not silence.
+"""
+
+ONION = "onion"
+PATCHRIGHT = "patchright"
+
+# Kept in step with license_api.billing.PRO_MIN_CREDIT_USD in oo-api. Written
+# here as a display string only -- the client never enforces the threshold, it
+# just repeats it, because the account is the server's to judge.
+PRO_MIN_CREDIT_USD = 10.00
+
+
+def _tier_of(attestation):
+    """The attested tier, or None if there isn't one we understand.
+
+    A payload missing the fields we read is a server we do not understand, and
+    the safe reading of "do not understand" is "no licence": guessing `pro`
+    would try to launch a binary that may not be on disk, guessing `free` just
+    works.
+    """
+    if not isinstance(attestation, dict):
+        return None
+    tier = attestation.get("tier")
+    return tier if isinstance(tier, str) else None
+
+
+def choose(attestation, onion_present):
+    """Pick an engine. Returns `(engine, note)` and never raises.
+
+    `attestation` is the decoded licence payload, or None when there isn't one
+    — no account, no licence, or oo-api was unreachable. All three mean the
+    same thing here, deliberately: they are all "we could not establish that
+    this is a paying customer", and none of them is a reason to withhold a
+    browser.
+
+    `note` is a single line for the person, or None when there is nothing worth
+    saying. It is not an error channel.
+    """
+    tier = _tier_of(attestation)
+
+    if tier != "pro":
+        if tier == "free":
+            return PATCHRIGHT, (
+                f"Using Chrome via patchright — the free engine. "
+                f"The privacy browser unlocks at ${PRO_MIN_CREDIT_USD:.2f} of credit."
+            )
+        # No licence at all, or a shape we do not recognise. Say nothing: an
+        # offline machine printing a sales line on every command is noise, and
+        # we have not established there is anything to sell to.
+        return PATCHRIGHT, None
+
+    # Entitled to the paid engine. Two things can still send us back to
+    # patchright, and neither is a failure the customer should see as one.
+    if not attestation.get("active", False):
+        # Entitled, but the session was refused — an empty balance. That is the
+        # licence layer's business; it is not a reason to leave someone with no
+        # browser at all.
+        return PATCHRIGHT, (
+            "Your balance is empty, so the privacy browser could not start a "
+            "session. Running on Chrome via patchright until it is topped up."
+        )
+
+    if not onion_present:
+        # `onionwright` is not a dependency of connectonion, so a fresh install
+        # has no paid binary on disk. A pro customer with nothing to launch must
+        # not end up worse off than a free one.
+        return PATCHRIGHT, (
+            "The privacy browser is not installed yet — running on Chrome via "
+            "patchright for now."
+        )
+
+    return ONION, None

--- a/tests/unit/test_browser_engine_choice.py
+++ b/tests/unit/test_browser_engine_choice.py
@@ -1,0 +1,104 @@
+"""Which engine `co browser` drives, given what the account is entitled to.
+
+The decision is a pure function on purpose. Everything around it -- fetching an
+attestation, downloading a binary -- can fail, and the one thing that must not
+acquire a new way to fail is the free path: a default install drives system
+Chrome through patchright today with no licence call at all, and that is
+measured, not assumed (see the e2e run on openonion/connectonion#511).
+
+So the rule the tests below encode is: **there is no input for which a browser
+refuses to start.** Every branch ends in an engine.
+"""
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import engine
+
+
+def att(tier="pro", active=True):
+    """The fields of an attestation this decision reads, and nothing else."""
+    return {"tier": tier, "active": active}
+
+
+# --- free is a product, not a refusal -------------------------------------
+
+
+def test_no_attestation_at_all_still_browses():
+    """No licence, no account, oo-api unreachable — all the same shape, and
+    none of them may stop a free user from opening a browser. This is the
+    behaviour a default install has today and must keep."""
+    chosen, _ = engine.choose(attestation=None, onion_present=False)
+
+    assert chosen == engine.PATCHRIGHT
+
+
+def test_the_free_tier_is_told_what_unlocks_the_other_one():
+    """The $5 signup grant is the common case: not broken, not yet enough."""
+    chosen, note = engine.choose(attestation=att(tier="free"), onion_present=False)
+
+    assert chosen == engine.PATCHRIGHT
+    assert note is not None
+    assert "10" in note, "the note has to name the number that unlocks it"
+
+
+def test_the_note_is_absent_when_there_is_nothing_to_say():
+    """A pro user driving the pro engine does not need a sales line on every
+    command."""
+    _, note = engine.choose(attestation=att(tier="pro"), onion_present=True)
+
+    assert note is None
+
+
+# --- paid gets what it paid for -------------------------------------------
+
+
+def test_pro_with_the_binary_present_drives_it():
+    chosen, _ = engine.choose(attestation=att(tier="pro"), onion_present=True)
+
+    assert chosen == engine.ONION
+
+
+def test_pro_without_the_binary_falls_back_rather_than_failing():
+    """`onionwright` is not a dependency of connectonion — a fresh install has
+    no paid binary on disk. A pro attestation with nothing to launch must not
+    leave the customer worse off than a free one, so it falls back and says
+    why."""
+    chosen, note = engine.choose(attestation=att(tier="pro"), onion_present=False)
+
+    assert chosen == engine.PATCHRIGHT
+    assert note is not None
+
+
+def test_an_inactive_pro_licence_still_browses():
+    """Entitled to the engine, refused the session — an empty balance. The
+    session refusal belongs to the licence layer; it is not a reason to leave
+    someone without a browser."""
+    chosen, _ = engine.choose(attestation=att(tier="pro", active=False),
+                              onion_present=True)
+
+    assert chosen == engine.PATCHRIGHT
+
+
+# --- nothing gets through without an engine -------------------------------
+
+
+@pytest.mark.parametrize("tier", ["free", "pro", "team", "mystery", None])
+@pytest.mark.parametrize("active", [True, False])
+@pytest.mark.parametrize("present", [True, False])
+def test_every_combination_yields_an_engine(tier, active, present):
+    """The property that matters more than any single branch: whatever the
+    server says, whatever is on disk, a browser starts."""
+    attestation = None if tier is None else att(tier=tier, active=active)
+
+    chosen, _ = engine.choose(attestation=attestation, onion_present=present)
+
+    assert chosen in (engine.ONION, engine.PATCHRIGHT)
+
+
+def test_a_malformed_attestation_is_treated_as_no_licence():
+    """A payload missing the fields we read is a server we do not understand.
+    Guessing 'pro' would launch a binary we may not have; guessing 'free' just
+    works."""
+    chosen, _ = engine.choose(attestation={"unexpected": True}, onion_present=True)
+
+    assert chosen == engine.PATCHRIGHT

--- a/tests/unit/test_browser_engine_resolve.py
+++ b/tests/unit/test_browser_engine_resolve.py
@@ -125,11 +125,19 @@ def test_the_paid_path_is_not_wired_up_yet():
     attestation and ignored it; `attest()` took a tier and never checked it.
     An assertion that the gap exists is the only version of "we know" that
     stops being true on its own when someone closes it.
+
+    Deliberately does not assert *which* exception. There are two, and which
+    one you get depends on the machine rather than on the code: without the
+    package it is ImportError, with it installed (a dev checkout, an editable
+    install) it is NotImplementedError. An earlier version asserted the
+    message contained the issue number, which is only true of the second — so
+    it passed on my machine and failed on all four Python versions in CI. The
+    property is "neither lookup can produce a paid engine", and that holds
+    either way.
     """
     for lookup in (engine._cached_attestation, engine._onion_path):
-        with pytest.raises(Exception) as raised:
+        with pytest.raises(Exception):
             lookup()
-        assert "511" in str(raised.value), "say where the open work is tracked"
 
     # And the consequence, from the outside: the defaults cannot reach ONION.
     chosen, _ = engine.resolve()

--- a/tests/unit/test_browser_engine_resolve.py
+++ b/tests/unit/test_browser_engine_resolve.py
@@ -1,0 +1,112 @@
+"""Getting from "a browser command was typed" to "this binary, this note".
+
+`choose()` is the policy and is tested next door. This is the part that has to
+touch the world -- is the paid package installed, is there a cached licence --
+and the only thing it may never do is make a browser command fail.
+
+The load-bearing design decision here is that **the presence of the
+`onionwright` package is itself the free/paid signal.** A default install does
+not have it (verified on a clean Ubuntu box: `pip list` shows patchright and no
+onionwright), so on a free machine there is no import, no licence call, and no
+network on the launch path at all -- which is exactly the behaviour that was
+measured before any of this existed, preserved by construction rather than by
+remembering to guard it.
+"""
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import engine
+
+
+def test_the_default_install_gives_up_at_the_import(monkeypatch):
+    """Where "no network on the free path" is actually enforced.
+
+    `resolve()` has to call the loader to find out there is nothing to load —
+    an earlier version of this test asserted the loader was never called,
+    which is not something the code can know in advance. The real property is
+    one level down: the production loader's first statement is
+    `from onionwright...`, so on a machine without the paid package it raises
+    before reading a token or opening a socket.
+    """
+    monkeypatch.setitem(__import__("sys").modules, "onionwright", None)
+
+    with pytest.raises(Exception):
+        engine._cached_attestation()
+
+
+def test_the_real_loader_on_a_free_machine_still_browses():
+    """The same thing from the outside: default wiring, no paid binary, and a
+    browser still starts."""
+    chosen, _ = engine.resolve(onion_path=lambda: None)
+
+    assert chosen == engine.PATCHRIGHT
+
+
+def test_a_licence_lookup_that_explodes_does_not_take_the_browser_with_it():
+    """oo-api down, token expired, disk unreadable, clock wrong. All the same
+    answer: browse anyway."""
+    def boom():
+        raise RuntimeError("oo-api unreachable")
+
+    chosen, _ = engine.resolve(load_attestation=boom,
+                               onion_path=lambda: "/opt/onion/chrome")
+
+    assert chosen == engine.PATCHRIGHT
+
+
+def test_a_pro_licence_with_the_binary_present_drives_it():
+    chosen, _ = engine.resolve(
+        load_attestation=lambda: {"tier": "pro", "active": True},
+        onion_path=lambda: "/opt/onion/chrome",
+    )
+
+    assert chosen == engine.ONION
+
+
+def test_the_onion_path_is_returned_so_the_caller_can_launch_it():
+    """A name is not enough to start a process."""
+    _, _, path = engine.resolve(
+        load_attestation=lambda: {"tier": "pro", "active": True},
+        onion_path=lambda: "/opt/onion/chrome",
+        with_path=True,
+    )
+
+    assert path == "/opt/onion/chrome"
+
+
+def test_a_free_resolve_returns_no_path_and_leaves_the_choice_to_the_usual_finder():
+    """patchright and system Chrome are already resolved by
+    installed_browser_path(); this module should not duplicate that."""
+    _, _, path = engine.resolve(load_attestation=lambda: None,
+                                onion_path=lambda: None, with_path=True)
+
+    assert path is None
+
+
+def test_a_probe_that_explodes_is_treated_as_absent():
+    """Asking where the paid binary is can fail on a machine mid-install."""
+    def boom():
+        raise OSError("permission denied")
+
+    chosen, note = engine.resolve(
+        load_attestation=lambda: {"tier": "pro", "active": True},
+        onion_path=boom,
+    )
+
+    assert chosen == engine.PATCHRIGHT
+    assert note is not None
+
+
+@pytest.mark.parametrize("attestation", [
+    None,
+    {},
+    {"tier": "free"},
+    {"tier": "pro", "active": False},
+    {"tier": "pro", "active": True},
+])
+@pytest.mark.parametrize("path", [None, "/opt/onion/chrome"])
+def test_resolve_always_produces_an_engine(attestation, path):
+    chosen, _ = engine.resolve(load_attestation=lambda: attestation,
+                               onion_path=lambda: path)
+
+    assert chosen in (engine.ONION, engine.PATCHRIGHT)

--- a/tests/unit/test_browser_engine_resolve.py
+++ b/tests/unit/test_browser_engine_resolve.py
@@ -110,3 +110,27 @@ def test_resolve_always_produces_an_engine(attestation, path):
                                onion_path=lambda: path)
 
     assert chosen in (engine.ONION, engine.PATCHRIGHT)
+
+
+def test_the_paid_path_is_not_wired_up_yet():
+    """A deliberate tombstone. Delete it when the wiring lands.
+
+    Both production lookups raise, because connectonion has no licence
+    configuration to give them — so on a machine that has paid, has a cached
+    attestation and has the binary, `resolve()` still answers patchright.
+
+    That is stated as a passing test rather than left in a comment because the
+    defects this whole change exists to fix were both of this shape: code that
+    looked like it was doing the work. `/license/download` computed an
+    attestation and ignored it; `attest()` took a tier and never checked it.
+    An assertion that the gap exists is the only version of "we know" that
+    stops being true on its own when someone closes it.
+    """
+    for lookup in (engine._cached_attestation, engine._onion_path):
+        with pytest.raises(Exception) as raised:
+            lookup()
+        assert "511" in str(raised.value), "say where the open work is tracked"
+
+    # And the consequence, from the outside: the defaults cannot reach ONION.
+    chosen, _ = engine.resolve()
+    assert chosen == engine.PATCHRIGHT


### PR DESCRIPTION
The decision half of #511. Server half is openonion/oo-api#134 (CI green), which is why the tier is now something a client can trust.

    free   patchright + the Chrome already on the machine
    pro    the onion browser, a patched Chromium

## The rule this is built around

**Nothing here may stop a browser from starting.**

That is not caution, it is preserving measured behaviour. E2E on a clean Ubuntu 22.04 box with no `co` installed:

```
pip install connectonion   ->  co 1.6.0, patchright 1.61.2, onionwright absent
co browser --headless go_to https://example.com
                           ->  Navigated to https://example.com/
ps -eo args | grep chrome  ->  /opt/google/chrome/chrome
take_screenshot            ->  21606 bytes of real PNG
```

A default install already drives system Chrome through patchright, with **no licence call anywhere on that path**. It cannot be blocked today by billing, an expired attestation, or an oo-api outage. Adding tiering must not hand a free user a new way to fail.

So every branch ends in an engine:

| input | engine | note |
|---|---|---|
| no attestation | patchright | silent — offline or no account is not a sales moment |
| `tier=free` | patchright | "unlocks at $10.00" |
| `pro`, not active | patchright | "balance empty" |
| `pro`, binary absent | patchright | "not installed yet" |
| `pro`, present | onion | silent |

## The branch I did not expect to need

`onionwright` is **not** a dependency of `connectonion` — verified on the same box, it is not in `pip list`. So a paying customer's first launch has a pro attestation and nothing on disk to run. Treating that as an error would leave the person who paid worse off than the person who did not, which is why it falls back and says so rather than raising.

A malformed payload reads as *no licence* on purpose: guessing `pro` tries to launch something that may not exist; guessing `free` just works.

## Tests

27, written before the module and shown red (collection error — no such module). Six name a branch. The rest is a parametrised sweep over every tier × active × present combination asserting only that *an engine comes out*, because that property is worth more than any individual branch.

```
27 passed          tests/unit/test_browser_engine_choice.py
225 passed         tests/unit -k browser
```

## Not in this PR

Wiring `choose()` into the launch path (`installed_browser_path` / `launch_persistent_context`), fetching the binary when a pro user lacks it, and the three-stage e2e (free -> fund to $10 -> pro -> spend down -> demote). Kept separate so the decision can be reviewed on its own — it is the part that is pure, and the part where a mistake is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YE2E7YwTvLnPp2qjfcofRq