### PR TITLE
deploy: print real paths for broken local skills

### DIFF
--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -258,7 +258,16 @@ def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) 
     """
     from ...useful_plugins.skills import skills_that_will_not_travel
 
-    bundled = {path.name for path in skills_paths}
+    bundled = set()
+    for path in skills_paths:
+        if (path / "SKILL.md").exists():
+            bundled.add(path.name)
+        else:
+            bundled.update(
+                child.name
+                for child in path.iterdir()
+                if child.is_dir() and (child / "SKILL.md").exists()
+            )
     staying = [s for s in skills_that_will_not_travel(project_dir=project_dir)
                if s.name not in bundled]
 
@@ -270,24 +279,58 @@ def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) 
         )
         console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
 
-    _print_deploy_skill_problems(project_dir, console)
-
-
-def _print_deploy_skill_problems(project_dir: Path, output: Console) -> None:
-    """Show a real repair path; only payload problems look like deploy failures."""
-    from ...useful_plugins.skills import (
-        TRAVELS_ON_DEPLOY,
-        find_skill_problem_details,
+    if _is_git_repo(project_dir):
+        ignored = _load_deploy_ignore_patterns(project_dir)
+        payload_entries = {
+            (project_dir / rel).absolute()
+            for rel in _iter_git_tracked_files(project_dir)
+            if not _is_ignored_for_deploy(rel, ignored)
+        }
+        project_roots = ()
+    else:
+        payload_entries = set()
+        project_roots = (project_dir.absolute(),)
+    _print_deploy_skill_problems(
+        project_dir,
+        console,
+        payload_entries=payload_entries,
+        payload_roots=project_roots + tuple(path.absolute() for path in skills_paths),
     )
 
+
+def _print_deploy_skill_problems(
+    project_dir: Path,
+    output: Console,
+    *,
+    payload_entries: set[Path] | None = None,
+    payload_roots: tuple[Path, ...] = (),
+) -> None:
+    """Show a real repair path; only payload problems look like deploy failures."""
+    from rich.markup import escape
+    from ...useful_plugins.skills import find_skill_problem_details
+
+    entries = payload_entries or set()
+
+    def is_in_payload(path: Path) -> bool:
+        if path in entries:
+            return True
+        for root in payload_roots:
+            try:
+                path.relative_to(root)
+                return True
+            except ValueError:
+                pass
+        return False
+
     for problem in find_skill_problem_details(project_dir=project_dir):
-        affects_payload = problem.location in TRAVELS_ON_DEPLOY
+        affects_payload = is_in_payload(problem.path)
         color, marker = ("red", "✗") if affects_payload else ("yellow", "!")
-        target = f" → {problem.target}" if problem.target is not None else ""
-        scope = "ships with deploy" if affects_payload else "stays on this machine"
+        target = f" → {escape(str(problem.target))}" if problem.target is not None else ""
+        scope = "affects this deploy" if affects_payload else "not in deploy payload"
         output.print(
-            f"  [{color}]{marker}[/{color}] {problem.path} — {problem.reason}"
-            f"{target} [dim]({problem.location}; {scope})[/dim]",
+            f"  [{color}]{marker}[/{color}] {escape(str(problem.path))} — "
+            f"{escape(problem.reason)}{target} "
+            f"[dim]({escape(problem.location)}; {scope})[/dim]",
             soft_wrap=True,
         )
 

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -256,7 +256,7 @@ def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) 
     A warning, not a failure: leaving a personal skill behind is often exactly what
     the operator wants. The cost is only that it happens silently.
     """
-    from ...useful_plugins.skills import skills_that_will_not_travel, find_skill_problems
+    from ...useful_plugins.skills import skills_that_will_not_travel
 
     bundled = {path.name for path in skills_paths}
     staying = [s for s in skills_that_will_not_travel(project_dir=project_dir)
@@ -270,8 +270,26 @@ def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) 
         )
         console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
 
-    for location, name, reason in find_skill_problems(project_dir=project_dir):
-        console.print(f"  [red]✗[/red] {location}/{name} — {reason}")
+    _print_deploy_skill_problems(project_dir, console)
+
+
+def _print_deploy_skill_problems(project_dir: Path, output: Console) -> None:
+    """Show a real repair path; only payload problems look like deploy failures."""
+    from ...useful_plugins.skills import (
+        TRAVELS_ON_DEPLOY,
+        find_skill_problem_details,
+    )
+
+    for problem in find_skill_problem_details(project_dir=project_dir):
+        affects_payload = problem.location in TRAVELS_ON_DEPLOY
+        color, marker = ("red", "✗") if affects_payload else ("yellow", "!")
+        target = f" → {problem.target}" if problem.target is not None else ""
+        scope = "ships with deploy" if affects_payload else "stays on this machine"
+        output.print(
+            f"  [{color}]{marker}[/{color}] {problem.path} — {problem.reason}"
+            f"{target} [dim]({problem.location}; {scope})[/dim]",
+            soft_wrap=True,
+        )
 
 
 def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -312,14 +312,23 @@ def _print_deploy_skill_problems(
     entries = payload_entries or set()
 
     def is_in_payload(path: Path) -> bool:
-        if path in entries:
-            return True
-        for root in payload_roots:
-            try:
-                path.relative_to(root)
-                return True
-            except ValueError:
-                pass
+        # Cloud entries are files, while a skill problem names its directory.
+        # Explicit --skills paths are resolved before they reach this function,
+        # while diagnosis deliberately preserves the repairable symlink path.
+        candidates = {path, path.resolve(strict=False)}
+        for candidate in candidates:
+            for entry in entries:
+                try:
+                    entry.relative_to(candidate)
+                    return True
+                except ValueError:
+                    pass
+            for root in payload_roots:
+                try:
+                    candidate.relative_to(root)
+                    return True
+                except ValueError:
+                    pass
         return False
 
     for problem in find_skill_problem_details(project_dir=project_dir):

--- a/connectonion/cli/commands/deploy_commands.py
+++ b/connectonion/cli/commands/deploy_commands.py
@@ -184,14 +184,36 @@ def _add_directory_to_tarball(
     arc_prefix: Path,
     ignore_patterns: list[str],
 ) -> None:
-    for path in sorted(source.rglob("*")):
-        if not path.is_file():
-            continue
+    for path in _deployable_directory_files(source, ignore_patterns):
         source_rel = path.relative_to(source)
-        if _is_ignored_for_deploy(source_rel, ignore_patterns):
-            continue
         rel = arc_prefix / source_rel
         tar.add(path, arcname=str(rel), recursive=False)
+
+
+def _deployable_directory_files(
+    source: Path, ignore_patterns: list[str]
+) -> list[Path]:
+    """Files the directory packer will really add, in stable order."""
+    return [
+        path
+        for path in sorted(source.rglob("*"))
+        if path.is_file()
+        and not _is_ignored_for_deploy(path.relative_to(source), ignore_patterns)
+    ]
+
+
+def _project_files_for_deploy(
+    project_dir: Path, ignore_patterns: list[str]
+) -> list[Path]:
+    """Project source files under the exact git/non-git packaging rules."""
+    if _is_git_repo(project_dir):
+        return [
+            project_dir / rel
+            for rel in sorted(_iter_git_tracked_files(project_dir))
+            if (project_dir / rel).is_file()
+            and not _is_ignored_for_deploy(rel, ignore_patterns)
+        ]
+    return _deployable_directory_files(project_dir, ignore_patterns)
 
 
 def _add_deployer_as_admin(tar: tarfile.TarFile, project_dir: Path) -> None:
@@ -279,22 +301,21 @@ def _warn_about_skills_left_behind(project_dir: Path, skills_paths: list[Path]) 
         )
         console.print("    [dim]co skills list  ·  move one into .co/skills/ to ship it[/dim]")
 
-    if _is_git_repo(project_dir):
-        ignored = _load_deploy_ignore_patterns(project_dir)
-        payload_entries = {
-            (project_dir / rel).absolute()
-            for rel in _iter_git_tracked_files(project_dir)
-            if not _is_ignored_for_deploy(rel, ignored)
-        }
-        project_roots = ()
-    else:
-        payload_entries = set()
-        project_roots = (project_dir.absolute(),)
+    ignored = _load_deploy_ignore_patterns(project_dir)
+    payload_entries = {
+        path.absolute() for path in _project_files_for_deploy(project_dir, ignored)
+    }
+    for path in skills_paths:
+        payload_entries.update(
+            source.absolute()
+            for source in _deployable_directory_files(
+                path, _load_skill_ignore_patterns(path)
+            )
+        )
     _print_deploy_skill_problems(
         project_dir,
         console,
         payload_entries=payload_entries,
-        payload_roots=project_roots + tuple(path.absolute() for path in skills_paths),
     )
 
 
@@ -361,21 +382,8 @@ def _build_tarball(project_dir: Path, skills_paths: list[Path]) -> Path:
     ])
     tarball = Path(tempfile.mkdtemp()) / "agent.tar.gz"
     with tarfile.open(tarball, "w:gz") as tar:
-        if _is_git_repo(project_dir):
-            for rel in sorted(_iter_git_tracked_files(project_dir)):
-                if _is_ignored_for_deploy(rel, ignore_patterns):
-                    continue
-                path = project_dir / rel
-                if path.is_file():
-                    tar.add(path, arcname=str(rel), recursive=False)
-        else:
-            for path in sorted(project_dir.rglob("*")):
-                if not path.is_file():
-                    continue
-                rel = path.relative_to(project_dir)
-                if _is_ignored_for_deploy(rel, ignore_patterns):
-                    continue
-                tar.add(path, arcname=str(rel), recursive=False)
+        for path in _project_files_for_deploy(project_dir, ignore_patterns):
+            tar.add(path, arcname=str(path.relative_to(project_dir)), recursive=False)
         for skills_path in skills_paths:
             # A path is either one skill (has SKILL.md) or a directory of skills.
             arc_prefix = Path(".co") / "skills"

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -132,7 +132,7 @@ def _warn_about_skills_left_behind(project_dir: Path) -> None:
     symlinks into a separate repo — are simply absent there. The agent then behaves
     differently for a reason nothing in its output explains.
     """
-    from ...useful_plugins.skills import skills_that_will_not_travel, find_skill_problems
+    from ...useful_plugins.skills import skills_that_will_not_travel
 
     staying = skills_that_will_not_travel(project_dir=project_dir)
     if staying:
@@ -143,8 +143,8 @@ def _warn_about_skills_left_behind(project_dir: Path) -> None:
         )
         console.print("    [dim]co skills copy <name> --to-project   to ship one[/dim]")
 
-    for location, name, reason in find_skill_problems(project_dir=project_dir):
-        console.print(f"  [red]✗[/red] {location}/{name} — {reason}")
+    from .deploy_commands import _print_deploy_skill_problems
+    _print_deploy_skill_problems(project_dir, console)
 
 
 def _read_provision(target: str, agent: str) -> dict:

--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -144,7 +144,9 @@ def _warn_about_skills_left_behind(project_dir: Path) -> None:
         console.print("    [dim]co skills copy <name> --to-project   to ship one[/dim]")
 
     from .deploy_commands import _print_deploy_skill_problems
-    _print_deploy_skill_problems(project_dir, console)
+    _print_deploy_skill_problems(
+        project_dir, console, payload_roots=(project_dir.absolute(),)
+    )
 
 
 def _read_provision(target: str, agent: str) -> dict:

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -99,6 +99,17 @@ class SkillInfo:
     requirements: Optional[SkillRequirements] = None
 
 
+@dataclass(frozen=True)
+class SkillProblem:
+    """A broken skill entry with enough context to repair it."""
+
+    location: str
+    name: str
+    reason: str
+    path: Path
+    target: Optional[Path] = None
+
+
 # The only locations a hosted agent publishes to clients: the two that ship inside
 # the project tree. user (~/.co/skills) and claude-user are the operator's personal
 # toolboxes and builtin is framework noise — none may leak into the public directory.
@@ -352,9 +363,9 @@ def _discover_all_skills(co_dir: Optional[Path] = None, project_dir: Optional[Pa
     return result
 
 
-def find_skill_problems(co_dir: Optional[Path] = None,
-                        project_dir: Optional[Path] = None) -> List[tuple]:
-    """Entries that look like skills but can never load. Returns (location, name, reason).
+def find_skill_problem_details(co_dir: Optional[Path] = None,
+                               project_dir: Optional[Path] = None) -> List[SkillProblem]:
+    """Entries that look like skills but can never load, with repairable paths.
 
     Discovery is deliberately forgiving — it skips anything without a readable
     SKILL.md and says nothing. That is right for loading and wrong for diagnosing:
@@ -379,16 +390,30 @@ def find_skill_problems(co_dir: Optional[Path] = None,
             if entry.is_symlink():
                 # exists() follows the link, so False here means the target is gone.
                 if not entry.exists():
-                    problems.append((location, entry.name, 'broken symlink'))
+                    try:
+                        target = entry.readlink()
+                    except OSError:
+                        target = None  # The entry changed again while diagnosing it.
+                    if target is not None and not target.is_absolute():
+                        target = (entry.parent / target).absolute()
+                    problems.append(SkillProblem(
+                        location, entry.name, 'broken symlink', entry.absolute(), target
+                    ))
                     continue
 
                 resolved = entry.resolve()
                 if resolved == skills_dir.resolve() or resolved in skills_dir.resolve().parents:
-                    problems.append((location, entry.name, 'symlink points at its own ancestor'))
+                    problems.append(SkillProblem(
+                        location, entry.name, 'symlink points at its own ancestor',
+                        entry.absolute(), resolved,
+                    ))
                     continue
 
                 if entry.is_dir() and not (entry / 'SKILL.md').exists():
-                    problems.append((location, entry.name, 'linked directory has no SKILL.md'))
+                    problems.append(SkillProblem(
+                        location, entry.name, 'linked directory has no SKILL.md',
+                        entry.absolute(), resolved,
+                    ))
                     continue
 
             # A plain directory without a SKILL.md is not a broken skill — people
@@ -400,9 +425,20 @@ def find_skill_problems(co_dir: Optional[Path] = None,
             if entry.is_dir() and (entry / 'SKILL.md').exists():
                 reason = _why_the_skill_cannot_be_read(entry / 'SKILL.md')
                 if reason:
-                    problems.append((location, entry.name, reason))
+                    problems.append(SkillProblem(
+                        location, entry.name, reason, entry.absolute()
+                    ))
 
     return problems
+
+
+def find_skill_problems(co_dir: Optional[Path] = None,
+                        project_dir: Optional[Path] = None) -> List[tuple]:
+    """Compatibility view of skill problems as (location, name, reason)."""
+    return [
+        (problem.location, problem.name, problem.reason)
+        for problem in find_skill_problem_details(co_dir, project_dir)
+    ]
 
 
 def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:

--- a/tests/unit/test_skill_tiers.py
+++ b/tests/unit/test_skill_tiers.py
@@ -79,15 +79,84 @@ class TestBrokenLinks:
         stream = StringIO()
 
         _print_deploy_skill_problems(
-            project, Console(file=stream, color_system=None, width=300)
+            project,
+            Console(file=stream, color_system=None, width=300),
+            payload_roots=(project,),
         )
 
         output = stream.getvalue()
         assert f"✗ {project_link} — broken symlink → {project / 'missing-project-skill'}" in output
-        assert "(project; ships with deploy)" in output
+        assert "(project; affects this deploy)" in output
         assert f"! {user_link} — broken symlink → {home / 'missing-user-skill'}" in output
-        assert "(user; stays on this machine)" in output
+        assert "(user; not in deploy payload)" in output
         assert "user/user-ghost" not in output
+
+    def test_an_explicitly_bundled_user_skill_affects_the_deploy(self, tree):
+        from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
+
+        project, home = tree
+        link = home / ".co" / "skills" / "ghost"
+        link.symlink_to(home / "missing")
+        stream = StringIO()
+
+        _print_deploy_skill_problems(
+            project,
+            Console(file=stream, color_system=None, width=300),
+            payload_roots=(home / ".co" / "skills",),
+        )
+
+        assert f"✗ {link}" in stream.getvalue()
+        assert "(user; affects this deploy)" in stream.getvalue()
+
+    def test_a_bundled_skill_directory_is_not_reported_as_staying(self, tree, monkeypatch):
+        from connectonion.cli.commands import deploy_commands
+
+        project, home = tree
+        stream = StringIO()
+        monkeypatch.setattr(
+            deploy_commands,
+            "console",
+            Console(file=stream, color_system=None, width=300),
+        )
+
+        deploy_commands._warn_about_skills_left_behind(
+            project, [home / ".co" / "skills"]
+        )
+
+        assert "stays" not in stream.getvalue()
+
+    def test_an_untracked_project_problem_is_not_called_payload(self, tree):
+        from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
+
+        project, _ = tree
+        link = project / ".co" / "skills" / "untracked"
+        link.symlink_to(project / "missing")
+        stream = StringIO()
+
+        _print_deploy_skill_problems(
+            project,
+            Console(file=stream, color_system=None, width=300),
+            payload_entries=set(),
+        )
+
+        assert f"! {link}" in stream.getvalue()
+        assert "not in deploy payload" in stream.getvalue()
+
+    def test_rich_markup_in_a_path_is_printed_literally(self, tree):
+        from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
+
+        project, home = tree
+        link = home / ".co" / "skills" / "[red]ghost"
+        link.symlink_to(home / "[blue]missing")
+        stream = StringIO()
+
+        _print_deploy_skill_problems(
+            project, Console(file=stream, color_system=None, width=300)
+        )
+
+        output = stream.getvalue()
+        assert str(link) in output
+        assert str(home / "[blue]missing") in output
 
     def test_a_symlink_to_its_own_ancestor_is_reported(self, tree):
         project, _ = tree

--- a/tests/unit/test_skill_tiers.py
+++ b/tests/unit/test_skill_tiers.py
@@ -164,6 +164,26 @@ class TestBrokenLinks:
         assert f"✗ {skill}" in stream.getvalue()
         assert "affects this deploy" in stream.getvalue()
 
+    def test_an_ignored_non_git_skill_is_not_payload(self, tree, monkeypatch):
+        from connectonion.cli.commands import deploy_commands
+
+        project, _ = tree
+        skill = project / ".co" / "skills" / "ignored-bad"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("---\ndescription: [broken\n---\n")
+        (project / ".gitignore").write_text(".co/skills/ignored-bad/\n")
+        stream = StringIO()
+        monkeypatch.setattr(
+            deploy_commands,
+            "console",
+            Console(file=stream, color_system=None, width=300),
+        )
+
+        deploy_commands._warn_about_skills_left_behind(project, [])
+
+        assert f"! {skill}" in stream.getvalue()
+        assert "not in deploy payload" in stream.getvalue()
+
     def test_rich_markup_in_a_path_is_printed_literally(self, tree):
         from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
 

--- a/tests/unit/test_skill_tiers.py
+++ b/tests/unit/test_skill_tiers.py
@@ -1,6 +1,8 @@
 """Tier visibility: which skills travel, and which links are broken."""
+from io import StringIO
 import pytest
 from pathlib import Path
+from rich.console import Console
 
 # useful_plugins/__init__ rebinds the name `skills` to the plugin LIST, so
 # `import ...skills as sk` hands back a list. Reach the module through sys.modules.
@@ -51,6 +53,41 @@ class TestBrokenLinks:
         problems = sk.find_skill_problems(project_dir=project)
 
         assert ("project", "ghost", "broken symlink") in problems
+
+    def test_a_dangling_symlink_reports_its_real_path_and_target(self, tree):
+        project, _ = tree
+        link = project / ".co" / "skills" / "ghost"
+        target = project / "missing" / "skill"
+        link.symlink_to(target)
+
+        problem = next(
+            p for p in sk.find_skill_problem_details(project_dir=project)
+            if p.name == "ghost"
+        )
+
+        assert problem.path == link
+        assert problem.target == target
+
+    def test_deploy_marks_only_a_broken_skill_that_travels_as_failure(self, tree):
+        from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
+
+        project, home = tree
+        project_link = project / ".co" / "skills" / "project-ghost"
+        project_link.symlink_to(project / "missing-project-skill")
+        user_link = home / ".co" / "skills" / "user-ghost"
+        user_link.symlink_to(home / "missing-user-skill")
+        stream = StringIO()
+
+        _print_deploy_skill_problems(
+            project, Console(file=stream, color_system=None, width=300)
+        )
+
+        output = stream.getvalue()
+        assert f"✗ {project_link} — broken symlink → {project / 'missing-project-skill'}" in output
+        assert "(project; ships with deploy)" in output
+        assert f"! {user_link} — broken symlink → {home / 'missing-user-skill'}" in output
+        assert "(user; stays on this machine)" in output
+        assert "user/user-ghost" not in output
 
     def test_a_symlink_to_its_own_ancestor_is_reported(self, tree):
         project, _ = tree

--- a/tests/unit/test_skill_tiers.py
+++ b/tests/unit/test_skill_tiers.py
@@ -95,14 +95,17 @@ class TestBrokenLinks:
         from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
 
         project, home = tree
+        target = home / "source" / "ghost"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("---\ndescription: [broken\n---\n")
         link = home / ".co" / "skills" / "ghost"
-        link.symlink_to(home / "missing")
+        link.symlink_to(target)
         stream = StringIO()
 
         _print_deploy_skill_problems(
             project,
             Console(file=stream, color_system=None, width=300),
-            payload_roots=(home / ".co" / "skills",),
+            payload_roots=(link.resolve(),),
         )
 
         assert f"✗ {link}" in stream.getvalue()
@@ -141,6 +144,25 @@ class TestBrokenLinks:
 
         assert f"! {link}" in stream.getvalue()
         assert "not in deploy payload" in stream.getvalue()
+
+    def test_a_tracked_file_below_a_problem_directory_is_payload(self, tree):
+        from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems
+
+        project, _ = tree
+        skill = project / ".co" / "skills" / "bad-yaml"
+        skill.mkdir()
+        manifest = skill / "SKILL.md"
+        manifest.write_text("---\ndescription: [broken\n---\n")
+        stream = StringIO()
+
+        _print_deploy_skill_problems(
+            project,
+            Console(file=stream, color_system=None, width=300),
+            payload_entries={manifest.absolute()},
+        )
+
+        assert f"✗ {skill}" in stream.getvalue()
+        assert "affects this deploy" in stream.getvalue()
 
     def test_rich_markup_in_a_path_is_printed_literally(self, tree):
         from connectonion.cli.commands.deploy_commands import _print_deploy_skill_problems


### PR DESCRIPTION
Closes #795.

## What changes

- Skill diagnosis now has a structured detail view containing scope, reason, the real filesystem entry path, and the symlink target when available.
- The existing three-value find_skill_problems contract remains intact for current callers.
- Cloud deploy and co deploy --to share one renderer, so their severity and path output cannot drift.
- A broken project/builtin skill that travels with the payload remains a red failure marker.
- A broken user/claude-user skill that stays on the laptop is a yellow warning, not a fake deploy failure.
- Output shows a copyable filesystem path and the missing target instead of constructing user/<name>.

The design and rejected string-only patch are documented in #795 before implementation.

## Verification

- 83 focused skill/deploy tests passed.
- Added regressions for real entry/target paths, project red severity, user yellow severity, and absence of the fabricated user/<name> path.
- git diff --check passes.