### PR TITLE
Keep Claude Code permissions operator-owned

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -80,7 +80,8 @@ _FROM = {
     **{name: ".useful_tools" for name in (
         "send_email", "get_emails", "mark_read", "mark_unread",
         "Memory", "Gmail", "GDrive", "Synology", "GoogleCalendar", "Outlook",
-        "MicrosoftCalendar", "WebFetch", "Shell", "bash", "codex", "claude_code",
+        "MicrosoftCalendar", "WebFetch", "Shell", "bash", "codex", "ClaudeCode",
+        "claude_code",
         "DiffWriter",
         "MODE_NORMAL", "MODE_AUTO", "MODE_PLAN",
         "pick", "yes_no", "autocomplete", "TodoList", "SlashCommand",
@@ -171,6 +172,7 @@ __all__ = [
     "Shell",
     "bash",
     "codex",
+    "ClaudeCode",
     "claude_code",
     "DiffWriter",
     "MODE_NORMAL",

--- a/connectonion/cli/co_ai/tools/claude_code.py
+++ b/connectonion/cli/co_ai/tools/claude_code.py
@@ -2,7 +2,7 @@
 
 import json
 
-from connectonion.useful_tools import claude_code as run_claude_code
+from connectonion.useful_tools.claude_code import _run_claude_code
 
 
 def claude_code(
@@ -43,7 +43,7 @@ def claude_code(
         "accept_edits": "acceptEdits",
         "ulw": "auto",
     }.get(session.get("mode"), "default")
-    return run_claude_code(
+    return _run_claude_code(
         prompt=prompt,
         session_id=session_id,
         cwd=cwd,

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -21,7 +21,7 @@ from .web_fetch import WebFetch
 from .shell import Shell
 from .bash import bash
 from .codex import codex
-from .claude_code import claude_code
+from .claude_code import ClaudeCode, claude_code
 from .diff_writer import DiffWriter, MODE_NORMAL, MODE_AUTO, MODE_PLAN
 from ..tui import pick
 from .terminal import yes_no, autocomplete
@@ -58,6 +58,7 @@ __all__ = [
     "Shell",
     "bash",
     "codex",
+    "ClaudeCode",
     "claude_code",
     "DiffWriter",
     "MODE_NORMAL",

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -25,17 +25,69 @@ def claude_code(
     prompt: str,
     session_id: str = "",
     cwd: str = "",
+    model: str = "",
+    timeout: int = 600,
+    agent=None,
+) -> str:
+    """Run Claude Code in manual mode and return one stable JSON envelope.
+
+    The permission policy is deliberately absent from this Agent-facing
+    signature. Use ``ClaudeCode(permission_mode=...)`` when an operator needs
+    to bind a different mode before registering the tool.
+    """
+    return _run_claude_code(
+        prompt=prompt,
+        session_id=session_id,
+        cwd=cwd,
+        permission_mode="default",
+        model=model,
+        timeout=timeout,
+        agent=agent,
+    )
+
+
+class ClaudeCode:
+    """Claude Code tool with an operator-owned permission policy."""
+
+    def __init__(self, permission_mode: str = "default") -> None:
+        if permission_mode not in PERMISSION_MODES:
+            choices = ", ".join(PERMISSION_MODES)
+            raise ValueError(
+                f"Invalid permission mode {permission_mode!r}. Use one of: {choices}."
+            )
+        self._permission_mode = permission_mode
+
+    def claude_code(
+        self,
+        prompt: str,
+        session_id: str = "",
+        cwd: str = "",
+        model: str = "",
+        timeout: int = 600,
+        agent=None,
+    ) -> str:
+        """Run or resume Claude Code with the operator-bound permission mode."""
+        return _run_claude_code(
+            prompt=prompt,
+            session_id=session_id,
+            cwd=cwd,
+            permission_mode=self._permission_mode,
+            model=model,
+            timeout=timeout,
+            agent=agent,
+        )
+
+
+def _run_claude_code(
+    prompt: str,
+    session_id: str = "",
+    cwd: str = "",
     permission_mode: str = "default",
     model: str = "",
     timeout: int = 600,
     agent=None,
 ) -> str:
-    """Run or resume Claude Code and return one stable JSON envelope.
-
-    ``default`` is ConnectOnion's stable name for Claude Code's current
-    ``manual`` CLI mode. ``bypassPermissions`` is available only when the
-    caller explicitly requests it.
-    """
+    """Private runner shared by safe, configured, and co-ai entry points."""
     if not isinstance(session_id, str):
         return _envelope("", error="Session ID must be a string.")
     if not isinstance(prompt, str) or not prompt.strip():

--- a/docs/useful_tools/claude_code.md
+++ b/docs/useful_tools/claude_code.md
@@ -14,24 +14,29 @@ dependency, and provider-specific parsing stays outside the ConnectOnion Agent
 loop. It accepts both the documented single result object and Claude Code
 versions that wrap the result as the final item of a JSON event array.
 
+The default `claude_code` function tool always starts Claude Code in its manual
+permission mode. Permission policy is deliberately not a tool argument, so the
+model cannot weaken it through a prompt or tool call.
+
 ## Direct use
 
 ```python
 import json
 
-from connectonion import claude_code
+from connectonion import ClaudeCode
 
-first = json.loads(claude_code(
+claude = ClaudeCode(permission_mode="plan")
+
+first = json.loads(claude.claude_code(
     "Find the failing test",
     cwd="./my-project",
-    permission_mode="plan",
 ))
 
-second = json.loads(claude_code(
+editor = ClaudeCode(permission_mode="acceptEdits")
+second = json.loads(editor.claude_code(
     "Now implement the fix",
     session_id=first["session_id"],
     cwd="./my-project",
-    permission_mode="acceptEdits",
 ))
 ```
 
@@ -57,12 +62,25 @@ output, and non-zero exits use the same envelope with `status` set to `error` or
 
 ## Permissions
 
-`permission_mode="default"` is the safe default and maps to Claude Code's
-current `manual` CLI spelling. Supported explicit modes are `manual`,
-`acceptEdits`, `plan`, `auto`, `dontAsk`, and `bypassPermissions`.
+The public `claude_code(...)` function always maps to Claude Code's current
+`manual` CLI mode. For an advanced mode, the operator binds policy before the
+tool reaches the Agent:
 
-`bypassPermissions` is never selected automatically. It disables Claude Code's
-permission protection and should only be used in an isolated environment.
+```python
+from connectonion import Agent, ClaudeCode
+
+claude = ClaudeCode(permission_mode="acceptEdits")
+agent = Agent("lead", tools=[claude])
+```
+
+The generated `claude_code` schema still contains only task, session, working
+directory, model, and timeout fields. Supported constructor modes are
+`default`, `manual`, `acceptEdits`, `plan`, `auto`, `dontAsk`, and
+`bypassPermissions`.
+
+`bypassPermissions` disables Claude Code's permission protection. Bind it only
+in operator-written code running inside an isolated environment; a model can
+never select it through the tool schema.
 
 The tool does not use Claude Code's `--bare` mode by default. This preserves the
 user's normal Claude Code authentication and project instructions such as

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -9,8 +9,9 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from connectonion import claude_code as root_claude_code
+from connectonion import Agent, ClaudeCode, claude_code as root_claude_code
 from connectonion.cli.commands.copy_commands import TOOLS
+from connectonion.useful_tools import ClaudeCode as UsefulClaudeCode
 from connectonion.useful_tools import claude_code
 
 claude_module = importlib.import_module("connectonion.useful_tools.claude_code")
@@ -32,10 +33,16 @@ def _run(tmp_path, completed=None, prompt="fix it", **kwargs):
             "total_cost_usd": 0.01,
         }
     )
+    permission_mode = kwargs.pop("permission_mode", None)
+    tool = (
+        ClaudeCode(permission_mode).claude_code
+        if permission_mode is not None
+        else claude_code
+    )
     with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
         claude_module, "_run_process", return_value=completed
     ) as run:
-        result = json.loads(claude_code(prompt, cwd=str(tmp_path), **kwargs))
+        result = json.loads(tool(prompt, cwd=str(tmp_path), **kwargs))
     return result, run
 
 
@@ -104,15 +111,28 @@ def test_documented_permission_modes_are_forwarded_only_when_explicit(
     assert argv[argv.index("--permission-mode") + 1] == mode
 
 
-def test_invalid_permission_mode_never_launches(tmp_path):
+def test_invalid_permission_mode_fails_before_a_provider_can_launch():
     with patch.object(claude_module, "_run_process") as run:
-        result = json.loads(
-            claude_code("fix", cwd=str(tmp_path), permission_mode="yolo")
-        )
+        with pytest.raises(ValueError, match="Invalid permission mode"):
+            ClaudeCode("yolo")
 
-    assert result["status"] == "error"
-    assert "Invalid permission mode" in result["error"]
     run.assert_not_called()
+
+
+@pytest.mark.parametrize("tool", [claude_code, ClaudeCode("bypassPermissions")])
+def test_agent_schema_never_exposes_provider_permission_policy(tmp_path, tool):
+    agent = Agent(
+        "schema",
+        llm=MagicMock(),
+        tools=[tool],
+        quiet=True,
+        log=False,
+        co_dir=tmp_path / ".co",
+    )
+
+    schemas = [registered.to_function_schema() for registered in agent.tools]
+    assert [schema["name"] for schema in schemas] == ["claude_code"]
+    assert "permission_mode" not in schemas[0]["parameters"]["properties"]
 
 
 @pytest.mark.parametrize("timeout", [0, -1, True, 1.5])
@@ -432,6 +452,7 @@ def test_real_posix_timeout_remains_a_timeout(tmp_path):
 
 def test_tool_is_exported_from_both_public_namespaces():
     assert root_claude_code is claude_code
+    assert ClaudeCode is UsefulClaudeCode
 
 
 def test_tool_is_registered_as_copyable():

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -33,7 +33,7 @@ def test_co_ai_mode_owns_claude_permission_mode(
         seen.update(kwargs)
         return '{"provider":"claude_code","session_id":"s"}'
 
-    monkeypatch.setattr(claude_wrapper, "run_claude_code", fake_claude_code)
+    monkeypatch.setattr(claude_wrapper, "_run_claude_code", fake_claude_code)
     agent = SimpleNamespace(current_session={"mode": mode})
 
     result = claude_code(
@@ -61,7 +61,7 @@ def test_unknown_or_missing_mode_uses_provider_default(monkeypatch, tmp_path):
     calls = []
     monkeypatch.setattr(
         claude_wrapper,
-        "run_claude_code",
+        "_run_claude_code",
         lambda **kwargs: calls.append(kwargs) or "result",
     )
 
@@ -80,7 +80,7 @@ def test_unknown_or_missing_mode_uses_provider_default(monkeypatch, tmp_path):
 @pytest.mark.parametrize("mode", ["safe", "accept_edits", "ulw"])
 def test_hosted_contact_cannot_start_claude_code(monkeypatch, tmp_path, mode):
     backend = pytest.fail
-    monkeypatch.setattr(claude_wrapper, "run_claude_code", backend)
+    monkeypatch.setattr(claude_wrapper, "_run_claude_code", backend)
     agent = SimpleNamespace(
         current_session={
             "mode": mode,

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -182,7 +182,7 @@ def test_abandoned_agent_tool_cannot_commit_session_or_registry_changes():
             "claude_code",
             co_ai_claude_code,
             "connectonion.cli.co_ai.tools.claude_code",
-            "run_claude_code",
+            "_run_claude_code",
         ),
     ],
 )


### PR DESCRIPTION
## Contract

The model may choose what work to delegate; only the operator may choose Claude Code's permission mode.

Closes #796.

## What changed

- `claude_code(prompt, ...)` is now the simple safe function tool and always maps to Claude Code `manual`.
- Its Agent schema no longer exposes `permission_mode`.
- `ClaudeCode(permission_mode=...)` binds an advanced provider mode in operator-written Python before the instance is registered with an Agent. Its discovered `claude_code` method also omits permission policy from the schema.
- The existing `co ai` wrapper calls the private shared runner and continues to derive `safe` / `accept_edits` / `ulw` as `default` / `acceptEdits` / `auto` from operator-owned session state.
- Public exports, direct-use docs, and regression tests now describe and enforce that split.

## Why this shape

ADR 012 separates tool task data from execution policy. ADR 020 requires security limits to be deterministic code, not a promise in the prompt. Relying on the optional approval plugin would leave the documented `Agent(..., tools=[claude_code])` path exposed; removing advanced modes would unnecessarily break the legitimate co-ai/operator use case. One safe function plus one stateful configuration object is the smallest API that preserves both.

## Verification

- 68 focused Claude/co-ai tests passed on the final commit.
- 113 Claude/co-ai/Agent/export/packaging/template tests passed before the final documentation-only wording correction.
- Two independent post-fix reviews:
  - reviewer A: 0 Blocker / 0 Medium / 0 Minor
  - reviewer B: implementation 0/0/0; one documentation wording Minor found and fixed before commit
- `compileall` and `git diff --check` pass.
- Actual generated schemas for `tools=[claude_code]` and `tools=[ClaudeCode("bypassPermissions")]` contain only prompt/session/cwd/model/timeout, never `permission_mode`.

## Real-provider gate

The same installed Claude Code CLI 2.1.226 that passed earlier real JSON/resume smoke was retried after this change. Both no-tool probes timed out at their existing 120-second boundary. Unit evidence confirms this patch emits the same safe `manual` argv, so no test was weakened or skipped; successful real-provider smoke remains a release gate and must be rerun when the external CLI/account is responsive.

This PR is intentionally Draft. Do not merge or release from this session.
