### PR TITLE
feat(acp): align live tool statuses with ACP

### DIFF
--- a/connectonion/cli/co_ai/acp_events.py
+++ b/connectonion/cli/co_ai/acp_events.py
@@ -69,20 +69,25 @@ def map_agent_event(event: Mapping[str, Any]) -> ACPEventMapping:
 
 
 def _tool_start(event: Mapping[str, Any]) -> ToolCallStart:
+    status = event.get("status", "in_progress")
+    if status == "running":
+        status = "in_progress"
+    if status not in {"pending", "in_progress"}:
+        raise ValueError(f"Unsupported tool start status: {status!r}")
     return ToolCallStart(
         session_update="tool_call",
         tool_call_id=_required_string(event, "tool_id"),
         title=_required_string(event, "name"),
-        status="in_progress",
+        status=status,
         raw_input=event.get("args"),
     )
 
 
 def _tool_progress(event: Mapping[str, Any]) -> ToolCallProgress:
     status = event.get("status")
-    if status == "success":
+    if status in {"success", "done", "completed"}:
         acp_status = "completed"
-    elif status in {"error", "not_found", "interrupted"}:
+    elif status in {"error", "failed", "not_found", "interrupted"}:
         acp_status = "failed"
     else:
         raise ValueError(f"Unsupported tool result status: {status!r}")

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -1,9 +1,9 @@
 """
 Purpose: Orchestrate AI agent execution with LLM calls, tool execution, and automatic logging
 LLM-Note:
-  Dependencies: imports from [llm.py, tool_factory.py, prompts.py, decorators.py, logger.py, tool_executor.py, tool_registry.py] | imported by [__init__.py, debug_agent/__init__.py] | tested by [tests/unit/test_agent.py, tests/test_agent_prompts.py, tests/test_agent_workflows.py]
+  Dependencies: imports from [llm.py, tool_factory.py, prompts.py, decorators.py, logger.py, tool_executor.py, tool_registry.py, wire_events.py] | imported by [__init__.py, debug_agent/__init__.py] | tested by [tests/unit/test_agent.py, tests/test_agent_prompts.py, tests/test_agent_workflows.py, tests/unit/test_wire_events.py]
   Data flow: receives user prompt: str from Agent.input() → creates/extends current_session with messages → calls llm.complete() with tool schemas → receives LLMResponse with tool_calls → executes tools via tool_executor.execute_and_record_tools() → appends tool results to messages → repeats loop until no tool_calls or max_iterations → logger logs to .co/logs/{name}.log and .co/evals/{name}.yaml → returns final response: str
-  State/Effects: modifies self.current_session['messages', 'trace', 'turn', 'iteration'] | writes to .co/logs/{name}.log and .co/evals/ via logger.py
+  State/Effects: modifies self.current_session['messages', 'trace', 'turn', 'iteration'] | writes to .co/logs/{name}.log and .co/evals/ via logger.py | streams a detached ACP-status-normalized copy without changing canonical trace statuses
   Integration: exposes Agent(name, tools, system_prompt, model, log, quiet), .input(prompt), .execute_tool(name, args), .add_tool(func), .remove_tool(name), .list_tools(), .reset_conversation() | tools stored in ToolRegistry with attribute access (agent.tools.tool_name) and instance storage (agent.tools.gmail) | tool execution delegates to tool_executor module | log defaults to .co/logs/ (None), can be True (current dir), False (disabled), or custom path | quiet=True suppresses console but keeps eval logging | trust enforcement moved to host() for network access control
   Performance: max_iterations=100 default (configurable per-input) | session state persists across turns for multi-turn conversations | ToolRegistry provides O(1) tool lookup via .get() or attribute access
   Errors: LLM errors bubble up | tool execution errors captured in trace and returned to LLM for retry
@@ -26,6 +26,7 @@ from .tool_executor import execute_and_record_tools, execute_single_tool
 from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
 from .tool_registry import ToolRegistry
 from .usage import get_context_limit, turn_usage_from_trace
+from .wire_events import normalize_wire_event
 
 
 class Agent:
@@ -190,7 +191,9 @@ class Agent:
             # persists. Sharing one object and deleting fields after send would
             # race asynchronous transports.
             # Canonical correlation and status fields always win collisions.
-            wire_entry = {**wire_extras, **entry} if wire_extras else entry
+            wire_entry = normalize_wire_event(
+                {**wire_extras, **entry} if wire_extras else entry
+            )
             # Send entry first (without session to avoid circular ref)
             self.io.send(wire_entry)
             # Then send session sync separately

--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -44,7 +44,11 @@ class InterruptibleIO:
         return messages
 
     def log(self, event_type: str, **data) -> None:
-        self.send({"type": event_type, **data})
+        with self._gate:
+            if not self._cancelled.is_set():
+                # Preserve the lease's atomic cancellation gate while reusing
+                # the underlying IO boundary's wire-event normalization.
+                self.__io.log(event_type, **data)
 
     def request_approval(self, tool: str, arguments) -> bool:
         self.send({"type": "approval_needed", "tool": tool, "arguments": arguments})

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -288,6 +288,16 @@ def execute_single_tool(
         "timing_ms": 0,
     }
 
+    # Every result must have a preceding start with the same stable ID.  This
+    # is required by ACP clients and also avoids a completion that cannot be
+    # correlated by ConnectOnion clients when the requested tool is unknown.
+    agent._record_trace({
+        "type": "tool_call",
+        "tool_id": tool_id,
+        "name": tool_name,
+        "args": tool_args,
+    })
+
     # Check if tool exists
     tool_func = tools.get(tool_name)
     if tool_func is None:
@@ -309,14 +319,6 @@ def execute_single_tool(
         entry.get("name") for entry in agent.current_session['trace']
         if entry.get("type") == "tool_result"
     ]
-
-    # Record tool_call event BEFORE execution (for real-time UI updates)
-    agent._record_trace({
-        "type": "tool_call",
-        "tool_id": tool_id,  # LLM's tool call ID
-        "name": tool_name,
-        "args": tool_args,
-    })
 
     # Inject xray context before tool execution
     inject_xray_context(

--- a/connectonion/core/wire_events.py
+++ b/connectonion/core/wire_events.py
@@ -1,0 +1,54 @@
+"""Normalize public IO events without rewriting canonical session traces.
+
+ConnectOnion keeps its historical trace statuses for persistence and evals, but
+uses ACP's four-state tool lifecycle on the live wire.  Provider adapters and
+protocol bridges therefore share one vocabulary while old trace files remain
+readable and stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+_TOOL_START_STATUSES = {
+    "pending": "pending",
+    "running": "in_progress",
+    "in_progress": "in_progress",
+}
+_TOOL_RESULT_STATUSES = {
+    "success": "completed",
+    "done": "completed",
+    "completed": "completed",
+    "error": "failed",
+    "failed": "failed",
+    "not_found": "failed",
+    "interrupted": "failed",
+}
+
+
+def normalize_wire_event(event: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a detached event with ACP-shaped tool lifecycle statuses.
+
+    Only tool lifecycle statuses change.  Event names, IDs, fields, and the
+    canonical object supplied by the caller stay untouched so this can sit at
+    both Agent trace and provider ``IO.log`` boundaries.
+    """
+
+    normalized = dict(event)
+    event_type = normalized.get("type")
+    if event_type == "tool_call":
+        status = normalized.get("status", "in_progress")
+        normalized["status"] = _normalize_status(
+            status, _TOOL_START_STATUSES
+        )
+    elif event_type == "tool_result":
+        normalized["status"] = _normalize_status(
+            normalized.get("status"), _TOOL_RESULT_STATUSES
+        )
+    return normalized
+
+
+def _normalize_status(value: Any, statuses: Mapping[str, str]) -> str:
+    if not isinstance(value, str) or value not in statuses:
+        raise ValueError(f"Unsupported tool event status: {value!r}")
+    return statuses[value]

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -844,7 +844,13 @@ class RemoteAgent:
                 if ui_event.get("type") == "tool_call" and (
                     ui_event.get("tool_id") or ui_event.get("id")
                 ) == key:
-                    ui_event["status"] = "done" if event.get("status") == "success" else "error"
+                    status = event.get("status")
+                    if status in {"success", "done", "completed"}:
+                        ui_event["status"] = "done"
+                    else:
+                        # Results are terminal. Unknown values must not be
+                        # presented as successful during a rolling upgrade.
+                        ui_event["status"] = "error"
                     ui_event["result"] = event.get("result")
                     break
 

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -71,13 +71,12 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
         name = entry.get('name')
         if not name:
             return None
-        raw = entry.get('status', 'done')
-        if raw in ('error', 'not_found'):
-            ui_status = 'error'
-        elif raw == 'running':
-            ui_status = 'running'
-        else:
-            ui_status = 'done'
+        raw = entry.get('status')
+        # A tool_result is terminal. Only known success values render as done;
+        # missing, start-only, and unknown statuses fail closed as errors.
+        ui_status = (
+            'done' if raw in ('success', 'done', 'completed') else 'error'
+        )
         return {
             'id': entry.get('tool_id') or f"tool-{idx}",
             'type': 'tool_call',

--- a/connectonion/network/io/base.py
+++ b/connectonion/network/io/base.py
@@ -1,8 +1,8 @@
 """
 Purpose: Abstract IO interface for bidirectional agent-client communication in hosted agents
 LLM-Note:
-  Dependencies: imports from [abc.ABC, typing] | imported by [network/io/websocket.py, network/__init__.py, agent.py] | tested by [tests/unit/test_io.py]
-  Data flow: agent.io.send(event) → client receives event → agent.io.receive() → blocks until client responds | high-level: io.log(type, **data) for one-way notifications | io.request_approval(tool, args) sends approval_needed → waits for client response → returns True/False
+  Dependencies: imports from [abc.ABC, typing, core/wire_events.py] | imported by [network/io/websocket.py, network/__init__.py, agent.py] | tested by [tests/unit/test_io.py, tests/unit/test_wire_events.py]
+  Data flow: agent.io.send(event) → client receives event → agent.io.receive() → blocks until client responds | high-level: io.log(type, **data) normalizes tool lifecycle status then sends one-way notifications | io.request_approval(tool, args) sends approval_needed → waits for client response → returns True/False
   State/Effects: no state (abstract base class) | implementations handle message queuing/transport
   Integration: exposes IO abstract class with send(event), receive() → dict primitives | convenience methods: log(type, **data), request_approval(tool, args) → bool | agent.io injected by host() for hosted execution | used in event handlers (@after_llm, @before_each_tool)
   Performance: abstract (implementation-specific) | WebSocketIO uses queue.Queue for thread-safe communication
@@ -12,6 +12,8 @@ IO interface for agent-client communication during hosted execution.
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict
+
+from ...core.wire_events import normalize_wire_event
 
 
 class IO(ABC):
@@ -88,7 +90,7 @@ class IO(ABC):
             io.log("thinking")
             io.log("tool_call", name="search", arguments={"q": "python"})
         """
-        self.send({"type": event_type, **data})
+        self.send(normalize_wire_event({"type": event_type, **data}))
 
     def request_approval(self, tool: str, arguments: Dict[str, Any]) -> bool:
         """Two-way: request permission, wait for response.

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -2,7 +2,7 @@
 Purpose: Run Codex via its native app-server protocol, stream steps and permission requests to the frontend, and resume sessions
 LLM-Note:
   Dependencies: imports from [json, os, shutil, subprocess, threading, time] | imported by [useful_tools/__init__.py] | tested by [tests/unit/test_codex_tool.py, tests/e2e/real_api/test_real_codex.py]
-  Data flow: codex(prompt, session_id, cwd, sandbox, model, timeout, approval, agent) → spawns `codex app-server` → CodexAppServer speaks newline-delimited JSON-RPC 2.0 → initialize/initialized → thread/start or thread/resume with the requested policy reapplied → turn/start → item/started+item/completed notifications converted to the FRONTEND's native events (tool_call / tool_result) via agent.io.log → method-specific approval responses are answered by the approval gate → waits for turn/completed → returns JSON envelope: str
+  Data flow: codex(prompt, session_id, cwd, sandbox, model, timeout, approval, agent) → spawns `codex app-server` → CodexAppServer speaks newline-delimited JSON-RPC 2.0 → initialize/initialized → thread/start or thread/resume with the requested policy reapplied → turn/start → item/started+item/completed notifications converted to ACP-status-aligned FRONTEND events (tool_call / tool_result) via agent.io.log → method-specific approval responses are answered by the approval gate → waits for turn/completed → returns JSON envelope: str
   State/Effects: spawns `codex app-server` subprocess | reader thread parses stdout | streams live events to agent.io using the tool_call/tool_result/approval_needed events the connectonion-ts SDK already renders (NO frontend changes) | Codex persists threads under ~/.codex; file writes depend on sandbox + granted approvals
   Integration: exposes codex(...) and CodexAppServer | this IS the adapter — ConnectOnion's own Python client drives the codex CLI's native app-server (no external codex-acp Node binary) | agent injected by tool_executor (hidden from LLM) | codex binary overridable via $CODEX_CMD | session_id resumes via thread/resume; envelope's resumed flag reports it
   Performance: long-lived process per call | streams incrementally | requests + turn wait have timeouts so a hung server can't block forever
@@ -199,10 +199,11 @@ def _forward_ui(agent, event):
     kind = event.get("kind", "")
     if kind == "tool_start":
         agent.io.log("tool_call", tool_id=event.get("id", ""),
-                     name=event.get("name", "codex"), args={})
+                     name=event.get("name", "codex"), args={},
+                     status="in_progress")
     elif kind == "tool_end":
         agent.io.log("tool_result", tool_id=event.get("id", ""),
-                     status="error" if event.get("failed") else "done",
+                     status="failed" if event.get("failed") else "completed",
                      result=event.get("name", ""))
 
 

--- a/docs/codex-tool-frontend-contract.md
+++ b/docs/codex-tool-frontend-contract.md
@@ -1,8 +1,9 @@
 # Codex tool ↔ frontend integration contract
 
-**TL;DR — the frontend (oo-chat) and `@connectonion/react` need NO changes.**
-The backend `codex` tool converts Codex's steps into the events the SDK already
-renders. This note records the research behind that and the exact contract.
+**TL;DR — oo-chat needs no component changes.** The backend `codex` tool
+converts Codex's steps into the events the SDK already renders. The SDK accepts
+both historical and ACP-aligned lifecycle statuses during rolling upgrades.
+This note records the research behind that and the exact contract.
 
 ## How the `codex` tool drives Codex
 
@@ -35,8 +36,8 @@ events already in that vocabulary:
 
 | Codex app-server event | tool emits `agent.io.log(...)` | SDK renders |
 |---|---|---|
-| `item/started` (commandExecution, fileChange, mcpToolCall, webSearch) | `tool_call` `{tool_id, name, args}` | running tool card |
-| `item/completed` (same item) | `tool_result` `{tool_id, status: done\|error}` | card completes / errors |
+| `item/started` (commandExecution, fileChange, mcpToolCall, webSearch) | `tool_call` `{tool_id, name, args, status: in_progress}` | running tool card |
+| `item/completed` (same item) | `tool_result` `{tool_id, status: completed\|failed}` | card completes / errors |
 | `item/completed` (agentMessage) | — (returned as the tool result `last_message`) | agent's own reply |
 | `item/*/requestApproval` (server → client) | `agent.io.request_approval(...)` → `approval_needed` | approval card, answer flows back |
 
@@ -44,6 +45,9 @@ Key points:
 
 - **Stable `tool_id`**: `tool_call` and its `tool_result` share the item id so the
   SDK correlates them (`chat-item-mapper.ts` finds the tool_call by id).
+- **ACP-aligned live status**: provider events use `in_progress`, `completed`,
+  and `failed`. The SDK also accepts the historical success/failure values;
+  canonical session traces keep their existing statuses.
 - **No custom event type.** An earlier draft emitted `io.log("codex_event", …)`,
   which matched nothing in the mapper and would not render — that was the bug to
   fix. The fix is emitting the native `tool_call` / `tool_result` vocabulary.

--- a/docs/design-decisions/028-acp-ordered-event-bridge.md
+++ b/docs/design-decisions/028-acp-ordered-event-bridge.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-08-10
-**Related:** [012 Tool Execution Separation](012-tool-execution-separation.md), [014 Hook System](014-hook-system-design.md), [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [026 Structured Turn Outcomes](026-structured-turn-outcomes.md), [027 Wire-only Structured Tool Output](027-wire-only-structured-tool-output.md)
+**Related:** [012 Tool Execution Separation](012-tool-execution-separation.md), [014 Hook System](014-hook-system-design.md), [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [026 Structured Turn Outcomes](026-structured-turn-outcomes.md), [027 Wire-only Structured Tool Output](027-wire-only-structured-tool-output.md), [034 ACP-aligned Wire Tool Statuses](034-acp-aligned-wire-tool-statuses.md)
 
 ## Decision
 
@@ -45,7 +45,7 @@ completed outcome.
 ## Mapping boundary
 
 - `tool_call` becomes `ToolCallStart` with the existing tool-call ID, required
-  title, in-progress status, and structured input.
+  title, normalized pending/in-progress status, and structured input.
 - `tool_result` becomes `ToolCallProgress` with ACP content objects, completed
   or failed status, and structured output when the SDK can represent it.
 - `thinking` becomes `AgentThoughtChunk`.

--- a/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
+++ b/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
@@ -1,0 +1,90 @@
+# DD-034: Align Live Tool Statuses With ACP Without Rewriting Traces
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Related:** [017 Session Logging and Eval Format](017-session-logging-and-eval-format.md), [018 Event API Naming](018-event-api-naming.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [027 Wire-only Structured Tool Output](027-wire-only-structured-tool-output.md), [028 ACP Ordered Event Bridge](028-acp-ordered-event-bridge.md)
+
+## Decision
+
+ConnectOnion keeps its established IO event names and fields. Live tool events
+use ACP's lifecycle statuses:
+
+| ConnectOnion event | Accepted producer statuses | Live wire status |
+|---|---|---|
+| `tool_call` | omitted, `pending`, `running`, `in_progress` | `pending` or `in_progress` |
+| `tool_result` | `success`, `done`, `completed` | `completed` |
+| `tool_result` | `error`, `failed`, `not_found`, `interrupted` | `failed` |
+
+One pure normalizer returns a detached event at both live producer boundaries:
+Agent trace streaming and provider-facing `IO.log`. Unknown or missing terminal
+statuses are rejected instead of being displayed as success.
+
+Canonical session traces do not change. They retain `success`, `error`,
+`not_found`, and `interrupted` under DD-017, while only the detached IO copy is
+normalized. Replay and rolling-upgrade consumers accept both vocabularies and
+reduce them to the existing UI states `running`, `done`, and `error`.
+
+Every `tool_result` has a preceding `tool_call` with the same `tool_id`,
+including an unknown tool. This lets the ACP bridge issue a start before an
+update and gives all clients a stable correlation target.
+
+## Vocabulary boundary
+
+The gap with ACP is deliberately not removed by renaming events:
+
+- `tool_call` already maps directly to ACP `tool_call`.
+- `tool_result` maps to ACP `tool_call_update` because ConnectOnion models a
+  terminal result while ACP models partial updates.
+- `thinking` and `assistant` map to ACP thought/message chunks.
+- `approval_needed` remains ConnectOnion's synchronous policy boundary and is
+  translated to ACP's asynchronous `session/request_permission` by DD-030.
+- `llm_call`, `llm_result`, and `session_sync` remain internal presentation or
+  persistence events with no ACP peer.
+
+IDs, names, arguments, results, and wire-only `raw_output` remain unchanged.
+The pure ACP mapper continues to create the official content models and camel-
+case serialization required by the pinned SDK.
+
+## Why
+
+Event names and fields are already consumed by Python `RemoteAgent`,
+`connectonion-ts`, and oo-chat. Renaming them would require a dual-vocabulary
+migration without eliminating the content and permission conversion that ACP
+necessarily requires.
+
+Status is the useful shared layer. ACP 0.12 and the current stable v1 protocol
+both use `pending`, `in_progress`, `completed`, and `failed`. Provider adapters
+can emit those states directly, and the ACP mapper no longer has to translate
+the normal path.
+
+Keeping persistence separate prevents a wire compatibility improvement from
+rewriting historical logs, eval fixtures, session snapshots, or hooks that
+inspect canonical tool outcomes.
+
+## Compatibility and rollout
+
+Python and TypeScript consumers recognize old and new success/failure values.
+The TypeScript mapper treats every unknown terminal status as an error so a
+newer server cannot be presented as successful by accident. oo-chat needs no
+direct change because it renders the SDK's normalized ChatItems.
+
+The Codex adapter now emits `in_progress`, `completed`, and `failed`. The
+Claude Code JSON adapter has no intermediate activity stream, so its final
+result envelope is outside this IO event contract.
+
+## Rejected alternatives
+
+- **Rename all events to ACP discriminators:** breaks established Python and
+  TypeScript consumers and still requires translation for content and approval.
+- **Rewrite canonical trace statuses:** changes persisted data, hook semantics,
+  and eval fixtures for no protocol benefit.
+- **Normalize only in the ACP mapper:** leaves provider adapters and other live
+  clients on divergent status vocabularies.
+- **Treat unknown status as success:** creates a fail-open presentation bug and
+  can hide provider or protocol drift.
+- **Add duplicate ACP field aliases to every event:** duplicates IDs, names,
+  inputs, and results without reducing the boundary's semantic work.
+
+## Reference
+
+- [ACP v1 tool calls](https://agentclientprotocol.com/protocol/v1/tool-calls)

--- a/tests/unit/test_co_ai_acp_events.py
+++ b/tests/unit/test_co_ai_acp_events.py
@@ -80,7 +80,21 @@ def test_successful_tool_result_keeps_text_and_structured_output():
     }
 
 
-@pytest.mark.parametrize("status", ["error", "not_found", "interrupted"])
+@pytest.mark.parametrize("status", ["success", "done", "completed"])
+def test_rolling_upgrade_success_statuses_map_to_completed(status):
+    mapped = map_agent_event({
+        "type": "tool_result",
+        "tool_id": "call-1",
+        "status": status,
+        "result": "ok",
+    })
+
+    assert mapped.updates[0].status == "completed"
+
+
+@pytest.mark.parametrize(
+    "status", ["error", "failed", "not_found", "interrupted"]
+)
 def test_unsuccessful_tool_statuses_map_to_failed(status):
     mapped = map_agent_event({
         "type": "tool_result",

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -179,8 +179,9 @@ class TestFrontendEventVocabulary:
 
         call = next(d for et, d in agent.io.events if et == "tool_call")
         assert call["tool_id"] == "c1" and call["name"] == "pytest"
+        assert call["status"] == "in_progress"
         result = next(d for et, d in agent.io.events if et == "tool_result")
-        assert result["tool_id"] == "c1" and result["status"] == "done"
+        assert result["tool_id"] == "c1" and result["status"] == "completed"
 
     def test_failed_tool_maps_to_error(self):
         agent = _Agent(_IO())
@@ -196,7 +197,7 @@ class TestFrontendEventVocabulary:
             codex("fix", approval="auto", agent=agent)
 
         result = next(d for et, d in agent.io.events if et == "tool_result")
-        assert result["status"] == "error"
+        assert result["status"] == "failed"
 
     def test_no_custom_codex_event_type(self):
         agent = _Agent(_IO())

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -233,6 +233,37 @@ class TestUIEventTransformation:
 
         assert agent.ui[0]["status"] == "error"
 
+    @pytest.mark.parametrize("status", ["failed", "not_found", "interrupted"])
+    def test_handle_acp_failure_statuses_as_errors(self, status):
+        agent = RemoteAgent("0x123")
+        agent._handle_stream_event(
+            {"type": "tool_call", "tool_id": "tc1", "name": "search"}
+        )
+
+        agent._handle_stream_event({
+            "type": "tool_result",
+            "tool_id": "tc1",
+            "result": "failed",
+            "status": status,
+        })
+
+        assert agent.ui[0]["status"] == "error"
+
+    def test_handle_unknown_tool_result_status_as_error(self):
+        agent = RemoteAgent("0x123")
+        agent._handle_stream_event(
+            {"type": "tool_call", "tool_id": "tc1", "name": "search"}
+        )
+
+        agent._handle_stream_event({
+            "type": "tool_result",
+            "tool_id": "tc1",
+            "result": "unknown",
+            "status": "mystery",
+        })
+
+        assert agent.ui[0]["status"] == "error"
+
     def test_handle_thinking_event(self):
         """Test thinking event adds thinking indicator."""
         agent = RemoteAgent("0x123")

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -651,15 +651,25 @@ class TestSessionToChatItems:
                 {'type': 'tool_result', 'tool_id': 'b', 'name': 'write', 'status': 'running'},
                 {'type': 'tool_result', 'tool_id': 'c', 'name': 'edit', 'status': 'success'},
                 {'type': 'tool_result', 'tool_id': 'd', 'name': 'cmd', 'status': 'not_found'},
+                {'type': 'tool_result', 'tool_id': 'e', 'name': 'wait', 'status': 'pending'},
+                {'type': 'tool_result', 'tool_id': 'f', 'name': 'wait', 'status': 'in_progress'},
+                {'type': 'tool_result', 'tool_id': 'g', 'name': 'new', 'status': 'mystery'},
+                {'type': 'tool_result', 'tool_id': 'h', 'name': 'old'},
+                {'type': 'tool_result', 'tool_id': 'i', 'name': 'new', 'status': 'completed'},
             ],
         }
 
         items = session_to_chat_items(session)
 
         assert items[0]['status'] == 'error'
-        assert items[1]['status'] == 'running'
+        assert items[1]['status'] == 'error'
         assert items[2]['status'] == 'done'
         assert items[3]['status'] == 'error'
+        assert items[4]['status'] == 'error'
+        assert items[5]['status'] == 'error'
+        assert items[6]['status'] == 'error'
+        assert items[7]['status'] == 'error'
+        assert items[8]['status'] == 'done'
 
     def test_skips_tool_call_placeholders(self):
         """Initial 'tool_call' trace entries (no result yet) are skipped — only 'tool_result' renders."""

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -385,6 +385,20 @@ def test_receive_all_interrupt_preserves_unrelated_mailbox_frames():
     assert io.receive_all() == [reply]
 
 
+def test_interruptible_io_log_uses_wire_status_normalization():
+    io = WebSocketIO()
+    lease = InterruptibleIO(io)
+
+    lease.log("tool_call", tool_id="call-1", status="running")
+    lease.log("tool_result", tool_id="call-1", status="success")
+
+    assert [
+        message["status"] for message in io._msgs_from_agent
+    ] == ["in_progress", "completed"]
+    with pytest.raises(ValueError, match="tool event status"):
+        lease.log("tool_result", tool_id="call-2", status="mystery")
+
+
 def test_interruptible_io_makes_request_approval_an_interrupted_tool():
     entered = threading.Event()
 

--- a/tests/unit/test_structured_tool_output.py
+++ b/tests/unit/test_structured_tool_output.py
@@ -472,5 +472,10 @@ def test_wire_extras_cannot_override_canonical_event_fields(tmp_path):
     )
 
     wire_result = io.events[0]
-    assert wire_result == {**canonical, "raw_output": {"ok": True}}
+    assert wire_result == {
+        **canonical,
+        "status": "completed",
+        "raw_output": {"ok": True},
+    }
     assert agent.current_session["trace"] == [canonical]
+    assert canonical["status"] == "success"

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -84,6 +84,13 @@ class TestToolExecutor:
             logger=logger,
         )
         assert trace["status"] == "not_found"
+        assert [entry["type"] for entry in agent.current_session["trace"]] == [
+            "tool_call",
+            "tool_result",
+        ]
+        assert {
+            entry["tool_id"] for entry in agent.current_session["trace"]
+        } == {"call_2"}
 
     def test_execute_async_tool_success(self):
         """Async tool functions are detected and awaited correctly."""

--- a/tests/unit/test_wire_events.py
+++ b/tests/unit/test_wire_events.py
@@ -1,0 +1,74 @@
+"""Provider-neutral IO event vocabulary aligned with ACP tool lifecycles."""
+
+import pytest
+
+from connectonion.core.wire_events import normalize_wire_event
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("pending", "pending"),
+        ("running", "in_progress"),
+        ("in_progress", "in_progress"),
+    ],
+)
+def test_tool_start_statuses_use_the_acp_vocabulary(source, expected):
+    event = {"type": "tool_call", "tool_id": "call-1", "status": source}
+
+    assert normalize_wire_event(event)["status"] == expected
+    assert event["status"] == source
+
+
+def test_tool_start_defaults_to_in_progress_without_mutating_the_trace():
+    event = {"type": "tool_call", "tool_id": "call-1"}
+
+    normalized = normalize_wire_event(event)
+
+    assert normalized == {
+        "type": "tool_call",
+        "tool_id": "call-1",
+        "status": "in_progress",
+    }
+    assert "status" not in event
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("success", "completed"),
+        ("done", "completed"),
+        ("completed", "completed"),
+        ("error", "failed"),
+        ("failed", "failed"),
+        ("not_found", "failed"),
+        ("interrupted", "failed"),
+    ],
+)
+def test_tool_result_statuses_use_the_acp_vocabulary(source, expected):
+    event = {"type": "tool_result", "tool_id": "call-1", "status": source}
+
+    assert normalize_wire_event(event)["status"] == expected
+    assert event["status"] == source
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "tool_call", "status": "completed"},
+        {"type": "tool_result"},
+        {"type": "tool_result", "status": "mystery"},
+    ],
+)
+def test_invalid_tool_lifecycle_statuses_fail_closed(event):
+    with pytest.raises(ValueError, match="tool event status"):
+        normalize_wire_event(event)
+
+
+def test_non_tool_events_are_detached_but_unchanged():
+    event = {"type": "thinking", "content": "checking"}
+
+    normalized = normalize_wire_event(event)
+
+    assert normalized == event
+    assert normalized is not event


### PR DESCRIPTION
## Summary

Align ConnectOnion's live tool lifecycle statuses with ACP while preserving the historical session/eval trace contract.

## Design

- normalize detached live-wire copies to ACP `pending`, `in_progress`, `completed`, and `failed`;
- keep canonical traces on `success`, `error`, `not_found`, and `interrupted` for log/eval compatibility;
- guarantee every tool result, including `not_found`, has a preceding start with the same ID;
- dual-read intended old/new aliases during rolling upgrades and fail closed on unknown terminal states;
- keep the ownership and rollout decision in DD-034.

The normalization is applied at Agent, base IO, and interruptible provider boundaries so wrappers cannot bypass it. No dependency changed.

## Frontend boundary

For React applications, `@connectonion/react` is the protocol-normalization boundary used by oo-chat. Its coordinated reader is openonion/connectonion-react#12, already merged.

openonion/connectonion-ts#35 is compatibility for the independent non-React TypeScript client. It is also merged, but it is not an oo-chat dependency or a frontend release gate.

## Compatibility and risk

Historical producer values are accepted and normalized only on detached wire copies. Persisted traces, evals, and provider-facing IO retain their existing vocabulary.

The least certain boundary is a third-party consumer that reads raw live events without either maintained mapper. Such a consumer may need to dual-read the ACP vocabulary during rollout; unknown terminal states must never render as success.

## Validation

Original focused review runs:

- wire/IO/tool executor/Codex/ACP/connect/replay: 244 passed;
- ACP and co-ai CLI: 157 passed;
- host session/wire/connect/structured output: 150 passed;
- interrupt/host session/wire: 92 passed;
- Ruff, compileall, diff check, Bandit, and pip-audit passed; no known vulnerabilities.

After merging current `main` (including #835 and Outlook attachment safety), an isolated combined run passed 354/354 tests across wire events, tool execution, connect/replay, host sessions, interrupts, structured output, Codex, ACP events, ACP/MCP, and Outlook.

Two independent expert reviews drove fixes for replay fail-open behavior and an interrupt-wrapper normalization bypass; both re-reviews returned clear.

Closes #239.
