### PR TITLE
security: separate admin access from billing credentials

### DIFF
--- a/connectonion/network/host/http_routes.py
+++ b/connectonion/network/host/http_routes.py
@@ -64,6 +64,27 @@ def _reserved(path: str) -> bool:
                for prefix in _RESERVED_PREFIXES)
 
 
+def _shadows_reserved(path: str) -> bool:
+    """Whether a publisher pattern can claim a framework-owned path."""
+    if _reserved(path):
+        return True
+    pattern, _, _ = _pattern(path)
+    if any(pattern.fullmatch(reserved) for reserved in _RESERVED_PATHS):
+        return True
+
+    route_segments = path.split("/")[1:]
+    for prefix in _RESERVED_PREFIXES:
+        prefix_segments = prefix.split("/")[1:]
+        if len(route_segments) < len(prefix_segments):
+            continue
+        if all(
+            _pattern("/" + route_segment)[0].fullmatch("/" + reserved_segment)
+            for route_segment, reserved_segment in zip(route_segments, prefix_segments)
+        ):
+            return True
+    return False
+
+
 def _pattern(path: str):
     names = []
     pieces = []
@@ -187,7 +208,7 @@ class HTTPRouter:
     def _decorator(self, method: str, audience: str, relative_path: str):
         parameter_names = _validate_relative_path(relative_path)
         full_path = AUDIENCE_PREFIXES[audience] + relative_path
-        if _reserved(full_path):
+        if _shadows_reserved(full_path):
             raise ValueError(f"HTTP path {full_path!r} is reserved by Connectonion")
 
         def register(handler: Callable):

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -844,8 +844,8 @@ def host(
         GET  /health         - Health check
         GET  /info           - Agent info (includes summary, examples)
         WS   /ws             - WebSocket
-        GET  /admin/logs     - Activity log (requires OPENONION_API_KEY)
-        GET  /admin/sessions - Activity sessions (requires OPENONION_API_KEY)
+        GET  /admin/logs     - Activity log (signed admin or admin token)
+        GET  /admin/sessions - Activity sessions (signed admin or admin token)
     """
     if http is not None:
         from .http_routes import HTTPRouter

--- a/connectonion/network/static/docs.html
+++ b/connectonion/network/static/docs.html
@@ -386,11 +386,11 @@
       <div class="row between">
         <div>
           <h3 style="margin:0;font-size:14px;">Admin Endpoints</h3>
-          <p style="margin:4px 0 0;font-size:12px;color:var(--muted);">Requires OPENONION_API_KEY authorization</p>
+          <p style="margin:4px 0 0;font-size:12px;color:var(--muted);">Use a signed admin identity or a dedicated CONNECTONION_ADMIN_TOKEN</p>
         </div>
         <div class="row" style="gap:8px;">
-          <label for="api-key" style="font-size:12px;margin:0;">API Key:</label>
-          <input type="password" id="api-key" placeholder="Enter API key..." style="width:200px;height:36px;font-size:12px;" />
+          <label for="admin-token" style="font-size:12px;margin:0;">Admin token:</label>
+          <input type="password" id="admin-token" placeholder="Enter admin token..." style="width:200px;height:36px;font-size:12px;" />
         </div>
       </div>
     </div>
@@ -409,7 +409,7 @@
           <h4>Curl</h4>
           <div class="curl-box">
             <pre id="admin-logs-curl">curl -X GET "http://localhost:8000/admin/logs" \
-  -H "Authorization: Bearer YOUR_API_KEY"</pre>
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"</pre>
             <button class="copy-btn" onclick="copyCurl('admin-logs-curl')">Copy</button>
           </div>
         </div>
@@ -434,7 +434,7 @@
           <h4>Curl</h4>
           <div class="curl-box">
             <pre id="admin-sessions-curl">curl -X GET "http://localhost:8000/admin/sessions" \
-  -H "Authorization: Bearer YOUR_API_KEY"</pre>
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"</pre>
             <button class="copy-btn" onclick="copyCurl('admin-sessions-curl')">Copy</button>
           </div>
         </div>
@@ -708,14 +708,14 @@ curl -X GET "${base}${path}" \\
     }
 
     async function fetchAdminLogs(){
-      const apiKey = $('api-key').value.trim();
-      if (!apiKey) {
-        $('admin-logs-result').textContent = '{"error": "Please enter API key"}';
+      const adminToken = $('admin-token').value.trim();
+      if (!adminToken) {
+        $('admin-logs-result').textContent = '{"error": "Please enter admin token"}';
         return;
       }
       $('admin-logs-result').textContent = 'Loading...';
       const res = await fetch(buildUrl('/admin/logs'), {
-        headers: { 'Authorization': 'Bearer ' + apiKey }
+        headers: { 'Authorization': 'Bearer ' + adminToken }
       });
       if (res.ok) {
         const text = await res.text();
@@ -727,14 +727,14 @@ curl -X GET "${base}${path}" \\
     }
 
     async function fetchAdminSessions(){
-      const apiKey = $('api-key').value.trim();
-      if (!apiKey) {
-        $('admin-sessions-result').textContent = '{"error": "Please enter API key"}';
+      const adminToken = $('admin-token').value.trim();
+      if (!adminToken) {
+        $('admin-sessions-result').textContent = '{"error": "Please enter admin token"}';
         return;
       }
       $('admin-sessions-result').textContent = 'Loading...';
       const res = await fetch(buildUrl('/admin/sessions'), {
-        headers: { 'Authorization': 'Bearer ' + apiKey }
+        headers: { 'Authorization': 'Bearer ' + adminToken }
       });
       const data = await res.json();
       $('admin-sessions-result').textContent = JSON.stringify(data, null, 2);

--- a/connectonion/network/trust/http_admin.py
+++ b/connectonion/network/trust/http_admin.py
@@ -3,11 +3,11 @@
 Purpose: Authenticate and dispatch /admin/* and /superadmin/* HTTP requests for the hosted agent's trust controls (promote/demote/block/unblock, level lookup, super-admin add/remove, and legacy admin logs/sessions).
 LLM-Note:
   Dependencies: imports from [hmac, json, os, network/host/auth.py] | imported by [network/host/http_router.py (handle_admin_routes called for paths starting with /admin or /superadmin)] | tested by [tests/unit/test_admin_signatures_are_route_bound.py, tests/unit/test_an_admin_signature_is_used_once.py, tests/unit/test_reading_logs_does_not_need_the_billing_key.py]
-  Data flow: receives ASGI scope/receive + parsed method/path from http_router → /admin/logs and /admin/sessions accept EITHER Bearer OPENONION_API_KEY (hmac.compare_digest) or a signed admin request; /admin/trust/* and /superadmin/* require a signature over payload + actual method/path. GETs use the shared X-Co-From/X-Co-Signature/X-Co-Timestamp scheme; legacy X-From headers remain read-only for 1.6 compatibility → calls into route_handlers callbacks (admin_logs, admin_sessions, admin_trust_promote/demote/block/unblock/level, admin_admins_add/remove) → responds via send_json/send_text
-  State/Effects: invokes route_handlers (which mutate trust agent state, file logs, sessions) | reads OPENONION_API_KEY from env for legacy auth | logs nothing directly
+  Data flow: receives ASGI scope/receive + parsed method/path from http_router → /admin/logs and /admin/sessions accept EITHER a distinct per-deployment CONNECTONION_ADMIN_TOKEN bearer or a signed admin request; /admin/trust/* and /superadmin/* require a signature over payload + actual method/path. GETs use the shared X-Co-From/X-Co-Signature/X-Co-Timestamp scheme; legacy X-From headers remain read-only for 1.6 compatibility → calls into route_handlers callbacks (admin_logs, admin_sessions, admin_trust_promote/demote/block/unblock/level, admin_admins_add/remove) → responds via send_json/send_text
+  State/Effects: invokes route_handlers (which mutate trust agent state, file logs, sessions) | reads CONNECTONION_ADMIN_TOKEN and OPENONION_API_KEY only to prevent credential reuse | logs nothing directly
   Integration: exposes async handle_admin_routes(method, path, scope, receive, route_handlers, *, send_json, send_text, read_body) -> bool (always True after this function — it owns the response for /admin/* and /superadmin/*) | route_handlers dict must include "trust_agent", "auth", and the admin_* callbacks
   Errors: returns 401 unauthorized on bad/unbound bearer/signature or a route_handlers with no verifier wired, 403 forbidden when not admin/superadmin, 400 on missing client_id/admin_id or invalid signature timestamp/JSON, 404 catch-all for unknown admin paths — never raises
-  Security: ⚠️ bearer comparison uses hmac.compare_digest to avoid timing leaks | signature verification delegated to route_handlers["auth"] | the bearer key is the model billing credential, which is why signing is now an alternative (#670)
+  Security: bearer comparison uses hmac.compare_digest to avoid timing leaks | the admin token fails closed when absent or equal to the model billing key | signature verification delegated to route_handlers["auth"] (#670)
 """
 
 import hmac
@@ -125,22 +125,29 @@ async def _admin_signature(method, path, scope, receive, route_handlers, *, read
 async def handle_admin_routes(method, path, scope, receive, route_handlers, *, send_json, send_text, read_body):
     """Handle /admin/* and /superadmin/* HTTP routes. Returns True if handled, False otherwise."""
 
-    # Legacy admin endpoints: Bearer OPENONION_API_KEY, or a signed admin request.
+    # Read-only admin endpoints: signed admin identity, or a dedicated bearer.
     #
-    # The Bearer key is what pays for co/* models — `co auth` obtains it, `co
-    # create` writes it into the project's .env, and every model call sends it to
-    # oo.openonion.ai. So letting someone read an agent's activity meant handing
-    # over the credential that spends its money (#670).
+    # OPENONION_API_KEY pays for co/* models and travels through CI, .env files,
+    # deploys and model calls. It must never authorize logs or sessions (#670).
     #
     # The signed path below is the one /admin/trust/* and /superadmin/* already
     # use, reused rather than reinvented: sign the request, be on admins.txt.
-    # Bearer stays because 1.6.0 is long-term and the curl in the shipped
-    # docs.html uses it; this widens what works, and a later major can drop it.
+    # Non-interactive monitoring can retain the Bearer transport shape with a
+    # separate per-deployment CONNECTONION_ADMIN_TOKEN. Explicitly reject reuse
+    # of the billing key so a renamed environment variable cannot preserve the
+    # original blast radius by accident.
     if path in ["/admin/logs", "/admin/sessions"]:
         headers_dict = dict(scope.get("headers", []))
         auth = headers_dict.get(b"authorization", b"").decode()
-        expected = os.environ.get("OPENONION_API_KEY", "")
-        by_key = bool(expected) and auth.startswith("Bearer ") and hmac.compare_digest(auth[7:], expected)
+        admin_token = os.environ.get("CONNECTONION_ADMIN_TOKEN", "")
+        billing_key = os.environ.get("OPENONION_API_KEY", "")
+        distinct = not billing_key or not hmac.compare_digest(admin_token, billing_key)
+        by_key = (
+            bool(admin_token)
+            and distinct
+            and auth.startswith("Bearer ")
+            and hmac.compare_digest(auth[7:], admin_token)
+        )
 
         if not by_key:
             signed, status, error, _ = await _admin_signature(

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -130,6 +130,7 @@ Variables from your `.env` file are securely passed to your agent container:
 ```bash
 # .env
 OPENONION_API_KEY=eyJ...    # Required for co/ models
+CONNECTONION_ADMIN_TOKEN=... # Optional: distinct 256-bit random token for admin monitoring
 OPENAI_API_KEY=sk-xxx       # Third-party API keys
 DATABASE_URL=postgres://...
 BROWSER_PROXY=http://user:pass@host:port  # Optional browser proxy
@@ -230,7 +231,7 @@ Your deployed agent exposes these endpoints:
 | `/info` | GET | Agent metadata (name, tools, trust, examples) |
 | `/health` | GET | Health check |
 | `/docs` | GET | Interactive API docs |
-| `/admin/logs` | GET | Activity logs (requires API key) |
+| `/admin/logs` | GET | Activity logs (signed admin or dedicated admin token) |
 
 ### Frontend (oo-chat)
 

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -463,13 +463,16 @@ Interactive UI to test your agent in the browser.
 http://localhost:8000/docs
 ```
 
-### GET /admin/logs (Requires API Key)
+### GET /admin/logs (Admin authentication)
 
-Fetch agent activity logs (plain text). Requires `OPENONION_API_KEY` authentication.
+Fetch agent activity logs (plain text). Prefer a signed identity listed in
+`.co/admins.txt`. Non-interactive monitoring may use a distinct,
+per-deployment `CONNECTONION_ADMIN_TOKEN`:
 
 ```bash
+export CONNECTONION_ADMIN_TOKEN="$(openssl rand -hex 32)"
 curl http://localhost:8000/admin/logs \
-  -H "Authorization: Bearer YOUR_OPENONION_API_KEY"
+  -H "Authorization: Bearer $CONNECTONION_ADMIN_TOKEN"
 ```
 
 **Response:**
@@ -479,13 +482,14 @@ curl http://localhost:8000/admin/logs \
 2024-01-15 10:23:46 [translator] Result: Hola
 ```
 
-### GET /admin/sessions (Requires API Key)
+### GET /admin/sessions (Admin authentication)
 
-Fetch eval sessions from `.co/evals` as JSON array. Requires `OPENONION_API_KEY` authentication.
+Fetch eval sessions from `.co/evals` as JSON array. It uses the same signed
+admin or dedicated admin-token authentication as `/admin/logs`.
 
 ```bash
 curl http://localhost:8000/admin/sessions \
-  -H "Authorization: Bearer YOUR_OPENONION_API_KEY"
+  -H "Authorization: Bearer YOUR_ADMIN_TOKEN"
 ```
 
 **Response:**
@@ -507,7 +511,10 @@ curl http://localhost:8000/admin/sessions \
 }
 ```
 
-**Note:** These endpoints require setting `OPENONION_API_KEY` as an environment variable when running your agent. The same key must be used to authenticate requests.
+**Important:** `OPENONION_API_KEY` is only a managed-model billing credential
+and is never an admin password. If bearer automation is needed, generate a
+separate random `CONNECTONION_ADMIN_TOKEN`; configuring it to the billing key
+fails closed. Signed admin requests need no bearer token.
 
 ---
 
@@ -838,8 +845,8 @@ your-project/
 │   ├── GET  /health         ← Health check                    │
 │   ├── GET  /info           ← Agent info                      │
 │   ├── GET  /docs           ← Interactive UI                  │
-│   ├── GET  /admin/logs     ← Activity logs (API key auth)    │
-│   ├── GET  /admin/sessions ← Session logs (API key auth)     │
+│   ├── GET  /admin/logs     ← Activity logs (admin auth)      │
+│   ├── GET  /admin/sessions ← Session logs (admin auth)       │
 │   └── WS   /ws             ← Real-time WebSocket             │
 │                                                              │
 │   P2P Relay Connection                                       │

--- a/tests/e2e/test_host.py
+++ b/tests/e2e/test_host.py
@@ -978,7 +978,7 @@ class TestCORS:
 
 
 class TestAdminEndpoints:
-    """Test admin endpoints requiring API key authentication."""
+    """Test admin endpoints requiring dedicated admin authentication."""
 
     @pytest.fixture
     def create_mock_agent(self):
@@ -1039,8 +1039,8 @@ class TestAdminEndpoints:
         assert b"unauthorized" in response.body
 
     def test_admin_logs_with_wrong_key(self, app, monkeypatch):
-        """GET /admin/logs with wrong API key should return 401."""
-        monkeypatch.setenv("OPENONION_API_KEY", "correct-key")
+        """GET /admin/logs with wrong admin token should return 401."""
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "correct-key")
 
         response = self._make_request(
             app, "GET", "/admin/logs",
@@ -1048,9 +1048,21 @@ class TestAdminEndpoints:
         )
         assert response.status_code == 401
 
+    def test_admin_logs_rejects_the_billing_key(self, app, monkeypatch):
+        """OPENONION_API_KEY must never authorize an admin endpoint."""
+        monkeypatch.setenv("OPENONION_API_KEY", "billing-key")
+        monkeypatch.delenv("CONNECTONION_ADMIN_TOKEN", raising=False)
+
+        response = self._make_request(
+            app, "GET", "/admin/logs",
+            headers=[[b"authorization", b"Bearer billing-key"]]
+        )
+
+        assert response.status_code == 401
+
     def test_admin_logs_with_correct_key(self, app, monkeypatch, tmp_path):
-        """GET /admin/logs with correct API key should return 200."""
-        monkeypatch.setenv("OPENONION_API_KEY", "test-api-key")
+        """GET /admin/logs with correct admin token should return 200."""
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "test-admin-token")
 
         # Create a log file
         log_dir = tmp_path / ".co" / "logs"
@@ -1065,7 +1077,7 @@ class TestAdminEndpoints:
         try:
             response = self._make_request(
                 app, "GET", "/admin/logs",
-                headers=[[b"authorization", b"Bearer test-api-key"]]
+                headers=[[b"authorization", b"Bearer test-admin-token"]]
             )
             # Should return 200 or 404 (if no logs) - not 401
             assert response.status_code in [200, 404]
@@ -1073,8 +1085,8 @@ class TestAdminEndpoints:
             os.chdir(original_cwd)
 
     def test_admin_sessions_with_correct_key(self, app, monkeypatch, tmp_path):
-        """GET /admin/sessions with correct API key should return 200."""
-        monkeypatch.setenv("OPENONION_API_KEY", "test-api-key")
+        """GET /admin/sessions with correct admin token should return 200."""
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "test-admin-token")
 
         # Change to tmp_path
         import os
@@ -1084,7 +1096,7 @@ class TestAdminEndpoints:
         try:
             response = self._make_request(
                 app, "GET", "/admin/sessions",
-                headers=[[b"authorization", b"Bearer test-api-key"]]
+                headers=[[b"authorization", b"Bearer test-admin-token"]]
             )
             assert response.status_code == 200
             data = json.loads(response.body)
@@ -1094,10 +1106,10 @@ class TestAdminEndpoints:
 
     def test_admin_unknown_endpoint_returns_404(self, app, monkeypatch):
         """GET /admin/unknown should return 404."""
-        monkeypatch.setenv("OPENONION_API_KEY", "test-api-key")
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "test-admin-token")
 
         response = self._make_request(
             app, "GET", "/admin/unknown",
-            headers=[[b"authorization", b"Bearer test-api-key"]]
+            headers=[[b"authorization", b"Bearer test-admin-token"]]
         )
         assert response.status_code == 404

--- a/tests/unit/test_an_admin_signature_is_used_once.py
+++ b/tests/unit/test_an_admin_signature_is_used_once.py
@@ -157,8 +157,8 @@ class TestAFreshSignatureStillWorks:
 
 
 @pytest.mark.asyncio
-class TestTheBearerPathIsUnaffected:
-    """It carries no signature to replay; its weakness is #670, not this."""
+class TestTheDedicatedBearerPathIsUnaffected:
+    """A distinct admin bearer carries no signature to replay."""
 
     async def test_a_bearer_call_does_not_consume_a_signature(
         self, call, monkeypatch
@@ -166,6 +166,7 @@ class TestTheBearerPathIsUnaffected:
         from connectonion.network.trust import http_admin
 
         monkeypatch.setenv("OPENONION_API_KEY", "billing-key")
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "admin-key")
 
         sent = {}
 
@@ -180,7 +181,7 @@ class TestTheBearerPathIsUnaffected:
 
         await http_admin.handle_admin_routes(
             "GET", "/admin/logs",
-            {"headers": [(b"authorization", b"Bearer billing-key")]},
+            {"headers": [(b"authorization", b"Bearer admin-key")]},
             None,
             {"admin_logs": lambda: {"content": "log body"}},
             send_json=send_json, send_text=send_text, read_body=read_body,

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -680,8 +680,8 @@ class TestAdminEndpoints:
 
         assert sent[0]["status"] == 401
 
-    async def test_admin_logs_with_valid_key(self):
-        """Admin logs endpoint with valid key succeeds."""
+    async def test_admin_logs_with_valid_admin_token(self):
+        """Admin logs endpoint with a dedicated admin token succeeds."""
         scope = {
             "method": "GET",
             "path": "/admin/logs",
@@ -697,7 +697,10 @@ class TestAdminEndpoints:
 
         handlers = {"admin_logs": lambda: {"content": "log content here"}}
 
-        with patch.dict(os.environ, {"OPENONION_API_KEY": "secret123"}):
+        with patch.dict(os.environ, {
+            "CONNECTONION_ADMIN_TOKEN": "secret123",
+            "OPENONION_API_KEY": "billing-key",
+        }):
             await handle_http(
                 scope, receive, send,
                 route_handlers=handlers,
@@ -709,8 +712,8 @@ class TestAdminEndpoints:
         assert sent[0]["status"] == 200
         assert sent[1]["body"] == b"log content here"
 
-    async def test_admin_sessions_with_valid_key(self):
-        """Admin sessions endpoint with valid key succeeds."""
+    async def test_admin_sessions_with_valid_admin_token(self):
+        """Admin sessions endpoint with a dedicated admin token succeeds."""
         scope = {
             "method": "GET",
             "path": "/admin/sessions",
@@ -726,7 +729,10 @@ class TestAdminEndpoints:
 
         handlers = {"admin_sessions": lambda: {"sessions": []}}
 
-        with patch.dict(os.environ, {"OPENONION_API_KEY": "mykey"}):
+        with patch.dict(os.environ, {
+            "CONNECTONION_ADMIN_TOKEN": "mykey",
+            "OPENONION_API_KEY": "billing-key",
+        }):
             await handle_http(
                 scope, receive, send,
                 route_handlers=handlers,

--- a/tests/unit/test_http_routes.py
+++ b/tests/unit/test_http_routes.py
@@ -59,6 +59,26 @@ def test_framework_routes_cannot_be_shadowed():
         http.admin.get("/logs")(lambda: None)
 
 
+@pytest.mark.parametrize("path", ["/{resource}", "/{resource}/{item}"])
+def test_parameter_routes_cannot_shadow_reserved_admin_paths(path):
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    with pytest.raises(ValueError, match="reserved by Connectonion"):
+        http.admin.get(path)(lambda **kwargs: kwargs)
+
+
+def test_parameter_routes_remain_available_outside_reserved_namespaces():
+    from connectonion import HTTPRouter
+
+    http = HTTPRouter()
+    http.admin.get("/reports/{item}")(lambda item: item)
+
+    route, params = http.match("GET", "/admin/reports/q3")
+    assert route.relative_path == "/reports/{item}"
+    assert params == {"item": "q3"}
+
+
 def test_static_route_wins_over_a_parameter_route():
     from connectonion import HTTPRouter
 

--- a/tests/unit/test_reading_logs_does_not_need_the_billing_key.py
+++ b/tests/unit/test_reading_logs_does_not_need_the_billing_key.py
@@ -1,4 +1,4 @@
-"""Reading an agent's logs requires the key that pays for its models (#670).
+"""Reading an agent's logs must not accept the key that pays for models (#670).
 
     if path in ["/admin/logs", "/admin/sessions"]:
         expected = os.environ.get("OPENONION_API_KEY", "")
@@ -18,9 +18,8 @@ So this adds that path to the two legacy routes rather than inventing anything:
 an admin can read logs by signing, and nobody has to be handed the billing key
 to do it.
 
-The Bearer path stays. Removing it would break the curl in the shipped
-docs.html and anything already using it, and 1.6.0 is a long-term release —
-this widens what works, and a later major can drop the key.
+Bearer automation uses a separate per-deployment admin token. The billing key
+is explicitly rejected even if it is copied into that setting.
 """
 
 import pytest
@@ -44,6 +43,7 @@ def call(monkeypatch):
     from connectonion.network.trust import http_admin
 
     monkeypatch.setenv("OPENONION_API_KEY", "the-billing-key")
+    monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "the-admin-token")
 
     async def run(path, *, headers=None, bearer=None):
         sent = {}
@@ -137,11 +137,15 @@ class TestSigningIsNotEnoughOnItsOwn:
 
 
 @pytest.mark.asyncio
-class TestTheBearerPathStillWorks:
-    """1.6.0 is long-term; the curl in the shipped docs.html must keep working."""
+class TestTheDedicatedBearerPath:
 
-    async def test_the_billing_key_still_reads_logs(self, call):
+    async def test_the_billing_key_cannot_read_logs(self, call):
         _, sent = await call("/admin/logs", bearer="the-billing-key")
+
+        assert sent["status"] == 401
+
+    async def test_a_distinct_admin_token_reads_logs(self, call):
+        _, sent = await call("/admin/logs", bearer="the-admin-token")
 
         assert sent["status"] == 200
         assert "line one" in sent["body"]
@@ -152,6 +156,15 @@ class TestTheBearerPathStillWorks:
         assert sent["status"] == 401
 
     async def test_sessions_too(self, call):
-        _, sent = await call("/admin/sessions", bearer="the-billing-key")
+        _, sent = await call("/admin/sessions", bearer="the-admin-token")
 
         assert sent["status"] == 200
+
+    async def test_reusing_the_billing_key_as_admin_token_fails_closed(
+        self, call, monkeypatch
+    ):
+        monkeypatch.setenv("CONNECTONION_ADMIN_TOKEN", "the-billing-key")
+
+        _, sent = await call("/admin/logs", bearer="the-billing-key")
+
+        assert sent["status"] == 401


### PR DESCRIPTION
## Security boundary

`OPENONION_API_KEY` pays for managed model calls. It must not also unlock hosted-agent activity logs and sessions.

This Draft PR:

- keeps signed identities from `.co/admins.txt` as the preferred admin path;
- moves Bearer automation to a dedicated per-deployment `CONNECTONION_ADMIN_TOKEN`;
- rejects `OPENONION_API_KEY` on `/admin/logs` and `/admin/sessions`;
- fails closed if the configured admin token equals the billing key;
- updates host, deploy, and embedded interactive docs;
- adds unit, ASGI, and end-to-end regressions for the credential boundary.

The design was discussed on #670 before implementation and follows the deterministic authentication boundary in DD-020 (`docs/design-decisions/020-trust-system-and-network-architecture.md`). No dependency or new endpoint is introduced.

## Migration note

This intentionally removes the old billing-key Bearer behavior. Monitoring automation should either sign requests with an admin identity or configure a distinct 256-bit `CONNECTONION_ADMIN_TOKEN`.

## Verification

- 120 focused unit/ASGI/E2E tests passed
- `python -m compileall -q connectonion/network/trust connectonion/network/host`
- `git diff --check`

## PR ordering

PR #805 also changes `http_admin.py` to inject the shared replay guard. Keep these PRs separate for review. If #805 merges first, this branch must be rebased and preserve its replay injection before #670 can merge.

Draft only. Do not merge as part of this work.

Fixes #670
