### PR TITLE
security: enforce Outlook attachment boundaries in the tool core

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -22,9 +22,6 @@ console = Console()
 
 INBOX_CACHE = Path.home() / ".co" / "outlook_last_inbox.json"
 
-ATTACHMENT_LIMIT = 3_000_000  # Graph sendMail rejects larger payloads
-
-
 def _outlook(required_scope: str = "Mail"):
     """Load Microsoft credentials and require the Graph scope this command needs."""
     from dotenv import load_dotenv
@@ -48,7 +45,7 @@ def _outlook(required_scope: str = "Mail"):
         raise typer.Exit(1)
 
     from ...useful_tools.outlook import Outlook
-    return Outlook()
+    return Outlook(allow_external_attachments=True)
 
 
 def _when(iso: str) -> str:
@@ -117,12 +114,14 @@ def _parse_send_at(at: str) -> str:
 
 def _check_attachments(attachments: list):
     """Precheck attachment paths before base64-encoding megabytes. Exits 1 on bad input."""
+    from ...useful_tools.outlook import OUTLOOK_ATTACHMENT_LIMIT
+
     paths = [Path(p).expanduser() for p in attachments]
     for given, path in zip(attachments, paths):
         if not path.is_file():
             console.print(f"\n❌ [bold red]Attachment not found:[/bold red] {given}\n")
             raise typer.Exit(1)
-    if sum(p.stat().st_size for p in paths) > ATTACHMENT_LIMIT:
+    if sum(p.stat().st_size for p in paths) > OUTLOOK_ATTACHMENT_LIMIT:
         console.print("\n❌ [bold red]Attachments exceed Outlook's 3MB send limit.[/bold red]\n")
         raise typer.Exit(1)
 

--- a/connectonion/useful_tools/_attachment_files.py
+++ b/connectonion/useful_tools/_attachment_files.py
@@ -1,0 +1,38 @@
+"""Small cross-platform primitives for attachment file authorization."""
+
+import os
+from pathlib import Path
+
+
+def path_of_open_file(handle) -> Path:
+    """Return the OS-reported final path for an already-open file handle."""
+    import sys
+
+    descriptor = handle.fileno()
+    if os.name == "nt":
+        import ctypes
+        import msvcrt
+
+        buffer = ctypes.create_unicode_buffer(32768)
+        length = ctypes.windll.kernel32.GetFinalPathNameByHandleW(
+            ctypes.c_void_p(msvcrt.get_osfhandle(descriptor)), buffer, len(buffer), 0
+        )
+        if not length or length >= len(buffer):
+            raise OSError("Windows could not resolve the open attachment handle")
+        path = buffer.value
+        if path.startswith("\\\\?\\UNC\\"):
+            path = "\\\\" + path[8:]
+        elif path.startswith("\\\\?\\"):
+            path = path[4:]
+        return Path(path)
+
+    if sys.platform == "darwin":
+        import fcntl
+
+        raw = fcntl.fcntl(descriptor, fcntl.F_GETPATH, bytes(1024))
+        return Path(raw.split(bytes(1), 1)[0].decode())
+
+    proc_path = Path(f"/proc/self/fd/{descriptor}")
+    if proc_path.exists():
+        return Path(os.readlink(proc_path))
+    raise OSError("This platform cannot resolve an open attachment handle")

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -61,43 +61,10 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from ..backend import backend_url
 from ..project import project_root
+from ._attachment_files import path_of_open_file
 
 
 GMAIL_ATTACHMENT_LIMIT = 25_000_000
-
-
-def _path_of_open_file(handle) -> Path:
-    """The OS-reported final path for an already-open file handle."""
-    import sys
-
-    descriptor = handle.fileno()
-    if os.name == "nt":
-        import ctypes
-        import msvcrt
-
-        buffer = ctypes.create_unicode_buffer(32768)
-        length = ctypes.windll.kernel32.GetFinalPathNameByHandleW(
-            ctypes.c_void_p(msvcrt.get_osfhandle(descriptor)), buffer, len(buffer), 0
-        )
-        if not length or length >= len(buffer):
-            raise OSError("Windows could not resolve the open attachment handle")
-        path = buffer.value
-        if path.startswith("\\\\?\\UNC\\"):
-            path = "\\\\" + path[8:]
-        elif path.startswith("\\\\?\\"):
-            path = path[4:]
-        return Path(path)
-
-    if sys.platform == "darwin":
-        import fcntl
-
-        raw = fcntl.fcntl(descriptor, fcntl.F_GETPATH, bytes(1024))
-        return Path(raw.split(bytes(1), 1)[0].decode())
-
-    proc_path = Path(f"/proc/self/fd/{descriptor}")
-    if proc_path.exists():
-        return Path(os.readlink(proc_path))
-    raise OSError("This platform cannot resolve an open attachment handle")
 
 
 class Gmail:
@@ -576,7 +543,7 @@ class Gmail:
                 raise PermissionError(f"Attachment is not a regular file: {given}")
             if not self._allow_external_attachments:
                 try:
-                    _path_of_open_file(handle).relative_to(self._attachment_root)
+                    path_of_open_file(handle).relative_to(self._attachment_root)
                 except (ValueError, OSError):
                     raise PermissionError(
                         f"Attachment is outside the project: {given}"

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -488,6 +488,10 @@ class Outlook:
                     raise PermissionError(f"Attachment is outside the project: {given}") from None
 
             flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            if os.name != "nt":
+                # Prevent a path swapped to a FIFO from blocking before fstat()
+                # can enforce the regular-file boundary below.
+                flags |= getattr(os, "O_NONBLOCK", 0)
             try:
                 descriptor_number = os.open(resolved, flags)
             except OSError as exc:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -50,6 +50,11 @@ from pathlib import Path
 
 import httpx
 from ..backend import backend_url
+from ..project import project_root
+from ._attachment_files import path_of_open_file
+
+
+OUTLOOK_ATTACHMENT_LIMIT = 3_000_000
 
 
 class Outlook:
@@ -57,7 +62,7 @@ class Outlook:
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
 
-    def __init__(self):
+    def __init__(self, allow_external_attachments: bool = False):
         """Initialize Outlook tool.
 
         Validates that Microsoft OAuth is configured.
@@ -78,6 +83,8 @@ class Outlook:
             )
 
         self._access_token = None
+        self._attachment_root = project_root().resolve()
+        self._allow_external_attachments = allow_external_attachments
 
     def _require_scope(self, required_scope: str) -> None:
         """Raise a re-consent hint when an operation's OAuth scope is absent."""
@@ -463,24 +470,57 @@ class Outlook:
 
     # === Sending ===
 
-    def _file_attachment(self, file_path: str) -> dict:
-        """Read a local file into a Graph fileAttachment object (base64 contentBytes)."""
+    def _open_attachments(self, attachments: list, stack) -> list[tuple[str, object]]:
+        """Open and validate every attachment before any contents are read."""
+        import stat
+
+        opened = []
+        total = 0
+        for given in attachments:
+            path = Path(given).expanduser()
+            if not path.is_file():
+                raise ValueError(f"Attachment not found: {given}")
+            resolved = path.resolve()
+            if not self._allow_external_attachments:
+                try:
+                    resolved.relative_to(self._attachment_root)
+                except ValueError:
+                    raise PermissionError(f"Attachment is outside the project: {given}") from None
+
+            flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
+            try:
+                descriptor_number = os.open(resolved, flags)
+            except OSError as exc:
+                raise PermissionError(f"Attachment changed while opening: {given}") from exc
+            handle = stack.enter_context(os.fdopen(descriptor_number, "rb"))
+            descriptor = os.fstat(handle.fileno())
+            if not stat.S_ISREG(descriptor.st_mode):
+                raise PermissionError(f"Attachment is not a regular file: {given}")
+            if not self._allow_external_attachments:
+                try:
+                    path_of_open_file(handle).relative_to(self._attachment_root)
+                except (ValueError, OSError):
+                    raise PermissionError(f"Attachment is outside the project: {given}") from None
+
+            total += descriptor.st_size
+            if total > OUTLOOK_ATTACHMENT_LIMIT:
+                raise ValueError("Attachments exceed Outlook's 3MB send limit.")
+            opened.append((path.name, handle))
+        return opened
+
+    @staticmethod
+    def _file_attachment(filename: str, content: bytes) -> dict:
+        """Build a Graph fileAttachment from already-authorized bytes."""
         import base64
         import mimetypes
 
-        path = os.path.expanduser(file_path)
-        if not os.path.isfile(path):
-            raise ValueError(f"Attachment not found: {file_path}")
-
-        content_type = mimetypes.guess_type(path)[0] or "application/octet-stream"
-        with open(path, "rb") as f:
-            content = base64.b64encode(f.read()).decode()
+        content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
         return {
             "@odata.type": "#microsoft.graph.fileAttachment",
-            "name": os.path.basename(path),
+            "name": filename,
             "contentType": content_type,
-            "contentBytes": content,
+            "contentBytes": base64.b64encode(content).decode(),
         }
 
     def send(self, to: str, subject: str, body: str, cc: str = None, bcc: str = None,
@@ -526,9 +566,19 @@ class Outlook:
             ]
 
         if attachments:
-            message["attachments"] = [
-                self._file_attachment(path) for path in attachments
-            ]
+            from contextlib import ExitStack
+
+            with ExitStack() as stack:
+                opened = self._open_attachments(attachments, stack)
+                remaining = OUTLOOK_ATTACHMENT_LIMIT
+                encoded = []
+                for filename, handle in opened:
+                    payload = handle.read(remaining + 1)
+                    if len(payload) > remaining:
+                        raise ValueError("Attachments exceed Outlook's 3MB send limit.")
+                    remaining -= len(payload)
+                    encoded.append(self._file_attachment(filename, payload))
+            message["attachments"] = encoded
 
         suffix = ""
         if attachments:

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -138,7 +138,9 @@ co outlook send bob@example.com "Report" "See attached." \
     --attach report.pdf --attach screenshot.png
 ```
 
-> Graph's `sendMail` limit is ~3MB total across attachments.
+> Graph's `sendMail` limit is ~3MB total across attachments. A human invoking
+> the CLI may explicitly name a file outside the project; agent-facing
+> `Outlook()` tools remain limited to project files.
 
 **Scheduling** — Exchange holds delivery until the time you give (deferred
 send), so it works with just the `Mail.Send` scope and no extra setup:

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -106,7 +106,9 @@ If Microsoft was connected before contacts were enabled, run
 - `cc`: Optional CC recipients
 - `bcc`: Optional BCC recipients
 - `attachments`: Optional list of local file paths (images, screenshots,
-  PDFs, etc. — Graph sendMail limit is ~3MB total)
+  PDFs, etc.). Agent-facing `Outlook()` instances can attach only resolved
+  files inside the current project. The ~3MB total limit is enforced before
+  file contents are read.
 - `send_at`: Optional UTC ISO time (e.g. `"2026-07-06T15:30:00Z"`) —
   Exchange holds delivery until then (deferred send, works with just the
   `Mail.Send` scope)

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -485,6 +485,25 @@ class TestOutlookSendOperations:
             with pytest.raises(PermissionError, match="outside the project"):
                 outlook.send("r@example.com", "S", "B", attachments=[str(local)])
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX FIFO semantics")
+    def test_fifo_replacement_cannot_block_the_attachment_open(self, tmp_path):
+        local = tmp_path / "report.txt"
+        local.write_text("safe")
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read Mail.Send"}):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook(allow_external_attachments=True)
+        original_open = os.open
+
+        def swap_for_fifo_then_open(path, flags):
+            local.unlink()
+            os.mkfifo(local)
+            assert flags & os.O_NONBLOCK
+            return original_open(path, flags)
+
+        with patch.object(os, "open", side_effect=swap_for_fifo_then_open):
+            with pytest.raises(PermissionError, match="not a regular file"):
+                outlook.send("r@example.com", "S", "B", attachments=[str(local)])
+
     def test_growth_after_fstat_is_rejected_before_graph(self, tmp_path):
         local = tmp_path / "growing.bin"
         local.write_bytes(b"x")

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -408,7 +408,7 @@ class TestOutlookSendOperations:
             "MICROSOFT_TOKEN_EXPIRES_AT": "2099-12-31T23:59:59Z"
         }, clear=False):
             from connectonion.useful_tools.outlook import Outlook
-            outlook = Outlook()
+            outlook = Outlook(allow_external_attachments=True)
             result = outlook.send(
                 to="recipient@example.com",
                 subject="Test Subject",
@@ -425,6 +425,86 @@ class TestOutlookSendOperations:
             assert attachment["name"] == "screenshot.png"
             assert attachment["contentType"] == "image/png"
             assert attachment["contentBytes"]
+
+    def test_agent_attachment_must_stay_inside_the_project(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".co").mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("secret")
+        monkeypatch.chdir(project)
+
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read Mail.Send"}):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+
+        with pytest.raises(PermissionError, match="outside the project"):
+            outlook.send("r@example.com", "S", "B", attachments=[str(outside)])
+
+    def test_core_rejects_oversize_before_the_graph_call(self, tmp_path):
+        huge = tmp_path / "huge.bin"
+        huge.write_bytes(b"")
+        os.truncate(huge, 3_000_001)
+
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read Mail.Send"}):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook(allow_external_attachments=True)
+        outlook._request = MagicMock()
+
+        with pytest.raises(ValueError, match="3MB"):
+            outlook.send("r@example.com", "S", "B", attachments=[str(huge)])
+
+        outlook._request.assert_not_called()
+
+    def test_parent_directory_replacement_cannot_change_the_opened_file(
+        self, tmp_path, monkeypatch
+    ):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".co").mkdir()
+        slot = project / "slot"
+        slot.mkdir()
+        local = slot / "report.txt"
+        local.write_text("safe")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "report.txt").write_text("SECRET")
+        monkeypatch.chdir(project)
+
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read Mail.Send"}):
+            from connectonion.useful_tools.outlook import Outlook
+            outlook = Outlook()
+        original_open = os.open
+
+        def swap_parent_then_open(path, flags):
+            slot.rename(project / "old-slot")
+            slot.symlink_to(outside, target_is_directory=True)
+            return original_open(path, flags)
+
+        with patch.object(os, "open", side_effect=swap_parent_then_open):
+            with pytest.raises(PermissionError, match="outside the project"):
+                outlook.send("r@example.com", "S", "B", attachments=[str(local)])
+
+    def test_growth_after_fstat_is_rejected_before_graph(self, tmp_path):
+        local = tmp_path / "growing.bin"
+        local.write_bytes(b"x")
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read Mail.Send"}):
+            from connectonion.useful_tools import outlook as outlook_module
+            outlook = outlook_module.Outlook(allow_external_attachments=True)
+        outlook._request = MagicMock()
+        original_open = outlook._open_attachments
+
+        def open_then_grow(attachments, stack):
+            opened = original_open(attachments, stack)
+            local.write_bytes(b"12345")
+            return opened
+
+        with patch.object(outlook_module, "OUTLOOK_ATTACHMENT_LIMIT", 4):
+            with patch.object(outlook, "_open_attachments", side_effect=open_then_grow):
+                with pytest.raises(ValueError, match="3MB"):
+                    outlook.send("r@example.com", "S", "B", attachments=[str(local)])
+
+        outlook._request.assert_not_called()
 
     @patch('connectonion.useful_tools.outlook.httpx')
     def test_send_email_scheduled(self, mock_httpx):

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -99,6 +99,7 @@ class TestOutlookGuard:
 
         from connectonion.useful_tools.outlook import Outlook
         assert isinstance(result, Outlook)
+        assert result._allow_external_attachments is True
 
     def test_contacts_scope_missing_exits_with_reconnect_hint(self, capsys):
         with patch.dict(os.environ, CONNECTED_ENV, clear=False):


### PR DESCRIPTION
Closes #810.

## Why

The CLI checked attachment size, but direct Outlook.send callers could read arbitrary host paths and bypass the 3 MB Graph limit. An agent tool must enforce those boundaries in the tool core, not only in a human-facing command wrapper.

## Design

- Agent-created Outlook instances accept project-local attachments only.
- The trusted CLI opts into explicit external paths at construction time; that capability is not exposed in the tool schema.
- Files are opened once and held through validation/read, checked as regular files, verified from the final OS handle path, and limited to 3 MB both before and during the read.
- POSIX opens are non-blocking so a path swapped to a FIFO cannot hang the agent.
- Gmail and Outlook share only the cross-platform final-handle path helper; provider-specific limits and message construction stay separate.
- Graph is called only after every attachment has passed validation and bounded reading.

The alternatives and security rationale were discussed in #810 before implementation, including symlink, parent-directory, growth, and FIFO races.

## Verification

- 225 focused Outlook + Gmail unit/CLI/E2E tests passed on the clean branch based on current main.
- Regression tests cover project escape, parent replacement, FIFO replacement, post-fstat growth, oversize-before-Graph, and the trusted CLI override.
- Two expert reviews of the stacked implementation reached P0/P1/P2 = 0/0/0 after the FIFO fix; this clean PR head will be re-reviewed and must pass remote CI before merge.