### PR TITLE
feat: mirror authoritative ACP Host mode updates

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -16,6 +16,7 @@ from acp.schema import (
     AgentMessageChunk,
     AgentRequest,
     CancelNotification,
+    CurrentModeUpdate,
     PermissionOption,
     RequestPermissionRequest,
     RequestPermissionResponse,
@@ -34,6 +35,7 @@ ACP_SCHEMA_VERSION = "schema-v1.19.0"
 ACP_SESSION_UPDATE_METHOD = "session/update"
 ACP_PERMISSION_METHOD = "session/request_permission"
 ACP_CANCEL_METHOD = "session/cancel"
+ACP_SESSION_MODE_IDS = frozenset({"safe", "accept_edits", "ulw"})
 
 ACP_PERMISSION_OPTIONS = (
     PermissionOption(
@@ -96,6 +98,27 @@ def map_message_event(
     )
 
 
+def session_mode_id(value: Any) -> str:
+    """Return one persisted server mode ID or reject it without coercion."""
+
+    if not isinstance(value, str) or value not in ACP_SESSION_MODE_IDS:
+        raise ValueError(f"Unsupported ACP session mode: {value!r}")
+    return value
+
+
+def map_mode_event(
+    event: Mapping[str, Any],
+) -> CurrentModeUpdate | None:
+    """Map an authoritative Host mode observation to ACP v1.19."""
+
+    if event.get("type") != "mode_changed":
+        return None
+    return CurrentModeUpdate(
+        session_update="current_mode_update",
+        current_mode_id=session_mode_id(event.get("mode")),
+    )
+
+
 def _tool_start(event: Mapping[str, Any]) -> ToolCallStart:
     return ToolCallStart(
         session_update="tool_call",
@@ -131,7 +154,11 @@ def acp_notification_frame(
 ) -> dict[str, Any] | None:
     """Return a detached ConnectOnion carrier for one supported ACP update."""
 
-    update = map_tool_event(event) or map_message_event(event)
+    update = (
+        map_tool_event(event)
+        or map_message_event(event)
+        or map_mode_event(event)
+    )
     if update is None:
         return None
     notification = SessionNotification(session_id=session_id, update=update)
@@ -277,6 +304,37 @@ def legacy_tool_event_from_acp(
 ) -> dict[str, Any] | None:
     """Decode an ACP tool notification for the legacy Python UI mapper."""
 
+    decoded = _session_update_from_acp(frame)
+    if decoded is None:
+        return None
+    _, update = decoded
+    return _legacy_tool_event(update)
+
+
+def legacy_stream_event_from_acp(
+    frame: Mapping[str, Any],
+    *,
+    expected_session_id: str | None,
+) -> dict[str, Any] | None:
+    """Decode one ACP notification for the legacy Python stream handler."""
+
+    decoded = _session_update_from_acp(frame)
+    if decoded is None:
+        return None
+    session_id, update = decoded
+    if update.get("sessionUpdate") == "current_mode_update":
+        if expected_session_id is None or session_id != expected_session_id:
+            raise ValueError("ACP mode update belongs to another session")
+        return {
+            "type": "mode_changed",
+            "mode": session_mode_id(update.get("currentModeId")),
+        }
+    return _legacy_tool_event(update)
+
+
+def _session_update_from_acp(
+    frame: Mapping[str, Any],
+) -> tuple[str, Mapping[str, Any]] | None:
     if frame.get("type") != ACP_FRAME_TYPE:
         return None
     if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
@@ -287,9 +345,9 @@ def legacy_tool_event_from_acp(
     if message.get("method") != ACP_SESSION_UPDATE_METHOD:
         raise ValueError("Unsupported ACP notification method")
     params = _required_mapping(message, "params")
-    _required_string(params, "sessionId")
+    session_id = _required_string(params, "sessionId")
     update = _required_mapping(params, "update")
-    return _legacy_tool_event(update)
+    return session_id, update
 
 
 def _legacy_tool_event(update: Mapping[str, Any]) -> dict[str, Any]:

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -31,7 +31,10 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import httpx
 
 from .. import address as addr
-from ..core.acp_wire import legacy_tool_event_from_acp
+from ..core.acp_wire import (
+    legacy_stream_event_from_acp,
+    session_mode_id,
+)
 
 
 def _tool_ui_status(status: Any, *, terminal: bool = False) -> str:
@@ -829,7 +832,14 @@ class RemoteAgent:
     def _handle_stream_event(self, event: Dict[str, Any]) -> None:
         """Handle streaming event and update UI."""
         try:
-            acp_event = legacy_tool_event_from_acp(event)
+            session_id = (
+                self._current_session.get("session_id")
+                if isinstance(self._current_session, dict)
+                else None
+            )
+            acp_event = legacy_stream_event_from_acp(
+                event, expected_session_id=session_id
+            )
         except (TypeError, ValueError):
             return
         if acp_event is not None:
@@ -902,6 +912,22 @@ class RemoteAgent:
                 "type": "agent",
                 "content": event.get("content")
             })
+
+        elif event_type == "mode_changed":
+            if not isinstance(self._current_session, dict):
+                return
+            current_session_id = self._current_session.get("session_id")
+            event_session_id = event.get("session_id")
+            if (
+                event_session_id is not None
+                and event_session_id != current_session_id
+            ):
+                return
+            try:
+                mode = session_mode_id(event.get("mode"))
+            except ValueError:
+                return
+            self._current_session["mode"] = mode
 
         elif event_type == "llm_call":
             # Internal event, add thinking indicator if not already present

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -137,13 +137,15 @@ async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holde
                 await send_msg(acp_request)
         acp_frame = (
             _acp_rollout_frame(event, session_id)
-            if event.get("type") in {"tool_call", "tool_result"}
+            if event.get("type") in {
+                "tool_call", "tool_result", "mode_changed"
+            }
             else None
         )
         if acp_frame is not None:
             await send_msg(acp_frame)
             # Rollout is dual-write: older clients still need the legacy event,
-            # while new clients de-duplicate both shapes by the stable tool ID.
+            # while new clients de-duplicate the matching logical transition.
         if session_id:
             event["session_id"] = session_id
         await send_msg(event)

--- a/docs/design-decisions/039-authoritative-acp-host-mode-updates.md
+++ b/docs/design-decisions/039-authoritative-acp-host-mode-updates.md
@@ -1,0 +1,65 @@
+# DD-039: Host mode updates report authority; they do not grant it
+
+**Status:** Accepted
+
+**Date:** 2026-08-11
+
+## Context
+
+DD-031 defines ACP session-mode authority for the local stdio adapter. The
+authenticated network Host still reports an Agent's completed mode change only
+as the ConnectOnion `mode_changed` event. The active browser path is Host →
+`@connectonion/react` → O Chat; the standalone TypeScript SDK is retired.
+
+The network carrier needs ACP-compatible output without turning a presentation
+field into a permission grant or changing persisted sessions during rollout.
+
+## Decision
+
+The Host mirrors an Agent-originated `mode_changed` event as the exact ACP v1.19
+`CurrentModeUpdate(sessionUpdate="current_mode_update")`. The persisted IDs are
+used directly: `safe`, `accept_edits`, and `ulw`. `plan` is a legacy request
+alias that the Agent normalizes to Safe; it is not valid authoritative output.
+
+The Host-owned connection session ID is placed in the ACP notification. A
+session ID supplied by the Agent event is never trusted. The ACP mirror is sent
+immediately before the existing legacy event, preserving event order. Invalid
+mode IDs skip the additive mirror without blocking the legacy stream or the
+terminal `OUTPUT`; updated readers validate both representations and ignore the
+invalid value.
+
+This notification reports policy that the Agent has already applied. It cannot
+change approval behavior, restore ULW, increase ULW turns, or bypass the
+operator checks in the tool-approval hooks. Canonical traces and session
+snapshots remain unchanged.
+
+Client `mode_change` is not renamed to ACP `session/set_mode` in this slice.
+That request needs its own transaction design covering an owned response,
+available-mode advertisement, busy-session rejection, durable commit, and the
+`--yolo` launch-authority ceiling from DD-031.
+
+## Consequences
+
+- React can consume one standard authoritative mode notification while O Chat
+  stays protocol-free.
+- New readers de-duplicate ACP plus legacy output; old readers keep working.
+- Unknown modes cannot become more permissive by coercion.
+- Rollback stops the additive mirror and does not rewrite stored data.
+
+## Rejected alternatives
+
+- **Treat `currentModeId` as authority:** a client-controlled field must not
+  grant tool permissions.
+- **Emit ACP only:** breaks released clients during a minor-version rollout.
+- **Map `plan` as a persisted ACP mode:** preserves a UI alias the Agent does
+  not actually enforce.
+- **Migrate the setter at the same time:** combines observation with a durable,
+  security-sensitive policy transaction.
+
+## Related decisions
+
+- DD-031: ACP session modes stay below launch authority
+- DD-035: Versioned ACP Host carrier
+- DD-037: Bound ACP Host permissions
+- DD-038: Negotiated ACP Host cancellation
+

--- a/tests/unit/test_acp_host_mode.py
+++ b/tests/unit/test_acp_host_mode.py
@@ -1,0 +1,175 @@
+"""Authoritative ACP Host mode notifications and compatibility readers."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+
+import pytest
+
+from connectonion.core.acp_wire import (
+    acp_notification_frame,
+    legacy_stream_event_from_acp,
+)
+from connectonion.network.connect import RemoteAgent
+from connectonion.network.host.ws_router.agent_io import (
+    forward_agent_msgs_to_client,
+)
+from connectonion.network.io import WebSocketIO
+
+SESSION_ID = "session-mode-881"
+
+
+def mode_frame(mode: str, session_id: str = SESSION_ID) -> dict:
+    return {
+        "type": "ACP_NOTIFICATION",
+        "acpSchema": "schema-v1.19.0",
+        "message": {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "currentModeId": mode,
+                    "sessionUpdate": "current_mode_update",
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize("mode", ["safe", "accept_edits", "ulw"])
+def test_host_serializes_exact_acp_mode_updates(mode):
+    event = {"type": "mode_changed", "mode": mode}
+    original = deepcopy(event)
+
+    assert acp_notification_frame(event, SESSION_ID) == mode_frame(mode)
+    assert event == original
+
+
+@pytest.mark.parametrize("mode", ["plan", "future", "", None, 1])
+def test_host_rejects_non_authoritative_output_modes(mode):
+    with pytest.raises(ValueError, match="Unsupported ACP session mode"):
+        acp_notification_frame(
+            {"type": "mode_changed", "mode": mode}, SESSION_ID
+        )
+
+
+def test_python_decoder_binds_mode_to_the_active_session():
+    assert legacy_stream_event_from_acp(
+        mode_frame("accept_edits"), expected_session_id=SESSION_ID
+    ) == {"type": "mode_changed", "mode": "accept_edits"}
+
+    with pytest.raises(ValueError, match="another session"):
+        legacy_stream_event_from_acp(
+            mode_frame("ulw", "other-session"),
+            expected_session_id=SESSION_ID,
+        )
+
+
+def test_python_remote_agent_deduplicates_acp_and_legacy_mode_output():
+    agent = RemoteAgent("0xabc")
+    agent._current_session = {
+        "session_id": SESSION_ID,
+        "mode": "safe",
+        "turn": 4,
+    }
+
+    agent._handle_stream_event(mode_frame("ulw"))
+    agent._handle_stream_event({
+        "type": "mode_changed",
+        "mode": "ulw",
+        "session_id": SESSION_ID,
+    })
+
+    assert agent.current_session == {
+        "session_id": SESSION_ID,
+        "mode": "ulw",
+        "turn": 4,
+    }
+    assert agent.ui == []
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        mode_frame("ulw", "other-session"),
+        {"type": "mode_changed", "mode": "future"},
+        {
+            "type": "mode_changed",
+            "mode": "ulw",
+            "session_id": "other-session",
+        },
+    ],
+)
+def test_python_remote_agent_ignores_unowned_or_unknown_modes(event):
+    agent = RemoteAgent("0xabc")
+    agent._current_session = {"session_id": SESSION_ID, "mode": "safe"}
+
+    agent._handle_stream_event(event)
+
+    assert agent.current_session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_host_dual_writes_mode_in_order():
+    io = WebSocketIO()
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    io.send({"type": "mode_changed", "mode": "accept_edits"})
+    io.mark_agent_done()
+
+    await asyncio.wait_for(
+        forward_agent_msgs_to_client(
+            send,
+            io,
+            SESSION_ID,
+            result_holder=[{
+                "result": "done",
+                "duration_ms": 1,
+                "session": {},
+            }],
+        ),
+        timeout=2,
+    )
+
+    assert [message["type"] for message in sent[:2]] == [
+        "ACP_NOTIFICATION",
+        "mode_changed",
+    ]
+    assert sent[0] == mode_frame("accept_edits")
+    assert sent[1]["type"] == "mode_changed"
+    assert sent[1]["mode"] == "accept_edits"
+    assert sent[1]["session_id"] == SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_bad_mode_mirror_preserves_legacy_and_output():
+    io = WebSocketIO()
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    io.send({"type": "mode_changed", "mode": "plan"})
+    io.mark_agent_done()
+
+    await forward_agent_msgs_to_client(
+        send,
+        io,
+        SESSION_ID,
+        result_holder=[{
+            "result": "done",
+            "duration_ms": 1,
+            "session": {},
+        }],
+    )
+
+    assert [message["type"] for message in sent[:2]] == [
+        "mode_changed",
+        "OUTPUT",
+    ]
+    assert sent[0]["mode"] == "plan"


### PR DESCRIPTION
## Summary
- mirror Host mode_changed output as exact ACP v1.19 current_mode_update before the legacy event
- bind the authoritative mode observation to the Host-owned session and reject unknown or request-only aliases
- update the Python compatibility reader without adding UI items or granting mode authority
- record the rollout/security boundary in DD-039

The active frontend path is Host -> @connectonion/react -> O Chat. React reader PR openonion/connectonion-react#21 is already merged; the retired standalone TypeScript SDK and O Chat protocol code are intentionally untouched.

## Security boundary
This is observation only. It does not implement session/set_mode, change approval behavior, restore ULW, extend ULW turns, or bypass launch authority. Invalid modes cannot become more permissive through coercion.

## Validation
- 109 ACP Host/stdio tests passed in an isolated declared-dependency environment
- broader focused ACP/approval/ULW/Host/Python suite: 330 passed
- full local unit run: 6353 passed, 13 skipped; permission-only failures re-ran 110/110 outside the sandbox; missing-MCP failures re-ran 25/25 after installing declared mcp 2.0
- Ruff passed on changed Python files
- uv lock --check passed
- locked production dependency audit: no known vulnerabilities
- source distribution and wheel build passed
- expert/self-review completed; one double-parse reader path was simplified before submission

Closes #881
Related to #838