### PR TITLE
Make HTTP route specificity deterministic

### DIFF
--- a/connectonion/network/host/http_routes.py
+++ b/connectonion/network/host/http_routes.py
@@ -67,11 +67,11 @@ def _reserved(path: str) -> bool:
 def _pattern(path: str):
     names = []
     pieces = []
-    static_segments = 0
+    specificity = []
     for segment in path.split("/")[1:]:
         matches = list(_PARAMETER.finditer(segment))
+        specificity.append(len(_PARAMETER.sub("", segment)))
         if not matches:
-            static_segments += 1
             pieces.append(re.escape(segment))
             continue
         cursor = 0
@@ -83,7 +83,11 @@ def _pattern(path: str):
             cursor = match.end()
         segment_pattern.append(re.escape(segment[cursor:]))
         pieces.append("".join(segment_pattern))
-    return re.compile("^/" + "/".join(pieces) + "$"), names, static_segments
+    return (
+        re.compile("^/" + "/".join(pieces) + "$"),
+        names,
+        tuple(specificity),
+    )
 
 
 def _shape(path: str) -> str:
@@ -144,7 +148,7 @@ class HTTPRoute:
     handler: Callable
     pattern: Any = field(repr=False)
     parameter_names: tuple[str, ...] = ()
-    static_segments: int = 0
+    specificity: tuple[int, ...] = ()
 
     async def invoke(self, request: HTTPRequest, params: dict[str, str]):
         signature = inspect.signature(self.handler)
@@ -232,26 +236,35 @@ class HTTPRouter:
                     f"its route: {', '.join(unsupported)}"
                 )
 
-            pattern, names, static_segments = _pattern(full_path)
+            pattern, names, specificity = _pattern(full_path)
             self._routes.append(HTTPRoute(
                 method, relative_path, full_path, audience, handler, pattern,
-                tuple(names), static_segments,
+                tuple(names), specificity,
             ))
             return handler
 
         return register
 
     def match(self, method: str, path: str):
-        candidates = sorted(
-            (route for route in self._routes if route.method == method.upper()),
-            key=lambda route: route.static_segments,
-            reverse=True,
-        )
-        for route in candidates:
+        matches = []
+        for route in self._routes:
+            if route.method != method.upper():
+                continue
             match = route.pattern.fullmatch(path)
             if match:
-                return route, dict(zip(route.parameter_names, match.groups()))
-        return None
+                matches.append(
+                    (route, dict(zip(route.parameter_names, match.groups())))
+                )
+        if not matches:
+            return None
+
+        best = max(route.specificity for route, _ in matches)
+        winners = [(route, params) for route, params in matches
+                   if route.specificity == best]
+        if len(winners) != 1:
+            routes = ", ".join(route.path for route, _ in winners)
+            raise ValueError(f"ambiguous HTTP routes for {method.upper()} {path}: {routes}")
+        return winners[0]
 
 
 def _scope_headers(scope) -> dict[str, str]:

--- a/tests/unit/test_http_routes.py
+++ b/tests/unit/test_http_routes.py
@@ -72,6 +72,44 @@ def test_static_route_wins_over_a_parameter_route():
     assert params == {}
 
 
+@pytest.mark.parametrize("generic_first", [True, False])
+def test_route_specificity_is_left_to_right_not_registration_order(generic_first):
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+
+    def generic(kind):
+        return kind
+
+    def users(item):
+        return item
+
+    routes = [
+        ("/{kind}/new", generic),
+        ("/users/{item}", users),
+    ]
+    if not generic_first:
+        routes.reverse()
+    for path, handler in routes:
+        http.public.get(path)(handler)
+
+    route, params = http.match("GET", "/public/users/new")
+
+    assert route.handler is users
+    assert params == {"item": "new"}
+
+
+def test_equally_specific_overlapping_routes_fail_before_invocation():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    http.public.post("/files/a{tail}")(lambda tail: tail)
+    http.public.post("/files/{head}z")(lambda head: head)
+
+    with pytest.raises(ValueError, match="ambiguous HTTP routes"):
+        http.match("POST", "/public/files/az")
+
+
 def test_method_mismatch_is_not_a_route_match():
     from connectonion import HTTPRouter
 


### PR DESCRIPTION
## Contract

Among matching HTTP routes, compare literal specificity from left to right; never use registration order to choose between equally specific handlers.

Closes #799.

## What changed

- Store each route's literal-character count per path segment as a small tuple.
- Match only candidates with the requested method and actual regex match.
- Select the lexicographically greatest tuple, so an earlier literal segment wins over a later one.
- If multiple actual matches share the best tuple, fail explicitly before returning any handler.
- Remove the old total `static_segments` counter, which no longer has a reason to exist.

The public router API and path-template syntax stay unchanged, including mixed segments such as `{category}.ics`.

## Design

ADR 012 keeps route selection separate from authorization and handler execution. ADR 020 requires the dispatcher to fail closed rather than let decorator/import order choose a side-effecting handler. A general-purpose router dependency would be disproportionate for this two-method template router; Python tuple comparison expresses the intended left-to-right rule directly.

## Verification

- 63 local route, host-auth, and custom HTTP E2E tests passed before review.
- Reviewer A independently ran the broader route/ASGI/auth set: 95 passed, 0/0/0.
- Reviewer B independently ran route + ASGI: 23 passed, 0/0/0.
- Tests cover both registration orders, exact handler identity and params, static-over-parameter behavior, and equal-specificity ambiguity.
- Control-flow review confirms ambiguity fails before body reading, auth, replay-cache mutation, or handler invocation.
- `git diff --check` passes.

This PR is intentionally Draft. Do not merge from this session.
