### PR TITLE
Close the pytest security alert and pin CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,19 +26,18 @@ jobs:
     permissions:
       # Required to upload the SARIF result to the Security tab.
       security-events: write
-      actions: read
       contents: read
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: python
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,8 +2,8 @@
 #
 # Deliberately minimal: default query suite, one language, no build step —
 # Python needs no compilation, so there is nothing to configure and nothing to
-# drift. The weekly schedule is what catches a newly published advisory against
-# code that has not changed; push/PR runs catch what we write.
+# drift. The weekly schedule applies updated CodeQL queries to code that has not
+# changed; push/PR runs catch what we write.
 name: CodeQL
 
 on:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
 ]

--- a/tests/unit/test_dependency_security_floors.py
+++ b/tests/unit/test_dependency_security_floors.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from packaging.version import Version
 
-
 REPO = Path(__file__).resolve().parents[2]
 
 PATCHED_FLOORS = {
@@ -23,14 +22,18 @@ PATCHED_FLOORS = {
 }
 
 
+def _locked_versions(lockfile: str) -> dict[str, str]:
+    return dict(re.findall(
+        r'\[\[package\]\]\s*name = "([^"]+)"\s*version = "([^"]+)"',
+        lockfile,
+    ))
+
+
 def test_security_sensitive_dependency_floors_are_patched(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
     lockfile = (REPO / "uv.lock").read_text(encoding="utf-8")
-    locked = dict(re.findall(
-        r'\[\[package\]\]\s*name = "([^"]+)"\s*version = "([^"]+)"',
-        lockfile,
-    ))
+    locked = _locked_versions(lockfile)
 
     for package, floor in PATCHED_FLOORS.items():
         published_floor = re.search(
@@ -48,3 +51,30 @@ def test_security_sensitive_dependency_floors_are_patched(monkeypatch, tmp_path)
         assert Version(locked[package]) >= Version(floor), (
             f"{package} {locked[package]} regressed below patched {floor}"
         )
+
+
+def test_pytest_dev_floor_is_patched(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    floor = "9.0.3"
+    pyproject = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    lockfile = (REPO / "uv.lock").read_text(encoding="utf-8")
+
+    assert re.search(
+        rf'^\s*"pytest>={re.escape(floor)}",\s*$',
+        pyproject,
+        re.MULTILINE,
+    ), f"pytest dev metadata does not require the patched floor {floor}"
+
+    root_requirement = (
+        f'{{ name = "pytest", marker = "extra == \'dev\'", '
+        f'specifier = ">={floor}" }}'
+    )
+    assert lockfile.count(root_requirement) == 1, (
+        "pytest's dev-only floor is missing from uv.lock root metadata"
+    )
+
+    locked = _locked_versions(lockfile)
+    assert "pytest" in locked, "pytest is missing from uv.lock"
+    assert Version(locked["pytest"]) >= Version(floor), (
+        f"pytest {locked['pytest']} regressed below patched {floor}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -361,7 +361,7 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pynacl", specifier = ">=1.6.2" },
     { name = "pypdf", specifier = ">=4.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-docx", specifier = ">=1.1.0" },
@@ -1437,7 +1437,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.1"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1448,9 +1448,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/56/f013048ac4bc4c1d9be45afd4ab209ea62822fb1598f40687e6bf45dcea4/pytest-9.0.1.tar.gz", hash = "sha256:3e9c069ea73583e255c3b21cf46b8d3c56f6e3a1a8f6da94ccb0fcf57b9d73c8", size = 1564125, upload_time = "2025-11-12T13:05:09.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload_time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/8b/6300fb80f858cda1c51ffa17075df5d846757081d11ab4aa35cef9e6258b/pytest-9.0.1-py3-none-any.whl", hash = "sha256:67be0030d194df2dfa7b556f2e56fb3c3315bd5c8822c6951162b92b32ce7dad", size = 373668, upload_time = "2025-11-12T13:05:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload_time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #771.

## What changed

- raise the optional development floor from `pytest>=7.0.0` to the first patched release, `pytest>=9.0.3`;
- refresh the exact lock from pytest 9.0.1 to 9.1.1;
- move the existing Python CodeQL workflow from mutable major tags to immutable current stable commits:
  - `actions/checkout` v7.0.1;
  - `github/codeql-action` v4.37.6;
- remove `actions: read`, which CodeQL does not require for this public repository;
- keep `security-events: write` scoped to the analysis job.

## Why

Dependabot alert #1 reports `GHSA-6w46-j5rx-g56g` / `CVE-2025-71176`: pytest before 9.0.3 has insecure UNIX tmpdir handling. Updating only the lock would allow a future resolver to select a vulnerable version again, so the declared development floor and lock move together.

The CodeQL workflow is already the correct small design; this PR only makes its supply-chain and permission boundary explicit. No new matrix, build step, custom query, or abstraction is added.

## Validation

- `uv lock --check`
- full lock including the `dev` extra: `pip-audit 2.10.1` reports **no known vulnerabilities**
- `actionlint 1.7.12 .github/workflows/codeql.yml`
- full pytest 9.1.1 run: **6092 passed, 26 skipped, 174 deselected, 1 failed**

The one local failure is the existing cross-check against the neighboring dirty docs-site checkout: it advertises 1.5.20 while ConnectOnion is 1.6.0. The same focused test fails identically on an untouched detached `origin/main` worktree, so it is not introduced by this diff. CI uses its isolated checkout and remains the authoritative matrix.

## Honest weakness

The Dependabot alert will remain open until this PR is merged into the default branch. Also, this PR does not enable GitHub Advanced Security for private `oo-api`; that owner/plan decision is documented on #771.

## AI assistance

AI assisted with the release-surface audit, advisory triage, implementation, and review. Advisory metadata, official action versions and SHAs, CodeQL permissions, the full dependency audit, and baseline failure comparison were independently verified before opening this Draft PR.
