### PR TITLE
release: ConnectOnion 1.7.0a1 preview

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,10 +208,15 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" "$wheel" "$sdist" --clobber
           else
+            release_flags=()
+            if [[ "$VERSION" =~ [a-zA-Z] ]]; then
+              release_flags+=(--prerelease --latest=false)
+            fi
             gh release create "$TAG" "$wheel" "$sdist" \
               --target "$GITHUB_SHA" \
               --generate-notes \
-              --title "$TAG"
+              --title "$TAG" \
+              "${release_flags[@]}"
           fi
 
       # Public announcements deliberately live outside this workflow. A broken

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,7 +1,8 @@
 # ConnectOnion Versioning Rules
 
 ## Version Format
-We follow semantic versioning: `MAJOR.MINOR.PATCH`
+We follow semantic versioning, with PEP 440 pre-release suffixes:
+`MAJOR.MINOR.PATCH`, `aN`, `bN`, and `rcN`.
 
 Example: `0.0.2`
 
@@ -38,9 +39,14 @@ patch releases; the minor is the statement that it no longer needs to be.
 - Reserved for breaking changes, or for a stable release worth naming
 - Same rule as any whole number: earned, not reached
 
-## Current Version: 1.6.0
+Stable users remain on 1.6.0 while the 1.7.0 feature train is exercised through
+alpha, beta, and release-candidate builds. Pre-releases are opt-in and must be
+marked as pre-releases on PyPI and GitHub.
+
+## Current Version: 1.7.0a1
 
 ### Version History
+- 1.7.0a1 (**the first 1.7 preview**: audience-scoped HTTP routes let an agent expose visibly public, contacts-only, and admin-only endpoints beside its existing WebSocket transport; ACP gains resumable sessions, ordered updates, official SDK conformance, tool approvals, MCP tools, and stable agent messages; Telegram messaging and safer attachment handling arrive; and billed operations now fail closed when ambient credentials belong to a different account. This is an opt-in preview; 1.6.0 remains the stable recommendation.)
 - 1.6.0 (**safer remote agents and a cleaner credential boundary**: host identity and temporary session-status probes are signed consistently; relay profile updates reject stale or conflicting state; Microsoft OAuth credentials and refresh-token rotation stay on the CLI machine instead of being stored by the backend; project invite credentials are private and no shared default invite code is documented; email sending has traceable, tenant-scoped idempotency and resilient provider-error handling; paid mailbox upgrades can preserve the existing address and are charged atomically; portable skills, dependency floors, cross-platform tests, and exact-artifact release verification are hardened for a stable release.)
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
 - 0.0.2 → 0.0.9 (Early production releases)
@@ -79,7 +85,7 @@ patch releases; the minor is the statement that it no longer needs to be.
 
 ## Files to Update When Versioning
 
-Three files carry the version, and `test_the_version_agrees_with_itself.py`
+Four files carry the package version, and `test_the_version_agrees_with_itself.py`
 fails if they disagree — so a release that misses one is caught rather than
 shipped.
 
@@ -89,9 +95,12 @@ shipped.
    there.
 2. `pyproject.toml` — the `version` field. This is what the wheel carries.
 3. `## Current Version:` at the top of this file.
+4. `uv.lock` — the editable root package metadata; refresh it after a bump.
 
 And one in the sibling docs repo, checked by the same test when it is beside
-this one: `docs-site/lib/version.ts` — `VERSION = 'X.Y.Z'`.
+this one: `docs-site/lib/version.ts`. Stable releases update `STABLE_VERSION`;
+pre-releases update `PREVIEW_VERSION` while the public site keeps advertising
+the stable channel through `VERSION`.
 
 The entry in the release list below is not optional either: a version with no
 entry fails `test_every_release_has_an_entry.py`.
@@ -103,7 +112,8 @@ When releasing a new version:
 - [ ] Update `__version__` in `connectonion/_version.py`
 - [ ] Update `version` in `pyproject.toml`
 - [ ] Update `## Current Version:` and add the release line in this file
-- [ ] Update `VERSION` in the docs site's `lib/version.ts`
+- [ ] Refresh `uv.lock`
+- [ ] Update the matching stable or preview channel in the docs site's `lib/version.ts`
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
 - [ ] Commit changes: `git commit -m "Release vX.Y.Z: Description"`
 - [ ] Create git tag: `git tag vX.Y.Z`

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.7.0a1"

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 ├── connectonion.md        # Framework architecture deep dive
 ├── examples.md            # Code examples and patterns
 ├── principles.md          # Design philosophy
+├── releases.md            # Stable and preview release channels
 ├── claude-code-plugin.md  # Official Claude Code build and review workflow
 ├── vibe-coding-guide.md   # Coding-assistant workflow and prompts
 ├── cli/                   # CLI commands documentation

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,12 @@
+# Release channels
+
+ConnectOnion has two release channels:
+
+- **Stable** is the default `pip install connectonion` channel. It is the version
+  recommended for production agents.
+- **Preview** contains alpha, beta, and release-candidate builds for features
+  that are still being exercised end to end. Install one explicitly, for
+  example: `pip install connectonion==1.7.0a1`.
+
+Preview releases never replace the stable recommendation on the documentation
+site, and GitHub marks them as pre-releases rather than latest releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.6.0"
+version = "1.7.0a1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_every_release_has_an_entry.py
+++ b/tests/unit/test_every_release_has_an_entry.py
@@ -38,7 +38,7 @@ DENSE_HISTORY_FROM = (1, 5, 0)
 
 
 def _documented_versions() -> set:
-    return set(re.findall(r'^- (\d+\.\d+\.\d+)', VERSIONING.read_text(encoding='utf-8'),
+    return set(re.findall(r'^- (\d+\.\d+\.\d+(?:[a-zA-Z]+\d+)?)', VERSIONING.read_text(encoding='utf-8'),
                           re.MULTILINE))
 
 

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -79,6 +79,11 @@ def test_only_the_current_pair_is_built_and_attached():
     assert "gh release create" in RELEASE
 
 
+def test_preview_releases_are_not_advertised_as_latest():
+    assert '"$VERSION" =~ [a-zA-Z]' in RELEASE
+    assert "--prerelease --latest=false" in RELEASE
+
+
 def test_artifact_job_installs_what_its_wheel_acceptance_test_needs():
     build_job = RELEASE.split("  build:", 1)[1].split("  publish:", 1)[0]
     install = 'python -m pip install --upgrade pip build twine ".[dev]"'

--- a/tests/unit/test_the_ship_skill_matches_this_repo.py
+++ b/tests/unit/test_the_ship_skill_matches_this_repo.py
@@ -75,8 +75,11 @@ class TestItNamesWhereTheVersionActuallyIs:
         pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
         version_py = (ROOT / "connectonion/_version.py").read_text(encoding="utf-8")
 
-        in_pyproject = re.search(r'^version = "([\d.]+)"', pyproject, re.M)
-        in_module = re.search(r'__version__ = "([\d.]+)"', version_py)
+        # PEP 440 versions may include a pre-release segment (for example,
+        # ``1.7.0a1``), so compare the complete quoted values rather than only
+        # digits and dots.
+        in_pyproject = re.search(r'^version = "([^"]+)"', pyproject, re.M)
+        in_module = re.search(r'__version__ = "([^"]+)"', version_py)
 
         assert in_pyproject and in_module
         assert in_pyproject.group(1) == in_module.group(1), (

--- a/tests/unit/test_the_version_agrees_with_itself.py
+++ b/tests/unit/test_the_version_agrees_with_itself.py
@@ -22,6 +22,7 @@ the wrong number in exactly the setup developers use. Four literals that are
 checked beat three that can lie.
 """
 
+import os
 import re
 from pathlib import Path
 
@@ -42,6 +43,10 @@ def _docs_site_path() -> Path:
 
     The git common dir always points into the main checkout.
     """
+    configured = os.environ.get("CONNECTONION_DOCS_SITE")
+    if configured:
+        return Path(configured).expanduser().resolve() / "lib" / "version.ts"
+
     candidates = [REPO.parent]
     common = REPO / '.git'
     if common.is_file():                       # a worktree: .git is a pointer file
@@ -73,8 +78,12 @@ def _versioning_md_version() -> str:
 
 
 def _docs_site_version() -> str:
-    match = re.search(r"VERSION\s*=\s*'([^']+)'", DOCS_SITE.read_text(encoding='utf-8'))
-    assert match, f"{DOCS_SITE} has no VERSION"
+    text = DOCS_SITE.read_text(encoding='utf-8')
+    name = "PREVIEW_VERSION" if re.search(r"[a-zA-Z]", connectonion.__version__) else "STABLE_VERSION"
+    match = re.search(rf"{name}\s*=\s*'([^']+)'", text)
+    if not match:
+        match = re.search(r"VERSION\s*=\s*'([^']+)'", text)
+    assert match, f"{DOCS_SITE} has no {name} or VERSION"
     return match.group(1)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -315,7 +315,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.6.0"
+version = "1.7.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- cut the first opt-in 1.7 preview with audience-scoped HTTP routes and the features merged since 1.6.0
- keep 1.6.0 as the stable recommendation and document stable/preview channels
- mark alpha/beta/rc GitHub releases as prereleases instead of latest
- teach release checks about PEP 440 prerelease versions and sibling docs worktrees

## Verification
- 98 focused release + HTTP + raw-ASGI E2E tests passed
- full local suite: 6,774 passed; 36 environment-only failures (missing declared MCP dependency in the current interpreter and sandbox-denied Unix sockets); release CI installs the declared dependencies and runs on a normal runner
- docs production build passed in the companion PR

Companion docs PR: https://github.com/wu-changxing/connectonion-docs-site/pull/new/agent/release-1.7.0a1