### PR TITLE
Guard OAuth refreshes by project account

### DIFF
--- a/connectonion/useful_tools/gdrive.py
+++ b/connectonion/useful_tools/gdrive.py
@@ -2,7 +2,7 @@
 Purpose: Google Drive integration tool for listing, searching, downloading, and uploading files via the Drive API
 LLM-Note:
   Dependencies: imports from [io, mimetypes, os, pathlib, googleapiclient.discovery, googleapiclient.http, google.oauth2.credentials] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gdrive.py]
-  Data flow: Agent calls GDrive methods → _get_service() refreshes the access token via oo-api once per instance → Drive v3 API → returns file dicts or confirmations | list_files()/search_files() page through files().list() with 'trashed = false' | download() picks get_media() for binary files and export_media() for Google-native docs | upload() sends a MediaFileUpload
+  Data flow: Agent calls GDrive methods → _get_service() validates the ambient OpenOnion account and refreshes the access token via oo-api once per instance → Drive v3 API → returns file dicts or confirmations | list_files()/search_files() page through files().list() with 'trashed = false' | download() picks get_media() for binary files and export_media() for Google-native docs | upload() sends a MediaFileUpload
   State/Effects: reads GOOGLE_* env vars for OAuth tokens | makes HTTP calls to the Drive API | creates/overwrites local files on download and remote files on upload | token refresh rewrites ~/.co/keys.env
   Integration: exposes GDrive class with list_files(), search_files(), download(), upload(), delete() | list_files()/search_files() return dicts for the CLI (cli/commands/gdrive_commands.py) | used as agent tool via Agent(tools=[GDrive()])
   Performance: network I/O per API call | listings page at 100/request | downloads stream in chunks
@@ -44,6 +44,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload, MediaIoBaseDownload
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 
 # Everything under this prefix is a Google-native doc: it has no bytes of its
 # own, so it must be exported to a real format rather than downloaded.
@@ -127,13 +128,7 @@ class GDrive:
         import httpx
 
         selected_backend = backend_url()
-        api_key = os.getenv("OPENONION_API_KEY")
-
-        if not api_key:
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
-            )
+        api_key = require_ambient_api_key()
 
         response = httpx.post(
             f"{selected_backend}/api/v1/oauth/google/refresh",
@@ -142,9 +137,7 @@ class GDrive:
         )
 
         if response.status_code != 200:
-            raise ValueError(
-                f"Failed to refresh token via backend: {response.text}"
-            )
+            raise ValueError("Failed to refresh Google authorization via backend")
 
         data = response.json()
         new_access_token = data["access_token"]

--- a/connectonion/useful_tools/gmail.py
+++ b/connectonion/useful_tools/gmail.py
@@ -2,7 +2,7 @@
 Purpose: Gmail integration tool for reading, sending, and managing emails via Google API
 LLM-Note:
   Dependencies: imports from [os, base64, google.oauth2.credentials, googleapiclient.discovery, googleapiclient.errors] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_gmail.py]
-  Data flow: Agent calls Gmail methods → _get_credentials() loads tokens from env → builds Gmail API service → API calls to Gmail REST endpoints → returns formatted results (email summaries, bodies, send confirmations)
+  Data flow: Agent calls Gmail methods → validates the ambient OpenOnion account and refreshes server-owned Google credentials via oo-api → builds Gmail API service → API calls to Gmail REST endpoints → returns formatted results (email summaries, bodies, send confirmations)
   State/Effects: reads GOOGLE_* env vars and OPENONION_API_KEY | persists refreshed tokens to ~/.co/keys.env | makes HTTP calls to Gmail API | can modify mailbox state (mark read/unread, archive, star, send emails)
   Integration: exposes Gmail class with read_inbox(), get_sent_emails(), search_emails(), get_email_body(), send(), reply(), mark_read(), mark_unread(), archive_email(), star_email(), get_labels(), add_label(), count_unread(), get_all_contacts(), analyze_contact(), get_unanswered_emails(), update_contact() | used as agent tool via Agent(tools=[Gmail()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately (lazy loading)
@@ -60,6 +60,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 from ..project import project_root
 from ._attachment_files import path_of_open_file
 
@@ -120,12 +121,6 @@ class Gmail:
         if self._service:
             return self._service
 
-        if not os.getenv("OPENONION_API_KEY"):
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "Run: co auth"
-            )
-
         access_token = self._refresh_via_backend(None)
         expiry = self._token_expiry()
 
@@ -171,13 +166,7 @@ class Gmail:
 
         # Get backend URL and auth
         selected_backend = backend_url()
-        api_key = os.getenv("OPENONION_API_KEY")
-
-        if not api_key:
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
-            )
+        api_key = require_ambient_api_key()
 
         # Call backend refresh endpoint
         response = httpx.post(

--- a/connectonion/useful_tools/google_calendar.py
+++ b/connectonion/useful_tools/google_calendar.py
@@ -2,7 +2,7 @@
 Purpose: Google Calendar integration tool for managing events and meetings via Google API
 LLM-Note:
   Dependencies: imports from [os, datetime, google.oauth2.credentials, googleapiclient.discovery] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth google' | tested by [tests/unit/test_google_calendar.py]
-  Data flow: Agent calls GoogleCalendar methods → _get_credentials() loads tokens from env → builds Calendar API service → API calls to Calendar REST endpoints → returns formatted results (event lists, confirmations, free slots)
+  Data flow: Agent calls GoogleCalendar methods → validates the ambient OpenOnion account and refreshes server-owned Google credentials via oo-api → builds Calendar API service → API calls to Calendar REST endpoints → returns formatted results (event lists, confirmations, free slots)
   State/Effects: reads GOOGLE_* env vars and OPENONION_API_KEY | persists refreshed tokens to ~/.co/keys.env | makes HTTP calls to Google Calendar API | can create/update/delete events
   Integration: exposes GoogleCalendar class with list_events(), get_today_events(), get_event(), create_event(), update_event(), delete_event(), create_meet(), get_upcoming_meetings(), find_free_slots() | used as agent tool via Agent(tools=[GoogleCalendar()])
   Performance: network I/O per API call | batch fetching for list operations | date parsing for queries
@@ -47,6 +47,7 @@ from pathlib import Path
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 
 
 class GoogleCalendar:
@@ -73,12 +74,6 @@ class GoogleCalendar:
         """Build a Calendar service backed by the server-owned token broker."""
         if self._service:
             return self._service
-
-        if not os.getenv("OPENONION_API_KEY"):
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "Run: co auth"
-            )
 
         access_token = self._refresh_via_backend(None)
         creds = Credentials(
@@ -119,13 +114,7 @@ class GoogleCalendar:
 
         # Get backend URL and auth
         selected_backend = backend_url()
-        api_key = os.getenv("OPENONION_API_KEY")
-
-        if not api_key:
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
-            )
+        api_key = require_ambient_api_key()
 
         # Call backend refresh endpoint
         response = httpx.post(

--- a/connectonion/useful_tools/microsoft_calendar.py
+++ b/connectonion/useful_tools/microsoft_calendar.py
@@ -2,7 +2,7 @@
 Purpose: Microsoft Calendar integration tool for managing events via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, datetime, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_microsoft_calendar.py]
-  Data flow: Agent calls MicrosoftCalendar methods → _get_headers() loads MICROSOFT_ACCESS_TOKEN from env → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (event lists, confirmations, free slots)
+  Data flow: Agent calls MicrosoftCalendar methods → refresh validates the ambient OpenOnion account before exchanging locally owned Microsoft tokens via oo-api → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns formatted results (event lists, confirmations, free slots)
   State/Effects: reads and locally refreshes MICROSOFT_* OAuth tokens | persists rotated tokens to user keys.env and an existing project .env | makes HTTP calls to Microsoft Graph API | can create/update/delete events, create Teams meetings
   Integration: exposes MicrosoftCalendar class with list_events(), get_today_events(), get_event(), create_event(), update_event(), delete_event(), create_teams_meeting(), get_upcoming_meetings(), find_free_slots(), check_availability() | used as agent tool via Agent(tools=[MicrosoftCalendar()])
   Performance: network I/O per API call | batch fetching for list operations | date parsing for queries
@@ -47,6 +47,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 import httpx
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 
 
 class MicrosoftCalendar:
@@ -101,13 +102,7 @@ class MicrosoftCalendar:
     def _refresh_via_backend(self, refresh_token: str) -> str:
         """Refresh access token via backend API."""
         selected_backend = backend_url()
-        api_key = os.getenv("OPENONION_API_KEY")
-
-        if not api_key:
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
-            )
+        api_key = require_ambient_api_key()
 
         response = httpx.post(
             f"{selected_backend}/api/v1/oauth/microsoft/refresh",

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,7 +2,7 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  Data flow: Agent calls Outlook methods → _get_access_token() validates the ambient OpenOnion account and refreshes locally owned Microsoft tokens via oo-api → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
@@ -50,6 +50,7 @@ from pathlib import Path
 
 import httpx
 from ..backend import backend_url
+from ..credentials import require_ambient_api_key
 from ..project import project_root
 from ._attachment_files import path_of_open_file
 
@@ -129,13 +130,7 @@ class Outlook:
             New access token
         """
         selected_backend = backend_url()
-        api_key = os.getenv("OPENONION_API_KEY")
-
-        if not api_key:
-            raise ValueError(
-                "OPENONION_API_KEY not found.\n"
-                "This is needed to refresh tokens via backend."
-            )
+        api_key = require_ambient_api_key()
 
         response = httpx.post(
             f"{selected_backend}/api/v1/oauth/microsoft/refresh",

--- a/tests/unit/test_gdrive.py
+++ b/tests/unit/test_gdrive.py
@@ -89,6 +89,21 @@ class TestGDriveInit:
         assert calls == ["test-refresh"]
         assert mock_build.call_args.kwargs["credentials"].token == "fresh"
 
+    @pytest.mark.real_refresh
+    def test_backend_refresh_error_does_not_expose_provider_body(self, monkeypatch):
+        from connectonion.useful_tools.gdrive import GDrive
+
+        monkeypatch.setenv("OPENONION_API_KEY", "opaque-api-key")
+        response = MagicMock(status_code=502, text="provider-refresh-secret")
+
+        with patch("httpx.post", return_value=response):
+            with pytest.raises(ValueError) as error:
+                GDrive.__new__(GDrive)._refresh_via_backend("local-refresh-secret")
+
+        assert str(error.value) == "Failed to refresh Google authorization via backend"
+        assert "provider-refresh-secret" not in str(error.value)
+        assert "local-refresh-secret" not in str(error.value)
+
 
 class TestListFiles:
 

--- a/tests/unit/test_gmail.py
+++ b/tests/unit/test_gmail.py
@@ -176,6 +176,7 @@ class TestGmailGetService:
 
         assert mock_build.call_args.kwargs["credentials"].token == "fresh_token"
 
+    @pytest.mark.real_refresh
     @patch.dict(os.environ, {"GOOGLE_SCOPES": "gmail.readonly gmail.send"}, clear=True)
     def test_get_service_missing_credentials(self):
         """Test _get_service raises error when credentials missing."""

--- a/tests/unit/test_oauth_account_guard.py
+++ b/tests/unit/test_oauth_account_guard.py
@@ -1,0 +1,73 @@
+"""Account-boundary tests shared by the OAuth provider tools."""
+
+import base64
+import importlib
+import json
+import os
+
+import httpx
+import pytest
+
+from connectonion import credentials
+from connectonion.credentials import AmbientAPIKeyAccountMismatch
+
+
+OAUTH_REFRESHERS = (
+    ("connectonion.useful_tools.gdrive", "GDrive"),
+    ("connectonion.useful_tools.gmail", "Gmail"),
+    ("connectonion.useful_tools.google_calendar", "GoogleCalendar"),
+    ("connectonion.useful_tools.outlook", "Outlook"),
+    ("connectonion.useful_tools.microsoft_calendar", "MicrosoftCalendar"),
+)
+
+
+def _token_for(public_key: str) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": public_key}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+@pytest.mark.parametrize("module_name,class_name", OAUTH_REFRESHERS)
+def test_oauth_refresh_rejects_a_foreign_account_before_network_or_mutation(
+    module_name, class_name, monkeypatch, tmp_path
+):
+    expected = "0x" + "1" * 64
+    foreign = "0x" + "2" * 64
+    openonion_token = _token_for(foreign)
+    provider_values = {
+        "GOOGLE_ACCESS_TOKEN": "google-access-before",
+        "GOOGLE_REFRESH_TOKEN": "google-refresh-before",
+        "GOOGLE_TOKEN_EXPIRES_AT": "google-expiry-before",
+        "MICROSOFT_ACCESS_TOKEN": "microsoft-access-before",
+        "MICROSOFT_REFRESH_TOKEN": "microsoft-refresh-before",
+        "MICROSOFT_TOKEN_EXPIRES_AT": "microsoft-expiry-before",
+    }
+    monkeypatch.setenv("OPENONION_API_KEY", openonion_token)
+    monkeypatch.setenv("AGENT_CONFIG_PATH", str(tmp_path / "config"))
+    for name, value in provider_values.items():
+        monkeypatch.setenv(name, value)
+    monkeypatch.setattr(
+        credentials,
+        "project_identity",
+        lambda: {"address": expected},
+    )
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda *args, **kwargs: pytest.fail("foreign account reached OAuth broker"),
+    )
+
+    module = importlib.import_module(module_name)
+    refresher = getattr(module, class_name).__new__(getattr(module, class_name))
+    with pytest.raises(AmbientAPIKeyAccountMismatch) as error:
+        refresher._refresh_via_backend("provider-refresh-secret")
+
+    assert openonion_token not in str(error.value)
+    assert "provider-refresh-secret" not in str(error.value)
+    assert foreign[:16] in str(error.value)
+    assert {
+        name: os.environ[name]
+        for name in provider_values
+    } == provider_values
+    assert not (tmp_path / "config" / "keys.env").exists()


### PR DESCRIPTION
Closes #862

## What changed

- Route the OpenOnion bearer token for GDrive, Gmail, Google Calendar, Outlook, and Microsoft Calendar refresh calls through the canonical `require_ambient_api_key()` guard.
- Remove duplicate missing-key branches from Gmail and Google Calendar; `AmbientCredentialError` already preserves their public `ValueError` contract.
- Reject an inspectable foreign-account token before `httpx.post` and before any provider environment/file mutation.
- Keep opaque tokens compatible so the backend remains authoritative for authentication.
- Redact the raw GDrive refresh response instead of surfacing provider debug content.

## Design boundary

This follows DD-011: global identity is the convenient default, while project-specific identity remains a real boundary. It does not merge provider ownership models: Google and Microsoft request payloads and token persistence stay as they were.

The frontend boundary remains `@connectonion/react` for oo-chat. This PR does not add, update, or depend on the obsolete standalone TypeScript SDK.

## Validation

- 214 focused credential/provider tests passed.
- 375 expanded OAuth tool, CLI, plugin, and auth tests passed.
- Python compilation passed for every changed module and the new shared regression test.
- `git diff --check` passed.
- Linus-style simplicity review: no new abstraction, five duplicate branches removed.
- Aaron-style framework/security review: no unresolved P1/P2 finding.

No live provider action, email, Drive mutation, calendar mutation, release, or publishing was performed.
