### PR TITLE
Advertise native ACP transport for downgrade-safe React negotiation

### DIFF
--- a/connectonion/network/asgi/http.py
+++ b/connectonion/network/asgi/http.py
@@ -69,11 +69,18 @@ async def read_body(receive) -> bytes:
     return body
 
 
-async def send_json(send, data: dict, status: int = 200):
+async def send_json(
+    send,
+    data: dict,
+    status: int = 200,
+    extra_headers: list[list[bytes]] | None = None,
+):
     """Send JSON response via ASGI send."""
     # Use pydantic_json_encoder to handle Pydantic models (e.g., TokenUsage) in response
     body = json.dumps(data, default=pydantic_json_encoder).encode()
     headers = [[b"content-type", b"application/json"]] + CORS_HEADERS
+    if extra_headers:
+        headers += extra_headers
     await send({"type": "http.response.start", "status": status, "headers": headers})
     await send({"type": "http.response.body", "body": body})
 

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable, Iterable
 from urllib.parse import urlsplit
 
+from acp import PROTOCOL_VERSION
 from acp.agent.connection import AgentSideConnection
 from acp.schema import InitializeRequest
 from pydantic import ValidationError
@@ -65,6 +66,19 @@ _UNIQUE_SECURITY_HEADERS = _CORS_REQUEST_HEADER_NAMES | frozenset(
     }
 )
 _IGNORED_WEBSOCKET_FRAME = object()
+
+
+def acp_transport_descriptor() -> dict[str, Any]:
+    """Return the public, non-authoritative discovery shape for this gateway."""
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "type": "websocket",
+        "path": ACP_PATH,
+        "authorization": {
+            "type": "connectonion-ticket",
+            "path": ACP_AUTHORIZE_PATH,
+        },
+    }
 
 
 def _reject_json_constant(value: str) -> None:
@@ -1051,5 +1065,6 @@ __all__ = [
     "DEFAULT_ACP_ORIGINS",
     "DEFAULT_INITIALIZE_TIMEOUT_SECONDS",
     "TICKET_SUBPROTOCOL_PREFIX",
+    "acp_transport_descriptor",
     "create_authenticated_acp_app",
 ]

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -295,6 +295,12 @@ def info_handler(agent_metadata: dict, trust, trust_config: dict | None = None,
         },
     }
 
+    # Public transport discovery is intentionally separate from ACP's
+    # post-initialize feature capabilities.  It contains fixed route metadata
+    # only: never copy connection, session, permission, or credential state here.
+    if agent_metadata.get("transports"):
+        result["transports"] = agent_metadata["transports"]
+
     # The balance is deliberately not here. /info needs no credentials, so on a
     # deployed agent this response is readable by the whole internet, and the
     # operator's account balance is both commercially revealing on its own and a
@@ -537,7 +543,13 @@ async def handle_http(
         await send_json(send, route_handlers["health"](start_time))
 
     elif method == "GET" and path == "/info":
-        await send_json(send, route_handlers["info"](trust, trust_config))
+        # Transport absence selects the legacy fallback.  Never let a browser or
+        # intermediary reuse an answer from before an ACP deployment or rollback.
+        await send_json(
+            send,
+            route_handlers["info"](trust, trust_config),
+            extra_headers=[[b"cache-control", b"no-store"]],
+        )
 
     elif method == "GET" and path == "/docs":
         base = Path(__file__).resolve().parent.parent

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -1030,7 +1030,10 @@ def host(
 
     acp_app = None
     if acp_agent_factory is not None:
-        from .acp_gateway import create_authenticated_acp_app
+        from .acp_gateway import (
+            acp_transport_descriptor,
+            create_authenticated_acp_app,
+        )
 
         acp_options = {
             "trust_agent": trust_agent,
@@ -1045,6 +1048,10 @@ def host(
             acp_agent_factory,
             **acp_options,
         )
+        # Discovery must describe the transport that was actually mounted.  React
+        # uses this before admission to select exactly one protocol; publishing it
+        # earlier (or from package version alone) could advertise a dead endpoint.
+        agent_metadata["transports"] = {"acp": acp_transport_descriptor()}
 
     # Parse trust config for /info onboard info
     trust_config = _parse_trust_config(trust)

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -123,6 +123,9 @@ ConnectOnion Host -> @connectonion/react -> O Chat
 ```
 
 Starting `/acp` and moving the released browser are separate rollback points.
+The explicit transport discovery and fail-closed downgrade rule used for that
+move are defined separately in
+[DD-046](046-explicit-acp-transport-discovery.md).
 
 ### Relay ACP is not approved here
 

--- a/docs/design-decisions/046-explicit-acp-transport-discovery.md
+++ b/docs/design-decisions/046-explicit-acp-transport-discovery.md
@@ -1,0 +1,91 @@
+# DD-046: Select native ACP through explicit transport discovery
+
+**Status:** Proposed
+
+**Date:** 2026-08-12
+
+**Related:** [DD-035 Versioned ACP Host Carrier](035-versioned-acp-host-carrier.md), [DD-045 Authenticated ACP WebSocket Gateway](045-authenticated-acp-websocket-gateway.md), [Issue #915](https://github.com/openonion/connectonion/issues/915), [React issue #32](https://github.com/openonion/connectonion-react/issues/32)
+
+## Context
+
+DD-045 mounts native ACP at `/acp`, while the released browser still uses the
+legacy ConnectOnion `/ws` transport. React must select one path before it can
+authenticate or initialize ACP. The legacy socket advertises ACP carrier
+capabilities only after its own authenticated `CONNECTED` handshake, which is
+too late for pre-connection selection.
+
+Trying `/acp` and falling back after an Origin, TLS, trust, authorization, or
+network failure would turn a security or operational error into a silent
+downgrade. Trying both paths could duplicate prompts, permission decisions, or
+cancellation. Package-version inference would also advertise endpoints that a
+generic `host()` did not mount.
+
+Upstream ACP negotiates protocol features during `initialize`; its remote
+transport remains Draft. ConnectOnion therefore needs a narrow, explicitly
+versioned preview descriptor for choosing the transport, without inventing a
+second set of ACP feature capabilities.
+
+## Decision
+
+An ACP-enabled Host publishes this public descriptor in `/info` only after it
+has successfully mounted the gateway:
+
+```json
+{
+  "transports": {
+    "acp": {
+      "protocol_version": 1,
+      "type": "websocket",
+      "path": "/acp",
+      "authorization": {
+        "type": "connectonion-ticket",
+        "path": "/acp/authorize"
+      }
+    }
+  }
+}
+```
+
+This descriptor selects a transport. It is not an ACP `initialize` capability,
+is not authentication, and grants no authority. It contains fixed public route
+metadata only; connection IDs, session IDs, permissions, identities beyond the
+existing public Agent address, tickets, and signatures remain absent.
+`/info` is returned with `Cache-Control: no-store`: a response cached before an
+ACP deployment could otherwise turn explicit native support back into legacy
+fallback, while a cached descriptor after rollback could advertise a dead
+endpoint.
+
+React selects exactly one path before admission:
+
+- no `transports.acp` descriptor means use the bounded legacy `/ws` fallback;
+- the exact supported descriptor means use native ACP;
+- a malformed or unsupported descriptor fails closed;
+- after native ACP is selected, every admission, Origin, TLS, trust, and
+  transport error fails closed rather than downgrading or attempting `/ws`.
+
+Protocol version 1 comes from the pinned official ACP SDK constant. ACP feature
+support remains negotiated with the official SDK after `initialize`.
+
+This is the narrow 1.7 compatibility slice of issue #345's later discovery and
+transport separation. It does not pull the 2.3 provider/adapter architecture
+into the preview train.
+
+## Rejected alternatives
+
+- **Probe `/acp` and downgrade on failure:** conflates absence with security,
+  policy, CORS, TLS, and network failures.
+- **Open `/ws` to read its capabilities first:** selects the old protocol before
+  discovering the new one and creates a dual-connection lifecycle.
+- **Infer support from the package version:** the optional ACP factory, not the
+  installed version, determines whether `/acp` exists.
+- **Call this an ACP capability:** ACP capabilities describe optional protocol
+  behavior after `initialize`; this metadata chooses how to reach initialize.
+- **Publish tickets or session details:** routing and admission state do not
+  belong in unauthenticated discovery.
+
+## Compatibility and rollback
+
+Hosts without native ACP omit `transports.acp` and old React clients ignore the
+new field. Removing the descriptor makes updated React choose legacy `/ws`
+without changing stored sessions. Once a valid descriptor was observed for a
+connection attempt, however, errors never trigger an automatic downgrade.

--- a/docs/network/acp-websocket.md
+++ b/docs/network/acp-websocket.md
@@ -85,6 +85,33 @@ transport limitations; it does not replace ConnectOnion identity or trust.
 The preflight accepts only the documented signing headers and supports Private
 Network Access when an HTTPS page reaches a loopback Agent.
 
+Before admission, an ACP-enabled Host advertises the transport in its public
+`/info` response:
+
+```json
+{
+  "transports": {
+    "acp": {
+      "protocol_version": 1,
+      "type": "websocket",
+      "path": "/acp",
+      "authorization": {
+        "type": "connectonion-ticket",
+        "path": "/acp/authorize"
+      }
+    }
+  }
+}
+```
+
+This is ConnectOnion transport discovery, not an ACP `initialize` capability.
+React selects native ACP when the exact supported descriptor is present and
+uses the compatibility `/ws` transport only when it is absent. A malformed or
+unsupported descriptor, or any later admission/transport failure, fails closed
+instead of silently downgrading or sending through both paths.
+The `/info` response is `Cache-Control: no-store`, so upgrade and rollback
+selection cannot reuse a stale transport descriptor.
+
 ## Session ownership and permissions
 
 Persistent network ACP sessions are stored under a stable namespace derived

--- a/tests/unit/test_acp_transport_discovery.py
+++ b/tests/unit/test_acp_transport_discovery.py
@@ -1,0 +1,141 @@
+"""Transport discovery selects one browser protocol without granting authority."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from acp import PROTOCOL_VERSION
+
+from connectonion.network.host.acp_gateway import acp_transport_descriptor
+from connectonion.network.host.http_router import info_handler
+
+
+def _trust():
+    trust = Mock()
+    trust.trust = "careful"
+    return trust
+
+
+def _capture_host_app(tmp_path, monkeypatch, *, acp_enabled):
+    from connectonion import Agent, address
+    from connectonion.network.host import server
+
+    project = tmp_path / ("native" if acp_enabled else "legacy")
+    co_dir = project / ".co"
+    co_dir.mkdir(parents=True)
+    address.save(address.generate(), co_dir)
+    monkeypatch.chdir(project)
+
+    captured = {}
+    monkeypatch.setattr(
+        server.uvicorn,
+        "run",
+        lambda app, **kwargs: captured.update(app=app, kwargs=kwargs),
+    )
+    monkeypatch.setattr(server, "_print_host_banner", lambda **kwargs: None)
+    monkeypatch.setattr(server, "create_schedule_lifespan", lambda *args, **kwargs: (None, None))
+
+    agent = Agent(
+        "test",
+        tools=[],
+        model="co/gemini-2.5-flash",
+        api_key="test-key",
+        quiet=True,
+    )
+    server.host(
+        agent,
+        co_dir=co_dir,
+        relay_url=None,
+        acp_agent_factory=(lambda principal: Mock()) if acp_enabled else None,
+    )
+    return captured["app"]
+
+
+async def _get(app, path):
+    sent = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    await app(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "scheme": "http",
+            "client": ("127.0.0.1", 40000),
+            "server": ("127.0.0.1", 8000),
+        },
+        receive,
+        send,
+    )
+    start = next(message for message in sent if message["type"] == "http.response.start")
+    body = next(message["body"] for message in sent if message["type"] == "http.response.body")
+    return start, json.loads(body)
+
+
+def test_legacy_info_omits_transport_discovery():
+    metadata = {"name": "agent", "tools": [], "address": "0x123"}
+
+    result = info_handler(metadata, _trust())
+
+    assert "transports" not in result
+
+
+def test_info_returns_only_the_public_acp_transport_descriptor():
+    metadata = {
+        "name": "agent",
+        "tools": [],
+        "address": "0x123",
+        "transports": {"acp": acp_transport_descriptor()},
+    }
+
+    result = info_handler(metadata, _trust())
+
+    assert result["transports"] == {
+        "acp": {
+            "protocol_version": PROTOCOL_VERSION,
+            "type": "websocket",
+            "path": "/acp",
+            "authorization": {
+                "type": "connectonion-ticket",
+                "path": "/acp/authorize",
+            },
+        }
+    }
+    public = repr(result["transports"]).lower()
+    assert "ticket." not in public
+    assert "session_id" not in public
+    assert "permission" not in public
+
+
+@pytest.mark.asyncio
+async def test_generic_host_omits_acp_and_forbids_cached_fallback(tmp_path, monkeypatch):
+    app = _capture_host_app(tmp_path, monkeypatch, acp_enabled=False)
+
+    response, info = await _get(app, "/info")
+
+    assert "transports" not in info
+    assert dict(response["headers"])[b"cache-control"] == b"no-store"
+
+
+@pytest.mark.asyncio
+async def test_host_advertises_acp_only_after_mounting_the_gateway(tmp_path, monkeypatch):
+    app = _capture_host_app(tmp_path, monkeypatch, acp_enabled=True)
+
+    response, info = await _get(app, "/info")
+    assert info["transports"]["acp"] == acp_transport_descriptor()
+    assert dict(response["headers"])[b"cache-control"] == b"no-store"
+
+    # The same composite app must actually dispatch the advertised endpoint.
+    acp_response, acp_body = await _get(app, "/acp")
+    assert acp_response["status"] == 426
+    assert acp_body == {
+        "error": "ACP Streamable HTTP is not enabled",
+        "transport": "websocket",
+        "path": "/acp",
+    }

--- a/tests/unit/test_asgi_http.py
+++ b/tests/unit/test_asgi_http.py
@@ -320,6 +320,7 @@ class TestHandleHttpRouting:
         body = json.loads(sent[1]["body"])
         assert body["name"] == "test"
         assert body["trust"] == "careful"
+        assert dict(sent[0]["headers"])[b"cache-control"] == b"no-store"
 
     async def test_sessions_list_endpoint(self):
         """GET /sessions returns session list."""


### PR DESCRIPTION
Closes #915
Parent: #893
Blocks: openonion/connectonion-react#32

## Why

React must choose native `/acp` or legacy `/ws` before authentication. Falling back after an Origin, TLS, trust, authorization, or network error would turn a real failure into a silent protocol downgrade and could dual-send prompts or authority decisions.

## What

- publish `transports.acp` from public `/info` only after the native ACP gateway is mounted;
- derive protocol version and paths from the pinned ACP SDK and gateway constants;
- return `/info` with `Cache-Control: no-store` so upgrade and rollback cannot reuse a stale transport choice;
- add proposed DD-046 to separate pre-connection transport discovery from post-`initialize` ACP feature capabilities;
- document the exact React selection rule: absence permits bounded legacy fallback; present/malformed/unsupported/native errors never trigger a second transport;
- test real generic and ACP-enabled `host()` composite apps, including the advertised `/acp` 426 route.

## Security invariants

- discovery publishes no tickets, signatures, session IDs, permissions, or private Agent capabilities;
- a descriptor appears only for an actually mounted gateway;
- stale `/info` cannot silently select the wrong protocol;
- no error-driven downgrade and no dual send.

## Validation

- 156 targeted Host, ASGI, ACP gateway, profile, and discovery tests pass;
- Ruff passes for changed focused source/test files;
- compileall and `git diff --check` pass;
- two independent self-reviews report 0 remaining P0/P1/P2 findings after fixes.

No package, tag, or release was published.