### PR TITLE
fix(gmail): parse HTML bodies safely

### DIFF
--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -379,7 +379,16 @@ class Gmail:
             soup = BeautifulSoup(html, 'html.parser')
             for tag in soup(['script', 'style']):
                 tag.decompose()
-            return ' '.join(soup.get_text(separator=' ', strip=True).split())
+            block_tags = (
+                'address', 'article', 'aside', 'blockquote', 'br', 'caption', 'dd', 'details',
+                'div', 'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form',
+                'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header', 'hr', 'li', 'main', 'nav',
+                'ol', 'p', 'pre', 'section', 'summary', 'table', 'tbody', 'td', 'tfoot',
+                'th', 'thead', 'tr', 'ul',
+            )
+            for tag in soup(block_tags):
+                tag.insert_after(' ')
+            return ' '.join(soup.get_text().split())
 
         # Single part email
         if 'body' in payload and payload['body'].get('data'):

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -373,15 +373,13 @@ class Gmail:
 
     def _extract_body(self, payload) -> str:
         """Extract body from email payload, preferring text/plain, falling back to stripped HTML."""
-        import re
-        from html import unescape
+        from bs4 import BeautifulSoup
 
         def strip_html(html: str) -> str:
-            html = re.sub(r'<style[^>]*>.*?</style>', '', html, flags=re.DOTALL | re.IGNORECASE)
-            html = re.sub(r'<script[^>]*>.*?</script>', '', html, flags=re.DOTALL | re.IGNORECASE)
-            text = re.sub(r'<[^>]+>', '', html)
-            text = unescape(text)
-            return re.sub(r'\s+', ' ', text).strip()
+            soup = BeautifulSoup(html, 'html.parser')
+            for tag in soup(['script', 'style']):
+                tag.decompose()
+            return ' '.join(soup.get_text(separator=' ', strip=True).split())
 
         # Single part email
         if 'body' in payload and payload['body'].get('data'):

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -637,6 +637,25 @@ class TestEmailContent:
 
         assert "Plain text version" in result
 
+    def test_extract_html_body_uses_parser_and_omits_non_text_content(self, gmail_with_mock):
+        """HTML variants cannot bypass the plain-text conversion boundary."""
+        import base64
+        gmail, _ = gmail_with_mock
+        html = (
+            '<p>Hello&nbsp;<strong>world</strong></p>'
+            '<ScRiPt data-example="true" >steal()</ScRiPt>'
+            '<style >p { display: none }</style>'
+            '<p>Next line</p>'
+        )
+        encoded_html = base64.urlsafe_b64encode(html.encode()).decode()
+
+        result = gmail._extract_body({
+            'mimeType': 'text/html',
+            'body': {'data': encoded_html},
+        })
+
+        assert result == "Hello world Next line"
+
     def test_get_email_attachments(self, gmail_with_mock):
         """Test get_email_attachments lists attachments."""
         gmail, mock_service = gmail_with_mock

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -643,6 +643,7 @@ class TestEmailContent:
         gmail, _ = gmail_with_mock
         html = (
             '<p>Hello&nbsp;<strong>world</strong></p>'
+            '<p>co<strong>de</strong>!</p>'
             '<ScRiPt data-example="true" >steal()</ScRiPt>'
             '<style >p { display: none }</style>'
             '<p>Next line</p>'
@@ -654,7 +655,7 @@ class TestEmailContent:
             'body': {'data': encoded_html},
         })
 
-        assert result == "Hello world Next line"
+        assert result == "Hello world code! Next line"
 
     def test_get_email_attachments(self, gmail_with_mock):
         """Test get_email_attachments lists attachments."""


### PR DESCRIPTION
## Summary

- replace regex-based Gmail HTML tag filtering with the repository's existing BeautifulSoup parser
- explicitly remove `script` and `style` elements before plain-text extraction
- preserve entity decoding and readable spacing
- add a regression test covering spaced, attributed, and mixed-case dangerous tags

Closes #789
Parent security baseline: #771

## Design

The design alternatives and ADR rationale were discussed on #789 before implementation. BeautifulSoup is already a required dependency and already establishes this repository's HTML-to-text pattern in `WebFetch.strip_tags()`. A sanitizer dependency would be unnecessary because Gmail's contract returns plain text, while expanding regexes would preserve the class of bug reported by CodeQL.

## Verification

- `python -m pytest tests/unit/test_gmail.py -q` — 56 passed
- `python -m ruff check connectonion/useful_tools/gmail.py tests/unit/test_gmail.py --ignore E402,I001,F401,E722` — passed; ignored codes are pre-existing findings in these legacy files
- `git diff --check` — passed

`ruff format --check` reports both whole legacy files would be reformatted; this PR intentionally avoids a noisy full-file formatting rewrite.

## Review notes

- Draft only: do not merge until maintainer review.
- The nine URL-substring and two clear-text-logging CodeQL findings are separately documented on #771 as test-only false positives; this PR does not hide or dismiss them.
