### PR TITLE
fix(auth): share replay protection across workers

### DIFF
--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -22,9 +22,11 @@ import uuid
 from typing import Dict
 
 from ..trust import TRUST_LEVELS, TrustAgent
-
-# Signature expiry window (5 minutes)
-SIGNATURE_EXPIRY_SECONDS = 300
+from .replay import (
+    SIGNATURE_EXPIRY_SECONDS,
+    ReplayProtectionError,
+    signature_digest,
+)
 
 
 def verify_signature(payload: dict, signature: str, public_key: str) -> bool:
@@ -359,6 +361,7 @@ def signature_already_used(data: dict) -> bool:
     signature = data.get("signature")
     if not signature:
         return False          # refused by the signature check itself
+    signature = signature_digest(signature)
 
     now = time.time()
     for old in [sig for sig, seen in _seen_signatures.items()
@@ -372,7 +375,10 @@ def signature_already_used(data: dict) -> bool:
 
 
 def authenticated_command_payload(
-    data: dict, expected_address: str, expected_recipient: str = None
+    data: dict,
+    expected_address: str,
+    expected_recipient: str = None,
+    replay_check=signature_already_used,
 ):
     """Return a verified command payload bound to the connected caller.
 
@@ -380,6 +386,7 @@ def authenticated_command_payload(
     every command with its type and a random nonce, so possession or injection
     into that socket is not enough to invent a different command.
     """
+    replay_check = replay_check or signature_already_used
     payload = data.get("payload")
     if not isinstance(payload, dict):
         return None, "unauthorized: signed command required"
@@ -396,7 +403,11 @@ def authenticated_command_payload(
     nonce = payload.get("nonce")
     if not isinstance(nonce, str) or not nonce:
         return None, "unauthorized: signed command nonce required"
-    if signature_already_used(data):
+    try:
+        already_used = replay_check(data)
+    except ReplayProtectionError:
+        return None, "misconfigured: replay protection unavailable"
+    if already_used:
         return None, "unauthorized: signed command already used"
     return payload, None
 

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -17,6 +17,7 @@ Trust evaluation (via TrustAgent.should_allow()):
 
 import hashlib
 import json
+import math
 import time
 import uuid
 from typing import Dict
@@ -348,7 +349,7 @@ def request_from_headers(headers: dict, method: str, path: str) -> dict:
 # commands include type, recipient and a random nonce in their signed payload;
 # v1 remains accepted so an upgraded host does not strand an older client.
 
-_seen_signatures: Dict[str, float] = {}
+_seen_signatures: Dict[bytes, float] = {}
 
 
 def signature_already_used(data: dict) -> bool:
@@ -364,13 +365,19 @@ def signature_already_used(data: dict) -> bool:
     signature = signature_digest(signature)
 
     now = time.time()
-    for old in [sig for sig, seen in _seen_signatures.items()
-                if now - seen > SIGNATURE_EXPIRY_SECONDS]:
+    timestamp = (data.get("payload") or {}).get("timestamp")
+    if (isinstance(timestamp, (int, float)) and not isinstance(timestamp, bool)
+            and math.isfinite(timestamp)):
+        expires_at = timestamp + SIGNATURE_EXPIRY_SECONDS
+    else:
+        expires_at = now + (2 * SIGNATURE_EXPIRY_SECONDS)
+    for old in [sig for sig, expiry in _seen_signatures.items()
+                if expiry < now]:
         del _seen_signatures[old]
 
     if signature in _seen_signatures:
         return True
-    _seen_signatures[signature] = now
+    _seen_signatures[signature] = expires_at
     return False
 
 
@@ -441,6 +448,8 @@ def _authenticate_signed(data: dict, *, blacklist=None, recipient_address=None):
         return None, agent_address, "unauthorized: timestamp required in payload"
     if not isinstance(timestamp, (int, float)) or isinstance(timestamp, bool):
         return None, agent_address, "unauthorized: timestamp must be numeric"
+    if not math.isfinite(timestamp):
+        return None, agent_address, "unauthorized: timestamp must be finite"
 
     # Check timestamp expiry (5 minute window)
     now = time.time()

--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -131,6 +131,12 @@ def extract_and_authenticate(data: dict, trust, *, blacklist=None, whitelist=Non
     if error:
         return prompt, agent_address, False, error
 
+    return _authorize_authenticated(data, prompt, agent_address, trust, whitelist)
+
+
+def _authorize_authenticated(data, prompt, agent_address, trust, whitelist=None):
+    """Apply trust policy after cryptographic authentication has succeeded."""
+
     # Parameter whitelist bypasses trust POLICY (not signature verification)
     if whitelist and agent_address in whitelist:
         return prompt, agent_address, True, None
@@ -379,6 +385,45 @@ def signature_already_used(data: dict) -> bool:
         return True
     _seen_signatures[signature] = expires_at
     return False
+
+
+def authenticate_connect(
+    data: dict,
+    trust,
+    *,
+    blacklist=None,
+    whitelist=None,
+    recipient_address=None,
+    replay_check=signature_already_used,
+):
+    """Authenticate CONNECT in security order: signature, claim, then policy."""
+    if "payload" not in data or "signature" not in data:
+        return None, None, False, "unauthorized: signed request required"
+
+    prompt, agent_address, error = _authenticate_signed(
+        data, blacklist=blacklist, recipient_address=recipient_address
+    )
+    if error:
+        return prompt, agent_address, False, error
+
+    try:
+        already_used = replay_check(data)
+    except ReplayProtectionError:
+        return (
+            None,
+            agent_address,
+            True,
+            "misconfigured: replay protection unavailable",
+        )
+    if already_used:
+        return (
+            None,
+            agent_address,
+            True,
+            "unauthorized: this CONNECT was already used",
+        )
+
+    return _authorize_authenticated(data, prompt, agent_address, trust, whitelist)
 
 
 def authenticated_command_payload(

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -429,6 +429,7 @@ async def handle_http(
                 recipient_address=route_handlers["agent_metadata"]["address"],
                 blacklist=blacklist,
                 whitelist=whitelist,
+                replay_check=route_handlers.get("replay"),
             )
             return
 

--- a/connectonion/network/host/http_routes.py
+++ b/connectonion/network/host/http_routes.py
@@ -315,6 +315,7 @@ async def dispatch_http_route(
     recipient_address: str,
     blacklist=None,
     whitelist=None,
+    replay_check=None,
 ):
     """Authenticate, invoke, and serialize one already-matched route."""
     body = await read_body(receive)
@@ -327,6 +328,7 @@ async def dispatch_http_route(
             request_from_http_headers,
             signature_already_used,
         )
+        from .replay import ReplayProtectionError
 
         try:
             data = request_from_http_headers(
@@ -358,7 +360,16 @@ async def dispatch_http_route(
                 media_type="application/json",
             ))
             return
-        if signature_already_used(data):
+        check_replay = replay_check or signature_already_used
+        try:
+            already_used = check_replay(data)
+        except ReplayProtectionError:
+            await _send(send, HTTPResponse(
+                json.dumps({"error": "misconfigured: replay protection unavailable"}),
+                status=503, media_type="application/json",
+            ))
+            return
+        if already_used:
             await _send(send, HTTPResponse(
                 json.dumps({"error": "unauthorized: signature already used"}),
                 status=401, media_type="application/json",

--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -15,7 +15,10 @@ from pathlib import Path
 
 
 SIGNATURE_EXPIRY_SECONDS = 300
-SQLITE_BUSY_TIMEOUT_SECONDS = 0.25
+# A healthy transaction is tiny, but another OS worker can be descheduled while
+# holding the write lock. Stay bounded and fail closed after ordinary runner
+# scheduling jitter has had time to clear (#804).
+SQLITE_BUSY_TIMEOUT_SECONDS = 2.0
 
 
 class ReplayProtectionError(RuntimeError):

--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -1,0 +1,86 @@
+"""
+Purpose: Cross-process one-use signature storage for hosted-agent authentication
+State/Effects: stores only signature digests and timestamps in .co/replay.sqlite3
+Integration: SignatureReplayStore.already_used is injected into every hosted route
+Errors: raises ReplayProtectionError so callers can fail closed with a safe message
+"""
+
+import hashlib
+import os
+import sqlite3
+import time
+from contextlib import closing
+from pathlib import Path
+
+
+SIGNATURE_EXPIRY_SECONDS = 300
+
+
+class ReplayProtectionError(RuntimeError):
+    """The host cannot safely decide whether a signature was already used."""
+
+
+def signature_digest(signature) -> bytes:
+    """Hash canonical signature bytes so equivalent hex spellings collide."""
+    text = str(signature)
+    encoded = text[2:] if text.startswith("0x") else text
+    try:
+        canonical = b"hex:" + bytes.fromhex(encoded)
+    except ValueError:
+        canonical = b"raw:" + text.encode()
+    return hashlib.sha256(canonical).digest()
+
+
+class SignatureReplayStore:
+    """Atomically claim signature digests across threads and OS workers."""
+
+    def __init__(self, path: str | Path, expiry_seconds=SIGNATURE_EXPIRY_SECONDS):
+        self.path = Path(path).resolve()
+        self.expiry_seconds = expiry_seconds
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(descriptor)
+            if os.name != "nt":
+                os.chmod(self.path, 0o600)
+            with closing(self._connect()) as database:
+                database.execute(
+                    "CREATE TABLE IF NOT EXISTS used_signatures ("
+                    "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+                    ") WITHOUT ROWID"
+                )
+        except (OSError, sqlite3.Error) as exc:
+            raise ReplayProtectionError(
+                f"replay protection storage is unavailable: {self.path}"
+            ) from exc
+
+    def _connect(self):
+        database = sqlite3.connect(self.path, timeout=5)
+        database.execute("PRAGMA busy_timeout = 5000")
+        return database
+
+    def already_used(self, data: dict, *, now=None) -> bool:
+        """Atomically record one signature, returning whether it existed."""
+        signature = data.get("signature")
+        if not signature:
+            return False
+
+        seen_at = time.time() if now is None else now
+        digest = signature_digest(signature)
+        try:
+            with closing(self._connect()) as database:
+                with database:
+                    database.execute(
+                        "DELETE FROM used_signatures WHERE seen_at < ?",
+                        (seen_at - self.expiry_seconds,),
+                    )
+                    inserted = database.execute(
+                        "INSERT OR IGNORE INTO used_signatures (digest, seen_at) "
+                        "VALUES (?, ?)",
+                        (digest, seen_at),
+                    ).rowcount
+            return inserted == 0
+        except (OSError, sqlite3.Error) as exc:
+            raise ReplayProtectionError(
+                f"replay protection storage is unavailable: {self.path}"
+            ) from exc

--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -6,6 +6,7 @@ Errors: raises ReplayProtectionError so callers can fail closed with a safe mess
 """
 
 import hashlib
+import math
 import os
 import sqlite3
 import time
@@ -14,6 +15,7 @@ from pathlib import Path
 
 
 SIGNATURE_EXPIRY_SECONDS = 300
+SQLITE_BUSY_TIMEOUT_SECONDS = 0.25
 
 
 class ReplayProtectionError(RuntimeError):
@@ -44,20 +46,54 @@ class SignatureReplayStore:
             if os.name != "nt":
                 os.chmod(self.path, 0o600)
             with closing(self._connect()) as database:
-                database.execute(
-                    "CREATE TABLE IF NOT EXISTS used_signatures ("
-                    "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
-                    ") WITHOUT ROWID"
-                )
+                with database:
+                    database.execute(
+                        "CREATE TABLE IF NOT EXISTS used_signatures ("
+                        "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+                        ", expires_at REAL"
+                        ") WITHOUT ROWID"
+                    )
+                    columns = {
+                        row[1] for row in database.execute(
+                            "PRAGMA table_info(used_signatures)"
+                        )
+                    }
+                    if "expires_at" not in columns:
+                        database.execute(
+                            "ALTER TABLE used_signatures "
+                            "ADD COLUMN expires_at REAL"
+                        )
+                    # A pre-fix row may have represented a future-dated
+                    # signature. Retain it for the maximum validity window.
+                    database.execute(
+                        "UPDATE used_signatures SET expires_at = seen_at + ? "
+                        "WHERE expires_at IS NULL",
+                        (2 * self.expiry_seconds,),
+                    )
+                    database.execute(
+                        "CREATE INDEX IF NOT EXISTS used_signatures_expiry "
+                        "ON used_signatures(expires_at)"
+                    )
         except (OSError, sqlite3.Error) as exc:
             raise ReplayProtectionError(
                 f"replay protection storage is unavailable: {self.path}"
             ) from exc
 
     def _connect(self):
-        database = sqlite3.connect(self.path, timeout=5)
-        database.execute("PRAGMA busy_timeout = 5000")
+        database = sqlite3.connect(self.path, timeout=SQLITE_BUSY_TIMEOUT_SECONDS)
+        database.execute(
+            f"PRAGMA busy_timeout = {int(SQLITE_BUSY_TIMEOUT_SECONDS * 1000)}"
+        )
         return database
+
+    def _expires_at(self, data: dict, seen_at: float) -> float:
+        """Return the point after which a verified signature cannot be valid."""
+        timestamp = (data.get("payload") or {}).get("timestamp")
+        if (isinstance(timestamp, (int, float))
+                and not isinstance(timestamp, bool)
+                and math.isfinite(timestamp)):
+            return timestamp + self.expiry_seconds
+        return seen_at + (2 * self.expiry_seconds)
 
     def already_used(self, data: dict, *, now=None) -> bool:
         """Atomically record one signature, returning whether it existed."""
@@ -66,18 +102,19 @@ class SignatureReplayStore:
             return False
 
         seen_at = time.time() if now is None else now
+        expires_at = self._expires_at(data, seen_at)
         digest = signature_digest(signature)
         try:
             with closing(self._connect()) as database:
                 with database:
                     database.execute(
-                        "DELETE FROM used_signatures WHERE seen_at < ?",
-                        (seen_at - self.expiry_seconds,),
+                        "DELETE FROM used_signatures WHERE expires_at < ?",
+                        (seen_at,),
                     )
                     inserted = database.execute(
-                        "INSERT OR IGNORE INTO used_signatures (digest, seen_at) "
-                        "VALUES (?, ?)",
-                        (digest, seen_at),
+                        "INSERT OR IGNORE INTO used_signatures "
+                        "(digest, seen_at, expires_at) VALUES (?, ?, ?)",
+                        (digest, seen_at, expires_at),
                     ).rowcount
             return inserted == 0
         except (OSError, sqlite3.Error) as exc:

--- a/connectonion/network/host/replay.py
+++ b/connectonion/network/host/replay.py
@@ -47,6 +47,8 @@ class SignatureReplayStore:
                 os.chmod(self.path, 0o600)
             with closing(self._connect()) as database:
                 with database:
+                    # Serialize schema inspection and migration across workers.
+                    database.execute("BEGIN IMMEDIATE")
                     database.execute(
                         "CREATE TABLE IF NOT EXISTS used_signatures ("
                         "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -45,7 +45,7 @@ from .ws_router import run_ws_session
 from .schedule import create_schedule_lifespan
 from ..trust import TrustAgent, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
-from .auth import extract_and_authenticate
+from .auth import authenticate_connect, extract_and_authenticate
 from .replay import SignatureReplayStore
 from .config import load_host_config, load_list_file, validate_files, validate_images, project_co_dir, DEFAULT_FILE_LIMITS
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
@@ -288,6 +288,7 @@ def _create_route_handlers(
         "health": handle_health,
         "info": handle_info,
         "auth": extract_and_authenticate,
+        "connect_auth": partial(authenticate_connect, replay_check=replay_check),
         "replay": replay_check,
         "ws_input": handle_ws_input,
         "ws_exec": handle_ws_exec,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -46,6 +46,7 @@ from .schedule import create_schedule_lifespan
 from ..trust import TrustAgent, parse_policy, TRUST_LEVELS
 from ..trust.factory import PROMPTS_DIR
 from .auth import extract_and_authenticate
+from .replay import SignatureReplayStore
 from .config import load_host_config, load_list_file, validate_files, validate_images, project_co_dir, DEFAULT_FILE_LIMITS
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
 from .http_router import (
@@ -213,7 +214,15 @@ def _build_agent_profile(agent_metadata: dict) -> dict:
     return profile
 
 
-def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_ttl: int, trust_agent, config: dict, exec_permissions: dict | None = None):
+def _create_route_handlers(
+    create_agent: Callable,
+    agent_metadata: dict,
+    result_ttl: int,
+    trust_agent,
+    config: dict,
+    exec_permissions: dict | None = None,
+    replay_check=None,
+):
     """Create route handler dict for ASGI app.
 
     Args:
@@ -227,9 +236,13 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         exec_permissions: The .co/host.yaml permission whitelist that gates WS
                           EXEC (direct tool execution). Same list the LLM
                           approval flow uses; empty dict → nothing runs directly.
+        replay_check: Atomic one-use signature guard for this hosted project.
     """
     agent_name = agent_metadata["name"]
     exec_permissions = exec_permissions or {}
+    if replay_check is None:
+        from .auth import signature_already_used
+        replay_check = signature_already_used
 
     def handle_input(storage, prompt, session=None, connection=None, images=None, files=None):
         validate_files(files, config)
@@ -275,6 +288,7 @@ def _create_route_handlers(create_agent: Callable, agent_metadata: dict, result_
         "health": handle_health,
         "info": handle_info,
         "auth": extract_and_authenticate,
+        "replay": replay_check,
         "ws_input": handle_ws_input,
         "ws_exec": handle_ws_exec,
         "admin_logs": handle_admin_logs,
@@ -965,7 +979,11 @@ def host(
     from ...useful_plugins.tool_approval.approval import load_permission_patterns
     exec_permissions = load_permission_patterns(co_dir)
 
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, config, exec_permissions)
+    replay_store = SignatureReplayStore(co_dir / "replay.sqlite3")
+    route_handlers = _create_route_handlers(
+        create_agent, agent_metadata, result_ttl, trust_agent, config,
+        exec_permissions, replay_store.already_used,
+    )
 
     # Parse trust config for /info onboard info
     trust_config = _parse_trust_config(trust)
@@ -1087,7 +1105,14 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
         trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
 
     from ...useful_plugins.tool_approval.approval import load_permission_patterns
-    route_handlers = _create_route_handlers(create_agent, agent_metadata, result_ttl, trust_agent, DEFAULT_FILE_LIMITS, load_permission_patterns())
+    storage_path = getattr(storage, "path", None)
+    replay_dir = Path(storage_path).parent if storage_path else project_co_dir()
+    replay_store = SignatureReplayStore(replay_dir / "replay.sqlite3")
+    route_handlers = _create_route_handlers(
+        create_agent, agent_metadata, result_ttl, trust_agent,
+        DEFAULT_FILE_LIMITS, load_permission_patterns(),
+        replay_store.already_used,
+    )
     balance_startup, balance_shutdown = _create_balance_lifespan(
         sample, agent_metadata
     )

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -19,32 +19,23 @@ console = Console()
 
 async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
     """Handle CONNECT message: auth, session merge, send CONNECTED. Returns (io, task) for reattach or None."""
-    from ..auth import signature_already_used
-    from ..replay import ReplayProtectionError
+    from ..auth import authenticate_connect, signature_already_used
 
     metadata = route_handlers.get("agent_metadata") or {}
     auth_kwargs = {"blacklist": blacklist, "whitelist": whitelist}
     if metadata.get("address"):
         auth_kwargs["recipient_address"] = metadata["address"]
-    _, agent_address, sig_valid, err = route_handlers["auth"](
-        data, trust, **auth_kwargs
-    )
-
-    # Invalid frames must not be able to fill or lock the shared ledger. A
-    # cryptographically valid signature is claimed before the trust result is
-    # applied, so forbidden/onboarding attempts remain one-use too (#649).
-    if sig_valid:
-        replay_check = route_handlers.get("replay", signature_already_used)
-        try:
-            already_used = replay_check(data)
-        except ReplayProtectionError:
-            await send_msg({"type": "ERROR",
-                            "message": "misconfigured: replay protection unavailable"})
-            return
-        if already_used:
-            await send_msg({"type": "ERROR",
-                            "message": "unauthorized: this CONNECT was already used"})
-            return
+    connect_auth = route_handlers.get("connect_auth")
+    if connect_auth is None:
+        _, agent_address, sig_valid, err = authenticate_connect(
+            data, trust,
+            replay_check=route_handlers.get("replay", signature_already_used),
+            **auth_kwargs,
+        )
+    else:
+        _, agent_address, sig_valid, err = connect_auth(
+            data, trust, **auth_kwargs
+        )
 
     if err and "forbidden" in err.lower():
         trust_agent = route_handlers["trust_agent"]

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -20,10 +20,18 @@ console = Console()
 async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
     """Handle CONNECT message: auth, session merge, send CONNECTED. Returns (io, task) for reattach or None."""
     from ..auth import signature_already_used
+    from ..replay import ReplayProtectionError
 
     # One signature opens one connection (#649). Checked before the trust gate
     # so a replay is refused whatever level the original caller had.
-    if signature_already_used(data):
+    replay_check = route_handlers.get("replay", signature_already_used)
+    try:
+        already_used = replay_check(data)
+    except ReplayProtectionError:
+        await send_msg({"type": "ERROR",
+                        "message": "misconfigured: replay protection unavailable"})
+        return
+    if already_used:
         await send_msg({"type": "ERROR",
                         "message": "unauthorized: this CONNECT was already used"})
         return

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -22,20 +22,6 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
     from ..auth import signature_already_used
     from ..replay import ReplayProtectionError
 
-    # One signature opens one connection (#649). Checked before the trust gate
-    # so a replay is refused whatever level the original caller had.
-    replay_check = route_handlers.get("replay", signature_already_used)
-    try:
-        already_used = replay_check(data)
-    except ReplayProtectionError:
-        await send_msg({"type": "ERROR",
-                        "message": "misconfigured: replay protection unavailable"})
-        return
-    if already_used:
-        await send_msg({"type": "ERROR",
-                        "message": "unauthorized: this CONNECT was already used"})
-        return
-
     metadata = route_handlers.get("agent_metadata") or {}
     auth_kwargs = {"blacklist": blacklist, "whitelist": whitelist}
     if metadata.get("address"):
@@ -43,6 +29,22 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
     _, agent_address, sig_valid, err = route_handlers["auth"](
         data, trust, **auth_kwargs
     )
+
+    # Invalid frames must not be able to fill or lock the shared ledger. A
+    # cryptographically valid signature is claimed before the trust result is
+    # applied, so forbidden/onboarding attempts remain one-use too (#649).
+    if sig_valid:
+        replay_check = route_handlers.get("replay", signature_already_used)
+        try:
+            already_used = replay_check(data)
+        except ReplayProtectionError:
+            await send_msg({"type": "ERROR",
+                            "message": "misconfigured: replay protection unavailable"})
+            return
+        if already_used:
+            await send_msg({"type": "ERROR",
+                            "message": "unauthorized: this CONNECT was already used"})
+            return
 
     if err and "forbidden" in err.lower():
         trust_agent = route_handlers["trust_agent"]

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -67,7 +67,8 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
 
                 signed_frame = data
                 verified, command_error = authenticated_command_payload(
-                    data, conn["agent_address"], conn.get("recipient_address")
+                    data, conn["agent_address"], conn.get("recipient_address"),
+                    route_handlers.get("replay"),
                 )
                 if command_error:
                     await send_msg({"type": "ERROR", "message": command_error})
@@ -106,8 +107,12 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
 
                     metadata = route_handlers.get("agent_metadata") or {}
                     verified, status_error = authenticated_command_payload(
-                        data, data.get("from"), metadata.get("address")
+                        data, data.get("from"), metadata.get("address"),
+                        route_handlers.get("replay"),
                     )
+                    if (status_error or "").startswith("misconfigured:"):
+                        await send_msg({"type": "ERROR", "message": status_error})
+                        continue
                     if status_error is None:
                         requester = data.get("from")
                         sid = verified.get("session_id")

--- a/connectonion/network/trust/http_admin.py
+++ b/connectonion/network/trust/http_admin.py
@@ -106,8 +106,14 @@ async def _admin_signature(method, path, scope, receive, route_handlers, *, read
     # the replay in #649, called here rather than reimplemented.
     #
     from ..host.auth import signature_already_used
+    from ..host.replay import ReplayProtectionError
 
-    if signature_already_used(data):
+    replay_check = route_handlers.get("replay", signature_already_used)
+    try:
+        already_used = replay_check(data)
+    except ReplayProtectionError:
+        return False, 503, "misconfigured: replay protection unavailable", data
+    if already_used:
         return False, 401, "unauthorized: signature already used", data
 
     trust_agent = route_handlers.get("trust_agent")

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -1250,6 +1250,8 @@ gunicorn myagent:app -w 4 -k uvicorn.workers.UvicornWorker
 All workers for one project share `.co/replay.sqlite3`, so a captured CONNECT,
 v2 command, admin request, or protected HTTP request cannot be accepted once by
 each process. The ledger contains only short-lived signature digests.
+Digests are retained until the signed timestamp leaves the freshness window;
+an unavailable or locked ledger fails closed rather than accepting a replay.
 
 ### Docker
 

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -1252,6 +1252,8 @@ v2 command, admin request, or protected HTTP request cannot be accepted once by
 each process. The ledger contains only short-lived signature digests.
 Digests are retained until the signed timestamp leaves the freshness window;
 an unavailable or locked ledger fails closed rather than accepting a replay.
+For CONNECT, the claim happens after Ed25519 verification but before trust
+policy evaluation, so replay rejection cannot repeat policy work or mutations.
 
 ### Docker
 

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -1247,6 +1247,10 @@ uvicorn myagent:app --workers 4
 gunicorn myagent:app -w 4 -k uvicorn.workers.UvicornWorker
 ```
 
+All workers for one project share `.co/replay.sqlite3`, so a captured CONNECT,
+v2 command, admin request, or protected HTTP request cannot be accepted once by
+each process. The ledger contains only short-lived signature digests.
+
 ### Docker
 
 ```dockerfile

--- a/docs/network/http-routes.md
+++ b/docs/network/http-routes.md
@@ -123,7 +123,10 @@ response = httpx.post(
 ```
 
 Pass the exact bytes sent on the wire to `sign_http_request`; changing the body
-or query after signing is refused. A signature is one-use and cannot be replayed.
+or query after signing is refused. A signature is one-use and cannot be replayed,
+including when the ASGI app runs in multiple OS workers. The host keeps only a
+short-lived digest in the project's `.co/replay.sqlite3`; raw signatures and
+request bodies are not stored there.
 
 Never put an admin private key in browser JavaScript. An H5 admin application
 needs a trusted backend or a future short-lived capability flow. Calendar apps

--- a/docs/network/http-routes.md
+++ b/docs/network/http-routes.md
@@ -126,7 +126,8 @@ Pass the exact bytes sent on the wire to `sign_http_request`; changing the body
 or query after signing is refused. A signature is one-use and cannot be replayed,
 including when the ASGI app runs in multiple OS workers. The host keeps only a
 short-lived digest in the project's `.co/replay.sqlite3`; raw signatures and
-request bodies are not stored there.
+request bodies are not stored there. Each digest remains until the signed
+timestamp is outside the accepted freshness window.
 
 Never put an admin private key in browser JavaScript. An H5 admin application
 needs a trusted backend or a future short-lived capability flow. Calendar apps

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -300,6 +300,9 @@ The one-use ledger is shared across ASGI workers and survives a worker restart;
 it stores only short-lived signature digests in `.co/replay.sqlite3`.
 Each digest remains until its signed timestamp is cryptographically expired;
 an unavailable or locked ledger fails closed.
+CONNECT processing verifies Ed25519 first, atomically claims the digest second,
+and only then evaluates trust or onboarding policy. A replay therefore cannot
+repeat an LLM policy call or a policy side effect.
 
 **A v2 command signs what the server executes.** Its payload contains `type`, all
 command fields, `to`, `timestamp`, and a random `nonce`. The server verifies the

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -296,6 +296,8 @@ onboarding to offer, so a stranger gets `ERROR` from the policy rather than an
 **A signature is single-use.** Replaying a captured CONNECT is refused with
 `ERROR unauthorized: this CONNECT was already used`. A v2 client also signs every
 application command; replaying one is refused with `signed command already used`.
+The one-use ledger is shared across ASGI workers and survives a worker restart;
+it stores only short-lived signature digests in `.co/replay.sqlite3`.
 
 **A v2 command signs what the server executes.** Its payload contains `type`, all
 command fields, `to`, `timestamp`, and a random `nonce`. The server verifies the

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -298,6 +298,8 @@ onboarding to offer, so a stranger gets `ERROR` from the policy rather than an
 application command; replaying one is refused with `signed command already used`.
 The one-use ledger is shared across ASGI workers and survives a worker restart;
 it stores only short-lived signature digests in `.co/replay.sqlite3`.
+Each digest remains until its signed timestamp is cryptographically expired;
+an unavailable or locked ledger fails closed.
 
 **A v2 command signs what the server executes.** Its payload contains `type`, all
 command fields, `to`, `timestamp`, and a random `nonce`. The server verifies the

--- a/tests/e2e/test_custom_http_routes.py
+++ b/tests/e2e/test_custom_http_routes.py
@@ -241,6 +241,12 @@ def test_admin_route_checks_admin_and_binds_query_and_body(tmp_path, monkeypatch
         "force": True,
     }
 
+    replay = request(
+        app, "POST", "/admin/refresh?scope=all", body=body, headers=headers,
+    )
+    assert replay.status_code == 401
+    assert "already used" in replay.json()["error"]
+
     reordered_headers = sign_http_request(
         caller, "POST", "/admin/refresh", query="scope=all&b=2&a=1", body=body,
         recipient_address=recipient,

--- a/tests/e2e/test_custom_http_routes.py
+++ b/tests/e2e/test_custom_http_routes.py
@@ -180,6 +180,33 @@ def test_contacts_route_requires_a_signed_contact_and_rejects_replay(tmp_path, m
     assert "already used" in replay.json()["error"]
 
 
+def test_separate_app_instances_share_the_project_replay_ledger(
+    tmp_path, monkeypatch
+):
+    from connectonion import HTTPRouter
+    from connectonion.network.host.auth import get_agent_address, sign_http_request
+
+    caller = address.generate()
+    recipient = get_agent_address(agent_factory())
+    trust = FixedTrust(levels={caller["address"]: "contact"})
+    http = HTTPRouter()
+    http.contacts.get("/profile")(lambda: {"ok": True})
+    first_worker = make_app(tmp_path, monkeypatch, http, trust=trust)
+    second_worker = make_app(tmp_path, monkeypatch, http, trust=trust)
+    headers = sign_http_request(
+        caller, "GET", "/contacts/profile", recipient_address=recipient,
+    )
+
+    assert request(
+        first_worker, "GET", "/contacts/profile", headers=headers
+    ).status_code == 200
+    replay = request(
+        second_worker, "GET", "/contacts/profile", headers=headers
+    )
+    assert replay.status_code == 401
+    assert "already used" in replay.json()["error"]
+
+
 def test_admin_route_checks_admin_and_binds_query_and_body(tmp_path, monkeypatch):
     from connectonion import HTTPRouter
     from connectonion.network.host.auth import get_agent_address, sign_http_request

--- a/tests/unit/test_an_admin_signature_is_used_once.py
+++ b/tests/unit/test_an_admin_signature_is_used_once.py
@@ -67,7 +67,7 @@ def call(monkeypatch):
 
     monkeypatch.delenv("OPENONION_API_KEY", raising=False)
 
-    async def run(path, signature, *, method="GET"):
+    async def run(path, signature, *, method="GET", replay_check=None):
         sent = {}
 
         async def send_json(body, status=200):
@@ -96,6 +96,8 @@ def call(monkeypatch):
             "admin_sessions": lambda: {"sessions": []},
             "admin_trust_level": lambda client_id: {"level": "contact"},
         }
+        if replay_check is not None:
+            handlers["replay"] = replay_check
 
         await http_admin.handle_admin_routes(
             method, path, {"headers": headers}, None, handlers,
@@ -108,6 +110,17 @@ def call(monkeypatch):
 
 @pytest.mark.asyncio
 class TestASignatureWorksOnce:
+
+    async def test_admin_route_uses_the_injected_replay_guard(self, call):
+        claimed = []
+
+        sent = await call(
+            "/admin/logs", "sig-one",
+            replay_check=lambda data: claimed.append(data) or True,
+        )
+
+        assert [item["signature"] for item in claimed] == ["sig-one"]
+        assert sent["status"] == 401
 
     async def test_the_first_use_is_allowed(self, call):
         sent = await call("/admin/logs", "sig-one")

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -236,6 +236,7 @@ class TestHandleWebSocket:
 
         handlers = {
             "auth": lambda *args, **kwargs: ("hello", "0xtest", True, None),
+            "connect_auth": lambda *args, **kwargs: ("hello", "0xtest", True, None),
             "ws_input": mock_ws_input,
             "trust_agent": Mock(config={}),
         }
@@ -276,6 +277,7 @@ class TestHandleWebSocket:
 
         handlers = {
             "auth": lambda *args, **kwargs: ("test", "0x", True, None),
+            "connect_auth": lambda *args, **kwargs: ("test", "0x", True, None),
             "ws_input": lambda storage, p, c, session=None, images=None, files=None, requester_address=None: {"result": "Expected result", "session_id": "abc-123", "duration_ms": 50, "session": {}, "status": "done"},
             "trust_agent": Mock(config={}),
         }

--- a/tests/unit/test_asgi_websocket_admin_onboard.py
+++ b/tests/unit/test_asgi_websocket_admin_onboard.py
@@ -83,6 +83,7 @@ class TestHandleWebSocketOnboardRequired:
         )
         handlers = {
             "auth": lambda data, trust, **kw: (None, "0xuser", True, "forbidden: strangers"),
+            "connect_auth": lambda data, trust, **kw: (None, "0xuser", True, "forbidden: strangers"),
             "ws_input": Mock(),
             "trust_agent": trust_agent,
         }
@@ -127,6 +128,7 @@ class TestHandleWebSocketOnboardRequired:
         trust_agent = SimpleNamespace(config={})
         handlers = {
             "auth": lambda data, trust, **kw: (None, "0xuser", True, "forbidden: strangers"),
+            "connect_auth": lambda data, trust, **kw: (None, "0xuser", True, "forbidden: strangers"),
             "ws_input": Mock(),
             "trust_agent": trust_agent,
         }
@@ -510,7 +512,10 @@ class TestOnboardCompletesConnect:
 
         await handle_websocket(
             scope, receive, send,
-            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            route_handlers={
+                "auth": auth, "connect_auth": auth,
+                "ws_input": ws_input, "trust_agent": trust_agent,
+            },
             storage=storage,
             registry=ActiveSessionRegistry(),
             trust="careful",
@@ -571,7 +576,10 @@ class TestOnboardCompletesConnect:
 
         await handle_websocket(
             scope, receive, send,
-            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            route_handlers={
+                "auth": auth, "connect_auth": auth,
+                "ws_input": ws_input, "trust_agent": trust_agent,
+            },
             storage=storage,
             registry=ActiveSessionRegistry(),
             trust="careful",
@@ -629,7 +637,10 @@ class TestOnboardCompletesConnect:
 
         await handle_websocket(
             scope, receive, send,
-            route_handlers={"auth": auth, "ws_input": ws_input, "trust_agent": trust_agent},
+            route_handlers={
+                "auth": auth, "connect_auth": auth,
+                "ws_input": ws_input, "trust_agent": trust_agent,
+            },
             storage=storage,
             registry=ActiveSessionRegistry(),
             trust="careful",

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import sqlite3
 from queue import Empty
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -12,6 +13,58 @@ from connectonion.network.host.replay import (
     ReplayProtectionError,
     SignatureReplayStore,
 )
+
+
+@pytest.mark.asyncio
+async def test_connect_claims_only_after_signature_verification():
+    from connectonion.network.host.ws_router.connect import handle_connect
+
+    frame = {"type": "CONNECT", "signature": "invalid", "payload": {}}
+    claimed = []
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await handle_connect(
+        frame, send, {"authenticated": False},
+        {
+            "auth": lambda *_args, **_kwargs: (
+                None, "caller", False, "unauthorized: invalid signature"
+            ),
+            "agent_metadata": {"address": "host"},
+            "replay": lambda value: claimed.append(value) or False,
+        },
+        MagicMock(), MagicMock(), "open", None, None,
+    )
+
+    assert claimed == []
+    assert sent[-1]["message"] == "unauthorized: invalid signature"
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_injected_guard_after_valid_signature():
+    from connectonion.network.host.ws_router.connect import handle_connect
+
+    frame = {"type": "CONNECT", "signature": "valid", "payload": {}}
+    claimed = []
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    await handle_connect(
+        frame, send, {"authenticated": False},
+        {
+            "auth": lambda *_args, **_kwargs: (None, "caller", True, None),
+            "agent_metadata": {"address": "host"},
+            "replay": lambda value: claimed.append(value) or True,
+        },
+        MagicMock(), MagicMock(), "open", None, None,
+    )
+
+    assert claimed == [frame]
+    assert "already used" in sent[-1]["message"]
 
 
 def _claim_signature(path, ready, start, results):
@@ -55,22 +108,71 @@ def test_two_os_workers_cannot_claim_the_same_signature(tmp_path):
 def test_store_keeps_only_a_digest_and_expires_old_entries(tmp_path):
     path = tmp_path / "replay.sqlite3"
     store = SignatureReplayStore(path, expiry_seconds=300)
-    data = {"signature": "raw-secret-shaped-signature"}
+    data = {
+        "signature": "raw-secret-shaped-signature",
+        "payload": {"timestamp": 1_000},
+    }
 
     assert store.already_used(data, now=1_000) is False
     assert store.already_used(data, now=1_001) is True
+    assert store.already_used(data, now=1_300) is True
     assert store.already_used(data, now=1_301) is False
 
     with sqlite3.connect(path) as database:
         rows = database.execute(
-            "SELECT digest, seen_at FROM used_signatures"
+            "SELECT digest, seen_at, expires_at FROM used_signatures"
         ).fetchall()
     assert len(rows) == 1
     assert len(rows[0][0]) == 32
     assert b"raw-secret-shaped-signature" not in rows[0][0]
     assert rows[0][1] == 1_301
+    assert rows[0][2] == 1_300
     if os.name != "nt":
         assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_future_dated_signature_is_kept_until_cryptographically_expired(tmp_path):
+    store = SignatureReplayStore(tmp_path / "replay.sqlite3", expiry_seconds=300)
+    data = {"signature": "future", "payload": {"timestamp": 1_300}}
+
+    assert store.already_used(data, now=1_000) is False
+    assert store.already_used(data, now=1_301) is True
+    assert store.already_used(data, now=1_601) is False
+
+
+def test_expiry_cleanup_is_indexed(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    SignatureReplayStore(path)
+
+    with sqlite3.connect(path) as database:
+        indexes = database.execute(
+            "PRAGMA index_list(used_signatures)"
+        ).fetchall()
+
+    assert "used_signatures_expiry" in {row[1] for row in indexes}
+
+
+def test_existing_seen_at_ledger_is_migrated_conservatively(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    digest = b"d" * 32
+    with sqlite3.connect(path) as database:
+        database.execute(
+            "CREATE TABLE used_signatures ("
+            "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+            ") WITHOUT ROWID"
+        )
+        database.execute(
+            "INSERT INTO used_signatures (digest, seen_at) VALUES (?, ?)",
+            (digest, 1_000),
+        )
+
+    SignatureReplayStore(path, expiry_seconds=300)
+
+    with sqlite3.connect(path) as database:
+        expires_at = database.execute(
+            "SELECT expires_at FROM used_signatures WHERE digest = ?", (digest,)
+        ).fetchone()[0]
+    assert expires_at == 1_600
 
 
 @pytest.mark.parametrize("factory", ["sqlite", "memory"])
@@ -102,6 +204,15 @@ def test_storage_failure_is_explicit_and_fails_closed(tmp_path, monkeypatch):
         store.already_used({"signature": "captured"})
 
 
+def test_locked_ledger_fails_closed(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    with sqlite3.connect(path) as blocker:
+        blocker.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(ReplayProtectionError, match="storage is unavailable"):
+            store.already_used({"signature": "captured"})
+
+
 def test_signed_command_translates_replay_storage_failure_to_misconfigured(
     monkeypatch,
 ):
@@ -127,3 +238,25 @@ def test_signed_command_translates_replay_storage_failure_to_misconfigured(
 
     assert payload is None
     assert error == "misconfigured: replay protection unavailable"
+
+
+@pytest.mark.parametrize("timestamp", [float("nan"), float("inf"), -float("inf")])
+def test_non_finite_timestamps_are_rejected_before_replay_claim(
+    monkeypatch, timestamp
+):
+    monkeypatch.setattr(auth, "verify_signature", lambda *_: True)
+    claimed = []
+    data = {
+        "type": "INPUT",
+        "from": "caller",
+        "signature": "signature",
+        "payload": {"type": "INPUT", "nonce": "one-use", "timestamp": timestamp},
+    }
+
+    payload, error = auth.authenticated_command_payload(
+        data, "caller", replay_check=lambda value: claimed.append(value) or False
+    )
+
+    assert payload is None
+    assert error == "unauthorized: timestamp must be finite"
+    assert claimed == []

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -144,6 +144,13 @@ def _migrate_store(path, ready, start, results):
         results.put(f"{type(exc).__name__}: {exc}")
 
 
+def _hold_ledger_lock(path, ready, hold_seconds):
+    with sqlite3.connect(path) as database:
+        database.execute("BEGIN EXCLUSIVE")
+        ready.put(True)
+        time.sleep(hold_seconds)
+
+
 def test_two_os_workers_cannot_claim_the_same_signature(tmp_path):
     context = multiprocessing.get_context("spawn")
     ready = context.Queue()
@@ -317,6 +324,27 @@ def test_locked_ledger_fails_closed(tmp_path):
         blocker.execute("BEGIN EXCLUSIVE")
         with pytest.raises(ReplayProtectionError, match="storage is unavailable"):
             store.already_used({"signature": "captured"})
+
+
+def test_claim_waits_for_a_short_lived_worker_lock(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path)
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    blocker = context.Process(
+        target=_hold_ledger_lock, args=(path, ready, 0.5)
+    )
+
+    blocker.start()
+    try:
+        assert ready.get(timeout=10) is True
+        assert store.already_used({"signature": "captured"}) is False
+    finally:
+        blocker.join(timeout=10)
+        if blocker.is_alive():
+            blocker.terminate()
+
+    assert blocker.exitcode == 0
 
 
 def test_signed_command_translates_replay_storage_failure_to_misconfigured(

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -332,19 +332,31 @@ def test_claim_waits_for_a_short_lived_worker_lock(tmp_path):
     context = multiprocessing.get_context("spawn")
     ready = context.Queue()
     blocker = context.Process(
-        target=_hold_ledger_lock, args=(path, ready, 0.5)
+        target=_hold_ledger_lock, args=(path, ready, 1.0)
     )
 
     blocker.start()
     try:
         assert ready.get(timeout=10) is True
+        started = time.monotonic()
         assert store.already_used({"signature": "captured"}) is False
+        assert time.monotonic() - started >= 0.4
     finally:
         blocker.join(timeout=10)
         if blocker.is_alive():
             blocker.terminate()
+            blocker.join(timeout=10)
 
     assert blocker.exitcode == 0
+
+
+def test_connection_has_the_bounded_two_second_busy_timeout(tmp_path):
+    store = SignatureReplayStore(tmp_path / "replay.sqlite3")
+
+    with store._connect() as database:
+        busy_timeout_ms = database.execute("PRAGMA busy_timeout").fetchone()[0]
+
+    assert busy_timeout_ms == 2_000
 
 
 def test_signed_command_translates_replay_storage_failure_to_misconfigured(

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -3,6 +3,8 @@
 import multiprocessing
 import os
 import sqlite3
+import time
+from functools import partial
 from queue import Empty
 from unittest.mock import MagicMock
 
@@ -19,7 +21,12 @@ from connectonion.network.host.replay import (
 async def test_connect_claims_only_after_signature_verification():
     from connectonion.network.host.ws_router.connect import handle_connect
 
-    frame = {"type": "CONNECT", "signature": "invalid", "payload": {}}
+    frame = {
+        "type": "CONNECT",
+        "from": "caller",
+        "signature": "invalid",
+        "payload": {"to": "host", "timestamp": time.time()},
+    }
     claimed = []
     sent = []
 
@@ -29,9 +36,6 @@ async def test_connect_claims_only_after_signature_verification():
     await handle_connect(
         frame, send, {"authenticated": False},
         {
-            "auth": lambda *_args, **_kwargs: (
-                None, "caller", False, "unauthorized: invalid signature"
-            ),
             "agent_metadata": {"address": "host"},
             "replay": lambda value: claimed.append(value) or False,
         },
@@ -43,10 +47,16 @@ async def test_connect_claims_only_after_signature_verification():
 
 
 @pytest.mark.asyncio
-async def test_connect_uses_injected_guard_after_valid_signature():
+async def test_connect_uses_injected_guard_after_valid_signature(monkeypatch):
     from connectonion.network.host.ws_router.connect import handle_connect
 
-    frame = {"type": "CONNECT", "signature": "valid", "payload": {}}
+    monkeypatch.setattr(auth, "verify_signature", lambda *_: True)
+    frame = {
+        "type": "CONNECT",
+        "from": "caller",
+        "signature": "valid",
+        "payload": {"to": "host", "timestamp": time.time()},
+    }
     claimed = []
     sent = []
 
@@ -56,9 +66,11 @@ async def test_connect_uses_injected_guard_after_valid_signature():
     await handle_connect(
         frame, send, {"authenticated": False},
         {
-            "auth": lambda *_args, **_kwargs: (None, "caller", True, None),
+            "connect_auth": partial(
+                auth.authenticate_connect,
+                replay_check=lambda value: claimed.append(value) or True,
+            ),
             "agent_metadata": {"address": "host"},
-            "replay": lambda value: claimed.append(value) or True,
         },
         MagicMock(), MagicMock(), "open", None, None,
     )
@@ -67,11 +79,69 @@ async def test_connect_uses_injected_guard_after_valid_signature():
     assert "already used" in sent[-1]["message"]
 
 
+def test_connect_replay_is_rejected_before_trust_policy(monkeypatch):
+    monkeypatch.setattr(auth, "verify_signature", lambda *_: True)
+    trust = MagicMock(spec=auth.TrustAgent)
+    frame = {
+        "from": "caller",
+        "signature": "captured",
+        "payload": {"timestamp": time.time()},
+    }
+
+    _, _, valid, error = auth.authenticate_connect(
+        frame, trust, replay_check=lambda _data: True
+    )
+
+    assert valid is True
+    assert error == "unauthorized: this CONNECT was already used"
+    trust.should_allow.assert_not_called()
+
+
+def test_connect_orders_signature_then_claim_then_trust(monkeypatch):
+    events = []
+    monkeypatch.setattr(
+        auth, "verify_signature", lambda *_: events.append("signature") or True
+    )
+    trust = auth.TrustAgent("open")
+    original_should_allow = trust.should_allow
+
+    def should_allow(*args, **kwargs):
+        events.append("trust")
+        return original_should_allow(*args, **kwargs)
+
+    monkeypatch.setattr(trust, "should_allow", should_allow)
+    frame = {
+        "from": "caller",
+        "signature": "fresh",
+        "payload": {"timestamp": time.time()},
+    }
+
+    _, _, valid, error = auth.authenticate_connect(
+        frame,
+        trust,
+        replay_check=lambda _data: events.append("claim") or False,
+    )
+
+    assert valid is True
+    assert error is None
+    assert events == ["signature", "claim", "trust"]
+
+
 def _claim_signature(path, ready, start, results):
     store = SignatureReplayStore(path)
     ready.put(True)
     start.wait(10)
     results.put(store.already_used({"signature": "same-captured-signature"}))
+
+
+def _migrate_store(path, ready, start, results):
+    ready.put(True)
+    start.wait(10)
+    try:
+        SignatureReplayStore(path)
+        results.put(None)
+    except Exception as exc:
+        results.put(f"{type(exc).__name__}: {exc}")
 
 
 def test_two_os_workers_cannot_claim_the_same_signature(tmp_path):
@@ -95,6 +165,42 @@ def test_two_os_workers_cannot_claim_the_same_signature(tmp_path):
         assert outcomes == [False, True]
     except Empty:
         pytest.fail("replay workers did not finish")
+    finally:
+        start.set()
+        for worker in workers:
+            worker.join(timeout=10)
+            if worker.is_alive():
+                worker.terminate()
+
+    assert all(worker.exitcode == 0 for worker in workers)
+
+
+def test_workers_serialize_old_schema_migration(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    with sqlite3.connect(path) as database:
+        database.execute(
+            "CREATE TABLE used_signatures ("
+            "digest BLOB PRIMARY KEY, seen_at REAL NOT NULL"
+            ") WITHOUT ROWID"
+        )
+
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    results = context.Queue()
+    start = context.Event()
+    workers = [
+        context.Process(target=_migrate_store, args=(path, ready, start, results))
+        for _ in range(8)
+    ]
+    for worker in workers:
+        worker.start()
+    try:
+        for _ in workers:
+            assert ready.get(timeout=15) is True
+        start.set()
+        assert [results.get(timeout=15) for _ in workers] == [None] * len(workers)
+    except Empty:
+        pytest.fail("schema migration workers did not finish")
     finally:
         start.set()
         for worker in workers:

--- a/tests/unit/test_cross_worker_replay.py
+++ b/tests/unit/test_cross_worker_replay.py
@@ -1,0 +1,129 @@
+"""The one-use signature contract is shared by every ASGI worker."""
+
+import multiprocessing
+import os
+import sqlite3
+from queue import Empty
+
+import pytest
+
+from connectonion.network.host import auth
+from connectonion.network.host.replay import (
+    ReplayProtectionError,
+    SignatureReplayStore,
+)
+
+
+def _claim_signature(path, ready, start, results):
+    store = SignatureReplayStore(path)
+    ready.put(True)
+    start.wait(10)
+    results.put(store.already_used({"signature": "same-captured-signature"}))
+
+
+def test_two_os_workers_cannot_claim_the_same_signature(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    ready = context.Queue()
+    results = context.Queue()
+    start = context.Event()
+    path = tmp_path / "replay.sqlite3"
+    workers = [
+        context.Process(target=_claim_signature, args=(path, ready, start, results))
+        for _ in range(2)
+    ]
+
+    for worker in workers:
+        worker.start()
+    try:
+        assert ready.get(timeout=10) is True
+        assert ready.get(timeout=10) is True
+        start.set()
+        outcomes = sorted([results.get(timeout=10), results.get(timeout=10)])
+        assert outcomes == [False, True]
+    except Empty:
+        pytest.fail("replay workers did not finish")
+    finally:
+        start.set()
+        for worker in workers:
+            worker.join(timeout=10)
+            if worker.is_alive():
+                worker.terminate()
+
+    assert all(worker.exitcode == 0 for worker in workers)
+
+
+def test_store_keeps_only_a_digest_and_expires_old_entries(tmp_path):
+    path = tmp_path / "replay.sqlite3"
+    store = SignatureReplayStore(path, expiry_seconds=300)
+    data = {"signature": "raw-secret-shaped-signature"}
+
+    assert store.already_used(data, now=1_000) is False
+    assert store.already_used(data, now=1_001) is True
+    assert store.already_used(data, now=1_301) is False
+
+    with sqlite3.connect(path) as database:
+        rows = database.execute(
+            "SELECT digest, seen_at FROM used_signatures"
+        ).fetchall()
+    assert len(rows) == 1
+    assert len(rows[0][0]) == 32
+    assert b"raw-secret-shaped-signature" not in rows[0][0]
+    assert rows[0][1] == 1_301
+    if os.name != "nt":
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+@pytest.mark.parametrize("factory", ["sqlite", "memory"])
+def test_equivalent_hex_spellings_cannot_bypass_replay_protection(
+    tmp_path, factory
+):
+    lower = {"signature": "0x" + "ab" * 64}
+    upper = {"signature": "0x" + "AB" * 64}
+    if factory == "sqlite":
+        already_used = SignatureReplayStore(
+            tmp_path / "replay.sqlite3"
+        ).already_used
+    else:
+        auth._seen_signatures.clear()
+        already_used = auth.signature_already_used
+
+    assert already_used(lower) is False
+    assert already_used(upper) is True
+
+
+def test_storage_failure_is_explicit_and_fails_closed(tmp_path, monkeypatch):
+    store = SignatureReplayStore(tmp_path / "replay.sqlite3")
+
+    def unavailable():
+        raise sqlite3.OperationalError("disk unavailable")
+
+    monkeypatch.setattr(store, "_connect", unavailable)
+    with pytest.raises(ReplayProtectionError, match="storage is unavailable"):
+        store.already_used({"signature": "captured"})
+
+
+def test_signed_command_translates_replay_storage_failure_to_misconfigured(
+    monkeypatch,
+):
+    monkeypatch.setattr(auth, "verify_signature", lambda *_: True)
+    data = {
+        "type": "INPUT",
+        "from": "caller",
+        "signature": "signature",
+        "payload": {
+            "type": "INPUT",
+            "nonce": "one-use",
+            "timestamp": 1_000,
+        },
+    }
+    monkeypatch.setattr(auth.time, "time", lambda: 1_000)
+
+    def unavailable(_data):
+        raise ReplayProtectionError("disk unavailable")
+
+    payload, error = auth.authenticated_command_payload(
+        data, "caller", replay_check=unavailable
+    )
+
+    assert payload is None
+    assert error == "misconfigured: replay protection unavailable"

--- a/tests/unit/test_each_command_is_signed.py
+++ b/tests/unit/test_each_command_is_signed.py
@@ -215,7 +215,8 @@ def test_top_level_type_cannot_relabel_a_signed_command(keys):
 
 
 async def _session_with(
-    messages, monkeypatch, *, signed_commands, ran, connect_calls=None
+    messages, monkeypatch, *, signed_commands, ran, connect_calls=None,
+    replay_check=None,
 ):
     from connectonion.network.host.ws_router import session
 
@@ -250,16 +251,39 @@ async def _session_with(
     async def send(message):
         sent.append(message)
 
+    route_handlers = {}
+    if replay_check is not None:
+        route_handlers["replay"] = replay_check
     await session.run_ws_session(
         send,
         recv,
-        route_handlers={},
+        route_handlers=route_handlers,
         storage=MagicMock(),
         registry=MagicMock(),
         trust="open",
         enable_ping=False,
     )
     return sent
+
+
+@pytest.mark.asyncio
+async def test_v2_session_uses_the_injected_replay_guard(keys, monkeypatch):
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    signed = agent._build_command_message(
+        {"type": "EXEC", "exec_id": "e1", "tool": "safe", "args": {}}
+    )
+    claimed = []
+    ran = []
+
+    sent = await _session_with(
+        [connect, signed], monkeypatch, signed_commands=True, ran=ran,
+        replay_check=lambda frame: claimed.append(frame) or True,
+    )
+
+    assert claimed == [signed]
+    assert ran == []
+    assert "already used" in sent[-1]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_host_relay.py
+++ b/tests/unit/test_host_relay.py
@@ -337,7 +337,11 @@ class TestCreateRouteHandlers:
         agent_metadata = {"name": "test_agent", "tools": [], "address": "0xtest"}
         handlers = host_module._create_route_handlers(create_mock_agent, agent_metadata, result_ttl=3600, trust_agent=mock_trust_agent, config={})
 
-        required = ["input", "session", "sessions", "health", "info", "auth", "ws_input", "admin_logs", "admin_sessions", "trust_agent"]
+        required = [
+            "input", "session", "sessions", "health", "info", "auth",
+            "connect_auth", "replay", "ws_input", "admin_logs",
+            "admin_sessions", "trust_agent",
+        ]
         for key in required:
             assert key in handlers, f"Missing handler: {key}"
 

--- a/tests/unit/test_session_status_needs_identity.py
+++ b/tests/unit/test_session_status_needs_identity.py
@@ -18,7 +18,9 @@ def clean_replay_cache():
     auth._seen_signatures.clear()
 
 
-async def _run(messages, *, owner, monkeypatch=None, connect_as=None):
+async def _run(
+    messages, *, owner, monkeypatch=None, connect_as=None, replay_check=None
+):
     from connectonion.network.host.ws_router import session
 
     if connect_as is not None:
@@ -42,10 +44,13 @@ async def _run(messages, *, owner, monkeypatch=None, connect_as=None):
     registry.get.side_effect = lambda sid: (
         SimpleNamespace(status="running", owner=owner) if sid == "s1" else None
     )
+    route_handlers = {"agent_metadata": {"address": "0x" + "12" * 20}}
+    if replay_check is not None:
+        route_handlers["replay"] = replay_check
     await session.run_ws_session(
         send,
         recv,
-        route_handlers={"agent_metadata": {"address": "0x" + "12" * 20}},
+        route_handlers=route_handlers,
         storage=MagicMock(),
         registry=registry,
         trust="open",
@@ -125,6 +130,21 @@ async def test_temporary_probe_replay_fails_closed():
     )
 
     assert [reply["status"] for reply in replies] == ["running", "not_found"]
+
+
+@pytest.mark.asyncio
+async def test_temporary_probe_uses_the_injected_replay_guard():
+    keys = address.generate()
+    frame = _signed_status(keys, "0x" + "12" * 20)
+    claimed = []
+
+    replies = await _run(
+        [frame], owner=keys["address"],
+        replay_check=lambda value: claimed.append(value) or True,
+    )
+
+    assert claimed == [frame]
+    assert replies[-1]["status"] == "not_found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace production's process-local replay cache with a project-local SQLite ledger shared by ASGI workers
- atomically claim short-lived signature digests for CONNECT, protocol-v2 commands/status, signed admin calls, and protected custom HTTP routes
- canonicalize equivalent hex spellings before hashing so changing signature case cannot bypass one-use enforcement
- retain each claim until its signed timestamp is cryptographically expired, including future-skewed signatures
- verify CONNECT signatures before writing the ledger; index expiry cleanup and cap lock waits at a bounded 2s
- reject CONNECT replay before any trust-policy/LLM evaluation or onboarding side effect
- serialize old-schema migration across concurrently starting workers
- fail closed when replay storage is unavailable, without persisting raw signatures, payloads, or request bodies

## Design

The design discussion, alternatives, and historical decisions were recorded in #804 before implementation.

The public signing protocol is unchanged. DD-007's client-signed timestamp, the five-minute freshness check, recipient/method/path/query/body binding, request IDs/nonces, and trust/audience gates remain intact. DD-020's hard-security-in-code rule now holds across processes, and DD-022's documented external ASGI multi-worker deployment no longer weakens the one-use claim.

`SignatureReplayStore` uses only Python's standard-library SQLite. In one transaction it deletes cryptographically expired entries through an `expires_at` index and `INSERT OR IGNORE`s a SHA-256 digest under a primary key. A database error or lock timeout becomes `ReplayProtectionError`; every production consumer refuses the request. CONNECT performs cryptographic verification, then the atomic claim, then trust policy. Invalid frames never create rows, and replays cannot repeat LLM policy cost or policy mutation.

The existing in-memory helper remains as the direct low-level compatibility seam, but app assembly always injects the project ledger.

## Verification

- 359 host/auth/ASGI/WebSocket/admin/custom-route tests passed
- 20 focused replay-store/pipeline tests passed
- spawned-process race: two independent OS workers sharing one database produce exactly `[new, used]`
- two separately constructed ASGI apps sharing one project reject a cross-app replay
- future-dated signatures remain claimed until their full cryptographic validity window ends
- exact CONNECT order assertion: signature verification → atomic claim → trust policy
- eight spawned workers concurrently migrate the old schema without duplicate-column failures
- deterministic cross-process contention waits through a 1s transient lock; a permanent lock still fails closed after the bounded 2s timeout
- injected-guard assertions cover CONNECT, v2 commands, temporary status, legacy signed admin, contacts HTTP, and admin HTTP
- equivalent upper/lowercase signature hex is rejected in both SQLite and compatibility-memory paths
- indexed expiry cleanup, old-schema migration, 0600 POSIX mode, digest-only storage, locked/unavailable failure behavior covered
- `python -m compileall -q connectonion/network/host connectonion/network/trust`
- `git diff --check`

## Security boundary

This fixes multiple workers on one host/project. A future multi-machine deployment still needs an injected distributed replay service; this PR does not claim cross-machine coordination.

## Review checklist

- [x] design discussed before code
- [x] no new runtime dependency
- [x] existing protocol remains compatible
- [x] storage failure fails closed
- [x] no raw signed material persisted
- [x] no merge, tag, publish, or deploy performed

Fixes #804
