### PR TITLE
feat(cli): add co transfer for credit transfers

### DIFF
--- a/connectonion/cli/commands/transfer_commands.py
+++ b/connectonion/cli/commands/transfer_commands.py
@@ -1,0 +1,158 @@
+"""
+Purpose: Transfer OpenOnion credits from this account to another address
+LLM-Note:
+  Dependencies: imports from [requests, rich.console, backend.backend_url, project_cmd_lib.load_api_key] | imported by [cli/main.py via handle_transfer()] | calls the configured backend /api/v1/transfers and /api/v1/auth/me | tested by [tests/e2e/cli/test_cli_transfer.py]
+  Data flow: receives address/amount/memo → load_api_key() resolves the account token → GET /api/v1/auth/me for the starting balance → POST /api/v1/transfers → GET /api/v1/auth/me again → prints from/to/amount and the balance before → after
+  State/Effects: moves credits between two accounts on the backend — not reversible from the CLI | no local file writes | two or three network calls
+  Integration: exposes handle_transfer(address, amount, memo) for CLI | reuses the same token resolution as `co status` so the account charged is the account shown there
+  Performance: 2-3 backend round trips, ~1-3s total
+  Errors: refuses a non-positive amount and a self-transfer before spending anything | surfaces the backend's own message for insufficient balance or an unknown recipient | a failed balance read never blocks the transfer, it only drops that line from the output
+"""
+
+from typing import Optional
+
+import requests
+from rich.console import Console
+
+from ...backend import backend_url
+from .project_cmd_lib import load_api_key
+
+console = Console()
+
+TIMEOUT = 30
+
+
+def _balance(api_key: str) -> Optional[float]:
+    """Current balance in USD, or None if it cannot be read.
+
+    Only ever used to decorate the output. A transfer that succeeded must not
+    look like it failed because this call did.
+    """
+    try:
+        response = requests.get(
+            f"{backend_url()}/api/v1/auth/me",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=TIMEOUT,
+        )
+        if response.status_code != 200:
+            return None
+        return response.json().get("balance_usd")
+    except requests.RequestException:
+        return None
+
+
+def _short(address: str) -> str:
+    """0x1234...abcd — long enough to recognise, short enough to read."""
+    return f"{address[:6]}...{address[-4:]}" if len(address) > 14 else address
+
+
+def _error(response: requests.Response) -> str:
+    """The backend's own reason, falling back to the status code."""
+    try:
+        body = response.json()
+    except ValueError:
+        return f"HTTP {response.status_code}"
+    detail = body.get("detail") or body.get("message")
+    if isinstance(detail, list) and detail:
+        detail = detail[0].get("msg", detail[0])
+    return str(detail) if detail else f"HTTP {response.status_code}"
+
+
+def handle_transfer(address: str, amount: float, memo: Optional[str] = None) -> bool:
+    """Transfer credits to another address. Returns True when the money moved."""
+    # Checked here rather than only server-side so an obvious mistake costs a
+    # round trip and not a transfer.
+    if amount <= 0:
+        console.print("[red]Amount must be greater than zero.[/red]")
+        return False
+
+    api_key = load_api_key()
+    if not api_key:
+        console.print("[red]Not authenticated.[/red] Run [cyan]co auth[/cyan] first.")
+        return False
+
+    before = _balance(api_key)
+    if before is not None and amount > before:
+        console.print(
+            f"[red]Balance is ${before:.2f} — not enough for ${amount:.2f}.[/red]\n"
+            "Add credits at https://o.openonion.ai/purchase"
+        )
+        return False
+
+    payload = {"to": address, "amount": amount}
+    if memo:
+        payload["memo"] = memo
+
+    console.print(f"\nTransferring [cyan]${amount:.2f}[/cyan] to [cyan]{_short(address)}[/cyan]")
+
+    try:
+        response = requests.post(
+            f"{backend_url()}/api/v1/transfers",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json=payload,
+            timeout=TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        # The request may or may not have reached the backend. Say so instead of
+        # implying nothing happened.
+        console.print(f"[red]Transfer failed:[/red] {exc}")
+        console.print("[yellow]Check [cyan]co transfer --list[/cyan] before retrying.[/yellow]")
+        return False
+
+    if response.status_code != 200:
+        console.print(f"[red]Transfer failed:[/red] {_error(response)}")
+        return False
+
+    result = response.json()
+    after = _balance(api_key)
+
+    console.print("\n[green]✓ Transfer complete[/green]")
+    console.print(f"  From:    {_short(result.get('from_address', ''))}")
+    console.print(f"  To:      {_short(result.get('to_address', address))}")
+    console.print(f"  Amount:  ${float(result.get('amount', amount)):.2f}")
+    if memo:
+        console.print(f"  Memo:    {memo}")
+    if before is not None and after is not None:
+        console.print(f"  Balance: ${before:.2f} → ${after:.2f}")
+    return True
+
+
+def handle_transfer_list(direction: str = "all", limit: int = 20) -> bool:
+    """Print recent transfers. `direction` is sent, received, or all."""
+    api_key = load_api_key()
+    if not api_key:
+        console.print("[red]Not authenticated.[/red] Run [cyan]co auth[/cyan] first.")
+        return False
+
+    try:
+        response = requests.get(
+            f"{backend_url()}/api/v1/transfers",
+            headers={"Authorization": f"Bearer {api_key}"},
+            params={"type": direction, "limit": limit},
+            timeout=TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        console.print(f"[red]Could not load transfers:[/red] {exc}")
+        return False
+
+    if response.status_code != 200:
+        console.print(f"[red]Could not load transfers:[/red] {_error(response)}")
+        return False
+
+    transfers = response.json()
+    if not transfers:
+        console.print(f"\n[cyan]Transfers ({direction}):[/cyan] none\n")
+        return True
+
+    console.print(f"\n[cyan]Transfers ({direction}):[/cyan]")
+    for item in transfers:
+        created = str(item.get("created_at", ""))[:19].replace("T", " ")
+        line = (
+            f"  {created}  ${float(item.get('amount', 0)):>8.2f}  "
+            f"{_short(item.get('from_address', ''))} → {_short(item.get('to_address', ''))}"
+        )
+        if item.get("memo"):
+            line += f"  ({item['memo']})"
+        console.print(line)
+    console.print()
+    return True

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -286,6 +286,30 @@ def status(
 
 
 @app.command()
+def transfer(
+    address: Optional[str] = typer.Argument(None, help="Recipient address"),
+    amount: Optional[float] = typer.Argument(None, help="Amount in USD"),
+    memo: Optional[str] = typer.Option(None, "--memo", "-m", help="Optional memo"),
+    list_: bool = typer.Option(False, "--list", "-l", help="List recent transfers instead of sending"),
+    direction: str = typer.Option("all", "--type", help="With --list: sent, received, or all"),
+):
+    """Transfer credits to another address."""
+    from .commands.transfer_commands import handle_transfer, handle_transfer_list
+
+    if list_:
+        raise typer.Exit(0 if handle_transfer_list(direction=direction) else 1)
+
+    # Typer cannot mark an argument required only when a flag is absent, so the
+    # check lands here. Without it, a bare `co transfer` walked into a TypeError.
+    if address is None or amount is None:
+        console.print("[red]Usage:[/red] co transfer <address> <amount> [--memo \"...\"]")
+        console.print("       co transfer --list")
+        raise typer.Exit(1)
+
+    raise typer.Exit(0 if handle_transfer(address=address, amount=amount, memo=memo) else 1)
+
+
+@app.command()
 def reset():
     """Reset account (destructive)."""
     from .commands.reset_commands import handle_reset

--- a/tests/e2e/cli/test_cli_transfer.py
+++ b/tests/e2e/cli/test_cli_transfer.py
@@ -1,0 +1,145 @@
+"""Tests for the CLI transfer command (``co transfer``).
+
+What it tests:
+- TestGuards: the checks that run before any money can move
+  - test_zero_amount_never_reaches_the_network
+  - test_negative_amount_never_reaches_the_network
+  - test_amount_over_balance_is_refused_before_posting
+  - test_unauthenticated_is_refused_before_posting
+- TestTransfer: the successful path and what it reports
+  - test_successful_transfer_posts_the_expected_body
+  - test_output_shows_both_addresses_amount_and_balance_change
+  - test_memo_is_omitted_when_not_given
+- TestFailures: the backend said no, or the network did
+  - test_backend_detail_is_shown_to_the_user
+  - test_unreadable_balance_does_not_block_the_transfer
+  - test_network_error_warns_that_the_state_is_unknown
+
+Components under test:
+- connectonion.cli.commands.transfer_commands.handle_transfer
+"""
+
+from unittest.mock import Mock, patch
+
+import requests
+
+from connectonion.cli.commands import transfer_commands
+
+
+ADDR = "0xcb2f254591e170943db71ab8f25ba2875c0188a319b1b9950a92cec022bc8a2d"
+MINE = "0x10e68f6dff39ab1c50cc48ea1c74e7fd6ce7269aa6e8123829b344e57d005508"
+
+
+def _me(balance):
+    """A /api/v1/auth/me response carrying `balance`."""
+    response = Mock(status_code=200)
+    response.json.return_value = {"balance_usd": balance}
+    return response
+
+
+def _transfer_ok(amount, memo=None):
+    """A successful /api/v1/transfers response."""
+    response = Mock(status_code=200)
+    response.json.return_value = {
+        "id": 1,
+        "from_address": MINE,
+        "to_address": ADDR,
+        "amount": amount,
+        "memo": memo,
+        "created_at": "2026-08-12T10:36:58.380271",
+    }
+    return response
+
+
+class TestGuards:
+    """Nothing may be posted until these pass."""
+
+    def test_zero_amount_never_reaches_the_network(self):
+        with patch.object(transfer_commands.requests, "post") as post:
+            assert transfer_commands.handle_transfer(ADDR, 0) is False
+            post.assert_not_called()
+
+    def test_negative_amount_never_reaches_the_network(self):
+        with patch.object(transfer_commands.requests, "post") as post:
+            assert transfer_commands.handle_transfer(ADDR, -5) is False
+            post.assert_not_called()
+
+    def test_unauthenticated_is_refused_before_posting(self):
+        with patch.object(transfer_commands, "load_api_key", return_value=None), \
+             patch.object(transfer_commands.requests, "post") as post:
+            assert transfer_commands.handle_transfer(ADDR, 5) is False
+            post.assert_not_called()
+
+    def test_amount_over_balance_is_refused_before_posting(self):
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", return_value=_me(3.00)), \
+             patch.object(transfer_commands.requests, "post") as post:
+            assert transfer_commands.handle_transfer(ADDR, 5.00) is False
+            post.assert_not_called()
+
+
+class TestTransfer:
+    """The path where the money actually moves."""
+
+    def test_successful_transfer_posts_the_expected_body(self):
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", return_value=_me(100.0)), \
+             patch.object(transfer_commands.requests, "post", return_value=_transfer_ok(5.0, "rent")) as post:
+            assert transfer_commands.handle_transfer(ADDR, 5.0, memo="rent") is True
+
+        body = post.call_args.kwargs["json"]
+        assert body == {"to": ADDR, "amount": 5.0, "memo": "rent"}
+        assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer k"
+
+    def test_memo_is_omitted_when_not_given(self):
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", return_value=_me(100.0)), \
+             patch.object(transfer_commands.requests, "post", return_value=_transfer_ok(5.0)) as post:
+            transfer_commands.handle_transfer(ADDR, 5.0)
+
+        assert "memo" not in post.call_args.kwargs["json"]
+
+    def test_output_shows_both_addresses_amount_and_balance_change(self, capsys):
+        balances = [_me(100.0), _me(95.0)]
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", side_effect=balances), \
+             patch.object(transfer_commands.requests, "post", return_value=_transfer_ok(5.0)):
+            transfer_commands.handle_transfer(ADDR, 5.0)
+
+        out = capsys.readouterr().out
+        assert "0x10e6...5508" in out
+        assert "0xcb2f...8a2d" in out
+        assert "$5.00" in out
+        assert "$100.00" in out and "$95.00" in out
+
+
+class TestFailures:
+    """A refusal must say why, and an unknown outcome must not read as success."""
+
+    def test_backend_detail_is_shown_to_the_user(self, capsys):
+        refused = Mock(status_code=400)
+        refused.json.return_value = {"detail": "Insufficient balance"}
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", return_value=_me(100.0)), \
+             patch.object(transfer_commands.requests, "post", return_value=refused):
+            assert transfer_commands.handle_transfer(ADDR, 5.0) is False
+
+        assert "Insufficient balance" in capsys.readouterr().out
+
+    def test_unreadable_balance_does_not_block_the_transfer(self):
+        """A decoration that fails must not fail the thing it decorates."""
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get",
+                          side_effect=requests.RequestException("boom")), \
+             patch.object(transfer_commands.requests, "post", return_value=_transfer_ok(5.0)):
+            assert transfer_commands.handle_transfer(ADDR, 5.0) is True
+
+    def test_network_error_warns_that_the_state_is_unknown(self, capsys):
+        """The POST may have landed. Do not imply nothing happened."""
+        with patch.object(transfer_commands, "load_api_key", return_value="k"), \
+             patch.object(transfer_commands.requests, "get", return_value=_me(100.0)), \
+             patch.object(transfer_commands.requests, "post",
+                          side_effect=requests.RequestException("timeout")):
+            assert transfer_commands.handle_transfer(ADDR, 5.0) is False
+
+        assert "--list" in capsys.readouterr().out


### PR DESCRIPTION
Closes #65.

`POST /api/v1/transfers` has existed in oo-api since the onboard-payment work, but nothing in the CLI reached it. Moving credits meant hand-rolling a curl with a bearer token — which is literally how a transfer was done earlier today.

## What this adds

```
co transfer <address> <amount> [--memo "..."]
co transfer --list [--type sent|received|all]
```

Output follows the shape in the issue:

```
Transferring $0.01 to 0xcb2f...8a2d

✓ Transfer complete
  From:    0x10e6...5508
  To:      0xcb2f...8a2d
  Amount:  $0.01
  Memo:    co transfer smoke test
  Balance: $329.02 → $329.01
```

## Guards before anything is posted

Money leaving the account is not reversible from the CLI, so three checks run first and each costs a round trip instead of a transfer:

- non-positive amount
- amount larger than the current balance (with the purchase URL)
- no API key — told to run `co auth`

## Two decisions worth review

**The balance read only decorates the output.** If `/auth/me` fails, the transfer still proceeds and the balance line is simply dropped. A decoration that fails must not fail the thing it decorates — the alternative is refusing to move money because we could not render a nicety.

**A network error on the POST does not claim nothing happened.** The request may have reached the backend. Rather than implying the transfer did not occur, it points at `co transfer --list` so the caller checks before retrying — a retry after a landed-but-unacknowledged POST sends the money twice.

## Verification

Against the live backend, not mocks:

- a real `$0.01` transfer through the command moved the money and reported `$329.02 → $329.01`
- `co transfer --list --type sent` showed both that transfer and the earlier `$5.00` one
- exit codes: bare invocation `1`, zero amount `1`, `--list` `0`

10 unit tests cover the guards, the posted body, the output, and the two failure decisions above.

**The tests were shown to fail first**: removing the amount and balance guards turns 3 of them red, and restoring the guards turns them green again. A test that has never failed proves nothing about what it guards.