### PR TITLE
ACP: bridge generation-scoped tool approvals

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -2,13 +2,14 @@
 
 The official ACP SDK owns JSON-RPC routing and schema validation.  This module
 only adapts the lifecycle to ConnectOnion: one real coding Agent per ACP
-session, an exclusive stdout protocol stream, and fail-closed approvals until
-the dedicated permission bridge lands.
+session, an exclusive stdout protocol stream, and generation-scoped permission
+requests that reuse ConnectOnion's existing approval policy.
 """
 
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import copy
 import logging
 import os
@@ -18,7 +19,7 @@ from collections import deque
 from contextlib import contextmanager, redirect_stdout, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Awaitable, Callable
 from uuid import uuid4
 
 from acp import (
@@ -35,12 +36,15 @@ from acp.schema import (
     ClientCapabilities,
     CloseSessionResponse,
     Implementation,
+    PermissionOption,
+    RequestPermissionResponse,
     ResourceContentBlock,
     ResumeSessionResponse,
     SessionCapabilities,
     SessionCloseCapabilities,
     SessionResumeCapabilities,
     TextContentBlock,
+    ToolCallUpdate,
 )
 
 from ..._version import __version__
@@ -64,12 +68,34 @@ from .one_shot_sessions import (
 )
 
 AgentFactory = Callable[..., Any]
+PermissionRequester = Callable[
+    [str, ToolCallUpdate, list[PermissionOption]],
+    Awaitable[RequestPermissionResponse],
+]
 ACP_EVENT_BUFFER_SIZE = 64
 logger = logging.getLogger(__name__)
 
+_ACP_PERMISSION_OPTIONS = (
+    PermissionOption(
+        option_id="allow_once",
+        name="Allow this call",
+        kind="allow_once",
+    ),
+    PermissionOption(
+        option_id="allow_session",
+        name="Allow for this session",
+        kind="allow_always",
+    ),
+    PermissionOption(
+        option_id="reject_once",
+        name="Reject and stop this turn",
+        kind="reject_once",
+    ),
+)
+
 
 class _FailClosedACPInput(IO):
-    """Keep sensitive tools closed until ACP approval bridging ships in #475."""
+    """Keep sensitive tools closed when no live ACP generation owns input."""
 
     def __init__(self) -> None:
         self._interrupted = threading.Event()
@@ -87,7 +113,7 @@ class _FailClosedACPInput(IO):
     def send(self, _message: dict[str, Any]) -> None:
         pass
 
-    def receive(self) -> dict[str, str]:
+    def receive(self) -> dict[str, Any]:
         if self.interrupted:
             return {"type": "INTERRUPT"}
         return {"type": "io_closed"}
@@ -104,7 +130,7 @@ class _FailClosedACPInput(IO):
             on_interrupt()
         return True
 
-    def receive_interruptibly(self, cancelled: threading.Event) -> dict[str, str]:
+    def receive_interruptibly(self, cancelled: threading.Event) -> dict[str, Any]:
         if self.interrupted or cancelled.is_set():
             return {"type": "INTERRUPT"}
         return {"type": "io_closed"}
@@ -132,6 +158,7 @@ class _TurnGeneration:
     terminal_claimed: bool = False
     terminal_reason: str | None = None
     assistant_claimed: bool = False
+    permission_future: concurrent.futures.Future[Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -154,8 +181,8 @@ class _ACPGenerationIO(IO):
     def send(self, message: dict[str, Any]) -> None:
         self._bridge.send_for(self._generation, message)
 
-    def receive(self) -> dict[str, str]:
-        return self._bridge.receive()
+    def receive(self) -> dict[str, Any]:
+        return self._bridge.receive_for(self._generation)
 
     def receive_all(self, message_type: str | None = None) -> list[Any]:
         return self._bridge.receive_all(message_type)
@@ -163,8 +190,8 @@ class _ACPGenerationIO(IO):
     def take_interrupt(self, on_interrupt: Callable[[], None] | None = None) -> bool:
         return self._bridge.take_interrupt(on_interrupt)
 
-    def receive_interruptibly(self, cancelled: threading.Event) -> dict[str, str]:
-        return self._bridge.receive_interruptibly(cancelled)
+    def receive_interruptibly(self, cancelled: threading.Event) -> dict[str, Any]:
+        return self._bridge.receive_for(self._generation, cancelled)
 
     def receive_all_interruptibly(
         self,
@@ -181,9 +208,16 @@ class _ACPGenerationIO(IO):
 class _ACPEventBridge(_FailClosedACPInput):
     """Move immutable Agent events from worker threads to one FIFO consumer."""
 
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        session_id: str,
+        permission_requester: PermissionRequester,
+    ) -> None:
         super().__init__()
         self._loop = loop
+        self._session_id = session_id
+        self._permission_requester = permission_requester
         self._outbound = threading.Condition()
         self._next_generation = 0
         self._active: _TurnGeneration | None = None
@@ -211,7 +245,118 @@ class _ACPEventBridge(_FailClosedACPInput):
         generation: _TurnGeneration,
         message: dict[str, Any],
     ) -> None:
+        if message.get("type") == "approval_needed":
+            self._request_permission_for(generation, message)
+            return
         self._send_for(generation, message, adapter_owned=False)
+
+    def _request_permission_for(
+        self,
+        generation: _TurnGeneration,
+        message: dict[str, Any],
+    ) -> None:
+        """Schedule one generation-owned ACP permission request."""
+
+        tool_call_id = message.get("tool_call_id")
+        tool = message.get("tool")
+        arguments = message.get("arguments")
+        if not isinstance(tool_call_id, str) or not tool_call_id:
+            raise ValueError("Approval request requires a tool-call ID")
+        if not isinstance(tool, str) or not tool:
+            raise ValueError("Approval request requires a tool name")
+        if not isinstance(arguments, dict):
+            raise ValueError("Approval request arguments must be a dictionary")
+
+        tool_call = ToolCallUpdate(
+            tool_call_id=tool_call_id,
+            title=tool,
+            status="pending",
+            raw_input=copy.deepcopy(arguments),
+        )
+        options = [option.model_copy(deep=True) for option in _ACP_PERMISSION_OPTIONS]
+        with self._outbound:
+            if self._active is not generation or self.interrupted:
+                raise RuntimeError("ACP prompt generation is not active")
+            if generation.permission_future is not None:
+                raise RuntimeError("ACP permission request is already pending")
+            generation.permission_future = asyncio.run_coroutine_threadsafe(
+                self._permission_requester(
+                    self._session_id,
+                    tool_call,
+                    options,
+                ),
+                self._loop,
+            )
+
+    def receive_for(
+        self,
+        generation: _TurnGeneration,
+        cancelled: threading.Event | None = None,
+    ) -> dict[str, Any]:
+        """Wait for one permission reply without blocking the event loop."""
+
+        while True:
+            with self._outbound:
+                future = generation.permission_future
+                interrupted = (
+                    self._active is not generation
+                    or self.interrupted
+                    or (cancelled is not None and cancelled.is_set())
+                )
+                if interrupted:
+                    generation.permission_future = None
+            if interrupted:
+                if future is not None:
+                    future.cancel()
+                return {"type": "INTERRUPT"}
+            if future is None:
+                return {"type": "io_closed"}
+
+            try:
+                response = future.result(timeout=0.05)
+            except concurrent.futures.TimeoutError:
+                continue
+            except BaseException:
+                with self._outbound:
+                    if generation.permission_future is future:
+                        generation.permission_future = None
+                return {"approved": False, "mode": "reject_hard"}
+
+            with self._outbound:
+                if (
+                    self._active is not generation
+                    or self.interrupted
+                    or (cancelled is not None and cancelled.is_set())
+                ):
+                    if generation.permission_future is future:
+                        generation.permission_future = None
+                    return {"type": "INTERRUPT"}
+                if generation.permission_future is not future:
+                    return {"type": "io_closed"}
+                generation.permission_future = None
+            return self._permission_response(response)
+
+    @staticmethod
+    def _permission_response(response: Any) -> dict[str, Any]:
+        """Map only exact advertised ACP outcomes to existing approval input."""
+
+        try:
+            parsed = (
+                response
+                if isinstance(response, RequestPermissionResponse)
+                else RequestPermissionResponse.model_validate(response)
+            )
+        except (TypeError, ValueError):
+            return {"approved": False, "mode": "reject_hard"}
+
+        outcome = parsed.outcome
+        if outcome.outcome != "selected":
+            return {"approved": False, "mode": "reject_hard"}
+        if outcome.option_id == "allow_once":
+            return {"approved": True, "scope": "once"}
+        if outcome.option_id == "allow_session":
+            return {"approved": True, "scope": "session"}
+        return {"approved": False, "mode": "reject_hard"}
 
     def send_terminal_for(
         self,
@@ -324,6 +469,8 @@ class _ACPEventBridge(_FailClosedACPInput):
         with self._outbound:
             if self._active is not generation:
                 return
+            permission_future = generation.permission_future
+            generation.permission_future = None
             ticket = generation.next_ticket
             generation.next_ticket += 1
             while (
@@ -345,13 +492,19 @@ class _ACPEventBridge(_FailClosedACPInput):
             generation.serving_ticket += 1
             self._active = None
             self._outbound.notify_all()
+        if permission_future is not None:
+            permission_future.cancel()
 
     def retire_turn(self, generation: _TurnGeneration) -> None:
         with self._outbound:
+            permission_future = generation.permission_future
+            generation.permission_future = None
             if self._active is generation:
                 self._active = None
             self._outbound.notify_all()
             self._signal(generation)
+        if permission_future is not None:
+            permission_future.cancel()
 
     async def next_for(self, generation: _TurnGeneration) -> Any:
         while True:
@@ -465,8 +618,12 @@ class ConnectOnionACPAgent:
     ) -> NewSessionResponse:
         self._reject_unsupported_session_inputs(additional_directories, mcp_servers)
         project_dir = self._validate_cwd(cwd)
-        acp_input = _ACPEventBridge(asyncio.get_running_loop())
         session_id = new_session_id()
+        acp_input = _ACPEventBridge(
+            asyncio.get_running_loop(),
+            session_id,
+            self._request_permission,
+        )
         try:
             runtime = await self._construct_runtime(
                 self._open_session_runtime,
@@ -502,7 +659,11 @@ class ConnectOnionACPAgent:
                 "Session is already open",
                 {"sessionId": session_id},
             )
-        acp_input = _ACPEventBridge(asyncio.get_running_loop())
+        acp_input = _ACPEventBridge(
+            asyncio.get_running_loop(),
+            session_id,
+            self._request_permission,
+        )
         try:
             runtime = await self._construct_runtime(
                 self._open_session_runtime,
@@ -665,6 +826,27 @@ class ConnectOnionACPAgent:
         if runtime is not None and runtime.prompt_active.is_set():
             runtime.acp_input.interrupt()
 
+    async def _request_permission(
+        self,
+        session_id: str,
+        tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
+    ) -> RequestPermissionResponse:
+        """Send one schema-validated permission request to the ACP client."""
+
+        if self._client is None:
+            raise RuntimeError("ACP client connection is not available")
+        response = await self._client.request_permission(
+            session_id=session_id,
+            tool_call=tool_call,
+            options=options,
+        )
+        return (
+            response
+            if isinstance(response, RequestPermissionResponse)
+            else RequestPermissionResponse.model_validate(response)
+        )
+
     def cancel_all(self) -> None:
         """Stop active turns before the stdio event loop shuts down."""
 
@@ -730,8 +912,8 @@ class ConnectOnionACPAgent:
                 yolo_turns=self._yolo_turns,
                 resumable=True,
             )
-        # A missing io currently means "skip approvals".  ACP must instead
-        # remain safe until request_permission is mapped in #475.
+        # A missing IO currently means "skip approvals". Keep construction
+        # fail-closed; live ACP sessions install their generation-bound bridge.
         agent.io = acp_input or _FailClosedACPInput()
         return agent
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -193,13 +193,13 @@ File Relationships:
                                     → raise ValueError or return
 """
 
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
-from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
+from ...core.events import after_iteration, after_user_input, before_each_tool, before_iteration
 from ...project import project_co_dir
-from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
+from .bash_parser import check_bash_chain_permitted
+from .constants import DANGEROUS_TOOLS, DEFAULT_MODE, FILE_EDIT_TOOLS, VALID_MODES
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -454,7 +454,7 @@ def check_approval(agent: 'Agent') -> None:
                 # Check if ALL commands in chain are permitted
                 permitted, reason, source = check_bash_chain_permitted(tool_args['command'], permissions)
                 if permitted:
-                    if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+                    if getattr(getattr(agent, 'logger', None), 'console', None):
                         agent.logger.console.log_permission_granted('bash', tool_args, source, reason)
                     return
 
@@ -483,7 +483,7 @@ def check_approval(agent: 'Agent') -> None:
                     # Pattern matched (and params matched if 'when' field exists)
                     reason = perm.get('reason', 'unknown')
                     source = perm.get('source', 'config')
-                    if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+                    if getattr(getattr(agent, 'logger', None), 'console', None):
                         agent.logger.console.log_permission_granted(tool_name, tool_args, source, reason)
                     return
 
@@ -494,7 +494,7 @@ def check_approval(agent: 'Agent') -> None:
         pending = agent.current_session.get('pending_tool')
         tool_name = pending['name'] if pending else 'unknown'
         tool_args = pending.get('arguments', {}) if pending else {}
-        if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+        if getattr(getattr(agent, 'logger', None), 'console', None):
             agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'ulw mode')
         return
 
@@ -520,7 +520,7 @@ def check_approval(agent: 'Agent') -> None:
     # =================================================================
     if mode == 'accept_edits':
         if tool_name in FILE_EDIT_TOOLS:
-            if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+            if getattr(getattr(agent, 'logger', None), 'console', None):
                 agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'accept_edits mode')
             return
         # Other dangerous tools fall through to approval logic
@@ -568,6 +568,7 @@ def check_approval(agent: 'Agent') -> None:
     # Send approval request to client
     approval_msg = {
         'type': 'approval_needed',
+        'tool_call_id': tool_id,
         'tool': approval_key,
         'arguments': tool_args,
         'description': tool_args.get('description', ''),

--- a/docs/design-decisions/030-acp-generation-scoped-tool-approvals.md
+++ b/docs/design-decisions/030-acp-generation-scoped-tool-approvals.md
@@ -1,0 +1,87 @@
+# Design Decision: Bind ACP Tool Approvals to One Prompt Generation
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Related:** [012 Tool Execution Separation](012-tool-execution-separation.md), [023 Trust Policy System](023-trust-policy-system-design.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [028 ACP Ordered Event Bridge](028-acp-ordered-event-bridge.md), [029 ACP Persistent Session Ownership](029-acp-persistent-session-ownership.md)
+
+## Decision
+
+ConnectOnion remains the policy owner for ACP tool calls. The existing
+`tool_approval` hook decides whether host configuration, a skill grant, a
+session grant, the active mode, or a non-overridable control-file refusal
+permits a call. ACP is used only when that policy reaches its existing human
+approval boundary.
+
+The synchronous Agent thread sends its existing `approval_needed` IO event
+with the current tool-call ID. The ACP generation bridge converts it to the
+official `session/request_permission` request and schedules the asynchronous
+client call on the bridge's owning event loop. The Agent thread waits through
+the same interruptible IO boundary used by hosted approvals; it never blocks
+the event loop.
+
+Every request is bound to one canonical session ID, one active prompt
+generation, and the existing tool-call ID. A generation accepts at most one
+pending permission request. Cancellation, close, EOF, or generation retirement
+wakes the waiter and cancels the local client future. A late remote response
+has no mailbox to enter and cannot authorize a later prompt or another
+session.
+
+The adapter advertises three stable options:
+
+- `allow_once` maps to the existing one-call approval;
+- `allow_session` uses ACP's `allow_always` presentation hint but is labelled
+  “Allow for this session” and maps only to ConnectOnion's session scope;
+- `reject_once` hard-rejects the current turn.
+
+Only those exact option IDs are accepted. ACP's cancelled outcome, unknown or
+malformed selected options, client errors, and disconnected transports all
+become hard rejection. This slice does not advertise `reject_always`, because
+ConnectOnion has no equivalent durable deny scope.
+
+A session grant remains part of the Agent session dictionary. It becomes
+durable only when the enclosing successful prompt crosses DD-029's atomic
+commit boundary. Cancellation, refusal, update failure, or persistence failure
+restores the prior checkpoint and therefore cannot accidentally retain a grant
+from an uncommitted turn.
+
+## Why
+
+Reimplementing tool classification in the ACP adapter would create a second
+authorization engine that could drift from host.yaml, bash-chain validation,
+skill permissions, control-file protection, and future policy work. Reusing
+the existing blocking gate keeps the decision in one place while the adapter
+only translates transport models.
+
+Session ID alone is not enough. An abandoned tool or late approval response
+can outlive its request, and tool-call IDs are not globally unique. Adding the
+prompt generation makes the reply a one-use capability with an explicit
+lifetime.
+
+ACP calls are asynchronous while Agent hooks are synchronous. Scheduling onto
+the event loop and waiting from the worker thread preserves both APIs without
+nested event loops, per-event tasks, or direct cross-thread client calls.
+
+## Consequences
+
+Allow-for-session survives ACP close/resume for the same logical session, but
+does not create a project-wide or cross-session grant. Tool side effects that
+completed before a later persistence failure cannot be rolled back; the
+permission state and conversation snapshot are rolled back together.
+
+The current ACP schema has no free-form feedback field in its permission
+outcome, so ACP rejection maps to ConnectOnion's hard-reject behavior without
+inventing text in protocol metadata. Session modes and a general
+principal/capability policy engine remain separate decisions.
+
+## Rejected alternatives
+
+- **An ACP-specific dangerous-tool list:** duplicates policy and inevitably
+  creates bypasses when one list changes.
+- **Accept any selected option ID:** lets a malformed or malicious client
+  manufacture authority the agent never offered.
+- **Treat `allow_always` as project-persistent:** ConnectOnion has no matching
+  audited grant contract in this milestone.
+- **Use only session ID for correlation:** stale replies can authorize a later
+  prompt with a reused tool-call ID.
+- **Block the event loop on the Agent approval gate:** deadlocks the very
+  client request needed to answer the gate.

--- a/tests/unit/test_co_ai_acp_approval.py
+++ b/tests/unit/test_co_ai_acp_approval.py
@@ -1,0 +1,567 @@
+"""ACP permission requests reuse ConnectOnion's fail-closed approval policy."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+
+import pytest
+from acp import RequestError, text_block
+from acp.schema import PermissionOption, RequestPermissionResponse, ToolCallUpdate
+
+from connectonion import Agent
+from connectonion.cli.co_ai import acp_server
+from connectonion.cli.co_ai.acp_server import ConnectOnionACPAgent, _ACPEventBridge
+from connectonion.cli.co_ai.one_shot_sessions import load_snapshot, session_lock
+from connectonion.core.llm import LLMResponse, ToolCall
+from connectonion.useful_plugins import tool_approval
+from tests.utils.mock_helpers import MockLLM
+
+
+def _selected(option_id: str) -> dict[str, Any]:
+    return {"outcome": {"outcome": "selected", "optionId": option_id}}
+
+
+def _cancelled() -> dict[str, Any]:
+    return {"outcome": {"outcome": "cancelled"}}
+
+
+class _ApprovalClient:
+    def __init__(self, *responses: Any) -> None:
+        self.responses = deque(responses)
+        self.requests: list[tuple[str, ToolCallUpdate, list[PermissionOption]]] = []
+        self.updates: list[tuple[str, Any]] = []
+
+    async def request_permission(
+        self,
+        session_id: str,
+        tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
+        **_kwargs: Any,
+    ) -> RequestPermissionResponse:
+        self.requests.append((session_id, tool_call, options))
+        response = self.responses.popleft()
+        if isinstance(response, BaseException):
+            raise response
+        return RequestPermissionResponse.model_validate(response)
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **_kwargs: Any,
+    ) -> None:
+        self.updates.append((session_id, update))
+
+
+class _BlockingApprovalClient(_ApprovalClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = asyncio.Event()
+        self.cancelled = asyncio.Event()
+
+    async def request_permission(self, **kwargs: Any) -> RequestPermissionResponse:
+        self.requests.append((
+            kwargs["session_id"],
+            kwargs["tool_call"],
+            kwargs["options"],
+        ))
+        self.started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.cancelled.set()
+            raise
+
+
+class _FailAfterSessionGrantClient(_ApprovalClient):
+    def __init__(self) -> None:
+        super().__init__(_selected("allow_session"))
+        self.granted = False
+
+    async def request_permission(self, **kwargs: Any) -> RequestPermissionResponse:
+        response = await super().request_permission(**kwargs)
+        self.granted = True
+        return response
+
+    async def session_update(self, **kwargs: Any) -> None:
+        if self.granted:
+            raise RuntimeError("private update marker")
+        await super().session_update(**kwargs)
+
+
+def _agent(
+    project,
+    executed: list[str],
+    tool_call_ids: list[str],
+) -> Agent:
+    def write(content: str) -> str:
+        """Record one deterministic write-like side effect."""
+
+        executed.append(content)
+        return f"wrote {content}"
+
+    responses: list[LLMResponse] = []
+    for index, tool_call_id in enumerate(tool_call_ids):
+        responses.extend([
+            LLMResponse(
+                content="",
+                tool_calls=[ToolCall(
+                    name="write",
+                    arguments={"content": f"value-{index}"},
+                    id=tool_call_id,
+                )],
+                raw_response={},
+            ),
+            LLMResponse(
+                content=f"finished-{index}",
+                tool_calls=[],
+                raw_response={},
+            ),
+        ])
+    return Agent(
+        name="acp-approval",
+        tools=[write],
+        plugins=[tool_approval],
+        llm=MockLLM(responses=responses),
+        max_iterations=max(2, len(tool_call_ids) * 2),
+        log=False,
+        quiet=True,
+        co_dir=project / ".co",
+    )
+
+
+def _server(state_dir, factory) -> ConnectOnionACPAgent:
+    return ConnectOnionACPAgent(
+        model="test",
+        max_iterations=4,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        session_co_dir=state_dir,
+    )
+
+
+def _project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def _dump(model: Any) -> dict[str, Any]:
+    return model.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+@pytest.mark.asyncio
+async def test_allow_once_uses_exact_acp_schema_without_persisting_grant(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    executed: list[str] = []
+    client = _ApprovalClient(_selected("allow_once"))
+    server = _server(
+        tmp_path / "state",
+        lambda **_: _agent(project, executed, ["same-call-id"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    response = await server.prompt(session.session_id, [text_block("write it")])
+
+    assert response.stop_reason == "end_turn"
+    assert executed == ["value-0"]
+    assert len(client.requests) == 1
+    request_session, tool_call, options = client.requests[0]
+    assert request_session == session.session_id
+    assert _dump(tool_call) == {
+        "toolCallId": "same-call-id",
+        "status": "pending",
+        "title": "write",
+        "rawInput": {"content": "value-0"},
+    }
+    assert [_dump(option) for option in options] == [
+        {
+            "optionId": "allow_once",
+            "name": "Allow this call",
+            "kind": "allow_once",
+        },
+        {
+            "optionId": "allow_session",
+            "name": "Allow for this session",
+            "kind": "allow_always",
+        },
+        {
+            "optionId": "reject_once",
+            "name": "Reject and stop this turn",
+            "kind": "reject_once",
+        },
+    ]
+    stored, _ = load_snapshot(tmp_path / "state", session.session_id)
+    assert "write" not in stored.get("permissions", {})
+
+
+@pytest.mark.asyncio
+async def test_allow_session_commits_once_and_survives_resume(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    first_executed: list[str] = []
+    first_client = _ApprovalClient(_selected("allow_session"))
+    first = _server(
+        state_dir,
+        lambda **_: _agent(project, first_executed, ["call-1"]),
+    )
+    first.on_connect(first_client)
+    session = await first.new_session(str(project), mcp_servers=[])
+
+    await first.prompt(session.session_id, [text_block("first")])
+
+    assert first_executed == ["value-0"]
+    assert len(first_client.requests) == 1
+    stored, _ = load_snapshot(state_dir, session.session_id)
+    assert stored["permissions"]["write"]["source"] == "user"
+    await first.close_session(session.session_id)
+
+    resumed_executed: list[str] = []
+    resumed_client = _ApprovalClient(RuntimeError("must not ask again"))
+    resumed = _server(
+        state_dir,
+        lambda **_: _agent(project, resumed_executed, ["call-3"]),
+    )
+    resumed.on_connect(resumed_client)
+    await resumed.resume_session(session.session_id, str(project), mcp_servers=[])
+    response = await resumed.prompt(
+        session.session_id,
+        [text_block("after resume")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert resumed_executed == ["value-0"]
+    assert resumed_client.requests == []
+    await resumed.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "decision",
+    [
+        _cancelled(),
+        _selected("unknown-option"),
+        _selected("reject_once"),
+        {"not": "an ACP outcome"},
+    ],
+)
+async def test_cancelled_unknown_and_reject_outcomes_execute_no_tool(
+    tmp_path,
+    monkeypatch,
+    decision,
+):
+    project = _project(tmp_path, monkeypatch)
+    executed: list[str] = []
+    client = _ApprovalClient(decision)
+    server = _server(
+        tmp_path / "state",
+        lambda **_: _agent(project, executed, ["call-reject"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    response = await server.prompt(session.session_id, [text_block("do not write")])
+
+    assert response.stop_reason == "refusal"
+    assert executed == []
+    stored, _ = load_snapshot(tmp_path / "state", session.session_id)
+    assert stored["turn"] == 0
+
+
+@pytest.mark.asyncio
+async def test_permission_transport_failure_rolls_back_without_private_details(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+    client = _ApprovalClient(RuntimeError("private transport marker"))
+    server = _server(
+        state_dir,
+        lambda **_: _agent(project, executed, ["call-fail"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    response = await server.prompt(
+        session.session_id,
+        [text_block("private prompt")],
+    )
+
+    assert response.stop_reason == "refusal"
+    assert executed == []
+    stored, _ = load_snapshot(state_dir, session.session_id)
+    assert stored["turn"] == 0
+
+
+@pytest.mark.asyncio
+async def test_session_grant_rolls_back_when_atomic_persistence_fails(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+    client = _ApprovalClient(_selected("allow_session"))
+    server = _server(
+        state_dir,
+        lambda **_: _agent(project, executed, ["call-save-fail"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    def fail_save(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("private persistence marker")
+
+    monkeypatch.setattr(acp_server, "save_snapshot", fail_save)
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.prompt(session.session_id, [text_block("write then fail")])
+
+    assert "private persistence marker" not in str(exc_info.value)
+    assert executed == ["value-0"]
+    runtime = server._sessions[session.session_id]
+    assert "write" not in runtime.agent.current_session.get("permissions", {})
+    stored, _ = load_snapshot(state_dir, session.session_id)
+    assert "write" not in stored.get("permissions", {})
+
+
+@pytest.mark.asyncio
+async def test_session_grant_rolls_back_when_a_later_acp_update_fails(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+    client = _FailAfterSessionGrantClient()
+    server = _server(
+        state_dir,
+        lambda **_: _agent(project, executed, ["call-update-fail"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+
+    with pytest.raises(RequestError) as exc_info:
+        await server.prompt(session.session_id, [text_block("write then fail")])
+
+    assert "private update marker" not in str(exc_info.value)
+    assert executed == ["value-0"]
+    runtime = server._sessions[session.session_id]
+    assert "write" not in runtime.agent.current_session.get("permissions", {})
+    stored, _ = load_snapshot(state_dir, session.session_id)
+    assert "write" not in stored.get("permissions", {})
+    assert stored["turn"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_while_permission_is_pending_is_bounded_and_fail_closed(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    executed: list[str] = []
+    client = _BlockingApprovalClient()
+    server = _server(
+        tmp_path / "state",
+        lambda **_: _agent(project, executed, ["call-blocked"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+
+    await server.cancel(session.session_id)
+    response = await asyncio.wait_for(prompting, timeout=1)
+
+    assert response.stop_reason == "cancelled"
+    assert executed == []
+    await asyncio.wait_for(client.cancelled.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_close_while_permission_is_pending_waits_then_releases_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+    client = _BlockingApprovalClient()
+    server = _server(
+        state_dir,
+        lambda **_: _agent(project, executed, ["call-close"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+
+    closing = asyncio.create_task(server.close_session(session.session_id))
+    response = await asyncio.wait_for(prompting, timeout=1)
+    await asyncio.wait_for(closing, timeout=1)
+
+    assert response.stop_reason == "cancelled"
+    assert executed == []
+    with session_lock(state_dir, session.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_eof_cleanup_while_permission_is_pending_releases_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+    client = _BlockingApprovalClient()
+    server = _server(
+        state_dir,
+        lambda **_: _agent(project, executed, ["call-eof"]),
+    )
+    server.on_connect(client)
+    session = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(session.session_id, [text_block("wait")])
+    )
+    await asyncio.wait_for(client.started.wait(), timeout=1)
+
+    closing = asyncio.create_task(server.close_all())
+    response = await asyncio.wait_for(prompting, timeout=1)
+    await asyncio.wait_for(closing, timeout=1)
+
+    assert response.stop_reason == "cancelled"
+    assert executed == []
+    assert server._sessions == {}
+    with session_lock(state_dir, session.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_identical_tool_ids_in_two_sessions_cannot_cross_decisions(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    executed: dict[str, list[str]] = {"first": [], "second": []}
+    created = 0
+
+    def factory(**_kwargs: Any) -> Agent:
+        nonlocal created
+        key = "first" if created == 0 else "second"
+        created += 1
+        return _agent(project, executed[key], ["shared-tool-id"])
+
+    class SessionClient(_ApprovalClient):
+        async def request_permission(self, **kwargs: Any) -> RequestPermissionResponse:
+            self.requests.append((
+                kwargs["session_id"],
+                kwargs["tool_call"],
+                kwargs["options"],
+            ))
+            option = "allow_once" if kwargs["session_id"] == first.session_id else "reject_once"
+            return RequestPermissionResponse.model_validate(_selected(option))
+
+    client = SessionClient()
+    server = _server(tmp_path / "state", factory)
+    server.on_connect(client)
+    first = await server.new_session(str(project), mcp_servers=[])
+    second = await server.new_session(str(project), mcp_servers=[])
+
+    first_result, second_result = await asyncio.gather(
+        server.prompt(first.session_id, [text_block("first")]),
+        server.prompt(second.session_id, [text_block("second")]),
+    )
+
+    assert first_result.stop_reason == "end_turn"
+    assert second_result.stop_reason == "refusal"
+    assert executed == {"first": ["value-0"], "second": []}
+    assert {session_id for session_id, _, _ in client.requests} == {
+        first.session_id,
+        second.session_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_late_cancelled_reply_cannot_enter_the_next_generation(
+    tmp_path,
+    monkeypatch,
+):
+    _project(tmp_path, monkeypatch)
+    first_started = asyncio.Event()
+    release_late_reply = asyncio.Event()
+    calls = 0
+
+    async def requester(
+        _session_id: str,
+        _tool_call: ToolCallUpdate,
+        _options: list[PermissionOption],
+    ) -> RequestPermissionResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                # Simulate a client/proxy that cannot abort its remote dialog.
+                await release_late_reply.wait()
+                return RequestPermissionResponse.model_validate(
+                    _selected("allow_once")
+                )
+        return RequestPermissionResponse.model_validate(_selected("reject_once"))
+
+    bridge = _ACPEventBridge(
+        asyncio.get_running_loop(),
+        "session-one",
+        requester,
+    )
+    first_generation, first_io = bridge.begin_turn()
+
+    def ask(io, tool_call_id: str) -> dict[str, Any]:
+        io.send({
+            "type": "approval_needed",
+            "tool_call_id": tool_call_id,
+            "tool": "write",
+            "arguments": {"content": tool_call_id},
+        })
+        return io.receive()
+
+    first_waiter = asyncio.create_task(
+        asyncio.to_thread(ask, first_io, "shared-id")
+    )
+    await asyncio.wait_for(first_started.wait(), timeout=1)
+    bridge.interrupt()
+    assert await asyncio.wait_for(first_waiter, timeout=1) == {
+        "type": "INTERRUPT"
+    }
+    bridge.retire_turn(first_generation)
+
+    second_generation, second_io = bridge.begin_turn()
+    second_response = await asyncio.wait_for(
+        asyncio.to_thread(ask, second_io, "shared-id"),
+        timeout=1,
+    )
+    assert second_response == {"approved": False, "mode": "reject_hard"}
+
+    release_late_reply.set()
+    await asyncio.sleep(0)
+    bridge.retire_turn(second_generation)
+    assert calls == 2


### PR DESCRIPTION
Stacked on #826. Implements #827, the approval-focused child of #475.

## Why

ACP Safe mode previously had to deny every sensitive tool because the blocking
ConnectOnion approval boundary had no ACP transport. This PR connects that
boundary without creating a second policy engine or allowing a reply to escape
the prompt that requested it.

## What changed

- preserve ConnectOnion `tool_approval` as the sole authority for host.yaml,
  skill/session grants, bash-chain validation, modes, and control-file refusal
- translate a required `approval_needed` event to official ACP
  `session/request_permission` using the existing tool-call ID
- bind the request future to one session and one active prompt generation
- accept only the advertised `allow_once`, `allow_session`, and `reject_once`
  option IDs; every malformed, cancelled, unknown, or failed response rejects
- cancel and retire pending permission futures on cancel, close, EOF, and turn
  retirement so late replies have no path into another generation
- persist allow-for-session only through #821's successful atomic prompt commit
- record the boundary and rejected alternatives in DD-030

## Security properties

- no ACP-specific tool allowlist or policy bypass
- exact option allowlist, fail closed on every unrecognised outcome
- no global mailbox keyed only by reusable tool-call ID
- no event-loop blocking while the synchronous Agent waits for approval
- failed update/persistence restores both in-memory and on-disk session grants
- no new dependencies or secrets

## Verification

- 111 ACP lifecycle/event/resume/approval/persistence tests passed, including 5
  real stdio E2E tests
- 14 focused adversarial approval cases cover exact wire schema, once/session
  scope, resume, malformed/unknown/cancelled responses, client failure,
  cancel/close/EOF, identical IDs across sessions, stale replies, and rollback
- Ruff and Python compilation passed
- Ruff security rules and Bandit passed on changed production files
- two independent expert reviews completed; one P2 test gap was fixed and then
  re-reviewed CLEAR; the concurrency/security review was CLEAR
- docs build passed separately (Next.js/TypeScript, 118 static pages); docs are
  in Draft PR https://github.com/wu-changxing/connectonion-docs-site/pull/42
- an attempted whole-repository local run was stopped after 3,626 passes when
  the borrowed editable virtualenv produced cross-suite asyncio/plugin and
  subprocess-path contamination; clean CI remains the full-suite authority

## Non-goals

No session-mode switching (#828), cross-session grants, policy-engine redesign,
merge, release, or Night Runner automation.
