### PR TITLE
fix(permissions): fail closed on unknown tools

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -35,6 +35,7 @@ Debug:
 from pathlib import Path
 
 from connectonion import Agent, TodoList, bash
+from connectonion.core.events import after_user_input
 from connectonion.useful_plugins import (
     auto_compact,
     enable_yolo,
@@ -66,6 +67,23 @@ from .tools import (
 PROMPTS_DIR = Path(__file__).parent / "prompts"
 # Global .co directory for co ai (consistent logs/evals location)
 GLOBAL_CO_DIR = Path.home() / ".co"
+
+
+@after_user_input
+def grant_managed_delegation_permissions(agent: Agent) -> None:
+    """Explicitly permit co ai wrappers that enforce their own inner policy.
+
+    Keep these grants local to co ai's LLM loop. Putting them in host.yaml's
+    shared defaults would also expose the wrappers to direct remote EXEC.
+    """
+    permissions = agent.current_session.setdefault('permissions', {})
+    for tool_name in ('codex', 'claude_code'):
+        permissions.setdefault(tool_name, {
+            'allowed': True,
+            'source': 'safe',
+            'reason': 'managed delegation owns inner approval',
+            'expires': {'type': 'never'},
+        })
 
 
 def agent_name(co_dir: Path = Path(".co")) -> str:
@@ -147,6 +165,7 @@ def create_agent(
         eval,
         system_reminder,
         prefer_write_tool,
+        [grant_managed_delegation_permissions],
         tool_approval,
         auto_compact,
         yolo,

--- a/connectonion/cli/co_ai/prompts/connectonion/network/connection.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/network/connection.md
@@ -163,29 +163,12 @@ host(agent)
 ### Tool Approval
 
 ```python
-from connectonion import Agent, host, before_each_tool
+from connectonion import Agent, host
+from connectonion.useful_plugins import tool_approval
 
-class ToolRejected(Exception):
-    pass
-
-DANGEROUS_TOOLS = ["delete_file", "send_email", "run_shell"]
-
-@before_each_tool
-def check_approval(agent):
-    if not agent.connection:
-        return
-
-    tool = agent.current_session['pending_tool']
-
-    # Notify tool is starting
-    agent.connection.log("tool_call", name=tool['name'], arguments=tool['arguments'])
-
-    # Request approval for dangerous tools
-    if tool['name'] in DANGEROUS_TOOLS:
-        if not agent.connection.request_approval(tool['name'], tool['arguments']):
-            raise ToolRejected(f"User rejected {tool['name']}")
-
-agent = Agent("helper", tools=[delete_file], on_events=[check_approval])
+# Explicit permissions are loaded from the host template and .co/host.yaml.
+# Every remaining live-IO tool asks, including names added by plugins later.
+agent = Agent("helper", tools=[delete_file], plugins=[tool_approval])
 host(agent)
 ```
 
@@ -390,11 +373,7 @@ from connectonion import (
     Agent, host,
     after_llm, before_each_tool, after_each_tool, on_complete, on_error
 )
-
-class ToolRejected(Exception):
-    pass
-
-DANGEROUS_TOOLS = ["delete_file", "send_email"]
+from connectonion.useful_plugins import tool_approval
 
 @after_llm
 def on_thinking(agent):
@@ -408,10 +387,6 @@ def on_tool_start(agent):
 
     tool = agent.current_session['pending_tool']
     agent.connection.log("tool_call", name=tool['name'], arguments=tool['arguments'])
-
-    if tool['name'] in DANGEROUS_TOOLS:
-        if not agent.connection.request_approval(tool['name'], tool['arguments']):
-            raise ToolRejected(tool['name'])
 
 @after_each_tool
 def on_tool_end(agent):
@@ -438,6 +413,7 @@ def on_fail(agent):
 agent = Agent(
     "helper",
     tools=[search, delete_file],
+    plugins=[tool_approval],
     on_events=[on_thinking, on_tool_start, on_tool_end, on_done, on_fail]
 )
 
@@ -535,4 +511,3 @@ if agent.connection:
 
 - **[host.md](host.md)** - Host agents over HTTP/WebSocket
 - **[connect.md](connect.md)** - Connect to remote agents
-

--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
@@ -9,13 +9,14 @@ The plugin is the same in every mode; what moves is the gate.
 
 | mode | behaviour |
 |---|---|
-| `safe` | dangerous tool calls are confirmed one at a time |
-| `plan` | the agent proposes a plan and waits for review before doing anything |
-| `accept_edits` | file edits land without asking; other dangerous calls still ask |
-| `ulw` | runs unattended for a bounded number of turns — see `useful_plugins/ulw` |
+| `safe` | local/admin operators confirm each unpermitted tool; hosted non-admin requesters are rejected without a dialog |
+| `plan` | legacy client request; normalized to `safe` |
+| `accept_edits` | local/admin-only: named file edits land without asking; every other unpermitted call still needs operator approval |
+| `ulw` | local/admin-only bounded approval bypass — see `useful_plugins/ulw` |
 
 Mode changes arrive over the WebSocket, so a client can move between them
-mid-session without restarting the agent.
+mid-session without restarting the agent. In a hosted session, only the admin
+operator can enable `accept_edits` or `ulw`; other requesters remain in `safe`.
 
 ## Scope of an approval
 
@@ -25,8 +26,16 @@ temporary grants are snapshotted and restored around the skill rather than
 merged into it — a permission the user gave for one turn must not survive
 into the next.
 
-## What it does not do
+## Classification boundary
 
-It does not decide what is dangerous. That comes from the tool's own
-declaration and the permission patterns, so adding a tool does not mean editing
-this plugin.
+The approval boundary is an allowlist, not a denylist. Template, config, skill,
+session, and explicit mode permissions run first. With live IO, every remaining
+tool must receive operator approval; a hosted non-admin requester is rejected
+without a dialog. Adding a plugin or MCP tool therefore cannot silently acquire
+side effects just because its name is new.
+
+The co ai `codex` and `claude_code` wrappers receive explicit grants only inside
+the outer LLM-loop session because their inner runtimes own action approval.
+That scope applies to CLI and hosted co-ai sessions, but the grants never enter
+the shared remote-EXEC whitelist. Hosted non-admin Claude delegation is refused;
+hosted non-admin Codex is read-only with nested approvals denied.

--- a/connectonion/useful_plugins/tool_approval/__init__.py
+++ b/connectonion/useful_plugins/tool_approval/__init__.py
@@ -8,7 +8,7 @@ LLM-Note:
   Performance: plugin registration is O(1) | event handler overhead per tool call depends on approval.py check_approval()
   Errors: no errors at import time | errors from approval.py bubble up during agent execution
 
-Tool Approval Plugin - Request client approval before executing dangerous tools.
+Tool Approval Plugin - Request client approval before executing unpermitted tools.
 
 WebSocket-only. Uses io.send/receive pattern:
 1. Sends {type: "approval_needed", tool, arguments} to client
@@ -22,13 +22,13 @@ Rejection Modes (client sends mode field):
 - "reject_explain": Like soft, but instructs LLM to explain in simple terms.
 
 Tool Classification:
-- Safe tools (read, glob, grep, etc.) - defined in host.yaml template, auto-approved
-- DANGEROUS_TOOLS: Write/execute operations (bash, write, edit, etc.) - need approval
-- Unknown tools: Treated as safe (no approval needed)
+- Template-permitted tools (read, glob, grep, etc.) are auto-approved
+- DANGEROUS_TOOLS remains a public reference set for known effectful tools
+- Unknown tools require approval when live IO is present
 
 Mode System:
-- "safe" (default): Dangerous tools need approval
-- "accept_edits": File edits auto-approved, other dangerous tools need approval
+- "safe" (default): Every unpermitted tool needs approval
+- "accept_edits": Named file edits are auto-approved; other unpermitted tools need approval
 - "ulw": Handled by ulw plugin - bypasses all approvals
 
 Session Memory:
@@ -184,13 +184,13 @@ File Relationships:
 
 from .approval import (
     check_approval,
-    load_config_permissions,
-    poll_mode_changes,
-    poll_interrupt,
-    handle_mode_change,
     get_current_mode,
+    handle_mode_change,
+    load_config_permissions,
+    poll_interrupt,
+    poll_mode_changes,
 )
-from .constants import VALID_MODES, DEFAULT_MODE
+from .constants import DEFAULT_MODE, VALID_MODES
 
 # Export as plugin (list of event handlers)
 # Usage: Agent("name", plugins=[tool_approval])

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -1,8 +1,8 @@
 """
 Purpose: Orchestrate WebSocket-based tool approval with mode system and permission validation
 LLM-Note:
-  Dependencies: imports from [../../core/events.py (before_each_tool, before_iteration, after_user_input), ./constants.py (VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS), ./bash_parser.py (extract_commands_from_bash, check_bash_chain_permitted), ../skills.py (matches_permission_pattern), pathlib.Path, typing.TYPE_CHECKING] | imported by [tool_approval/__init__.py] | tested by [tests/unit/test_tool_approval.py, tests/integration/test_config_permissions.py, tests/unit/test_tool_approval.py, tests/unit/test_shell_approval.py]
-  Data flow: after_user_input → load_config_permissions() loads .co/host.yaml permissions into session['permissions'] | before_iteration → poll_mode_changes() checks for mode_change messages | before_each_tool → check_approval() validates tool against mode+permissions → if dangerous: agent.io.send(approval_needed) → agent.io.receive() blocks for client response → if approved: return (execute tool) | if rejected: raise ValueError (LLM sees rejection message)
+  Dependencies: imports from [../../core/events.py (before_each_tool, before_iteration, after_user_input), ./constants.py (VALID_MODES, DEFAULT_MODE, FILE_EDIT_TOOLS), ./bash_parser.py (check_bash_chain_permitted), ../skills.py (matches_permission_pattern), pathlib.Path, typing.TYPE_CHECKING] | imported by [tool_approval/__init__.py] | tested by [tests/unit/test_tool_approval.py, tests/integration/test_config_permissions.py, tests/unit/test_tool_approval.py, tests/unit/test_shell_approval.py]
+  Data flow: after_user_input → load_config_permissions() loads .co/host.yaml permissions into session['permissions'] | before_iteration → poll_mode_changes() checks for mode_change messages | before_each_tool → check_approval() validates tool against mode+permissions → if unpermitted with live IO: agent.io.send(approval_needed) → agent.io.receive() blocks for client response → if approved: return (execute tool) | if rejected: raise ValueError (LLM sees rejection message)
   State/Effects: modifies session['permissions'] (permission cache), session['approval']['approved_tools'] (session-scoped approvals), session['mode'] (safe/accept_edits) | reads .co/host.yaml file | writes to agent.logger for approval logs | sends WebSocket messages via agent.io | blocks execution waiting for user approval
   Integration: exposes check_approval (before_each_tool hook), load_config_permissions (after_user_input hook), poll_mode_changes (before_iteration hook), handle_mode_change(agent, mode), get_current_mode(agent) | uses agent.io.send/receive for client communication | integrates with skills plugin for permission pattern matching | integrates with ulw plugin for ulw mode handling
   Performance: yaml file loaded once per session (cached) | permission checks are O(n) where n=number of permission patterns | WebSocket receive() blocks until user responds (can be seconds/minutes)
@@ -28,13 +28,13 @@ Architecture:
 
 Mode System (session['mode']):
     safe (default):
-        - Safe tools: auto-approved (read, glob, grep)
-        - Dangerous tools: need approval (bash, write, delete)
+        - Explicitly permitted tools are auto-approved
+        - Every remaining tool needs approval when live IO is present
         - Used for: normal coding assistance
 
     accept_edits:
         - File edit tools: auto-approved (write, edit, multi_edit)
-        - Other dangerous tools: need approval (bash, send_email)
+        - Every other unpermitted tool needs approval
         - Used for: rapid editing with approval only for risky ops
 
     ulw (handled by ulw plugin):
@@ -193,13 +193,13 @@ File Relationships:
                                     → raise ValueError or return
 """
 
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
-from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
+from ...core.events import after_iteration, after_user_input, before_each_tool, before_iteration
 from ...project import project_co_dir
-from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
+from .bash_parser import check_bash_chain_permitted
+from .constants import DEFAULT_MODE, FILE_EDIT_TOOLS, VALID_MODES
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -318,13 +318,19 @@ def _get_mode(agent: 'Agent') -> str:
     """Get current approval mode from session.
 
     Modes:
-        'safe': Dangerous tools need approval (default)
-        'accept_edits': No approvals, agent runs freely
+        'safe': Unpermitted tools need approval (default)
+        'accept_edits': Named file edits are auto-approved
     """
     mode = agent.current_session.get('mode', DEFAULT_MODE)
     if mode in VALID_MODES or mode == 'ulw':
         return mode
     return DEFAULT_MODE
+
+
+def _requester_is_operator(agent: 'Agent') -> bool:
+    """Whether this session may select a mode that bypasses approvals."""
+    requester = agent.current_session.get('requester')
+    return not requester or requester.get('level') == 'admin'
 
 
 def _set_mode(agent: 'Agent', mode: str) -> None:
@@ -408,10 +414,10 @@ def check_approval(agent: 'Agent') -> None:
     """Check if tool needs approval based on current mode.
 
     Mode behavior:
-        'safe': Dangerous tools need approval
-        'accept_edits': File edit tools auto-approved, other dangerous tools need approval
+        'safe': Every unpermitted tool needs approval when live IO is present
+        'accept_edits': Named file-edit tools auto-approved; other unpermitted tools need approval
 
-    Other plugins can set session['skip_tool_approval'] = True to bypass all checks.
+    The explicit ulw mode bypasses checks only for the local/admin operator.
 
     Raises:
         ValueError: If tool rejected or blocked by mode
@@ -488,9 +494,10 @@ def check_approval(agent: 'Agent') -> None:
                     return
 
     # =================================================================
-    # Check if another plugin requested to skip approvals (e.g., ulw)
+    # Check the explicit unlimited mode (local/admin operator only)
     # =================================================================
-    if agent.current_session.get('mode') == 'ulw':
+    requester_is_operator = _requester_is_operator(agent)
+    if agent.current_session.get('mode') == 'ulw' and requester_is_operator:
         pending = agent.current_session.get('pending_tool')
         tool_name = pending['name'] if pending else 'unknown'
         tool_args = pending.get('arguments', {}) if pending else {}
@@ -519,19 +526,14 @@ def check_approval(agent: 'Agent') -> None:
     # MODE: accept_edits - File edits auto-approved, others need approval
     # =================================================================
     if mode == 'accept_edits':
-        if tool_name in FILE_EDIT_TOOLS:
+        if tool_name in FILE_EDIT_TOOLS and requester_is_operator:
             if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
                 agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'accept_edits mode')
             return
-        # Other dangerous tools fall through to approval logic
+        # Every other unpermitted tool falls through to approval logic.
 
     # =================================================================
-    # MODE: safe - Dangerous tools need approval
-    # =================================================================
-    # Unknown tools (not in SAFE or DANGEROUS) are treated as safe
-    if tool_name not in DANGEROUS_TOOLS:
-        return
-
+    # Fail closed: every remaining live-IO tool needs approval
     # =================================================================
     # The dialog belongs to the operator, not to whoever is connected
     # =================================================================
@@ -679,10 +681,10 @@ def _convert_permission_patterns(raw: dict) -> dict:
 def load_permission_patterns(co_dir=None) -> dict:
     """Load the merged permission whitelist: template safe defaults + project host.yaml.
 
-    Returns the same dict shape used in session['permissions']. This whitelist is
-    the single source of truth for "what may run without a human in the loop" —
-    honored both by the session approval flow (load_config_permissions) and by
-    direct tool execution (network EXEC), so there is only one list to maintain.
+    Returns the same dict shape used in session['permissions']. This shared
+    whitelist is honored both by the session approval flow and direct network
+    EXEC. A specialized local agent may add narrower loop-only permissions after
+    loading it; those grants deliberately do not enter remote EXEC.
 
     Args:
         co_dir: Project .co directory (default: cwd/.co). The template defaults
@@ -878,6 +880,9 @@ def poll_mode_changes(agent: 'Agent') -> None:
     if agent.current_session.get('mode') == 'plan':
         handle_mode_change(agent, 'plan')
 
+    if not _requester_is_operator(agent) and _get_mode(agent) != DEFAULT_MODE:
+        handle_mode_change(agent, DEFAULT_MODE)
+
     if not agent.io:
         return
 
@@ -886,8 +891,12 @@ def poll_mode_changes(agent: 'Agent') -> None:
         if new_mode in VALID_MODES or new_mode == 'plan':
             handle_mode_change(agent, new_mode)
         elif new_mode == 'ulw':
-            from ..ulw import handle_ulw_mode_change
-            handle_ulw_mode_change(agent, msg.get('turns'))
+            if _requester_is_operator(agent):
+                from ..ulw import handle_ulw_mode_change
+                handle_ulw_mode_change(agent, msg.get('turns'))
+            else:
+                _set_mode(agent, DEFAULT_MODE)
+                _log(agent, "[yellow]Only the operator can enable ulw mode[/yellow]")
 
 
 @after_iteration
@@ -926,6 +935,11 @@ def handle_mode_change(agent: 'Agent', mode: str) -> None:
     requested_mode = mode
     if mode == 'plan':
         mode = DEFAULT_MODE
+
+    if mode == 'accept_edits' and not _requester_is_operator(agent):
+        _set_mode(agent, DEFAULT_MODE)
+        _log(agent, "[yellow]Only the operator can enable accept_edits mode[/yellow]")
+        return
 
     if mode not in VALID_MODES:
         # Unknown mode - might be handled by another plugin (e.g., ulw)

--- a/connectonion/useful_plugins/tool_approval/constants.py
+++ b/connectonion/useful_plugins/tool_approval/constants.py
@@ -2,24 +2,24 @@
 Purpose: Define tool classification and mode constants for approval system
 LLM-Note:
   Dependencies: no imports | imported by [tool_approval/approval.py, tool_approval/__init__.py] | tested by [tests/unit/test_tool_approval.py, tests/integration/test_config_permissions.py]
-  Data flow: provides read-only constants → consumed by approval.py check_approval() → determines which tools need approval based on mode
+  Data flow: provides read-only constants → consumed by approval.py check_approval() and callers → identifies modes, named edit tools, command tools, and known effectful tools
   State/Effects: no state | no side effects | pure constant definitions
-  Integration: exposes VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS sets | used by approval logic to classify tool calls
+  Integration: exposes VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS sets | approval.py uses modes, edit tools, and command tools; DANGEROUS_TOOLS remains public compatibility metadata
   Performance: O(1) set membership checks for tool classification
   Errors: none (constants cannot fail)
 
 Constants Overview:
     VALID_MODES = {'safe', 'accept_edits'}
-        - safe: dangerous tools need approval (default)
-        - accept_edits: file edits auto-approved
+        - safe: unpermitted tools need approval (default)
+        - accept_edits: named file edits auto-approved
 
-    DANGEROUS_TOOLS: bash, write, edit, send_email, delete, etc.
+    DANGEROUS_TOOLS: known effectful tools kept as a public reference set
     FILE_EDIT_TOOLS: write, edit, multi_edit (subset of DANGEROUS)
     COMMAND_TOOLS: bash, shell, run (approval is per-command-name)
 
 Tool Classification:
-    Safe tools (unlisted): read, glob, grep, ls → auto-approved
-    Dangerous tools: DANGEROUS_TOOLS set → need approval in safe mode
+    Permitted tools: supplied by template, config, skills, or the user → auto-approved
+    Unpermitted tools: require approval with live IO, including unclassified tools
     File edit tools: FILE_EDIT_TOOLS set → auto-approved in accept_edits mode
     Command tools: COMMAND_TOOLS set → tool-level approval (approving "bash" approves all)
 """
@@ -28,8 +28,8 @@ Tool Classification:
 # MODE SYSTEM
 # =============================================================================
 # Two modes control approval behavior:
-#   - 'safe' (default): Dangerous tools need approval
-#   - 'accept_edits': File edit tools auto-approved, other dangerous tools need approval
+#   - 'safe' (default): Unpermitted tools need approval
+#   - 'accept_edits': File edit tools auto-approved, other unpermitted tools need approval
 #
 # Other modes (handled by separate plugins via skip_tool_approval flag):
 #   - 'ulw': Handled by ulw plugin - sets skip_tool_approval=True
@@ -42,8 +42,11 @@ VALID_MODES = {'safe', 'accept_edits'}
 DEFAULT_MODE = 'safe'
 
 
-# Tools that need approval in 'safe' mode
-# These tools can modify files, execute code, or have external effects.
+# Known tools that modify files, execute code, or have external effects.
+#
+# This public set is retained for compatibility and discoverability. It is not
+# the security boundary: check_approval() requires approval for every tool that
+# lacks an explicit permission when live IO is present.
 DANGEROUS_TOOLS = {
     # Shell execution
     'bash', 'shell', 'run', 'run_in_dir',

--- a/docs/design-decisions/fail-closed-unclassified-tools.md
+++ b/docs/design-decisions/fail-closed-unclassified-tools.md
@@ -1,0 +1,61 @@
+# Fail Closed for Unclassified Tools
+
+*Date: 2026-08-10*  
+*Status: Accepted*
+
+## Context
+
+ConnectOnion can register tools dynamically through plugins and, increasingly, external protocols such as ACP and MCP. The tool approval hook previously used `DANGEROUS_TOOLS` as a denylist: a live tool whose name was not in that set skipped approval automatically.
+
+That assumption was valid only while the framework controlled every tool name. A plugin can expose a new name with file, process, network, or external-service effects. Classifying that name as safe merely because core has never seen it turns extensibility into an approval bypass.
+
+## Decision
+
+When an agent has live IO, approval is allowlist-based:
+
+1. Explicit template, config, skill, and user permissions are evaluated first.
+2. `accept_edits` auto-approves only the named file-edit tools.
+3. `ulw` remains an explicit authority bypass owned by its plugin.
+4. Every other tool call must receive operator approval; a hosted non-admin requester is rejected without a dialog.
+
+In a hosted session, only an admin operator may enable `accept_edits` or `ulw`.
+Non-admin requesters are normalized to `safe`, and the approval hook also
+refuses to honor stale elevated mode state as defense in depth.
+
+Local library use without `agent.io` remains non-interactive. `DANGEROUS_TOOLS` remains public compatibility metadata for known effectful tools, but it is no longer the security boundary.
+
+This policy stays inside the approval hook. Tool registration and execution remain separate concerns.
+
+## Consequences
+
+- New plugin and protocol-provided tools cannot silently acquire live side effects.
+- Custom read-only tools may prompt once for the operator until they receive a template, config, skill, or session permission.
+- Existing standard read-only tools keep their current experience because the host template explicitly permits them.
+- co ai grants `codex` and `claude_code` only inside its outer LLM-loop session because those wrappers own inner action approval. This applies to CLI and hosted co-ai sessions but never enters the shared remote-EXEC whitelist. Hosted non-admin Claude delegation is refused; hosted non-admin Codex is read-only with nested approvals denied.
+- Non-admin remote requesters fail closed instead of receiving an approval dialog they do not own.
+- A remote mode-change frame cannot escalate a requester past that owner gate.
+- ACP can forward future MCP tools through the same deterministic approval boundary.
+
+## Alternatives Rejected
+
+### Expand the denylist
+
+No finite list can classify names introduced after release. Missing one entry recreates the vulnerability.
+
+### Trust tool prefixes or descriptions
+
+Names and descriptions are supplied by extension authors and are not enforceable capabilities. A tool called `read_data` can still write files or use the network.
+
+### Prompt during local no-IO use
+
+There is no approval channel in that mode. Changing it would break ordinary library workflows without adding a usable security decision point.
+
+### Put policy in the executor
+
+Execution should run the already-authorized call. Keeping policy in the approval hook preserves the separation established in [DD-012](012-tool-execution-separation.md).
+
+## Related Decisions
+
+- [DD-012: Tool Execution Separation](012-tool-execution-separation.md)
+- [DD-020: Trust System and Network Architecture](020-trust-system-and-network-architecture.md)
+- [DD-023: Trust Policy System](023-trust-policy-system-design.md)

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -25,7 +25,7 @@ session['permissions'] = {
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ 1. SAFE_TOOLS - Always auto-approved                       │
+│ 1. Template Permissions - Explicit built-in allowlist      │
 │    read_file, glob, grep (read-only operations)            │
 │    Stored as: source='safe', expires='never'               │
 └─────────────────────────────────────────────────────────────┘
@@ -52,9 +52,9 @@ session['permissions'] = {
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. Tool Approval - Ask user for dangerous operations       │
-│    bash, edit, write → require explicit user approval      │
-│    If no permission in unified dict → ask user             │
+│ 5. Tool Approval - Resolve unpermitted operations          │
+│    Local/admin operator → explicit approval                │
+│    Hosted non-admin requester → reject without a dialog    │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -114,9 +114,9 @@ def create_agent():
 
 host(create_agent)  # Loads permissions from .co/host.yaml
 
-# Safe tools - always auto-approved
+# Template-permitted tools - auto-approved
 agent.input("Read the README")
-# → read_file auto-approved (SAFE_TOOLS) ✓
+# → read_file auto-approved (template permission) ✓
 
 # Config permissions - auto-approved from host.yaml
 agent.input("Check git status")
@@ -137,9 +137,10 @@ agent.input("Run tests")
 # → User approves for "session"
 # → Future pytest calls auto-approved for this session ✓
 
-# Dangerous operations - always ask
+# Unpermitted operations - operator approval or fail closed
 agent.input("Delete all files")
-# → User approval required (destructive operation)
+# → Local/admin operator: approval required
+# → Hosted non-admin requester: rejected without a dialog
 ```
 
 ## Unified Permission Format
@@ -224,22 +225,21 @@ permissions = snapshot  # Restore - user's 'write' preserved, skill's 'bash' cle
 
 **Result**: Skills grant temporary permissions without losing user approvals.
 
-## 1. SAFE_TOOLS - Always Auto-Approved
+## 1. Template Permissions - Explicit Built-In Allowlist
 
-Read-only operations that can't harm the system.
+The standard host template explicitly permits its built-in read-only tools. The permission entries use `source: safe`; safety does not come from a tool being absent from a denylist.
 
-```python
-SAFE_TOOLS = [
-    'FileTools.read_file',
-    'FileTools.glob',
-    'FileTools.grep',
-    'ls',
-    'list_directory',
-    'tree'
-]
+```yaml
+permissions:
+  "read_file":
+    allowed: true
+    source: safe
+    reason: read-only operation
+    expires:
+      type: never
 ```
 
-**No approval needed** - these tools are always safe to execute.
+These named tools need no approval. A custom or dynamically registered tool is not implicitly safe just because its name is new.
 
 ### Example
 
@@ -759,11 +759,11 @@ def check_approval(agent):
     # ... ask user for approval
 ```
 
-## 5. Tool Approval - Ask User for Dangerous Operations
+## 5. Tool Approval - Ask User for Unpermitted Operations
 
-Web-based approval UI for dangerous tools.
+With live IO, the web approval UI handles every tool call that did not match an explicit template, config, skill, user, or mode permission. Known effectful tools remain documented for discoverability, but that list is not the security boundary.
 
-### Dangerous Tools
+### Known Effectful Tools
 
 ```python
 DANGEROUS_TOOLS = [
@@ -782,7 +782,7 @@ DANGEROUS_TOOLS = [
    ↓
 2. Tool approval plugin intercepts
    ↓
-3. Send approval request to web UI
+3. Local/admin operator receives an approval request
    ┌──────────────────────────────────┐
    │ ⚠️ Approval needed: bash         │
    │                                  │
@@ -792,7 +792,7 @@ DANGEROUS_TOOLS = [
    │ [Approve for session]            │
    │ [Deny]                           │
    └──────────────────────────────────┘
-4. User decides
+4. Operator decides (a hosted non-admin is rejected before this step)
    ↓
 5. Tool executes (or blocked)
 ```
@@ -804,8 +804,10 @@ DANGEROUS_TOOLS = [
 def check_approval(agent):
     """Check if tool needs approval before execution."""
 
-    tool_name = agent.current_session['pending_tool_call']['name']
-    tool_args = agent.current_session['pending_tool_call']['arguments']
+    pending = agent.current_session['pending_tool']
+    tool_name = pending['name']
+    tool_args = pending['arguments']
+    requester = agent.current_session.get('requester')
 
     # 1. Check skill permission scope (highest priority)
     scope = agent.current_session.get('permission_scope')
@@ -813,8 +815,9 @@ def check_approval(agent):
         if _matches_pattern(tool_name, tool_args, scope['allowed_tools']):
             return  # Auto-approve
 
-    # 2. Check SAFE_TOOLS
-    if tool_name in SAFE_TOOLS:
+    # 2. Check explicit template/config/skill permissions
+    permissions = agent.current_session.get('permissions', {})
+    if matches_permission(tool_name, tool_args, permissions):
         return  # Auto-approve
 
     # 3. Check session memory
@@ -826,24 +829,24 @@ def check_approval(agent):
     if tool_name in approved_tools and approved_tools[tool_name] == 'deny':
         raise ToolDenied(f"{tool_name} was denied")
 
-    # 5. Ask user for dangerous tools
-    if tool_name in DANGEROUS_TOOLS:
-        response = agent.io.send({
-            'type': 'approval_needed',
-            'tool_name': tool_name,
-            'tool_args': tool_args
-        })
+    # 5. Fail closed: only the local/admin operator may approve
+    if requester and requester.get('level') != 'admin':
+        raise ToolDenied(f"{tool_name} requires operator approval")
 
-        scope = response['scope']  # 'once', 'session', 'deny'
+    agent.io.send({
+        'type': 'approval_needed',
+        'tool': tool_name,
+        'arguments': tool_args,
+    })
+    response = agent.io.receive()
 
-        if scope == 'deny':
-            agent.current_session.setdefault('approval', {})['approved_tools'][tool_name] = 'deny'
-            raise ToolDenied(f"User denied {tool_name}")
+    if not response.get('approved', False):
+        raise ToolDenied(f"User denied {tool_name}")
 
-        if scope == 'session':
-            agent.current_session.setdefault('approval', {})['approved_tools'][tool_name] = 'session'
+    if response.get('scope', 'once') == 'session':
+        agent.current_session.setdefault('approval', {})['approved_tools'][tool_name] = 'session'
 
-        # scope == 'once' → just execute this time
+    # scope == 'once' → just execute this time
 
 tool_approval = [before_each_tool(check_approval)]
 ```
@@ -862,7 +865,8 @@ The approval system uses unified permissions - all permissions stored in `sessio
        └─ Log: "⚡ tool_name (reason from permission)"
 
 2. If no match in permissions
-   └─ ASK USER (web approval UI)
+   ├─ Hosted non-admin requester → REJECT without a dialog
+   └─ Local/admin operator → ASK USER (web approval UI)
        └─ If approved for "session" → Add to permissions dict
 ```
 
@@ -905,11 +909,11 @@ agent = Agent(
 )
 
 # ────────────────────────────────────────────────────────
-# Scenario 1: Safe tools (always auto-approved)
+# Scenario 1: Template-permitted tools
 # ────────────────────────────────────────────────────────
 agent.input("Find all tests")
-# → glob("**/test_*.py") - SAFE_TOOLS ✓
-# → read_file("test_agent.py") - SAFE_TOOLS ✓
+# → glob("**/test_*.py") - template permission ✓
+# → read_file("test_agent.py") - template permission ✓
 
 # ────────────────────────────────────────────────────────
 # Scenario 2: Skills (scoped permissions for one turn)
@@ -939,12 +943,13 @@ agent.input("Deploy")
 # → bash("./deploy.sh") - session memory ✓
 
 # ────────────────────────────────────────────────────────
-# Scenario 5: Dangerous operations (always ask)
+# Scenario 5: Unpermitted operations (operator approval or fail closed)
 # ────────────────────────────────────────────────────────
 agent.input("Create new config file")
 # → write("config.json", ...) - REQUIRES APPROVAL
 # → User approves "once"
 # → Executes this time only
+# → A hosted non-admin requester is rejected without a dialog instead
 
 agent.input("Create another file")
 # → write("data.json", ...) - REQUIRES APPROVAL again
@@ -953,50 +958,32 @@ agent.input("Create another file")
 ## Flow Diagram
 
 ```
-┌─────────────────────────┐
-│ Agent wants to use tool │
-└────────────┬────────────┘
-             │
-             ▼
-┌────────────────────────────────┐
-│ 1. Skills permission scope?    │
-│    (turn-specific)              │
-└─────┬──────────────────────┬───┘
-  YES │                      │ NO
-      ▼                      ▼
-   ┌──────┐     ┌────────────────────────┐
-   │ ✓ OK │     │ 2. SAFE_TOOLS?         │
-   └──────┘     └─────┬──────────────┬───┘
-                  YES │              │ NO
-                      ▼              ▼
-                   ┌──────┐     ┌────────────────────────┐
-                   │ ✓ OK │     │ 3. Plan mode + edit?   │
-                   └──────┘     └─────┬──────────────┬───┘
-                                  YES │              │ NO
-                                      ▼              ▼
-                                   ┌──────┐     ┌────────────────────────┐
-                                   │ ✓ OK │     │ 4. Session memory?     │
-                                   └──────┘     └─────┬──────────────┬───┘
-                                                  YES │              │ NO
-                                                      ▼              ▼
-                                               ┌────────────┐   ┌──────────────┐
-                                               │ ✓ approved │   │ 5. Ask user  │
-                                               │ ✗ denied   │   └──────┬───────┘
-                                               └────────────┘          │
-                                                                       ▼
-                                                            ┌─────────────────────┐
-                                                            │ once / session /    │
-                                                            │ deny                │
-                                                            └──────┬──────────────┘
-                                                                   │
-                                                        ┌──────────┼──────────┐
-                                                        │          │          │
-                                                        ▼          ▼          ▼
-                                                     ┌────┐   ┌────────┐  ┌──────┐
-                                                     │ ✓  │   │ ✓ save │  │ ✗    │
-                                                     │once│   │ to     │  │deny  │
-                                                     └────┘   │session │  └──────┘
-                                                              └────────┘
+Agent wants to use a tool
+          │
+          ▼
+Explicit template, config, skill,
+user, or session permission?
+    ├─ yes → execute
+    └─ no
+          │
+          ▼
+No live IO?
+    ├─ yes → execute
+    └─ no
+          │
+          ▼
+Operator-owned mode bypass?
+(`ulw`, or `accept_edits` for named edit tools)
+    ├─ yes → execute
+    └─ no
+          │
+          ▼
+Hosted non-admin requester?
+    ├─ yes → reject without a dialog
+    └─ no  → ask the local/admin operator
+                 ├─ once → execute once
+                 ├─ session → save permission and execute
+                 └─ deny → reject
 ```
 
 ## Best Practices
@@ -1090,7 +1077,7 @@ User decisions don't persist across sessions.
 
 ### Tool Approval Is Final Layer
 
-Even with all auto-approval mechanisms, dangerous tools not covered by other layers still require explicit user approval.
+Even with all auto-approval mechanisms, every remaining live-IO tool requires an operator decision. A local/admin operator receives the approval dialog; a hosted non-admin requester is rejected without one. Unknown plugin and protocol-provided tools fail closed too.
 
 ## Related Documentation
 

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -193,9 +193,9 @@ The `tool_approval` plugin checks permissions in this order:
 
 ```
 1. Check skill's allowed_tools → Auto-approve if match
-2. Check SAFE_TOOLS (read, glob, grep) → Auto-approve
-3. Check session memory (previous approvals) → Auto-approve
-4. Check DANGEROUS_TOOLS → Ask user
+2. Check template/config permissions → Auto-approve if match
+3. Check session memory and explicit mode permissions → Auto-approve if match
+4. Ask for every remaining live-IO tool
 ```
 
 **Pattern matching** for flexible permissions:
@@ -460,16 +460,6 @@ def check_approval(agent):
     # Check unified permissions dict
     permissions = agent.current_session.get('permissions', {})
 
-    # Ensure safe tools are in permissions
-    if tool_name in SAFE_TOOLS:
-        if tool_name not in permissions:
-            permissions[tool_name] = {
-                'allowed': True,
-                'source': 'safe',
-                'reason': 'read-only operation',
-                'expires': {'type': 'never'}
-            }
-
     # Check each permission with pattern matching
     if permissions:
         for pattern, perm in permissions.items():
@@ -481,10 +471,9 @@ def check_approval(agent):
                 log(f"⚡ {tool_name} ({reason})")
                 return  # Auto-approve
 
-    # Ask user for dangerous tools
-    if tool_name in DANGEROUS_TOOLS:
-        response = agent.io.send({'type': 'approval_needed', ...})
-        # If approved for session, add to permissions dict
+    # Fail closed for every remaining tool when live IO is present
+    response = agent.io.send({'type': 'approval_needed', ...})
+    # If approved for session, add to permissions dict
 ```
 
 ### Pattern Matching

--- a/docs/network/io.md
+++ b/docs/network/io.md
@@ -166,29 +166,12 @@ host(agent)
 ### Tool Approval
 
 ```python
-from connectonion import Agent, host, before_each_tool
+from connectonion import Agent, host
+from connectonion.useful_plugins import tool_approval
 
-class ToolRejected(Exception):
-    pass
-
-DANGEROUS_TOOLS = ["delete_file", "send_email", "run_shell"]
-
-@before_each_tool
-def check_approval(agent):
-    if not agent.io:
-        return
-
-    tool = agent.current_session['pending_tool']
-
-    # Notify tool is starting
-    agent.io.log("tool_call", name=tool['name'], arguments=tool['arguments'])
-
-    # Request approval for dangerous tools
-    if tool['name'] in DANGEROUS_TOOLS:
-        if not agent.io.request_approval(tool['name'], tool['arguments']):
-            raise ToolRejected(f"User rejected {tool['name']}")
-
-agent = Agent("helper", tools=[delete_file], on_events=[check_approval])
+# Explicit permissions are loaded from the host template and .co/host.yaml.
+# Every remaining live-IO tool asks, including names added by plugins later.
+agent = Agent("helper", tools=[delete_file], plugins=[tool_approval])
 host(agent)
 ```
 
@@ -393,11 +376,7 @@ from connectonion import (
     Agent, host,
     after_llm, before_each_tool, after_each_tool, on_complete, on_error
 )
-
-class ToolRejected(Exception):
-    pass
-
-DANGEROUS_TOOLS = ["delete_file", "send_email"]
+from connectonion.useful_plugins import tool_approval
 
 @after_llm
 def on_thinking(agent):
@@ -411,10 +390,6 @@ def on_tool_start(agent):
 
     tool = agent.current_session['pending_tool']
     agent.io.log("tool_call", name=tool['name'], arguments=tool['arguments'])
-
-    if tool['name'] in DANGEROUS_TOOLS:
-        if not agent.io.request_approval(tool['name'], tool['arguments']):
-            raise ToolRejected(tool['name'])
 
 @after_each_tool
 def on_tool_end(agent):
@@ -441,6 +416,7 @@ def on_fail(agent):
 agent = Agent(
     "helper",
     tools=[search, delete_file],
+    plugins=[tool_approval],
     on_events=[on_thinking, on_tool_start, on_tool_end, on_done, on_fail]
 )
 

--- a/docs/useful_plugins/skills.md
+++ b/docs/useful_plugins/skills.md
@@ -129,9 +129,9 @@ The `tool_approval` plugin checks `permission_scope` first:
 
 ```
 1. Skill's allowed_tools → Auto-approve if match
-2. SAFE_TOOLS → Auto-approve
-3. Session memory → Auto-approve if previously approved
-4. DANGEROUS_TOOLS → Ask user
+2. Template/config permissions → Auto-approve if match
+3. Session memory and explicit mode permissions → Auto-approve if match
+4. Ask for every remaining live-IO tool
 ```
 
 ## Security Model

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -1,6 +1,6 @@
 # tool_approval
 
-Web-based approval for dangerous tools via WebSocket. Requires user confirmation before executing tools that can modify files or run commands.
+Web-based approval for tools via WebSocket. With live IO, a tool without an explicit permission must receive approval from the local/admin operator before execution. A hosted non-admin requester is rejected without a dialog.
 
 ## Quick Start
 
@@ -19,6 +19,9 @@ agent.input("Install dependencies")
 
 ## Lifecycle
 
+This example shows a local/admin operator session. Hosted non-admin requesters
+are rejected before an approval request is sent.
+
 ```
 User sends prompt
     ↓
@@ -30,8 +33,7 @@ tool_executor iterates sequentially:
     ↓
 ┌─ Tool #1: bash("npm install")
 │   before_each_tool fires → check_approval()
-│   → Is it safe? No (bash is DANGEROUS)
-│   → Already approved for session? No
+│   → Explicitly permitted? No
 │   → Send to client:
 │       {
 │         "type": "approval_needed",
@@ -50,7 +52,7 @@ tool_executor iterates sequentially:
 │
 ├─ Tool #2: write("config.json")
 │   before_each_tool fires → check_approval()
-│   → Is it safe? No (write is DANGEROUS)
+│   → Explicitly permitted? No
 │   → Send approval_needed (batch_remaining: [bash(...)])
 │   → Client responds: {"approved": false, "mode": "reject_soft"}
 │   → Skip this tool, continue to next
@@ -114,9 +116,9 @@ When a tool needs approval, the server includes `batch_remaining` — a list of 
 
 ## Tool Classification
 
-### Safe Tools (No Approval)
+### Template-Permitted Tools (No Approval)
 
-Read-only operations that never modify state:
+The standard host template grants explicit permissions to its built-in read-only tools:
 
 ```
 read, read_file, glob, grep, search
@@ -124,7 +126,7 @@ list_files, get_file_info, task, load_guide
 task_output, ask_user
 ```
 
-### Dangerous Tools (Require Approval)
+### Known Effectful Tools (Require Approval Unless Permitted)
 
 Operations that can modify files or have side effects:
 
@@ -137,7 +139,18 @@ send_email, post, delete, remove
 
 ### Unknown Tools
 
-Tools not in either list are treated as safe (no approval needed).
+Unknown and dynamically registered tools require operator approval when live IO is present. A hosted non-admin requester is rejected without a dialog. This fail-closed default keeps plugin and MCP tools behind the same approval boundary as built-in effectful tools.
+
+Three explicit exceptions preserve existing workflows:
+
+- Local library use without `agent.io` stays non-interactive.
+- `accept_edits` auto-approves only the named file-edit tools (`write`, `edit`, and `multi_edit`).
+- `ulw` remains an explicit bypass controlled by its own plugin.
+
+Only a local/admin operator receives approval dialogs or may enable
+`accept_edits` or `ulw`. In hosted sessions, only the admin operator can enable them.
+A contact, whitelisted caller, or stranger may switch back to `safe`, but cannot
+turn a mode-change frame into file or dynamic-tool authority.
 
 ## Config-Based Auto-Approval
 
@@ -258,11 +271,11 @@ All commands are whitelisted for bash command chains - if ALL commands in a chai
 
 Config permissions integrate with the existing approval system:
 
-1. **Safe tools** - Always approved (SAFE_TOOLS list)
+1. **Template permissions** - Explicit built-in allowlist (`source: safe`)
 2. **Config permissions** - Loaded from host.yaml (`source: config`)
 3. **Skill permissions** - Temporary, turn-scoped (`source: skill`)
 4. **Session approvals** - User approved for session (`source: user`)
-5. **Runtime approval** - Ask user (if none of above match)
+5. **Runtime approval** - Ask user for every remaining live-IO tool
 
 ### Terminal Logging
 

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -1,5 +1,5 @@
-"""Tests for co_ai agent creation and server entrypoint."""
-"""
+"""Tests for co_ai agent creation and server entrypoint.
+
 LLM-Note: Tests for co ai agent main
 
 What it tests:
@@ -9,12 +9,28 @@ Components under test:
 - Module: co_ai_agent_main
 """
 
-
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import connectonion.cli.co_ai.agent as agent_mod
 import connectonion.cli.co_ai.main as main_mod
+from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
+
+
+def test_managed_delegation_permissions_are_explicit(tmp_path):
+    """Nested coding agents own inner approval without reopening unknown tools."""
+    agent = SimpleNamespace(current_session={'permissions': {}})
+
+    agent_mod.grant_managed_delegation_permissions(agent)
+
+    assert set(agent.current_session['permissions']) == {'codex', 'claude_code'}
+    assert all(
+        permission['allowed'] is True
+        and permission['source'] == 'safe'
+        for permission in agent.current_session['permissions'].values()
+    )
+    shared_exec_permissions = load_permission_patterns(tmp_path / '.co')
+    assert not {'codex', 'claude_code'} & set(shared_exec_permissions)
 
 
 def test_create_coding_agent(monkeypatch, tmp_path):

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -179,6 +179,13 @@ def test_outer_approval_does_not_duplicate_claude_permissions():
     agent = SimpleNamespace(
         current_session={
             "mode": "safe",
+            "permissions": {
+                "claude_code": {
+                    "allowed": True,
+                    "source": "safe",
+                    "reason": "managed delegation owns inner approval",
+                }
+            },
             "pending_tool": {
                 "id": "call-1",
                 "name": "claude_code",

--- a/tests/unit/test_co_ai_codex.py
+++ b/tests/unit/test_co_ai_codex.py
@@ -160,6 +160,13 @@ def test_outer_approval_does_not_duplicate_codex_action_approval():
     agent = SimpleNamespace(
         current_session={
             "mode": "safe",
+            "permissions": {
+                "codex": {
+                    "allowed": True,
+                    "source": "safe",
+                    "reason": "managed delegation owns inner approval",
+                }
+            },
             "pending_tool": {
                 "id": "call-1",
                 "name": "codex",

--- a/tests/unit/test_only_the_owner_approves.py
+++ b/tests/unit/test_only_the_owner_approves.py
@@ -49,6 +49,7 @@ class FakeAgent:
 
 DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
                                            'description': 'clean'}}
+UNCLASSIFIED = {'name': 'third_party_tool', 'arguments': {'value': 'example'}}
 
 
 class TestOnlyAnAdminIsAsked:
@@ -85,6 +86,18 @@ class TestOnlyAnAdminIsAsked:
         assert 'host.yaml' in message
         assert 'bash' in message
 
+    def test_an_unclassified_tool_also_fails_closed(self):
+        """Dynamic tools do not bypass the operator gate by using a new name."""
+        io = FakeIO()
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': 'contact'})
+        agent.current_session['pending_tool'] = UNCLASSIFIED
+
+        with pytest.raises(ValueError, match='third_party_tool'):
+            check_approval(agent)
+
+        assert io.sent == []
+
     def test_an_admin_is_still_asked(self):
         io = FakeIO(responses=[{'approved': True}])
         agent = FakeAgent(io=io, requester={'address': '0x' + 'f' * 64,
@@ -97,10 +110,17 @@ class TestOnlyAnAdminIsAsked:
         assert io.sent[0]['type'] == 'approval_needed'
 
     def test_a_safe_tool_is_unaffected_for_everyone(self):
-        """This gates approval, not access. A contact may still use the agent."""
+        """This gates approval, not explicitly permitted access."""
         io = FakeIO()
         agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
                                             'level': 'contact'})
+        agent.current_session['permissions'] = {
+            'read_file': {
+                'allowed': True,
+                'source': 'safe',
+                'reason': 'read-only operation',
+            }
+        }
         agent.current_session['pending_tool'] = {'name': 'read_file',
                                                  'arguments': {'path': 'a.md'}}
 

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -1,15 +1,15 @@
 """Unit tests for connectonion/useful_plugins/tool_approval.py
 
 Tests cover:
-- Safe tools skip approval
+- Explicitly permitted safe tools skip approval
 - Dangerous tools require approval
+- Unclassified tools require approval when live IO is present
 - Session-level approval memory
 - reject_soft: skip tool, loop continues, system reminder to call ask_user with options
 - reject_hard: skip tool + remaining batch, loop stops
 - batch_remaining: approval_needed includes upcoming tools
 - No IO = skip (not web mode)
-"""
-"""
+
 LLM-Note: Tests for tool approval
 
 What it tests:
@@ -19,29 +19,27 @@ Components under test:
 - Module: tool_approval
 """
 
-
-import pytest
 from unittest.mock import Mock
 
+import pytest
+
 from connectonion.useful_plugins.tool_approval import (
-    check_approval,
-    poll_mode_changes,
-    poll_interrupt,
-    handle_mode_change,
-    tool_approval,
     VALID_MODES,
-)
-from connectonion.useful_plugins.tool_approval.constants import (
-    DANGEROUS_TOOLS,
-    COMMAND_TOOLS,
+    check_approval,
+    poll_interrupt,
+    poll_mode_changes,
+    tool_approval,
 )
 from connectonion.useful_plugins.tool_approval.approval import (
+    _get_approval_key,
+    _get_batch_remaining,
+    _init_approval_state,
     _is_approved_for_session,
     _save_session_approval,
-    _init_approval_state,
-    _get_batch_remaining,
-    _get_approval_key,
-    _resolve_display_name,
+)
+from connectonion.useful_plugins.tool_approval.constants import (
+    COMMAND_TOOLS,
+    DANGEROUS_TOOLS,
 )
 
 
@@ -98,6 +96,13 @@ class FakeAgent:
         }
 
 
+@pytest.fixture(autouse=True)
+def _isolate_project_lookup(tmp_path, monkeypatch):
+    """Keep permission tests independent from any parent project config."""
+
+    monkeypatch.chdir(tmp_path)
+
+
 class TestToolClassification:
     """Test tool classification - DANGEROUS tools need approval."""
 
@@ -138,9 +143,16 @@ class TestSafeTools:
 
     @pytest.mark.parametrize("tool_name", ['read', 'read_file', 'glob', 'grep', 'search', 'task'])
     def test_safe_tools_skip_approval(self, tool_name):
-        """Safe tools should not trigger approval request."""
+        """Template-style safe permissions should not trigger approval."""
         io = FakeIO()
         agent = FakeAgent(io=io)
+        agent.current_session['permissions'] = {
+            tool_name: {
+                'allowed': True,
+                'source': 'safe',
+                'reason': 'read-only operation',
+            }
+        }
         agent.current_session['pending_tool'] = {
             'name': tool_name,
             'arguments': {}
@@ -297,11 +309,18 @@ class TestCheckpoint:
         # Should not raise
         check_approval(agent)
 
-    def test_no_checkpoint_for_safe_tools(self):
-        """checkpoint() not called for safe tools."""
+    def test_no_checkpoint_for_explicitly_permitted_tools(self):
+        """checkpoint() is not called for explicitly permitted tools."""
         storage = FakeStorage()
         io = FakeIO()
         agent = FakeAgent(io=io, storage=storage)
+        agent.current_session['permissions'] = {
+            'read': {
+                'allowed': True,
+                'source': 'safe',
+                'reason': 'read-only operation',
+            }
+        }
         agent.current_session['pending_tool'] = {
             'name': 'read',
             'arguments': {},
@@ -613,19 +632,110 @@ class TestApprovalKey:
 class TestUnknownTools:
     """Test unknown tools behavior."""
 
-    def test_unknown_tool_skips_approval(self):
-        """Unknown tools (not in SAFE or DANGEROUS) should skip approval."""
-        io = FakeIO()
+    @pytest.mark.parametrize("mode", ['safe', 'accept_edits'])
+    def test_unknown_tool_requests_approval(self, mode):
+        """Live unclassified tools require explicit approval in both modes."""
+        io = FakeIO(responses=[{'approved': True, 'scope': 'once'}])
         agent = FakeAgent(io=io)
+        agent.current_session['mode'] = mode
         agent.current_session['pending_tool'] = {
             'name': 'my_custom_tool',
-            'arguments': {}
+            'arguments': {'value': 'example'},
         }
 
         check_approval(agent)
 
-        # No approval request sent
-        assert len(io.sent) == 0
+        assert len(io.sent) == 1
+        assert io.sent[0]['type'] == 'approval_needed'
+        assert io.sent[0]['tool'] == 'my_custom_tool'
+        assert io.sent[0]['arguments'] == {'value': 'example'}
+        assert io.sent[0]['description'] == ''
+
+    def test_explicit_permission_allows_an_unknown_tool(self):
+        """The allowlist stays extensible for custom and plugin tools."""
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['permissions'] = {
+            'my_custom_tool': {
+                'allowed': True,
+                'source': 'config',
+                'reason': 'operator configured',
+            }
+        }
+        agent.current_session['pending_tool'] = {
+            'name': 'my_custom_tool',
+            'arguments': {},
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+
+    def test_unknown_tool_without_io_remains_noninteractive(self):
+        """Local library use has no approval channel and keeps existing behavior."""
+        agent = FakeAgent(io=None)
+        agent.current_session['pending_tool'] = {
+            'name': 'my_custom_tool',
+            'arguments': {},
+        }
+
+        check_approval(agent)
+
+    def test_unknown_tool_in_ulw_uses_explicit_bypass(self):
+        """ULW remains an explicit authority decision made by another plugin."""
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = 'ulw'
+        agent.current_session['pending_tool'] = {
+            'name': 'my_custom_tool',
+            'arguments': {},
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+
+    def test_accept_edits_still_allows_named_file_edits(self):
+        """The fail-closed fallback must not redefine accept_edits."""
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = 'accept_edits'
+        agent.current_session['pending_tool'] = {
+            'name': 'edit',
+            'arguments': {'file_path': 'README.md'},
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+
+    @pytest.mark.parametrize(
+        ('mode', 'tool_name', 'arguments'),
+        [
+            ('ulw', 'third_party_tool', {}),
+            ('accept_edits', 'write', {'file_path': 'owned.txt', 'content': 'no'}),
+        ],
+    )
+    def test_stale_elevated_mode_does_not_bypass_remote_owner_gate(
+        self, mode, tool_name, arguments
+    ):
+        """The approval hook defends even if before_iteration was skipped."""
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = mode
+        agent.current_session['requester'] = {
+            'address': '0x' + 'e' * 64,
+            'level': 'contact',
+        }
+        agent.current_session['pending_tool'] = {
+            'name': tool_name,
+            'arguments': arguments,
+        }
+
+        with pytest.raises(ValueError, match="operator's approval"):
+            check_approval(agent)
+
+        assert io.sent == []
 
 
 class TestSessionState:
@@ -741,6 +851,55 @@ class TestPollModeChanges:
         assert agent.current_session['mode'] == 'ulw'
         assert agent.current_session['ulw_turns'] == 50
         assert agent.current_session['skip_tool_approval'] is True
+
+    def test_remote_contact_cannot_use_ulw_to_run_an_unknown_tool(self):
+        """A live caller cannot turn a mode frame into dynamic-tool authority."""
+        io = FakeIO(pending_signals=[
+            {'type': 'mode_change', 'mode': 'ulw', 'turns': 50},
+        ])
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = 'safe'
+        agent.current_session['requester'] = {
+            'address': '0x' + 'e' * 64,
+            'level': 'contact',
+        }
+
+        poll_mode_changes(agent)
+        agent.current_session['pending_tool'] = {
+            'name': 'third_party_tool',
+            'arguments': {},
+        }
+
+        with pytest.raises(ValueError, match="operator's approval"):
+            check_approval(agent)
+
+        assert agent.current_session['mode'] == 'safe'
+        assert 'skip_tool_approval' not in agent.current_session
+        assert not any(msg.get('type') == 'approval_needed' for msg in io.sent)
+
+    def test_remote_contact_cannot_use_accept_edits_to_write(self):
+        """The named edit bypass belongs to the operator, not the socket."""
+        io = FakeIO(pending_signals=[
+            {'type': 'mode_change', 'mode': 'accept_edits'},
+        ])
+        agent = FakeAgent(io=io)
+        agent.current_session['mode'] = 'safe'
+        agent.current_session['requester'] = {
+            'address': '0x' + 'e' * 64,
+            'level': 'contact',
+        }
+
+        poll_mode_changes(agent)
+        agent.current_session['pending_tool'] = {
+            'name': 'write',
+            'arguments': {'file_path': 'owned.txt', 'content': 'no'},
+        }
+
+        with pytest.raises(ValueError, match="operator's approval"):
+            check_approval(agent)
+
+        assert agent.current_session['mode'] == 'safe'
+        assert not any(msg.get('type') == 'approval_needed' for msg in io.sent)
 
     def test_poll_mode_changes_handles_multiple_signals(self):
         """poll_mode_changes should process multiple mode_change signals."""


### PR DESCRIPTION
## Related

- Closes #832 when merged.
- Security prerequisite for #332, #475, and future ACP-to-MCP tool forwarding.

## Design

- Replace the known-tool denylist boundary with explicit template, config, skill, user, and session permissions.
- Require operator approval for every remaining live-IO tool; hosted non-admin requesters fail closed without receiving the operator's dialog.
- Restrict stale and queued `accept_edits` / `ulw` mode changes to local or admin operators.
- Keep `co ai` coding wrappers usable through outer-loop-only grants that never enter the shared remote-EXEC whitelist.
- Record the choice and rejected alternatives in the new fail-closed design decision.

## Compatibility

- Local library use without live IO remains non-interactive.
- Named edit tools retain the operator-owned `accept_edits` behavior.
- `DANGEROUS_TOOLS` remains public compatibility metadata, but no longer decides authorization.
- Hosted non-admin Claude delegation remains refused; hosted non-admin Codex remains read-only with nested approvals denied.

## Verification

- 458 directly impacted permission, co-ai, and documentation tests passed during implementation.
- Final focused runs: 153 permission/co-ai/docs tests and 18 documentation assembly tests passed.
- Stacked onto ACP #831 in an isolated worktree: all 119 ACP tests and all 105 focused security/approval tests passed.
- Ruff, production-module `py_compile`, and `git diff --check` passed.
- Two independent expert reviews are CLEAR. Review findings about remote mode escalation and stale documentation were fixed and re-reviewed.

Draft only. Do not merge until the security boundary and ACP stack are reviewed together.
