### PR TITLE
Stop the project walk at the repository and at $HOME

### DIFF
--- a/connectonion/project.py
+++ b/connectonion/project.py
@@ -26,14 +26,36 @@ CO_DIR = ".co"
 def project_root(start: Optional[Union[str, Path]] = None) -> Path:
     """The directory that owns ``.co/``, found by walking up from ``start``.
 
+    The walk stops where the project must stop: at the repository, and at
+    ``$HOME``. A ``.co/`` reached only by climbing out of those belongs to
+    something else — most often ``~/.co``, which is the *global* config
+    directory and sits above every directory the user owns. Without the bound,
+    ``co`` run from anywhere under ``$HOME`` outside a project resolved to
+    ``$HOME`` and read the machine's own config as that project's, trust list
+    included: the silent, fail-open case this module's history is made of.
+
+    The global ``~/.co`` is still read where it is genuinely global — see
+    ``project_identity()``, which falls back to it by name. What it no longer
+    does is stand in for a project nobody created.
+
     Falls back to ``start`` when there is no ``.co/`` above it — an agent hosted
     outside a project still works, its files just live where it was started.
     """
     start = Path(start or Path.cwd()).resolve()
+    home = Path.home().resolve()
+
     for directory in (start, *start.parents):
-        if (directory / CO_DIR).is_dir():
+        # $HOME/.co is the machine's config, not a project's.
+        if (directory / CO_DIR).is_dir() and directory != home:
             return directory
+        if directory == home or _is_repository(directory):
+            break
     return start
+
+
+def _is_repository(directory: Path) -> bool:
+    """A checkout boundary. ``.git`` is a directory in a clone, a file in a worktree."""
+    return (directory / ".git").exists()
 
 
 def project_co_dir(start: Optional[Union[str, Path]] = None) -> Path:

--- a/tests/unit/test_the_project_walk_stops_at_the_project.py
+++ b/tests/unit/test_the_project_walk_stops_at_the_project.py
@@ -1,0 +1,155 @@
+"""`project_root()` climbed out of the project and kept going.
+
+The walk looks for the nearest `.co/` above the working directory and has no
+upper bound, so it does not stop at anything that means "you have left the
+project" — not the repository, not `$HOME`, not the filesystem root. The module
+docstring already records what that costs:
+
+    Two of those bugs failed open: a project configured ``trust: strict`` ran as
+    ``careful``, and an address on the blocklist read back as a stranger.
+
+It notes that a stray `.co/` shadows the project's own. What it does not say is
+that on any ordinary machine there is always one, because `~/.co` — the *global*
+config directory, holding keys and machine defaults — sits directly above every
+directory the user owns. Measured before this change:
+
+    ~/Desktop   ->  /Users/me       (that is $HOME, via the global ~/.co)
+    /tmp        ->  /private/tmp    (a stray .co/ any user on the box can create)
+
+So `co` run anywhere under `$HOME` that is not inside a project believes it is in
+a project rooted at `$HOME`, and reads the global `~/.co` as that project's
+config — trust lists included. The failure is silent and it fails open.
+
+Two boundaries, both meaning "the project cannot be above here":
+
+- a directory holding `.git` — a `.co/` reached by climbing out of the
+  repository belongs to something else
+- `$HOME` — and `$HOME/.co` is the global config, never a project's own
+
+What is deliberately *not* changed: the global `~/.co` stays reachable for the
+things that are genuinely global. `project_identity()` already falls back to
+`address.load(Path.home() / CO_DIR)` by name, and must keep working. The bug is
+not that `~/.co` gets read; it is that it gets read *as a particular project's
+configuration* by anyone standing in the wrong directory.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from connectonion.project import project_root
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """A machine whose $HOME has the usual global ~/.co."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".co").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+    return fake_home
+
+
+class TestTheGlobalConfigIsNotAProject:
+    """`~/.co` holds keys and defaults for the machine, not for a project."""
+
+    def test_a_plain_directory_under_home_is_not_the_home_project(self, home, monkeypatch):
+        desktop = home / "Desktop"
+        desktop.mkdir()
+        monkeypatch.chdir(desktop)
+
+        assert project_root() != home, (
+            "standing in ~/Desktop resolved the project to $HOME, so the global "
+            "~/.co — keys, trust defaults — is now read as this project's config"
+        )
+
+    def test_it_resolves_to_where_you_are(self, home, monkeypatch):
+        desktop = home / "Desktop"
+        desktop.mkdir()
+        monkeypatch.chdir(desktop)
+
+        assert project_root() == desktop
+
+    def test_home_itself_is_not_a_project(self, home, monkeypatch):
+        monkeypatch.chdir(home)
+
+        assert project_root() == home, "cwd is still the fallback"
+        # …but not because ~/.co made it one: the same answer with no ~/.co.
+
+
+class TestTheRepositoryIsABoundary:
+
+    def test_a_co_above_the_repo_is_not_this_repos_project(self, tmp_path, monkeypatch):
+        """A git worktree has no `.co/`; the walk used to leave the checkout."""
+        (tmp_path / ".co").mkdir()                 # stray, above everything
+        repo = tmp_path / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "elsewhere"))
+        monkeypatch.chdir(repo)
+
+        assert project_root() != tmp_path, (
+            f"walked out of the repository at {repo} and took the .co/ above it"
+        )
+        assert project_root() == repo
+
+    def test_a_subdirectory_of_the_repo_stops_at_the_repo(self, tmp_path, monkeypatch):
+        (tmp_path / ".co").mkdir()
+        repo = tmp_path / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        deep = repo / "src" / "pkg"
+        deep.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "elsewhere"))
+        monkeypatch.chdir(deep)
+
+        assert project_root() == deep, "no .co/ inside the repo, so files live here"
+
+    def test_a_worktree_git_file_is_a_boundary_too(self, tmp_path, monkeypatch):
+        """In a worktree `.git` is a file, not a directory."""
+        (tmp_path / ".co").mkdir()
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        (worktree / ".git").write_text("gitdir: /somewhere/.git/worktrees/wt\n")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "elsewhere"))
+        monkeypatch.chdir(worktree)
+
+        assert project_root() != tmp_path
+        assert project_root() == worktree
+
+
+class TestARealProjectStillResolves:
+    """The whole point of the walk, which must keep working."""
+
+    def test_a_subdirectory_finds_its_project(self, home, monkeypatch):
+        project = home / "work" / "agent"
+        (project / ".co").mkdir(parents=True)
+        deep = project / "src" / "tools"
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+
+        assert project_root() == project
+
+    def test_the_project_wins_over_the_global_config(self, home, monkeypatch):
+        project = home / "work" / "agent"
+        (project / ".co").mkdir(parents=True)
+        monkeypatch.chdir(project)
+
+        assert project_root() == project
+
+    def test_a_project_inside_a_repo_is_found(self, tmp_path, monkeypatch):
+        repo = tmp_path / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        project = repo / "agents" / "mine"
+        (project / ".co").mkdir(parents=True)
+        deep = project / "sub"
+        deep.mkdir()
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "elsewhere"))
+        monkeypatch.chdir(deep)
+
+        assert project_root() == project, "the boundary must not hide a real project"
+
+    def test_an_explicit_start_is_still_honoured(self, home):
+        project = home / "work" / "agent"
+        (project / ".co").mkdir(parents=True)
+        deep = project / "src"
+        deep.mkdir()
+
+        assert project_root(deep) == project


### PR DESCRIPTION
Closes #846.

## What was wrong

`project_root()` walked up looking for the nearest `.co/` with no upper bound, so nothing ever told it that it had left the project. The module docstring already records what came of that:

> Two of those bugs failed open: a project configured `trust: strict` ran as `careful`, and an address on the blocklist read back as a stranger.

It attributes this to a "stray `.co/`". The part not written down: on any ordinary machine there is always one. **`~/.co` is the global config directory**, and it sits directly above every directory the user owns.

Measured before this change:

```
~/Desktop   ->  /Users/me       ($HOME, via the global ~/.co)
/tmp        ->  /private/tmp    (a stray any user on the box can create)
```

So `co` run anywhere under `$HOME` outside a project believed it was in a project rooted at `$HOME`, and read the machine's own config — trust lists included — as that project's configuration. Silent, and it fails open.

## The fix

Two boundaries, both meaning "the project cannot be above here":

- **a directory holding `.git`** — a `.co/` reached by climbing out of the checkout belongs to something else. Tested with `.exists()`, not `.is_dir()`, because `.git` is a *file* in a worktree.
- **`$HOME`** — and `$HOME/.co` never counts as a project's own.

After:

```
~/Desktop                    ->  ~/Desktop        (was $HOME)
a git worktree with no .co/  ->  the worktree     (was wherever it escaped to)
a subdirectory of a project  ->  the project      (unchanged)
```

## What is deliberately not changed

**The global `~/.co` is still read where it is genuinely global.** `project_identity()` falls back to `address.load(Path.home() / CO_DIR)` by name and is untouched, so keys and machine defaults resolve exactly as before.

The bug was never that `~/.co` gets read. It is that it got read *as one particular project's configuration* by whoever happened to be standing in the wrong directory. Separating "global config" from "this project's config" is the whole change.

The fallback is also unchanged: no `.co/` above you still resolves to where you started, so an agent hosted outside a project keeps working with its files where it was launched. I considered raising instead — "you are not in a project, run `co init`" — and did not, because it converts a documented working configuration into an error for a benefit the boundary already delivers.

## Tests

`tests/unit/test_the_project_walk_stops_at_the_project.py`, covering both measured scenarios plus the worktree `.git`-as-a-file case.

Confirmed red first: **5 failed, 5 passed** before the change, where the 5 passing are the "a real project still resolves" group — so the file is not vacuously green. All 10 pass after.