### PR TITLE
Add ACP lifecycle mode to co ai

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -1,0 +1,352 @@
+"""ACP v1 stdio lifecycle adapter for ``co ai``.
+
+The official ACP SDK owns JSON-RPC routing and schema validation.  This module
+only adapts the lifecycle to ConnectOnion: one real coding Agent per ACP
+session, an exclusive stdout protocol stream, and fail-closed approvals until
+the dedicated permission bridge lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import threading
+from contextlib import contextmanager, redirect_stdout
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+from acp import (
+    PROTOCOL_VERSION,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    RequestError,
+    run_agent,
+    update_agent_message_text,
+)
+from acp.interfaces import Client
+from acp.schema import (
+    AgentCapabilities,
+    ClientCapabilities,
+    Implementation,
+    ResourceContentBlock,
+    SessionCapabilities,
+    TextContentBlock,
+)
+
+from ..._version import __version__
+from .acp_transport import open_stdio_transport
+
+AgentFactory = Callable[..., Any]
+logger = logging.getLogger(__name__)
+
+
+class _FailClosedACPInput:
+    """Keep sensitive tools closed until ACP approval bridging ships in #475."""
+
+    def __init__(self) -> None:
+        self._interrupted = threading.Event()
+
+    def start_prompt(self) -> None:
+        self._interrupted.clear()
+
+    def interrupt(self) -> None:
+        self._interrupted.set()
+
+    @property
+    def interrupted(self) -> bool:
+        return self._interrupted.is_set()
+
+    def send(self, _message: dict[str, Any]) -> None:
+        pass
+
+    def receive(self) -> dict[str, str]:
+        if self.interrupted:
+            return {"type": "INTERRUPT"}
+        return {"type": "io_closed"}
+
+    def receive_all(self, _message_type: str | None = None) -> list[Any]:
+        if self.interrupted and _message_type in (None, "INTERRUPT"):
+            return [{"type": "INTERRUPT"}]
+        return []
+
+    def take_interrupt(self, on_interrupt: Callable[[], None] | None = None) -> bool:
+        if not self.interrupted:
+            return False
+        if on_interrupt:
+            on_interrupt()
+        return True
+
+    def receive_interruptibly(self, cancelled: threading.Event) -> dict[str, str]:
+        if self.interrupted or cancelled.is_set():
+            return {"type": "INTERRUPT"}
+        return {"type": "io_closed"}
+
+    def receive_all_interruptibly(
+        self,
+        cancelled: threading.Event,
+        message_type: str | None = None,
+    ) -> list[Any]:
+        if (self.interrupted or cancelled.is_set()) and message_type in (
+            None,
+            "INTERRUPT",
+        ):
+            return [{"type": "INTERRUPT"}]
+        return []
+
+
+@dataclass
+class _SessionRuntime:
+    cwd: Path
+    agent: Any
+    acp_input: _FailClosedACPInput
+    prompt_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    prompt_active: threading.Event = field(default_factory=threading.Event)
+
+
+class ConnectOnionACPAgent:
+    """Expose the real ``co ai`` Agent through the stable ACP v1 lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        model: str,
+        max_iterations: int,
+        yolo: bool,
+        yolo_turns: int,
+        agent_factory: AgentFactory | None = None,
+    ) -> None:
+        self._model = model
+        self._max_iterations = max_iterations
+        self._yolo = yolo
+        self._yolo_turns = yolo_turns
+        self._agent_factory = agent_factory
+        self._client: Client | None = None
+        self._sessions: dict[str, _SessionRuntime] = {}
+        # cwd and redirect_stdout are process-global.  ACP request handlers stay
+        # asynchronous, while this lock makes those short global scopes explicit.
+        self._process_context_lock = threading.RLock()
+
+    def on_connect(self, client: Client) -> None:
+        self._client = client
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **_kwargs: Any,
+    ) -> InitializeResponse:
+        del client_capabilities, client_info
+        # ACP asks an agent to return its latest supported version when it does
+        # not support the client's version. The client then decides whether it
+        # can continue (v1 initialization, "Version Negotiation").
+        selected_version = PROTOCOL_VERSION
+        return InitializeResponse(
+            protocol_version=selected_version,
+            agent_capabilities=AgentCapabilities(
+                load_session=False,
+                session_capabilities=SessionCapabilities(),
+            ),
+            agent_info=Implementation(
+                name="connectonion",
+                title="ConnectOnion co ai",
+                version=__version__,
+            ),
+            auth_methods=[],
+        )
+
+    async def new_session(
+        self,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: list[Any] | None = None,
+        **_kwargs: Any,
+    ) -> NewSessionResponse:
+        if additional_directories:
+            raise RequestError.invalid_params(
+                {"details": "co ai ACP does not support additionalDirectories yet"}
+            )
+        if mcp_servers:
+            raise RequestError.invalid_params(
+                {"details": "co ai ACP does not support mcpServers yet"}
+            )
+
+        project_dir = self._validate_cwd(cwd)
+        try:
+            agent = await asyncio.to_thread(self._build_agent, project_dir)
+        except Exception:
+            logger.exception("Failed to create co ai ACP session")
+            raise RequestError(
+                -32603,
+                "Unable to create the coding agent session",
+            ) from None
+        session_id = uuid4().hex
+        self._sessions[session_id] = _SessionRuntime(
+            cwd=project_dir,
+            agent=agent,
+            acp_input=agent.io,
+        )
+        return NewSessionResponse(session_id=session_id)
+
+    async def prompt(
+        self,
+        session_id: str,
+        prompt: list[Any],
+        **_kwargs: Any,
+    ) -> PromptResponse:
+        runtime = self._sessions.get(session_id)
+        if runtime is None:
+            raise RequestError(
+                -32002,
+                "Session not found",
+                {"sessionId": session_id},
+            )
+        if runtime.prompt_lock.locked():
+            raise RequestError(
+                -32000,
+                "Session is busy",
+                {"sessionId": session_id},
+            )
+
+        prompt_text = self._prompt_text(prompt)
+        async with runtime.prompt_lock:
+            runtime.acp_input.start_prompt()
+            runtime.prompt_active.set()
+            try:
+                result = await asyncio.to_thread(
+                    self._run_prompt,
+                    runtime,
+                    prompt_text,
+                )
+            except Exception:
+                logger.exception("co ai ACP prompt failed for session %s", session_id)
+                raise RequestError(
+                    -32603,
+                    "co ai prompt failed",
+                ) from None
+
+            if runtime.acp_input.interrupted:
+                return PromptResponse(stop_reason="cancelled")
+
+            if self._client is None:
+                raise RequestError.internal_error(
+                    {"details": "ACP client connection is not available"}
+                )
+            await self._client.session_update(
+                session_id=session_id,
+                update=update_agent_message_text(str(result)),
+            )
+        return PromptResponse(stop_reason="end_turn")
+
+    async def cancel(self, session_id: str, **_kwargs: Any) -> None:
+        """Cooperatively stop the active turn for an ACP session."""
+
+        runtime = self._sessions.get(session_id)
+        if runtime is not None and runtime.prompt_active.is_set():
+            runtime.acp_input.interrupt()
+
+    def cancel_all(self) -> None:
+        """Stop active turns before the stdio event loop shuts down."""
+
+        for runtime in self._sessions.values():
+            if runtime.prompt_active.is_set():
+                runtime.acp_input.interrupt()
+
+    def _build_agent(self, project_dir: Path) -> Any:
+        factory = self._agent_factory
+        if factory is None:
+            from ..commands.ai_commands import _create_agent
+
+            factory = _create_agent
+
+        with self._process_context(project_dir):
+            agent = factory(
+                model=self._model,
+                max_iterations=self._max_iterations,
+                yolo=self._yolo,
+                yolo_turns=self._yolo_turns,
+            )
+        # A missing io currently means "skip approvals".  ACP must instead
+        # remain safe until request_permission is mapped in #475.
+        agent.io = _FailClosedACPInput()
+        return agent
+
+    def _run_prompt(self, runtime: _SessionRuntime, prompt: str) -> Any:
+        try:
+            with self._process_context(runtime.cwd):
+                return runtime.agent.input(prompt)
+        finally:
+            runtime.prompt_active.clear()
+
+    @contextmanager
+    def _process_context(self, cwd: Path):
+        with self._process_context_lock:
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(cwd)
+                with redirect_stdout(sys.stderr):
+                    yield
+            finally:
+                os.chdir(previous_cwd)
+
+    @staticmethod
+    def _validate_cwd(cwd: str) -> Path:
+        path = Path(cwd)
+        if not path.is_absolute():
+            raise RequestError.invalid_params(
+                {"details": "cwd must be an absolute path"}
+            )
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError:
+            raise RequestError.invalid_params(
+                {"details": "cwd does not exist"}
+            ) from None
+        if not resolved.is_dir():
+            raise RequestError.invalid_params(
+                {"details": "cwd must be a directory"}
+            )
+        return resolved
+
+    @staticmethod
+    def _prompt_text(prompt: list[Any]) -> str:
+        parts: list[str] = []
+        for block in prompt:
+            if isinstance(block, TextContentBlock):
+                parts.append(block.text)
+                continue
+            if isinstance(block, ResourceContentBlock):
+                label = block.title or block.name
+                parts.append(f"Referenced resource: {label} ({block.uri})")
+                continue
+            raise RequestError.invalid_params(
+                {"details": f"Unsupported ACP content block: {type(block).__name__}"}
+            )
+        return "\n\n".join(parts)
+
+
+async def serve_acp(
+    *,
+    model: str,
+    max_iterations: int,
+    yolo: bool,
+    yolo_turns: int,
+) -> None:
+    """Serve ``co ai`` as an ACP v1 Agent until the client closes stdin."""
+
+    transport = await open_stdio_transport()
+    agent = ConnectOnionACPAgent(
+        model=model,
+        max_iterations=max_iterations,
+        yolo=yolo,
+        yolo_turns=yolo_turns,
+    )
+    try:
+        await run_agent(agent, input_stream=transport)
+    finally:
+        agent.cancel_all()

--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -1,0 +1,204 @@
+"""Strict ACP v1 newline framing for the ``co ai`` stdio boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import platform
+import sys
+from contextlib import suppress
+from typing import Any
+
+from acp import RequestError, stdio_streams
+from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+
+
+class _BoundStdoutWriter:
+    """Windows writer bound to original stdout with blocking write-all drain."""
+
+    def __init__(self, output: Any, stream_owner: Any = None) -> None:
+        self._output = output
+        self._stream_owner = stream_owner
+        self._pending = bytearray()
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        if self._closed:
+            raise ConnectionError("ACP stdout is closed")
+        self._pending.extend(data)
+
+    async def drain(self) -> None:
+        payload = bytes(self._pending)
+        self._pending.clear()
+        await asyncio.to_thread(self._write_all, payload)
+
+    def _write_all(self, payload: bytes) -> None:
+        view = memoryview(payload)
+        while view:
+            written = self._output.write(view)
+            if written is None:
+                break
+            if written <= 0:
+                raise BrokenPipeError("ACP stdout stopped accepting bytes")
+            view = view[written:]
+        self._output.flush()
+
+    def close(self) -> None:
+        self._closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+class _StrictNDJSONTransport:
+    """Add deterministic malformed-frame errors around the SDK transport seam."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: Any,
+        *,
+        max_frame_bytes: int = DEFAULT_STDIO_BUFFER_LIMIT_BYTES,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._max_frame_bytes = max_frame_bytes
+        self._write_lock = asyncio.Lock()
+        self._closed = False
+
+    async def receive(self) -> dict[str, Any] | None:
+        while True:
+            try:
+                line = await self._read_line()
+            except _FrameTooLarge:
+                await self._send_error(
+                    None,
+                    RequestError.parse_error(
+                        {
+                            "details": (
+                                "ACP frame exceeds the configured "
+                                f"{self._max_frame_bytes}-byte limit"
+                            )
+                        }
+                    ),
+                )
+                return None
+            if not line:
+                return None
+            if not line.strip():
+                continue
+            try:
+                message = json.loads(line, parse_constant=_reject_json_constant)
+            except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+                await self._send_error(None, RequestError.parse_error())
+                continue
+            if not self._is_json_rpc_message(message):
+                request_id = self._request_id(message)
+                await self._send_error(request_id, RequestError.invalid_request())
+                continue
+            return message
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._closed:
+            raise ConnectionError("ACP stdio transport is closed")
+        payload = json.dumps(
+            message,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8") + b"\n"
+        async with self._write_lock:
+            self._writer.write(payload)
+            await self._writer.drain()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._writer.close()
+        with suppress(Exception):
+            await self._writer.wait_closed()
+
+    async def _send_error(self, request_id: Any, error: RequestError) -> None:
+        await self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": error.to_error_obj(),
+            }
+        )
+
+    async def _read_line(self) -> bytes:
+        """Read one frame even when it exceeds StreamReader's chunk limit."""
+
+        chunks: list[bytes] = []
+        total_bytes = 0
+        try:
+            while True:
+                try:
+                    line = await self._reader.readuntil(b"\n")
+                except asyncio.LimitOverrunError as exc:
+                    if total_bytes + exc.consumed > self._max_frame_bytes:
+                        raise _FrameTooLarge from None
+                    chunk = await self._reader.readexactly(exc.consumed)
+                    chunks.append(chunk)
+                    total_bytes += len(chunk)
+                else:
+                    if total_bytes + len(line) > self._max_frame_bytes:
+                        raise _FrameTooLarge
+                    chunks.append(line)
+                    return b"".join(chunks)
+        except asyncio.IncompleteReadError as exc:
+            if total_bytes + len(exc.partial) > self._max_frame_bytes:
+                raise _FrameTooLarge from None
+            chunks.append(exc.partial)
+            return b"".join(chunks)
+
+    @staticmethod
+    def _request_id(message: Any) -> str | int | None:
+        if not isinstance(message, dict):
+            return None
+        request_id = message.get("id")
+        if isinstance(request_id, bool):
+            return None
+        return request_id if isinstance(request_id, (str, int)) else None
+
+    @classmethod
+    def _is_json_rpc_message(cls, message: Any) -> bool:
+        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+            return False
+        if "method" in message:
+            if not isinstance(message["method"], str):
+                return False
+            if "id" in message and cls._request_id(message) != message.get("id"):
+                return False
+            params = message.get("params")
+            return params is None or isinstance(params, (dict, list))
+        if "id" not in message or (("result" in message) == ("error" in message)):
+            return False
+        return cls._request_id(message) == message.get("id")
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+class _FrameTooLarge(Exception):
+    pass
+
+
+async def open_stdio_transport() -> _StrictNDJSONTransport:
+    """Open stdio while permanently binding ACP writes to original stdout."""
+
+    protocol_output = sys.stdout.buffer
+    reader, sdk_writer = await stdio_streams(
+        limit=DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+    )
+    # The SDK writer owns the platform-specific stdout pipe. Keep it alive even
+    # though protocol writes use the captured handle above.
+    writer = (
+        _BoundStdoutWriter(protocol_output, stream_owner=sdk_writer)
+        if platform.system() == "Windows"
+        else sdk_writer
+    )
+    return _StrictNDJSONTransport(reader, writer)

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -7,6 +7,7 @@ LLM-Note:
   Errors: known LLM provider failures print one actionable message and exit 1; programmer errors still propagate with their traceback
 """
 
+import asyncio
 import json
 import sys
 from contextlib import nullcontext, redirect_stdout
@@ -26,6 +27,7 @@ def handle_ai(
     yolo_turns: int = 100,
     json_output: bool = False,
     resume: str = None,
+    acp: bool = False,
 ):
     """Start AI coding agent or run one-shot prompt.
 
@@ -38,11 +40,16 @@ def handle_ai(
         yolo_turns: Maximum autonomous turns before a checkpoint
         json_output: Emit one JSON envelope to stdout
         resume: Continue a prior one-shot session ID
+        acp: Serve the coding agent over ACP v1 on stdio
 
     Examples:
         co ai                                    # Start web server
         co ai "Create a calculator agent"        # One-shot
     """
+    if acp and (prompt or json_output or resume):
+        console.print("[red]--acp cannot be combined with a prompt, --json, or --resume[/red]")
+        raise typer.Exit(2)
+
     if not prompt and (json_output or resume):
         message = "--json and --resume require a one-shot prompt"
         if json_output:
@@ -58,6 +65,19 @@ def handle_ai(
     if prompt and json_output:
         _handle_json_one_shot(
             prompt, model, max_iterations, yolo, yolo_turns, resume
+        )
+        return
+
+    if acp:
+        from ..co_ai.acp_server import serve_acp
+
+        asyncio.run(
+            serve_acp(
+                model=model,
+                max_iterations=max_iterations,
+                yolo=yolo,
+                yolo_turns=yolo_turns,
+            )
         )
         return
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -361,6 +361,9 @@ def ai(
     resume: Optional[str] = typer.Option(
         None, "--resume", help="Resume a prior one-shot session"
     ),
+    acp: bool = typer.Option(
+        False, "--acp", help="Serve co ai as an ACP v1 agent over stdio"
+    ),
 ):
     """Start AI coding agent or run one-shot prompt."""
     from .commands.ai_commands import handle_ai
@@ -373,6 +376,7 @@ def ai(
         yolo_turns=yolo_turns,
         json_output=json_output,
         resume=resume,
+        acp=acp,
     )
 
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -10,7 +10,7 @@ co ai
 
 Opens a web chat at `chat.openonion.ai` connected to a coding agent running locally. The agent can read and edit your project files, run shell commands, manage tasks, and more.
 
-## Two Modes
+## Three Modes
 
 ### Web Server Mode (default)
 
@@ -55,6 +55,30 @@ Use foreground shell commands when the next subprocess must retain their result.
 On Windows, snapshot files rely on the current user's profile-directory ACLs;
 POSIX systems additionally enforce `0700` directories and `0600` files.
 
+### ACP Agent Mode
+
+```bash
+co ai --acp
+```
+
+Starts a stable ACP v1 agent server over stdio so an ACP-compatible editor or
+CLI can create a session and drive the real `co ai` coding agent. ACP messages
+are newline-delimited JSON-RPC on stdin/stdout; human-readable diagnostics stay
+on stderr.
+
+Each ACP session owns one in-memory `co ai` Agent, so later prompts in that
+session reuse its conversation and tool state. The working directory supplied
+by the client must be an existing absolute directory. MCP servers and
+additional workspace roots are not accepted yet.
+
+This first ACP slice streams the terminal assistant response and cooperatively
+stops an active turn on `session/cancel` or client EOF. Structured thinking,
+tool calls, results, usage, richer cancellation of external actions, and
+client-mediated approvals are tracked in the follow-up ACP issues. Until the
+approval bridge is available, Safe mode fails closed when a sensitive tool
+requires approval; `--yolo` remains an explicit operator choice at process
+launch.
+
 ## Options
 
 | Option | Short | Default | Description |
@@ -66,12 +90,14 @@ POSIX systems additionally enforce `0700` directories and `0600` files.
 | `--yolo-turns` | | `100` | Autonomous turns before a checkpoint; must be positive |
 | `--json` | | off | Emit one JSON envelope to stdout in one-shot mode |
 | `--resume` | | | With `--json`, continue a one-shot session by ID |
+| `--acp` | | off | Serve stable ACP v1 over stdin/stdout |
 
 ```bash
 co ai --port 9000
 co ai --model co/gemini-3.6-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 co ai --yolo "Fix the failing suite" --yolo-turns 20
+co ai --acp
 ```
 
 ## YOLO mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
+    # ACP is pre-1.0, so bound the minor API used by cli/co_ai/acp_server.py.
+    "agent-client-protocol>=0.12.0,<0.13.0",
     "openai>=1.0.0",
     "anthropic>=0.18.0",
     "pydantic>=2.0.0",

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -7,7 +7,6 @@ from typer.testing import CliRunner
 
 from connectonion.cli.main import app
 
-
 runner = CliRunner()
 
 
@@ -28,6 +27,7 @@ def test_ai_forwards_yolo_options():
         yolo_turns=4,
         json_output=False,
         resume=None,
+        acp=False,
     )
 
 
@@ -48,7 +48,33 @@ def test_ai_forwards_json_and_resume_options():
         yolo_turns=100,
         json_output=True,
         resume="session-id",
+        acp=False,
     )
+
+
+def test_ai_forwards_acp_mode():
+    with patch("connectonion.cli.commands.ai_commands.handle_ai") as handler:
+        result = runner.invoke(app, ["ai", "--acp"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        prompt=None,
+        port=8000,
+        model="co/gemini-3.6-flash",
+        max_iterations=100,
+        yolo=False,
+        yolo_turns=100,
+        json_output=False,
+        resume=None,
+        acp=True,
+    )
+
+
+def test_ai_rejects_acp_with_one_shot_options():
+    result = runner.invoke(app, ["ai", "task", "--acp"])
+
+    assert result.exit_code == 2
+    assert "--acp cannot be combined" in strip_ansi(result.output)
 
 
 def test_ai_rejects_non_positive_yolo_turns():

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -1,0 +1,219 @@
+"""Production stdio checks for ``co ai --acp`` without a live model."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import textwrap
+from asyncio.subprocess import PIPE, Process
+from contextlib import asynccontextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_FAKE_ACP_SERVER = textwrap.dedent(
+    """
+    import asyncio
+    import time
+
+    from connectonion.cli.co_ai.acp_server import serve_acp
+    from connectonion.cli.commands import ai_commands
+
+
+    class FakeAgent:
+        io = None
+
+        def input(self, prompt):
+            print(f"fake agent received: {prompt}", flush=True)
+            if prompt == "large":
+                return "x" * 5_000_000
+            if prompt != "block":
+                return f"answer: {prompt}"
+            while not self.io.receive_all("INTERRUPT"):
+                time.sleep(0.01)
+            return "late cancelled answer"
+
+
+    ai_commands._create_agent = lambda **kwargs: FakeAgent()
+    asyncio.run(
+        serve_acp(
+            model="test",
+            max_iterations=2,
+            yolo=False,
+            yolo_turns=2,
+        )
+    )
+    """
+)
+
+
+@asynccontextmanager
+async def _server():
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _FAKE_ACP_SERVER,
+        stdin=PIPE,
+        stdout=PIPE,
+        stderr=PIPE,
+        limit=10 * 1024 * 1024,
+    )
+    try:
+        yield process
+    finally:
+        if process.returncode is None:
+            if process.stdin is not None:
+                process.stdin.close()
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(process.wait(), timeout=1)
+            if process.returncode is None:
+                process.kill()
+                await process.wait()
+
+
+async def _send(process: Process, message: dict[str, Any]) -> None:
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(message, separators=(",", ":")).encode() + b"\n")
+    await process.stdin.drain()
+
+
+async def _read_frame(process: Process) -> dict[str, Any]:
+    assert process.stdout is not None
+    line = await asyncio.wait_for(process.stdout.readline(), timeout=30)
+    assert line
+    return json.loads(line)
+
+
+async def _request(
+    process: Process,
+    request_id: int,
+    method: str,
+    params: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    await _send(
+        process,
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        },
+    )
+    notifications = []
+    while True:
+        frame = await _read_frame(process)
+        if frame.get("id") == request_id:
+            return frame, notifications
+        notifications.append(frame)
+
+
+async def _initialize_and_create_session(
+    process: Process,
+    cwd: Path,
+) -> str:
+    initialized, _ = await _request(
+        process,
+        1,
+        "initialize",
+        {"protocolVersion": 1, "clientCapabilities": {}},
+    )
+    assert initialized["result"]["protocolVersion"] == 1
+    created, _ = await _request(
+        process,
+        2,
+        "session/new",
+        {"cwd": str(cwd), "mcpServers": []},
+    )
+    return created["result"]["sessionId"]
+
+
+async def _close_stdin(process: Process) -> None:
+    assert process.stdin is not None
+    process.stdin.close()
+    await process.stdin.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_path):
+    async with _server() as process:
+        session_id = await _initialize_and_create_session(process, tmp_path)
+
+        response, notifications = await _request(
+            process,
+            3,
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "hello"}],
+            },
+        )
+        await _close_stdin(process)
+        return_code = await asyncio.wait_for(process.wait(), timeout=2)
+        assert process.stderr is not None
+        stderr = (await process.stderr.read()).decode()
+
+        assert return_code == 0
+        assert response["result"]["stopReason"] == "end_turn"
+        assert [item["method"] for item in notifications] == ["session/update"]
+        assert notifications[0]["params"]["update"]["content"]["text"] == (
+            "answer: hello"
+        )
+        assert "fake agent received: hello" in stderr
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_eof_cancels_an_active_prompt(tmp_path):
+    async with _server() as process:
+        session_id = await _initialize_and_create_session(process, tmp_path)
+        await _send(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "block"}],
+                },
+            },
+        )
+        assert process.stderr is not None
+        while True:
+            line = await asyncio.wait_for(process.stderr.readline(), timeout=30)
+            assert line
+            if b"fake agent received: block" in line:
+                break
+
+        await _close_stdin(process)
+        return_code = await asyncio.wait_for(process.wait(), timeout=2)
+        assert process.stdout is not None
+        remaining_stdout = await process.stdout.read()
+
+        assert return_code == 0
+        assert b"late cancelled answer" not in remaining_stdout
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_preserves_a_large_response(tmp_path):
+    async with _server() as process:
+        session_id = await _initialize_and_create_session(process, tmp_path)
+
+        response, notifications = await _request(
+            process,
+            3,
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "large"}],
+            },
+        )
+        await _close_stdin(process)
+        return_code = await asyncio.wait_for(process.wait(), timeout=2)
+
+        content = notifications[0]["params"]["update"]["content"]["text"]
+        assert return_code == 0
+        assert response["result"]["stopReason"] == "end_turn"
+        assert len(content) == 5_000_000
+        assert content.startswith("xxx") and content.endswith("xxx")

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1,0 +1,389 @@
+"""ACP lifecycle tests that do not require a live model or external client."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from acp import PROTOCOL_VERSION, RequestError, connect_to_agent, run_agent, text_block
+from acp.interfaces import Client
+
+from connectonion.cli.co_ai.acp_server import (
+    ConnectOnionACPAgent,
+    _FailClosedACPInput,
+)
+from connectonion.cli.co_ai.acp_transport import (
+    _BoundStdoutWriter,
+    _StrictNDJSONTransport,
+)
+from connectonion.useful_plugins.tool_approval import check_approval
+
+
+class _MemoryTransport:
+    def __init__(self) -> None:
+        self.inbox: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+        self.peer: _MemoryTransport | None = None
+        self.closed = False
+
+    async def send(self, message: dict[str, Any]) -> None:
+        assert self.peer is not None
+        await self.peer.inbox.put(message)
+
+    async def receive(self) -> dict[str, Any] | None:
+        return await self.inbox.get()
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        assert self.peer is not None
+        await self.peer.inbox.put(None)
+
+
+def _transport_pair() -> tuple[_MemoryTransport, _MemoryTransport]:
+    left = _MemoryTransport()
+    right = _MemoryTransport()
+    left.peer = right
+    right.peer = left
+    return left, right
+
+
+class _RecordingClient(Client):
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(self, session_id: str, update: Any, **_kwargs: Any) -> None:
+        self.updates.append((session_id, update))
+
+    async def request_permission(self, **_kwargs: Any) -> dict[str, Any]:
+        return {"outcome": {"outcome": "cancelled"}}
+
+
+class _FakeAgent:
+    def __init__(self) -> None:
+        self.io: Any = None
+        self.prompts: list[str] = []
+
+    def input(self, prompt: str) -> str:
+        print("deliberate fake-agent stdout noise")
+        self.prompts.append(prompt)
+        return f"answer {len(self.prompts)}: {prompt}"
+
+
+class _BlockingFakeAgent(_FakeAgent):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+
+    def input(self, prompt: str) -> str:
+        self.started.set()
+        while not self.io.receive_all("INTERRUPT"):
+            time.sleep(0.01)
+        return f"cancelled: {prompt}"
+
+
+@pytest.mark.asyncio
+async def test_acp_lifecycle_reuses_agent_and_exits_on_eof(tmp_path, capsys):
+    created: list[_FakeAgent] = []
+
+    def factory(**_kwargs: Any) -> _FakeAgent:
+        agent = _FakeAgent()
+        created.append(agent)
+        return agent
+
+    server_transport, client_transport = _transport_pair()
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+    )
+    server_task = asyncio.create_task(
+        run_agent(acp_agent, input_stream=server_transport)
+    )
+    recording_client = _RecordingClient()
+    connection = connect_to_agent(recording_client, client_transport)
+
+    initialized = await connection.initialize(protocol_version=PROTOCOL_VERSION)
+    session = await connection.new_session(cwd=str(tmp_path), mcp_servers=[])
+    first = await connection.prompt(
+        session_id=session.session_id,
+        prompt=[text_block("first")],
+    )
+    second = await connection.prompt(
+        session_id=session.session_id,
+        prompt=[text_block("second")],
+    )
+    for _ in range(20):
+        if len(recording_client.updates) == 2:
+            break
+        await asyncio.sleep(0)
+
+    assert initialized.protocol_version == PROTOCOL_VERSION
+    assert first.stop_reason == "end_turn"
+    assert second.stop_reason == "end_turn"
+    assert len(created) == 1
+    assert created[0].prompts == ["first", "second"]
+    assert [update.content.text for _, update in recording_client.updates] == [
+        "answer 1: first",
+        "answer 2: second",
+    ]
+    assert "deliberate fake-agent stdout noise" in capsys.readouterr().err
+
+    await connection.close()
+    await asyncio.wait_for(server_task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_acp_reports_its_supported_version_for_any_client_version():
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+
+    older = await acp_agent.initialize(protocol_version=0)
+    newer = await acp_agent.initialize(protocol_version=PROTOCOL_VERSION + 1)
+
+    assert older.protocol_version == PROTOCOL_VERSION
+    assert newer.protocol_version == PROTOCOL_VERSION
+
+
+@pytest.mark.asyncio
+async def test_acp_rejects_unknown_session():
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+
+    with pytest.raises(RequestError, match="Session not found"):
+        await acp_agent.prompt("missing", [text_block("hello")])
+
+
+@pytest.mark.asyncio
+async def test_acp_cancel_stops_an_active_prompt(tmp_path):
+    fake_agent = _BlockingFakeAgent()
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: fake_agent,
+    )
+    session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
+    prompt_task = asyncio.create_task(
+        acp_agent.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(fake_agent.started.wait), timeout=1)
+
+    await acp_agent.cancel(session.session_id)
+    response = await asyncio.wait_for(prompt_task, timeout=1)
+
+    assert response.stop_reason == "cancelled"
+
+
+def test_acp_approval_input_denies_sensitive_tools_unless_mode_is_explicit_ulw():
+    acp_input = _FailClosedACPInput()
+    session = {
+        "mode": "safe",
+        "permissions": {},
+        "pending_tool": {
+            "name": "bash",
+            "arguments": {"command": "echo hello"},
+        },
+    }
+    agent = SimpleNamespace(
+        current_session=session,
+        io=acp_input,
+        storage=None,
+    )
+
+    with pytest.raises(ValueError, match="Connection closed"):
+        check_approval(agent)
+
+    session["mode"] = "ulw"
+    check_approval(agent)
+
+
+@pytest.mark.asyncio
+async def test_acp_errors_do_not_echo_agent_exception_details(tmp_path):
+    class _FailingAgent(_FakeAgent):
+        def input(self, prompt: str) -> str:
+            raise RuntimeError(f"secret-marker in {prompt}")
+
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FailingAgent(),
+    )
+    session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
+
+    with pytest.raises(RequestError) as exc_info:
+        await acp_agent.prompt(session.session_id, [text_block("private-value")])
+
+    assert "secret-marker" not in str(exc_info.value)
+    assert "private-value" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_acp_rejects_unsupported_session_inputs(tmp_path):
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+
+    with pytest.raises(RequestError, match="Invalid params"):
+        await acp_agent.new_session(
+            str(tmp_path),
+            additional_directories=[str(tmp_path / "extra")],
+        )
+    with pytest.raises(RequestError, match="Invalid params"):
+        await acp_agent.new_session(str(tmp_path), mcp_servers=[object()])
+    with pytest.raises(RequestError, match="Invalid params"):
+        await acp_agent.new_session("relative/path")
+
+
+class _BufferWriter:
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_returns_errors_and_keeps_reading():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(b"{not json}\n")
+    reader.feed_data(b"[]\n")
+    reader.feed_data(
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n'
+    )
+
+    message = await transport.receive()
+
+    assert message == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {},
+    }
+    errors = [json.loads(line) for line in writer.buffer.splitlines()]
+    assert [item["error"]["code"] for item in errors] == [-32700, -32600]
+    assert [item["id"] for item in errors] == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_accepts_a_frame_larger_than_stream_chunk_limit():
+    reader = asyncio.StreamReader(limit=64)
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)
+    large_text = "x" * 70_000
+    frame = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "session/prompt",
+        "params": {"text": large_text},
+    }
+    reader.feed_data(json.dumps(frame).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == frame
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_rejects_a_frame_over_the_configured_limit():
+    reader = asyncio.StreamReader(limit=64)
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer, max_frame_bytes=128)
+    reader.feed_data(b'{"jsonrpc":"2.0","id":1,"value":"' + b"x" * 200 + b'"}\n')
+
+    message = await transport.receive()
+
+    assert message is None
+    error = json.loads(writer.buffer)
+    assert error["error"]["code"] == -32700
+    assert error["error"]["data"]["details"] == (
+        "ACP frame exceeds the configured 128-byte limit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_rejects_an_oversized_final_frame_without_newline():
+    reader = asyncio.StreamReader(limit=512)
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer, max_frame_bytes=128)
+    reader.feed_data(b'{"jsonrpc":"2.0","id":1,"value":"' + b"x" * 200 + b'"}')
+    reader.feed_eof()
+
+    message = await transport.receive()
+
+    assert message is None
+    assert json.loads(writer.buffer)["error"]["code"] == -32700
+
+
+@pytest.mark.asyncio
+async def test_bound_stdout_writer_uses_the_captured_binary_handle():
+    captured_stdout = io.BytesIO()
+    writer = _BoundStdoutWriter(captured_stdout)
+
+    writer.write(b'{"jsonrpc":"2.0"}\n')
+    await writer.drain()
+
+    assert captured_stdout.getvalue() == b'{"jsonrpc":"2.0"}\n'
+
+
+@pytest.mark.asyncio
+async def test_bound_stdout_writer_retries_partial_writes():
+    class _PartialWriter:
+        def __init__(self) -> None:
+            self.buffer = bytearray()
+            self.flushes = 0
+
+        def write(self, data: bytes) -> int:
+            chunk = bytes(data[:3])
+            self.buffer.extend(chunk)
+            return len(chunk)
+
+        def flush(self) -> None:
+            self.flushes += 1
+
+    output = _PartialWriter()
+    writer = _BoundStdoutWriter(output)
+    payload = b'{"jsonrpc":"2.0","result":"complete"}\n'
+
+    writer.write(payload)
+    await writer.drain()
+
+    assert output.buffer == payload
+    assert output.flushes == 1

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/50/65bfb4e3e13f350a52c368cbfc4bc36a1b3b3f34a6b3f5a2e3551e1bd63b/agent_client_protocol-0.12.0.tar.gz", hash = "sha256:4d42ac680388556b038cb6dd58dbbbd1561f9e545a334c1a352cc055f98b1c79", size = 135037, upload_time = "2026-08-01T15:58:22.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/c7/b84b8698879464bd8f869551bac31454bed14a3a22910f65d9693f3701bd/agent_client_protocol-0.12.0-py3-none-any.whl", hash = "sha256:233626748034896214de118f5cf5a319484ad2186705fd595219afee92237ccc", size = 92992, upload_time = "2026-08-01T15:58:21.216Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -294,6 +306,7 @@ name = "connectonion"
 version = "1.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-client-protocol" },
     { name = "anthropic" },
     { name = "bashlex" },
     { name = "beautifulsoup4" },
@@ -340,6 +353,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-client-protocol", specifier = ">=0.12.0,<0.13.0" },
     { name = "anthropic", specifier = ">=0.18.0" },
     { name = "bashlex", specifier = ">=0.18" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },


### PR DESCRIPTION
## What

- add `co ai --acp` using the official ACP Python SDK and stable ACP v1
- keep one real coding Agent per ACP session and reuse its conversation/tool state
- validate session cwd; reject unsupported additional roots and MCP servers
- map text/resource-link prompts and emit terminal assistant updates
- handle cooperative `session/cancel` and client EOF
- keep stdout protocol-only with strict newline JSON-RPC framing and a 50 MiB frame ceiling
- preserve POSIX SDK backpressure and use write-all handling for Windows stdout
- fail closed for sensitive-tool approvals until the permission bridge in #475
- document the bounded first slice and pin the pre-1.0 ACP SDK minor version

This implements the lifecycle slice discussed on #473. Structured events, permission mediation, richer modes, and conformance remain split across #474, #475, and #476.

## Why

ACP clients need a small, explicit lifecycle boundary before we add richer event and approval mappings. This slice keeps protocol transport, Agent ownership, process-global cwd/stdout handling, and security defaults independently testable.

## Validation

- full suite: `6438 passed, 26 skipped, 176 deselected`
- focused ACP/CLI tests: `20 passed`
- subprocess coverage includes stdout purity, EOF cancellation, and a complete 5 MB response
- Ruff: clean
- Bandit: clean
- pip-audit: no known vulnerabilities in the local environment
- wheel/sdist: built successfully; both ACP modules and dependency metadata verified
- two expert review passes; final review found no P0/P1/P2 issues

Closes #473