### PR TITLE
fix: refresh Codex app-server managed auth

### DIFF
--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -118,6 +118,7 @@ def codex(prompt: str, session_id: str = "", cwd: str = "",
     try:
         client.start()
         client.initialize(timeout=_remaining(deadline))
+        client.refresh_account(timeout=_remaining(deadline))
         approval_policy = "untrusted" if approval == "manual" else "never"
         if session_id:
             sid = client.resume_thread(
@@ -470,6 +471,10 @@ class CodexAppServer:
                                                             "item/reasoning/textDelta"]},
         }, timeout=timeout)
         self._notify("initialized", {})
+
+    def refresh_account(self, timeout=60):
+        """Let Codex refresh its managed auth without exposing credentials."""
+        return self.request("account/read", {"refreshToken": True}, timeout=timeout)
 
     def start_thread(
         self,

--- a/tests/e2e/real_api/test_real_claude_code.py
+++ b/tests/e2e/real_api/test_real_claude_code.py
@@ -15,16 +15,33 @@ from connectonion.useful_tools import claude_code
 
 pytestmark = pytest.mark.real_api
 HAS_CLAUDE = bool(os.environ.get("CLAUDE_CODE_CMD") or shutil.which("claude"))
+REAL_CLAUDE_CONFIG_DIR = (
+    os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+)
 requires_claude = pytest.mark.skipif(
     not HAS_CLAUDE, reason="Claude Code CLI is not installed"
 )
+
+
+@pytest.fixture(autouse=True)
+def _use_real_claude_config(monkeypatch):
+    """Opt-in real tests use Claude's config without exposing the whole HOME."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", REAL_CLAUDE_CONFIG_DIR)
 
 
 def _require_success(result):
     if result["status"] == "completed":
         return
     error = result["error"].lower()
-    if any(word in error for word in ("authentication", "log in", "login", "api key")):
+    auth_errors = (
+        "authentication",
+        "authenticate",
+        "log in",
+        "login",
+        "api key",
+        "oauth access token has expired",
+    )
+    if any(message in error for message in auth_errors):
         pytest.skip(result["error"])
     pytest.fail(result["error"])
 

--- a/tests/e2e/real_api/test_real_codex.py
+++ b/tests/e2e/real_api/test_real_codex.py
@@ -27,11 +27,21 @@ from connectonion.useful_tools import codex
 pytestmark = pytest.mark.real_api
 
 HAS_CODEX = bool(os.environ.get("CODEX_CMD") or shutil.which("codex"))
-HAS_AUTH = bool(os.environ.get("OPENAI_API_KEY") or os.environ.get("CODEX_API_KEY")
-                or os.path.exists(os.path.expanduser("~/.codex/auth.json")))
+REAL_CODEX_HOME = os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+HAS_AUTH = bool(
+    os.environ.get("OPENAI_API_KEY")
+    or os.environ.get("CODEX_API_KEY")
+    or os.path.exists(os.path.join(REAL_CODEX_HOME, "auth.json"))
+)
 
 requires_codex = pytest.mark.skipif(
     not HAS_CODEX, reason="codex CLI not installed (npm i -g @openai/codex) / set $CODEX_CMD")
+
+
+@pytest.fixture(autouse=True)
+def _use_real_codex_config(monkeypatch):
+    """Opt-in real tests use Codex's config without exposing the whole HOME."""
+    monkeypatch.setenv("CODEX_HOME", REAL_CODEX_HOME)
 
 
 class _RecordingIO:

--- a/tests/unit/test_co_ai_codex.py
+++ b/tests/unit/test_co_ai_codex.py
@@ -109,6 +109,9 @@ def test_mode_policy_is_reapplied_through_the_resume_protocol(monkeypatch, tmp_p
         def initialize(self, timeout=60):
             pass
 
+        def refresh_account(self, timeout=60):
+            pass
+
         def start_thread(self, **kwargs):
             calls.append(("start", kwargs))
             return "thread-1"

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -45,6 +45,9 @@ class FakeServer:
     def initialize(self, timeout=60):
         self.calls.append("initialize")
 
+    def refresh_account(self, timeout=60):
+        self.calls.append("refresh_account")
+
     def start_thread(
         self,
         sandbox="workspace-write",
@@ -118,6 +121,38 @@ class TestCodexRun:
         assert result["last_message"] == "Hello world"
         assert result["exit_code"] == 0
         assert result["usage"]["input_tokens"] == 5
+        assert FakeServer.last.calls[:4] == [
+            "start",
+            "initialize",
+            "refresh_account",
+            ("start_thread", "workspace-write", "", "never"),
+        ]
+
+    def test_auth_refresh_failure_does_not_start_a_thread(self):
+        class AuthFailureServer(FakeServer):
+            def refresh_account(self, timeout=60):
+                super().refresh_account(timeout)
+                raise RuntimeError("account/read failed: login required")
+
+        with (
+            patch.object(codex_module, "CodexAppServer", AuthFailureServer),
+            patch.object(
+                codex_module,
+                "_base_command",
+                return_value=["codex", "app-server"],
+            ),
+        ):
+            result = json.loads(codex("fix", approval="auto"))
+
+        assert result["error"] == (
+            "codex app-server: account/read failed: login required"
+        )
+        assert AuthFailureServer.last.calls == [
+            "start",
+            "initialize",
+            "refresh_account",
+            "close",
+        ]
 
     def test_resume_reapplies_sandbox_and_model(self):
         agent = _Agent(_IO())
@@ -336,6 +371,15 @@ class TestApprovalDetails:
 
 
 class TestResumeProtocol:
+    def test_account_refresh_uses_codex_managed_auth(self):
+        client = codex_module.CodexAppServer(["codex", "app-server"])
+        with patch.object(client, "request", return_value={}) as request:
+            client.refresh_account(timeout=9)
+
+        request.assert_called_once_with(
+            "account/read", {"refreshToken": True}, timeout=9
+        )
+
     def test_start_uses_separate_process_group_and_drains_stderr(self):
         client = codex_module.CodexAppServer(["codex", "app-server"], cwd="/repo")
         process = MagicMock()


### PR DESCRIPTION
## Summary\n\n- refresh Codex-managed authentication through the official app-server account/read RPC after initialization and before thread start/resume\n- fail before creating a thread when account refresh itself fails\n- let explicitly selected real_api tests use CODEX_HOME and CLAUDE_CONFIG_DIR while preserving the default isolated HOME\n- classify Claude's current expired OAuth response as unavailable authentication, matching the existing skip policy\n\nCloses #874.\nCloses #875.\n\n## Design and security\n\nCodex remains the only credential owner. ConnectOnion never reads, copies, parses, logs, or injects auth.json or bearer tokens. The adapter only asks Codex to refresh its own managed authentication.\n\nNormal tests still receive an empty temporary HOME. Only opt-in real_api tests point each CLI at its tool-specific config directory; the rest of the user's HOME is not restored.\n\nOfficial references:\n\n- https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#auth-endpoints\n- https://code.claude.com/docs/en/env-vars\n\n## Verification\n\n- focused Codex/co-ai/Claude/paid-test gate suite: 131 passed\n- final Codex unit/co-ai rerun: 59 passed\n- real Codex CLI 0.145.0: 2 passed\n  - app-server handshake plus real pong\n  - resume of the same thread and remembered context\n- real Claude Code 2.1.227: correctly reached the actual config, then 2 skipped because the local OAuth token is expired\n- ruff: passed\n- git diff --check: passed\n\n## External follow-up\n\nA user must re-authenticate Claude Code before its real reply/resume checks can pass. This PR does not attempt login or weaken authentication.