### PR TITLE
feat: add authenticated ACP WebSocket gateway

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -1650,6 +1650,27 @@ class ConnectOnionACPAgent:
         return "\n\n".join(parts)
 
 
+def create_acp_agent(
+    *,
+    model: str,
+    max_iterations: int,
+    yolo: bool,
+    yolo_turns: int,
+    session_co_dir: Path | None = None,
+    allow_mcp: bool = False,
+) -> ConnectOnionACPAgent:
+    """Build the shared ACP lifecycle adapter for stdio or network transport."""
+
+    return ConnectOnionACPAgent(
+        model=model,
+        max_iterations=max_iterations,
+        yolo=yolo,
+        yolo_turns=yolo_turns,
+        session_co_dir=session_co_dir,
+        allow_mcp=allow_mcp,
+    )
+
+
 async def serve_acp(
     *,
     model: str,
@@ -1661,7 +1682,7 @@ async def serve_acp(
     """Serve ``co ai`` as an ACP v1 Agent until the client closes stdin."""
 
     transport = await open_stdio_transport()
-    agent = ConnectOnionACPAgent(
+    agent = create_acp_agent(
         model=model,
         max_iterations=max_iterations,
         yolo=yolo,

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -9,24 +9,23 @@ This file provides the `start_server()` function that:
 Architecture:
 - Uses one hosted coding agent for the web chat session
 - Trust level set to "careful" for web deployment
-- Auto-approve mode for web usage (no terminal prompts)
+- Host-acknowledged permission profiles for network sessions
 
 Used by:
 - CLI command: `co ai` (see cli/main.py)
 - Web chat interface at chat.openonion.ai
 """
 
+import hashlib
 import logging
-import webbrowser
 import threading
 import time
+import webbrowser
 from pathlib import Path
-from connectonion import host, address
 
-logging.basicConfig(
-    level=logging.WARNING,
-    format='[%(levelname)s] %(name)s: %(message)s'
-)
+from connectonion import address, host
+
+logging.basicConfig(level=logging.WARNING, format="[%(levelname)s] %(name)s: %(message)s")
 
 
 # Note: .env files already loaded by __init__.py with fallback chain:
@@ -38,12 +37,21 @@ logging.basicConfig(
 def start_server(
     agent,
     port: int = 8000,
+    *,
+    model: str | None = None,
+    max_iterations: int | None = None,
+    yolo: bool = False,
+    yolo_turns: int = 100,
 ):
     """Start AI coding agent web server.
 
     Args:
         agent: Agent instance to host
         port: Port to run server on
+        model: Model for per-connection ACP coding agents
+        max_iterations: Tool iteration limit for ACP coding agents
+        yolo: Whether an administrator may select bounded Full access
+        yolo_turns: Maximum Full access turns before a checkpoint
 
     The server will be accessible at:
     - POST http://localhost:{port}/input
@@ -52,18 +60,60 @@ def start_server(
     - GET http://localhost:{port}/info
     """
     # Use global ~/.co/ for consistent identity across all co ai sessions
-    co_dir = Path.home() / '.co'
+    co_dir = Path.home() / ".co"
     addr_data = address.load(co_dir)
 
     # Open chat URL after agent successfully starts (2 second delay)
     if addr_data:
+
         def open_chat_delayed():
             time.sleep(2)
             webbrowser.open(f"https://chat.openonion.ai/{addr_data['address']}")
 
         threading.Thread(target=open_chat_delayed, daemon=True).start()
 
+    # ACP needs one isolated lifecycle adapter per authenticated connection.
+    # The existing /ws web client remains available during its native-ACP
+    # migration; both doors share the host's signature and trust boundary.
+    from .acp_server import create_acp_agent
+
+    acp_model = model or getattr(getattr(agent, "llm", None), "model", None)
+    acp_model = acp_model or "co/claude-opus-4-5"
+    acp_max_iterations = max_iterations if max_iterations is not None else getattr(agent, "max_iterations", 100)
+
+    def create_network_acp_agent(principal):
+        # A session ID is a routing value, never a credential. Keep persistent
+        # network sessions in a stable namespace selected only from the
+        # authenticated connection principal so copied IDs cross no boundary.
+        owner = "\0".join(
+            (
+                "v1",
+                principal.recipient,
+                principal.address,
+                principal.origin or "",
+                principal.auth_method,
+            )
+        )
+        owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()
+        session_co_dir = co_dir / "acp-principals" / owner_id
+        return create_acp_agent(
+            model=acp_model,
+            max_iterations=acp_max_iterations,
+            # --yolo is an operator ceiling, not authority delegated to every
+            # trusted remote caller. Only the authenticated administrator can
+            # receive the Full access profile on this direct endpoint.
+            yolo=yolo and principal.level == "admin",
+            yolo_turns=yolo_turns,
+            session_co_dir=session_co_dir,
+        )
+
     # Start server with same co_dir (relay enabled by default for web chat).
     # co ai keeps one Agent instance so browser/tool state can persist across
     # continued inputs in the same local web server.
-    host(agent, port=port, trust="careful", co_dir=co_dir)
+    host(
+        agent,
+        port=port,
+        trust="careful",
+        co_dir=co_dir,
+        acp_agent_factory=create_network_acp_agent,
+    )

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -93,7 +93,14 @@ def handle_ai(
         _handle_plain_one_shot(agent, prompt)
     else:
         from ..co_ai.main import start_server
-        start_server(agent, port=port)
+        start_server(
+            agent,
+            port=port,
+            model=model,
+            max_iterations=max_iterations,
+            yolo=yolo,
+            yolo_turns=yolo_turns,
+        )
 
 
 def _create_agent(model, max_iterations, yolo, yolo_turns, *, resumable=False):

--- a/connectonion/network/asgi/__init__.py
+++ b/connectonion/network/asgi/__init__.py
@@ -13,12 +13,14 @@ Raw ASGI instead of Starlette/FastAPI for full protocol control.
 Supports ASGI lifespan for startup/shutdown hooks (relay connection).
 """
 
+import logging
 import time
-import asyncio
-from typing import Callable, Awaitable
+from typing import Awaitable, Callable
 
-from .http import send_json, send_html, send_text, read_body, CORS_HEADERS
+from .http import CORS_HEADERS, read_body, send_html, send_json, send_text
 from .websocket import handle_websocket
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(
@@ -31,6 +33,7 @@ def create_app(
     blacklist: list | None = None,
     whitelist: list | None = None,
     http=None,
+    acp=None,
     on_startup: Callable[[], Awaitable[None]] | None = None,
     on_shutdown: Callable[[], Awaitable[None]] | None = None,
 ):
@@ -46,6 +49,7 @@ def create_app(
         whitelist: Allowed identities
         on_startup: Async function to run on startup (e.g., start relay connection)
         on_shutdown: Async function to run on shutdown (e.g., close relay connection)
+        acp: Optional authenticated ACP ASGI sub-application mounted at /acp
 
     Returns:
         ASGI application callable
@@ -70,13 +74,23 @@ def create_app(
                         return
                 elif message["type"] == "lifespan.shutdown":
                     try:
-                        if on_shutdown:
-                            await on_shutdown()
+                        try:
+                            if acp is not None:
+                                await acp.close()
+                        finally:
+                            if on_shutdown:
+                                await on_shutdown()
                         await send({"type": "lifespan.shutdown.complete"})
                     except Exception:
+                        logger.exception("ASGI shutdown cleanup failed")
                         await send({"type": "lifespan.shutdown.complete"})
                     return
 
+        elif acp is not None and (
+            (scope["type"] == "websocket" and scope.get("path") == "/acp")
+            or (scope["type"] == "http" and scope.get("path") in ("/acp", "/acp/authorize"))
+        ):
+            await acp(scope, receive, send)
         elif scope["type"] == "http":
             await handle_http(
                 scope,

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -1,0 +1,1055 @@
+"""Authenticated ACP v1 WebSocket gateway for hosted agents.
+
+ACP defines the agent/client conversation.  ConnectOnion still owns admission:
+caller signatures, recipient binding, replay protection, trust policy, and
+browser-origin checks all run before an ACP Agent is constructed.
+
+The first remote profile is deliberately WebSocket-only.  Uvicorn does not
+serve the HTTP/2 required by ACP Streamable HTTP, while ACP's remote transport
+allows a server to offer WebSocket alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import ipaddress
+import json
+import logging
+import math
+import secrets
+import time
+import uuid
+from collections import deque
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Iterable
+from urllib.parse import urlsplit
+
+from acp.agent.connection import AgentSideConnection
+from acp.schema import InitializeRequest
+from pydantic import ValidationError
+
+from .auth import _authenticate_signed, request_from_http_headers
+from .replay import ReplayProtectionError
+
+logger = logging.getLogger(__name__)
+
+ACP_PATH = "/acp"
+ACP_AUTHORIZE_PATH = "/acp/authorize"
+ACP_SUBPROTOCOL = "acp"
+TICKET_SUBPROTOCOL_PREFIX = "connectonion.ticket."
+DEFAULT_ACP_ORIGINS = ("https://chat.openonion.ai",)
+DEFAULT_TICKET_TTL_SECONDS = 60
+DEFAULT_INITIALIZE_TIMEOUT_SECONDS = 10
+DEFAULT_MAX_CONNECTIONS = 16
+DEFAULT_MAX_CONNECTIONS_PER_PRINCIPAL = 2
+DEFAULT_ADMISSIONS_PER_MINUTE = 30
+DEFAULT_RATE_LIMIT_PRINCIPALS = 1024
+ACP_QUEUE_MESSAGES = 8
+MAX_AUTHORIZATION_BODY_BYTES = 16 * 1024
+MAX_ACP_MESSAGE_BYTES = 1024 * 1024
+MAX_INVITE_CODE_LENGTH = 512
+
+_CORS_REQUEST_HEADERS = "content-type,x-co-from,x-co-signature,x-co-timestamp,x-co-to,x-co-request-id"
+_CORS_REQUEST_HEADER_NAMES = frozenset(_CORS_REQUEST_HEADERS.split(","))
+_UNIQUE_SECURITY_HEADERS = _CORS_REQUEST_HEADER_NAMES | frozenset(
+    {
+        "origin",
+        "host",
+        "content-type",
+        "access-control-request-method",
+        "access-control-request-headers",
+        "access-control-request-private-network",
+    }
+)
+_IGNORED_WEBSOCKET_FRAME = object()
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+def _payment_is_valid(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return False
+    try:
+        return math.isfinite(float(value))
+    except OverflowError:
+        return False
+
+
+@dataclass(frozen=True)
+class ACPPrincipal:
+    """Verified identity attached to one admitted ACP connection."""
+
+    address: str
+    level: str
+    recipient: str
+    origin: str | None
+    auth_method: str
+    authenticated_at: float
+
+
+@dataclass(frozen=True)
+class _TicketRecord:
+    principal: ACPPrincipal
+    expires_at: float
+
+
+class ACPTicketRegistry:
+    """Short-lived, single-use browser tickets stored only as SHA-256 digests."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int = DEFAULT_TICKET_TTL_SECONDS,
+        max_pending: int = 256,
+        max_pending_per_principal: int = 8,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.ttl_seconds = ttl_seconds
+        self.max_pending = max_pending
+        self.max_pending_per_principal = max_pending_per_principal
+        self._clock = clock
+        self._records: dict[bytes, _TicketRecord] = {}
+
+    @staticmethod
+    def _digest(ticket: str) -> bytes:
+        return hashlib.sha256(ticket.encode("utf-8")).digest()
+
+    def _drop_expired(self, now: float) -> None:
+        for digest in [digest for digest, record in self._records.items() if record.expires_at <= now]:
+            del self._records[digest]
+
+    def issue(self, principal: ACPPrincipal) -> str:
+        now = self._clock()
+        self._drop_expired(now)
+        if len(self._records) >= self.max_pending:
+            raise RuntimeError("too many pending ACP authorization tickets")
+        owner = (
+            principal.recipient,
+            principal.address,
+            principal.origin,
+            principal.auth_method,
+        )
+        if (
+            sum(
+                (
+                    record.principal.recipient,
+                    record.principal.address,
+                    record.principal.origin,
+                    record.principal.auth_method,
+                )
+                == owner
+                for record in self._records.values()
+            )
+            >= self.max_pending_per_principal
+        ):
+            raise RuntimeError("too many pending ACP authorization tickets")
+        ticket = secrets.token_urlsafe(32)
+        self._records[self._digest(ticket)] = _TicketRecord(
+            principal=principal,
+            expires_at=now + self.ttl_seconds,
+        )
+        return ticket
+
+    def consume(self, ticket: str, *, origin: str | None) -> ACPPrincipal | None:
+        """Consume once.  A mismatched-origin attempt also burns the ticket."""
+
+        now = self._clock()
+        self._drop_expired(now)
+        record = self._records.pop(self._digest(ticket), None)
+        if record is None or record.expires_at <= now:
+            return None
+        if record.principal.origin != origin:
+            return None
+        return record.principal
+
+
+class ACPAdmissionRateLimiter:
+    """Bound verified admission attempts without retaining unbounded identities."""
+
+    def __init__(
+        self,
+        *,
+        limit: int = DEFAULT_ADMISSIONS_PER_MINUTE,
+        window_seconds: float = 60.0,
+        max_principals: int = DEFAULT_RATE_LIMIT_PRINCIPALS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self.max_principals = max_principals
+        self._clock = clock
+        self._attempts: dict[
+            tuple[str, str, str | None, str],
+            deque[float],
+        ] = {}
+
+    @staticmethod
+    def _key(principal: ACPPrincipal) -> tuple[str, str, str | None, str]:
+        return (
+            principal.recipient,
+            principal.address,
+            principal.origin,
+            principal.auth_method,
+        )
+
+    def allow(self, principal: ACPPrincipal) -> bool:
+        now = self._clock()
+        cutoff = now - self.window_seconds
+        for key in list(self._attempts):
+            attempts = self._attempts[key]
+            while attempts and attempts[0] <= cutoff:
+                attempts.popleft()
+            if not attempts:
+                del self._attempts[key]
+
+        key = self._key(principal)
+        attempts = self._attempts.get(key)
+        if attempts is None:
+            if len(self._attempts) >= self.max_principals:
+                return False
+            attempts = deque()
+            self._attempts[key] = attempts
+        if len(attempts) >= self.limit:
+            return False
+        attempts.append(now)
+        return True
+
+
+class _ACPTransport:
+    """Message transport joining AgentSideConnection to one ASGI WebSocket."""
+
+    def __init__(self) -> None:
+        self._to_agent: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=ACP_QUEUE_MESSAGES)
+        self._to_client: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=ACP_QUEUE_MESSAGES)
+        self._closed = False
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._closed:
+            raise ConnectionError("ACP WebSocket transport is closed")
+        await self._to_client.put(dict(message))
+
+    async def receive(self) -> dict[str, Any] | None:
+        return await self._to_agent.get()
+
+    async def feed(self, message: dict[str, Any]) -> None:
+        if self._closed:
+            raise ConnectionError("ACP WebSocket transport is closed")
+        await self._to_agent.put(message)
+
+    async def next_outgoing(self) -> dict[str, Any] | None:
+        return await self._to_client.get()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._put_eof(self._to_agent)
+        self._put_eof(self._to_client)
+
+    @staticmethod
+    def _put_eof(queue: asyncio.Queue) -> None:
+        while True:
+            try:
+                queue.put_nowait(None)
+                return
+            except asyncio.QueueFull:
+                with suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+
+
+ACPAgentFactory = Callable[[ACPPrincipal], Any]
+ReplayCheck = Callable[[dict[str, Any]], bool]
+
+
+class AuthenticatedACPApp:
+    """ASGI sub-application for signed ACP admission and WebSocket transport."""
+
+    def __init__(
+        self,
+        agent_factory: ACPAgentFactory,
+        *,
+        trust_agent: Any,
+        recipient_address: str,
+        replay_check: ReplayCheck,
+        allowed_origins: Iterable[str] = DEFAULT_ACP_ORIGINS,
+        blacklist: Iterable[str] | None = None,
+        whitelist: Iterable[str] | None = None,
+        tickets: ACPTicketRegistry | None = None,
+        rate_limiter: ACPAdmissionRateLimiter | None = None,
+        initialize_timeout_seconds: float = DEFAULT_INITIALIZE_TIMEOUT_SECONDS,
+        max_connections: int = DEFAULT_MAX_CONNECTIONS,
+        max_connections_per_principal: int = DEFAULT_MAX_CONNECTIONS_PER_PRINCIPAL,
+    ) -> None:
+        self._agent_factory = agent_factory
+        self._trust_agent = trust_agent
+        self._recipient_address = recipient_address
+        self._replay_check = replay_check
+        self._allowed_origins = frozenset(allowed_origins)
+        self._blacklist = set(blacklist or ())
+        self._whitelist = set(whitelist or ())
+        self._tickets = tickets or ACPTicketRegistry()
+        self._rate_limiter = rate_limiter or ACPAdmissionRateLimiter()
+        self._initialize_timeout_seconds = initialize_timeout_seconds
+        self._max_connections = max_connections
+        self._max_connections_per_principal = max_connections_per_principal
+        self._connection_tasks: set[asyncio.Task] = set()
+        self._active_principals: dict[tuple[str, str, str | None, str], int] = {}
+
+    async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        if scope["type"] == "websocket":
+            await self._handle_websocket(scope, receive, send)
+            return
+        if scope["type"] != "http":
+            return
+
+        path = scope.get("path", "")
+        method = scope.get("method", "GET").upper()
+        if path == ACP_AUTHORIZE_PATH:
+            if method == "OPTIONS":
+                await self._handle_options(scope, send)
+            elif method == "POST":
+                await self._handle_authorize(scope, receive, send)
+            else:
+                await self._send_json(send, 405, {"error": "Method not allowed"})
+            return
+
+        # This release advertises only the transport Uvicorn can serve without
+        # pretending HTTP/1.1 is ACP's HTTP/2 Streamable HTTP profile.
+        await self._send_json(
+            send,
+            426,
+            {
+                "error": "ACP Streamable HTTP is not enabled",
+                "transport": "websocket",
+                "path": ACP_PATH,
+            },
+            extra_headers=[(b"upgrade", b"websocket")],
+        )
+
+    async def close(self) -> None:
+        """Cancel active ACP sockets during the host lifespan shutdown."""
+
+        current = asyncio.current_task()
+        tasks = [task for task in self._connection_tasks if task is not current]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _handle_options(self, scope: dict, send: Callable) -> None:
+        if self._has_ambiguous_security_headers(scope):
+            await self._send_json(send, 400, {"error": "Ambiguous security headers"})
+            return
+        origin = self._origin(scope)
+        if not self._origin_allowed(origin):
+            await self._send_json(send, 403, {"error": "Origin not allowed"})
+            return
+        headers = self._headers(scope)
+        requested_method = headers.get("access-control-request-method", "").upper()
+        if requested_method != "POST":
+            await self._send_json(
+                send,
+                400,
+                {"error": "CORS preflight must request POST"},
+                origin=origin,
+            )
+            return
+        requested_headers = {
+            item.strip().lower()
+            for item in headers.get("access-control-request-headers", "").split(",")
+            if item.strip()
+        }
+        if not requested_headers.issubset(_CORS_REQUEST_HEADER_NAMES):
+            await self._send_json(
+                send,
+                400,
+                {"error": "CORS preflight requested unsupported headers"},
+                origin=origin,
+            )
+            return
+        response_headers = self._cors_headers(origin)
+        if headers.get("access-control-request-private-network", "").lower() == "true":
+            response_headers.append((b"access-control-allow-private-network", b"true"))
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": response_headers,
+            }
+        )
+        await send({"type": "http.response.body", "body": b""})
+
+    async def _handle_authorize(
+        self,
+        scope: dict,
+        receive: Callable,
+        send: Callable,
+    ) -> None:
+        if self._has_ambiguous_security_headers(scope):
+            await self._send_json(send, 400, {"error": "Ambiguous security headers"})
+            return
+        origin = self._origin(scope)
+        if not self._origin_allowed(origin):
+            await self._send_json(send, 403, {"error": "Origin not allowed"})
+            return
+        if not self._transport_is_secure(scope):
+            await self._send_json(
+                send,
+                403,
+                {"error": "Secure transport is required for non-loopback ACP"},
+                origin=origin,
+            )
+            return
+        content_type = self._headers(scope).get("content-type", "")
+        media_type = content_type.partition(";")[0].strip().lower()
+        if media_type != "application/json":
+            await self._send_json(
+                send,
+                415,
+                {"error": "Content-Type must be application/json"},
+                origin=origin,
+            )
+            return
+
+        body, too_large = await self._read_body(receive)
+        if too_large:
+            await self._send_json(
+                send,
+                413,
+                {"error": "Authorization request is too large"},
+                origin=origin,
+            )
+            return
+        try:
+            options = (
+                json.loads(
+                    body,
+                    parse_constant=_reject_json_constant,
+                )
+                if body
+                else {}
+            )
+        except (ValueError, RecursionError):
+            await self._send_json(send, 400, {"error": "Invalid JSON"}, origin=origin)
+            return
+        if not isinstance(options, dict):
+            await self._send_json(send, 400, {"error": "JSON object required"}, origin=origin)
+            return
+        invite_code = options.get("invite_code")
+        payment = options.get("payment", 0)
+        if invite_code is not None and (not isinstance(invite_code, str) or len(invite_code) > MAX_INVITE_CODE_LENGTH):
+            await self._send_json(send, 400, {"error": "Invalid invite_code"}, origin=origin)
+            return
+        if not _payment_is_valid(payment):
+            await self._send_json(send, 400, {"error": "Invalid payment"}, origin=origin)
+            return
+
+        principal, error, status = self._admit_signed(
+            scope,
+            method="POST",
+            path=ACP_AUTHORIZE_PATH,
+            body=body,
+            origin=origin,
+            request_data={
+                "prompt": "Open an ACP WebSocket connection",
+                "invite_code": invite_code,
+                "payment": payment,
+            },
+        )
+        if error:
+            await self._send_json(send, status, {"error": error}, origin=origin)
+            return
+
+        try:
+            ticket = self._tickets.issue(principal)
+        except RuntimeError:
+            await self._send_json(
+                send,
+                503,
+                {"error": "ACP authorization is temporarily busy"},
+                origin=origin,
+            )
+            return
+        await self._send_json(
+            send,
+            201,
+            {
+                "ticket": ticket,
+                "expires_in": self._tickets.ttl_seconds,
+                "websocket_path": ACP_PATH,
+                "protocols": [
+                    ACP_SUBPROTOCOL,
+                    f"{TICKET_SUBPROTOCOL_PREFIX}{ticket}",
+                ],
+            },
+            origin=origin,
+            extra_headers=[(b"cache-control", b"no-store")],
+        )
+
+    async def _handle_websocket(
+        self,
+        scope: dict,
+        receive: Callable,
+        send: Callable,
+    ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._connection_tasks.add(task)
+        agent = None
+        connection = None
+        transport = None
+        pump_tasks: set[asyncio.Task] = set()
+        principal_key = None
+        principal_counted = False
+        try:
+            event = await receive()
+            if event.get("type") != "websocket.connect":
+                return
+            if scope.get("path") != ACP_PATH:
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4404,
+                        "reason": "ACP WebSocket path not found",
+                    }
+                )
+                return
+            if self._has_ambiguous_security_headers(scope):
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4400,
+                        "reason": "Ambiguous ACP security headers",
+                    }
+                )
+                return
+            if len(self._connection_tasks) > self._max_connections:
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4429,
+                        "reason": "ACP connection limit reached",
+                    }
+                )
+                return
+            if not self._transport_is_secure(scope):
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4403,
+                        "reason": "Secure transport is required",
+                    }
+                )
+                return
+            principal, error, status = self._admit_websocket(scope)
+            if error:
+                close_code = 4403 if status == 403 else 4429 if status == 429 else 4401
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": close_code,
+                        "reason": "ACP admission refused",
+                    }
+                )
+                return
+            principal_key = self._principal_key(principal)
+            active_for_principal = self._active_principals.get(principal_key, 0)
+            if active_for_principal >= self._max_connections_per_principal:
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4429,
+                        "reason": "ACP principal connection limit reached",
+                    }
+                )
+                return
+            self._active_principals[principal_key] = active_for_principal + 1
+            principal_counted = True
+
+            connection_id = str(uuid.uuid4())
+            accept: dict[str, Any] = {
+                "type": "websocket.accept",
+                "headers": [
+                    (b"acp-connection-id", connection_id.encode("ascii")),
+                ],
+            }
+            if ACP_SUBPROTOCOL in scope.get("subprotocols", ()):
+                accept["subprotocol"] = ACP_SUBPROTOCOL
+            await send(accept)
+
+            deadline = asyncio.get_running_loop().time() + self._initialize_timeout_seconds
+            while True:
+                try:
+                    first = await asyncio.wait_for(
+                        receive(),
+                        timeout=max(0, deadline - asyncio.get_running_loop().time()),
+                    )
+                except asyncio.TimeoutError:
+                    await send(
+                        {
+                            "type": "websocket.close",
+                            "code": 4408,
+                            "reason": "ACP initialize timed out",
+                        }
+                    )
+                    return
+                payload = await self._decode_websocket_message(first, send)
+                if payload is _IGNORED_WEBSOCKET_FRAME:
+                    continue
+                if payload is None:
+                    return
+                break
+            if not self._is_initialize_request(payload):
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 4400,
+                        "reason": "First ACP message must be initialize",
+                    }
+                )
+                return
+
+            # Authentication and the mandatory initialize frame have both
+            # succeeded before any coding Agent or session state exists.
+            agent = self._agent_factory(principal)
+            with suppress(AttributeError):
+                agent.connection_principal = principal
+            transport = _ACPTransport()
+            connection = AgentSideConnection(
+                agent,
+                transport,
+                listening=True,
+                use_unstable_protocol=True,
+            )
+            await transport.feed(payload)
+            pump_tasks = {
+                asyncio.create_task(
+                    self._pump_inbound(transport, receive, send),
+                    name="connectonion.acp.websocket.inbound",
+                ),
+                asyncio.create_task(
+                    self._pump_outbound(transport, send),
+                    name="connectonion.acp.websocket.outbound",
+                ),
+            }
+            done, pending = await asyncio.wait(
+                pump_tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for pending_task in pending:
+                pending_task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            for completed_task in done:
+                completed_task.result()
+        finally:
+            if agent is not None:
+                cancel_all = getattr(agent, "cancel_all", None)
+                if callable(cancel_all):
+                    try:
+                        cancel_all()
+                    except Exception:
+                        logger.exception("ACP Agent cancellation cleanup failed")
+            if transport is not None:
+                await transport.close()
+            if connection is not None:
+                try:
+                    await connection.close()
+                except Exception:
+                    logger.exception("ACP connection cleanup failed")
+            for pump_task in pump_tasks:
+                pump_task.cancel()
+            if pump_tasks:
+                await asyncio.gather(*pump_tasks, return_exceptions=True)
+            if agent is not None:
+                close_all = getattr(agent, "close_all", None)
+                if callable(close_all):
+                    try:
+                        result = close_all()
+                        if inspect.isawaitable(result):
+                            await result
+                    except Exception:
+                        logger.exception("ACP Agent session cleanup failed")
+            if task is not None:
+                self._connection_tasks.discard(task)
+            if principal_counted:
+                remaining = self._active_principals.get(principal_key, 1) - 1
+                if remaining > 0:
+                    self._active_principals[principal_key] = remaining
+                else:
+                    self._active_principals.pop(principal_key, None)
+
+    def _admit_websocket(
+        self,
+        scope: dict,
+    ) -> tuple[ACPPrincipal | None, str | None, int]:
+        origin = self._origin(scope)
+        if origin is not None and not self._origin_allowed(origin):
+            return None, "Origin not allowed", 403
+
+        tickets = self._tickets_from_subprotocols(scope.get("subprotocols", ()))
+        if len(tickets) > 1:
+            return None, "Ambiguous ACP ticket protocols", 401
+        if tickets:
+            if ACP_SUBPROTOCOL not in scope.get("subprotocols", ()):
+                return None, "ACP subprotocol is required with a browser ticket", 401
+            principal = self._tickets.consume(tickets[0], origin=origin)
+            if principal is None:
+                return None, "Invalid or expired ACP ticket", 401
+            return replace(principal, auth_method="browser_ticket"), None, 200
+
+        return self._admit_signed(
+            scope,
+            method="GET",
+            path=ACP_PATH,
+            body=b"",
+            origin=origin,
+            request_data={"prompt": "Open an ACP WebSocket connection"},
+        )
+
+    def _admit_signed(
+        self,
+        scope: dict,
+        *,
+        method: str,
+        path: str,
+        body: bytes,
+        origin: str | None,
+        request_data: dict[str, Any],
+    ) -> tuple[ACPPrincipal | None, str | None, int]:
+        data = request_from_http_headers(
+            self._headers(scope),
+            method,
+            path,
+            query=scope.get("query_string", b""),
+            body=body,
+        )
+        _, caller, error = _authenticate_signed(
+            data,
+            blacklist=self._blacklist,
+            recipient_address=self._recipient_address,
+        )
+        if error:
+            return None, error, self._status_for_auth_error(error)
+        try:
+            if self._replay_check(data):
+                return None, "unauthorized: signed request already used", 401
+        except ReplayProtectionError:
+            return None, "misconfigured: replay protection unavailable", 503
+
+        if caller not in self._whitelist:
+            try:
+                decision = self._trust_agent.should_allow(caller, request_data)
+            except (OSError, UnicodeDecodeError) as exc:
+                return None, f"misconfigured: {exc}", 503
+            if not decision.allow:
+                return None, f"forbidden: {decision.reason}", 403
+
+        try:
+            level = "admin" if self._trust_agent.is_admin(caller) else self._trust_agent.get_level(caller)
+        except (OSError, UnicodeDecodeError) as exc:
+            return None, f"misconfigured: {exc}", 503
+        principal = ACPPrincipal(
+            address=caller,
+            level=level,
+            recipient=self._recipient_address,
+            origin=origin,
+            auth_method="signed_headers",
+            authenticated_at=time.time(),
+        )
+        if not self._rate_limiter.allow(principal):
+            return None, "too many ACP admission attempts", 429
+        return principal, None, 200
+
+    async def _pump_inbound(
+        self,
+        transport: _ACPTransport,
+        receive: Callable,
+        send: Callable,
+    ) -> None:
+        while True:
+            event = await receive()
+            payload = await self._decode_websocket_message(event, send)
+            if payload is _IGNORED_WEBSOCKET_FRAME:
+                continue
+            if payload is None:
+                return
+            await transport.feed(payload)
+
+    @staticmethod
+    async def _pump_outbound(
+        transport: _ACPTransport,
+        send: Callable,
+    ) -> None:
+        while True:
+            message = await transport.next_outgoing()
+            if message is None:
+                return
+            try:
+                text = json.dumps(
+                    message,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            except (TypeError, ValueError, RecursionError):
+                logger.exception("ACP response could not be serialized")
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 1011,
+                        "reason": "ACP response could not be serialized",
+                    }
+                )
+                return
+            if len(text.encode("utf-8")) > MAX_ACP_MESSAGE_BYTES:
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 1009,
+                        "reason": "ACP response is too large",
+                    }
+                )
+                return
+            await send(
+                {
+                    "type": "websocket.send",
+                    "text": text,
+                }
+            )
+
+    async def _decode_websocket_message(
+        self,
+        event: dict,
+        send: Callable,
+    ) -> dict[str, Any] | object | None:
+        if event.get("type") == "websocket.disconnect":
+            return None
+        if event.get("type") != "websocket.receive":
+            return None
+        text = event.get("text")
+        if text is None:
+            binary = event.get("bytes")
+            if binary is not None and len(binary) > MAX_ACP_MESSAGE_BYTES:
+                await send(
+                    {
+                        "type": "websocket.close",
+                        "code": 1009,
+                        "reason": "ACP message is too large",
+                    }
+                )
+                return None
+            return _IGNORED_WEBSOCKET_FRAME
+        if len(text.encode("utf-8")) > MAX_ACP_MESSAGE_BYTES:
+            await send(
+                {
+                    "type": "websocket.close",
+                    "code": 1009,
+                    "reason": "ACP message is too large",
+                }
+            )
+            return None
+        try:
+            payload = json.loads(text, parse_constant=_reject_json_constant)
+        except (ValueError, RecursionError):
+            payload = None
+        if not isinstance(payload, dict):
+            await send(
+                {
+                    "type": "websocket.close",
+                    "code": 1007,
+                    "reason": "Invalid ACP JSON-RPC message",
+                }
+            )
+            return None
+        return payload
+
+    async def _read_body(self, receive: Callable) -> tuple[bytes, bool]:
+        chunks: list[bytes] = []
+        size = 0
+        while True:
+            event = await receive()
+            if event.get("type") == "http.disconnect":
+                break
+            if event.get("type") != "http.request":
+                continue
+            chunk = event.get("body", b"")
+            size += len(chunk)
+            if size > MAX_AUTHORIZATION_BODY_BYTES:
+                return b"", True
+            chunks.append(chunk)
+            if not event.get("more_body", False):
+                break
+        return b"".join(chunks), False
+
+    @staticmethod
+    def _headers(scope: dict) -> dict[str, str]:
+        return {key.decode("latin-1").lower(): value.decode("latin-1") for key, value in scope.get("headers", ())}
+
+    @staticmethod
+    def _has_ambiguous_security_headers(scope: dict) -> bool:
+        seen: set[str] = set()
+        for raw_name, _ in scope.get("headers", ()):
+            name = raw_name.decode("latin-1").lower()
+            if name not in _UNIQUE_SECURITY_HEADERS:
+                continue
+            if name in seen:
+                return True
+            seen.add(name)
+        return False
+
+    def _origin(self, scope: dict) -> str | None:
+        return self._headers(scope).get("origin")
+
+    def _origin_allowed(self, origin: str | None) -> bool:
+        return origin is not None and origin in self._allowed_origins
+
+    @staticmethod
+    def _principal_key(
+        principal: ACPPrincipal,
+    ) -> tuple[str, str, str | None, str]:
+        return (
+            principal.recipient,
+            principal.address,
+            principal.origin,
+            principal.auth_method,
+        )
+
+    @staticmethod
+    def _is_initialize_request(payload: dict[str, Any]) -> bool:
+        request_id = payload.get("id")
+        envelope_valid = (
+            payload.get("jsonrpc") == "2.0"
+            and payload.get("method") == "initialize"
+            and isinstance(payload.get("params"), dict)
+            and (isinstance(request_id, str) or (isinstance(request_id, int) and not isinstance(request_id, bool)))
+        )
+        if not envelope_valid:
+            return False
+        protocol_version = payload["params"].get("protocolVersion")
+        if (
+            isinstance(protocol_version, bool)
+            or not isinstance(protocol_version, int)
+            or not 0 <= protocol_version <= 65535
+        ):
+            return False
+        try:
+            InitializeRequest.model_validate(payload["params"])
+        except ValidationError:
+            return False
+        return True
+
+    @staticmethod
+    def _transport_is_secure(scope: dict) -> bool:
+        if scope.get("scheme") in {"https", "wss"}:
+            return True
+        client = scope.get("client")
+        if not client:
+            return False
+        host = str(client[0]).split("%", 1)[0]
+        try:
+            peer_is_loopback = host.lower() == "localhost" or ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            return False
+        if not peer_is_loopback:
+            return False
+
+        # A local reverse proxy is also a loopback peer. Plaintext is local-only
+        # only when the request authority is local too; a public authority must
+        # arrive with a trusted HTTPS/WSS scheme from the proxy.
+        authority = AuthenticatedACPApp._headers(scope).get("host", "")
+        try:
+            hostname = urlsplit(f"//{authority}").hostname or ""
+        except ValueError:
+            return False
+        if hostname.lower() == "localhost" or hostname.lower().endswith(".localhost"):
+            return True
+        try:
+            return ipaddress.ip_address(hostname.split("%", 1)[0]).is_loopback
+        except ValueError:
+            return False
+
+    @staticmethod
+    def _tickets_from_subprotocols(protocols: Iterable[str]) -> list[str]:
+        return [
+            ticket
+            for protocol in protocols
+            if protocol.startswith(TICKET_SUBPROTOCOL_PREFIX)
+            for ticket in [protocol[len(TICKET_SUBPROTOCOL_PREFIX) :]]
+            if ticket
+        ]
+
+    @staticmethod
+    def _status_for_auth_error(error: str) -> int:
+        if error.startswith("forbidden:"):
+            return 403
+        if error.startswith("misconfigured:"):
+            return 503
+        return 401
+
+    def _cors_headers(self, origin: str) -> list[tuple[bytes, bytes]]:
+        return [
+            (b"access-control-allow-origin", origin.encode("latin-1")),
+            (b"access-control-allow-methods", b"POST, OPTIONS"),
+            (b"access-control-allow-headers", _CORS_REQUEST_HEADERS.encode()),
+            (b"access-control-max-age", b"600"),
+            (
+                b"vary",
+                b"Origin, Access-Control-Request-Method, "
+                b"Access-Control-Request-Headers, "
+                b"Access-Control-Request-Private-Network",
+            ),
+        ]
+
+    async def _send_json(
+        self,
+        send: Callable,
+        status: int,
+        body: dict[str, Any],
+        *,
+        origin: str | None = None,
+        extra_headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> None:
+        headers = [(b"content-type", b"application/json")]
+        if origin is not None and self._origin_allowed(origin):
+            headers.extend(self._cors_headers(origin))
+        if extra_headers:
+            headers.extend(extra_headers)
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": headers,
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": json.dumps(body, separators=(",", ":")).encode(),
+            }
+        )
+
+
+def create_authenticated_acp_app(
+    agent_factory: ACPAgentFactory,
+    **kwargs: Any,
+) -> AuthenticatedACPApp:
+    return AuthenticatedACPApp(agent_factory, **kwargs)
+
+
+__all__ = [
+    "ACP_AUTHORIZE_PATH",
+    "ACP_PATH",
+    "ACP_SUBPROTOCOL",
+    "ACPPrincipal",
+    "ACPAdmissionRateLimiter",
+    "ACPTicketRegistry",
+    "AuthenticatedACPApp",
+    "DEFAULT_ACP_ORIGINS",
+    "DEFAULT_INITIALIZE_TIMEOUT_SECONDS",
+    "TICKET_SUBPROTOCOL_PREFIX",
+    "create_authenticated_acp_app",
+]

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -483,6 +483,7 @@ def _print_host_banner(
     trust: str,
     trust_config: dict | None,
     co_dir: Path = None,
+    acp_enabled: bool = False,
 ):
     """Print clean host startup banner focused on server info.
 
@@ -517,7 +518,10 @@ def _print_host_banner(
     console.print()
     console.print(f"{prefix} [dim]{'─' * 35}[/dim]")
     console.print(f"{indent}[cyan]{base_url}[/cyan]")
-    console.print(f"{indent}[bold]POST[/bold] /input · [bold]WS[/bold] /ws · [dim]GET /docs[/dim]")
+    endpoints = "[bold]POST[/bold] /input · [bold]WS[/bold] /ws"
+    if acp_enabled:
+        endpoints += " · [bold]ACP[/bold] /acp"
+    console.print(f"{indent}{endpoints} · [dim]GET /docs[/dim]")
     console.print()
 
     # Full address, and the chat site — but only when this agent announces on the
@@ -830,6 +834,8 @@ def host(
     summary: str = None,
     examples: list = None,
     http=None,
+    acp_agent_factory: Callable | None = None,
+    acp_origins: list[str] | tuple[str, ...] | None = None,
 ):
     """
     Host an agent over HTTP/WebSocket with P2P relay discovery (enabled by default).
@@ -876,6 +882,10 @@ def host(
         summary: Agent description (default: from config or agent.system_prompt)
         examples: Example prompts (default: from config or auto-generated)
         http: Optional HTTPRouter with publisher-defined resource routes
+        acp_agent_factory: Optional ``factory(principal)`` returning an ACP Agent.
+            When set, the host serves authenticated ACP v1 over WS /acp.
+        acp_origins: Exact browser origins allowed to request an ACP ticket.
+            Defaults to https://chat.openonion.ai when ACP is enabled.
 
     Direct execution (WS EXEC):
         Clients can run a tool directly, bypassing the LLM, via
@@ -1018,6 +1028,24 @@ def host(
         mode_policy=_host_mode_policy(sample),
     )
 
+    acp_app = None
+    if acp_agent_factory is not None:
+        from .acp_gateway import create_authenticated_acp_app
+
+        acp_options = {
+            "trust_agent": trust_agent,
+            "recipient_address": addr_data["address"],
+            "replay_check": replay_store.already_used,
+            "blacklist": blacklist,
+            "whitelist": whitelist,
+        }
+        if acp_origins is not None:
+            acp_options["allowed_origins"] = acp_origins
+        acp_app = create_authenticated_acp_app(
+            acp_agent_factory,
+            **acp_options,
+        )
+
     # Parse trust config for /info onboard info
     trust_config = _parse_trust_config(trust)
 
@@ -1075,6 +1103,7 @@ def host(
         on_startup=on_startup,
         on_shutdown=on_shutdown,
         http=http,
+        acp=acp_app,
     )
 
     # Display host startup banner (agent info shown separately by Agent class)
@@ -1085,6 +1114,7 @@ def host(
         trust=trust,
         trust_config=trust_config,
         co_dir=co_dir,
+        acp_enabled=acp_app is not None,
     )
 
     workers, reload = usable_uvicorn_options(workers, reload)

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -22,6 +22,19 @@ co ai
 - Opens `chat.openonion.ai/{your-address}` in your browser
 - You chat with the agent through the web UI
 - Agent runs in your project directory
+- Starts an authenticated ACP v1 WebSocket at `/acp` for compatible clients
+
+The current O Chat release still connects through the authenticated `/ws`
+compatibility transport. The `/acp` endpoint is started now so native ACP
+clients can be validated before the React/O Chat migration. Both endpoints use
+the same ConnectOnion identity, recipient binding, replay protection, and trust
+policy; starting ACP does not make the coding Agent anonymous or public.
+
+Browser ACP connections first exchange a signed request for a short-lived,
+single-use, Origin-bound ticket. Programmatic clients can sign the WebSocket
+upgrade directly. See [Authenticated ACP WebSocket](../network/acp-websocket.md).
+This preview supports direct loopback or TLS/WSS connections only. It does not
+claim end-to-end encryption through an untrusted TLS-terminating relay.
 
 ### One-Shot Mode
 
@@ -65,6 +78,11 @@ Starts a stable ACP v1 agent server over stdio so an ACP-compatible editor or
 CLI can create a session and drive the real `co ai` coding agent. ACP messages
 are newline-delimited JSON-RPC on stdin/stdout; human-readable diagnostics stay
 on stderr.
+
+Use `--acp` when another local process launches `co ai` and owns its stdio.
+Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a
+network endpoint and therefore keeps ConnectOnion authentication and trust in
+front of ACP initialization.
 
 Each ACP session owns one in-memory `co ai` Agent, so later prompts in that
 session reuse its conversation and tool state. The working directory supplied

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -1,0 +1,179 @@
+# DD-045: Put direct native ACP behind ConnectOnion admission
+
+**Status:** Proposed
+
+**Date:** 2026-08-12
+
+**Related:** [DD-029 Persistent ACP Session Ownership](029-acp-persistent-session-ownership.md), [DD-030 Generation-scoped ACP Tool Approvals](030-acp-generation-scoped-tool-approvals.md), [DD-035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md), [DD-044 Canonical Approval Mode Vocabulary](044-canonical-approval-mode-vocabulary.md), [Issue #895](https://github.com/openonion/connectonion/issues/895), [Relay security RFC #898](https://github.com/openonion/connectonion/issues/898)
+
+## Context
+
+ConnectOnion has two working paths:
+
+- `co ai --acp` is an ACP v1 Agent over local stdio;
+- the authenticated `/ws` Host protocol drives the released browser and carries
+  additive ACP messages inside compatibility envelopes.
+
+The browser, editors, and authorized remote clients should eventually use one
+ACP interaction plane without discarding ConnectOnion identity, trust,
+onboarding, and permission ceilings.
+
+ACP v1 formally documents stdio. Its Streamable HTTP/WebSocket remote
+transport remains an Active RFD. The RFD defines one `/acp` endpoint, plain
+UTF-8 JSON-RPC WebSocket text frames, and `initialize` as the first protocol
+message. In v1, reconnect, liveness, and disconnected-message recovery remain
+implementation responsibilities. This decision therefore defines a
+ConnectOnion remote-transport preview, not a claim that the upstream remote
+profile is stable.
+
+## Decision
+
+### Direct ACP is the interaction plane; ConnectOnion is the security plane
+
+Default `co ai` serves native ACP at `/acp` beside the existing `/ws` route.
+After admission, frames use the same `ConnectOnionACPAgent` lifecycle as stdio.
+Both entry points call the same ACP agent factory; transports do not duplicate
+agent construction policy.
+Before accepting executable protocol work, the Host verifies:
+
+- the caller's Ed25519 identity and signature;
+- the signed recipient, request path, body digest, timestamp, and one-use
+  request ID;
+- cross-process replay protection;
+- blacklist, whitelist, contact/admin state, onboarding, and trust policy;
+- exact browser Origin;
+- loopback peer plus loopback request authority, or TLS/WSS otherwise.
+
+Duplicate security headers fail closed rather than allowing proxy-dependent
+interpretation. Admission attempts, pending browser tickets, total
+connections, and per-principal connections are bounded.
+
+A public request authority is never accepted over a plaintext loopback backend
+connection. A reverse proxy must supply a correctly trusted HTTPS/WSS scheme;
+otherwise the Host rejects the request even though the immediate proxy peer is
+local.
+
+The first JSON-RPC text frame must be a JSON-RPC 2.0 request with a non-boolean
+string/integer ID, method `initialize`, and parameters accepted by the pinned
+official ACP SDK. Binary frames before it are ignored as required by the RFD.
+`protocolVersion` must also satisfy the SDK's published integer range before a
+coding Agent is constructed. The upgrade response
+carries an `Acp-Connection-Id`; it and every ACP session ID are routing values,
+never credentials.
+
+### Browsers exchange a signed request for a one-use ticket
+
+Browser JavaScript cannot add `X-Co-*` headers to a WebSocket upgrade. It first
+sends a signed JSON `POST /acp/authorize` from an exact allowed Origin.
+
+The Host returns a random 256-bit ticket with a 60-second lifetime and stores
+only its SHA-256 digest. The ticket is bound to the verified caller, recipient,
+and Origin, is consumed on the first attempt including a mismatched Origin,
+and travels only in `Sec-WebSocket-Protocol` beside the `acp` protocol. It is
+never accepted in a URL. Authorization responses are non-cacheable. CORS
+preflight allows only the documented signing headers and supports the browser
+Private Network Access preflight for a loopback Agent.
+
+The ticket adapts a browser API limitation. It is not a session bearer token,
+does not bypass trust, and cannot resume a different principal's session.
+
+### Network persistence is namespaced by the authenticated principal
+
+Every connection receives a new ACP adapter, so in-memory sessions, pending
+permissions, and cancellation state are not shared. Persistent snapshots use a
+stable, non-client-selectable namespace derived from version, recipient,
+verified caller, exact Origin, and admission method. The directory name is a
+SHA-256 digest; raw identity values are not placed in a filesystem path.
+
+The same principal may reauthenticate and explicitly resume its session. A
+different principal sees a separate namespace even if it copies the exact
+session UUID and working directory. This is the narrow ownership invariant
+needed for this endpoint; the broader cross-ingress `VerifiedPrincipal` model
+remains #896.
+
+### Collaboration and permission remain separate
+
+DD-044 applies unchanged:
+
+- `default` and `plan` are React-owned collaboration state and are not stored
+  as Host authority;
+- `:read-only`, `:workspace`, and `:danger-full-access` are the only permission
+  profiles the Host newly emits;
+- `--yolo` is an operator shorthand for the Full access ceiling, not a fourth
+  protocol mode.
+
+On the network endpoint, Full access is advertised only when the process was
+launched with `--yolo` **and** the authenticated principal is an administrator.
+The existing turn/checkpoint bound still applies. A contact never inherits the
+operator's Full access launch flag merely by passing the trust gate.
+
+### WebSocket-only preview and bounded rollback
+
+The embedded Uvicorn path does not provide the HTTP/2 required by the proposed
+Streamable HTTP profile. Ordinary HTTP `/acp` returns `426`; this build does not
+label an HTTP/1.1 approximation as ACP.
+
+The released O Chat remains on `/ws` until React owns native admission,
+protocol validation, reconnect, correlation, de-duplication, and explicit
+fallback. The standalone TypeScript SDK is retired. The supported browser
+dependency direction remains:
+
+```text
+ConnectOnion Host -> @connectonion/react -> O Chat
+```
+
+Starting `/acp` and moving the released browser are separate rollback points.
+
+### Relay ACP is not approved here
+
+This decision covers direct loopback/TLS/WSS only. A relay that terminates TLS
+can still read ACP content. Per-message Ed25519 proofs in ACP `_meta` can offer
+provenance or integrity, but cannot provide confidentiality, forward secrecy,
+or an end-to-end encrypted channel.
+
+#898 must select and externally review a secure channel established before ACP
+`initialize`, with separate encryption keys, downgrade resistance, and
+cross-language malicious-relay vectors. Until then this endpoint must not be
+routed through an untrusted TLS-terminating relay or described as relay-E2E
+encrypted. #897 is deferred and may retain only a narrower post-decryption
+provenance role after #898 decides it.
+
+## Failure and resource behavior
+
+- Unknown, blocked, stale, replayed, wrong-recipient, wrong-Origin, ambiguous,
+  rate-limited, and insecure non-loopback admissions fail before Agent creation.
+- Binary frames are ignored as required by the upstream RFD unless they exceed
+  the transport limit. Malformed text and oversized frames close the connection.
+  Each direction has a bounded eight-message queue and applies backpressure
+  rather than dropping protocol messages.
+- `initialize` has a bounded deadline. Disconnect and Host shutdown cancel
+  active turns, close the ACP connection, settle session work, and release
+  leases. One failing cleanup callback does not skip the remaining cleanup.
+- Provider `authenticate` remains an ACP application method and is never used
+  as network caller authentication.
+
+## Rejected alternatives
+
+- **Treat `/ws` compatibility envelopes as native ACP:** `/ws` has no ACP
+  initialization and contains ConnectOnion control frames.
+- **Use ACP `authenticate` for caller admission:** it runs inside the protocol
+  and concerns credentials offered by the Agent, not the network peer.
+- **Put a token or session ID in the URL:** URLs leak into logs and routing IDs
+  are not authorization roots.
+- **Accept wildcard Origin or duplicate security headers:** either lets an
+  unrelated page or intermediary ambiguity spend local Agent authority.
+- **Create one global ACP Agent:** it mixes sessions, permissions, and cleanup
+  across authenticated callers.
+- **Give every trusted caller launch `--yolo`:** trust to connect is not
+  administrator authority to select Full access.
+- **Claim relay encryption through ACP `_meta`:** signatures do not encrypt.
+- **Claim Streamable HTTP over Uvicorn HTTP/1.1:** it would create false
+  interoperability evidence.
+
+## Compatibility and rollback
+
+Removing the optional ACP factory removes `/acp` without changing `/ws`, stdio
+ACP, or stored legacy browser sessions. Principal-namespaced ACP snapshots are
+private preview state; they are not silently migrated into another identity or
+transport namespace. Any future namespace migration requires an authenticated,
+explicit rule.

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -1,6 +1,6 @@
 # DD-045: Put direct native ACP behind ConnectOnion admission
 
-**Status:** Proposed
+**Status:** Accepted
 
 **Date:** 2026-08-12
 

--- a/docs/network/acp-websocket.md
+++ b/docs/network/acp-websocket.md
@@ -1,0 +1,138 @@
+# Authenticated ACP WebSocket
+
+`co ai` starts an ACP v1 WebSocket preview at `/acp` alongside the existing web-chat
+transport at `/ws`. ACP owns the coding-agent conversation. ConnectOnion still
+owns who may open it.
+
+The upstream remote transport is still an Active ACP RFD. This is the first
+direct remote-ACP preview slice. The current O Chat release still
+uses `/ws`; moving `@connectonion/react` and O Chat to native ACP is tracked
+separately. Starting `/acp` by default does not bypass the existing trust gate
+and does not make a local coding agent public by itself.
+
+## Security boundary
+
+The gateway performs these checks before it constructs an ACP Agent:
+
+1. Verify the caller's Ed25519 signature.
+2. Verify the signed recipient is this hosted Agent.
+3. Atomically reject a reused signature.
+4. Apply the Host's `open`, `careful`, `strict`, or custom trust policy.
+5. For browsers, require an exact allowed `Origin`.
+6. Require the first JSON-RPC text frame to be ACP `initialize`.
+7. Bound verified admission attempts, tickets, connections, frames, and queues.
+
+Only then does the gateway create one isolated `ConnectOnionACPAgent` for the
+connection. The verified caller, trust level, recipient, Origin, and admission
+method are attached as the connection principal. A connection or ACP session
+ID is routing state, never authentication. The server returns a fresh
+`Acp-Connection-Id` in the upgrade response, but it does not grant access.
+Stdio and WebSocket call the same ACP agent factory; only their transports and
+network admission differ.
+
+Plain HTTP/WS is accepted only when both the ASGI peer and request authority are
+loopback/localhost. A public authority requires TLS/WSS even when the immediate
+peer is a local reverse proxy. The proxy must provide a correctly trusted secure
+scheme; an ambiguous deployment fails closed.
+
+ACP `authenticate` is not used for network admission. That ACP method remains
+available for credentials an Agent itself may need, such as signing in to a
+model provider.
+
+## Programmatic client flow
+
+A non-browser client signs the WebSocket upgrade as an ordinary ConnectOnion
+HTTP request:
+
+- method: `GET`
+- path: `/acp`
+- body: empty
+- signed fields: method, path, canonical query, body hash, timestamp,
+  one-use request ID, and recipient
+- headers: `X-Co-From`, `X-Co-Signature`, `X-Co-Timestamp`, `X-Co-To`, and
+  `X-Co-Request-Id`
+
+After the server accepts the upgrade, the client sends ordinary ACP JSON-RPC
+text frames. The first is `initialize`; subsequent session lifecycle,
+permission, mode, prompt, cancel, resume, and close messages use the same ACP
+v1 behavior as `co ai --acp` on stdio.
+
+## Browser flow
+
+Browsers cannot set custom headers on a WebSocket upgrade, so the future
+React/O Chat native-ACP client will use a two-step admission flow:
+
+1. Sign and `POST` a JSON object to `/acp/authorize` using the same `X-Co-*`
+   headers. The exact browser Origin must be allowlisted.
+2. Receive a random 256-bit ticket that expires after 60 seconds.
+3. Open `/acp` with the returned subprotocols, for example:
+
+   ```js
+   const socket = new WebSocket(url, [
+     "acp",
+     `connectonion.ticket.${ticket}`,
+   ])
+   ```
+
+The server stores only the ticket's SHA-256 digest. A ticket is bound to the
+verified caller, this Agent's address, and the exact Origin. It is removed on
+its first use, including a mismatched-Origin attempt, and is never accepted in
+a URL query string. Responses use `Cache-Control: no-store` and an exact
+`Access-Control-Allow-Origin`, never `*`.
+
+The browser still signs the authorization request. The ticket adapts browser
+transport limitations; it does not replace ConnectOnion identity or trust.
+The preflight accepts only the documented signing headers and supports Private
+Network Access when an HTTPS page reaches a loopback Agent.
+
+## Session ownership and permissions
+
+Persistent network ACP sessions are stored under a stable namespace derived
+from the recipient Agent, verified caller, exact Origin, and admission method.
+The same principal can reauthenticate and resume; another principal cannot
+load the snapshot even with the copied session UUID and working directory.
+
+Collaboration and permission are independent under DD-044. React owns
+`default` / `plan` workflow state. The Host advertises only `:read-only`,
+`:workspace`, and, when authorized, `:danger-full-access`. A launch `--yolo`
+flag exposes the bounded Full access profile only to an authenticated admin;
+contacts do not inherit it.
+
+## Transport scope
+
+This preview is WebSocket-only. ACP Streamable HTTP requires HTTP/2, while the
+current embedded Uvicorn server serves HTTP/1.1. An ordinary HTTP request to
+`/acp` therefore returns `426` and names WebSocket as the supported transport.
+ConnectOnion will not label an HTTP/1.1 approximation as ACP Streamable HTTP.
+
+This direct profile is not end-to-end encrypted through an untrusted relay.
+TLS protects a direct connection; a relay that terminates TLS can read it.
+Signed `_meta` does not change that. Relay ACP remains blocked on the secure
+channel design and review gates in issue #898.
+
+The legacy `/ws` protocol remains available during the frontend migration. It
+continues to carry CONNECT/INPUT/EXEC and compatibility ACP envelopes; it is
+not itself an ACP connection. See [WebSocket Protocol](websocket-protocol.md)
+and [DD-045](../design-decisions/045-authenticated-acp-websocket-gateway.md).
+
+Frames are UTF-8 JSON-RPC text with a 1 MiB maximum. Ordinary binary frames are
+ignored per the upstream RFD; malformed text and oversized frames close the
+socket. Each direction uses an eight-message bounded queue;
+backpressure is applied instead of silently dropping ACP messages. The first
+`initialize` frame has a 10-second deadline. Host shutdown and disconnect
+settle turns and release persistent session leases.
+
+## Hosting another ACP Agent
+
+`host()` enables the endpoint only when given an ACP factory:
+
+```python
+host(
+    agent,
+    acp_agent_factory=lambda principal: MyACPAgent(principal),
+    acp_origins=["https://app.example.com"],
+)
+```
+
+The factory receives the verified `ACPPrincipal`. Do not infer authority from
+an ACP session ID or accept an Origin wildcard for browser tickets.

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -2,6 +2,12 @@
 
 > CONNECT to start or resume, INPUT to message, EXEC to run one tool directly. Session stays alive between executions.
 
+> **Migration note:** this page documents the ConnectOnion compatibility
+> socket at `/ws`; that socket is not ACP. `co ai` now also starts native ACP
+> v1 over the authenticated `/acp` WebSocket. O Chat continues using `/ws`
+> until its React client migration is complete. See
+> [Authenticated ACP WebSocket](acp-websocket.md).
+
 ---
 
 ## Overview

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,6 +4,33 @@ ConnectOnion's development roadmap. Track progress on [GitHub](https://github.co
 
 ## Current Milestones
 
+### 1.7.0 — ACP + coding-agent preview train
+
+The 1.7 preview train makes one coding-agent lifecycle available to editors,
+CLIs, and the browser without removing ConnectOnion's authentication and trust
+boundary.
+
+**Merge order:**
+
+1. [#895](https://github.com/openonion/connectonion/issues/895) — native `/acp`
+   WebSocket behind signed admission and exact browser-Origin tickets
+2. [#896](https://github.com/openonion/connectonion/issues/896) — complete the
+   shared principal model and bind canonical permission profiles to it;
+   collaboration `default` / `plan` remains React-owned
+3. [#893](https://github.com/openonion/connectonion/issues/893) — migrate
+   `@connectonion/react` and O Chat from `/ws` to native ACP
+4. [#894](https://github.com/openonion/connectonion/issues/894) — run direct
+   conformance, security, and browser reconnect gates before beta promotion
+5. [#898](https://github.com/openonion/connectonion/issues/898) — separately
+   decide and review an end-to-end secure relay channel before relay ACP ships
+
+The parent design and exit criteria live in
+[#892](https://github.com/openonion/connectonion/issues/892). The legacy `/ws`
+path remains a bounded compatibility fallback during the preview; it is not
+renamed or presented as ACP. #897's signed `_meta` proposal is not relay
+encryption and is deferred until #898 decides whether it has a narrower
+post-decryption provenance role.
+
 ### Launch the Network (Q4 2025)
 
 Implement the ConnectOnion peer-to-peer network protocol where agents discover and collaborate using public keys as addresses.

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -1,0 +1,1093 @@
+"""Security and lifecycle tests for the hosted ACP WebSocket boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from acp import PROTOCOL_VERSION
+from acp.schema import ResumeSessionResponse
+
+import connectonion.network.asgi as asgi_module
+from connectonion import address
+from connectonion.cli.co_ai.acp_server import ConnectOnionACPAgent
+from connectonion.network.host.acp_gateway import (
+    ACP_AUTHORIZE_PATH,
+    ACP_PATH,
+    ACP_QUEUE_MESSAGES,
+    ACP_SUBPROTOCOL,
+    MAX_ACP_MESSAGE_BYTES,
+    ACPAdmissionRateLimiter,
+    ACPPrincipal,
+    ACPTicketRegistry,
+    AuthenticatedACPApp,
+)
+from connectonion.network.host.auth import sign_http_request
+from connectonion.network.host.session import ActiveSessionRegistry
+
+ORIGIN = "https://chat.openonion.ai"
+
+
+class _Trust:
+    def __init__(self, *, allow=True, level="contact"):
+        self.allow = allow
+        self.level = level
+        self.requests = []
+
+    def should_allow(self, address, request):
+        self.requests.append((address, request))
+        return SimpleNamespace(allow=self.allow, reason="test policy")
+
+    def is_admin(self, _address):
+        return self.level == "admin"
+
+    def get_level(self, _address):
+        return self.level
+
+
+class _Replay:
+    def __init__(self):
+        self.seen = set()
+
+    def __call__(self, data):
+        signature = data["signature"]
+        existed = signature in self.seen
+        self.seen.add(signature)
+        return existed
+
+
+class _Agent(ConnectOnionACPAgent):
+    def __init__(self):
+        super().__init__(
+            model="test/model",
+            max_iterations=1,
+            yolo=False,
+            yolo_turns=1,
+        )
+        self.cancelled = False
+        self.closed = False
+
+    def cancel_all(self):
+        self.cancelled = True
+        super().cancel_all()
+
+    async def close_all(self):
+        self.closed = True
+        await super().close_all()
+
+    async def resume_session(self, session_id, cwd, **_kwargs):
+        self.resumed = (session_id, cwd)
+        return ResumeSessionResponse()
+
+
+def _headers(values):
+    return [(str(key).lower().encode("latin-1"), str(value).encode("latin-1")) for key, value in values.items()]
+
+
+def _app(*, trust=None, tickets=None):
+    caller = address.generate()
+    recipient = address.generate()
+    agents = []
+
+    def create_agent(principal):
+        agent = _Agent()
+        agents.append((principal, agent))
+        return agent
+
+    app = AuthenticatedACPApp(
+        create_agent,
+        trust_agent=trust or _Trust(),
+        recipient_address=recipient["address"],
+        replay_check=_Replay(),
+        allowed_origins=[ORIGIN],
+        tickets=tickets,
+    )
+    return app, caller, recipient, agents
+
+
+async def _http(app, *, method, path, headers=None, body=b""):
+    sent = []
+    received = False
+
+    async def receive():
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "scheme": "http",
+            "client": ("127.0.0.1", 49152),
+            "query_string": b"",
+            "headers": _headers({"host": "127.0.0.1:8000", **(headers or {})}),
+        },
+        receive,
+        send,
+    )
+    status = next(message["status"] for message in sent if message["type"] == "http.response.start")
+    response_headers = dict(next(message["headers"] for message in sent if message["type"] == "http.response.start"))
+    raw = next(message["body"] for message in sent if message["type"] == "http.response.body")
+    return status, response_headers, json.loads(raw) if raw else None
+
+
+async def _authorize(app, caller, recipient, *, origin=ORIGIN, body=b"{}"):
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+    return await _http(
+        app,
+        method="POST",
+        path=ACP_AUTHORIZE_PATH,
+        headers={**signed, "origin": origin, "content-type": "application/json"},
+        body=body,
+    )
+
+
+async def _websocket(
+    app,
+    *,
+    headers=None,
+    protocols=(),
+    frames=(),
+    expected_sends=1,
+    path=ACP_PATH,
+    scheme="ws",
+    client=("127.0.0.1", 49152),
+):
+    sent = []
+    frames = list(frames)
+    outgoing = asyncio.Condition()
+    outgoing_count = 0
+    index = 0
+
+    async def receive():
+        nonlocal index
+        if index == 0:
+            index += 1
+            return {"type": "websocket.connect"}
+        frame_index = index - 1
+        if frame_index < len(frames):
+            index += 1
+            if isinstance(frames[frame_index], bytes):
+                return {"type": "websocket.receive", "bytes": frames[frame_index]}
+            return {"type": "websocket.receive", "text": json.dumps(frames[frame_index])}
+        async with outgoing:
+            await asyncio.wait_for(
+                outgoing.wait_for(lambda: outgoing_count >= expected_sends),
+                timeout=2,
+            )
+        return {"type": "websocket.disconnect", "code": 1000}
+
+    async def send(message):
+        nonlocal outgoing_count
+        sent.append(message)
+        if message["type"] in ("websocket.send", "websocket.close"):
+            async with outgoing:
+                outgoing_count += 1
+                outgoing.notify_all()
+
+    await asyncio.wait_for(
+        app(
+            {
+                "type": "websocket",
+                "path": path,
+                "scheme": scheme,
+                "client": client,
+                "query_string": b"",
+                "headers": _headers({"host": "127.0.0.1:8000", **(headers or {})}),
+                "subprotocols": list(protocols),
+            },
+            receive,
+            send,
+        ),
+        timeout=3,
+    )
+    return sent
+
+
+def _initialize():
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"protocolVersion": PROTOCOL_VERSION},
+    }
+
+
+def test_ticket_registry_hashes_binds_and_consumes_once():
+    clock = [100.0]
+    registry = ACPTicketRegistry(ttl_seconds=10, clock=lambda: clock[0])
+    principal = ACPPrincipal(
+        address="0xcaller",
+        level="contact",
+        recipient="0xrecipient",
+        origin=ORIGIN,
+        auth_method="signed_headers",
+        authenticated_at=clock[0],
+    )
+
+    ticket = registry.issue(principal)
+
+    assert ticket.encode() not in registry._records
+    assert registry.consume(ticket, origin="https://evil.example") is None
+    assert registry.consume(ticket, origin=ORIGIN) is None
+
+    expiring = registry.issue(principal)
+    clock[0] = 110.0
+    assert registry.consume(expiring, origin=ORIGIN) is None
+
+
+def test_transport_queues_are_bounded_for_backpressure():
+    from connectonion.network.host.acp_gateway import _ACPTransport
+
+    transport = _ACPTransport()
+
+    assert transport._to_agent.maxsize == ACP_QUEUE_MESSAGES == 8
+    assert transport._to_client.maxsize == ACP_QUEUE_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_outbound_rejects_unserializable_and_oversized_messages():
+    from connectonion.network.host.acp_gateway import _ACPTransport
+
+    async def run(message):
+        transport = _ACPTransport()
+        sent = []
+
+        async def send(frame):
+            sent.append(frame)
+
+        await transport.send(message)
+        await AuthenticatedACPApp._pump_outbound(transport, send)
+        return sent
+
+    unserializable = await run({"value": object()})
+    non_standard_number = await run({"value": float("nan")})
+    oversized = await run({"value": "x" * MAX_ACP_MESSAGE_BYTES})
+
+    assert unserializable == [
+        {
+            "type": "websocket.close",
+            "code": 1011,
+            "reason": "ACP response could not be serialized",
+        }
+    ]
+    assert non_standard_number == [
+        {
+            "type": "websocket.close",
+            "code": 1011,
+            "reason": "ACP response could not be serialized",
+        }
+    ]
+    assert oversized == [
+        {
+            "type": "websocket.close",
+            "code": 1009,
+            "reason": "ACP response is too large",
+        }
+    ]
+
+
+def test_ticket_registry_bounds_one_principals_pending_tickets():
+    registry = ACPTicketRegistry(max_pending=3, max_pending_per_principal=1)
+    principal = ACPPrincipal(
+        address="0xcaller",
+        level="contact",
+        recipient="0xrecipient",
+        origin=ORIGIN,
+        auth_method="signed_headers",
+        authenticated_at=100.0,
+    )
+
+    registry.issue(principal)
+
+    with pytest.raises(RuntimeError, match="too many pending"):
+        registry.issue(principal)
+
+
+def test_admission_rate_limiter_is_principal_scoped_bounded_and_expires():
+    clock = [100.0]
+    limiter = ACPAdmissionRateLimiter(
+        limit=1,
+        window_seconds=10,
+        max_principals=1,
+        clock=lambda: clock[0],
+    )
+    principal = ACPPrincipal(
+        address="0xcaller",
+        level="contact",
+        recipient="0xrecipient",
+        origin=ORIGIN,
+        auth_method="signed_headers",
+        authenticated_at=100.0,
+    )
+    other = ACPPrincipal(
+        address="0xother",
+        level="contact",
+        recipient="0xrecipient",
+        origin=ORIGIN,
+        auth_method="signed_headers",
+        authenticated_at=100.0,
+    )
+
+    assert limiter.allow(principal) is True
+    assert limiter.allow(principal) is False
+    assert limiter.allow(other) is False
+    clock[0] = 110.0
+    assert limiter.allow(other) is True
+
+
+@pytest.mark.asyncio
+async def test_rejected_connection_does_not_release_an_existing_principal_slot():
+    caller = address.generate()
+    recipient = address.generate()
+    app = AuthenticatedACPApp(
+        lambda _principal: _Agent(),
+        trust_agent=_Trust(),
+        recipient_address=recipient["address"],
+        replay_check=_Replay(),
+        allowed_origins=[ORIGIN],
+        max_connections_per_principal=1,
+    )
+    key = (recipient["address"], caller["address"], None, "signed_headers")
+    app._active_principals[key] = 1
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(app, headers=signed)
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4429,
+            "reason": "ACP principal connection limit reached",
+        }
+    ]
+    assert app._active_principals[key] == 1
+
+
+@pytest.mark.asyncio
+async def test_browser_preflight_accepts_standard_headers_and_private_network():
+    app, _, _, _ = _app()
+
+    status, headers, response = await _http(
+        app,
+        method="OPTIONS",
+        path=ACP_AUTHORIZE_PATH,
+        headers={
+            "origin": ORIGIN,
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "content-type, x-co-from",
+            "access-control-request-private-network": "true",
+        },
+    )
+
+    assert status == 204
+    assert response is None
+    assert headers[b"access-control-allow-origin"] == ORIGIN.encode()
+    assert headers[b"access-control-allow-private-network"] == b"true"
+
+
+@pytest.mark.asyncio
+async def test_browser_preflight_rejects_unadvertised_headers():
+    app, _, _, _ = _app()
+
+    status, _, response = await _http(
+        app,
+        method="OPTIONS",
+        path=ACP_AUTHORIZE_PATH,
+        headers={
+            "origin": ORIGIN,
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "x-co-from, x-secret-bypass",
+        },
+    )
+
+    assert status == 400
+    assert response == {"error": "CORS preflight requested unsupported headers"}
+
+
+@pytest.mark.asyncio
+async def test_authorize_requires_json_content_type_before_admission():
+    app, caller, recipient, agents = _app()
+    body = b"{}"
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+
+    status, _, response = await _http(
+        app,
+        method="POST",
+        path=ACP_AUTHORIZE_PATH,
+        headers={**signed, "origin": ORIGIN, "content-type": "text/plain"},
+        body=body,
+    )
+
+    assert status == 415
+    assert response == {"error": "Content-Type must be application/json"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_authorize_rejects_json_prefixed_non_json_media_type():
+    app, caller, recipient, agents = _app()
+    body = b"{}"
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+
+    status, _, response = await _http(
+        app,
+        method="POST",
+        path=ACP_AUTHORIZE_PATH,
+        headers={
+            **signed,
+            "origin": ORIGIN,
+            "content-type": "application/json-evil",
+        },
+        body=body,
+    )
+
+    assert status == 415
+    assert response == {"error": "Content-Type must be application/json"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "error"),
+    [
+        (b'{"payment":NaN}', "Invalid JSON"),
+        (b'{"payment":true}', "Invalid payment"),
+        (b'{"payment":-1}', "Invalid payment"),
+        (b'{"payment":' + (b"9" * 4000) + b"}", "Invalid payment"),
+        (b'{"invite_code":{}}', "Invalid invite_code"),
+    ],
+)
+async def test_authorize_validates_onboarding_fields_before_trust(body, error):
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+
+    status, _, response = await _http(
+        app,
+        method="POST",
+        path=ACP_AUTHORIZE_PATH,
+        headers={
+            **signed,
+            "origin": ORIGIN,
+            "content-type": "application/json",
+        },
+        body=body,
+    )
+
+    assert status == 400
+    assert response == {"error": error}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_duplicate_signed_header_is_rejected_before_admission():
+    app, caller, recipient, agents = _app()
+    body = b"{}"
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+    raw_headers = _headers(
+        {
+            **signed,
+            "origin": ORIGIN,
+            "content-type": "application/json",
+        }
+    )
+    raw_headers.append((b"x-co-from", b"0xduplicate"))
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": ACP_AUTHORIZE_PATH,
+            "scheme": "http",
+            "client": ("127.0.0.1", 49152),
+            "query_string": b"",
+            "headers": raw_headers,
+        },
+        receive,
+        send,
+    )
+
+    start = next(item for item in sent if item["type"] == "http.response.start")
+    response = json.loads(next(item["body"] for item in sent if item["type"] == "http.response.body"))
+    assert start["status"] == 400
+    assert response == {"error": "Ambiguous security headers"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_verified_principal_admission_is_rate_limited():
+    limiter = ACPAdmissionRateLimiter(limit=1)
+    caller = address.generate()
+    recipient = address.generate()
+    agents = []
+
+    app = AuthenticatedACPApp(
+        lambda principal: agents.append(principal) or _Agent(),
+        trust_agent=_Trust(),
+        recipient_address=recipient["address"],
+        replay_check=_Replay(),
+        allowed_origins=[ORIGIN],
+        rate_limiter=limiter,
+    )
+
+    first = await _authorize(app, caller, recipient)
+    second = await _authorize(app, caller, recipient)
+
+    assert first[0] == 201
+    assert second[0] == 429
+    assert second[2] == {"error": "too many ACP admission attempts"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_browser_ticket_requires_signed_trusted_exact_origin_then_runs_acp():
+    trust = _Trust(level="contact")
+    app, caller, recipient, agents = _app(trust=trust)
+
+    status, headers, response = await _authorize(app, caller, recipient)
+
+    assert status == 201
+    assert headers[b"access-control-allow-origin"] == ORIGIN.encode()
+    assert headers[b"cache-control"] == b"no-store"
+    assert agents == []
+    assert trust.requests == [
+        (
+            caller["address"],
+            {
+                "prompt": "Open an ACP WebSocket connection",
+                "invite_code": None,
+                "payment": 0,
+            },
+        )
+    ]
+
+    sent = await _websocket(
+        app,
+        protocols=response["protocols"],
+        headers={"origin": ORIGIN},
+        frames=[_initialize()],
+    )
+
+    assert sent[0]["type"] == "websocket.accept"
+    assert sent[0]["subprotocol"] == "acp"
+    connection_id = dict(sent[0]["headers"])[b"acp-connection-id"].decode()
+    assert len(connection_id) == 36
+    initialized = next(json.loads(item["text"]) for item in sent if item["type"] == "websocket.send")
+    assert initialized["id"] == 1
+    assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert len(agents) == 1
+    principal, agent = agents[0]
+    assert principal.address == caller["address"]
+    assert principal.recipient == recipient["address"]
+    assert principal.origin == ORIGIN
+    assert principal.auth_method == "browser_ticket"
+    assert agent.connection_principal == principal
+    assert agent.cancelled is True
+    assert agent.closed is True
+
+    replayed = await _websocket(
+        app,
+        protocols=response["protocols"],
+        headers={"origin": ORIGIN},
+    )
+    assert replayed == [
+        {
+            "type": "websocket.close",
+            "code": 4401,
+            "reason": "ACP admission refused",
+        }
+    ]
+    assert len(agents) == 1
+
+
+@pytest.mark.asyncio
+async def test_untrusted_or_wrong_origin_never_creates_an_agent():
+    app, caller, recipient, agents = _app(trust=_Trust(allow=False))
+
+    status, _, response = await _authorize(app, caller, recipient)
+    assert status == 403
+    assert response["error"] == "forbidden: test policy"
+
+    status, headers, response = await _authorize(
+        app,
+        caller,
+        recipient,
+        origin="https://evil.example",
+    )
+    assert status == 403
+    assert b"access-control-allow-origin" not in headers
+    assert response == {"error": "Origin not allowed"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_insecure_non_loopback_authorize_fails_before_admission():
+    app, caller, recipient, agents = _app()
+    body = b"{}"
+    signed = sign_http_request(
+        caller,
+        "POST",
+        ACP_AUTHORIZE_PATH,
+        recipient_address=recipient["address"],
+        body=body,
+    )
+    sent = []
+    received = False
+
+    async def receive():
+        nonlocal received
+        if received:
+            return {"type": "http.disconnect"}
+        received = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": ACP_AUTHORIZE_PATH,
+            "scheme": "http",
+            "client": ("203.0.113.10", 49152),
+            "query_string": b"",
+            "headers": _headers(
+                {
+                    **signed,
+                    "origin": ORIGIN,
+                    "content-type": "application/json",
+                }
+            ),
+        },
+        receive,
+        send,
+    )
+
+    start = next(item for item in sent if item["type"] == "http.response.start")
+    response = json.loads(next(item["body"] for item in sent if item["type"] == "http.response.body"))
+    assert start["status"] == 403
+    assert response == {"error": "Secure transport is required for non-loopback ACP"}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_programmatic_client_can_sign_upgrade_without_browser_ticket():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(app, headers=signed, frames=[_initialize()])
+
+    assert sent[0]["type"] == "websocket.accept"
+    assert b"acp-connection-id" in dict(sent[0]["headers"])
+    assert any(item["type"] == "websocket.send" for item in sent)
+    assert agents[0][0].auth_method == "signed_headers"
+
+
+@pytest.mark.asyncio
+async def test_binary_frame_is_ignored_while_waiting_for_initialize():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[b"ignored transport data", _initialize()],
+    )
+
+    assert sent[0]["type"] == "websocket.accept"
+    assert any(item["type"] == "websocket.send" for item in sent)
+    assert len(agents) == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_ticket_protocols_are_rejected_without_agent_creation():
+    app, caller, recipient, agents = _app()
+    first = (await _authorize(app, caller, recipient))[2]
+    second = (await _authorize(app, caller, recipient))[2]
+
+    sent = await _websocket(
+        app,
+        protocols=[
+            ACP_SUBPROTOCOL,
+            first["protocols"][1],
+            second["protocols"][1],
+        ],
+        headers={"origin": ORIGIN},
+    )
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4401,
+            "reason": "ACP admission refused",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_browser_ticket_requires_acp_subprotocol():
+    app, caller, recipient, agents = _app()
+    authorized = (await _authorize(app, caller, recipient))[2]
+
+    sent = await _websocket(
+        app,
+        protocols=[authorized["protocols"][1]],
+        headers={"origin": ORIGIN},
+    )
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4401,
+            "reason": "ACP admission refused",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_remote_transport_keeps_resume_route_enabled():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    resume = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "session/resume",
+        "params": {"sessionId": "saved-session", "cwd": "/tmp"},
+    }
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[_initialize(), resume],
+        expected_sends=2,
+    )
+
+    responses = [json.loads(item["text"]) for item in sent if item["type"] == "websocket.send"]
+    assert [response["id"] for response in responses] == [1, 2]
+    assert responses[1]["result"] == {}
+    assert agents[0][1].resumed == ("saved-session", "/tmp")
+
+
+@pytest.mark.asyncio
+async def test_first_frame_must_initialize_before_agent_creation():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[{"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {}}],
+    )
+
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 4400
+    assert agents == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "first",
+    [
+        {"jsonrpc": "1.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": True, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": []},
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "not-an-integer"},
+        },
+    ],
+)
+async def test_malformed_initialize_never_creates_an_agent(first):
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(app, headers=signed, frames=[first])
+
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 4400
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_non_standard_json_constant_is_rejected_before_agent_creation():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    first = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"protocolVersion": float("nan")},
+    }
+
+    sent = await _websocket(app, headers=signed, frames=[first])
+
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 1007
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_wrong_websocket_path_never_runs_admission_or_agent_factory():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(app, path=ACP_AUTHORIZE_PATH, headers=signed)
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4404,
+            "reason": "ACP WebSocket path not found",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_insecure_non_loopback_websocket_never_runs_admission():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        client=("203.0.113.10", 49152),
+    )
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4403,
+            "reason": "Secure transport is required",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_plaintext_loopback_proxy_with_public_authority_fails_closed():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(
+        app,
+        headers={**signed, "host": "agent.example.com"},
+        client=("127.0.0.1", 49152),
+        scheme="ws",
+    )
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4403,
+            "reason": "Secure transport is required",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_unsigned_websocket_is_closed_before_agent_creation():
+    app, _, _, agents = _app()
+
+    sent = await _websocket(app)
+
+    assert sent == [
+        {
+            "type": "websocket.close",
+            "code": 4401,
+            "reason": "ACP admission refused",
+        }
+    ]
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_top_level_asgi_routes_only_exact_acp_endpoints(monkeypatch):
+    calls = []
+
+    class _ACPApp:
+        async def __call__(self, scope, _receive, _send):
+            calls.append(("acp", scope["type"], scope["path"]))
+
+        async def close(self):
+            calls.append(("acp-close",))
+
+    async def legacy_websocket(scope, _receive, _send, **_kwargs):
+        calls.append(("legacy", scope["type"], scope["path"]))
+
+    monkeypatch.setattr(asgi_module, "handle_websocket", legacy_websocket)
+    app = asgi_module.create_app(
+        route_handlers={},
+        storage=Mock(),
+        registry=ActiveSessionRegistry(),
+        acp=_ACPApp(),
+    )
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    async def send(_message):
+        pass
+
+    await app({"type": "websocket", "path": ACP_PATH}, receive, send)
+    await app({"type": "websocket", "path": ACP_AUTHORIZE_PATH}, receive, send)
+    await app({"type": "websocket", "path": "/ws"}, receive, send)
+    await app(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": ACP_AUTHORIZE_PATH,
+        },
+        receive,
+        send,
+    )
+
+    assert calls == [
+        ("acp", "websocket", ACP_PATH),
+        ("legacy", "websocket", ACP_AUTHORIZE_PATH),
+        ("legacy", "websocket", "/ws"),
+        ("acp", "http", ACP_AUTHORIZE_PATH),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_runs_host_cleanup_if_acp_cleanup_fails(caplog):
+    events = []
+
+    class _FailingACPApp:
+        async def close(self):
+            events.append("acp")
+            raise RuntimeError("cleanup failure")
+
+    async def host_shutdown():
+        events.append("host")
+
+    app = asgi_module.create_app(
+        route_handlers={},
+        storage=Mock(),
+        registry=ActiveSessionRegistry(),
+        acp=_FailingACPApp(),
+        on_shutdown=host_shutdown,
+    )
+    received = False
+    sent = []
+
+    async def receive():
+        nonlocal received
+        if received:
+            raise AssertionError("lifespan receive called twice")
+        received = True
+        return {"type": "lifespan.shutdown"}
+
+    async def send(message):
+        sent.append(message)
+
+    await app({"type": "lifespan"}, receive, send)
+
+    assert events == ["acp", "host"]
+    assert sent == [{"type": "lifespan.shutdown.complete"}]
+    assert "ASGI shutdown cleanup failed" in caplog.text

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -44,6 +44,10 @@ def test_handle_ai_calls_start_server(monkeypatch):
     )
 
     assert called["port"] == 1111
+    assert called["model"] == "m"
+    assert called["max_iterations"] == 3
+    assert called["yolo"] is True
+    assert called["yolo_turns"] == 7
     assert called["agent"] is created["agent"]
     assert created["model"] == "m"
     assert created["max_iterations"] == 3

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -12,8 +12,16 @@ Components under test:
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import connectonion.cli.co_ai.agent as agent_mod
 import connectonion.cli.co_ai.main as main_mod
+from connectonion.cli.co_ai.one_shot_sessions import (
+    SessionSnapshotError,
+    load_snapshot,
+    save_snapshot,
+)
+from connectonion.network.host.acp_gateway import ACPPrincipal
 from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
 
 
@@ -94,8 +102,14 @@ def test_start_server_hosts_provided_agent(monkeypatch):
     agent = SimpleNamespace(name="agent")
     called = {}
 
-    def fake_host(agent, port, trust, co_dir=None, relay_url=None):
-        called.update({"agent": agent, "port": port, "trust": trust, "relay_url": relay_url})
+    def fake_host(agent, port, trust, co_dir=None, relay_url=None, **kwargs):
+        called.update({
+            "agent": agent,
+            "port": port,
+            "trust": trust,
+            "relay_url": relay_url,
+            **kwargs,
+        })
 
     monkeypatch.setattr(main_mod, "host", fake_host)
 
@@ -105,6 +119,70 @@ def test_start_server_hosts_provided_agent(monkeypatch):
     assert called["trust"] == "careful"
     assert called["relay_url"] is None
     assert called["agent"] is agent
+    assert callable(called["acp_agent_factory"])
+
+
+def test_network_acp_sessions_are_principal_scoped_and_full_access_is_admin_only(
+    monkeypatch,
+    tmp_path,
+):
+    agent = SimpleNamespace(name="agent")
+    called = {}
+    monkeypatch.setattr(main_mod.Path, "home", lambda: tmp_path)
+
+    def fake_host(_agent, **kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(main_mod, "host", fake_host)
+    main_mod.start_server(agent, yolo=True, yolo_turns=7)
+    factory = called["acp_agent_factory"]
+
+    def principal(address, level, *, method="browser_ticket"):
+        return ACPPrincipal(
+            address=address,
+            level=level,
+            recipient="0xrecipient",
+            origin="https://chat.openonion.ai",
+            auth_method=method,
+            authenticated_at=1.0,
+        )
+
+    contact = factory(principal("0xcontact", "contact"))
+    same_contact = factory(principal("0xcontact", "contact"))
+    other_contact = factory(principal("0xother", "contact"))
+    signed_contact = factory(
+        principal("0xcontact", "contact", method="signed_headers")
+    )
+    admin = factory(principal("0xadmin", "admin"))
+
+    assert contact._session_co_dir == same_contact._session_co_dir
+    assert contact._session_co_dir != other_contact._session_co_dir
+    assert contact._session_co_dir != signed_contact._session_co_dir
+    assert contact._session_co_dir.is_relative_to(
+        tmp_path / ".co" / "acp-principals"
+    )
+    assert contact._yolo is False
+    assert admin._yolo is True
+    assert admin._yolo_turns == 7
+
+    session_id = "40c0397c-972b-4133-899b-5ab4cc5c4883"
+    snapshot = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "mode": ":read-only",
+        "plan": [],
+    }
+    save_snapshot(contact._session_co_dir, snapshot, {}, cwd=tmp_path)
+    loaded, _ = load_snapshot(
+        same_contact._session_co_dir,
+        session_id,
+        cwd=tmp_path,
+    )
+    assert loaded["session_id"] == session_id
+    with pytest.raises(SessionSnapshotError, match="was not found"):
+        load_snapshot(other_contact._session_co_dir, session_id, cwd=tmp_path)
 
 
 def test_role_reaches_the_assembler(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- mount an authenticated ACP JSON-RPC WebSocket endpoint at `/acp` while keeping the legacy `/ws` endpoint unchanged
- reuse the same `ConnectOnionACPAgent` factory for stdio and network transports
- add signed programmatic upgrades plus short-lived, one-use browser tickets issued by `POST /acp/authorize`
- isolate resumable sessions by authenticated principal and bind Full access to an explicit `--yolo` operator ceiling plus administrator trust
- record the design in DD-045 and document the direct-endpoint deployment/security contract

Closes #895.

## Design alignment

- DD-044 remains authoritative: collaboration mode (`default` / `plan`) is separate from Host permission profile (`:read-only` / `:workspace` / `:danger-full-access`).
- `--yolo` is a launch-time authority ceiling, not a fourth mode and not authority delegated to every remote contact.
- ACP stdio and WebSocket share one lifecycle adapter; the only new layer is transport authentication/admission.
- The remote transport follows the upstream ACP Streamable HTTP/WebSocket RFD. This PR implements the WebSocket carrier only; ordinary HTTP `/acp` returns `426` rather than claiming Streamable HTTP support.
- The standalone TypeScript SDK remains retired. Native browser consumption belongs in openonion/connectonion-react#32, then openonion/oo-chat#136; this PR leaves O Chat's current `/ws` path compatible.
- Relay ACP is explicitly out of scope until #897/#898 provide message-level end-to-end confidentiality. Signed metadata is authentication, not encryption.

## Security boundary

- exact `/acp` routing, signed canonical upgrade headers, trust policy, blacklist/whitelist, replay store, and route binding
- exact-origin browser authorization with strict content type/JSON validation and Private Network Access preflight support
- random ticket material stored as a digest, 60-second expiry, one use, bounded storage, origin/principal binding, and mismatch burn
- direct loopback plaintext only; non-loopback clients require a trusted secure ASGI scheme (`wss`)
- strict first JSON-RPC text request (`initialize`), official SDK model validation, absolute initialization deadline, 1 MiB frames, finite JSON, bounded queues, rate limits, and global/per-principal connection caps
- principal-namespaced snapshots prevent a copied session ID from crossing an authenticated identity boundary
- shutdown cancels both transport pumps and all agent lifecycles

## Verification

- 427 related ACP/ASGI/auth/CLI regression tests passed
- 20/20 cross-worker replay tests passed
- Ruff lint and format checks pass for the new Gateway implementation and its 1,093-line security/protocol test matrix
- `compileall` passed for changed runtime modules
- local `uv build` produced `connectonion-1.7.0a1` wheel and sdist; both contain the Gateway, DD-045, and network documentation
- credential/debug-residue scan found no secrets, TODO/FIXME/WIP markers, breakpoints, or debug prints in the added implementation

No package was published and no release was created.
