### PR TITLE
fix(syno): send the upload sid in the query, and let it survive a stale session

### DIFF
--- a/connectonion/useful_tools/synology.py
+++ b/connectonion/useful_tools/synology.py
@@ -401,18 +401,33 @@ class Synology:
             # Always explicit: DSM returns error 1805 rather than a default when
             # the destination exists and this is missing.
             "overwrite": "true" if overwrite else "false",
-            "_sid": self.sid,
         }
 
-        with self._client() as client:
-            with open(local, "rb") as handle:
-                reply = client.post(
-                    f"/webapi/{self._path_for('SYNO.FileStation.Upload')}",
-                    data=fields,
-                    files={"file": (local.name, handle, "application/octet-stream")},
-                )
+        def attempt() -> dict:
+            """One upload, reopening the file because the last one consumed it."""
+            with self._client() as client:
+                with open(local, "rb") as handle:
+                    reply = client.post(
+                        f"/webapi/{self._path_for('SYNO.FileStation.Upload')}",
+                        # The sid goes in the query, like _call() and download()
+                        # already do. SYNO.FileStation.Upload does not read it
+                        # from the multipart body, which is why every upload
+                        # failed with "SID not found" while ls and get worked.
+                        params={"_sid": self.sid},
+                        data=fields,
+                        files={"file": (local.name, handle, "application/octet-stream")},
+                    )
+            return reply.json()
 
-        body = reply.json()
+        body = attempt()
+
+        if not body.get("success") and body.get("error", {}).get("code") in STALE_SESSION:
+            # The same recovery _request() gives every other call. Upload posts
+            # multipart and cannot go through _request(), so it went without —
+            # leaving the one command that could not survive a dead session.
+            self._login()
+            body = attempt()
+
         if not body.get("success"):
             code = body.get("error", {}).get("code", 0)
             raise ValueError(f"Synology upload failed: {ERRORS.get(code, f'error {code}')}")

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -318,3 +318,89 @@ def test_missing_url_tells_the_user_to_log_in(monkeypatch):
     monkeypatch.delenv("SYNOLOGY_URL")
     with pytest.raises(ValueError, match="co syno login"):
         Synology()
+
+
+def _upload_client(replies):
+    """A client whose post() returns each reply in turn."""
+    client = MagicMock()
+    client.post.side_effect = [MagicMock(json=lambda b=b: b) for b in replies]
+    client.__enter__ = lambda self: client
+    client.__exit__ = lambda *a: None
+    return client
+
+
+def test_upload_sends_the_sid_in_the_query_not_the_form(tmp_path):
+    """#794: every path failed with 'SID not found' (DSM 119).
+
+    `_call()` and `download()` both put `_sid` in the query string; upload put
+    it in the multipart body, and SYNO.FileStation.Upload does not read it
+    there. One inconsistency, one command broken.
+    """
+    from connectonion.useful_tools.synology import Synology
+
+    local = tmp_path / "clip.mp4"
+    local.write_bytes(b"data")
+    client = _upload_client([{"success": True}])
+
+    with patch.object(Synology, "_client", return_value=client):
+        nas().upload(str(local), "/home/Social Media Content")
+
+    kwargs = client.post.call_args.kwargs
+    assert kwargs.get("params", {}).get("_sid"), "the sid has to travel in the query"
+    assert "_sid" not in kwargs.get("data", {}), "and not in the form body"
+
+
+def test_upload_retries_once_after_a_stale_session(tmp_path):
+    """119 is already in STALE_SESSION, but only `_request()` acts on it and
+    upload does not go through `_request()`. So the one command that could not
+    recover from a dead session was the one that hit it."""
+    from connectonion.useful_tools.synology import Synology
+
+    local = tmp_path / "clip.mp4"
+    local.write_bytes(b"data")
+    client = _upload_client([
+        {"success": False, "error": {"code": 119}},
+        {"success": True},
+    ])
+    logins = []
+
+    with patch.object(Synology, "_client", return_value=client):
+        with patch.object(Synology, "_login", side_effect=lambda: logins.append(1)):
+            result = nas().upload(str(local), "/home/docs")
+
+    assert len(logins) == 1, "a stale session should re-login exactly once"
+    assert client.post.call_count == 2
+    assert "clip.mp4" in result
+
+
+def test_upload_does_not_retry_a_real_failure(tmp_path):
+    """Only the stale-session codes get a second attempt. Retrying a genuine
+    refusal doubles the wait before the user sees the reason."""
+    from connectonion.useful_tools.synology import Synology
+
+    local = tmp_path / "clip.mp4"
+    local.write_bytes(b"data")
+    client = _upload_client([{"success": False, "error": {"code": 1805}}])
+
+    with patch.object(Synology, "_client", return_value=client):
+        with pytest.raises(ValueError):
+            nas().upload(str(local), "/home/docs")
+
+    assert client.post.call_count == 1
+
+
+def test_upload_still_puts_the_binary_part_last(tmp_path):
+    """The RFC 1867 constraint the original test protects — moving the sid
+    must not disturb it."""
+    from connectonion.useful_tools.synology import Synology
+
+    local = tmp_path / "note.txt"
+    local.write_text("hello")
+    client = _upload_client([{"success": True}])
+
+    with patch.object(Synology, "_client", return_value=client):
+        nas().upload(str(local), "/home/docs", overwrite=True)
+
+    kwargs = client.post.call_args.kwargs
+    assert "file" in kwargs["files"]
+    assert kwargs["data"]["overwrite"] == "true"


### PR DESCRIPTION
Closes #794.

`co syno put` failed on **every** path with `SID not found` (DSM 119) while `ls`, `get` and `share` worked on the same session. The issue had already ruled out the session, the path, the quoting and `--overwrite`, and pointed at the right place.

## Two causes, one root

`upload()` is the only call that does not go through `_request()`, and it was missing both things `_request()` provides.

**1. The sid was in the wrong part of the request.**

```python
_call():      query = {"api": ..., "_sid": self.sid}        # query string
download():   query = {"api": ..., "_sid": self.sid}        # query string
upload():     fields = {"api": ..., "_sid": self.sid}       # multipart body  <-
```

`SYNO.FileStation.Upload` does not read it from the body. One inconsistency, one broken command — and it broke *completely*, which is why no amount of re-logging in helped.

**2. It could not recover from a dead session.**

`119` is already in `STALE_SESSION = {106, 107, 119}`, but only `_request()` acts on that set. Upload posts multipart and cannot route through `_request()`, so it simply went without — leaving the command most likely to *meet* a stale session, a long upload, as the only one that could not survive one.

## The fix

The sid moves to `params`, and the retry is inlined rather than faked through `_request()`. Two details worth naming:

- the retry **reopens the file** — the first attempt consumed the handle, and rewinding a spent one is the kind of thing that works in a test and truncates in production
- it fires **only** for the stale-session codes. Retrying a genuine refusal like 1805 just doubles the wait before the user is told why.

## Tests

4 new, 2 shown red first (sid placement, retry-once). The other two pin behaviour the fix must not disturb: the binary part staying last per RFC 1867, and a real failure *not* being retried.

```
26 passed   tests/unit/test_synology.py
```

Not verified against a live NAS — I have no DSM host here. The failing call is fully described by the issue's reproduction and the asymmetry above, but a confirmation from whoever hit it would close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YE2E7YwTvLnPp2qjfcofRq