### PR TITLE
feat: emit stable ACP agent messages

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from acp import text_block, tool_content
-from acp.schema import SessionNotification, ToolCallProgress, ToolCallStart
+from acp.schema import (
+    AgentMessageChunk,
+    SessionNotification,
+    ToolCallProgress,
+    ToolCallStart,
+)
 
 from .wire_events import normalize_wire_event
 
@@ -33,6 +38,20 @@ def map_tool_event(
     if event_type == "tool_call":
         return _tool_start(normalized)
     return _tool_update(normalized)
+
+
+def map_message_event(
+    event: Mapping[str, Any],
+) -> AgentMessageChunk | None:
+    """Map one complete Host assistant message to an ACP text chunk."""
+
+    if event.get("type") != "assistant":
+        return None
+    return AgentMessageChunk(
+        session_update="agent_message_chunk",
+        message_id=_required_string(event, "id"),
+        content=text_block(_required_string(event, "content")),
+    )
 
 
 def _tool_start(event: Mapping[str, Any]) -> ToolCallStart:
@@ -68,9 +87,9 @@ def _tool_update(event: Mapping[str, Any]) -> ToolCallProgress:
 def acp_notification_frame(
     event: Mapping[str, Any], session_id: str
 ) -> dict[str, Any] | None:
-    """Return a detached ConnectOnion carrier for one ACP tool update."""
+    """Return a detached ConnectOnion carrier for one supported ACP update."""
 
-    update = map_tool_event(event)
+    update = map_tool_event(event) or map_message_event(event)
     if update is None:
         return None
     notification = SessionNotification(session_id=session_id, update=update)

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -22,6 +22,7 @@ from ..prompts import load_system_prompt
 from .events import EventHandler
 from .interrupt import run_interruptible
 from .llm import LLM, TokenUsage, create_llm
+from .provider_messages import messages_for_provider
 from .tool_executor import execute_and_record_tools, execute_single_tool
 from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
 from .tool_registry import ToolRegistry
@@ -547,7 +548,11 @@ class Agent:
             if response is not None:
                 if not response.tool_calls:
                     content = response.content or ""
-                    self.current_session['messages'].append({"role": "assistant", "content": content})
+                    self.current_session['messages'].append({
+                        "role": "assistant",
+                        "content": content,
+                        "id": self._next_trace_id(),
+                    })
                 else:
                     # Process tool calls
                     self._execute_and_record_tools(response.tool_calls)
@@ -617,7 +622,7 @@ class Agent:
         })
 
         start = time.time()
-        messages = list(self.current_session['messages'])
+        messages = messages_for_provider(self.current_session['messages'])
         response, interrupted = run_interruptible(
             lambda: self.llm.complete(messages, tools=tool_schemas),
             self.io,

--- a/connectonion/core/provider_messages.py
+++ b/connectonion/core/provider_messages.py
@@ -1,0 +1,17 @@
+"""Build detached provider input from canonical ConnectOnion messages."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def messages_for_provider(
+    messages: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Copy messages without ConnectOnion's top-level domain identity."""
+
+    return [
+        {key: value for key, value in message.items() if key != "id"}
+        for message in messages
+    ]

--- a/connectonion/debug/auto_debug.py
+++ b/connectonion/debug/auto_debug.py
@@ -12,8 +12,10 @@ LLM-Note:
   Debugger pauses DURING tool execution (inside execute_single_tool), so current tool's result hasn't been added to messages yet. Timeline: 1) assistant message with tool_calls added, 2) tool executes → PAUSE HERE, 3) tool result message NOT YET ADDED. Must manually append current tool result to temp_messages for LLM preview to work correctly.
 """
 
-from typing import Any, Dict, Optional, List
-from .auto_debug_ui import AutoDebugUI, BreakpointContext, BreakpointAction
+from typing import Any, Dict, List, Optional
+
+from ..core.provider_messages import messages_for_provider
+from .auto_debug_ui import AutoDebugUI, BreakpointAction, BreakpointContext
 
 
 class AutoDebugger:
@@ -266,7 +268,9 @@ class AutoDebugger:
         """
         try:
             # Start with current messages (has assistant message + previous tool results)
-            temp_messages = self.agent.current_session['messages'].copy()
+            temp_messages = messages_for_provider(
+                self.agent.current_session['messages']
+            )
 
             # Add the current tool's result to complete the message history
             # (See docstring above for why this is necessary - we're paused mid-execution)

--- a/connectonion/debug/debug_explainer/explain_context.py
+++ b/connectonion/debug/debug_explainer/explain_context.py
@@ -1,7 +1,7 @@
 """
 Purpose: Provide experimental debugging tools to understand and fix unwanted tool calls via prompt testing
 LLM-Note:
-  Dependencies: imports from [typing, pathlib, pydantic, ../llm_do.py] | imported by [explain_agent.py] | no dedicated tests found
+  Dependencies: imports from [typing, pathlib, pydantic, core.provider_messages, ../llm_do.py] | imported by [explain_agent.py] | tested by [tests/unit/test_explain_context.py]
   Data flow: explain_tool_choice() creates RuntimeContext(breakpoint_context, agent) → stores bp_ctx and agent state → methods test_system_prompt_variation(new_prompt), suggest_prompt_improvements(), verify_stability() call llm_do() with modified prompts → returns RootCauseAnalysis (Pydantic model with primary_cause_source, influential_text, explanation, is_correct_choice, suggested_fix)
   State/Effects: stores breakpoint_context and agent_instance | no file I/O | calls llm_do() for LLM analysis (multiple LLM requests per method) | no global state
   Integration: exposes RuntimeContext class, RootCauseAnalysis (Pydantic model) | used by explain_agent.py to provide experimental debugging | methods help developers understand why agent chose specific tool and how to fix unwanted choices via prompt engineering
@@ -9,9 +9,12 @@ LLM-Note:
   Errors: LLM call failures propagate from llm_do() | Pydantic validation errors if LLM returns invalid structure
 """
 
-from typing import Dict, List, Any
 from pathlib import Path
+from typing import Any
+
 from pydantic import BaseModel
+
+from ...core.provider_messages import messages_for_provider
 from ...llm_do import llm_do
 
 
@@ -57,7 +60,9 @@ class RuntimeContext:
             What the agent would do with the modified prompt
         """
         # Get messages up to the decision point
-        temp_messages = self.agent.current_session['messages'].copy()
+        temp_messages = messages_for_provider(
+            self.agent.current_session['messages']
+        )
 
         # Remove the assistant message that made this tool call
         if temp_messages and temp_messages[-1].get('role') == 'assistant':
@@ -107,7 +112,9 @@ class RuntimeContext:
             Analysis of decision stability
         """
         # Get messages up to decision point
-        temp_messages = self.agent.current_session['messages'].copy()
+        temp_messages = messages_for_provider(
+            self.agent.current_session['messages']
+        )
         if temp_messages and temp_messages[-1].get('role') == 'assistant':
             temp_messages = temp_messages[:-1]
 
@@ -154,7 +161,9 @@ class RuntimeContext:
         current_next = self.bp_ctx.next_actions or []
 
         # Build modified message history with different result
-        temp_messages = self.agent.current_session['messages'].copy()
+        temp_messages = messages_for_provider(
+            self.agent.current_session['messages']
+        )
 
         # Find the assistant message with tool calls and add modified result
         for msg in reversed(temp_messages):
@@ -205,7 +214,9 @@ class RuntimeContext:
             Agent's explanation of why it chose this tool
         """
         # Use the agent's current messages up to this point
-        temp_messages = self.agent.current_session['messages'].copy()
+        temp_messages = messages_for_provider(
+            self.agent.current_session['messages']
+        )
 
         # Remove the assistant message that made the tool call
         if temp_messages and temp_messages[-1].get('role') == 'assistant':

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -2,7 +2,7 @@
 Purpose: Convert session storage format to ChatItems wire format for frontend rendering
 LLM-Note:
   Dependencies: imports from [useful_plugins/runtime_input.py for RUNTIME_INPUT_FRAME_PREFIX] | imported by [host/http_router.py, host/ws_router/agent_io.py, host/ws_router/connect.py, host/session/__init__.py] | tested by [tests/unit/test_host_session.py]
-  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking
+  Data flow: session dict {messages, trace} → ChatItem[] with types: user, agent, tool_call, files_received, intent, eval, thinking | persisted assistant message IDs survive reconstruction; legacy messages fall back to their index
   State/Effects: pure function, no side effects
   Integration: exposes session_to_chat_items(session) → list[dict] | used by http_router and ws_router when delivering server_newer state and OUTPUT
   Performance: O(n) where n = messages + trace entries
@@ -141,7 +141,14 @@ def session_to_chat_items(session: dict) -> list[dict]:
                     if item_ui:
                         items_ui.append(item_ui)
         elif role == 'assistant' and msg.get('content'):
-            items_ui.append({'id': f"msg-{msg_idx}", 'type': 'agent', 'content': msg.get('content', '')})
+            message_id = msg.get('id')
+            if not isinstance(message_id, str) or not message_id:
+                message_id = f"msg-{msg_idx}"
+            items_ui.append({
+                'id': message_id,
+                'type': 'agent',
+                'content': msg.get('content', ''),
+            })
 
     # Fallback: if no user_input markers found in trace, append all remaining trace
     # entries at the end so the data isn't silently dropped (older sessions).

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -2,9 +2,9 @@
 Purpose: Agent thread orchestration + io → client streaming — the bridge between the sync agent and the async transport
 LLM-Note:
   Dependencies: imports from [...io (WebSocketIO), ..session (session_to_chat_items via lazy import), asyncio, threading, rich.console] | imported by [.session (start_agent), .connect (resume_forwarding)]
-  Data flow: start_agent: validate INPUT → create WebSocketIO → register in registry BEFORE thread.start (race-safe) → spawn _agent_thread_body (thread target running route_handlers["ws_input"]) → success or exception always returns registry to connected → spawn forward_task = forward_agent_msgs_to_client → return (io, task) | resume_forwarding: same forward_task spawn but on existing active.io | forward_agent_msgs_to_client: read_msgs_from_agent → send_msg loop → on agent finish read result_holder → emit OUTPUT (success) / ERROR (exception)
+  Data flow: start_agent: validate INPUT → create WebSocketIO → register in registry BEFORE thread.start (race-safe) → spawn _agent_thread_body (thread target running route_handlers["ws_input"]) → success or exception always returns registry to connected → spawn forward_task = forward_agent_msgs_to_client → return (io, task) | resume_forwarding: same forward_task spawn but on existing active.io | forward_agent_msgs_to_client: read_msgs_from_agent → send_msg loop → on agent finish read result_holder → mirror a persisted final assistant item as ACP → emit authoritative OUTPUT (success) / ERROR (exception)
   State/Effects: spawns daemon Thread + asyncio.Task | mutates registry (register / mark_session_running) | calls io.mark_agent_done() in finally
-  Integration: start_agent(data, send_msg, conn, route_handlers, storage, registry) → (io, forward_task) | None | resume_forwarding(send_msg, active, registry, session_id, storage, conn) → (io, forward_task) | forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder, conn, storage) — async, runs until io marked done
+  Integration: imports core.acp_wire.acp_notification_frame and session.session_to_chat_items lazily | start_agent(data, send_msg, conn, route_handlers, storage, registry) → (io, forward_task) | None | resume_forwarding(send_msg, active, registry, session_id, storage, conn) → (io, forward_task) | forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder, conn, storage) — async, runs until io marked done
   Performance: thread-per-INPUT (worker isolation) | one forward_task per WS connection
   Errors: agent thread exceptions captured in result_holder[0]; surfaced as ERROR frame by the forwarder (threads don't propagate exceptions natively)
 """
@@ -31,6 +31,73 @@ def _acp_rollout_frame(event, session_id):
         return None
 
 
+def _final_agent_event(result, session, chat_items):
+    """Return a terminal answer with transport-neutral persisted identity."""
+    if (
+        not isinstance(result, str)
+        or not result
+        or not isinstance(session, dict)
+    ):
+        return None
+    final_message = next(
+        (
+            message for message in reversed(session.get("messages", []))
+            if message.get("role") == "assistant" and message.get("content")
+        ),
+        None,
+    )
+    if (
+        final_message is None
+        or final_message.get("content") != result
+        or not isinstance(final_message.get("id"), str)
+        or not final_message["id"]
+    ):
+        return None
+    final_agent = next(
+        (
+            item for item in reversed(chat_items)
+            if item.get("type") == "agent"
+            and item.get("id") == final_message["id"]
+            and item.get("content") == result
+        ),
+        None,
+    )
+    if final_agent is None:
+        return None
+    return {
+        "type": "assistant",
+        "id": final_message["id"],
+        "content": result,
+    }
+
+
+async def _send_output(
+    send_msg,
+    *,
+    result,
+    session_id,
+    duration_ms,
+    session,
+):
+    """Send the additive ACP message mirror, then authoritative OUTPUT."""
+    from ..session import session_to_chat_items
+
+    chat_items = session_to_chat_items(session or {})
+    final_event = _final_agent_event(result, session, chat_items)
+    if final_event is not None:
+        acp_frame = _acp_rollout_frame(final_event, session_id)
+        if acp_frame is not None:
+            await send_msg(acp_frame)
+    await send_msg({
+        "type": "OUTPUT",
+        "result": result,
+        "session_id": session_id,
+        "duration_ms": duration_ms,
+        "session": session,
+        "chat_items": chat_items,
+    })
+
+
 def _agent_thread_body(route_handlers, storage, prompt, io, session, images, files, registry, session_id, result_holder, requester_address=None):
     """Thread target: run agent and store result. Calls io.mark_agent_done() when done."""
     try:
@@ -47,10 +114,12 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
 
 async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder=None, conn=None, storage=None):
     """Forward agent events to client. Send OUTPUT (or ERROR) when agent finishes."""
-    from ..session import session_to_chat_items
-
     async for event in io.read_msgs_from_agent():
-        acp_frame = _acp_rollout_frame(event, session_id)
+        acp_frame = (
+            _acp_rollout_frame(event, session_id)
+            if event.get("type") in {"tool_call", "tool_result"}
+            else None
+        )
         if acp_frame is not None:
             await send_msg(acp_frame)
             # Rollout is dual-write: older clients still need the legacy event,
@@ -67,25 +136,23 @@ async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holde
         session_data = result.get('session', {})
         if conn:
             conn["session"] = session_data
-        await send_msg({
-            "type": "OUTPUT",
-            "result": result["result"],
-            "session_id": session_id,
-            "duration_ms": result["duration_ms"],
-            "session": session_data,
-            "chat_items": session_to_chat_items(session_data),
-        })
+        await _send_output(
+            send_msg,
+            result=result["result"],
+            session_id=session_id,
+            duration_ms=result["duration_ms"],
+            session=session_data,
+        )
     elif storage:
         stored = storage.get(session_id)
         if stored and stored.status == "done":
-            await send_msg({
-                "type": "OUTPUT",
-                "result": stored.result,
-                "session_id": session_id,
-                "duration_ms": stored.duration_ms,
-                "session": stored.session,
-                "chat_items": session_to_chat_items(stored.session or {}),
-            })
+            await _send_output(
+                send_msg,
+                result=stored.result,
+                session_id=session_id,
+                duration_ms=stored.duration_ms,
+                session=stored.session,
+            )
     else:
         await send_msg({"type": "ERROR", "message": "Agent completed without result"})
 

--- a/docs/design-decisions/036-stable-acp-agent-message-identity.md
+++ b/docs/design-decisions/036-stable-acp-agent-message-identity.md
@@ -1,0 +1,68 @@
+# DD-036: Persist Domain Identity for ACP Agent Messages
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Related:** [028 Ordered ACP Event Bridge](028-acp-ordered-event-bridge.md), [035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md)
+
+## Decision
+
+Every new terminal assistant message receives a UUID when it is added to the
+canonical session. This ID is transport-neutral message identity: session
+reconstruction uses it as the agent `ChatItem.id`, and the ACP adapter uses the
+same value as `agent_message_chunk.messageId`.
+
+The ID is persistence and presentation metadata, not provider input. Every
+provider entry point that reuses canonical history, including debug previews,
+uses one shared sanitizer to build a detached list without top-level message
+IDs. Tool-call IDs nested inside provider messages are unaffected.
+
+Legacy stored messages remain readable. `session_to_chat_items()` retains its
+index fallback for messages without IDs, but the Host emits no ACP agent-message
+mirror for such a message. The existing `OUTPUT` remains authoritative, and a
+new answer added to a restored session receives a stable ID normally.
+
+One complete, non-empty, persisted assistant answer is serialized as one ACP
+v1.19 text chunk immediately before `OUTPUT`. The final stored message must
+carry a non-empty ID and have content exactly equal to `OUTPUT.result`. The live
+forwarding loop mirrors only tool lifecycle events; plugin or arbitrary
+`assistant` events cannot become ACP agent messages.
+
+This carrier profile does not promise provider token streaming. DD-028 already
+established that a complete provider response may be one ACP message chunk. A
+future streaming design must define chunk ordering and replay independently.
+
+`@connectonion/react` owns browser decoding, verifies that the ACP carrier's
+session ID matches its active session, and upserts by the preserved message ID.
+oo-chat renders the SDK's `ChatItem` and does not parse ACP. The standalone
+TypeScript SDK is not part of the frontend rollout.
+
+## Compatibility and failure behavior
+
+The message notification is additive. `OUTPUT.result`, session, and chat items
+remain unchanged and authoritative. Older clients keep their current
+completion path; updated React clients converge ACP and the authoritative
+snapshot on one stable card.
+
+Empty text, synthetic terminal notices, legacy messages without IDs, mismatched
+results, and conversion failures produce no ACP message notification. The
+legacy `OUTPUT` still drains, so presentation conversion cannot make completed
+work look retryable.
+
+## Rollback
+
+Stop emitting the additive notification and stop assigning IDs to new terminal
+messages. Existing IDs are inert metadata and remain hidden from providers, so
+stored sessions need no migration or downgrade.
+
+## Rejected alternatives
+
+- **Use `msg-{message index}`:** auto-compaction rewrites the message array, so
+  later answers can reuse an old ID and overwrite an existing browser card.
+- **Generate an ID only in the ACP adapter:** reconnect would produce a second
+  identity for the same stored answer.
+- **Persist an ACP-specific field:** couples canonical storage to one protocol;
+  a generic domain message ID is reusable by every transport and UI.
+- **Derive identity from content hashes:** identical answers in different turns
+  are different messages, and content is not a safe identity boundary.
+- **Treat every terminal result string as an agent message:** max-iteration and
+  other synthetic outcomes are not persisted assistant speech.

--- a/tests/fixtures/acp_agent_message_events.json
+++ b/tests/fixtures/acp_agent_message_events.json
@@ -1,0 +1,30 @@
+{
+  "legacy": [
+    {
+      "type": "assistant",
+      "id": "6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e",
+      "content": "The final answer."
+    }
+  ],
+  "acp": [
+    {
+      "type": "ACP_NOTIFICATION",
+      "acpSchema": "schema-v1.19.0",
+      "message": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "session-1",
+          "update": {
+            "content": {
+              "text": "The final answer.",
+              "type": "text"
+            },
+            "messageId": "6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e",
+            "sessionUpdate": "agent_message_chunk"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/test_acp_wire.py
+++ b/tests/unit/test_acp_wire.py
@@ -10,11 +10,19 @@ import pytest
 from connectonion.core.acp_wire import (
     acp_notification_frame,
     legacy_tool_event_from_acp,
+    map_message_event,
 )
 from connectonion.network.connect import RemoteAgent
 
 FIXTURE = json.loads(
     (Path(__file__).parents[1] / "fixtures" / "acp_tool_events.json").read_text()
+)
+MESSAGE_FIXTURE = json.loads(
+    (
+        Path(__file__).parents[1]
+        / "fixtures"
+        / "acp_agent_message_events.json"
+    ).read_text()
 )
 
 
@@ -25,6 +33,28 @@ def test_tool_events_match_the_shared_acp_fixture():
     ]
 
     assert actual == FIXTURE["acp"]
+
+
+def test_agent_messages_match_the_shared_acp_fixture():
+    actual = [
+        acp_notification_frame(event, "session-1")
+        for event in MESSAGE_FIXTURE["legacy"]
+    ]
+
+    assert actual == MESSAGE_FIXTURE["acp"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "assistant", "id": "", "content": "answer"},
+        {"type": "assistant", "id": "message-2", "content": ""},
+        {"type": "assistant", "id": "message-2", "content": None},
+    ],
+)
+def test_empty_or_malformed_agent_messages_are_rejected(event):
+    with pytest.raises(ValueError):
+        map_message_event(event)
 
 
 def test_acp_tool_events_decode_to_the_legacy_python_ui_shape():

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -10,6 +10,7 @@ Components under test:
 """
 
 from unittest.mock import Mock
+from uuid import UUID
 
 import pytest
 
@@ -1008,10 +1009,10 @@ class TestGracefulInterrupt:
         threading.Thread(target=complete_with_interrupt, daemon=True).start()
 
         assert agent.input("finish") == "completed answer"
-        assert agent.current_session['messages'][-1] == {
-            'role': 'assistant',
-            'content': 'completed answer',
-        }
+        final_message = agent.current_session['messages'][-1]
+        assert final_message['role'] == 'assistant'
+        assert final_message['content'] == 'completed answer'
+        UUID(final_message['id'])
         assert 'stop_signal' not in agent.current_session
 
     def test_completed_final_response_wins_interrupt_from_after_iteration(self):
@@ -1055,13 +1056,31 @@ class TestGracefulInterrupt:
         agent.io = io
 
         assert agent.input("finish") == "completed answer"
-        assert agent.current_session['messages'][-1] == {
-            'role': 'assistant',
-            'content': 'completed answer',
-        }
+        final_message = agent.current_session['messages'][-1]
+        assert final_message['role'] == 'assistant'
+        assert final_message['content'] == 'completed answer'
+        UUID(final_message['id'])
         assert io.messages == []
         assert 'stop_signal' not in agent.current_session
         assert '_final_response_ready' not in agent.current_session
+
+    def test_terminal_message_ids_are_unique_and_never_reach_the_provider(self):
+        llm = MockLLM(responses=[
+            LLMResponse(content="first", tool_calls=[], raw_response={}, usage=TokenUsage()),
+            LLMResponse(content="second", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        ])
+        agent = Agent("message-identity", llm=llm, log=False, quiet=True)
+
+        assert agent.input("one") == "first"
+        first = agent.current_session['messages'][-1]
+        UUID(first['id'])
+
+        assert agent.input("two") == "second"
+        second = agent.current_session['messages'][-1]
+        UUID(second['id'])
+
+        assert first['id'] != second['id']
+        assert all('id' not in message for message in llm.last_call['messages'])
 
     def test_runtime_input_continuation_does_not_swallow_interrupt(self):
         from connectonion.network.io.websocket import WebSocketIO

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -166,11 +166,15 @@ class TestForwardAgentEvents:
             mock_send_msg, io, "s1", result_holder=result_holder
         )
 
-        assert [message["type"] for message in sent_messages] == [
+        terminal_messages = [
+            message for message in sent_messages
+            if message.get("type") in {"ACP_NOTIFICATION", "OUTPUT"}
+        ]
+        assert [message["type"] for message in terminal_messages] == [
             "ACP_NOTIFICATION",
             "OUTPUT",
         ]
-        params = sent_messages[0]["message"]["params"]
+        params = terminal_messages[0]["message"]["params"]
         assert params == {
             "sessionId": "s1",
             "update": {
@@ -179,7 +183,7 @@ class TestForwardAgentEvents:
                 "sessionUpdate": "agent_message_chunk",
             },
         }
-        assert sent_messages[1]["chat_items"][-1] == {
+        assert terminal_messages[1]["chat_items"][-1] == {
             "id": self.FINAL_MESSAGE_ID,
             "type": "agent",
             "content": "answer",
@@ -202,7 +206,10 @@ class TestForwardAgentEvents:
             mock_send_msg, io, "s1", result_holder=result_holder
         )
 
-        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+        assert [
+            message["type"] for message in sent_messages
+            if message.get("type") in {"ACP_NOTIFICATION", "OUTPUT"}
+        ] == ["OUTPUT"]
 
     async def test_legacy_stored_answer_without_id_uses_output_only(self):
         io = WebSocketIO()
@@ -223,7 +230,10 @@ class TestForwardAgentEvents:
             mock_send_msg, io, "s1", result_holder=result_holder
         )
 
-        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+        assert [
+            message["type"] for message in sent_messages
+            if message.get("type") in {"ACP_NOTIFICATION", "OUTPUT"}
+        ] == ["OUTPUT"]
 
     async def test_terminal_text_does_not_reuse_an_older_matching_answer(self):
         io = WebSocketIO()
@@ -248,7 +258,10 @@ class TestForwardAgentEvents:
             mock_send_msg, io, "s1", result_holder=result_holder
         )
 
-        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+        assert [
+            message["type"] for message in sent_messages
+            if message.get("type") in {"ACP_NOTIFICATION", "OUTPUT"}
+        ] == ["OUTPUT"]
 
     async def test_stored_completion_reuses_the_same_message_id(self):
         io = WebSocketIO()
@@ -316,7 +329,10 @@ class TestForwardAgentEvents:
                 mock_send_msg, io, "s1", result_holder=result_holder
             )
 
-        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+        assert [
+            message["type"] for message in sent_messages
+            if message.get("type") in {"ACP_NOTIFICATION", "OUTPUT"}
+        ] == ["OUTPUT"]
 
     async def test_stray_live_assistant_event_cannot_duplicate_final_answer(self):
         io = WebSocketIO()
@@ -346,7 +362,12 @@ class TestForwardAgentEvents:
             mock_send_msg, io, "s1", result_holder=result_holder
         )
 
-        assert [message["type"] for message in sent_messages] == [
+        assert [
+            message["type"] for message in sent_messages
+            if message.get("type") in {
+                "assistant", "ACP_NOTIFICATION", "OUTPUT"
+            }
+        ] == [
             "assistant",
             "ACP_NOTIFICATION",
             "OUTPUT",

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -24,6 +24,7 @@ from connectonion.network.asgi import (
     read_body,
 )
 from connectonion.network.host.ws_router.agent_io import forward_agent_msgs_to_client
+from connectonion.network.host.ws_router import agent_io as agent_io_module
 from connectonion.network.io import WebSocketIO
 from connectonion.network.host.session import ActiveSessionRegistry
 
@@ -74,6 +75,8 @@ class TestWebSocketIOInASGI:
 @pytest.mark.asyncio
 class TestForwardAgentEvents:
     """Test forward_agent_msgs_to_client async function."""
+
+    FINAL_MESSAGE_ID = "6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e"
 
     async def test_sends_outgoing_messages_to_client(self):
         """Test that outgoing events are forwarded via send_msg."""
@@ -134,6 +137,228 @@ class TestForwardAgentEvents:
         output_msgs = [m for m in sent_messages if m.get("type") == "OUTPUT"]
         assert len(output_msgs) == 1
         assert output_msgs[0]["result"] == "answer"
+
+    async def test_persisted_final_answer_precedes_output_as_acp_message(self):
+        io = WebSocketIO()
+        sent_messages = []
+        session = {
+            "messages": [
+                {"role": "system", "content": "help"},
+                {"role": "user", "content": "question"},
+                {
+                    "role": "assistant",
+                    "content": "answer",
+                    "id": self.FINAL_MESSAGE_ID,
+                },
+            ]
+        }
+        result_holder = [{
+            "result": "answer",
+            "duration_ms": 50,
+            "session": session,
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert [message["type"] for message in sent_messages] == [
+            "ACP_NOTIFICATION",
+            "OUTPUT",
+        ]
+        params = sent_messages[0]["message"]["params"]
+        assert params == {
+            "sessionId": "s1",
+            "update": {
+                "content": {"text": "answer", "type": "text"},
+                "messageId": self.FINAL_MESSAGE_ID,
+                "sessionUpdate": "agent_message_chunk",
+            },
+        }
+        assert sent_messages[1]["chat_items"][-1] == {
+            "id": self.FINAL_MESSAGE_ID,
+            "type": "agent",
+            "content": "answer",
+        }
+
+    async def test_unpersisted_terminal_text_uses_legacy_output_only(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "Task incomplete: Maximum iterations reached.",
+            "duration_ms": 50,
+            "session": {"messages": []},
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+
+    async def test_legacy_stored_answer_without_id_uses_output_only(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "answer",
+            "duration_ms": 50,
+            "session": {
+                "messages": [{"role": "assistant", "content": "answer"}],
+            },
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+
+    async def test_terminal_text_does_not_reuse_an_older_matching_answer(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "same text",
+            "duration_ms": 50,
+            "session": {
+                "messages": [
+                    {"role": "assistant", "content": "same text"},
+                    {"role": "user", "content": "new question"},
+                    {"role": "assistant", "content": "different answer"},
+                ]
+            },
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+
+    async def test_stored_completion_reuses_the_same_message_id(self):
+        io = WebSocketIO()
+        sent_messages = []
+        stored = Mock(
+            status="done",
+            result="answer",
+            duration_ms=50,
+            session={
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "id": self.FINAL_MESSAGE_ID,
+                    },
+                ]
+            },
+        )
+        storage = Mock()
+        storage.get.return_value = stored
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", storage=storage
+        )
+
+        assert (
+            sent_messages[0]["message"]["params"]["update"]["messageId"]
+            == self.FINAL_MESSAGE_ID
+        )
+        assert sent_messages[1]["chat_items"][-1]["id"] == self.FINAL_MESSAGE_ID
+
+    async def test_bad_final_message_mirror_still_sends_output(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "answer",
+            "duration_ms": 50,
+            "session": {
+                "messages": [
+                    {"role": "user", "content": "question"},
+                    {
+                        "role": "assistant",
+                        "content": "answer",
+                        "id": self.FINAL_MESSAGE_ID,
+                    },
+                ]
+            },
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.mark_agent_done()
+        with patch.object(
+            agent_io_module,
+            "acp_notification_frame",
+            side_effect=ValueError("bad mirror"),
+        ):
+            await forward_agent_msgs_to_client(
+                mock_send_msg, io, "s1", result_holder=result_holder
+            )
+
+        assert [message["type"] for message in sent_messages] == ["OUTPUT"]
+
+    async def test_stray_live_assistant_event_cannot_duplicate_final_answer(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "answer",
+            "duration_ms": 50,
+            "session": {
+                "messages": [{
+                    "role": "assistant",
+                    "content": "answer",
+                    "id": self.FINAL_MESSAGE_ID,
+                }],
+            },
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.send({
+            "type": "assistant",
+            "id": "plugin-message",
+            "content": "plugin text",
+        })
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert [message["type"] for message in sent_messages] == [
+            "assistant",
+            "ACP_NOTIFICATION",
+            "OUTPUT",
+        ]
+        acp_updates = [
+            message["message"]["params"]["update"]
+            for message in sent_messages
+            if message["type"] == "ACP_NOTIFICATION"
+        ]
+        assert [update["messageId"] for update in acp_updates] == [
+            self.FINAL_MESSAGE_ID
+        ]
 
     async def test_bad_acp_mirror_falls_back_without_inviting_a_retry(self):
         io = WebSocketIO()

--- a/tests/unit/test_explain_context.py
+++ b/tests/unit/test_explain_context.py
@@ -238,6 +238,29 @@ class TestRuntimeContextAnalyzeWhy:
         assert result == "I chose search because the user asked to find something"
         mock_agent.llm.complete.assert_called_once()
 
+    def test_persisted_message_ids_do_not_reach_debug_provider_calls(self):
+        from connectonion.debug.debug_explainer.explain_context import RuntimeContext
+
+        mock_bp = Mock(tool_name="search", tool_args={"query": "test"})
+        mock_agent = Mock()
+        mock_agent.current_session = {
+            'messages': [
+                {'role': 'user', 'content': 'First question'},
+                {
+                    'role': 'assistant',
+                    'content': 'First answer',
+                    'id': '6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e',
+                },
+            ],
+        }
+        mock_agent.llm.complete.return_value = Mock(content="Because", tool_calls=[])
+
+        RuntimeContext(mock_bp, mock_agent).analyze_why_this_tool()
+
+        messages = mock_agent.llm.complete.call_args.args[0]
+        assert all('id' not in message for message in messages)
+        assert mock_agent.current_session['messages'][1]['id'].startswith('6d1f')
+
 
 class TestRuntimeContextRootCause:
     """Tests for analyze_root_cause method."""
@@ -306,4 +329,3 @@ class TestRuntimeContextRootCause:
         # Verify model was passed
         call_kwargs = mock_llm_do.call_args.kwargs
         assert call_kwargs.get('model') == "claude-3-sonnet"
-

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -623,6 +623,24 @@ class TestSessionToChatItems:
         assert items[0]['type'] == 'agent'
         assert items[0]['content'] == 'Hi there'
 
+    def test_persisted_assistant_identity_survives_index_shift(self):
+        """Compaction may move a message, but its domain identity stays fixed."""
+        message = {
+            'role': 'assistant',
+            'content': 'Stable answer',
+            'id': '6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e',
+        }
+        before = session_to_chat_items({
+            'messages': [
+                {'role': 'system', 'content': 'help'},
+                {'role': 'user', 'content': 'old question'},
+                message,
+            ],
+        })
+        after = session_to_chat_items({'messages': [message]})
+
+        assert before[-1]['id'] == after[-1]['id'] == message['id']
+
     def test_converts_trace_to_tool_calls(self):
         """Converts trace entries to tool_call ChatItems (matches tool_executor shape)."""
         session = {

--- a/tests/unit/test_interactive_debugger.py
+++ b/tests/unit/test_interactive_debugger.py
@@ -308,6 +308,11 @@ class TestGetLLMNextActionPreview:
         mock_agent.current_session = {
             'messages': [
                 {'role': 'user', 'content': 'Find and save'},
+                {
+                    'role': 'assistant',
+                    'content': 'Earlier answer',
+                    'id': '6d1fcd7e-2e31-4ac4-9f39-7de8f73cd82e',
+                },
                 {'role': 'assistant', 'tool_calls': [
                     {'id': 'call_1', 'function': {'name': 'search'}}
                 ]}
@@ -324,6 +329,9 @@ class TestGetLLMNextActionPreview:
         assert len(result) == 1
         assert result[0]['name'] == "save"
         assert result[0]['args'] == {"data": "result"}
+        messages = mock_llm.complete.call_args.args[0]
+        assert all('id' not in message for message in messages)
+        assert mock_agent.current_session['messages'][1]['id'].startswith('6d1f')
 
     def test_preview_returns_empty_list_when_no_tools(self):
         """Test preview returns empty list when no tools planned."""


### PR DESCRIPTION
## Summary

- persist a stable UUID on every assistant message and reuse it across session replay
- emit ACP v1.19 `agent_message_chunk` notifications immediately before the authoritative host `OUTPUT`
- mirror only persisted final assistant output; keep live ACP mirroring limited to tool events
- strip ConnectOnion's top-level message identity before all provider calls, including debug flows, without mutating canonical history or nested tool-call IDs
- document the decision and share one protocol fixture with `@connectonion/react`

This keeps the architecture boundary explicit: the Python host owns ACP transport, `@connectonion/react` is the browser SDK, and O Chat consumes React without parsing ACP itself.

## Design

See `docs/design-decisions/036-stable-acp-agent-message-identity.md`.

Legacy sessions without persisted assistant IDs continue to receive the existing `OUTPUT` carrier; they do not receive a fabricated ACP identity. A final ACP notification is emitted only when the completed result matches the persisted final assistant record.

## Validation

- full unit suite: `6311 passed, 13 skipped, 15 deselected`
- focused ACP/session/debug regression suite: `179 passed`
- isolated socket-heavy regression suite: `110 passed`
- production-file Ruff checks passed (existing repository-wide style debt excluded)
- `git diff --check` and `compileall` passed
- wheel and sdist built successfully; the wheel contains the new sanitizer and DD-036
- dependency audit: no known vulnerabilities in the exercised Python environment
- expert code review: no findings after provider-boundary and session-identity fixes
- paired React PR: openonion/connectonion-react#14 (merged, 67 tests); packed React integration in O Chat: 65 tests, lint, and production build passed

Closes #867
Related to #838

