### PR TITLE
feat(acp): persist and resume owned sessions

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -33,9 +33,13 @@ from acp.interfaces import Client
 from acp.schema import (
     AgentCapabilities,
     ClientCapabilities,
+    CloseSessionResponse,
     Implementation,
     ResourceContentBlock,
+    ResumeSessionResponse,
     SessionCapabilities,
+    SessionCloseCapabilities,
+    SessionResumeCapabilities,
     TextContentBlock,
 )
 
@@ -47,6 +51,17 @@ from .acp_events import (
     map_agent_event,
 )
 from .acp_transport import open_stdio_transport
+from .agent import GLOBAL_CO_DIR
+from .one_shot_sessions import (
+    SessionLease,
+    SessionSnapshotError,
+    acquire_session_lease,
+    capture_tool_state,
+    load_snapshot,
+    new_session_id,
+    restore_tool_state,
+    save_snapshot,
+)
 
 AgentFactory = Callable[..., Any]
 ACP_EVENT_BUFFER_SIZE = 64
@@ -369,11 +384,19 @@ class _ACPEventBridge(_FailClosedACPInput):
 
 @dataclass
 class _SessionRuntime:
+    session_id: str
     cwd: Path
     agent: Any
     acp_input: _ACPEventBridge
+    session_lease: SessionLease
+    last_good_session: dict[str, Any]
+    last_good_tools: dict[str, Any]
+    session_for_next_prompt: dict[str, Any] | None
     prompt_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     prompt_active: threading.Event = field(default_factory=threading.Event)
+    closing: threading.Event = field(default_factory=threading.Event)
+    active_operation: asyncio.Task[Any] | None = None
+    close_task: asyncio.Task[None] | None = None
 
 
 class ConnectOnionACPAgent:
@@ -387,12 +410,14 @@ class ConnectOnionACPAgent:
         yolo: bool,
         yolo_turns: int,
         agent_factory: AgentFactory | None = None,
+        session_co_dir: Path | None = None,
     ) -> None:
         self._model = model
         self._max_iterations = max_iterations
         self._yolo = yolo
         self._yolo_turns = yolo_turns
         self._agent_factory = agent_factory
+        self._session_co_dir = Path(session_co_dir or GLOBAL_CO_DIR)
         self._client: Client | None = None
         self._sessions: dict[str, _SessionRuntime] = {}
         # cwd and redirect_stdout are process-global.  ACP request handlers stay
@@ -418,7 +443,10 @@ class ConnectOnionACPAgent:
             protocol_version=selected_version,
             agent_capabilities=AgentCapabilities(
                 load_session=False,
-                session_capabilities=SessionCapabilities(),
+                session_capabilities=SessionCapabilities(
+                    resume=SessionResumeCapabilities(),
+                    close=SessionCloseCapabilities(),
+                ),
             ),
             agent_info=Implementation(
                 name="connectonion",
@@ -435,22 +463,17 @@ class ConnectOnionACPAgent:
         mcp_servers: list[Any] | None = None,
         **_kwargs: Any,
     ) -> NewSessionResponse:
-        if additional_directories:
-            raise RequestError.invalid_params(
-                {"details": "co ai ACP does not support additionalDirectories yet"}
-            )
-        if mcp_servers:
-            raise RequestError.invalid_params(
-                {"details": "co ai ACP does not support mcpServers yet"}
-            )
-
+        self._reject_unsupported_session_inputs(additional_directories, mcp_servers)
         project_dir = self._validate_cwd(cwd)
         acp_input = _ACPEventBridge(asyncio.get_running_loop())
+        session_id = new_session_id()
         try:
-            agent = await asyncio.to_thread(
-                self._build_agent,
+            runtime = await self._construct_runtime(
+                self._open_session_runtime,
                 project_dir,
                 acp_input,
+                session_id,
+                False,
             )
         except Exception:
             logger.exception("Failed to create co ai ACP session")
@@ -458,13 +481,74 @@ class ConnectOnionACPAgent:
                 -32603,
                 "Unable to create the coding agent session",
             ) from None
-        session_id = uuid4().hex
-        self._sessions[session_id] = _SessionRuntime(
-            cwd=project_dir,
-            agent=agent,
-            acp_input=acp_input,
-        )
+        self._sessions[session_id] = runtime
         return NewSessionResponse(session_id=session_id)
+
+    async def resume_session(
+        self,
+        session_id: str,
+        cwd: str,
+        additional_directories: list[str] | None = None,
+        mcp_servers: list[Any] | None = None,
+        **_kwargs: Any,
+    ) -> ResumeSessionResponse:
+        """Resume one persisted session without replaying its transcript."""
+
+        self._reject_unsupported_session_inputs(additional_directories, mcp_servers)
+        project_dir = self._validate_cwd(cwd)
+        if session_id in self._sessions:
+            raise RequestError(
+                -32000,
+                "Session is already open",
+                {"sessionId": session_id},
+            )
+        acp_input = _ACPEventBridge(asyncio.get_running_loop())
+        try:
+            runtime = await self._construct_runtime(
+                self._open_session_runtime,
+                project_dir,
+                acp_input,
+                session_id,
+                True,
+            )
+        except SessionSnapshotError as exc:
+            raise RequestError(
+                -32002,
+                "Unable to resume session",
+                {"details": str(exc)},
+            ) from None
+        except Exception:
+            logger.exception("Failed to resume co ai ACP session")
+            raise RequestError(
+                -32603,
+                "Unable to resume the coding agent session",
+            ) from None
+        self._sessions[session_id] = runtime
+        return ResumeSessionResponse()
+
+    async def close_session(
+        self,
+        session_id: str,
+        **_kwargs: Any,
+    ) -> CloseSessionResponse:
+        """Close one live runtime and release its exclusive disk lease."""
+
+        runtime = self._sessions.get(session_id)
+        if runtime is None:
+            raise RequestError(
+                -32002,
+                "Session not found",
+                {"sessionId": session_id},
+            )
+        close_task = self._ensure_close_task(runtime)
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            # Closing is an ownership boundary. Repeated caller cancellation
+            # must not release the request while its runtime can still mutate.
+            await self._settle_owned_task(close_task)
+            raise
+        return CloseSessionResponse()
 
     async def prompt(
         self,
@@ -488,6 +572,15 @@ class ConnectOnionACPAgent:
 
         prompt_text = self._prompt_text(prompt)
         async with runtime.prompt_lock:
+            if (
+                runtime.closing.is_set()
+                or self._sessions.get(session_id) is not runtime
+            ):
+                raise RequestError(
+                    -32002,
+                    "Session not found",
+                    {"sessionId": session_id},
+                )
             if self._client is None:
                 raise RequestError.internal_error(
                     {"details": "ACP client connection is not available"}
@@ -503,26 +596,58 @@ class ConnectOnionACPAgent:
                     prompt_text,
                 )
             )
+            operation: asyncio.Task[Any] | None = worker
+            commit: asyncio.Task[Any] | None = None
+            runtime.active_operation = worker
             try:
                 terminal, finished = await self._consume_generation(
                     runtime.acp_input,
                     generation,
                     session_id,
                 )
-                await worker
+                await asyncio.shield(worker)
+                runtime.active_operation = None
+                operation = None
                 if finished.error is not None:
                     raise finished.error
                 if terminal is None or terminal.stop_reason is None:
                     raise RuntimeError("Agent turn ended without an ACP stop reason")
+                if terminal.stop_reason in {"end_turn", "max_turn_requests"}:
+                    commit = asyncio.create_task(
+                        asyncio.to_thread(self._commit_runtime, runtime)
+                    )
+                    operation = commit
+                    runtime.active_operation = commit
+                    await asyncio.shield(commit)
+                else:
+                    operation = asyncio.create_task(
+                        asyncio.to_thread(self._restore_runtime, runtime)
+                    )
+                    runtime.active_operation = operation
+                    await asyncio.shield(operation)
+                runtime.active_operation = None
+                operation = None
             except asyncio.CancelledError:
                 runtime.acp_input.interrupt()
                 runtime.acp_input.retire_turn(generation)
-                await self._settle_failed_worker(worker)
+                if operation is not None:
+                    await self._settle_owned_task(operation)
+                # Atomic replacement is the commit point. If it completed,
+                # _commit_runtime also advanced the detached checkpoint and a
+                # cancelled waiter must not split disk from memory by rolling
+                # the successful transaction back. Before that point, restore
+                # the previous checkpoint.
+                if commit is None or not self._task_succeeded(commit):
+                    await self._restore_after_failure(runtime)
+                runtime.active_operation = None
                 raise
             except Exception:
                 runtime.acp_input.interrupt()
                 runtime.acp_input.retire_turn(generation)
-                await self._settle_failed_worker(worker)
+                if operation is not None:
+                    await self._settle_owned_task(operation)
+                await self._restore_after_failure(runtime)
+                runtime.active_operation = None
                 logger.exception("co ai ACP prompt failed for session %s", session_id)
                 raise RequestError(
                     -32603,
@@ -547,6 +672,45 @@ class ConnectOnionACPAgent:
             if runtime.prompt_active.is_set():
                 runtime.acp_input.interrupt()
 
+    async def close_all(self) -> None:
+        """Settle every prompt before releasing persistent session leases."""
+
+        runtimes = list(self._sessions.values())
+        close_tasks = [self._ensure_close_task(runtime) for runtime in runtimes]
+        # EOF cleanup is deliberately cancellation-resistant: the event loop
+        # must not disappear while a runtime-owned worker or writer is alive.
+        for close_task in close_tasks:
+            await self._settle_owned_task(close_task)
+
+    async def _construct_runtime(
+        self,
+        constructor: Callable[..., _SessionRuntime],
+        *args: Any,
+    ) -> _SessionRuntime:
+        """Finish threaded construction even if its ACP request is cancelled."""
+
+        construction = asyncio.create_task(asyncio.to_thread(constructor, *args))
+        try:
+            return await asyncio.shield(construction)
+        except asyncio.CancelledError:
+            await self._settle_owned_task(construction)
+            if self._task_succeeded(construction):
+                construction.result().session_lease.close()
+            raise
+
+    def _ensure_close_task(self, runtime: _SessionRuntime) -> asyncio.Task[None]:
+        runtime.closing.set()
+        runtime.acp_input.interrupt()
+        if runtime.close_task is None:
+            runtime.close_task = asyncio.create_task(self._finish_close(runtime))
+        return runtime.close_task
+
+    async def _finish_close(self, runtime: _SessionRuntime) -> None:
+        async with runtime.prompt_lock:
+            if self._sessions.get(runtime.session_id) is runtime:
+                self._sessions.pop(runtime.session_id)
+            runtime.session_lease.close()
+
     def _build_agent(
         self,
         project_dir: Path,
@@ -564,11 +728,139 @@ class ConnectOnionACPAgent:
                 max_iterations=self._max_iterations,
                 yolo=self._yolo,
                 yolo_turns=self._yolo_turns,
+                resumable=True,
             )
         # A missing io currently means "skip approvals".  ACP must instead
         # remain safe until request_permission is mapped in #475.
         agent.io = acp_input or _FailClosedACPInput()
         return agent
+
+    def _open_session_runtime(
+        self,
+        project_dir: Path,
+        acp_input: _ACPEventBridge,
+        session_id: str,
+        resume: bool,
+    ) -> _SessionRuntime:
+        """Acquire ownership, validate state, then construct one runtime."""
+
+        lease = acquire_session_lease(self._session_co_dir, session_id)
+        try:
+            if resume:
+                session, tools = load_snapshot(
+                    self._session_co_dir,
+                    session_id,
+                    cwd=project_dir,
+                )
+            else:
+                session, tools = None, {}
+
+            agent = self._build_agent(project_dir, acp_input)
+            if session is None:
+                session = self._fresh_persistent_session(agent, session_id)
+            restore_tool_state(agent, tools)
+            normalized_tools = capture_tool_state(agent)
+            if not resume:
+                save_snapshot(
+                    self._session_co_dir,
+                    session,
+                    normalized_tools,
+                    cwd=project_dir,
+                )
+            return _SessionRuntime(
+                session_id=session_id,
+                cwd=project_dir,
+                agent=agent,
+                acp_input=acp_input,
+                session_lease=lease,
+                last_good_session=copy.deepcopy(session),
+                last_good_tools=copy.deepcopy(normalized_tools),
+                session_for_next_prompt=copy.deepcopy(session),
+            )
+        except BaseException:
+            lease.close()
+            raise
+
+    def _commit_runtime(self, runtime: _SessionRuntime) -> None:
+        """Prepare every checkpoint before the final atomic commit point."""
+
+        session = copy.deepcopy(runtime.agent.current_session)
+        if not isinstance(session, dict):
+            raise SessionSnapshotError("Agent did not produce a session snapshot.")
+        session["session_id"] = runtime.session_id
+        tools = capture_tool_state(runtime.agent)
+        last_good_session = copy.deepcopy(session)
+        last_good_tools = copy.deepcopy(tools)
+        # Assignment and checkpoint preparation happen before disk commit. If
+        # any of them fails, prompt rollback can still rely on the old file.
+        runtime.agent.current_session = session
+        save_snapshot(
+            self._session_co_dir,
+            session,
+            tools,
+            cwd=runtime.cwd,
+        )
+        # os.replace inside save_snapshot is the final fallible commit step.
+        # These reference assignments cannot split the durable snapshot from
+        # the already-prepared in-memory checkpoint.
+        runtime.last_good_session = last_good_session
+        runtime.last_good_tools = last_good_tools
+
+    @staticmethod
+    def _restore_runtime(runtime: _SessionRuntime) -> None:
+        """Roll Agent and supported tool state back to the last disk commit."""
+
+        runtime.agent.current_session = copy.deepcopy(runtime.last_good_session)
+        restore_tool_state(
+            runtime.agent,
+            copy.deepcopy(runtime.last_good_tools),
+        )
+
+    async def _restore_after_failure(self, runtime: _SessionRuntime) -> None:
+        restore = asyncio.create_task(asyncio.to_thread(self._restore_runtime, runtime))
+        runtime.active_operation = restore
+        await self._settle_owned_task(restore)
+        if not self._task_succeeded(restore):
+            error = self._task_exception(restore)
+            logger.error(
+                "Failed to restore co ai ACP session %s",
+                runtime.session_id,
+                exc_info=(type(error), error, error.__traceback__) if error else None,
+            )
+            # Never keep serving a runtime whose in-memory state may have
+            # diverged from its last atomic snapshot. The worker is settled
+            # before this method runs, so a clean process may resume safely.
+            runtime.closing.set()
+            if self._sessions.get(runtime.session_id) is runtime:
+                self._sessions.pop(runtime.session_id)
+            runtime.session_lease.close()
+        runtime.active_operation = None
+
+    @staticmethod
+    def _fresh_persistent_session(agent: Any, session_id: str) -> dict[str, Any]:
+        return {
+            "session_id": session_id,
+            "messages": [{
+                "role": "system",
+                "content": str(getattr(agent, "system_prompt", "")),
+            }],
+            "trace": [],
+            "turn": 0,
+        }
+
+    @staticmethod
+    def _reject_unsupported_session_inputs(
+        additional_directories: list[str] | None,
+        mcp_servers: list[Any] | None,
+    ) -> None:
+        if additional_directories:
+            raise RequestError.invalid_params(
+                {"details": "co ai ACP does not support additionalDirectories yet"}
+            )
+        if mcp_servers:
+            raise RequestError.invalid_params(
+                {"details": "co ai ACP does not support mcpServers yet"}
+            )
 
     def _run_prompt_generation(
         self,
@@ -631,9 +923,35 @@ class ConnectOnionACPAgent:
                 )
 
     @staticmethod
-    async def _settle_failed_worker(worker: asyncio.Task[Any]) -> None:
-        with suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(asyncio.shield(worker), timeout=1.0)
+    async def _settle_owned_task(task: asyncio.Task[Any]) -> bool:
+        """Wait through repeated caller cancellation until ``task`` is done.
+
+        Returns whether this waiter was cancelled while settling. The child is
+        always shielded: cancelling an ACP request must never abandon a thread
+        that still owns or mutates persistent session state.
+        """
+
+        cancelled = False
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                cancelled = True
+            except BaseException:
+                break
+        with suppress(BaseException):
+            task.result()
+        return cancelled
+
+    @staticmethod
+    def _task_succeeded(task: asyncio.Task[Any]) -> bool:
+        return task.done() and not task.cancelled() and task.exception() is None
+
+    @staticmethod
+    def _task_exception(task: asyncio.Task[Any]) -> BaseException | None:
+        if not task.done() or task.cancelled():
+            return None
+        return task.exception()
 
     @staticmethod
     def _trace_length(agent: Any) -> int:
@@ -666,8 +984,15 @@ class ConnectOnionACPAgent:
 
     def _run_prompt(self, runtime: _SessionRuntime, prompt: str) -> Any:
         try:
+            session = runtime.session_for_next_prompt
+            runtime.session_for_next_prompt = None
             with self._process_context(runtime.cwd):
-                return runtime.agent.input(prompt)
+                if session is None:
+                    return runtime.agent.input(prompt)
+                return runtime.agent.input(
+                    prompt,
+                    session=copy.deepcopy(session),
+                )
         finally:
             runtime.prompt_active.clear()
 
@@ -735,6 +1060,13 @@ async def serve_acp(
         yolo_turns=yolo_turns,
     )
     try:
-        await run_agent(agent, input_stream=transport)
+        # ACP Python 0.12 gates the schema-v1.19 resume/close routes behind
+        # this transport flag even though their capability models are stable.
+        await run_agent(
+            agent,
+            input_stream=transport,
+            use_unstable_protocol=True,
+        )
     finally:
         agent.cancel_all()
+        await agent.close_all()

--- a/connectonion/cli/co_ai/one_shot_sessions.py
+++ b/connectonion/cli/co_ai/one_shot_sessions.py
@@ -1,7 +1,10 @@
 """Private, versioned snapshots for resumable ``co ai`` subprocess turns."""
 
+from __future__ import annotations
+
 import json
 import os
+import stat
 import tempfile
 import uuid
 from contextlib import contextmanager
@@ -9,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 SNAPSHOT_VERSION = 1
+_TODO_STATUSES = {"pending", "in_progress", "completed"}
 
 
 class SessionSnapshotError(ValueError):
@@ -39,20 +43,68 @@ def _session_path(co_dir: Path, canonical_id: str) -> Path:
     return _session_dir(co_dir) / f"{canonical_id}.json"
 
 
-def _resolved_cwd() -> str:
-    return str(Path.cwd().resolve())
+def _resolved_cwd(cwd: Path | str | None = None) -> str:
+    return str((Path.cwd() if cwd is None else Path(cwd)).resolve())
 
 
-@contextmanager
-def session_lock(co_dir: Path, session_id: str):
-    """Fail fast unless this process exclusively owns a resumed turn."""
+class SessionLease:
+    """Exclusive OS-backed ownership that can outlive one function call."""
+
+    def __init__(self, session_id: str, handle: Any) -> None:
+        self.session_id = session_id
+        self._handle = handle
+
+    @property
+    def closed(self) -> bool:
+        return self._handle is None
+
+    def close(self) -> None:
+        """Release ownership once; repeated shutdown paths are harmless."""
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+        handle.close()
+
+    def __enter__(self) -> SessionLease:
+        return self
+
+    def __exit__(self, *_exc_info: Any) -> None:
+        self.close()
+
+
+def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
+    """Fail fast unless this process can exclusively own ``session_id``."""
     canonical = _canonical_id(session_id)
     directory = _session_dir(co_dir)
     directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     if os.name != "nt":
         os.chmod(directory, 0o700)
     lock_path = directory / f"{canonical}.lock"
-    handle = lock_path.open("a+", encoding="utf-8")
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError:
+        raise SessionSnapshotError(
+            f"Session {canonical} lock is unavailable."
+        ) from None
+    try:
+        handle = os.fdopen(descriptor, "a+", encoding="utf-8")
+        descriptor = -1
+        if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+            raise OSError("session lock is not a regular file")
+        if hasattr(os, "fchmod"):
+            os.fchmod(handle.fileno(), 0o600)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        else:
+            handle.close()
+        raise SessionSnapshotError(
+            f"Session {canonical} lock is unavailable."
+        ) from None
     try:
         if os.name == "nt":
             import msvcrt
@@ -68,24 +120,35 @@ def session_lock(co_dir: Path, session_id: str):
         raise SessionSnapshotError(
             f"Session {canonical} is already running in another process."
         ) from None
+    return SessionLease(canonical, handle)
+
+
+@contextmanager
+def session_lock(co_dir: Path, session_id: str):
+    """Fail fast unless this process exclusively owns a resumed turn."""
+    lease = acquire_session_lease(co_dir, session_id)
     try:
         yield
     finally:
-        handle.close()
+        lease.close()
 
 
 def save_snapshot(
     co_dir: Path,
     session: dict[str, Any],
     tool_state: dict[str, Any] | None = None,
+    *,
+    cwd: Path | str | None = None,
 ) -> None:
     """Atomically persist one completed Agent turn."""
     session_id = _canonical_id(session.get("session_id"))
+    tools = {} if tool_state is None else tool_state
+    _validate_tool_state(tools, session_id)
     payload = {
         "version": SNAPSHOT_VERSION,
-        "cwd": _resolved_cwd(),
+        "cwd": _resolved_cwd(cwd),
         "session": session,
-        "tools": tool_state or {},
+        "tools": tools,
     }
     try:
         encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
@@ -114,7 +177,12 @@ def save_snapshot(
             Path(temporary).unlink(missing_ok=True)
 
 
-def load_snapshot(co_dir: Path, session_id: str) -> tuple[dict, dict]:
+def load_snapshot(
+    co_dir: Path,
+    session_id: str,
+    *,
+    cwd: Path | str | None = None,
+) -> tuple[dict, dict]:
     """Load and validate the exact snapshot named by ``session_id``."""
     canonical = _canonical_id(session_id)
     path = _session_path(co_dir, canonical)
@@ -133,7 +201,7 @@ def load_snapshot(co_dir: Path, session_id: str) -> tuple[dict, dict]:
     saved_cwd = payload.get("cwd")
     if not isinstance(saved_cwd, str) or not Path(saved_cwd).is_absolute():
         raise SessionSnapshotError(f"Session {canonical} has an invalid working directory.")
-    current_cwd = _resolved_cwd()
+    current_cwd = _resolved_cwd(cwd)
     if os.path.normcase(str(Path(saved_cwd).resolve())) != os.path.normcase(current_cwd):
         raise SessionSnapshotError(
             f"Session {canonical} belongs to {saved_cwd}; resume it from that directory."
@@ -150,12 +218,44 @@ def load_snapshot(co_dir: Path, session_id: str) -> tuple[dict, dict]:
         raise SessionSnapshotError(f"Session {canonical} has an invalid trace.")
     if not isinstance(session.get("turn"), int):
         raise SessionSnapshotError(f"Session {canonical} has an invalid turn counter.")
+    _validate_tool_state(tools, canonical)
     return session, tools
+
+
+def _validate_tool_state(state: Any, session_id: str) -> None:
+    """Validate every supported tool snapshot before constructing an Agent."""
+
+    if not isinstance(state, dict) or set(state) - {"todolist"}:
+        raise SessionSnapshotError(
+            f"Session {session_id} contains unsupported tool state."
+        )
+    if "todolist" not in state:
+        return
+    todos = state["todolist"]
+    if not isinstance(todos, list):
+        raise SessionSnapshotError(
+            f"Session {session_id} has invalid TodoList state."
+        )
+    required = {"content", "status", "active_form"}
+    for item in todos:
+        if (
+            not isinstance(item, dict)
+            or set(item) != required
+            or not isinstance(item["content"], str)
+            or not isinstance(item["status"], str)
+            or item["status"] not in _TODO_STATUSES
+            or not isinstance(item["active_form"], str)
+        ):
+            raise SessionSnapshotError(
+                f"Session {session_id} has invalid TodoList state."
+            )
 
 
 def capture_tool_state(agent) -> dict[str, Any]:
     """Capture only tool state with an explicit, private snapshot contract."""
-    todo = agent.tools.get_instance("todolist")
+    tools = getattr(agent, "tools", None)
+    get_instance = getattr(tools, "get_instance", None)
+    todo = get_instance("todolist") if callable(get_instance) else None
     return {"todolist": todo._dump_state()} if todo is not None else {}
 
 
@@ -163,7 +263,9 @@ def restore_tool_state(agent, state: dict[str, Any]) -> None:
     """Restore supported tool state without deserializing arbitrary objects."""
     if "todolist" not in state:
         return
-    todo = agent.tools.get_instance("todolist")
+    tools = getattr(agent, "tools", None)
+    get_instance = getattr(tools, "get_instance", None)
+    todo = get_instance("todolist") if callable(get_instance) else None
     if todo is None:
         raise SessionSnapshotError("This co ai build cannot restore TodoList state.")
     todo._load_state(state["todolist"])

--- a/docs/design-decisions/029-acp-persistent-session-ownership.md
+++ b/docs/design-decisions/029-acp-persistent-session-ownership.md
@@ -1,0 +1,102 @@
+# Design Decision: Persist ACP Sessions Under One Runtime-Long Lease
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Related:** [011 Global Config and Identity](011-global-config-identity-management.md), [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [019 Agent Lifecycle](019-agent-lifecycle-design.md), [021 Task Storage JSONL](021-task-storage-jsonl-design.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [026 Structured Turn Outcomes](026-structured-turn-outcomes.md), [028 ACP Ordered Event Bridge](028-acp-ordered-event-bridge.md)
+
+## Decision
+
+Persistent ACP sessions use the same private, versioned JSON envelope as
+machine-readable one-shot `co ai` sessions. A snapshot contains the complete
+JSON-compatible Agent session plus only tool state with an explicit snapshot
+contract. Its ID is a canonical UUID, its resolved working directory is part of
+its ownership boundary, and a completed write uses a private temporary file,
+`fsync`, and atomic replacement.
+
+`session/new` acquires an OS-backed exclusive lease and writes the initial
+empty snapshot before returning its ID. `session/resume` acquires that same
+lease, then validates the ID, snapshot version and shape, and requested working
+directory before constructing an Agent or granting it filesystem tools. The
+lease remains held across every prompt until `session/close`, stdio EOF, or
+failed runtime construction. Lock files are private regular files and symbolic
+links are not followed where the operating system supports that guarantee.
+The current tool contract accepts only TodoList items with string `content` and
+`active_form` fields plus a known `status`; unknown tools or malformed items
+fail before Agent construction.
+
+Each prompt is a transaction over a detached last-good session and supported
+tool-state checkpoint:
+
+- `end_turn` and `max_turn_requests` atomically persist the complete new state
+  after all ordered ACP updates have drained, then advance the checkpoint.
+- cancellation, refusal, Agent/provider failure, client update failure,
+  persistence failure, or async request cancellation before the commit phase
+  leaves the disk snapshot untouched and restores both in-memory session and
+  tool state.
+- after a successful terminal turn enters its commit phase, that operation is
+  cancellation-shielded. Atomic replacement is the commit point: success
+  advances disk and memory together even if the waiting request is cancelled;
+  failure restores the previous checkpoint. Ownership is retained until that
+  outcome is fully settled.
+- if rollback itself fails, the runtime is quarantined and releases its lease
+  only after its worker has settled; a clean runtime can then resume the last
+  disk checkpoint.
+
+Close and EOF mark a runtime unavailable, interrupt active work, wait until the
+worker can no longer mutate Agent state, and only then release ownership. This
+supersedes DD-028's bounded failed-worker settlement for persistent ACP
+runtimes. Releasing after a timeout would permit a new owner to resume while an
+old worker was still changing the same logical session.
+
+The adapter advertises ACP `session/resume` and `session/close`, keeps
+`loadSession=false`, and never replays historical transcript updates. The
+pinned ACP Python SDK gates these schema routes behind its
+`use_unstable_protocol` transport flag, so the production stdio server enables
+that compatibility flag while continuing to validate and return the official
+models.
+
+## Why
+
+Locking only the load and save calls prevents simultaneous file replacement but
+does not prevent two long-lived Agents from independently advancing the same
+snapshot. The later writer would silently erase the earlier conversation and
+tool state. Runtime-long ownership makes the single writer explicit.
+
+Skipping a failed save is also insufficient in a long-lived process. The
+failed turn has already mutated `current_session` and stateful tools, so a later
+successful prompt would otherwise commit those abandoned mutations. A detached
+checkpoint and rollback make the atomic disk boundary the actual conversation
+boundary.
+
+Resume is intentionally not transcript replay. An ACP client already owns what
+it rendered; resuming restores the Agent's private continuation state without
+duplicating old user, assistant, or tool updates on the wire.
+
+## Consequences
+
+Only one process or runtime can own a session ID at a time. Explicit close and
+normal EOF make it immediately resumable elsewhere without deleting its
+snapshot. A worker that ignores cooperative interruption can delay close: this
+is preferable to releasing a lease while that worker can still mutate state.
+Because commit is non-cancellable once started, a client that disconnects at
+that boundary must resume before deciding whether to retry its prompt.
+
+ACP runtimes omit process-local background task tools because their handles
+cannot survive a process boundary. Snapshot evolution requires a new explicit
+version and validation path. Listing, loading/replaying, forking, deletion,
+retention, and migrations remain separate features.
+
+## Rejected alternatives
+
+- **Lock each prompt only:** another runtime can load the same old snapshot
+  between prompts and later overwrite valid work.
+- **Release ownership after a shutdown timeout:** an abandoned worker can race
+  the new owner and violate the single-writer invariant.
+- **Keep only disk rollback:** the next prompt can persist mutations from the
+  failed turn.
+- **Pickle Agent and tool objects:** executable deserialization and
+  process-local handles are not a safe persistence contract.
+- **Replay history during resume:** duplicates client-visible events and
+  confuses restore with ACP `session/load`.
+- **Add a second ACP snapshot format:** creates divergent validation,
+  migration, and security behavior for the same Agent session.

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import textwrap
 from asyncio.subprocess import PIPE, Process
@@ -11,6 +12,7 @@ from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
+import acp as acp_package
 import pytest
 
 _FAKE_ACP_SERVER = textwrap.dedent(
@@ -23,6 +25,8 @@ _FAKE_ACP_SERVER = textwrap.dedent(
 
 
     class FakeAgent:
+        system_prompt = "system"
+
         def __init__(self):
             self.io = None
             self.current_session = {"trace": [], "turn": 0}
@@ -37,7 +41,11 @@ _FAKE_ACP_SERVER = textwrap.dedent(
             self.current_session["trace"].append(event)
             self.io.send(event)
 
-        def input(self, prompt):
+        def input(self, prompt, session=None):
+            if session is not None:
+                self.current_session = dict(session)
+                self.current_session["messages"] = list(session["messages"])
+                self.current_session["trace"] = list(session["trace"])
             print(f"fake agent received: {prompt}", flush=True)
             self.current_session["turn"] += 1
             if prompt == "large":
@@ -68,7 +76,14 @@ _FAKE_ACP_SERVER = textwrap.dedent(
 
 
 @asynccontextmanager
-async def _server():
+async def _server(state_root: Path):
+    child_env = dict(os.environ)
+    child_env["HOME"] = str(state_root)
+    repo_root = Path(__file__).resolve().parents[3]
+    acp_site_packages = Path(acp_package.__file__).resolve().parents[1]
+    child_env["PYTHONPATH"] = os.pathsep.join(
+        (str(repo_root), str(acp_site_packages))
+    )
     process = await asyncio.create_subprocess_exec(
         sys.executable,
         "-c",
@@ -76,6 +91,7 @@ async def _server():
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE,
+        env=child_env,
         limit=10 * 1024 * 1024,
     )
     try:
@@ -131,13 +147,7 @@ async def _initialize_and_create_session(
     process: Process,
     cwd: Path,
 ) -> str:
-    initialized, _ = await _request(
-        process,
-        1,
-        "initialize",
-        {"protocolVersion": 1, "clientCapabilities": {}},
-    )
-    assert initialized["result"]["protocolVersion"] == 1
+    await _initialize(process)
     created, _ = await _request(
         process,
         2,
@@ -147,15 +157,30 @@ async def _initialize_and_create_session(
     return created["result"]["sessionId"]
 
 
+async def _initialize(process: Process) -> None:
+    initialized, _ = await _request(
+        process,
+        1,
+        "initialize",
+        {"protocolVersion": 1, "clientCapabilities": {}},
+    )
+    assert initialized["result"]["protocolVersion"] == 1
+
+
 async def _close_stdin(process: Process) -> None:
     assert process.stdin is not None
     process.stdin.close()
     await process.stdin.wait_closed()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_project_lookup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
 @pytest.mark.asyncio
 async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_path):
-    async with _server() as process:
+    async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)
 
         response, notifications = await _request(
@@ -183,7 +208,7 @@ async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_pa
 
 @pytest.mark.asyncio
 async def test_acp_subprocess_eof_cancels_an_active_prompt(tmp_path):
-    async with _server() as process:
+    async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)
         await _send(
             process,
@@ -215,7 +240,7 @@ async def test_acp_subprocess_eof_cancels_an_active_prompt(tmp_path):
 
 @pytest.mark.asyncio
 async def test_acp_subprocess_preserves_a_large_response(tmp_path):
-    async with _server() as process:
+    async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)
 
         response, notifications = await _request(
@@ -235,3 +260,69 @@ async def test_acp_subprocess_preserves_a_large_response(tmp_path):
         assert response["result"]["stopReason"] == "end_turn"
         assert len(content) == 5_000_000
         assert content.startswith("xxx") and content.endswith("xxx")
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_lease_blocks_a_second_process_until_close(tmp_path):
+    state_root = tmp_path / "home"
+    async with _server(state_root) as owner, _server(state_root) as contender:
+        session_id = await _initialize_and_create_session(owner, tmp_path)
+        await _initialize(contender)
+
+        rejected, _ = await _request(
+            contender,
+            2,
+            "session/resume",
+            {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
+        )
+        assert rejected["error"]["code"] == -32002
+
+        closed, _ = await _request(
+            owner,
+            3,
+            "session/close",
+            {"sessionId": session_id},
+        )
+        assert closed["result"] == {}
+
+        resumed, notifications = await _request(
+            contender,
+            3,
+            "session/resume",
+            {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
+        )
+        assert resumed["result"] == {}
+        assert notifications == []
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_eof_releases_lease_for_later_resume(tmp_path):
+    state_root = tmp_path / "home"
+    async with _server(state_root) as first:
+        session_id = await _initialize_and_create_session(first, tmp_path)
+        await _close_stdin(first)
+        assert await asyncio.wait_for(first.wait(), timeout=2) == 0
+
+    async with _server(state_root) as second:
+        await _initialize(second)
+        resumed, notifications = await _request(
+            second,
+            2,
+            "session/resume",
+            {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
+        )
+        assert resumed["result"] == {}
+        assert notifications == []
+
+        response, notifications = await _request(
+            second,
+            3,
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "continued"}],
+            },
+        )
+        assert response["result"]["stopReason"] == "end_turn"
+        assert notifications[0]["params"]["update"]["content"]["text"] == (
+            "answer: continued"
+        )

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -7,6 +7,7 @@ import io
 import json
 import threading
 import time
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 
@@ -14,6 +15,7 @@ import pytest
 from acp import PROTOCOL_VERSION, RequestError, connect_to_agent, run_agent, text_block
 from acp.interfaces import Client
 
+from connectonion.cli.co_ai import acp_server
 from connectonion.cli.co_ai.acp_server import (
     ConnectOnionACPAgent,
     _FailClosedACPInput,
@@ -66,6 +68,8 @@ class _RecordingClient(Client):
 
 
 class _FakeAgent:
+    system_prompt = "system"
+
     def __init__(self) -> None:
         self.io: Any = None
         self.prompts: list[str] = []
@@ -81,7 +85,13 @@ class _FakeAgent:
         self.current_session["trace"].append(event)
         self.io.send(event)
 
-    def input(self, prompt: str) -> str:
+    def input(
+        self,
+        prompt: str,
+        session: dict[str, Any] | None = None,
+    ) -> str:
+        if session is not None:
+            self.current_session = deepcopy(session)
         print("deliberate fake-agent stdout noise")
         self.prompts.append(prompt)
         self.current_session["turn"] += 1
@@ -94,13 +104,25 @@ class _BlockingFakeAgent(_FakeAgent):
         super().__init__()
         self.started = threading.Event()
 
-    def input(self, prompt: str) -> str:
+    def input(
+        self,
+        prompt: str,
+        session: dict[str, Any] | None = None,
+    ) -> str:
+        if session is not None:
+            self.current_session = deepcopy(session)
         self.current_session["turn"] += 1
         self.started.set()
         while not self.io.receive_all("INTERRUPT"):
             time.sleep(0.01)
         self._finish("interrupted")
         return f"cancelled: {prompt}"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_acp_session_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(acp_server, "GLOBAL_CO_DIR", tmp_path / "acp-state")
+    monkeypatch.chdir(tmp_path)
 
 
 @pytest.mark.asyncio
@@ -236,7 +258,13 @@ def test_acp_approval_input_denies_sensitive_tools_unless_mode_is_explicit_ulw()
 @pytest.mark.asyncio
 async def test_acp_errors_do_not_echo_agent_exception_details(tmp_path):
     class _FailingAgent(_FakeAgent):
-        def input(self, prompt: str) -> str:
+        def input(
+            self,
+            prompt: str,
+            session: dict[str, Any] | None = None,
+        ) -> str:
+            if session is not None:
+                self.current_session = deepcopy(session)
             self.current_session["turn"] += 1
             self._finish("error")
             raise RuntimeError(f"secret-marker in {prompt}")

--- a/tests/unit/test_co_ai_acp_events.py
+++ b/tests/unit/test_co_ai_acp_events.py
@@ -196,6 +196,8 @@ class _Client:
 
 
 class _ScriptedAgent:
+    system_prompt = "system"
+
     def __init__(self, script: Callable[["_ScriptedAgent", str], str]) -> None:
         self.io: Any = None
         self.current_session: dict[str, Any] = {"trace": [], "turn": 0}
@@ -206,9 +208,21 @@ class _ScriptedAgent:
             self.current_session["trace"].append(event)
         self.io.send(event)
 
-    def input(self, prompt: str) -> str:
+    def input(
+        self,
+        prompt: str,
+        session: dict[str, Any] | None = None,
+    ) -> str:
+        if session is not None:
+            self.current_session = deepcopy(session)
         self.current_session["turn"] += 1
         return self._script(self, prompt)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_acp_session_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(acp_server, "GLOBAL_CO_DIR", tmp_path / "acp-state")
+    monkeypatch.chdir(tmp_path)
 
 
 def _server(agent: _ScriptedAgent) -> ConnectOnionACPAgent:

--- a/tests/unit/test_co_ai_acp_resume.py
+++ b/tests/unit/test_co_ai_acp_resume.py
@@ -1,0 +1,782 @@
+"""Persistent ACP session ownership and transactional resume behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import os
+import threading
+import time
+from typing import Any
+from uuid import UUID
+
+import pytest
+from acp import RequestError, text_block
+from acp.schema import CloseSessionResponse, ResumeSessionResponse
+
+from connectonion.cli.co_ai import acp_server
+from connectonion.cli.co_ai.acp_server import ConnectOnionACPAgent
+from connectonion.cli.co_ai.one_shot_sessions import (
+    SessionSnapshotError,
+    acquire_session_lease,
+    load_snapshot,
+    save_snapshot,
+    session_lock,
+)
+
+
+def _todo(content: str) -> dict[str, str]:
+    return {
+        "content": content,
+        "status": "pending",
+        "active_form": f"Working on {content}",
+    }
+
+
+class _Todo:
+    def __init__(self) -> None:
+        self.state: list[dict[str, str]] = []
+
+    def _dump_state(self) -> list[dict[str, str]]:
+        return copy.deepcopy(self.state)
+
+    def _load_state(self, state: list[dict[str, str]]) -> None:
+        self.state = copy.deepcopy(state)
+
+
+class _Tools:
+    def __init__(self) -> None:
+        self.todo = _Todo()
+
+    def get_instance(self, name: str, default: Any = None) -> Any:
+        return self.todo if name == "todolist" else default
+
+
+class _Client:
+    def __init__(self, *, fail_updates: bool = False) -> None:
+        self.fail_updates = fail_updates
+        self.updates: list[tuple[str, Any]] = []
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **_kwargs: Any,
+    ) -> None:
+        if self.fail_updates:
+            raise RuntimeError("private update transport failure")
+        self.updates.append((session_id, update))
+
+
+class _PersistentFakeAgent:
+    system_prompt = "system"
+
+    def __init__(self, actions: list[str] | None = None) -> None:
+        self.actions = list(actions or ["natural"])
+        self.current_session: dict[str, Any] | None = None
+        self.io: Any = None
+        self.tools = _Tools()
+        self.received_sessions: list[dict[str, Any] | None] = []
+        self.started = threading.Event()
+
+    def input(self, prompt: str, session: dict[str, Any] | None = None) -> str:
+        self.received_sessions.append(copy.deepcopy(session))
+        if session is not None:
+            self.current_session = copy.deepcopy(session)
+        if self.current_session is None:
+            self.current_session = {
+                "messages": [{"role": "system", "content": self.system_prompt}],
+                "trace": [],
+                "turn": 0,
+            }
+
+        action = self.actions.pop(0) if self.actions else "natural"
+        self.current_session["turn"] += 1
+        self.current_session["messages"].append({"role": "user", "content": prompt})
+        self.tools.todo.state.append(_todo(prompt))
+        self.started.set()
+        if action == "block":
+            while not self.io.receive_all("INTERRUPT"):
+                time.sleep(0.01)
+            action = "interrupted"
+
+        result = f"answer: {prompt}"
+        if action in {"natural", "max_iterations"}:
+            self.current_session["messages"].append({
+                "role": "assistant",
+                "content": result,
+            })
+        terminal = {
+            "type": "turn_result",
+            "turn": self.current_session["turn"],
+            "reason": action,
+            "usage": None,
+        }
+        self.current_session["trace"].append(terminal)
+        self.io.send(terminal)
+        if action == "error":
+            raise RuntimeError("private agent failure")
+        return result
+
+
+class _GateAgent(_PersistentFakeAgent):
+    """Keep a worker alive until a test explicitly permits it to finish."""
+
+    def __init__(self, actions: list[str] | None = None) -> None:
+        super().__init__(actions)
+        self.release = threading.Event()
+
+    def input(self, prompt: str, session: dict[str, Any] | None = None) -> str:
+        self.started.set()
+        self.release.wait()
+        return super().input(prompt, session=session)
+
+
+def _server(
+    state_dir,
+    factory,
+) -> ConnectOnionACPAgent:
+    return ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        session_co_dir=state_dir,
+    )
+
+
+def _project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project_lookup(tmp_path, monkeypatch):
+    """Keep project discovery independent from a developer's parent .co dir."""
+    monkeypatch.chdir(tmp_path)
+
+
+def test_explicit_session_lease_is_idempotently_closeable(tmp_path):
+    session_id = "6c1fd90a-e0bf-4363-bcc2-c1ae32643f39"
+    lease = acquire_session_lease(tmp_path, session_id)
+
+    with pytest.raises(SessionSnapshotError, match="already running"):
+        with session_lock(tmp_path, session_id):
+            pass
+
+    lease.close()
+    lease.close()
+    with session_lock(tmp_path, session_id):
+        pass
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="no O_NOFOLLOW")
+def test_session_lease_rejects_a_symlink_lock_without_touching_target(tmp_path):
+    session_id = "1f7aed9b-b25a-4472-9fbf-9625763ec743"
+    target = tmp_path / "target"
+    target.write_text("private", encoding="utf-8")
+    target.chmod(0o644)
+    lock_dir = tmp_path / "ai" / "sessions"
+    lock_dir.mkdir(parents=True)
+    (lock_dir / f"{session_id}.lock").symlink_to(target)
+
+    with pytest.raises(SessionSnapshotError, match="lock is unavailable"):
+        acquire_session_lease(tmp_path, session_id)
+
+    assert target.read_text(encoding="utf-8") == "private"
+    assert target.stat().st_mode & 0o777 == 0o644
+
+
+@pytest.mark.asyncio
+async def test_initialize_advertises_resume_and_close_but_not_load(tmp_path):
+    server = _server(tmp_path / "state", lambda **_: _PersistentFakeAgent())
+
+    initialized = await server.initialize(protocol_version=1)
+
+    capabilities = initialized.agent_capabilities
+    assert capabilities.load_session is False
+    assert capabilities.session_capabilities.resume is not None
+    assert capabilities.session_capabilities.close is not None
+
+
+@pytest.mark.asyncio
+async def test_new_session_persists_canonical_snapshot_and_holds_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _PersistentFakeAgent())
+
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    assert str(UUID(created.session_id)) == created.session_id
+    session, tools = load_snapshot(state_dir, created.session_id)
+    assert session == {
+        "session_id": created.session_id,
+        "messages": [{"role": "system", "content": "system"}],
+        "trace": [],
+        "turn": 0,
+    }
+    assert tools == {"todolist": []}
+    with pytest.raises(SessionSnapshotError, match="already running"):
+        with session_lock(state_dir, created.session_id):
+            pass
+
+    closed = await server.close_session(created.session_id)
+    assert isinstance(closed, CloseSessionResponse)
+    with session_lock(state_dir, created.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_session_and_tool_state_without_replay(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "8bb6aebe-4a92-4e1c-8bb0-f3c7743470db"
+    saved = {
+        "session_id": session_id,
+        "messages": [{"role": "system", "content": "old"}],
+        "trace": [{"type": "old"}],
+        "turn": 4,
+        "mode": "accept_edits",
+    }
+    save_snapshot(state_dir, saved, {"todolist": [_todo("old todo")]})
+    agent = _PersistentFakeAgent()
+    created_with: list[dict[str, Any]] = []
+
+    def factory(**kwargs: Any) -> _PersistentFakeAgent:
+        created_with.append(kwargs)
+        return agent
+
+    server = _server(state_dir, factory)
+    client = _Client()
+    server.on_connect(client)
+
+    resumed = await server.resume_session(session_id, str(project), mcp_servers=[])
+    assert isinstance(resumed, ResumeSessionResponse)
+    assert client.updates == []
+    assert created_with[0]["resumable"] is True
+
+    response = await server.prompt(session_id, [text_block("next")])
+
+    assert response.stop_reason == "end_turn"
+    assert agent.received_sessions[0]["turn"] == 4
+    assert agent.received_sessions[0]["mode"] == "accept_edits"
+    stored, tools = load_snapshot(state_dir, session_id)
+    assert stored["turn"] == 5
+    assert tools == {"todolist": [_todo("old todo"), _todo("next")]}
+    await server.close_session(session_id)
+
+
+@pytest.mark.asyncio
+async def test_runtime_lease_blocks_a_second_server_until_close(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    owner = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    contender = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    session = await owner.new_session(str(project), mcp_servers=[])
+
+    with pytest.raises(RequestError, match="Unable to resume session"):
+        await contender.resume_session(
+            session.session_id,
+            str(project),
+            mcp_servers=[],
+        )
+
+    await owner.close_session(session.session_id)
+    await contender.resume_session(session.session_id, str(project), mcp_servers=[])
+    await contender.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_wrong_cwd_before_agent_construction(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    other = tmp_path / "other"
+    other.mkdir()
+    state_dir = tmp_path / "state"
+    session_id = "7f02ea66-c266-4991-82bb-dc07ca461301"
+    save_snapshot(state_dir, {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    })
+    constructed = []
+    server = _server(
+        state_dir,
+        lambda **_: constructed.append(True) or _PersistentFakeAgent(),
+    )
+
+    with pytest.raises(RequestError):
+        await server.resume_session(session_id, str(other), mcp_servers=[])
+
+    assert constructed == []
+    with session_lock(state_dir, session_id):
+        pass
+    monkeypatch.chdir(project)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "snapshot",
+    ["missing", "corrupt", "old-version", "malformed-tool"],
+)
+async def test_resume_rejects_unusable_snapshots_before_agent_construction(
+    tmp_path,
+    monkeypatch,
+    snapshot,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "731948c4-1194-442b-b678-9b5d5a3871c4"
+    if snapshot != "missing":
+        session_dir = state_dir / "ai" / "sessions"
+        session_dir.mkdir(parents=True)
+        payload = "not json"
+        if snapshot == "old-version":
+            payload = json.dumps({"version": 0, "session": {}, "tools": {}})
+        elif snapshot == "malformed-tool":
+            payload = json.dumps({
+                "version": 1,
+                "cwd": str(project.resolve()),
+                "session": {
+                    "session_id": session_id,
+                    "messages": [],
+                    "trace": [],
+                    "turn": 0,
+                },
+                "tools": {"todolist": [{"content": "missing fields"}]},
+            })
+        (session_dir / f"{session_id}.json").write_text(
+            payload,
+            encoding="utf-8",
+        )
+    constructed = []
+    server = _server(
+        state_dir,
+        lambda **_: constructed.append(True) or _PersistentFakeAgent(),
+    )
+
+    with pytest.raises(RequestError, match="Unable to resume session"):
+        await server.resume_session(session_id, str(project), mcp_servers=[])
+
+    assert constructed == []
+    with session_lock(state_dir, session_id):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["new", "resume"])
+async def test_cancelled_runtime_construction_settles_and_releases_lease(
+    tmp_path,
+    monkeypatch,
+    operation,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "70d27939-748d-4f6a-8cc7-236e4029813f"
+    if operation == "resume":
+        save_snapshot(state_dir, {
+            "session_id": session_id,
+            "messages": [],
+            "trace": [],
+            "turn": 0,
+        })
+    server = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    real_open = server._open_session_runtime
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocked_open(*args: Any) -> Any:
+        started.set()
+        release.wait()
+        return real_open(*args)
+
+    monkeypatch.setattr(server, "_open_session_runtime", blocked_open)
+    if operation == "new":
+        opening = asyncio.create_task(server.new_session(str(project), mcp_servers=[]))
+    else:
+        opening = asyncio.create_task(
+            server.resume_session(session_id, str(project), mcp_servers=[])
+        )
+    await asyncio.wait_for(asyncio.to_thread(started.wait), timeout=1)
+
+    opening.cancel()
+    await asyncio.sleep(0)
+    opening.cancel()
+    assert not opening.done()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(opening, timeout=1)
+    assert server._sessions == {}
+    if operation == "new":
+        snapshots = list((state_dir / "ai" / "sessions").glob("*.json"))
+        assert len(snapshots) == 1
+        session_id = snapshots[0].stem
+    with session_lock(state_dir, session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_successful_turns_commit_in_order(tmp_path, monkeypatch):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _PersistentFakeAgent(["natural", "max_iterations"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    first = await server.prompt(session.session_id, [text_block("one")])
+    second = await server.prompt(session.session_id, [text_block("two")])
+
+    stored, tools = load_snapshot(state_dir, session.session_id)
+    assert first.stop_reason == "end_turn"
+    assert second.stop_reason == "max_turn_requests"
+    assert stored["turn"] == 2
+    assert [message["content"] for message in stored["messages"][-4:]] == [
+        "one",
+        "answer: one",
+        "two",
+        "answer: two",
+    ]
+    assert tools == {"todolist": [_todo("one"), _todo("two")]}
+    await server.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["interrupted", "error", "update"])
+async def test_unsuccessful_turn_rolls_back_disk_and_runtime(
+    tmp_path,
+    monkeypatch,
+    failure,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    action = "natural" if failure == "update" else failure
+    agent = _PersistentFakeAgent([action, "natural"])
+    server = _server(state_dir, lambda **_: agent)
+    client = _Client(fail_updates=failure == "update")
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+    before, before_tools = load_snapshot(state_dir, session.session_id)
+
+    if failure == "error" or failure == "update":
+        with pytest.raises(RequestError):
+            await server.prompt(session.session_id, [text_block("bad")])
+    else:
+        response = await server.prompt(session.session_id, [text_block("bad")])
+        assert response.stop_reason == "cancelled"
+
+    stored, tools = load_snapshot(state_dir, session.session_id)
+    assert stored == before
+    assert tools == before_tools
+    assert agent.current_session == before
+    assert agent.tools.todo.state == []
+
+    client.fail_updates = False
+    recovered = await server.prompt(session.session_id, [text_block("good")])
+    assert recovered.stop_reason == "end_turn"
+    stored, tools = load_snapshot(state_dir, session.session_id)
+    assert stored["turn"] == 1
+    assert tools == {"todolist": [_todo("good")]}
+    await server.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_restores_last_good_state(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _PersistentFakeAgent(["natural"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    before, _ = load_snapshot(state_dir, session.session_id)
+
+    def fail_save(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(acp_server, "save_snapshot", fail_save)
+    with pytest.raises(RequestError):
+        await server.prompt(session.session_id, [text_block("bad")])
+
+    stored, stored_tools = load_snapshot(state_dir, session.session_id)
+    assert stored == before
+    assert stored_tools == {"todolist": []}
+    assert agent.current_session == before
+    assert agent.tools.todo.state == []
+    await server.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_atomic_replace_is_the_last_fallible_commit_step(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _PersistentFakeAgent(["natural"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    real_save = acp_server.save_snapshot
+    real_deepcopy = acp_server.copy.deepcopy
+    committed = False
+
+    def tracked_save(*args: Any, **kwargs: Any) -> None:
+        nonlocal committed
+        real_save(*args, **kwargs)
+        committed = True
+
+    def reject_post_commit_copy(value: Any) -> Any:
+        if committed:
+            raise AssertionError("nothing fallible may run after atomic replace")
+        return real_deepcopy(value)
+
+    monkeypatch.setattr(acp_server, "save_snapshot", tracked_save)
+    monkeypatch.setattr(acp_server.copy, "deepcopy", reject_post_commit_copy)
+
+    response = await server.prompt(session.session_id, [text_block("durable")])
+
+    assert response.stop_reason == "end_turn"
+    stored, tools = load_snapshot(state_dir, session.session_id)
+    runtime = server._sessions[session.session_id]
+    assert stored == runtime.last_good_session == agent.current_session
+    assert tools == runtime.last_good_tools == {"todolist": [_todo("durable")]}
+    await server.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_commit_uses_explicit_cwd_without_a_fallible_context_exit(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _PersistentFakeAgent()
+    server = _server(state_dir, lambda **_: agent)
+    session = await server.new_session(str(project), mcp_servers=[])
+    runtime = server._sessions[session.session_id]
+    runtime.agent.current_session = copy.deepcopy(runtime.last_good_session)
+    runtime.agent.current_session["turn"] = 1
+    runtime.agent.current_session["messages"].append({
+        "role": "user",
+        "content": "explicit cwd",
+    })
+    runtime.agent.tools.todo.state.append(_todo("explicit cwd"))
+
+    def reject_process_context(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("snapshot commit must not change process cwd")
+
+    monkeypatch.setattr(server, "_process_context", reject_process_context)
+    monkeypatch.chdir(tmp_path)
+
+    server._commit_runtime(runtime)
+
+    stored, tools = load_snapshot(
+        state_dir,
+        session.session_id,
+        cwd=project,
+    )
+    assert stored == runtime.last_good_session == runtime.agent.current_session
+    assert tools == runtime.last_good_tools == {
+        "todolist": [_todo("explicit cwd")]
+    }
+    await server.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_failed_rollback_quarantines_runtime_and_releases_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _PersistentFakeAgent(["natural"]))
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    def fail_save(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("disk full")
+
+    def fail_restore(_runtime: Any) -> None:
+        raise RuntimeError("restore failed")
+
+    monkeypatch.setattr(acp_server, "save_snapshot", fail_save)
+    monkeypatch.setattr(server, "_restore_runtime", fail_restore)
+    with pytest.raises(RequestError):
+        await server.prompt(session.session_id, [text_block("bad")])
+
+    with pytest.raises(RequestError, match="Session not found"):
+        await server.prompt(session.session_id, [text_block("late")])
+    with session_lock(state_dir, session.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_close_interrupts_active_prompt_then_releases_ownership(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _PersistentFakeAgent(["block"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    prompt = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(agent.started.wait), timeout=1)
+
+    closed = await asyncio.wait_for(server.close_session(session.session_id), timeout=1)
+
+    assert isinstance(closed, CloseSessionResponse)
+    assert (await prompt).stop_reason == "cancelled"
+    with session_lock(state_dir, session.session_id):
+        pass
+    with pytest.raises(RequestError, match="Session not found"):
+        await server.prompt(session.session_id, [text_block("late")])
+
+
+@pytest.mark.asyncio
+async def test_repeated_prompt_cancellation_cannot_release_a_live_worker(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _GateAgent(["natural"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    before, _ = load_snapshot(state_dir, session.session_id)
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(agent.started.wait), timeout=1)
+
+    prompting.cancel()
+    await asyncio.sleep(0)
+    prompting.cancel()
+    closing = asyncio.create_task(server.close_session(session.session_id))
+    await asyncio.sleep(0)
+
+    assert not prompting.done()
+    assert not closing.done()
+    with pytest.raises(SessionSnapshotError, match="already running"):
+        with session_lock(state_dir, session.session_id):
+            pass
+
+    agent.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(prompting, timeout=1)
+    assert isinstance(await asyncio.wait_for(closing, timeout=1), CloseSessionResponse)
+    stored, _ = load_snapshot(state_dir, session.session_id)
+    assert stored == before
+    with session_lock(state_dir, session.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_still_finishes_before_releasing_ownership(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _GateAgent(["block"])
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(agent.started.wait), timeout=1)
+    closing = asyncio.create_task(server.close_session(session.session_id))
+    await asyncio.sleep(0)
+
+    closing.cancel()
+    await asyncio.sleep(0)
+    closing.cancel()
+    assert not closing.done()
+    with pytest.raises(SessionSnapshotError, match="already running"):
+        with session_lock(state_dir, session.session_id):
+            pass
+
+    agent.release.set()
+    assert (await asyncio.wait_for(prompting, timeout=1)).stop_reason == "cancelled"
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(closing, timeout=1)
+    with session_lock(state_dir, session.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cancelled_commit_and_eof_wait_for_the_atomic_writer(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _PersistentFakeAgent(["natural"]))
+    contender = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    server.on_connect(_Client())
+    session = await server.new_session(str(project), mcp_servers=[])
+    real_save = acp_server.save_snapshot
+    save_started = threading.Event()
+    allow_save = threading.Event()
+
+    def blocked_save(*args: Any, **kwargs: Any) -> None:
+        save_started.set()
+        allow_save.wait()
+        real_save(*args, **kwargs)
+
+    monkeypatch.setattr(acp_server, "save_snapshot", blocked_save)
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("committed")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(save_started.wait), timeout=1)
+
+    prompting.cancel()
+    await asyncio.sleep(0)
+    prompting.cancel()
+    eof_cleanup = asyncio.create_task(server.close_all())
+    await asyncio.sleep(0)
+
+    assert not prompting.done()
+    assert not eof_cleanup.done()
+    with pytest.raises(RequestError, match="Unable to resume session"):
+        await contender.resume_session(
+            session.session_id,
+            str(project),
+            mcp_servers=[],
+        )
+
+    allow_save.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(prompting, timeout=1)
+    await asyncio.wait_for(eof_cleanup, timeout=1)
+    stored, tools = load_snapshot(state_dir, session.session_id)
+    assert stored["turn"] == 1
+    assert tools == {"todolist": [_todo("committed")]}
+
+    await contender.resume_session(session.session_id, str(project), mcp_servers=[])
+    await contender.close_session(session.session_id)

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -20,6 +20,14 @@ from connectonion.useful_tools.todo_list import TodoList
 from tests.utils.mock_helpers import MockLLM
 
 
+def _todo(content):
+    return {
+        "content": content,
+        "status": "pending",
+        "active_form": f"Working on {content}",
+    }
+
+
 class _ToolRegistry:
     def __init__(self, todo=None):
         self.todo = todo
@@ -69,7 +77,7 @@ class _Agent:
             "turn": base.get("turn", 0) + 1,
             "mode": "ulw",
         }
-        self.tools.todo.state.append(prompt)
+        self.tools.todo.state.append(_todo(prompt))
         return "done"
 
 
@@ -84,11 +92,11 @@ def test_snapshot_round_trip_preserves_full_session_and_tool_state(tmp_path):
         "permissions": {"Bash(git *)": {"allowed": True}},
     }
 
-    save_snapshot(tmp_path, session, {"todolist": [{"content": "ship"}]})
+    save_snapshot(tmp_path, session, {"todolist": [_todo("ship")]})
     loaded_session, tool_state = load_snapshot(tmp_path, session_id)
 
     assert loaded_session == session
-    assert tool_state == {"todolist": [{"content": "ship"}]}
+    assert tool_state == {"todolist": [_todo("ship")]}
     if os.name != "nt":
         assert oct((tmp_path / "ai" / "sessions").stat().st_mode & 0o777) == "0o700"
         snapshot = tmp_path / "ai" / "sessions" / f"{session_id}.json"
@@ -258,7 +266,7 @@ def test_json_mode_emits_one_stdout_object_and_saves_resume_state(
     stored, tools = load_snapshot(tmp_path, envelope["session_id"])
     assert stored["mode"] == "ulw"
     assert stored["turn"] == 1
-    assert tools == {"todolist": ["first"]}
+    assert tools == {"todolist": [_todo("first")]}
 
 
 def test_resume_restores_messages_plugin_state_and_todos(tmp_path, monkeypatch, capsys):
@@ -272,7 +280,7 @@ def test_resume_restores_messages_plugin_state_and_todos(tmp_path, monkeypatch, 
             "turn": 4,
             "mode": "accept_edits",
         },
-        {"todolist": ["old todo"]},
+        {"todolist": [_todo("old todo")]},
     )
     agent = _Agent()
     monkeypatch.setattr("connectonion.cli.co_ai.agent.GLOBAL_CO_DIR", tmp_path)
@@ -284,7 +292,7 @@ def test_resume_restores_messages_plugin_state_and_todos(tmp_path, monkeypatch, 
     assert envelope["session_id"] == session_id
     assert agent.received_session["mode"] == "accept_edits"
     assert agent.received_session["turn"] == 4
-    assert agent.tools.todo.state == ["old todo", "next"]
+    assert agent.tools.todo.state == [_todo("old todo"), _todo("next")]
 
 
 def test_failed_resume_preserves_the_last_atomic_snapshot(
@@ -298,13 +306,13 @@ def test_failed_resume_preserves_the_last_atomic_snapshot(
         "turn": 4,
         "mode": "accept_edits",
     }
-    save_snapshot(tmp_path, original, {"todolist": ["old todo"]})
+    save_snapshot(tmp_path, original, {"todolist": [_todo("old todo")]})
 
     class BrokenResumeAgent(_Agent):
         def input(self, prompt, session=None):
             session["turn"] = 99
             session["messages"].append({"role": "user", "content": prompt})
-            self.tools.todo.state.append("uncommitted todo")
+            self.tools.todo.state.append(_todo("uncommitted todo"))
             raise RuntimeError("follow-up failed")
 
     monkeypatch.setattr("connectonion.cli.co_ai.agent.GLOBAL_CO_DIR", tmp_path)
@@ -327,7 +335,7 @@ def test_failed_resume_preserves_the_last_atomic_snapshot(
     }
     stored, tools = load_snapshot(tmp_path, session_id)
     assert stored == original
-    assert tools == {"todolist": ["old todo"]}
+    assert tools == {"todolist": [_todo("old todo")]}
 
 
 def test_json_failure_is_structured_and_nonzero(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- add persistent ACP `session/new`, `session/resume`, and `session/close` lifecycle support
- retain an exclusive cross-process lease for the full runtime lifetime
- persist only completed prompts through an atomic, non-cancellable commit boundary
- restore the last-good in-memory and on-disk state after cancellation or failure
- validate cwd ownership and snapshot/tool state before constructing an Agent

## Design

This follows DD-029 and the design discussion on #821. ACP reuses the canonical UUID and versioned snapshot envelope from #333, but keeps `loadSession=false`: resume restores state without transcript replay. Snapshot I/O receives an explicit cwd so async tasks never depend on process-wide `chdir` state.

The runtime owns construction, worker, commit, rollback, and close tasks. Close and stdio EOF wait for active work to settle before releasing the lease. Once a successful terminal turn enters the atomic commit phase, the commit wins even if the waiting request is cancelled.

## Verification

- 97 focused ACP/session tests passed, including 5 real stdio subprocess tests
- 25 dedicated resume/ownership adversarial tests passed
- full suite: 6563 passed, 18 skipped, 176 deselected, 0 failed
- Ruff passed for all changed files
- Ruff security rules and Bandit passed for production files
- locked runtime dependencies audited with no known vulnerabilities
- two independent expert review rounds: CLEAR, no blocking findings

GitHub still reports an open pytest tmpdir advisory, but `main` and this branch both declare `pytest>=9.0.3` and lock pytest 9.1.1. The open alert appears to be awaiting Dependabot re-evaluation; no vulnerable pytest version is introduced here.

## Stack and scope

- stacked on Draft PR #825 (`agent/co-acp-events-820`)
- docs are in the companion Draft PR in `connectonion-docs-site`
- no merge or release is performed by this PR

Closes #821
