### PR TITLE
outlook: save attachments to disk with co outlook download

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -209,6 +209,25 @@ def handle_outlook_read(email_id: str):
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 
+def handle_outlook_download(email_id: str, out_dir: str = "."):
+    """Save an email's attachments to disk. Accepts the listing # or a full message id."""
+    outlook = _outlook()
+    resolved = _resolve_email_id(outlook, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    saved = outlook.download_attachments(resolved, out_dir)
+    if not saved:
+        console.print("\n[yellow]No file attachments on that email.[/yellow]\n")
+        return
+
+    console.print()
+    for path in saved:
+        console.print(f"[green]✓[/green] {path}")
+    console.print()
+
+
 def handle_outlook_reply(email_id: str, message: str, at: str = None):
     """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin."""
     if message == "-":

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1056,6 +1056,16 @@ def outlook_read(email_id: str = typer.Argument(..., help="Email # from your las
     handle_outlook_read(email_id)
 
 
+@outlook_app.command("download")
+def outlook_download(
+    email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
+    out_dir: str = typer.Option(".", "--to", help="Directory to save attachments into"),
+):
+    """Save an email's attachments to disk."""
+    from .commands.outlook_commands import handle_outlook_download
+    handle_outlook_download(email_id, out_dir)
+
+
 @outlook_app.command("reply")
 def outlook_reply(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,8 +2,8 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
-  State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) and create contacts | token refresh rewrites ~/.co/keys.env | no other local file persistence
+  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
@@ -468,7 +468,7 @@ class Outlook:
 
         return "\n".join(output)
 
-    def download_attachments(self, email_id: str, out_dir: str = ".") -> list:
+    def download_attachments(self, email_id: str, out_dir: str = ".") -> list[str]:
         """Save an email's file attachments to disk.
 
         Args:
@@ -498,9 +498,33 @@ class Outlook:
                 continue
             # The name is sender-controlled: keep the last path segment only, so
             # "../../.ssh/authorized_keys" cannot escape the chosen directory.
-            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/")) or "attachment"
+            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/"))
+            # Control characters can forge CLI output (including ANSI escapes).
+            name = "".join(
+                "_" if ord(character) < 32 or ord(character) == 127 else character
+                for character in name
+            )
+            if name in {"", ".", ".."}:
+                name = "attachment"
             path = destination / name
-            path.write_bytes(base64.b64decode(content))
+            data = base64.b64decode(content, validate=True)
+            flags = (
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_BINARY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            try:
+                descriptor_number = os.open(path, flags, 0o600)
+            except FileExistsError as exc:
+                raise FileExistsError(f"Refusing to overwrite existing attachment: {path}") from exc
+            try:
+                with os.fdopen(descriptor_number, "wb") as handle:
+                    handle.write(data)
+            except Exception:
+                path.unlink(missing_ok=True)
+                raise
             saved.append(str(path))
         return saved
 

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -468,6 +468,42 @@ class Outlook:
 
         return "\n".join(output)
 
+    def download_attachments(self, email_id: str, out_dir: str = ".") -> list:
+        """Save an email's file attachments to disk.
+
+        Args:
+            email_id: Outlook message ID
+            out_dir: Directory to write the files into
+
+        Returns:
+            List of saved file paths
+        """
+        import base64
+
+        destination = Path(out_dir).expanduser().resolve()
+        if not self._allow_external_attachments:
+            try:
+                destination.relative_to(self._attachment_root)
+            except ValueError:
+                raise PermissionError(f"Download directory is outside the project: {out_dir}") from None
+        destination.mkdir(parents=True, exist_ok=True)
+
+        attachments = self._request("GET", f"/me/messages/{email_id}/attachments").get("value", [])
+
+        saved = []
+        for attachment in attachments:
+            content = attachment.get("contentBytes")
+            if not content:
+                # itemAttachment and referenceAttachment carry no bytes to write.
+                continue
+            # The name is sender-controlled: keep the last path segment only, so
+            # "../../.ssh/authorized_keys" cannot escape the chosen directory.
+            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/")) or "attachment"
+            path = destination / name
+            path.write_bytes(base64.b64decode(content))
+            saved.append(str(path))
+        return saved
+
     # === Sending ===
 
     def _open_attachments(self, attachments: list, stack) -> list[tuple[str, object]]:

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -971,3 +971,57 @@ class TestOutlookContacts:
             outlook = Outlook()
             with pytest.raises(ValueError, match="Contacts.ReadWrite"):
                 outlook.list_contacts()
+
+
+class TestDownloadAttachments:
+    """Saving attachments to disk, including the sender-controlled filename."""
+
+    def _outlook(self, monkeypatch, tmp_path, attachments):
+        from connectonion.useful_tools import outlook as outlook_module
+
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.ReadWrite Mail.Send")
+        monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "token")
+        monkeypatch.setenv("MICROSOFT_REFRESH_TOKEN", "refresh")
+        monkeypatch.setattr(outlook_module, "project_root", lambda: tmp_path)
+
+        instance = outlook_module.Outlook()
+        monkeypatch.setattr(instance, "_request", lambda *a, **k: {"value": attachments})
+        return instance
+
+    def test_saves_file_attachment_bytes(self, monkeypatch, tmp_path):
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": base64.b64encode(b"pixels").decode()},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"pixels"
+        assert saved == [str(tmp_path / "out" / "cover.jpg")]
+
+    def test_sender_cannot_escape_the_directory_with_a_relative_name(self, monkeypatch, tmp_path):
+        """A sender names the attachment '../../owned.txt'; it must stay put."""
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "../../owned.txt", "contentBytes": base64.b64encode(b"x").decode()},
+        ])
+
+        outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert (tmp_path / "out" / "owned.txt").exists()
+        assert not (tmp_path.parent / "owned.txt").exists()
+
+    def test_refuses_a_destination_outside_the_project(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [])
+
+        with pytest.raises(PermissionError):
+            outlook.download_attachments("msg-id", tmp_path.parent / "elsewhere")
+
+    def test_skips_attachments_without_bytes(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "linked.docx", "@odata.type": "#microsoft.graph.referenceAttachment"},
+        ])
+
+        assert outlook.download_attachments("msg-id", tmp_path / "out") == []

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1013,6 +1013,61 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "owned.txt").exists()
         assert not (tmp_path.parent / "owned.txt").exists()
 
+    def test_refuses_to_overwrite_an_existing_file(self, monkeypatch, tmp_path):
+        import base64
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        existing = out_dir / "pyproject.toml"
+        existing.write_bytes(b"keep me")
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "pyproject.toml", "contentBytes": base64.b64encode(b"replace me").decode()},
+        ])
+
+        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+            outlook.download_attachments("msg-id", out_dir)
+
+        assert existing.read_bytes() == b"keep me"
+
+    def test_refuses_to_follow_an_existing_symlink(self, monkeypatch, tmp_path):
+        import base64
+
+        outside = tmp_path / "outside.txt"
+        outside.write_bytes(b"keep me")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "cover.jpg").symlink_to(outside)
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": base64.b64encode(b"replace me").decode()},
+        ])
+
+        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+            outlook.download_attachments("msg-id", out_dir)
+
+        assert outside.read_bytes() == b"keep me"
+
+    def test_replaces_control_characters_in_sender_filename(self, monkeypatch, tmp_path):
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover\n\x1b[31m.jpg", "contentBytes": base64.b64encode(b"pixels").decode()},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [str(tmp_path / "out" / "cover__[31m.jpg")]
+        assert (tmp_path / "out" / "cover__[31m.jpg").read_bytes() == b"pixels"
+
+    def test_rejects_malformed_base64_without_creating_a_file(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "broken.pdf", "contentBytes": "not base64!"},
+        ])
+
+        with pytest.raises(ValueError):
+            outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert not (tmp_path / "out" / "broken.pdf").exists()
+
     def test_refuses_a_destination_outside_the_project(self, monkeypatch, tmp_path):
         outlook = self._outlook(monkeypatch, tmp_path, [])
 


### PR DESCRIPTION
`co outlook` could send attachments but never read one back. An emailed file — a cover image, a research PDF — had to be fetched by hand through the web client, which is what happened today when a co-host emailed event artwork.

```
co outlook download 3 --to ./covers
✓ ./covers/ai-sales-engine-linkedin-cover-16x9.jpg
```

## What it does

`Outlook.download_attachments(email_id, out_dir)` writes an email's `fileAttachment` bytes to a directory and returns the saved paths. The CLI wraps it as `co outlook download <#> --to <dir>`, accepting the same listing numbers as `read` and `reply`.

## Boundaries

Reading attachments in has the mirror image of the risks #811 closed for sending them out, so it reuses the same rules:

- The destination directory goes through the project boundary — outside it raises `PermissionError` unless `allow_external_attachments` is set, exactly as the send path does.
- **The attachment name is sender-controlled.** It is reduced to its last path segment before joining, so a message whose attachment is named `../../.ssh/authorized_keys` still lands inside the chosen directory. A test asserts the file appears in `out/` and not in the parent.
- `itemAttachment` and `referenceAttachment` carry no `contentBytes`; they are skipped rather than written empty.

## Tests

Four cases in `tests/unit/test_outlook.py`: bytes land on disk, the traversal name stays contained, an out-of-project destination is refused, and byte-less attachments are skipped.

Note on running them locally: the suite's `_no_stray_project_above_the_test` teardown guard fails for every test in the file when the checkout sits under a directory that has its own `.co/` (a worktree under `$HOME`, for instance). The 41 tests themselves pass; the teardown assertions are about where the checkout lives, not about this change.