### PR TITLE
fix(outlook): support attachments on replies

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -2,7 +2,7 @@
 Purpose: CLI surface for Outlook email and contacts — send/read/search mail and add/list/search contacts from the terminal
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
-  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env and checks the operation scope → Outlook() instance | mail commands use list/read/send methods and the numbered inbox cache | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
+  Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env and checks the operation scope → Outlook() instance | mail commands use list/read/send/reply methods and the numbered inbox cache | send and reply share _check_attachments() to reject missing or oversize --attach files before megabytes are base64-encoded | handle_outlook_reply(email_id, message, at, *, attachments) keeps `at` third positional for pre-attachment callers, so attachments is keyword-only | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
   State/Effects: writes ~/.co/outlook_last_inbox.json for mail numbering | read changes mailbox state only with --mark-read; send/reply/contact commands mutate their named data | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
   Integration: exposes handle_outlook_* functions for cli/main.py, including handle_outlook_contact_add/list/search | presentation mirrors existing mail tables | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
   Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/Mail/Contacts.ReadWrite scopes, invalid files/times/ids | Graph API errors propagate from Outlook
@@ -233,11 +233,17 @@ def handle_outlook_download(email_id: str, out_dir: str = "."):
     console.print()
 
 
-def handle_outlook_reply(email_id: str, message: str, at: str = None):
-    """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin."""
+def handle_outlook_reply(email_id: str, message: str, at: str = None, *, attachments: list = None):
+    """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin.
+
+    `at` keeps its third-positional slot from before attachments existed;
+    attachments is keyword-only so no caller can pass a schedule as a file.
+    """
     if message == "-":
         message = sys.stdin.read()
     send_at = _parse_send_at(at) if at else None
+    if attachments:
+        _check_attachments(attachments)
 
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
@@ -245,11 +251,15 @@ def handle_outlook_reply(email_id: str, message: str, at: str = None):
         console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook reply <#> <message>.[/yellow]\n")
         raise typer.Exit(1)
 
-    outlook.reply(resolved, message, send_at=send_at)
+    outlook.reply(resolved, message, attachments=attachments, send_at=send_at)
     if send_at:
-        console.print(f"\n[green]✓ Reply scheduled[/green] for [bold]{send_at}[/bold] to email {email_id}\n")
+        console.print(f"\n[green]✓ Reply scheduled[/green] for [bold]{send_at}[/bold] to email {email_id}")
     else:
-        console.print(f"\n[green]✓ Replied[/green] to email {email_id}\n")
+        console.print(f"\n[green]✓ Replied[/green] to email {email_id}")
+    if attachments:
+        names = ", ".join(Path(p).name for p in attachments)
+        console.print(f"  Attached: {names}")
+    console.print()
 
 
 def handle_outlook_sent(last: int = 10):

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1147,15 +1147,18 @@ def outlook_download(
     handle_outlook_download(email_id, out_dir)
 
 
-@outlook_app.command("reply")
+@outlook_app.command("reply", epilog="Examples:  co outlook reply 3 \"Sounds good\"  |  "
+                                     "cat notes.txt | co outlook reply 3 -  |  "
+                                     "co outlook reply 3 \"Signed copy attached\" --attach signed.pdf")
 def outlook_reply(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     message: str = typer.Argument(..., help="Reply body (plain text, or '-' to read from stdin)"),
+    attach: Optional[List[str]] = typer.Option(None, "--attach", "-a", help="File to attach (repeat for multiple)"),
     at: Optional[str] = typer.Option(None, "--at", help="Schedule delivery: +30m, +2h, or UTC ISO time (2026-07-06T15:30:00Z)"),
 ):
     """Reply to an email (threaded), now or scheduled with --at."""
     from .commands.outlook_commands import handle_outlook_reply
-    handle_outlook_reply(email_id, message, at=at)
+    handle_outlook_reply(email_id, message, attachments=attach, at=at)
 
 
 @outlook_app.command("scheduled")

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,9 +2,9 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() validates the ambient OpenOnion account and refreshes locally owned Microsoft tokens via oo-api → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  Data flow: Agent calls Outlook methods → _get_access_token() validates the ambient OpenOnion account and refreshes locally owned Microsoft tokens via oo-api → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with attachments share _encoded_attachments() (validate, size-check, base64) and place fileAttachments on the sent message — reply() puts them on the reply action's message so Graph still threads it | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
   State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
-  Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
+  Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()]) | reply(email_id, body, send_at, *, attachments) keeps send_at third positional for pre-attachment callers, so attachments is keyword-only
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
 
@@ -22,7 +22,7 @@ Usage:
     # - search_emails(query, max_results)
     # - get_email_body(email_id)
     # - send(to, subject, body, cc, bcc, attachments, send_at)
-    # - reply(email_id, body, send_at)
+    # - reply(email_id, body, send_at, *, attachments)
     # - get_scheduled(max_results)
     # - add_contact(name, email)
     # - list_contacts(max_results)
@@ -604,6 +604,34 @@ class Outlook:
             "contentBytes": base64.b64encode(content).decode(),
         }
 
+    def _encoded_attachments(self, attachments: list) -> list[dict]:
+        """Validate and encode every attachment before any Graph call.
+
+        Reading happens under the open descriptors _open_attachments checked,
+        so a file swapped after validation cannot smuggle its contents in.
+        """
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            opened = self._open_attachments(attachments, stack)
+            remaining = OUTLOOK_ATTACHMENT_LIMIT
+            encoded = []
+            for filename, handle in opened:
+                payload = handle.read(remaining + 1)
+                if len(payload) > remaining:
+                    raise ValueError("Attachments exceed Outlook's 3MB send limit.")
+                remaining -= len(payload)
+                encoded.append(self._file_attachment(filename, payload))
+        return encoded
+
+    @staticmethod
+    def _attachment_suffix(attachments: list) -> str:
+        """Name the attached files in a send/reply confirmation message."""
+        if not attachments:
+            return ""
+        names = ", ".join(os.path.basename(os.path.expanduser(p)) for p in attachments)
+        return f" with attachment(s): {names}"
+
     def send(self, to: str, subject: str, body: str, cc: str = None, bcc: str = None,
              attachments: list = None, send_at: str = None) -> str:
         """Send email via Microsoft Graph API, immediately or at a scheduled time.
@@ -647,24 +675,9 @@ class Outlook:
             ]
 
         if attachments:
-            from contextlib import ExitStack
+            message["attachments"] = self._encoded_attachments(attachments)
 
-            with ExitStack() as stack:
-                opened = self._open_attachments(attachments, stack)
-                remaining = OUTLOOK_ATTACHMENT_LIMIT
-                encoded = []
-                for filename, handle in opened:
-                    payload = handle.read(remaining + 1)
-                    if len(payload) > remaining:
-                        raise ValueError("Attachments exceed Outlook's 3MB send limit.")
-                    remaining -= len(payload)
-                    encoded.append(self._file_attachment(filename, payload))
-            message["attachments"] = encoded
-
-        suffix = ""
-        if attachments:
-            names = ", ".join(os.path.basename(os.path.expanduser(p)) for p in attachments)
-            suffix = f" with attachment(s): {names}"
+        suffix = self._attachment_suffix(attachments)
 
         if send_at:
             # PidTagDeferredSendTime — Exchange holds delivery until this time.
@@ -679,14 +692,22 @@ class Outlook:
             return f"Email scheduled for {send_at} to {to}{suffix}"
         return f"Email sent successfully to {to}{suffix}"
 
-    def reply(self, email_id: str, body: str, send_at: str = None) -> str:
+    def reply(self, email_id: str, body: str, send_at: str = None, *,
+              attachments: list = None) -> str:
         """Reply to an email, immediately or at a scheduled time.
+
+        send_at stays third positional — callers written before attachments
+        existed pass reply(email_id, body, "2026-07-06T15:30:00Z"), and a
+        timestamp read as a file path would be a silent, mail-sending bug.
+        attachments is keyword-only so the argument order can never shift.
 
         Args:
             email_id: Outlook message ID to reply to
             body: Reply message body (plain text)
             send_at: Optional UTC ISO time (e.g. "2026-07-06T15:30:00Z") to
                 schedule delivery — Exchange holds the reply until then
+            attachments: Optional list of local file paths to attach — same
+                files and ~3MB total Graph limit as send()
 
         Returns:
             Confirmation message
@@ -697,23 +718,31 @@ class Outlook:
         body = "".join(f"<p>{p}</p>" for p in paragraphs)
 
         endpoint = f"/me/messages/{email_id}/reply"
-        data = {
-            "comment": body
-        }
+        # The reply action takes writable message properties beside the
+        # comment, so attachments ride along without giving up the threading
+        # Graph does for us (In-Reply-To, References, same conversation).
+        reply_message = {}
+        if attachments:
+            # Encode first: a rejected file must not leave a reply already
+            # sent and unattached.
+            reply_message["attachments"] = self._encoded_attachments(attachments)
         if send_at:
             # Same deferred-send property as send(); the reply action accepts
             # message properties alongside the comment.
-            data["message"] = {
-                "singleValueExtendedProperties": [
-                    {"id": "SystemTime 0x3FEF", "value": send_at}
-                ]
-            }
+            reply_message["singleValueExtendedProperties"] = [
+                {"id": "SystemTime 0x3FEF", "value": send_at}
+            ]
+
+        data = {"comment": body}
+        if reply_message:
+            data["message"] = reply_message
 
         self._request("POST", endpoint, json=data)
 
+        suffix = self._attachment_suffix(attachments)
         if send_at:
-            return f"Reply scheduled for {send_at}"
-        return "Reply sent successfully"
+            return f"Reply scheduled for {send_at}{suffix}"
+        return f"Reply sent successfully{suffix}"
 
     def get_scheduled(self, max_results: int = 25) -> list:
         """List emails waiting for scheduled delivery (deferred-send drafts).

--- a/docs/blog/2026-08-15-the-third-argument-was-already-taken.md
+++ b/docs/blog/2026-08-15-the-third-argument-was-already-taken.md
@@ -1,0 +1,65 @@
+# The Third Argument Was Already Taken
+
+`co outlook reply` could not attach a file. `co outlook send` could. The fix
+looked like an afternoon's work: reuse the validation, the 3MB ceiling, and the
+MIME sniffing that `send()` already had, then hang the result off Graph's reply
+action so the message stays inside its original thread.
+
+The signature wrote itself, because `send()` was sitting right there:
+
+```python
+def send(self, to, subject, body, cc=None, bcc=None, attachments=None, send_at=None)
+def reply(self, email_id, body, attachments=None, send_at=None)
+```
+
+Two methods, same tail: `attachments`, then `send_at`. It reads as symmetry.
+Eighty-nine tests passed, including every attachment case I could think of — a
+missing file, an oversize file, a file outside the project, a Graph rejection
+that must not be reported as a sent reply.
+
+Then a reviewer asked what happens to the code that was already there.
+
+`send()` was born with `attachments` in that slot. `reply()` was not. Its third
+positional argument had been `send_at` since the day it shipped:
+
+```python
+outlook.reply(email_id, "See you then", "2026-07-06T15:30:00Z")
+```
+
+No test in the repo caught this, because every test in the repo passes
+`send_at=` by keyword. Callers outside the repo have no such habit. After my
+change, that line handed a timestamp to `attachments` — and `attachments` gets
+iterated:
+
+```
+ValueError: Attachment not found: 2
+```
+
+`"2026-07-06T15:30:00Z"` is not a list holding one path. It is a sequence of
+twenty characters, and the first one is `2`. The CLI version of the same
+mistake is better still: the old `handle_outlook_reply(id, message, "+30m")`
+now complains about a missing file named `+`. The scheduled reply never leaves,
+and the error blames a file the user never typed.
+
+I had been careful about the parts that looked dangerous — a file swapped
+between validation and read, an encode that must finish before the POST so a
+rejected attachment cannot leave a reply already sent and unattached. The bug
+was in the part that looked like tidiness.
+
+The repair is one `*` and a swap:
+
+```python
+def reply(self, email_id, body, send_at=None, *, attachments=None)
+```
+
+`send_at` keeps the position it has always had. `attachments` moves behind the
+star, where argument order cannot reach it — not now, and not the next time
+someone adds a parameter and wants the two signatures to line up. Two
+regression tests pin the legacy positional call, and a third asserts the
+parameter list itself, so the contract now breaks in CI instead of quietly in
+somebody's mailbox.
+
+The lesson isn't "be careful when adding parameters." It's that symmetry
+between two functions was something I wanted, while positional order was a
+promise the older function had already made. When those two disagree, the
+promise wins.

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -118,6 +118,21 @@ Sends a threaded reply to an email from your last listing. Use `-` as the
 message to read the reply body from stdin, and `--at +2h` (or a UTC ISO
 time) to schedule the reply like a scheduled send.
 
+**Options**
+- `--attach, -a FILE` — attach a local file; repeat for multiple
+- `--at` — schedule delivery: `+30m`, `+2h`, or a UTC ISO time
+
+**Attachments** — same files, limit, and flag as `send`, still a real reply:
+
+```bash
+co outlook reply 3 "Signed copy attached." \
+    --attach signed.pdf --attach cover.png
+```
+
+The files ride on Graph's reply action, so the message stays in the original
+conversation instead of going out as a new email. Attachments and `--at`
+combine — a scheduled reply keeps its files.
+
 ### `co outlook send <to> <subject> <message>` — Send
 
 ```bash

--- a/docs/integrations/microsoft.md
+++ b/docs/integrations/microsoft.md
@@ -140,6 +140,8 @@ outlook.send(to="alice@example.com", subject="Report", body="See attached.",
              attachments=["report.pdf"],              # local files, ~3MB Graph limit
              send_at="2026-07-06T15:30:00Z")           # deferred send (UTC ISO)
 outlook.reply(email_id, body="Thanks for your message")
+outlook.reply(email_id, body="Signed copy attached.",
+              attachments=["signed.pdf"])              # threaded, same limit as send
 
 # Contacts
 outlook.add_contact("Zhou Yifei", "zhou@example.com")

--- a/docs/useful_tools/outlook.md
+++ b/docs/useful_tools/outlook.md
@@ -121,12 +121,24 @@ outlook.send(
 )
 ```
 
-**`reply(email_id, body, send_at=None)`**
+**`reply(email_id, body, send_at=None, *, attachments=None)`**
 - Reply to an existing email (threaded), now or scheduled
 - `body` is plain text — paragraphs (blank-line separated) convert to HTML
   `<p>` blocks and single newlines to `<br>`, with HTML characters escaped,
   so replies keep their formatting in Outlook
-- `send_at`: Optional UTC ISO time — Exchange holds delivery until then
+- `send_at`: Optional UTC ISO time — Exchange holds delivery until then. It
+  keeps the third-positional slot it has always had, so
+  `reply(email_id, body, "2026-07-06T15:30:00Z")` still schedules
+- `attachments`: Keyword-only list of local file paths, validated and limited
+  exactly like `send()`. They travel on Graph's reply action, so the message
+  stays in the original conversation
+
+```python
+outlook.reply(
+    email_id, "Signed copy attached.",
+    attachments=["signed.pdf"],
+)
+```
 
 ### Scheduled sends
 

--- a/tests/e2e/cli/test_cli_outlook_reply.py
+++ b/tests/e2e/cli/test_cli_outlook_reply.py
@@ -1,0 +1,53 @@
+"""CLI routing tests for `co outlook reply`."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+runner = CliRunner()
+
+
+def test_outlook_reply_routes_without_attachments():
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_reply"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "reply", "3", "Sounds good",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("3", "Sounds good", attachments=None, at=None)
+
+
+def test_outlook_reply_collects_repeated_attach_flags():
+    """--attach and -a are repeatable, like `co outlook send`."""
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_reply"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "reply", "3", "Both attached",
+            "--attach", "report.pdf", "-a", "chart.png",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "3", "Both attached",
+        attachments=["report.pdf", "chart.png"], at=None,
+    )
+
+
+def test_outlook_reply_routes_attachments_with_schedule():
+    with patch(
+        "connectonion.cli.commands.outlook_commands.handle_outlook_reply"
+    ) as handler:
+        result = runner.invoke(app, [
+            "outlook", "reply", "3", "Tomorrow",
+            "-a", "report.pdf", "--at", "+2h",
+        ])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with(
+        "3", "Tomorrow", attachments=["report.pdf"], at="+2h",
+    )

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -3,13 +3,14 @@
 LLM-Note: Tests for outlook
 
 What it tests:
-- Outlook functionality: init scope checks, token management, formatting, read/search, send (attachments, send_at scheduling), reply (plain-text→HTML paragraph conversion, scheduled), get_scheduled (paging), mark read, unread count
+- Outlook functionality: init scope checks, token management, formatting, read/search, send (attachments, send_at scheduling), reply (plain-text→HTML paragraph conversion, attachments on the threaded reply action, scheduled, send_at still third positional with attachments keyword-only), get_scheduled (paging), mark read, unread count
 
 Components under test:
 - Module: outlook
 """
 
 
+import base64
 import os
 import pytest
 from unittest.mock import patch, MagicMock
@@ -671,6 +672,190 @@ class TestOutlookReply:
 
             comment = mock_httpx.request.call_args.kwargs["json"]["comment"]
             assert comment == "<p>cost &lt; $10 &amp; rising</p>"
+
+
+class TestOutlookReplyAttachments:
+    """Replying with files attached, without giving up Graph's threading."""
+
+    @pytest.fixture(autouse=True)
+    def _connected(self, monkeypatch):
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.Read,Mail.Send")
+        monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "test-token")
+        monkeypatch.setenv("MICROSOFT_REFRESH_TOKEN", "test-refresh")
+
+    def _outlook(self, allow_external_attachments=True):
+        from connectonion.useful_tools.outlook import Outlook
+        return Outlook(allow_external_attachments=allow_external_attachments)
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_with_one_attachment_still_replies_to_the_thread(self, mock_httpx, tmp_path):
+        """The file rides on the reply action, so the thread is kept."""
+        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+        signed = tmp_path / "signed.pdf"
+        signed.write_bytes(b"%PDF-1.4 fake")
+
+        result = self._outlook().reply("msg-1", "Signed copy attached",
+                                      attachments=[str(signed)])
+
+        assert "sent" in result.lower()
+        assert "signed.pdf" in result
+
+        method, url = mock_httpx.request.call_args.args[:2]
+        assert method == "POST"
+        # A reply must not degrade into a fresh sendMail — that loses threading.
+        assert url.endswith("/me/messages/msg-1/reply")
+
+        payload = mock_httpx.request.call_args.kwargs["json"]
+        assert payload["comment"] == "<p>Signed copy attached</p>"
+        attachment = payload["message"]["attachments"][0]
+        assert attachment["@odata.type"] == "#microsoft.graph.fileAttachment"
+        assert attachment["name"] == "signed.pdf"
+        assert attachment["contentType"] == "application/pdf"
+        assert base64.b64decode(attachment["contentBytes"]) == b"%PDF-1.4 fake"
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_reply_attaches_every_file_in_order(self, mock_httpx, tmp_path):
+        """Several attachments all reach Graph, each with its own MIME type."""
+        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+        chart = tmp_path / "chart.png"
+        chart.write_bytes(b"\x89PNG chart")
+
+        result = self._outlook().reply("msg-1", "Both attached",
+                                      attachments=[str(report), str(chart)])
+
+        attachments = mock_httpx.request.call_args.kwargs["json"]["message"]["attachments"]
+        assert [(a["name"], a["contentType"]) for a in attachments] == [
+            ("report.pdf", "application/pdf"),
+            ("chart.png", "image/png"),
+        ]
+        assert [base64.b64decode(a["contentBytes"]) for a in attachments] == [
+            b"%PDF report", b"\x89PNG chart",
+        ]
+        assert "report.pdf, chart.png" in result
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_scheduled_reply_keeps_both_attachments_and_deferred_send(self, mock_httpx, tmp_path):
+        """--attach and --at are not a choice: one message carries both."""
+        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+        signed = tmp_path / "signed.pdf"
+        signed.write_bytes(b"%PDF-1.4 fake")
+
+        result = self._outlook().reply("msg-1", "Tomorrow", attachments=[str(signed)],
+                                      send_at="2026-07-06T15:30:00Z")
+
+        assert "scheduled" in result.lower()
+        assert "signed.pdf" in result
+
+        message = mock_httpx.request.call_args.kwargs["json"]["message"]
+        assert message["attachments"][0]["name"] == "signed.pdf"
+        assert message["singleValueExtendedProperties"] == [
+            {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+        ]
+
+    def test_missing_attachment_reports_no_reply_sent(self, tmp_path):
+        """A path that isn't there must fail before anything reaches Graph."""
+        outlook = self._outlook()
+        outlook._request = MagicMock()
+
+        with pytest.raises(ValueError, match="Attachment not found"):
+            outlook.reply("msg-1", "Attached", attachments=[str(tmp_path / "gone.pdf")])
+
+        outlook._request.assert_not_called()
+
+    def test_oversize_attachment_reports_no_reply_sent(self, tmp_path):
+        """The 3MB send limit applies to replies, and stops the POST."""
+        huge = tmp_path / "huge.bin"
+        huge.write_bytes(b"")
+        os.truncate(huge, 3_000_001)
+        outlook = self._outlook()
+        outlook._request = MagicMock()
+
+        with pytest.raises(ValueError, match="3MB"):
+            outlook.reply("msg-1", "Attached", attachments=[str(huge)])
+
+        outlook._request.assert_not_called()
+
+    def test_agent_reply_attachment_must_stay_inside_the_project(self, tmp_path, monkeypatch):
+        """Agent-facing instances cannot attach a file outside the project."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".co").mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("secret")
+        monkeypatch.chdir(project)
+
+        outlook = self._outlook(allow_external_attachments=False)
+        outlook._request = MagicMock()
+
+        with pytest.raises(PermissionError, match="outside the project"):
+            outlook.reply("msg-1", "Attached", attachments=[str(outside)])
+
+        outlook._request.assert_not_called()
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_graph_rejection_is_not_reported_as_a_sent_reply(self, mock_httpx, tmp_path):
+        """A Graph error on the upload must raise, not return 'Reply sent'."""
+        mock_httpx.request.return_value = MagicMock(
+            status_code=413, text="attachment too large"
+        )
+        signed = tmp_path / "signed.pdf"
+        signed.write_bytes(b"%PDF-1.4 fake")
+
+        with pytest.raises(ValueError, match="Microsoft Graph API error"):
+            self._outlook().reply("msg-1", "Attached", attachments=[str(signed)])
+
+
+class TestOutlookReplyPositionalCompatibility:
+    """reply()'s third positional argument is send_at, as it always was."""
+
+    @pytest.fixture(autouse=True)
+    def _connected(self, monkeypatch):
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.Read,Mail.Send")
+        monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "test-token")
+        monkeypatch.setenv("MICROSOFT_REFRESH_TOKEN", "test-refresh")
+
+    def _outlook(self):
+        from connectonion.useful_tools.outlook import Outlook
+        return Outlook(allow_external_attachments=True)
+
+    @patch('connectonion.useful_tools.outlook.httpx')
+    def test_legacy_third_positional_argument_still_schedules(self, mock_httpx):
+        """A caller written before attachments existed still schedules, not attaches."""
+        mock_httpx.request.return_value = MagicMock(status_code=202, text="")
+
+        result = self._outlook().reply("msg-1", "See you then", "2026-07-06T15:30:00Z")
+
+        assert "scheduled" in result.lower()
+        payload = mock_httpx.request.call_args.kwargs["json"]
+        assert payload["message"]["singleValueExtendedProperties"] == [
+            {"id": "SystemTime 0x3FEF", "value": "2026-07-06T15:30:00Z"}
+        ]
+        # The timestamp must never be read as a file path.
+        assert "attachments" not in payload["message"]
+
+    def test_attachments_cannot_be_passed_positionally(self, tmp_path):
+        """Keyword-only attachments freeze the positional order for good."""
+        signed = tmp_path / "signed.pdf"
+        signed.write_bytes(b"%PDF-1.4 fake")
+        outlook = self._outlook()
+        outlook._request = MagicMock()
+
+        with pytest.raises(TypeError):
+            outlook.reply("msg-1", "Attached", None, [str(signed)])
+
+        outlook._request.assert_not_called()
+
+    def test_reply_signature_keeps_send_at_third(self):
+        """Guard the contract itself, so a future edit can't quietly reorder it."""
+        import inspect
+
+        from connectonion.useful_tools.outlook import Outlook
+
+        params = inspect.signature(Outlook.reply).parameters
+        assert list(params) == ["self", "email_id", "body", "send_at", "attachments"]
+        assert params["attachments"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 class TestOutlookActions:

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -8,6 +8,7 @@ What it tests:
 - _resolve_email_id short-number resolution via cache file and list_inbox fallback
 - handle_outlook_inbox writes the {#: message_id} cache
 - handle_outlook_send reads the body from stdin when message is '-'
+- handle_outlook_reply forwards --attach files (and stdin bodies, and --at) to Outlook.reply, rejects missing/oversize files before replying, and keeps `at` third positional with attachments keyword-only
 
 Components under test:
 - Module: connectonion.cli.commands.outlook_commands
@@ -34,6 +35,7 @@ from connectonion.cli.commands.outlook_commands import (
     handle_outlook_contact_list,
     handle_outlook_contact_search,
     handle_outlook_inbox,
+    handle_outlook_reply,
     handle_outlook_send,
 )
 
@@ -325,6 +327,157 @@ class TestHandleOutlookSend:
                     handle_outlook_send(to="bob@example.com", subject="Hi", message="hello")
 
         mock_cls.assert_not_called()
+
+
+class TestHandleOutlookReply:
+    """handle_outlook_reply carries --attach files through to the Outlook tool."""
+
+    def _reply(self, outlook, monkeypatch, **kwargs):
+        cache = {"3": "msg-cached-3"}
+        monkeypatch.setattr(outlook_commands, "_resolve_email_id",
+                            lambda _outlook, email_id: cache.get(email_id, ""))
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_reply(**kwargs)
+
+    def test_without_attachments_replies_as_before(self, monkeypatch, capsys):
+        outlook = MagicMock()
+        self._reply(outlook, monkeypatch, email_id="3", message="Sounds good")
+
+        outlook.reply.assert_called_once_with(
+            "msg-cached-3", "Sounds good", attachments=None, send_at=None,
+        )
+        output = capsys.readouterr().out
+        assert "Replied" in output
+        assert "Attached" not in output
+
+    def test_forwards_repeated_attachments(self, tmp_path, monkeypatch, capsys):
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+        chart = tmp_path / "chart.png"
+        chart.write_bytes(b"\x89PNG chart")
+
+        outlook = MagicMock()
+        self._reply(outlook, monkeypatch, email_id="3", message="Both attached",
+                    attachments=[str(report), str(chart)])
+
+        outlook.reply.assert_called_once_with(
+            "msg-cached-3", "Both attached",
+            attachments=[str(report), str(chart)], send_at=None,
+        )
+        output = capsys.readouterr().out
+        assert "Replied" in output
+        assert "Attached: report.pdf, chart.png" in output
+
+    def test_stdin_body_still_works_with_an_attachment(self, tmp_path, monkeypatch):
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+        monkeypatch.setattr(sys, "stdin", io.StringIO("Body from stdin\nline two\n"))
+
+        outlook = MagicMock()
+        self._reply(outlook, monkeypatch, email_id="3", message="-",
+                    attachments=[str(report)])
+
+        outlook.reply.assert_called_once_with(
+            "msg-cached-3", "Body from stdin\nline two\n",
+            attachments=[str(report)], send_at=None,
+        )
+
+    def test_scheduled_reply_keeps_its_attachment(self, tmp_path, monkeypatch, capsys):
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+
+        outlook = MagicMock()
+        self._reply(outlook, monkeypatch, email_id="3", message="Tomorrow",
+                    attachments=[str(report)], at="2026-07-06T15:30:00Z")
+
+        outlook.reply.assert_called_once_with(
+            "msg-cached-3", "Tomorrow",
+            attachments=[str(report)], send_at="2026-07-06T15:30:00Z",
+        )
+        output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+        assert "Reply scheduled" in output
+        assert "2026-07-06T15:30:00Z" in output
+        assert "Attached: report.pdf" in output
+
+    def test_missing_attachment_exits_without_replying(self, tmp_path, monkeypatch, capsys):
+        outlook = MagicMock()
+
+        with pytest.raises(typer.Exit):
+            self._reply(outlook, monkeypatch, email_id="3", message="Attached",
+                        attachments=[str(tmp_path / "gone.pdf")])
+
+        outlook.reply.assert_not_called()
+        assert "Attachment not found" in capsys.readouterr().out
+
+    def test_oversize_attachments_exit_without_replying(self, tmp_path, monkeypatch, capsys):
+        huge = tmp_path / "huge.bin"
+        huge.write_bytes(b"")
+        os.truncate(huge, 3_000_001)
+        outlook = MagicMock()
+
+        with pytest.raises(typer.Exit):
+            self._reply(outlook, monkeypatch, email_id="3", message="Attached",
+                        attachments=[str(huge)])
+
+        outlook.reply.assert_not_called()
+        assert "3MB" in capsys.readouterr().out
+
+    def test_unknown_email_number_does_not_reply(self, tmp_path, monkeypatch, capsys):
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+        outlook = MagicMock()
+
+        with pytest.raises(typer.Exit):
+            self._reply(outlook, monkeypatch, email_id="99", message="Attached",
+                        attachments=[str(report)])
+
+        outlook.reply.assert_not_called()
+        assert "No email #99" in capsys.readouterr().out
+
+
+class TestHandleOutlookReplyPositionalCompatibility:
+    """handle_outlook_reply's third positional argument is `at`, as it always was."""
+
+    def _call(self, outlook, monkeypatch, *args, **kwargs):
+        cache = {"3": "msg-cached-3"}
+        monkeypatch.setattr(outlook_commands, "_resolve_email_id",
+                            lambda _outlook, email_id: cache.get(email_id, ""))
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(outlook_commands, "_outlook", return_value=outlook):
+                handle_outlook_reply(*args, **kwargs)
+
+    def test_legacy_third_positional_argument_still_schedules(self, monkeypatch, capsys):
+        """The old handle_outlook_reply(id, message, at) call still schedules."""
+        outlook = MagicMock()
+        self._call(outlook, monkeypatch, "3", "See you then", "2026-07-06T15:30:00Z")
+
+        outlook.reply.assert_called_once_with(
+            "msg-cached-3", "See you then",
+            attachments=None, send_at="2026-07-06T15:30:00Z",
+        )
+        output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+        assert "Reply scheduled" in output
+        assert "Attached" not in output
+
+    def test_attachments_cannot_be_passed_positionally(self, tmp_path, monkeypatch):
+        """A fourth positional argument is a TypeError, not a silent schedule/attach swap."""
+        report = tmp_path / "report.pdf"
+        report.write_bytes(b"%PDF report")
+        outlook = MagicMock()
+
+        with pytest.raises(TypeError):
+            self._call(outlook, monkeypatch, "3", "Attached", None, [str(report)])
+
+        outlook.reply.assert_not_called()
+
+    def test_handler_signature_keeps_at_third(self):
+        """Guard the contract itself, so a future edit can't quietly reorder it."""
+        import inspect
+
+        params = inspect.signature(handle_outlook_reply).parameters
+        assert list(params) == ["email_id", "message", "at", "attachments"]
+        assert params["attachments"].kind is inspect.Parameter.KEYWORD_ONLY
 
 
 class TestHandleOutlookContacts:


### PR DESCRIPTION
## Summary

- add repeatable `--attach` / `-a` options to `co outlook reply`
- reuse the existing Outlook attachment validation, size limit, MIME detection, and encoding path
- attach files through the Graph reply action so replies remain threaded, including scheduled replies
- keep `send_at` third positional in `Outlook.reply()` and `at` third positional in `handle_outlook_reply()`, with `attachments` keyword-only, so callers written before attachments existed are unaffected
- document the CLI and tool behavior and add unit plus CLI routing regressions

Closes #847.

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** Claude Opus 5, driving Claude Code.

- *Least confident about:* whether the deferred-send extended property behaves the same on an Exchange Online work/school tenant as it does on the personal Outlook.com account the smoke run used. The docs already note that `cancel_scheduled` returns 403 on some work/school tenants while it succeeds on a personal account, so those two environments are known to diverge.
- *Not verified:* any Exchange Online work/school tenant, on any platform. Also unverified: that Exchange releases a deferred reply at the scheduled minute with its attachment intact — the scheduled replies in the smoke run were cancelled rather than left to fire, so only "held as a deferred draft, with the file attached" is established.
- *If this is wrong, what breaks first:* `co outlook reply --attach` returns a Graph 4xx and no reply is sent. It fails loudly rather than silently, because encoding completes before the POST and the response status is checked — a rejected attachment cannot leave a reply already sent and unattached. The fallback design would be `createReply` → PATCH the draft's attachments → `send`: more round trips, same threading.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-15-the-third-argument-was-already-taken.md

The story is this review. The dangerous-looking parts of the diff — a file swapped between validation and read, a Graph rejection reported as "Reply sent" — were the parts I had been careful about. The bug was in the part that looked like tidiness: giving `reply()` the same parameter tail as `send()` silently repurposed `reply()`'s third positional argument, which had been `send_at` since it shipped.

## Changes Made

- `connectonion/useful_tools/outlook.py` — extract `_encoded_attachments()` and `_attachment_suffix()` out of `send()` and reuse both in `reply()`; put `fileAttachments` on the reply action's `message` alongside the deferred-send property; signature is now `reply(email_id, body, send_at=None, *, attachments=None)`.
- `connectonion/cli/commands/outlook_commands.py` — `handle_outlook_reply(email_id, message, at=None, *, attachments=None)` precheck attachments via the shared `_check_attachments()` before anything is encoded, and print the attached names on success.
- `connectonion/cli/main.py` — repeatable `--attach` / `-a` on `co outlook reply`, plus an examples epilog.
- `docs/cli/outlook.md`, `docs/useful_tools/outlook.md`, `docs/integrations/microsoft.md` — document the flag, the keyword-only argument, and that attachments and `--at` combine.
- `docs/blog/2026-08-15-the-third-argument-was-already-taken.md` — dev-blog post.
- `tests/unit/test_outlook.py`, `tests/unit/test_outlook_commands.py`, `tests/e2e/cli/test_cli_outlook_reply.py` — attachment behavior, failure paths, CLI routing, and the positional-compatibility regressions.

No dependencies added.

## Testing

```
$ pytest tests/ -m "not slow and not real_api and not network"
7421 passed, 20 skipped, 201 deselected, 7 warnings in 306.23s (0:05:06)
```

Targeted run of the three affected files:

```
$ pytest tests/unit/test_outlook.py tests/unit/test_outlook_commands.py tests/e2e/cli/test_cli_outlook_reply.py -q
95 passed in 3.20s
```

- [x] I have added tests for new functionality

## Scope

- `useful_tools/outlook.py` — the Graph call that has to carry the files.
- `cli/commands/outlook_commands.py` and `cli/main.py` — the CLI surface that reaches it; the flag and its precheck.
- `docs/` — the flag and signature are user-facing.
- `tests/` — the behavior and the compatibility contract.

One concern: attachments on `co outlook reply`.

## Example Usage

```bash
co outlook reply 3 "Signed copy attached." --attach signed.pdf --attach cover.png
co outlook reply 3 "Tomorrow" -a report.pdf --at +2h
```

```python
from connectonion import Outlook

outlook = Outlook()
outlook.reply(email_id, "Signed copy attached.", attachments=["signed.pdf"])

# send_at keeps its position from before attachments existed
outlook.reply(email_id, "See you then", "2026-07-06T15:30:00Z")
```

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Live-tenant smoke run

The Graph request shape is no longer only mocked. Against live Graph from a personal Microsoft account backed by Outlook.com:

- **one attachment** — `co outlook reply <id> "…" -a smoke-one.txt` → sent; the recipient's copy carries `smoke-one.txt`.
- **multiple attachments** — `-a smoke-one.txt -a smoke-two.csv` → sent; the recipient's copy carries `smoke-one.txt` (32B, `text/plain`) and `smoke-two.csv` (19B, `text/csv`).
- **scheduled with an attachment** — `-a smoke-one.txt --at +30m` → Exchange holds it as a deferred draft *with* the file, and `get_scheduled()` lists it. Attachments and the `SystemTime 0x3FEF` property coexist on one `message` in a single POST, which is exactly the shape this PR had assumed.
- **threading** — every reply's `conversationId` equals the original's, and delivered mail quotes the original and threads under it rather than arriving as a new message.
- **legacy positional call** — `reply(email_id, body, "2026-08-15T14:19:39Z")` schedules and attaches nothing. On the pre-fix signature this same call raised `ValueError: Attachment not found: 2`.

Limits of that run are recorded in "How this was written" above: personal account rather than an Exchange Online work/school tenant, and the deferred replies were cancelled rather than left to fire. One display anomaly is also worth flagging — a recipient mail client rendered the single-attachment reply as "2 attachments", listing the same file twice, while the raw MIME we sent contains exactly one `Content-Disposition: attachment` part and Graph's own attachment collection for that message returns one. I could not reproduce or explain the client's rendering.

Tests, CodeQL, and blog-gate are at `action_required` rather than failing: as a fork PR, the runs need a maintainer to approve them. `POST /actions/runs/<id>/approve` returns `403 Must have admin rights to Repository` for me.
