### PR TITLE
Superseded: paid engine cache lookup spike (reimplement via Onionwright session API)

### DIFF
--- a/connectonion/useful_tools/browser_tools/engine.py
+++ b/connectonion/useful_tools/browser_tools/engine.py
@@ -98,23 +98,6 @@ def choose(attestation, onion_present):
 
 # The paid engine is not reachable from here yet, and this names exactly what
 # is missing rather than leaving a stub that reads as finished.
-#
-# `onionwright.licence.license.load(path, server_key)` needs a cache path and
-# the pinned server key; `onionwright.launcher.resolve_binary(token,
-# server_key, pin)` needs an authenticated token and a Chromium revision.
-# connectonion holds none of those three today. Supplying them is the open
-# work in openonion/connectonion#511 — not something to fake here.
-#
-# Until then the defaults below raise, `resolve()` reads that as "no licence"
-# the same way it reads an offline machine, and everyone gets the free engine.
-# That is the right failure direction and the wrong end state, so
-# test_the_paid_path_is_not_wired_up_yet asserts it out loud: when the wiring
-# lands, that test fails and has to be deleted, which is the point of it.
-PAID_WIRING_PENDING = (
-    "onionwright is installed but connectonion has no licence configuration "
-    "yet (cache path, pinned server key, Chromium revision) — see "
-    "openonion/connectonion#511"
-)
 
 
 def _cached_attestation():
@@ -130,10 +113,23 @@ def _cached_attestation():
     command is not the right place to discover that oo-api is slow. The
     refresh belongs to the licence client's own schedule (it renews at the
     12-hour half-life of a 24-hour attestation), not to `co browser go_to`.
-    """
-    import onionwright.licence  # noqa: F401
 
-    raise NotImplementedError(PAID_WIRING_PENDING)
+    The cached payload is read but its signature is not checked here, and that
+    is a deliberate scope choice rather than an omission. Verifying needs the
+    server key, which `onionwright.launcher.server_public_key()` fetches over
+    the network -- exactly what this function promises not to do. Nothing is
+    lost by trusting it: the only thing a forged local file buys is an attempt
+    to launch the paid binary, which compiles the server's public key into
+    itself (browser patches/core/0005) and refuses a licence it cannot verify.
+    The gate is the engine and the download, not this hint.
+    """
+    import json
+
+    from onionwright.launcher import HOME
+
+    path = HOME / "attestation.json"
+    payload = json.loads(path.read_text())["payload"]
+    return json.loads(bytes.fromhex(payload).decode())
 
 
 def _onion_path():
@@ -144,10 +140,17 @@ def _onion_path():
     it answer "absent" on every machine including a paid one -- a silent
     permanent downgrade that the tests could not see because they inject this
     function. A name that is wrong should fail loudly enough to notice.
-    """
-    import onionwright.launcher  # noqa: F401
 
-    raise NotImplementedError(PAID_WIRING_PENDING)
+    `resolve_binary()` is what puts the executable here, under
+    `~/.onionwright/chrome/<revision>/`. This only reports what that already
+    did: a browser command must not start a 180 MB download, so a machine that
+    has paid but not yet fetched the binary is a machine that runs patchright
+    and says so.
+    """
+    from onionwright.launcher import HOME
+
+    executables = sorted((HOME / "chrome").glob("*/chrome"))
+    return executables[-1] if executables else None
 
 
 def resolve(load_attestation=_cached_attestation, onion_path=_onion_path,

--- a/tests/unit/test_browser_engine_resolve.py
+++ b/tests/unit/test_browser_engine_resolve.py
@@ -112,33 +112,79 @@ def test_resolve_always_produces_an_engine(attestation, path):
     assert chosen in (engine.ONION, engine.PATCHRIGHT)
 
 
-def test_the_paid_path_is_not_wired_up_yet():
-    """A deliberate tombstone. Delete it when the wiring lands.
+def test_a_machine_without_onionwright_still_browses():
+    """The free install, which is most installs.
 
-    Both production lookups raise, because connectonion has no licence
-    configuration to give them — so on a machine that has paid, has a cached
-    attestation and has the binary, `resolve()` still answers patchright.
-
-    That is stated as a passing test rather than left in a comment because the
-    defects this whole change exists to fix were both of this shape: code that
-    looked like it was doing the work. `/license/download` computed an
-    attestation and ignored it; `attest()` took a tier and never checked it.
-    An assertion that the gap exists is the only version of "we know" that
-    stops being true on its own when someone closes it.
-
-    Deliberately does not assert *which* exception. There are two, and which
-    one you get depends on the machine rather than on the code: without the
-    package it is ImportError, with it installed (a dev checkout, an editable
-    install) it is NotImplementedError. An earlier version asserted the
-    message contained the issue number, which is only true of the second — so
-    it passed on my machine and failed on all four Python versions in CI. The
-    property is "neither lookup can produce a paid engine", and that holds
-    either way.
+    `onionwright` is not a dependency, so both production lookups raise
+    ImportError before touching the disk or the network. `resolve()` reads
+    that the same way it reads an offline machine, and the answer is a working
+    browser. Asserted through the real defaults rather than injected doubles,
+    because the property being protected is that the *defaults* are safe.
     """
-    for lookup in (engine._cached_attestation, engine._onion_path):
-        with pytest.raises(Exception):
-            lookup()
-
-    # And the consequence, from the outside: the defaults cannot reach ONION.
     chosen, _ = engine.resolve()
+
     assert chosen == engine.PATCHRIGHT
+
+
+def test_the_paid_lookups_read_what_onionwright_actually_wrote(tmp_path, monkeypatch):
+    """The wiring, against the real on-disk layout.
+
+    `resolve_binary()` extracts to `~/.onionwright/chrome/<revision>/chrome`
+    and `ensure_licensed()` caches `~/.onionwright/attestation.json` holding a
+    hex-encoded payload. Both readers are pointed at a fake HOME with exactly
+    that shape — the same shape verified on a real paid Linux box, where the
+    binary refuses to start without the licence and runs with it.
+    """
+    import json
+    import sys
+    import types
+
+    launcher = types.ModuleType("onionwright.launcher")
+    launcher.HOME = tmp_path
+    package = types.ModuleType("onionwright")
+    package.launcher = launcher
+    monkeypatch.setitem(sys.modules, "onionwright", package)
+    monkeypatch.setitem(sys.modules, "onionwright.launcher", launcher)
+
+    payload = {"tier": "pro", "active": True, "max_concurrent": 1}
+    (tmp_path / "attestation.json").write_text(json.dumps({
+        "payload": json.dumps(payload).encode().hex(),
+        "signature": "00" * 64,
+    }))
+    executable = tmp_path / "chrome" / "150.0.7871.187" / "chrome"
+    executable.parent.mkdir(parents=True)
+    executable.touch()
+
+    assert engine._cached_attestation() == payload
+    assert engine._onion_path() == executable
+
+    chosen, note, path = engine.resolve(with_path=True)
+    assert (chosen, note, path) == (engine.ONION, None, executable)
+
+
+def test_paid_without_the_binary_downloaded_falls_back(tmp_path, monkeypatch):
+    """Paid, licensed, but `resolve_binary()` has not run yet.
+
+    A browser command must not start a 180 MB download, so this is patchright
+    plus a line saying why — not a stall and not a failure.
+    """
+    import json
+    import sys
+    import types
+
+    launcher = types.ModuleType("onionwright.launcher")
+    launcher.HOME = tmp_path
+    package = types.ModuleType("onionwright")
+    package.launcher = launcher
+    monkeypatch.setitem(sys.modules, "onionwright", package)
+    monkeypatch.setitem(sys.modules, "onionwright.launcher", launcher)
+
+    (tmp_path / "attestation.json").write_text(json.dumps({
+        "payload": json.dumps({"tier": "pro", "active": True}).encode().hex(),
+        "signature": "00" * 64,
+    }))
+
+    chosen, note = engine.resolve()
+
+    assert chosen == engine.PATCHRIGHT
+    assert note is not None


### PR DESCRIPTION
## Superseded — do not merge

This PR preserves useful investigation and real Linux launch evidence, but its architecture is no longer the ConnectOnion 1.8 contract.

It directly reads Onionwright's private cache layout:

- `~/.onionwright/attestation.json`;
- `~/.onionwright/chrome/<revision>/chrome`.

It also implements the superseded Free/Pro and cumulative-credit decision and does not provide the required paid-session heartbeat, `paid_until` watchdog, runtime licence-file refresh or actual launch-seam integration.

The canonical 1.8 implementation is now:

- #511 — PAYG product and launch contract;
- openonion/onionwright#40 — one public launcher/session-supervision API;
- openonion/oo-api#168 — atomic billing and server-signed runtime licence;
- openonion/browser#96 — C++ runtime verification;
- #1154 — cross-repository release control.

ConnectOnion must consume Onionwright's public API rather than its filesystem internals. The feature remains required for 1.8; this particular PR is closed so it cannot be mistaken for merge-ready implementation. Useful tests/evidence may be carried forward into a new PR against the canonical contract.