### PR TITLE
Guard ambient API keys at billed boundaries

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -9,9 +9,6 @@ LLM-Note:
   Errors: validate_project_name() returns (False, error_msg) for invalid names | detect_api_provider() returns ("unknown", "unknown") for unrecognized keys | generate_custom_template_with_name() may fail if LLM API unreachable | api_key_setup_menu() catches KeyboardInterrupt and returns ("", "", None) | no try-except blocks (follows fail-fast principle)
 """
 
-import base64
-import binascii
-import json
 import os
 import re
 import sys
@@ -29,6 +26,7 @@ from typing import Optional, Tuple, List
 
 from ... import __version__
 from ... import address
+from ...credentials import account_in_token
 
 # What a new user may spend free credits on. The list lives in core.usage with
 # the other model facts, and PaidModelRequiredError offers the same tuple when a
@@ -1067,28 +1065,6 @@ def load_api_key() -> Optional[str]:
             if api_key := os.getenv("OPENONION_API_KEY"):
                 return _token_for_this_account(api_key)
     return None
-
-
-def account_in_token(token: str) -> Optional[str]:
-    """The public key a JWT claims, read without verifying it.
-
-    Not authentication — the server does that. This is only to notice that the
-    token in hand names a different account than the key on disk, which the
-    server cannot tell us until we have already asked it the wrong question.
-    """
-    parts = token.split(".")
-    if len(parts) != 3:
-        return None
-    payload = parts[1]
-    payload += "=" * (-len(payload) % 4)          # base64url, padding stripped
-    try:
-        decoded = json.loads(base64.urlsafe_b64decode(payload))
-    except (ValueError, binascii.Error):
-        return None
-    if not isinstance(decoded, dict):
-        return None
-    public_key = decoded.get("public_key")
-    return public_key if isinstance(public_key, str) and public_key else None
 
 
 def _token_for_this_account(token: str) -> Optional[str]:

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1056,12 +1056,14 @@ class OpenOnionLLM(LLM):
         # For co/ models, api_key is actually the auth token
         # Framework auto-loads .env, so OPENONION_API_KEY will be in environment
         import openai
-        self.auth_token = api_key or os.getenv("OPENONION_API_KEY")
-        if not self.auth_token:
-            raise ValueError(
-                "OPENONION_API_KEY not found in environment.\n"
-                "Run 'co init' to get started or set OPENONION_API_KEY in your .env file."
-            )
+        if api_key:
+            # Explicit dependency injection is caller-owned. Only the implicit
+            # environment fallback is checked against the local project.
+            self.auth_token = api_key
+        else:
+            from ..credentials import require_ambient_api_key
+
+            self.auth_token = require_ambient_api_key()
 
         # Strip co/ prefix - it's only for client-side routing
         self.model = model.removeprefix("co/")

--- a/connectonion/credentials.py
+++ b/connectonion/credentials.py
@@ -1,0 +1,111 @@
+"""Non-mutating validation for ambient OpenOnion credentials.
+
+Ambient credentials are convenient, but their source is implicit: package
+startup may load a project ``.env`` and then the global ``~/.co/keys.env``.
+Before a library call spends credit or reads mail, make sure the selected token
+names the identity this project acts as. Explicit ``api_key=`` arguments remain
+caller-owned dependency injection and do not pass through this resolver.
+
+This module never authenticates, searches for dotenv files, writes credentials,
+or makes a network request. CLI reauthentication is a separate policy layer.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+from typing import Any, Mapping
+
+from .project import project_identity
+
+
+class AmbientCredentialError(ValueError):
+    """Base error for an unusable ambient OpenOnion credential."""
+
+
+class MissingAmbientAPIKey(AmbientCredentialError):
+    """No OpenOnion token is available in the process environment."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "OpenOnion API key required: OPENONION_API_KEY not found in "
+            "environment. Run 'co init' or 'co auth' to authenticate."
+        )
+
+
+class AmbientAPIKeyAccountMismatch(AmbientCredentialError):
+    """The ambient token names a different account than the current project."""
+
+    def __init__(self, *, claimed: str, expected: str) -> None:
+        self.claimed = claimed
+        self.expected = expected
+        super().__init__(
+            "OPENONION_API_KEY belongs to account "
+            f"{_short_address(claimed)}, but this project acts as "
+            f"{_short_address(expected)}. Run 'co auth' from this project or "
+            "pass an explicit api_key when another account is intentional."
+        )
+
+
+def account_in_token(token: str) -> str | None:
+    """Return the public-key claim from a JWT-shaped token, if inspectable.
+
+    This is not authentication. The server still verifies the token signature.
+    Local inspection only prevents an implicit credential from silently billing
+    or reading mail for a different local project identity.
+    """
+
+    if not isinstance(token, str):
+        return None
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, UnicodeDecodeError, binascii.Error):
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    public_key = decoded.get("public_key")
+    return public_key if isinstance(public_key, str) and public_key else None
+
+
+def require_ambient_api_key() -> str:
+    """Return the ambient token after checking its local account claim.
+
+    A token with no inspectable account claim is returned unchanged; rejecting
+    token formats locally would duplicate server authentication and break
+    opaque future formats. A valid claim that conflicts with the canonical
+    project identity fails closed before any billed or mailbox request.
+    """
+
+    token = os.getenv("OPENONION_API_KEY")
+    if not token:
+        raise MissingAmbientAPIKey()
+
+    claimed = account_in_token(token)
+    expected = _identity_address(project_identity())
+    if (
+        claimed is not None
+        and expected is not None
+        and claimed.casefold() != expected.casefold()
+    ):
+        raise AmbientAPIKeyAccountMismatch(
+            claimed=claimed,
+            expected=expected,
+        )
+    return token
+
+
+def _identity_address(identity: Any) -> str | None:
+    if not isinstance(identity, Mapping):
+        return None
+    value = identity.get("address")
+    return value if isinstance(value, str) and value else None
+
+
+def _short_address(address: str) -> str:
+    return f"{address[:16]}…" if len(address) > 16 else address

--- a/connectonion/transcribe.py
+++ b/connectonion/transcribe.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Optional
 import httpx
 from connectonion.backend import backend_url
+from connectonion.credentials import require_ambient_api_key
 
 
 # MIME type mapping for audio formats
@@ -67,14 +68,7 @@ def _get_mime_type(file_path: Path) -> str:
 def _get_api_key(model: str) -> str:
     """Get API key based on model."""
     if model.startswith("co/"):
-        # Use OpenOnion managed keys
-        api_key = os.getenv("OPENONION_API_KEY")
-        if not api_key:
-            raise ValueError(
-                "OpenOnion API key required for co/ models. "
-                "Run `co auth` to authenticate or set OPENONION_API_KEY."
-            )
-        return api_key
+        return require_ambient_api_key()
     else:
         # Use Gemini API key directly
         api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")

--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -26,6 +26,7 @@ import requests
 from typing import TYPE_CHECKING
 from ..core.events import after_tools
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -154,9 +155,10 @@ def _upload_to_oo_api(base64_data: str, mime_type: str) -> str:
     broken image pipeline while re-inflating the context.
     """
     base = backend_url()
+    token = require_ambient_api_key()
     resp = requests.post(
         f"{base}/api/v1/images",
-        headers={"Authorization": f"Bearer {os.environ['OPENONION_API_KEY']}"},
+        headers={"Authorization": f"Bearer {token}"},
         files={"file": ("screenshot", base64.b64decode(base64_data), mime_type)},
         timeout=30,
     )

--- a/connectonion/useful_tools/get_emails.py
+++ b/connectonion/useful_tools/get_emails.py
@@ -1,20 +1,18 @@
 """
 Purpose: Retrieve emails from agent's inbox via OpenOnion API with filtering options
 LLM-Note:
-  Dependencies: imports from [os, json, yaml, requests, pathlib, typing, dotenv] | imported by [__init__.py, useful_tools/__init__.py] | tested by [tests/unit/test_email_functions.py, tests/test_real_email.py]
-  Data flow: Agent calls get_emails(last=10, unread=False) → searches for .env file → loads OPENONION_API_KEY → GET to the configured backend /api/v1/email/received with query params → returns List[Dict] with emails: {id, from, to, subject, body, html_body, date, read} | mark_read(email_id) PUTs to /api/v1/email/s/mark-read
-  State/Effects: reads .env files | makes HTTP GET/PUT requests | no local caching | mark_read() modifies server-side read status
+  Dependencies: imports from [requests, typing, backend, credentials] | imported by [__init__.py, useful_tools/__init__.py] | tested by [tests/unit/test_email_functions.py, tests/unit/test_credentials.py, tests/test_real_email.py]
+  Data flow: Agent calls a mailbox function → require_ambient_api_key() checks the already-loaded environment token against the canonical project identity → request to the configured backend → normalized result
+  State/Effects: reads the ambient token and local identity keys | makes HTTP GET/POST requests | no local caching | mark_read()/mark_unread() modify server-side read status
   Integration: exposes get_emails(last, unread), mark_read(email_id) | used as agent tool functions | requires 'co auth' setup | API endpoints: GET /api/v1/email/received?last=N&unread=true, PUT /api/v1/email/s/mark-read
   Performance: one HTTP request per call | no pagination (uses 'last' param) | synchronous blocking | no local cache
-  Errors: returns empty list [] on failure | HTTP errors caught and wrapped in error dict | missing auth returns error | let-it-crash pattern for API failures
+  Errors: missing/mismatched ambient credentials and HTTP failures raise | no credential value is included in errors
 """
 
-import os
-import json
 import requests
-from pathlib import Path
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Union
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 
 
 def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
@@ -33,17 +31,7 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
             - timestamp: ISO format timestamp
             - read: Boolean read status
     """
-    # Get authentication token from environment
-    # Emails are hosted by OpenOnion and require OPENONION_API_KEY for authentication
-    token = os.getenv("OPENONION_API_KEY")
-
-    if not token:
-        raise ValueError(
-            "OPENONION_API_KEY not found in .env file. "
-            "Agent emails are hosted by OpenOnion and require authentication. "
-            "Check your .env file for OPENONION_API_KEY, or run 'co init' to copy "
-            "OPENONION_API_KEY from ~/.co/keys.env to your project."
-        )
+    token = require_ambient_api_key()
     
     # Fetch emails from backend API
     endpoint = f"{backend_url()}/api/v1/email/received"
@@ -104,15 +92,7 @@ def get_sent(last: int = 10, to: str = None) -> List[Dict]:
             - message_id: Provider message ID
             - timestamp: ISO format send time
     """
-    token = os.getenv("OPENONION_API_KEY")
-
-    if not token:
-        raise ValueError(
-            "OPENONION_API_KEY not found in .env file. "
-            "Agent emails are hosted by OpenOnion and require authentication. "
-            "Check your .env file for OPENONION_API_KEY, or run 'co init' to copy "
-            "OPENONION_API_KEY from ~/.co/keys.env to your project."
-        )
+    token = require_ambient_api_key()
 
     params = {"limit": last}
     if to:
@@ -154,15 +134,7 @@ def mark_read(email_ids: Union[str, List[str]]) -> bool:
     if not email_ids:
         raise ValueError("No email IDs provided to mark as read")
 
-    # Get authentication token from environment
-    token = os.getenv("OPENONION_API_KEY")
-
-    if not token:
-        raise ValueError(
-            "OPENONION_API_KEY not found in .env file. "
-            "Check your .env file for OPENONION_API_KEY, or run 'co init' to copy "
-            "OPENONION_API_KEY from ~/.co/keys.env to your project."
-        )
+    token = require_ambient_api_key()
     
     # Mark emails as read via backend API
     endpoint = f"{backend_url()}/api/v1/email/s/mark-read"
@@ -201,15 +173,7 @@ def mark_unread(email_ids: Union[str, List[str]]) -> bool:
     if not email_ids:
         raise ValueError("No email IDs provided to mark as unread")
 
-    # Get authentication token from environment
-    token = os.getenv("OPENONION_API_KEY")
-
-    if not token:
-        raise ValueError(
-            "OPENONION_API_KEY not found in .env file. "
-            "Check your .env file for OPENONION_API_KEY, or run 'co init' to copy "
-            "OPENONION_API_KEY from ~/.co/keys.env to your project."
-        )
+    token = require_ambient_api_key()
 
     # Mark emails as unread via backend API
     endpoint = f"{backend_url()}/api/v1/email/s/mark-unread"

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -1,0 +1,196 @@
+"""Ambient OpenOnion credentials fail closed at billed and mailbox boundaries."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from connectonion import credentials
+from connectonion.credentials import (
+    AmbientAPIKeyAccountMismatch,
+    MissingAmbientAPIKey,
+    account_in_token,
+    require_ambient_api_key,
+)
+
+
+PROJECT = "0x" + "12" * 32
+GLOBAL = "0x" + "34" * 32
+FOREIGN = "0x" + "56" * 32
+
+
+def token_with_payload(payload_value) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_value).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def token_for(address: str) -> str:
+    return token_with_payload({"public_key": address})
+
+
+@pytest.fixture
+def project(monkeypatch):
+    monkeypatch.setattr(
+        credentials,
+        "project_identity",
+        lambda: {"address": PROJECT},
+    )
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+
+
+def test_project_token_is_the_canonical_ambient_credential(project, monkeypatch):
+    token = token_for(PROJECT)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+
+    assert require_ambient_api_key() == token
+
+
+def test_global_fallback_identity_is_accepted(monkeypatch):
+    token = token_for(GLOBAL)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+    monkeypatch.setattr(
+        credentials,
+        "project_identity",
+        lambda: {"address": GLOBAL},
+    )
+
+    assert require_ambient_api_key() == token
+
+
+def test_account_comparison_is_case_insensitive(project, monkeypatch):
+    token = token_for(PROJECT.upper())
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+
+    assert require_ambient_api_key() == token
+
+
+def test_mismatch_raises_without_exposing_the_token(project, monkeypatch):
+    token = token_for(FOREIGN)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+
+    with pytest.raises(AmbientAPIKeyAccountMismatch) as caught:
+        require_ambient_api_key()
+
+    assert caught.value.claimed == FOREIGN
+    assert caught.value.expected == PROJECT
+    assert token not in str(caught.value)
+
+
+def test_missing_token_has_one_actionable_typed_error(project):
+    with pytest.raises(MissingAmbientAPIKey, match="OPENONION_API_KEY not found"):
+        require_ambient_api_key()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [[], "text", 7, None, {}, {"public_key": []}, {"public_key": 7}],
+)
+def test_uninspectable_claims_do_not_duplicate_server_authentication(
+    project, monkeypatch, payload
+):
+    token = token_with_payload(payload)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+
+    assert account_in_token(token) is None
+    assert require_ambient_api_key() == token
+
+
+def test_no_local_identity_leaves_server_authentication_authoritative(monkeypatch):
+    token = token_for(FOREIGN)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+    monkeypatch.setattr(credentials, "project_identity", lambda: None)
+
+    assert require_ambient_api_key() == token
+
+
+@pytest.mark.parametrize(
+    ("function_name", "args"),
+    [
+        ("get_emails", ()),
+        ("get_sent", ()),
+        ("mark_read", ("message-id",)),
+        ("mark_unread", ("message-id",)),
+    ],
+)
+def test_mailbox_mismatch_stops_before_the_http_request(
+    project, monkeypatch, function_name, args
+):
+    from importlib import import_module
+
+    get_emails_module = import_module("connectonion.useful_tools.get_emails")
+    monkeypatch.setenv("OPENONION_API_KEY", token_for(FOREIGN))
+
+    def fail(*args, **kwargs):
+        pytest.fail("mail request used foreign token")
+
+    monkeypatch.setattr(get_emails_module.requests, "get", fail)
+    monkeypatch.setattr(get_emails_module.requests, "post", fail)
+
+    with pytest.raises(AmbientAPIKeyAccountMismatch):
+        getattr(get_emails_module, function_name)(*args)
+
+
+def test_transcribe_mismatch_stops_before_a_billed_request(project, monkeypatch):
+    from connectonion.transcribe import _get_api_key
+
+    monkeypatch.setenv("OPENONION_API_KEY", token_for(FOREIGN))
+
+    with pytest.raises(AmbientAPIKeyAccountMismatch):
+        _get_api_key("co/gemini-3.6-flash")
+
+
+def test_image_upload_mismatch_stops_before_http(project, monkeypatch):
+    from importlib import import_module
+
+    formatter = import_module(
+        "connectonion.useful_plugins.image_result_formatter"
+    )
+    monkeypatch.setenv("OPENONION_API_KEY", token_for(FOREIGN))
+    monkeypatch.setattr(
+        formatter.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("image request used foreign token"),
+    )
+
+    with pytest.raises(AmbientAPIKeyAccountMismatch):
+        formatter._upload_to_oo_api("eA==", "image/png")
+
+
+def test_llm_environment_mismatch_stops_before_client_creation(
+    project, monkeypatch
+):
+    import openai
+    from connectonion.core.llm import OpenOnionLLM
+
+    monkeypatch.setenv("OPENONION_API_KEY", token_for(FOREIGN))
+    monkeypatch.setattr(
+        openai,
+        "OpenAI",
+        lambda *args, **kwargs: pytest.fail("LLM client used foreign token"),
+    )
+
+    with pytest.raises(AmbientAPIKeyAccountMismatch):
+        OpenOnionLLM(model="co/gemini-3.6-flash")
+
+
+def test_explicit_llm_key_remains_caller_owned(project, monkeypatch):
+    import openai
+    from connectonion.core.llm import OpenOnionLLM
+
+    captured = {}
+
+    def client(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(openai, "OpenAI", client)
+    monkeypatch.setenv("OPENONION_API_KEY", token_for(FOREIGN))
+
+    llm = OpenOnionLLM(api_key="explicit-key", model="co/gemini-3.6-flash")
+
+    assert llm.auth_token == "explicit-key"
+    assert captured["api_key"] == "explicit-key"

--- a/tests/unit/test_host_yaml_is_found_from_a_subdirectory.py
+++ b/tests/unit/test_host_yaml_is_found_from_a_subdirectory.py
@@ -125,7 +125,8 @@ class TestHostItselfUsesIt:
         monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: seen.update(kw))
         monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: None)
 
-        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash",
+                                 api_key="test-key"),
                            relay_url=None)
 
         assert seen.get("port") == 8806
@@ -141,7 +142,8 @@ class TestHostItselfUsesIt:
         monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: None)
         monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: seen.update(kw))
 
-        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash",
+                                 api_key="test-key"),
                            relay_url=None)
 
         assert seen.get("trust") == "strict", "the agent served a looser trust than configured"

--- a/tests/unit/test_the_host_serves_the_address_you_were_told.py
+++ b/tests/unit/test_the_host_serves_the_address_you_were_told.py
@@ -156,7 +156,8 @@ class TestHostActuallyUsesIt:
         monkeypatch.setattr(server_module, "_print_host_banner",
                             lambda **kw: seen.update(kw))
 
-        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash",
+                                 api_key="test-key"),
                            relay_url=None)
 
         assert seen.get("address") == machine_keys["address"], (

--- a/tests/unit/test_the_session_history_belongs_to_the_project.py
+++ b/tests/unit/test_the_session_history_belongs_to_the_project.py
@@ -149,7 +149,8 @@ class TestHostUsesIt:
         monkeypatch.setattr(server_module.uvicorn, "run", lambda app, **kw: None)
         monkeypatch.setattr(server_module, "_print_host_banner", lambda **kw: None)
 
-        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash",
+                                 api_key="test-key"),
                            relay_url=None)
 
         assert not (project / "sub" / ".co").exists()

--- a/tests/unit/test_workers_and_reload_do_not_kill_the_agent.py
+++ b/tests/unit/test_workers_and_reload_do_not_kill_the_agent.py
@@ -115,7 +115,8 @@ class TestHostActuallyUsesIt:
         monkeypatch.setattr(server_module.uvicorn, "run",
                             lambda app, **kw: seen.update(kw))
 
-        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash"),
+        server_module.host(Agent("t", tools=[], model="co/gemini-2.5-flash",
+                                 api_key="test-key"),
                            relay_url=None)
         return seen
 


### PR DESCRIPTION
## Summary

- add one non-mutating ambient OpenOnion credential validator using the canonical project-first, global-fallback identity rule
- fail closed with typed, redacted errors when an inspectable environment token belongs to another account
- route mailbox reads/state changes, managed transcription, image uploads, and the implicit managed-LLM fallback through that boundary
- preserve explicit `api_key=` injection and leave opaque token authentication to the server
- reuse the robust JWT-claim decoder in the CLI account guard instead of maintaining two parsers

## Design boundary

The validator does not authenticate, search dotenv files, write credentials, or call the network. CLI reauthentication remains a higher-level recovery policy. The standalone TypeScript SDK and frontend package topology are unrelated to this Python security slice; `@connectonion/react` remains the frontend boundary.

## Review

- token values are never logged or embedded in errors
- valid JSON payloads that are not an object, and non-string account claims, cannot crash callers
- all four migrated mailbox operations reject a foreign token before GET/POST
- explicit LLM keys retain the existing caller-owned behavior
- remaining direct credential reads in OAuth and `send_email` stay explicitly outside this slice and remain tracked by #848

## Verification

- 158 focused credential, mailbox, transcription, image, LLM, CLI-account, and browser-guard tests passed on Python 3.10 after integrating current `main`
- reproduced the CI environment with a valid foreign-account JWT; 120 credential/LLM/host tests passed after isolating unrelated host tests with explicit test-only keys
- built the wheel and confirmed the new credential module and migrated callers are included
- `git diff --check` passed

## CI regression note

The first Linux run exposed seven host tests that implicitly consumed the repository CI billing token while generating unrelated temporary project identities. The production guard correctly rejected that foreign token. Those tests now inject an explicit `test-key`; the runtime guard and its fail-closed behavior are unchanged.

Closes #856
Advances #848
