### PR TITLE
feat: mirror persisted public thoughts over ACP

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -15,6 +15,7 @@ from acp import text_block, tool_content
 from acp.schema import (
     AgentMessageChunk,
     AgentRequest,
+    AgentThoughtChunk,
     CancelNotification,
     CurrentModeUpdate,
     PermissionOption,
@@ -123,6 +124,25 @@ def map_message_event(
         message_id=_required_string(event, "id"),
         content=text_block(_required_string(event, "content")),
     )
+
+
+def map_thought_event(
+    event: Mapping[str, Any],
+) -> AgentThoughtChunk | None:
+    """Map one persisted public application thought to ACP v1.19."""
+
+    if event.get("type") != "thinking":
+        return None
+    kwargs: dict[str, Any] = {
+        "session_update": "agent_thought_chunk",
+        "message_id": _required_string(event, "id"),
+        "content": text_block(_required_string(event, "content")),
+    }
+    kind = event.get("kind")
+    if isinstance(kind, str) and kind:
+        # Product presentation metadata is an extension, never authority.
+        kwargs["field_meta"] = {"connectonion": {"kind": kind}}
+    return AgentThoughtChunk(**kwargs)
 
 
 def session_mode_id(value: Any) -> str:
@@ -418,6 +438,7 @@ def acp_notification_frame(
     update = (
         map_tool_event(event)
         or map_message_event(event)
+        or map_thought_event(event)
         or map_mode_event(event)
     )
     if update is None:

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -196,7 +196,10 @@ class Agent:
                 {**wire_extras, **entry} if wire_extras else entry
             )
             # Send entry first (without session to avoid circular ref)
-            self.io.send(wire_entry)
+            send_persisted_trace = getattr(
+                self.io, "_send_persisted_trace", self.io.send
+            )
+            send_persisted_trace(wire_entry)
             # Then send session sync separately
             self.io.send({
                 'type': 'session_sync',

--- a/connectonion/network/host/ws_router/agent_io.py
+++ b/connectonion/network/host/ws_router/agent_io.py
@@ -141,17 +141,18 @@ def _agent_thread_body(route_handlers, storage, prompt, io, session, images, fil
 async def forward_agent_msgs_to_client(send_msg, io, session_id, *, result_holder=None, conn=None, storage=None):
     """Forward agent events to client. Send OUTPUT (or ERROR) when agent finishes."""
     async for event in io.read_msgs_from_agent():
+        persisted_trace = io.is_persisted_trace_event(event)
+        event_type = event.get("type")
         if event.get("type") == "approval_needed":
             acp_request = _acp_permission_rollout_frame(event, session_id)
             io.register_permission_request(event, session_id, acp_request)
             if acp_request is not None:
                 await send_msg(acp_request)
+        should_mirror = event_type in {
+            "tool_call", "tool_result", "mode_changed"
+        } or (event_type == "thinking" and persisted_trace)
         acp_frame = (
-            _acp_rollout_frame(event, session_id)
-            if event.get("type") in {
-                "tool_call", "tool_result", "mode_changed"
-            }
-            else None
+            _acp_rollout_frame(event, session_id) if should_mirror else None
         )
         if acp_frame is not None:
             await send_msg(acp_frame)

--- a/connectonion/network/io/base.py
+++ b/connectonion/network/io/base.py
@@ -2,9 +2,9 @@
 Purpose: Abstract IO interface for bidirectional agent-client communication in hosted agents
 LLM-Note:
   Dependencies: imports from [abc.ABC, typing, core/wire_events.py] | imported by [network/io/websocket.py, network/__init__.py, agent.py] | tested by [tests/unit/test_io.py, tests/unit/test_wire_events.py]
-  Data flow: agent.io.send(event) → client receives event → agent.io.receive() → blocks until client responds | high-level: io.log(type, **data) normalizes tool lifecycle status then sends one-way notifications | io.request_approval(tool, args) sends approval_needed → waits for client response → returns True/False
+  Data flow: agent.io.send(event) → client receives event → agent.io.receive() → blocks until client responds | Agent._record_trace() → internal _send_persisted_trace(event) transport hook | high-level: io.log(type, **data) normalizes tool lifecycle status then sends one-way notifications | io.request_approval(tool, args) sends approval_needed → waits for client response → returns True/False
   State/Effects: no state (abstract base class) | implementations handle message queuing/transport
-  Integration: exposes IO abstract class with send(event), receive() → dict primitives | convenience methods: log(type, **data), request_approval(tool, args) → bool | agent.io injected by host() for hosted execution | used in event handlers (@after_llm, @before_each_tool)
+  Integration: exposes IO abstract class with send(event), receive() → dict primitives and internal _send_persisted_trace(event) hook | convenience methods: log(type, **data), request_approval(tool, args) → bool | agent.io injected by host() for hosted execution | used in event handlers (@after_llm, @before_each_tool)
   Performance: abstract (implementation-specific) | WebSocketIO uses queue.Queue for thread-safe communication
   Errors: abstract methods must be implemented by subclasses | request_approval() blocks until response (timeout handled by implementation)
 IO interface for agent-client communication during hosted execution.
@@ -50,6 +50,15 @@ class IO(ABC):
             event: Dict with at least 'type' key, e.g. {"type": "thinking"}
         """
         pass
+
+    def _send_persisted_trace(self, event: Dict[str, Any]) -> None:
+        """Send an event that was committed to the canonical session trace.
+
+        Agent owns this internal path. Transports that expose persisted trace
+        events differently from ad-hoc ``send()`` calls can override it; other
+        transports keep their existing behavior through this safe default.
+        """
+        self.send(event)
 
     @abstractmethod
     def receive(self) -> Dict[str, Any]:

--- a/connectonion/network/io/websocket.py
+++ b/connectonion/network/io/websocket.py
@@ -2,9 +2,9 @@
 Purpose: WebSocket IO bridging async WebSocket transport to sync agent code via thread-safe message channels
 LLM-Note:
   Dependencies: imports from [network/io/base.IO, asyncio, threading, time, uuid] | imported by [network/host/ws_router/agent_io.py] | tested by [tests/unit/test_io.py, tests/unit/test_io_image_support.py]
-  Data flow: agent calls io.send(event) → auto-stamps id (UUID) and ts if missing → enqueues for async forwarder | client message → enqueued for agent | read_msgs_from_agent() async-iterates outgoing for forwarding to client | send_to_agent() pushes incoming messages to agent
+  Data flow: agent calls io.send(event) → auto-stamps id (UUID) and ts if missing → enqueues for async forwarder | Agent._record_trace() calls internal _send_persisted_trace(event) → queues a private dict subtype as Host-local provenance | client message → enqueued for agent | read_msgs_from_agent() async-iterates outgoing for forwarding to client | send_to_agent() pushes incoming messages to agent
   State/Effects: maintains incoming + outgoing channels (async-safe) | finished flag prevents sends after close | unblocks agent's blocking receive on close
-  Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs/finish_runtime_inputs for lossless mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
+  Integration: exposes WebSocketIO() implementing IO interface | send/receive for agent-side, internal persisted-trace provenance queried by Host forwarder, read_msgs_from_agent/send_to_agent for transport-side, push_runtime_input/pop_runtime_inputs/finish_runtime_inputs for lossless mid-execution interjection, rewind_to(last_msg_id) for replay on reconnect, mark_agent_done() to terminate
   Performance: queue-based coordination between sync agent thread and async transport | blocking receive() is intended for agent thread | _wait_for_msgs_from_agent waits at most ~1s so idle-session forwarders don't pin executor-pool threads
   Errors: closed IO unblocks pending receive() so agent thread doesn't hang | no exceptions raised — channel coordination handled internally
 """
@@ -16,6 +16,10 @@ import uuid
 from typing import Any, Dict
 
 from .base import IO
+
+
+class _PersistedTraceEvent(dict):
+    """Cooperative Host-local provenance; never an extra wire field or sandbox."""
 
 
 class WebSocketIO(IO):
@@ -57,6 +61,19 @@ class WebSocketIO(IO):
 
         Auto-generates 'id' (UUID) and 'ts' (timestamp) if not present.
         """
+        self._append_agent_message(message)
+
+    def _send_persisted_trace(self, message: Dict[str, Any]) -> None:
+        """Queue one canonical trace event with cooperative Host provenance."""
+        self._append_agent_message(_PersistedTraceEvent(message))
+
+    @staticmethod
+    def is_persisted_trace_event(message: Dict[str, Any]) -> bool:
+        """Return whether this exact queued event came from Agent._record_trace."""
+        return isinstance(message, _PersistedTraceEvent)
+
+    def _append_agent_message(self, message: Dict[str, Any]) -> None:
+        """Stamp and append one agent event to the replayable outgoing log."""
         if not self._closed:
             if 'id' not in message:
                 message['id'] = str(uuid.uuid4())

--- a/docs/design-decisions/041-public-acp-host-thoughts.md
+++ b/docs/design-decisions/041-public-acp-host-thoughts.md
@@ -1,0 +1,98 @@
+# DD-041: ACP Host thoughts mirror only persisted application text
+
+**Status:** Accepted
+
+**Date:** 2026-08-12
+
+**Related:** [028 Ordered ACP Event Bridge](028-acp-ordered-event-bridge.md), [035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md), [036 Stable ACP Agent Message Identity](036-stable-acp-agent-message-identity.md)
+
+## Context
+
+The local stdio ACP adapter already maps ConnectOnion `thinking` events to
+`AgentThoughtChunk`. The authenticated network Host still sends only the legacy
+event. Its event vocabulary also contains `llm_call` and `llm_result`, which are
+provider/status diagnostics rather than text the application chose to show.
+
+The active browser path is Host -> `@connectonion/react` -> O Chat. React owns
+the protocol reader and O Chat renders normalized `ChatItem` state. The
+standalone TypeScript SDK is retired.
+
+## Decision
+
+The Host maps only a canonical event with `type=thinking`, a non-empty persisted
+event ID, and non-empty string content to the official ACP v1.19
+`AgentThoughtChunk`. `Agent._record_trace()` already assigns a UUID before it
+persists and streams these events, so the same domain identity becomes ACP
+`messageId` and the replayed `thinking` ChatItem ID.
+
+Persistence provenance is transport-local, not a client-controlled JSON field.
+`Agent._record_trace()` uses an internal IO path that queues a private dictionary
+subtype in `WebSocketIO`; ordinary `agent.io.send()` events remain plain
+dictionaries. The Host requires that provenance before mirroring `thinking`,
+and both objects serialize to the same legacy JSON shape. This prevents an
+ordinary direct `send({"type": "thinking", ...})` from being misclassified as
+an ACP thought while preserving provenance when the outgoing log is replayed.
+
+This is a cooperative in-process API boundary, not a Python sandbox. Extensions
+running inside the Agent process are trusted code: they can import private
+objects, call private methods, or mutate the Agent directly. Isolating hostile
+plugins requires a separate process/capability boundary and is outside this
+carrier decision.
+
+Known `re_act` and `reflect` producers explicitly create application text and
+already expose it to the same authenticated browser in the legacy event and
+session replay. This slice does not inspect or infer model reasoning. It never
+maps `llm_call`, `llm_result`, raw provider responses, system prompts, debug
+payloads, content-free busy indicators, or arbitrary trace entries.
+
+One complete persisted thought becomes one ACP text chunk. This Host carrier
+does not claim provider token streaming. ACP gives chunks message identity but
+no sequence or offset, so browser accumulation cannot distinguish repeated
+text from retransmission. A future streaming design must define generation,
+ordering, resume, and replay rather than adding hidden client state.
+
+If the canonical thought has a non-empty string `kind`, the adapter carries it
+as `_meta.connectonion.kind`. This is a presentation hint only. Invalid hints
+are omitted without discarding otherwise valid public content, and `_meta`
+never affects authority, persistence, ordering, or execution.
+
+The Host sends the additive ACP notification immediately before the matching
+legacy thought event. The React reader lands first, validates active-session
+ownership, and upserts ACP, legacy, and replay by the persisted ID. O Chat does
+not parse ACP. A malformed mirror is logged and skipped while the legacy event
+and authoritative `OUTPUT` continue, so presentation conversion cannot invite
+a retry of completed work.
+
+## Privacy and trust boundary
+
+ACP's generic thought field can contain internal reasoning. React cannot
+classify text origin, and this decision does not claim otherwise. The narrower
+ConnectOnion Host writer contract is what limits this carrier to persisted,
+already-visible application text. A different ACP agent or Host defines its own
+privacy contract.
+
+## Compatibility and rollback
+
+Canonical traces and session snapshots remain unchanged. Updated React readers
+de-duplicate the additive frame; older clients keep the legacy event. The
+Python compatibility client ignores unsupported ACP thought updates and then
+renders the legacy twin, so it does not duplicate UI during rollout.
+
+Rollback removes `thinking` from the Host mirror whitelist and the pure mapper.
+No stored session, provider input, authentication state, or O Chat code needs a
+migration or downgrade. Removing the legacy event remains a separate major-
+version decision backed by usage evidence.
+
+## Rejected alternatives
+
+- **Map `llm_call` or `llm_result`:** status and usage diagnostics are not
+  application-authored thought content and may expose provider internals.
+- **Read provider responses or traces to find reasoning:** expands the privacy
+  surface and bypasses the explicit public event boundary.
+- **Generate `messageId` in the adapter:** breaks ACP/legacy/replay identity.
+- **Accumulate arbitrary chunks in React:** without chunk identity or a resume
+  generation, retransmission and repeated content are indistinguishable.
+- **Store ACP envelopes in trace:** couples canonical persistence to one
+  transport and makes rollback destructive.
+- **Trust a JSON provenance flag:** any direct IO caller could forge the flag,
+  and an internal transport concern would leak onto the public wire.

--- a/tests/fixtures/acp_thought_events.json
+++ b/tests/fixtures/acp_thought_events.json
@@ -1,0 +1,36 @@
+{
+  "legacy": [
+    {
+      "type": "thinking",
+      "id": "fe524e77-f886-48de-a0c2-84f67f4db706",
+      "kind": "reflect",
+      "content": "The search result needs one more check."
+    }
+  ],
+  "acp": [
+    {
+      "type": "ACP_NOTIFICATION",
+      "acpSchema": "schema-v1.19.0",
+      "message": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "session-1",
+          "update": {
+            "content": {
+              "text": "The search result needs one more check.",
+              "type": "text"
+            },
+            "messageId": "fe524e77-f886-48de-a0c2-84f67f4db706",
+            "_meta": {
+              "connectonion": {
+                "kind": "reflect"
+              }
+            },
+            "sessionUpdate": "agent_thought_chunk"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/test_acp_wire.py
+++ b/tests/unit/test_acp_wire.py
@@ -11,6 +11,7 @@ from connectonion.core.acp_wire import (
     acp_notification_frame,
     legacy_tool_event_from_acp,
     map_message_event,
+    map_thought_event,
 )
 from connectonion.network.connect import RemoteAgent
 
@@ -22,6 +23,13 @@ MESSAGE_FIXTURE = json.loads(
         Path(__file__).parents[1]
         / "fixtures"
         / "acp_agent_message_events.json"
+    ).read_text()
+)
+THOUGHT_FIXTURE = json.loads(
+    (
+        Path(__file__).parents[1]
+        / "fixtures"
+        / "acp_thought_events.json"
     ).read_text()
 )
 
@@ -44,6 +52,15 @@ def test_agent_messages_match_the_shared_acp_fixture():
     assert actual == MESSAGE_FIXTURE["acp"]
 
 
+def test_public_thoughts_match_the_shared_acp_fixture():
+    actual = [
+        acp_notification_frame(event, "session-1")
+        for event in THOUGHT_FIXTURE["legacy"]
+    ]
+
+    assert actual == THOUGHT_FIXTURE["acp"]
+
+
 @pytest.mark.parametrize(
     "event",
     [
@@ -55,6 +72,41 @@ def test_agent_messages_match_the_shared_acp_fixture():
 def test_empty_or_malformed_agent_messages_are_rejected(event):
     with pytest.raises(ValueError):
         map_message_event(event)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "thinking", "id": "", "content": "checking"},
+        {"type": "thinking", "id": "thought-1", "content": ""},
+        {"type": "thinking", "id": "thought-1", "content": None},
+        {"type": "thinking", "id": "thought-1"},
+    ],
+)
+def test_empty_or_malformed_thoughts_are_rejected(event):
+    with pytest.raises(ValueError):
+        map_thought_event(event)
+
+
+@pytest.mark.parametrize("kind", [None, "", 42, {"name": "reflect"}])
+def test_invalid_thought_kind_is_omitted_without_losing_public_text(kind):
+    event = {
+        "type": "thinking",
+        "id": "thought-1",
+        "content": "checking",
+        "kind": kind,
+    }
+
+    update = map_thought_event(event)
+
+    assert update is not None
+    assert update.model_dump(
+        mode="json", by_alias=True, exclude_none=True, exclude_unset=True
+    ) == {
+        "content": {"text": "checking", "type": "text"},
+        "messageId": "thought-1",
+        "sessionUpdate": "agent_thought_chunk",
+    }
 
 
 def test_acp_tool_events_decode_to_the_legacy_python_ui_shape():
@@ -147,9 +199,19 @@ def test_python_remote_agent_applies_partial_acp_updates():
     assert "result" not in agent.ui[0]
 
 
-def test_non_tool_events_stay_in_the_connectonion_namespace():
-    event = {"type": "thinking", "content": "checking"}
-
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "llm_call", "id": "provider-1", "status": "running"},
+        {
+            "type": "llm_result",
+            "id": "provider-1",
+            "content": "must not become public reasoning",
+        },
+        {"type": "compact", "content": "private diagnostic"},
+    ],
+)
+def test_provider_and_internal_events_stay_connectonion_only(event):
     assert acp_notification_frame(event, "session-1") is None
     assert legacy_tool_event_from_acp(event) is None
 

--- a/tests/unit/test_asgi.py
+++ b/tests/unit/test_asgi.py
@@ -122,6 +122,155 @@ class TestForwardAgentEvents:
         assert acp_message["method"] == "session/update"
         assert acp_message["params"]["sessionId"] == "test-session"
 
+    async def test_public_thought_acp_mirror_precedes_legacy_event(self):
+        io = WebSocketIO()
+        sent_messages = []
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        thought = {
+            "type": "thinking",
+            "id": "thought-1",
+            "kind": "reflect",
+            "content": "checking the result",
+        }
+        io._send_persisted_trace(thought)
+        io.mark_agent_done()
+
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "session-1"
+        )
+
+        assert [message["type"] for message in sent_messages[:2]] == [
+            "ACP_NOTIFICATION",
+            "thinking",
+        ]
+        assert sent_messages[0]["message"]["params"] == {
+            "sessionId": "session-1",
+            "update": {
+                "content": {"text": "checking the result", "type": "text"},
+                "messageId": "thought-1",
+                "_meta": {"connectonion": {"kind": "reflect"}},
+                "sessionUpdate": "agent_thought_chunk",
+            },
+        }
+        assert sent_messages[1]["type"] == "thinking"
+        assert sent_messages[1]["id"] == thought["id"]
+        assert sent_messages[1]["kind"] == thought["kind"]
+        assert sent_messages[1]["content"] == thought["content"]
+        assert sent_messages[1]["session_id"] == "session-1"
+        assert isinstance(sent_messages[1]["ts"], float)
+
+    async def test_direct_thinking_event_stays_legacy_only(self):
+        """The public IO primitive does not classify direct events as thoughts."""
+        io = WebSocketIO()
+        sent_messages = []
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        thought = {
+            "type": "thinking",
+            "id": "direct-thought",
+            "content": "not a persisted trace entry",
+        }
+        io.send(thought)
+        io.mark_agent_done()
+
+        await forward_agent_msgs_to_client(
+            mock_send_msg, io, "session-1"
+        )
+
+        protocol_types = [
+            message["type"] for message in sent_messages
+            if message["type"] != "DASHBOARD_SNAPSHOT"
+        ]
+        assert protocol_types == [
+            "thinking",
+            "ERROR",
+        ]
+        assert sent_messages[0] == {**thought, "session_id": "session-1"}
+        assert not any(
+            message.get("type") == "ACP_NOTIFICATION"
+            for message in sent_messages
+        )
+
+    async def test_bad_thought_mirror_still_drains_legacy_and_output(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "committed",
+            "duration_ms": 5,
+            "session": {},
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io._send_persisted_trace({
+            "type": "thinking",
+            "id": "thought-1",
+            "content": "already visible",
+        })
+        io.mark_agent_done()
+
+        with patch.object(
+            agent_io_module,
+            "acp_notification_frame",
+            side_effect=ValueError("bad thought mirror"),
+        ):
+            await forward_agent_msgs_to_client(
+                mock_send_msg,
+                io,
+                "session-1",
+                result_holder=result_holder,
+            )
+
+        protocol_types = [
+            message["type"] for message in sent_messages
+            if message["type"] != "DASHBOARD_SNAPSHOT"
+        ]
+        assert protocol_types == [
+            "thinking",
+            "OUTPUT",
+        ]
+
+    async def test_provider_diagnostics_are_not_acp_thoughts(self):
+        io = WebSocketIO()
+        sent_messages = []
+        result_holder = [{
+            "result": "committed",
+            "duration_ms": 5,
+            "session": {},
+        }]
+
+        async def mock_send_msg(msg):
+            sent_messages.append(msg)
+
+        io.send({
+            "type": "llm_result",
+            "id": "provider-1",
+            "content": "must not become public reasoning",
+        })
+        io.mark_agent_done()
+
+        await forward_agent_msgs_to_client(
+            mock_send_msg,
+            io,
+            "session-1",
+            result_holder=result_holder,
+        )
+
+        protocol_types = [
+            message["type"] for message in sent_messages
+            if message["type"] != "DASHBOARD_SNAPSHOT"
+        ]
+        assert protocol_types == [
+            "llm_result",
+            "OUTPUT",
+        ]
+
     async def test_sends_output_from_result_holder(self):
         """Test that OUTPUT is sent when agent completes with result."""
         io = WebSocketIO()

--- a/tests/unit/test_host_session.py
+++ b/tests/unit/test_host_session.py
@@ -714,7 +714,8 @@ class TestSessionToChatItems:
                 {'type': 'intent', 'id': 'i1', 'ack': 'Got it', 'is_build': False},
                 {'type': 'eval', 'id': 'e1', 'passed': True, 'summary': 'ok',
                  'expected': 'q', 'eval_path': '/tmp/x.yaml'},
-                {'type': 'thinking', 'kind': 'reflect', 'content': 'reflecting'},
+                {'type': 'thinking', 'id': 'th1', 'kind': 'reflect',
+                 'content': 'reflecting'},
             ],
         }
 
@@ -724,6 +725,7 @@ class TestSessionToChatItems:
         assert items[1]['ack'] == 'Got it'
         assert items[2]['summary'] == 'ok'
         assert items[3]['kind'] == 'reflect'
+        assert items[3]['id'] == 'th1'
 
     def test_interleaves_multi_turn_by_user_input(self):
         """Multi-turn: each user_input marker bounds a turn; trace items emit in their turn."""

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -61,6 +61,43 @@ class TestWebSocketIO:
 
         assert io._msgs_from_agent[0]["id"] == "custom-id-123"  # preserved, not overwritten
 
+    def test_only_internal_trace_path_marks_persisted_events(self):
+        """A plain send cannot forge the Host's persisted-trace provenance."""
+        io = WebSocketIO()
+        direct = {"type": "thinking", "id": "direct"}
+        persisted = {"type": "thinking", "id": "persisted"}
+
+        io.send(direct)
+        io._send_persisted_trace(persisted)
+
+        assert io.is_persisted_trace_event(io._msgs_from_agent[0]) is False
+        assert io.is_persisted_trace_event(io._msgs_from_agent[1]) is True
+        assert type(io._msgs_from_agent[0]) is dict
+        assert type(io._msgs_from_agent[1]) is not dict
+        assert io._msgs_from_agent[1]["type"] == persisted["type"]
+        assert io._msgs_from_agent[1]["id"] == persisted["id"]
+        assert isinstance(io._msgs_from_agent[1]["ts"], float)
+
+    def test_agent_record_trace_uses_internal_provenance_path(self):
+        """Only Agent's canonical trace writer marks the streamed trace event."""
+        from connectonion import Agent
+
+        io = WebSocketIO()
+        agent = Agent.__new__(Agent)
+        agent.current_session = {"trace": []}
+        agent.io = io
+
+        agent._record_trace({
+            "type": "thinking",
+            "content": "persisted public thought",
+        })
+
+        assert len(io._msgs_from_agent) == 2
+        assert io.is_persisted_trace_event(io._msgs_from_agent[0]) is True
+        assert io.is_persisted_trace_event(io._msgs_from_agent[1]) is False
+        assert io._msgs_from_agent[0]["id"] == agent.current_session["trace"][0]["id"]
+        assert io._msgs_from_agent[1]["type"] == "session_sync"
+
     def test_send_skips_when_closed(self):
         """send() does nothing when IO is closed."""
         io = WebSocketIO()


### PR DESCRIPTION
## Summary

- map persisted public `thinking` trace entries to official ACP v1.19 `agent_thought_chunk` notifications
- preserve the canonical UUID across ACP, legacy dual-write, and session replay
- require Host-local persisted-trace provenance so ordinary `agent.io.send(thinking)` remains legacy-only
- keep provider diagnostics and internal events out of the ACP thought channel
- document privacy, trusted in-process extension boundary, rollout, and rollback in DD-041

The active frontend path is ConnectOnion Host -> `@connectonion/react` -> O Chat. The React reader landed first in `openonion/connectonion-react#27`; the retired standalone TypeScript SDK is untouched. This PR does not release or publish a version.

## Design and security

- one complete persisted thought becomes one ACP text chunk; this does not claim provider token streaming
- `_meta.connectonion.kind` is an optional presentation hint only
- provenance is a private in-memory dict subtype, not a forgeable/public JSON flag
- ordinary direct `send()` events cannot be misclassified, while replay preserves provenance
- in-process Python extensions remain trusted code; this cooperative boundary is not a sandbox
- malformed ACP conversion falls back to the legacy event and authoritative `OUTPUT`

## Validation

- `pytest -q tests/unit/test_io.py tests/unit/test_asgi.py tests/unit/test_acp_wire.py tests/unit/test_host_session.py tests/unit/test_agent.py tests/unit/test_co_ai_acp_events.py tests/unit/test_co_ai_acp.py` — 227 passed
- related mode/permission/tool/interrupt/stdio ACP suite — 211 passed
- reviewer random-order reproduction (`--randomly-seed=1306858393`) — 188 passed
- production source `ruff check` — passed
- `git diff --check` — passed
- `python -m build --wheel` — passed
- `uv lock --check` — passed
- `pip-audit` against the frozen production lock — no known vulnerabilities
- packed `@connectonion/react` consumer validation in O Chat — tests, lint, and Next build passed
- two independent final code/security reviews — no findings

Local all-tests probing also surfaced two environment/release-adjacent failures outside this diff: a sibling docs-site checkout advertising 1.6.0 while this branch is 1.7.0a1, and the current Python environment missing the declared `mcp` dependency. Clean PR CI installs project dependencies and is the merge gate.

Closes #885
