### PR TITLE
Document the official Claude Code plugin workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@
 ├── connectonion.md        # Framework architecture deep dive
 ├── examples.md            # Code examples and patterns
 ├── principles.md          # Design philosophy
+├── claude-code-plugin.md  # Official Claude Code build and review workflow
+├── vibe-coding-guide.md   # Coding-assistant workflow and prompts
 ├── cli/                   # CLI commands documentation
 ├── concepts/              # Core concepts (agents, tools, trust)
 ├── debug/                 # Debugging and @xray documentation

--- a/docs/claude-code-plugin.md
+++ b/docs/claude-code-plugin.md
@@ -1,0 +1,82 @@
+# Claude Code plugin
+
+ConnectOnion has an official Claude Code plugin for framework development and
+code review.
+
+## Install or update
+
+Install it from the ConnectOnion marketplace inside Claude Code:
+
+```text
+/plugin marketplace add openonion/connectonion-claude-plugin
+/plugin install connectonion@connectonion-marketplace
+/reload-plugins
+```
+
+The single-template build and review workflows require plugin **1.2.0 or
+later**. If the plugin is already installed, refresh the marketplace and update
+the cached plugin:
+
+```text
+/plugin marketplace update connectonion-marketplace
+/plugin update connectonion@connectonion-marketplace
+/reload-plugins
+```
+
+## Use it with an agent
+
+Create a project and open it in Claude Code:
+
+```bash
+co create my-agent
+cd my-agent
+claude
+```
+
+Ask the plugin to build or specialize the agent:
+
+```text
+/connectonion:aaron-build-my-agent
+```
+
+In a generated `co-ai` project, the build skill reads `.co/docs/`, keeps the
+small `create_agent(...) + host(...)` entrypoint, and puts specialized
+procedures in `.co/skills/`. In a direct SDK project, it preserves the existing
+`Agent(...)` lifecycle.
+
+Use the plugin to review the project after making changes:
+
+```text
+/connectonion:aaron-review-my-code .
+/connectonion:linus-review-my-code .
+```
+
+The plugin repository owns the source and current plugin documentation. See the
+[ConnectOnion Claude Code plugin repository](https://github.com/openonion/connectonion-claude-plugin)
+for those details.
+
+## Give Claude Code framework context
+
+`co create` and `co init` put the framework reference in `.co/docs/`. The
+plugin provides explicit build and review procedures; the project docs provide
+the version-specific ConnectOnion API and design context.
+
+Tell Claude Code to read that context before a framework-wide change:
+
+```text
+Read .co/docs/README.md and the relevant design decisions, then add a skill
+that watches an RSS feed and files an issue for each new item.
+```
+
+Be explicit about the files that matter. Do not rely on an editor discovering
+every hidden project file automatically.
+
+## Why there is only one template
+
+ConnectOnion used to ship several agent templates. They drifted as the SDK
+changed, so `co create` now starts from one small, deployable `co-ai` agent.
+Add skills in `.co/skills/` to specialize it; use the Claude Code plugin to
+build or review those changes.
+
+See [Templates](templates/) for the current project shape and
+[Vibe Coding](vibe-coding-guide.md) for an editor-agnostic workflow.

--- a/docs/design-decisions/004-cli-create-flow.md
+++ b/docs/design-decisions/004-cli-create-flow.md
@@ -4,7 +4,12 @@
 2024-09-12
 
 ## Status
-Implemented
+Superseded by the single-template design in [Templates](../templates/README.md)
+(implemented in [#294](https://github.com/openonion/connectonion/pull/294)).
+
+This document records the historical six-template flow. It is not the current
+`co create` contract: `co create` now defaults to one deployable `co-ai`
+template, with `custom` as the explicit AI-generated alternative.
 
 ## Context
 The original `co create` command flow asked users for the project name first, then template selection, then AI configuration. This created a poor user experience where users had to name something before they knew what they were building.

--- a/docs/design-decisions/010-cli-ux-progressive-disclosure.md
+++ b/docs/design-decisions/010-cli-ux-progressive-disclosure.md
@@ -2,6 +2,16 @@
 
 *Date: 2025-09-04*
 
+## Status
+
+Partially superseded by the single-template design in
+[Templates](../templates/README.md) (implemented in
+[#294](https://github.com/openonion/connectonion/pull/294)). The progressive
+disclosure principles remain current, but the template questionnaire and
+template-preview examples below are historical. `co create` now defaults to
+one deployable `co-ai` template, with `custom` as the explicit AI-generated
+alternative.
+
 ## The Problem with Traditional CLI Tools
 
 Most framework CLIs suffer from what we call "initialization fatigue" - they bombard users with questions that don't matter yet:

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -45,6 +45,20 @@ agent = create_agent(role="coding")
 host(agent)
 ```
 
+## Build it with Claude Code
+
+This workflow requires plugin **1.2.0 or later**. Existing installations should
+[update the plugin first](../claude-code-plugin.md#install-or-update).
+
+Install the official ConnectOnion Claude Code plugin, open the generated
+project, and run `/connectonion:aaron-build-my-agent` to specialize it. The
+skill reads `.co/docs/`, keeps the generated `agent.py` small, and puts the
+procedure in `.co/skills/`. Then run `/connectonion:aaron-review-my-code .` to
+review the result.
+
+See [Claude Code plugin](../claude-code-plugin.md) for installation and the
+build and review commands.
+
 ## Specialising it
 
 **Skills** are the procedures your agent follows. Drop one in

--- a/docs/vibe-coding-guide.md
+++ b/docs/vibe-coding-guide.md
@@ -1,97 +1,78 @@
-# Vibe Coding Guide: Build Agents with Cursor AI
+# Vibe coding with ConnectOnion
 
-> **Quick Start**: Drag our docs into Cursor → Ask AI → Get your agent
+Start from a working ConnectOnion project, give your coding assistant the
+framework context that ships with it, and describe the behavior you want.
 
-## Two Ways to Get Started
+## Claude Code
 
-### Method 1: Drag & Drop
-1. **Open Cursor AI editor**
-2. **Drag our documentation** into Cursor:
-   - From website: Go to [docs.connectonion.com](https://docs.connectonion.com) → Drag any page
-   - From local: After `co init`, drag `.co/docs/co-vibecoding-principles-docs-contexts-all-in-one.md`
-3. **Ask Cursor**: "Help me create an agent using these docs"
+The official ConnectOnion plugin is the shortest path:
 
-### Method 2: Copy All
-1. **Visit** [docs.connectonion.com](https://docs.connectonion.com)
-2. **Click** "Copy All Docs" (purple button in sidebar)
-3. **Paste** into Cursor chat
-4. **Ask Cursor**: "Help me create an agent using these docs"
+The build workflow requires plugin **1.2.0 or later**. Existing installations
+should [update the plugin first](claude-code-plugin.md#install-or-update).
 
-## Example: What Cursor Generates
-
-When you ask Cursor: **"Using ConnectOnion docs, create a calculator agent"**
-
-Cursor generates:
-
-```python
-from connectonion import Agent
-
-def add(a: float, b: float) -> float:
-    """Add two numbers."""
-    return a + b
-
-def multiply(a: float, b: float) -> float:
-    """Multiply two numbers."""
-    return a * b
-
-# Create agent
-calculator = Agent(
-    "calculator",
-    tools=[add, multiply],
-    instructions="You are a helpful calculator"
-)
-
-# Use it
-result = calculator.input("What is 5 plus 3?")
-print(result)  # Output: "5 plus 3 equals 8"
+```text
+/plugin marketplace add openonion/connectonion-claude-plugin
+/plugin install connectonion@connectonion-marketplace
 ```
 
-## The Magic
+Create and open an agent:
 
-The agent automatically:
-- ✅ Understands "plus" means use `add()`
-- ✅ Picks the right tool
-- ✅ Returns natural language
-
-## What to Ask Cursor
-
-**Basic:**
-```
-"Using ConnectOnion docs, create a calculator agent"
+```bash
+co create my-agent
+cd my-agent
+claude
 ```
 
-**Advanced:**
-```
-"Add more math functions to this agent"
-```
+Then run `/connectonion:aaron-build-my-agent`, or ask Claude Code to read
+`.co/docs/README.md` before making a specific change:
 
-**Custom:**
-```
-"Create an agent that [your specific need]"
+```text
+Read .co/docs/README.md and the relevant design decisions. Add a skill that
+summarizes new support emails, with tests, and keep agent.py unchanged.
 ```
 
-## Why It Works
+See [Claude Code plugin](claude-code-plugin.md) for review commands and the
+division between plugin skills and project documentation.
 
-Cursor + Our Docs = Complete Understanding:
-- How to create agents
-- How to add tools  
-- Best practices
-- Natural language processing
+## Cursor and other coding assistants
 
-## Quick Start
+The same project context works without the plugin:
 
-1. **Install**: `pip install connectonion`
-2. **Initialize**: `co init`
-3. **Open in Cursor**
-4. **Drag our docs** into Cursor
-5. **Ask**: "Create an agent"
-6. **Run**: `python agent.py`
+1. Run `co create my-agent` or `co init` in an existing project.
+2. Add `.co/docs/README.md` and the relevant linked pages to the assistant's
+   context.
+3. Describe one behavior change and ask for tests with it.
+4. Review the diff and run the project's checks before accepting it.
 
-## Get Our Docs
+If the editor cannot read hidden directories, attach the relevant `.co/docs/`
+files explicitly. You can also use the documentation website's **Copy All
+Docs** action.
 
-- **Website**: [docs.connectonion.com](https://docs.connectonion.com) → Copy All Docs
-- **Local**: `.co/docs/co-vibecoding-principles-docs-contexts-all-in-one.md` (after `co init`)
+## Prompt examples
 
----
+Start with the outcome and name the constraints that matter:
 
-*Drag, drop, ask. Your agent is ready!* 🎉
+```text
+Read .co/docs/README.md. Add a weather skill to this agent. Keep agent.py
+small, put the procedure in .co/skills/weather/SKILL.md, and add an offline
+test for skill discovery.
+```
+
+```text
+Review this ConnectOnion agent against the design decisions in
+.co/docs/design-decisions/. Report correctness problems before style issues;
+do not edit files yet.
+```
+
+```text
+Add a stateful browser tool following the installed ConnectOnion docs. Explain
+why state is required, make the smallest change, and run the relevant tests.
+```
+
+## Why this works
+
+ConnectOnion keeps the generated agent deliberately small. The stable project
+shape comes from `co create`; skills hold specialized procedures; `.co/docs/`
+grounds coding assistants in the framework version the project actually uses.
+That separation lets the assistant change behavior without inventing another
+template or copying framework internals into the project.

--- a/tests/unit/test_claude_code_plugin_docs.py
+++ b/tests/unit/test_claude_code_plugin_docs.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+ROOT = Path(__file__).parents[2]
+PLUGIN_DOC = ROOT / "docs" / "claude-code-plugin.md"
+VIBE_DOC = ROOT / "docs" / "vibe-coding-guide.md"
+TEMPLATE_DOC = ROOT / "docs" / "templates" / "README.md"
+HISTORICAL_TEMPLATE_DECISIONS = (
+    ROOT / "docs" / "design-decisions" / "004-cli-create-flow.md",
+    ROOT / "docs" / "design-decisions" / "010-cli-ux-progressive-disclosure.md",
+)
+
+
+def test_plugin_docs_use_the_published_marketplace_identity():
+    pages = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (PLUGIN_DOC, VIBE_DOC)
+    )
+
+    assert "/plugin marketplace add openonion/connectonion-claude-plugin" in pages
+    assert "/plugin install connectonion@connectonion-marketplace" in pages
+    assert "https://github.com/openonion/connectonion-claude-plugin" in pages
+
+
+def test_first_installation_reloads_the_plugin():
+    plugin = PLUGIN_DOC.read_text(encoding="utf-8")
+    install = plugin.split("The single-template", 1)[0]
+
+    assert "/plugin install connectonion@connectonion-marketplace" in install
+    assert "/reload-plugins" in install
+
+
+def test_existing_installations_are_updated_to_the_single_template_contract():
+    plugin = PLUGIN_DOC.read_text(encoding="utf-8")
+
+    assert "1.2.0 or" in plugin
+    assert "/plugin marketplace update connectonion-marketplace" in plugin
+    assert "/plugin update connectonion@connectonion-marketplace" in plugin
+    assert "/reload-plugins" in plugin
+
+
+def test_every_build_entry_point_requires_the_corrected_plugin():
+    for path in (PLUGIN_DOC, VIBE_DOC, TEMPLATE_DOC):
+        text = path.read_text(encoding="utf-8")
+        if "/connectonion:aaron-build-my-agent" not in text:
+            continue
+        assert "1.2.0" in text, path
+        if path != PLUGIN_DOC:
+            assert "claude-code-plugin.md#install-or-update" in text, path
+
+
+def test_plugin_commands_are_namespaced_and_linked_from_the_template():
+    plugin = PLUGIN_DOC.read_text(encoding="utf-8")
+    template = TEMPLATE_DOC.read_text(encoding="utf-8")
+
+    assert "/connectonion:aaron-build-my-agent" in plugin
+    assert "/connectonion:aaron-review-my-code" in plugin
+    assert "/connectonion:linus-review-my-code" in plugin
+    assert "../claude-code-plugin.md" in template
+
+
+def test_plugin_guide_follows_the_single_template_design():
+    plugin = PLUGIN_DOC.read_text(encoding="utf-8")
+
+    assert "one small, deployable `co-ai` agent" in plugin
+    assert "per-template prompts" not in plugin
+
+
+def test_historical_template_decisions_point_to_the_current_contract():
+    for path in HISTORICAL_TEMPLATE_DECISIONS:
+        decision = path.read_text(encoding="utf-8")
+        prose = " ".join(decision.split())
+        assert "superseded" in decision.lower(), path
+        assert "[Templates](../templates/README.md)" in decision, path
+        assert "one deployable `co-ai` template" in prose, path


### PR DESCRIPTION
## What changed

- add one focused entry point for the official Claude Code plugin
- document the real marketplace, plugin identity, namespaced build/review commands, and first-install/update reload flows
- require plugin 1.2.0+ at every build-command entry point
- explain how plugin procedures and versioned `.co/docs/` context complement each other
- mark DD-004 and the template-specific part of DD-010 as superseded by the single-template contract
- update the stale Cursor-only vibe-coding guide without claiming hidden files are auto-loaded
- connect the current single `co-ai` template to skill-based specialization
- add contract tests for marketplace identity, namespaces, version/update safety, historical DD scope, and the single-template boundary

## Why

Issue #48 was based on an old multi-template architecture and users still had no discoverable path to the official plugin. The documentation now follows the current design: one deployable scaffold, behavior in `.co/skills/`, roles for domain doctrine, and explicit project-local documentation context. Historical design records remain readable but can no longer be mistaken for the current six-template contract.

## Required dependency and merge order

**Depends on openonion/connectonion-claude-plugin#5. Do not merge this PR until that Draft PR is merged and plugin 1.2.0 is installable from `connectonion-marketplace`.**

The dependency updates the build and review skills to preserve generated `agent.py`, distinguish generated co-ai from direct SDK projects, and use `.co/docs/`. Plugin 1.1.0 has the old contract and is not compatible with the workflow documented here.

Before this PR can merge, verify all of the following on the plugin's merged default branch:

- both manifests declare 1.2.0
- `claude plugin validate .` passes
- `python -m unittest discover -s tests` passes
- a fresh install exposes the three documented namespaced commands
- an existing 1.1.0 install reaches 1.2.0 after marketplace update, plugin update, and reload

## Validation

- 38 relevant docs/template/project tests passed
- new documentation contract tests: 7 passed
- `ruff check tests/unit/test_claude_code_plugin_docs.py`
- `git diff --check`
- companion 1.2.0 marketplace validates locally with Claude Code
- two independent final reviews: blocker/medium/minor = 0/0/0

Fixes #48

This PR is Draft and has not been merged.