### PR TITLE
test(acp): add official SDK conformance

### DIFF
--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -1,0 +1,79 @@
+# DD-032: ACP interoperability needs typed and framing evidence
+
+**Status:** Accepted
+
+**Date:** 2026-08-10
+
+## Context
+
+The ACP adapter already has direct unit tests and raw JSON-RPC subprocess
+tests. Those tests can prove ConnectOnion behavior and newline-delimited stdio
+framing, but project-owned dictionaries cannot prove that an independent ACP
+implementation accepts the messages.
+
+ACP also distinguishes clients from agents. ConnectOnion, Claude Code, and
+Codex are agents. Editors such as Zed and JetBrains are clients that launch an
+agent subprocess. Compatibility documentation must not present one peer agent
+as the host for another.
+
+## Decision
+
+### Keep two complementary CI boundaries
+
+Raw subprocess tests continue to own transport properties that an SDK hides:
+stdout contains protocol frames only, large frames are not truncated, EOF
+settles work, and retired generations cannot leak output.
+
+A second subprocess suite uses the official Python ACP client API to launch a
+deterministic fixture that calls the production `serve_acp` stdio adapter. The
+official client models validate requests, responses, notifications, modes, and
+permission callbacks while they cross the real stdio boundary. Only the
+model-backed coding Agent is replaced; the ACP router and server remain
+production code.
+
+Both suites are isolated from user state, credentials, and the network. Client
+permission callbacks reject by default.
+
+### State the tested version contract
+
+The package supports `agent-client-protocol>=0.12.0,<0.13.0` and negotiates
+ACP `protocolVersion=1`. Compatibility claims name that range instead of the
+unbounded phrase “ACP compatible.” A future SDK-minor upgrade must update the
+bound and rerun both test layers before the table changes.
+
+### Separate automated conformance from editor smoke paths
+
+Zed and JetBrains receive copy-paste custom-agent configurations that run
+`co ai --acp` in the selected project. CI validates the same production stdio
+adapter through the official client SDK; CLI argument wiring remains a separate
+test boundary. We do not claim that a GUI editor binary runs in CI;
+editor-specific installation and UI behavior remain documented smoke paths
+until a stable headless host runner exists.
+
+Claude Code and Codex may be listed as peer ACP agents for orientation, but not
+as clients that launch ConnectOnion.
+
+## Consequences
+
+- Schema or router drift fails in the official SDK client before release.
+- Framing regressions remain visible instead of being hidden by SDK helpers.
+- Interoperability claims say exactly which layer and version were exercised.
+- The deterministic fixture is shared by raw and typed subprocess suites.
+- GUI integration can still change independently and must not be overstated.
+
+## Rejected alternatives
+
+- **Only raw JSON fixtures:** validates our expectations against themselves.
+- **Only the official SDK client:** hides stdout pollution and framing details.
+- **Copy ACP schemas into tests:** creates a second protocol implementation to
+  maintain.
+- **Install a desktop IDE in the normal test matrix:** slow, brittle, and not a
+  reliable headless contract.
+- **Call Claude Code or Codex a host:** reverses the ACP client/agent roles.
+
+## Related decisions
+
+- DD-028: Ordered ACP event generations
+- DD-029: Persistent ACP session ownership
+- DD-030: Generation-scoped ACP tool approvals
+- DD-031: ACP session mode authority

--- a/tests/e2e/cli/acp_test_agent.py
+++ b/tests/e2e/cli/acp_test_agent.py
@@ -1,0 +1,87 @@
+"""Deterministic model-free Agent behind the production ACP stdio adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from unittest.mock import patch
+
+from connectonion.cli.co_ai.acp_server import serve_acp
+from connectonion.cli.commands import ai_commands
+
+
+class ACPTestAgent:
+    system_prompt = "system"
+
+    def __init__(self) -> None:
+        self.io = None
+        self.current_session = {"trace": [], "turn": 0}
+
+    def _finish(self, reason: str) -> None:
+        event = {
+            "type": "turn_result",
+            "turn": self.current_session["turn"],
+            "reason": reason,
+            "usage": None,
+        }
+        self.current_session["trace"].append(event)
+        self.io.send(event)
+
+    def input(self, prompt: str, session=None) -> str:
+        if session is not None:
+            self.current_session = dict(session)
+            self.current_session["messages"] = list(session["messages"])
+            self.current_session["trace"] = list(session["trace"])
+        print(f"fake agent received: {prompt}", flush=True)
+        self.current_session["turn"] += 1
+        if prompt == "large":
+            result = "x" * 5_000_000
+            self._finish("natural")
+            return result
+        if prompt == "environment":
+            result = f"secret inherited: {'ACP_TEST_SECRET' in os.environ}"
+            self._finish("natural")
+            return result
+        if prompt == "approval":
+            self.io.send({
+                "type": "approval_needed",
+                "tool_call_id": "sdk-permission",
+                "tool": "write",
+                "arguments": {"content": "value"},
+            })
+            decision = self.io.receive()
+            result = f"permission approved: {decision.get('approved') is True}"
+            self._finish("natural")
+            return result
+        if prompt != "block":
+            result = f"answer: {prompt}"
+            self._finish("natural")
+            return result
+        while not self.io.receive_all("INTERRUPT"):
+            time.sleep(0.01)
+        self._finish("interrupted")
+        return "late cancelled answer"
+
+
+def main() -> None:
+    ai_commands._create_agent = lambda **_kwargs: ACPTestAgent()
+    network_error = RuntimeError("ACP test fixture network access is disabled")
+    with (
+        patch.object(socket.socket, "connect", side_effect=network_error),
+        patch.object(socket.socket, "connect_ex", side_effect=network_error),
+        patch.object(socket, "create_connection", side_effect=network_error),
+    ):
+        asyncio.run(
+            serve_acp(
+                model="test",
+                max_iterations=2,
+                yolo=False,
+                yolo_turns=2,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/cli/test_cli_ai_acp_sdk.py
+++ b/tests/e2e/cli/test_cli_ai_acp_sdk.py
@@ -124,7 +124,7 @@ def _isolate_project_lookup(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_official_sdk_validates_lifecycle_mode_prompt_and_resume(tmp_path):
+async def test_official_sdk_validates_lifecycle_content_mode_and_resume(tmp_path):
     async def scenario() -> None:
         client = _ConformanceClient()
         async with _sdk_agent(client, tmp_path) as (agent, process):
@@ -146,7 +146,15 @@ async def test_official_sdk_validates_lifecycle_mode_prompt_and_resume(tmp_path)
             await agent.set_session_mode(created.session_id, "accept_edits")
             prompted = await agent.prompt(
                 created.session_id,
-                [acp.text_block("hello")],
+                [
+                    acp.text_block("hello"),
+                    acp.resource_link_block(
+                        "api.md",
+                        "file:///workspace/docs/api.md",
+                        title="API guide",
+                        mime_type="text/markdown",
+                    ),
+                ],
             )
             assert prompted.stop_reason == "end_turn"
             assert [
@@ -154,7 +162,11 @@ async def test_official_sdk_validates_lifecycle_mode_prompt_and_resume(tmp_path)
                 for session_id, update in client.updates
                 if session_id == created.session_id
                 and isinstance(update, AgentMessageChunk)
-            ] == ["answer: hello"]
+            ] == [
+                "answer: hello\n\n"
+                "Referenced resource: API guide "
+                "(file:///workspace/docs/api.md)"
+            ]
 
             await agent.close_session(created.session_id)
             resumed = await agent.resume_session(

--- a/tests/e2e/cli/test_cli_ai_acp_sdk.py
+++ b/tests/e2e/cli/test_cli_ai_acp_sdk.py
@@ -1,0 +1,203 @@
+"""Official ACP client SDK conformance checks for ``co ai --acp``."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from asyncio.subprocess import Process
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+import acp
+import pytest
+from acp.schema import (
+    AgentMessageChunk,
+    ClientCapabilities,
+    Implementation,
+    PermissionOption,
+    RequestPermissionResponse,
+    ToolCallUpdate,
+)
+
+
+class _ConformanceClient:
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, Any]] = []
+        self.permission_requests: list[
+            tuple[str, ToolCallUpdate, list[PermissionOption]]
+        ] = []
+
+    async def session_update(
+        self,
+        session_id: str,
+        update: Any,
+        **_kwargs: Any,
+    ) -> None:
+        self.updates.append((session_id, update))
+
+    async def request_permission(
+        self,
+        session_id: str,
+        tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
+        **_kwargs: Any,
+    ) -> RequestPermissionResponse:
+        self.permission_requests.append((session_id, tool_call, options))
+        return RequestPermissionResponse.model_validate({
+            "outcome": {
+                "outcome": "selected",
+                "optionId": "reject_once",
+            }
+        })
+
+
+def _agent_environment(state_root: Path) -> dict[str, str]:
+    repo_root = Path(__file__).resolve().parents[3]
+    acp_site_packages = Path(acp.__file__).resolve().parents[1]
+    return {
+        "HOME": str(state_root),
+        "USERPROFILE": str(state_root),
+        "APPDATA": str(state_root / "AppData" / "Roaming"),
+        "LOCALAPPDATA": str(state_root / "AppData" / "Local"),
+        "PYTHONPATH": os.pathsep.join((str(repo_root), str(acp_site_packages))),
+    }
+
+
+async def _drain_stderr(
+    reader: asyncio.StreamReader,
+    captured: bytearray,
+) -> None:
+    """Drain child diagnostics continuously while retaining at most 64 KiB."""
+
+    while chunk := await reader.read(8192):
+        remaining = 64 * 1024 - len(captured)
+        if remaining > 0:
+            captured.extend(chunk[:remaining])
+
+
+@asynccontextmanager
+async def _sdk_agent(
+    client: _ConformanceClient,
+    tmp_path: Path,
+) -> AsyncIterator[tuple[Any, Process]]:
+    fixture = Path(__file__).with_name("acp_test_agent.py")
+    captured = bytearray()
+    stderr_task: asyncio.Task[None] | None = None
+    process: Process | None = None
+    failed = False
+    try:
+        async with acp.spawn_agent_process(
+            client,
+            sys.executable,
+            str(fixture),
+            env=_agent_environment(tmp_path / "home"),
+            cwd=tmp_path,
+            transport_kwargs={"limit": 10 * 1024 * 1024},
+        ) as (agent, process):
+            assert process.stderr is not None
+            stderr_task = asyncio.create_task(
+                _drain_stderr(process.stderr, captured)
+            )
+            yield agent, process
+    except BaseException:
+        failed = True
+        raise
+    finally:
+        if stderr_task is not None:
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(stderr_task, timeout=2)
+        if failed and captured:
+            print(captured.decode(errors="replace"), file=sys.stderr)
+    if process is None or process.returncode != 0:
+        raise AssertionError(
+            "ACP fixture did not exit cleanly:\n"
+            + captured.decode(errors="replace")
+        )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_project_lookup(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_official_sdk_validates_lifecycle_mode_prompt_and_resume(tmp_path):
+    async def scenario() -> None:
+        client = _ConformanceClient()
+        async with _sdk_agent(client, tmp_path) as (agent, process):
+            initialized = await agent.initialize(
+                protocol_version=acp.PROTOCOL_VERSION,
+                client_capabilities=ClientCapabilities(),
+                client_info=Implementation(
+                    name="connectonion-conformance",
+                    version="test",
+                ),
+            )
+            assert initialized.protocol_version == acp.PROTOCOL_VERSION == 1
+            capabilities = initialized.agent_capabilities.session_capabilities
+            assert capabilities.resume is not None
+            assert capabilities.close is not None
+
+            created = await agent.new_session(str(tmp_path), mcp_servers=[])
+            assert created.modes.current_mode_id == "safe"
+            await agent.set_session_mode(created.session_id, "accept_edits")
+            prompted = await agent.prompt(
+                created.session_id,
+                [acp.text_block("hello")],
+            )
+            assert prompted.stop_reason == "end_turn"
+            assert [
+                update.content.text
+                for session_id, update in client.updates
+                if session_id == created.session_id
+                and isinstance(update, AgentMessageChunk)
+            ] == ["answer: hello"]
+
+            await agent.close_session(created.session_id)
+            resumed = await agent.resume_session(
+                created.session_id,
+                str(tmp_path),
+                mcp_servers=[],
+            )
+            assert resumed.modes.current_mode_id == "accept_edits"
+            await agent.close_session(created.session_id)
+            assert process.returncode is None
+
+    await asyncio.wait_for(scenario(), timeout=30)
+
+
+@pytest.mark.asyncio
+async def test_official_sdk_routes_permission_request_and_typed_rejection(tmp_path):
+    async def scenario() -> None:
+        client = _ConformanceClient()
+        async with _sdk_agent(client, tmp_path) as (agent, _process):
+            await agent.initialize(protocol_version=acp.PROTOCOL_VERSION)
+            created = await agent.new_session(str(tmp_path), mcp_servers=[])
+
+            prompted = await agent.prompt(
+                created.session_id,
+                [acp.text_block("approval")],
+            )
+
+            assert prompted.stop_reason == "end_turn"
+            assert len(client.permission_requests) == 1
+            session_id, tool_call, options = client.permission_requests[0]
+            assert session_id == created.session_id
+            assert tool_call.tool_call_id == "sdk-permission"
+            assert tool_call.raw_input == {"content": "value"}
+            assert [option.option_id for option in options] == [
+                "allow_once",
+                "allow_session",
+                "reject_once",
+            ]
+            messages = [
+                update.content.text
+                for _, update in client.updates
+                if isinstance(update, AgentMessageChunk)
+            ]
+            assert messages == ["permission approved: False"]
+
+    await asyncio.wait_for(scenario(), timeout=30)

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import os
 import sys
-import textwrap
 from asyncio.subprocess import PIPE, Process
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -15,70 +14,14 @@ from typing import Any
 import acp as acp_package
 import pytest
 
-_FAKE_ACP_SERVER = textwrap.dedent(
-    """
-    import asyncio
-    import time
-
-    from connectonion.cli.co_ai.acp_server import serve_acp
-    from connectonion.cli.commands import ai_commands
-
-
-    class FakeAgent:
-        system_prompt = "system"
-
-        def __init__(self):
-            self.io = None
-            self.current_session = {"trace": [], "turn": 0}
-
-        def finish(self, reason):
-            event = {
-                "type": "turn_result",
-                "turn": self.current_session["turn"],
-                "reason": reason,
-                "usage": None,
-            }
-            self.current_session["trace"].append(event)
-            self.io.send(event)
-
-        def input(self, prompt, session=None):
-            if session is not None:
-                self.current_session = dict(session)
-                self.current_session["messages"] = list(session["messages"])
-                self.current_session["trace"] = list(session["trace"])
-            print(f"fake agent received: {prompt}", flush=True)
-            self.current_session["turn"] += 1
-            if prompt == "large":
-                result = "x" * 5_000_000
-                self.finish("natural")
-                return result
-            if prompt != "block":
-                result = f"answer: {prompt}"
-                self.finish("natural")
-                return result
-            while not self.io.receive_all("INTERRUPT"):
-                time.sleep(0.01)
-            self.finish("interrupted")
-            return "late cancelled answer"
-
-
-    ai_commands._create_agent = lambda **kwargs: FakeAgent()
-    asyncio.run(
-        serve_acp(
-            model="test",
-            max_iterations=2,
-            yolo=False,
-            yolo_turns=2,
-        )
-    )
-    """
-)
-
 
 @asynccontextmanager
 async def _server(state_root: Path):
-    child_env = dict(os.environ)
+    child_env = acp_package.default_environment()
     child_env["HOME"] = str(state_root)
+    child_env["USERPROFILE"] = str(state_root)
+    child_env["APPDATA"] = str(state_root / "AppData" / "Roaming")
+    child_env["LOCALAPPDATA"] = str(state_root / "AppData" / "Local")
     repo_root = Path(__file__).resolve().parents[3]
     acp_site_packages = Path(acp_package.__file__).resolve().parents[1]
     child_env["PYTHONPATH"] = os.pathsep.join(
@@ -86,8 +29,7 @@ async def _server(state_root: Path):
     )
     process = await asyncio.create_subprocess_exec(
         sys.executable,
-        "-c",
-        _FAKE_ACP_SERVER,
+        str(Path(__file__).with_name("acp_test_agent.py")),
         stdin=PIPE,
         stdout=PIPE,
         stderr=PIPE,
@@ -263,6 +205,31 @@ async def test_acp_subprocess_preserves_a_large_response(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_acp_subprocess_does_not_inherit_unapproved_environment(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("ACP_TEST_SECRET", "must-not-cross-process-boundary")
+
+    async with _server(tmp_path / "home") as process:
+        session_id = await _initialize_and_create_session(process, tmp_path)
+        response, notifications = await _request(
+            process,
+            3,
+            "session/prompt",
+            {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "environment"}],
+            },
+        )
+
+        assert response["result"]["stopReason"] == "end_turn"
+        assert notifications[0]["params"]["update"]["content"]["text"] == (
+            "secret inherited: False"
+        )
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_lease_blocks_a_second_process_until_close(tmp_path):
     state_root = tmp_path / "home"
     async with _server(state_root) as owner, _server(state_root) as contender:
@@ -293,6 +260,7 @@ async def test_acp_subprocess_lease_blocks_a_second_process_until_close(tmp_path
         )
         assert resumed["result"]["modes"]["currentModeId"] == "safe"
         assert notifications == []
+
 
 @pytest.mark.asyncio
 async def test_acp_subprocess_eof_releases_lease_for_later_resume(tmp_path):


### PR DESCRIPTION
## Stack

- Depends on #830
- Closes #476 when this stack is merged
- Companion documentation PR follows separately

## What changed

- Exercise the production serve_acp stdio adapter through the official typed ACP Python client SDK.
- Share one deterministic, model-free fixture between raw framing and SDK conformance tests.
- Cover initialize, new, prompt, close, resume, modes, typed permission rejection, EOF, cancellation, leases, and large frames.
- Record the evidence boundary and version contract in DD-032.

## Reliability and security

- Bound SDK scenarios to 30 seconds and continuously drain child stderr with a 64 KiB diagnostic cap.
- Use the ACP environment allowlist, isolated user-state roots, and explicit socket blocking.
- Verify an unapproved parent secret is not inherited by the child process.
- Default the conformance client permission callback to rejection.

## Verification

- 119 focused ACP tests passed.
- 9 raw/official-SDK subprocess tests passed.
- Ruff, security Ruff, py_compile, and git diff checks passed.
- Two independent expert reviews: CLEAR, no P1/P2/P3 findings.

Draft only. Do not merge until the stacked ACP PRs are reviewed in order.