### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ from connectonion.useful_tools.browser_tools import BrowserAutomation
 - `co deploy` for one-command deployment
 
 **Recently Completed:**
-- Multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Grok, OpenRouter)
+- Multiple LLM providers (OpenAI, Anthropic, Gemini, Groq, Grok, OpenRouter, OrcaRouter)
 - Managed API keys (`co/` prefix)
 - Plugin system
 - Google OAuth integration

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -152,6 +152,8 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
                         detected_keys["grok"] = env_value.strip()
                     elif env_key_name == "OPENROUTER_API_KEY" and env_value.strip():
                         detected_keys["openrouter"] = env_value.strip()
+                    elif env_key_name == "ORCAROUTER_API_KEY" and env_value.strip():
+                        detected_keys["orcarouter"] = env_value.strip()
                     elif env_key_name == "OPENONION_API_KEY" and env_value.strip():
                         detected_keys["openonion"] = env_value.strip()
 
@@ -398,6 +400,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
                 "# GEMINI_API_KEY=",
                 "# XAI_API_KEY=",
                 "# OPENROUTER_API_KEY=",
+                "# ORCAROUTER_API_KEY=",
             ])
 
         env_content = "\n".join(env_lines) + "\n"

--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -392,6 +392,7 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         "GROQ_API_KEY": "set GROQ_API_KEY in <project>/.env",
         "XAI_API_KEY": "set XAI_API_KEY in <project>/.env",
         "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in <project>/.env",
+        "ORCAROUTER_API_KEY": "set ORCAROUTER_API_KEY in <project>/.env",
         "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
     }
     api_key = None

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -270,6 +270,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
 # GROQ_API_KEY=
 # XAI_API_KEY=
 # OPENROUTER_API_KEY=
+# ORCAROUTER_API_KEY=
 
 # Optional: Override default model
 # MODEL=co/gemini-3.6-flash

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [os, re, sys, time, shutil, rich.console, rich.prompt, rich.progress, rich.table, rich.panel, datetime, pathlib, __version__, address] | imported by [cli/commands/init.py, cli/commands/create.py] | calls LLM APIs for custom template generation | tested indirectly via test_cli_init.py and test_cli_create.py
   Data flow: provides utility functions called by init.py and create.py → validate_project_name() checks regex patterns → check_environment_for_api_keys() scans env vars for OpenAI/Anthropic/Google/Groq/Grok/OpenRouter keys → detect_api_provider() inspects key format to identify provider → api_key_setup_menu() displays interactive menu for key selection → generate_custom_template_with_name() calls LLM API with custom prompt to generate agent.py code → show_progress() displays Rich spinner → LoadingAnimation context manager for long operations → get_special_directory_warning() warns about home/root dirs
   State/Effects: no persistent state | reads from environment variables | writes to stdout via rich.Console | calls LLM APIs (OpenAI/Anthropic/Google) when generating custom templates | creates Rich UI elements (tables, panels, progress bars, prompts) | writes no files except create_host_yaml() (.co/host.yaml)
-  Integration: exposes 16+ utility functions and 1 class (LoadingAnimation) | used by init.py and create.py for shared logic | validate_project_name() enforces naming conventions for the project/directory name (starts with letter, no spaces, max 50 chars) | normalize_deploy_name()/DEPLOY_NAME_PATTERN cover the separate, stricter rule for the deploy name written into host.yaml (a DNS label and Docker tag: lowercase, digits, hyphens), applied by create_host_yaml() and re-checked by deploy_commands.py | check_environment_for_api_keys() scans OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY | detect_api_provider() identifies provider by key prefix (sk- for OpenAI, sk-ant- for Anthropic, AIzaSy for Google, gsk- for Groq, xai- for Grok, sk-or- for OpenRouter) | generate_custom_template_with_name() uses LLM to create agent.py from natural language description
+  Integration: exposes 16+ utility functions and 1 class (LoadingAnimation) | used by init.py and create.py for shared logic | validate_project_name() enforces naming conventions for the project/directory name (starts with letter, no spaces, max 50 chars) | normalize_deploy_name()/DEPLOY_NAME_PATTERN cover the separate, stricter rule for the deploy name written into host.yaml (a DNS label and Docker tag: lowercase, digits, hyphens), applied by create_host_yaml() and re-checked by deploy_commands.py | check_environment_for_api_keys() scans OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY, GROQ_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, ORCAROUTER_API_KEY | detect_api_provider() identifies provider by key prefix (sk- for OpenAI, sk-ant- for Anthropic, AIzaSy for Google, gsk- for Groq, xai- for Grok, sk-or- for OpenRouter, sk-orca- for OrcaRouter) | generate_custom_template_with_name() uses LLM to create agent.py from natural language description
   Performance: environment scanning is O(n) env vars | regex validation is fast (<1ms) | LLM API calls for custom templates (5-15s) | Rich UI rendering is lightweight | LoadingAnimation runs in main thread (non-blocking spinner)
   Errors: validate_project_name() returns (False, error_msg) for invalid names | detect_api_provider() returns ("unknown", "unknown") for unrecognized keys | generate_custom_template_with_name() may fail if LLM API unreachable | api_key_setup_menu() catches KeyboardInterrupt and returns ("", "", None) | no try-except blocks (follows fail-fast principle)
 """
@@ -563,6 +563,7 @@ def check_environment_for_api_keys() -> Optional[Tuple[str, str]]:
         ('GROQ_API_KEY', 'groq'),
         ('XAI_API_KEY', 'grok'),
         ('OPENROUTER_API_KEY', 'openrouter'),
+        ('ORCAROUTER_API_KEY', 'orcarouter'),
     ]
 
     for env_var, provider in checks:
@@ -586,7 +587,19 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     # OpenAI formats
     if api_key.startswith('sk-proj-'):
         return 'openai', 'project'
-    elif api_key.startswith('sk-'):
+
+    # OpenRouter. Checked before the generic `sk-` OpenAI prefix so its
+    # `sk-or-` keys are not claimed as plain OpenAI user keys.
+    if api_key.startswith('sk-or-'):
+        return 'openrouter', 'openrouter'
+
+    # OrcaRouter. Checked after the disjoint `sk-or-` OpenRouter prefix and
+    # before the generic `sk-` OpenAI prefix so `sk-orca-` keys are not
+    # claimed as plain OpenAI user keys.
+    if api_key.startswith('sk-orca-'):
+        return 'orcarouter', 'orcarouter'
+
+    if api_key.startswith('sk-'):
         return 'openai', 'user'
 
     # Google (Gemini)
@@ -600,10 +613,6 @@ def detect_api_provider(api_key: str) -> Tuple[str, str]:
     # xAI Grok
     if api_key.startswith('xai-'):
         return 'grok', 'xai'
-
-    # OpenRouter
-    if api_key.startswith('sk-or-'):
-        return 'openrouter', 'openrouter'
 
     # Default to OpenAI if unsure
     return 'openai', 'unknown'
@@ -643,6 +652,10 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         'openrouter': {
             'var': 'OPENROUTER_API_KEY',
             'model': 'openrouter/openai/o4-mini'
+        },
+        'orcarouter': {
+            'var': 'ORCAROUTER_API_KEY',
+            'model': 'orcarouter/openai/gpt-4o'
         },
         'connectonion': {
             'var': 'CONNECTONION_API_KEY',
@@ -925,6 +938,7 @@ PROVIDER_TO_ENV = {
     "groq": "GROQ_API_KEY",
     "grok": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+    "orcarouter": "ORCAROUTER_API_KEY",
     "openonion": "OPENONION_API_KEY",
 }
 

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -35,6 +35,7 @@ CREDENTIAL_ENV_VARS = (
     ("GROQ_API_KEY", "Groq"),
     ("XAI_API_KEY", "xAI"),
     ("OPENROUTER_API_KEY", "OpenRouter"),
+    ("ORCAROUTER_API_KEY", "OrcaRouter"),
     ("MISTRAL_API_KEY", "Mistral"),
 )
 

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1,17 +1,17 @@
 """
-Purpose: Unified LLM provider abstraction with factory pattern for OpenAI, Anthropic, Gemini, Groq, Grok, Mistral, OpenRouter, and OpenOnion
+Purpose: Unified LLM provider abstraction with factory pattern for OpenAI, Anthropic, Gemini, Groq, Grok, Mistral, OpenRouter, OrcaRouter, and OpenOnion
 LLM-Note:
   Dependencies: imports from [abc, typing, dataclasses, json, os, base64, openai, anthropic, requests, pathlib, yaml, pydantic, .usage, .exceptions] | imported by [agent.py, llm_do.py, conftest.py] | tested by [tests/unit/test_llm.py, tests/test_llm_do.py, tests/test_real_*.py, tests/unit/test_exceptions.py, tests/unit/test_uniform_provider_errors.py]
   Data flow: Agent/llm_do calls create_llm(model, api_key) → factory routes to provider class → Provider.__init__() validates API key → Agent calls complete(messages, tools) OR structured_complete(messages, output_schema) → provider converts to native format → calls API → parses response → returns LLMResponse(content, tool_calls, raw_response) OR Pydantic model instance
-  State/Effects: reads environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, XAI_API_KEY, OPENONION_API_KEY) | reads OPENONION_API_KEY from env / .env / ~/.co/keys.env | makes HTTP requests to LLM APIs | no caching or persistence
-  Integration: exposes create_llm(model, api_key), LLM abstract base class, OpenAILLM, AnthropicLLM, GeminiLLM, GroqLLM, GrokLLM, OpenRouterLLM, OpenOnionLLM, LLMResponse, ToolCall dataclasses | providers implement complete() and structured_complete() | OpenAI message format is lingua franca | tool calling uses OpenAI schema converted per-provider
+  State/Effects: reads environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY/GOOGLE_API_KEY, GROQ_API_KEY, OPENROUTER_API_KEY, ORCAROUTER_API_KEY, XAI_API_KEY, OPENONION_API_KEY) | reads OPENONION_API_KEY from env / .env / ~/.co/keys.env | makes HTTP requests to LLM APIs | no caching or persistence
+  Integration: exposes create_llm(model, api_key), LLM abstract base class, OpenAILLM, AnthropicLLM, GeminiLLM, GroqLLM, GrokLLM, OpenRouterLLM, OrcaRouterLLM, OpenOnionLLM, LLMResponse, ToolCall dataclasses | providers implement complete() and structured_complete() | OpenAI message format is lingua franca | tool calling uses OpenAI schema converted per-provider
   Performance: openai/anthropic are imported inside the functions that use them, so importing this module does not pay for either SDK | stateless (no caching) | synchronous (no streaming) | default max_tokens=8192 for Anthropic (required) | each call hits API
   Errors: raises ValueError for missing API keys, unknown models, invalid parameters | provider-specific errors bubble up (openai.APIError, anthropic.APIError, etc.) | OpenOnionLLM transforms 402 errors to InsufficientCreditsError with formatted message and typed attributes | Pydantic ValidationError for invalid structured output
 
 Unified LLM provider abstraction layer for ConnectOnion framework.
 
 This module provides a consistent interface for interacting with multiple LLM providers
-(OpenAI, Anthropic, Google Gemini, Groq, Grok, Mistral, OpenRouter, and ConnectOnion managed keys)
+(OpenAI, Anthropic, Google Gemini, Groq, Grok, Mistral, OpenRouter, OrcaRouter, and ConnectOnion managed keys)
 through a common API.
 
 Architecture Overview
@@ -31,6 +31,7 @@ The module follows a factory pattern with provider-specific implementations:
    - GrokLLM: xAI Grok via OpenAI-compatible endpoint
    - MistralLLM: Mistral AI via OpenAI-compatible endpoint
    - OpenRouterLLM: OpenRouter via OpenAI-compatible endpoint
+   - OrcaRouterLLM: OrcaRouter via OpenAI-compatible endpoint
    - OpenOnionLLM: Managed keys using OpenAI-compatible proxy endpoint
 
 3. **Factory Function (create_llm)**:
@@ -108,6 +109,7 @@ Required (pick one):
   - OPENROUTER_API_KEY: For openrouter/ prefixed models
   - OPENROUTER_HTTP_REFERER: Optional attribution header for OpenRouter
   - OPENROUTER_X_TITLE: Optional app title header for OpenRouter
+  - ORCAROUTER_API_KEY: For orcarouter/ prefixed models
   - XAI_API_KEY: For grok/ prefixed models (xAI)
   - MISTRAL_API_KEY: For mistral/ prefixed models
 
@@ -930,6 +932,83 @@ class OpenRouterLLM(LLM):
         return output_schema.model_validate_json(content)
 
 
+class OrcaRouterLLM(LLM):
+    """OrcaRouter LLM implementation using OpenAI-compatible endpoint."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "orcarouter/openai/gpt-4o", **kwargs):
+        import openai
+        self.api_key = api_key or os.getenv("ORCAROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OrcaRouter API key required. Set ORCAROUTER_API_KEY environment variable or pass api_key parameter.")
+
+        self.model = model.removeprefix("orcarouter/")
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url="https://api.orcarouter.ai/v1"
+        )
+
+    def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
+        """Complete a conversation using OrcaRouter's OpenAI-compatible endpoint."""
+        api_kwargs = {
+            "model": self.model,
+            "messages": messages,
+            **kwargs
+        }
+
+        if tools:
+            api_kwargs["tools"] = [{"type": "function", "function": tool} for tool in tools]
+            api_kwargs["tool_choice"] = "auto"
+
+        response = self._call_provider(
+            lambda: self.client.chat.completions.create(**api_kwargs))
+        message = response.choices[0].message
+
+        tool_calls = []
+        if hasattr(message, 'tool_calls') and message.tool_calls:
+            for tc in message.tool_calls:
+                tool_calls.append(ToolCall(
+                    name=tc.function.name,
+                    arguments=json.loads(tc.function.arguments) if isinstance(tc.function.arguments, str) else tc.function.arguments,
+                    id=tc.id
+                ))
+
+        usage = None
+        if hasattr(response, 'usage') and response.usage:
+            input_tokens = response.usage.prompt_tokens
+            output_tokens = response.usage.completion_tokens
+            cost = calculate_cost(self.model, input_tokens, output_tokens)
+            usage = TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost=cost,
+            )
+
+        return LLMResponse(content=message.content, tool_calls=tool_calls, raw_response=response, usage=usage)
+
+    def structured_complete(self, messages: List[Dict], output_schema: Type[BaseModel], **kwargs) -> BaseModel:
+        """Get structured Pydantic output using JSON-mode + schema validation.
+
+        Uses chat.completions with JSON response format for compatibility with
+        OpenAI-like providers that may not support beta parse endpoints.
+        """
+        schema_json = json.dumps(output_schema.model_json_schema(), indent=2)
+        schema_instruction = (
+            "Return ONLY valid JSON (no markdown) that matches this JSON Schema:\n"
+            f"{schema_json}"
+        )
+
+        structured_messages = [{"role": "system", "content": schema_instruction}, *messages]
+
+        completion = self._call_provider(lambda: self.client.chat.completions.create(
+            model=self.model,
+            messages=structured_messages,
+            response_format={"type": "json_object"},
+            **kwargs,
+        ))
+        content = completion.choices[0].message.content or "{}"
+        return output_schema.model_validate_json(content)
+
+
 class MistralLLM(LLM):
     """Mistral AI LLM implementation using OpenAI-compatible endpoint."""
 
@@ -1280,6 +1359,8 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
         return GroqLLM(api_key=api_key, model=model, **kwargs)
     if model.startswith("openrouter/"):
         return OpenRouterLLM(api_key=api_key, model=model, **kwargs)
+    if model.startswith("orcarouter/"):
+        return OrcaRouterLLM(api_key=api_key, model=model, **kwargs)
     if model.startswith("grok/"):
         return GrokLLM(api_key=api_key, model=model, **kwargs)
     if model.startswith("mistral/"):

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -369,6 +369,9 @@ export OPENROUTER_API_KEY="sk-or-..."
 export OPENROUTER_HTTP_REFERER="https://your-app.example"
 export OPENROUTER_X_TITLE="Your App Name"
 
+# OrcaRouter (use orcarouter/ model prefix)
+export ORCAROUTER_API_KEY="sk-orca-..."
+
 # xAI Grok (use grok/ model prefix)
 export XAI_API_KEY="xai-..."
 
@@ -385,6 +388,7 @@ agent = Agent("assistant", model="gemini-2.5-pro")
 agent = Agent("assistant", model="claude-opus-4.1")
 agent = Agent("assistant", model="groq/llama-3.3-70b-versatile")
 agent = Agent("assistant", model="openrouter/openai/gpt-4o-mini")
+agent = Agent("assistant", model="orcarouter/openai/gpt-4o-mini")
 agent = Agent("assistant", model="grok/grok-4")
 agent = Agent("assistant", model="mistral/mistral-large-latest")
 ```
@@ -396,6 +400,11 @@ agent = Agent("assistant", model="mistral/mistral-large-latest")
 - Set `OPENROUTER_API_KEY`.
 - Optional (recommended): set `OPENROUTER_HTTP_REFERER` and `OPENROUTER_X_TITLE` for request attribution headers.
 - OpenRouter is treated as an OpenAI-compatible provider in ConnectOnion.
+
+**OrcaRouter (`orcarouter/...`)**
+- Prefix model names with `orcarouter/` (for example: `orcarouter/openai/gpt-4o-mini`).
+- Set `ORCAROUTER_API_KEY`.
+- OrcaRouter is treated as an OpenAI-compatible provider in ConnectOnion.
 
 **xAI Grok (`grok/...`)**
 - Prefix model names with `grok/` (for example: `grok/grok-4`).

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -172,6 +172,18 @@ class TestCliCreate:
                 if result.exit_code == 0:
                     assert os.path.exists('openrouter-agent')
 
+    def test_api_key_detection_orcarouter(self):
+        """Test that OrcaRouter API key is detected from environment."""
+        with self.runner.isolated_filesystem():
+            from connectonion.cli.main import cli
+
+            with patch.dict(os.environ, {'ORCAROUTER_API_KEY': 'sk-orca-test-key'}):
+                result = self.runner.invoke(cli, ['create', 'orcarouter-agent'],
+                                            input='co-ai\n')
+
+                if result.exit_code == 0:
+                    assert os.path.exists('orcarouter-agent')
+
     def test_create_existing_directory_fails(self):
         """Test that create fails if directory already exists."""
         with self.runner.isolated_filesystem():

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -119,6 +119,7 @@ class TestCredentialStatus:
             "GROQ_API_KEY=your-api-key-here\n"
             "XAI_API_KEY=\n"
             "OPENROUTER_API_KEY=${OPENROUTER_API_KEY}\n"
+            "ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY}\n"
         )
 
         rows = _credential_rows(
@@ -127,7 +128,7 @@ class TestCredentialStatus:
             environ={},
         )
 
-        for credential in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY"):
+        for credential in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY", "ORCAROUTER_API_KEY"):
             assert self._row(rows, credential)["status"] == "missing"
 
     @patch('connectonion.address.load')

--- a/tests/unit/test_llm_errors.py
+++ b/tests/unit/test_llm_errors.py
@@ -38,6 +38,7 @@ from connectonion.core.llm import (
     GroqLLM,
     GrokLLM,
     OpenRouterLLM,
+    OrcaRouterLLM,
     OpenOnionLLM,
     LLMResponse,
     ToolCall
@@ -106,6 +107,15 @@ class TestMissingAPIKeys:
 
             assert "OpenRouter API key required" in str(exc_info.value)
             assert "OPENROUTER_API_KEY" in str(exc_info.value)
+
+    def test_orcarouter_missing_api_key_env(self):
+        """Test OrcaRouter raises ValueError when API key missing from environment."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                OrcaRouterLLM(model="orcarouter/openai/gpt-4o-mini")
+
+            assert "OrcaRouter API key required" in str(exc_info.value)
+            assert "ORCAROUTER_API_KEY" in str(exc_info.value)
 
     def test_grok_missing_api_key_env(self):
         """Test Grok raises ValueError when API key missing from environment."""
@@ -348,6 +358,17 @@ class TestOpenAICompatibleProviders:
                 assert kwargs["default_headers"]["HTTP-Referer"] == "https://example.com"
                 assert kwargs["default_headers"]["X-Title"] == "My App"
 
+    def test_orcarouter_points_at_the_orcarouter_endpoint(self):
+        """OrcaRouter should target its own OpenAI-compatible endpoint."""
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key"}):
+            with patch("openai.OpenAI") as mock_openai:
+                llm = OrcaRouterLLM(model="orcarouter/openai/gpt-4o-mini")
+
+                _, kwargs = mock_openai.call_args
+                assert kwargs["base_url"] == "https://api.orcarouter.ai/v1"
+                assert kwargs["api_key"] == "test-key"
+                assert llm.model == "openai/gpt-4o-mini"
+
     def test_groq_structured_complete_json_mode(self):
         """Groq structured output should use JSON mode and validate with Pydantic."""
         with patch.dict(os.environ, {"GROQ_API_KEY": "test-key"}):
@@ -414,6 +435,28 @@ class TestOpenAICompatibleProviders:
             called = llm.client.chat.completions.create.call_args.kwargs
             assert called["response_format"] == {"type": "json_object"}
 
+    def test_orcarouter_structured_complete_json_mode(self):
+        """OrcaRouter structured output should use JSON mode and validate with Pydantic."""
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key"}):
+            llm = OrcaRouterLLM(model="orcarouter/openai/gpt-4o-mini")
+
+            mock_message = Mock()
+            mock_message.content = '{"value": 8, "message": "routed"}'
+            mock_response = Mock()
+            mock_response.choices = [Mock(message=mock_message)]
+            llm.client.chat.completions.create = Mock(return_value=mock_response)
+
+            result = llm.structured_complete(
+                [{"role": "user", "content": "Return test payload"}],
+                StructuredOutputSchema
+            )
+
+            assert result.value == 8
+            assert result.message == "routed"
+            llm.client.chat.completions.create.assert_called_once()
+            called = llm.client.chat.completions.create.call_args.kwargs
+            assert called["response_format"] == {"type": "json_object"}
+
 
 class TestModelInference:
     """Test model provider inference from model names."""
@@ -430,6 +473,12 @@ class TestModelInference:
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
             llm = create_llm("openrouter/openai/o4-mini")
             assert isinstance(llm, OpenRouterLLM)
+
+    def test_infer_orcarouter_from_prefix(self):
+        """Test that orcarouter/* models are routed to OrcaRouterLLM."""
+        with patch.dict(os.environ, {"ORCAROUTER_API_KEY": "test-key"}):
+            llm = create_llm("orcarouter/openai/gpt-4o-mini")
+            assert isinstance(llm, OrcaRouterLLM)
 
     def test_infer_grok_from_prefix(self):
         """Test that grok/* models are routed to GrokLLM."""

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -2,7 +2,34 @@
 
 import sys
 
-from connectonion.cli.commands.project_cmd_lib import upsert_env
+import pytest
+
+from connectonion.cli.commands.project_cmd_lib import (
+    detect_api_provider,
+    upsert_env,
+)
+
+
+class TestDetectApiProvider:
+    """detect_api_provider maps key prefixes to providers, most-specific first."""
+
+    @pytest.mark.parametrize(
+        ("key", "provider"),
+        [
+            ("sk-ant-test", "anthropic"),
+            ("sk-proj-test", "openai"),
+            ("sk-or-v1-test", "openrouter"),
+            # sk-orca- must not be claimed by the shorter sk- OpenAI prefix.
+            ("sk-orca-test", "orcarouter"),
+            ("sk-regular-openai", "openai"),
+            ("AIza-test", "google"),
+            ("gsk_test", "groq"),
+            ("xai-test", "grok"),
+            ("totally-unknown", "openai"),
+        ],
+    )
+    def test_detects_by_prefix(self, key, provider):
+        assert detect_api_provider(key)[0] == provider
 
 
 class TestUpsertEnv:

--- a/tests/unit/test_uniform_provider_errors.py
+++ b/tests/unit/test_uniform_provider_errors.py
@@ -42,14 +42,16 @@ def _make_fail(llm, exc):
 
 
 OPENAI_LIKE = ["o4-mini", "groq/llama-3.3-70b-versatile", "grok/grok-4",
-               "openrouter/meta-llama/llama-3-8b", "mistral/mistral-small"]
+               "openrouter/meta-llama/llama-3-8b", "orcarouter/openai/gpt-4o-mini",
+               "mistral/mistral-small"]
 
 
 class TestAuthFailsTheSameWayEverywhere:
     @pytest.mark.parametrize("model", OPENAI_LIKE)
     def test_openai_compatible_providers(self, model, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "k")
-        for var in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY", "MISTRAL_API_KEY"):
+        for var in ("GROQ_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
+                    "ORCAROUTER_API_KEY", "MISTRAL_API_KEY"):
             monkeypatch.setenv(var, "k")
         llm = create_llm(model, api_key="k")
         _make_fail(llm, _openai_error(openai.AuthenticationError, 401))


### PR DESCRIPTION
## Description

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing `OpenRouter` provider is wired, so the model picker, config reference and docs stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Related Issue

None — new provider addition.

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** DeepSeek V4 Flash via Claude Code.

**Which part of this are you least confident about?**
The exact set of models on the OrcaRouter gateway can grow, so the docs example pins `orcarouter/openai/gpt-4o-mini`, which is in the live `/v1/models` catalog today. The `sk-orca-` prefix check in `detect_api_provider()` had to be placed before the generic `sk-` OpenAI branch; the ordering is locked down by a new parameterized test.

**What did you *not* verify — which paths did you never actually run?**
I did not run the real-API test suite (`-m real_api`, needs keys) or the Windows `co browser` e2e suite (needs Chrome). A full `pytest tests/` on this Windows machine ends at 5755 passed / 145 failed / 59 skipped; every failure is in test files this PR does not touch (Windows-only issues: symlink privilege, `bash is Unix/Mac only` skips, GBK codec on CJK file reads, missing `docs-site` submodule). I verified all test files this PR touches pass, but I did not exhaustively diff the 145 unrelated failures against a pristine checkout.

**If this is wrong, what breaks first?**
If the prefix-ordering regressed, an `sk-orca-` key would be detected as a plain OpenAI user key and stored under `OPENAI_API_KEY`, so the agent would send it to OpenAI and get a 401. The new `TestDetectApiProvider` test guards exactly this.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made

- `connectonion/core/llm.py`: new `OrcaRouterLLM` class mirroring `OpenRouterLLM` — OpenAI-compatible `chat.completions` wire to `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY`, `orcarouter/` model-prefix stripping, JSON-mode `structured_complete()`. `create_llm()` factory gains an `orcarouter/` branch.
- `connectonion/cli/commands/project_cmd_lib.py`: `ORCAROUTER_API_KEY` added to the environment check, `configure_env_for_provider`, and `PROVIDER_TO_ENV`. `detect_api_provider()` now checks `sk-or-` (OpenRouter) and `sk-orca-` (OrcaRouter) before the generic `sk-` OpenAI prefix, so neither router key is misdetected as a plain OpenAI user key.
- `connectonion/cli/commands/create.py`, `init.py`, `doctor_commands.py`, `status_commands.py`: OrcaRouter key detection, `.env` template line, doctor credential guidance, and status credential table entry.
- `docs/concepts/models.md` and `README.md`: OrcaRouter env block, usage example, and provider notes mirroring OpenRouter.
- Tests: `tests/unit/test_llm_errors.py` (missing-key, endpoint, structured JSON mode, factory routing), `tests/unit/test_project_cmd_lib.py` (prefix detection ordering), `tests/unit/test_uniform_provider_errors.py` (uniform auth-error translation), `tests/e2e/cli/test_cli_create.py` and `tests/e2e/cli/test_cli_status.py` (CLI key detection and status rows).

No new dependencies.

## Testing

```
$ pytest tests/unit/test_llm_errors.py tests/unit/test_uniform_provider_errors.py tests/unit/test_project_cmd_lib.py tests/e2e/cli/test_cli_create.py tests/e2e/cli/test_cli_status.py -q
122 passed in 53.33s
```

Live test against the real OrcaRouter gateway (real key, same endpoint and model-name semantics this PR registers):

```
$ ORCAROUTER_API_KEY=... python _work/connectonion/l3_test.py
[1] picked model: openai/gpt-4o-mini
[2] create_llm -> OrcaRouterLLM, stripped model: openai/gpt-4o-mini
[2] complete() -> 'ok'
[2] usage: input_tokens=12 output_tokens=1 cached_tokens=0 cache_write_tokens=0 cost=1.5e-05 total_tokens=0
[3] structured_complete() -> ticker='AAPL' direction='up' score=8
[4] detect_api_provider -> orcarouter
L3 OK
```

- [x] I have added tests for new functionality

## Scope

The change is confined to the LLM provider layer and its CLI plumbing, exactly where the existing OpenRouter integration already lives: the provider class and factory in `core/llm.py`, the shared provider registry in `project_cmd_lib.py`, the four CLI command modules that enumerate credentials, the two docs files, and the corresponding tests. Adding a named provider alongside OpenRouter keeps the model picker, `.env` templates, `co doctor`, and `co status` consistent rather than introducing a second pattern for routing gateways.

## Example Usage

```python
from connectonion import Agent

agent = Agent("assistant", model="orcarouter/openai/gpt-4o-mini")
response = agent.input("What is 2+2?")
```

Set `ORCAROUTER_API_KEY` in the environment or in `<project>/.env`.

## Checklist
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The `detect_api_provider()` reorder also fixes a pre-existing latent bug: an OpenRouter `sk-or-...` key was previously matched by the generic `sk-` OpenAI branch before its own dedicated branch, so `--key sk-or-...` was stored as `OPENAI_API_KEY`. Both router prefixes are now checked before the OpenAI fallback.
