### PR TITLE
Refuse a token that bills an account this machine is not; keep URLs in read mail

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1082,9 +1082,13 @@ def account_in_token(token: str) -> Optional[str]:
     payload = parts[1]
     payload += "=" * (-len(payload) % 4)          # base64url, padding stripped
     try:
-        return json.loads(base64.urlsafe_b64decode(payload)).get("public_key")
+        decoded = json.loads(base64.urlsafe_b64decode(payload))
     except (ValueError, binascii.Error):
         return None
+    if not isinstance(decoded, dict):
+        return None
+    public_key = decoded.get("public_key")
+    return public_key if isinstance(public_key, str) and public_key else None
 
 
 def _token_for_this_account(token: str) -> Optional[str]:

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1046,13 +1046,20 @@ def load_api_key() -> Optional[str]:
     2. Local .env file
     3. Global ~/.co/keys.env file
 
+    Every source goes through `_token_for_this_account()`. The environment used
+    to skip it, which made the check dead code in practice: `connectonion/
+    __init__.py` calls `load_dotenv(Path.cwd() / ".env")` at import time, so by
+    the time any command runs the variable is already set and the early return
+    always fired. A `.env` in whatever directory you happened to be standing in
+    could then bill and read another agent's account in silence.
+
     Returns:
         API key if found, None otherwise
     """
     from dotenv import load_dotenv
 
     if api_key := os.getenv("OPENONION_API_KEY"):
-        return api_key
+        return _token_for_this_account(api_key)
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
         if env_path.exists():
@@ -1080,7 +1087,7 @@ def account_in_token(token: str) -> Optional[str]:
         return None
 
 
-def _token_for_this_account(token: str) -> str:
+def _token_for_this_account(token: str) -> Optional[str]:
     """Re-authenticate when the stored token names an account we are not.
 
     `co server new` and `co deploy` bill whatever the token says; `co status`
@@ -1111,8 +1118,19 @@ def _token_for_this_account(token: str) -> str:
     if authenticate(co_dir, save_to_project=False, quiet=True):
         from dotenv import load_dotenv
         load_dotenv(co_dir / "keys.env", override=True)
-        return os.getenv("OPENONION_API_KEY", token)
-    return token
+        refreshed = os.getenv("OPENONION_API_KEY")
+        if refreshed and account_in_token(refreshed) == identity["address"]:
+            return refreshed
+
+    # Re-authentication did not produce a token for this machine. Returning the
+    # mismatched one anyway is the failure this function exists to prevent — it
+    # reads another account's mailbox and spends another account's credit while
+    # looking like an ordinary working session. No key at all is recoverable:
+    # callers say "run co auth", and the operator knows something is wrong.
+    console.print("[yellow]Could not get a token for this machine's key. "
+                  "Not using the one on hand — it bills another account. "
+                  "Run [bold]co auth[/bold].[/yellow]")
+    return None
 
 
 def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> None:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -453,7 +453,29 @@ class Outlook:
             import re
             from html import unescape
             body_content = re.sub(r'<style[^>]*>.*?</style>', '', body_content, flags=re.DOTALL | re.IGNORECASE)
-            body_content = re.sub(r'<[^>]+>', '', body_content)
+            # Keep the address before the tags go. Stripping <a href="..."> as
+            # markup leaves the words and loses the link, and a URL carrying a
+            # per-recipient token is not one the reader can reconstruct.
+            def anchor_as_text(match) -> str:
+                url = match.group(1)
+                text = re.sub(r'<[^>]+>', '', match.group(2)).strip()
+                # Clients often use the URL as its own link text; printing it
+                # twice reads as two different links.
+                if not text or unescape(text) == unescape(url):
+                    return url
+                return f"{text} <{url}>"
+
+            body_content = re.sub(
+                r'<a\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+                anchor_as_text,
+                body_content,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+            # Everything that is markup, but not the `<scheme://…>` the step
+            # above just wrote — `<[^>]+>` cannot tell those apart and ate the
+            # very addresses it was meant to preserve.
+            body_content = re.sub(r'<(?![a-zA-Z][a-zA-Z0-9+.-]*://)[^>]+>', '',
+                                  body_content)
             body_content = unescape(body_content)
             body_content = re.sub(r'\s+', ' ', body_content).strip()
 

--- a/tests/unit/test_a_read_email_keeps_its_links.py
+++ b/tests/unit/test_a_read_email_keeps_its_links.py
@@ -1,0 +1,129 @@
+"""`co outlook read` used to drop every URL in an HTML mail.
+
+`get_email_body()` renders HTML by deleting every tag:
+
+    body_content = re.sub(r'<[^>]+>', '', body_content)
+
+For `<a href="https://…">Complete the questionnaire</a>` that keeps the words
+and throws away the address. The reader is left with an instruction to click
+something that is no longer there.
+
+On 2026-08-11 that cost two reference-check questionnaires. Their links carried
+a per-recipient token:
+
+    https://forms.example.com/r/AbC123?t=9f2c…
+
+which is not a URL anyone can reconstruct from the anchor text, the sender, or
+the subject — unlike a bare marketing link, where you can just visit the site.
+The mail was readable, looked complete, and the one thing it existed to deliver
+was gone.
+
+So: the words stay where they are, and the address follows in angle brackets —
+the convention plain-text mail has used for decades, and one an agent reading
+the output can pick up without being taught a new format.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_token_refresh(monkeypatch):
+    from connectonion.useful_tools.outlook import Outlook
+    monkeypatch.setattr(Outlook, "_refresh_via_backend", lambda self, rt: "test-token")
+
+
+def body_rendered_from(html: str) -> str:
+    """Whatever `co outlook read` would print for this HTML mail."""
+    from connectonion.useful_tools.outlook import Outlook
+
+    with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read,Mail.Send"}, clear=False):
+        outlook = Outlook()
+        with patch.object(outlook, "_request", return_value={
+            "from": {"emailAddress": {"name": "HR", "address": "hr@example.com"}},
+            "toRecipients": [{"emailAddress": {"address": "me@example.com"}}],
+            "subject": "Reference check",
+            "receivedDateTime": "2026-08-11T00:00:00Z",
+            "body": {"contentType": "html", "content": html},
+        }):
+            return outlook.get_email_body("msg-id")
+
+
+class TestALinkSurvives:
+
+    def test_the_url_is_kept(self):
+        url = "https://forms.example.com/r/AbC123?t=9f2c"
+        out = body_rendered_from(f'<p>Please <a href="{url}">complete it</a>.</p>')
+
+        assert url in out, (
+            "the anchor's href was dropped; this URL carries a per-recipient "
+            "token and cannot be reconstructed from the text around it"
+        )
+
+    def test_the_link_text_is_kept_too(self):
+        url = "https://forms.example.com/r/AbC123?t=9f2c"
+        out = body_rendered_from(f'<p>Please <a href="{url}">complete it</a>.</p>')
+
+        assert "complete it" in out, "the sentence lost its words"
+
+    def test_several_links_each_keep_their_own_url(self):
+        out = body_rendered_from(
+            '<a href="https://a.example/1">first</a> and '
+            '<a href="https://b.example/2">second</a>'
+        )
+
+        assert "https://a.example/1" in out
+        assert "https://b.example/2" in out
+
+    def test_single_quoted_href_works(self):
+        out = body_rendered_from("<a href='https://a.example/1'>x</a>")
+
+        assert "https://a.example/1" in out
+
+    def test_other_attributes_do_not_hide_the_href(self):
+        out = body_rendered_from(
+            '<a class="btn" href="https://a.example/1" target="_blank">x</a>'
+        )
+
+        assert "https://a.example/1" in out
+
+
+class TestNothingElseChanges:
+
+    def test_a_bare_url_as_link_text_is_not_printed_twice(self):
+        """Mail clients often render the URL as its own anchor text."""
+        url = "https://a.example/1"
+        out = body_rendered_from(f'<a href="{url}">{url}</a>')
+
+        assert out.count(url) == 1, f"printed twice: {out!r}"
+
+    def test_plain_text_mail_is_untouched(self):
+        from connectonion.useful_tools.outlook import Outlook
+
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
+            outlook = Outlook()
+            with patch.object(outlook, "_request", return_value={
+                "from": {"emailAddress": {"name": "A", "address": "a@example.com"}},
+                "toRecipients": [],
+                "subject": "s",
+                "receivedDateTime": "2026-08-11T00:00:00Z",
+                "body": {"contentType": "text",
+                         "content": "see <https://a.example/1>"},
+            }):
+                out = outlook.get_email_body("id")
+
+        assert "see <https://a.example/1>" in out
+
+    def test_styles_are_still_stripped(self):
+        out = body_rendered_from("<style>a {color: red}</style><p>hello</p>")
+
+        assert "color: red" not in out
+        assert "hello" in out
+
+    def test_markup_is_still_stripped(self):
+        out = body_rendered_from('<p class="x">hello <b>there</b></p>')
+
+        assert "<p" not in out and "<b>" not in out
+        assert "hello" in out and "there" in out

--- a/tests/unit/test_the_key_in_hand_is_this_machines.py
+++ b/tests/unit/test_the_key_in_hand_is_this_machines.py
@@ -45,12 +45,17 @@ THIS_MACHINE = "0x" + "10e68f6d" * 8
 SOMEONE_ELSE = "0x" + "561605f3" * 8
 
 
-def token_for(public_key: str) -> str:
-    """A JWT shaped like the server's, signature not checked by the decoder."""
+def token_with_payload(payload_value) -> str:
+    """A JWT-shaped value; its signature is not checked by the local decoder."""
     payload = base64.urlsafe_b64encode(
-        json.dumps({"public_key": public_key}).encode()
+        json.dumps(payload_value).encode()
     ).decode().rstrip("=")
     return f"header.{payload}.signature"
+
+
+def token_for(public_key: str) -> str:
+    """A JWT shaped like the server's, signature not checked by the decoder."""
+    return token_with_payload({"public_key": public_key})
 
 
 @pytest.fixture
@@ -135,6 +140,26 @@ class TestTheOrdinaryCaseIsUndisturbed:
         )
 
         assert load_api_key() == "not-a-jwt"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [[], "text", 7, None, {}, {"public_key": []}, {"public_key": 7}],
+    )
+    def test_a_non_string_account_claim_is_unreadable(
+        self, this_machine, monkeypatch, payload
+    ):
+        """A syntactically valid JSON payload must not crash every CLI call."""
+        token = token_with_payload(payload)
+        monkeypatch.setenv("OPENONION_API_KEY", token)
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated over an unreadable token")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == token
 
     def test_no_key_anywhere_still_returns_none(self, this_machine, monkeypatch, tmp_path):
         monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))

--- a/tests/unit/test_the_key_in_hand_is_this_machines.py
+++ b/tests/unit/test_the_key_in_hand_is_this_machines.py
@@ -1,0 +1,142 @@
+"""Whose account does the token in `OPENONION_API_KEY` actually bill?
+
+`_token_for_this_account()` exists to answer that. Its docstring names the cost
+of getting it wrong — "One $180 server was bought that way" — and it works: a
+local JWT decode, and a re-authentication only when the token names an account
+this machine does not hold the key for.
+
+It just never runs. `load_api_key()` returns at the top:
+
+    if api_key := os.getenv("OPENONION_API_KEY"):
+        return api_key                          # <- guard skipped
+
+and `connectonion/__init__.py` guarantees that variable is always set, because
+it calls `load_dotenv(Path.cwd() / ".env")` at import time, before any command
+starts. So the guard protects only the path nothing takes.
+
+What that costs, observed on this operator's machine on 2026-08-11:
+
+    ~/.co/keys.env   0x10e68f6d…   the real account, $408 balance
+    ~/.env           0x561605f3…   a different agent, drained to $0.001
+
+    cd ~           && co email inbox   ->  1 email    (0x5616…)
+    cd ~/project/… && co email inbox   ->  full inbox (0x10e6…)
+
+Same command, same machine, two mailboxes — and the empty one is indistinguishable
+from a quiet week. Both files carried the same `AGENT_EMAIL=aaron.xie@…`, so the
+declared identity agreed everywhere; only the key differed, and the key is what
+picks the mailbox. It reads as "no mail arrived", never as "you are someone else".
+
+The rule this pins: a token that names an account whose key this machine does not
+hold must not be handed to a caller, whichever source it arrived from. Reaching
+the environment first is not evidence that it is ours.
+"""
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import project_cmd_lib
+from connectonion.cli.commands.project_cmd_lib import load_api_key
+
+THIS_MACHINE = "0x" + "10e68f6d" * 8
+SOMEONE_ELSE = "0x" + "561605f3" * 8
+
+
+def token_for(public_key: str) -> str:
+    """A JWT shaped like the server's, signature not checked by the decoder."""
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": public_key}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+@pytest.fixture
+def this_machine(monkeypatch, tmp_path):
+    """A machine holding the key for THIS_MACHINE, and nothing in the env."""
+    # Own project dir, so the walk-up for `.co` stops here instead of escaping
+    # to whatever shared parent the tmp dir happens to sit under.
+    (tmp_path / ".co").mkdir()
+    monkeypatch.chdir(tmp_path)          # no .env above the test
+    monkeypatch.setattr(
+        project_cmd_lib.address, "load",
+        lambda co_dir: {"address": THIS_MACHINE},
+    )
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+
+
+class TestTheTokenNamesAnotherAccount:
+    """`~/.env` shadowing `~/.co/keys.env` — the 2026-08-11 incident."""
+
+    def test_the_foreign_token_is_not_returned(self, this_machine, monkeypatch):
+        monkeypatch.setenv("OPENONION_API_KEY", token_for(SOMEONE_ELSE))
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate",
+            lambda *a, **k: False,
+        )
+
+        returned = load_api_key()
+
+        assert returned != token_for(SOMEONE_ELSE), (
+            "load_api_key() handed back a token billing "
+            f"{SOMEONE_ELSE[:14]}… while this machine holds the key for "
+            f"{THIS_MACHINE[:14]}… — every command downstream now reads that "
+            "account's mailbox and spends its credit, with no error shown"
+        )
+
+    def test_re_authentication_is_attempted(self, this_machine, monkeypatch):
+        """The mismatch is recoverable — the signing key is right here."""
+        monkeypatch.setenv("OPENONION_API_KEY", token_for(SOMEONE_ELSE))
+        attempts = []
+
+        def authenticate(*args, **kwargs):
+            attempts.append(kwargs)
+            return False
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        load_api_key()
+
+        assert attempts, (
+            "no re-authentication was attempted; the CLI holds the key that "
+            "would have produced a correct token"
+        )
+
+
+class TestTheOrdinaryCaseIsUndisturbed:
+    """The guard costs one local base64 decode when the token is ours."""
+
+    def test_our_own_token_is_returned_unchanged(self, this_machine, monkeypatch):
+        ours = token_for(THIS_MACHINE)
+        monkeypatch.setenv("OPENONION_API_KEY", ours)
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated for a token already ours")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == ours
+
+    def test_a_token_with_no_account_is_left_alone(self, this_machine, monkeypatch):
+        """Not every token is a JWT we can read; an unreadable one is not a mismatch."""
+        monkeypatch.setenv("OPENONION_API_KEY", "not-a-jwt")
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated over an undecodable token")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == "not-a-jwt"
+
+    def test_no_key_anywhere_still_returns_none(self, this_machine, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        assert load_api_key() is None


### PR DESCRIPTION
Fixes #839 and #840, and removes the mechanism behind #841.

## What was broken

`_token_for_this_account()` already existed to catch a token naming an account this machine does not hold the key for. Its docstring records what that costs: *"One $180 server was bought that way."*

It never ran. `load_api_key()` returned early whenever `OPENONION_API_KEY` was already in the environment:

```python
if api_key := os.getenv("OPENONION_API_KEY"):
    return api_key                     # guard skipped
```

and `connectonion/__init__.py:34-40` calls `load_dotenv(Path.cwd() / ".env")` at import time, before any command runs — so the variable was always set and the early return always fired. The guard protected the one path nothing takes.

## Who this hit

On an operator machine, 2026-08-11:

| File | Agent | Account |
|---|---|---|
| `~/.co/keys.env` | `0x10e68f6d…` | the real one |
| `~/.env` | `0x561605f3…` | a different agent, drained to $0.001 |

```
cd ~            && co email inbox   ->  1 message   (0x5616…)
cd ~/project/…  && co email inbox   ->  real mailbox (0x10e6…)
```

Same command, same machine, two accounts. The near-empty mailbox is indistinguishable from a quiet week, so it reads as *"no mail arrived"*, never as *"you are someone else"*. Both files carried the same `AGENT_EMAIL`, so the declared identity agreed everywhere — only the key differed, and the key is what picks the mailbox.

Anyone with a stray `.env` in a directory they run `co` from is exposed, which includes `$HOME`.

## Changes

**1. The guard runs for every source** (`project_cmd_lib.py`) — the environment path goes through `_token_for_this_account()` like the file paths already did.

**2. A failed re-authentication no longer falls back to the mismatched token.** It previously ended `return token`, handing back the foreign token when re-auth failed — the exact outcome the function exists to prevent. It now returns `None` and says to run `co auth`. No key is recoverable and visible; the wrong key is neither.

**3. `co outlook read` keeps URLs** (`outlook.py`). `<a href="...">text</a>` was stripped as markup, keeping the words and losing the address. Anchors now render `text <url>`.

Two things worth noting in that last one: the URL is printed only once when it is also the link text, and the tag stripper had to stop treating `<https://…>` as a tag — `<[^>]+>` matched the very addresses the change had just written, so the first version of this fix silently did nothing.

## Tests

`tests/unit/test_the_key_in_hand_is_this_machines.py` and `tests/unit/test_a_read_email_keeps_its_links.py`.

Both were confirmed red before the fix — 2 failed / 3 passed and 4 failed / 5 passed respectively, with the passing cases being the no-regression assertions, so neither file is vacuously green.

## Not addressed here

#841 also notes that `co status` reports an identity derived from the on-disk keypair (`status_commands.py:417-421`) while `co email` authenticates with the JWT in the environment (`get_emails.py:38`). This PR removes the case where those disagree *silently*, but does not yet make `co status` print the account its token resolves to. Left open deliberately — it is a display change with its own decisions, and this is the part that stops credit being spent on the wrong account.