### PR TITLE
feat: carry bound ACP Host permissions

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -2,8 +2,9 @@
 
 The Host WebSocket also transports ConnectOnion authentication, onboarding,
 session persistence, and dashboard frames, so it is not an ACP connection. An
-``ACP_NOTIFICATION`` frame carries one exact ACP JSON-RPC notification without
-pretending that the surrounding socket negotiated ACP capabilities.
+``ACP_NOTIFICATION`` and ``ACP_REQUEST`` frames carry exact nested ACP JSON-RPC
+messages without pretending that the surrounding socket negotiated ACP
+capabilities.
 """
 
 from __future__ import annotations
@@ -13,16 +14,55 @@ from typing import Any, Mapping
 from acp import text_block, tool_content
 from acp.schema import (
     AgentMessageChunk,
+    AgentRequest,
+    PermissionOption,
+    RequestPermissionRequest,
+    RequestPermissionResponse,
     SessionNotification,
     ToolCallProgress,
     ToolCallStart,
+    ToolCallUpdate,
 )
 
 from .wire_events import normalize_wire_event
 
 ACP_FRAME_TYPE = "ACP_NOTIFICATION"
+ACP_REQUEST_FRAME_TYPE = "ACP_REQUEST"
+ACP_RESPONSE_FRAME_TYPE = "ACP_RESPONSE"
 ACP_SCHEMA_VERSION = "schema-v1.19.0"
 ACP_SESSION_UPDATE_METHOD = "session/update"
+ACP_PERMISSION_METHOD = "session/request_permission"
+
+ACP_PERMISSION_OPTIONS = (
+    PermissionOption(
+        option_id="allow_once",
+        name="Allow this call",
+        kind="allow_once",
+    ),
+    PermissionOption(
+        option_id="allow_session",
+        name="Allow for this session",
+        kind="allow_always",
+    ),
+    PermissionOption(
+        option_id="reject_soft",
+        name="Reject this call and continue",
+        kind="reject_once",
+    ),
+    PermissionOption(
+        option_id="reject_hard",
+        name="Reject and stop this turn",
+        kind="reject_once",
+    ),
+    PermissionOption(
+        option_id="reject_explain",
+        name="Reject and explain first",
+        kind="reject_once",
+    ),
+)
+ACP_PERMISSION_OPTION_IDS = frozenset(
+    option.option_id for option in ACP_PERMISSION_OPTIONS
+)
 
 
 def map_tool_event(
@@ -108,6 +148,101 @@ def acp_notification_frame(
             "params": params,
         },
     }
+
+
+def acp_permission_request_frame(
+    event: Mapping[str, Any], session_id: str
+) -> dict[str, Any]:
+    """Carry one exact ACP permission request beside the legacy Host event."""
+
+    if event.get("type") != "approval_needed":
+        raise ValueError("ACP permission source must be approval_needed")
+    arguments = _required_mapping(event, "arguments")
+    params = RequestPermissionRequest(
+        session_id=_required_nonempty(session_id, "session_id"),
+        tool_call=ToolCallUpdate(
+            tool_call_id=_required_string(event, "tool_call_id"),
+            title=_required_string(event, "tool"),
+            status="pending",
+            raw_input=dict(arguments),
+        ),
+        options=[option.model_copy(deep=True) for option in ACP_PERMISSION_OPTIONS],
+    )
+    request = AgentRequest(
+        id=_required_string(event, "id"),
+        method=ACP_PERMISSION_METHOD,
+        params=params,
+    )
+    message = request.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    return {
+        "type": ACP_REQUEST_FRAME_TYPE,
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "message": {"jsonrpc": "2.0", **message},
+    }
+
+
+def legacy_approval_response_from_acp(
+    frame: Mapping[str, Any],
+    *,
+    expected_session_id: str,
+    expected_request_id: str,
+) -> dict[str, Any]:
+    """Validate one bound ACP response and return the existing policy input."""
+
+    if frame.get("type") != ACP_RESPONSE_FRAME_TYPE:
+        raise ValueError("Unsupported ACP permission response carrier")
+    if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
+        raise ValueError("Unsupported ACP carrier schema")
+    if frame.get("sessionId") != expected_session_id:
+        raise ValueError("ACP permission response belongs to another session")
+    message = _required_mapping(frame, "message")
+    if message.get("jsonrpc") != "2.0":
+        raise ValueError("ACP response jsonrpc must be '2.0'")
+    if message.get("id") != expected_request_id:
+        raise ValueError("ACP permission response belongs to another request")
+    result = RequestPermissionResponse.model_validate(
+        _required_mapping(message, "result")
+    )
+    outcome = result.outcome
+    if outcome.outcome == "cancelled":
+        return _hard_rejection()
+
+    option_id = outcome.option_id
+    if option_id not in ACP_PERMISSION_OPTION_IDS:
+        raise ValueError("ACP permission response selected an unknown option")
+    if option_id == "allow_once":
+        return {"approved": True, "scope": "once"}
+    if option_id == "allow_session":
+        return {"approved": True, "scope": "session"}
+
+    response = {
+        "approved": False,
+        "scope": "once",
+        "mode": option_id,
+    }
+    feedback = _permission_feedback(result.field_meta)
+    if feedback:
+        response["feedback"] = feedback
+    return response
+
+
+def _hard_rejection() -> dict[str, Any]:
+    return {"approved": False, "scope": "once", "mode": "reject_hard"}
+
+
+def _permission_feedback(field_meta: Any) -> str | None:
+    if not isinstance(field_meta, Mapping):
+        return None
+    connectonion = field_meta.get("connectonion")
+    if not isinstance(connectonion, Mapping):
+        return None
+    feedback = connectonion.get("feedback")
+    return feedback if isinstance(feedback, str) and feedback else None
 
 
 def legacy_tool_event_from_acp(
@@ -237,3 +372,9 @@ def _required_string(value: Mapping[str, Any], field: str) -> str:
     if not isinstance(item, str) or not item:
         raise ValueError(f"ACP event field {field!r} must be a non-empty string")
     return item
+
+
+def _required_nonempty(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"ACP event field {field!r} must be a non-empty string")
+    return value

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -13,7 +13,10 @@ import threading
 
 from rich.console import Console
 
-from ....core.acp_wire import acp_notification_frame
+from ....core.acp_wire import (
+    acp_notification_frame,
+    acp_permission_request_frame,
+)
 from ...io import WebSocketIO
 
 console = Console()
@@ -27,6 +30,18 @@ def _acp_rollout_frame(event, session_id):
     except (TypeError, ValueError) as exc:
         console.print(
             f"[yellow]ACP mirror skipped; legacy event continues: {exc}[/yellow]"
+        )
+        return None
+
+
+def _acp_permission_rollout_frame(event, session_id):
+    if not session_id:
+        return None
+    try:
+        return acp_permission_request_frame(event, session_id)
+    except (TypeError, ValueError) as exc:
+        console.print(
+            f"[yellow]ACP permission mirror skipped; legacy request continues: {exc}[/yellow]"
         )
         return None
 
@@ -115,6 +130,11 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
 async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder=None, conn=None, storage=None):
     """Forward agent events to client. Send OUTPUT (or ERROR) when agent finishes."""
     async for event in io.read_msgs_from_agent():
+        if event.get("type") == "approval_needed":
+            acp_request = _acp_permission_rollout_frame(event, session_id)
+            io.register_permission_request(event, session_id, acp_request)
+            if acp_request is not None:
+                await send_msg(acp_request)
         acp_frame = (
             _acp_rollout_frame(event, session_id)
             if event.get("type") in {"tool_call", "tool_result"}
@@ -170,7 +190,7 @@ def resume_forwarding(send_msg, active, registry, session_id, storage, conn=None
     alive. The io stayed live in ActiveSession across the WS drop; we just
     spawn a fresh task to pump it to the new client.
     """
-    console.print(f"  [dim]↻ resuming forwarding to running agent[/dim]")
+    console.print("  [dim]↻ resuming forwarding to running agent[/dim]")
     io = active.io
     registry.update_ping(session_id)
     task = asyncio.create_task(
@@ -222,7 +242,7 @@ def verified_prompt(data: dict, route_handlers) -> tuple:
 async def start_agent(data, send_msg, conn, route_handlers, storage, registry):
     """Validate INPUT, spawn agent thread + forward task. Returns (io, forward_task) or None on error."""
     if not conn["authenticated"]:
-        console.print(f"[red]✗ INPUT rejected:[/red] not authenticated (send CONNECT first)")
+        console.print("[red]✗ INPUT rejected:[/red] not authenticated (send CONNECT first)")
         await send_msg({"type": "ERROR", "message": "authenticate first (send CONNECT)"})
         return None
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -12,9 +12,10 @@ import asyncio
 import uuid
 
 from rich.console import Console
+
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
-from .connect import handle_connect, establish_connection
 from .agent_io import start_agent
+from .connect import establish_connection, handle_connect
 from .exec import run_exec
 from .ping import ping_loop
 
@@ -203,6 +204,25 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                         run_exec(data, send_msg, route_handlers, conn["agent_address"]))
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
+
+            elif msg_type == "ACP_RESPONSE":
+                if not active_io or not active_io.resolve_acp_permission(
+                    data, conn.get("session_id")
+                ):
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "unknown or stale ACP permission response",
+                    })
+
+            elif msg_type == "APPROVAL_RESPONSE" and active_io:
+                resolver = getattr(active_io, "resolve_legacy_permission", None)
+                if resolver is None:
+                    active_io.send_to_agent(data)
+                elif not resolver(data):
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "unknown or stale approval response",
+                    })
 
             elif active_io:
                 # Anything else (ASK_USER_RESPONSE, APPROVAL_RESPONSE, mode_change, ...)

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -45,6 +45,7 @@ class WebSocketIO(IO):
         self._accepting_runtime_inputs = False
 
         self._closed = False
+        self._pending_permission: Dict[str, Any] | None = None
 
     # ═══════════════════════════════════════════════════════
     # Agent side (sync)
@@ -154,6 +155,104 @@ class WebSocketIO(IO):
         with self._client_condition:
             self._msgs_from_client.append(msg)
             self._client_condition.notify_all()
+
+    def register_permission_request(
+        self,
+        event: Dict[str, Any],
+        session_id: str,
+        acp_frame: Dict[str, Any] | None,
+    ) -> bool:
+        """Bind one replayable approval event to this session's live mailbox."""
+
+        request_id = event.get("id")
+        if not isinstance(request_id, str) or not request_id:
+            return False
+        pending = {
+            "request_id": request_id,
+            "session_id": session_id,
+            "tool_call_id": event.get("tool_call_id"),
+            "acp": acp_frame is not None,
+        }
+        with self._client_condition:
+            if self._pending_permission is None:
+                self._pending_permission = pending
+                return True
+            return self._pending_permission == pending
+
+    def resolve_acp_permission(
+        self, frame: Dict[str, Any], session_id: str
+    ) -> bool:
+        """Consume one matching ACP response and enqueue a fail-closed decision."""
+
+        message = frame.get("message")
+        response_id = message.get("id") if isinstance(message, dict) else None
+        with self._client_condition:
+            pending = self._pending_permission
+            if (
+                pending is None
+                or not pending["acp"]
+                or pending["session_id"] != session_id
+                or frame.get("sessionId") != session_id
+                or response_id != pending["request_id"]
+            ):
+                return False
+            self._pending_permission = None
+
+        from ...core.acp_wire import legacy_approval_response_from_acp
+
+        try:
+            response = legacy_approval_response_from_acp(
+                frame,
+                expected_session_id=session_id,
+                expected_request_id=pending["request_id"],
+            )
+        except (TypeError, ValueError):
+            response = {
+                "approved": False,
+                "scope": "once",
+                "mode": "reject_hard",
+            }
+        self.send_to_agent(response)
+        return True
+
+    def resolve_legacy_permission(self, response: Dict[str, Any]) -> bool:
+        """Bind a rolling-upgrade legacy answer to the one pending request."""
+
+        with self._client_condition:
+            if self._pending_permission is None:
+                return False
+            self._pending_permission = None
+            self._msgs_from_client.append(
+                self._normalized_legacy_permission(response)
+            )
+            self._client_condition.notify_all()
+            return True
+
+    @staticmethod
+    def _normalized_legacy_permission(response: Dict[str, Any]) -> Dict[str, Any]:
+        """Accept only the legacy choices the policy gate actually implements."""
+
+        rejected = {
+            "approved": False,
+            "scope": "once",
+            "mode": "reject_hard",
+        }
+        approved = response.get("approved")
+        if not isinstance(approved, bool):
+            return rejected
+        scope = response.get("scope", "once")
+        if scope not in {"once", "session"}:
+            return rejected
+        if approved:
+            return {"approved": True, "scope": scope}
+        mode = response.get("mode", "reject_hard")
+        if mode not in {"reject_soft", "reject_hard", "reject_explain"}:
+            return rejected
+        result = {"approved": False, "scope": "once", "mode": mode}
+        feedback = response.get("feedback")
+        if isinstance(feedback, str) and feedback:
+            result["feedback"] = feedback
+        return result
 
     def push_runtime_input(self, msg: Dict[str, Any]) -> bool:
         """Queue mid-execution input only while the current turn can consume it."""

--- a/docs/design-decisions/035-versioned-acp-host-carrier.md
+++ b/docs/design-decisions/035-versioned-acp-host-carrier.md
@@ -49,8 +49,10 @@ applications, `@connectonion/react` is the browser protocol boundary and the
 only SDK used by oo-chat; its reader ships before or with the writer in a
 coordinated release. The standalone `connectonion` TypeScript client may carry
 the same compatibility reader for non-React consumers, but it is not an
-oo-chat dependency or a React release gate. Legacy removal requires a future
-major version, usage evidence, and a separate decision.
+oo-chat dependency or a React release gate. DD-037 later retired that package
+from the frontend rollout entirely: new browser protocol work belongs in
+`@connectonion/react`. Legacy removal requires a future major version, usage
+evidence, and a separate decision.
 
 ACP mirroring is additive and non-authoritative. A malformed internal event or
 conversion failure is logged, the legacy frame is still delivered, and the

--- a/docs/design-decisions/037-bound-acp-host-permissions.md
+++ b/docs/design-decisions/037-bound-acp-host-permissions.md
@@ -1,0 +1,69 @@
+# DD-037: Bind ACP Host Permissions to One Session and Request
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Related:** [030 Generation-scoped Tool Approvals](030-acp-generation-scoped-tool-approvals.md), [035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md)
+
+## Decision
+
+The authenticated ConnectOnion Host WebSocket carries ACP
+`session/request_permission` as one exact nested JSON-RPC request. The socket
+itself remains a ConnectOnion transport: it performs no ACP `initialize` and
+continues to own authentication, onboarding, reconnect, persistence, and
+dashboard control.
+
+The Host sends an `ACP_REQUEST` immediately before the existing
+`approval_needed` event. Both frames preserve the same event UUID, session ID,
+and tool-call ID. The request uses the carrier version established by DD-035
+and advertises exactly five choices:
+
+- `allow_once` maps to the existing one-call grant.
+- `allow_session` uses ACP `allow_always`, but maps only to the current
+  ConnectOnion session grant.
+- `reject_soft`, `reject_hard`, and `reject_explain` all use ACP `reject_once`;
+  their ConnectOnion-specific behavior is selected by the stable option ID.
+
+`WebSocketIO` registers one pending permission request before either response
+can reach the agent mailbox. An `ACP_RESPONSE` must match the active session
+and the pending JSON-RPC ID. A matching response is consumed once. Unknown or
+stale responses are rejected, while a matching malformed response and ACP
+`cancelled` both become `reject_hard`. The legacy response path is also
+one-shot and accepts only real booleans, the implemented scopes, and the three
+implemented rejection modes. This keeps the existing permission policy engine
+authoritative and prevents a transport value from manufacturing authority.
+
+Human feedback is optional presentation data under
+`_meta.connectonion.feedback`. It is copied only into a rejection and never
+changes whether a call is allowed.
+
+`@connectonion/react` is the browser protocol boundary. It validates and
+de-duplicates the paired frames, exposes one normalized approval item, and
+sends at most one response for that item. oo-chat renders and answers the
+React package's normalized state; it does not parse ACP. The standalone
+TypeScript SDK is retired and receives no new ACP frontend work.
+
+## Compatibility and reconnect
+
+Dual-write preserves released clients during the migration. An old browser
+sees `approval_needed`; a new React client prefers the ACP request and uses the
+legacy event only to enrich the same card. A mirror conversion failure logs a
+warning and leaves the legacy request usable.
+
+The pending identity lives on the session's `WebSocketIO`, not on one physical
+socket. Reconnect therefore replays the same request ID and accepts one bound
+answer. A later response cannot approve a different request. Removing the ACP
+mirror is a safe rollback because canonical approval events and the policy
+engine remain unchanged.
+
+## Rejected alternatives
+
+- **Treat the Host socket as an ACP connection:** it never negotiated ACP
+  capabilities and carries non-ACP control frames.
+- **Give ACP a second permission engine:** two policy implementations can
+  disagree about the same side effect.
+- **Trust any matching option kind:** several product choices intentionally
+  share ACP `reject_once`; the advertised option ID is the stable mapping.
+- **Put feedback in authorization fields:** explanatory text is untrusted
+  metadata and must not grant capability.
+- **Teach oo-chat or the retired TypeScript SDK ACP:** protocol ownership would
+  be duplicated across frontend layers and drift during rollout.

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -391,6 +391,35 @@ The tool is checked against the host's `.co/host.yaml` permission whitelist (the
 { "type": "APPROVAL_RESPONSE", "approved": true, "scope": "once" }
 ```
 
+Legacy approval responses are consumed once and are bound to the currently
+pending request. Updated React clients answer the paired ACP request instead.
+
+#### ACP_RESPONSE
+
+Answer one `ACP_REQUEST`. The outer carrier binds the response to the Host
+session; `message` is the exact ACP JSON-RPC result for the request ID.
+
+```json
+{
+  "type": "ACP_RESPONSE",
+  "acpSchema": "schema-v1.19.0",
+  "sessionId": "550e8400-...",
+  "message": {
+    "jsonrpc": "2.0",
+    "id": "approval-event-uuid",
+    "result": {
+      "outcome": {"outcome": "selected", "optionId": "allow_once"}
+    }
+  }
+}
+```
+
+The Host accepts only an advertised option for the active request and session.
+`allow_once` and `allow_session` grant one call or the current session;
+`reject_soft`, `reject_hard`, and `reject_explain` deny. A matching malformed
+response or `cancelled` fails closed. Optional rejection feedback belongs at
+`result._meta.connectonion.feedback` and has no authorization meaning.
+
 #### ONBOARD_SUBMIT
 
 Pass the trust gate. Sent in reply to `ONBOARD_REQUIRED`, on the same socket.
@@ -481,6 +510,45 @@ Keep-alive. Sent every 30 seconds.
 ```json
 { "type": "PING" }
 ```
+
+#### ACP_REQUEST
+
+The Host sends this immediately before its legacy `approval_needed` event.
+The outer envelope is ConnectOnion; `message` is one exact ACP
+`session/request_permission` JSON-RPC request.
+
+```json
+{
+  "type": "ACP_REQUEST",
+  "acpSchema": "schema-v1.19.0",
+  "message": {
+    "jsonrpc": "2.0",
+    "id": "approval-event-uuid",
+    "method": "session/request_permission",
+    "params": {
+      "sessionId": "550e8400-...",
+      "toolCall": {
+        "toolCallId": "call-1",
+        "title": "Bash(npm test)",
+        "status": "pending",
+        "rawInput": {"command": "npm test"}
+      },
+      "options": [
+        {"optionId": "allow_once", "name": "Allow this call", "kind": "allow_once"},
+        {"optionId": "allow_session", "name": "Allow for this session", "kind": "allow_always"},
+        {"optionId": "reject_soft", "name": "Reject this call and continue", "kind": "reject_once"},
+        {"optionId": "reject_hard", "name": "Reject and stop this turn", "kind": "reject_once"},
+        {"optionId": "reject_explain", "name": "Reject and explain first", "kind": "reject_once"}
+      ]
+    }
+  }
+}
+```
+
+The request UUID, Host session ID, and tool-call ID are stable across replay.
+New browser code belongs in `@connectonion/react`; oo-chat consumes its
+normalized approval item and does not parse this envelope. The standalone
+TypeScript SDK is retired from this rollout.
 
 #### Stream Events
 

--- a/tests/unit/test_acp_host_permission.py
+++ b/tests/unit/test_acp_host_permission.py
@@ -1,0 +1,349 @@
+"""ACP permission requests on the authenticated Host carrier."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from connectonion.core.acp_wire import acp_permission_request_frame
+from connectonion.network.host.ws_router.agent_io import (
+    forward_agent_msgs_to_client,
+)
+from connectonion.network.io import WebSocketIO
+
+SESSION_ID = "session-1"
+REQUEST_ID = "approval-event-1"
+TOOL_CALL_ID = "call-1"
+
+
+def approval_event() -> dict:
+    return {
+        "type": "approval_needed",
+        "id": REQUEST_ID,
+        "tool_call_id": TOOL_CALL_ID,
+        "tool": "Bash(npm test)",
+        "arguments": {"command": "npm test"},
+        "description": "Run the test suite",
+    }
+
+
+def selected_response(
+    option_id: str,
+    *,
+    request_id: str = REQUEST_ID,
+    session_id: str = SESSION_ID,
+    feedback: str | None = None,
+) -> dict:
+    result: dict = {
+        "outcome": {"outcome": "selected", "optionId": option_id}
+    }
+    if feedback is not None:
+        result["_meta"] = {"connectonion": {"feedback": feedback}}
+    return {
+        "type": "ACP_RESPONSE",
+        "acpSchema": "schema-v1.19.0",
+        "sessionId": session_id,
+        "message": {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result,
+        },
+    }
+
+
+def test_permission_request_uses_the_exact_pinned_acp_shape():
+    assert acp_permission_request_frame(approval_event(), SESSION_ID) == {
+        "type": "ACP_REQUEST",
+        "acpSchema": "schema-v1.19.0",
+        "message": {
+            "jsonrpc": "2.0",
+            "id": REQUEST_ID,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": SESSION_ID,
+                "toolCall": {
+                    "toolCallId": TOOL_CALL_ID,
+                    "title": "Bash(npm test)",
+                    "status": "pending",
+                    "rawInput": {"command": "npm test"},
+                },
+                "options": [
+                    {
+                        "optionId": "allow_once",
+                        "name": "Allow this call",
+                        "kind": "allow_once",
+                    },
+                    {
+                        "optionId": "allow_session",
+                        "name": "Allow for this session",
+                        "kind": "allow_always",
+                    },
+                    {
+                        "optionId": "reject_soft",
+                        "name": "Reject this call and continue",
+                        "kind": "reject_once",
+                    },
+                    {
+                        "optionId": "reject_hard",
+                        "name": "Reject and stop this turn",
+                        "kind": "reject_once",
+                    },
+                    {
+                        "optionId": "reject_explain",
+                        "name": "Reject and explain first",
+                        "kind": "reject_once",
+                    },
+                ],
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["id", "tool_call_id", "tool", "arguments"],
+)
+def test_permission_request_rejects_missing_identity_or_input(field):
+    event = approval_event()
+    event.pop(field)
+
+    with pytest.raises((TypeError, ValueError)):
+        acp_permission_request_frame(event, SESSION_ID)
+
+
+@pytest.mark.asyncio
+async def test_host_sends_acp_request_before_the_legacy_fallback():
+    io = WebSocketIO()
+    sent: list[dict] = []
+    event = approval_event()
+
+    async def send(message):
+        sent.append(copy.deepcopy(message))
+
+    io.send(event)
+    io.mark_agent_done()
+    await forward_agent_msgs_to_client(send, io, SESSION_ID)
+
+    assert [message["type"] for message in sent[:2]] == [
+        "ACP_REQUEST",
+        "approval_needed",
+    ]
+    assert sent[0]["message"]["id"] == sent[1]["id"] == REQUEST_ID
+
+
+@pytest.mark.parametrize(
+    ("option_id", "expected"),
+    [
+        ("allow_once", {"approved": True, "scope": "once"}),
+        ("allow_session", {"approved": True, "scope": "session"}),
+        (
+            "reject_soft",
+            {
+                "approved": False,
+                "scope": "once",
+                "mode": "reject_soft",
+                "feedback": "use the smaller command",
+            },
+        ),
+        (
+            "reject_hard",
+            {"approved": False, "scope": "once", "mode": "reject_hard"},
+        ),
+        (
+            "reject_explain",
+            {
+                "approved": False,
+                "scope": "once",
+                "mode": "reject_explain",
+                "feedback": "why is this needed?",
+            },
+        ),
+    ],
+)
+def test_only_advertised_acp_options_reach_the_agent_once(option_id, expected):
+    io = WebSocketIO()
+    frame = acp_permission_request_frame(approval_event(), SESSION_ID)
+    io.register_permission_request(approval_event(), SESSION_ID, frame)
+    feedback = expected.get("feedback")
+
+    assert io.resolve_acp_permission(
+        selected_response(option_id, feedback=feedback), SESSION_ID
+    ) is True
+    assert io.receive_all() == [expected]
+    assert io.resolve_acp_permission(
+        selected_response(option_id, feedback=feedback), SESSION_ID
+    ) is False
+    assert io.receive_all() == []
+
+
+def test_wrong_request_or_session_cannot_cross_into_the_mailbox():
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+
+    assert io.resolve_acp_permission(
+        selected_response("allow_once", request_id="stale"), SESSION_ID
+    ) is False
+    assert io.resolve_acp_permission(
+        selected_response("allow_once", session_id="other"), SESSION_ID
+    ) is False
+    assert io.receive_all() == []
+
+    assert io.resolve_acp_permission(
+        selected_response("allow_once"), SESSION_ID
+    ) is True
+    assert io.receive_all() == [{"approved": True, "scope": "once"}]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda frame: frame["message"]["result"]["outcome"].update(
+            optionId="manufactured_allow"
+        ),
+        lambda frame: frame["message"].update(jsonrpc="1.0"),
+        lambda frame: frame["message"].pop("result"),
+    ],
+)
+def test_a_matching_but_invalid_response_consumes_the_request_fail_closed(mutate):
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+    response = selected_response("allow_once")
+    mutate(response)
+
+    assert io.resolve_acp_permission(response, SESSION_ID) is True
+    assert io.receive_all() == [
+        {"approved": False, "scope": "once", "mode": "reject_hard"}
+    ]
+
+
+def test_cancelled_response_is_a_hard_rejection():
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+    response = selected_response("allow_once")
+    response["message"]["result"] = {"outcome": {"outcome": "cancelled"}}
+
+    assert io.resolve_acp_permission(response, SESSION_ID) is True
+    assert io.receive_all() == [
+        {"approved": False, "scope": "once", "mode": "reject_hard"}
+    ]
+
+
+def test_legacy_response_is_bound_to_the_current_request_and_consumed_once():
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+    response = {"type": "APPROVAL_RESPONSE", "approved": True, "scope": "once"}
+
+    assert io.resolve_legacy_permission(response) is True
+    assert io.resolve_legacy_permission(response) is False
+    assert io.receive_all() == [{"approved": True, "scope": "once"}]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"type": "APPROVAL_RESPONSE", "approved": "yes", "scope": "once"},
+        {"type": "APPROVAL_RESPONSE", "approved": True, "scope": "forever"},
+        {
+            "type": "APPROVAL_RESPONSE",
+            "approved": False,
+            "scope": "once",
+            "mode": "manufactured_mode",
+        },
+    ],
+)
+def test_malformed_legacy_answers_also_fail_closed(response):
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+
+    assert io.resolve_legacy_permission(response) is True
+    assert io.receive_all() == [
+        {"approved": False, "scope": "once", "mode": "reject_hard"}
+    ]
+
+
+def test_reconnect_re_registers_the_same_request_but_not_a_second_one():
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+
+    assert io.register_permission_request(event, SESSION_ID, frame) is True
+    assert io.register_permission_request(event, SESSION_ID, frame) is True
+
+    other = {**event, "id": "other"}
+    other_frame = acp_permission_request_frame(other, SESSION_ID)
+    assert io.register_permission_request(other, SESSION_ID, other_frame) is False
+
+
+async def _run_bound_response(monkeypatch, response):
+    from connectonion.network.host.ws_router import session as ws_session
+
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+    sent = []
+    frames = [{"type": "CONNECT"}, response]
+
+    async def fake_connect(
+        data, send_msg, conn, route_handlers, storage, registry, trust,
+        blacklist, whitelist,
+    ):
+        conn.update(
+            authenticated=True,
+            agent_address="operator",
+            session_id=SESSION_ID,
+        )
+        return io, None
+
+    async def recv_msg():
+        return frames.pop(0) if frames else None
+
+    async def send_msg(message):
+        sent.append(message)
+
+    monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    await ws_session.run_ws_session(
+        send_msg,
+        recv_msg,
+        route_handlers={},
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+    )
+    return io.receive_all(), sent
+
+
+@pytest.mark.asyncio
+async def test_session_dispatch_routes_a_bound_acp_response(monkeypatch):
+    mailbox, sent = await _run_bound_response(
+        monkeypatch, selected_response("allow_once")
+    )
+
+    assert mailbox == [{"approved": True, "scope": "once"}]
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_session_dispatch_answers_a_stale_acp_response(monkeypatch):
+    mailbox, sent = await _run_bound_response(
+        monkeypatch,
+        selected_response("allow_once", request_id="stale"),
+    )
+
+    assert mailbox == []
+    assert sent == [{
+        "type": "ERROR",
+        "message": "unknown or stale ACP permission response",
+    }]


### PR DESCRIPTION
## Summary

- carry exact ACP v1.19 `session/request_permission` requests over the authenticated Host WebSocket
- bind each response to one session, request UUID, and existing tool-call ID
- map the five advertised ACP choices into the existing ConnectOnion permission engine
- make both ACP and legacy approval responses strict and one-shot
- dual-write the ACP request before the legacy `approval_needed` fallback
- document the architecture in DD-037 and the WebSocket protocol reference

## Rollout order

Merge the compatibility reader first: openonion/connectonion-react#16 and its
packed-package identity/session follow-up openonion/connectonion-react#17.
The Host writer remains backward-compatible because it dual-writes the legacy event.

Closes #871
Parent RFC: #838

## Verification

- `python -m ruff check ...` — passed
- 161 related Host/ACP/approval/ASGI tests — passed
- full suite sampled 1,841 passes before stopping; three unrelated tests were blocked by the workspace sandbox writing `~/.co/ssh`, and one CLI result was interrupted with the run
- `git diff --check`

## Security and review notes

- wrong-session, wrong-request, stale, duplicate, cancelled, and malformed matching responses are covered
- malformed matching responses fail closed as `reject_hard`
- legacy truthy strings and unsupported scopes/modes cannot approve
- `_meta.connectonion.feedback` is accepted only on rejection and never changes authority
- no canonical trace, policy engine, authentication, or persistence format changes
