### PR TITLE
Add versioned ACP tool notifications

### DIFF
--- a/connectonion/cli/co_ai/acp_events.py
+++ b/connectonion/cli/co_ai/acp_events.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
-from acp import text_block, tool_content
+from acp import text_block
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
@@ -15,6 +15,8 @@ from acp.schema import (
     ToolCallStart,
     Usage,
 )
+
+from ...core.acp_wire import map_tool_event
 
 ACPUpdate = (
     AgentMessageChunk
@@ -53,10 +55,10 @@ def map_agent_event(event: Mapping[str, Any]) -> ACPEventMapping:
     """Map one immutable internal event to exact ACP 0.12 models."""
 
     event_type = event.get("type")
-    if event_type == "tool_call":
-        return ACPEventMapping(updates=(_tool_start(event),))
-    if event_type == "tool_result":
-        return ACPEventMapping(updates=(_tool_progress(event),))
+    if event_type in {"tool_call", "tool_result"}:
+        update = map_tool_event(event)
+        assert update is not None
+        return ACPEventMapping(updates=(update,))
     if event_type == "thinking":
         return ACPEventMapping(updates=(_thought(event),))
     if event_type == "assistant":
@@ -66,42 +68,6 @@ def map_agent_event(event: Mapping[str, Any]) -> ACPEventMapping:
     if event_type == "turn_result":
         return ACPEventMapping(terminal=_terminal(event))
     return ACPEventMapping()
-
-
-def _tool_start(event: Mapping[str, Any]) -> ToolCallStart:
-    status = event.get("status", "in_progress")
-    if status == "running":
-        status = "in_progress"
-    if status not in {"pending", "in_progress"}:
-        raise ValueError(f"Unsupported tool start status: {status!r}")
-    return ToolCallStart(
-        session_update="tool_call",
-        tool_call_id=_required_string(event, "tool_id"),
-        title=_required_string(event, "name"),
-        status=status,
-        raw_input=event.get("args"),
-    )
-
-
-def _tool_progress(event: Mapping[str, Any]) -> ToolCallProgress:
-    status = event.get("status")
-    if status in {"success", "done", "completed"}:
-        acp_status = "completed"
-    elif status in {"error", "failed", "not_found", "interrupted"}:
-        acp_status = "failed"
-    else:
-        raise ValueError(f"Unsupported tool result status: {status!r}")
-
-    kwargs: dict[str, Any] = {
-        "session_update": "tool_call_update",
-        "tool_call_id": _required_string(event, "tool_id"),
-        "status": acp_status,
-        "content": [tool_content(text_block(_required_string(event, "result")))],
-    }
-    raw_output = event.get("raw_output")
-    if raw_output is not None:
-        kwargs["raw_output"] = raw_output
-    return ToolCallProgress(**kwargs)
 
 
 def _thought(event: Mapping[str, Any]) -> AgentThoughtChunk:

--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -1,0 +1,220 @@
+"""ACP-native events carried over the authenticated ConnectOnion socket.
+
+The Host WebSocket also transports ConnectOnion authentication, onboarding,
+session persistence, and dashboard frames, so it is not an ACP connection. An
+``ACP_NOTIFICATION`` frame carries one exact ACP JSON-RPC notification without
+pretending that the surrounding socket negotiated ACP capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from acp import text_block, tool_content
+from acp.schema import SessionNotification, ToolCallProgress, ToolCallStart
+
+from .wire_events import normalize_wire_event
+
+ACP_FRAME_TYPE = "ACP_NOTIFICATION"
+ACP_SCHEMA_VERSION = "schema-v1.19.0"
+ACP_SESSION_UPDATE_METHOD = "session/update"
+
+
+def map_tool_event(
+    event: Mapping[str, Any],
+) -> ToolCallStart | ToolCallProgress | None:
+    """Map one tool event to an official ACP v1.19 update model."""
+
+    event_type = event.get("type")
+    if event_type not in {"tool_call", "tool_result"}:
+        return None
+
+    normalized = normalize_wire_event(event)
+    if event_type == "tool_call":
+        return _tool_start(normalized)
+    return _tool_update(normalized)
+
+
+def _tool_start(event: Mapping[str, Any]) -> ToolCallStart:
+    return ToolCallStart(
+        session_update="tool_call",
+        tool_call_id=_required_string(event, "tool_id"),
+        title=_required_string(event, "name"),
+        status=event["status"],
+        raw_input=event.get("args"),
+    )
+
+
+def _tool_update(event: Mapping[str, Any]) -> ToolCallProgress:
+    kwargs: dict[str, Any] = {
+        "session_update": "tool_call_update",
+        "tool_call_id": _required_string(event, "tool_id"),
+        "status": event["status"],
+        "content": [
+            tool_content(text_block(_required_string(event, "result")))
+        ],
+    }
+    if event.get("raw_output") is not None:
+        kwargs["raw_output"] = event["raw_output"]
+    if isinstance(event.get("timing_ms"), (int, float)) and not isinstance(
+        event["timing_ms"], bool
+    ):
+        kwargs["field_meta"] = {
+            "connectonion": {"timingMs": event["timing_ms"]}
+        }
+    return ToolCallProgress(**kwargs)
+
+
+def acp_notification_frame(
+    event: Mapping[str, Any], session_id: str
+) -> dict[str, Any] | None:
+    """Return a detached ConnectOnion carrier for one ACP tool update."""
+
+    update = map_tool_event(event)
+    if update is None:
+        return None
+    notification = SessionNotification(session_id=session_id, update=update)
+    params = notification.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    return {
+        "type": ACP_FRAME_TYPE,
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "message": {
+            "jsonrpc": "2.0",
+            "method": ACP_SESSION_UPDATE_METHOD,
+            "params": params,
+        },
+    }
+
+
+def legacy_tool_event_from_acp(
+    frame: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Decode an ACP tool notification for the legacy Python UI mapper."""
+
+    if frame.get("type") != ACP_FRAME_TYPE:
+        return None
+    if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
+        raise ValueError("Unsupported ACP carrier schema")
+    message = _required_mapping(frame, "message")
+    if message.get("jsonrpc") != "2.0":
+        raise ValueError("ACP notification jsonrpc must be '2.0'")
+    if message.get("method") != ACP_SESSION_UPDATE_METHOD:
+        raise ValueError("Unsupported ACP notification method")
+    params = _required_mapping(message, "params")
+    _required_string(params, "sessionId")
+    update = _required_mapping(params, "update")
+    return _legacy_tool_event(update)
+
+
+def _legacy_tool_event(update: Mapping[str, Any]) -> dict[str, Any]:
+    update_type = update.get("sessionUpdate")
+    if update_type == "tool_call":
+        event = {
+            "type": "tool_call",
+            "tool_id": _required_string(update, "toolCallId"),
+            "name": _required_string(update, "title"),
+        }
+        return _with_optional_tool_fields(event, update)
+    if update_type == "tool_call_update":
+        event = {
+            "type": "tool_call_update",
+            "tool_id": _required_string(update, "toolCallId"),
+        }
+        return _with_optional_tool_fields(
+            event, update, allow_unknown_status=True
+        )
+    raise ValueError(f"Unsupported ACP session update: {update_type!r}")
+
+
+def _with_optional_tool_fields(
+    event: dict[str, Any],
+    update: Mapping[str, Any],
+    *,
+    allow_unknown_status: bool = False,
+) -> dict[str, Any]:
+    status = update.get("status")
+    if status is not None:
+        event["status"] = _tool_status(
+            status, allow_unknown=allow_unknown_status
+        )
+    title = update.get("title")
+    if title is not None:
+        if not isinstance(title, str) or not title:
+            raise ValueError("ACP tool title must be a non-empty string")
+        event["name"] = title
+    if "rawInput" in update:
+        event["args"] = update["rawInput"]
+    result = _tool_result_text(update)
+    if result is not None:
+        event["result"] = result
+    event.update(_timing(update))
+    return event
+
+
+def _tool_status(value: Any, *, allow_unknown: bool) -> str:
+    allowed = {"pending", "in_progress", "completed", "failed"}
+    if not isinstance(value, str):
+        raise ValueError(f"Unsupported ACP tool status: {value!r}")
+    if value not in allowed:
+        if allow_unknown:
+            return "unknown"
+        raise ValueError(f"Unsupported ACP tool status: {value!r}")
+    return value
+
+
+def _tool_result_text(update: Mapping[str, Any]) -> str | None:
+    texts: list[str] = []
+    content = update.get("content")
+    if content is not None and not isinstance(content, list):
+        raise ValueError("ACP tool content must be an array")
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, Mapping) or item.get("type") != "content":
+                continue
+            block = item.get("content")
+            if (
+                isinstance(block, Mapping)
+                and block.get("type") == "text"
+                and isinstance(block.get("text"), str)
+            ):
+                texts.append(block["text"])
+    if texts:
+        return "\n".join(texts)
+    raw_output = update.get("rawOutput")
+    if isinstance(raw_output, str):
+        return raw_output
+    return None
+
+
+def _timing(update: Mapping[str, Any]) -> dict[str, int | float]:
+    field_meta = update.get("_meta")
+    if not isinstance(field_meta, Mapping):
+        return {}
+    connectonion = field_meta.get("connectonion")
+    if not isinstance(connectonion, Mapping):
+        return {}
+    timing = connectonion.get("timingMs")
+    if isinstance(timing, (int, float)) and not isinstance(timing, bool):
+        return {"timing_ms": timing}
+    return {}
+
+
+def _required_mapping(
+    value: Mapping[str, Any], field: str
+) -> Mapping[str, Any]:
+    item = value.get(field)
+    if not isinstance(item, Mapping):
+        raise ValueError(f"ACP notification field {field!r} must be an object")
+    return item
+
+
+def _required_string(value: Mapping[str, Any], field: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"ACP event field {field!r} must be a non-empty string")
+    return item

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -31,6 +31,17 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import httpx
 
 from .. import address as addr
+from ..core.acp_wire import legacy_tool_event_from_acp
+
+
+def _tool_ui_status(status: Any, *, terminal: bool = False) -> str:
+    if status in {"pending", "running", "in_progress"}:
+        return "running"
+    if status is None and not terminal:
+        return "running"
+    if status in {"success", "done", "completed"}:
+        return "done"
+    return "error"
 
 
 def _this_callers_identity():
@@ -817,20 +828,49 @@ class RemoteAgent:
 
     def _handle_stream_event(self, event: Dict[str, Any]) -> None:
         """Handle streaming event and update UI."""
+        try:
+            acp_event = legacy_tool_event_from_acp(event)
+        except (TypeError, ValueError):
+            return
+        if acp_event is not None:
+            event = acp_event
         event_type = event.get("type")
 
         if event_type == "tool_call":
-            # Add new tool_call UI event with running status
-            self._add_ui_event({
+            tool_id = event.get("tool_id") or event.get("id")
+            existing = next((
+                item for item in self._ui_events
+                if item.get("type") == "tool_call"
+                and (item.get("tool_id") or item.get("id")) == tool_id
+            ), None)
+            tool_item = {
                 "type": "tool_call",
                 "id": event.get("id"),
                 # The LLM's call id, which the result carries too. `id` is this
                 # event's own and differs between the call and its result.
-                "tool_id": event.get("tool_id"),
+                "tool_id": tool_id,
                 "name": event.get("name"),
                 "args": event.get("args"),
-                "status": "running"
-            })
+                "status": _tool_ui_status(event.get("status")),
+            }
+            if existing is None:
+                self._add_ui_event(tool_item)
+            else:
+                existing.update(tool_item)
+
+        elif event_type == "tool_call_update":
+            tool_id = event.get("tool_id") or event.get("id")
+            existing = next((
+                item for item in self._ui_events
+                if item.get("type") == "tool_call"
+                and (item.get("tool_id") or item.get("id")) == tool_id
+            ), None)
+            if existing is not None:
+                if event.get("status") is not None:
+                    existing["status"] = _tool_ui_status(event["status"])
+                for field in ("name", "args", "result", "timing_ms"):
+                    if field in event:
+                        existing[field] = event[field]
 
         elif event_type == "tool_result":
             # Correlate on tool_id -- the LLM's call id, which both frames
@@ -844,13 +884,9 @@ class RemoteAgent:
                 if ui_event.get("type") == "tool_call" and (
                     ui_event.get("tool_id") or ui_event.get("id")
                 ) == key:
-                    status = event.get("status")
-                    if status in {"success", "done", "completed"}:
-                        ui_event["status"] = "done"
-                    else:
-                        # Results are terminal. Unknown values must not be
-                        # presented as successful during a rolling upgrade.
-                        ui_event["status"] = "error"
+                    ui_event["status"] = _tool_ui_status(
+                        event.get("status"), terminal=True
+                    )
                     ui_event["result"] = event.get("result")
                     break
 

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -12,9 +12,23 @@ import asyncio
 import threading
 
 from rich.console import Console
+
+from ....core.acp_wire import acp_notification_frame
 from ...io import WebSocketIO
 
 console = Console()
+
+
+def _acp_rollout_frame(event, session_id):
+    if not session_id:
+        return None
+    try:
+        return acp_notification_frame(event, session_id)
+    except (TypeError, ValueError) as exc:
+        console.print(
+            f"[yellow]ACP mirror skipped; legacy event continues: {exc}[/yellow]"
+        )
+        return None
 
 
 def _agent_thread_body(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder, requester_address=None):
@@ -36,6 +50,11 @@ async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holde
     from ..session import session_to_chat_items
 
     async for event in io.read_msgs_from_agent():
+        acp_frame = _acp_rollout_frame(event, session_id)
+        if acp_frame is not None:
+            await send_msg(acp_frame)
+            # Rollout is dual-write: older clients still need the legacy event,
+            # while new clients de-duplicate both shapes by the stable tool ID.
         if session_id:
             event["session_id"] = session_id
         await send_msg(event)

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -3,7 +3,7 @@ Purpose: Run Codex via its native app-server protocol, stream steps and permissi
 LLM-Note:
   Dependencies: imports from [json, os, shutil, subprocess, threading, time] | imported by [useful_tools/__init__.py] | tested by [tests/unit/test_codex_tool.py, tests/e2e/real_api/test_real_codex.py]
   Data flow: codex(prompt, session_id, cwd, sandbox, model, timeout, approval, agent) → spawns `codex app-server` → CodexAppServer speaks newline-delimited JSON-RPC 2.0 → initialize/initialized → thread/start or thread/resume with the requested policy reapplied → turn/start → item/started+item/completed notifications converted to ACP-status-aligned FRONTEND events (tool_call / tool_result) via agent.io.log → method-specific approval responses are answered by the approval gate → waits for turn/completed → returns JSON envelope: str
-  State/Effects: spawns `codex app-server` subprocess | reader thread parses stdout | streams live events to agent.io using the tool_call/tool_result/approval_needed events the connectonion-ts SDK already renders (NO frontend changes) | Codex persists threads under ~/.codex; file writes depend on sandbox + granted approvals
+  State/Effects: spawns `codex app-server` subprocess | reader thread parses stdout | streams live events to agent.io using the tool_call/tool_result/approval_needed events that @connectonion/react already renders (NO frontend changes) | Codex persists threads under ~/.codex; file writes depend on sandbox + granted approvals
   Integration: exposes codex(...) and CodexAppServer | this IS the adapter — ConnectOnion's own Python client drives the codex CLI's native app-server (no external codex-acp Node binary) | agent injected by tool_executor (hidden from LLM) | codex binary overridable via $CODEX_CMD | session_id resumes via thread/resume; envelope's resumed flag reports it
   Performance: long-lived process per call | streams incrementally | requests + turn wait have timeouts so a hung server can't block forever
   Errors: returns envelope with error on missing binary, JSON-RPC failure/timeout, or exception | never raises to the agent loop
@@ -19,8 +19,8 @@ when the selected policy requires them. Those callbacks map onto
 agent.io.request_approval.
 
 Frontend contract: Codex's steps are streamed as the SAME events the
-connectonion-ts SDK already maps to ChatItems — `tool_call` (stable tool_id)
-and `tool_result` — so no frontend or SDK change is needed.
+`@connectonion/react` package already maps to ChatItems — `tool_call` (stable
+tool_id) and `tool_result` — so no oo-chat change is needed.
 
 Usage:
     from connectonion import Agent
@@ -190,9 +190,9 @@ def _base_command():
 def _forward_ui(agent, event):
     """Convert one Codex thread event into the frontend's native event stream.
 
-    The connectonion-ts SDK maps `tool_call` (stable tool_id) → a running tool
-    card and `tool_result` (same id) → its completion, so Codex's inner command
-    runs / file edits render live with no frontend change.
+    The @connectonion/react package maps `tool_call` (stable tool_id) → a
+    running tool card and `tool_result` (same id) → its completion, so Codex's
+    inner command runs / file edits render live with no oo-chat change.
     """
     if agent is None or getattr(agent, "io", None) is None:
         return

--- a/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
+++ b/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
@@ -47,10 +47,11 @@ case serialization required by the pinned SDK.
 
 ## Why
 
-Event names and fields are already consumed by Python `RemoteAgent`,
-`connectonion-ts`, and oo-chat. Renaming them would require a dual-vocabulary
-migration without eliminating the content and permission conversion that ACP
-necessarily requires.
+Event names and fields are already consumed by Python `RemoteAgent` and the
+browser connection layer in `@connectonion/react`, which is the only SDK used
+by oo-chat. Renaming them would require a dual-vocabulary migration without
+eliminating the content and permission conversion that ACP necessarily
+requires.
 
 Status is the useful shared layer. ACP 0.12 and the current stable v1 protocol
 both use `pending`, `in_progress`, `completed`, and `failed`. Provider adapters
@@ -63,10 +64,11 @@ inspect canonical tool outcomes.
 
 ## Compatibility and rollout
 
-Python and TypeScript consumers recognize old and new success/failure values.
-The TypeScript mapper treats every unknown terminal status as an error so a
-newer server cannot be presented as successful by accident. oo-chat needs no
-direct change because it renders the SDK's normalized ChatItems.
+Python and `@connectonion/react` consumers recognize old and new
+success/failure values. The React package's browser mapper treats every
+unknown terminal status as an error so a newer server cannot be presented as
+successful by accident. oo-chat needs no direct change because it renders the
+React package's normalized ChatItems.
 
 The Codex adapter now emits `in_progress`, `completed`, and `failed`. The
 Claude Code JSON adapter has no intermediate activity stream, so its final
@@ -75,7 +77,7 @@ result envelope is outside this IO event contract.
 ## Rejected alternatives
 
 - **Rename all events to ACP discriminators:** breaks established Python and
-  TypeScript consumers and still requires translation for content and approval.
+  React consumers and still requires translation for content and approval.
 - **Rewrite canonical trace statuses:** changes persisted data, hook semantics,
   and eval fixtures for no protocol benefit.
 - **Normalize only in the ACP mapper:** leaves provider adapters and other live

--- a/docs/design-decisions/035-versioned-acp-host-carrier.md
+++ b/docs/design-decisions/035-versioned-acp-host-carrier.md
@@ -1,0 +1,76 @@
+# DD-035: Carry Versioned ACP Notifications Beside Legacy Host Events
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Related:** [028 Ordered ACP Event Bridge](028-acp-ordered-event-bridge.md), [032 ACP Interoperability Evidence](032-acp-interoperability-evidence.md), [034 ACP-aligned Wire Tool Statuses](034-acp-aligned-wire-tool-statuses.md)
+
+## Decision
+
+The authenticated ConnectOnion Host WebSocket remains a ConnectOnion
+transport. It also carries a versioned `ACP_NOTIFICATION` envelope whose
+`message` is one exact ACP JSON-RPC `session/update` notification:
+
+```json
+{
+  "type": "ACP_NOTIFICATION",
+  "acpSchema": "schema-v1.19.0",
+  "message": {
+    "jsonrpc": "2.0",
+    "method": "session/update",
+    "params": { "sessionId": "...", "update": {} }
+  }
+}
+```
+
+The outer envelope is not ACP. It exists because this socket also owns
+authentication, onboarding, reconnect, persistence, and dashboard control and
+does not perform ACP `initialize`. The nested message is serialized from the
+official Python models with ACP camelCase fields.
+
+Python pins `agent-client-protocol==0.12.0`; TypeScript readers pin
+`@agentclientprotocol/sdk==1.2.1`. Both were generated from stable
+`schema-v1.19.0`. The exact pair changes together with the carrier version and
+the shared cross-repository fixture. This supersedes DD-032's SDK range for
+the cross-language Host carrier; DD-032's typed stdio conformance boundary
+otherwise remains in force.
+
+The first carrier slice includes `tool_call` and `tool_call_update`. Canonical
+trace events and provider-facing IO keep their ConnectOnion names and statuses.
+This narrows DD-034's “do not rename wire events” decision: it still governs
+canonical and legacy frames, while the public Host socket may add versioned ACP
+aliases.
+
+## Rollout and compatibility
+
+Host dual-writes ACP and legacy tool frames during the migration. Released
+clients therefore continue to receive the old event, while updated Python,
+TypeScript, and React readers accept both and de-duplicate by stable tool ID.
+Readers ship before or with the writer. Legacy removal requires a future major
+version, usage evidence, and a separate decision.
+
+ACP mirroring is additive and non-authoritative. A malformed internal event or
+conversion failure is logged, the legacy frame is still delivered, and the
+forwarder drains to the single authoritative `OUTPUT`. This prevents a
+completed side effect from looking retryable because its presentation mirror
+failed.
+
+Unknown schema versions and malformed envelopes are rejected. Valid ACP
+partial tool updates preserve optional fields; unknown lifecycle values never
+become a successful UI state.
+
+## Rollback
+
+Stop emitting `ACP_NOTIFICATION` frames. No trace, session snapshot, provider
+event, authentication flow, or legacy consumer changes, so rollback does not
+rewrite data and does not require a coordinated client downgrade.
+
+## Rejected alternatives
+
+- **Call the Host socket ACP:** it has no ACP initialization or capability
+  negotiation and carries ConnectOnion-only control frames.
+- **Replace legacy frames immediately:** breaks released clients before they
+  can learn the new envelope.
+- **Use compatible dependency ranges across languages:** pre-1.0 generated
+  models can drift while package managers still consider the upgrade valid.
+- **Store ACP envelopes in canonical traces:** couples persistence and evals to
+  a transport migration and makes rollback destructive.

--- a/docs/design-decisions/035-versioned-acp-host-carrier.md
+++ b/docs/design-decisions/035-versioned-acp-host-carrier.md
@@ -27,12 +27,12 @@ authentication, onboarding, reconnect, persistence, and dashboard control and
 does not perform ACP `initialize`. The nested message is serialized from the
 official Python models with ACP camelCase fields.
 
-Python pins `agent-client-protocol==0.12.0`; TypeScript readers pin
-`@agentclientprotocol/sdk==1.2.1`. Both were generated from stable
-`schema-v1.19.0`. The exact pair changes together with the carrier version and
-the shared cross-repository fixture. This supersedes DD-032's SDK range for
-the cross-language Host carrier; DD-032's typed stdio conformance boundary
-otherwise remains in force.
+Python pins `agent-client-protocol==0.12.0`; the JavaScript ACP models used by
+`@connectonion/react` pin `@agentclientprotocol/sdk==1.2.1`. Both were generated
+from stable `schema-v1.19.0`. The exact pair changes together with the carrier
+version and the shared cross-repository fixture. This supersedes DD-032's SDK
+range for the cross-language Host carrier; DD-032's typed stdio conformance
+boundary otherwise remains in force.
 
 The first carrier slice includes `tool_call` and `tool_call_update`. Canonical
 trace events and provider-facing IO keep their ConnectOnion names and statuses.
@@ -43,10 +43,14 @@ aliases.
 ## Rollout and compatibility
 
 Host dual-writes ACP and legacy tool frames during the migration. Released
-clients therefore continue to receive the old event, while updated Python,
-TypeScript, and React readers accept both and de-duplicate by stable tool ID.
-Readers ship before or with the writer. Legacy removal requires a future major
-version, usage evidence, and a separate decision.
+clients therefore continue to receive the old event, while updated Python and
+React readers accept both and de-duplicate by stable tool ID. For React
+applications, `@connectonion/react` is the browser protocol boundary and the
+only SDK used by oo-chat; its reader ships before or with the writer in a
+coordinated release. The standalone `connectonion` TypeScript client may carry
+the same compatibility reader for non-React consumers, but it is not an
+oo-chat dependency or a React release gate. Legacy removal requires a future
+major version, usage evidence, and a separate decision.
 
 ACP mirroring is additive and non-authoritative. A malformed internal event or
 conversion failure is logged, the legacy frame is still delivered, and the

--- a/docs/network/session-websocket-lifecycle.md
+++ b/docs/network/session-websocket-lifecycle.md
@@ -38,7 +38,7 @@ ws.send(JSON.stringify({
 
 ### Phase 1: Client Sends INPUT
 
-**Client (TypeScript SDK):**
+**Client (`@connectonion/react` browser connection):**
 ```typescript
 // After CONNECTED, send prompt (no signature needed — already authenticated)
 ws.send(JSON.stringify({

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -525,8 +525,8 @@ A client that has not connected — or has not passed onboarding — should show
 answer and not treat it as an incomplete version of this one. It is what that viewer is
 entitled to see.
 
-TypeScript SDK: `agent.profile` and `useAgentForHuman().profile`, `null` until the frame
-lands.
+React package: `agent.profile` and `useAgentForHuman().profile`, `null` until the
+frame lands.
 
 **There is a third profile surface, and it is not this one.** `host()` also sends a
 profile to the relay inside its `ANNOUNCE` frame — that is what registers the agent and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,9 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    # ACP is pre-1.0, so bound the minor API used by cli/co_ai/acp_server.py.
-    "agent-client-protocol>=0.12.0,<0.13.0",
+    # ACP Python 0.12.0 is generated from stable schema-v1.19.0. Keep the
+    # cross-language wire pair exact until Python and TypeScript move together.
+    "agent-client-protocol==0.12.0",
     # MCP v2 is stable; bound the next major used by cli/co_ai/acp_mcp.py.
     "mcp>=2.0.0,<3",
     "openai>=1.0.0",

--- a/tests/fixtures/acp_tool_events.json
+++ b/tests/fixtures/acp_tool_events.json
@@ -1,0 +1,65 @@
+{
+  "schema": "https://github.com/agentclientprotocol/agent-client-protocol/releases/tag/schema-v1.19.0",
+  "legacy": [
+    {
+      "type": "tool_call",
+      "tool_id": "call-1",
+      "name": "search_docs",
+      "args": {"query": "ACP"},
+      "status": "in_progress"
+    },
+    {
+      "type": "tool_result",
+      "tool_id": "call-1",
+      "name": "search_docs",
+      "status": "completed",
+      "result": "2 matches",
+      "raw_output": {"matches": [1, 2]},
+      "timing_ms": 42
+    }
+  ],
+  "acp": [
+    {
+      "type": "ACP_NOTIFICATION",
+      "acpSchema": "schema-v1.19.0",
+      "message": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "session-1",
+          "update": {
+            "toolCallId": "call-1",
+            "title": "search_docs",
+            "status": "in_progress",
+            "rawInput": {"query": "ACP"},
+            "sessionUpdate": "tool_call"
+          }
+        }
+      }
+    },
+    {
+      "type": "ACP_NOTIFICATION",
+      "acpSchema": "schema-v1.19.0",
+      "message": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "session-1",
+          "update": {
+            "toolCallId": "call-1",
+            "status": "completed",
+            "content": [
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "2 matches"}
+              }
+            ],
+            "rawOutput": {"matches": [1, 2]},
+            "_meta": {"connectonion": {"timingMs": 42}},
+            "sessionUpdate": "tool_call_update"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/test_acp_wire.py
+++ b/tests/unit/test_acp_wire.py
@@ -1,0 +1,164 @@
+"""ACP-native Host wire notifications and rolling-upgrade decoding."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from connectonion.core.acp_wire import (
+    acp_notification_frame,
+    legacy_tool_event_from_acp,
+)
+from connectonion.network.connect import RemoteAgent
+
+FIXTURE = json.loads(
+    (Path(__file__).parents[1] / "fixtures" / "acp_tool_events.json").read_text()
+)
+
+
+def test_tool_events_match_the_shared_acp_fixture():
+    actual = [
+        acp_notification_frame(event, "session-1")
+        for event in FIXTURE["legacy"]
+    ]
+
+    assert actual == FIXTURE["acp"]
+
+
+def test_acp_tool_events_decode_to_the_legacy_python_ui_shape():
+    decoded = [legacy_tool_event_from_acp(event) for event in FIXTURE["acp"]]
+
+    assert decoded == [
+        {
+            "type": "tool_call",
+            "tool_id": "call-1",
+            "name": "search_docs",
+            "args": {"query": "ACP"},
+            "status": "in_progress",
+        },
+        {
+            "type": "tool_call_update",
+            "tool_id": "call-1",
+            "status": "completed",
+            "result": "2 matches",
+            "timing_ms": 42,
+        },
+    ]
+
+
+def test_python_remote_agent_renders_one_card_during_a_rolling_upgrade():
+    agent = RemoteAgent("0xabc")
+    for event in [*FIXTURE["legacy"], *FIXTURE["acp"]]:
+        agent._handle_stream_event(event)
+
+    assert agent.ui == [{
+        "type": "tool_call",
+        "id": None,
+        "tool_id": "call-1",
+        "name": "search_docs",
+        "args": {"query": "ACP"},
+        "status": "done",
+        "result": "2 matches",
+        "timing_ms": 42,
+    }]
+
+
+def test_python_decoder_accepts_partial_and_content_free_updates():
+    partial = json.loads(json.dumps(FIXTURE["acp"][1]))
+    partial["message"]["params"]["update"] = {
+        "toolCallId": "call-1",
+        "title": "searching",
+        "status": "in_progress",
+        "sessionUpdate": "tool_call_update",
+    }
+    completed = json.loads(json.dumps(partial))
+    completed["message"]["params"]["update"] = {
+        "toolCallId": "call-1",
+        "status": "completed",
+        "sessionUpdate": "tool_call_update",
+    }
+
+    assert legacy_tool_event_from_acp(partial) == {
+        "type": "tool_call_update",
+        "tool_id": "call-1",
+        "name": "searching",
+        "status": "in_progress",
+    }
+    assert legacy_tool_event_from_acp(completed) == {
+        "type": "tool_call_update",
+        "tool_id": "call-1",
+        "status": "completed",
+    }
+
+
+def test_python_remote_agent_applies_partial_acp_updates():
+    agent = RemoteAgent("0xabc")
+    partial = json.loads(json.dumps(FIXTURE["acp"][1]))
+    partial["message"]["params"]["update"] = {
+        "toolCallId": "call-1",
+        "title": "searching",
+        "status": "in_progress",
+        "sessionUpdate": "tool_call_update",
+    }
+    completed = json.loads(json.dumps(partial))
+    completed["message"]["params"]["update"] = {
+        "toolCallId": "call-1",
+        "status": "completed",
+        "sessionUpdate": "tool_call_update",
+    }
+
+    for event in (FIXTURE["acp"][0], partial, completed):
+        agent._handle_stream_event(event)
+
+    assert agent.ui[0]["name"] == "searching"
+    assert agent.ui[0]["status"] == "done"
+    assert "result" not in agent.ui[0]
+
+
+def test_non_tool_events_stay_in_the_connectonion_namespace():
+    event = {"type": "thinking", "content": "checking"}
+
+    assert acp_notification_frame(event, "session-1") is None
+    assert legacy_tool_event_from_acp(event) is None
+
+
+def test_python_remote_agent_ignores_a_malformed_acp_carrier():
+    agent = RemoteAgent("0xabc")
+    malformed = json.loads(json.dumps(FIXTURE["acp"][0]))
+    malformed["acpSchema"] = "schema-v9.0.0"
+
+    agent._handle_stream_event(malformed)
+
+    assert agent.ui == []
+
+
+def test_python_remote_agent_fails_an_unknown_terminal_status_closed():
+    agent = RemoteAgent("0xabc")
+    unknown = json.loads(json.dumps(FIXTURE["acp"][1]))
+    unknown["message"]["params"]["update"]["status"] = "future"
+
+    agent._handle_stream_event(FIXTURE["acp"][0])
+    agent._handle_stream_event(unknown)
+
+    assert agent.ui[0]["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda frame: frame.update(acpSchema="schema-v9.0.0"),
+        lambda frame: frame["message"].update(jsonrpc="1.0"),
+        lambda frame: frame["message"].update(method="session/prompt"),
+        lambda frame: frame["message"]["params"]["update"].pop(
+            "toolCallId"
+        ),
+    ],
+)
+def test_malformed_or_unknown_acp_tool_updates_fail_closed(mutation):
+    frame = json.loads(json.dumps(FIXTURE["acp"][1]))
+    mutation(frame)
+
+    with pytest.raises(ValueError):
+        legacy_tool_event_from_acp(frame)

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -84,7 +84,13 @@ class TestForwardAgentEvents:
             sent_messages.append(msg)
 
         io.send({"type": "thinking"})
-        io.send({"type": "tool_call", "name": "search"})
+        io.send({
+            "type": "tool_call",
+            "tool_id": "call-1",
+            "name": "search",
+            "args": {},
+            "status": "in_progress",
+        })
 
         def agent_done():
             import time
@@ -100,7 +106,14 @@ class TestForwardAgentEvents:
 
         event_types = [m["type"] for m in sent_messages if m.get("type") not in ("ERROR",)]
         assert "thinking" in event_types
+        assert "ACP_NOTIFICATION" in event_types
         assert "tool_call" in event_types
+        acp_message = next(
+            message for message in sent_messages
+            if message.get("type") == "ACP_NOTIFICATION"
+        )["message"]
+        assert acp_message["method"] == "session/update"
+        assert acp_message["params"]["sessionId"] == "test-session"
 
     async def test_sends_output_from_result_holder(self):
         """Test that OUTPUT is sent when agent completes with result."""
@@ -121,6 +134,31 @@ class TestForwardAgentEvents:
         output_msgs = [m for m in sent_messages if m.get("type") == "OUTPUT"]
         assert len(output_msgs) == 1
         assert output_msgs[0]["result"] == "answer"
+
+    async def test_bad_acp_mirror_falls_back_without_inviting_a_retry(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "committed",
+            "duration_ms": 5,
+            "session": {},
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.send({"type": "tool_result", "status": "success", "result": "ok"})
+        io.mark_agent_done()
+
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        event_types = [message["type"] for message in sent_messages]
+        assert event_types.count("tool_result") == 1
+        assert event_types.count("OUTPUT") == 1
+        assert "ACP_NOTIFICATION" not in event_types
+        assert "ERROR" not in event_types
 
     async def test_sends_error_from_exception(self):
         """Test that ERROR is sent when agent raises."""

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.12.0,<0.13.0" },
+    { name = "agent-client-protocol", specifier = "==0.12.0" },
     { name = "anthropic", specifier = ">=0.18.0" },
     { name = "bashlex", specifier = ">=0.18" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },


### PR DESCRIPTION
## Summary

Implement the first slice of #838: carry versioned ACP tool notifications beside legacy Host events.

## Design

- add an `ACP_NOTIFICATION` carrier containing an exact ACP JSON-RPC `session/update`;
- keep the authenticated Host socket explicitly ConnectOnion-owned rather than calling it a full ACP transport;
- dual-write ACP and legacy tool frames during rollout using the same stable tool ID;
- decode ACP tool starts and legal partial updates in Python;
- fail closed on malformed versions, structures, and unknown terminal states;
- keep traces, sessions, approvals, authentication, and non-tool frames unchanged;
- record schema pins, ownership, rollout, and rollback in DD-035.

## Frontend boundary

`@connectonion/react` is the browser protocol boundary and the only SDK used by oo-chat. Its reader (openonion/connectonion-react#12) and the oo-chat presentation boundary (openonion/oo-chat#125) are merged.

The standalone client reader (openonion/connectonion-ts#37) is optional compatibility for non-React consumers. It is not an oo-chat dependency or a React release gate.

## Compatibility and safety

- ACP mirror conversion is additive and non-authoritative; conversion failure still forwards legacy and drains to the single authoritative `OUTPUT`;
- old clients continue to receive the unchanged legacy frame;
- updated readers de-duplicate rollout aliases by stable tool ID;
- partial/title-only/content-free tool updates remain legal;
- malformed or unknown schema values are rejected, and unknown terminal states render as errors rather than success.

## Validation already completed

- ACP/Host/bridge: 66 tests passed;
- broader unit run: 6,197 passed; three cross-process timing cases passed 3/3 in isolation;
- pip-audit: no known vulnerabilities;
- Ruff passed for new Python files;
- shared fixture hash matched Python, React, and the optional standalone client;
- two independent expert reviews returned clear after fixes.

This PR implements only the tool-notification slice of #838. The parent RFC remains open for message, thought, plan, permission, mode, cancellation, stop-reason, and legacy-removal decisions.
