### PR TITLE
Stream bounded structured tool output

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -164,7 +164,12 @@ class Agent:
         import uuid
         return str(uuid.uuid4())
 
-    def _record_trace(self, entry: dict) -> None:
+    def _record_trace(
+        self,
+        entry: dict,
+        *,
+        wire_extras: Optional[dict] = None,
+    ) -> None:
         """Record trace entry and stream to io if connected.
 
         This is the single place where trace entries are recorded.
@@ -180,8 +185,14 @@ class Agent:
         self.current_session['trace'].append(entry)
 
         if self.io:
+            # Wire-only fields belong on a separate top-level object. The
+            # canonical entry is already in trace and is what session_sync
+            # persists. Sharing one object and deleting fields after send would
+            # race asynchronous transports.
+            # Canonical correlation and status fields always win collisions.
+            wire_entry = {**wire_extras, **entry} if wire_extras else entry
             # Send entry first (without session to avoid circular ref)
-            self.io.send(entry)
+            self.io.send(wire_entry)
             # Then send session sync separately
             self.io.send({
                 'type': 'session_sync',

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -9,26 +9,126 @@ LLM-Note:
   Errors: catches all tool execution exceptions | wraps errors in trace_entry with error, error_type fields | returns error message to LLM for retry | prints error to logger with red ✗
 """
 
-import time
-import json
 import asyncio
 import copy
 import inspect
+import json
+import math
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Dict, Any, Optional, Callable
+from typing import Any, Dict, List, Optional
 
-from ..debug.xray import (
-    inject_xray_context,
-    clear_xray_context,
-    is_xray_enabled
-)
+from ..debug.xray import clear_xray_context, inject_xray_context, is_xray_enabled
 from .interrupt import InterruptibleIO, UserInterrupt, run_interruptible
-
 
 _async_loop: Optional[asyncio.AbstractEventLoop] = None
 _async_loop_thread: Optional[threading.Thread] = None
 _async_loop_lock = threading.Lock()
+
+STRUCTURED_OUTPUT_MAX_DEPTH = 8
+STRUCTURED_OUTPUT_MAX_BYTES = 64 * 1024
+
+
+def _structured_tool_output(value: Any) -> tuple[bool, Any]:
+    """Return a bounded detached JSON-native copy for transport."""
+    budget = [STRUCTURED_OUTPUT_MAX_BYTES]
+    try:
+        detached = _copy_structured_output(value, 0, set(), budget)
+    except (TypeError, ValueError, OverflowError, RecursionError, RuntimeError):
+        return False, None
+    return True, detached
+
+
+def _copy_structured_output(
+    value: Any,
+    depth: int,
+    active: set[int],
+    budget: list[int],
+) -> Any:
+    value_type = type(value)
+    if value is None or value_type in (bool, int, float, str):
+        _spend_json_scalar(value, budget)
+        return value
+    if value_type is list:
+        return _copy_structured_list(value, depth, active, budget)
+    if value_type is dict:
+        return _copy_structured_dict(value, depth, active, budget)
+    raise TypeError("structured tool output must be JSON-native")
+
+
+def _spend_json_scalar(value: Any, budget: list[int]) -> None:
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError("non-finite floats are not interoperable JSON")
+    if type(value) is str and len(value) > STRUCTURED_OUTPUT_MAX_BYTES:
+        raise ValueError("structured tool output exceeds its byte limit")
+    if type(value) is int and value.bit_length() > STRUCTURED_OUTPUT_MAX_BYTES * 4:
+        raise ValueError("structured tool output exceeds its byte limit")
+    encoded = json.dumps(value, ensure_ascii=False, allow_nan=False)
+    _spend(len(encoded.encode("utf-8")), budget)
+
+
+def _spend(size: int, budget: list[int]) -> None:
+    if size > budget[0]:
+        raise ValueError("structured tool output exceeds its byte limit")
+    budget[0] -= size
+
+
+def _copy_structured_list(
+    value: list,
+    depth: int,
+    active: set[int],
+    budget: list[int],
+) -> list:
+    _enter_container(value, depth, active, budget)
+    detached = []
+    try:
+        for index, item in enumerate(value):
+            if index:
+                _spend(1, budget)
+            detached.append(_copy_structured_output(item, depth + 1, active, budget))
+        _spend(1, budget)
+        return detached
+    finally:
+        active.remove(id(value))
+
+
+def _copy_structured_dict(
+    value: dict,
+    depth: int,
+    active: set[int],
+    budget: list[int],
+) -> dict:
+    _enter_container(value, depth, active, budget)
+    detached = {}
+    try:
+        for index, (key, item) in enumerate(value.items()):
+            if type(key) is not str:
+                raise TypeError("structured tool output keys must be strings")
+            if index:
+                _spend(1, budget)
+            _spend_json_scalar(key, budget)
+            _spend(1, budget)
+            detached[key] = _copy_structured_output(item, depth + 1, active, budget)
+        _spend(1, budget)
+        return detached
+    finally:
+        active.remove(id(value))
+
+
+def _enter_container(
+    value: list | dict,
+    depth: int,
+    active: set[int],
+    budget: list[int],
+) -> None:
+    if depth >= STRUCTURED_OUTPUT_MAX_DEPTH:
+        raise ValueError("structured tool output exceeds its depth limit")
+    identity = id(value)
+    if identity in active:
+        raise ValueError("structured tool output contains a cycle")
+    active.add(identity)
+    _spend(1, budget)
 
 
 def _get_async_tool_loop():
@@ -353,21 +453,6 @@ def execute_single_tool(
         trace_entry["result"] = str(result)
         trace_entry["status"] = "success"
 
-        agent._record_trace(trace_entry)
-        logger.log_tool_result(str(result), tool_duration)
-
-        # Auto-print Rich table if @xray enabled
-        if xray_enabled:
-            logger.print_xray_table(
-                tool_name=tool_name,
-                tool_args=tool_args,
-                result=result,
-                timing=tool_duration,
-                agent=agent
-            )
-
-        # Note: after_tool event will fire in execute_and_record_tools after result message added
-
     except UserInterrupt:
         return interrupted_tool_result()
 
@@ -395,6 +480,36 @@ def execute_single_tool(
         logger.print(f"[red]✗[/red] Error ({time_str}): {str(e)}")
 
         # Note: on_error event will fire in execute_and_record_tools after result message added
+
+    else:
+        wire_extras = None
+        if agent.io:
+            try:
+                structured, raw_output = _structured_tool_output(result)
+            except Exception:
+                structured, raw_output = False, None
+            if structured:
+                try:
+                    matches_canonical = str(raw_output) == trace_entry["result"]
+                except Exception:
+                    matches_canonical = False
+                if matches_canonical:
+                    wire_extras = {"raw_output": raw_output}
+            agent._record_trace(trace_entry, wire_extras=wire_extras)
+        else:
+            agent._record_trace(trace_entry)
+        logger.log_tool_result(trace_entry["result"], tool_duration)
+
+        if xray_enabled:
+            logger.print_xray_table(
+                tool_name=tool_name,
+                tool_args=tool_args,
+                result=result,
+                timing=tool_duration,
+                agent=agent
+            )
+
+        # after_tool fires later, after the LLM tool message is added.
 
     finally:
         if tool_io:

--- a/docs/design-decisions/027-wire-only-structured-tool-output.md
+++ b/docs/design-decisions/027-wire-only-structured-tool-output.md
@@ -1,0 +1,56 @@
+# Design Decision: Stream Structured Tool Output Without Persisting It
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Related:** [012 Tool Execution Separation](012-tool-execution-separation.md), [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [026 Structured Turn Outcomes](026-structured-turn-outcomes.md)
+
+## Decision
+
+A successful tool result may add a detached JSON-native `raw_output` value to
+its streamed `tool_result` event. The canonical trace entry, session snapshot,
+LLM tool message, logger, and console keep the existing string `result` only.
+Protocol adapters may map the internal snake-case field to their wire schema,
+including ACP `rawOutput`.
+
+Tool execution builds the structured value because it alone still owns the
+original Python return value. `Agent._record_trace` accepts optional wire-only
+fields and creates a separate top-level event for transport after appending the
+canonical entry. Both representations share one event ID and timestamp. The
+following `session_sync` contains only canonical state.
+
+The accepted tree is deliberately narrow: null, exact booleans, integers,
+finite floats, strings, lists, and dictionaries with exact string keys. It is
+rebuilt recursively with a maximum container depth of 8 and a maximum compact
+UTF-8 JSON size of 64 KiB. Cycles, non-finite floats, bytes, Paths, tuples,
+non-string keys, custom objects, oversized values, and any mixed tree that
+contains them omit `raw_output` and use the existing string result.
+
+## Why
+
+JSON-native results are useful to protocol clients, but adding arbitrary Python
+objects to the trace would weaken the trace's JSON-compatible persistence
+contract. Appending a raw value and deleting it after send would also be racy:
+host transports can encode entries concurrently.
+
+A bounded detached wire copy keeps the persisted source of truth stable while
+allowing clients to preserve structure. Keeping the structured value on the
+same event preserves tool-result ordering without a second correlation path.
+
+## Security boundary
+
+This is not a redaction layer. Tool authors remain responsible for the content
+they return, as they are for today's string result. The runtime never
+introspects custom attributes, invokes model serializers, pickles objects, or
+implicitly decodes bytes. Error results do not receive structured output.
+Depth and byte limits bound the additional serialization work and payload.
+
+## Rejected alternatives
+
+- **Persist the structured value:** expands snapshot compatibility and secret
+  exposure for data needed only by live protocol clients.
+- **Append then delete:** races asynchronous session forwarding.
+- **Use `json.dumps(default=str)`:** silently invokes arbitrary object string
+  conversion and misrepresents non-JSON values as structured data.
+- **Support Pydantic or dataclasses automatically:** introspection and custom
+  serializers create a much broader execution and disclosure surface.
+- **Send a second raw-result event:** adds ordering and correlation complexity.

--- a/tests/unit/test_ask_user.py
+++ b/tests/unit/test_ask_user.py
@@ -32,7 +32,7 @@ class FakeAgent:
         self._trace_id += 1
         return self._trace_id
 
-    def _record_trace(self, entry):
+    def _record_trace(self, entry, *, wire_extras=None):
         """Record trace entry (simplified for testing)."""
         import time
         if 'id' not in entry:
@@ -41,7 +41,8 @@ class FakeAgent:
             entry['ts'] = time.time()
         self.current_session['trace'].append(entry)
         if self.io:
-            self.io.send(entry)
+            wire_entry = {**wire_extras, **entry} if wire_extras else entry
+            self.io.send(wire_entry)
 
     def _invoke_events(self, event_type: str):
         pass

--- a/tests/unit/test_structured_tool_output.py
+++ b/tests/unit/test_structured_tool_output.py
@@ -1,0 +1,476 @@
+"""Structured tool output is bounded, detached, and wire-only."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import BaseModel
+
+from connectonion import Agent
+from connectonion.core.llm import LLMResponse, ToolCall
+from connectonion.core.tool_executor import (
+    STRUCTURED_OUTPUT_MAX_BYTES,
+    STRUCTURED_OUTPUT_MAX_DEPTH,
+    _structured_tool_output,
+)
+from tests.utils.mock_helpers import MockLLM
+
+
+def response(
+    content: str = "done",
+    *,
+    tool_calls: list[ToolCall] | None = None,
+) -> LLMResponse:
+    return LLMResponse(
+        content=content,
+        tool_calls=tool_calls or [],
+        raw_response={},
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        True,
+        False,
+        42,
+        -3.5,
+        "hello",
+        [1, "two", None, {"ok": True}],
+        {"items": [1, 2], "meta": {"ready": True}},
+    ],
+)
+def test_json_native_values_are_detached(value):
+    accepted, detached = _structured_tool_output(value)
+
+    assert accepted is True
+    assert detached == value
+    if isinstance(value, (dict, list)):
+        assert detached is not value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        b"secret",
+        bytearray(b"secret"),
+        Path("report.txt"),
+        (1, 2),
+        {1: "non-string key"},
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+    ],
+)
+def test_non_json_or_non_interoperable_values_fall_back(value):
+    assert _structured_tool_output(value) == (False, None)
+
+
+def test_custom_objects_are_not_introspected():
+    class ModelLike:
+        @property
+        def model_dump(self):
+            raise AssertionError("custom attributes must not be inspected")
+
+    assert _structured_tool_output(ModelLike()) == (False, None)
+
+
+def test_pydantic_models_are_not_implicitly_serialized():
+    class Payload(BaseModel):
+        value: int
+
+    assert _structured_tool_output(Payload(value=1)) == (False, None)
+
+
+def test_cycles_fall_back_without_recursing_forever():
+    value = []
+    value.append(value)
+
+    assert _structured_tool_output(value) == (False, None)
+
+
+def test_shared_non_cyclic_values_are_copied_normally():
+    shared = [1, 2]
+    value = [shared, shared]
+
+    accepted, detached = _structured_tool_output(value)
+
+    assert accepted is True
+    assert detached == [[1, 2], [1, 2]]
+    assert detached[0] is not shared
+    assert detached[1] is not shared
+
+
+def test_container_depth_has_an_exact_boundary():
+    at_limit = "leaf"
+    for _ in range(STRUCTURED_OUTPUT_MAX_DEPTH):
+        at_limit = [at_limit]
+
+    accepted, _detached = _structured_tool_output(at_limit)
+    assert accepted is True
+    assert _structured_tool_output([at_limit]) == (False, None)
+
+
+def test_compact_utf8_size_has_an_exact_boundary():
+    # A compact JSON string adds exactly two quote bytes for plain ASCII.
+    at_limit = "x" * (STRUCTURED_OUTPUT_MAX_BYTES - 2)
+    over_limit = at_limit + "x"
+
+    assert _structured_tool_output(at_limit)[0] is True
+    assert _structured_tool_output(over_limit) == (False, None)
+
+
+def test_detached_output_does_not_follow_later_mutation():
+    original = {"items": [{"value": 1}]}
+
+    accepted, detached = _structured_tool_output(original)
+    original["items"][0]["value"] = 99
+    original["items"].append({"value": 2})
+
+    assert accepted is True
+    assert detached == {"items": [{"value": 1}]}
+
+
+class CaptureIO:
+    def __init__(self):
+        self.events: list[dict] = []
+        self.snapshots: list[dict] = []
+
+    def send(self, event: dict) -> None:
+        self.events.append(event)
+        self.snapshots.append(deepcopy(event))
+
+    def receive_all(self, message_type: str | None = None) -> list[dict]:
+        return []
+
+
+def test_agent_streams_structured_result_without_persisting_it(tmp_path):
+    returned = {"items": [{"id": 1}], "count": 1}
+
+    def lookup() -> dict:
+        """Return structured search results."""
+        return returned
+
+    llm = MockLLM(responses=[
+        response(tool_calls=[ToolCall(name="lookup", arguments={}, id="call-1")]),
+        response("complete"),
+    ])
+    agent = Agent(
+        name="structured-wire",
+        tools=[lookup],
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    io = CaptureIO()
+    agent.io = io
+
+    assert agent.input("look it up") == "complete"
+
+    wire_result = next(event for event in io.events if event.get("type") == "tool_result")
+    tool_call_index = next(
+        index for index, event in enumerate(io.events) if event.get("type") == "tool_call"
+    )
+    tool_result_index = io.events.index(wire_result)
+    trace_result = next(
+        event
+        for event in agent.current_session["trace"]
+        if event.get("type") == "tool_result"
+    )
+    assert wire_result["raw_output"] == returned
+    assert tool_call_index < tool_result_index
+    assert wire_result["id"] == trace_result["id"]
+    assert wire_result["ts"] == trace_result["ts"]
+    assert wire_result is not trace_result
+    assert "raw_output" not in trace_result
+    assert all(
+        "raw_output" not in event
+        for event in agent.current_session["trace"]
+    )
+    assert llm.calls[1]["messages"][-1] == {
+        "role": "tool",
+        "content": str(returned),
+        "tool_call_id": "call-1",
+    }
+
+    returned["items"][0]["id"] = 99
+    assert wire_result["raw_output"] == {"items": [{"id": 1}], "count": 1}
+
+
+def test_fallback_result_keeps_existing_wire_and_persisted_shape(tmp_path):
+    def read_bytes() -> bytes:
+        """Return bytes that must use the string compatibility path."""
+        return b"data"
+
+    agent = Agent(
+        name="fallback-wire",
+        tools=[read_bytes],
+        llm=MockLLM(responses=[
+            response(tool_calls=[ToolCall(name="read_bytes", arguments={}, id="call-1")]),
+            response("complete"),
+        ]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    io = CaptureIO()
+    agent.io = io
+
+    assert agent.input("read") == "complete"
+
+    wire_result = next(event for event in io.events if event.get("type") == "tool_result")
+    assert wire_result["result"] == "b'data'"
+    assert "raw_output" not in wire_result
+
+
+def test_session_sync_never_contains_structured_wire_output(tmp_path):
+    def lookup() -> dict:
+        """Return a nested object."""
+        return {"private": {"value": "wire-only"}}
+
+    agent = Agent(
+        name="canonical-sync",
+        tools=[lookup],
+        llm=MockLLM(responses=[
+            response(tool_calls=[ToolCall(name="lookup", arguments={}, id="call-1")]),
+            response("complete"),
+        ]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    io = CaptureIO()
+    agent.io = io
+
+    agent.input("look up")
+
+    syncs = [event for event in io.snapshots if event.get("type") == "session_sync"]
+    assert syncs
+    assert all(
+        "raw_output" not in trace_entry
+        for sync in syncs
+        for trace_entry in sync["session"]["trace"]
+    )
+
+
+def test_projection_failure_cannot_change_successful_tool_semantics(tmp_path):
+    def lookup() -> dict:
+        """Return a result even if optional projection fails."""
+        return {"value": 1}
+
+    llm = MockLLM(responses=[
+        response(tool_calls=[ToolCall(name="lookup", arguments={}, id="call-1")]),
+        response("complete"),
+    ])
+    agent = Agent(
+        name="projection-fallback",
+        tools=[lookup],
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    io = CaptureIO()
+    agent.io = io
+
+    with patch(
+        "connectonion.core.tool_executor._structured_tool_output",
+        side_effect=RuntimeError("dictionary changed size during iteration"),
+    ):
+        assert agent.input("look up") == "complete"
+
+    wire_result = next(event for event in io.events if event.get("type") == "tool_result")
+    trace_result = next(
+        event for event in agent.current_session["trace"]
+        if event.get("type") == "tool_result"
+    )
+    assert wire_result["result"] == "{'value': 1}"
+    assert "raw_output" not in wire_result
+    assert trace_result["status"] == "success"
+    assert "error" not in trace_result
+    assert llm.calls[1]["messages"][-1]["content"] == "{'value': 1}"
+
+
+def test_aba_mutation_omits_raw_and_keeps_existing_string(tmp_path):
+    returned = {"value": 1}
+
+    def lookup() -> dict:
+        """Return a value that changes while the wire snapshot is built."""
+        return returned
+
+    def snapshot_then_restore(value):
+        value["value"] = 2
+        detached = dict(value)
+        value["value"] = 1
+        return True, detached
+
+    llm = MockLLM(responses=[
+        response(tool_calls=[ToolCall(name="lookup", arguments={}, id="call-1")]),
+        response("complete"),
+    ])
+    agent = Agent(
+        name="stable-snapshot",
+        tools=[lookup],
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    io = CaptureIO()
+    agent.io = io
+
+    with patch(
+        "connectonion.core.tool_executor._structured_tool_output",
+        side_effect=snapshot_then_restore,
+    ):
+        assert agent.input("look up") == "complete"
+
+    wire_result = next(event for event in io.events if event.get("type") == "tool_result")
+    trace_result = next(
+        event for event in agent.current_session["trace"]
+        if event.get("type") == "tool_result"
+    )
+    assert returned == {"value": 1}
+    assert "raw_output" not in wire_result
+    assert wire_result["result"] == "{'value': 1}"
+    assert trace_result["result"] == "{'value': 1}"
+    assert llm.calls[1]["messages"][-1]["content"] == "{'value': 1}"
+
+
+@pytest.mark.parametrize("failure_point", ["tool_result", "session_sync"])
+def test_transport_failure_does_not_reclassify_or_duplicate_success(
+    tmp_path,
+    failure_point,
+):
+    class FailingIO(CaptureIO):
+        def __init__(self):
+            super().__init__()
+            self.saw_tool_result = False
+            self.failed = False
+
+        def send(self, event: dict) -> None:
+            event_type = event.get("type")
+            should_fail = (
+                failure_point == "tool_result" and event_type == "tool_result"
+            ) or (
+                failure_point == "session_sync"
+                and self.saw_tool_result
+                and event_type == "session_sync"
+            )
+            if should_fail and not self.failed:
+                self.failed = True
+                raise OSError(f"{failure_point} transport failed")
+            if event_type == "tool_result":
+                self.saw_tool_result = True
+            super().send(event)
+
+    def write_once() -> dict:
+        """Represent a tool with side effects that must not be retried."""
+        return {"written": True}
+
+    llm = MockLLM(responses=[
+        response(tool_calls=[ToolCall(name="write_once", arguments={}, id="call-1")]),
+        response("must not be reached"),
+    ])
+    agent = Agent(
+        name=f"transport-{failure_point}",
+        tools=[write_once],
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.io = FailingIO()
+
+    with pytest.raises(OSError, match=f"{failure_point} transport failed"):
+        agent.input("write")
+
+    tool_results = [
+        event for event in agent.current_session["trace"]
+        if event.get("type") == "tool_result"
+    ]
+    assert len(tool_results) == 1
+    assert tool_results[0]["status"] == "success"
+    assert tool_results[0]["result"] == "{'written': True}"
+    assert "raw_output" not in tool_results[0]
+    assert "error" not in tool_results[0]
+    assert llm.call_count == 1
+
+
+def test_logger_failure_does_not_reclassify_or_duplicate_success(tmp_path):
+    def write_once() -> dict:
+        """Represent a tool with side effects that must not be retried."""
+        return {"written": True}
+
+    llm = MockLLM(responses=[
+        response(tool_calls=[ToolCall(name="write_once", arguments={}, id="call-1")]),
+        response("must not be reached"),
+    ])
+    agent = Agent(
+        name="logger-failure",
+        tools=[write_once],
+        llm=llm,
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    with patch.object(
+        agent.logger,
+        "log_tool_result",
+        side_effect=OSError("logger failed"),
+    ):
+        with pytest.raises(OSError, match="logger failed"):
+            agent.input("write")
+
+    tool_results = [
+        event for event in agent.current_session["trace"]
+        if event.get("type") == "tool_result"
+    ]
+    assert len(tool_results) == 1
+    assert tool_results[0]["status"] == "success"
+    assert tool_results[0]["result"] == "{'written': True}"
+    assert "error" not in tool_results[0]
+    assert llm.call_count == 1
+
+
+def test_wire_extras_cannot_override_canonical_event_fields(tmp_path):
+    agent = Agent(
+        name="canonical-wire-fields",
+        llm=MockLLM(),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+    agent.current_session = {"trace": []}
+    io = CaptureIO()
+    agent.io = io
+    canonical = {
+        "type": "tool_result",
+        "id": "canonical-id",
+        "ts": 123.0,
+        "tool_id": "call-1",
+        "status": "success",
+        "result": "ok",
+    }
+
+    agent._record_trace(
+        canonical,
+        wire_extras={
+            "type": "forged",
+            "id": "forged-id",
+            "ts": 999.0,
+            "tool_id": "forged-call",
+            "status": "error",
+            "raw_output": {"ok": True},
+        },
+    )
+
+    wire_result = io.events[0]
+    assert wire_result == {**canonical, "raw_output": {"ok": True}}
+    assert agent.current_session["trace"] == [canonical]

--- a/tests/unit/test_the_agent_is_not_an_argument.py
+++ b/tests/unit/test_the_agent_is_not_an_argument.py
@@ -32,6 +32,7 @@ from connectonion.core.tool_executor import execute_single_tool
 class FakeLogger:
     def print(self, *a, **k): pass
     def log_tool_call(self, *a, **k): pass
+    def log_tool_result(self, *a, **k): pass
 
 
 class RecordingAgent:

--- a/tests/unit/test_tool_executor_errors.py
+++ b/tests/unit/test_tool_executor_errors.py
@@ -42,6 +42,7 @@ from connectonion.logger import Logger
 def create_mock_agent():
     """Create a mock agent with all required methods for tool execution."""
     mock_agent = Mock()
+    mock_agent.io = None
     mock_agent.current_session = {
         'messages': [],
         'trace': [],


### PR DESCRIPTION
## Summary

- stream a detached JSON-native `raw_output` on successful live `tool_result` events
- keep canonical traces, session snapshots, LLM messages, logs, and console output on the existing string `result`
- reject non-native, cyclic, non-finite, over-depth, and oversized values with a safe string fallback
- keep transport, projection, and logger failures from reclassifying or duplicating a successful tool execution
- record the contract and rejected alternatives in DD-027

## Design

This follows DD-012 (tool execution separation), DD-017 (session logging and eval format), and DD-026 (structured turn outcomes). The structured projection accepts exact JSON-native types only, copies them without introspection, caps container depth at 8, and caps compact UTF-8 JSON size at 64 KiB.

The additional value is wire-only. The persisted canonical event remains unchanged, and canonical event fields win any collision with wire-only fields.

## Stacked dependency

This Draft PR is stacked on Draft #822 (`agent/co-turn-outcome-818`). It should remain draft and must not merge before its base. After #822 lands, retarget/rebase this PR onto `main`.

## Validation

- full suite: 6,468 passed, 26 skipped, 176 deselected
- focused tool/structured/fixture regression set: 88 passed
- transport regression set: 18 passed
- Ruff: production files and new structured-output tests clean
- `git diff --check`: clean
- Bandit: no medium/high findings (one pre-existing low-severity assert)
- pip-audit: no known vulnerabilities in the synced environment
- two independent expert reviews: no open P0/P1/P2 findings

Part of #474.
Closes #819.

Draft only: do not merge or release yet.
