### PR TITLE
Add structured agent turn outcomes

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -9,29 +9,28 @@ LLM-Note:
   Errors: LLM errors bubble up | tool execution errors captured in trace and returned to LLM for retry
 """
 
-import os
-import sys
-import time
 import base64
-from typing import List, Optional, Dict, Any, Callable, Union
+import os
+import time
+from contextlib import suppress
 from pathlib import Path
-from .llm import LLM, create_llm, TokenUsage
-from .usage import get_context_limit
-from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
-from .tool_registry import ToolRegistry
-from ..prompts import load_system_prompt
-from ..debug.decorators import (
-    _is_replay_enabled  # Only need this for replay check
-)
+from typing import Any, Callable, Dict, List, Optional, Union
+from uuid import uuid4
+
 from ..logger import Logger
-from .tool_executor import execute_and_record_tools, execute_single_tool
+from ..prompts import load_system_prompt
 from .events import EventHandler
 from .interrupt import run_interruptible
+from .llm import LLM, TokenUsage, create_llm
+from .tool_executor import execute_and_record_tools, execute_single_tool
+from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
+from .tool_registry import ToolRegistry
+from .usage import get_context_limit, turn_usage_from_trace
 
 
 class Agent:
     """Agent that can use tools to complete tasks."""
-    
+
     def __init__(
         self,
         name: str,
@@ -241,11 +240,12 @@ class Agent:
         Returns:
             The agent's response after processing the input
         """
-        start_time = time.time()
         if self.logger.console:
             self.logger.console.print_task(prompt)
 
         # Session restoration: if session passed, restore it (stateless API continuation)
+        start_logger_session = False
+        logger_session_id = None
         if session is not None:
             # Everything the caller passed, not four chosen keys. Plugins keep
             # their state here — ULW's mode and turn budget, the approval gate's
@@ -262,8 +262,8 @@ class Agent:
             self.current_session['messages'] = list(session.get('messages', []))
             self.current_session['trace'] = list(session.get('trace', []))
             self.current_session['turn'] = session.get('turn', 0)
-            # Start YAML session logging with session_id for thread safety
-            self.logger.start_session(self.system_prompt, session_id=session.get('session_id'))
+            start_logger_session = True
+            logger_session_id = session.get('session_id')
         elif self.current_session is None:
             # Initialize new session
             self.current_session = {
@@ -271,95 +271,128 @@ class Agent:
                 'trace': [],
                 'turn': 0  # Track conversation turns
             }
-            # Start YAML session logging
-            self.logger.start_session(self.system_prompt)
+            start_logger_session = True
 
-        # Save uploaded files to .co/uploads/ and build file path references
-        saved_files = []
-        if files:
-            uploads_dir = self.logger.co_dir / "uploads"
-            uploads_dir.mkdir(parents=True, exist_ok=True)
-            for f in files:
-                safe_name = Path(f["name"]).name
-                # Add timestamp prefix to avoid collisions
-                prefix = str(int(time.time()))
-                file_path = uploads_dir / f"{prefix}_{safe_name}"
-                # Decode base64 data URL and write to disk
-                data_url = f["data"]
-                if "," in data_url:
-                    raw_data = base64.b64decode(data_url.split(",", 1)[1])
-                else:
-                    raw_data = base64.b64decode(data_url)
-                file_path.write_bytes(raw_data)
-                saved_files.append(str(file_path.resolve()))
-
-        if saved_files and self.logger.console:
-            names = [Path(p).name for p in saved_files]
-            self.logger.console.print(f"  [dim]↑ {len(saved_files)} file(s): {', '.join(names)}[/dim]")
-
-        # The upload notice is context ABOUT the turn, not part of what the user
-        # typed. It used to be concatenated onto `prompt`, which is the string
-        # that becomes the user message, the stored user_prompt AND the
-        # user_input trace — so the raw tags showed up in the chat bubble, in
-        # xray, and in the transcript. Carried as its own internal message below.
-        upload_notice = None
-        if saved_files:
-            file_list = "\n".join(f"- {p}" for p in saved_files)
-            upload_notice = (
-                f"The user uploaded the following files:\n{file_list}\n"
-                f"Use your read_file tool or other available tools to read the file "
-                f"contents before responding. Do not assume or guess the contents."
-            )
-
-        # Add user message to conversation (multimodal if images provided)
-        if images:
-            content = [{"type": "text", "text": prompt}]
-            for img in images:
-                content.append({"type": "image_url", "image_url": {"url": img}})
-            self.current_session['messages'].append({"role": "user", "content": content})
-        else:
-            self.current_session['messages'].append({"role": "user", "content": prompt})
-
-        if upload_notice:
-            from ..useful_plugins.system_reminder import reminder_message
-            self.current_session['messages'].append(reminder_message(upload_notice))
-
-        # Track this turn
+        # Session shape is the turn boundary: from here, preprocessing, model
+        # work, hooks, and their failures all receive one terminal outcome.
         self.current_session['turn'] += 1
         self.current_session['user_prompt'] = prompt  # Store user prompt for xray/debugging
         turn_start = time.time()
+        turn_trace_start = len(self.current_session['trace'])
 
-        # Record trace entry (also streams to io if connected)
-        self._record_trace({
-            'type': 'user_input',
-            'content': prompt,
-            'turn': self.current_session['turn'],
-            'ts': turn_start,
-        })
+        try:
+            if start_logger_session:
+                self.logger.start_session(
+                    self.system_prompt,
+                    session_id=logger_session_id,
+                )
 
-        if saved_files:
+            # Add user message to conversation (multimodal if images provided)
+            if images:
+                content = [{"type": "text", "text": prompt}]
+                for img in images:
+                    content.append({"type": "image_url", "image_url": {"url": img}})
+                self.current_session['messages'].append({"role": "user", "content": content})
+            else:
+                self.current_session['messages'].append({"role": "user", "content": prompt})
+
+            # Record only after messages contains this turn. The following
+            # session_sync must never expose a trace ahead of its source state.
             self._record_trace({
-                'type': 'files_received',
-                'files': [{'name': Path(p).name, 'path': p} for p in saved_files],
+                'type': 'user_input',
+                'content': prompt,
                 'turn': self.current_session['turn'],
-                'ts': time.time(),
+                'ts': turn_start,
             })
 
-        # Invoke after_user_input events
-        self._invoke_events('after_user_input')
+            # Save uploaded files to .co/uploads/ and build file path references.
+            saved_files = []
+            if files:
+                uploads_dir = self.logger.co_dir / "uploads"
+                uploads_dir.mkdir(parents=True, exist_ok=True)
+                pending_files = []
+                for f in files:
+                    safe_name = Path(f["name"]).name
+                    file_path = uploads_dir / f"{uuid4().hex}_{safe_name}"
+                    data_url = f["data"]
+                    if "," in data_url:
+                        raw_data = base64.b64decode(data_url.split(",", 1)[1])
+                    else:
+                        raw_data = base64.b64decode(data_url)
+                    pending_files.append((file_path, raw_data))
 
-        # Process
-        self.current_session['iteration'] = 0  # Reset iteration for this turn
-        result = self._run_iteration_loop(
-            max_iterations or self.max_iterations
-        )
+                written_files = []
+                try:
+                    for file_path, raw_data in pending_files:
+                        file_path.write_bytes(raw_data)
+                        written_files.append(file_path)
+                except BaseException:
+                    # write_bytes can create a partial file before raising.
+                    # UUID paths are owned by this turn, so clean every target,
+                    # not only calls that returned successfully.
+                    for file_path, _raw_data in pending_files:
+                        with suppress(Exception):
+                            file_path.unlink(missing_ok=True)
+                    raise
+                saved_files = [str(path.resolve()) for path in written_files]
+
+            if saved_files:
+                self._record_trace({
+                    'type': 'files_received',
+                    'files': [{'name': Path(p).name, 'path': p} for p in saved_files],
+                    'turn': self.current_session['turn'],
+                    'ts': time.time(),
+                })
+                if self.logger.console:
+                    names = [Path(path).name for path in saved_files]
+                    self.logger.console.print(
+                        f"  [dim]↑ {len(saved_files)} file(s): {', '.join(names)}[/dim]"
+                    )
+                # File paths are internal context, not part of the user's text.
+                from ..useful_plugins.system_reminder import reminder_message
+
+                file_list = "\n".join(f"- {path}" for path in saved_files)
+                upload_notice = (
+                    f"The user uploaded the following files:\n{file_list}\n"
+                    "Use your read_file tool or other available tools to read the file "
+                    "contents before responding. Do not assume or guess the contents."
+                )
+                self.current_session['messages'].append(
+                    reminder_message(upload_notice)
+                )
+
+            # Invoke after_user_input events
+            self._invoke_events('after_user_input')
+
+            # Process
+            self.current_session['iteration'] = 0  # Reset iteration for this turn
+            result, reason = self._run_iteration_loop(
+                max_iterations or self.max_iterations
+            )
+
+            self.current_session['result'] = result
+
+            self._invoke_events('on_complete')
+            # A broken adapter must not turn completed work into a retryable
+            # failure merely because best-effort stale-signal cleanup failed.
+            with suppress(Exception):
+                self._drain_completed_turn_interrupt(reason)
+        except BaseException as error:
+            # Outcome streaming must not replace the exception that ended the
+            # turn. _record_trace appends before sending, so a failing adapter
+            # still leaves the local terminal entry available.
+            with suppress(Exception):
+                self._record_turn_result(
+                    reason='error',
+                    trace_start=turn_trace_start,
+                    error_type=type(error).__name__,
+                )
+            raise
+
+        self._record_turn_result(reason=reason, trace_start=turn_trace_start)
 
         # Calculate duration
         duration = time.time() - turn_start
-
-        self.current_session['result'] = result
-
-        self._invoke_events('on_complete')
 
         # Log turn to YAML eval (after on_complete so handlers can modify state)
         self.logger.log_turn(prompt, result, duration * 1000, self.current_session, self.llm.model)
@@ -370,6 +403,45 @@ class Agent:
             self.logger.console.print_completion(duration, self.current_session, eval_path)
 
         return result
+
+    def _drain_completed_turn_interrupt(self, reason: str) -> None:
+        """Discard a Stop that lost its race with already completed work."""
+        if reason not in ('natural', 'max_iterations'):
+            return
+        if self.io and hasattr(self.io, 'receive_all'):
+            self.io.receive_all('INTERRUPT')
+        if self.current_session.get('stop_signal') == 'user_interrupt':
+            self.current_session.pop('stop_signal', None)
+
+    def _record_turn_result(
+        self,
+        *,
+        reason: str,
+        trace_start: int,
+        error_type: str | None = None,
+    ) -> None:
+        """Write one structured terminal event without changing input()'s API."""
+        entry = {
+            'type': 'turn_result',
+            'turn': self.current_session['turn'],
+            'reason': reason,
+            'usage': turn_usage_from_trace(
+                self.current_session['trace'][trace_start:]
+            ),
+        }
+        if error_type is not None:
+            entry['error_type'] = error_type
+        trace = self.current_session['trace']
+        trace_length = len(trace)
+        try:
+            self._record_trace(entry)
+        except Exception:
+            # Once the local terminal entry exists, the Agent turn is complete.
+            # Reporting a failed turn because only its terminal IO frame failed
+            # would invite callers to retry already-committed side effects.
+            if len(trace) == trace_length + 1 and trace[-1] is entry:
+                return
+            raise
 
     def reset_conversation(self):
         """Reset the conversation session. Start fresh."""
@@ -447,8 +519,8 @@ class Agent:
             {"role": "user", "content": prompt}
         ]
 
-    def _run_iteration_loop(self, max_iterations: int) -> str:
-        """Run the main LLM/tool iteration loop until complete or max iterations."""
+    def _run_iteration_loop(self, max_iterations: int) -> tuple[str, str]:
+        """Return the existing response string and its private terminal reason."""
         while self.current_session['iteration'] < max_iterations:
             self.current_session['iteration'] += 1
 
@@ -479,9 +551,15 @@ class Agent:
                     self.current_session.pop('stop_signal', None)
 
             # Check if plugin set stop_signal (stop loop, wait for user input)
-            if self.current_session.pop('stop_signal', None):
+            stop_signal = self.current_session.pop('stop_signal', None)
+            if stop_signal:
                 self._invoke_events('on_stop_signal')
-                return "What would you like me to do?"
+                reason = (
+                    'interrupted'
+                    if stop_signal in ('user_interrupt', 'Interrupted by user')
+                    else 'stopped'
+                )
+                return "What would you like me to do?", reason
 
             if response is None:
                 raise RuntimeError("LLM returned no response without an interrupt")
@@ -492,10 +570,13 @@ class Agent:
                     # needs even when the original request used its full budget.
                     max_iterations += 1
                     continue
-                return content
+                return content, 'natural'
 
         # Hit max iterations
-        return f"Task incomplete: Maximum iterations ({max_iterations}) reached."
+        return (
+            f"Task incomplete: Maximum iterations ({max_iterations}) reached.",
+            'max_iterations',
+        )
 
     def _get_llm_decision(self):
         """Get the next action/decision from the LLM."""

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -352,3 +352,51 @@ def totals_from_trace(trace: list) -> tuple:
     return (sum(u.get('total_tokens') or u['input_tokens'] + u['output_tokens']
                 for u in usages),
             sum(u['cost'] for u in usages))
+
+
+def turn_usage_from_trace(trace: list) -> dict | None:
+    """Aggregate measured usage entries from one already-sliced Agent turn.
+
+    Callers choose the turn boundary. Keeping that choice out of this helper
+    prevents restored or concurrent session history from being counted by
+    accident. Missing usage stays missing instead of becoming a misleading
+    all-zero measurement.
+    """
+    usages = [
+        entry.get('usage')
+        for entry in trace
+        if isinstance(entry, dict) and entry.get('type') == 'llm_result'
+    ]
+    usages = [usage for usage in usages if isinstance(usage, dict) and usage]
+    if not usages:
+        return None
+
+    totals = {
+        'input_tokens': 0,
+        'output_tokens': 0,
+        'cached_tokens': 0,
+        'cache_write_tokens': 0,
+        'total_tokens': 0,
+        'cost': 0.0,
+    }
+    for usage in usages:
+        input_tokens = _usage_int(usage, 'input_tokens')
+        output_tokens = _usage_int(usage, 'output_tokens')
+        explicit_total = _usage_int(usage, 'total_tokens')
+        totals['input_tokens'] += input_tokens
+        totals['output_tokens'] += output_tokens
+        totals['cached_tokens'] += _usage_int(usage, 'cached_tokens')
+        totals['cache_write_tokens'] += _usage_int(usage, 'cache_write_tokens')
+        totals['total_tokens'] += explicit_total or input_tokens + output_tokens
+
+        cost = usage.get('cost', 0.0)
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
+            totals['cost'] += float(cost)
+    return totals
+
+
+def _usage_int(usage: dict, field: str) -> int:
+    value = usage.get(field, 0)
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return 0

--- a/docs/design-decisions/026-structured-turn-outcomes.md
+++ b/docs/design-decisions/026-structured-turn-outcomes.md
@@ -1,0 +1,59 @@
+# Design Decision: Record One Structured Outcome Per Agent Turn
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Related:** [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [019 Agent Lifecycle](019-agent-lifecycle-design.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md)
+
+## Decision
+
+Every attempted Agent turn records one terminal `turn_result` trace entry after
+its lifecycle handlers finish. The entry identifies the turn and one
+provider-neutral reason: `natural`, `max_iterations`, `interrupted`, `stopped`,
+or `error`. `interrupted` is reserved for a real client interrupt; policy
+rejection, approval feedback, and progress checkpoints are `stopped`. Errors
+include only their Python type, not their message.
+
+The entry also contains the usage measured by `llm_result` entries created in
+that turn. Input, output, cache-read, cache-write, explicit provider total, and
+cost values are summed independently. An explicit provider total wins for its
+call; otherwise that call contributes input plus output. Missing usage remains
+`null`, and unlabelled reasoning tokens are never invented.
+
+`Agent.input()` continues returning the same string as before. User-facing
+completion and maximum-iteration text remains presentation, not a protocol
+contract. Adapters consume `turn_result` instead of parsing those strings.
+
+## Why
+
+Sessions contain multiple turns and a turn may make multiple LLM calls. The
+Agent already records each call's measured usage, but consumers had no
+unambiguous boundary or terminal reason. Inferring either from the last string
+mixes presentation with control flow and can accidentally count restored
+history.
+
+The trace is already the ordered, JSON-compatible source shared by local
+logging and hosted IO. A terminal trace entry keeps that single source of truth
+without changing the simple string API.
+
+## Consequences
+
+The turn boundary begins after a valid session shape exists and before logging
+setup, message/file preprocessing, lifecycle hooks, or model work. Failures in
+any of those turn stages record an error outcome and re-raise the original
+exception. Logging and console rendering after the terminal entry remain
+downstream and do not redefine whether the Agent work completed.
+
+Consumers can map the neutral reason into their own protocol. For ACP,
+`natural` becomes `end_turn`, `max_iterations` becomes `max_turn_requests`, and
+a client `interrupted` becomes `cancelled`. The adapter maps `stopped` according
+to its approval/refusal policy rather than misreporting it as cancellation.
+
+## Rejected alternatives
+
+- **Parse returned text:** wording is presentation and changes independently.
+- **Read cumulative Agent counters:** they include earlier turns and cannot
+  reconcile provider-reported totals.
+- **Return a new result object from `Agent.input()`:** breaks the two-line API
+  and every existing string consumer for data already available in the trace.
+- **Copy exception messages into the outcome:** provider and tool errors may
+  contain credentials or private request data.

--- a/tests/unit/test_turn_outcome.py
+++ b/tests/unit/test_turn_outcome.py
@@ -1,0 +1,558 @@
+"""The Agent exposes one structured outcome for each attempted turn."""
+
+from __future__ import annotations
+
+import threading
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from connectonion import Agent, after_iteration, on_complete
+from connectonion.core.llm import LLMResponse, ToolCall
+from connectonion.core.usage import TokenUsage
+from tests.utils.mock_helpers import MockLLM
+
+
+def response(
+    content: str = "done",
+    *,
+    tool_calls: list[ToolCall] | None = None,
+    usage: TokenUsage | None = None,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        raw_response={},
+        usage=usage,
+    )
+
+
+def outcomes(agent: Agent) -> list[dict]:
+    return [
+        event
+        for event in agent.current_session['trace']
+        if event.get('type') == 'turn_result'
+    ]
+
+
+def test_natural_turn_keeps_string_api_and_records_measured_usage(tmp_path):
+    usage = TokenUsage(
+        input_tokens=120,
+        output_tokens=30,
+        cached_tokens=20,
+        cache_write_tokens=4,
+        total_tokens=170,
+        cost=0.0012,
+    )
+    agent = Agent(
+        name="outcome",
+        llm=MockLLM(responses=[response("answer", usage=usage)]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("question") == "answer"
+    assert outcomes(agent) == [
+        {
+            'type': 'turn_result',
+            'turn': 1,
+            'reason': 'natural',
+            'usage': {
+                'input_tokens': 120,
+                'output_tokens': 30,
+                'cached_tokens': 20,
+                'cache_write_tokens': 4,
+                'total_tokens': 170,
+                'cost': pytest.approx(0.0012),
+            },
+            'id': outcomes(agent)[0]['id'],
+            'ts': outcomes(agent)[0]['ts'],
+        }
+    ]
+
+
+def test_usage_is_aggregated_per_turn_not_over_session_history(tmp_path):
+    agent = Agent(
+        name="multi-turn",
+        llm=MockLLM(responses=[
+            response("first", usage=TokenUsage(
+                input_tokens=10, output_tokens=2, total_tokens=20, cost=0.1
+            )),
+            response("second", usage=TokenUsage(
+                input_tokens=30, output_tokens=4, cached_tokens=5, cost=0.2
+            )),
+        ]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("one") == "first"
+    assert agent.input("two") == "second"
+
+    first, second = outcomes(agent)
+    assert first['turn'] == 1
+    assert first['usage']['total_tokens'] == 20
+    assert second['turn'] == 2
+    assert second['usage'] == {
+        'input_tokens': 30,
+        'output_tokens': 4,
+        'cached_tokens': 5,
+        'cache_write_tokens': 0,
+        'total_tokens': 34,
+        'cost': pytest.approx(0.2),
+    }
+
+
+def test_multiple_llm_calls_use_explicit_or_reconciled_totals(tmp_path):
+    def lookup(query: str) -> str:
+        """Look up a value."""
+        return query.upper()
+
+    agent = Agent(
+        name="multi-call",
+        tools=[lookup],
+        llm=MockLLM(responses=[
+            response(
+                tool_calls=[ToolCall(name="lookup", arguments={"query": "x"}, id="t1")],
+                usage=TokenUsage(
+                    input_tokens=12, output_tokens=3, total_tokens=25, cost=0.01
+                ),
+            ),
+            response("complete", usage=TokenUsage(
+                input_tokens=20,
+                output_tokens=5,
+                cached_tokens=4,
+                cache_write_tokens=2,
+                cost=0.02,
+            )),
+        ]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("work") == "complete"
+    assert outcomes(agent)[0]['usage'] == {
+        'input_tokens': 32,
+        'output_tokens': 8,
+        'cached_tokens': 4,
+        'cache_write_tokens': 2,
+        'total_tokens': 50,
+        'cost': pytest.approx(0.03),
+    }
+
+
+def test_missing_usage_remains_null(tmp_path):
+    agent = Agent(
+        name="no-usage",
+        llm=MockLLM(responses=[response(usage=None)]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    agent.input("question")
+
+    assert outcomes(agent)[0]['usage'] is None
+
+
+def test_max_iterations_has_structured_reason_and_existing_text(tmp_path):
+    def noop() -> str:
+        """Do nothing."""
+        return "ok"
+
+    agent = Agent(
+        name="limited",
+        tools=[noop],
+        llm=MockLLM(responses=[response(
+            tool_calls=[ToolCall(name="noop", arguments={}, id="t1")],
+            usage=TokenUsage(input_tokens=4, output_tokens=1),
+        )]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("work", max_iterations=1) == (
+        "Task incomplete: Maximum iterations (1) reached."
+    )
+    assert outcomes(agent)[0]['reason'] == 'max_iterations'
+
+
+def test_policy_stop_signal_has_stopped_reason(tmp_path):
+    @after_iteration
+    def stop(agent):
+        agent.current_session['stop_signal'] = 'stop requested'
+
+    agent = Agent(
+        name="stopped",
+        llm=MockLLM(responses=[response("unused", usage=TokenUsage())]),
+        on_events=[stop],
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("work") == "What would you like me to do?"
+    assert outcomes(agent)[0]['reason'] == 'stopped'
+
+
+def test_no_progress_stop_signal_has_stopped_reason(tmp_path):
+    @after_iteration
+    def stop(agent):
+        agent.current_session['stop_signal'] = True
+
+    agent = Agent(
+        name="no-progress",
+        llm=MockLLM(responses=[response("unused", usage=TokenUsage())]),
+        on_events=[stop],
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("work") == "What would you like me to do?"
+    assert outcomes(agent)[0]['reason'] == 'stopped'
+
+
+def test_client_interrupt_has_interrupted_reason(tmp_path):
+    def noop() -> str:
+        """Do nothing."""
+        return "ok"
+
+    @after_iteration
+    def interrupt(agent):
+        agent.current_session['stop_signal'] = 'user_interrupt'
+
+    agent = Agent(
+        name="client-interrupt",
+        tools=[noop],
+        llm=MockLLM(responses=[response(
+            tool_calls=[ToolCall(name="noop", arguments={}, id="t1")],
+            usage=TokenUsage(),
+        )]),
+        on_events=[interrupt],
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    assert agent.input("work") == "What would you like me to do?"
+    assert outcomes(agent)[0]['reason'] == 'interrupted'
+
+
+def test_exception_records_type_without_message_then_reraises(tmp_path):
+    class FailingLLM:
+        model = "failing"
+
+        def complete(self, messages, tools=None):
+            raise RuntimeError("super-secret provider detail")
+
+    agent = Agent(
+        name="error",
+        llm=FailingLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    with pytest.raises(RuntimeError, match="super-secret provider detail"):
+        agent.input("work")
+
+    assert len(outcomes(agent)) == 1
+    assert outcomes(agent)[0]['reason'] == 'error'
+    assert outcomes(agent)[0]['error_type'] == 'RuntimeError'
+    assert 'super-secret' not in str(outcomes(agent)[0])
+    assert outcomes(agent)[0]['usage'] is None
+
+
+def test_outcome_stream_failure_does_not_mask_original_turn_error(tmp_path):
+    class FailingIO:
+        def send(self, event):
+            raise OSError("transport is closed")
+
+    agent = Agent(
+        name="error-order",
+        llm=MockLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = FailingIO()
+
+    with pytest.raises(OSError, match="transport is closed"):
+        agent.input("work")
+
+    assert len(outcomes(agent)) == 1
+    assert outcomes(agent)[0]['reason'] == 'error'
+    assert outcomes(agent)[0]['error_type'] == 'OSError'
+
+
+def test_terminal_stream_failure_does_not_turn_completed_work_into_failure(tmp_path):
+    class TerminalFailingIO:
+        def send(self, event):
+            if event.get('type') == 'turn_result':
+                raise OSError("terminal frame failed")
+
+        def receive_all(self, message_type=None):
+            return []
+
+    agent = Agent(
+        name="completed-before-stream-failure",
+        llm=MockLLM(responses=[response("answer", usage=TokenUsage())]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = TerminalFailingIO()
+
+    assert agent.input("work") == "answer"
+    assert len(outcomes(agent)) == 1
+    assert outcomes(agent)[0]['reason'] == 'natural'
+
+
+def test_interrupt_during_on_complete_is_not_carried_into_next_turn(tmp_path):
+    class InterruptIO:
+        def __init__(self):
+            self.messages = []
+            self.lock = threading.Lock()
+
+        def send(self, event):
+            pass
+
+        def receive_all(self, message_type=None):
+            with self.lock:
+                matched = [
+                    message for message in self.messages
+                    if message.get('type') == message_type
+                ]
+                self.messages[:] = [
+                    message for message in self.messages
+                    if message.get('type') != message_type
+                ]
+                return matched
+
+        def interrupt(self):
+            with self.lock:
+                self.messages.append({'type': 'INTERRUPT'})
+
+    hook_started = threading.Event()
+    release_hook = threading.Event()
+
+    @on_complete
+    def block_first_completion(agent):
+        if agent.current_session['turn'] == 1:
+            hook_started.set()
+            assert release_hook.wait(timeout=1)
+
+    io = InterruptIO()
+    agent = Agent(
+        name="completion-race",
+        llm=MockLLM(responses=[
+            response("first", usage=TokenUsage()),
+            response("second", usage=TokenUsage()),
+        ]),
+        on_events=[block_first_completion],
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = io
+
+    def interrupt_completion():
+        assert hook_started.wait(timeout=1)
+        io.interrupt()
+        release_hook.set()
+
+    threading.Thread(target=interrupt_completion, daemon=True).start()
+
+    assert agent.input("one") == "first"
+    assert agent.input("two") == "second"
+    assert [outcome['reason'] for outcome in outcomes(agent)] == [
+        'natural',
+        'natural',
+    ]
+
+
+def test_completed_turn_survives_late_interrupt_drain_failure(tmp_path):
+    class DrainFailingIO:
+        def __init__(self):
+            self.receive_calls = 0
+
+        def send(self, event):
+            pass
+
+        def receive_all(self, message_type=None):
+            self.receive_calls += 1
+            if self.receive_calls == 3:
+                raise OSError("mailbox unavailable")
+            return []
+
+    io = DrainFailingIO()
+    agent = Agent(
+        name="drain-failure",
+        llm=MockLLM(responses=[response("answer", usage=TokenUsage())]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = io
+
+    assert agent.input("work") == "answer"
+    assert io.receive_calls == 3
+    assert outcomes(agent)[0]['reason'] == 'natural'
+
+
+def test_first_session_sync_contains_the_current_user_message(tmp_path):
+    class CapturingIO:
+        def __init__(self):
+            self.events = []
+
+        def send(self, event):
+            self.events.append(deepcopy(event))
+
+        def receive_all(self, message_type=None):
+            return []
+
+    io = CapturingIO()
+    agent = Agent(
+        name="sync-order",
+        llm=MockLLM(responses=[response("answer", usage=TokenUsage())]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = io
+
+    agent.input("current turn")
+
+    first_sync = next(event for event in io.events if event['type'] == 'session_sync')
+    assert first_sync['session']['messages'][-1] == {
+        'role': 'user',
+        'content': 'current turn',
+    }
+    user_messages = [
+        message for message in first_sync['session']['messages']
+        if message.get('role') == 'user'
+    ]
+    assert user_messages == [{'role': 'user', 'content': 'current turn'}]
+
+
+def test_upload_preprocessing_error_has_terminal_outcome(tmp_path, monkeypatch):
+    llm = MockLLM()
+    agent = Agent(
+        name="upload-error",
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    def fail_decode(_encoded):
+        raise ValueError("malformed upload")
+
+    monkeypatch.setattr("connectonion.core.agent.base64.b64decode", fail_decode)
+
+    with pytest.raises(ValueError, match="malformed upload"):
+        agent.input(
+            "inspect",
+            files=[{"name": "bad.txt", "data": "data:text/plain;base64,bad"}],
+        )
+
+    assert llm.call_count == 0
+    assert outcomes(agent)[0]['reason'] == 'error'
+    assert outcomes(agent)[0]['error_type'] == 'ValueError'
+    assert agent.current_session['turn'] == 1
+
+
+def test_partial_multi_file_write_is_rolled_back(tmp_path, monkeypatch):
+    agent = Agent(
+        name="partial-upload",
+        llm=MockLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    original_write_bytes = Path.write_bytes
+    writes = 0
+
+    def fail_second_write(path, data):
+        nonlocal writes
+        writes += 1
+        if writes == 2:
+            original_write_bytes(path, b"partial")
+            raise OSError("disk full")
+        return original_write_bytes(path, data)
+
+    monkeypatch.setattr(Path, "write_bytes", fail_second_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        agent.input(
+            "inspect",
+            files=[
+                {"name": "one.txt", "data": "data:text/plain;base64,b25l"},
+                {"name": "two.txt", "data": "data:text/plain;base64,dHdv"},
+            ],
+        )
+
+    uploads = tmp_path / ".co" / "uploads"
+    assert list(uploads.iterdir()) == []
+    assert outcomes(agent)[0]['reason'] == 'error'
+    assert not any(
+        event.get('type') == 'files_received'
+        for event in agent.current_session['trace']
+    )
+
+
+def test_upload_cleanup_failure_does_not_replace_write_error(tmp_path, monkeypatch):
+    agent = Agent(
+        name="cleanup-error",
+        llm=MockLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    original_write_bytes = Path.write_bytes
+
+    def partial_write_then_fail(path, data):
+        original_write_bytes(path, b"partial")
+        raise OSError("original disk error")
+
+    def fail_cleanup(path, missing_ok=False):
+        raise PermissionError("cleanup denied")
+
+    monkeypatch.setattr(Path, "write_bytes", partial_write_then_fail)
+    monkeypatch.setattr(Path, "unlink", fail_cleanup)
+
+    with pytest.raises(OSError, match="original disk error"):
+        agent.input(
+            "inspect",
+            files=[{"name": "one.txt", "data": "data:text/plain;base64,b25l"}],
+        )
+
+    assert outcomes(agent)[0]['reason'] == 'error'
+
+
+def test_logger_setup_error_is_inside_attempted_turn_boundary(tmp_path, monkeypatch):
+    agent = Agent(
+        name="logger-error",
+        llm=MockLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    def fail_start(*_args, **_kwargs):
+        raise OSError("logger unavailable")
+
+    monkeypatch.setattr(agent.logger, "start_session", fail_start)
+
+    with pytest.raises(OSError, match="logger unavailable"):
+        agent.input("work")
+
+    assert outcomes(agent)[0]['reason'] == 'error'
+    assert outcomes(agent)[0]['error_type'] == 'OSError'
+    assert agent.current_session['turn'] == 1


### PR DESCRIPTION
## Summary

- record exactly one provider-neutral `turn_result` trace entry for every attempted Agent turn
- aggregate measured per-turn token/cache/cost usage without changing the existing string-returning `Agent.input()` API
- distinguish real client interruption from policy/approval/no-progress stops
- preserve committed turn outcomes across terminal transport failure and roll back partial multi-file uploads
- document the contract in DD-026

## Design

This follows the trace-as-source-of-truth and lifecycle ordering decisions in DD-017, DD-019, and DD-025. Adapters consume the structured terminal event instead of parsing presentation text.

Part of #474.
Closes #818.

## Validation

- `pytest -q`: 6435 passed, 26 skipped, 176 deselected
- `tests/unit/test_turn_outcome.py`: 18 passed
- focused Agent / approval / interruption / session / host suites: passed
- Ruff: passed
- Bandit: no new findings (existing model-name B105 false positives excluded)
- pip-audit: no known vulnerabilities
- two independent expert reviews: no remaining P0/P1/P2 findings
- `git diff --check`: clean

This PR is intentionally Draft for maintainer review. It has not been merged or released.