### PR TITLE
fix(acp): bind network sessions to host workspace

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -88,6 +88,90 @@ PermissionRequester = Callable[
 ACP_EVENT_BUFFER_SIZE = 64
 logger = logging.getLogger(__name__)
 
+# cwd and redirect_stdout are process-global, so every ACP adapter in this
+# process must share one lock rather than protecting only itself.
+_PROCESS_CONTEXT_LOCK = threading.RLock()
+
+
+class _BoundNetworkWorkspace:
+    """The exact directory object that existed when the network Host started."""
+
+    def __init__(self, path: Path, descriptor: int | None) -> None:
+        self.path = path
+        self._descriptor = descriptor
+        stat_result = os.fstat(descriptor) if descriptor is not None else path.stat()
+        self._identity = (stat_result.st_dev, stat_result.st_ino)
+
+    @property
+    def namespace_key(self) -> str:
+        """Private namespace input; the caller stores only its digest."""
+
+        return f"{self.path}\0{self._identity[0]}:{self._identity[1]}"
+
+    @contextmanager
+    def enter(self):
+        if self._descriptor is not None and hasattr(os, "fchdir"):
+            flags = os.O_RDONLY
+            if hasattr(os, "O_DIRECTORY"):
+                flags |= os.O_DIRECTORY
+            if hasattr(os, "O_CLOEXEC"):
+                flags |= os.O_CLOEXEC
+            previous = os.open(".", flags)
+            try:
+                os.fchdir(self._descriptor)
+                yield
+            finally:
+                os.fchdir(previous)
+                os.close(previous)
+            return
+
+        self._verify_path_identity()
+        previous_path = Path.cwd()
+        try:
+            os.chdir(self.path)
+            current = os.stat(".")
+            if (current.st_dev, current.st_ino) != self._identity:
+                raise RuntimeError("Network ACP workspace changed after Host startup")
+            yield
+        finally:
+            os.chdir(previous_path)
+
+    def _verify_path_identity(self) -> None:
+        try:
+            current = self.path.stat()
+        except OSError:
+            raise RuntimeError("Network ACP workspace is no longer available") from None
+        if (current.st_dev, current.st_ino) != self._identity:
+            raise RuntimeError("Network ACP workspace changed after Host startup")
+
+
+def capture_network_workspace(path: Path) -> _BoundNetworkWorkspace:
+    """Bind the network workspace to a directory object, not a reusable path."""
+
+    resolved = Path(path).resolve(strict=True)
+    if not resolved.is_dir():
+        raise NotADirectoryError(resolved)
+    if not hasattr(os, "fchdir"):
+        return _BoundNetworkWorkspace(resolved, None)
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(resolved, flags)
+    try:
+        before = resolved.stat()
+        opened = os.fstat(descriptor)
+        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+            raise RuntimeError("Network ACP workspace changed during Host startup")
+        return _BoundNetworkWorkspace(resolved, descriptor)
+    except BaseException:
+        os.close(descriptor)
+        raise
+
 _ACP_PERMISSION_OPTIONS = (
     PermissionOption(
         option_id="allow_once",
@@ -609,7 +693,7 @@ class ConnectOnionACPAgent:
         yolo_turns: int,
         agent_factory: AgentFactory | None = None,
         session_co_dir: Path | None = None,
-        network_workspace: Path | None = None,
+        network_workspace: _BoundNetworkWorkspace | None = None,
         allow_mcp: bool = False,
         mcp_connector: MCPConnector | None = None,
     ) -> None:
@@ -619,18 +703,11 @@ class ConnectOnionACPAgent:
         self._yolo_turns = yolo_turns
         self._agent_factory = agent_factory
         self._session_co_dir = Path(session_co_dir or GLOBAL_CO_DIR)
-        self._network_workspace = (
-            Path(network_workspace).resolve(strict=True)
-            if network_workspace is not None
-            else None
-        )
+        self._network_workspace = network_workspace
         self._allow_mcp = allow_mcp
         self._mcp_connector = mcp_connector
         self._client: Client | None = None
         self._sessions: dict[str, _SessionRuntime] = {}
-        # cwd and redirect_stdout are process-global.  ACP request handlers stay
-        # asynchronous, while this lock makes those short global scopes explicit.
-        self._process_context_lock = threading.RLock()
 
     def on_connect(self, client: Client) -> None:
         self._client = client
@@ -1088,7 +1165,7 @@ class ConnectOnionACPAgent:
                 session, tools = load_snapshot(
                     self._session_co_dir,
                     session_id,
-                    cwd=project_dir,
+                    cwd=self._snapshot_cwd(project_dir),
                 )
             else:
                 session, tools = None, {}
@@ -1192,7 +1269,7 @@ class ConnectOnionACPAgent:
                     self._session_co_dir,
                     session,
                     normalized_tools,
-                    cwd=project_dir,
+                    cwd=self._snapshot_cwd(project_dir),
                 )
             return _SessionRuntime(
                 session_id=session_id,
@@ -1230,7 +1307,7 @@ class ConnectOnionACPAgent:
             self._session_co_dir,
             persistent_session,
             tools,
-            cwd=runtime.cwd,
+            cwd=self._snapshot_cwd(runtime.cwd),
         )
         # os.replace inside save_snapshot is the final fallible commit step.
         # These reference assignments cannot split the durable snapshot from
@@ -1397,7 +1474,7 @@ class ConnectOnionACPAgent:
             self._session_co_dir,
             session,
             tools,
-            cwd=runtime.cwd,
+            cwd=self._snapshot_cwd(runtime.cwd),
         )
         runtime.agent.current_session = agent_session
         runtime.last_good_session = last_good_session
@@ -1612,7 +1689,12 @@ class ConnectOnionACPAgent:
 
     @contextmanager
     def _process_context(self, cwd: Path):
-        with self._process_context_lock:
+        with _PROCESS_CONTEXT_LOCK:
+            if self._network_workspace is not None:
+                with self._network_workspace.enter():
+                    with redirect_stdout(sys.stderr):
+                        yield
+                return
             previous_cwd = Path.cwd()
             try:
                 os.chdir(cwd)
@@ -1649,7 +1731,12 @@ class ConnectOnionACPAgent:
             raise RequestError.invalid_params(
                 {"details": "network ACP cwd must be the virtual workspace root /"}
             )
-        return self._network_workspace
+        return self._network_workspace.path
+
+    def _snapshot_cwd(self, cwd: Path) -> Path | str:
+        """Keep network persistence on the virtual path, never a Host path."""
+
+        return "/" if self._network_workspace is not None else cwd
 
     @staticmethod
     def _prompt_text(prompt: list[Any]) -> str:
@@ -1675,7 +1762,7 @@ def create_acp_agent(
     yolo: bool,
     yolo_turns: int,
     session_co_dir: Path | None = None,
-    network_workspace: Path | None = None,
+    network_workspace: _BoundNetworkWorkspace | None = None,
     allow_mcp: bool = False,
 ) -> ConnectOnionACPAgent:
     """Build the shared ACP lifecycle adapter for stdio or network transport."""

--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -609,6 +609,7 @@ class ConnectOnionACPAgent:
         yolo_turns: int,
         agent_factory: AgentFactory | None = None,
         session_co_dir: Path | None = None,
+        network_workspace: Path | None = None,
         allow_mcp: bool = False,
         mcp_connector: MCPConnector | None = None,
     ) -> None:
@@ -618,6 +619,11 @@ class ConnectOnionACPAgent:
         self._yolo_turns = yolo_turns
         self._agent_factory = agent_factory
         self._session_co_dir = Path(session_co_dir or GLOBAL_CO_DIR)
+        self._network_workspace = (
+            Path(network_workspace).resolve(strict=True)
+            if network_workspace is not None
+            else None
+        )
         self._allow_mcp = allow_mcp
         self._mcp_connector = mcp_connector
         self._client: Client | None = None
@@ -666,7 +672,7 @@ class ConnectOnionACPAgent:
         **_kwargs: Any,
     ) -> NewSessionResponse:
         self._validate_session_inputs(additional_directories, mcp_servers)
-        project_dir = self._validate_cwd(cwd)
+        project_dir = self._session_cwd(cwd)
         session_id = new_session_id()
         acp_input = _ACPEventBridge(
             asyncio.get_running_loop(),
@@ -704,7 +710,7 @@ class ConnectOnionACPAgent:
         """Resume one persisted session without replaying its transcript."""
 
         self._validate_session_inputs(additional_directories, mcp_servers)
-        project_dir = self._validate_cwd(cwd)
+        project_dir = self._session_cwd(cwd)
         if session_id in self._sessions:
             raise RequestError(
                 -32000,
@@ -1633,6 +1639,17 @@ class ConnectOnionACPAgent:
             )
         return resolved
 
+    def _session_cwd(self, cwd: str) -> Path:
+        """Resolve local stdio paths or the network-only virtual root."""
+
+        if self._network_workspace is None:
+            return self._validate_cwd(cwd)
+        if cwd != "/":
+            raise RequestError.invalid_params(
+                {"details": "network ACP cwd must be the virtual workspace root /"}
+            )
+        return self._network_workspace
+
     @staticmethod
     def _prompt_text(prompt: list[Any]) -> str:
         parts: list[str] = []
@@ -1657,6 +1674,7 @@ def create_acp_agent(
     yolo: bool,
     yolo_turns: int,
     session_co_dir: Path | None = None,
+    network_workspace: Path | None = None,
     allow_mcp: bool = False,
 ) -> ConnectOnionACPAgent:
     """Build the shared ACP lifecycle adapter for stdio or network transport."""
@@ -1667,6 +1685,7 @@ def create_acp_agent(
         yolo=yolo,
         yolo_turns=yolo_turns,
         session_co_dir=session_co_dir,
+        network_workspace=network_workspace,
         allow_mcp=allow_mcp,
     )
 

--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -99,7 +99,10 @@ class _BoundNetworkWorkspace:
     def __init__(self, path: Path, descriptor: int | None) -> None:
         self.path = path
         self._descriptor = descriptor
+        self._closed = False
         stat_result = os.fstat(descriptor) if descriptor is not None else path.stat()
+        if stat_result.st_ino == 0:
+            raise RuntimeError("Network ACP requires a stable workspace identity")
         self._identity = (stat_result.st_dev, stat_result.st_ino)
 
     @property
@@ -110,6 +113,8 @@ class _BoundNetworkWorkspace:
 
     @contextmanager
     def enter(self):
+        if self._closed:
+            raise RuntimeError("Network ACP workspace is closed")
         if self._descriptor is not None and hasattr(os, "fchdir"):
             flags = os.O_RDONLY
             if hasattr(os, "O_DIRECTORY"):
@@ -135,6 +140,21 @@ class _BoundNetworkWorkspace:
             yield
         finally:
             os.chdir(previous_path)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        """Release the pinned directory handle once the Host has stopped."""
+
+        if self._closed:
+            return
+        self._closed = True
+        descriptor = self._descriptor
+        self._descriptor = None
+        if descriptor is not None:
+            os.close(descriptor)
 
     def _verify_path_identity(self) -> None:
         try:
@@ -1165,7 +1185,7 @@ class ConnectOnionACPAgent:
                 session, tools = load_snapshot(
                     self._session_co_dir,
                     session_id,
-                    cwd=self._snapshot_cwd(project_dir),
+                    **self._snapshot_location(project_dir),
                 )
             else:
                 session, tools = None, {}
@@ -1269,7 +1289,7 @@ class ConnectOnionACPAgent:
                     self._session_co_dir,
                     session,
                     normalized_tools,
-                    cwd=self._snapshot_cwd(project_dir),
+                    **self._snapshot_location(project_dir),
                 )
             return _SessionRuntime(
                 session_id=session_id,
@@ -1307,7 +1327,7 @@ class ConnectOnionACPAgent:
             self._session_co_dir,
             persistent_session,
             tools,
-            cwd=self._snapshot_cwd(runtime.cwd),
+            **self._snapshot_location(runtime.cwd),
         )
         # os.replace inside save_snapshot is the final fallible commit step.
         # These reference assignments cannot split the durable snapshot from
@@ -1474,7 +1494,7 @@ class ConnectOnionACPAgent:
             self._session_co_dir,
             session,
             tools,
-            cwd=self._snapshot_cwd(runtime.cwd),
+            **self._snapshot_location(runtime.cwd),
         )
         runtime.agent.current_session = agent_session
         runtime.last_good_session = last_good_session
@@ -1733,10 +1753,12 @@ class ConnectOnionACPAgent:
             )
         return self._network_workspace.path
 
-    def _snapshot_cwd(self, cwd: Path) -> Path | str:
-        """Keep network persistence on the virtual path, never a Host path."""
+    def _snapshot_location(self, cwd: Path) -> dict[str, Path | str]:
+        """Keep network persistence on an opaque virtual path."""
 
-        return "/" if self._network_workspace is not None else cwd
+        if self._network_workspace is not None:
+            return {"virtual_cwd": "/"}
+        return {"cwd": cwd}
 
     @staticmethod
     def _prompt_text(prompt: list[Any]) -> str:

--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -731,10 +731,11 @@ class ConnectOnionACPAgent:
                 mcp_servers or [],
             )
         except SessionSnapshotError as exc:
+            details = None if self._network_workspace is not None else str(exc)
             raise RequestError(
                 -32002,
                 "Unable to resume session",
-                {"details": str(exc)},
+                {"details": details} if details is not None else None,
             ) from None
         except Exception:
             logger.exception("Failed to resume co ai ACP session")

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -62,6 +62,7 @@ def start_server(
     # Use global ~/.co/ for consistent identity across all co ai sessions
     co_dir = Path.home() / ".co"
     addr_data = address.load(co_dir)
+    network_workspace = Path.cwd().resolve(strict=True)
 
     # Open chat URL after agent successfully starts (2 second delay)
     if addr_data:
@@ -105,6 +106,7 @@ def start_server(
             yolo=yolo and principal.level == "admin",
             yolo_turns=yolo_turns,
             session_co_dir=session_co_dir,
+            network_workspace=network_workspace,
         )
 
     # Start server with same co_dir (relay enabled by default for web chat).

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -59,10 +59,13 @@ def start_server(
     - GET http://localhost:{port}/health
     - GET http://localhost:{port}/info
     """
+    from .acp_server import capture_network_workspace, create_acp_agent
+
+    network_workspace = capture_network_workspace(Path.cwd())
+
     # Use global ~/.co/ for consistent identity across all co ai sessions
     co_dir = Path.home() / ".co"
     addr_data = address.load(co_dir)
-    network_workspace = Path.cwd().resolve(strict=True)
 
     # Open chat URL after agent successfully starts (2 second delay)
     if addr_data:
@@ -76,8 +79,6 @@ def start_server(
     # ACP needs one isolated lifecycle adapter per authenticated connection.
     # The existing /ws web client remains available during its native-ACP
     # migration; both doors share the host's signature and trust boundary.
-    from .acp_server import create_acp_agent
-
     acp_model = model or getattr(getattr(agent, "llm", None), "model", None)
     acp_model = acp_model or "co/claude-opus-4-5"
     acp_max_iterations = max_iterations if max_iterations is not None else getattr(agent, "max_iterations", 100)
@@ -93,6 +94,7 @@ def start_server(
                 principal.address,
                 principal.origin or "",
                 principal.auth_method,
+                network_workspace.namespace_key,
             )
         )
         owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -62,62 +62,64 @@ def start_server(
     from .acp_server import capture_network_workspace, create_acp_agent
 
     network_workspace = capture_network_workspace(Path.cwd())
+    try:
+        # Use global ~/.co/ for consistent identity across all co ai sessions
+        co_dir = Path.home() / ".co"
+        addr_data = address.load(co_dir)
 
-    # Use global ~/.co/ for consistent identity across all co ai sessions
-    co_dir = Path.home() / ".co"
-    addr_data = address.load(co_dir)
+        # Open chat URL after agent successfully starts (2 second delay)
+        if addr_data:
 
-    # Open chat URL after agent successfully starts (2 second delay)
-    if addr_data:
+            def open_chat_delayed():
+                time.sleep(2)
+                webbrowser.open(f"https://chat.openonion.ai/{addr_data['address']}")
 
-        def open_chat_delayed():
-            time.sleep(2)
-            webbrowser.open(f"https://chat.openonion.ai/{addr_data['address']}")
+            threading.Thread(target=open_chat_delayed, daemon=True).start()
 
-        threading.Thread(target=open_chat_delayed, daemon=True).start()
+        # ACP needs one isolated lifecycle adapter per authenticated connection.
+        # The existing /ws web client remains available during its native-ACP
+        # migration; both doors share the host's signature and trust boundary.
+        acp_model = model or getattr(getattr(agent, "llm", None), "model", None)
+        acp_model = acp_model or "co/claude-opus-4-5"
+        acp_max_iterations = max_iterations if max_iterations is not None else getattr(agent, "max_iterations", 100)
 
-    # ACP needs one isolated lifecycle adapter per authenticated connection.
-    # The existing /ws web client remains available during its native-ACP
-    # migration; both doors share the host's signature and trust boundary.
-    acp_model = model or getattr(getattr(agent, "llm", None), "model", None)
-    acp_model = acp_model or "co/claude-opus-4-5"
-    acp_max_iterations = max_iterations if max_iterations is not None else getattr(agent, "max_iterations", 100)
-
-    def create_network_acp_agent(principal):
-        # A session ID is a routing value, never a credential. Keep persistent
-        # network sessions in a stable namespace selected only from the
-        # authenticated connection principal so copied IDs cross no boundary.
-        owner = "\0".join(
-            (
-                "v1",
-                principal.recipient,
-                principal.address,
-                principal.origin or "",
-                principal.auth_method,
-                network_workspace.namespace_key,
+        def create_network_acp_agent(principal):
+            # A session ID is a routing value, never a credential. Keep persistent
+            # network sessions in a stable namespace selected only from the
+            # authenticated connection principal so copied IDs cross no boundary.
+            owner = "\0".join(
+                (
+                    "v1",
+                    principal.recipient,
+                    principal.address,
+                    principal.origin or "",
+                    principal.auth_method,
+                    network_workspace.namespace_key,
+                )
             )
-        )
-        owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()
-        session_co_dir = co_dir / "acp-principals" / owner_id
-        return create_acp_agent(
-            model=acp_model,
-            max_iterations=acp_max_iterations,
-            # --yolo is an operator ceiling, not authority delegated to every
-            # trusted remote caller. Only the authenticated administrator can
-            # receive the Full access profile on this direct endpoint.
-            yolo=yolo and principal.level == "admin",
-            yolo_turns=yolo_turns,
-            session_co_dir=session_co_dir,
-            network_workspace=network_workspace,
-        )
+            owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()
+            session_co_dir = co_dir / "acp-principals" / owner_id
+            return create_acp_agent(
+                model=acp_model,
+                max_iterations=acp_max_iterations,
+                # --yolo is an operator ceiling, not authority delegated to every
+                # trusted remote caller. Only the authenticated administrator can
+                # receive the Full access profile on this direct endpoint.
+                yolo=yolo and principal.level == "admin",
+                yolo_turns=yolo_turns,
+                session_co_dir=session_co_dir,
+                network_workspace=network_workspace,
+            )
 
-    # Start server with same co_dir (relay enabled by default for web chat).
-    # co ai keeps one Agent instance so browser/tool state can persist across
-    # continued inputs in the same local web server.
-    host(
-        agent,
-        port=port,
-        trust="careful",
-        co_dir=co_dir,
-        acp_agent_factory=create_network_acp_agent,
-    )
+        # Start server with same co_dir (relay enabled by default for web chat).
+        # co ai keeps one Agent instance so browser/tool state can persist across
+        # continued inputs in the same local web server.
+        host(
+            agent,
+            port=port,
+            trust="careful",
+            co_dir=co_dir,
+            acp_agent_factory=create_network_acp_agent,
+        )
+    finally:
+        network_workspace.close()

--- a/connectonion/cli/co_ai/one_shot_sessions.py
+++ b/connectonion/cli/co_ai/one_shot_sessions.py
@@ -49,6 +49,17 @@ def _resolved_cwd(cwd: Path | str | None = None) -> str:
     return str((Path.cwd() if cwd is None else Path(cwd)).resolve())
 
 
+def _snapshot_cwd(
+    cwd: Path | str | None,
+    virtual_cwd: str | None,
+) -> str:
+    if virtual_cwd is None:
+        return _resolved_cwd(cwd)
+    if cwd is not None or virtual_cwd != "/":
+        raise SessionSnapshotError("Invalid virtual session working directory.")
+    return virtual_cwd
+
+
 class SessionLease:
     """Exclusive OS-backed ownership that can outlive one function call."""
 
@@ -141,6 +152,7 @@ def save_snapshot(
     tool_state: dict[str, Any] | None = None,
     *,
     cwd: Path | str | None = None,
+    virtual_cwd: str | None = None,
 ) -> None:
     """Atomically persist one completed Agent turn."""
     session_id = _canonical_id(session.get("session_id"))
@@ -150,7 +162,7 @@ def save_snapshot(
     _validate_plan_matches_tools(session, tools, session_id)
     payload = {
         "version": SNAPSHOT_VERSION,
-        "cwd": _resolved_cwd(cwd),
+        "cwd": _snapshot_cwd(cwd, virtual_cwd),
         "session": session,
         "tools": tools,
     }
@@ -186,6 +198,7 @@ def load_snapshot(
     session_id: str,
     *,
     cwd: Path | str | None = None,
+    virtual_cwd: str | None = None,
 ) -> tuple[dict, dict]:
     """Load and validate the exact snapshot named by ``session_id``."""
     canonical = _canonical_id(session_id)
@@ -207,10 +220,14 @@ def load_snapshot(
             f"Session {canonical} uses unsupported snapshot version {version}."
         )
     saved_cwd = payload.get("cwd")
-    if not isinstance(saved_cwd, str) or not Path(saved_cwd).is_absolute():
+    if not isinstance(saved_cwd, str):
         raise SessionSnapshotError(f"Session {canonical} has an invalid working directory.")
-    current_cwd = _resolved_cwd(cwd)
-    if os.path.normcase(str(Path(saved_cwd).resolve())) != os.path.normcase(current_cwd):
+    current_cwd = _snapshot_cwd(cwd, virtual_cwd)
+    if virtual_cwd is None:
+        if not Path(saved_cwd).is_absolute():
+            raise SessionSnapshotError(f"Session {canonical} has an invalid working directory.")
+        saved_cwd = str(Path(saved_cwd).resolve())
+    if os.path.normcase(saved_cwd) != os.path.normcase(current_cwd):
         raise SessionSnapshotError(
             f"Session {canonical} belongs to {saved_cwd}; resume it from that directory."
         )

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -35,6 +35,10 @@ single-use, Origin-bound ticket. Programmatic clients can sign the WebSocket
 upgrade directly. See [Authenticated ACP WebSocket](../network/acp-websocket.md).
 This preview supports direct loopback or TLS/WSS connections only. It does not
 claim end-to-end encryption through an untrusted TLS-terminating relay.
+Network clients send `/` as their ACP workspace; the Host maps that virtual
+root to the project directory captured when `co ai` started. They cannot select
+another Host path. Local stdio ACP clients continue to provide an existing
+absolute working directory.
 
 ### One-Shot Mode
 

--- a/docs/design-decisions/047-network-acp-virtual-workspace.md
+++ b/docs/design-decisions/047-network-acp-virtual-workspace.md
@@ -28,6 +28,8 @@ the Host accepts connections. On POSIX it keeps an open directory descriptor;
 on platforms without descriptor-relative directory entry it records the
 directory identity and verifies it before and after entry. A later rename,
 symlink, or replacement at the old pathname therefore cannot redirect a turn.
+If the platform or filesystem cannot provide a stable nonzero directory
+identity, network ACP fails closed at startup.
 Every network ACP adapter receives that immutable binding. `session/new` and
 `session/resume` map the exact protocol string `/` to it. Every other value
 fails as invalid parameters before session ownership, MCP startup, or Agent
@@ -37,7 +39,8 @@ The public protocol never returns the real Host path. Traversal spellings,
 symlink aliases, absolute Host paths, and path-like hints in extensible metadata
 cannot select a workspace. `additionalDirectories` remains unsupported and
 fails closed. Metadata is not an authority source. Network snapshots also store
-the virtual root rather than the Host pathname and use the bound directory
+the virtual root as protocol data rather than resolving it through Host path
+semantics, and use the bound directory
 identity as part of their private principal namespace.
 
 The shared ACP lifecycle adapter takes an explicit optional bound

--- a/docs/design-decisions/047-network-acp-virtual-workspace.md
+++ b/docs/design-decisions/047-network-acp-virtual-workspace.md
@@ -1,0 +1,61 @@
+# DD-047: Give network ACP one virtual workspace root
+
+**Status:** Accepted
+
+**Date:** 2026-08-12
+
+**Related:** [DD-029 Persistent ACP Session Ownership](029-acp-persistent-session-ownership.md), [DD-033 ACP stdio MCP Authority](033-acp-stdio-mcp-authority.md), [DD-045 Authenticated ACP WebSocket Gateway](045-authenticated-acp-websocket-gateway.md), [Issue #917](https://github.com/openonion/connectonion/issues/917)
+
+## Context
+
+ACP `session/new` and `session/resume` include a `cwd`. For stdio, the client is
+a local process launched by the same operator, so selecting an existing
+absolute directory is useful and does not cross a network trust boundary.
+
+The network endpoint has a different authority model. Authentication grants a
+caller access to the project served by this `co ai` process. If the same `cwd`
+rule were reused literally, a remote browser could name any existing absolute
+directory on the Host. Read-only mode would reduce mutation authority, but it
+would not authorize disclosure of a different project. A browser path also has
+no portable meaning on the Host.
+
+## Decision
+
+Network ACP exposes exactly one protocol workspace root: `/`.
+
+When `co ai` starts, it resolves and captures its launch directory before the
+Host accepts connections. Every network ACP adapter receives that immutable
+path. `session/new` and `session/resume` map the exact protocol string `/` to
+the captured directory. Every other value fails as invalid parameters before
+session ownership, MCP startup, or Agent construction.
+
+The public protocol never returns the real Host path. Traversal spellings,
+symlink aliases, absolute Host paths, and path-like hints in extensible metadata
+cannot select a workspace. `additionalDirectories` remains unsupported and
+fails closed. Metadata is not an authority source.
+
+The shared ACP lifecycle adapter takes an explicit optional
+`network_workspace`. Stdio leaves it unset and keeps its existing absolute-path
+behavior. This makes the transport boundary visible without duplicating the
+session implementation.
+
+## Rejected alternatives
+
+- **Accept any existing absolute path after authentication:** admission to one
+  launched project is not authority over the Host filesystem.
+- **Allow paths beneath the launch directory:** it leaks Host path structure
+  and creates platform-specific normalization and symlink rules that the
+  browser does not need.
+- **Use the browser's local working directory:** it describes a different
+  machine and cannot safely name a Host resource.
+- **Infer the workspace from ACP metadata:** extensible metadata is untrusted
+  application data, not an authority channel.
+- **Change stdio to `/` too:** local editor and CLI integrations legitimately
+  choose their project directory; no network boundary requires that break.
+
+## Compatibility and rollback
+
+Stdio clients are unchanged. Native network clients in the 1.7 preview must
+send `/`; no released browser used the native endpoint before this rule. If the
+network endpoint is rolled back under DD-045, the legacy `/ws` route and stdio
+ACP path behavior remain unchanged.

--- a/docs/design-decisions/047-network-acp-virtual-workspace.md
+++ b/docs/design-decisions/047-network-acp-virtual-workspace.md
@@ -23,21 +23,28 @@ no portable meaning on the Host.
 
 Network ACP exposes exactly one protocol workspace root: `/`.
 
-When `co ai` starts, it resolves and captures its launch directory before the
-Host accepts connections. Every network ACP adapter receives that immutable
-path. `session/new` and `session/resume` map the exact protocol string `/` to
-the captured directory. Every other value fails as invalid parameters before
-session ownership, MCP startup, or Agent construction.
+When `co ai` starts, it resolves and binds the launch directory object before
+the Host accepts connections. On POSIX it keeps an open directory descriptor;
+on platforms without descriptor-relative directory entry it records the
+directory identity and verifies it before and after entry. A later rename,
+symlink, or replacement at the old pathname therefore cannot redirect a turn.
+Every network ACP adapter receives that immutable binding. `session/new` and
+`session/resume` map the exact protocol string `/` to it. Every other value
+fails as invalid parameters before session ownership, MCP startup, or Agent
+construction.
 
 The public protocol never returns the real Host path. Traversal spellings,
 symlink aliases, absolute Host paths, and path-like hints in extensible metadata
 cannot select a workspace. `additionalDirectories` remains unsupported and
-fails closed. Metadata is not an authority source.
+fails closed. Metadata is not an authority source. Network snapshots also store
+the virtual root rather than the Host pathname and use the bound directory
+identity as part of their private principal namespace.
 
-The shared ACP lifecycle adapter takes an explicit optional
+The shared ACP lifecycle adapter takes an explicit optional bound
 `network_workspace`. Stdio leaves it unset and keeps its existing absolute-path
-behavior. This makes the transport boundary visible without duplicating the
-session implementation.
+behavior. All adapters share one process-context lock because `cwd` and stdout
+redirection are process-global. This makes the transport boundary visible
+without duplicating the session implementation.
 
 ## Rejected alternatives
 

--- a/docs/network/acp-websocket.md
+++ b/docs/network/acp-websocket.md
@@ -119,6 +119,12 @@ from the recipient Agent, verified caller, exact Origin, and admission method.
 The same principal can reauthenticate and resume; another principal cannot
 load the snapshot even with the copied session UUID and working directory.
 
+Network sessions use `/` as a virtual workspace root. The Host maps it to the
+directory captured when `co ai` started and rejects every other `cwd` before
+constructing an Agent. The actual Host path is not part of the public protocol.
+Stdio ACP keeps accepting an existing absolute directory from its local
+launcher. See [DD-047](../design-decisions/047-network-acp-virtual-workspace.md).
+
 Collaboration and permission are independent under DD-044. React owns
 `default` / `plan` workflow state. The Host advertises only `:read-only`,
 `:workspace`, and, when authorized, `:danger-full-access`. A launch `--yolo`

--- a/docs/network/acp-websocket.md
+++ b/docs/network/acp-websocket.md
@@ -115,7 +115,8 @@ selection cannot reuse a stale transport descriptor.
 ## Session ownership and permissions
 
 Persistent network ACP sessions are stored under a stable namespace derived
-from the recipient Agent, verified caller, exact Origin, and admission method.
+from the recipient Agent, verified caller, exact Origin, admission method, and
+bound workspace identity.
 The same principal can reauthenticate and resume; another principal cannot
 load the snapshot even with the copied session UUID and working directory.
 

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -20,6 +20,7 @@ from acp.interfaces import Client
 from connectonion.cli.co_ai import acp_server
 from connectonion.cli.co_ai.acp_server import (
     ConnectOnionACPAgent,
+    _BoundNetworkWorkspace,
     _FailClosedACPInput,
     capture_network_workspace,
 )
@@ -512,6 +513,15 @@ async def test_acp_adapters_share_one_process_context_lock(tmp_path):
         ("first-end", first_dir.resolve()),
         ("second", second_dir.resolve()),
     ]
+
+
+def test_network_acp_rejects_filesystem_without_stable_directory_identity():
+    class UnstableDirectory:
+        def stat(self):
+            return SimpleNamespace(st_dev=1, st_ino=0)
+
+    with pytest.raises(RuntimeError, match="stable workspace identity"):
+        _BoundNetworkWorkspace(UnstableDirectory(), None)  # type: ignore[arg-type]
 
 
 class _BufferWriter:

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -25,6 +25,7 @@ from connectonion.cli.co_ai.acp_transport import (
     _BoundStdoutWriter,
     _StrictNDJSONTransport,
 )
+from connectonion.cli.co_ai.one_shot_sessions import save_snapshot
 from connectonion.useful_plugins.tool_approval import check_approval
 
 
@@ -380,6 +381,45 @@ async def test_network_acp_rejects_host_paths_before_agent_construction(tmp_path
         )
 
     assert constructed == 0
+
+
+@pytest.mark.asyncio
+async def test_network_acp_resume_does_not_disclose_saved_host_workspace(tmp_path):
+    old_workspace = tmp_path / "old-private-project"
+    new_workspace = tmp_path / "new-private-project"
+    old_workspace.mkdir()
+    new_workspace.mkdir()
+    session_id = "40c0397c-972b-4133-899b-5ab4cc5c4883"
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "mode": ":read-only",
+        "plan": [],
+    }
+    save_snapshot(
+        tmp_path / "network-state",
+        session,
+        {},
+        cwd=old_workspace,
+    )
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+        session_co_dir=tmp_path / "network-state",
+        network_workspace=new_workspace,
+    )
+
+    with pytest.raises(RequestError, match="Unable to resume session") as exc_info:
+        await acp_agent.resume_session(session_id, "/", mcp_servers=[])
+
+    error = str(exc_info.value)
+    assert str(old_workspace) not in error
+    assert str(new_workspace) not in error
 
 
 class _BufferWriter:

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -8,6 +8,7 @@ import json
 import threading
 import time
 from copy import deepcopy
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -314,6 +315,71 @@ async def test_acp_rejects_unsupported_session_inputs(tmp_path):
         await acp_agent.new_session(str(tmp_path), mcp_servers=[object()])
     with pytest.raises(RequestError, match="Invalid params"):
         await acp_agent.new_session("relative/path")
+
+
+@pytest.mark.asyncio
+async def test_network_acp_maps_only_virtual_root_to_host_workspace(tmp_path):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    constructed_in: list[Path] = []
+
+    def factory(**_kwargs: Any) -> _FakeAgent:
+        constructed_in.append(Path.cwd())
+        return _FakeAgent()
+
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        network_workspace=workspace,
+    )
+
+    session = await acp_agent.new_session(
+        "/",
+        mcp_servers=[],
+        _meta={"cwd": "/tmp", "additionalDirectories": ["/private"]},
+    )
+
+    assert constructed_in == [workspace.resolve()]
+    assert acp_agent._sessions[session.session_id].cwd == workspace.resolve()
+
+
+@pytest.mark.asyncio
+async def test_network_acp_rejects_host_paths_before_agent_construction(tmp_path):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    constructed = 0
+
+    def factory(**_kwargs: Any) -> _FakeAgent:
+        nonlocal constructed
+        constructed += 1
+        return _FakeAgent()
+
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        network_workspace=workspace,
+    )
+
+    for cwd in (str(workspace), "/./", "/tmp"):
+        with pytest.raises(RequestError, match="Invalid params") as exc_info:
+            await acp_agent.new_session(cwd, mcp_servers=[])
+        assert str(workspace) not in str(exc_info.value)
+        with pytest.raises(RequestError, match="Invalid params"):
+            await acp_agent.resume_session("copied-session", cwd, mcp_servers=[])
+
+    with pytest.raises(RequestError, match="Invalid params"):
+        await acp_agent.new_session(
+            "/",
+            additional_directories=[str(tmp_path / "other")],
+        )
+
+    assert constructed == 0
 
 
 class _BufferWriter:

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import io
 import json
+import os
 import threading
 import time
 from copy import deepcopy
@@ -20,6 +21,7 @@ from connectonion.cli.co_ai import acp_server
 from connectonion.cli.co_ai.acp_server import (
     ConnectOnionACPAgent,
     _FailClosedACPInput,
+    capture_network_workspace,
 )
 from connectonion.cli.co_ai.acp_transport import (
     _BoundStdoutWriter,
@@ -334,7 +336,7 @@ async def test_network_acp_maps_only_virtual_root_to_host_workspace(tmp_path):
         yolo=False,
         yolo_turns=2,
         agent_factory=factory,
-        network_workspace=workspace,
+        network_workspace=capture_network_workspace(workspace),
     )
 
     session = await acp_agent.new_session(
@@ -364,7 +366,7 @@ async def test_network_acp_rejects_host_paths_before_agent_construction(tmp_path
         yolo=False,
         yolo_turns=2,
         agent_factory=factory,
-        network_workspace=workspace,
+        network_workspace=capture_network_workspace(workspace),
     )
 
     for cwd in (str(workspace), "/./", "/tmp"):
@@ -411,7 +413,7 @@ async def test_network_acp_resume_does_not_disclose_saved_host_workspace(tmp_pat
         yolo_turns=2,
         agent_factory=lambda **_kwargs: _FakeAgent(),
         session_co_dir=tmp_path / "network-state",
-        network_workspace=new_workspace,
+        network_workspace=capture_network_workspace(new_workspace),
     )
 
     with pytest.raises(RequestError, match="Unable to resume session") as exc_info:
@@ -420,6 +422,96 @@ async def test_network_acp_resume_does_not_disclose_saved_host_workspace(tmp_pat
     error = str(exc_info.value)
     assert str(old_workspace) not in error
     assert str(new_workspace) not in error
+
+
+@pytest.mark.asyncio
+async def test_network_acp_workspace_does_not_follow_replaced_launch_path(tmp_path):
+    launch_path = tmp_path / "project"
+    moved_path = tmp_path / "moved-project"
+    replacement = tmp_path / "replacement"
+    launch_path.mkdir()
+    replacement.mkdir()
+    (launch_path / "workspace-marker").write_text("original", encoding="utf-8")
+    (replacement / "workspace-marker").write_text("replacement", encoding="utf-8")
+    workspace = capture_network_workspace(launch_path)
+    launch_path.rename(moved_path)
+    if os.name == "nt":
+        launch_path.mkdir()
+    else:
+        launch_path.symlink_to(replacement, target_is_directory=True)
+    observed: list[str] = []
+
+    def factory(**_kwargs: Any) -> _FakeAgent:
+        observed.append(Path("workspace-marker").read_text(encoding="utf-8"))
+        return _FakeAgent()
+
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        network_workspace=workspace,
+    )
+
+    if hasattr(os, "fchdir"):
+        await acp_agent.new_session("/", mcp_servers=[])
+        assert observed == ["original"]
+    else:
+        with pytest.raises(RequestError, match="Unable to create"):
+            await acp_agent.new_session("/", mcp_servers=[])
+        assert observed == []
+
+
+@pytest.mark.asyncio
+async def test_acp_adapters_share_one_process_context_lock(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_started = threading.Event()
+    release_first = threading.Event()
+    observed: list[tuple[str, Path]] = []
+
+    def first_factory(**_kwargs: Any) -> _FakeAgent:
+        observed.append(("first-start", Path.cwd()))
+        first_started.set()
+        assert release_first.wait(timeout=1)
+        observed.append(("first-end", Path.cwd()))
+        return _FakeAgent()
+
+    def second_factory(**_kwargs: Any) -> _FakeAgent:
+        observed.append(("second", Path.cwd()))
+        return _FakeAgent()
+
+    first = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=first_factory,
+    )
+    second = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=second_factory,
+    )
+
+    first_task = asyncio.create_task(first.new_session(str(first_dir), mcp_servers=[]))
+    await asyncio.wait_for(asyncio.to_thread(first_started.wait), timeout=1)
+    second_task = asyncio.create_task(second.new_session(str(second_dir), mcp_servers=[]))
+    await asyncio.sleep(0.05)
+    assert observed == [("first-start", first_dir.resolve())]
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert observed == [
+        ("first-start", first_dir.resolve()),
+        ("first-end", first_dir.resolve()),
+        ("second", second_dir.resolve()),
+    ]
 
 
 class _BufferWriter:

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -211,7 +211,39 @@ def test_network_acp_workspace_is_captured_when_server_starts(monkeypatch, tmp_p
     )
     network_agent = called["acp_agent_factory"](principal)
 
-    assert network_agent._network_workspace == launch_dir.resolve()
+    assert network_agent._network_workspace.path == launch_dir.resolve()
+
+
+def test_network_acp_session_namespace_is_workspace_scoped(monkeypatch, tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    agent = SimpleNamespace(name="agent")
+    factories = []
+    monkeypatch.setattr(main_mod.Path, "home", lambda: tmp_path)
+
+    def fake_host(_agent, **kwargs):
+        factories.append(kwargs["acp_agent_factory"])
+
+    monkeypatch.setattr(main_mod, "host", fake_host)
+    principal = ACPPrincipal(
+        address="0xcontact",
+        level="contact",
+        recipient="0xrecipient",
+        origin="https://chat.openonion.ai",
+        auth_method="browser_ticket",
+        authenticated_at=1.0,
+    )
+
+    monkeypatch.chdir(first_dir)
+    main_mod.start_server(agent)
+    monkeypatch.chdir(second_dir)
+    main_mod.start_server(agent)
+
+    first_agent = factories[0](principal)
+    second_agent = factories[1](principal)
+    assert first_agent._session_co_dir != second_agent._session_co_dir
 
 
 def test_role_reaches_the_assembler(monkeypatch, tmp_path):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -212,6 +212,31 @@ def test_network_acp_workspace_is_captured_when_server_starts(monkeypatch, tmp_p
     network_agent = called["acp_agent_factory"](principal)
 
     assert network_agent._network_workspace.path == launch_dir.resolve()
+    assert network_agent._network_workspace.closed is True
+
+
+def test_network_acp_workspace_closes_when_host_raises(monkeypatch, tmp_path):
+    from connectonion.cli.co_ai import acp_server as acp_server_mod
+
+    captured = []
+    real_capture = acp_server_mod.capture_network_workspace
+
+    def capture(path):
+        workspace = real_capture(path)
+        captured.append(workspace)
+        return workspace
+
+    def fail_host(*_args, **_kwargs):
+        raise RuntimeError("host startup failed")
+
+    # start_server imports the function lazily from acp_server.
+    monkeypatch.setattr("connectonion.cli.co_ai.acp_server.capture_network_workspace", capture)
+    monkeypatch.setattr(main_mod, "host", fail_host)
+
+    with pytest.raises(RuntimeError, match="host startup failed"):
+        main_mod.start_server(SimpleNamespace(name="agent"))
+
+    assert captured and captured[0].closed is True
 
 
 def test_network_acp_session_namespace_is_workspace_scoped(monkeypatch, tmp_path):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -185,6 +185,35 @@ def test_network_acp_sessions_are_principal_scoped_and_full_access_is_admin_only
         load_snapshot(other_contact._session_co_dir, session_id, cwd=tmp_path)
 
 
+def test_network_acp_workspace_is_captured_when_server_starts(monkeypatch, tmp_path):
+    launch_dir = tmp_path / "launch"
+    later_dir = tmp_path / "later"
+    launch_dir.mkdir()
+    later_dir.mkdir()
+    agent = SimpleNamespace(name="agent")
+    called = {}
+    monkeypatch.chdir(launch_dir)
+
+    def fake_host(_agent, **kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(main_mod, "host", fake_host)
+    main_mod.start_server(agent)
+    monkeypatch.chdir(later_dir)
+
+    principal = ACPPrincipal(
+        address="0xcontact",
+        level="contact",
+        recipient="0xrecipient",
+        origin="https://chat.openonion.ai",
+        auth_method="browser_ticket",
+        authenticated_at=1.0,
+    )
+    network_agent = called["acp_agent_factory"](principal)
+
+    assert network_agent._network_workspace == launch_dir.resolve()
+
+
 def test_role_reaches_the_assembler(monkeypatch, tmp_path):
     """The factory→assembler hop was untested: assemble_prompt(role=) had tests
     and the template's role string had tests, but nothing checked that

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -575,3 +575,29 @@ def test_resume_requires_the_machine_readable_contract(capsys):
 
     assert caught.value.exit_code == 2
     assert "--resume requires --json" in capsys.readouterr().out
+
+
+def test_virtual_session_cwd_is_opaque_protocol_data(tmp_path):
+    session_id = new_session_id()
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+        "mode": ":read-only",
+        "plan": [],
+    }
+
+    save_snapshot(tmp_path, session, {}, virtual_cwd="/")
+    payload = json.loads(
+        (tmp_path / "ai" / "sessions" / f"{session_id}.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    restored, tools = load_snapshot(tmp_path, session_id, virtual_cwd="/")
+
+    assert payload["cwd"] == "/"
+    assert restored == session
+    assert tools == {}
+    with pytest.raises(SessionSnapshotError, match="Invalid virtual"):
+        save_snapshot(tmp_path, session, {}, cwd=tmp_path, virtual_cwd="/")


### PR DESCRIPTION
## Summary
- capture the resolved `co ai` launch directory before accepting network connections
- expose only the ACP virtual workspace root `/` and reject every other network `cwd` before Agent construction
- preserve existing stdio ACP absolute-path behavior
- document the boundary in accepted DD-047 and the network/CLI guides

## Security invariant
Authentication authorizes access to the project served by this `co ai` process. It does not authorize a browser to select arbitrary existing paths on the Host. Host paths, traversal spellings, symlink aliases, additional directories, and path-like `_meta` hints cannot expand the workspace or probe path existence.

## Verification
- `ruff check connectonion/cli/co_ai/acp_server.py connectonion/cli/co_ai/main.py tests/unit/test_co_ai_acp.py tests/unit/test_co_ai_agent_main.py`
- 246 focused ACP, gateway, discovery, route, and CLI tests passed
- 3 dedicated network-workspace tests passed after final metadata/additional-directory assertions
- `git diff --check`

Closes #917