### PR TITLE
Diagnose credential account mismatches safely

### DIFF
--- a/connectonion/cli/commands/doctor_commands.py
+++ b/connectonion/cli/commands/doctor_commands.py
@@ -1,8 +1,8 @@
 """
 Purpose: Diagnose ConnectOnion installation and configuration issues
 LLM-Note:
-  Dependencies: imports from [sys, os, shutil, pathlib, requests, rich.console, rich.panel, rich.table, __version__] | imported by [cli/main.py via handle_doctor()] | checks local files and backend connectivity
-  Data flow: receives no args → checks system info → checks config files → checks API key → tests backend connectivity → displays results with ✓/✗ indicators
+  Dependencies: imports from [sys, os, shutil, pathlib, requests, rich.console, rich.panel, rich.table, credentials, project, __version__] | imported by [cli/main.py via handle_doctor()] | checks local files and backend connectivity
+  Data flow: receives no args → checks system/config files → inspects credential sources without loading or rewriting them → compares an inspectable OpenOnion token account with the canonical project identity → tests backend connectivity → displays results with ✓/✗ indicators
   State/Effects: no state modifications | reads from filesystem | makes HTTP request | writes to stdout via rich.Console
   Integration: exposes handle_doctor() for CLI | helps users self-diagnose setup issues
   Performance: fast local checks (<100ms) | network check to backend (1-2s)
@@ -15,7 +15,8 @@ import shlex
 import shutil
 from pathlib import Path
 
-from ...project import project_co_dir
+from ...credentials import account_in_token, api_key_account_mismatch
+from ...project import project_co_dir, project_identity
 import requests
 from rich.console import Console
 from rich.panel import Panel
@@ -381,7 +382,13 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
     # first 20 characters of OPENONION_API_KEY as a "preview" in normal output;
     # that is enough credential material to leak into support logs and has no
     # diagnostic value.
-    from .status_commands import _credential_rows, _oauth_rows
+    from .status_commands import (
+        _credential_rows,
+        _is_configured,
+        _oauth_rows,
+        _selected_credential_values,
+        _short_account,
+    )
 
     credential_actions = {
         "OPENONION_API_KEY": "co auth",
@@ -394,26 +401,52 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         "OPENROUTER_API_KEY": "set OPENROUTER_API_KEY in <project>/.env",
         "MISTRAL_API_KEY": "set MISTRAL_API_KEY in <project>/.env",
     }
-    api_key = None
-    for row in _credential_rows(project_dir=project_co_dir().parent):
+    project_dir = project_co_dir().parent
+    selected_api_key = _selected_credential_values(
+        ("OPENONION_API_KEY",),
+        project_dir=project_dir,
+    )["OPENONION_API_KEY"]
+    # Preserve the existing connectivity gate: a discovered-but-not-loaded key
+    # is useful to diagnose, but does not make the current process configured.
+    api_key = os.getenv("OPENONION_API_KEY")
+    if not _is_configured(api_key):
+        api_key = None
+    addr_data = project_identity()
+    for row in _credential_rows(project_dir=project_dir):
         status = row["status"]
+        source = row["source"]
         action = credential_actions[row["credential"]]
+        is_conflict = status == "conflict"
+        is_mismatch = False
+        if row["credential"] == "OPENONION_API_KEY" and selected_api_key:
+            # Inspect only. Diagnostics must never call the CLI resolver that
+            # can re-authenticate and rewrite the credential being diagnosed.
+            mismatch = api_key_account_mismatch(selected_api_key, addr_data)
+            claim = account_in_token(selected_api_key)
+            if mismatch is not None:
+                _claimed, expected = mismatch
+                is_mismatch = True
+                status = f"{status} · account mismatch" if is_conflict else "account mismatch"
+                source = f"{source} · project account {_short_account(expected)}"
+            elif claim is None:
+                status = f"{status} · account not inspectable locally"
+            elif not addr_data or not addr_data.get("address"):
+                status = f"{status} · project identity unavailable"
         if status == "configured":
             mark, style = "✓", "green"
-        elif status == "conflict":
+        elif is_conflict or is_mismatch:
             mark, style = "✗", "red"
-            found.append(f"credential {row['credential']} is shadowed — {action}")
+            if is_conflict:
+                found.append(f"credential {row['credential']} is shadowed — {action}")
+            if is_mismatch:
+                found.append(f"credential {row['credential']} has an account mismatch — {action}")
         else:
             mark, style = "○", "yellow"
         config_table.add_row(
             row["provider"],
-            f"[{style}]{mark}[/{style}] {status} · {row['source']} · {action}",
+            f"[{style}]{mark}[/{style}] {status} · {source} · {action}",
         )
-        if row["credential"] == "OPENONION_API_KEY" and status == "configured":
-            # Presence gates the probe; the secret itself is never rendered.
-            # Normal CLI startup has already loaded the selected project env.
-            api_key = os.getenv("OPENONION_API_KEY")
-    for row in _oauth_rows(project_dir=project_co_dir().parent):
+    for row in _oauth_rows(project_dir=project_dir):
         status = row["status"]
         if status == "connected":
             mark, style = "✓", "green"
@@ -532,9 +565,6 @@ def handle_doctor(*, fix: bool = False, yes: bool = False, json_output: bool = F
         # names above and the identity it authenticates as here were decided
         # independently, and doctor could report on an account that is not the
         # one in question.
-        from ...project import project_identity
-
-        addr_data = project_identity()
         if addr_data:
             from ... import address
             import time

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -1,9 +1,9 @@
 """
 Purpose: Display and manage agent keys, credentials, and OAuth connections with masked/revealed output
 LLM-Note:
-  Dependencies: imports from [os, pathlib, rich.console, rich.panel, rich.table, dotenv.load_dotenv, address] | imported by [cli/main.py via handle_keys()] | tested by [tests/e2e/cli/test_cli_keys.py]
-  Data flow: receives reveal flag (bool) → _find_co_dir() searches for .co/keys/ (local first, then ~/.co) → address.load() reads Ed25519 keypair → _load_env_vars() loads from local .env and global ~/.co/keys.env → _mask() obscures secrets unless --reveal → displays Identity table (address, short ID, email, source, key file) → displays Secrets table (recovery phrase, API key) → displays OAuth table (Google/Microsoft email and tokens if connected) → displays Env Files table (global and local paths with ✓/✗ status)
-  State/Effects: no state modifications | reads from .co/keys/agent.key, recovery.txt, .env, ~/.co/keys.env | writes to stdout via rich.Console | does NOT modify any files
+  Dependencies: imports from [os, pathlib, rich.console, rich.panel, rich.table, credentials, project, status_commands, address] | imported by [cli/main.py via handle_keys()] | tested by [tests/e2e/cli/test_cli_keys.py]
+  Data flow: receives reveal flag (bool) → _find_co_dir() resolves project/global identity → _load_env_vars() inspects process/project-root/global sources without loading them → compares an inspectable OpenOnion account claim with that identity → masks secrets unless --reveal → displays Identity, Secrets, OAuth, and Env Files tables
+  State/Effects: no state modifications | reads from .co/keys/agent.key, recovery.txt, project-root .env, ~/.co/keys.env | writes to stdout via rich.Console | does not mutate os.environ or credential files
   Integration: exposes handle_keys() for CLI | similar to status command but focuses on credentials | relies on address module for keypair loading | uses Rich for formatted panel output | checks env vars in priority order: OPENONION_API_KEY, GOOGLE_EMAIL/tokens, MICROSOFT_EMAIL/tokens | recovery phrase shown if recovery.txt exists
   Performance: file I/O for key loading and env vars (<50ms) | Rich table rendering is fast | no network calls
   Errors: prints message if no .co directory found (run 'co init' or 'co create') | prints message if keys fail to load | gracefully handles missing recovery.txt (shows "missing" message) | gracefully handles missing OAuth tokens (not shown in table) | gracefully handles missing env files (shows red ✗)
@@ -14,7 +14,10 @@ from pathlib import Path
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from dotenv import load_dotenv
+
+from ...credentials import account_in_token, api_key_account_mismatch
+from ...project import project_root
+from .status_commands import _selected_credential_values, _short_account
 
 console = Console()
 
@@ -50,35 +53,33 @@ def _find_co_dir() -> Path:
     return None
 
 
-def _load_env_vars() -> dict:
-    """Load all relevant env vars from .env files."""
-    # Load global first, then local (local overrides)
-    global_env = Path.home() / ".co" / "keys.env"
-    if global_env.exists():
-        load_dotenv(global_env, override=False)
+def _load_env_vars(
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: dict[str, str] | None = None,
+) -> dict[str, str | None]:
+    """Select credentials without mutating the process environment."""
 
-    local_env = Path(".env")
-    if local_env.exists():
-        load_dotenv(local_env, override=True)
-
-    return {
-        "OPENONION_API_KEY": os.getenv("OPENONION_API_KEY"),
-        "AGENT_ADDRESS": os.getenv("AGENT_ADDRESS"),
-        "AGENT_EMAIL": os.getenv("AGENT_EMAIL"),
-        "GOOGLE_EMAIL": os.getenv("GOOGLE_EMAIL"),
-        "GOOGLE_ACCESS_TOKEN": os.getenv("GOOGLE_ACCESS_TOKEN"),
-        "GOOGLE_REFRESH_TOKEN": os.getenv("GOOGLE_REFRESH_TOKEN"),
-        "MICROSOFT_EMAIL": os.getenv("MICROSOFT_EMAIL"),
-        "MICROSOFT_ACCESS_TOKEN": os.getenv("MICROSOFT_ACCESS_TOKEN"),
-        "MICROSOFT_REFRESH_TOKEN": os.getenv("MICROSOFT_REFRESH_TOKEN"),
-    }
+    names = (
+        "OPENONION_API_KEY",
+        "GOOGLE_EMAIL",
+        "GOOGLE_ACCESS_TOKEN",
+        "GOOGLE_REFRESH_TOKEN",
+        "MICROSOFT_EMAIL",
+        "MICROSOFT_ACCESS_TOKEN",
+        "MICROSOFT_REFRESH_TOKEN",
+    )
+    return _selected_credential_values(
+        names,
+        project_dir=project_dir,
+        home=home,
+        environ=environ,
+    )
 
 
 def _mask(value: str, show: int = 8, secret: bool = False) -> str:
     """Mask a value, showing a prefix — or nothing at all when `secret`.
-
-    A prefix is useful for an API key: `eyJhbGci` is the constant base64 of a
-    JWT header, carries nothing, and is how you tell two configured keys apart.
 
     It is not useful for the recovery phrase, which was masked the same way and
     so printed its first two words under a panel that ends "Secrets are masked."
@@ -182,7 +183,30 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     # API key
     api_key = env_vars.get("OPENONION_API_KEY")
     if api_key:
-        sec_table.add_row("API Key", api_key if reveal else _mask(api_key))
+        sec_table.add_row(
+            "API Key",
+            api_key if reveal else _mask(api_key, secret=True),
+        )
+        claim = account_in_token(api_key)
+        mismatch = api_key_account_mismatch(api_key, addr_data)
+        if mismatch is not None:
+            claimed, expected = mismatch
+            sec_table.add_row(
+                "Account",
+                "[red]✗[/red] token account "
+                f"{_short_account(claimed)} does not match identity "
+                f"{_short_account(expected)} — run 'co auth'",
+            )
+        elif claim:
+            sec_table.add_row(
+                "Account",
+                f"[green]✓[/green] matches {_short_account(claim)}",
+            )
+        else:
+            sec_table.add_row(
+                "Account",
+                "[yellow]○[/yellow] not inspectable locally; server verifies it",
+            )
     else:
         sec_table.add_row("API Key", "[dim]not set — run 'co auth'[/dim]")
 
@@ -225,7 +249,7 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
     files_table.add_column("value")
 
     global_env = Path.home() / ".co" / "keys.env"
-    local_env = Path(".env")
+    local_env = project_root() / ".env"
 
     files_table.add_row("Global", f"{'[green]✓[/green]' if global_env.exists() else '[red]✗[/red]'} {_short_path(global_env)}")
     files_table.add_row("Local", f"{'[green]✓[/green]' if local_env.exists() else '[red]✗[/red]'} {_short_path(local_env)}")
@@ -324,4 +348,3 @@ def _show_ssh_key(addr_data: dict, write: bool = False) -> None:
     else:
         console.print("[dim]Each line goes in ~/.ssh/authorized_keys on that server only.[/dim]")
         console.print("[dim]Use [bold]--write[/bold] to cache the private halves under ~/.co/ssh/.[/dim]\n")
-

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -16,6 +16,7 @@ from typing import Mapping
 import requests
 from dotenv import dotenv_values
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
@@ -118,11 +119,37 @@ def _credential_sources(
     )
 
 
+def _selected_credential_values(
+    names: tuple[str, ...],
+    *,
+    project_dir: Path | None = None,
+    home: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str | None]:
+    """Select the first configured value from the canonical source inventory."""
+    sources = _credential_sources(
+        project_dir=project_dir,
+        home=home,
+        environ=environ,
+    )
+    return {
+        name: next(
+            (
+                str(values[name])
+                for _source, values in sources
+                if _is_configured(values.get(name))
+            ),
+            None,
+        )
+        for name in names
+    }
+
+
 def _short_account(account: str) -> str:
-    """A public address that distinguishes accounts without dominating a row."""
+    """A Rich-safe public address that distinguishes accounts in one row."""
     if len(account) <= 20:
-        return account
-    return f"{account[:16]}…{account[-4:]}"
+        return escape(account)
+    return escape(f"{account[:16]}…{account[-4:]}")
 
 
 def _openonion_source_status(

--- a/connectonion/credentials.py
+++ b/connectonion/credentials.py
@@ -86,18 +86,36 @@ def require_ambient_api_key() -> str:
     if not token:
         raise MissingAmbientAPIKey()
 
-    claimed = account_in_token(token)
-    expected = _identity_address(project_identity())
-    if (
-        claimed is not None
-        and expected is not None
-        and claimed.casefold() != expected.casefold()
-    ):
+    mismatch = api_key_account_mismatch(token, project_identity())
+    if mismatch is not None:
+        claimed, expected = mismatch
         raise AmbientAPIKeyAccountMismatch(
             claimed=claimed,
             expected=expected,
         )
     return token
+
+
+def api_key_account_mismatch(
+    token: str,
+    identity: Any,
+) -> tuple[str, str] | None:
+    """Return ``(claimed, expected)`` when an inspectable token is foreign.
+
+    Diagnostics use the same comparison as the runtime guard without loading,
+    authenticating, or rewriting credentials. Opaque tokens and an unavailable
+    local identity cannot be classified here; the server remains authoritative.
+    """
+
+    claimed = account_in_token(token)
+    expected = _identity_address(identity)
+    if (
+        claimed is not None
+        and expected is not None
+        and claimed.casefold() != expected.casefold()
+    ):
+        return claimed, expected
+    return None
 
 
 def _identity_address(identity: Any) -> str | None:

--- a/tests/e2e/cli/test_cli_keys.py
+++ b/tests/e2e/cli/test_cli_keys.py
@@ -27,12 +27,21 @@ Components under test:
 - Helper functions: _find_co_dir, _load_env_vars, _mask, _short_path, _source_label
 """
 
+import base64
+import json
 import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 from .argparse_runner import ArgparseCliRunner
+
+
+def _token_for(address: str) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": address}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
 
 
 class TestMask:
@@ -201,6 +210,45 @@ class TestLoadEnvVars:
             finally:
                 os.chdir(original_cwd)
 
+    def test_uses_canonical_sources_from_a_deep_directory_without_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        project = tmp_path / "project"
+        deep = project.joinpath(*("deep",) * 8)
+        home = tmp_path / "home"
+        (project / ".co").mkdir(parents=True)
+        (home / ".co").mkdir(parents=True)
+        deep.mkdir(parents=True)
+        (project / ".env").write_text(
+            "OPENONION_API_KEY=project-key\nGOOGLE_EMAIL=project@gmail.com\n"
+        )
+        (home / ".co" / "keys.env").write_text(
+            "OPENONION_API_KEY=global-key\nMICROSOFT_EMAIL=global@outlook.com\n"
+        )
+        monkeypatch.chdir(deep)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        for name in (
+            "OPENONION_API_KEY",
+            "GOOGLE_EMAIL",
+            "GOOGLE_ACCESS_TOKEN",
+            "GOOGLE_REFRESH_TOKEN",
+            "MICROSOFT_EMAIL",
+            "MICROSOFT_ACCESS_TOKEN",
+            "MICROSOFT_REFRESH_TOKEN",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("OPENONION_API_KEY", "process-key")
+
+        from connectonion.cli.commands.keys_commands import _load_env_vars
+
+        before = dict(os.environ)
+        result = _load_env_vars()
+
+        assert result["OPENONION_API_KEY"] == "process-key"
+        assert result["GOOGLE_EMAIL"] == "project@gmail.com"
+        assert result["MICROSOFT_EMAIL"] == "global@outlook.com"
+        assert dict(os.environ) == before
+
 
 class TestHandleKeysNoKeys:
     """Tests for handle_keys when no keys exist."""
@@ -322,6 +370,81 @@ class TestHandleKeysSuccess:
         handle_keys()
 
         assert mock_console.print.called
+
+    def test_reports_a_foreign_token_without_exposing_token_material(
+        self, monkeypatch, capsys
+    ):
+        from connectonion import address
+        from connectonion.cli.commands import keys_commands
+        from rich.console import Console
+
+        expected = self.MOCK_ADDR["address"]
+        foreign = "0x" + "2" * 64
+        token = _token_for(foreign)
+        monkeypatch.setattr(
+            keys_commands,
+            "console",
+            Console(width=200, color_system=None),
+        )
+        monkeypatch.setattr(keys_commands, "_find_co_dir", lambda: Path(".co"))
+        monkeypatch.setattr(address, "load", lambda _path: self.MOCK_ADDR)
+        monkeypatch.setattr(
+            keys_commands,
+            "_load_env_vars",
+            lambda: {
+                "OPENONION_API_KEY": token,
+                "GOOGLE_EMAIL": None,
+                "GOOGLE_ACCESS_TOKEN": None,
+                "GOOGLE_REFRESH_TOKEN": None,
+                "MICROSOFT_EMAIL": None,
+                "MICROSOFT_ACCESS_TOKEN": None,
+                "MICROSOFT_REFRESH_TOKEN": None,
+            },
+        )
+
+        keys_commands.handle_keys()
+        output = capsys.readouterr().out
+
+        assert "does not match identity" in output
+        assert foreign[:16] in output
+        assert expected[:16] in output
+        assert token not in output
+        assert token[:8] not in output
+
+    def test_opaque_token_is_not_reported_as_a_false_mismatch(
+        self, monkeypatch, capsys
+    ):
+        from connectonion import address
+        from connectonion.cli.commands import keys_commands
+        from rich.console import Console
+
+        monkeypatch.setattr(
+            keys_commands,
+            "console",
+            Console(width=200, color_system=None),
+        )
+        monkeypatch.setattr(keys_commands, "_find_co_dir", lambda: Path(".co"))
+        monkeypatch.setattr(address, "load", lambda _path: self.MOCK_ADDR)
+        monkeypatch.setattr(
+            keys_commands,
+            "_load_env_vars",
+            lambda: {
+                "OPENONION_API_KEY": "opaque-token",
+                "GOOGLE_EMAIL": None,
+                "GOOGLE_ACCESS_TOKEN": None,
+                "GOOGLE_REFRESH_TOKEN": None,
+                "MICROSOFT_EMAIL": None,
+                "MICROSOFT_ACCESS_TOKEN": None,
+                "MICROSOFT_REFRESH_TOKEN": None,
+            },
+        )
+
+        keys_commands.handle_keys()
+        output = capsys.readouterr().out
+
+        assert "not inspectable locally" in output
+        assert "does not match" not in output
+        assert "opaque-token" not in output
 
 
 class TestHandleKeysOAuth:

--- a/tests/e2e/cli/test_cli_status.py
+++ b/tests/e2e/cli/test_cli_status.py
@@ -66,6 +66,11 @@ class TestCredentialStatus:
         }
         assert secret not in repr(rows)
 
+    def test_account_labels_escape_rich_markup(self):
+        from connectonion.cli.commands.status_commands import _short_account
+
+        assert _short_account("[red]foreign[/red]") == r"\[red]foreign\[/red]"
+
     def test_reports_discovered_key_without_loading_environment(self, tmp_path):
         from connectonion.cli.commands.status_commands import _credential_rows
 

--- a/tests/unit/test_credentials.py
+++ b/tests/unit/test_credentials.py
@@ -12,6 +12,7 @@ from connectonion.credentials import (
     AmbientAPIKeyAccountMismatch,
     MissingAmbientAPIKey,
     account_in_token,
+    api_key_account_mismatch,
     require_ambient_api_key,
 )
 
@@ -78,6 +79,18 @@ def test_mismatch_raises_without_exposing_the_token(project, monkeypatch):
     assert caught.value.claimed == FOREIGN
     assert caught.value.expected == PROJECT
     assert token not in str(caught.value)
+
+
+def test_diagnostics_share_the_runtime_account_comparison():
+    token = token_for(FOREIGN)
+
+    assert api_key_account_mismatch(token, {"address": PROJECT}) == (
+        FOREIGN,
+        PROJECT,
+    )
+    assert api_key_account_mismatch(token_for(PROJECT.upper()), {"address": PROJECT}) is None
+    assert api_key_account_mismatch("opaque-token", {"address": PROJECT}) is None
+    assert api_key_account_mismatch(token, None) is None
 
 
 def test_missing_token_has_one_actionable_typed_error(project):

--- a/tests/unit/test_doctor_credentials_are_redacted.py
+++ b/tests/unit/test_doctor_credentials_are_redacted.py
@@ -1,8 +1,20 @@
 """Credential diagnostics must be useful without becoming a secret leak."""
 
+import base64
+import json
+import os
 from types import SimpleNamespace
 
+import pytest
+
 from connectonion.cli.commands.status_commands import _oauth_rows
+
+
+def _token_for(address: str) -> str:
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"public_key": address}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
 
 
 def _oauth(rows, provider):
@@ -125,3 +137,106 @@ def test_doctor_never_renders_an_api_key_preview(tmp_path, monkeypatch, capsys):
     assert "Key Preview" not in output
     assert secret not in output
     assert secret[:20] not in output
+
+
+def test_doctor_reports_account_mismatch_without_mutating_credentials(
+    tmp_path, monkeypatch, capsys
+):
+    from connectonion import address
+    from connectonion.cli.commands import doctor_commands
+    from connectonion.useful_tools.browser_tools import browser as browser_module
+
+    expected = "0x" + "1" * 64
+    foreign = "0x" + "2" * 64
+    token = _token_for(foreign)
+    project = tmp_path / "project"
+    home = tmp_path / "home"
+    (project / ".co").mkdir(parents=True)
+    home.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+    monkeypatch.setenv("OPENONION_API_KEY", token)
+    monkeypatch.setenv("COLUMNS", "300")
+    monkeypatch.setattr(
+        doctor_commands,
+        "project_identity",
+        lambda: {"address": expected},
+    )
+    monkeypatch.setattr(address, "sign", lambda *_args, **_kwargs: b"signature")
+    monkeypatch.setattr(
+        browser_module,
+        "driver_stealth_status",
+        lambda: ("missing", None, "patchright not installed"),
+    )
+    monkeypatch.setattr(
+        doctor_commands.requests,
+        "get",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=200),
+    )
+    monkeypatch.setattr(
+        doctor_commands.requests,
+        "post",
+        lambda *_args, **_kwargs: SimpleNamespace(status_code=200),
+    )
+
+    before = dict(os.environ)
+    code = doctor_commands.handle_doctor()
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "account mismatch" in output
+    assert foreign[:16] in output
+    assert expected[:16] in output
+    assert token not in output
+    assert dict(os.environ) == before
+
+
+@pytest.mark.parametrize("identity_source", ["project", "global"])
+def test_doctor_compares_discovered_token_with_canonical_identity(
+    identity_source, tmp_path, monkeypatch, capsys
+):
+    from connectonion import address
+    from connectonion.cli.commands import doctor_commands
+    from connectonion.useful_tools.browser_tools import browser as browser_module
+
+    project = tmp_path / "project"
+    deep = project / "one" / "two" / "three"
+    home = tmp_path / "home"
+    (project / ".co").mkdir(parents=True)
+    (home / ".co").mkdir(parents=True)
+    deep.mkdir(parents=True)
+
+    identity = address.generate()
+    identity_dir = project / ".co" if identity_source == "project" else home / ".co"
+    address.save(identity, identity_dir)
+    foreign = "0x" + "2" * 64
+    token = _token_for(foreign)
+    credential_file = (
+        project / ".env"
+        if identity_source == "project"
+        else home / ".co" / "keys.env"
+    )
+    credential_file.write_text(f"OPENONION_API_KEY={token}\n")
+
+    monkeypatch.chdir(deep)
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+    monkeypatch.setenv("COLUMNS", "300")
+    monkeypatch.setattr(
+        browser_module,
+        "driver_stealth_status",
+        lambda: ("missing", None, "patchright not installed"),
+    )
+
+    before_env = dict(os.environ)
+    before_file = credential_file.read_bytes()
+    code = doctor_commands.handle_doctor()
+    output = capsys.readouterr().out
+
+    assert code == 1
+    assert "account mismatch" in output
+    assert foreign[:16] in output
+    assert identity["address"][:16] in output
+    assert token not in output
+    assert dict(os.environ) == before_env
+    assert credential_file.read_bytes() == before_file


### PR DESCRIPTION
Closes #864
Parent: #848

## Decision

Keep diagnostics read-only and reuse the canonical source order introduced by `co status`: process environment, project-root `.env`, then `~/.co/keys.env`. Compare only inspectable public account claims with `project_identity()`; opaque tokens stay server-authoritative.

This follows DD-011: the global identity is the default, while an existing project identity takes precedence. Diagnostics must report a mismatch; they must not authenticate, refresh, or repair credentials.

## What changed

- share one non-mutating selected-value helper across status, doctor, and keys
- make `co keys` resolve the project root from arbitrarily deep subdirectories
- report matching, foreign, and opaque OpenOnion account relationships
- make `co doctor` fail red for a selected foreign token, including discovered-but-not-loaded project/global values
- preserve the existing connectivity gate so a discovered value does not silently become process configuration
- replace the default API-token prefix preview with a fixed-width mask
- escape decoded public claims before Rich renders them
- keep `co keys --reveal` explicit and unchanged

## Security / side effects

- no `load_api_key()`, reauthentication, OAuth refresh, or provider operation
- no writes to `os.environ`, `.env`, or `~/.co/keys.env`
- no raw, partial, hashed, or fingerprinted token material in default output
- account labels are public addresses and are Rich-escaped
- no release work and no frontend SDK changes; `@connectonion/react` remains the oo-chat frontend boundary

## Verification

- 189 doctor/keys/status/credential regression tests pass locally
- project identity and global fallback both covered
- deep-subdirectory discovery covered
- opaque tokens do not produce false mismatches
- environment and credential files are byte-for-byte unchanged in mutation tests
- changed modules compile; `git diff --check` passes
- Linus-style simplicity review: no unresolved P1/P2
- Aaron-style correctness/security review: no unresolved P1/P2
