### PR TITLE
feat(acp): enforce session mode authority

### DIFF
--- a/connectonion/cli/co_ai/acp_events.py
+++ b/connectonion/cli/co_ai/acp_events.py
@@ -9,15 +9,23 @@ from acp import text_block, tool_content
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
+    CurrentModeUpdate,
     StopReason,
     ToolCallProgress,
     ToolCallStart,
     Usage,
 )
 
-ACPUpdate = AgentMessageChunk | AgentThoughtChunk | ToolCallStart | ToolCallProgress
+ACPUpdate = (
+    AgentMessageChunk
+    | AgentThoughtChunk
+    | CurrentModeUpdate
+    | ToolCallStart
+    | ToolCallProgress
+)
 STREAMED_AGENT_EVENT_TYPES = frozenset({
     "assistant",
+    "mode_changed",
     "thinking",
     "tool_call",
     "tool_result",
@@ -53,6 +61,8 @@ def map_agent_event(event: Mapping[str, Any]) -> ACPEventMapping:
         return ACPEventMapping(updates=(_thought(event),))
     if event_type == "assistant":
         return ACPEventMapping(updates=(_assistant(event),))
+    if event_type == "mode_changed":
+        return ACPEventMapping(updates=(_current_mode(event),))
     if event_type == "turn_result":
         return ACPEventMapping(terminal=_terminal(event))
     return ACPEventMapping()
@@ -102,6 +112,16 @@ def _assistant(event: Mapping[str, Any]) -> AgentMessageChunk:
         session_update="agent_message_chunk",
         message_id=_required_string(event, "message_id"),
         content=text_block(_required_string(event, "content")),
+    )
+
+
+def _current_mode(event: Mapping[str, Any]) -> CurrentModeUpdate:
+    mode = _required_string(event, "mode")
+    if mode not in {"safe", "accept_edits", "ulw"}:
+        raise ValueError(f"Unsupported Agent mode: {mode!r}")
+    return CurrentModeUpdate(
+        session_update="current_mode_update",
+        current_mode_id=mode,
     )
 
 

--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -35,6 +35,7 @@ from acp.schema import (
     AgentCapabilities,
     ClientCapabilities,
     CloseSessionResponse,
+    CurrentModeUpdate,
     Implementation,
     PermissionOption,
     RequestPermissionResponse,
@@ -42,7 +43,10 @@ from acp.schema import (
     ResumeSessionResponse,
     SessionCapabilities,
     SessionCloseCapabilities,
+    SessionMode,
+    SessionModeState,
     SessionResumeCapabilities,
+    SetSessionModeResponse,
     TextContentBlock,
     ToolCallUpdate,
 )
@@ -92,6 +96,26 @@ _ACP_PERMISSION_OPTIONS = (
         kind="reject_once",
     ),
 )
+
+_ACP_SESSION_MODES = (
+    SessionMode(
+        id="safe",
+        name="Safe",
+        description="Ask before tools with side effects.",
+    ),
+    SessionMode(
+        id="accept_edits",
+        name="Auto",
+        description="Apply file edits automatically; ask before other risky tools.",
+    ),
+    SessionMode(
+        id="ulw",
+        name="ULW",
+        description="Run autonomously within the launch-time turn budget.",
+    ),
+)
+_ACP_MODE_IDS = frozenset(mode.id for mode in _ACP_SESSION_MODES)
+_ULW_STATE_KEYS = ("skip_tool_approval", "ulw_turns", "ulw_turns_used")
 
 
 class _FailClosedACPInput(IO):
@@ -639,7 +663,10 @@ class ConnectOnionACPAgent:
                 "Unable to create the coding agent session",
             ) from None
         self._sessions[session_id] = runtime
-        return NewSessionResponse(session_id=session_id)
+        return NewSessionResponse(
+            session_id=session_id,
+            modes=self._session_mode_state(runtime),
+        )
 
     async def resume_session(
         self,
@@ -685,7 +712,69 @@ class ConnectOnionACPAgent:
                 "Unable to resume the coding agent session",
             ) from None
         self._sessions[session_id] = runtime
-        return ResumeSessionResponse()
+        return ResumeSessionResponse(modes=self._session_mode_state(runtime))
+
+    async def set_session_mode(
+        self,
+        session_id: str,
+        mode_id: str,
+        **_kwargs: Any,
+    ) -> SetSessionModeResponse:
+        """Persist one idle mode change without exceeding launch authority."""
+
+        runtime = self._sessions.get(session_id)
+        if runtime is None:
+            raise RequestError(
+                -32002,
+                "Session not found",
+                {"sessionId": session_id},
+            )
+        if mode_id not in _ACP_MODE_IDS:
+            raise RequestError.invalid_params(
+                {"details": "Unsupported session mode"}
+            )
+        if mode_id == "ulw" and not self._yolo:
+            raise RequestError.invalid_params(
+                {"details": "ULW mode was not authorized when ACP started"}
+            )
+        if runtime.prompt_lock.locked() or runtime.prompt_active.is_set():
+            raise RequestError(
+                -32000,
+                "Session is busy",
+                {"sessionId": session_id},
+            )
+
+        async with runtime.prompt_lock:
+            if (
+                runtime.closing.is_set()
+                or self._sessions.get(session_id) is not runtime
+            ):
+                raise RequestError(
+                    -32002,
+                    "Session not found",
+                    {"sessionId": session_id},
+                )
+            operation = asyncio.create_task(
+                asyncio.to_thread(self._commit_mode, runtime, mode_id)
+            )
+            runtime.active_operation = operation
+            try:
+                await asyncio.shield(operation)
+            except asyncio.CancelledError:
+                await self._settle_owned_task(operation)
+                raise
+            except Exception:
+                logger.exception(
+                    "Failed to change co ai ACP mode for session %s",
+                    session_id,
+                )
+                raise RequestError(
+                    -32603,
+                    "Unable to change session mode",
+                ) from None
+            finally:
+                runtime.active_operation = None
+        return SetSessionModeResponse()
 
     async def close_session(
         self,
@@ -761,7 +850,7 @@ class ConnectOnionACPAgent:
             commit: asyncio.Task[Any] | None = None
             runtime.active_operation = worker
             try:
-                terminal, finished = await self._consume_generation(
+                terminal, finished, current_mode_update = await self._consume_generation(
                     runtime.acp_input,
                     generation,
                     session_id,
@@ -774,12 +863,25 @@ class ConnectOnionACPAgent:
                 if terminal is None or terminal.stop_reason is None:
                     raise RuntimeError("Agent turn ended without an ACP stop reason")
                 if terminal.stop_reason in {"end_turn", "max_turn_requests"}:
+                    if current_mode_update is not None and (
+                        not isinstance(runtime.agent.current_session, dict)
+                        or runtime.agent.current_session.get("mode")
+                        != current_mode_update.current_mode_id
+                    ):
+                        raise RuntimeError(
+                            "Agent mode event does not match session state"
+                        )
                     commit = asyncio.create_task(
                         asyncio.to_thread(self._commit_runtime, runtime)
                     )
                     operation = commit
                     runtime.active_operation = commit
                     await asyncio.shield(commit)
+                    if current_mode_update is not None:
+                        await self._publish_committed_mode(
+                            runtime,
+                            current_mode_update,
+                        )
                 else:
                     operation = asyncio.create_task(
                         asyncio.to_thread(self._restore_runtime, runtime)
@@ -940,6 +1042,15 @@ class ConnectOnionACPAgent:
             agent = self._build_agent(project_dir, acp_input)
             if session is None:
                 session = self._fresh_persistent_session(agent, session_id)
+            else:
+                session = self._normalized_session_mode(session)
+            if hasattr(agent, "_yolo_turns"):
+                # In ACP, --yolo is an authority ceiling rather than a request
+                # to re-arm ULW before every input. The persisted session below
+                # already carries the exact current mode and bounded budget.
+                agent._yolo_turns = None
+            if hasattr(agent, "_yolo_needs_activation"):
+                agent._yolo_needs_activation = False
             restore_tool_state(agent, tools)
             normalized_tools = capture_tool_state(agent)
             if not resume:
@@ -970,6 +1081,7 @@ class ConnectOnionACPAgent:
         if not isinstance(session, dict):
             raise SessionSnapshotError("Agent did not produce a session snapshot.")
         session["session_id"] = runtime.session_id
+        session = self._normalized_session_mode(session)
         tools = capture_tool_state(runtime.agent)
         last_good_session = copy.deepcopy(session)
         last_good_tools = copy.deepcopy(tools)
@@ -1018,9 +1130,12 @@ class ConnectOnionACPAgent:
             runtime.session_lease.close()
         runtime.active_operation = None
 
-    @staticmethod
-    def _fresh_persistent_session(agent: Any, session_id: str) -> dict[str, Any]:
-        return {
+    def _fresh_persistent_session(
+        self,
+        agent: Any,
+        session_id: str,
+    ) -> dict[str, Any]:
+        session = {
             "session_id": session_id,
             "messages": [{
                 "role": "system",
@@ -1028,7 +1143,97 @@ class ConnectOnionACPAgent:
             }],
             "trace": [],
             "turn": 0,
+            "mode": "safe",
         }
+        if self._yolo:
+            self._apply_mode(session, "ulw")
+        return self._normalized_session_mode(session)
+
+    def _session_mode_state(self, runtime: _SessionRuntime) -> SessionModeState:
+        modes = _ACP_SESSION_MODES if self._yolo else _ACP_SESSION_MODES[:2]
+        return SessionModeState(
+            current_mode_id=runtime.last_good_session["mode"],
+            available_modes=[mode.model_copy(deep=True) for mode in modes],
+        )
+
+    def _normalized_session_mode(
+        self,
+        session: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Validate persisted authority-bearing mode state fail closed."""
+
+        normalized = copy.deepcopy(session)
+        mode = normalized.get("mode", "safe")
+        if not isinstance(mode, str) or mode not in _ACP_MODE_IDS:
+            raise SessionSnapshotError("Session has an unsupported mode.")
+        if mode == "ulw":
+            if not self._yolo:
+                raise SessionSnapshotError(
+                    "Session requires ULW launch authority."
+                )
+            turns = normalized.get("ulw_turns")
+            turns_used = normalized.get("ulw_turns_used")
+            if (
+                isinstance(turns, bool)
+                or not isinstance(turns, int)
+                or turns <= 0
+                or isinstance(turns_used, bool)
+                or not isinstance(turns_used, int)
+                or turns_used < 0
+                or turns_used >= turns
+                or isinstance(self._yolo_turns, bool)
+                or not isinstance(self._yolo_turns, int)
+                or self._yolo_turns <= 0
+                or turns - turns_used > self._yolo_turns
+                or normalized.get("skip_tool_approval") is not True
+            ):
+                raise SessionSnapshotError("Session has invalid ULW state.")
+        elif any(key in normalized for key in _ULW_STATE_KEYS):
+            raise SessionSnapshotError(
+                "Session has ULW authority outside ULW mode."
+            )
+        normalized["mode"] = mode
+        return normalized
+
+    def _apply_mode(self, session: dict[str, Any], mode: str) -> None:
+        for key in _ULW_STATE_KEYS:
+            session.pop(key, None)
+        session["mode"] = mode
+        if mode == "ulw":
+            session["ulw_turns"] = self._yolo_turns
+            session["ulw_turns_used"] = 0
+            session["skip_tool_approval"] = True
+
+    def _commit_mode(self, runtime: _SessionRuntime, mode: str) -> None:
+        """Write the detached mode checkpoint before exposing it in memory."""
+
+        session = copy.deepcopy(runtime.last_good_session)
+        if session.get("mode") == mode:
+            return
+        self._apply_mode(session, mode)
+        session = self._normalized_session_mode(session)
+        tools = copy.deepcopy(runtime.last_good_tools)
+        agent_session = copy.deepcopy(session)
+        last_good_session = copy.deepcopy(session)
+        next_prompt_session = (
+            copy.deepcopy(session)
+            if runtime.session_for_next_prompt is not None
+            else None
+        )
+        save_snapshot(
+            self._session_co_dir,
+            session,
+            tools,
+            cwd=runtime.cwd,
+        )
+        runtime.agent.current_session = agent_session
+        runtime.last_good_session = last_good_session
+        if next_prompt_session is not None:
+            runtime.session_for_next_prompt = next_prompt_session
+        if hasattr(runtime.agent, "_yolo_turns"):
+            runtime.agent._yolo_turns = None
+        if hasattr(runtime.agent, "_yolo_needs_activation"):
+            runtime.agent._yolo_needs_activation = False
 
     @staticmethod
     def _reject_unsupported_session_inputs(
@@ -1087,22 +1292,62 @@ class ConnectOnionACPAgent:
         bridge: _ACPEventBridge,
         generation: _TurnGeneration,
         session_id: str,
-    ) -> tuple[ACPTerminal | None, _TurnFinished]:
+    ) -> tuple[ACPTerminal | None, _TurnFinished, CurrentModeUpdate | None]:
         terminal = None
+        current_mode_update = None
         while True:
             item = await bridge.next_for(generation)
             if isinstance(item, _TurnFinished):
-                return terminal, item
+                return terminal, item, current_mode_update
             mapped = map_agent_event(item)
             if mapped.terminal is not None:
                 if terminal is not None:
                     raise RuntimeError("Agent turn emitted more than one terminal event")
                 terminal = mapped.terminal
             for update in mapped.updates:
+                if isinstance(update, CurrentModeUpdate):
+                    current_mode_update = update
+                    continue
                 await self._client.session_update(
                     session_id=session_id,
                     update=update,
                 )
+
+    async def _publish_committed_mode(
+        self,
+        runtime: _SessionRuntime,
+        update: CurrentModeUpdate,
+    ) -> None:
+        """Announce internal mode only after its snapshot is durable."""
+
+        try:
+            await self._client.session_update(
+                session_id=runtime.session_id,
+                update=update,
+            )
+        except asyncio.CancelledError:
+            self._quarantine_mode_desync(runtime)
+            raise
+        except Exception:
+            # The disk commit is already authoritative. Rolling memory back
+            # here would split it from disk. The client may still display a
+            # less privileged mode, so quarantine this runtime before it can
+            # execute another prompt. Reconnect/resume re-advertises the exact
+            # durable mode while the released lease keeps that path available.
+            logger.warning(
+                "Unable to publish committed ACP mode for session %s",
+                runtime.session_id,
+                exc_info=True,
+            )
+            self._quarantine_mode_desync(runtime)
+
+    def _quarantine_mode_desync(self, runtime: _SessionRuntime) -> None:
+        """Retire a runtime whose client missed a committed policy change."""
+
+        runtime.closing.set()
+        if self._sessions.get(runtime.session_id) is runtime:
+            self._sessions.pop(runtime.session_id)
+        runtime.session_lease.close()
 
     @staticmethod
     async def _settle_owned_task(task: asyncio.Task[Any]) -> bool:

--- a/docs/design-decisions/031-acp-session-mode-authority.md
+++ b/docs/design-decisions/031-acp-session-mode-authority.md
@@ -1,0 +1,105 @@
+# DD-031: ACP session modes stay below launch authority
+
+**Status:** Accepted
+
+**Date:** 2026-08-10
+
+## Context
+
+ACP can advertise session modes and lets a client request `session/set_mode`.
+ConnectOnion already persists `safe`, `accept_edits`, and `ulw` in the Agent
+session. Those values are security policy, not presentation preferences:
+`accept_edits` skips file-edit approval and `ulw` skips every tool approval for
+a bounded number of autonomous turns.
+
+The ACP client owns the user interface, but it must not gain more authority
+than the operator granted when starting `co ai --acp`. Mode changes must also
+share the persistent ownership and rollback boundary from DD-029 and the
+approval boundary from DD-030.
+
+## Decision
+
+### Keep the existing session vocabulary
+
+ACP IDs are the persisted ConnectOnion IDs:
+
+- `safe`, displayed as **Safe**
+- `accept_edits`, displayed as **Auto**
+- `ulw`, displayed as **ULW**
+
+The adapter does not translate a second set of mode names. New sessions store
+an explicit mode, and new/resumed responses return the official
+`SessionModeState`.
+
+### Treat process launch as the authority ceiling
+
+Safe and Auto are available to a local stdio client. ULW is advertised and
+accepted only if the server was started with `--yolo`. A saved ULW session
+cannot be resumed by a server without that launch authority. Its saved
+remaining autonomous turns must also be no greater than this process's
+`--yolo-turns` ceiling.
+
+ULW state is valid only when all three bounded fields agree with `mode=ulw`:
+`skip_tool_approval=true`, a positive `ulw_turns`, and a non-negative
+`ulw_turns_used` below that limit. Safe or Auto snapshots containing ULW bypass
+state are rejected. Unknown and malformed persisted modes fail closed before
+the Agent can run.
+
+The normal `enable_yolo` hook is disarmed after ACP constructs the runtime.
+ACP's validated snapshot is the current mode; the launch flag only controls
+whether that snapshot may enter ULW. This prevents a deliberate downgrade to
+Safe or Auto from being silently reversed on the next prompt.
+
+### Change mode only at an idle transaction boundary
+
+`session/set_mode` and `session/prompt` use the same per-session lock. A busy
+session rejects a mode request, so policy cannot change between a model
+decision, approval request, and tool execution.
+
+An idle change is prepared in a detached copy and written with the existing
+atomic snapshot replacement. Only after that succeeds do the live Agent,
+last-good checkpoint, and first-prompt resume copy observe the new mode. A
+failed write exposes no partial in-memory grant. Cancellation and close wait
+for an owned write to settle before the runtime or lease can be released.
+
+### Use ACP's ordered update for internal changes
+
+An Agent-originated `mode_changed` event maps to ACP
+`CurrentModeUpdate(sessionUpdate="current_mode_update")` in the same ordered
+generation stream as tool and message updates. The adapter defers that one
+state notification until the prompt snapshot commits, so a failed save cannot
+announce a mode that was rolled back. If notification delivery then fails, the
+durable state remains authoritative and disk is never rolled back after the
+commit point. The live runtime is quarantined and its lease released so it
+cannot execute another prompt under stale client policy; reconnect/resume
+re-advertises the durable mode. Unknown internal mode IDs abort the prompt and
+its checkpoint instead of being announced as usable policy.
+
+## Consequences
+
+- An ACP UI can present and persist Safe/Auto without a parallel policy model.
+- ULW remains an operator-granted capability; a client request or stored file
+  cannot manufacture it.
+- Mode changes may return “Session is busy” and be retried after the prompt.
+- Older snapshots without a mode normalize to Safe. Corrupt or over-authorized
+  snapshots require an explicit operator decision instead of silent repair.
+
+## Rejected alternatives
+
+- **Always advertise ULW:** lets a client escalate beyond process launch.
+- **Silently downgrade saved ULW to Safe:** hides a material policy change and
+  rewrites the meaning of a resumable session.
+- **Change mode during a prompt:** creates a race at the approval boundary.
+- **Mutate memory before saving:** can leave the runtime more permissive than
+  the durable checkpoint after a disk failure.
+- **Use adapter-only mode names:** creates translation and migration work with
+  no security or usability benefit.
+
+## Related decisions
+
+- DD-019: Agent lifecycle and session-owned mode state
+- DD-023: Trust and policy boundaries
+- DD-025: Interruptible Agent steps
+- DD-028: Ordered ACP event generations
+- DD-029: Persistent ACP session ownership
+- DD-030: Generation-scoped ACP tool approvals

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -291,7 +291,7 @@ async def test_acp_subprocess_lease_blocks_a_second_process_until_close(tmp_path
             "session/resume",
             {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
         )
-        assert resumed["result"] == {}
+        assert resumed["result"]["modes"]["currentModeId"] == "safe"
         assert notifications == []
 
 @pytest.mark.asyncio
@@ -310,7 +310,7 @@ async def test_acp_subprocess_eof_releases_lease_for_later_resume(tmp_path):
             "session/resume",
             {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
         )
-        assert resumed["result"] == {}
+        assert resumed["result"]["modes"]["currentModeId"] == "safe"
         assert notifications == []
 
         response, notifications = await _request(
@@ -326,3 +326,51 @@ async def test_acp_subprocess_eof_releases_lease_for_later_resume(tmp_path):
         assert notifications[0]["params"]["update"]["content"]["text"] == (
             "answer: continued"
         )
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_sets_and_resumes_the_official_mode_state(tmp_path):
+    state_root = tmp_path / "home"
+    async with _server(state_root) as first:
+        await _initialize(first)
+        created, notifications = await _request(
+            first,
+            2,
+            "session/new",
+            {"cwd": str(tmp_path), "mcpServers": []},
+        )
+        session_id = created["result"]["sessionId"]
+        modes = created["result"]["modes"]
+        assert modes["currentModeId"] == "safe"
+        assert [mode["id"] for mode in modes["availableModes"]] == [
+            "safe",
+            "accept_edits",
+        ]
+        assert notifications == []
+
+        changed, notifications = await _request(
+            first,
+            3,
+            "session/set_mode",
+            {"sessionId": session_id, "modeId": "accept_edits"},
+        )
+        assert changed["result"] == {}
+        assert notifications == []
+        closed, _ = await _request(
+            first,
+            4,
+            "session/close",
+            {"sessionId": session_id},
+        )
+        assert closed["result"] == {}
+
+    async with _server(state_root) as second:
+        await _initialize(second)
+        resumed, notifications = await _request(
+            second,
+            2,
+            "session/resume",
+            {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
+        )
+        assert resumed["result"]["modes"]["currentModeId"] == "accept_edits"
+        assert notifications == []

--- a/tests/unit/test_co_ai_acp_events.py
+++ b/tests/unit/test_co_ai_acp_events.py
@@ -14,6 +14,7 @@ from acp import RequestError, text_block
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
+    CurrentModeUpdate,
     ToolCallProgress,
     ToolCallStart,
 )
@@ -123,6 +124,25 @@ def test_thought_and_assistant_messages_keep_their_message_ids():
     assert assistant.message_id == "2359f04e-8e17-49d9-a634-ec14d2ecf754"
     assert thought.content.text == "checking"
     assert assistant.content.text == "done"
+
+
+def test_mode_change_maps_to_the_exact_current_mode_update():
+    update = map_agent_event({
+        "type": "mode_changed",
+        "mode": "accept_edits",
+        "triggered_by": "agent",
+    }).updates[0]
+
+    assert isinstance(update, CurrentModeUpdate)
+    assert dumped(update) == {
+        "currentModeId": "accept_edits",
+        "sessionUpdate": "current_mode_update",
+    }
+
+
+def test_unknown_internal_mode_fails_closed():
+    with pytest.raises(ValueError, match="Unsupported Agent mode"):
+        map_agent_event({"type": "mode_changed", "mode": "future"})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_co_ai_acp_modes.py
+++ b/tests/unit/test_co_ai_acp_modes.py
@@ -1,0 +1,755 @@
+"""ACP session modes stay transactional and below launch authority."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import threading
+import time
+from typing import Any
+
+import pytest
+from acp import RequestError, text_block
+from acp.schema import CurrentModeUpdate, SetSessionModeResponse
+
+from connectonion import Agent
+from connectonion.cli.co_ai import acp_server
+from connectonion.cli.co_ai.acp_server import ConnectOnionACPAgent
+from connectonion.cli.co_ai.one_shot_sessions import (
+    load_snapshot,
+    save_snapshot,
+    session_lock,
+)
+from connectonion.core.llm import LLMResponse, ToolCall
+from connectonion.useful_plugins import enable_yolo, tool_approval, yolo
+from tests.utils.mock_helpers import MockLLM
+
+
+class _Client:
+    def __init__(self, *, fail_mode_update: bool = False) -> None:
+        self.updates: list[tuple[str, Any]] = []
+        self.permission_requests: list[dict[str, Any]] = []
+        self.fail_mode_update = fail_mode_update
+
+    async def request_permission(self, **kwargs: Any) -> dict[str, Any]:
+        self.permission_requests.append(kwargs)
+        return {
+            "outcome": {
+                "outcome": "selected",
+                "optionId": "reject_once",
+            }
+        }
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **_kwargs: Any,
+    ) -> None:
+        if self.fail_mode_update and isinstance(update, CurrentModeUpdate):
+            raise RuntimeError("private mode transport marker")
+        self.updates.append((session_id, update))
+
+
+class _BlockingModeClient(_Client):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mode_update_started = asyncio.Event()
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **kwargs: Any,
+    ) -> None:
+        if isinstance(update, CurrentModeUpdate):
+            self.mode_update_started.set()
+            await asyncio.Future()
+        await super().session_update(session_id, update, **kwargs)
+
+
+class _ModeAgent:
+    system_prompt = "system"
+
+    def __init__(
+        self,
+        *,
+        block: bool = False,
+        internal_mode: str | None = None,
+    ) -> None:
+        self.current_session: dict[str, Any] | None = None
+        self.io: Any = None
+        self.block = block
+        self.internal_mode = internal_mode
+        self.started = threading.Event()
+
+    def input(
+        self,
+        prompt: str,
+        session: dict[str, Any] | None = None,
+    ) -> str:
+        if session is not None:
+            self.current_session = copy.deepcopy(session)
+        assert self.current_session is not None
+        self.current_session["turn"] += 1
+        self.started.set()
+        if self.block:
+            while not self.io.receive_all("INTERRUPT"):
+                time.sleep(0.01)
+        if self.internal_mode is not None:
+            self.current_session["mode"] = self.internal_mode
+            self.io.send({
+                "type": "mode_changed",
+                "mode": self.internal_mode,
+                "triggered_by": "agent",
+            })
+        reason = "interrupted" if self.block else "natural"
+        terminal = {
+            "type": "turn_result",
+            "turn": self.current_session["turn"],
+            "reason": reason,
+            "usage": None,
+        }
+        self.current_session["trace"].append(terminal)
+        self.io.send(terminal)
+        return prompt
+
+
+def _server(
+    state_dir,
+    factory,
+    *,
+    yolo: bool = False,
+    yolo_turns: int = 7,
+) -> ConnectOnionACPAgent:
+    return ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=yolo,
+        yolo_turns=yolo_turns,
+        agent_factory=factory,
+        session_co_dir=state_dir,
+    )
+
+
+def _project(tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def _dump(model: Any) -> dict[str, Any]:
+    return model.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project_lookup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_new_safe_session_returns_exact_modes_and_persists_default(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _ModeAgent())
+
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    assert _dump(created.modes) == {
+        "currentModeId": "safe",
+        "availableModes": [
+            {
+                "id": "safe",
+                "name": "Safe",
+                "description": "Ask before tools with side effects.",
+            },
+            {
+                "id": "accept_edits",
+                "name": "Auto",
+                "description": (
+                    "Apply file edits automatically; ask before other risky tools."
+                ),
+            },
+        ],
+    }
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "safe"
+    assert not {"skip_tool_approval", "ulw_turns", "ulw_turns_used"} & stored.keys()
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_yolo_launch_advertises_and_persists_bounded_ulw(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(
+        state_dir,
+        lambda **_: _ModeAgent(),
+        yolo=True,
+        yolo_turns=7,
+    )
+
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    assert created.modes.current_mode_id == "ulw"
+    assert [mode.id for mode in created.modes.available_modes] == [
+        "safe",
+        "accept_edits",
+        "ulw",
+    ]
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "ulw"
+    assert stored["ulw_turns"] == 7
+    assert stored["ulw_turns_used"] == 0
+    assert stored["skip_tool_approval"] is True
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_idle_auto_change_commits_memory_disk_and_resume(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    first = _server(state_dir, lambda **_: _ModeAgent())
+    created = await first.new_session(str(project), mcp_servers=[])
+
+    changed = await first.set_session_mode(created.session_id, "accept_edits")
+
+    assert isinstance(changed, SetSessionModeResponse)
+    runtime = first._sessions[created.session_id]
+    assert runtime.last_good_session["mode"] == "accept_edits"
+    assert runtime.session_for_next_prompt["mode"] == "accept_edits"
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    await first.close_session(created.session_id)
+
+    resumed_server = _server(state_dir, lambda **_: _ModeAgent())
+    resumed = await resumed_server.resume_session(
+        created.session_id,
+        str(project),
+        mcp_servers=[],
+    )
+    assert resumed.modes.current_mode_id == "accept_edits"
+    await resumed_server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_unknown_and_unauthorized_ulw_do_not_mutate_session(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _ModeAgent())
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    for mode in ("future", "ulw"):
+        with pytest.raises(RequestError, match="Invalid params"):
+            await server.set_session_mode(created.session_id, mode)
+
+    runtime = server._sessions[created.session_id]
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert runtime.last_good_session["mode"] == "safe"
+    assert stored["mode"] == "safe"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_authorized_ulw_upgrade_and_downgrade_clean_bypass_state(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(
+        state_dir,
+        lambda **_: _ModeAgent(),
+        yolo=True,
+        yolo_turns=9,
+    )
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    await server.set_session_mode(created.session_id, "safe")
+    safe, _ = load_snapshot(state_dir, created.session_id)
+    assert safe["mode"] == "safe"
+    assert not {"skip_tool_approval", "ulw_turns", "ulw_turns_used"} & safe.keys()
+
+    await server.set_session_mode(created.session_id, "ulw")
+    ulw, _ = load_snapshot(state_dir, created.session_id)
+    assert ulw["mode"] == "ulw"
+    assert ulw["ulw_turns"] == 9
+    assert ulw["ulw_turns_used"] == 0
+    assert ulw["skip_tool_approval"] is True
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_auto_mode_drives_the_existing_tool_approval_policy(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+
+    def write(content: str) -> str:
+        """Record a deterministic file-edit-like effect."""
+
+        executed.append(content)
+        return content
+
+    def factory(**_kwargs: Any) -> Agent:
+        return Agent(
+            name="acp-mode",
+            tools=[write],
+            plugins=[tool_approval],
+            llm=MockLLM(responses=[
+                LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="write",
+                        arguments={"content": "value"},
+                        id="call-auto",
+                    )],
+                    raw_response={},
+                ),
+                LLMResponse(
+                    content="done",
+                    tool_calls=[],
+                    raw_response={},
+                ),
+            ]),
+            max_iterations=2,
+            log=False,
+            quiet=True,
+            co_dir=project / ".co",
+        )
+
+    server = _server(state_dir, factory)
+    server.on_connect(_Client())
+    created = await server.new_session(str(project), mcp_servers=[])
+    await server.set_session_mode(created.session_id, "accept_edits")
+
+    response = await server.prompt(created.session_id, [text_block("write")])
+
+    assert response.stop_reason == "end_turn"
+    assert executed == ["value"]
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_safe_downgrade_disarms_real_agent_yolo_activation(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    executed: list[str] = []
+
+    def write(content: str) -> str:
+        """Record a side effect that Safe mode must not auto-approve."""
+
+        executed.append(content)
+        return content
+
+    def factory(**_kwargs: Any) -> Agent:
+        agent = Agent(
+            name="acp-yolo-downgrade",
+            tools=[write],
+            plugins=[tool_approval, yolo],
+            llm=MockLLM(responses=[LLMResponse(
+                content="",
+                tool_calls=[ToolCall(
+                    name="write",
+                    arguments={"content": "must ask"},
+                    id="call-safe",
+                )],
+                raw_response={},
+            )]),
+            max_iterations=2,
+            log=False,
+            quiet=True,
+            co_dir=project / ".co",
+        )
+        enable_yolo(agent, turns=7)
+        return agent
+
+    client = _Client()
+    server = _server(state_dir, factory, yolo=True, yolo_turns=7)
+    server.on_connect(client)
+    created = await server.new_session(str(project), mcp_servers=[])
+    runtime = server._sessions[created.session_id]
+    assert runtime.agent._yolo_turns is None
+    await server.set_session_mode(created.session_id, "safe")
+
+    response = await server.prompt(created.session_id, [text_block("write")])
+
+    assert response.stop_reason == "refusal"
+    assert executed == []
+    assert len(client.permission_requests) == 1
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "safe"
+    assert "skip_tool_approval" not in stored
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_busy_prompt_rejects_mode_change_without_policy_race(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    agent = _ModeAgent(block=True)
+    server = _server(tmp_path / "state", lambda **_: agent)
+    server.on_connect(_Client())
+    created = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(created.session_id, [text_block("block")])
+    )
+    await asyncio.wait_for(asyncio.to_thread(agent.started.wait), timeout=1)
+
+    with pytest.raises(RequestError, match="Session is busy"):
+        await server.set_session_mode(created.session_id, "accept_edits")
+
+    await server.cancel(created.session_id)
+    response = await asyncio.wait_for(prompting, timeout=1)
+    assert response.stop_reason == "cancelled"
+    stored, _ = load_snapshot(tmp_path / "state", created.session_id)
+    assert stored["mode"] == "safe"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_leaves_mode_unchanged_without_private_details(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _ModeAgent())
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    def fail_save(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("private mode persistence marker")
+
+    monkeypatch.setattr(acp_server, "save_snapshot", fail_save)
+    with pytest.raises(RequestError) as exc_info:
+        await server.set_session_mode(created.session_id, "accept_edits")
+
+    assert "private mode persistence marker" not in str(exc_info.value)
+    runtime = server._sessions[created.session_id]
+    assert runtime.last_good_session["mode"] == "safe"
+    assert runtime.session_for_next_prompt["mode"] == "safe"
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "safe"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_internal_mode_update_is_published_only_after_commit(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _ModeAgent(internal_mode="accept_edits")
+    client = _Client()
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(client)
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    response = await server.prompt(created.session_id, [text_block("change")])
+
+    assert response.stop_reason == "end_turn"
+    mode_updates = [
+        update for _, update in client.updates
+        if isinstance(update, CurrentModeUpdate)
+    ]
+    assert [update.current_mode_id for update in mode_updates] == ["accept_edits"]
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_failed_prompt_commit_does_not_publish_internal_mode(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _ModeAgent(internal_mode="accept_edits")
+    client = _Client()
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(client)
+    created = await server.new_session(str(project), mcp_servers=[])
+
+    def fail_save(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("private prompt commit marker")
+
+    monkeypatch.setattr(acp_server, "save_snapshot", fail_save)
+    with pytest.raises(RequestError):
+        await server.prompt(created.session_id, [text_block("change then fail")])
+
+    assert not any(
+        isinstance(update, CurrentModeUpdate) for _, update in client.updates
+    )
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "safe"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_mode_notification_failure_cannot_roll_back_durable_commit(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _ModeAgent(internal_mode="accept_edits")
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(_Client(fail_mode_update=True))
+    created = await server.new_session(str(project), mcp_servers=[])
+    runtime = server._sessions[created.session_id]
+
+    response = await server.prompt(created.session_id, [text_block("change")])
+
+    assert response.stop_reason == "end_turn"
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    assert runtime.last_good_session["mode"] == "accept_edits"
+    assert created.session_id not in server._sessions
+    with session_lock(state_dir, created.session_id):
+        pass
+
+    with pytest.raises(RequestError, match="Session not found"):
+        await server.prompt(created.session_id, [text_block("must reconnect")])
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mode_notification_quarantines_committed_runtime(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    agent = _ModeAgent(internal_mode="accept_edits")
+    client = _BlockingModeClient()
+    server = _server(state_dir, lambda **_: agent)
+    server.on_connect(client)
+    created = await server.new_session(str(project), mcp_servers=[])
+    prompting = asyncio.create_task(
+        server.prompt(created.session_id, [text_block("change")])
+    )
+    await asyncio.wait_for(client.mode_update_started.wait(), timeout=1)
+
+    prompting.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await prompting
+
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    assert created.session_id not in server._sessions
+    with session_lock(state_dir, created.session_id):
+        pass
+    with pytest.raises(RequestError, match="Session not found"):
+        await server.prompt(created.session_id, [text_block("must reconnect")])
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mode_request_settles_atomic_commit(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _ModeAgent())
+    created = await server.new_session(str(project), mcp_servers=[])
+    real_save = acp_server.save_snapshot
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_save(*args: Any, **kwargs: Any) -> None:
+        started.set()
+        release.wait()
+        real_save(*args, **kwargs)
+
+    monkeypatch.setattr(acp_server, "save_snapshot", blocking_save)
+    changing = asyncio.create_task(
+        server.set_session_mode(created.session_id, "accept_edits")
+    )
+    await asyncio.wait_for(asyncio.to_thread(started.wait), timeout=1)
+    changing.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await changing
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    assert server._sessions[created.session_id].last_good_session["mode"] == "accept_edits"
+    await server.close_session(created.session_id)
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_mode_commit_then_releases_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    server = _server(state_dir, lambda **_: _ModeAgent())
+    created = await server.new_session(str(project), mcp_servers=[])
+    real_save = acp_server.save_snapshot
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_save(*args: Any, **kwargs: Any) -> None:
+        started.set()
+        release.wait()
+        real_save(*args, **kwargs)
+
+    monkeypatch.setattr(acp_server, "save_snapshot", blocking_save)
+    changing = asyncio.create_task(
+        server.set_session_mode(created.session_id, "accept_edits")
+    )
+    await asyncio.wait_for(asyncio.to_thread(started.wait), timeout=1)
+    closing = asyncio.create_task(server.close_session(created.session_id))
+    await asyncio.sleep(0)
+    assert not closing.done()
+    release.set()
+
+    await asyncio.wait_for(changing, timeout=1)
+    await asyncio.wait_for(closing, timeout=1)
+    stored, _ = load_snapshot(state_dir, created.session_id)
+    assert stored["mode"] == "accept_edits"
+    with session_lock(state_dir, created.session_id):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_resume_preserves_committed_ulw_budget_without_reset(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "7840827a-480b-43f7-b773-266071f71b72"
+    saved = {
+        "session_id": session_id,
+        "messages": [{"role": "system", "content": "system"}],
+        "trace": [],
+        "turn": 2,
+        "mode": "ulw",
+        "ulw_turns": 8,
+        "ulw_turns_used": 3,
+        "skip_tool_approval": True,
+    }
+    save_snapshot(state_dir, saved, {}, cwd=project)
+    server = _server(
+        state_dir,
+        lambda **_: _ModeAgent(),
+        yolo=True,
+        yolo_turns=99,
+    )
+
+    resumed = await server.resume_session(session_id, str(project), mcp_servers=[])
+
+    assert resumed.modes.current_mode_id == "ulw"
+    runtime = server._sessions[session_id]
+    assert runtime.last_good_session["ulw_turns"] == 8
+    assert runtime.last_good_session["ulw_turns_used"] == 3
+    await server.close_session(session_id)
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_ulw_budget_above_current_launch_ceiling(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "f80d832e-58d5-40a7-af89-46686efcc62b"
+    saved = {
+        "session_id": session_id,
+        "messages": [{"role": "system", "content": "system"}],
+        "trace": [],
+        "turn": 2,
+        "mode": "ulw",
+        "ulw_turns": 8,
+        "ulw_turns_used": 3,
+        "skip_tool_approval": True,
+    }
+    save_snapshot(state_dir, saved, {}, cwd=project)
+    server = _server(
+        state_dir,
+        lambda **_: _ModeAgent(),
+        yolo=True,
+        yolo_turns=4,
+    )
+
+    with pytest.raises(RequestError, match="Unable to resume session"):
+        await server.resume_session(session_id, str(project), mcp_servers=[])
+
+    with session_lock(state_dir, session_id):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode_state", "yolo"),
+    [
+        ({"mode": "future"}, False),
+        ({
+            "mode": "ulw",
+            "ulw_turns": 8,
+            "ulw_turns_used": 3,
+            "skip_tool_approval": True,
+        }, False),
+        ({"mode": "safe", "skip_tool_approval": True}, False),
+        ({
+            "mode": "ulw",
+            "ulw_turns": 8,
+            "ulw_turns_used": 8,
+            "skip_tool_approval": True,
+        }, True),
+    ],
+)
+async def test_resume_rejects_unknown_or_over_authorized_mode_state(
+    tmp_path,
+    monkeypatch,
+    mode_state,
+    yolo,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    session_id = "88eb833d-a7cc-4483-9833-ec6bda4b7602"
+    saved = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        **mode_state,
+    }
+    save_snapshot(state_dir, saved, {}, cwd=project)
+    server = _server(
+        state_dir,
+        lambda **_: _ModeAgent(),
+        yolo=yolo,
+    )
+
+    with pytest.raises(RequestError, match="Unable to resume session"):
+        await server.resume_session(session_id, str(project), mcp_servers=[])
+
+    with session_lock(state_dir, session_id):
+        pass

--- a/tests/unit/test_co_ai_acp_resume.py
+++ b/tests/unit/test_co_ai_acp_resume.py
@@ -221,6 +221,7 @@ async def test_new_session_persists_canonical_snapshot_and_holds_lease(
         "messages": [{"role": "system", "content": "system"}],
         "trace": [],
         "turn": 0,
+        "mode": "safe",
     }
     assert tools == {"todolist": []}
     with pytest.raises(SessionSnapshotError, match="already running"):


### PR DESCRIPTION
## Summary

- advertise exact ACP Safe, Auto, and authorized ULW session mode state on new and resume
- persist idle session/set_mode changes atomically under the prompt ownership boundary
- keep ULW below launch-time authority and reject malformed or oversized restored budgets
- publish internal CurrentModeUpdate only after durable commit, quarantining a runtime if delivery fails or is cancelled
- document the decision and rejected alternatives in DD-031

## Stack

Depends on Draft #829. Review only the changes after agent/co-acp-approval-827.

Refs #828
Parent #475
Milestone: 1.7.1

## Verification

- 116 ACP unit and real-stdio E2E tests passed
- focused mode suite: 21 passed, including real Agent plus tool_approval plus yolo downgrade behavior
- Ruff passed for all changed Python files
- Ruff security rules passed for changed production files
- Bandit passed for changed production files
- py_compile and git diff --check passed
- two independent expert reviews are CLEAR after fixing two authority-boundary findings

## Security notes

- ACP launch flags are the authority ceiling; persisted remaining ULW turns cannot exceed the current launch budget
- the normal Agent YOLO activation hook is disarmed inside ACP so a Safe or Auto downgrade cannot be silently reversed
- mode changes are idle-only and share the prompt lock
- failed or cancelled post-commit mode notification retires the runtime and releases its lease; resume re-advertises durable policy

## Local test environment

Repository-wide pytest from this nested worktree is not a valid signal because the parent checkout contains a .co directory that intentionally trips the project-root isolation guard. The focused ACP suite above is clean; CI remains the clean-checkout authority.

## Merge policy

Draft only. Do not merge or release until the stack is reviewed in dependency order.