### PR TITLE
Make co status report the account in use

### DIFF
--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1101,8 +1101,8 @@ def _token_for_this_account(token: str) -> Optional[str]:
     if not claimed or claimed.casefold() == identity["address"].casefold():
         return token
 
-    console.print(f"[dim]Your saved token is for {claimed[:16]}…, but this "
-                  f"project acts as {identity['address'][:16]}…. "
+    console.print(f"[dim]Your saved token is for {claimed[:16]}…, but the "
+                  f"current identity is {identity['address'][:16]}…. "
                   f"Authenticating again.[/dim]")
     if authenticate(co_dir, save_to_project=False, quiet=True):
         from dotenv import load_dotenv
@@ -1127,7 +1127,7 @@ def _token_for_this_account(token: str) -> Optional[str]:
     # reads another account's mailbox and spends another account's credit while
     # looking like an ordinary working session. No key at all is recoverable:
     # callers say "run co auth", and the operator knows something is wrong.
-    console.print("[yellow]Could not get a token for this project's identity. "
+    console.print("[yellow]Could not get a token for the current identity. "
                   "Not using the one on hand — it bills another account. "
                   "Run [bold]co auth[/bold].[/yellow]")
     return None

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1041,7 +1041,7 @@ def load_api_key() -> Optional[str]:
 
     Checks in order:
     1. Environment variable
-    2. Local .env file
+    2. Project-root .env file
     3. Global ~/.co/keys.env file
 
     Every source goes through `_token_for_this_account()`. The environment used
@@ -1055,11 +1055,15 @@ def load_api_key() -> Optional[str]:
         API key if found, None otherwise
     """
     from dotenv import load_dotenv
+    from ...project import project_root
 
     if api_key := os.getenv("OPENONION_API_KEY"):
         return _token_for_this_account(api_key)
 
-    for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
+    for env_path in [
+        project_root() / ".env",
+        Path.home() / ".co" / "keys.env",
+    ]:
         if env_path.exists():
             load_dotenv(env_path)
             if api_key := os.getenv("OPENONION_API_KEY"):
@@ -1070,44 +1074,60 @@ def load_api_key() -> Optional[str]:
 def _token_for_this_account(token: str) -> Optional[str]:
     """Re-authenticate when the stored token names an account we are not.
 
-    `co server new` and `co deploy` bill whatever the token says; `co status`
-    signs fresh and reads the key on disk. After `co account migrate` those are
-    two different accounts, and nothing fails — `/api/v1/auth` creates an
-    account for any key that authenticates, so the old address quietly becomes a
-    fresh, empty, working one. The operator sees a balance that is not theirs
-    and spends credit they did not migrate. One $180 server was bought that way.
+    `co server new` and `co deploy` bill whatever the token says. After
+    `co account migrate`, or when a project has its own key, a token can name a
+    different account than the canonical project-first identity. Nothing fails
+    at the API boundary, so the operator sees and spends another account's
+    credit. One $180 server was bought that way.
 
     The CLI holds the signing key, so it can see the mismatch itself rather than
     waiting for a balance to look wrong. Cheap: a local decode, and a network
     call only when the two disagree.
     """
     from .auth_commands import authenticate
+    from ...project import project_co_dir, project_identity
 
-    co_dir = Path.home() / ".co"
-    identity = address.load(co_dir)
+    project_dir = project_co_dir()
+    global_dir = Path.home() / ".co"
+    identity = project_identity()
     if not identity:
         return token
 
+    # authenticate() needs the directory that owns the selected signing key.
+    # This mirrors project_identity(): local project key, else machine key.
+    co_dir = project_dir if address.load(project_dir) else global_dir
+
     claimed = account_in_token(token)
-    if not claimed or claimed == identity["address"]:
+    if not claimed or claimed.casefold() == identity["address"].casefold():
         return token
 
     console.print(f"[dim]Your saved token is for {claimed[:16]}…, but this "
-                  f"machine is {identity['address'][:16]}…. "
+                  f"project acts as {identity['address'][:16]}…. "
                   f"Authenticating again.[/dim]")
     if authenticate(co_dir, save_to_project=False, quiet=True):
         from dotenv import load_dotenv
-        load_dotenv(co_dir / "keys.env", override=True)
+
+        token_file = (
+            co_dir / "keys.env"
+            if co_dir.resolve() == global_dir.resolve()
+            else co_dir.parent / ".env"
+        )
+        load_dotenv(token_file, override=True)
         refreshed = os.getenv("OPENONION_API_KEY")
-        if refreshed and account_in_token(refreshed) == identity["address"]:
+        refreshed_account = account_in_token(refreshed) if refreshed else None
+        if (
+            refreshed
+            and refreshed_account
+            and refreshed_account.casefold() == identity["address"].casefold()
+        ):
             return refreshed
 
-    # Re-authentication did not produce a token for this machine. Returning the
-    # mismatched one anyway is the failure this function exists to prevent — it
+    # Re-authentication did not produce a token for the selected identity.
+    # Returning the mismatched one anyway is the failure this function exists to prevent — it
     # reads another account's mailbox and spends another account's credit while
     # looking like an ordinary working session. No key at all is recoverable:
     # callers say "run co auth", and the operator knows something is wrong.
-    console.print("[yellow]Could not get a token for this machine's key. "
+    console.print("[yellow]Could not get a token for this project's identity. "
                   "Not using the one on hand — it bills another account. "
                   "Run [bold]co auth[/bold].[/yellow]")
     return None

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -109,10 +109,11 @@ def _credential_sources(
     )
     home = (home or Path.home()).resolve()
     environ = os.environ if environ is None else environ
+    project_source = "~/.env" if project_dir == home else "<project>/.env"
 
     return (
         ("process environment", environ),
-        ("<project>/.env", _read_credential_file(project_dir / ".env")),
+        (project_source, _read_credential_file(project_dir / ".env")),
         ("~/.co/keys.env", _read_credential_file(home / ".co" / "keys.env")),
     )
 

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -1,9 +1,9 @@
 """
-Purpose: Display account status, deployments, and credential-source diagnostics without re-authenticating
+Purpose: Display redacted credential diagnostics, canonical account status, and deployments
 LLM-Note:
-  Dependencies: imports from [os, requests, pathlib, dotenv.dotenv_values, rich.console, rich.panel, rich.table, rich.text, address] | imported by [cli/main.py via handle_status()] | calls the configured backend /api/v1/auth | tested by [tests/e2e/cli/test_cli_status.py]
-  Data flow: receives reveal=False by default → inspects supported provider variable names in process env/local .env/global ~/.co/keys.env without loading values → displays redacted name/status/source table → if reveal=True, displays full values in a separate warning-marked table → load_api_key() resolves OPENONION_API_KEY → address.load() reads Ed25519 keypair → creates fresh auth message with timestamp → address.sign() creates signature → POST to /api/v1/auth → displays account and deployments
-  State/Effects: no state modifications | makes network requests to the configured backend after local diagnostics | reads env vars, .env, ~/.co/keys.env without exporting them | default output contains no secret material; explicit --reveal writes full values to the terminal | does NOT update any files
+  Dependencies: imports from [os, requests, pathlib, dotenv.dotenv_values, rich.console, rich.panel, rich.table, rich.text, credentials.account_in_token, project_identity, project_root, address] | imported by [cli/main.py via handle_status()] | calls the configured backend /api/v1/auth | tested by [tests/e2e/cli/test_cli_status.py]
+  Data flow: receives reveal=False by default → inspects supported provider variable names in process env/project-root .env/global ~/.co/keys.env without loading values → compares OpenOnion sources by public account claim while keeping token values redacted → if reveal=True, displays full values in a separate warning-marked table → load_api_key() performs guarded resolution/recovery → project_identity() selects the project key or global fallback → creates and signs a fresh auth message → POST to /api/v1/auth → displays account and deployments
+  State/Effects: discovery is non-mutating and makes no network call | account resolution may re-authenticate and repair a stored token only when the guarded CLI policy finds a different account | then makes account/deployment requests | default output contains no secret material; explicit --reveal writes full values to the terminal
   Integration: exposes handle_status(reveal=False) for CLI | credential discovery supports every provider in core/llm.py | OpenOnion auth still uses load_api_key() priority | source paths are privacy-safe (<project>/.env and ~/.co/keys.env)
   Performance: network call to backend (1-2s) | signature generation is fast (<10ms) | file I/O for .env files
   Errors: credential parse/read failures are treated as no discovered keys | account status fails gracefully if OPENONION_API_KEY or identity keys are missing | backend errors do not expose credential values; only explicit --reveal prints them
@@ -20,6 +20,8 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 from ...backend import backend_url
+from ...credentials import account_in_token
+from ...project import project_identity, project_root
 
 from .project_cmd_lib import load_api_key
 
@@ -100,7 +102,11 @@ def _credential_sources(
     environ: Mapping[str, str] | None = None,
 ) -> tuple[tuple[str, Mapping[str, str]], ...]:
     """Return supported credential values grouped by privacy-safe source."""
-    project_dir = (project_dir or Path.cwd()).resolve()
+    project_dir = (
+        Path(project_dir).resolve()
+        if project_dir is not None
+        else project_root().resolve()
+    )
     home = (home or Path.home()).resolve()
     environ = os.environ if environ is None else environ
 
@@ -109,6 +115,47 @@ def _credential_sources(
         ("<project>/.env", _read_credential_file(project_dir / ".env")),
         ("~/.co/keys.env", _read_credential_file(home / ".co" / "keys.env")),
     )
+
+
+def _short_account(account: str) -> str:
+    """A public address that distinguishes accounts without dominating a row."""
+    if len(account) <= 20:
+        return account
+    return f"{account[:16]}…{account[-4:]}"
+
+
+def _openonion_source_status(
+    found: list[tuple[str, str]],
+) -> tuple[str, str]:
+    """Describe OpenOnion sources by account identity, never token text.
+
+    JWTs rotate, so two different strings can still authorize the same account.
+    When every token has an inspectable public claim, the claims define whether
+    there is a conflict. If any token is opaque, value equality is the only safe
+    fallback; server authentication remains authoritative.
+    """
+    claims = [account_in_token(value) for _source, value in found]
+    if all(claim is not None for claim in claims):
+        conflict = len({claim.casefold() for claim in claims if claim}) > 1
+    else:
+        conflict = len({value for _source, value in found}) > 1
+
+    labels = []
+    for index, ((source, _value), claim) in enumerate(zip(found, claims)):
+        details = []
+        if conflict and index == 0:
+            details.append("used")
+        if claim:
+            details.append(f"account {_short_account(claim)}")
+        labels.append(
+            f"{source} ({' · '.join(details)})" if details else source
+        )
+
+    if conflict:
+        return "conflict", " + ".join(labels)
+    if found[0][0] == "process environment":
+        return "configured", " + ".join(labels)
+    return "discovered · not loaded", " + ".join(labels)
 
 
 def _credential_rows(
@@ -140,6 +187,8 @@ def _credential_rows(
         if not found:
             status = "missing"
             source = "—"
+        elif name == "OPENONION_API_KEY":
+            status, source = _openonion_source_status(found)
         elif len(unique_values) > 1:
             status = "conflict"
             # Which one is actually used. _credential_sources returns its
@@ -386,7 +435,11 @@ def _show_deployments(deployments):
 
 
 def handle_status(reveal: bool = False):
-    """Check account status without re-authenticating.
+    """Check canonical account status after redacted local diagnostics.
+
+    Credential discovery itself is read-only. The subsequent account phase uses
+    the ordinary CLI guard, which re-authenticates only to recover an explicit
+    account mismatch.
 
     Args:
         reveal: If True, print full provider credential values.
@@ -413,12 +466,9 @@ def handle_status(reveal: bool = False):
 
     from ... import address
 
-    # Load keys to re-sign
-    co_dir = Path(".co")
-    if not (co_dir.exists() and (co_dir / "keys" / "agent.key").exists()):
-        co_dir = Path.home() / ".co"
-
-    addr_data = address.load(co_dir)
+    # Sign as the same canonical identity the credential guard expects:
+    # project key first (including from nested directories), global fallback.
+    addr_data = project_identity()
     if not addr_data:
         console.print("\n❌ [bold red]No keys found[/bold red]")
         console.print("[yellow]Run 'co auth' first.[/yellow]\n")

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -113,6 +113,19 @@ class TestCredentialStatus:
         assert (project / ".env").read_text() == "OPENAI_API_KEY=project-secret\n"
         assert "project-secret" not in repr(rows)
 
+    def test_home_dotenv_is_named_as_home_not_as_a_project(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / ".env").write_text("OPENAI_API_KEY=home-secret\n")
+
+        rows = _credential_rows(project_dir=home, home=home, environ={})
+        openai = self._row(rows, "OPENAI_API_KEY")
+
+        assert openai["source"] == "~/.env"
+        assert "home-secret" not in repr(rows)
+
     def test_reports_conflicting_sources_without_values(self, tmp_path):
         from connectonion.cli.commands.status_commands import _credential_rows
 

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -14,6 +14,8 @@ Components under test:
 - connectonion.cli.commands.status_commands.handle_status
 """
 
+import base64
+import json
 import os
 import tempfile
 from io import StringIO
@@ -23,6 +25,13 @@ from unittest.mock import Mock, patch
 from rich.console import Console
 
 from .argparse_runner import ArgparseCliRunner
+
+
+def _token_for(public_key: str, nonce: str = "") -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": public_key, "nonce": nonce}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
 
 
 class TestCredentialStatus:
@@ -79,6 +88,31 @@ class TestCredentialStatus:
         assert environment == {}
         assert "local-secret" not in repr(rows)
 
+    def test_default_discovery_uses_the_project_root_from_a_subdirectory(
+        self, tmp_path, monkeypatch
+    ):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        nested = project / "src" / "deeper"
+        home = tmp_path / "home"
+        (project / ".co").mkdir(parents=True)
+        nested.mkdir(parents=True)
+        home.mkdir()
+        (project / ".env").write_text("OPENAI_API_KEY=project-secret\n")
+        environment = {}
+        monkeypatch.chdir(nested)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        rows = _credential_rows(environ=environment)
+        openai = self._row(rows, "OPENAI_API_KEY")
+
+        assert openai["status"] == "discovered · not loaded"
+        assert openai["source"] == "<project>/.env"
+        assert environment == {}
+        assert (project / ".env").read_text() == "OPENAI_API_KEY=project-secret\n"
+        assert "project-secret" not in repr(rows)
+
     def test_reports_conflicting_sources_without_values(self, tmp_path):
         from connectonion.cli.commands.status_commands import _credential_rows
 
@@ -107,6 +141,88 @@ class TestCredentialStatus:
         assert "local-secret" not in repr(rows)
         assert "global-secret" not in repr(rows)
         assert str(tmp_path) not in repr(rows)
+
+    def test_rotated_openonion_tokens_for_one_account_are_not_a_conflict(
+        self, tmp_path
+    ):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        (home / ".co").mkdir(parents=True)
+        account = "0x" + "a" * 64
+        process_token = _token_for(account, "new")
+        stored_token = _token_for(account.upper(), "old")
+        (project / ".env").write_text(
+            f"OPENONION_API_KEY={stored_token}\n"
+        )
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ={"OPENONION_API_KEY": process_token},
+        )
+        openonion = self._row(rows, "OPENONION_API_KEY")
+
+        assert openonion["status"] == "configured"
+        assert "process environment" in openonion["source"]
+        assert "<project>/.env" in openonion["source"]
+        assert account[:16] in openonion["source"].lower()
+        assert process_token not in repr(rows)
+        assert stored_token not in repr(rows)
+
+    def test_openonion_account_conflict_names_redacted_accounts(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        (home / ".co").mkdir(parents=True)
+        used_account = "0x" + "1" * 64
+        other_account = "0x" + "2" * 64
+        used_token = _token_for(used_account)
+        other_token = _token_for(other_account)
+        (project / ".env").write_text(
+            f"OPENONION_API_KEY={other_token}\n"
+        )
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ={"OPENONION_API_KEY": used_token},
+        )
+        openonion = self._row(rows, "OPENONION_API_KEY")
+
+        assert openonion["status"] == "conflict"
+        assert "process environment (used" in openonion["source"]
+        assert used_account[:16] in openonion["source"]
+        assert other_account[:16] in openonion["source"]
+        assert used_token not in repr(rows)
+        assert other_token not in repr(rows)
+
+    def test_opaque_openonion_tokens_fall_back_without_crashing(self, tmp_path):
+        from connectonion.cli.commands.status_commands import _credential_rows
+
+        project = tmp_path / "project"
+        home = tmp_path / "home"
+        project.mkdir()
+        home.mkdir()
+        (project / ".env").write_text("OPENONION_API_KEY=other-opaque\n")
+        environment = {"OPENONION_API_KEY": "opaque-token"}
+
+        rows = _credential_rows(
+            project_dir=project,
+            home=home,
+            environ=environment,
+        )
+        openonion = self._row(rows, "OPENONION_API_KEY")
+
+        assert openonion["status"] == "conflict"
+        assert "account" not in openonion["source"]
+        assert "opaque-token" not in repr(rows)
+        assert "other-opaque" not in repr(rows)
+        assert environment == {"OPENONION_API_KEY": "opaque-token"}
 
     def test_ignores_placeholders_and_empty_values(self, tmp_path):
         from connectonion.cli.commands.status_commands import _credential_rows
@@ -262,6 +378,26 @@ class TestLoadApiKey:
             finally:
                 os.chdir(original_cwd)
 
+    def test_load_api_key_finds_the_project_env_from_a_subdirectory(
+        self, tmp_path, monkeypatch
+    ):
+        from connectonion.cli.commands.project_cmd_lib import load_api_key
+
+        project = tmp_path / "project"
+        nested = project / "src" / "deeper"
+        home = tmp_path / "home"
+        (project / ".co").mkdir(parents=True)
+        nested.mkdir(parents=True)
+        home.mkdir()
+        (project / ".env").write_text(
+            "OPENONION_API_KEY=project-root-token\n"
+        )
+        monkeypatch.chdir(nested)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+
+        assert load_api_key() == "project-root-token"
+
     def test_load_api_key_from_global_keys_env(self):
         """Test loading API key from ~/.co/keys.env."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -374,6 +510,100 @@ class TestHandleStatusNoKeys:
                 assert mock_console.print.called
             finally:
                 os.chdir(original_cwd)
+
+
+class TestStatusUsesTheCanonicalProjectIdentity:
+    """The account panel and signed request must describe the project in cwd."""
+
+    @staticmethod
+    def _successful_account():
+        return Mock(
+            status_code=200,
+            json=lambda: {
+                "user": {
+                    "balance_usd": 1.0,
+                    "total_cost_usd": 0.0,
+                    "credits_usd": 1.0,
+                }
+            },
+        )
+
+    @patch('connectonion.cli.commands.status_commands.console')
+    @patch('connectonion.cli.commands.status_commands.load_api_key', return_value="token")
+    @patch('connectonion.address.load')
+    @patch('connectonion.address.sign', return_value=b'\x00' * 64)
+    @patch('connectonion.cli.commands.status_commands.requests.get')
+    @patch('connectonion.cli.commands.status_commands.requests.post')
+    def test_nested_directory_signs_as_the_project(
+        self, mock_post, mock_get, mock_sign, mock_load, _mock_key, _mock_console,
+        tmp_path, monkeypatch,
+    ):
+        from connectonion.cli.commands.status_commands import handle_status
+
+        project = tmp_path / "project"
+        project_co = project / ".co"
+        nested = project / "src" / "deeper"
+        home = tmp_path / "home"
+        global_co = home / ".co"
+        project_co.mkdir(parents=True)
+        nested.mkdir(parents=True)
+        global_co.mkdir(parents=True)
+        project_identity = {"address": "0x" + "1" * 64}
+        global_identity = {"address": "0x" + "2" * 64}
+
+        def identity_at(path):
+            path = Path(path).resolve()
+            if path == project_co.resolve():
+                return project_identity
+            if path == global_co.resolve():
+                return global_identity
+            return None
+
+        mock_load.side_effect = identity_at
+        mock_post.return_value = self._successful_account()
+        mock_get.return_value = Mock(status_code=200, json=lambda: {"deployments": []})
+        monkeypatch.chdir(nested)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        handle_status()
+
+        assert mock_post.call_args.kwargs["json"]["public_key"] == project_identity["address"]
+        assert mock_sign.call_args.args[0] == project_identity
+
+    @patch('connectonion.cli.commands.status_commands.console')
+    @patch('connectonion.cli.commands.status_commands.load_api_key', return_value="token")
+    @patch('connectonion.address.load')
+    @patch('connectonion.address.sign', return_value=b'\x00' * 64)
+    @patch('connectonion.cli.commands.status_commands.requests.get')
+    @patch('connectonion.cli.commands.status_commands.requests.post')
+    def test_project_without_a_key_signs_as_the_global_fallback(
+        self, mock_post, mock_get, mock_sign, mock_load, _mock_key, _mock_console,
+        tmp_path, monkeypatch,
+    ):
+        from connectonion.cli.commands.status_commands import handle_status
+
+        project = tmp_path / "project"
+        nested = project / "src"
+        home = tmp_path / "home"
+        global_co = home / ".co"
+        (project / ".co").mkdir(parents=True)
+        nested.mkdir()
+        global_co.mkdir(parents=True)
+        global_identity = {"address": "0x" + "2" * 64}
+        mock_load.side_effect = lambda path: (
+            global_identity
+            if Path(path).resolve() == global_co.resolve()
+            else None
+        )
+        mock_post.return_value = self._successful_account()
+        mock_get.return_value = Mock(status_code=200, json=lambda: {"deployments": []})
+        monkeypatch.chdir(nested)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        handle_status()
+
+        assert mock_post.call_args.kwargs["json"]["public_key"] == global_identity["address"]
+        assert mock_sign.call_args.args[0] == global_identity
 
 
 class TestHandleStatusSuccess:

--- a/tests/unit/test_project_cmd_lib.py
+++ b/tests/unit/test_project_cmd_lib.py
@@ -1,6 +1,7 @@
 """Tests for CLI project helpers — upsert_env credential writing."""
 
 import sys
+from pathlib import Path
 
 from connectonion.cli.commands.project_cmd_lib import upsert_env
 
@@ -107,6 +108,49 @@ class TestATokenThatNamesAnotherAccount:
 
         assert lib._token_for_this_account(token) == token
         assert not calls, "re-authenticated for no reason"
+
+    def test_a_project_mismatch_reauthenticates_with_the_project_key(
+        self, tmp_path, monkeypatch
+    ):
+        from connectonion.cli.commands import project_cmd_lib as lib
+
+        project = tmp_path / "project"
+        nested = project / "src"
+        project_co = project / ".co"
+        home = tmp_path / "home"
+        global_co = home / ".co"
+        project_co.mkdir(parents=True)
+        nested.mkdir()
+        global_co.mkdir(parents=True)
+        project_account = "0x" + "c" * 64
+        global_account = "0x" + "d" * 64
+        fresh = self._token(project_account)
+        calls = []
+
+        def identity_at(path):
+            path = Path(path).resolve()
+            if path == project_co.resolve():
+                return {"address": project_account}
+            if path == global_co.resolve():
+                return {"address": global_account}
+            return None
+
+        def authenticate(co_dir, **_kwargs):
+            calls.append(Path(co_dir).resolve())
+            monkeypatch.setenv("OPENONION_API_KEY", fresh)
+            return True
+
+        monkeypatch.chdir(nested)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setattr(lib.address, "load", identity_at)
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate",
+            authenticate,
+        )
+        monkeypatch.setattr("dotenv.load_dotenv", lambda *a, **k: True)
+
+        assert lib._token_for_this_account(self._token(self.THEIRS)) == fresh
+        assert calls == [project_co.resolve()]
 
     def test_an_unreadable_token_is_left_alone(self, monkeypatch):
         """It may be a shape we do not know. The server is the authority on


### PR DESCRIPTION
## Summary

- make `co status` discover the project-root `.env` from nested directories and sign its account request with the canonical project-first, global-fallback identity
- compare OpenOnion credential sources by public account claim so rotated JWTs for one account are benign while different accounts are a real conflict
- show privacy-safe source/short-address evidence and which source is currently used without exposing token material
- distinguish an actual `~/.env` from `<project>/.env` in the diagnostic output
- make guarded CLI token recovery authenticate with the selected project key and reload the token file it actually updated

## Design boundary

Credential discovery is read-only: it does not export environment variables, authenticate, write files, or call the network. The later account phase retains the existing guarded recovery policy and only reauthenticates when an inspectable token explicitly names a different account. Opaque tokens remain subject to server authentication.

This is a Python CLI/account diagnostic change. It does not change frontend package topology; `@connectonion/react` remains the frontend SDK boundary and the retired standalone TypeScript SDK is not involved.

## Review

- different JWT strings with the same case-insensitive account claim do not report a conflict
- different inspectable claims show only public shortened addresses, never token values
- opaque/malformed values fall back to equality without crashing or inventing an account
- nested project status, deployment token recovery, and the signed account request all select the same identity
- projects without their own key retain the global fallback
- review corrected the home-directory source label and kept project/global user-facing identity language accurate
- no unresolved P1/P2 issue found in code/security review

## Verification

- 72 focused status, credential, and CLI guard tests passed
- 132 expanded status, OAuth, deploy, browser-account, and credential tests passed; the loopback OAuth assertion was rerun outside the socket-restricted sandbox
- changed modules compile successfully
- `git diff --check` passed

Closes #841
Advances #848
