### PR TITLE
feat: stream Claude Code tool activity to co ai

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -183,6 +183,7 @@ def create_agent(
         max_iterations=max_iterations,
         co_dir=co_dir,
     )
+    agent._delegation_workspace = Path.cwd().resolve()
     # This browser helper blocks on stdin, which is wrong for co ai's websocket
     # chat runtime. Use browser tools plus frontend-mediated user handoffs.
     agent.tools.remove("wait_for_manual_login")

--- a/connectonion/cli/co_ai/prompts/tools/claude_code.md
+++ b/connectonion/cli/co_ai/prompts/tools/claude_code.md
@@ -15,7 +15,7 @@ separate coding agent is better suited to implement or investigate it.
   exit is a result to handle; never claim the delegated work completed.
 - Claude Code runs headlessly here. Its inner tool starts and results appear
   automatically as live cards in co ai, so do not narrate or duplicate them.
-  Safe Mode can read and use actions already allowed by Claude's settings, but
+  Safe Mode can use actions allowed by its bound mode, but
   it cannot open an unmatched Claude permission prompt in the co ai UI. Accept
   Edits can edit in-scope files; other actions that need a prompt fail closed.
   Claude may describe a denied action in a successful JSON result, so inspect
@@ -35,6 +35,11 @@ uses Claude Auto mode and its safety classifier. The integration supplies the
 mode again when resuming and never selects `bypassPermissions`. Auto mode is
 available only for supported accounts, models, Anthropic API connections, and
 organization policy; an unavailable Auto mode is a provider failure to report.
+Claude's safe mode disables ordinary project and user customizations—including
+`CLAUDE.md`, skills, plugins, hooks, MCP servers, commands, and custom agents—so
+they cannot raise the selected mode's authority. Put all relevant task and
+project instructions in the prompt. The requested `cwd` must remain inside the
+project root where `co ai` started.
 
 ## Example
 
@@ -47,7 +52,7 @@ first = claude_code(
 # After retaining the session_id from the JSON result:
 follow_up = claude_code(
     prompt="Address the review finding about malformed UTF-8 input.",
-    session_id="0b7e...",
+    session_id="0b7e2f13-9c44-48ef-91bc-426bbff68671",
     cwd="/absolute/path/to/repo",
 )
 ```

--- a/connectonion/cli/co_ai/prompts/tools/claude_code.md
+++ b/connectonion/cli/co_ai/prompts/tools/claude_code.md
@@ -13,11 +13,13 @@ separate coding agent is better suited to implement or investigate it.
 - Read the structured `status`, `result`, and `error` fields. A missing CLI,
   authentication failure, unavailable Auto mode/model, timeout, or non-zero
   exit is a result to handle; never claim the delegated work completed.
-- Claude Code runs headlessly here. Safe Mode can read and use actions already
-  allowed by Claude's settings, but it cannot open a permission prompt in the
-  co ai UI. Accept Edits can edit in-scope files; other actions that need a
-  prompt fail closed. Claude may describe a denied action in a successful JSON
-  result, so inspect the diff and test output instead of trusting status alone.
+- Claude Code runs headlessly here. Its inner tool starts and results appear
+  automatically as live cards in co ai, so do not narrate or duplicate them.
+  Safe Mode can read and use actions already allowed by Claude's settings, but
+  it cannot open an unmatched Claude permission prompt in the co ai UI. Accept
+  Edits can edit in-scope files; other actions that need a prompt fail closed.
+  Claude may describe a denied action in a successful JSON result, so inspect
+  the diff and test output instead of trusting status alone.
 - In a hosted session, Claude Code delegation is operator-only. Shared contacts
   receive a structured refusal and the local CLI is not started.
 

--- a/connectonion/cli/co_ai/tools/claude_code.py
+++ b/connectonion/cli/co_ai/tools/claude_code.py
@@ -1,6 +1,7 @@
 """Expose Claude Code to co ai without exposing its permission policy."""
 
 import json
+from pathlib import Path
 
 from connectonion.useful_tools.claude_code import _run_claude_code
 
@@ -51,4 +52,9 @@ def claude_code(
         model=model,
         timeout=timeout,
         agent=agent,
+        workspace=(
+            getattr(agent, "_delegation_workspace", Path.cwd())
+            if agent is not None
+            else None
+        ),
     )

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -1,12 +1,15 @@
-"""Run or resume Claude Code through its headless JSON CLI contract."""
+"""Run Claude Code once while streaming its inner tools to ConnectOnion IO."""
 
 import json
 import os
+import queue
 import shlex
 import shutil
 import signal
 import subprocess
+import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -18,6 +21,21 @@ PERMISSION_MODES = (
     "auto",
     "dontAsk",
     "bypassPermissions",
+)
+
+_MAX_ARGUMENT_CHARS = 4_000
+_MAX_FIELD_CHARS = 1_000
+_MAX_RESULT_CHARS = 4_000
+_MAX_STDERR_CHARS = 16_000
+_MAX_COLLECTION_ITEMS = 20
+_SENSITIVE_KEY_PARTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "password",
+    "secret",
+    "token",
 )
 
 
@@ -88,87 +106,36 @@ def _run_claude_code(
     agent=None,
 ) -> str:
     """Private runner shared by safe, configured, and co-ai entry points."""
-    if not isinstance(session_id, str):
-        return _envelope("", error="Session ID must be a string.")
-    if not isinstance(prompt, str) or not prompt.strip():
-        return _envelope(session_id, error="Prompt must be a non-empty string.")
-    if not isinstance(cwd, str):
-        return _envelope(session_id, error="Working directory must be a string.")
-    if not isinstance(model, str):
-        return _envelope(session_id, error="Model must be a string.")
+    validation = _validate_request(prompt, session_id, cwd, model, timeout)
+    if validation:
+        return _envelope(session_id if isinstance(session_id, str) else "", error=validation)
     if permission_mode not in PERMISSION_MODES:
         choices = ", ".join(PERMISSION_MODES)
         return _envelope(
             session_id,
             error=f"Invalid permission mode {permission_mode!r}. Use one of: {choices}.",
         )
-    if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout <= 0:
-        return _envelope(session_id, error="Timeout must be a positive integer.")
 
+    working_directory, error = _working_directory(cwd)
+    if error:
+        return _envelope(session_id, error=error)
+    command, error = _claude_command()
+    if error:
+        return _envelope(session_id, error=error)
+
+    argv = _stream_command(command, prompt, session_id, permission_mode, model)
+    forwarder = _ClaudeStreamForwarder(agent)
+    cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
     try:
-        working_directory = Path(cwd or ".").expanduser().resolve(strict=True)
-    except (OSError, RuntimeError, ValueError) as exc:
-        return _envelope(session_id, error=f"Working directory is unavailable: {exc}")
-    if not working_directory.is_dir():
-        return _envelope(
-            session_id,
-            error=f"Working directory is not a directory: {working_directory}",
-        )
-
-    try:
-        command = _base_command()
-    except ValueError as exc:
-        return _envelope(
-            session_id,
-            error=f"Invalid $CLAUDE_CODE_CMD: {_one_line(exc)}",
-        )
-    if command is None:
-        return _envelope(
-            session_id,
-            error=(
-                "Claude Code CLI not found. Install it or set $CLAUDE_CODE_CMD."
-            ),
-        )
-    if _is_unsafe_windows_batch(command[0]):
-        return _envelope(
-            session_id,
-            error=(
-                "Claude Code resolved to a Windows .cmd/.bat wrapper, which cannot "
-                "safely receive arbitrary prompts. Install the native executable or "
-                "set $CLAUDE_CODE_CMD to a native .exe (or node.exe plus its script)."
-            ),
-        )
-
-    cli_mode = "manual" if permission_mode == "default" else permission_mode
-    argv = [
-        *command,
-        "-p",
-        "--output-format",
-        "json",
-        "--permission-mode",
-        cli_mode,
-    ]
-    if session_id:
-        argv.extend(["--resume", session_id])
-    if model:
-        argv.extend(["--model", model])
-    argv.extend(["--", prompt])
-
-    try:
-        cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
         completed = _run_process(
             argv,
             cwd=str(working_directory),
             timeout=timeout,
             cancelled=cancelled if callable(cancelled) else None,
+            on_event=forwarder.handle,
         )
     except FileNotFoundError:
-        return _envelope(
-            session_id,
-            error=(
-                "Claude Code CLI not found. Install it or set $CLAUDE_CODE_CMD."
-            ),
-        )
+        return _envelope(session_id, error="Claude Code CLI not found during launch.")
     except subprocess.TimeoutExpired:
         return _envelope(
             session_id,
@@ -177,6 +144,11 @@ def _run_claude_code(
         )
     except _ProviderCancelled:
         return _envelope(session_id, error="Claude Code was interrupted.")
+    except _ProviderStreamError as exc:
+        return _envelope(
+            session_id,
+            error=f"Claude Code live event forwarding failed: {_one_line(exc)}",
+        )
     except OSError as exc:
         return _envelope(session_id, error=f"Claude Code could not start: {exc}")
     except ValueError as exc:
@@ -184,53 +156,100 @@ def _run_claude_code(
             session_id,
             error=f"Claude Code received an invalid launch argument: {_one_line(exc)}",
         )
+    return _completed_envelope(completed, session_id)
 
+
+def _validate_request(prompt, session_id, cwd, model, timeout) -> str:
+    if not isinstance(session_id, str):
+        return "Session ID must be a string."
+    if not isinstance(prompt, str) or not prompt.strip():
+        return "Prompt must be a non-empty string."
+    if not isinstance(cwd, str):
+        return "Working directory must be a string."
+    if not isinstance(model, str):
+        return "Model must be a string."
+    if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout <= 0:
+        return "Timeout must be a positive integer."
+    return ""
+
+
+def _working_directory(cwd: str) -> tuple[Path | None, str]:
     try:
-        output = json.loads(completed.stdout)
-    except (TypeError, json.JSONDecodeError):
-        detail = _one_line(completed.stderr or completed.stdout)
-        suffix = f": {detail}" if detail else ""
-        return _envelope(
-            session_id,
-            exit_code=completed.returncode,
-            error=f"Claude Code returned invalid JSON{suffix}",
+        directory = Path(cwd or ".").expanduser().resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        return None, f"Working directory is unavailable: {exc}"
+    if not directory.is_dir():
+        return None, f"Working directory is not a directory: {directory}"
+    return directory, ""
+
+
+def _claude_command() -> tuple[list[str] | None, str]:
+    try:
+        command = _base_command()
+    except ValueError as exc:
+        return None, f"Invalid $CLAUDE_CODE_CMD: {_one_line(exc)}"
+    if command is None:
+        return None, "Claude Code CLI not found. Install it or set $CLAUDE_CODE_CMD."
+    if _is_unsafe_windows_batch(command[0]):
+        return None, (
+            "Claude Code resolved to a Windows .cmd/.bat wrapper, which cannot "
+            "safely receive arbitrary prompts. Install the native executable or "
+            "set $CLAUDE_CODE_CMD to a native .exe."
         )
-    payload = _result_payload(output)
-    if payload is None:
-        detail = _one_line(completed.stderr)
+    return command, ""
+
+
+def _stream_command(command, prompt, session_id, permission_mode, model):
+    cli_mode = "manual" if permission_mode == "default" else permission_mode
+    argv = [
+        *command,
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--forward-subagent-text",
+        "--permission-mode",
+        cli_mode,
+    ]
+    if session_id:
+        argv.extend(["--resume", session_id])
+    if model:
+        argv.extend(["--model", model])
+    argv.extend(["--", prompt])
+    return argv
+
+
+def _completed_envelope(completed, requested_session: str) -> str:
+    payload = completed.payload
+    if not isinstance(payload, dict) or payload.get("type") != "result":
+        detail = _one_line(completed.stderr or completed.invalid_output)
         suffix = f": {detail}" if detail else ""
         return _envelope(
-            session_id,
+            requested_session,
             exit_code=completed.returncode,
-            error=f"Claude Code JSON did not contain a result object{suffix}.",
+            error=f"Claude Code stream did not contain a result object{suffix}",
         )
 
     provider_session = payload.get("session_id")
-    valid_provider_session = (
-        isinstance(provider_session, str) and bool(provider_session.strip())
-    )
-    returned_session = (
-        session_id
-        if session_id
-        else provider_session if valid_provider_session else ""
-    )
+    valid_session = isinstance(provider_session, str) and bool(provider_session.strip())
+    returned_session = requested_session or (provider_session if valid_session else "")
     result = payload.get("result", "")
     result = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
     failed = completed.returncode != 0 or bool(payload.get("is_error"))
     error = _provider_error(payload, completed.stderr, completed.returncode) if failed else ""
-    if session_id and valid_provider_session and provider_session != session_id:
+    if requested_session and valid_session and provider_session != requested_session:
         mismatch = (
-            f"Claude Code resumed {session_id!r} but returned a different session "
-            f"ID {provider_session!r}."
+            f"Claude Code resumed {requested_session!r} but returned a different "
+            f"session ID {provider_session!r}."
         )
         failed = True
         error = f"{mismatch} Provider error: {error}" if error else mismatch
-    elif not failed and not valid_provider_session:
+    elif not failed and not valid_session:
         failed = True
         error = "Claude Code completed without a resumable session ID."
     return _envelope(
         returned_session,
-        resumed=bool(session_id),
+        resumed=bool(requested_session),
         status="error" if failed else "completed",
         result=result,
         error=error,
@@ -238,6 +257,343 @@ def _run_claude_code(
         usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else {},
         total_cost_usd=payload.get("total_cost_usd"),
     )
+
+
+class _ClaudeStreamForwarder:
+    """Translate Claude stream-json messages into native live tool events."""
+
+    def __init__(self, agent) -> None:
+        self._io = getattr(agent, "io", None) if agent is not None else None
+        self._tools: dict[str, dict[str, Any]] = {}
+
+    def handle(self, event: dict[str, Any]) -> None:
+        if self._io is None or not isinstance(event, dict):
+            return
+        event_type = event.get("type")
+        if event_type == "assistant":
+            self._assistant(event)
+        elif event_type == "user":
+            self._user(event)
+
+    def _assistant(self, event: dict[str, Any]) -> None:
+        for block in _content_blocks(event):
+            if block.get("type") != "tool_use":
+                continue
+            provider_id = block.get("id")
+            if not isinstance(provider_id, str) or not provider_id or provider_id in self._tools:
+                continue
+            metadata = _event_metadata(event)
+            metadata["name"] = str(block.get("name") or "Tool")
+            self._tools[provider_id] = metadata
+            self._io.log(
+                "tool_call",
+                tool_id=_wire_tool_id(provider_id),
+                name=f"Claude Code › {metadata['name']}",
+                args=_bounded_args(block.get("input")),
+                status="in_progress",
+                provider="claude_code",
+                child_session_id=metadata["session_id"],
+                parent_tool_id=metadata["parent_tool_id"],
+            )
+
+    def _user(self, event: dict[str, Any]) -> None:
+        for block in _content_blocks(event):
+            if block.get("type") != "tool_result":
+                continue
+            provider_id = block.get("tool_use_id")
+            if not isinstance(provider_id, str) or not provider_id:
+                continue
+            metadata = self._tools.get(provider_id) or _event_metadata(event)
+            if provider_id not in self._tools:
+                self._emit_unknown_start(provider_id, metadata)
+            self._io.log(
+                "tool_result",
+                tool_id=_wire_tool_id(provider_id),
+                status="failed" if block.get("is_error") else "completed",
+                result=_bounded_result(block.get("content")),
+                provider="claude_code",
+                child_session_id=metadata["session_id"],
+                parent_tool_id=metadata["parent_tool_id"],
+            )
+
+    def _emit_unknown_start(self, provider_id: str, metadata: dict[str, Any]) -> None:
+        self._tools[provider_id] = {**metadata, "name": "Tool"}
+        self._io.log(
+            "tool_call",
+            tool_id=_wire_tool_id(provider_id),
+            name="Claude Code › Tool",
+            args={},
+            status="in_progress",
+            provider="claude_code",
+            child_session_id=metadata["session_id"],
+            parent_tool_id=metadata["parent_tool_id"],
+        )
+
+
+def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
+    message = event.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, dict):
+        content = [content]
+    if not isinstance(content, list):
+        return []
+    return [block for block in content if isinstance(block, dict)]
+
+
+def _event_metadata(event: dict[str, Any]) -> dict[str, Any]:
+    session_id = event.get("session_id")
+    parent_id = event.get("parent_tool_use_id")
+    return {
+        "session_id": session_id if isinstance(session_id, str) else "",
+        "parent_tool_id": parent_id if isinstance(parent_id, str) else None,
+    }
+
+
+def _wire_tool_id(provider_id: str) -> str:
+    return f"claude:{provider_id}"
+
+
+def _bounded_args(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"value": _bounded_result(value)}
+    safe, truncated, redacted = _redact_value(value)
+    if truncated:
+        safe["_truncated"] = True
+    if redacted:
+        safe["_redacted"] = True
+    encoded = json.dumps(safe, ensure_ascii=False, default=str)
+    if len(encoded) > _MAX_ARGUMENT_CHARS:
+        safe = _argument_summary(safe, encoded)
+        safe["_truncated"] = True
+        if redacted:
+            safe["_redacted"] = True
+    return safe
+
+
+def _redact_value(
+    value: Any, key: str = "", depth: int = 0
+) -> tuple[Any, bool, bool]:
+    if any(part in key.lower() for part in _SENSITIVE_KEY_PARTS):
+        return "[redacted]", False, True
+    if isinstance(value, str):
+        if len(value) <= _MAX_FIELD_CHARS:
+            return value, False, False
+        return value[: _MAX_FIELD_CHARS - 1] + "…", True, False
+    if isinstance(value, dict):
+        if depth >= 4:
+            return _redact_deep_mapping(value)
+        return _redact_mapping(value, depth)
+    if isinstance(value, (list, tuple)):
+        if depth >= 4:
+            return ["[omitted]"], True, False
+        return _redact_sequence(value, depth)
+    return value, False, False
+
+
+def _redact_mapping(value: dict, depth: int) -> tuple[dict, bool, bool]:
+    result = {}
+    truncated = len(value) > _MAX_COLLECTION_ITEMS
+    redacted = False
+    for item_key, item_value in list(value.items())[:_MAX_COLLECTION_ITEMS]:
+        safe, item_truncated, item_redacted = _redact_value(
+            item_value, str(item_key), depth + 1
+        )
+        result[str(item_key)] = safe
+        truncated = truncated or item_truncated
+        redacted = redacted or item_redacted
+    return result, truncated, redacted
+
+
+def _redact_deep_mapping(value: dict) -> tuple[dict, bool, bool]:
+    result = {}
+    redacted = False
+    for item_key in list(value)[:_MAX_COLLECTION_ITEMS]:
+        key = str(item_key)
+        sensitive = any(part in key.lower() for part in _SENSITIVE_KEY_PARTS)
+        result[key] = "[redacted]" if sensitive else "[omitted]"
+        redacted = redacted or sensitive
+    return result, True, redacted
+
+
+def _redact_sequence(value, depth: int) -> tuple[list, bool, bool]:
+    result = []
+    truncated = len(value) > _MAX_COLLECTION_ITEMS
+    redacted = False
+    for item in list(value)[:_MAX_COLLECTION_ITEMS]:
+        safe, item_truncated, item_redacted = _redact_value(item, depth=depth + 1)
+        result.append(safe)
+        truncated = truncated or item_truncated
+        redacted = redacted or item_redacted
+    return result, truncated, redacted
+
+
+def _argument_summary(value: dict[str, Any], encoded: str) -> dict[str, Any]:
+    priority = ("command", "description", "file_path", "path", "query", "pattern")
+    summary = {}
+    remaining = _MAX_ARGUMENT_CHARS - 100
+    for key in priority:
+        if key not in value or remaining <= 0:
+            continue
+        text = _bounded_result(value[key], remaining)
+        summary[key] = text
+        remaining -= len(text) + len(key)
+    if not summary:
+        summary["preview"] = encoded[: _MAX_ARGUMENT_CHARS - 100] + "…"
+    return summary
+
+
+def _bounded_result(value: Any, limit: int = _MAX_RESULT_CHARS) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            text = str(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+@dataclass
+class _StreamCompleted:
+    payload: dict[str, Any] | None
+    returncode: int
+    stderr: str
+    invalid_output: str
+
+
+class _ProviderCancelled(Exception):
+    """The enclosing agent revoked this provider invocation."""
+
+
+class _ProviderStreamError(Exception):
+    """The live IO consumer rejected a provider event."""
+
+
+def _run_process(
+    argv: list[str],
+    *,
+    cwd: str,
+    timeout: int,
+    cancelled: Callable[[], bool] | None = None,
+    on_event: Callable[[dict[str, Any]], None],
+) -> _StreamCompleted:
+    """Read Claude NDJSON without blocking cancellation on one quiet stream."""
+    process = _start_process(argv, cwd)
+    mailbox: queue.Queue = queue.Queue()
+    _start_reader(process.stdout, "stdout", mailbox)
+    _start_reader(process.stderr, "stderr", mailbox)
+    deadline = time.monotonic() + timeout
+    payload = None
+    stderr_parts: list[str] = []
+    invalid_parts: list[str] = []
+    eof: set[str] = set()
+
+    try:
+        while len(eof) < 2 or process.poll() is None:
+            _check_process_boundary(process, argv, timeout, deadline, cancelled)
+            try:
+                source, line = mailbox.get(timeout=0.05)
+            except queue.Empty:
+                continue
+            if line is None:
+                eof.add(source)
+            elif source == "stderr":
+                _append_bounded(stderr_parts, line, _MAX_STDERR_CHARS)
+            else:
+                event = _parse_stream_line(line, invalid_parts)
+                if event is not None:
+                    on_event(event)
+                    if event.get("type") == "result":
+                        payload = event
+    except (_ProviderCancelled, subprocess.TimeoutExpired):
+        raise
+    except Exception as exc:
+        _kill_process_tree(process)
+        _close_pipes(process)
+        raise _ProviderStreamError(_one_line(exc)) from exc
+    returncode = process.wait(timeout=1)
+    _close_pipes(process)
+    return _StreamCompleted(
+        payload=payload,
+        returncode=returncode,
+        stderr="".join(stderr_parts),
+        invalid_output="".join(invalid_parts),
+    )
+
+
+def _start_process(argv: list[str], cwd: str):
+    platform_options = (
+        {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+        if os.name == "nt"
+        else {"start_new_session": True}
+    )
+    return subprocess.Popen(
+        argv,
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        shell=False,
+        **platform_options,
+    )
+
+
+def _start_reader(stream, source: str, mailbox: queue.Queue) -> None:
+    def read() -> None:
+        try:
+            for line in stream:
+                mailbox.put((source, line))
+        except (OSError, ValueError) as exc:
+            mailbox.put(("stderr", f"Claude Code {source} reader failed: {exc}\n"))
+        finally:
+            mailbox.put((source, None))
+
+    threading.Thread(
+        target=read,
+        name=f"claude-code-{source}",
+        daemon=True,
+    ).start()
+
+
+def _check_process_boundary(process, argv, timeout, deadline, cancelled) -> None:
+    if cancelled is not None and cancelled():
+        _kill_process_tree(process)
+        _close_pipes(process)
+        raise _ProviderCancelled()
+    if time.monotonic() >= deadline:
+        _terminate_process_tree(process)
+        _close_pipes(process)
+        raise subprocess.TimeoutExpired(argv, timeout)
+
+
+def _parse_stream_line(line: str, invalid_parts: list[str]) -> dict | None:
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        _append_bounded(invalid_parts, line, _MAX_STDERR_CHARS)
+        return None
+    if isinstance(event, dict):
+        return event
+    _append_bounded(invalid_parts, line, _MAX_STDERR_CHARS)
+    return None
+
+
+def _append_bounded(parts: list[str], value: str, limit: int) -> None:
+    used = sum(len(part) for part in parts)
+    if used < limit:
+        parts.append(value[: limit - used])
+
+
+def _close_pipes(process) -> None:
+    for stream in (process.stdout, process.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except OSError:
+                pass
 
 
 def _base_command() -> list[str] | None:
@@ -267,77 +623,7 @@ def _is_unsafe_windows_batch(command: str, *, windows: bool | None = None) -> bo
     return windows and Path(command).suffix.lower() in (".cmd", ".bat")
 
 
-class _ProviderCancelled(Exception):
-    """The enclosing agent revoked this provider invocation."""
-
-
-def _run_process(
-    argv: list[str],
-    *,
-    cwd: str,
-    timeout: int,
-    cancelled: Callable[[], bool] | None = None,
-):
-    """Run headlessly and best-effort terminate its launch group on timeout."""
-    platform_options = (
-        {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
-        if os.name == "nt"
-        else {"start_new_session": True}
-    )
-    process = subprocess.Popen(
-        argv,
-        cwd=cwd,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        shell=False,
-        **platform_options,
-    )
-    deadline = time.monotonic() + timeout
-    while True:
-        if cancelled is not None and cancelled():
-            _stop_and_drain(process, force=True)
-            raise _ProviderCancelled() from None
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            stdout, stderr = _stop_and_drain(process)
-            raise subprocess.TimeoutExpired(
-                argv, timeout, output=stdout, stderr=stderr
-            ) from None
-        try:
-            stdout, stderr = process.communicate(timeout=min(0.1, remaining))
-            return subprocess.CompletedProcess(
-                argv, process.returncode, stdout, stderr
-            )
-        except subprocess.TimeoutExpired:
-            continue
-
-
-def _stop_and_drain(process, *, force: bool = False) -> tuple[str, str]:
-    """Stop a launch group and never let inherited pipes defeat cancellation."""
-    if force:
-        _kill_process_tree(process)
-    else:
-        _terminate_process_tree(process)
-    try:
-        return process.communicate(timeout=3)
-    except subprocess.TimeoutExpired:
-        for stream in (process.stdout, process.stderr):
-            if stream is not None:
-                stream.close()
-        try:
-            process.kill()
-            process.wait(timeout=1)
-        except (OSError, subprocess.TimeoutExpired):
-            pass
-        return "", ""
-
-
 def _kill_process_tree(process) -> None:
-    """Immediately stop a revoked provider; no post-interrupt grace window."""
     if os.name == "nt":
         _terminate_process_tree(process)
         return
@@ -346,10 +632,7 @@ def _kill_process_tree(process) -> None:
     except ProcessLookupError:
         return
     except OSError:
-        try:
-            process.kill()
-        except OSError:
-            return
+        _try_process_signal(process.kill)
     try:
         process.wait(timeout=1)
     except subprocess.TimeoutExpired:
@@ -358,37 +641,36 @@ def _kill_process_tree(process) -> None:
 
 def _terminate_process_tree(process) -> None:
     if os.name == "nt":
-        try:
-            result = subprocess.run(
-                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=5,
-                check=False,
-                shell=False,
-            )
-            if result.returncode != 0:
-                process.kill()
-        except (OSError, subprocess.TimeoutExpired):
-            try:
-                process.kill()
-            except OSError:
-                pass
+        _terminate_windows_tree(process)
         return
     try:
         os.killpg(process.pid, signal.SIGTERM)
     except ProcessLookupError:
         return
     except OSError:
-        try:
-            process.terminate()
-        except OSError:
-            pass
+        _try_process_signal(process.terminate)
         return
+    _wait_for_process_group(process)
 
-    # The group leader can exit while grandchildren continue to own stdout or
-    # stderr. Observe the process group itself, then force-kill whatever remains.
+
+def _terminate_windows_tree(process) -> None:
+    try:
+        result = subprocess.run(
+            ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+            shell=False,
+        )
+        if result.returncode != 0:
+            _try_process_signal(process.kill)
+    except (OSError, subprocess.TimeoutExpired):
+        _try_process_signal(process.kill)
+
+
+def _wait_for_process_group(process) -> None:
     deadline = time.monotonic() + 2
     while time.monotonic() < deadline:
         process.poll()
@@ -402,20 +684,22 @@ def _terminate_process_tree(process) -> None:
     try:
         os.killpg(process.pid, signal.SIGKILL)
     except OSError:
-        try:
-            process.kill()
-        except OSError:
-            pass
+        _try_process_signal(process.kill)
+
+
+def _try_process_signal(action: Callable[[], Any]) -> None:
+    try:
+        action()
+    except OSError:
+        pass
 
 
 def _provider_error(payload: dict, stderr: str, exit_code: int) -> str:
     error = payload.get("error")
     if isinstance(error, str) and error.strip():
         return _one_line(error)
-    if isinstance(error, dict):
-        message = error.get("message")
-        if isinstance(message, str) and message.strip():
-            return _one_line(message)
+    if isinstance(error, dict) and isinstance(error.get("message"), str):
+        return _one_line(error["message"])
     result = payload.get("result")
     if payload.get("is_error") and isinstance(result, str) and result.strip():
         return _one_line(result)
@@ -425,20 +709,6 @@ def _provider_error(payload: dict, stderr: str, exit_code: int) -> str:
     if isinstance(result, str) and result.strip():
         return _one_line(result)
     return f"Claude Code exited with status {exit_code}."
-
-
-def _result_payload(output: Any) -> dict | None:
-    """Accept documented object output and newer event-array output."""
-    if isinstance(output, dict):
-        return output
-    if not isinstance(output, list):
-        return None
-    results = [
-        item
-        for item in output
-        if isinstance(item, dict) and item.get("type") == "result"
-    ]
-    return results[-1] if results else None
 
 
 def _one_line(value: Any, limit: int = 500) -> str:

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -1,6 +1,8 @@
 """Run Claude Code once while streaming its inner tools to ConnectOnion IO."""
 
+import hashlib
 import json
+import math
 import os
 import queue
 import shlex
@@ -12,6 +14,9 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
+from uuid import UUID
+
+from acp import default_environment
 
 PERMISSION_MODES = (
     "default",
@@ -28,6 +33,19 @@ _MAX_FIELD_CHARS = 1_000
 _MAX_RESULT_CHARS = 4_000
 _MAX_STDERR_CHARS = 16_000
 _MAX_COLLECTION_ITEMS = 20
+_MAX_STREAM_LINE_CHARS = 1024 * 1024
+_MAX_FINAL_RESULT_CHARS = 64 * 1024
+_MAX_USAGE_CHARS = 16 * 1024
+_MAX_IDENTIFIER_CHARS = 512
+_MAX_LIVE_EVENTS = 2_048
+_MAX_ACTIVE_TOOLS = 256
+_MAX_MAILBOX_LINES = 1_024
+_MAX_CAPTURE_PARTS = 1_024
+_MAX_PROMPT_CHARS = 1024 * 1024
+_MAX_SESSION_CHARS = 512
+_MAX_PATH_CHARS = 4_096
+_MAX_MODEL_CHARS = 128
+_MAX_TIMEOUT_SECONDS = 3_600
 _SENSITIVE_KEY_PARTS = (
     "api_key",
     "apikey",
@@ -36,6 +54,28 @@ _SENSITIVE_KEY_PARTS = (
     "password",
     "secret",
     "token",
+)
+_CLAUDE_ENVIRONMENT_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "APPDATA",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CONFIG_DIR",
+    "COMSPEC",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LOCALAPPDATA",
+    "NODE_EXTRA_CA_CERTS",
+    "PATHEXT",
+    "PROGRAMDATA",
+    "SSL_CERT_FILE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "WINDIR",
 )
 
 
@@ -61,19 +101,25 @@ def claude_code(
         model=model,
         timeout=timeout,
         agent=agent,
+        workspace=Path.cwd() if agent is not None else None,
     )
 
 
 class ClaudeCode:
     """Claude Code tool with an operator-owned permission policy."""
 
-    def __init__(self, permission_mode: str = "default") -> None:
+    def __init__(
+        self,
+        permission_mode: str = "default",
+        workspace: str | Path | None = None,
+    ) -> None:
         if permission_mode not in PERMISSION_MODES:
             choices = ", ".join(PERMISSION_MODES)
             raise ValueError(
                 f"Invalid permission mode {permission_mode!r}. Use one of: {choices}."
             )
         self._permission_mode = permission_mode
+        self._workspace = _resolve_workspace(workspace)
 
     def claude_code(
         self,
@@ -93,6 +139,7 @@ class ClaudeCode:
             model=model,
             timeout=timeout,
             agent=agent,
+            workspace=self._workspace,
         )
 
 
@@ -104,6 +151,7 @@ def _run_claude_code(
     model: str = "",
     timeout: int = 600,
     agent=None,
+    workspace: str | Path | None = None,
 ) -> str:
     """Private runner shared by safe, configured, and co-ai entry points."""
     validation = _validate_request(prompt, session_id, cwd, model, timeout)
@@ -116,7 +164,7 @@ def _run_claude_code(
             error=f"Invalid permission mode {permission_mode!r}. Use one of: {choices}.",
         )
 
-    working_directory, error = _working_directory(cwd)
+    working_directory, error = _working_directory(cwd, workspace)
     if error:
         return _envelope(session_id, error=error)
     command, error = _claude_command()
@@ -164,22 +212,60 @@ def _validate_request(prompt, session_id, cwd, model, timeout) -> str:
         return "Session ID must be a string."
     if not isinstance(prompt, str) or not prompt.strip():
         return "Prompt must be a non-empty string."
+    if len(prompt) > _MAX_PROMPT_CHARS:
+        return "Prompt must not exceed 1 MiB."
+    if len(session_id) > _MAX_SESSION_CHARS:
+        return "Session ID is too long."
+    if session_id and not _is_uuid(session_id):
+        return "Session ID must be a canonical UUID."
     if not isinstance(cwd, str):
         return "Working directory must be a string."
     if not isinstance(model, str):
         return "Model must be a string."
+    if len(cwd) > _MAX_PATH_CHARS:
+        return "Working directory path is too long."
+    if len(model) > _MAX_MODEL_CHARS:
+        return "Model name is too long."
     if isinstance(timeout, bool) or not isinstance(timeout, int) or timeout <= 0:
         return "Timeout must be a positive integer."
+    if timeout > _MAX_TIMEOUT_SECONDS:
+        return "Timeout must not exceed 3600 seconds."
     return ""
 
 
-def _working_directory(cwd: str) -> tuple[Path | None, str]:
+def _is_uuid(value: str) -> bool:
     try:
-        directory = Path(cwd or ".").expanduser().resolve(strict=True)
+        return str(UUID(value)) == value
+    except (ValueError, AttributeError):
+        return False
+
+
+def _resolve_workspace(workspace: str | Path | None) -> Path:
+    root = Path.cwd() if workspace is None else Path(workspace)
+    try:
+        resolved = root.expanduser().resolve(strict=True)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise ValueError(f"Claude Code workspace is unavailable: {exc}") from exc
+    if not resolved.is_dir():
+        raise ValueError(f"Claude Code workspace is not a directory: {resolved}")
+    return resolved
+
+
+def _working_directory(
+    cwd: str, workspace: str | Path | None
+) -> tuple[Path | None, str]:
+    try:
+        root = _resolve_workspace(workspace) if workspace is not None else None
+        requested = Path(cwd).expanduser() if cwd else (root or Path.cwd())
+        if not requested.is_absolute():
+            requested = (root or Path.cwd()) / requested
+        directory = requested.resolve(strict=True)
     except (OSError, RuntimeError, ValueError) as exc:
         return None, f"Working directory is unavailable: {exc}"
     if not directory.is_dir():
         return None, f"Working directory is not a directory: {directory}"
+    if root is not None and not directory.is_relative_to(root):
+        return None, f"Working directory must stay inside workspace: {root}"
     return directory, ""
 
 
@@ -208,6 +294,7 @@ def _stream_command(command, prompt, session_id, permission_mode, model):
         "stream-json",
         "--verbose",
         "--forward-subagent-text",
+        "--safe-mode",
         "--permission-mode",
         cli_mode,
     ]
@@ -231,10 +318,14 @@ def _completed_envelope(completed, requested_session: str) -> str:
         )
 
     provider_session = payload.get("session_id")
-    valid_session = isinstance(provider_session, str) and bool(provider_session.strip())
+    valid_session = (
+        isinstance(provider_session, str)
+        and bool(provider_session.strip())
+        and len(provider_session) <= _MAX_SESSION_CHARS
+        and _is_uuid(provider_session)
+    )
     returned_session = requested_session or (provider_session if valid_session else "")
-    result = payload.get("result", "")
-    result = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    result = _bounded_result(payload.get("result", ""), _MAX_FINAL_RESULT_CHARS)
     failed = completed.returncode != 0 or bool(payload.get("is_error"))
     error = _provider_error(payload, completed.stderr, completed.returncode) if failed else ""
     if requested_session and valid_session and provider_session != requested_session:
@@ -254,8 +345,8 @@ def _completed_envelope(completed, requested_session: str) -> str:
         result=result,
         error=error,
         exit_code=completed.returncode,
-        usage=payload.get("usage") if isinstance(payload.get("usage"), dict) else {},
-        total_cost_usd=payload.get("total_cost_usd"),
+        usage=_bounded_usage(payload.get("usage")),
+        total_cost_usd=_finite_number(payload.get("total_cost_usd")),
     )
 
 
@@ -265,6 +356,7 @@ class _ClaudeStreamForwarder:
     def __init__(self, agent) -> None:
         self._io = getattr(agent, "io", None) if agent is not None else None
         self._tools: dict[str, dict[str, Any]] = {}
+        self._event_count = 0
 
     def handle(self, event: dict[str, Any]) -> None:
         if self._io is None or not isinstance(event, dict):
@@ -280,12 +372,20 @@ class _ClaudeStreamForwarder:
             if block.get("type") != "tool_use":
                 continue
             provider_id = block.get("id")
-            if not isinstance(provider_id, str) or not provider_id or provider_id in self._tools:
+            if not isinstance(provider_id, str) or not provider_id:
+                continue
+            tool_id = _stable_identifier(provider_id)
+            if tool_id in self._tools:
+                continue
+            if len(self._tools) >= _MAX_ACTIVE_TOOLS:
+                continue
+            # Reserve one later event for this tool's matching result. This
+            # keeps the hard cap from leaving a visible card permanently open.
+            if self._event_count + len(self._tools) + 2 > _MAX_LIVE_EVENTS:
                 continue
             metadata = _event_metadata(event)
-            metadata["name"] = str(block.get("name") or "Tool")
-            self._tools[provider_id] = metadata
-            self._io.log(
+            metadata["name"] = _bounded_text(block.get("name") or "Tool")
+            self._emit(
                 "tool_call",
                 tool_id=_wire_tool_id(provider_id),
                 name=f"Claude Code › {metadata['name']}",
@@ -295,6 +395,7 @@ class _ClaudeStreamForwarder:
                 child_session_id=metadata["session_id"],
                 parent_tool_id=metadata["parent_tool_id"],
             )
+            self._tools[tool_id] = metadata
 
     def _user(self, event: dict[str, Any]) -> None:
         for block in _content_blocks(event):
@@ -303,10 +404,13 @@ class _ClaudeStreamForwarder:
             provider_id = block.get("tool_use_id")
             if not isinstance(provider_id, str) or not provider_id:
                 continue
-            metadata = self._tools.get(provider_id) or _event_metadata(event)
-            if provider_id not in self._tools:
+            tool_id = _stable_identifier(provider_id)
+            metadata = self._tools.get(tool_id) or _event_metadata(event)
+            if tool_id not in self._tools:
+                if self._event_count + len(self._tools) + 2 > _MAX_LIVE_EVENTS:
+                    continue
                 self._emit_unknown_start(provider_id, metadata)
-            self._io.log(
+            self._emit(
                 "tool_result",
                 tool_id=_wire_tool_id(provider_id),
                 status="failed" if block.get("is_error") else "completed",
@@ -315,10 +419,10 @@ class _ClaudeStreamForwarder:
                 child_session_id=metadata["session_id"],
                 parent_tool_id=metadata["parent_tool_id"],
             )
+            self._tools.pop(tool_id, None)
 
     def _emit_unknown_start(self, provider_id: str, metadata: dict[str, Any]) -> None:
-        self._tools[provider_id] = {**metadata, "name": "Tool"}
-        self._io.log(
+        self._emit(
             "tool_call",
             tool_id=_wire_tool_id(provider_id),
             name="Claude Code › Tool",
@@ -329,6 +433,12 @@ class _ClaudeStreamForwarder:
             parent_tool_id=metadata["parent_tool_id"],
         )
 
+    def _emit(self, event_type: str, **fields: Any) -> None:
+        if self._event_count >= _MAX_LIVE_EVENTS:
+            return
+        self._event_count += 1
+        self._io.log(event_type, **fields)
+
 
 def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
     message = event.get("message")
@@ -337,20 +447,32 @@ def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
         content = [content]
     if not isinstance(content, list):
         return []
-    return [block for block in content if isinstance(block, dict)]
+    return [block for block in content[:_MAX_COLLECTION_ITEMS] if isinstance(block, dict)]
 
 
 def _event_metadata(event: dict[str, Any]) -> dict[str, Any]:
     session_id = event.get("session_id")
     parent_id = event.get("parent_tool_use_id")
     return {
-        "session_id": session_id if isinstance(session_id, str) else "",
-        "parent_tool_id": parent_id if isinstance(parent_id, str) else None,
+        "session_id": _stable_identifier(session_id) if isinstance(session_id, str) else "",
+        "parent_tool_id": (
+            _stable_identifier(parent_id) if isinstance(parent_id, str) else None
+        ),
     }
 
 
 def _wire_tool_id(provider_id: str) -> str:
-    return f"claude:{provider_id}"
+    return f"claude:{_stable_identifier(provider_id)}"
+
+
+def _stable_identifier(value: str) -> str:
+    if len(value) <= _MAX_IDENTIFIER_CHARS:
+        return value
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _bounded_text(value: Any) -> str:
+    return _bounded_result(value, _MAX_FIELD_CHARS)
 
 
 def _bounded_args(value: Any) -> dict[str, Any]:
@@ -453,6 +575,24 @@ def _bounded_result(value: Any, limit: int = _MAX_RESULT_CHARS) -> str:
     return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
+def _bounded_usage(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    safe = {}
+    for key, item in list(value.items())[:_MAX_COLLECTION_ITEMS]:
+        number = _finite_number(item)
+        if number is not None:
+            safe[_bounded_text(key)] = number
+    encoded = json.dumps(safe, ensure_ascii=False, default=str)
+    return safe if len(encoded) <= _MAX_USAGE_CHARS else {}
+
+
+def _finite_number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value if math.isfinite(value) else None
+
+
 @dataclass
 class _StreamCompleted:
     payload: dict[str, Any] | None
@@ -479,9 +619,10 @@ def _run_process(
 ) -> _StreamCompleted:
     """Read Claude NDJSON without blocking cancellation on one quiet stream."""
     process = _start_process(argv, cwd)
-    mailbox: queue.Queue = queue.Queue()
-    _start_reader(process.stdout, "stdout", mailbox)
-    _start_reader(process.stderr, "stderr", mailbox)
+    mailbox: queue.Queue = queue.Queue(maxsize=_MAX_MAILBOX_LINES)
+    readers_stopped = threading.Event()
+    _start_reader(process.stdout, "stdout", mailbox, readers_stopped)
+    _start_reader(process.stderr, "stderr", mailbox, readers_stopped)
     deadline = time.monotonic() + timeout
     payload = None
     stderr_parts: list[str] = []
@@ -506,11 +647,14 @@ def _run_process(
                     if event.get("type") == "result":
                         payload = event
     except (_ProviderCancelled, subprocess.TimeoutExpired):
+        readers_stopped.set()
         raise
     except Exception as exc:
+        readers_stopped.set()
         _kill_process_tree(process)
         _close_pipes(process)
         raise _ProviderStreamError(_one_line(exc)) from exc
+    readers_stopped.set()
     returncode = process.wait(timeout=1)
     _close_pipes(process)
     return _StreamCompleted(
@@ -536,26 +680,56 @@ def _start_process(argv: list[str], cwd: str):
         text=True,
         encoding="utf-8",
         errors="replace",
+        env=_claude_environment(),
         shell=False,
         **platform_options,
     )
 
 
-def _start_reader(stream, source: str, mailbox: queue.Queue) -> None:
+def _claude_environment() -> dict[str, str]:
+    environment = default_environment()
+    for key in _CLAUDE_ENVIRONMENT_KEYS:
+        value = os.environ.get(key)
+        if value and not value.startswith("()"):
+            environment[key] = value
+    return environment
+
+
+def _start_reader(
+    stream, source: str, mailbox: queue.Queue, stopped: threading.Event
+) -> threading.Thread:
+    def put(item) -> None:
+        while not stopped.is_set():
+            try:
+                mailbox.put(item, timeout=0.1)
+                return
+            except queue.Full:
+                continue
+
     def read() -> None:
         try:
-            for line in stream:
-                mailbox.put((source, line))
+            while True:
+                line = stream.readline(_MAX_STREAM_LINE_CHARS + 1)
+                if not line:
+                    break
+                if len(line) > _MAX_STREAM_LINE_CHARS:
+                    while line and not line.endswith("\n"):
+                        line = stream.readline(_MAX_STREAM_LINE_CHARS + 1)
+                    put(("stderr", f"Claude Code {source} line exceeded 1 MiB\n"))
+                    continue
+                put((source, line))
         except (OSError, ValueError) as exc:
-            mailbox.put(("stderr", f"Claude Code {source} reader failed: {exc}\n"))
+            put(("stderr", f"Claude Code {source} reader failed: {exc}\n"))
         finally:
-            mailbox.put((source, None))
+            put((source, None))
 
-    threading.Thread(
+    thread = threading.Thread(
         target=read,
         name=f"claude-code-{source}",
         daemon=True,
-    ).start()
+    )
+    thread.start()
+    return thread
 
 
 def _check_process_boundary(process, argv, timeout, deadline, cancelled) -> None:
@@ -570,6 +744,9 @@ def _check_process_boundary(process, argv, timeout, deadline, cancelled) -> None
 
 
 def _parse_stream_line(line: str, invalid_parts: list[str]) -> dict | None:
+    if len(line) > _MAX_STREAM_LINE_CHARS:
+        _append_bounded(invalid_parts, "oversized stream line\n", _MAX_STDERR_CHARS)
+        return None
     try:
         event = json.loads(line)
     except json.JSONDecodeError:
@@ -582,7 +759,9 @@ def _parse_stream_line(line: str, invalid_parts: list[str]) -> dict | None:
 
 
 def _append_bounded(parts: list[str], value: str, limit: int) -> None:
-    used = sum(len(part) for part in parts)
+    if len(parts) >= _MAX_CAPTURE_PARTS:
+        return
+    used = sum(map(len, parts))
     if used < limit:
         parts.append(value[: limit - used])
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -230,20 +230,26 @@ answer and reviews Claude's result.
 Safe Mode retains Claude's normal permission rules, Accept Edits allows
 in-workspace edits, and explicit YOLO/ULW uses Claude Auto mode. The integration
 never selects `bypassPermissions`, and the selected mode is supplied again when
-a session resumes.
+a session resumes. Delegated runs use Claude's `--safe-mode`, which disables
+ordinary user and project customizations—including `CLAUDE.md`, skills,
+plugins, hooks, MCP servers, commands, and custom agents—so they cannot raise
+that mode's authority; admin-managed policy still applies. The directory
+passed by the model must resolve inside the project root where `co ai` started.
+Relevant project instructions are already carried by the parent prompt instead
+of being reloaded as provider-side filesystem configuration.
 
 Claude Code runs in headless `stream-json` mode. Its inner tool activity is
 visible, but it still cannot display an unmatched Claude permission prompt in
-the `co ai` UI: Safe Mode can read and run actions already allowed by Claude
-settings, while other protected actions fail closed. Accept Edits automatically
+the `co ai` UI: Safe Mode can run actions allowed by its bound mode, while other
+protected actions fail closed. Accept Edits automatically
 permits in-scope edits, but shell or network actions that still need a prompt
 also fail closed. A denied action can be described in a successful provider
 result, so always review the diff and test output rather than treating `status`
 alone as proof of completion.
 
-Because Claude's local settings can pre-approve actions, hosted Claude Code
-delegation is operator-only. Shared contacts receive a structured error and the
-local Claude CLI is not started.
+Because delegation starts a local coding subprocess with operator-bound
+authority, hosted Claude Code remains operator-only. Shared contacts receive a
+structured error and the local Claude CLI is not started.
 
 Auto mode is narrower than `bypassPermissions`, but it is not universally
 available. It requires an eligible account and model, an Anthropic API

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -208,6 +208,7 @@ Codex runs with permission requests denied.
 **Claude Code delegation**
 - Hand a scoped coding task to the installed Claude Code CLI
 - Continue the same Claude Code session by passing back its `session_id`
+- Watch Claude's inner tools start and finish as live O Chat cards
 - Receive one stable JSON result for success, timeout, or provider errors
 
 ### Delegate to Claude Code
@@ -220,19 +221,25 @@ Ask Claude Code to implement the parser in /path/to/repo and run the focused
 tests. Review its diff, then continue the same session for any fixes.
 ```
 
-The Claude Code CLI must be installed and authenticated. Safe Mode retains
-Claude's normal permission rules, Accept Edits allows in-workspace edits, and
-explicit YOLO/ULW uses Claude Auto mode.
-The integration never selects `bypassPermissions`, and the selected mode is
-supplied again when a session resumes.
+The Claude Code CLI must be installed and authenticated. `co ai` still makes
+one ordinary `claude_code` tool call, but the web UI now shows inner activity
+such as `Claude Code › Read`, `Claude Code › Edit`, and `Claude Code › Bash` as
+it happens. The enclosing ConnectOnion agent keeps ownership of the final
+answer and reviews Claude's result.
 
-Claude Code runs in headless print mode. It cannot display an inner permission
-prompt in the co ai UI: Safe Mode can read and run actions already allowed by
-Claude settings, while other protected actions fail closed. Accept Edits
-automatically permits in-scope edits, but shell or network actions that still
-need a prompt also fail closed. A denied action can be described in a
-successful provider result, so always review the diff and test output rather
-than treating `status` alone as proof of completion.
+Safe Mode retains Claude's normal permission rules, Accept Edits allows
+in-workspace edits, and explicit YOLO/ULW uses Claude Auto mode. The integration
+never selects `bypassPermissions`, and the selected mode is supplied again when
+a session resumes.
+
+Claude Code runs in headless `stream-json` mode. Its inner tool activity is
+visible, but it still cannot display an unmatched Claude permission prompt in
+the `co ai` UI: Safe Mode can read and run actions already allowed by Claude
+settings, while other protected actions fail closed. Accept Edits automatically
+permits in-scope edits, but shell or network actions that still need a prompt
+also fail closed. A denied action can be described in a successful provider
+result, so always review the diff and test output rather than treating `status`
+alone as proof of completion.
 
 Because Claude's local settings can pre-approve actions, hosted Claude Code
 delegation is operator-only. Shared contacts receive a structured error and the

--- a/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
+++ b/docs/design-decisions/034-acp-aligned-wire-tool-statuses.md
@@ -70,9 +70,9 @@ unknown terminal status as an error so a newer server cannot be presented as
 successful by accident. oo-chat needs no direct change because it renders the
 React package's normalized ChatItems.
 
-The Codex adapter now emits `in_progress`, `completed`, and `failed`. The
-Claude Code JSON adapter has no intermediate activity stream, so its final
-result envelope is outside this IO event contract.
+The Codex adapter emits `in_progress`, `completed`, and `failed`. Under DD-043,
+the Claude Code stream adapter emits the same statuses for its inner tool
+activity; its final result envelope remains outside this IO event contract.
 
 ## Rejected alternatives
 

--- a/docs/design-decisions/043-claude-code-live-tool-events.md
+++ b/docs/design-decisions/043-claude-code-live-tool-events.md
@@ -33,9 +33,12 @@ and parent tool-use metadata without requiring current clients to understand
 nested agents.
 
 Arguments and results are bounded before live delivery. Common secret-shaped
-argument keys are redacted. Duplicate starts are ignored, and an out-of-order
-result receives a synthetic start so every result has a stable correlation
-target under DD-034.
+argument keys are redacted. Provider-controlled IDs, names, result text, final
+output, usage, stream lines, event counts, and active correlation state all
+have hard limits; oversized IDs become stable SHA-256-based identifiers.
+Duplicate starts are ignored, completed entries are released, and an
+out-of-order result receives a synthetic start so every result has a stable
+correlation target under DD-034.
 
 Cancellation and timeout remain owned by the parent tool call. The adapter
 checks cancellation while the stream is quiet, terminates the provider process
@@ -51,9 +54,26 @@ and claim of completion.
 Permission mode remains operator-owned and absent from the model-visible tool
 schema. Safe, Accept Edits, and explicit YOLO/ULW modes continue to bind a
 Claude mode before launch; `bypassPermissions` is never selected by `co ai`.
+The adapter explicitly supplies the CLI's `--safe-mode` boundary so ordinary
+user, project, and local customizations cannot raise the authority of the
+current mode. Safe mode disables `CLAUDE.md`,
+skills, plugins, hooks, MCP servers, custom commands and agents, and related
+customizations; callers put the relevant instructions in the delegated prompt.
+Authentication and admin-managed policy still apply, and admin policy may be
+stricter. The child process receives a small process/locale environment plus
+Claude-specific authentication variables; unrelated provider, cloud, and
+GitHub credentials from the parent process are not inherited.
+
+The operator also binds a workspace root. A model-selected working directory
+must resolve to that root or one of its descendants; symlink escapes fail
+closed. This limits launch selection, not every filesystem syscall. Hostile
+child code still requires a container or operating-system sandbox.
+
+Resume accepts only the canonical UUID returned by an earlier invocation; it
+does not expose Claude CLI's fuzzy session search to the model.
 
 This decision adds observability, not an approval bridge. Headless Claude Code
-can execute actions allowed by its bound mode and local settings, but an
+can execute actions allowed by its bound mode and admin-managed policy, but an
 unmatched interactive permission request cannot round-trip through O Chat in
 this version and fails closed.
 
@@ -65,8 +85,8 @@ environment is unsatisfiable. Weakening ConnectOnion's MCP v2 boundary to gain
 one provider callback would create a framework-wide regression.
 
 The CLI stream is Claude Code's documented automation interface, preserves the
-user's installed authentication and `CLAUDE.md` behavior, and exposes the tool
-events needed for the first product slice without another Python dependency.
+user's installed authentication under safe mode, and exposes the tool events
+needed for the first product slice without another Python dependency.
 
 Revisit the Agent SDK or an isolated sidecar when it is compatible with MCP v2,
 or when a separately versioned bridge can support interactive permission
@@ -80,6 +100,8 @@ callbacks without sharing ConnectOnion's dependency environment.
 - **Install the Python Agent SDK beside MCP v2:** has an unsatisfiable declared
   dependency set at this decision date.
 - **Lower ConnectOnion to MCP v1:** breaks the chosen 1.7 protocol baseline.
+- **Inherit interactive Claude setting sources:** allows a persistent local
+  rule to bypass the permission ceiling selected for this delegated turn.
 - **Forward all Claude text into the parent transcript:** creates two competing
   authors and unstable message ownership.
 - **Claim live approval from tool events:** observability is not permission

--- a/docs/design-decisions/043-claude-code-live-tool-events.md
+++ b/docs/design-decisions/043-claude-code-live-tool-events.md
@@ -1,0 +1,93 @@
+# DD-043: Stream Claude Code tool activity through native Agent IO
+
+**Status:** Accepted
+
+**Date:** 2026-08-12
+
+**Related:** [018 Event API Naming](018-event-api-naming.md), [025 Interruptible Agent Steps](025-interruptible-agent-steps.md), [034 ACP-aligned Wire Tool Statuses](034-acp-aligned-wire-tool-statuses.md), [GitHub issue #902](https://github.com/openonion/connectonion/issues/902)
+
+## Context
+
+`co ai` could already delegate one task to Claude Code and resume the returned
+session, but the adapter waited for one final JSON result. In O Chat this looked
+like a long-running opaque tool call. Users could not see whether Claude was
+reading a file, editing it, or running a command.
+
+The product goal is narrower than exposing ConnectOnion as an ACP service:
+`co ai` remains the parent agent, calls Claude Code as one tool, and shows
+Claude's inner tool activity in the existing web experience. Public ACP ingress
+and third-party clients are separate protocol work.
+
+## Decision
+
+The `claude_code` tool launches the installed Claude Code CLI with its
+documented `--output-format stream-json --verbose` contract. It reads stdout
+and stderr concurrently, parses newline-delimited events, and returns the same
+stable final JSON envelope as before.
+
+Claude `tool_use` blocks are translated to native `tool_call` IO events, and
+matching `tool_result` blocks become native `tool_result` events. Wire IDs are
+namespaced with `claude:`. Display names are prefixed with `Claude Code ›` so a
+flat client remains understandable. Events also carry provider, child session,
+and parent tool-use metadata without requiring current clients to understand
+nested agents.
+
+Arguments and results are bounded before live delivery. Common secret-shaped
+argument keys are redacted. Duplicate starts are ignored, and an out-of-order
+result receives a synthetic start so every result has a stable correlation
+target under DD-034.
+
+Cancellation and timeout remain owned by the parent tool call. The adapter
+checks cancellation while the stream is quiet, terminates the provider process
+group, closes inherited pipes, and relies on the parent interruptible IO lease
+to reject late events.
+
+Claude's intermediate text is not copied into the parent transcript. The
+parent ConnectOnion agent remains responsible for the final response, review,
+and claim of completion.
+
+## Permission boundary
+
+Permission mode remains operator-owned and absent from the model-visible tool
+schema. Safe, Accept Edits, and explicit YOLO/ULW modes continue to bind a
+Claude mode before launch; `bypassPermissions` is never selected by `co ai`.
+
+This decision adds observability, not an approval bridge. Headless Claude Code
+can execute actions allowed by its bound mode and local settings, but an
+unmatched interactive permission request cannot round-trip through O Chat in
+this version and fails closed.
+
+## Why the CLI stream instead of the Python Agent SDK
+
+At the decision date, `claude-agent-sdk` 0.2.136 requires Python `mcp>=1.23,<2`,
+while ConnectOnion 1.7 requires `mcp>=2,<3`. Installing both in the same Python
+environment is unsatisfiable. Weakening ConnectOnion's MCP v2 boundary to gain
+one provider callback would create a framework-wide regression.
+
+The CLI stream is Claude Code's documented automation interface, preserves the
+user's installed authentication and `CLAUDE.md` behavior, and exposes the tool
+events needed for the first product slice without another Python dependency.
+
+Revisit the Agent SDK or an isolated sidecar when it is compatible with MCP v2,
+or when a separately versioned bridge can support interactive permission
+callbacks without sharing ConnectOnion's dependency environment.
+
+## Rejected alternatives
+
+- **Wait only for final JSON:** preserves the old opaque web experience.
+- **Treat Claude Code as ACP ingress:** reverses the immediate client/agent goal
+  and does not make the existing `co ai` delegation visible.
+- **Install the Python Agent SDK beside MCP v2:** has an unsatisfiable declared
+  dependency set at this decision date.
+- **Lower ConnectOnion to MCP v1:** breaks the chosen 1.7 protocol baseline.
+- **Forward all Claude text into the parent transcript:** creates two competing
+  authors and unstable message ownership.
+- **Claim live approval from tool events:** observability is not permission
+  authority; unmatched prompts still need a real request/response bridge.
+
+## Rollback
+
+Return the CLI output format to final JSON and stop emitting provider events.
+The public function signature, permission binding, session IDs, and final
+result envelope do not need to change, so rollback does not require a data
+migration.

--- a/docs/useful_tools/README.md
+++ b/docs/useful_tools/README.md
@@ -8,7 +8,7 @@ Pre-built tools for common agent tasks.
 |------|---------|--------|
 | [bash](bash.md) | Execute bash commands (Unix/Mac) | `from connectonion import bash` |
 | [Shell](shell.md) | Execute shell commands (cross-platform) | `from connectonion import Shell` |
-| [Claude Code](claude_code.md) | Run or resume Claude Code with explicit permissions | `from connectonion import claude_code` |
+| [Claude Code](claude_code.md) | Run or resume Claude Code with live inner tool cards | `from connectonion import claude_code` |
 | [FileTools](file_tools.md) | Read/edit files with safety tracking | `from connectonion.useful_tools import FileTools` |
 | [read_file](read_file.md) | Read any file: text, images, PDF, PPTX, DOCX, audio, video | `co copy read_file` |
 | [BrowserAutomation](browser_tools.md) | Natural language browser automation | `from connectonion.useful_tools.browser_tools import BrowserAutomation` |

--- a/docs/useful_tools/claude_code.md
+++ b/docs/useful_tools/claude_code.md
@@ -9,10 +9,11 @@ agent = Agent("lead", tools=[claude_code])
 agent.input("Ask Claude Code to review this repository")
 ```
 
-The adapter uses Claude Code's headless JSON interface. It does not add an SDK
-dependency, and provider-specific parsing stays outside the ConnectOnion Agent
-loop. It accepts both the documented single result object and Claude Code
-versions that wrap the result as the final item of a JSON event array.
+The adapter uses Claude Code's documented headless `stream-json` interface. It
+keeps one normal ConnectOnion tool call around the delegated turn while
+forwarding Claude's inner tool starts and results through the Agent's live IO.
+Provider-specific parsing stays outside the ConnectOnion Agent loop, and the
+final return value remains one stable JSON envelope.
 
 The default `claude_code` function tool always starts Claude Code in its manual
 permission mode. Permission policy is deliberately not a tool argument, so the
@@ -60,6 +61,24 @@ Missing binaries, invalid arguments, timeouts, authentication errors, malformed
 output, and non-zero exits use the same envelope with `status` set to `error` or
 `timeout`.
 
+## Live tool activity
+
+When the function receives its injected `agent` argument, every Claude Code
+`tool_use` becomes an ordinary live ConnectOnion tool card such as
+`Claude Code › Bash` or `Claude Code › Read`. The matching `tool_result`
+completes or fails that same card. This works automatically in `co ai` web chat;
+callers do not need a second protocol or a separate Claude UI.
+
+The forwarded event also carries `provider=claude_code`, the Claude session ID,
+and any parent tool-use ID. Current clients can render a flat card immediately;
+future clients can use the parent ID for nested sub-agent presentation. Tool
+arguments and results are bounded before they reach live IO, and common
+credential-shaped argument keys are redacted.
+
+Only tool activity is forwarded in this release. Claude's intermediate text is
+not added to the parent transcript, so the final answer still has one owner:
+the enclosing ConnectOnion agent.
+
 ## Permissions
 
 The public `claude_code(...)` function always maps to Claude Code's current
@@ -86,6 +105,12 @@ The tool does not use Claude Code's `--bare` mode by default. This preserves the
 user's normal Claude Code authentication and project instructions such as
 `CLAUDE.md`.
 
+Headless Claude Code cannot open its own interactive permission prompt inside
+O Chat. Actions already allowed by the operator-bound mode or local Claude
+settings can run and appear as live cards; an unmatched permission request
+fails closed. Live web approval for those unmatched inner requests is a
+separate integration boundary and is not implemented by this adapter.
+
 ## Installation and testing
 
 The `claude` executable must be on `PATH`. For a custom installation or test
@@ -109,8 +134,8 @@ pytest -m real_api tests/e2e/real_api/test_real_claude_code.py
 
 ## Difference from the Codex tool
 
-The Codex adapter uses its app-server JSON-RPC protocol for live inner-step
-events and per-action approval callbacks. Claude Code's adapter intentionally
-uses one documented headless JSON subprocess per turn. It provides native
-session resume and an explicit baseline permission mode, but does not claim live
-approval-card streaming.
+The Codex adapter uses its app-server JSON-RPC protocol for both live inner-step
+events and per-action approval callbacks. Claude Code uses its documented
+`stream-json` subprocess contract for live inner tool cards and session resume.
+It does not yet translate Claude's unmatched permission requests into
+ConnectOnion approval cards.

--- a/docs/useful_tools/claude_code.md
+++ b/docs/useful_tools/claude_code.md
@@ -26,18 +26,18 @@ import json
 
 from connectonion import ClaudeCode
 
-claude = ClaudeCode(permission_mode="plan")
+claude = ClaudeCode(permission_mode="plan", workspace="./my-project")
 
 first = json.loads(claude.claude_code(
     "Find the failing test",
-    cwd="./my-project",
+    cwd=".",
 ))
 
-editor = ClaudeCode(permission_mode="acceptEdits")
+editor = ClaudeCode(permission_mode="acceptEdits", workspace="./my-project")
 second = json.loads(editor.claude_code(
     "Now implement the fix",
     session_id=first["session_id"],
-    cwd="./my-project",
+    cwd=".",
 ))
 ```
 
@@ -73,7 +73,8 @@ The forwarded event also carries `provider=claude_code`, the Claude session ID,
 and any parent tool-use ID. Current clients can render a flat card immediately;
 future clients can use the parent ID for nested sub-agent presentation. Tool
 arguments and results are bounded before they reach live IO, and common
-credential-shaped argument keys are redacted.
+credential-shaped argument keys are redacted. Provider-controlled IDs, names,
+event counts, stream lines, and active tool state are bounded as well.
 
 Only tool activity is forwarded in this release. Claude's intermediate text is
 not added to the parent transcript, so the final answer still has one owner:
@@ -88,7 +89,7 @@ tool reaches the Agent:
 ```python
 from connectonion import Agent, ClaudeCode
 
-claude = ClaudeCode(permission_mode="acceptEdits")
+claude = ClaudeCode(permission_mode="acceptEdits", workspace="./my-project")
 agent = Agent("lead", tools=[claude])
 ```
 
@@ -101,15 +102,27 @@ directory, model, and timeout fields. Supported constructor modes are
 in operator-written code running inside an isolated environment; a model can
 never select it through the tool schema.
 
-The tool does not use Claude Code's `--bare` mode by default. This preserves the
-user's normal Claude Code authentication and project instructions such as
-`CLAUDE.md`.
-
 Headless Claude Code cannot open its own interactive permission prompt inside
-O Chat. Actions already allowed by the operator-bound mode or local Claude
-settings can run and appear as live cards; an unmatched permission request
-fails closed. Live web approval for those unmatched inner requests is a
-separate integration boundary and is not implemented by this adapter.
+O Chat. The adapter uses Claude's `--safe-mode`, which disables `CLAUDE.md`,
+skills, plugins, hooks, MCP servers, custom commands and agents, and related
+customizations. This preserves installed authentication but prevents ordinary
+user, project, and local configuration from raising this delegated turn's
+authority. Include relevant project instructions in the delegated prompt.
+Admin-managed policy still applies and may be stricter. Actions allowed by the
+operator-bound mode can run and appear as live cards; an unmatched permission
+request fails closed.
+
+The subprocess receives only a small process/locale environment and
+Claude-specific authentication variables. Unrelated API keys and cloud/GitHub
+credentials from the parent process are not copied into Claude's environment.
+
+The operator-bound workspace becomes the launch root. A model may choose that
+directory or a resolved descendant; paths and symlinks outside it fail closed.
+This is not an operating-system sandbox, so run hostile tasks inside a
+container or other OS isolation boundary.
+
+Pass back only the canonical UUID returned in `session_id`. Fuzzy Claude CLI
+session search is intentionally unavailable through this tool.
 
 ## Installation and testing
 

--- a/tests/e2e/real_api/test_real_claude_code.py
+++ b/tests/e2e/real_api/test_real_claude_code.py
@@ -47,7 +47,7 @@ def _require_success(result):
 
 
 @requires_claude
-def test_real_claude_code_json_contract(tmp_path):
+def test_real_claude_code_stream_contract(tmp_path):
     result = json.loads(
         claude_code("Reply with exactly: pong", cwd=str(tmp_path), timeout=120)
     )

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -1,6 +1,7 @@
 """Unit contract for live Claude Code delegation."""
 
 import importlib
+import inspect
 import io
 import json
 import subprocess
@@ -18,6 +19,8 @@ from connectonion.useful_tools import ClaudeCode as UsefulClaudeCode
 from connectonion.useful_tools import claude_code
 
 claude_module = importlib.import_module("connectonion.useful_tools.claude_code")
+NEW_SESSION = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+OLD_SESSION = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 
 
 def _completed(payload=None, returncode=0, stderr="", invalid_output=""):
@@ -26,7 +29,7 @@ def _completed(payload=None, returncode=0, stderr="", invalid_output=""):
         or {
             "type": "result",
             "result": "done",
-            "session_id": "session-new",
+            "session_id": NEW_SESSION,
             "is_error": False,
             "usage": {"input_tokens": 4},
             "total_cost_usd": 0.01,
@@ -41,7 +44,7 @@ def _run(tmp_path, completed=None, prompt="fix it", **kwargs):
     completed = completed or _completed()
     permission_mode = kwargs.pop("permission_mode", None)
     tool = (
-        ClaudeCode(permission_mode).claude_code
+        ClaudeCode(permission_mode, workspace=tmp_path).claude_code
         if permission_mode is not None
         else claude_code
     )
@@ -66,7 +69,7 @@ def test_success_preserves_the_stable_envelope_and_uses_stream_json(tmp_path):
 
     assert result == {
         "provider": "claude_code",
-        "session_id": "session-new",
+        "session_id": NEW_SESSION,
         "resumed": False,
         "status": "completed",
         "result": "done",
@@ -82,6 +85,7 @@ def test_success_preserves_the_stable_envelope_and_uses_stream_json(tmp_path):
         "stream-json",
         "--verbose",
         "--forward-subagent-text",
+        "--safe-mode",
         "--permission-mode",
         "acceptEdits",
         "--model",
@@ -99,15 +103,15 @@ def test_resume_passes_the_exact_session_id(tmp_path):
         {
             "type": "result",
             "result": "continued",
-            "session_id": "session-old",
+            "session_id": OLD_SESSION,
             "is_error": False,
         }
     )
-    result, run = _run(tmp_path, completed=completed, session_id="session-old")
+    result, run = _run(tmp_path, completed=completed, session_id=OLD_SESSION)
 
     argv = run.call_args.args[0]
-    assert argv[argv.index("--resume") + 1] == "session-old"
-    assert result["session_id"] == "session-old"
+    assert argv[argv.index("--resume") + 1] == OLD_SESSION
+    assert result["session_id"] == OLD_SESSION
     assert result["resumed"] is True
 
 
@@ -115,6 +119,47 @@ def test_public_default_maps_to_current_manual_cli_mode(tmp_path):
     _, run = _run(tmp_path)
     argv = run.call_args.args[0]
     assert argv[argv.index("--permission-mode") + 1] == "manual"
+    assert "--safe-mode" in argv
+
+
+def test_operator_workspace_is_not_model_visible(tmp_path):
+    tool = ClaudeCode(workspace=tmp_path).claude_code
+    assert "workspace" not in inspect.signature(tool).parameters
+
+
+def test_agent_cannot_launch_outside_its_runtime_workspace(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    agent = _agent()
+    with patch.object(claude_module, "_run_process") as run:
+        result = json.loads(
+            claude_module._run_claude_code(
+                prompt="inspect",
+                cwd=str(outside),
+                agent=agent,
+                workspace=workspace,
+            )
+        )
+    assert "must stay inside workspace" in result["error"]
+    run.assert_not_called()
+
+
+def test_workspace_rejects_a_symlink_escape(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    link = workspace / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    result = json.loads(
+        ClaudeCode(workspace=workspace).claude_code("inspect", cwd="escape")
+    )
+    assert "must stay inside workspace" in result["error"]
 
 
 def test_inner_tool_start_becomes_a_provider_labelled_native_card():
@@ -279,6 +324,90 @@ def test_oversized_tool_arguments_and_results_are_bounded():
     assert len(result) <= claude_module._MAX_RESULT_CHARS
 
 
+def test_provider_ids_and_metadata_are_bounded_and_active_tools_are_released():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+    huge = "海" * 10_000
+    forwarder.handle({
+        "type": "assistant",
+        "session_id": huge,
+        "parent_tool_use_id": huge,
+        "message": {"content": [{
+            "type": "tool_use", "id": huge, "name": huge, "input": {}
+        }]},
+    })
+    start = agent.io.log.call_args.kwargs
+    assert start["tool_id"].startswith("claude:sha256:")
+    assert start["child_session_id"].startswith("sha256:")
+    assert start["parent_tool_id"].startswith("sha256:")
+    assert len(start["name"]) <= claude_module._MAX_FIELD_CHARS + len("Claude Code › ")
+
+    forwarder.handle({
+        "type": "user",
+        "message": {"content": [{
+            "type": "tool_result", "tool_use_id": huge, "content": "done"
+        }]},
+    })
+    assert forwarder._tools == {}
+
+
+def test_provider_event_and_active_tool_counts_are_bounded():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+    for index in range(claude_module._MAX_LIVE_EVENTS + 100):
+        forwarder.handle({
+            "type": "assistant",
+            "message": {"content": [{
+                "type": "tool_use", "id": f"tool-{index}", "name": "Read", "input": {}
+            }]},
+        })
+    assert agent.io.log.call_count <= claude_module._MAX_LIVE_EVENTS
+    assert len(forwarder._tools) <= claude_module._MAX_ACTIVE_TOOLS
+
+
+def test_event_cap_reserves_a_result_for_every_emitted_start(monkeypatch):
+    monkeypatch.setattr(claude_module, "_MAX_LIVE_EVENTS", 3)
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+
+    for tool_id in ("one", "two"):
+        forwarder.handle({
+            "type": "assistant",
+            "message": {"content": [{
+                "type": "tool_use", "id": tool_id, "name": "Read", "input": {}
+            }]},
+        })
+
+    assert agent.io.log.call_count == 1
+    forwarder.handle({
+        "type": "user",
+        "message": {"content": [{
+            "type": "tool_result", "tool_use_id": "one", "content": "done"
+        }]},
+    })
+    assert [call.args[0] for call in agent.io.log.call_args_list] == [
+        "tool_call",
+        "tool_result",
+    ]
+    assert forwarder._tools == {}
+
+
+def test_final_result_usage_and_provider_session_are_bounded():
+    completed = _completed({
+        "type": "result",
+        "result": "x" * 100_000,
+        "session_id": "s" * 10_000,
+        "usage": {f"counter_{i}": i for i in range(100)},
+        "total_cost_usd": float("inf"),
+    })
+    result = json.loads(claude_module._completed_envelope(completed, ""))
+    assert len(result["result"]) <= claude_module._MAX_FINAL_RESULT_CHARS
+    assert result["session_id"] == ""
+    assert result["status"] == "error"
+    assert len(result["usage"]) <= claude_module._MAX_COLLECTION_ITEMS
+    assert result["total_cost_usd"] is None
+
+
 def test_sensitive_tool_arguments_are_redacted_before_they_reach_io():
     agent = _agent()
     forwarder = claude_module._ClaudeStreamForwarder(agent)
@@ -372,6 +501,28 @@ def test_string_arguments_are_validated(tmp_path, kwargs, message):
     assert message in result["error"]
 
 
+def test_request_values_have_hard_upper_bounds(tmp_path):
+    assert "1 MiB" in json.loads(claude_code("x" * (1024 * 1024 + 1)))["error"]
+    assert "Session ID is too long" in json.loads(
+        claude_code("x", session_id="s" * 513)
+    )["error"]
+    assert "3600" in json.loads(claude_code("x", timeout=3601))["error"]
+    assert "canonical UUID" in json.loads(
+        claude_code("x", session_id="most recent")
+    )["error"]
+    assert "canonical UUID" in json.loads(
+        claude_code("x", session_id=OLD_SESSION.upper())
+    )["error"]
+
+
+def test_oversized_stream_line_is_not_parsed():
+    invalid = []
+    assert claude_module._parse_stream_line(
+        "x" * (claude_module._MAX_STREAM_LINE_CHARS + 1), invalid
+    ) is None
+    assert invalid == ["oversized stream line\n"]
+
+
 def test_cwd_must_exist_and_be_a_directory(tmp_path):
     missing = json.loads(claude_code("fix", cwd=str(tmp_path / "missing")))
     file_path = tmp_path / "file"
@@ -407,13 +558,13 @@ def test_provider_error_and_session_mismatch_stay_structured(tmp_path):
         {
             "type": "result",
             "result": "Authentication required",
-            "session_id": "session-new",
+            "session_id": NEW_SESSION,
             "is_error": True,
         },
         returncode=1,
     )
-    result, _ = _run(tmp_path, completed=failed, session_id="session-old")
-    assert result["session_id"] == "session-old"
+    result, _ = _run(tmp_path, completed=failed, session_id=OLD_SESSION)
+    assert result["session_id"] == OLD_SESSION
     assert result["status"] == "error"
     assert "different session ID" in result["error"]
     assert "Authentication required" in result["error"]
@@ -453,6 +604,18 @@ def test_process_reader_delivers_each_json_line_and_final_result(tmp_path):
     assert [event["type"] for event in events] == ["system", "assistant", "result"]
     assert completed.payload["result"] == "done"
     assert completed.stderr == "warning\n"
+
+
+def test_reader_stops_when_a_full_mailbox_is_revoked():
+    mailbox = claude_module.queue.Queue(maxsize=1)
+    mailbox.put(("stdout", "occupied"))
+    stopped = threading.Event()
+    thread = claude_module._start_reader(
+        io.StringIO("line\n"), "stdout", mailbox, stopped
+    )
+    stopped.set()
+    thread.join(timeout=1)
+    assert not thread.is_alive()
 
 
 def test_process_reader_reaps_claude_when_live_io_rejects_an_event(tmp_path):
@@ -510,6 +673,27 @@ def test_process_runner_is_headless_and_does_not_use_a_shell(tmp_path):
         )
     assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
     assert popen.call_args.kwargs["shell"] is False
+
+
+def test_provider_process_does_not_inherit_unrelated_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-cross")
+    monkeypatch.setenv("GH_TOKEN", "must-not-cross")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-auth")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    process = MagicMock()
+    process.stdout = io.StringIO('{"type":"result","session_id":"s"}\n')
+    process.stderr = io.StringIO("")
+    process.poll.return_value = 0
+    process.wait.return_value = 0
+    with patch.object(claude_module.subprocess, "Popen", return_value=process) as popen:
+        claude_module._run_process(
+            ["claude"], cwd=str(tmp_path), timeout=2, on_event=lambda event: None
+        )
+    environment = popen.call_args.kwargs["env"]
+    assert "OPENAI_API_KEY" not in environment
+    assert "GH_TOKEN" not in environment
+    assert environment["ANTHROPIC_API_KEY"] == "provider-auth"
+    assert environment["CLAUDE_CONFIG_DIR"] == str(tmp_path / "claude")
 
 
 @pytest.mark.skipif(claude_module.os.name == "nt", reason="POSIX process-group regression")

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -1,15 +1,18 @@
-"""Unit contract for the built-in Claude Code subprocess adapter."""
+"""Unit contract for live Claude Code delegation."""
 
 import importlib
+import io
 import json
 import subprocess
 import sys
+import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from connectonion import Agent, ClaudeCode, claude_code as root_claude_code
+from connectonion import Agent, ClaudeCode
+from connectonion import claude_code as root_claude_code
 from connectonion.cli.commands.copy_commands import TOOLS
 from connectonion.useful_tools import ClaudeCode as UsefulClaudeCode
 from connectonion.useful_tools import claude_code
@@ -17,22 +20,25 @@ from connectonion.useful_tools import claude_code
 claude_module = importlib.import_module("connectonion.useful_tools.claude_code")
 
 
-def _completed(payload, returncode=0, stderr=""):
+def _completed(payload=None, returncode=0, stderr="", invalid_output=""):
     return SimpleNamespace(
-        stdout=json.dumps(payload), returncode=returncode, stderr=stderr
-    )
-
-
-def _run(tmp_path, completed=None, prompt="fix it", **kwargs):
-    completed = completed or _completed(
-        {
+        payload=payload
+        or {
+            "type": "result",
             "result": "done",
             "session_id": "session-new",
             "is_error": False,
             "usage": {"input_tokens": 4},
             "total_cost_usd": 0.01,
-        }
+        },
+        returncode=returncode,
+        stderr=stderr,
+        invalid_output=invalid_output,
     )
+
+
+def _run(tmp_path, completed=None, prompt="fix it", **kwargs):
+    completed = completed or _completed()
     permission_mode = kwargs.pop("permission_mode", None)
     tool = (
         ClaudeCode(permission_mode).claude_code
@@ -46,7 +52,11 @@ def _run(tmp_path, completed=None, prompt="fix it", **kwargs):
     return result, run
 
 
-def test_success_returns_stable_envelope_and_safe_argv(tmp_path):
+def _agent():
+    return SimpleNamespace(io=MagicMock(), current_session={})
+
+
+def test_success_preserves_the_stable_envelope_and_uses_stream_json(tmp_path):
     result, run = _run(
         tmp_path,
         permission_mode="acceptEdits",
@@ -69,7 +79,9 @@ def test_success_returns_stable_envelope_and_safe_argv(tmp_path):
         "claude",
         "-p",
         "--output-format",
-        "json",
+        "stream-json",
+        "--verbose",
+        "--forward-subagent-text",
         "--permission-mode",
         "acceptEdits",
         "--model",
@@ -79,33 +91,244 @@ def test_success_returns_stable_envelope_and_safe_argv(tmp_path):
     ]
     assert run.call_args.kwargs["cwd"] == str(tmp_path.resolve())
     assert run.call_args.kwargs["timeout"] == 30
+    assert callable(run.call_args.kwargs["on_event"])
 
 
 def test_resume_passes_the_exact_session_id(tmp_path):
     completed = _completed(
-        {"result": "continued", "session_id": "session-old", "is_error": False}
+        {
+            "type": "result",
+            "result": "continued",
+            "session_id": "session-old",
+            "is_error": False,
+        }
     )
     result, run = _run(tmp_path, completed=completed, session_id="session-old")
 
+    argv = run.call_args.args[0]
+    assert argv[argv.index("--resume") + 1] == "session-old"
     assert result["session_id"] == "session-old"
     assert result["resumed"] is True
-    assert ["--resume", "session-old"] == run.call_args.args[0][6:8]
 
 
 def test_public_default_maps_to_current_manual_cli_mode(tmp_path):
     _, run = _run(tmp_path)
-
     argv = run.call_args.args[0]
     assert argv[argv.index("--permission-mode") + 1] == "manual"
 
 
+def test_inner_tool_start_becomes_a_provider_labelled_native_card():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "session_id": "session-1",
+            "parent_tool_use_id": None,
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Bash",
+                        "input": {"command": "pytest -q"},
+                    }
+                ]
+            },
+        }
+    )
+
+    agent.io.log.assert_called_once_with(
+        "tool_call",
+        tool_id="claude:toolu_1",
+        name="Claude Code › Bash",
+        args={"command": "pytest -q"},
+        status="in_progress",
+        provider="claude_code",
+        child_session_id="session-1",
+        parent_tool_id=None,
+    )
+
+
+def test_duplicate_assistant_messages_do_not_duplicate_tool_cards():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+    event = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {}}
+            ]
+        },
+    }
+
+    forwarder.handle(event)
+    forwarder.handle(event)
+
+    assert agent.io.log.call_count == 1
+
+
+@pytest.mark.parametrize(("is_error", "status"), [(False, "completed"), (True, "failed")])
+def test_inner_tool_result_completes_the_same_card(is_error, status):
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "session_id": "s",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {}}
+                ]
+            },
+        }
+    )
+    agent.io.log.reset_mock()
+
+    forwarder.handle(
+        {
+            "type": "user",
+            "session_id": "s",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "file contents",
+                        "is_error": is_error,
+                    }
+                ]
+            },
+        }
+    )
+
+    agent.io.log.assert_called_once_with(
+        "tool_result",
+        tool_id="claude:toolu_1",
+        status=status,
+        result="file contents",
+        provider="claude_code",
+        child_session_id="s",
+        parent_tool_id=None,
+    )
+
+
+def test_subagent_parent_id_is_preserved_for_future_nested_ui():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "session_id": "s",
+            "parent_tool_use_id": "agent-tool-1",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_nested",
+                        "name": "Grep",
+                        "input": {"pattern": "TODO"},
+                    }
+                ]
+            },
+        }
+    )
+
+    assert agent.io.log.call_args.kwargs["parent_tool_id"] == "agent-tool-1"
+
+
+def test_oversized_tool_arguments_and_results_are_bounded():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+    huge = "x" * 20_000
+
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Write",
+                        "input": {"file_path": "a.txt", "content": huge},
+                    }
+                ]
+            },
+        }
+    )
+    start = agent.io.log.call_args.kwargs
+    assert start["args"]["file_path"] == "a.txt"
+    assert start["args"]["_truncated"] is True
+    assert len(json.dumps(start["args"], ensure_ascii=False)) <= claude_module._MAX_ARGUMENT_CHARS
+
+    forwarder.handle(
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "toolu_1", "content": huge}
+                ]
+            },
+        }
+    )
+    result = agent.io.log.call_args.kwargs["result"]
+    assert result.endswith("…")
+    assert len(result) <= claude_module._MAX_RESULT_CHARS
+
+
+def test_sensitive_tool_arguments_are_redacted_before_they_reach_io():
+    agent = _agent()
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "Fetch",
+                        "input": {
+                            "url": "https://example.com",
+                            "headers": {"Authorization": "Bearer private"},
+                            "api_key": "private",
+                            "deep": {"one": {"two": {"three": {"token": "private"}}}},
+                        },
+                    }
+                ]
+            },
+        }
+    )
+
+    args = agent.io.log.call_args.kwargs["args"]
+    assert args["headers"]["Authorization"] == "[redacted]"
+    assert args["api_key"] == "[redacted]"
+    assert "private" not in json.dumps(args)
+    assert args["_redacted"] is True
+
+
+def test_events_are_silent_without_live_agent_io():
+    forwarder = claude_module._ClaudeStreamForwarder(None)
+    forwarder.handle(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {}}
+                ]
+            },
+        }
+    )
+
+
 @pytest.mark.parametrize(
-    "mode",
-    ["manual", "acceptEdits", "plan", "auto", "dontAsk", "bypassPermissions"],
+    "mode", ["manual", "acceptEdits", "plan", "auto", "dontAsk", "bypassPermissions"]
 )
-def test_documented_permission_modes_are_forwarded_only_when_explicit(
-    tmp_path, mode
-):
+def test_documented_permission_modes_are_operator_bound(tmp_path, mode):
     _, run = _run(tmp_path, permission_mode=mode)
     argv = run.call_args.args[0]
     assert argv[argv.index("--permission-mode") + 1] == mode
@@ -115,21 +338,14 @@ def test_invalid_permission_mode_fails_before_a_provider_can_launch():
     with patch.object(claude_module, "_run_process") as run:
         with pytest.raises(ValueError, match="Invalid permission mode"):
             ClaudeCode("yolo")
-
     run.assert_not_called()
 
 
 @pytest.mark.parametrize("tool", [claude_code, ClaudeCode("bypassPermissions")])
 def test_agent_schema_never_exposes_provider_permission_policy(tmp_path, tool):
     agent = Agent(
-        "schema",
-        llm=MagicMock(),
-        tools=[tool],
-        quiet=True,
-        log=False,
-        co_dir=tmp_path / ".co",
+        "schema", llm=MagicMock(), tools=[tool], quiet=True, log=False, co_dir=tmp_path / ".co"
     )
-
     schemas = [registered.to_function_schema() for registered in agent.tools]
     assert [schema["name"] for schema in schemas] == ["claude_code"]
     assert "permission_mode" not in schemas[0]["parameters"]["properties"]
@@ -161,7 +377,6 @@ def test_cwd_must_exist_and_be_a_directory(tmp_path):
     file_path = tmp_path / "file"
     file_path.write_text("x", encoding="utf-8")
     file_result = json.loads(claude_code("fix", cwd=str(file_path)))
-
     assert "Working directory" in missing["error"]
     assert "not a directory" in file_result["error"]
 
@@ -169,291 +384,151 @@ def test_cwd_must_exist_and_be_a_directory(tmp_path):
 def test_missing_binary_is_one_structured_result(tmp_path):
     with patch.object(claude_module, "_base_command", return_value=None):
         result = json.loads(claude_code("fix", cwd=str(tmp_path)))
-
-    assert result["provider"] == "claude_code"
     assert result["status"] == "error"
-    assert result["exit_code"] == -1
     assert "CLI not found" in result["error"]
 
 
-def test_file_not_found_race_is_structured(tmp_path):
+def test_timeout_and_cancellation_are_structured(tmp_path):
     with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
-        claude_module, "_run_process", side_effect=FileNotFoundError
+        claude_module, "_run_process", side_effect=subprocess.TimeoutExpired(["claude"], 2)
     ):
-        result = json.loads(claude_code("fix", cwd=str(tmp_path)))
-    assert "CLI not found" in result["error"]
-
-
-def test_malformed_command_override_is_structured(tmp_path, monkeypatch):
-    monkeypatch.setenv("CLAUDE_CODE_CMD", '"unterminated')
-    result = json.loads(claude_code("fix", cwd=str(tmp_path)))
-    assert result["status"] == "error"
-    assert "Invalid $CLAUDE_CODE_CMD" in result["error"]
-
-
-def test_invalid_subprocess_argument_is_structured(tmp_path):
+        timed_out = json.loads(claude_code("fix", cwd=str(tmp_path), timeout=2))
     with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
-        claude_module,
-        "_run_process",
-        side_effect=ValueError("embedded null byte"),
+        claude_module, "_run_process", side_effect=claude_module._ProviderCancelled
     ):
-        result = json.loads(claude_code("bad\0prompt", cwd=str(tmp_path)))
-    assert "invalid launch argument" in result["error"]
+        cancelled = json.loads(claude_code("fix", cwd=str(tmp_path)))
+    assert timed_out["status"] == "timeout"
+    assert cancelled["status"] == "error"
+    assert "interrupted" in cancelled["error"].lower()
 
 
-def test_timeout_is_structured_and_preserves_resume_id(tmp_path):
-    with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
-        claude_module,
-        "_run_process",
-        side_effect=subprocess.TimeoutExpired(["claude"], 2),
-    ):
-        result = json.loads(
-            claude_code("continue", session_id="session-old", cwd=str(tmp_path), timeout=2)
-        )
-
-    assert result["session_id"] == "session-old"
-    assert result["resumed"] is True
-    assert result["status"] == "timeout"
-    assert "2s" in result["error"]
-
-
-def test_authentication_failure_uses_provider_json_message(tmp_path):
-    completed = _completed(
+def test_provider_error_and_session_mismatch_stay_structured(tmp_path):
+    failed = _completed(
         {
-            "result": "Authentication required\nRun /login",
-            "session_id": "session-1",
-            "is_error": True,
-        },
-        returncode=1,
-        stderr="debug noise",
-    )
-
-    result, _ = _run(tmp_path, completed=completed)
-
-    assert result["status"] == "error"
-    assert result["exit_code"] == 1
-    assert result["error"] == "Authentication required Run /login"
-
-
-def test_zero_exit_provider_error_is_still_an_error(tmp_path):
-    completed = _completed(
-        {"result": "permission denied", "session_id": "s", "is_error": True}
-    )
-    result, _ = _run(tmp_path, completed=completed)
-    assert result["status"] == "error"
-    assert result["error"] == "permission denied"
-
-
-def test_success_requires_a_resumable_session_id(tmp_path):
-    result, _ = _run(tmp_path, completed=_completed({"result": "done"}))
-    assert result["status"] == "error"
-    assert "resumable session ID" in result["error"]
-
-
-def test_resume_rejects_a_different_returned_session_id(tmp_path):
-    completed = _completed(
-        {"result": "done", "session_id": "session-new", "is_error": False}
-    )
-    result, _ = _run(tmp_path, completed=completed, session_id="session-old")
-    assert result["status"] == "error"
-    assert "different session ID" in result["error"]
-
-
-def test_failed_resume_cannot_replace_the_requested_session_id(tmp_path):
-    completed = _completed(
-        {
-            "result": "authentication failed",
+            "type": "result",
+            "result": "Authentication required",
             "session_id": "session-new",
             "is_error": True,
         },
         returncode=1,
     )
-
-    result, _ = _run(tmp_path, completed=completed, session_id="session-old")
-
-    assert result["status"] == "error"
+    result, _ = _run(tmp_path, completed=failed, session_id="session-old")
     assert result["session_id"] == "session-old"
+    assert result["status"] == "error"
     assert "different session ID" in result["error"]
-    assert "authentication failed" in result["error"]
+    assert "Authentication required" in result["error"]
 
 
-@pytest.mark.parametrize("provider_session", [7, {"id": "s"}, ["s"]])
-def test_invalid_provider_session_id_never_leaks_into_the_envelope(
-    tmp_path, provider_session
-):
-    completed = _completed(
-        {"result": "done", "session_id": provider_session, "is_error": False}
-    )
-    fresh, _ = _run(tmp_path, completed=completed)
-    resumed, _ = _run(
-        tmp_path, completed=completed, session_id="session-old"
-    )
-    assert fresh["session_id"] == ""
-    assert fresh["status"] == "error"
-    assert resumed["session_id"] == "session-old"
-    assert resumed["status"] == "error"
-
-
-def test_event_array_uses_its_final_result_object(tmp_path):
-    completed = _completed(
-        [
-            {"type": "system", "subtype": "init", "session_id": "s"},
-            {"type": "assistant", "message": {"content": []}},
-            {
-                "type": "result",
-                "result": "done",
-                "session_id": "s",
-                "is_error": False,
-                "usage": {"output_tokens": 2},
-            },
-        ]
-    )
-
+@pytest.mark.parametrize("payload", [None, {}, {"type": "assistant"}])
+def test_missing_result_object_is_structured(tmp_path, payload):
+    completed = _completed()
+    completed.payload = payload
+    completed.invalid_output = "not json" if payload is None else ""
     result, _ = _run(tmp_path, completed=completed)
-
-    assert result["status"] == "completed"
-    assert result["session_id"] == "s"
-    assert result["result"] == "done"
-    assert result["usage"] == {"output_tokens": 2}
-
-
-@pytest.mark.parametrize("payload", [[], [1, 2], "text", None])
-def test_json_without_a_result_object_is_structured(tmp_path, payload):
-    result, _ = _run(tmp_path, completed=_completed(payload))
     assert result["status"] == "error"
     assert "did not contain a result object" in result["error"]
 
 
-def test_nonzero_json_without_result_includes_stderr(tmp_path):
-    completed = _completed([], returncode=1, stderr="authentication failed")
-    result, _ = _run(tmp_path, completed=completed)
-    assert "authentication failed" in result["error"]
+def test_process_reader_delivers_each_json_line_and_final_result(tmp_path):
+    lines = "\n".join(
+        json.dumps(event)
+        for event in (
+            {"type": "system", "subtype": "init", "session_id": "s"},
+            {"type": "assistant", "message": {"content": []}},
+            {"type": "result", "result": "done", "session_id": "s"},
+        )
+    ) + "\n"
+    process = MagicMock()
+    process.stdout = io.StringIO(lines)
+    process.stderr = io.StringIO("warning\n")
+    process.poll.return_value = 0
+    process.wait.return_value = 0
+    events = []
+
+    with patch.object(claude_module.subprocess, "Popen", return_value=process):
+        completed = claude_module._run_process(
+            ["claude"], cwd=str(tmp_path), timeout=2, on_event=events.append
+        )
+
+    assert [event["type"] for event in events] == ["system", "assistant", "result"]
+    assert completed.payload["result"] == "done"
+    assert completed.stderr == "warning\n"
 
 
-def test_invalid_json_is_structured(tmp_path):
-    completed = SimpleNamespace(stdout="not json", stderr="bad output\n", returncode=1)
-    result, _ = _run(tmp_path, completed=completed)
-    assert result["status"] == "error"
-    assert result["exit_code"] == 1
-    assert result["error"] == "Claude Code returned invalid JSON: bad output"
+def test_process_reader_reaps_claude_when_live_io_rejects_an_event(tmp_path):
+    process = MagicMock()
+    process.stdout = io.StringIO('{"type":"assistant","message":{"content":[]}}\n')
+    process.stderr = io.StringIO("")
+    process.poll.return_value = None
+
+    with patch.object(claude_module.subprocess, "Popen", return_value=process), patch.object(
+        claude_module, "_kill_process_tree"
+    ) as kill:
+        with pytest.raises(claude_module._ProviderStreamError, match="lease retired"):
+            claude_module._run_process(
+                ["claude"],
+                cwd=str(tmp_path),
+                timeout=2,
+                on_event=MagicMock(side_effect=RuntimeError("lease retired")),
+            )
+
+    kill.assert_called_once_with(process)
 
 
-def test_command_override_is_parsed_as_argv(monkeypatch):
-    monkeypatch.setenv("CLAUDE_CODE_CMD", "'/path with spaces/claude' --flag")
-    assert claude_module._base_command() == ["/path with spaces/claude", "--flag"]
+def test_process_reader_kills_the_group_on_cooperative_cancellation(tmp_path):
+    process = MagicMock()
+    process.stdout = io.StringIO("")
+    process.stderr = io.StringIO("")
+    process.poll.return_value = None
+    cancelled = threading.Event()
+    cancelled.set()
 
+    with patch.object(claude_module.subprocess, "Popen", return_value=process), patch.object(
+        claude_module, "_kill_process_tree"
+    ) as kill:
+        with pytest.raises(claude_module._ProviderCancelled):
+            claude_module._run_process(
+                ["claude"],
+                cwd=str(tmp_path),
+                timeout=2,
+                cancelled=cancelled.is_set,
+                on_event=lambda event: None,
+            )
 
-def test_windows_command_override_removes_wrapper_quotes():
-    assert claude_module._split_command(
-        '"C:\\Program Files\\Claude\\claude.exe" --flag', windows=True
-    ) == ["C:\\Program Files\\Claude\\claude.exe", "--flag"]
-
-
-@pytest.mark.parametrize("suffix", ["cmd", "CMD", "bat", "BAT"])
-def test_windows_batch_wrappers_are_rejected(tmp_path, suffix):
-    command = f"C:\\bin\\claude.{suffix}"
-    assert claude_module._is_unsafe_windows_batch(command, windows=True)
-    with patch.object(claude_module, "_base_command", return_value=[command]), patch.object(
-        claude_module, "_is_unsafe_windows_batch", return_value=True
-    ), patch.object(claude_module, "_run_process") as run:
-        result = json.loads(claude_code("fix", cwd=str(tmp_path)))
-    assert result["status"] == "error"
-    assert ".cmd/.bat" in result["error"]
-    run.assert_not_called()
-
-
-def test_metacharacters_remain_one_argument_without_a_shell(tmp_path):
-    prompt = "fix & whoami | echo $HOME"
-    _, run = _run(tmp_path, prompt=prompt)
-    assert run.call_args.args[0][-2:] == ["--", prompt]
+    kill.assert_called_once_with(process)
 
 
 def test_process_runner_is_headless_and_does_not_use_a_shell(tmp_path):
-    process = SimpleNamespace(
-        communicate=lambda timeout: ("{}", ""), returncode=0
-    )
+    process = MagicMock()
+    process.stdout = io.StringIO('{"type":"result","session_id":"s"}\n')
+    process.stderr = io.StringIO("")
+    process.poll.return_value = 0
+    process.wait.return_value = 0
     with patch.object(claude_module.subprocess, "Popen", return_value=process) as popen:
-        completed = claude_module._run_process(
-            ["claude", "--", "x"], cwd=str(tmp_path), timeout=2
+        claude_module._run_process(
+            ["claude", "--", "x"], cwd=str(tmp_path), timeout=2, on_event=lambda event: None
         )
-    assert completed.returncode == 0
     assert popen.call_args.kwargs["stdin"] is subprocess.DEVNULL
     assert popen.call_args.kwargs["shell"] is False
 
 
-def test_process_runner_never_waits_unboundedly_after_timeout(tmp_path):
-    process = MagicMock()
-    process.communicate.side_effect = [
-        subprocess.TimeoutExpired(["claude"], 1),
-        subprocess.TimeoutExpired(["claude"], 3),
-    ]
-    process.stdout = MagicMock()
-    process.stderr = MagicMock()
-    with patch.object(
-        claude_module.subprocess, "Popen", return_value=process
-    ), patch.object(claude_module, "_terminate_process_tree") as terminate, patch.object(
-        claude_module.time, "monotonic", side_effect=[0, 0, 2]
-    ):
-        with pytest.raises(subprocess.TimeoutExpired):
-            claude_module._run_process(
-                ["claude", "--", "x"], cwd=str(tmp_path), timeout=1
-            )
-
-    assert process.communicate.call_args_list == [
-        call(timeout=0.1),
-        call(timeout=3),
-    ]
-    terminate.assert_called_once_with(process)
-    process.stdout.close.assert_called_once()
-    process.stderr.close.assert_called_once()
-    process.wait.assert_called_once_with(timeout=1)
-
-
-@pytest.mark.parametrize("outcome", [0, 1, "timeout"])
-def test_windows_process_tree_cleanup_handles_taskkill_outcomes(outcome):
-    process = MagicMock(pid=42)
-    with patch.object(claude_module.os, "name", "nt"), patch.object(
-        claude_module.subprocess, "run"
-    ) as taskkill:
-        if outcome == "timeout":
-            taskkill.side_effect = subprocess.TimeoutExpired("taskkill", 5)
-        else:
-            taskkill.return_value.returncode = outcome
-
-        claude_module._terminate_process_tree(process)
-
-    taskkill.assert_called_once()
-    assert taskkill.call_args.args[0] == [
-        "taskkill",
-        "/F",
-        "/T",
-        "/PID",
-        "42",
-    ]
-    assert taskkill.call_args.kwargs["timeout"] == 5
-    assert taskkill.call_args.kwargs["shell"] is False
-    if outcome == 0:
-        process.kill.assert_not_called()
-    else:
-        process.kill.assert_called_once()
-
-
-@pytest.mark.skipif(
-    claude_module.os.name == "nt", reason="POSIX process-group regression"
-)
+@pytest.mark.skipif(claude_module.os.name == "nt", reason="POSIX process-group regression")
 def test_real_posix_timeout_remains_a_timeout(tmp_path):
     with pytest.raises(subprocess.TimeoutExpired):
         claude_module._run_process(
             [sys.executable, "-c", "import time; time.sleep(30)"],
             cwd=str(tmp_path),
             timeout=1,
+            on_event=lambda event: None,
         )
 
 
-def test_tool_is_exported_from_both_public_namespaces():
+def test_command_override_is_parsed_without_a_shell(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_CMD", "'/path with spaces/claude' --flag")
+    assert claude_module._base_command() == ["/path with spaces/claude", "--flag"]
+
+
+def test_tool_is_exported_and_copyable():
     assert root_claude_code is claude_code
     assert ClaudeCode is UsefulClaudeCode
-
-
-def test_tool_is_registered_as_copyable():
     assert TOOLS["claude_code"] == "claude_code.py"

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -134,14 +134,14 @@ def test_resume_reapplies_mode_through_the_library_adapter(monkeypatch, tmp_path
     def fake_run(argv, **kwargs):
         calls.append((argv, kwargs))
         return SimpleNamespace(
-            stdout=json.dumps(
-                {
-                    "result": "continued",
-                    "session_id": "session-old",
-                    "is_error": False,
-                }
-            ),
+            payload={
+                "type": "result",
+                "result": "continued",
+                "session_id": "session-old",
+                "is_error": False,
+            },
             stderr="",
+            invalid_output="",
             returncode=0,
         )
 

--- a/tests/unit/test_co_ai_claude_code.py
+++ b/tests/unit/test_co_ai_claude_code.py
@@ -14,6 +14,7 @@ claude_wrapper = importlib.import_module(
     "connectonion.cli.co_ai.tools.claude_code"
 )
 claude_library = importlib.import_module("connectonion.useful_tools.claude_code")
+OLD_SESSION = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
 
 
 @pytest.mark.parametrize(
@@ -34,7 +35,10 @@ def test_co_ai_mode_owns_claude_permission_mode(
         return '{"provider":"claude_code","session_id":"s"}'
 
     monkeypatch.setattr(claude_wrapper, "_run_claude_code", fake_claude_code)
-    agent = SimpleNamespace(current_session={"mode": mode})
+    agent = SimpleNamespace(
+        current_session={"mode": mode},
+        _delegation_workspace=tmp_path,
+    )
 
     result = claude_code(
         "fix it",
@@ -54,6 +58,7 @@ def test_co_ai_mode_owns_claude_permission_mode(
         "model": "sonnet",
         "timeout": 42,
         "agent": agent,
+        "workspace": tmp_path,
     }
 
 
@@ -137,7 +142,7 @@ def test_resume_reapplies_mode_through_the_library_adapter(monkeypatch, tmp_path
             payload={
                 "type": "result",
                 "result": "continued",
-                "session_id": "session-old",
+                "session_id": OLD_SESSION,
                 "is_error": False,
             },
             stderr="",
@@ -151,17 +156,20 @@ def test_resume_reapplies_mode_through_the_library_adapter(monkeypatch, tmp_path
         claude_code(
             "continue",
             cwd=str(tmp_path),
-            session_id="session-old",
-            agent=SimpleNamespace(current_session={"mode": "accept_edits"}),
+            session_id=OLD_SESSION,
+            agent=SimpleNamespace(
+                current_session={"mode": "accept_edits"},
+                _delegation_workspace=tmp_path,
+            ),
         )
     )
 
     argv = calls[0][0]
     assert argv[argv.index("--permission-mode") + 1] == "acceptEdits"
-    assert argv[argv.index("--resume") + 1] == "session-old"
+    assert argv[argv.index("--resume") + 1] == OLD_SESSION
     assert calls[0][1]["cwd"] == str(tmp_path.resolve())
     assert result["resumed"] is True
-    assert result["session_id"] == "session-old"
+    assert result["session_id"] == OLD_SESSION
 
 
 def test_structured_library_failure_passes_through(monkeypatch, tmp_path):

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -299,6 +299,7 @@ def test_interrupt_stops_provider_process_before_late_write(
         log=False,
         quiet=True,
     )
+    agent._delegation_workspace = tmp_path
     agent.current_session = {
         "messages": [],
         "trace": [],


### PR DESCRIPTION
## Summary

- stream installed Claude Code CLI activity through native AgentIO tool cards
- preserve the existing single outer call, stable result envelope, canonical session resume, timeout, and cancellation behavior
- enforce operator-owned permission and workspace boundaries without exposing them in the model tool schema
- run the child in Claude `--safe-mode` with a minimal credential environment
- bound provider-controlled IDs, fields, collections, stream lines, event counts, active correlations, final output, and usage

## Product boundary

This is the native product path: Host -> `@connectonion/react` -> O Chat. React owns protocol decoding and typed state; O Chat renders it. The retired standalone TypeScript SDK is not changed. Public ACP ingress is separate work in #900 / #901 and is not required by this PR.

Child text, thoughts, and plans are not forwarded into the parent transcript or top-level O Chat plan. The parent agent remains the author of the final answer and owner of review.

## Security and permission boundary

- Claude safe mode disables ordinary `CLAUDE.md`, skills, plugins, hooks, MCP servers, commands, custom agents, and related customizations.
- Admin-managed policy and installed Claude authentication still apply.
- Unrelated parent provider, cloud, and GitHub credentials are not inherited.
- A requested `cwd` must resolve inside the operator-bound workspace; symlink escapes fail closed.
- Resume accepts only the exact canonical UUID returned by an earlier run, not CLI fuzzy search.
- Event capacity reserves a matching result for every emitted start so the UI cannot retain an orphaned in-progress card.

This adds observability, not an interactive child approval bridge. An unmatched permission request cannot round-trip through O Chat in this version and fails closed.

## Why CLI stream

`claude-agent-sdk==0.2.136` requires Python `mcp>=1.23,<2`, while ConnectOnion 1.7 requires `mcp>=2,<3`. The documented CLI stream provides the needed tool lifecycle without weakening that dependency boundary.

## Verification

- 138 related delegation, co ai assembly, import-surface, and tool-registry tests pass
- Ruff and `git diff --check` pass
- real installed-provider smoke: safe-mode completion succeeds
- real installed-provider smoke: native `tool_call` and `tool_result` are emitted
- real installed-provider smoke: unmatched Read permission fails closed and the canonical UUID resumes successfully
- one repository-existing `FileTools.permission` annotation warning remains unrelated

## Scope

- no public ACP ingress
- no interactive child approval bridge
- no TypeScript SDK changes
- no version bump, release, or package publication

Refs #902