### PR TITLE
feat: accept negotiated ACP Host cancellation

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -15,6 +15,7 @@ from acp import text_block, tool_content
 from acp.schema import (
     AgentMessageChunk,
     AgentRequest,
+    CancelNotification,
     PermissionOption,
     RequestPermissionRequest,
     RequestPermissionResponse,
@@ -32,6 +33,7 @@ ACP_RESPONSE_FRAME_TYPE = "ACP_RESPONSE"
 ACP_SCHEMA_VERSION = "schema-v1.19.0"
 ACP_SESSION_UPDATE_METHOD = "session/update"
 ACP_PERMISSION_METHOD = "session/request_permission"
+ACP_CANCEL_METHOD = "session/cancel"
 
 ACP_PERMISSION_OPTIONS = (
     PermissionOption(
@@ -229,6 +231,31 @@ def legacy_approval_response_from_acp(
     if feedback:
         response["feedback"] = feedback
     return response
+
+
+def legacy_interrupt_from_acp_cancel(
+    frame: Mapping[str, Any], *, expected_session_id: str
+) -> dict[str, str]:
+    """Validate one exact ACP cancel notification and map it to Host IO."""
+
+    if frame.get("type") != ACP_FRAME_TYPE:
+        raise ValueError("Unsupported ACP cancel carrier")
+    if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
+        raise ValueError("Unsupported ACP carrier schema")
+    message = _required_mapping(frame, "message")
+    if set(message) != {"jsonrpc", "method", "params"}:
+        raise ValueError("ACP cancel must be a JSON-RPC notification")
+    if message.get("jsonrpc") != "2.0":
+        raise ValueError("ACP cancel jsonrpc must be '2.0'")
+    if message.get("method") != ACP_CANCEL_METHOD:
+        raise ValueError("Unsupported ACP client notification method")
+    params = _required_mapping(message, "params")
+    if not isinstance(params.get("sessionId"), str):
+        raise ValueError("ACP cancel sessionId must be a string")
+    cancel = CancelNotification.model_validate(params)
+    if cancel.session_id != expected_session_id:
+        raise ValueError("ACP cancel belongs to another session")
+    return {"type": "INTERRUPT"}
 
 
 def _hard_rejection() -> dict[str, Any]:

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -11,6 +11,8 @@ LLM-Note:
 import uuid
 
 from rich.console import Console
+
+from ....core.acp_wire import ACP_CANCEL_METHOD, ACP_SCHEMA_VERSION
 from ...trust.ws_admin import get_onboard_requirements
 from .agent_io import resume_forwarding
 
@@ -120,7 +122,7 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
             client = conn["session"] or {}
             conn["session"], server_newer = merge_sessions(client_session=client, server_session=stored.session)
             if server_newer:
-                console.print(f"  [dim]↕ merged sessions (server newer)[/dim]")
+                console.print("  [dim]↕ merged sessions (server newer)[/dim]")
 
     # The live half, and the worse one: resume_forwarding rewinds and streams
     # the output of a turn already in progress. A caller who does not own it was
@@ -136,7 +138,17 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
 
     console.print(f"[green]✓ CONNECT[/green] agent_address={agent_address[:16]}... session={session_id[:8]}... status={status}{' (server_newer)' if server_newer else ''}")
 
-    connected_msg = {"type": "CONNECTED", "session_id": session_id, "status": status}
+    connected_msg = {
+        "type": "CONNECTED",
+        "session_id": session_id,
+        "status": status,
+        "carrier_capabilities": {
+            "acp": {
+                "schema": ACP_SCHEMA_VERSION,
+                "client_notifications": [ACP_CANCEL_METHOD],
+            }
+        },
+    }
     if server_newer and conn["session"]:
         from ..session import session_to_chat_items
         connected_msg["server_newer"] = True

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -206,7 +206,14 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     task.add_done_callback(exec_tasks.discard)
 
             elif msg_type == "ACP_NOTIFICATION":
-                if not active_io:
+                sid = conn.get("session_id")
+                registered = registry.get(sid) if sid else None
+                if (
+                    not active_io
+                    or not registered
+                    or registered.status != "running"
+                    or registered.io is not active_io
+                ):
                     await send_msg({
                         "type": "ERROR",
                         "message": "ACP cancel requires an active turn",
@@ -231,7 +238,14 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     request_interrupt()
 
             elif msg_type == "INTERRUPT":
-                if not active_io:
+                sid = conn.get("session_id")
+                registered = registry.get(sid) if sid else None
+                if (
+                    not active_io
+                    or not registered
+                    or registered.status != "running"
+                    or registered.io is not active_io
+                ):
                     await send_msg({
                         "type": "ERROR",
                         "message": "interrupt requires an active turn",

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -205,6 +205,44 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
 
+            elif msg_type == "ACP_NOTIFICATION":
+                if not active_io:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "ACP cancel requires an active turn",
+                    })
+                    continue
+                from ....core.acp_wire import legacy_interrupt_from_acp_cancel
+
+                try:
+                    interrupt = legacy_interrupt_from_acp_cancel(
+                        data, expected_session_id=conn.get("session_id")
+                    )
+                except (TypeError, ValueError) as exc:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": f"invalid ACP cancel: {exc}",
+                    })
+                    continue
+                request_interrupt = getattr(active_io, "request_interrupt", None)
+                if request_interrupt is None:
+                    active_io.send_to_agent(interrupt)
+                else:
+                    request_interrupt()
+
+            elif msg_type == "INTERRUPT":
+                if not active_io:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "interrupt requires an active turn",
+                    })
+                    continue
+                request_interrupt = getattr(active_io, "request_interrupt", None)
+                if request_interrupt is None:
+                    active_io.send_to_agent(data)
+                else:
+                    request_interrupt()
+
             elif msg_type == "ACP_RESPONSE":
                 if not active_io or not active_io.resolve_acp_permission(
                     data, conn.get("session_id")

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -46,6 +46,7 @@ class WebSocketIO(IO):
 
         self._closed = False
         self._pending_permission: Dict[str, Any] | None = None
+        self._interrupt_requested = False
 
     # ═══════════════════════════════════════════════════════
     # Agent side (sync)
@@ -155,6 +156,17 @@ class WebSocketIO(IO):
         with self._client_condition:
             self._msgs_from_client.append(msg)
             self._client_condition.notify_all()
+
+    def request_interrupt(self) -> bool:
+        """Deliver at most one interrupt for this turn's IO generation."""
+
+        with self._client_condition:
+            if self._interrupt_requested:
+                return False
+            self._interrupt_requested = True
+            self._msgs_from_client.append({"type": "INTERRUPT"})
+            self._client_condition.notify_all()
+            return True
 
     def register_permission_request(
         self,

--- a/docs/design-decisions/038-negotiated-acp-host-cancellation.md
+++ b/docs/design-decisions/038-negotiated-acp-host-cancellation.md
@@ -1,0 +1,56 @@
+# DD-038: Negotiate ACP Host Cancellation Without Duplicate Interrupts
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Related:** [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md), [037 Bound ACP Host Permissions](037-bound-acp-host-permissions.md)
+
+## Decision
+
+The authenticated Host WebSocket accepts an `ACP_NOTIFICATION` carrier whose
+nested message is one exact ACP v1.19 `session/cancel` JSON-RPC notification.
+The Host validates the carrier schema and connection-owned session ID, then
+maps it to the existing internal `INTERRUPT` lifecycle from DD-025. Canonical
+traces, persistence, provider calls, and stop-signal semantics do not gain a
+second cancellation implementation.
+
+`CONNECTED.carrier_capabilities` advertises the exact ACP schema and accepted
+client notification method. `@connectonion/react` sends the ACP form only when
+that capability is present and otherwise sends the legacy `INTERRUPT`. It must
+never send both: a second queued interrupt could be consumed by a later turn.
+
+Each active `WebSocketIO` generation accepts one interrupt request. The guard
+lives on the IO rather than a physical socket, so reconnects and repeated
+clicks cannot enqueue another signal. A new turn receives a new IO and a fresh
+guard. A cancellation that loses the completion race stays in the completed
+IO and cannot reach the next input.
+
+When an ACP permission request is pending, the React client answers that exact
+request with `RequestPermissionOutcome::Cancelled` rather than also sending a
+session cancellation. DD-037 maps the outcome to the existing hard rejection,
+which stops the turn without leaving an orphan interrupt.
+
+## Compatibility and security
+
+Released clients may continue sending `INTERRUPT`; the Host routes it through
+the same one-shot IO guard. A client notification must arrive on an
+authenticated connection and, when signed-command mode is negotiated, pass
+the existing command signature and replay gate before ACP validation.
+
+Wrong session IDs, unknown schemas or methods, malformed JSON-RPC messages,
+and cancellation without an active turn receive explicit errors and execute
+no cancellation. The capability is ConnectOnion carrier metadata, not ACP
+`initialize` negotiation and not a grant of authority.
+
+## Rollout and rollback
+
+The Host reader and capability land first. The React writer lands second, and
+O Chat then delegates its Stop action to React. Rollback removes the advertised
+capability and ACP adapter; React falls back to the unchanged legacy frame.
+
+## Rejected alternatives
+
+- **Dual-send ACP and legacy cancel:** duplicate signals can cross a turn boundary.
+- **Assume all Hosts understand ACP cancel:** breaks released Host versions.
+- **Teach O Chat the capability or JSON-RPC shape:** duplicates protocol ownership.
+- **Cancel arbitrary Python threads:** DD-025 rejects unsafe termination; this
+  adapter preserves bounded abandonment and its documented side-effect limits.

--- a/tests/unit/test_acp_host_cancel.py
+++ b/tests/unit/test_acp_host_cancel.py
@@ -1,6 +1,7 @@
 """ACP session/cancel over the authenticated Host carrier."""
 
 from copy import deepcopy
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -66,7 +67,7 @@ def test_one_io_generation_accepts_one_interrupt_but_the_next_is_fresh():
     assert second.receive_all() == [{"type": "INTERRUPT"}]
 
 
-async def run_cancel(monkeypatch, *frames, active=True):
+async def run_cancel(monkeypatch, *frames, active=True, registry_status="running"):
     from connectonion.network.host.ws_router import session as ws_session
 
     io = WebSocketIO()
@@ -88,12 +89,16 @@ async def run_cancel(monkeypatch, *frames, active=True):
         sent.append(message)
 
     monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    registry = Mock()
+    registry.get.return_value = (
+        SimpleNamespace(status=registry_status, io=io) if active else None
+    )
     await ws_session.run_ws_session(
         send_msg,
         recv_msg,
         route_handlers={},
         storage=None,
-        registry=None,
+        registry=registry,
         trust=None,
         enable_ping=False,
     )
@@ -133,6 +138,19 @@ async def test_dispatch_rejects_cross_session_cancel_without_interrupt(monkeypat
 async def test_dispatch_rejects_cancel_without_an_active_turn(monkeypatch):
     mailbox, sent = await run_cancel(
         monkeypatch, cancel_frame(), active=False
+    )
+
+    assert mailbox == []
+    assert sent == [{
+        "type": "ERROR",
+        "message": "ACP cancel requires an active turn",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_cancel_after_the_turn_finished(monkeypatch):
+    mailbox, sent = await run_cancel(
+        monkeypatch, cancel_frame(), registry_status="connected"
     )
 
     assert mailbox == []

--- a/tests/unit/test_acp_host_cancel.py
+++ b/tests/unit/test_acp_host_cancel.py
@@ -1,0 +1,171 @@
+"""ACP session/cancel over the authenticated Host carrier."""
+
+from copy import deepcopy
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from connectonion.core.acp_wire import (
+    ACP_SCHEMA_VERSION,
+    legacy_interrupt_from_acp_cancel,
+)
+from connectonion.network.io import WebSocketIO
+
+SESSION_ID = "session-cancel"
+
+
+def cancel_frame(session_id=SESSION_ID):
+    return {
+        "type": "ACP_NOTIFICATION",
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "message": {
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": {"sessionId": session_id},
+        },
+    }
+
+
+def test_exact_cancel_maps_to_the_existing_interrupt_lifecycle():
+    assert legacy_interrupt_from_acp_cancel(
+        cancel_frame(), expected_session_id=SESSION_ID
+    ) == {"type": "INTERRUPT"}
+
+
+@pytest.mark.parametrize(
+    "mutate, message",
+    [
+        (lambda frame: frame.update(acpSchema="schema-v9"), "schema"),
+        (lambda frame: frame["message"].update(jsonrpc="1.0"), "jsonrpc"),
+        (lambda frame: frame["message"].update(method="session/update"), "method"),
+        (lambda frame: frame["message"].update(id="request-not-notification"), "notification"),
+        (lambda frame: frame["message"]["params"].update(sessionId="other"), "another session"),
+        (lambda frame: frame["message"]["params"].update(sessionId=7), "string"),
+    ],
+)
+def test_malformed_or_cross_session_cancel_fails_closed(mutate, message):
+    frame = deepcopy(cancel_frame())
+    mutate(frame)
+
+    with pytest.raises(ValueError, match=message):
+        legacy_interrupt_from_acp_cancel(
+            frame, expected_session_id=SESSION_ID
+        )
+
+
+def test_one_io_generation_accepts_one_interrupt_but_the_next_is_fresh():
+    first = WebSocketIO()
+    assert first.request_interrupt() is True
+    assert first.request_interrupt() is False
+    assert first.receive_all() == [{"type": "INTERRUPT"}]
+    assert first.request_interrupt() is False
+    assert first.receive_all() == []
+
+    second = WebSocketIO()
+    assert second.request_interrupt() is True
+    assert second.receive_all() == [{"type": "INTERRUPT"}]
+
+
+async def run_cancel(monkeypatch, *frames, active=True):
+    from connectonion.network.host.ws_router import session as ws_session
+
+    io = WebSocketIO()
+    queue = [{"type": "CONNECT"}, *frames]
+    sent = []
+
+    async def fake_connect(data, send_msg, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address="operator",
+            session_id=SESSION_ID,
+        )
+        return (io, None) if active else None
+
+    async def recv_msg():
+        return queue.pop(0) if queue else None
+
+    async def send_msg(message):
+        sent.append(message)
+
+    monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    await ws_session.run_ws_session(
+        send_msg,
+        recv_msg,
+        route_handlers={},
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+    )
+    return io.receive_all(), sent
+
+
+@pytest.mark.asyncio
+async def test_dispatch_delivers_repeated_acp_cancel_once(monkeypatch):
+    mailbox, sent = await run_cancel(
+        monkeypatch, cancel_frame(), cancel_frame()
+    )
+
+    assert mailbox == [{"type": "INTERRUPT"}]
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_keeps_legacy_interrupt_but_makes_it_one_shot(monkeypatch):
+    mailbox, sent = await run_cancel(
+        monkeypatch, {"type": "INTERRUPT"}, {"type": "INTERRUPT"}
+    )
+
+    assert mailbox == [{"type": "INTERRUPT"}]
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_cross_session_cancel_without_interrupt(monkeypatch):
+    mailbox, sent = await run_cancel(monkeypatch, cancel_frame("other"))
+
+    assert mailbox == []
+    assert sent[0]["type"] == "ERROR"
+    assert "another session" in sent[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_cancel_without_an_active_turn(monkeypatch):
+    mailbox, sent = await run_cancel(
+        monkeypatch, cancel_frame(), active=False
+    )
+
+    assert mailbox == []
+    assert sent == [{
+        "type": "ERROR",
+        "message": "ACP cancel requires an active turn",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_connected_advertises_the_cancel_adapter(tmp_path, monkeypatch):
+    from connectonion.network.host.ws_router.connect import establish_connection
+
+    monkeypatch.chdir(tmp_path)
+    sent = []
+    storage = Mock()
+    storage.get.return_value = None
+    registry = Mock()
+    registry.get.return_value = None
+
+    await establish_connection(
+        {},
+        "0xoperator",
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        {},
+        storage,
+        registry,
+    )
+
+    connected = next(message for message in sent if message["type"] == "CONNECTED")
+    assert connected["carrier_capabilities"] == {
+        "acp": {
+            "schema": "schema-v1.19.0",
+            "client_notifications": ["session/cancel"],
+        }
+    }


### PR DESCRIPTION
Closes #878.

## Summary

- accept an exact schema-v1.19.0 session/cancel notification inside the existing Host carrier
- advertise that client-notification capability in CONNECTED so React sends exactly one protocol form
- map ACP and legacy cancellation to one one-shot WebSocketIO interrupt generation
- reject wrong-session, malformed, unsupported, and idle cancellation without changing canonical traces
- record the lifecycle, compatibility, security, rollout, and rejected alternatives in DD-038

## Architecture

The Host WebSocket remains a ConnectOnion transport. The nested message is exact ACP; the outer carrier, authentication, session ownership, persistence, and DD-025 interrupt lifecycle remain ConnectOnion-owned. The frontend path is Host -> @connectonion/react -> O Chat. The retired standalone TypeScript SDK is not involved.

## Compatibility and safety

The Host reader lands first. A future React writer uses session/cancel only after CONNECTED advertises it and otherwise sends legacy INTERRUPT. It must never dual-send. The IO-scoped one-shot guard survives reconnects and prevents a repeated or completion-boundary signal from cancelling the next turn. Signed-command mode continues to authenticate and replay-check the entire carrier before this adapter runs.

## Verification

- 346 Host, ASGI WebSocket, IO, ACP, signature, interrupt, runtime-input, and session-ownership tests passed
- focused post-review run: 73 passed
- ruff, compileall, and git diff checks passed
- package sdist and wheel build passed
- Linus-style simplicity review removed an unnecessary one-use capability helper and found no remaining blocker

Bandit is not installed in the local environment; the repository CodeQL/security workflow remains a required merge gate.