### PR TITLE
Wire Claude Code delegation into co ai

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -34,19 +34,7 @@ Debug:
 
 from pathlib import Path
 
-from .context import load_project_context
-from .prompts.assembler import assemble_prompt
-from .tools import (
-    FileTools,
-    ask_user,
-    run_background, task_output, kill_task,
-    load_guide,
-    codex,
-    claude_code,
-)
-from .skills import skill
-from .plugins import system_reminder
-from connectonion import Agent, bash, TodoList
+from connectonion import Agent, TodoList, bash
 from connectonion.useful_plugins import (
     auto_compact,
     enable_yolo,
@@ -60,6 +48,20 @@ from connectonion.useful_plugins import (
 )
 from connectonion.useful_plugins.skills import skills as skills_plugin
 
+from .context import load_project_context
+from .plugins import system_reminder
+from .prompts.assembler import assemble_prompt
+from .skills import skill
+from .tools import (
+    FileTools,
+    ask_user,
+    claude_code,
+    codex,
+    kill_task,
+    load_guide,
+    run_background,
+    task_output,
+)
 
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 # Global .co directory for co ai (consistent logs/evals location)

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -42,6 +42,7 @@ from .tools import (
     run_background, task_output, kill_task,
     load_guide,
     codex,
+    claude_code,
 )
 from .skills import skill
 from .plugins import system_reminder
@@ -119,6 +120,7 @@ def create_agent(
         # derives that policy from the current mode instead of exposing it to
         # the planner model as another set of permission switches.
         codex,
+        claude_code,
     ]
 
     base_prompt = assemble_prompt(

--- a/connectonion/cli/co_ai/commands/help.py
+++ b/connectonion/cli/co_ai/commands/help.py
@@ -66,6 +66,7 @@ oo -y "task"                      # Auto-approve file changes
 **Search:** `glob`, `grep`
 **Files:** `read_file`, `edit`, `write`
 **Execute:** `bash`
+**Coding agents:** `claude_code` (resumable Claude Code handoff)
 **Sub-agents:** `task` (explore, plan)
 **Todos:** `add`, `start`, `complete`, `list`
 **Interaction:** `ask_user`, `confirm`

--- a/connectonion/cli/co_ai/prompts/tools/claude_code.md
+++ b/connectonion/cli/co_ai/prompts/tools/claude_code.md
@@ -1,0 +1,49 @@
+# Tool: Claude Code delegation
+
+Delegate a scoped coding task to the user's installed Claude Code CLI when a
+separate coding agent is better suited to implement or investigate it.
+
+## Contract
+
+- Always pass an explicit `cwd` for the target repository.
+- Save the returned `session_id`. Pass the exact same ID on follow-up calls so
+  Claude Code resumes its existing session instead of starting over.
+- Give Claude Code a bounded task with the requirements and constraints. You
+  remain responsible for planning, checking the diff, and reviewing the code.
+- Read the structured `status`, `result`, and `error` fields. A missing CLI,
+  authentication failure, unavailable Auto mode/model, timeout, or non-zero
+  exit is a result to handle; never claim the delegated work completed.
+- Claude Code runs headlessly here. Safe Mode can read and use actions already
+  allowed by Claude's settings, but it cannot open a permission prompt in the
+  co ai UI. Accept Edits can edit in-scope files; other actions that need a
+  prompt fail closed. Claude may describe a denied action in a successful JSON
+  result, so inspect the diff and test output instead of trusting status alone.
+
+Do not wrap `claude_code()` in `run_background()`. The adapter already owns a
+bounded subprocess and returns a resumable JSON result.
+
+## Permission boundary
+
+The current co ai mode determines Claude Code's mode. Plan Mode is read-only.
+Safe Mode uses Claude's normal permission rules. Accept Edits permits in-scope
+file edits while retaining Claude's rules for other actions. Explicit YOLO/ULW
+uses Claude Auto mode and its safety classifier. The integration supplies the
+mode again when resuming and never selects `bypassPermissions`. Auto mode is
+available only for supported accounts, models, Anthropic API connections, and
+organization policy; an unavailable Auto mode is a provider failure to report.
+
+## Example
+
+```python
+first = claude_code(
+    prompt="Implement the parser described in issue #42 and run focused tests.",
+    cwd="/absolute/path/to/repo",
+)
+
+# After retaining the session_id from the JSON result:
+follow_up = claude_code(
+    prompt="Address the review finding about malformed UTF-8 input.",
+    session_id="0b7e...",
+    cwd="/absolute/path/to/repo",
+)
+```

--- a/connectonion/cli/co_ai/prompts/tools/claude_code.md
+++ b/connectonion/cli/co_ai/prompts/tools/claude_code.md
@@ -24,8 +24,8 @@ bounded subprocess and returns a resumable JSON result.
 
 ## Permission boundary
 
-The current co ai mode determines Claude Code's mode. Plan Mode is read-only.
-Safe Mode uses Claude's normal permission rules. Accept Edits permits in-scope
+The current co ai mode determines Claude Code's mode. Safe Mode uses Claude's
+normal permission rules. Accept Edits permits in-scope
 file edits while retaining Claude's rules for other actions. Explicit YOLO/ULW
 uses Claude Auto mode and its safety classifier. The integration supplies the
 mode again when resuming and never selects `bypassPermissions`. Auto mode is

--- a/connectonion/cli/co_ai/prompts/tools/claude_code.md
+++ b/connectonion/cli/co_ai/prompts/tools/claude_code.md
@@ -18,6 +18,8 @@ separate coding agent is better suited to implement or investigate it.
   co ai UI. Accept Edits can edit in-scope files; other actions that need a
   prompt fail closed. Claude may describe a denied action in a successful JSON
   result, so inspect the diff and test output instead of trusting status alone.
+- In a hosted session, Claude Code delegation is operator-only. Shared contacts
+  receive a structured refusal and the local CLI is not started.
 
 Do not wrap `claude_code()` in `run_background()`. The adapter already owns a
 bounded subprocess and returns a resumable JSON result.

--- a/connectonion/cli/co_ai/tools/__init__.py
+++ b/connectonion/cli/co_ai/tools/__init__.py
@@ -57,6 +57,9 @@ from connectonion.cli.co_ai.tools.background import run_background, task_output,
 # ask_user from useful_tools (single source of truth)
 from connectonion.useful_tools import ask_user
 
+# Coding-agent delegation (CLI-specific policy wrapper)
+from connectonion.cli.co_ai.tools.claude_code import claude_code
+
 # Interaction tools (CLI-specific)
 from connectonion.cli.co_ai.tools.load_guide import load_guide
 from connectonion.cli.co_ai.tools.codex import codex
@@ -71,6 +74,7 @@ __all__ = [
     "kill_task",
     # Interaction tools
     "ask_user",
+    "claude_code",
     "load_guide",
     "codex",
     # Utility classes

--- a/connectonion/cli/co_ai/tools/claude_code.py
+++ b/connectonion/cli/co_ai/tools/claude_code.py
@@ -18,7 +18,6 @@ def claude_code(
     """
     session = getattr(agent, "current_session", {}) or {}
     permission_mode = {
-        "plan": "plan",
         "safe": "default",
         "accept_edits": "acceptEdits",
         "ulw": "auto",

--- a/connectonion/cli/co_ai/tools/claude_code.py
+++ b/connectonion/cli/co_ai/tools/claude_code.py
@@ -1,5 +1,7 @@
 """Expose Claude Code to co ai without exposing its permission policy."""
 
+import json
+
 from connectonion.useful_tools import claude_code as run_claude_code
 
 
@@ -15,8 +17,27 @@ def claude_code(
 
     Pass the returned ``session_id`` back on a later call. The current co ai
     mode owns Claude Code's permission mode; it is not model-selectable.
+    Hosted non-admin requesters cannot start the local coding subprocess.
     """
     session = getattr(agent, "current_session", {}) or {}
+    requester = session.get("requester")
+    if requester and requester.get("level") != "admin":
+        return json.dumps(
+            {
+                "provider": "claude_code",
+                "session_id": session_id,
+                "resumed": bool(session_id),
+                "status": "error",
+                "result": "",
+                "error": (
+                    "Claude Code delegation is available only to the operator "
+                    "in a hosted session."
+                ),
+                "exit_code": -1,
+                "usage": {},
+                "total_cost_usd": None,
+            }
+        )
     permission_mode = {
         "safe": "default",
         "accept_edits": "acceptEdits",

--- a/connectonion/cli/co_ai/tools/claude_code.py
+++ b/connectonion/cli/co_ai/tools/claude_code.py
@@ -1,0 +1,34 @@
+"""Expose Claude Code to co ai without exposing its permission policy."""
+
+from connectonion.useful_tools import claude_code as run_claude_code
+
+
+def claude_code(
+    prompt: str,
+    cwd: str,
+    session_id: str = "",
+    model: str = "",
+    timeout: int = 600,
+    agent=None,
+) -> str:
+    """Delegate a coding task to Claude Code and optionally resume it.
+
+    Pass the returned ``session_id`` back on a later call. The current co ai
+    mode owns Claude Code's permission mode; it is not model-selectable.
+    """
+    session = getattr(agent, "current_session", {}) or {}
+    permission_mode = {
+        "plan": "plan",
+        "safe": "default",
+        "accept_edits": "acceptEdits",
+        "ulw": "auto",
+    }.get(session.get("mode"), "default")
+    return run_claude_code(
+        prompt=prompt,
+        session_id=session_id,
+        cwd=cwd,
+        permission_mode=permission_mode,
+        model=model,
+        timeout=timeout,
+        agent=agent,
+    )

--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -20,6 +20,10 @@ class InterruptibleIO:
         with self._gate:
             self._cancelled.set()
 
+    def is_cancelled(self) -> bool:
+        """Let cooperative blocking tools stop their own external work."""
+        return self._cancelled.is_set()
+
     def send(self, event) -> None:
         with self._gate:
             if not self._cancelled.is_set():

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -8,7 +8,7 @@ import signal
 import subprocess
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 PERMISSION_MODES = (
     "default",
@@ -103,10 +103,12 @@ def claude_code(
     argv.extend(["--", prompt])
 
     try:
+        cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
         completed = _run_process(
             argv,
             cwd=str(working_directory),
             timeout=timeout,
+            cancelled=cancelled if callable(cancelled) else None,
         )
     except FileNotFoundError:
         return _envelope(
@@ -121,6 +123,8 @@ def claude_code(
             status="timeout",
             error=f"Claude Code timed out after {timeout}s.",
         )
+    except _ProviderCancelled:
+        return _envelope(session_id, error="Claude Code was interrupted.")
     except OSError as exc:
         return _envelope(session_id, error=f"Claude Code could not start: {exc}")
     except ValueError as exc:
@@ -211,7 +215,17 @@ def _is_unsafe_windows_batch(command: str, *, windows: bool | None = None) -> bo
     return windows and Path(command).suffix.lower() in (".cmd", ".bat")
 
 
-def _run_process(argv: list[str], *, cwd: str, timeout: int):
+class _ProviderCancelled(Exception):
+    """The enclosing agent revoked this provider invocation."""
+
+
+def _run_process(
+    argv: list[str],
+    *,
+    cwd: str,
+    timeout: int,
+    cancelled: Callable[[], bool] | None = None,
+):
     """Run headlessly and best-effort terminate its launch group on timeout."""
     platform_options = (
         {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
@@ -230,29 +244,64 @@ def _run_process(argv: list[str], *, cwd: str, timeout: int):
         shell=False,
         **platform_options,
     )
-    try:
-        stdout, stderr = process.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        _terminate_process_tree(process)
+    deadline = time.monotonic() + timeout
+    while True:
+        if cancelled is not None and cancelled():
+            _stop_and_drain(process, force=True)
+            raise _ProviderCancelled() from None
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            stdout, stderr = _stop_and_drain(process)
+            raise subprocess.TimeoutExpired(
+                argv, timeout, output=stdout, stderr=stderr
+            ) from None
         try:
-            stdout, stderr = process.communicate(timeout=3)
+            stdout, stderr = process.communicate(timeout=min(0.1, remaining))
+            return subprocess.CompletedProcess(
+                argv, process.returncode, stdout, stderr
+            )
         except subprocess.TimeoutExpired:
-            # A detached descendant can keep inherited pipes open even after the
-            # process tree has been signalled. Never let that defeat our public
-            # timeout contract.
-            for stream in (process.stdout, process.stderr):
-                if stream is not None:
-                    stream.close()
-            try:
-                process.kill()
-                process.wait(timeout=1)
-            except (OSError, subprocess.TimeoutExpired):
-                pass
-            stdout, stderr = "", ""
-        raise subprocess.TimeoutExpired(
-            argv, timeout, output=stdout, stderr=stderr
-        ) from None
-    return subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
+            continue
+
+
+def _stop_and_drain(process, *, force: bool = False) -> tuple[str, str]:
+    """Stop a launch group and never let inherited pipes defeat cancellation."""
+    if force:
+        _kill_process_tree(process)
+    else:
+        _terminate_process_tree(process)
+    try:
+        return process.communicate(timeout=3)
+    except subprocess.TimeoutExpired:
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                stream.close()
+        try:
+            process.kill()
+            process.wait(timeout=1)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        return "", ""
+
+
+def _kill_process_tree(process) -> None:
+    """Immediately stop a revoked provider; no post-interrupt grace window."""
+    if os.name == "nt":
+        _terminate_process_tree(process)
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            process.kill()
+        except OSError:
+            return
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def _terminate_process_tree(process) -> None:

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -105,9 +105,16 @@ def codex(prompt: str, session_id: str = "", cwd: str = "",
     def on_approval(method, params):
         return _approval_allowed(method, params, approval, agent)
 
-    client = CodexAppServer(command=command, cwd=cwd or ".",
-                            on_event=on_event, on_approval=on_approval)
+    cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
+    client = CodexAppServer(
+        command=command,
+        cwd=cwd or ".",
+        on_event=on_event,
+        on_approval=on_approval,
+        cancelled=cancelled if callable(cancelled) else None,
+    )
     deadline = time.monotonic() + timeout
+    force_close = False
     try:
         client.start()
         client.initialize(timeout=_remaining(deadline))
@@ -135,10 +142,16 @@ def codex(prompt: str, session_id: str = "", cwd: str = "",
             cwd=cwd,
             timeout=_remaining(deadline),
         )
+    except _ProviderCancelled as e:
+        force_close = True
+        return _envelope(session_id, error=f"codex app-server: {e}")
     except Exception as e:
         return _envelope(session_id, error=f"codex app-server: {e}")
     finally:
-        client.close()
+        if force_close:
+            client.close(force=True)
+        else:
+            client.close()
 
     turn = turn or {}
     status = turn.get("status", "")
@@ -320,7 +333,19 @@ def _terminate_process_tree(process):
 
     try:
         os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
     except OSError:
+        try:
+            process.terminate()
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                process.kill()
+            except OSError:
+                pass
+        except OSError:
+            pass
         return
     try:
         process.wait(timeout=2)
@@ -340,14 +365,46 @@ def _terminate_process_tree(process):
         pass
 
 
+def _kill_process_tree(process):
+    """Immediately stop a revoked provider; no post-interrupt grace window."""
+    if os.name == "nt":
+        _terminate_process_tree(process)
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        try:
+            process.kill()
+        except OSError:
+            return
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+class _ProviderCancelled(Exception):
+    """The enclosing agent revoked this provider invocation."""
+
+
 class CodexAppServer:
     """Minimal client for `codex app-server`: JSON-RPC 2.0 over stdio."""
 
-    def __init__(self, command, cwd=None, on_event=None, on_approval=None):
+    def __init__(
+        self,
+        command,
+        cwd=None,
+        on_event=None,
+        on_approval=None,
+        cancelled=None,
+    ):
         self.command = command
         self.cwd = cwd
         self.on_event = on_event or (lambda e: None)
         self.on_approval = on_approval or (lambda method, params: False)
+        self.cancelled = cancelled or (lambda: False)
         self.proc = None
         self._next_id = 0
         self._pending = {}
@@ -380,10 +437,13 @@ class CodexAppServer:
         self._stderr_thread.start()
         threading.Thread(target=self._read_loop, daemon=True).start()
 
-    def close(self):
+    def close(self, force=False):
         if not self.proc:
             return
-        _terminate_process_tree(self.proc)
+        if force:
+            _kill_process_tree(self.proc)
+        else:
+            _terminate_process_tree(self.proc)
         for stream in (self.proc.stdin, self.proc.stdout, self.proc.stderr):
             if stream is not None:
                 try:
@@ -457,8 +517,7 @@ class CodexAppServer:
             "threadId": thread_id, "cwd": cwd or self.cwd or ".",
             "input": [{"type": "text", "text": prompt}],
         }, timeout=_remaining(deadline))
-        if not self._turn_done.wait(_remaining(deadline)):
-            raise TimeoutError(f"turn timed out after {timeout}s")
+        self._wait_for(self._turn_done, deadline, "turn", timeout)
         return self._turn_result
 
     # ── JSON-RPC plumbing ────────────────────────────────────────
@@ -478,13 +537,28 @@ class CodexAppServer:
                 self._pending.pop(req_id, None)
                 error = self._exit_error
             raise RuntimeError(error or f"{method} could not be sent: {exc}") from exc
-        if not slot["event"].wait(timeout):
+        try:
+            self._wait_for(
+                slot["event"], time.monotonic() + timeout, method, timeout
+            )
+        except (TimeoutError, _ProviderCancelled):
             with self._lock:
                 self._pending.pop(req_id, None)
-            raise TimeoutError(f"{method} timed out after {timeout}s")
+            raise
         if slot["error"] is not None:
             raise RuntimeError(f"{method} failed: {slot['error']}")
         return slot["result"]
+
+    def _wait_for(self, event, deadline, operation, timeout):
+        """Wait within one budget while honoring the worker's revoked lease."""
+        while True:
+            if self.cancelled():
+                raise _ProviderCancelled(f"{operation} interrupted")
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"{operation} timed out after {timeout}s")
+            if event.wait(min(0.1, remaining)):
+                return
 
     def _notify(self, method, params):
         self._send({"method": method, "params": params})

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -186,6 +186,11 @@ The real-binary smoke test is opt-in because it can use an authenticated model:
 pytest -m real_api tests/e2e/real_api/test_real_claude_code.py
 ```
 
+When a hosted turn is interrupted, both built-in coding adapters cooperatively
+stop their launch process group and discard late session state and UI events.
+This bounds future provider work; filesystem or external effects completed
+before the interrupt are not rolled back.
+
 **Skills**
 - Load and run user-defined skills from `~/.claude/skills/`
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -141,6 +141,47 @@ the integration. In a hosted session, only the operator can approve Codex's
 nested permission requests; shared contacts are always confined to read-only
 Codex runs with permission requests denied.
 
+**Claude Code delegation**
+- Hand a scoped coding task to the installed Claude Code CLI
+- Continue the same Claude Code session by passing back its `session_id`
+- Receive one stable JSON result for success, timeout, or provider errors
+
+### Delegate to Claude Code
+
+`co ai` can delegate an implementation or investigation while retaining
+responsibility for the plan and review:
+
+```text
+Ask Claude Code to implement the parser in /path/to/repo and run the focused
+tests. Review its diff, then continue the same session for any fixes.
+```
+
+The Claude Code CLI must be installed and authenticated. Plan Mode delegates
+read-only work, Safe Mode retains Claude's normal permission rules, Accept
+Edits allows in-workspace edits, and explicit YOLO/ULW uses Claude Auto mode.
+The integration never selects `bypassPermissions`, and the selected mode is
+supplied again when a session resumes.
+
+Claude Code runs in headless print mode. It cannot display an inner permission
+prompt in the co ai UI: Safe Mode can read and run actions already allowed by
+Claude settings, while other protected actions fail closed. Accept Edits
+automatically permits in-scope edits, but shell or network actions that still
+need a prompt also fail closed. A denied action can be described in a
+successful provider result, so always review the diff and test output rather
+than treating `status` alone as proof of completion.
+
+Auto mode is narrower than `bypassPermissions`, but it is not universally
+available. It requires an eligible account and model, an Anthropic API
+connection (not Bedrock, Vertex, or Foundry), and any required organization
+administrator setting. Ineligible Auto mode is returned as a provider error;
+the integration does not fall back to a more permissive mode.
+
+The real-binary smoke test is opt-in because it can use an authenticated model:
+
+```bash
+pytest -m real_api tests/e2e/real_api/test_real_claude_code.py
+```
+
 **Skills**
 - Load and run user-defined skills from `~/.claude/skills/`
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -156,9 +156,9 @@ Ask Claude Code to implement the parser in /path/to/repo and run the focused
 tests. Review its diff, then continue the same session for any fixes.
 ```
 
-The Claude Code CLI must be installed and authenticated. Plan Mode delegates
-read-only work, Safe Mode retains Claude's normal permission rules, Accept
-Edits allows in-workspace edits, and explicit YOLO/ULW uses Claude Auto mode.
+The Claude Code CLI must be installed and authenticated. Safe Mode retains
+Claude's normal permission rules, Accept Edits allows in-workspace edits, and
+explicit YOLO/ULW uses Claude Auto mode.
 The integration never selects `bypassPermissions`, and the selected mode is
 supplied again when a session resumes.
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -170,6 +170,10 @@ need a prompt also fail closed. A denied action can be described in a
 successful provider result, so always review the diff and test output rather
 than treating `status` alone as proof of completion.
 
+Because Claude's local settings can pre-approve actions, hosted Claude Code
+delegation is operator-only. Shared contacts receive a structured error and the
+local Claude CLI is not started.
+
 Auto mode is narrower than `bypassPermissions`, but it is not universally
 available. It requires an eligible account and model, an Anthropic API
 connection (not Bedrock, Vertex, or Foundry), and any required organization

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import sys
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -369,19 +369,53 @@ def test_process_runner_never_waits_unboundedly_after_timeout(tmp_path):
     ]
     process.stdout = MagicMock()
     process.stderr = MagicMock()
-    with patch.object(claude_module.subprocess, "Popen", return_value=process), patch.object(
-        claude_module, "_terminate_process_tree"
-    ) as terminate:
+    with patch.object(
+        claude_module.subprocess, "Popen", return_value=process
+    ), patch.object(claude_module, "_terminate_process_tree") as terminate, patch.object(
+        claude_module.time, "monotonic", side_effect=[0, 0, 2]
+    ):
         with pytest.raises(subprocess.TimeoutExpired):
             claude_module._run_process(
                 ["claude", "--", "x"], cwd=str(tmp_path), timeout=1
             )
 
-    assert process.communicate.call_args_list[1].kwargs == {"timeout": 3}
+    assert process.communicate.call_args_list == [
+        call(timeout=0.1),
+        call(timeout=3),
+    ]
     terminate.assert_called_once_with(process)
     process.stdout.close.assert_called_once()
     process.stderr.close.assert_called_once()
     process.wait.assert_called_once_with(timeout=1)
+
+
+@pytest.mark.parametrize("outcome", [0, 1, "timeout"])
+def test_windows_process_tree_cleanup_handles_taskkill_outcomes(outcome):
+    process = MagicMock(pid=42)
+    with patch.object(claude_module.os, "name", "nt"), patch.object(
+        claude_module.subprocess, "run"
+    ) as taskkill:
+        if outcome == "timeout":
+            taskkill.side_effect = subprocess.TimeoutExpired("taskkill", 5)
+        else:
+            taskkill.return_value.returncode = outcome
+
+        claude_module._terminate_process_tree(process)
+
+    taskkill.assert_called_once()
+    assert taskkill.call_args.args[0] == [
+        "taskkill",
+        "/F",
+        "/T",
+        "/PID",
+        "42",
+    ]
+    assert taskkill.call_args.kwargs["timeout"] == 5
+    assert taskkill.call_args.kwargs["shell"] is False
+    if outcome == 0:
+        process.kill.assert_not_called()
+    else:
+        process.kill.assert_called_once()
 
 
 @pytest.mark.skipif(

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -45,6 +45,16 @@ def test_create_coding_agent(monkeypatch, tmp_path):
         "timeout",
     }
     assert codex_schema["required"] == ["prompt", "cwd"]
+    assert "claude_code" in agent.tools._tools
+    claude_schema = agent.tools.get("claude_code").to_function_schema()["parameters"]
+    assert set(claude_schema["properties"]) == {
+        "prompt",
+        "session_id",
+        "cwd",
+        "model",
+        "timeout",
+    }
+    assert claude_schema["required"] == ["prompt", "cwd"]
     # agent.py removes this stdin-blocking helper; it must not come back
     assert "wait_for_manual_login" not in agent.tools._tools
     # The browser is driven through the `co browser` CLI, so no in-process
@@ -125,6 +135,7 @@ def test_the_real_prompt_differs_with_and_without_a_role(tmp_path, monkeypatch):
 
     assert len(coding) > len(plain)
     assert "# Tool: Codex delegation" in coding
+    assert "# Tool: Claude Code delegation" in coding
     assert "you are a coding agent" not in plain.lower()
     # Behaviour that every agent needs survives dropping the role.
     for prompt in (coding, plain):

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -77,6 +77,42 @@ def test_unknown_or_missing_mode_uses_provider_default(monkeypatch, tmp_path):
     assert all(call["permission_mode"] == "default" for call in calls)
 
 
+@pytest.mark.parametrize("mode", ["safe", "accept_edits", "ulw"])
+def test_hosted_contact_cannot_start_claude_code(monkeypatch, tmp_path, mode):
+    backend = pytest.fail
+    monkeypatch.setattr(claude_wrapper, "run_claude_code", backend)
+    agent = SimpleNamespace(
+        current_session={
+            "mode": mode,
+            "requester": {"address": "0xcontact", "level": "contact"},
+        }
+    )
+
+    result = json.loads(
+        claude_code(
+            "change it",
+            cwd=str(tmp_path),
+            session_id="existing-session",
+            agent=agent,
+        )
+    )
+
+    assert result == {
+        "provider": "claude_code",
+        "session_id": "existing-session",
+        "resumed": True,
+        "status": "error",
+        "result": "",
+        "error": (
+            "Claude Code delegation is available only to the operator in a "
+            "hosted session."
+        ),
+        "exit_code": -1,
+        "usage": {},
+        "total_cost_usd": None,
+    }
+
+
 def test_model_cannot_select_claude_permission_mode():
     parameters = inspect.signature(claude_code).parameters
     assert "permission_mode" not in parameters

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -1,0 +1,157 @@
+"""The co ai Claude Code handoff keeps provider policy out of model input."""
+
+import importlib
+import inspect
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from connectonion.cli.co_ai.tools.claude_code import claude_code
+from connectonion.useful_plugins.tool_approval import check_approval
+
+claude_wrapper = importlib.import_module(
+    "connectonion.cli.co_ai.tools.claude_code"
+)
+claude_library = importlib.import_module("connectonion.useful_tools.claude_code")
+
+
+@pytest.mark.parametrize(
+    ("mode", "permission_mode"),
+    [
+        ("plan", "plan"),
+        ("safe", "default"),
+        ("accept_edits", "acceptEdits"),
+        ("ulw", "auto"),
+    ],
+)
+def test_co_ai_mode_owns_claude_permission_mode(
+    monkeypatch, tmp_path, mode, permission_mode
+):
+    seen = {}
+
+    def fake_claude_code(**kwargs):
+        seen.update(kwargs)
+        return '{"provider":"claude_code","session_id":"s"}'
+
+    monkeypatch.setattr(claude_wrapper, "run_claude_code", fake_claude_code)
+    agent = SimpleNamespace(current_session={"mode": mode})
+
+    result = claude_code(
+        "fix it",
+        session_id="s",
+        cwd=str(tmp_path),
+        model="sonnet",
+        timeout=42,
+        agent=agent,
+    )
+
+    assert result == '{"provider":"claude_code","session_id":"s"}'
+    assert seen == {
+        "prompt": "fix it",
+        "session_id": "s",
+        "cwd": str(tmp_path.resolve()),
+        "permission_mode": permission_mode,
+        "model": "sonnet",
+        "timeout": 42,
+        "agent": agent,
+    }
+
+
+def test_unknown_or_missing_mode_uses_provider_default(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        claude_wrapper,
+        "run_claude_code",
+        lambda **kwargs: calls.append(kwargs) or "result",
+    )
+
+    assert claude_code("one", cwd=str(tmp_path), agent=None) == "result"
+    assert (
+        claude_code(
+            "two",
+            cwd=str(tmp_path),
+            agent=SimpleNamespace(current_session={"mode": "future"}),
+        )
+        == "result"
+    )
+    assert all(call["permission_mode"] == "default" for call in calls)
+
+
+def test_model_cannot_select_claude_permission_mode():
+    parameters = inspect.signature(claude_code).parameters
+    assert "permission_mode" not in parameters
+    assert parameters["agent"].default is None
+
+
+@pytest.mark.parametrize("cwd", ["~definitely_no_such_user_776/repo", "\0"])
+def test_invalid_cwd_stays_a_structured_library_error(cwd):
+    result = json.loads(claude_code("inspect", cwd=cwd))
+
+    assert result["provider"] == "claude_code"
+    assert result["status"] == "error"
+    assert "Working directory" in result["error"]
+
+
+def test_resume_reapplies_mode_through_the_library_adapter(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(
+            stdout=json.dumps(
+                {
+                    "result": "continued",
+                    "session_id": "session-old",
+                    "is_error": False,
+                }
+            ),
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(claude_library, "_base_command", lambda: ["claude"])
+    monkeypatch.setattr(claude_library, "_run_process", fake_run)
+    result = json.loads(
+        claude_code(
+            "continue",
+            cwd=str(tmp_path),
+            session_id="session-old",
+            agent=SimpleNamespace(current_session={"mode": "accept_edits"}),
+        )
+    )
+
+    argv = calls[0][0]
+    assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
+    assert argv[argv.index("--resume") + 1] == "session-old"
+    assert calls[0][1]["cwd"] == str(tmp_path.resolve())
+    assert result["resumed"] is True
+    assert result["session_id"] == "session-old"
+
+
+def test_structured_library_failure_passes_through(monkeypatch, tmp_path):
+    monkeypatch.setattr(claude_library, "_base_command", lambda: None)
+
+    result = json.loads(claude_code("inspect", cwd=str(tmp_path)))
+
+    assert result["provider"] == "claude_code"
+    assert result["status"] == "error"
+    assert "CLI not found" in result["error"]
+
+
+def test_outer_approval_does_not_duplicate_claude_permissions():
+    io = SimpleNamespace(send=lambda *_: pytest.fail("outer approval must not prompt"))
+    agent = SimpleNamespace(
+        current_session={
+            "mode": "safe",
+            "pending_tool": {
+                "id": "call-1",
+                "name": "claude_code",
+                "arguments": {"prompt": "fix it", "cwd": "/repo"},
+            },
+        },
+        io=io,
+        logger=None,
+    )
+
+    assert check_approval(agent) is None

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -19,7 +19,6 @@ claude_library = importlib.import_module("connectonion.useful_tools.claude_code"
 @pytest.mark.parametrize(
     ("mode", "permission_mode"),
     [
-        ("plan", "plan"),
         ("safe", "default"),
         ("accept_edits", "acceptEdits"),
         ("ulw", "auto"),

--- a/tests/unit/test_co_ai_codex.py
+++ b/tests/unit/test_co_ai_codex.py
@@ -98,7 +98,9 @@ def test_mode_policy_is_reapplied_through_the_resume_protocol(monkeypatch, tmp_p
     calls = []
 
     class FakeServer:
-        def __init__(self, command, cwd=None, on_event=None, on_approval=None):
+        def __init__(
+            self, command, cwd=None, on_event=None, on_approval=None, cancelled=None
+        ):
             self.on_event = on_event
 
         def start(self):

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -24,11 +24,14 @@ class FakeServer:
     """Stand-in CodexAppServer that simulates one turn via callbacks."""
     last = None
 
-    def __init__(self, command, cwd=None, on_event=None, on_approval=None):
+    def __init__(
+        self, command, cwd=None, on_event=None, on_approval=None, cancelled=None
+    ):
         self.command = command
         self.cwd = cwd
         self.on_event = on_event
         self.on_approval = on_approval
+        self.cancelled = cancelled
         self.calls = []
         self.approval_decision = None
         FakeServer.last = self
@@ -399,7 +402,7 @@ class TestResumeProtocol:
             client.run_turn("thread-1", "continue", timeout=10)
 
         assert request.call_args.kwargs["timeout"] == 10
-        done.wait.assert_called_once_with(6)
+        done.wait.assert_called_once_with(0.1)
 
     def test_close_reaps_the_process_tree_and_closes_every_pipe(self):
         client = codex_module.CodexAppServer(["codex", "app-server"])
@@ -427,6 +430,44 @@ class TestResumeProtocol:
             (42, 0),
             (42, codex_module.signal.SIGKILL),
         ]
+
+    def test_posix_process_tree_falls_back_when_group_signal_is_denied(self):
+        process = MagicMock(pid=42)
+        with patch.object(codex_module.os, "name", "posix"), patch.object(
+            codex_module.os, "killpg", side_effect=PermissionError
+        ):
+            codex_module._terminate_process_tree(process)
+
+        process.terminate.assert_called_once()
+        process.wait.assert_called_once_with(timeout=1)
+
+    @pytest.mark.parametrize("outcome", [0, 1, "timeout"])
+    def test_windows_process_tree_cleanup_handles_taskkill_outcomes(self, outcome):
+        process = MagicMock(pid=42)
+        with patch.object(codex_module.os, "name", "nt"), patch.object(
+            codex_module.subprocess, "run"
+        ) as taskkill:
+            if outcome == "timeout":
+                taskkill.side_effect = subprocess.TimeoutExpired("taskkill", 5)
+            else:
+                taskkill.return_value.returncode = outcome
+
+            codex_module._terminate_process_tree(process)
+
+        taskkill.assert_called_once()
+        assert taskkill.call_args.args[0] == [
+            "taskkill",
+            "/F",
+            "/T",
+            "/PID",
+            "42",
+        ]
+        assert taskkill.call_args.kwargs["timeout"] == 5
+        assert taskkill.call_args.kwargs["shell"] is False
+        if outcome == 0:
+            process.kill.assert_not_called()
+        else:
+            process.kill.assert_called_once()
 
     def test_reader_eof_immediately_fails_pending_requests_with_stderr(self):
         client = codex_module.CodexAppServer(["codex", "app-server"])

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -1,6 +1,7 @@
 """Unit tests for interruptible blocking agent steps."""
 
 import importlib
+import sys
 import threading
 import time
 
@@ -256,6 +257,78 @@ def test_interrupted_coding_provider_cannot_commit_late_state_or_io(
     ]
     assert [message["phase"] for message in progress] == ["started"]
     assert agent.io.receive_all() == [next_reply]
+
+
+@pytest.mark.parametrize(
+    ("provider", "tool", "library_module"),
+    [
+        ("codex", co_ai_codex, "connectonion.useful_tools.codex"),
+        (
+            "claude_code",
+            co_ai_claude_code,
+            "connectonion.useful_tools.claude_code",
+        ),
+    ],
+)
+def test_interrupt_stops_provider_process_before_late_write(
+    monkeypatch, tmp_path, provider, tool, library_module
+):
+    """Cooperative adapters stop their launch group after the lease is revoked."""
+    script = tmp_path / "slow_provider.py"
+    started = tmp_path / f"{provider}.started"
+    late = tmp_path / f"{provider}.late"
+    script.write_text(
+        "from pathlib import Path\n"
+        "import signal, sys, time\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "Path(sys.argv[1]).write_text('started')\n"
+        "time.sleep(0.6)\n"
+        "Path(sys.argv[2]).write_text('late')\n",
+        encoding="utf-8",
+    )
+    library = importlib.import_module(library_module)
+    monkeypatch.setattr(
+        library,
+        "_base_command",
+        lambda: [sys.executable, str(script), str(started), str(late)],
+    )
+    agent = Agent(
+        f"{provider}-process-cancel",
+        llm=MockLLM(),
+        tools=[tool],
+        log=False,
+        quiet=True,
+    )
+    agent.current_session = {
+        "messages": [],
+        "trace": [],
+        "iteration": 1,
+        "mode": "safe",
+    }
+    agent.io = WebSocketIO()
+
+    def interrupt_after_launch():
+        deadline = time.monotonic() + 1
+        while not started.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert started.exists()
+        agent.io.send_to_agent({"type": "INTERRUPT"})
+
+    threading.Thread(target=interrupt_after_launch, daemon=True).start()
+    trace = execute_single_tool(
+        provider,
+        {"prompt": "inspect", "cwd": str(tmp_path)},
+        f"{provider}-process-call",
+        agent.tools,
+        agent,
+        Logger(f"{provider}-process-cancel", log=False),
+    )
+
+    assert trace["status"] == "interrupted"
+    assert trace["result"] == "Interrupted by user"
+    assert started.exists()
+    time.sleep(0.7)
+    assert not late.exists()
 
 
 def test_cancelled_receive_all_cannot_drain_the_next_turn_mailbox():

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -188,7 +188,11 @@ def test_abandoned_agent_tool_cannot_commit_session_or_registry_changes():
 def test_interrupted_coding_provider_cannot_commit_late_state_or_io(
     monkeypatch, tmp_path, provider, tool, module_name, backend_name
 ):
-    """Both real co-ai wrappers must cross the same revocable tool boundary."""
+    """Both wrappers revoke framework state and IO after an interrupt.
+
+    Subprocess/filesystem rollback is deliberately outside this transaction;
+    providers still need their own bounded cleanup and cooperative cancellation.
+    """
     started = threading.Event()
     release = threading.Event()
     finished = threading.Event()

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -1,11 +1,14 @@
 """Unit tests for interruptible blocking agent steps."""
 
+import importlib
 import threading
 import time
 
 import pytest
 
 from connectonion import Agent, before_each_tool
+from connectonion.cli.co_ai.tools.claude_code import claude_code as co_ai_claude_code
+from connectonion.cli.co_ai.tools.codex import codex as co_ai_codex
 from connectonion.core.interrupt import InterruptibleIO, UserInterrupt, run_interruptible
 from connectonion.core.tool_executor import execute_single_tool
 from connectonion.logger import Logger
@@ -162,6 +165,92 @@ def test_abandoned_agent_tool_cannot_commit_session_or_registry_changes():
     assert "late_worker_poison" not in new_session
     assert "late_worker_poison" not in old_session
     assert "victim" in agent.tools
+    assert agent.io.receive_all() == [next_reply]
+
+
+@pytest.mark.parametrize(
+    ("provider", "tool", "module_name", "backend_name"),
+    [
+        (
+            "codex",
+            co_ai_codex,
+            "connectonion.cli.co_ai.tools.codex",
+            "run_codex",
+        ),
+        (
+            "claude_code",
+            co_ai_claude_code,
+            "connectonion.cli.co_ai.tools.claude_code",
+            "run_claude_code",
+        ),
+    ],
+)
+def test_interrupted_coding_provider_cannot_commit_late_state_or_io(
+    monkeypatch, tmp_path, provider, tool, module_name, backend_name
+):
+    """Both real co-ai wrappers must cross the same revocable tool boundary."""
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def slow_backend(**kwargs):
+        tool_agent = kwargs["agent"]
+        tool_agent.io.log("provider_progress", provider=provider, phase="started")
+        started.set()
+        release.wait(timeout=2)
+        tool_agent.current_session["provider_session_id"] = "late-session"
+        tool_agent.io.log("provider_progress", provider=provider, phase="late")
+        try:
+            tool_agent.io.receive()
+        except UserInterrupt:
+            pass
+        finally:
+            finished.set()
+        return '{"session_id":"late-session","last_message":"late"}'
+
+    module = importlib.import_module(module_name)
+    monkeypatch.setattr(module, backend_name, slow_backend)
+    agent = Agent(
+        f"{provider}-interrupt",
+        llm=MockLLM(),
+        tools=[tool],
+        log=False,
+        quiet=True,
+    )
+    old_session = {"messages": [], "trace": [], "iteration": 1, "mode": "safe"}
+    agent.current_session = old_session
+    agent.io = WebSocketIO()
+
+    def interrupt():
+        assert started.wait(timeout=1)
+        agent.io.send_to_agent({"type": "INTERRUPT"})
+
+    threading.Thread(target=interrupt, daemon=True).start()
+    trace = execute_single_tool(
+        provider,
+        {"prompt": "inspect", "cwd": str(tmp_path)},
+        f"{provider}-call",
+        agent.tools,
+        agent,
+        Logger(f"{provider}-interrupt", log=False),
+    )
+
+    assert trace["status"] == "interrupted"
+    new_session = {"messages": [], "trace": [], "iteration": 1, "mode": "safe"}
+    agent.current_session = new_session
+    next_reply = {"type": "ask_user_response", "answer": "next turn"}
+    agent.io.send_to_agent(next_reply)
+    release.set()
+
+    assert finished.wait(timeout=1)
+    assert "provider_session_id" not in old_session
+    assert "provider_session_id" not in new_session
+    progress = [
+        message
+        for message in agent.io._msgs_from_agent
+        if message.get("type") == "provider_progress"
+    ]
+    assert [message["phase"] for message in progress] == ["started"]
     assert agent.io.receive_all() == [next_reply]
 
 


### PR DESCRIPTION
Closes #776.

## What changed

- Registers a thin co-ai Claude Code delegation tool with an explicit working directory and resumable session ID.
- For local/operator sessions, maps co-ai policy to Claude Code:
  - Safe → `default/manual`
  - Accept Edits → `acceptEdits`
  - YOLO/ULW → `auto`
- Never exposes `permission_mode` to the planner model and never selects `bypassPermissions`.
- Refuses hosted non-admin delegation with a stable JSON error before the local Claude CLI starts. Claude's `default` mode and local allow rules are not treated as a ConnectOnion read-only sandbox.
- Preserves both Codex and Claude registration, prompts, docs, and tests after stacking onto #783; removes only the obsolete co-ai Plan mapping.
- Makes both coding adapters cooperate with hard interrupts:
  - the revoked tool lease is observed within 100ms;
  - user cancellation immediately kills the provider launch group;
  - normal close/timeout retains graceful cleanup;
  - late session state, events, results, mailbox reads, and delayed subprocess writes are blocked.
- Documents that effects completed before an interrupt are not rolled back.

## Design basis

The issue discussion records the final correction after reviewing DD-010, DD-012, DD-024, DD-025, the operator-only approval boundary, and Claude Code's official permission-mode contract: keep the provider wrapper thin, let co-ai own the mode for local/operator sessions, do not use provider `plan` as a framework security sandbox, and fail closed before process launch for shared contacts.

## Verification

- 252 focused provider, approval, co-ai, JSON-resume, hard-stop, and packaging tests passed.
- Real delayed-write subprocess regressions cover both Claude and Codex; each child ignores `SIGTERM`, so only the force-cancel path can pass.
- POSIX group-signal fallback and Windows `taskkill /F /T` success/nonzero/timeout paths are covered.
- Ruff and `git diff --check` passed.
- Two independent final expert reviews: Blocker 0 / Medium 0 / Minor 0.
- The earlier full stacked release rehearsal passed 5,796 unit tests; its only intentional external failure was the unreleased docs-site version mismatch tracked by #792.
- No paid provider/model call was used.

Draft only. Please review; do not merge automatically.