### PR TITLE
docs: require design journal for meaningful releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,17 @@ A PR that says *"I didn't test the Windows path and I'm unsure the retry logic i
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 
+## Design Journal Impact
+
+- [ ] Release notes only — maintenance change with no reusable design lesson
+- [ ] Update an existing Design Journal post
+- [ ] Add a new Design Journal post for a feature train, phase promotion, stable release, or material design decision
+- [ ] Not applicable
+
+Link the draft or explain the choice:
+
+>
+
 ## Changes Made
 - List the main changes
 - Be specific about what was modified
@@ -69,6 +80,7 @@ from connectonion import Agent
 - [ ] I have read every line of this diff and can defend each change
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
+- [ ] I have handled the Design Journal impact described above
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,12 @@ git push
 - Mobile-friendly, scannable structure
 - Command blocks use `CommandBlock` component (no $ in copy text)
 - Each page has "copy all as markdown" button
+- Meaningful feature-train launches, phase promotions, stable releases, and
+  material architecture or workflow decisions need a public Design Journal
+  entry. Draft it with the change, record alternatives and tradeoffs, and
+  publish it only after any claimed package and GitHub Release are visible.
+- Maintenance-only patches need release notes, not a thin duplicate blog post,
+  unless they contain a reusable design lesson.
 
 ## Common Development Tasks
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -114,6 +114,10 @@ When releasing a new version:
 - [ ] Update `## Current Version:` and add the release line in this file
 - [ ] Refresh `uv.lock`
 - [ ] Update the matching stable or preview channel in the docs site's `lib/version.ts`
+- [ ] Draft or substantially update a Design Journal post for a feature-train
+      launch, first beta, first RC, stable release, or material architecture or
+      workflow decision. Maintenance-only patches need release notes unless
+      they contain a reusable design lesson.
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
 - [ ] Commit changes: `git commit -m "Release vX.Y.Z: Description"`
 - [ ] Create git tag: `git tag vX.Y.Z`
@@ -124,6 +128,10 @@ When releasing a new version:
 - [ ] Validate both current-version artifacts: `python -m twine check dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`
 - [ ] Check what you built: `pytest tests/e2e/test_the_wheel_works_when_installed.py -m slow`
 - [ ] Upload only the two artifacts just validated: `python -m twine upload dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`
+- [ ] After PyPI and the GitHub Release are visible, publish the docs-site
+      version state and Design Journal. Verify the canonical URL, social and
+      structured metadata, sitemap, AI-readable indexes, internal links, and
+      mobile layout.
 
 Replace `X.Y.Z` with the version being released. Do not upload the whole dist
 directory with a wildcard: build does not remove older artifacts, so that can

--- a/connectonion/useful_skills/ship-feature/SKILL.md
+++ b/connectonion/useful_skills/ship-feature/SKILL.md
@@ -56,14 +56,34 @@ If `docs-site/` exists:
 - Find the corresponding page: `glob("docs-site/app/**/*.{tsx,mdx}")`
 - Update it to match what you changed in `docs/`
 - Respect existing component structure (`CommandBlock`, `CodeBlock`, etc.)
-- Commit and push it as a separate commit in that repo:
-  ```bash
-  cd docs-site && git add . && git commit -m "Update docs for <feature>" && git push && cd ..
-  ```
+- Run its lint and production build. Prepare the docs commit, but do not publish
+  version availability before the matching PyPI package and GitHub Release are
+  public. Publish the prepared docs in Step 5e.
 
 If `docs-site/` does NOT exist locally:
 - Tell the user explicitly: "docs-site was not updated — clone it and run `co copy ship-feature --force` to re-run"
 - Do NOT silently skip — the user must know this is incomplete
+
+### Step 4b: Record the design and release story
+
+For a feature-train launch, first beta, first RC, stable release, or material
+architecture/workflow decision, create or substantially update a Design Journal
+post in the docs site. Maintenance-only patches need release notes unless they
+contain a reusable lesson.
+
+The post must explain:
+- the problem and user impact;
+- alternatives considered;
+- the decision and tradeoffs;
+- evidence and current limitations;
+- what would make the team revisit the decision.
+
+Keep one canonical Markdown source and a rendered blog page. Add the post to the
+blog index, internal navigation, site search, dynamic and static sitemaps,
+`llms.txt`, and relevant AI-readable indexes. Give it unique metadata, a
+canonical URL, social metadata, and `TechArticle` or `BlogPosting` structured
+data. Test desktop and mobile layouts. Draft with provisional wording; do not
+claim that an artifact is published until that is verified.
 
 ## Step 5: Release
 
@@ -112,17 +132,27 @@ twine upload dist/*X.Y.Z*
 
 Confirm upload succeeded by checking the output for "View at: https://pypi.org/project/<package>/X.Y.Z/"
 
+### 5e. Publish documentation and the Design Journal
+
+After the exact PyPI package and GitHub Release are public, commit and push only
+the reviewed docs-site files. Verify the deployed stable/preview labels,
+installation commands, canonical blog URL, structured data, sitemap entry,
+internal links, AI-readable indexes, and mobile rendering. If the docs site
+cannot be published, report the release handoff as incomplete rather than
+silently skipping it.
+
 ## Checklist
 
 - [ ] Tests updated and passing
 - [ ] `docs/` updated
-- [ ] `docs-site/` updated and pushed
+- [ ] `docs-site/` and any required Design Journal post updated; lint and build pass
 - [ ] Version bumped in every file that held it, and they agree
       (in connectonion: `connectonion/_version.py` and `pyproject.toml`;
        `__init__.py` only re-exports it and there is no `setup.py`)
 - [ ] Committed and tagged
 - [ ] Pushed to remote
 - [ ] Published to PyPI
+- [ ] Docs-site version state and Design Journal published after public artifacts were verified
 
 ## Notes
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -10,3 +10,19 @@ ConnectOnion has two release channels:
 
 Preview releases never replace the stable recommendation on the documentation
 site, and GitHub marks them as pre-releases rather than latest releases.
+
+## Design Journal
+
+Release notes record what changed. A Design Journal post records the problem,
+alternatives, decision, tradeoffs, evidence, and what would make us revisit it.
+Meaningful feature-train launches, the first beta and RC, stable releases, and
+material architecture or workflow decisions receive a new or substantially
+updated post.
+
+Maintenance-only patches stay in release history unless they contain a reusable
+design lesson. Drafts can be prepared with the candidate, but the public post
+must not claim that a version is available until PyPI and its GitHub Release are
+visible.
+
+The current release-train decision is documented in
+[Why Alpha, Beta, and RC Come Before ConnectOnion 1.7 LTS](https://docs.connectonion.com/blog/alpha-beta-rc-before-lts).

--- a/docs/useful_skills/ship-feature.md
+++ b/docs/useful_skills/ship-feature.md
@@ -15,13 +15,17 @@ co copy ship-feature
 /ship-feature
 ```
 
-The skill walks through 5 steps automatically:
+The skill walks through 6 steps automatically:
 
 1. **Understand** — reads `git diff` and recent commits to know what changed
 2. **Tests** — finds the matching test file, adds/updates tests, runs them
 3. **docs/** — updates the relevant markdown doc; creates a new one if none exists
-4. **docs-site** — updates the Next.js docs site and pushes its own commit
-5. **Release** — bumps version, commits, tags, pushes, builds, uploads to PyPI
+4. **docs-site** — updates and validates the Next.js docs site without claiming
+   that an unpublished artifact is available
+5. **Design Journal** — records the problem, alternatives, decision, tradeoffs,
+   and evidence for a meaningful release or architecture change
+6. **Release** — bumps version, commits, tags, pushes, publishes the package,
+   then publishes the prepared docs
 
 ## What It Does In Detail
 
@@ -49,16 +53,32 @@ git log --oneline -5  # recent context
 ### Step 4: docs-site
 
 - Checks if `docs-site/` is cloned locally
-- If yes: finds the matching page, updates it, commits and pushes separately
+- If yes: finds the matching page, updates it, and runs lint and a production
+  build
+- Publishes the docs-site commit only after the matching PyPI package and GitHub
+  Release are public
 - If no: **warns you** — does not silently skip
 
-### Step 5: Release
+### Step 5: Design Journal
+
+- Creates or substantially updates a post for a feature-train launch, first
+  beta, first RC, stable release, or material architecture/workflow decision
+- Keeps the canonical Markdown and rendered page aligned
+- Adds metadata, structured data, blog and search entries, sitemap links, and
+  AI-readable index links
+- Tests desktop and mobile layouts
+- Leaves maintenance-only patches in release notes unless they contain a
+  reusable design lesson
+
+### Step 6: Release
 
 - Detects current version from `__init__.py`, `pyproject.toml`, or `setup.py`
 - Reads `VERSIONING.md` for rollover rules if present
 - Updates all files containing the version string
 - Commits, tags, and pushes
 - Builds with `python -m build` and uploads with `twine`
+- Publishes the verified docs-site version state and Design Journal after the
+  public package and GitHub Release exist
 
 ## Required Permissions
 

--- a/tests/unit/test_the_release_checklist_names_real_files.py
+++ b/tests/unit/test_the_release_checklist_names_real_files.py
@@ -147,3 +147,18 @@ class TestReleaseArtifactsCannotMixVersions:
         assert "twine upload dist/*" not in sections
         assert "dist/connectonion-X.Y.Z.tar.gz" in sections
         assert "dist/connectonion-X.Y.Z-py3-none-any.whl" in sections
+
+
+class TestTheReleaseDecisionIsPublished:
+    def test_the_checklist_requires_a_design_journal(self):
+        sections = _release_sections()
+
+        assert "Design Journal" in sections
+        assert "canonical URL" in sections
+
+    def test_the_journal_waits_for_public_artifacts(self):
+        sections = _release_sections()
+
+        assert sections.index("PyPI and the GitHub") < sections.index(
+            "publish the docs-site"
+        )

--- a/tests/unit/test_the_ship_skill_matches_this_repo.py
+++ b/tests/unit/test_the_ship_skill_matches_this_repo.py
@@ -136,3 +136,14 @@ class TestTheSkillIsStillAReleaseProcedure:
 
     def test_it_is_not_empty(self, skill):
         assert len(skill.splitlines()) > 20
+
+
+class TestTheDesignJournalIsPartOfShipping:
+    """A public design record is part of a meaningful release, not cleanup."""
+
+    def test_the_skill_names_the_design_journal_surfaces(self, skill):
+        for required in ("Design Journal", "canonical URL", "sitemaps", "llms.txt"):
+            assert required in skill
+
+    def test_the_skill_does_not_publish_availability_before_artifacts(self, skill):
+        assert "After the exact PyPI package and GitHub Release are public" in skill


### PR DESCRIPTION
## Description

Make a public Design Journal part of the release process for meaningful feature-train launches, phase promotions, stable releases, and material architecture or workflow decisions.

Release notes continue to answer what changed. The journal records the problem, alternatives, decision, tradeoffs, evidence, current limitations, and what would make the team revisit the decision. Maintenance-only patches do not create thin duplicate blog posts unless they contain a reusable lesson.

## Related Issue

Related to #792.

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** Codex (GPT-5).

- Least confidence: the boundary between a reusable design lesson and an ordinary maintenance note still requires maintainer judgment.
- Not verified: the full package suite was not run because this changes only Markdown procedures, the PR template, and focused regression tests.
- If this is wrong, the first failure is process friction: a release may request an unnecessary post or omit one that should have been public.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Design Journal Impact

- [ ] Release notes only
- [x] Update an existing Design Journal post
- [ ] Add a new Design Journal post
- [ ] Not applicable

Published post: https://docs.connectonion.com/blog/alpha-beta-rc-before-lts

## Changes Made

- add Design Journal impact to the PR template
- require the journal in `VERSIONING.md`, `AGENTS.md`, and the shipped `ship-feature` skill
- document the six-step workflow in the user-facing skill page
- make docs publication wait until the claimed PyPI package and GitHub Release are public
- add regression tests that protect the journal surfaces and publication ordering

## Testing

```text
$ pytest -q tests/unit/test_the_ship_skill_matches_this_repo.py tests/unit/test_the_release_checklist_names_real_files.py
27 passed in 1.79s
```

## Scope

Eight files: release instructions, PR template, shipped and user-facing skill documentation, plus focused process tests. No runtime code, version number, tag, or package artifact changes.
