### PR TITLE
feat: add durable ACP Host session mode transactions

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -89,7 +89,8 @@ _FROM = {
         "read_file", "edit", "multi_edit", "glob", "grep", "write",
     )},
     **{name: ".network" for name in (
-        "connect", "RemoteAgent", "Response", "ExecResult", "host", "create_app",
+        "connect", "RemoteAgent", "Response", "ExecResult", "ACPModeError",
+        "host", "create_app",
         "IO", "relay", "announce", "HTTPRequest", "HTTPResponse", "HTTPRoute",
         "HTTPRouter",
     )},
@@ -198,6 +199,7 @@ __all__ = [
     "RemoteAgent",
     "Response",
     "ExecResult",
+    "ACPModeError",
     "host",
     "create_app",
     "IO",

--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -20,7 +20,11 @@ from acp.schema import (
     PermissionOption,
     RequestPermissionRequest,
     RequestPermissionResponse,
+    SessionMode,
+    SessionModeState,
     SessionNotification,
+    SetSessionModeRequest,
+    SetSessionModeResponse,
     ToolCallProgress,
     ToolCallStart,
     ToolCallUpdate,
@@ -35,7 +39,26 @@ ACP_SCHEMA_VERSION = "schema-v1.19.0"
 ACP_SESSION_UPDATE_METHOD = "session/update"
 ACP_PERMISSION_METHOD = "session/request_permission"
 ACP_CANCEL_METHOD = "session/cancel"
+ACP_SET_SESSION_MODE_METHOD = "session/set_mode"
 ACP_SESSION_MODE_IDS = frozenset({"safe", "accept_edits", "ulw"})
+
+ACP_SESSION_MODES = {
+    "safe": SessionMode(
+        id="safe",
+        name="Safe",
+        description="Ask before side effects.",
+    ),
+    "accept_edits": SessionMode(
+        id="accept_edits",
+        name="Auto",
+        description="Apply edits without asking; other tools still require approval.",
+    ),
+    "ulw": SessionMode(
+        id="ulw",
+        name="ULW",
+        description="Run without tool approvals within the Host launch ceiling.",
+    ),
+}
 
 ACP_PERMISSION_OPTIONS = (
     PermissionOption(
@@ -104,6 +127,129 @@ def session_mode_id(value: Any) -> str:
     if not isinstance(value, str) or value not in ACP_SESSION_MODE_IDS:
         raise ValueError(f"Unsupported ACP session mode: {value!r}")
     return value
+
+
+def acp_session_mode_state(
+    current_mode_id: Any, available_mode_ids: list[str] | tuple[str, ...]
+) -> dict[str, Any]:
+    """Serialize one exact official SessionModeState for CONNECTED."""
+
+    current = session_mode_id(current_mode_id)
+    available: list[SessionMode] = []
+    seen: set[str] = set()
+    for value in available_mode_ids:
+        mode_id = session_mode_id(value)
+        if mode_id in seen:
+            raise ValueError(f"ACP session mode is duplicate: {mode_id!r}")
+        seen.add(mode_id)
+        available.append(ACP_SESSION_MODES[mode_id].model_copy(deep=True))
+    if current not in seen:
+        raise ValueError(f"Current ACP session mode is not advertised: {current!r}")
+    state = SessionModeState(
+        current_mode_id=current,
+        available_modes=available,
+    )
+    return state.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+
+
+def acp_set_mode_request_id(frame: Mapping[str, Any]) -> str | None:
+    """Return correlation identity only for this supported carrier method."""
+
+    if (
+        frame.get("type") != ACP_REQUEST_FRAME_TYPE
+        or frame.get("acpSchema") != ACP_SCHEMA_VERSION
+    ):
+        return None
+    message = frame.get("message")
+    if not isinstance(message, Mapping):
+        return None
+    if message.get("method") != ACP_SET_SESSION_MODE_METHOD:
+        return None
+    request_id = message.get("id")
+    return request_id if isinstance(request_id, str) and request_id else None
+
+
+def acp_set_mode_request(
+    frame: Mapping[str, Any], *, expected_session_id: str
+) -> tuple[str, str]:
+    """Validate one exact owned ACP session/set_mode request."""
+
+    if frame.get("type") != ACP_REQUEST_FRAME_TYPE:
+        raise ValueError("Unsupported ACP request carrier")
+    if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
+        raise ValueError("Unsupported ACP carrier schema")
+    message = _required_mapping(frame, "message")
+    if set(message) != {"jsonrpc", "id", "method", "params"}:
+        raise ValueError("ACP set mode must be an exact JSON-RPC request")
+    if message.get("jsonrpc") != "2.0":
+        raise ValueError("ACP request jsonrpc must be '2.0'")
+    request_id = _required_string(message, "id")
+    if message.get("method") != ACP_SET_SESSION_MODE_METHOD:
+        raise ValueError("Unsupported ACP client request method")
+    params = _required_mapping(message, "params")
+    if not set(params).issubset({"sessionId", "modeId", "_meta"}):
+        raise ValueError("ACP set mode params contain unsupported fields")
+    parsed = SetSessionModeRequest.model_validate(params)
+    if parsed.session_id != expected_session_id:
+        raise ValueError("ACP mode request belongs to another session")
+    return request_id, session_mode_id(parsed.mode_id)
+
+
+def acp_set_mode_response_frame(
+    request_id: str, session_id: str
+) -> dict[str, Any]:
+    """Return the exact empty official set-mode success response."""
+
+    result = SetSessionModeResponse().model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    return {
+        "type": ACP_RESPONSE_FRAME_TYPE,
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "sessionId": _required_nonempty(session_id, "session_id"),
+        "message": {
+            "jsonrpc": "2.0",
+            "id": _required_nonempty(request_id, "request_id"),
+            "result": result,
+        },
+    }
+
+
+def acp_set_mode_error_frame(
+    request_id: str,
+    session_id: str,
+    code: int,
+    message: str,
+    data: Any = None,
+) -> dict[str, Any]:
+    """Return one correlated JSON-RPC error in the Host ACP carrier."""
+
+    if isinstance(code, bool) or not isinstance(code, int):
+        raise ValueError("ACP error code must be an integer")
+    error: dict[str, Any] = {
+        "code": code,
+        "message": _required_nonempty(message, "error_message"),
+    }
+    if data is not None:
+        error["data"] = data
+    return {
+        "type": ACP_RESPONSE_FRAME_TYPE,
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "sessionId": _required_nonempty(session_id, "session_id"),
+        "message": {
+            "jsonrpc": "2.0",
+            "id": _required_nonempty(request_id, "request_id"),
+            "error": error,
+        },
+    }
 
 
 def map_mode_event(

--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -60,6 +60,10 @@ ACP_SESSION_MODES = {
     ),
 }
 
+
+class ACPSessionMismatchError(ValueError):
+    """A valid owned ACP message names a different Host session."""
+
 ACP_PERMISSION_OPTIONS = (
     PermissionOption(
         option_id="allow_once",
@@ -174,6 +178,31 @@ def acp_set_mode_request_id(frame: Mapping[str, Any]) -> str | None:
     return request_id if isinstance(request_id, str) and request_id else None
 
 
+def acp_set_mode_request_frame(
+    request_id: str, session_id: str, mode_id: Any
+) -> dict[str, Any]:
+    """Return one exact official session/set_mode client request carrier."""
+    params = SetSessionModeRequest(
+        session_id=_required_nonempty(session_id, "session_id"),
+        mode_id=session_mode_id(mode_id),
+    ).model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    return {
+        "type": ACP_REQUEST_FRAME_TYPE,
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "message": {
+            "jsonrpc": "2.0",
+            "id": _required_nonempty(request_id, "request_id"),
+            "method": ACP_SET_SESSION_MODE_METHOD,
+            "params": params,
+        },
+    }
+
+
 def acp_set_mode_request(
     frame: Mapping[str, Any], *, expected_session_id: str
 ) -> tuple[str, str]:
@@ -196,8 +225,47 @@ def acp_set_mode_request(
         raise ValueError("ACP set mode params contain unsupported fields")
     parsed = SetSessionModeRequest.model_validate(params)
     if parsed.session_id != expected_session_id:
-        raise ValueError("ACP mode request belongs to another session")
+        raise ACPSessionMismatchError(
+            "ACP mode request belongs to another session"
+        )
     return request_id, session_mode_id(parsed.mode_id)
+
+
+def host_session_mode_state(connected: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Read an exact advertised Host SessionModeState or return unsupported."""
+    capabilities = connected.get("carrier_capabilities")
+    if not isinstance(capabilities, Mapping):
+        return None
+    acp = capabilities.get("acp")
+    if not isinstance(acp, Mapping) or acp.get("schema") != ACP_SCHEMA_VERSION:
+        return None
+    requests = acp.get("client_requests")
+    if not isinstance(requests, list) or ACP_SET_SESSION_MODE_METHOD not in requests:
+        return None
+    raw_state = connected.get("session_modes")
+    if not isinstance(raw_state, Mapping):
+        return None
+    if not set(raw_state).issubset({"currentModeId", "availableModes", "_meta"}):
+        return None
+    try:
+        state = SessionModeState.model_validate(raw_state)
+        current = session_mode_id(state.current_mode_id)
+        seen: set[str] = set()
+        for mode in state.available_modes:
+            mode_id = session_mode_id(mode.id)
+            if mode_id in seen or not mode.name:
+                return None
+            seen.add(mode_id)
+        if current not in seen:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return state.model_dump(
+        mode="json",
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
 
 
 def acp_set_mode_response_frame(
@@ -250,6 +318,53 @@ def acp_set_mode_error_frame(
             "error": error,
         },
     }
+
+
+def acp_set_mode_response(
+    frame: Mapping[str, Any], *, expected_request_id: str,
+    expected_session_id: str,
+) -> dict[str, Any]:
+    """Decode one complete owned set-mode response for a Host client."""
+    if frame.get("type") != ACP_RESPONSE_FRAME_TYPE:
+        raise ValueError("Unsupported ACP response carrier")
+    if frame.get("acpSchema") != ACP_SCHEMA_VERSION:
+        raise ValueError("Unsupported ACP carrier schema")
+    if frame.get("sessionId") != expected_session_id:
+        raise ValueError("ACP mode response belongs to another session")
+    message = _required_mapping(frame, "message")
+    if message.get("jsonrpc") != "2.0":
+        raise ValueError("ACP response jsonrpc must be '2.0'")
+    if message.get("id") != expected_request_id:
+        raise ValueError("ACP mode response belongs to another request")
+    has_result = "result" in message
+    has_error = "error" in message
+    if has_result == has_error:
+        raise ValueError("ACP mode response needs exactly one result or error")
+    expected_keys = {"jsonrpc", "id", "result" if has_result else "error"}
+    if set(message) != expected_keys:
+        raise ValueError("ACP mode response has unexpected fields")
+    if has_result:
+        raw_result = _required_mapping(message, "result")
+        if not set(raw_result).issubset({"_meta"}):
+            raise ValueError("ACP mode result has unexpected fields")
+        result = SetSessionModeResponse.model_validate(raw_result)
+        return {"result": result.model_dump(
+            mode="json", by_alias=True, exclude_none=True, exclude_unset=True
+        )}
+
+    error = _required_mapping(message, "error")
+    if not set(error).issubset({"code", "message", "data"}):
+        raise ValueError("ACP mode error has unexpected fields")
+    code = error.get("code")
+    text = error.get("message")
+    if isinstance(code, bool) or not isinstance(code, int):
+        raise ValueError("ACP mode error code must be an integer")
+    if not isinstance(text, str) or not text:
+        raise ValueError("ACP mode error message must be non-empty")
+    decoded: dict[str, Any] = {"code": code, "message": text}
+    if "data" in error:
+        decoded["data"] = error["data"]
+    return {"error": decoded}
 
 
 def map_mode_event(

--- a/connectonion/network/__init__.py
+++ b/connectonion/network/__init__.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [host/, io/, connect.py, relay.py, announce.py, trust/] | imported by [__init__.py main package, user code] | tested via submodule tests
   Data flow: pure re-export module aggregating networking functionality
   State/Effects: no state
-  Integration: exposes host(agent, port, trust), create_app(), IO/WebSocketIO, SessionStorage/Session, connect(url), RemoteAgent, Response, relay server (relay_connect, serve_loop), announce (create_announce_message), trust (TrustAgent) | unified networking API surface
+  Integration: exposes host(agent, port, trust), create_app(), IO/WebSocketIO, SessionStorage/Session, connect(url), RemoteAgent, Response, ACPModeError, relay server (relay_connect, serve_loop), announce (create_announce_message), trust (TrustAgent) | unified networking API surface
   Performance: trivial
   Errors: none
 Network layer for hosting and connecting agents.
@@ -24,7 +24,7 @@ from .host import (
     HTTPRequest, HTTPResponse, HTTPRoute, HTTPRouter,
 )
 from .io import IO, WebSocketIO
-from .connect import connect, RemoteAgent, Response, ExecResult
+from .connect import ACPModeError, connect, RemoteAgent, Response, ExecResult
 from .relay import connect as relay_connect, serve_loop
 from .announce import create_announce_message
 from .trust import TrustAgent, Decision, TRUST_LEVELS, parse_policy
@@ -41,6 +41,7 @@ __all__ = [
     "RemoteAgent",
     "Response",
     "ExecResult",
+    "ACPModeError",
     "HTTPRequest",
     "HTTPResponse",
     "HTTPRoute",

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -1,12 +1,12 @@
 """
-Purpose: Client SDK for talking to remote ConnectOnion agents over websockets — handles relay/direct endpoint resolution, signed CONNECT and per-command frames, streaming UI events, and onboard (invite/payment) flows.
+Purpose: Python client SDK for talking to remote ConnectOnion agents over websockets — handles signed transport, acknowledged ACP session modes, streaming UI events, and onboarding.
 LLM-Note:
-  Dependencies: imports from [asyncio, json, time, uuid, dataclasses, typing, httpx, websockets (lazy), .. address (sign)] | imported by [network/__init__.py (re-exports connect, RemoteAgent, Response), connectonion/__init__.py (top-level re-export)] | tested by [tests/unit/test_connect.py, tests/unit/test_connect.py]
-  Data flow: connect(address, keys, relay_url) → RemoteAgent → .input(prompt) opens ws → CONNECT (signed payload {to, timestamp, signed_commands}, optional session) → CONNECTED {session_id} → INPUT (complete command duplicated top-level for v1 compatibility and signed as payload for v2) → streams (tool_call, tool_result, thinking, assistant, ask_user, ONBOARD_REQUIRED/SUCCESS) → OUTPUT {result, session} → returns Response(text, done)
-  State/Effects: mutates self._current_session, self._ui_events, self._status; opens outbound websocket connection; performs signed payloads via address.sign(keys, canonical_json) when keys provided; resolve_endpoint() makes httpx GETs to relay /api/agents/{addr} and /info on each candidate to pick localhost/LAN/public WS endpoint (cached after first attempt)
-  Integration: exposes connect(address, keys=None, relay_url=None) -> RemoteAgent | omitted relay resolves from the shared backend selector | RemoteAgent.input/input_async/reset, .status, .current_session, .ui properties | Response dataclass(text, done) | resolve_endpoint(agent_address, relay_url, timeout=3.0) helper
+  Dependencies: imports from [asyncio, copy, json, time, uuid, dataclasses, typing, httpx, websockets (lazy), ..address (sign), ..core.acp_wire] | imported by [network/__init__.py, connectonion/__init__.py] | tested by [test_connect.py, test_each_command_is_signed.py, test_acp_host_set_mode.py]
+  Data flow: input() sends signed CONNECT/INPUT and consumes stream/OUTPUT | set_session_mode() validates Host SessionModeState, sends signed ACP_REQUEST, and waits for its exact ACP_RESPONSE before changing local mode
+  State/Effects: mutates current session/modes/UI/status only from authenticated carrier responses; opens outbound sockets; signs deep-detached command payloads; endpoint resolution may query relay and candidate /info endpoints
+  Integration: exposes connect(), RemoteAgent, Response, ExecResult, ACPModeError; RemoteAgent provides input/call/set_session_mode sync+async actions and read-only state
   Performance: endpoint resolution attempted once per RemoteAgent (cached in _endpoint_resolved/_resolved_endpoint) | per-recv asyncio.wait_for to avoid hangs (default timeout=60s, 30s for CONNECTED) | sync .input() rejected inside running event loop (use input_async)
-  Errors: raises ConnectionError on auth/agent ERROR frames | TimeoutError on ws recv timeout | RuntimeError if .input() called from async context | ValueError when interactive onboard prompt yields no credentials
+  Errors: raises ConnectionError on transport/auth failure, ACPModeError on owned policy refusal, TimeoutError on receive timeout, RuntimeError for sync calls in async contexts, ValueError for invalid choices
 Protocol: CONNECT → CONNECTED → INPUT → streaming events → OUTPUT
 See docs/network/websocket-protocol.md for full specification.
 
@@ -21,17 +21,21 @@ Lifecycle:
 """
 
 import asyncio
+import copy
 import json
 import sys
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional
 
 import httpx
 
 from .. import address as addr
 from ..core.acp_wire import (
+    acp_set_mode_request_frame,
+    acp_set_mode_response,
+    host_session_mode_state,
     legacy_stream_event_from_acp,
     session_mode_id,
 )
@@ -245,6 +249,15 @@ class ExecResult:
         return re.findall(r'data:image/[a-z]+;base64,[A-Za-z0-9+/=]+', self.text)
 
 
+class ACPModeError(ConnectionError):
+    """An acknowledged Host session-mode policy rejection."""
+
+    def __init__(self, code: int, message: str, data: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
 class RemoteAgent:
     """
     Interface to a remote agent with real-time UI updates.
@@ -282,6 +295,7 @@ class RemoteAgent:
         self._status = "idle"
         self._current_session: Optional[Dict[str, Any]] = None
         self._ui_events: List[Dict[str, Any]] = []
+        self._available_modes: List[Dict[str, Any]] = []
         self._resolved_endpoint: Optional[str] = None
         self._endpoint_resolved = False
 
@@ -305,6 +319,68 @@ class RemoteAgent:
         - assistant → type: 'agent'
         """
         return self._ui_events
+
+    @property
+    def available_modes(self) -> List[Dict[str, Any]]:
+        """Server-authorized ACP modes from the latest CONNECTED frame."""
+        return copy.deepcopy(self._available_modes)
+
+    def set_session_mode(self, mode_id: str, timeout: float = 30.0) -> None:
+        """Persist Host policy and return only after its owned acknowledgement."""
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError(
+                "set_session_mode() cannot be used inside async context. "
+                "Use 'await agent.set_session_mode_async()' instead."
+            )
+        except RuntimeError as exc:
+            if "set_session_mode() cannot be used" in str(exc):
+                raise
+        asyncio.run(self.set_session_mode_async(mode_id, timeout=timeout))
+
+    async def set_session_mode_async(
+        self, mode_id: str, timeout: float = 30.0
+    ) -> None:
+        """Commit a Host mode, or time out with the remote outcome unknown."""
+        mode_id = session_mode_id(mode_id)
+        if (
+            isinstance(timeout, bool)
+            or not isinstance(timeout, (int, float))
+            or timeout <= 0
+        ):
+            raise ValueError("timeout must be a positive number")
+        try:
+            await asyncio.wait_for(
+                self._set_session_mode_transaction(mode_id), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"Session mode change timed out after {timeout}s"
+            ) from None
+
+    async def _set_session_mode_transaction(self, mode_id: str) -> None:
+        """Run negotiation and response handling under the caller's deadline."""
+        import websockets
+
+        await self._try_resolve_endpoint()
+        connection, is_direct = await self._open_best_connection(websockets)
+        request_id = str(uuid.uuid4())
+
+        async with connection as ws:
+            await ws.send(json.dumps(self._build_connect_message(is_direct)))
+            state = await self._wait_for_mode_connected(ws)
+            if not any(mode.get("id") == mode_id for mode in state["availableModes"]):
+                raise ValueError(f"Session mode is not available: {mode_id}")
+            session_id = self._current_session["session_id"]
+            request = acp_set_mode_request_frame(
+                request_id, session_id, mode_id
+            )
+            await ws.send(json.dumps(
+                self._build_command_message(request, is_direct)
+            ))
+            await self._wait_for_mode_response(
+                ws, request_id, session_id, mode_id
+            )
 
     def input(
         self,
@@ -579,11 +655,7 @@ class RemoteAgent:
                     raw = await asyncio.wait_for(ws.recv(), timeout=30)
                     event = json.loads(raw)
                     if event.get("type") == "CONNECTED":
-                        sid = event.get("session_id")
-                        if sid and not self._current_session:
-                            self._current_session = {"session_id": sid}
-                        elif sid and self._current_session:
-                            self._current_session["session_id"] = sid
+                        self._consume_connected_mode_state(event)
                         break
                     elif event.get("type") == "ERROR":
                         self._status = "idle"
@@ -706,6 +778,74 @@ class RemoteAgent:
             self._status = "idle"
             raise TimeoutError(f"Request timed out after {timeout}s")
 
+    async def _wait_for_mode_connected(self, ws) -> Dict[str, Any]:
+        while True:
+            event = json.loads(await ws.recv())
+            event_type = event.get("type")
+            if event_type == "CONNECTED":
+                state = self._consume_connected_mode_state(event)
+                if state is None:
+                    raise ConnectionError(
+                        "Host does not support acknowledged ACP session modes"
+                    )
+                return state
+            if event_type == "PING":
+                await ws.send(json.dumps({"type": "PONG"}))
+            elif event_type == "ERROR":
+                raise ConnectionError(
+                    f"Auth error: {event.get('message', event.get('error'))}"
+                )
+
+    async def _wait_for_mode_response(
+        self, ws, request_id: str, session_id: str, mode_id: str,
+    ) -> None:
+        while True:
+            event = json.loads(await ws.recv())
+            event_type = event.get("type")
+            if event_type == "PING":
+                await ws.send(json.dumps({"type": "PONG"}))
+                continue
+            if event_type == "ERROR":
+                raise ConnectionError(
+                    event.get("message", "Session mode change failed")
+                )
+            if event_type != "ACP_RESPONSE":
+                self._handle_stream_event(event)
+                continue
+            response = acp_set_mode_response(
+                event,
+                expected_request_id=request_id,
+                expected_session_id=session_id,
+            )
+            if "error" in response:
+                error = response["error"]
+                raise ACPModeError(
+                    error["code"], error["message"], error.get("data")
+                )
+            for field in (
+                "skip_tool_approval", "ulw_turns", "ulw_turns_used"
+            ):
+                self._current_session.pop(field, None)
+            self._current_session["mode"] = mode_id
+            return
+
+    def _consume_connected_mode_state(
+        self, event: Dict[str, Any]
+    ) -> Dict[str, Any] | None:
+        sid = event.get("session_id")
+        if sid and not self._current_session:
+            self._current_session = {"session_id": sid}
+        elif sid and self._current_session:
+            self._current_session["session_id"] = sid
+        state = host_session_mode_state(event)
+        if state is None:
+            self._available_modes = []
+            return None
+        self._available_modes = copy.deepcopy(state["availableModes"])
+        if self._current_session is not None:
+            self._current_session["mode"] = state["currentModeId"]
+        return state
+
     def _build_connect_message(self, is_direct: bool = False) -> Dict[str, Any]:
         """Build CONNECT message with signing."""
         connect_msg: Dict[str, Any] = {
@@ -774,7 +914,7 @@ class RemoteAgent:
         Fields remain duplicated at the top level so pre-v2 hosts can consume
         the frame. A v2 host discards those copies and executes this payload.
         """
-        command = dict(message)
+        command = copy.deepcopy(message)
         command["timestamp"] = int(time.time())
         command["nonce"] = str(uuid.uuid4())
         # Recipient stays in the signature even on a direct socket. Only the
@@ -782,7 +922,7 @@ class RemoteAgent:
         # captured for one agent from being delivered to another.
         command["to"] = self.address
 
-        frame = dict(command)
+        frame = copy.deepcopy(command)
         if self._keys:
             canonical = json.dumps(command, sort_keys=True, separators=(',', ':'))
             frame["payload"] = command

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -1,126 +1,125 @@
 """
-Purpose: HTTP route handlers for agent hosting endpoints (POST /input, session/admin/health/info)
+Purpose: HTTP routes for hosted agents, atomic prompt claims, and policy restore
 LLM-Note:
-  Dependencies: imports from [network/host/session/ (Session, SessionStorage, merge_sessions, session_to_chat_items), network/asgi/http (read_body, send_json, send_html, send_text, CORS_HEADERS), network/trust/http_admin] | imported by [network/host/server.py, network/asgi/http.py] | tested by [tests/unit/test_host_routes.py]
-  Data flow: input_handler() receives prompt+session → calls create_agent() factory → merges client+server session via merge_sessions() if stored exists → calls agent.input(prompt, session) → records 'running' shell + final 'done' to SessionStorage → returns {session_id, status, result, duration_ms, session, chat_items, server_newer}
-  State/Effects: reads/writes SessionStorage via storage.save()/get() | factory creates fresh agent per request (prevents state bleeding) | session records carry TTL expiry
-  Integration: exposes input_handler, session_handler, sessions_handler, health_handler, info_handler, admin_logs/sessions/trust/admins handlers | used by server.py and ASGI adapters
-  Performance: factory creates fresh agent per request (thread-safe) | SessionStorage TTL auto-cleanup | session continuation via session_id provided by client
-  Errors: input_handler raises ValueError if session_id missing | session_handler returns None if session_id not found | admin_logs_handler returns {"error": "..."} if log file missing
+  Dependencies: imports from [host/session, session.mode, asgi/http, trust/http_admin]
+  Data flow: claim durable session → create/disarm Agent → input → normalize → save
+  State/Effects: reads/writes append-only SessionStorage; rejects busy/foreign claims
+  Integration: route handlers used by server.py and ASGI adapters
+  Performance: creates one isolated Agent per request; storage applies TTL cleanup
+  Errors: missing session IDs are invalid; missing sessions return None
 
 Session ID ownership:
-  - Client generates UUID on first request (TypeScript SDK: generateUUID())
+  - A frontend client (normally @connectonion/react) generates a UUID on first request
   - Server uses client's session_id for storage and reconnection
   - Security: session_id is a correlation ID, not credential. Ed25519 signature provides auth.
 """
 
+import copy
 import json
+import logging
 import time
 import uuid
 from functools import partial
 from pathlib import Path
 from typing import Callable
-from ...project import project_co_dir
 
-from ..asgi.http import read_body, send_json, send_html, send_text, CORS_HEADERS
+from ...project import project_co_dir
+from ..asgi.http import CORS_HEADERS, read_body, send_html, send_json, send_text
 from ..trust.http_admin import handle_admin_routes
-from .session import Session, SessionStorage, merge_sessions, session_to_chat_items
+from .session import SessionStorage, session_to_chat_items
+from .session.mode import SERVER_OWNED_SESSION_KEYS as SERVER_OWNED_SESSION_KEYS
+from .session.mode import (
+    HostModePolicy,
+    ModeTransactionError,
+    claim_host_prompt,
+)
+
+logger = logging.getLogger(__name__)
 
 
 # ═══════════════════════════════════════════════════════
-# State a client carries but does not author. Set server-side — by a validated
-# mode_change, by the trust layer at CONNECT — and restored from storage so it
-# survives the round trip without the client being able to invent it.
-SERVER_OWNED_SESSION_KEYS = (
-    'mode', 'ulw_turns', 'ulw_turns_used', 'skip_tool_approval',
-    'permissions', 'approval', 'requester',
-)
-
-
 # Handlers
 # ═══════════════════════════════════════════════════════
 
 def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, result_ttl: int,
                   session: dict | None = None, connection=None, images: list[str] | None = None,
-                  files: list[dict] | None = None, requester: dict | None = None) -> dict:
+                  files: list[dict] | None = None, requester: dict | None = None,
+                  mode_policy: HostModePolicy | None = None,
+                  is_admin: bool = False) -> dict:
     """POST /input (and WebSocket /ws) with session merge and UI conversion."""
-    agent = create_agent()
-    agent.io = connection
-    agent.storage = storage
-    now = time.time()
-
     session = session or {}
     session_id = session.get('session_id')
     if not session_id:
         raise ValueError("session_id required in session dict")
-    server_newer = False
 
-    stored = storage.get(session_id)
-    # Same rule CONNECT applies, because this is the same decision: a session
-    # belongs to whoever started it, and the id is on the client's frame.
-    #
-    # Fixing it only in establish_connection was not enough -- measured. B
-    # connected, was correctly given a fresh session ("belongs to another
-    # caller"), and then its INPUT named the same id and this lookup handed
-    # over A's conversation anyway:
-    #
-    #     B CONNECTED session=47edf32c… status=new     <- the CONNECT fix worked
-    #     B <- "PURPLE-OTTER-42."                      <- and it leaked here
-    #
-    # `requester` is the signature-verified address for this turn.
-    from .session import session_owner
-
-    owner = session_owner(stored)
-    if owner and requester and owner != requester.get('address'):
-        stored = None
-    if stored and stored.session:
-        session, server_newer = merge_sessions(
-            client_session=session,
-            server_session=stored.session
-        )
-
-    # Answers the server already gave, which the client does not get to change.
-    #
-    # merge_sessions picks one whole session, so a client that wins the merge
-    # would otherwise hand the agent its own `skip_tool_approval: True` and skip
-    # every approval check. These come from what the server stored, or from
-    # nowhere.
-    stored_session = (stored.session if stored and stored.session else {}) or {}
-    for key in SERVER_OWNED_SESSION_KEYS:
-        session.pop(key, None)
-        if key in stored_session:
-            session[key] = stored_session[key]
-
-    # After the merge, and overwriting whatever arrived. The session dict
-    # round-trips through the client, so anything read out of it is their
-    # input — a level taken from there would make "I am the operator" a matter
-    # of editing one JSON field. The caller recomputes this every turn from the
-    # signature-verified address.
-    if requester is not None:
-        session['requester'] = requester
-    else:
-        session.pop('requester', None)
-
-    record = Session(
-        session_id=session_id,
-        status="running",
-        prompt=prompt,
-        created=now,
-        expires=now + result_ttl,
+    # Preserve the legacy internal/scheduler order when no Host policy is in
+    # play. Network routes always pass a policy and must claim before factory
+    # side effects; standalone callers historically construct first.
+    agent = create_agent() if mode_policy is None else None
+    record, server_newer = claim_host_prompt(
+        storage,
+        session_id,
+        prompt,
+        result_ttl,
+        session,
+        requester=requester,
+        policy=mode_policy,
+        is_admin=is_admin,
     )
-    storage.save(record)
+    session = record.session
 
     start = time.time()
-    result = agent.input(prompt, session=session, images=images, files=files)
-    duration_ms = int((time.time() - start) * 1000)
+    try:
+        if agent is None:
+            agent = create_agent()
+        agent.io = connection
+        agent.storage = storage
+        if mode_policy is not None:
+            if hasattr(agent, "_yolo_turns"):
+                agent._yolo_turns = None
+            if hasattr(agent, "_yolo_needs_activation"):
+                agent._yolo_needs_activation = False
+            agent._host_ulw_turns_ceiling = mode_policy.ulw_turns
 
-    agent.current_session['updated'] = time.time()
+        result = agent.input(
+            prompt, session=session, images=images, files=files
+        )
+        duration_ms = int((time.time() - start) * 1000)
 
-    record.status = "done"
-    record.result = result
-    record.duration_ms = duration_ms
-    record.session = agent.current_session
-    storage.save(record)
+        if mode_policy is not None:
+            agent.current_session = _normalized_host_result(
+                agent.current_session,
+                requester=requester,
+                mode_policy=mode_policy,
+                is_admin=is_admin,
+            )
+
+        agent.current_session['updated'] = time.time()
+
+        record.status = "done"
+        record.result = result
+        record.duration_ms = duration_ms
+        record.session = agent.current_session
+        storage.save(record)
+    except Exception:
+        # The claim is already durable. Always terminate it so a factory/model
+        # exception cannot leave this session busy until Host restarts.
+        record.status = "failed"
+        record.duration_ms = int((time.time() - start) * 1000)
+        if mode_policy is not None:
+            record.session = _normalized_host_result(
+                record.session,
+                requester=requester,
+                mode_policy=mode_policy,
+                is_admin=is_admin,
+            )
+        try:
+            storage.save(record)
+        except Exception:
+            logger.exception(
+                "Unable to persist failed Host prompt %s", session_id
+            )
+        raise
 
     chat_items = session_to_chat_items(agent.current_session)
 
@@ -133,6 +132,28 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
         "chat_items": chat_items,
         "server_newer": server_newer,
     }
+
+
+def _normalized_host_result(
+    session: dict,
+    *,
+    requester: dict | None,
+    mode_policy: HostModePolicy,
+    is_admin: bool,
+) -> dict:
+    """Restore verified identity and fail invalid Agent policy state to Safe."""
+    final_session = copy.deepcopy(session)
+    if requester is not None:
+        final_session["requester"] = copy.deepcopy(requester)
+    else:
+        final_session.pop("requester", None)
+    try:
+        return mode_policy.normalized(final_session, is_admin=is_admin)
+    except ModeTransactionError:
+        logger.exception(
+            "Agent produced invalid Host session policy; downgrading to Safe"
+        )
+        return mode_policy.apply(final_session, "safe", is_admin=is_admin)
 
 
 def exec_handler(create_agent: Callable, permissions: dict, tool_name: str, args: dict) -> dict:
@@ -263,7 +284,10 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
             "images": True,
             "files": {
                 "max_file_size_mb": file_config.get("max_file_size", DEFAULT_FILE_LIMITS["max_file_size"]),
-                "max_files_per_request": file_config.get("max_files_per_request", DEFAULT_FILE_LIMITS["max_files_per_request"]),
+                "max_files_per_request": file_config.get(
+                    "max_files_per_request",
+                    DEFAULT_FILE_LIMITS["max_files_per_request"],
+                ),
             },
         },
     }
@@ -464,7 +488,21 @@ async def handle_http(
         images = data.get("images")
         files = data.get("files")
         try:
-            result = route_handlers["input"](storage, prompt, session, images=images, files=files)
+            result = route_handlers["input"](
+                storage,
+                prompt,
+                session,
+                images=images,
+                files=files,
+                requester_address=agent_address,
+            )
+        except ModeTransactionError as exc:
+            status = 404 if exc.code == -32002 else 409 if exc.code == -32000 else 400
+            body = {"error": exc.message, "code": exc.code}
+            if exc.data:
+                body["data"] = exc.data
+            await send_json(send, body, status)
+            return
         except ValueError as e:
             await send_json(send, {"error": str(e)}, 400)
             return
@@ -475,7 +513,7 @@ async def handle_http(
         # has no body, so the signature is in headers over {method, path,
         # timestamp} and is verified by the same _authenticate_signed as every
         # other frame -- same freshness window, same blacklist (#683).
-        from .auth import request_from_headers, _authenticate_signed
+        from .auth import _authenticate_signed, request_from_headers
 
         headers = {k.decode(): v.decode() for k, v in scope.get("headers") or []}
         _, caller, err = _authenticate_signed(

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -49,6 +49,7 @@ from .auth import authenticate_connect, extract_and_authenticate
 from .replay import SignatureReplayStore
 from .config import load_host_config, load_list_file, validate_files, validate_images, project_co_dir, DEFAULT_FILE_LIMITS
 from .session import SessionStorage, ActiveSessionRegistry, start_cleanup_job
+from .session.mode import HostModePolicy
 from .http_router import (
     input_handler,
     exec_handler,
@@ -222,6 +223,7 @@ def _create_route_handlers(
     config: dict,
     exec_permissions: dict | None = None,
     replay_check=None,
+    mode_policy: HostModePolicy | None = None,
 ):
     """Create route handler dict for ASGI app.
 
@@ -240,14 +242,31 @@ def _create_route_handlers(
     """
     agent_name = agent_metadata["name"]
     exec_permissions = exec_permissions or {}
+    mode_policy = mode_policy or HostModePolicy()
     if replay_check is None:
         from .auth import signature_already_used
         replay_check = signature_already_used
 
-    def handle_input(storage, prompt, session=None, connection=None, images=None, files=None):
+    def requester_for(requester_address):
+        if not requester_address:
+            return None
+        level = (
+            "admin" if trust_agent.is_admin(requester_address)
+            else trust_agent.get_level(requester_address)
+        )
+        requester = {'address': requester_address, 'level': level}
+        return requester
+
+    def handle_input(storage, prompt, session=None, connection=None, images=None,
+                     files=None, requester_address=None):
         validate_files(files, config)
         validate_images(images, config)
-        return input_handler(create_agent, storage, prompt, result_ttl, session, connection, images, files)
+        requester = requester_for(requester_address)
+        return input_handler(
+            create_agent, storage, prompt, result_ttl, session, connection,
+            images, files, requester=requester, mode_policy=mode_policy,
+            is_admin=bool(requester and requester["level"] == "admin"),
+        )
 
     def handle_ws_input(storage, prompt, connection, session=None, images=None,
                         files=None, requester_address=None):
@@ -258,13 +277,11 @@ def _create_route_handlers(
         # contact / whitelist / blocked. The operator is whoever is in
         # .co/admins.txt, which is a separate question, and conflating them
         # would have refused the owner as loudly as everyone else.
-        requester = None
-        if requester_address:
-            level = ('admin' if trust_agent.is_admin(requester_address)
-                     else trust_agent.get_level(requester_address))
-            requester = {'address': requester_address, 'level': level}
+        requester = requester_for(requester_address)
         return input_handler(create_agent, storage, prompt, result_ttl, session,
-                             connection, images, files, requester=requester)
+                             connection, images, files, requester=requester,
+                             mode_policy=mode_policy,
+                             is_admin=bool(requester and requester["level"] == "admin"))
 
     handle_ws_exec = _make_ws_exec(create_agent, exec_permissions, trust_agent)
 
@@ -309,7 +326,21 @@ def _create_route_handlers(
         # unauthenticated and carry the published subset only; this is the copy a client
         # gets after CONNECT has passed the trust gate.
         "agent_metadata": agent_metadata,
+        "result_ttl": result_ttl,
+        "session_modes": mode_policy,
     }
+
+
+def _host_mode_policy(sample) -> HostModePolicy:
+    """Capture only an explicitly configured positive Agent ULW ceiling."""
+    turns = getattr(sample, "_yolo_turns", None)
+    if (
+        isinstance(turns, bool)
+        or not isinstance(turns, int)
+        or turns <= 0
+    ):
+        turns = None
+    return HostModePolicy(turns)
 
 
 def resolve_agent_identity(co_dir: Path) -> dict:
@@ -984,6 +1015,7 @@ def host(
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent, config,
         exec_permissions, replay_store.already_used,
+        mode_policy=_host_mode_policy(sample),
     )
 
     # Parse trust config for /info onboard info
@@ -1113,6 +1145,7 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
         create_agent, agent_metadata, result_ttl, trust_agent,
         DEFAULT_FILE_LIMITS, load_permission_patterns(),
         replay_store.already_used,
+        mode_policy=_host_mode_policy(sample),
     )
     balance_startup, balance_shutdown = _create_balance_lifespan(
         sample, agent_metadata

--- a/connectonion/network/host/session/mode.py
+++ b/connectonion/network/host/session/mode.py
@@ -1,0 +1,279 @@
+"""
+Purpose: Durable, authority-bounded Host session mode transactions
+LLM-Note:
+  Dependencies: imports from [core.acp_wire, .storage, copy, dataclasses, time] | imported by [host/ws_router/connect.py, host/ws_router/session.py, host/http_router.py] | tested by [tests/unit/test_acp_host_set_mode.py]
+  Data flow: CONNECT -> ensure_host_mode_session() appends an owned Safe snapshot when needed -> CONNECTED advertises policy.state() | ACP/legacy setter -> commit_host_session_mode() checks process-local busy state -> storage.atomic_update() rechecks durable owner/status and appends a detached policy copy -> caller acknowledges and updates conn
+  State/Effects: appends Session records through SessionStorage.atomic_update; never mutates caller or stored dictionaries before commit
+  Integration: HostModePolicy captures the launch-time ULW ceiling and derives identity-bounded mode lists; ModeTransactionError carries owned JSON-RPC errors
+  Errors: missing/wrong owner=-32002, busy=-32000 retryable, invalid/unavailable=-32602; storage exceptions deliberately propagate for -32603 mapping at the carrier boundary
+"""
+
+from __future__ import annotations
+
+import copy
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from ....core.acp_wire import acp_session_mode_state, session_mode_id
+from .storage import Session, SessionStorage, session_owner
+
+_ULW_FIELDS = ("skip_tool_approval", "ulw_turns", "ulw_turns_used")
+SERVER_OWNED_SESSION_KEYS = (
+    "mode", *_ULW_FIELDS, "permissions", "approval", "requester"
+)
+
+
+class ModeTransactionError(Exception):
+    """A client-owned policy failure safe to expose through JSON-RPC."""
+
+    def __init__(
+        self,
+        code: int,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+@dataclass(frozen=True)
+class HostModePolicy:
+    """Available Host modes below identity and Agent launch authority."""
+
+    ulw_turns: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.ulw_turns is not None and (
+            isinstance(self.ulw_turns, bool)
+            or not isinstance(self.ulw_turns, int)
+            or self.ulw_turns <= 0
+        ):
+            raise ValueError("ULW launch ceiling must be a positive integer")
+
+    def available_mode_ids(self, *, is_admin: bool) -> tuple[str, ...]:
+        if not is_admin:
+            return ("safe",)
+        if self.ulw_turns is None:
+            return ("safe", "accept_edits")
+        return ("safe", "accept_edits", "ulw")
+
+    def state(self, session: dict, *, is_admin: bool) -> dict[str, Any]:
+        normalized = self.normalized(session, is_admin=is_admin)
+        return acp_session_mode_state(
+            normalized["mode"], self.available_mode_ids(is_admin=is_admin)
+        )
+
+    def normalized(self, session: dict, *, is_admin: bool) -> dict:
+        """Return a detached validated snapshot or fail closed."""
+        normalized = copy.deepcopy(session)
+        mode = normalized.get("mode", "safe")
+        try:
+            mode = session_mode_id(mode)
+        except ValueError as exc:
+            raise ModeTransactionError(-32602, str(exc)) from None
+        if mode not in self.available_mode_ids(is_admin=is_admin):
+            raise ModeTransactionError(-32602, "Session mode is not available")
+        if mode == "ulw":
+            self._validate_ulw(normalized)
+        elif any(field in normalized for field in _ULW_FIELDS):
+            raise ModeTransactionError(
+                -32602, "Session has ULW authority outside ULW mode"
+            )
+        normalized["mode"] = mode
+        return normalized
+
+    def apply(self, session: dict, mode_id: Any, *, is_admin: bool) -> dict:
+        """Apply one validated mode to a detached copy."""
+        try:
+            mode = session_mode_id(mode_id)
+        except ValueError as exc:
+            raise ModeTransactionError(-32602, str(exc)) from None
+        if mode not in self.available_mode_ids(is_admin=is_admin):
+            raise ModeTransactionError(-32602, "Session mode is not available")
+        changed = copy.deepcopy(session)
+        for field in _ULW_FIELDS:
+            changed.pop(field, None)
+        changed["mode"] = mode
+        if mode == "ulw":
+            changed["ulw_turns"] = self.ulw_turns
+            changed["ulw_turns_used"] = 0
+            changed["skip_tool_approval"] = True
+        return self.normalized(changed, is_admin=is_admin)
+
+    def _validate_ulw(self, session: dict) -> None:
+        turns = session.get("ulw_turns")
+        used = session.get("ulw_turns_used")
+        if (
+            self.ulw_turns is None
+            or isinstance(turns, bool)
+            or not isinstance(turns, int)
+            or turns <= 0
+            or isinstance(used, bool)
+            or not isinstance(used, int)
+            or used < 0
+            or used >= turns
+            or turns - used > self.ulw_turns
+            or session.get("skip_tool_approval") is not True
+        ):
+            raise ModeTransactionError(-32602, "Session has invalid ULW state")
+
+
+def ensure_host_mode_session(
+    storage: SessionStorage,
+    session_id: str,
+    *,
+    requester: dict,
+    result_ttl: int,
+    policy: HostModePolicy,
+    is_admin: bool,
+) -> Session:
+    """Persist an owned Safe snapshot before a Host session's first prompt."""
+    owner = requester.get("address")
+    if not isinstance(owner, str) or not owner:
+        raise ValueError("requester address is required")
+
+    def ensure(current: Session | None) -> Session:
+        if current is None:
+            now = time.time()
+            return Session(
+                session_id=session_id,
+                status="connected",
+                prompt="",
+                session=_fresh_session(session_id, requester),
+                created=now,
+                expires=now + result_ttl,
+            )
+        existing_owner = session_owner(current)
+        if existing_owner and existing_owner != owner:
+            raise _not_found()
+        session = policy.normalized(
+            current.session or _fresh_session(session_id, requester),
+            is_admin=is_admin,
+        )
+        session["session_id"] = session_id
+        if not existing_owner:
+            session["requester"] = copy.deepcopy(requester)
+        return current.model_copy(update={"session": session})
+
+    return storage.atomic_update(session_id, ensure)
+
+
+def commit_host_session_mode(
+    storage: SessionStorage,
+    registry,
+    session_id: str,
+    owner: str,
+    mode_id: Any,
+    policy: HostModePolicy,
+    is_admin: bool,
+) -> Session:
+    """Commit one idle policy change under the cross-worker storage lock."""
+    active = registry.get(session_id) if registry is not None else None
+    if active is not None and getattr(active, "owner", None) not in (None, owner):
+        raise _not_found()
+    if active is not None and getattr(active, "status", None) == "running":
+        raise _busy()
+
+    def commit(current: Session | None) -> Session:
+        if current is None or session_owner(current) != owner:
+            raise _not_found()
+        if current.status in SessionStorage.UNFINISHED:
+            raise _busy()
+        session = policy.normalized(current.session or {}, is_admin=is_admin)
+        session = policy.apply(session, mode_id, is_admin=is_admin)
+        return current.model_copy(update={"session": session})
+
+    return storage.atomic_update(session_id, commit)
+
+
+def session_with_durable_policy(client_session: dict | None, durable: dict) -> dict:
+    """Keep client conversation fields but replace every server policy field."""
+    merged = copy.deepcopy(client_session or {})
+    for field in SERVER_OWNED_SESSION_KEYS:
+        merged.pop(field, None)
+        if field in durable:
+            merged[field] = copy.deepcopy(durable[field])
+    if durable.get("session_id"):
+        merged["session_id"] = durable["session_id"]
+    return merged
+
+
+def claim_host_prompt(
+    storage: SessionStorage,
+    session_id: str,
+    prompt: str,
+    result_ttl: int,
+    client_session: dict,
+    *,
+    requester: dict | None,
+    policy: HostModePolicy | None,
+    is_admin: bool,
+) -> tuple[Session, bool]:
+    """Atomically claim an idle session and return its prepared prompt state."""
+    server_newer = False
+
+    def claim(current: Session | None) -> Session:
+        nonlocal server_newer
+        owner = session_owner(current)
+        address = requester.get("address") if requester else None
+        if owner and owner != address:
+            raise _not_found()
+        if current is not None and current.status in SessionStorage.UNFINISHED:
+            raise _busy()
+
+        session = copy.deepcopy(client_session)
+        durable = current.session if current and current.session else {}
+        if durable:
+            from .merge import merge_sessions
+
+            session, server_newer = merge_sessions(
+                client_session=session,
+                server_session=durable,
+            )
+        session = session_with_durable_policy(session, durable)
+        session["session_id"] = session_id
+        session.setdefault("messages", [])
+        session.setdefault("trace", [])
+        session.setdefault("turn", 0)
+        if requester is not None:
+            session["requester"] = copy.deepcopy(requester)
+        else:
+            session.pop("requester", None)
+        if policy is not None:
+            session = policy.normalized(session, is_admin=is_admin)
+
+        now = time.time()
+        return Session(
+            session_id=session_id,
+            status="running",
+            prompt=prompt,
+            session=session,
+            created=now,
+            expires=now + result_ttl,
+        )
+
+    return storage.atomic_update(session_id, claim), server_newer
+
+
+def _fresh_session(session_id: str, requester: dict) -> dict:
+    return {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "mode": "safe",
+        "requester": copy.deepcopy(requester),
+    }
+
+
+def _not_found() -> ModeTransactionError:
+    return ModeTransactionError(-32002, "Session not found")
+
+
+def _busy() -> ModeTransactionError:
+    return ModeTransactionError(
+        -32000, "Session is busy", {"retryable": True}
+    )

--- a/connectonion/network/host/session/storage.py
+++ b/connectonion/network/host/session/storage.py
@@ -1,19 +1,20 @@
 """
 Purpose: Persistent session storage for hosted agent requests with TTL expiry
 LLM-Note:
-  Dependencies: imports from [pydantic, pathlib, json, time] | imported by [host/http_router.py, host/server.py, host/ws_router/agent_io.py, host/session/__init__.py] | tested by [tests/unit/test_session_storage.py]
-  Data flow: save(session) appends to JSONL → get(session_id) reads backwards, returns latest if not expired → list() loads all, filters expired
-  State/Effects: writes to .co/session_results.jsonl (append-only) | creates .co/ directory if missing
-  Integration: exposes Session (Pydantic model), SessionStorage class with save/get/list | used by http_router.input_handler and ws_router agent execution paths
-  Performance: append-only writes O(1) | linear scan on read O(n) - acceptable for thousands of sessions
-  Errors: returns None if session not found or expired | creates parent directory if missing
+  Dependencies: imports from [pydantic, pathlib, json, os, threading, time] | imported by [host/http_router.py, host/server.py, host/ws_router/, host/session/] | tested by [test_session_storage.py, test_acp_host_set_mode.py]
+  Data flow: save() appends under the file lock | atomic_update() locks, reads detached latest, validates replacement, and appends if changed | get() reads newest matching valid line | compact() replaces under the same lock
+  State/Effects: append-only JSONL plus sibling lock file; thread-local depth permits same-thread nested operations while OS locks serialize threads/processes
+  Integration: atomic_update is the durable boundary shared by prompt claims and Host policy transactions
+  Performance: append O(1); reverse get usually finds recent state near EOF; list/compaction scan the file
+  Errors: missing/expired returns None; torn records are skipped; lock timeout and invalid updater fail closed without an unlocked append
 """
 
 import json
 import os
+import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from pydantic import BaseModel
 
@@ -122,6 +123,7 @@ class SessionStorage:
         # tool calling os.chdir would move the history mid-run.
         self.path = Path(path) if path else project_co_dir() / "session_results.jsonl"
         self.path.parent.mkdir(exist_ok=True)
+        self._lock_state = threading.local()
 
     @property
     def _lock_path(self) -> Path:
@@ -129,12 +131,70 @@ class SessionStorage:
 
     def save(self, session: Session):
         # Excludes compact(), which replaces this file wholesale.
-        handle = _exclusive(self._lock_path)
+        if not self._acquire_lock():
+            raise TimeoutError("could not acquire session storage lock")
         try:
-            with open(self.path, "a", encoding="utf-8") as f:
-                f.write(session.model_dump_json() + "\n")
+            self._append_locked(session)
         finally:
-            _release(handle)
+            self._release_lock()
+
+    def atomic_update(
+        self,
+        session_id: str,
+        updater: Callable[[Session | None], Session],
+    ) -> Session:
+        """Read latest, prepare a replacement, and append under one lock.
+
+        The callback receives a detached Pydantic record. Raising leaves the
+        append-only log unchanged; returning a different session id is refused.
+        This is the short cross-process commit boundary used by prompt claims
+        and policy writes -- never hold it across an Agent or network wait.
+        """
+        if not self._acquire_lock():
+            raise TimeoutError("could not acquire session storage lock")
+        try:
+            current = self.get(session_id)
+            if current is not None:
+                current = current.model_copy(deep=True)
+            replacement = updater(current)
+            if not isinstance(replacement, Session):
+                raise TypeError("session storage updater must return Session")
+            if replacement.session_id != session_id:
+                raise ValueError("session storage updater changed session id")
+            if current is None or replacement != current:
+                self._append_locked(replacement)
+            return replacement.model_copy(deep=True)
+        finally:
+            self._release_lock()
+
+    def _append_locked(self, session: Session) -> None:
+        with open(self.path, "a", encoding="utf-8") as f:
+            f.write(session.model_dump_json() + "\n")
+
+    def _acquire_lock(self, *, wait: bool = True) -> bool:
+        """Acquire this storage lock, reusing it only in the owning thread."""
+        depth = getattr(self._lock_state, "depth", 0)
+        if depth:
+            self._lock_state.depth = depth + 1
+            return True
+        handle = _exclusive(self._lock_path, wait=wait)
+        if handle is None:
+            return False
+        self._lock_state.handle = handle
+        self._lock_state.depth = 1
+        return True
+
+    def _release_lock(self) -> None:
+        depth = getattr(self._lock_state, "depth", 0)
+        if depth <= 0:
+            raise RuntimeError("session storage lock is not held")
+        if depth > 1:
+            self._lock_state.depth = depth - 1
+            return
+        handle = self._lock_state.handle
+        del self._lock_state.handle
+        del self._lock_state.depth
+        _release(handle)
 
     def _records(self) -> list:
         """Every parseable record, oldest first. A torn line costs itself, nothing more.
@@ -240,13 +300,12 @@ class SessionStorage:
         if not self.path.exists():
             return
 
-        handle = _exclusive(self._lock_path, wait=False)
-        if handle is None:
+        if not self._acquire_lock(wait=False):
             return          # someone is writing; the next cycle compacts
         try:
             self._compact_locked()
         finally:
-            _release(handle)
+            self._release_lock()
 
     def _compact_locked(self) -> None:
         now = time.time()

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -25,13 +25,6 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
-class _AgentExecutionError(RuntimeError):
-    """Private Agent failure marker with a fixed public representation."""
-
-    def __init__(self):
-        super().__init__("Unable to run agent")
-
-
 def _acp_rollout_frame(event, session_id):
     if not session_id:
         return None
@@ -130,11 +123,14 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
                                                       requester_address=requester_address)
     except ModeTransactionError as exc:
         result_holder[0] = exc
-    except Exception:
+    except Exception as exc:
         logger.exception(
             "Hosted Agent execution failed for session %s", session_id
         )
-        result_holder[0] = _AgentExecutionError()
+        # Keep the original exception for in-process diagnostics and legacy
+        # callers. The WebSocket boundary below owns disclosure and maps every
+        # unexpected exception to one fixed -32603 response.
+        result_holder[0] = exc
     finally:
         # A failed run is finished too. Leaving it marked "running" routes the
         # next INPUT into a dead IO queue and creates another false ACK.

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -1,14 +1,15 @@
 """
-Purpose: Agent thread orchestration + io → client streaming — the bridge between the sync agent and the async transport
+Purpose: Bridge synchronous hosted Agents to the async WebSocket transport
 LLM-Note:
-  Dependencies: imports from [...io (WebSocketIO), ..session (session_to_chat_items via lazy import), asyncio, threading, rich.console] | imported by [.session (start_agent), .connect (resume_forwarding)]
-  Data flow: start_agent: validate INPUT → create WebSocketIO → register in registry BEFORE thread.start (race-safe) → spawn _agent_thread_body (thread target running route_handlers["ws_input"]) → success or exception always returns registry to connected → spawn forward_task = forward_agent_msgs_to_client → return (io, task) | resume_forwarding: same forward_task spawn but on existing active.io | forward_agent_msgs_to_client: read_msgs_from_agent → send_msg loop → on agent finish read result_holder → mirror a persisted final assistant item as ACP → emit authoritative OUTPUT (success) / ERROR (exception)
-  State/Effects: spawns daemon Thread + asyncio.Task | mutates registry (register / mark_session_running) | calls io.mark_agent_done() in finally
-  Integration: imports core.acp_wire.acp_notification_frame and session.session_to_chat_items lazily | start_agent(data, send_msg, conn, route_handlers, storage, registry) → (io, forward_task) | None | resume_forwarding(send_msg, active, registry, session_id, storage, conn) → (io, forward_task) | forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder, conn, storage) — async, runs until io marked done
+  Dependencies: imports from [core.acp_wire, network.io, session.mode]
+  Data flow: INPUT → Agent thread → WebSocketIO → async forwarder → OUTPUT/ERROR
+  State/Effects: spawns Agent threads/tasks; updates the active-session registry
+  Integration: start_agent(), resume_forwarding(), forward_agent_msgs_to_client()
   Performance: thread-per-INPUT (worker isolation) | one forward_task per WS connection
-  Errors: agent thread exceptions captured in result_holder[0]; surfaced as ERROR frame by the forwarder (threads don't propagate exceptions natively)
+  Errors: owned failures stay public; unexpected failures log and become -32603
 """
 import asyncio
+import logging
 import threading
 
 from rich.console import Console
@@ -18,8 +19,17 @@ from ....core.acp_wire import (
     acp_permission_request_frame,
 )
 from ...io import WebSocketIO
+from ..session.mode import ModeTransactionError
 
 console = Console()
+logger = logging.getLogger(__name__)
+
+
+class _AgentExecutionError(RuntimeError):
+    """Private Agent failure marker with a fixed public representation."""
+
+    def __init__(self):
+        super().__init__("Unable to run agent")
 
 
 def _acp_rollout_frame(event, session_id):
@@ -118,8 +128,13 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
     try:
         result_holder[0] = route_handlers["ws_input"](storage, prompt, io, session, images, files,
                                                       requester_address=requester_address)
-    except Exception as e:
-        result_holder[0] = e
+    except ModeTransactionError as exc:
+        result_holder[0] = exc
+    except Exception:
+        logger.exception(
+            "Hosted Agent execution failed for session %s", session_id
+        )
+        result_holder[0] = _AgentExecutionError()
     finally:
         # A failed run is finished too. Leaving it marked "running" routes the
         # next INPUT into a dead IO queue and creates another false ACK.
@@ -151,8 +166,23 @@ async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holde
         await send_msg(event)
 
     if result_holder and isinstance(result_holder[0], Exception):
-        console.print(f"[red]✗ agent error:[/red] {result_holder[0]}")
-        await send_msg({"type": "ERROR", "message": str(result_holder[0])})
+        error = result_holder[0]
+        if isinstance(error, ModeTransactionError):
+            message = {
+                "type": "ERROR",
+                "code": error.code,
+                "message": error.message,
+            }
+            if error.data:
+                message.update(error.data)
+        else:
+            message = {
+                "type": "ERROR",
+                "code": -32603,
+                "message": "Unable to run agent",
+            }
+        console.print(f"[red]✗ agent error:[/red] {message['message']}")
+        await send_msg(message)
     elif result_holder and result_holder[0]:
         result = result_holder[0]
         session_data = result.get('session', {})

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -1,22 +1,29 @@
 """
-Purpose: Handle the CONNECT message — Ed25519 signature auth, session merge, status decision, optional reattach to a still-running agent
+Purpose: Authenticate CONNECT, bind session ownership, initialize durable Host mode policy, advertise capabilities, and optionally reattach running work
 LLM-Note:
   Dependencies: imports from [..session (merge_sessions, session_to_chat_items via lazy local import), ...trust.ws_admin (get_onboard_requirements), .agent_io (resume_forwarding), uuid, rich.console] | imported by [.session as part of CONNECT dispatch]
-  Data flow: route_handlers["auth"] verifies sig → if forbidden + onboard methods configured: stash conn['pending_connect'] + send ONBOARD_REQUIRED | else if other err: send ERROR | else: establish_connection(): populate conn (authenticated/agent_address/session_id/session) → merge_sessions if stored exists → registry status check (running/connected/new) → send CONNECTED → if running: io.rewind_to(last_msg_id) + resume_forwarding (returns (io, task)) | establish_connection is also called by the session loop after a successful onboard, with the onboard-verified agent_address (no CONNECT replay — its signature may have aged past the 5-minute window)
-  State/Effects: mutates conn dict in place (authenticated, agent_address, session_id, session) | calls registry.update_ping when reattaching to 'connected'
+  Data flow: verify identity/trust → bind/replace session ID by owner → merge conversation → ensure durable Safe/current policy → derive identity-bounded SessionModeState → CONNECTED → optional running-agent rewind/resume
+  State/Effects: mutates authenticated connection state; may append initial/normalized durable session; refreshes registry ping when reattaching
   Integration: handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist) → returns (io, forward_task) for reattach or None
-  Performance: one storage.get + optional merge_sessions per CONNECT | one registry.get for status decision
-  Errors: auth errors surface to client as ERROR (let it crash for unexpected internals)
+  Performance: one ownership read plus one atomic mode-state initialization and registry checks per CONNECT
+  Errors: auth/policy/storage initialization failures surface as bounded ERROR frames; private storage exceptions are not sent
 """
+import asyncio
+import logging
 import uuid
 
 from rich.console import Console
 
-from ....core.acp_wire import ACP_CANCEL_METHOD, ACP_SCHEMA_VERSION
+from ....core.acp_wire import (
+    ACP_CANCEL_METHOD,
+    ACP_SCHEMA_VERSION,
+    ACP_SET_SESSION_MODE_METHOD,
+)
 from ...trust.ws_admin import get_onboard_requirements
 from .agent_io import resume_forwarding
 
 console = Console()
+logger = logging.getLogger(__name__)
 
 
 async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
@@ -78,19 +85,25 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     ``route_handlers`` is optional so a caller that only needs the session half can
     omit it; without it no AGENT_PROFILE is sent.
     """
-    conn["authenticated"] = True
-    conn["agent_address"] = agent_address
-    conn["signed_commands"] = (
+    # A second CONNECT on the same socket must not inherit the first identity
+    # while durable policy initialization is in flight or after it fails.
+    conn["authenticated"] = False
+    for key in (
+        "agent_address", "signed_commands", "recipient_address", "session_id",
+        "session", "mode_is_admin",
+    ):
+        conn.pop(key, None)
+
+    signed_commands = (
         data.get("payload", {}).get("signed_commands") == 1
     )
-    conn["recipient_address"] = data.get("payload", {}).get("to")
+    recipient_address = data.get("payload", {}).get("to")
     session_id = data.get("session_id") or str(uuid.uuid4())
-    conn["session_id"] = session_id
-    conn["session"] = data.get("session")
+    client_session = data.get("session")
     server_newer = False
 
-    if conn["session"]:
-        msg_count = len(conn["session"].get("messages", []))
+    if client_session:
+        msg_count = len(client_session.get("messages", []))
         console.print(f"  [dim]↑ client session: {msg_count} messages[/dim]")
 
     if session_id:
@@ -117,10 +130,11 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
                           f"caller — starting a new one[/dim]")
             stored = None
             session_id = str(uuid.uuid4())
-            conn["session_id"] = session_id
         if stored and stored.session:
-            client = conn["session"] or {}
-            conn["session"], server_newer = merge_sessions(client_session=client, server_session=stored.session)
+            client = client_session or {}
+            client_session, server_newer = merge_sessions(
+                client_session=client, server_session=stored.session
+            )
             if server_newer:
                 console.print("  [dim]↕ merged sessions (server newer)[/dim]")
 
@@ -136,6 +150,69 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     else:
         status = "new"
 
+    mode_state = None
+    mode_policy = (
+        route_handlers.get("session_modes") if route_handlers is not None else None
+    )
+    mode_is_admin = None
+    if mode_policy is not None:
+        from ..session.mode import (
+            ModeTransactionError,
+            ensure_host_mode_session,
+            session_with_durable_policy,
+        )
+
+        trust_agent = route_handlers["trust_agent"]
+        is_admin = trust_agent.is_admin(agent_address)
+        level = "admin" if is_admin else trust_agent.get_level(agent_address)
+        try:
+            mode_record = await asyncio.to_thread(
+                ensure_host_mode_session,
+                storage,
+                session_id,
+                requester={"address": agent_address, "level": level},
+                result_ttl=route_handlers["result_ttl"],
+                policy=mode_policy,
+                is_admin=is_admin,
+            )
+            client_session = session_with_durable_policy(
+                client_session, mode_record.session
+            )
+            mode_state = mode_policy.state(
+                mode_record.session, is_admin=is_admin
+            )
+        except ModeTransactionError as exc:
+            logger.warning(
+                "Host mode initialization rejected for session %s: %s",
+                session_id,
+                exc,
+            )
+            await send_msg({"type": "ERROR", "message": exc.message})
+            return None
+        except Exception:
+            logger.exception(
+                "Host mode initialization failed for session %s", session_id
+            )
+            await send_msg({
+                "type": "ERROR",
+                "message": "Unable to initialize session mode",
+            })
+            return None
+        mode_is_admin = is_admin
+
+    # Publish the verified identity only after every durable initialization and
+    # policy derivation above has succeeded.
+    conn.update({
+        "authenticated": True,
+        "agent_address": agent_address,
+        "signed_commands": signed_commands,
+        "recipient_address": recipient_address,
+        "session_id": session_id,
+        "session": client_session,
+    })
+    if mode_is_admin is not None:
+        conn["mode_is_admin"] = mode_is_admin
+
     console.print(f"[green]✓ CONNECT[/green] agent_address={agent_address[:16]}... session={session_id[:8]}... status={status}{' (server_newer)' if server_newer else ''}")
 
     connected_msg = {
@@ -146,14 +223,18 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
             "acp": {
                 "schema": ACP_SCHEMA_VERSION,
                 "client_notifications": [ACP_CANCEL_METHOD],
+                **({"client_requests": [ACP_SET_SESSION_MODE_METHOD]}
+                   if mode_state is not None else {}),
             }
         },
     }
-    if server_newer and conn["session"]:
+    if mode_state is not None:
+        connected_msg["session_modes"] = mode_state
+    if server_newer and client_session:
         from ..session import session_to_chat_items
         connected_msg["server_newer"] = True
-        connected_msg["session"] = conn["session"]
-        connected_msg["chat_items"] = session_to_chat_items(conn["session"])
+        connected_msg["session"] = client_session
+        connected_msg["chat_items"] = session_to_chat_items(client_session)
     await send_msg(connected_msg)
 
     # This socket is now past signature verification and the trust gate, so it is the

--- a/connectonion/network/host/ws_router/mode.py
+++ b/connectonion/network/host/ws_router/mode.py
@@ -1,0 +1,153 @@
+"""
+Purpose: Dispatch acknowledged ACP and bounded legacy Host mode commands
+LLM-Note:
+  Dependencies: imports from [core.acp_wire, host.session.mode, rich.console] | imported by [.session] | tested by [tests/unit/test_acp_host_set_mode.py]
+  Data flow: run_ws_session routes ACP_REQUEST/mode_change here -> validate request identity/session -> commit_host_session_mode() -> update conn only after append -> send ACP_RESPONSE or legacy mode_changed
+  State/Effects: tracks a bounded insertion-ordered map of consumed request IDs in conn; mutates conn['session'] only after durable success
+  Integration: handle_acp_mode_request returns False for an unsupported schema/method so session.py can reject without forwarding; handle_legacy_mode_change maps the temporary plan alias to Safe
+  Errors: policy failures retain their owned JSON-RPC code; malformed params=-32602, storage failure=-32603 without private exception details
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from ....core.acp_wire import (
+    ACPSessionMismatchError,
+    acp_set_mode_error_frame,
+    acp_set_mode_request,
+    acp_set_mode_request_id,
+    acp_set_mode_response_frame,
+)
+from ..session.mode import ModeTransactionError, commit_host_session_mode
+
+logger = logging.getLogger(__name__)
+_MAX_REQUEST_IDS = 256
+
+
+async def handle_acp_mode_request(
+    frame, send_msg, conn, route_handlers, storage, registry
+) -> bool:
+    """Handle this supported ACP method; return False for another method."""
+    request_id = acp_set_mode_request_id(frame)
+    policy = route_handlers.get("session_modes")
+    if request_id is None or policy is None:
+        return False
+    session_id = conn.get("session_id")
+    if not conn.get("authenticated") or not session_id:
+        await send_msg({"type": "ERROR", "message": "authenticate first (send CONNECT)"})
+        return True
+    if _request_id_was_seen(conn, request_id):
+        await send_msg(acp_set_mode_error_frame(
+            request_id, session_id, -32602, "Duplicate request ID"
+        ))
+        return True
+
+    try:
+        _, mode_id = acp_set_mode_request(
+            frame, expected_session_id=session_id
+        )
+        record = await asyncio.to_thread(
+            commit_host_session_mode,
+            storage,
+            registry,
+            session_id,
+            conn.get("agent_address"),
+            mode_id,
+            policy,
+            bool(conn.get("mode_is_admin")),
+        )
+    except ModeTransactionError as exc:
+        await _send_owned_error(send_msg, request_id, session_id, exc)
+        return True
+    except ACPSessionMismatchError as exc:
+        await send_msg(acp_set_mode_error_frame(
+            request_id, session_id, -32002, str(exc)
+        ))
+        return True
+    except (TypeError, ValueError) as exc:
+        await send_msg(acp_set_mode_error_frame(
+            request_id, session_id, -32602, str(exc)
+        ))
+        return True
+    except Exception:
+        logger.exception(
+            "ACP mode persistence failed for session %s", session_id
+        )
+        await send_msg(acp_set_mode_error_frame(
+            request_id, session_id, -32603, "Unable to change session mode"
+        ))
+        return True
+
+    conn["session"] = record.session
+    await send_msg(acp_set_mode_response_frame(request_id, session_id))
+    return True
+
+
+async def handle_legacy_mode_change(
+    frame, send_msg, conn, route_handlers, storage, registry
+) -> None:
+    """Commit the rolling-compatibility setter through the same authority."""
+    policy = route_handlers.get("session_modes")
+    session_id = conn.get("session_id")
+    if not conn.get("authenticated") or policy is None or not session_id:
+        await send_msg({"type": "ERROR", "message": "mode change is unavailable"})
+        return
+    mode_id = "safe" if frame.get("mode") == "plan" else frame.get("mode")
+    try:
+        record = await asyncio.to_thread(
+            commit_host_session_mode,
+            storage,
+            registry,
+            session_id,
+            conn.get("agent_address"),
+            mode_id,
+            policy,
+            bool(conn.get("mode_is_admin")),
+        )
+    except ModeTransactionError as exc:
+        error = {"type": "ERROR", "code": exc.code, "message": exc.message}
+        if exc.data:
+            error.update(exc.data)
+        await send_msg(error)
+        return
+    except Exception:
+        logger.exception(
+            "Legacy mode persistence failed for session %s", session_id
+        )
+        await send_msg({
+            "type": "ERROR",
+            "code": -32603,
+            "message": "Unable to change session mode",
+        })
+        return
+
+    conn["session"] = record.session
+    await send_msg({
+        "type": "mode_changed",
+        "mode": record.session["mode"],
+        "session_id": session_id,
+    })
+
+
+def _request_id_was_seen(conn: dict, request_id: str) -> bool:
+    seen = conn.setdefault("mode_request_ids", {})
+    if request_id in seen:
+        return True
+    seen[request_id] = None
+    if len(seen) > _MAX_REQUEST_IDS:
+        seen.pop(next(iter(seen)))
+    return False
+
+
+async def _send_owned_error(
+    send_msg, request_id: str, session_id: str, error: ModeTransactionError
+) -> None:
+    await send_msg(acp_set_mode_error_frame(
+        request_id,
+        session_id,
+        error.code,
+        error.message,
+        error.data,
+    ))

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -1,10 +1,10 @@
 """
 Purpose: Run one client session — read loop, per-type dispatch, lifecycle of forward + ping tasks
 LLM-Note:
-  Dependencies: imports from [.connect (handle_connect), .agent_io (start_agent), .ping (ping_loop), ...trust.ws_admin (handle_admin_message, handle_onboard_submit), asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
-  Data flow: recv_msg() → match data["type"] → dispatch | PONG → registry.update_ping | SESSION_STATUS → registry lookup + reply (inline) | CONNECT → handle_connect (auth + reattach) | INPUT → if running session: push_runtime_input + RUNTIME_INPUT_ACK (inline); else: start_agent | EXEC → run_exec as own task (direct tool call, no LLM; requires auth) | other types with active_io → active_io.send_to_agent | finally: cancel forward + ping + exec tasks
+  Dependencies: imports from [.connect, .agent_io, .exec, .mode, .ping, ...trust.ws_admin, asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
+  Data flow: recv → verify every v2 application command → dispatch CONNECT/INPUT/EXEC/ACP_REQUEST/mode_change/ACP_NOTIFICATION/admin/runtime frames → bounded response → cancel spawned tasks on close
   State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally
-  Integration: run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registry, trust, blacklist=None, whitelist=None, enable_ping=True) | enable_ping=True on both direct and relay paths: the 30s client PING is forwarded through the relay to the client, since the relay's ANNOUNCE heartbeat only keeps the agent↔relay link alive and never reaches the client
+  Integration: ACP session/set_mode and legacy mode_change use .mode durable authority; ACP cancel requires registered active IO; signed-command clients execute only verified payload copies
   Performance: single-reader of recv_msg | O(1) per-message dispatch | bounded local state
   Errors: recv_msg returning None → exit loop normally | other exceptions propagate out (transport-level errors, programmer bugs)
 """
@@ -17,6 +17,7 @@ from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
 from .agent_io import start_agent
 from .connect import establish_connection, handle_connect
 from .exec import run_exec
+from .mode import handle_acp_mode_request, handle_legacy_mode_change
 from .ping import ping_loop
 
 console = Console()
@@ -204,6 +205,21 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                         run_exec(data, send_msg, route_handlers, conn["agent_address"]))
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
+
+            elif msg_type == "ACP_REQUEST":
+                handled = await handle_acp_mode_request(
+                    data, send_msg, conn, route_handlers, storage, registry
+                )
+                if not handled:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "unsupported ACP client request",
+                    })
+
+            elif msg_type == "mode_change":
+                await handle_legacy_mode_change(
+                    data, send_msg, conn, route_handlers, storage, registry
+                )
 
             elif msg_type == "ACP_NOTIFICATION":
                 sid = conn.get("session_id")

--- a/connectonion/useful_plugins/ulw.py
+++ b/connectonion/useful_plugins/ulw.py
@@ -23,7 +23,7 @@ Usage:
 
 from typing import TYPE_CHECKING
 
-from ..core.events import after_user_input, on_complete, before_iteration, before_llm
+from ..core.events import after_user_input, before_iteration, before_llm, on_complete
 
 if TYPE_CHECKING:
     from ..core.agent import Agent
@@ -148,6 +148,19 @@ def ulw_keep_working(agent: 'Agent') -> None:
     max_turns = agent.current_session.get('ulw_turns', ULW_DEFAULT_TURNS)
 
     if turns_used >= max_turns:
+        # A hosted grant is bounded by the launch-time authority captured by
+        # Host. The local mailbox extension below is a standalone Agent
+        # compatibility path; it must never increase remote authority.
+        if getattr(agent, '_host_ulw_turns_ceiling', None) is not None:
+            if agent.io:
+                agent.io.send({
+                    'type': 'ulw_turns_reached',
+                    'turns_used': turns_used,
+                    'max_turns': max_turns
+                })
+            _exit_ulw_mode(agent, 'safe')
+            return
+
         # Max turns reached - pause for user (if IO available)
         if agent.io:
             agent.io.send({

--- a/docs/api.md
+++ b/docs/api.md
@@ -483,6 +483,11 @@ remote = connect("0x3d40...")
 # LLM-driven task
 resp = remote.input("Book a flight")      # -> Response(text, done)
 
+# The Host advertises the modes this identity may select. The setter returns
+# only after the Host has durably committed the new policy.
+remote.set_session_mode("accept_edits")
+print(remote.available_modes)
+
 # Direct tool execution — no LLM (see network/remote-call.md)
 res = remote.call("bash", command="co status")   # -> ExecResult
 ```
@@ -491,6 +496,13 @@ res = remote.call("bash", command="co status")   # -> ExecResult
 |--------|---------|---------|
 | `remote.input(prompt, timeout=60)` | `Response(text, done)` | Hand the remote LLM a task |
 | `remote.call(tool, timeout=60, **args)` | `ExecResult(text, status, duration_ms, error)` | Run one tool directly, no LLM |
+| `remote.set_session_mode(mode_id, timeout=30)` | `None` | Durably select one Host-advertised ACP session mode |
+
+`set_session_mode()` returning means the Host committed the policy. A
+`TimeoutError` is an unknown outcome, not a rollback: the Host may have
+committed before its acknowledgement was lost. Reconnect and read
+`available_modes` plus `current_session["mode"]` from the next authoritative
+`CONNECTED` response before retrying.
 
 `ExecResult`: `.ok` (bool), `.images` (base64 data URLs pulled from `.text`).
 Direct execution is gated by the host's `.co/host.yaml` permission whitelist.

--- a/docs/design-decisions/040-durable-acp-host-session-mode-transactions.md
+++ b/docs/design-decisions/040-durable-acp-host-session-mode-transactions.md
@@ -56,6 +56,11 @@ CONNECT creates an owned, durable Safe snapshot for a new session. INPUT and
 while holding the same lock. A `running` or `waiting_approval` record rejects
 the mode request as retryable and prevents a second prompt claim.
 
+Both WebSocket INPUT and HTTP `/input` carry the signature-verified requester
+into that prompt claim. An existing owned session cannot be claimed by a
+different identity or by a path that dropped the identity after authentication;
+the session ID remains correlation, never authority.
+
 The mutation is prepared in a detached copy. Ownership, TTL, history, trace,
 permissions, and unrelated fields are preserved. Only a successful append may
 update the connection snapshot or produce a success response. Storage lock
@@ -65,6 +70,58 @@ write or an in-memory policy grant.
 The process-local active-session registry remains a fast busy check, but it is
 not the authority because another worker has another registry. The latest
 locked durable record decides.
+
+The storage implementation is intentionally synchronous, but WebSocket
+CONNECT and mode handlers never run that file-lock wait on the async event
+loop. They delegate the complete transaction to a worker thread and await its
+result. This changes scheduling only: the JSONL lock remains the sole commit
+boundary.
+
+CONNECT does not publish authenticated connection state until durable mode
+initialization and mode-state derivation both succeed. A failure sends a
+bounded error, logs the private exception on the server, and leaves later
+frames on that socket subject to the unauthenticated gate.
+
+### Make the Host ceiling terminal for each ULW grant
+
+The captured launch ceiling is also attached to the fresh hosted Agent as a
+Host-only runtime boundary. When that many turns have been consumed, the Host
+may emit the existing checkpoint observation but must immediately exit to
+Safe, remove all bypass fields, and stop. The legacy local-Agent mailbox may
+still extend a locally configured ULW run; it cannot extend a Host grant. A
+client that wants another hosted ULW run must make another durable
+`session/set_mode` transaction after the prompt is idle.
+
+Before the final Host record is appended, the verified requester is restored
+and the session is normalized against the captured policy. Invalid plugin or
+Agent state is downgraded to Safe and has every ULW bypass field removed. This
+prevents a terminal `used == turns` snapshot, or any expanded ceiling, from
+stranding the durable session.
+
+If Agent construction or execution raises after the atomic prompt claim, the
+Host appends a policy-normalized terminal `failed` replacement before the
+exception crosses the carrier boundary. A failed factory cannot leave the
+session permanently `running` and block later prompt or mode transactions.
+
+### Keep carrier failures stable and bounded
+
+HTTP prompt claims map the same owned policy failures to transport status:
+missing or foreign ownership is 404, busy/running is 409, and invalid policy
+input is 400. Internal storage details are logged but never returned.
+
+The Python client applies one caller-supplied deadline to endpoint resolution,
+CONNECT negotiation, PING handling, and the owned ACP response together.
+Successful acknowledgements remove any local ULW bypass fields before
+mirroring Safe or Auto, so the client snapshot cannot retain stale authority.
+The deadline bounds client waiting, not the already-running Host transaction:
+a timeout is an unknown outcome, never proof of rollback. The client keeps its
+old local snapshot and reconnects to read authoritative `CONNECTED` mode state
+before retrying.
+
+WebSocket prompt execution uses the same disclosure boundary. Owned
+`ModeTransactionError` policy results retain their stable public fields;
+unexpected Agent or storage exceptions are logged with traceback on the Host
+and collapse to `-32603 / Unable to run agent` on the wire.
 
 ### Bound compatibility to the same transaction
 
@@ -79,7 +136,9 @@ durable commit. The legacy path cannot supply a turn ceiling.
 - A mode selected before the first prompt persists and governs that prompt.
 - A response means the policy is durable, not merely queued in memory.
 - Multiple sockets and workers cannot grant policy while a turn is running.
+- Slow storage cannot stall unrelated WebSocket work on the event loop.
 - Non-admin callers see Safe only; clients cannot manufacture Auto or ULW.
+- A hosted ULW grant ends at its launch ceiling and requires a new transaction.
 - Old clients keep a bounded transition path while React and O Chat migrate.
 - A storage error is visible and leaves the prior policy authoritative.
 

--- a/docs/design-decisions/040-durable-acp-host-session-mode-transactions.md
+++ b/docs/design-decisions/040-durable-acp-host-session-mode-transactions.md
@@ -1,0 +1,105 @@
+# DD-040: Host session modes commit before acknowledgement
+
+**Status:** Accepted
+
+**Date:** 2026-08-11
+
+## Context
+
+DD-031 defines session-mode authority for the local ACP stdio adapter, and
+DD-039 lets the authenticated network Host report an Agent-originated mode
+change. The Host's client setter is still the legacy `mode_change` mailbox
+message. It exists only while an Agent is running, has no owned response, can
+cross a prompt boundary, and cannot persist a change made before the first
+prompt.
+
+The supported browser path is Host → `@connectonion/react` → O Chat. The
+standalone TypeScript SDK is retired. React therefore needs one acknowledged
+Host transaction; O Chat must remain protocol-free.
+
+## Decision
+
+### Carry one exact ACP request and response
+
+The authenticated Host carrier accepts `ACP_REQUEST` with schema
+`schema-v1.19.0` and an exact nested JSON-RPC `session/set_mode` request. Its
+params validate through the official `SetSessionModeRequest` model and contain
+only `sessionId` and `modeId`; `_meta` is never treated as authority. A
+syntactically owned request receives one `ACP_RESPONSE`, correlated by the
+request ID and the Host-bound session ID, containing the official empty
+`SetSessionModeResponse` or a JSON-RPC error.
+
+`CONNECTED` advertises `session/set_mode` only with an exact
+`SessionModeState`. The persisted IDs remain `safe`, `accept_edits`, and `ulw`.
+`plan` remains a temporary legacy UI alias for Safe and is never serialized as
+an ACP mode.
+
+### Derive modes from server authority
+
+Safe is always available. Auto (`accept_edits`) is available only to the Host
+operator/admin. ULW is available only to that identity when the Agent factory
+was explicitly configured with a positive `_yolo_turns` ceiling. The Host
+captures that launch ceiling once and disarms the Agent's automatic first-turn
+activation; the durable session mode, not a constructor side effect, decides
+the prompt policy.
+
+An ACP client cannot select or extend ULW turns because
+`SetSessionModeRequest` has no turns field. Entering ULW initializes the three
+bounded server-owned fields from the captured ceiling. Leaving it removes all
+three before persistence.
+
+### Serialize prompt claims and policy writes in storage
+
+The JSONL storage lock is the cross-socket and cross-worker commit boundary.
+CONNECT creates an owned, durable Safe snapshot for a new session. INPUT and
+`session/set_mode` each read the latest record and append their replacement
+while holding the same lock. A `running` or `waiting_approval` record rejects
+the mode request as retryable and prevents a second prompt claim.
+
+The mutation is prepared in a detached copy. Ownership, TTL, history, trace,
+permissions, and unrelated fields are preserved. Only a successful append may
+update the connection snapshot or produce a success response. Storage lock
+timeouts and append failures raise; they never fall through to an unlocked
+write or an in-memory policy grant.
+
+The process-local active-session registry remains a fast busy check, but it is
+not the authority because another worker has another registry. The latest
+locked durable record decides.
+
+### Bound compatibility to the same transaction
+
+Legacy `mode_change` is intercepted by the Host rather than forwarded into the
+Agent mailbox. Its `plan` alias normalizes to Safe for rolling compatibility;
+all other mode, ownership, busy-state, admin, and ULW-ceiling checks are the
+same as ACP. It emits the existing `mode_changed` observation only after the
+durable commit. The legacy path cannot supply a turn ceiling.
+
+## Consequences
+
+- A mode selected before the first prompt persists and governs that prompt.
+- A response means the policy is durable, not merely queued in memory.
+- Multiple sockets and workers cannot grant policy while a turn is running.
+- Non-admin callers see Safe only; clients cannot manufacture Auto or ULW.
+- Old clients keep a bounded transition path while React and O Chat migrate.
+- A storage error is visible and leaves the prior policy authoritative.
+
+## Rejected alternatives
+
+- **Forward ACP into the running mailbox:** no idle receiver, no durable commit,
+  and the request can cross an approval/tool boundary.
+- **Trust the client session snapshot:** the client round-trips that JSON and
+  could add `skip_tool_approval` itself.
+- **Use only the in-memory registry:** worker processes do not share it.
+- **Hold a file lock for the whole prompt:** it would serialize unrelated
+  storage operations for the duration of model and human waits.
+- **Accept a client `turns` extension:** ACP defines no such field and it would
+  exceed the operator's launch authority.
+
+## Related decisions
+
+- DD-029: persistent ACP session ownership
+- DD-030: generation-scoped ACP tool approvals
+- DD-031: ACP session modes stay below launch authority
+- DD-035: versioned ACP Host carrier
+- DD-037: bound ACP Host permissions
+- DD-039: authoritative ACP Host mode updates

--- a/docs/network/connect.md
+++ b/docs/network/connect.md
@@ -768,13 +768,22 @@ agent = connect("0x...", relay_url="ws://localhost:8000/ws/announce")
 class RemoteAgent:
     # Actions
     def input(self, prompt: str) -> Response
+    def set_session_mode(self, mode_id: str, timeout: float = 30.0) -> None
     def reset(self) -> None
 
     # State (read-only)
     current_session: dict    # Full session data
+    available_modes: list    # Host-advertised ACP modes for this identity
     ui: List[UIEvent]        # Shortcut to current_session['trace']
     status: str              # 'idle' | 'working' | 'waiting'
 ```
+
+`set_session_mode()` uses one timeout budget for endpoint resolution,
+CONNECT, PING handling, and the owned ACP response. If it raises
+`TimeoutError`, the durable outcome is unknown: Host persistence may have
+completed even though the acknowledgement did not arrive. Reconnect and use
+the next `CONNECTED` mode state (`available_modes` and
+`current_session["mode"]`) as authority before retrying.
 
 ### useAgentForHuman() (React)
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -420,6 +420,54 @@ The Host accepts only an advertised option for the active request and session.
 response or `cancelled` fails closed. Optional rejection feedback belongs at
 `result._meta.connectonion.feedback` and has no authorization meaning.
 
+#### ACP_REQUEST (`session/set_mode`)
+
+An authenticated client selects one Host-advertised session mode with the exact
+ACP v1.19 request. On a signed-command connection the complete request is also
+the signed `payload`; the Host executes that verified copy.
+
+```json
+{
+  "type": "ACP_REQUEST",
+  "acpSchema": "schema-v1.19.0",
+  "message": {
+    "jsonrpc": "2.0",
+    "id": "mode-request-uuid",
+    "method": "session/set_mode",
+    "params": {
+      "sessionId": "550e8400-...",
+      "modeId": "accept_edits"
+    }
+  },
+  "payload": {
+    "type": "ACP_REQUEST",
+    "acpSchema": "schema-v1.19.0",
+    "message": {
+      "jsonrpc": "2.0",
+      "id": "mode-request-uuid",
+      "method": "session/set_mode",
+      "params": {
+        "sessionId": "550e8400-...",
+        "modeId": "accept_edits"
+      }
+    },
+    "to": "0x3d4017c3e843...",
+    "timestamp": 1702234567,
+    "nonce": "550e8400-..."
+  },
+  "from": "0xClientPublicKey",
+  "signature": "0x..."
+}
+```
+
+The request is accepted only while the durable session is idle and owned by
+the authenticated caller. `safe` is always available; `accept_edits` and `ulw`
+are identity- and launch-authority-bounded. No client field can supply or extend
+ULW turns. Success is an `ACP_RESPONSE` with an empty result and means the JSONL
+commit completed; busy, policy, ownership, and persistence failures are
+correlated JSON-RPC errors. `@connectonion/react` owns this browser operation;
+O Chat consumes it without constructing protocol frames.
+
 #### ONBOARD_SUBMIT
 
 Pass the trust gate. Sent in reply to `ONBOARD_REQUIRED`, on the same socket.
@@ -458,6 +506,20 @@ Response to CONNECT.
   "type": "CONNECTED",
   "session_id": "550e8400-...",
   "status": "new",
+  "carrier_capabilities": {
+    "acp": {
+      "schema": "schema-v1.19.0",
+      "client_notifications": ["session/cancel"],
+      "client_requests": ["session/set_mode"]
+    }
+  },
+  "session_modes": {
+    "currentModeId": "safe",
+    "availableModes": [
+      {"id": "safe", "name": "Safe", "description": "Ask before side effects."},
+      {"id": "accept_edits", "name": "Auto", "description": "Apply edits without asking; other tools still require approval."}
+    ]
+  },
   "server_newer": true,
   "session": { "messages": [...] },
   "chat_items": [...]
@@ -471,6 +533,8 @@ Response to CONNECT.
 | `"running"` | Agent still running | Wait for events/OUTPUT |
 
 `server_newer`, `session`, and `chat_items` are only included when the server's session data is newer than the client's (e.g., agent completed while client was away).
+`session_modes` is present only with the matching advertised client request and
+is the authoritative current/available state for this authenticated identity.
 
 #### OUTPUT
 

--- a/docs/useful_plugins/image_result_formatter.md
+++ b/docs/useful_plugins/image_result_formatter.md
@@ -107,7 +107,7 @@ agent = Agent("chart_bot", tools=[generate_chart])
 - Tools that need to send images should declare `agent` as a parameter
 - The `agent` parameter is automatically injected by the tool executor
 - Check `if agent.io` before calling `send_image()` (it's None in non-hosted mode)
-- Images appear in real-time in oo-chat and TypeScript SDK frontends
+- Images appear in real-time in O Chat and `@connectonion/react` frontends
 
 ## Customizing
 

--- a/tests/unit/test_acp_host_set_mode.py
+++ b/tests/unit/test_acp_host_set_mode.py
@@ -1,17 +1,44 @@
+import asyncio
+import threading
+import time
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from connectonion.core.acp_wire import (
     ACP_SCHEMA_VERSION,
+    acp_session_mode_state,
     acp_set_mode_error_frame,
     acp_set_mode_request,
+    acp_set_mode_request_frame,
     acp_set_mode_request_id,
+    acp_set_mode_response,
     acp_set_mode_response_frame,
-    acp_session_mode_state,
+    host_session_mode_state,
 )
-
+from connectonion.network.connect import ACPModeError, RemoteAgent
+from connectonion.network.host.session import SessionStorage
+from connectonion.network.host.session.mode import (
+    HostModePolicy,
+    ModeTransactionError,
+    claim_host_prompt,
+    commit_host_session_mode,
+    ensure_host_mode_session,
+)
 
 SESSION_ID = "session-mode-883"
 REQUEST_ID = "request-mode-883"
+
+
+@pytest.fixture
+def storage(tmp_path):
+    return SessionStorage(tmp_path / "sessions.jsonl")
+
+
+def requester(address="0xowner", level="admin"):
+    return {"address": address, "level": level}
 
 
 def request(*, session_id=SESSION_ID, mode_id="accept_edits", **message_fields):
@@ -65,6 +92,9 @@ def test_mode_state_rejects_plan_unknown_duplicates_and_unadvertised_current():
 
 
 def test_exact_set_mode_request_parses_through_official_model():
+    assert acp_set_mode_request_frame(
+        REQUEST_ID, SESSION_ID, "accept_edits"
+    ) == request()
     assert acp_set_mode_request(
         request(), expected_session_id=SESSION_ID
     ) == (REQUEST_ID, "accept_edits")
@@ -109,6 +139,42 @@ def test_exact_success_and_error_response_carriers():
             "result": {},
         },
     }
+
+
+def test_client_decodes_exact_advertisement_and_owned_response():
+    connected = {
+        "type": "CONNECTED",
+        "carrier_capabilities": {
+            "acp": {
+                "schema": ACP_SCHEMA_VERSION,
+                "client_requests": ["session/set_mode"],
+            }
+        },
+        "session_modes": acp_session_mode_state(
+            "safe", ["safe", "accept_edits"]
+        ),
+    }
+
+    assert host_session_mode_state(connected)["currentModeId"] == "safe"
+    assert acp_set_mode_response(
+        acp_set_mode_response_frame(REQUEST_ID, SESSION_ID),
+        expected_request_id=REQUEST_ID,
+        expected_session_id=SESSION_ID,
+    ) == {"result": {}}
+    assert acp_set_mode_response(
+        acp_set_mode_error_frame(
+            REQUEST_ID, SESSION_ID, -32000, "Session is busy",
+            {"retryable": True},
+        ),
+        expected_request_id=REQUEST_ID,
+        expected_session_id=SESSION_ID,
+    ) == {
+        "error": {
+            "code": -32000,
+            "message": "Session is busy",
+            "data": {"retryable": True},
+        }
+    }
     assert acp_set_mode_error_frame(
         REQUEST_ID,
         SESSION_ID,
@@ -129,3 +195,1122 @@ def test_exact_success_and_error_response_carriers():
             },
         },
     }
+
+
+def test_mode_policy_advertises_only_identity_and_launch_authority():
+    safe_only = HostModePolicy()
+    with_ulw = HostModePolicy(ulw_turns=7)
+
+    assert safe_only.available_mode_ids(is_admin=False) == ("safe",)
+    assert safe_only.available_mode_ids(is_admin=True) == (
+        "safe", "accept_edits"
+    )
+    assert with_ulw.available_mode_ids(is_admin=False) == ("safe",)
+    assert with_ulw.available_mode_ids(is_admin=True) == (
+        "safe", "accept_edits", "ulw"
+    )
+
+
+@pytest.mark.parametrize("turns", [True, 0, -1, "7"])
+def test_mode_policy_rejects_an_invalid_launch_ceiling(turns):
+    with pytest.raises(ValueError, match="positive integer"):
+        HostModePolicy(ulw_turns=turns)
+
+
+def test_connect_persists_an_owned_safe_session_before_first_prompt(storage):
+    policy = HostModePolicy()
+
+    record = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    assert record.status == "connected"
+    assert record.prompt == ""
+    assert record.session == {
+        "session_id": SESSION_ID,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "mode": "safe",
+        "requester": requester(),
+    }
+    assert storage.get(SESSION_ID).session == record.session
+    assert 3599 <= record.expires - time.time() <= 3600
+
+
+def test_idle_mode_commit_preserves_history_owner_and_ttl(storage):
+    policy = HostModePolicy()
+    original = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    original.session["messages"] = [{"role": "user", "content": "keep"}]
+    original.session["permissions"] = {"bash": ["git status"]}
+    storage.save(original)
+
+    changed = commit_host_session_mode(
+        storage,
+        registry=None,
+        session_id=SESSION_ID,
+        owner="0xowner",
+        mode_id="accept_edits",
+        policy=policy,
+        is_admin=True,
+    )
+
+    assert changed.session["mode"] == "accept_edits"
+    assert changed.session["messages"] == [
+        {"role": "user", "content": "keep"}
+    ]
+    assert changed.session["permissions"] == {"bash": ["git status"]}
+    assert changed.session["requester"] == requester()
+    assert changed.created == original.created
+    assert changed.expires == original.expires
+
+
+def test_ulw_uses_only_server_ceiling_and_downgrade_removes_all_bypass(storage):
+    policy = HostModePolicy(ulw_turns=7)
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    ulw = commit_host_session_mode(
+        storage, None, SESSION_ID, "0xowner", "ulw", policy, True
+    )
+    assert ulw.session["mode"] == "ulw"
+    assert ulw.session["ulw_turns"] == 7
+    assert ulw.session["ulw_turns_used"] == 0
+    assert ulw.session["skip_tool_approval"] is True
+
+    safe = commit_host_session_mode(
+        storage, None, SESSION_ID, "0xowner", "safe", policy, True
+    )
+    assert safe.session["mode"] == "safe"
+    assert not {
+        "ulw_turns", "ulw_turns_used", "skip_tool_approval"
+    } & safe.session.keys()
+
+
+@pytest.mark.parametrize(
+    "corrupt",
+    [
+        {
+            "mode": "safe",
+            "skip_tool_approval": True,
+            "ulw_turns": 7,
+            "ulw_turns_used": 0,
+        },
+        {
+            "mode": "ulw",
+            "skip_tool_approval": True,
+            "ulw_turns": 100,
+            "ulw_turns_used": 0,
+        },
+    ],
+)
+def test_corrupt_durable_authority_fails_closed_without_append(storage, corrupt):
+    policy = HostModePolicy(ulw_turns=7)
+    record = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    corrupt_session = deepcopy(record.session)
+    corrupt_session.update(corrupt)
+    storage.save(record.model_copy(update={"session": corrupt_session}))
+    before = storage.path.read_text()
+
+    with pytest.raises(ModeTransactionError) as exc_info:
+        commit_host_session_mode(
+            storage, None, SESSION_ID, "0xowner", "safe", policy, True
+        )
+
+    assert exc_info.value.code == -32602
+    assert storage.path.read_text() == before
+    assert storage.get(SESSION_ID).session == corrupt_session
+
+
+@pytest.mark.parametrize("mode_id", ["accept_edits", "ulw"])
+def test_non_admin_cannot_select_more_authority(storage, mode_id):
+    policy = HostModePolicy(ulw_turns=7)
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(level="contact"),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=False,
+    )
+
+    with pytest.raises(ModeTransactionError) as exc_info:
+        commit_host_session_mode(
+            storage, None, SESSION_ID, "0xowner", mode_id, policy, False
+        )
+
+    assert exc_info.value.code == -32602
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.parametrize("status", ["running", "waiting_approval"])
+def test_durable_busy_record_rejects_without_mutation(storage, status):
+    policy = HostModePolicy()
+    record = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    storage.save(record.model_copy(update={"status": status}))
+
+    with pytest.raises(ModeTransactionError) as exc_info:
+        commit_host_session_mode(
+            storage, None, SESSION_ID, "0xowner", "accept_edits", policy, True
+        )
+
+    assert exc_info.value.code == -32000
+    assert exc_info.value.data == {"retryable": True}
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+def test_wrong_owner_and_missing_session_are_indistinguishable(storage):
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    for session_id, owner in [
+        (SESSION_ID, "0xattacker"),
+        ("missing", "0xowner"),
+    ]:
+        with pytest.raises(ModeTransactionError) as exc_info:
+            commit_host_session_mode(
+                storage, None, session_id, owner, "safe", policy, True
+            )
+        assert exc_info.value.code == -32002
+        assert exc_info.value.message == "Session not found"
+
+
+@pytest.mark.parametrize(
+    "claimant",
+    [None, requester(address="0xattacker")],
+)
+def test_owned_prompt_cannot_be_claimed_without_matching_identity(storage, claimant):
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    before = storage.path.read_text()
+
+    with pytest.raises(ModeTransactionError) as exc_info:
+        claim_host_prompt(
+            storage,
+            SESSION_ID,
+            "steal this session",
+            3600,
+            {"session_id": SESSION_ID},
+            requester=claimant,
+            policy=policy,
+            is_admin=False,
+        )
+
+    assert exc_info.value.code == -32002
+    assert storage.path.read_text() == before
+
+
+def test_process_local_running_registry_is_a_fast_busy_guard(storage):
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    class Registry:
+        def get(self, _session_id):
+            return type("Active", (), {"status": "running", "owner": "0xowner"})()
+
+    with pytest.raises(ModeTransactionError) as exc_info:
+        commit_host_session_mode(
+            storage, Registry(), SESSION_ID, "0xowner",
+            "accept_edits", policy, True,
+        )
+
+    assert exc_info.value.code == -32000
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+class Trust:
+    def __init__(self, admin=True):
+        self.admin = admin
+
+    def is_admin(self, _address):
+        return self.admin
+
+    def get_level(self, _address):
+        return "contact"
+
+
+@pytest.mark.asyncio
+async def test_connected_advertises_exact_identity_bounded_mode_state(storage):
+    from connectonion.network.host.ws_router.connect import establish_connection
+
+    sent = []
+    policy = HostModePolicy(ulw_turns=7)
+    route_handlers = {
+        "session_modes": policy,
+        "trust_agent": Trust(admin=True),
+        "result_ttl": 3600,
+    }
+    registry = Mock()
+    registry.get.return_value = None
+
+    await establish_connection(
+        {"session_id": SESSION_ID},
+        "0xowner",
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        {},
+        storage,
+        registry,
+        route_handlers,
+    )
+
+    connected = next(message for message in sent if message["type"] == "CONNECTED")
+    assert connected["carrier_capabilities"]["acp"]["client_requests"] == [
+        "session/set_mode"
+    ]
+    assert connected["session_modes"] == policy.state(
+        storage.get(SESSION_ID).session, is_admin=True
+    )
+    assert connected["session_modes"]["currentModeId"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_connected_non_admin_sees_safe_only(storage):
+    from connectonion.network.host.ws_router.connect import establish_connection
+
+    sent = []
+    registry = Mock()
+    registry.get.return_value = None
+    await establish_connection(
+        {"session_id": SESSION_ID},
+        "0xcontact",
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        {},
+        storage,
+        registry,
+        {
+            "session_modes": HostModePolicy(ulw_turns=7),
+            "trust_agent": Trust(admin=False),
+            "result_ttl": 3600,
+        },
+    )
+
+    connected = next(message for message in sent if message["type"] == "CONNECTED")
+    assert connected["session_modes"]["availableModes"] == [{
+        "id": "safe",
+        "name": "Safe",
+        "description": "Ask before side effects.",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_connect_mode_initialization_failure_keeps_socket_unauthenticated(
+    monkeypatch, storage, caplog
+):
+    from connectonion.network.host.ws_router.connect import establish_connection
+
+    private_detail = "private mode storage failure"
+    monkeypatch.setattr(
+        storage,
+        "atomic_update",
+        Mock(side_effect=OSError(private_detail)),
+    )
+    sent = []
+    conn = {}
+    registry = Mock()
+    registry.get.return_value = None
+
+    await establish_connection(
+        {"session_id": SESSION_ID},
+        "0xowner",
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        conn,
+        storage,
+        registry,
+        {
+            "session_modes": HostModePolicy(),
+            "trust_agent": Trust(admin=True),
+            "result_ttl": 3600,
+        },
+    )
+
+    assert conn.get("authenticated") is not True
+    assert sent == [{
+        "type": "ERROR",
+        "message": "Unable to initialize session mode",
+    }]
+    assert private_detail not in str(sent)
+    assert private_detail in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_idle_mode_commit_survives_a_fresh_connection(storage):
+    from connectonion.network.host.ws_router.connect import establish_connection
+
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    commit_host_session_mode(
+        storage, None, SESSION_ID, "0xowner", "accept_edits", policy, True
+    )
+    sent = []
+    conn = {}
+    registry = Mock()
+    registry.get.return_value = None
+
+    await establish_connection(
+        {"session_id": SESSION_ID, "session": {"mode": "safe"}},
+        "0xowner",
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        conn,
+        SessionStorage(storage.path),
+        registry,
+        {
+            "session_modes": policy,
+            "trust_agent": Trust(admin=True),
+            "result_ttl": 3600,
+        },
+    )
+
+    connected = next(message for message in sent if message["type"] == "CONNECTED")
+    assert connected["session_modes"]["currentModeId"] == "accept_edits"
+    assert conn["session"]["mode"] == "accept_edits"
+
+
+async def run_mode_dispatch(
+    monkeypatch,
+    storage,
+    *frames,
+    is_admin=True,
+    policy=None,
+    registry_status=None,
+):
+    from connectonion.network.host.ws_router import session as ws_session
+
+    policy = policy or HostModePolicy(ulw_turns=7)
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(level="admin" if is_admin else "contact"),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=is_admin,
+    )
+    queue = [{"type": "CONNECT"}, *frames]
+    sent = []
+
+    async def fake_connect(_data, _send_msg, conn, *_args):
+        conn.update(
+            authenticated=True,
+            agent_address="0xowner",
+            session_id=SESSION_ID,
+            session=storage.get(SESSION_ID).session,
+            mode_is_admin=is_admin,
+        )
+        return None
+
+    async def recv_msg():
+        return queue.pop(0) if queue else None
+
+    async def send_msg(message):
+        sent.append(message)
+
+    monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    registry = Mock()
+    registry.get.return_value = (
+        SimpleNamespace(status=registry_status, owner="0xowner")
+        if registry_status else None
+    )
+    await ws_session.run_ws_session(
+        send_msg,
+        recv_msg,
+        route_handlers={"session_modes": policy},
+        storage=storage,
+        registry=registry,
+        trust=None,
+        enable_ping=False,
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_idle_acp_request_commits_then_acknowledges(monkeypatch, storage):
+    sent = await run_mode_dispatch(monkeypatch, storage, request())
+
+    assert sent == [acp_set_mode_response_frame(REQUEST_ID, SESSION_ID)]
+    assert storage.get(SESSION_ID).session["mode"] == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_busy_acp_request_returns_owned_retryable_error(monkeypatch, storage):
+    sent = await run_mode_dispatch(
+        monkeypatch, storage, request(), registry_status="running"
+    )
+
+    assert sent[0]["type"] == "ACP_RESPONSE"
+    assert sent[0]["message"]["id"] == REQUEST_ID
+    assert sent[0]["message"]["error"] == {
+        "code": -32000,
+        "message": "Session is busy",
+        "data": {"retryable": True},
+    }
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_malformed_owned_request_returns_invalid_params(monkeypatch, storage):
+    malformed = request()
+    malformed["message"]["params"]["modeId"] = "plan"
+
+    sent = await run_mode_dispatch(monkeypatch, storage, malformed)
+
+    assert sent[0]["type"] == "ACP_RESPONSE"
+    assert sent[0]["message"]["error"]["code"] == -32602
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_request_for_another_session_returns_not_found(monkeypatch, storage):
+    sent = await run_mode_dispatch(
+        monkeypatch, storage, request(session_id="another-session")
+    )
+
+    assert sent[0]["message"]["error"] == {
+        "code": -32002,
+        "message": "ACP mode request belongs to another session",
+    }
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_non_admin_dispatch_cannot_gain_accept_edits(monkeypatch, storage):
+    sent = await run_mode_dispatch(
+        monkeypatch, storage, request(), is_admin=False
+    )
+
+    assert sent[0]["message"]["error"] == {
+        "code": -32602,
+        "message": "Session mode is not available",
+    }
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_returns_internal_error_without_granting_mode(
+    monkeypatch, storage
+):
+    from connectonion.network.host.ws_router.mode import handle_acp_mode_request
+
+    policy = HostModePolicy()
+    record = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    conn = {
+        "authenticated": True,
+        "agent_address": "0xowner",
+        "session_id": SESSION_ID,
+        "session": deepcopy(record.session),
+        "mode_is_admin": True,
+    }
+    sent = []
+    monkeypatch.setattr(
+        storage,
+        "atomic_update",
+        Mock(side_effect=OSError("private storage path and details")),
+    )
+
+    handled = await handle_acp_mode_request(
+        request(),
+        AsyncMock(side_effect=lambda message: sent.append(message)),
+        conn,
+        {"session_modes": policy},
+        storage,
+        registry=None,
+    )
+
+    assert handled is True
+    assert sent[0]["message"]["error"] == {
+        "code": -32603,
+        "message": "Unable to change session mode",
+    }
+    assert "private" not in str(sent)
+    assert conn["session"]["mode"] == "safe"
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_mode_commit_does_not_block_the_async_event_loop(
+    monkeypatch, storage
+):
+    from connectonion.network.host.ws_router import mode as mode_router
+
+    policy = HostModePolicy()
+    record = ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_commit(*_args, **_kwargs):
+        entered.set()
+        release.wait(timeout=0.5)
+        return record
+
+    monkeypatch.setattr(mode_router, "commit_host_session_mode", blocking_commit)
+    conn = {
+        "authenticated": True,
+        "agent_address": "0xowner",
+        "session_id": SESSION_ID,
+        "session": deepcopy(record.session),
+        "mode_is_admin": True,
+    }
+    started = time.monotonic()
+    task = asyncio.create_task(mode_router.handle_acp_mode_request(
+        request(mode_id="safe"),
+        AsyncMock(),
+        conn,
+        {"session_modes": policy},
+        storage,
+        registry=None,
+    ))
+    try:
+        while not entered.is_set() and time.monotonic() - started < 0.2:
+            await asyncio.sleep(0.001)
+        assert entered.is_set()
+        assert time.monotonic() - started < 0.2
+    finally:
+        release.set()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_duplicate_request_id_is_consumed_once(monkeypatch, storage):
+    sent = await run_mode_dispatch(monkeypatch, storage, request(), request())
+
+    assert sent[0] == acp_set_mode_response_frame(REQUEST_ID, SESSION_ID)
+    assert sent[1]["message"]["error"]["code"] == -32602
+    assert sent[1]["message"]["error"]["message"] == "Duplicate request ID"
+
+
+def test_request_id_cache_evicts_only_the_oldest_entry():
+    from connectonion.network.host.ws_router.mode import _request_id_was_seen
+
+    conn = {}
+    for index in range(257):
+        assert not _request_id_was_seen(conn, f"request-{index}")
+
+    assert len(conn["mode_request_ids"]) == 256
+    assert "request-0" not in conn["mode_request_ids"]
+    assert _request_id_was_seen(conn, "request-256")
+
+
+@pytest.mark.asyncio
+async def test_unknown_acp_request_is_not_forwarded_to_agent(monkeypatch, storage):
+    unknown = request()
+    unknown["message"]["method"] = "session/future"
+
+    sent = await run_mode_dispatch(monkeypatch, storage, unknown)
+
+    assert sent == [{
+        "type": "ERROR",
+        "message": "unsupported ACP client request",
+    }]
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_legacy_mode_change_uses_same_commit_and_plan_alias(monkeypatch, storage):
+    policy = HostModePolicy()
+    sent = await run_mode_dispatch(
+        monkeypatch,
+        storage,
+        {"type": "mode_change", "mode": "accept_edits"},
+        {"type": "mode_change", "mode": "plan", "turns": 999999},
+        policy=policy,
+    )
+
+    assert sent == [
+        {"type": "mode_changed", "mode": "accept_edits", "session_id": SESSION_ID},
+        {"type": "mode_changed", "mode": "safe", "session_id": SESSION_ID},
+    ]
+    safe = storage.get(SESSION_ID).session
+    assert safe["mode"] == "safe"
+    assert "ulw_turns" not in safe
+
+
+@pytest.mark.asyncio
+async def test_legacy_ulw_ignores_client_turns_and_uses_launch_ceiling(
+    monkeypatch, storage
+):
+    sent = await run_mode_dispatch(
+        monkeypatch,
+        storage,
+        {"type": "mode_change", "mode": "ulw", "turns": 999999},
+        policy=HostModePolicy(ulw_turns=7),
+    )
+
+    assert sent == [{
+        "type": "mode_changed",
+        "mode": "ulw",
+        "session_id": SESSION_ID,
+    }]
+    durable = storage.get(SESSION_ID).session
+    assert durable["ulw_turns"] == 7
+    assert durable["ulw_turns_used"] == 0
+
+
+class RecordingAgent:
+    def __init__(self, seen, started=None, release=None):
+        self.seen = seen
+        self.started = started
+        self.release = release
+        self.current_session = None
+        self._yolo_turns = 999999
+        self._yolo_needs_activation = True
+        self.io = None
+        self.storage = None
+
+    def input(self, prompt, session, images=None, files=None):
+        self.seen.append({
+            "prompt": prompt,
+            "session": deepcopy(session),
+            "yolo_turns": self._yolo_turns,
+            "yolo_needs_activation": self._yolo_needs_activation,
+            "host_ulw_turns_ceiling": getattr(
+                self, "_host_ulw_turns_ceiling", None
+            ),
+        })
+        if self.started:
+            self.started.set()
+        if self.release:
+            assert self.release.wait(timeout=2)
+        self.current_session = deepcopy(session)
+        self.current_session["messages"].append({
+            "role": "assistant", "content": "done"
+        })
+        return "done"
+
+
+def test_mode_before_first_prompt_drives_agent_and_disarms_auto_yolo(storage):
+    from connectonion.network.host.http_router import input_handler
+
+    policy = HostModePolicy(ulw_turns=7)
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    commit_host_session_mode(
+        storage, None, SESSION_ID, "0xowner", "accept_edits", policy, True
+    )
+    seen = []
+
+    result = input_handler(
+        lambda: RecordingAgent(seen),
+        storage,
+        "first prompt",
+        3600,
+        {"session_id": SESSION_ID},
+        requester=requester(),
+        mode_policy=policy,
+        is_admin=True,
+    )
+
+    assert seen[0]["session"]["mode"] == "accept_edits"
+    assert seen[0]["yolo_turns"] is None
+    assert seen[0]["yolo_needs_activation"] is False
+    assert seen[0]["host_ulw_turns_ceiling"] == 7
+    assert result["session"]["mode"] == "accept_edits"
+
+
+def test_final_host_snapshot_downgrades_invalid_agent_authority(storage, caplog):
+    from connectonion.network.host.http_router import input_handler
+
+    class CorruptingAgent(RecordingAgent):
+        def input(self, *args, **kwargs):
+            result = super().input(*args, **kwargs)
+            self.current_session.update({
+                "mode": "ulw",
+                "ulw_turns": 999999,
+                "ulw_turns_used": 0,
+                "skip_tool_approval": True,
+                "requester": requester(address="0xattacker"),
+            })
+            return result
+
+    policy = HostModePolicy(ulw_turns=7)
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    result = input_handler(
+        lambda: CorruptingAgent([]),
+        storage,
+        "prompt",
+        3600,
+        {"session_id": SESSION_ID},
+        requester=requester(),
+        mode_policy=policy,
+        is_admin=True,
+    )
+
+    assert result["session"]["mode"] == "safe"
+    assert result["session"]["requester"] == requester()
+    assert not {
+        "ulw_turns", "ulw_turns_used", "skip_tool_approval"
+    } & result["session"].keys()
+    assert storage.get(SESSION_ID).session == result["session"]
+    assert "invalid Host session policy" in caplog.text
+
+
+def test_agent_factory_failure_releases_the_durable_prompt_claim(storage):
+    from connectonion.network.host.http_router import input_handler
+
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+
+    def fail_factory():
+        raise RuntimeError("factory failed")
+
+    with pytest.raises(RuntimeError, match="factory failed"):
+        input_handler(
+            fail_factory,
+            storage,
+            "prompt",
+            3600,
+            {"session_id": SESSION_ID},
+            requester=requester(),
+            mode_policy=policy,
+            is_admin=True,
+        )
+
+    failed = storage.get(SESSION_ID)
+    assert failed.status == "failed"
+    assert failed.session["mode"] == "safe"
+    changed = commit_host_session_mode(
+        storage, None, SESSION_ID, "0xowner",
+        "accept_edits", policy, True,
+    )
+    assert changed.session["mode"] == "accept_edits"
+
+
+def test_cross_worker_mode_write_loses_to_running_prompt_claim(storage):
+    from connectonion.network.host.http_router import input_handler
+
+    policy = HostModePolicy()
+    ensure_host_mode_session(
+        storage,
+        SESSION_ID,
+        requester=requester(),
+        result_ttl=3600,
+        policy=policy,
+        is_admin=True,
+    )
+    started = threading.Event()
+    release = threading.Event()
+    seen = []
+    failures = []
+
+    def run_prompt():
+        try:
+            input_handler(
+                lambda: RecordingAgent(seen, started, release),
+                storage,
+                "blocking prompt",
+                3600,
+                {"session_id": SESSION_ID},
+                requester=requester(),
+                mode_policy=policy,
+                is_admin=True,
+            )
+        except Exception as exc:
+            failures.append(exc)
+
+    thread = threading.Thread(target=run_prompt)
+    thread.start()
+    assert started.wait(timeout=2)
+
+    other_worker_storage = SessionStorage(storage.path)
+    with pytest.raises(ModeTransactionError) as exc_info:
+        commit_host_session_mode(
+            other_worker_storage, None, SESSION_ID, "0xowner",
+            "accept_edits", policy, True,
+        )
+    assert exc_info.value.code == -32000
+
+    release.set()
+    thread.join(timeout=2)
+    assert not thread.is_alive()
+    assert failures == []
+    assert storage.get(SESSION_ID).session["mode"] == "safe"
+
+
+class ModeClientSocket:
+    def __init__(self, *, error=None, advertise=True):
+        self.error = error
+        self.advertise = advertise
+        self.sent = []
+        self.outbox = []
+
+    async def send(self, raw):
+        message = __import__("json").loads(raw)
+        self.sent.append(message)
+        if message.get("type") == "CONNECT":
+            connected = {
+                "type": "CONNECTED",
+                "session_id": SESSION_ID,
+                "status": "new",
+            }
+            if self.advertise:
+                connected.update({
+                    "carrier_capabilities": {
+                        "acp": {
+                            "schema": ACP_SCHEMA_VERSION,
+                            "client_requests": ["session/set_mode"],
+                        }
+                    },
+                    "session_modes": acp_session_mode_state(
+                        "safe", ["safe", "accept_edits"]
+                    ),
+                })
+            self.outbox.append(connected)
+        elif message.get("type") == "ACP_REQUEST":
+            request_id = message["message"]["id"]
+            response_frame = (
+                acp_set_mode_error_frame(
+                    request_id,
+                    SESSION_ID,
+                    self.error["code"],
+                    self.error["message"],
+                    self.error.get("data"),
+                )
+                if self.error else
+                acp_set_mode_response_frame(request_id, SESSION_ID)
+            )
+            self.outbox.append(response_frame)
+
+    async def recv(self):
+        if not self.outbox:
+            raise AssertionError("client waited without an owned response")
+        return __import__("json").dumps(self.outbox.pop(0))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def python_mode_client(socket):
+    agent = RemoteAgent("0xagent", keys=False, relay_url="ws://relay.test")
+    agent._try_resolve_endpoint = AsyncMock()
+    agent._open_best_connection = AsyncMock(return_value=(socket, True))
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_python_client_waits_for_ack_and_applies_mode_once():
+    socket = ModeClientSocket()
+    agent = python_mode_client(socket)
+
+    await agent.set_session_mode_async("accept_edits")
+
+    assert agent.current_session == {
+        "session_id": SESSION_ID,
+        "mode": "accept_edits",
+    }
+    assert [mode["id"] for mode in agent.available_modes] == [
+        "safe", "accept_edits"
+    ]
+    request_frame = next(
+        frame for frame in socket.sent if frame["type"] == "ACP_REQUEST"
+    )
+    assert request_frame["message"]["params"] == {
+        "sessionId": SESSION_ID,
+        "modeId": "accept_edits",
+    }
+
+
+@pytest.mark.asyncio
+async def test_python_client_ack_clears_stale_ulw_authority():
+    socket = ModeClientSocket()
+    agent = python_mode_client(socket)
+    agent._current_session = {
+        "session_id": SESSION_ID,
+        "mode": "ulw",
+        "ulw_turns": 7,
+        "ulw_turns_used": 2,
+        "skip_tool_approval": True,
+    }
+
+    await agent.set_session_mode_async("safe")
+
+    assert agent.current_session == {
+        "session_id": SESSION_ID,
+        "mode": "safe",
+    }
+
+
+class PingingModeClientSocket(ModeClientSocket):
+    async def recv(self):
+        await asyncio.sleep(0.01)
+        return __import__("json").dumps({"type": "PING"})
+
+
+@pytest.mark.asyncio
+async def test_python_client_timeout_is_one_total_deadline_across_pings():
+    agent = python_mode_client(PingingModeClientSocket())
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="timed out"):
+        await agent.set_session_mode_async("safe", timeout=0.025)
+
+    assert time.monotonic() - started < 0.2
+
+
+class CommitWithoutAckSocket(ModeClientSocket):
+    def __init__(self):
+        super().__init__()
+        self.committed_mode = None
+
+    async def send(self, raw):
+        message = __import__("json").loads(raw)
+        if message.get("type") == "ACP_REQUEST":
+            self.sent.append(message)
+            self.committed_mode = message["message"]["params"]["modeId"]
+            return
+        await super().send(raw)
+
+    async def recv(self):
+        if self.outbox:
+            return await super().recv()
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_python_client_timeout_keeps_local_state_until_reconnect():
+    socket = CommitWithoutAckSocket()
+    agent = python_mode_client(socket)
+
+    with pytest.raises(TimeoutError):
+        await agent.set_session_mode_async("accept_edits", timeout=0.025)
+
+    assert socket.committed_mode == "accept_edits"
+    assert agent.current_session["mode"] == "safe"
+
+    agent._consume_connected_mode_state({
+        "type": "CONNECTED",
+        "session_id": SESSION_ID,
+        "carrier_capabilities": {
+            "acp": {
+                "schema": ACP_SCHEMA_VERSION,
+                "client_requests": ["session/set_mode"],
+            }
+        },
+        "session_modes": acp_session_mode_state(
+            "accept_edits", ["safe", "accept_edits"]
+        ),
+    })
+
+    assert agent.current_session["mode"] == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_python_client_keeps_mode_on_owned_policy_error():
+    socket = ModeClientSocket(error={
+        "code": -32000,
+        "message": "Session is busy",
+        "data": {"retryable": True},
+    })
+    agent = python_mode_client(socket)
+
+    with pytest.raises(ACPModeError) as exc_info:
+        await agent.set_session_mode_async("accept_edits")
+
+    assert exc_info.value.code == -32000
+    assert exc_info.value.data == {"retryable": True}
+    assert agent.current_session["mode"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_python_client_rejects_old_host_instead_of_inventing_durability():
+    socket = ModeClientSocket(advertise=False)
+    agent = python_mode_client(socket)
+
+    with pytest.raises(ConnectionError, match="does not support"):
+        await agent.set_session_mode_async("accept_edits")
+
+    assert [frame["type"] for frame in socket.sent] == ["CONNECT"]

--- a/tests/unit/test_acp_host_set_mode.py
+++ b/tests/unit/test_acp_host_set_mode.py
@@ -1,0 +1,131 @@
+import pytest
+
+from connectonion.core.acp_wire import (
+    ACP_SCHEMA_VERSION,
+    acp_set_mode_error_frame,
+    acp_set_mode_request,
+    acp_set_mode_request_id,
+    acp_set_mode_response_frame,
+    acp_session_mode_state,
+)
+
+
+SESSION_ID = "session-mode-883"
+REQUEST_ID = "request-mode-883"
+
+
+def request(*, session_id=SESSION_ID, mode_id="accept_edits", **message_fields):
+    return {
+        "type": "ACP_REQUEST",
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "message": {
+            "jsonrpc": "2.0",
+            "id": REQUEST_ID,
+            "method": "session/set_mode",
+            "params": {"sessionId": session_id, "modeId": mode_id},
+            **message_fields,
+        },
+    }
+
+
+def test_exact_official_session_mode_state_uses_persisted_ids():
+    assert acp_session_mode_state(
+        "accept_edits", ["safe", "accept_edits", "ulw"]
+    ) == {
+        "currentModeId": "accept_edits",
+        "availableModes": [
+            {
+                "id": "safe",
+                "name": "Safe",
+                "description": "Ask before side effects.",
+            },
+            {
+                "id": "accept_edits",
+                "name": "Auto",
+                "description": "Apply edits without asking; other tools still require approval.",
+            },
+            {
+                "id": "ulw",
+                "name": "ULW",
+                "description": "Run without tool approvals within the Host launch ceiling.",
+            },
+        ],
+    }
+
+
+def test_mode_state_rejects_plan_unknown_duplicates_and_unadvertised_current():
+    with pytest.raises(ValueError, match="Unsupported ACP session mode"):
+        acp_session_mode_state("plan", ["safe"])
+    with pytest.raises(ValueError, match="Unsupported ACP session mode"):
+        acp_session_mode_state("safe", ["safe", "future"])
+    with pytest.raises(ValueError, match="duplicate"):
+        acp_session_mode_state("safe", ["safe", "safe"])
+    with pytest.raises(ValueError, match="not advertised"):
+        acp_session_mode_state("accept_edits", ["safe"])
+
+
+def test_exact_set_mode_request_parses_through_official_model():
+    assert acp_set_mode_request(
+        request(), expected_session_id=SESSION_ID
+    ) == (REQUEST_ID, "accept_edits")
+    assert acp_set_mode_request_id(request()) == REQUEST_ID
+
+
+@pytest.mark.parametrize(
+    "frame, message",
+    [
+        (request(session_id="another-session"), "another session"),
+        (request(mode_id="plan"), "Unsupported ACP session mode"),
+        (request(extra=True), "exact JSON-RPC request"),
+        ({**request(), "acpSchema": "future"}, "carrier schema"),
+        ({**request(), "type": "ACP_RESPONSE"}, "request carrier"),
+    ],
+)
+def test_set_mode_request_fails_closed(frame, message):
+    with pytest.raises(ValueError, match=message):
+        acp_set_mode_request(frame, expected_session_id=SESSION_ID)
+
+
+def test_set_mode_request_allows_meta_but_never_reads_authority_from_it():
+    frame = request(mode_id="safe")
+    frame["message"]["params"]["_meta"] = {
+        "turns": 999999,
+        "modeId": "ulw",
+    }
+
+    assert acp_set_mode_request(
+        frame, expected_session_id=SESSION_ID
+    ) == (REQUEST_ID, "safe")
+
+
+def test_exact_success_and_error_response_carriers():
+    assert acp_set_mode_response_frame(REQUEST_ID, SESSION_ID) == {
+        "type": "ACP_RESPONSE",
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "sessionId": SESSION_ID,
+        "message": {
+            "jsonrpc": "2.0",
+            "id": REQUEST_ID,
+            "result": {},
+        },
+    }
+    assert acp_set_mode_error_frame(
+        REQUEST_ID,
+        SESSION_ID,
+        -32000,
+        "Session is busy",
+        {"retryable": True},
+    ) == {
+        "type": "ACP_RESPONSE",
+        "acpSchema": ACP_SCHEMA_VERSION,
+        "sessionId": SESSION_ID,
+        "message": {
+            "jsonrpc": "2.0",
+            "id": REQUEST_ID,
+            "error": {
+                "code": -32000,
+                "message": "Session is busy",
+                "data": {"retryable": True},
+            },
+        },
+    }

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -434,7 +434,7 @@ class TestForwardAgentEvents:
         }]
         assert "private" not in str(sent_messages)
 
-    async def test_agent_thread_logs_private_error_before_sanitizing(
+    async def test_agent_thread_keeps_private_error_for_output_boundary(
         self, caplog
     ):
         io = WebSocketIO()
@@ -456,8 +456,8 @@ class TestForwardAgentEvents:
             "0xowner",
         )
 
-        assert isinstance(result_holder[0], Exception)
-        assert str(result_holder[0]) == "Unable to run agent"
+        assert isinstance(result_holder[0], OSError)
+        assert str(result_holder[0]) == private_detail
         assert private_detail in caplog.text
         registry.mark_session_connected.assert_called_once_with("s1")
 

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -23,7 +23,11 @@ from connectonion.network.asgi import (
     send_json,
     read_body,
 )
-from connectonion.network.host.ws_router.agent_io import forward_agent_msgs_to_client
+from connectonion.network.host.session.mode import ModeTransactionError
+from connectonion.network.host.ws_router.agent_io import (
+    _agent_thread_body,
+    forward_agent_msgs_to_client,
+)
 from connectonion.network.host.ws_router import agent_io as agent_io_module
 from connectonion.network.io import WebSocketIO
 from connectonion.network.host.session import ActiveSessionRegistry
@@ -407,10 +411,10 @@ class TestForwardAgentEvents:
         assert "ERROR" not in event_types
 
     async def test_sends_error_from_exception(self):
-        """Test that ERROR is sent when agent raises."""
+        """Unexpected Agent errors never disclose their raw details."""
         io = WebSocketIO()
         sent_messages = []
-        result_holder = [RuntimeError("boom")]
+        result_holder = [OSError("private /srv/agent/.co/session_results.jsonl")]
 
         async def mock_send_msg(msg):
             sent_messages.append(msg)
@@ -423,8 +427,64 @@ class TestForwardAgentEvents:
         )
 
         error_msgs = [m for m in sent_messages if m.get("type") == "ERROR"]
-        assert len(error_msgs) == 1
-        assert "boom" in error_msgs[0]["message"]
+        assert error_msgs == [{
+            "type": "ERROR",
+            "code": -32603,
+            "message": "Unable to run agent",
+        }]
+        assert "private" not in str(sent_messages)
+
+    async def test_agent_thread_logs_private_error_before_sanitizing(
+        self, caplog
+    ):
+        io = WebSocketIO()
+        result_holder = [None]
+        registry = Mock()
+        private_detail = "private /srv/agent/.co/session_results.jsonl"
+
+        _agent_thread_body(
+            {"ws_input": Mock(side_effect=OSError(private_detail))},
+            Mock(),
+            "prompt",
+            io,
+            {"session_id": "s1"},
+            None,
+            None,
+            registry,
+            "s1",
+            result_holder,
+            "0xowner",
+        )
+
+        assert isinstance(result_holder[0], Exception)
+        assert str(result_holder[0]) == "Unable to run agent"
+        assert private_detail in caplog.text
+        registry.mark_session_connected.assert_called_once_with("s1")
+
+    async def test_owned_prompt_policy_error_keeps_stable_public_details(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [ModeTransactionError(
+            -32000, "Session is busy", {"retryable": True}
+        )]
+
+        async def mock_send_msg(message):
+            sent_messages.append(message)
+
+        io.mark_agent_done()
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "s1", result_holder=result_holder
+        )
+
+        assert next(
+            message for message in sent_messages
+            if message.get("type") == "ERROR"
+        ) == {
+            "type": "ERROR",
+            "code": -32000,
+            "message": "Session is busy",
+            "retryable": True,
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -9,30 +9,21 @@ Tests cover:
 - CORS headers
 - Admin endpoint authentication
 """
-"""
-LLM-Note: Tests for asgi http
-
-What it tests:
-- Asgi Http functionality
-
-Components under test:
-- Module: asgi_http
-"""
-
-
 import json
 import os
+from unittest.mock import Mock, patch
+
 import pytest
-from unittest.mock import Mock, AsyncMock, patch
 
 from connectonion.network.asgi.http import (
-    read_body,
-    send_json,
-    send_html,
-    send_text,
     CORS_HEADERS,
+    read_body,
+    send_html,
+    send_json,
+    send_text,
 )
 from connectonion.network.host.http_router import handle_http
+from connectonion.network.host.session.mode import ModeTransactionError
 
 
 @pytest.mark.asyncio
@@ -467,6 +458,7 @@ class TestHandleHttpRouting:
         def mock_input(storage, prompt, session, **kw):
             captured["images"] = kw.get("images")
             captured["files"] = kw.get("files")
+            captured["requester_address"] = kw.get("requester_address")
             return {"result": "OK", "session_id": "x"}
 
         handlers = {
@@ -485,6 +477,7 @@ class TestHandleHttpRouting:
         assert sent[0]["status"] == 200
         assert captured["images"] == ["data:image/png;base64,abc"]
         assert captured["files"] == [{"name": "doc.pdf", "data": "data:application/pdf;base64,xyz"}]
+        assert captured["requester_address"] == "0xtest"
 
     async def test_input_endpoint_rejects_invalid_files(self):
         """POST /input returns 400 when file validation fails."""
@@ -524,6 +517,60 @@ class TestHandleHttpRouting:
         assert sent[0]["status"] == 400
         body = json.loads(sent[1]["body"])
         assert "File too large" in body["error"]
+
+    @pytest.mark.parametrize(
+        "error, status",
+        [
+            (ModeTransactionError(-32002, "Session not found"), 404),
+            (ModeTransactionError(
+                -32000, "Session is busy", {"retryable": True}
+            ), 409),
+            (ModeTransactionError(-32602, "Session mode is invalid"), 400),
+        ],
+    )
+    async def test_input_endpoint_maps_owned_mode_policy_errors(
+        self, error, status
+    ):
+        scope = {"method": "POST", "path": "/input", "headers": []}
+        sent = []
+
+        async def receive():
+            return {
+                "body": json.dumps({
+                    "payload": {"prompt": "Hello", "timestamp": 123},
+                    "from": "0xtest",
+                    "signature": "0xsig",
+                    "session": {"session_id": "owned"},
+                }).encode(),
+                "more_body": False,
+            }
+
+        async def send(message):
+            sent.append(message)
+
+        handlers = {
+            "auth": lambda data, trust, **kw: (
+                "Hello", "0xtest", True, None
+            ),
+            "input": Mock(side_effect=error),
+        }
+
+        await handle_http(
+            scope,
+            receive,
+            send,
+            route_handlers=handlers,
+            storage=Mock(),
+            trust="open",
+            start_time=0,
+        )
+
+        assert sent[0]["status"] == status
+        assert json.loads(sent[1]["body"]) == {
+            "error": error.message,
+            "code": error.code,
+            **({"data": error.data} if error.data else {}),
+        }
 
     async def test_input_endpoint_auth_error(self):
         """POST /input returns 401 on auth error."""

--- a/tests/unit/test_each_command_is_signed.py
+++ b/tests/unit/test_each_command_is_signed.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from connectonion import address
+from connectonion.core.acp_wire import acp_set_mode_request_frame
 from connectonion.network.connect import RemoteAgent
 from connectonion.network.host import auth
 
@@ -334,6 +335,51 @@ async def test_v2_session_executes_the_verified_payload(keys, monkeypatch):
 
     assert ran[0][0]["tool"] == "safe"
     assert ran[0][1] == keys["address"]
+
+
+@pytest.mark.asyncio
+async def test_v2_session_passes_only_verified_acp_mode_request(keys, monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    agent = RemoteAgent("0x" + "12" * 20, keys=keys)
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    signed = agent._build_command_message(
+        acp_set_mode_request_frame("request-1", "s1", "safe")
+    )
+    signed["message"]["params"]["modeId"] = "ulw"
+    handled = []
+
+    async def fake_mode(data, *_args):
+        handled.append(data)
+        return True
+
+    monkeypatch.setattr(session, "handle_acp_mode_request", fake_mode)
+    await _session_with(
+        [connect, signed], monkeypatch, signed_commands=True, ran=[]
+    )
+
+    assert handled[0]["message"]["params"]["modeId"] == "safe"
+
+
+@pytest.mark.asyncio
+async def test_v2_session_rejects_unsigned_acp_mode_request(keys, monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    connect = {"type": "CONNECT", "from": keys["address"]}
+    unsigned = acp_set_mode_request_frame("request-1", "s1", "safe")
+    handled = []
+
+    async def fake_mode(data, *_args):
+        handled.append(data)
+        return True
+
+    monkeypatch.setattr(session, "handle_acp_mode_request", fake_mode)
+    sent = await _session_with(
+        [connect, unsigned], monkeypatch, signed_commands=True, ran=[]
+    )
+
+    assert handled == []
+    assert "signed command required" in sent[-1]["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_session_storage.py
+++ b/tests/unit/test_session_storage.py
@@ -1,6 +1,8 @@
 """Unit tests for connectonion/network/host/session/storage.py"""
 
+import importlib
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -136,3 +138,62 @@ def test_checkpoint_noop_when_session_lacks_id(storage):
     """No session_id → silent no-op (don't corrupt store)."""
     storage.checkpoint({'messages': ['hi']})  # no session_id key
     assert storage.list() == []
+
+
+# ---------- atomic update ----------
+
+def test_atomic_update_reads_latest_and_appends_replacement(storage):
+    storage.save(_make_session(sid="mode", result="safe"))
+
+    updated = storage.atomic_update(
+        "mode",
+        lambda current: current.model_copy(update={"result": "accept_edits"}),
+    )
+
+    assert updated.result == "accept_edits"
+    assert storage.get("mode").result == "accept_edits"
+
+
+def test_atomic_update_serializes_competing_writers(storage):
+    storage.save(_make_session(sid="counter", result="0"))
+
+    def increment(_):
+        def replace(current):
+            return current.model_copy(
+                update={"result": str(int(current.result) + 1)}
+            )
+
+        storage.atomic_update("counter", replace)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(increment, range(40)))
+
+    assert storage.get("counter").result == "40"
+
+
+def test_atomic_update_failure_appends_nothing(storage):
+    storage.save(_make_session(sid="unchanged", result="before"))
+
+    def fail(_current):
+        raise ValueError("policy rejected")
+
+    with pytest.raises(ValueError, match="policy rejected"):
+        storage.atomic_update("unchanged", fail)
+
+    assert storage.get("unchanged").result == "before"
+
+
+def test_save_and_atomic_update_fail_closed_when_lock_is_unavailable(
+    storage, monkeypatch
+):
+    storage_module = importlib.import_module(
+        "connectonion.network.host.session.storage"
+    )
+
+    monkeypatch.setattr(storage_module, "_exclusive", lambda *_a, **_k: None)
+
+    with pytest.raises(TimeoutError, match="session storage lock"):
+        storage.save(_make_session(sid="save"))
+    with pytest.raises(TimeoutError, match="session storage lock"):
+        storage.atomic_update("update", lambda _current: _make_session("update"))
+    assert not storage.path.exists()

--- a/tests/unit/test_ulw.py
+++ b/tests/unit/test_ulw.py
@@ -15,8 +15,8 @@ from connectonion.useful_plugins.ulw import (
     handle_yolo_mode_change,
     inject_ulw_prompt,
     poll_prompt_update,
-    yolo,
     ulw_keep_working,
+    yolo,
 )
 from tests.utils.mock_helpers import MockLLM
 
@@ -285,6 +285,25 @@ def test_keep_working_at_max_without_io_returns_silently():
     ulw_keep_working(agent)
     assert agent.input_calls == []
     assert agent.current_session['mode'] == 'ulw'  # state untouched
+
+
+def test_host_bounded_ulw_checkpoint_exits_safe_without_mailbox_extension():
+    io = Mock()
+    io.receive.return_value = {'action': 'continue', 'turns': 999999}
+    agent = FakeAgent(io=io, mode='ulw')
+    agent._host_ulw_turns_ceiling = 5
+    agent.current_session['ulw_turns'] = 5
+    agent.current_session['ulw_turns_used'] = 4
+    agent.current_session['skip_tool_approval'] = True
+
+    ulw_keep_working(agent)
+
+    io.receive.assert_not_called()
+    assert agent.current_session['mode'] == 'safe'
+    assert not {
+        'ulw_turns', 'ulw_turns_used', 'skip_tool_approval'
+    } & agent.current_session.keys()
+    assert agent.input_calls == []
 
 
 # ---------- poll_prompt_update ----------


### PR DESCRIPTION
## Summary

- implement exact ACP session/set_mode request and response handling on Host
- persist identity-bounded Safe, Auto, and ULW mode state through one cross-worker atomic transaction
- make prompt claims, CONNECT initialization, timeout behavior, and Agent failures fail closed
- expose the acknowledged operation in the Python client
- keep the browser boundary at @connectonion/react; O Chat remains protocol-free and the standalone TypeScript SDK remains retired

## Security and correctness

- session IDs remain correlation IDs; signature-verified requester identity owns the session
- durable JSONL state, not the process-local registry, is authoritative across workers
- no ACK is emitted before the durable append succeeds
- unexpected Agent and storage failures are logged server-side and sanitized on the wire
- hosted ULW cannot exceed the launch-time ceiling or be extended through the legacy mailbox
- client timeout means outcome unknown and requires reconnecting for authoritative state

## Validation

- 225 related unit tests passed
- changed production scope Ruff E/F/I checks passed
- Python compileall passed
- uv lock check passed
- package sdist and wheel build passed
- pip-audit against frozen runtime dependencies: no known vulnerabilities
- diff check clean
- no TypeScript or JavaScript files changed

Closes #883