### PR TITLE
fix(action): keep review sessions transient

### DIFF
--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -101,8 +101,9 @@ def _handle_json_one_shot(
     resume,
     *,
     agent_factory=None,
+    persist_session=True,
 ):
-    session_id = resume
+    session_id = resume if persist_session else None
     try:
         with redirect_stdout(sys.stderr):
             from ..co_ai.agent import GLOBAL_CO_DIR
@@ -115,6 +116,8 @@ def _handle_json_one_shot(
                 session_lock,
             )
 
+            if resume and not persist_session:
+                raise ValueError("A transient one-shot run cannot resume a session.")
             lock = session_lock(GLOBAL_CO_DIR, resume) if resume else nullcontext()
             with lock:
                 # Loading validates the project cwd before agent construction reads
@@ -128,13 +131,16 @@ def _handle_json_one_shot(
                 )
                 restore_tool_state(agent, tools)
                 if session is None:
-                    session_id = new_session_id()
-                    session = _fresh_session(agent, session_id)
+                    runtime_session_id = new_session_id()
+                    session = _fresh_session(agent, runtime_session_id)
+                    if persist_session:
+                        session_id = runtime_session_id
                 result = agent.input(prompt, session=session)
-                agent.current_session["session_id"] = session_id
-                save_snapshot(
-                    GLOBAL_CO_DIR, agent.current_session, capture_tool_state(agent)
-                )
+                if persist_session:
+                    agent.current_session["session_id"] = session_id
+                    save_snapshot(
+                        GLOBAL_CO_DIR, agent.current_session, capture_tool_state(agent)
+                    )
     except Exception as exc:
         _print_envelope(resume, None, str(exc))
         raise typer.Exit(1) from None

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -142,7 +142,8 @@ def _handle_json_one_shot(
                         GLOBAL_CO_DIR, agent.current_session, capture_tool_state(agent)
                     )
     except Exception as exc:
-        _print_envelope(resume, None, str(exc))
+        error_session_id = resume if persist_session else None
+        _print_envelope(error_session_id, None, str(exc))
         raise typer.Exit(1) from None
     _print_envelope(session_id, result, None)
 

--- a/connectonion/cli/github_action.py
+++ b/connectonion/cli/github_action.py
@@ -136,6 +136,7 @@ def _invoke_json_review(prompt: str, model: str, agent_factory: Callable) -> tup
                 1,
                 None,
                 agent_factory=agent_factory,
+                persist_session=False,
             )
     except typer.Exit as exc:
         exit_code = exc.exit_code

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -354,6 +354,26 @@ def test_json_failure_is_structured_and_nonzero(tmp_path, monkeypatch, capsys):
     assert "before failure" in captured.err
 
 
+def test_transient_one_shot_rejects_resume_without_echoing_the_session_id(capsys):
+    with pytest.raises(typer.Exit) as caught:
+        ai_commands._handle_json_one_shot(
+            "task",
+            "co/test",
+            4,
+            True,
+            1,
+            new_session_id(),
+            persist_session=False,
+        )
+
+    assert caught.value.exit_code == 1
+    assert json.loads(capsys.readouterr().out) == {
+        "session_id": None,
+        "result": None,
+        "error": "A transient one-shot run cannot resume a session.",
+    }
+
+
 def test_missing_resume_is_an_error_not_a_new_conversation(tmp_path, monkeypatch, capsys):
     missing = new_session_id()
     monkeypatch.setattr("connectonion.cli.co_ai.agent.GLOBAL_CO_DIR", tmp_path)

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -62,11 +62,12 @@ def test_json_review_uses_the_333_agent_factory_seam(tmp_path, monkeypatch):
 
     assert exit_code == 0
     assert json.loads(stdout) == {
-        "session_id": json.loads(stdout)["session_id"],
+        "session_id": None,
         "result": "review result",
         "error": None,
     }
     assert calls == [(("co/test", 4, True, 1), {"resumable": True})]
+    assert not (tmp_path / "ai" / "sessions").exists()
 
 
 def test_pr_number_prefers_input_and_falls_back_to_event(tmp_path):
@@ -181,6 +182,13 @@ def test_comment_is_bounded_without_splitting_utf8():
     assert body.startswith(COMMENT_MARKER)
     assert len(body.encode("utf-8")) <= 60_000
     assert "Review truncated" in body
+
+
+def test_transient_review_comment_does_not_advertise_a_session():
+    body = render_comment("Looks good", None)
+
+    assert "Looks good" in body
+    assert "ConnectOnion session" not in body
 
 
 def test_model_reader_uses_only_fixed_get_requests_for_one_pr():


### PR DESCRIPTION
## Summary

- make the GitHub Action's private JSON review invocation explicitly transient
- preserve the normal `co ai --json` / `--resume` persistence contract
- emit `session_id: null`, create no snapshot, and omit the unusable session footer from Action comments

## Design

The design discussion and rejected alternatives are recorded in #802 before implementation. The Action owns the lifecycle decision, while the shared private one-shot executor retains one execution path through a keyword-only `persist_session` boundary.

This follows DD-010 (do not expose a useless choice) and DD-012 (keep lifecycle orchestration separate from execution). It intentionally does not weaken the project-directory validation on resumable CLI snapshots.

## Verification

- `pytest -q tests/unit/test_github_action.py tests/unit/test_github_action_metadata.py tests/unit/test_co_ai_one_shot_sessions.py tests/unit/test_co_ai_commands.py tests/e2e/cli/test_cli_ai.py` — 60 passed
- `git diff --check`

The first local run's 44 assertions passed but teardown detected the parent workspace's `.co` directory. Re-running from the dedicated worktree with its own local `.co` boundary passed cleanly; no user configuration was removed or changed.

## Review checklist

- [x] no production CLI resume behavior changed
- [x] no snapshot is created for Action reviews
- [x] exact JSON envelope retained
- [x] transient failures never echo a supplied session ID
- [x] no merge, tag, publish, or deploy performed

Fixes #802
