### PR TITLE
Guard send_email with the canonical project account

### DIFF
--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -1,12 +1,12 @@
 """
 Purpose: Send emails via OpenOnion API using agent's authenticated email address
 LLM-Note:
-  Dependencies: imports from [os, json, yaml, requests, pathlib, typing, dotenv] | imported by [__init__.py, useful_tools/__init__.py] | tested by [tests/unit/test_email_functions.py, tests/test_real_email.py]
-  Data flow: Agent calls send_email(to, subject, message) → searches for .env file (cwd → parent dirs → ~/.co/keys.env) → loads OPENONION_API_KEY and AGENT_EMAIL → validates email format → POST to the configured backend /api/v1/email/send with auth token → returns {success, message_id, from, error}
-  State/Effects: reads .env files from filesystem | loads environment variables via dotenv | makes HTTP POST request to OpenOnion API | no local state persistence
+  Dependencies: imports from [os, json, yaml, requests, pathlib, typing, dotenv, credentials, project] | imported by [__init__.py, useful_tools/__init__.py] | tested by [tests/unit/test_email_functions.py, tests/test_real_email.py]
+  Data flow: Agent calls send_email(to, subject, message) → preserves environment precedence and fills missing values from project-root .env then ~/.co/keys.env → validates the selected ambient token against the canonical project identity → validates email format → POST to /api/v1/email/send → returns {success, message_id, from, error}
+  State/Effects: reads canonical credential files and loads missing values into the process environment | makes one HTTP POST only after credential validation | no local state persistence
   Integration: exposes send_email(to, subject, message) → returns dict | used as agent tool function | requires prior 'co auth' to set OPENONION_API_KEY and AGENT_EMAIL | API endpoint: POST /api/v1/email/send with Bearer token
-  Performance: file search up to 5 parent dirs | one HTTP request per email | no caching | synchronous (blocks on network)
-  Errors: returns {success: False, error: str} for: missing .env, missing keys, invalid email format, API failures | HTTP errors caught and wrapped | validates @ and . in email | let-it-crash pattern (returns errors, doesn't raise)
+  Performance: canonical project-root lookup plus at most two dotenv reads | one HTTP request per email | no caching | synchronous (blocks on network)
+  Errors: returns {success: False, error: str} for missing/mismatched credentials, invalid email format, and API failures | credential errors are redacted and non-retryable | HTTP errors caught and wrapped
 """
 
 import os
@@ -15,7 +15,8 @@ import yaml
 import requests
 import uuid
 from pathlib import Path
-from ..project import project_co_dir
+from ..credentials import AmbientCredentialError, require_ambient_api_key
+from ..project import project_co_dir, project_root
 from typing import Dict, Optional
 from dotenv import load_dotenv
 from ..backend import backend_url
@@ -48,45 +49,29 @@ def send_email(
             - retryable (bool): Whether retrying this key is currently safe
     """
     send_key = idempotency_key or str(uuid.uuid4())
-    # Credentials come from the environment. A .env file is a convenience fallback,
-    # NOT a precondition: env vars set directly (container / CI / systemd, or already
-    # loaded by the `co` CLI) are equally valid. Load a .env if we can find one to
-    # populate any missing vars, but never require the file to exist on disk.
-    env_file = None
-    current_dir = Path.cwd()
+    # Environment values (container, CI, systemd, or an importing application)
+    # keep precedence. Canonical project/global files only fill missing values;
+    # the arbitrary five-parent crawl used here before disagreed with every
+    # other project boundary in the framework.
+    for env_file in (
+        project_root() / ".env",
+        Path.home() / ".co" / "keys.env",
+    ):
+        if env_file.is_file():
+            load_dotenv(env_file)
 
-    # Search up to 5 levels for a local .env
-    for _ in range(5):
-        potential_env = current_dir / ".env"
-        if potential_env.exists():
-            env_file = potential_env
-            break
-        if current_dir == current_dir.parent:  # Reached root
-            break
-        current_dir = current_dir.parent
-
-    # Fall back to the global keys.env
-    if not env_file:
-        global_keys_env = Path.home() / ".co" / "keys.env"
-        if global_keys_env.exists():
-            env_file = global_keys_env
-
-    # Load it if present (does not override vars already set in the environment)
-    if env_file:
-        load_dotenv(env_file)
-
-    # Get authentication token and agent email from the environment
-    token = os.getenv("OPENONION_API_KEY")
-    from_email = os.getenv("AGENT_EMAIL")
-
-    if not token:
+    try:
+        token = require_ambient_api_key()
+    except AmbientCredentialError as exc:
         return {
             "success": False,
-            "error": "OPENONION_API_KEY not set. Run 'co auth' to authenticate.",
+            "error": str(exc),
             "request_id": send_key,
             "idempotency_key": send_key,
             "retryable": False,
         }
+
+    from_email = os.getenv("AGENT_EMAIL")
 
     if not from_email:
         return {

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -10,6 +10,7 @@ Components under test:
 """
 
 
+import base64
 from unittest.mock import patch, MagicMock, mock_open
 from pathlib import Path
 import tempfile
@@ -36,6 +37,13 @@ from tests.utils.config_helpers import (
     SAMPLE_EMAILS,
     ProjectHelper,
 )
+
+
+def _token_for(public_key: str) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": public_key}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
 
 
 # -------- send_email tests -------- #
@@ -94,6 +102,119 @@ def test_send_email_no_project():
     result = send_email("test@example.com", "Test", "Message")
     assert result["success"] is False
     assert ("OPENONION_API_KEY" in result["error"]) or ("No .env file" in result["error"])
+
+
+def test_send_email_rejects_a_foreign_account_before_post(monkeypatch):
+    from connectonion import credentials
+
+    expected = "0x" + "1" * 64
+    foreign = "0x" + "2" * 64
+    token = _token_for(foreign)
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+    monkeypatch.setenv("AGENT_EMAIL", "agent@mail.openonion.ai")
+    monkeypatch.setattr(
+        credentials,
+        "project_identity",
+        lambda: {"address": expected},
+    )
+    monkeypatch.setattr(
+        send_email_module.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("foreign token reached email POST"),
+    )
+
+    result = send_email(
+        "test@example.com",
+        "Subject",
+        "Message",
+        idempotency_key="send-foreign",
+    )
+
+    assert result["success"] is False
+    assert result["retryable"] is False
+    assert result["request_id"] == "send-foreign"
+    assert result["idempotency_key"] == "send-foreign"
+    assert token not in result["error"]
+    assert foreign[:16] in result["error"]
+
+
+@patch.dict('os.environ', {}, clear=True)
+@patch('requests.post')
+def test_send_email_finds_the_project_env_from_a_deep_subdirectory(
+    mock_post, tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    nested = project.joinpath(*("deep",) * 8)
+    home = tmp_path / "home"
+    (project / ".co").mkdir(parents=True)
+    nested.mkdir(parents=True)
+    home.mkdir()
+    (project / ".env").write_text(
+        "OPENONION_API_KEY=project-token\n"
+        "AGENT_EMAIL=project@mail.openonion.ai\n"
+    )
+    monkeypatch.chdir(nested)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    mock_post.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {"message_id": "project-message"},
+    )
+
+    result = send_email("test@example.com", "Subject", "Message")
+
+    assert result["success"] is True
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer project-token"
+
+
+@patch.dict('os.environ', {}, clear=True)
+@patch('requests.post')
+def test_send_email_keeps_the_global_keys_fallback(mock_post, tmp_path, monkeypatch):
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    project.mkdir()
+    (home / ".co").mkdir(parents=True)
+    (home / ".co" / "keys.env").write_text(
+        "OPENONION_API_KEY=global-token\n"
+        "AGENT_EMAIL=global@mail.openonion.ai\n"
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    mock_post.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {"message_id": "global-message"},
+    )
+
+    result = send_email("test@example.com", "Subject", "Message")
+
+    assert result["success"] is True
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer global-token"
+
+
+@patch('requests.post')
+def test_send_email_keeps_process_environment_precedence(
+    mock_post, tmp_path, monkeypatch
+):
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    (project / ".co").mkdir(parents=True)
+    home.mkdir()
+    (project / ".env").write_text(
+        "OPENONION_API_KEY=project-token\n"
+        "AGENT_EMAIL=project@mail.openonion.ai\n"
+    )
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("OPENONION_API_KEY", "process-token")
+    monkeypatch.setenv("AGENT_EMAIL", "process@mail.openonion.ai")
+    mock_post.return_value = MagicMock(
+        status_code=200,
+        json=lambda: {"message_id": "process-message"},
+    )
+
+    result = send_email("test@example.com", "Subject", "Message")
+
+    assert result["success"] is True
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "Bearer process-token"
 
 
 @patch.dict('os.environ', {'OPENONION_API_KEY': 'test-token-123', 'AGENT_EMAIL': 'test@openonion.ai'})


### PR DESCRIPTION
## Summary

- remove `send_email()`'s independent five-parent dotenv crawl
- preserve process-environment precedence while filling missing values from the canonical project-root `.env` and global `~/.co/keys.env`
- validate the selected ambient OpenOnion token against the canonical project identity before constructing headers or calling the email backend
- convert typed credential failures into the existing non-retryable tool result while preserving request/idempotency correlation IDs

## Design boundary

The low-level credential validator remains non-mutating and network-free. Dotenv loading stays a compatibility policy of this higher-level email tool. The email API, payload, sender metadata, HTTP error handling, and idempotency contract are unchanged.

No real email was sent during verification. This Python security slice does not change frontend packages; `@connectonion/react` remains the frontend SDK boundary and the retired standalone TypeScript SDK is not involved.

## Review

- a foreign inspectable token fails before the email POST
- credential errors contain no token and preserve the caller's stable correlation key
- project-root discovery works from eight nested directory levels
- global fallback and process-environment precedence remain covered
- opaque tokens retain server-authoritative authentication behavior
- no unresolved P1/P2 issue found in code/security review

## Verification

- 49 focused send-email and ambient-credential tests passed
- 74 expanded email CLI, ask_user, upgrade, link-preservation, send/read, and credential tests passed
- changed modules compile successfully
- `git diff --check` passed

Closes #860
Advances #848
