### PR TITLE
fix(acp): bound durable session storage

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -83,8 +83,11 @@ from .agent import GLOBAL_CO_DIR
 from .one_shot_sessions import (
     SessionLease,
     SessionSnapshotError,
+    SnapshotStorageLimits,
+    acquire_bounded_new_session_lease,
     acquire_session_lease,
     capture_tool_state,
+    discard_unpublished_session,
     load_snapshot,
     new_session_id,
     restore_tool_state,
@@ -783,6 +786,9 @@ class ConnectOnionACPAgent:
         max_count = limits.get("max_files_per_request")
         max_storage_mb = limits.get("max_acp_upload_storage")
         max_stored_files = limits.get("max_acp_upload_files")
+        max_sessions = limits.get("max_acp_sessions")
+        max_session_storage_mb = limits.get("max_acp_session_storage")
+        max_snapshot_mb = limits.get("max_acp_snapshot_size")
         if (
             isinstance(max_size_mb, bool)
             or not isinstance(max_size_mb, (int, float))
@@ -798,8 +804,19 @@ class ConnectOnionACPAgent:
             or isinstance(max_stored_files, bool)
             or not isinstance(max_stored_files, int)
             or max_stored_files <= 0
+            or isinstance(max_sessions, bool)
+            or not isinstance(max_sessions, int)
+            or max_sessions <= 0
+            or isinstance(max_session_storage_mb, bool)
+            or not isinstance(max_session_storage_mb, (int, float))
+            or not math.isfinite(max_session_storage_mb)
+            or max_session_storage_mb <= 0
+            or isinstance(max_snapshot_mb, bool)
+            or not isinstance(max_snapshot_mb, (int, float))
+            or not math.isfinite(max_snapshot_mb)
+            or max_snapshot_mb <= 0
         ):
-            raise ValueError("ACP attachment limits must be positive numbers")
+            raise ValueError("ACP storage and attachment limits must be positive numbers")
         max_attachment_bytes = max_size_mb * 1024 * 1024
         if not math.isfinite(max_attachment_bytes) or max_attachment_bytes < 1:
             raise ValueError("ACP attachment size limit must be at least one byte")
@@ -813,6 +830,27 @@ class ConnectOnionACPAgent:
             raise ValueError("ACP upload storage limit must be at least one byte")
         self._max_upload_storage_bytes = int(max_upload_storage_bytes)
         self._max_upload_files = max_stored_files
+        max_session_storage_bytes = max_session_storage_mb * 1024 * 1024
+        max_snapshot_bytes = max_snapshot_mb * 1024 * 1024
+        if (
+            not math.isfinite(max_session_storage_bytes)
+            or max_session_storage_bytes < 1
+            or not math.isfinite(max_snapshot_bytes)
+            or max_snapshot_bytes < 1
+            or max_snapshot_bytes > max_session_storage_bytes
+        ):
+            raise ValueError(
+                "ACP session storage limits must be at least one byte and consistent"
+            )
+        self._snapshot_storage_limits = (
+            SnapshotStorageLimits(
+                max_sessions=max_sessions,
+                max_total_bytes=int(max_session_storage_bytes),
+                max_snapshot_bytes=int(max_snapshot_bytes),
+            )
+            if network_workspace is not None
+            else None
+        )
         self._allow_mcp = allow_mcp
         self._mcp_connector = mcp_connector
         self._client: Client | None = None
@@ -1229,22 +1267,6 @@ class ConnectOnionACPAgent:
         for close_task in close_tasks:
             await self._settle_owned_task(close_task)
 
-    async def _construct_runtime(
-        self,
-        constructor: Callable[..., _SessionRuntime],
-        *args: Any,
-    ) -> _SessionRuntime:
-        """Finish threaded construction even if its ACP request is cancelled."""
-
-        construction = asyncio.create_task(asyncio.to_thread(constructor, *args))
-        try:
-            return await asyncio.shield(construction)
-        except asyncio.CancelledError:
-            await self._settle_owned_task(construction)
-            if self._task_succeeded(construction):
-                construction.result().session_lease.close()
-            raise
-
     async def _construct_session_runtime(
         self,
         project_dir: Path,
@@ -1263,20 +1285,33 @@ class ConnectOnionACPAgent:
         mcp_pool = None
         try:
             mcp_pool = await self._connect_mcp_servers(mcp_servers, project_dir)
-            runtime = await self._construct_runtime(
-                self._open_session_runtime,
-                project_dir,
-                acp_input,
-                session_id,
-                list(mcp_pool.tools) if mcp_pool is not None else [],
-                ownership,
+            construction = asyncio.create_task(
+                asyncio.to_thread(
+                    self._open_session_runtime,
+                    project_dir,
+                    acp_input,
+                    session_id,
+                    list(mcp_pool.tools) if mcp_pool is not None else [],
+                    ownership,
+                )
             )
+            try:
+                runtime = await asyncio.shield(construction)
+            except asyncio.CancelledError:
+                await self._settle_owned_task(construction)
+                raise
         except BaseException:
             try:
                 if mcp_pool is not None:
                     await mcp_pool.close()
             finally:
-                ownership.lease.close()
+                if not resume and self._snapshot_storage_limits is not None:
+                    await self._settle_unpublished_session_cleanup(
+                        session_id,
+                        ownership.lease,
+                    )
+                else:
+                    ownership.lease.close()
             raise
         runtime.mcp_pool = mcp_pool
         return runtime
@@ -1302,7 +1337,14 @@ class ConnectOnionACPAgent:
         except asyncio.CancelledError:
             await self._settle_owned_task(acquisition)
             if self._task_succeeded(acquisition):
-                acquisition.result().lease.close()
+                ownership = acquisition.result()
+                if not resume and self._snapshot_storage_limits is not None:
+                    await self._settle_unpublished_session_cleanup(
+                        session_id,
+                        ownership.lease,
+                    )
+                else:
+                    ownership.lease.close()
             raise
 
     def _load_owned_session(
@@ -1311,19 +1353,52 @@ class ConnectOnionACPAgent:
         session_id: str,
         resume: bool,
     ) -> _SessionOwnership:
-        lease = acquire_session_lease(self._session_co_dir, session_id)
+        # A remote caller can supply arbitrary resume IDs. Confirm a bounded,
+        # existing snapshot before creating its per-session lease file, then
+        # reload after acquiring ownership so a live writer cannot race resume.
+        # New network sessions reserve their lease under the principal quota
+        # lock so simultaneous admissions cannot make every contender fail.
+        if resume and self._snapshot_storage_limits is not None:
+            load_snapshot(
+                self._session_co_dir,
+                session_id,
+                **self._snapshot_location(project_dir),
+                storage_limits=self._snapshot_storage_limits,
+            )
+        if not resume and self._snapshot_storage_limits is not None:
+            lease = acquire_bounded_new_session_lease(
+                self._session_co_dir,
+                session_id,
+                self._snapshot_storage_limits,
+            )
+        else:
+            lease = acquire_session_lease(self._session_co_dir, session_id)
         try:
             if resume:
                 session, tools = load_snapshot(
                     self._session_co_dir,
                     session_id,
                     **self._snapshot_location(project_dir),
+                    storage_limits=self._snapshot_storage_limits,
                 )
             else:
                 session, tools = None, {}
             return _SessionOwnership(lease, session, tools)
         except BaseException:
-            lease.close()
+            if not resume and self._snapshot_storage_limits is not None:
+                try:
+                    discard_unpublished_session(
+                        self._session_co_dir,
+                        session_id,
+                        lease,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Unable to remove failed ACP session admission",
+                        exc_info=True,
+                    )
+            else:
+                lease.close()
             raise
 
     async def _connect_mcp_servers(
@@ -1430,6 +1505,7 @@ class ConnectOnionACPAgent:
                     session,
                     normalized_tools,
                     **self._snapshot_location(project_dir),
+                    storage_limits=self._snapshot_storage_limits,
                 )
             return _SessionRuntime(
                 session_id=session_id,
@@ -1468,6 +1544,7 @@ class ConnectOnionACPAgent:
             persistent_session,
             tools,
             **self._snapshot_location(runtime.cwd),
+            storage_limits=self._snapshot_storage_limits,
         )
         # os.replace inside save_snapshot is the final fallible commit step.
         # These reference assignments cannot split the durable snapshot from
@@ -1635,6 +1712,7 @@ class ConnectOnionACPAgent:
             session,
             tools,
             **self._snapshot_location(runtime.cwd),
+            storage_limits=self._snapshot_storage_limits,
         )
         runtime.agent.current_session = agent_session
         runtime.last_good_session = last_good_session
@@ -1794,6 +1872,33 @@ class ConnectOnionACPAgent:
         with suppress(BaseException):
             task.result()
         return cancelled
+
+    async def _settle_unpublished_session_cleanup(
+        self,
+        session_id: str,
+        lease: SessionLease,
+    ) -> None:
+        """Finish blocking unpublished-state cleanup without stalling the loop."""
+
+        cleanup = asyncio.create_task(
+            asyncio.to_thread(
+                discard_unpublished_session,
+                self._session_co_dir,
+                session_id,
+                lease,
+            )
+        )
+        await self._settle_owned_task(cleanup)
+        if cleanup.cancelled() or cleanup.exception() is None:
+            return
+        error = cleanup.exception()
+        assert error is not None
+        # Preserve the request's original failure or cancellation. An orphaned
+        # canonical lease ID still consumes quota and therefore fails closed.
+        logger.warning(
+            "Unable to remove unpublished ACP session state",
+            exc_info=(type(error), error, error.__traceback__),
+        )
 
     @staticmethod
     def _task_succeeded(task: asyncio.Task[Any]) -> bool:

--- a/connectonion/cli/co_ai/one_shot_sessions.py
+++ b/connectonion/cli/co_ai/one_shot_sessions.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import stat
 import tempfile
 import uuid
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -15,10 +17,20 @@ SNAPSHOT_VERSION = 2
 _LEGACY_SNAPSHOT_VERSION = 1
 _TODO_STATUSES = {"pending", "in_progress", "completed"}
 _TODO_PRIORITIES = {"high", "medium", "low"}
+logger = logging.getLogger(__name__)
 
 
 class SessionSnapshotError(ValueError):
     """A one-shot session cannot be safely saved or resumed."""
+
+
+@dataclass(frozen=True)
+class SnapshotStorageLimits:
+    """Hard bounds for one authenticated principal's durable ACP snapshots."""
+
+    max_sessions: int
+    max_total_bytes: int
+    max_snapshot_bytes: int
 
 
 def new_session_id() -> str:
@@ -86,7 +98,12 @@ class SessionLease:
         self.close()
 
 
-def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
+def acquire_session_lease(
+    co_dir: Path,
+    session_id: str,
+    *,
+    exclusive_create: bool = False,
+) -> SessionLease:
     """Fail fast unless this process can exclusively own ``session_id``."""
     canonical = _canonical_id(session_id)
     directory = _session_dir(co_dir)
@@ -95,6 +112,8 @@ def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
         os.chmod(directory, 0o700)
     lock_path = directory / f"{canonical}.lock"
     flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
+    if exclusive_create:
+        flags |= os.O_EXCL
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
     try:
@@ -103,11 +122,17 @@ def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
         raise SessionSnapshotError(
             f"Session {canonical} lock is unavailable."
         ) from None
+    opened_identity: tuple[int, int] | None = None
     try:
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
+            raise OSError("session lock is not a regular file")
+        opened_identity = (opened.st_dev, opened.st_ino)
+        if exclusive_create and 0 in opened_identity:
+            opened_identity = None
+            raise OSError("session lock identity is unavailable")
         handle = os.fdopen(descriptor, "a+", encoding="utf-8")
         descriptor = -1
-        if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
-            raise OSError("session lock is not a regular file")
         if hasattr(os, "fchmod"):
             os.fchmod(handle.fileno(), 0o600)
     except BaseException:
@@ -115,6 +140,8 @@ def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
             os.close(descriptor)
         else:
             handle.close()
+        if exclusive_create:
+            _unlink_created_lock(lock_path, opened_identity)
         raise SessionSnapshotError(
             f"Session {canonical} lock is unavailable."
         ) from None
@@ -130,10 +157,37 @@ def acquire_session_lease(co_dir: Path, session_id: str) -> SessionLease:
             fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
         handle.close()
+        if exclusive_create:
+            _unlink_created_lock(lock_path, opened_identity)
         raise SessionSnapshotError(
             f"Session {canonical} is already running in another process."
         ) from None
     return SessionLease(canonical, handle)
+
+
+def _unlink_created_lock(
+    lock_path: Path,
+    opened_identity: tuple[int, int] | None,
+) -> None:
+    """Remove only the lease pathname exclusively created by this attempt."""
+
+    if opened_identity is None or 0 in opened_identity:
+        return
+    try:
+        current = lock_path.lstat()
+    except OSError:
+        return
+    if not stat.S_ISREG(current.st_mode):
+        return
+    if (
+        current.st_dev,
+        current.st_ino,
+    ) != opened_identity:
+        return
+    try:
+        lock_path.unlink()
+    except OSError:
+        pass
 
 
 @contextmanager
@@ -146,6 +200,55 @@ def session_lock(co_dir: Path, session_id: str):
         lease.close()
 
 
+def discard_unpublished_session(
+    co_dir: Path,
+    session_id: str,
+    lease: SessionLease,
+) -> None:
+    """Remove a newly committed session whose ID was never returned to a client."""
+
+    canonical = _canonical_id(session_id)
+    try:
+        with _snapshot_storage_lock(co_dir):
+            directory = _session_dir(co_dir)
+            snapshot_path = directory / f"{canonical}.json"
+            lock_path = directory / f"{canonical}.lock"
+            try:
+                snapshot_stat = snapshot_path.lstat()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                raise SessionSnapshotError("Session storage is unavailable.") from None
+            else:
+                if not stat.S_ISREG(snapshot_stat.st_mode):
+                    raise SessionSnapshotError("Session storage is unavailable.")
+                try:
+                    snapshot_path.unlink()
+                except OSError:
+                    raise SessionSnapshotError("Session storage is unavailable.") from None
+            # Keep the per-session lease held until the snapshot is gone. A
+            # resume preflight shares the quota lock, so nobody can observe the
+            # unpublished file and then acquire ownership between deletion and
+            # lease release.
+            lease.close()
+            try:
+                lock_stat = lock_path.lstat()
+            except FileNotFoundError:
+                return
+            except OSError:
+                raise SessionSnapshotError("Session storage is unavailable.") from None
+            if not stat.S_ISREG(lock_stat.st_mode):
+                raise SessionSnapshotError("Session storage is unavailable.")
+            try:
+                lock_path.unlink()
+            except OSError:
+                raise SessionSnapshotError("Session storage is unavailable.") from None
+    finally:
+        # Lock acquisition and validation can fail before the context body.
+        # Ownership must never outlive unpublished-session cleanup.
+        lease.close()
+
+
 def save_snapshot(
     co_dir: Path,
     session: dict[str, Any],
@@ -153,6 +256,7 @@ def save_snapshot(
     *,
     cwd: Path | str | None = None,
     virtual_cwd: str | None = None,
+    storage_limits: SnapshotStorageLimits | None = None,
 ) -> None:
     """Atomically persist one completed Agent turn."""
     session_id = _canonical_id(session.get("session_id"))
@@ -167,22 +271,66 @@ def save_snapshot(
         "tools": tools,
     }
     try:
-        encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
-    except (TypeError, ValueError) as exc:
+        encoded = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, UnicodeEncodeError, ValueError) as exc:
         raise SessionSnapshotError(
             f"Session {session_id} cannot be serialized: {exc}"
         ) from None
 
-    directory = _session_dir(co_dir)
-    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if os.name != "nt":
-        os.chmod(directory, 0o700)
-    target = _session_path(co_dir, session_id)
+    if storage_limits is None:
+        directory = _session_dir(co_dir)
+        _ensure_private_directory(directory)
+        _write_snapshot(directory, session_id, encoded)
+        return
+
+    _validate_storage_limits(storage_limits)
+    directory = prepare_snapshot_storage(co_dir)
+    if len(encoded) > storage_limits.max_snapshot_bytes:
+        logger.warning(
+            "ACP session snapshot exceeds quota: bytes=%d/%d",
+            len(encoded),
+            storage_limits.max_snapshot_bytes,
+        )
+        raise SessionSnapshotError("Session snapshot exceeds the storage limit.")
+    with _snapshot_storage_lock(co_dir):
+        stored_sessions, stored_bytes, target_bytes, target_counted = (
+            _snapshot_storage_usage(
+                directory,
+                session_id,
+                max_sessions=storage_limits.max_sessions,
+                max_total_bytes=storage_limits.max_total_bytes,
+            )
+        )
+        candidate_sessions = stored_sessions + (0 if target_counted else 1)
+        candidate_bytes = stored_bytes - (target_bytes or 0) + len(encoded)
+        if (
+            candidate_sessions > storage_limits.max_sessions
+            or candidate_bytes > storage_limits.max_total_bytes
+        ):
+            logger.warning(
+                "ACP session storage quota exceeded: sessions=%d/%d bytes=%d/%d",
+                candidate_sessions,
+                storage_limits.max_sessions,
+                candidate_bytes,
+                storage_limits.max_total_bytes,
+            )
+            raise SessionSnapshotError("Session storage quota exceeded.")
+        _write_snapshot(directory, session_id, encoded)
+
+
+def _write_snapshot(directory: Path, session_id: str, encoded: bytes) -> None:
+    """Replace one private snapshot after every fallible check has passed."""
+
+    target = directory / f"{session_id}.json"
     fd, temporary = tempfile.mkstemp(prefix=f".{session_id}.", dir=directory)
     try:
         if hasattr(os, "fchmod"):
             os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as file:
+        with os.fdopen(fd, "wb") as file:
             file.write(encoded)
             file.flush()
             os.fsync(file.fileno())
@@ -199,15 +347,42 @@ def load_snapshot(
     *,
     cwd: Path | str | None = None,
     virtual_cwd: str | None = None,
+    storage_limits: SnapshotStorageLimits | None = None,
 ) -> tuple[dict, dict]:
     """Load and validate the exact snapshot named by ``session_id``."""
     canonical = _canonical_id(session_id)
     path = _session_path(co_dir, canonical)
-    if not path.is_file():
-        raise SessionSnapshotError(f"Session {canonical} was not found.")
+    if storage_limits is None:
+        encoded = _read_snapshot(path, canonical)
+    else:
+        _validate_storage_limits(storage_limits)
+        directory = prepare_snapshot_storage(co_dir)
+        with _snapshot_storage_lock(co_dir):
+            stored_sessions, stored_bytes, target_bytes, _target_counted = (
+                _snapshot_storage_usage(
+                    directory,
+                    canonical,
+                    max_sessions=storage_limits.max_sessions,
+                    max_total_bytes=storage_limits.max_total_bytes,
+                )
+            )
+            if target_bytes is None:
+                raise SessionSnapshotError(f"Session {canonical} was not found.")
+            if (
+                stored_sessions > storage_limits.max_sessions
+                or stored_bytes > storage_limits.max_total_bytes
+                or target_bytes > storage_limits.max_snapshot_bytes
+            ):
+                raise SessionSnapshotError("Session storage quota exceeded.")
+            encoded = _read_snapshot(
+                path,
+                canonical,
+                max_bytes=storage_limits.max_snapshot_bytes,
+                require_stable_identity=True,
+            )
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        payload = json.loads(encoded.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise SessionSnapshotError(f"Session {canonical} is unreadable: {exc}") from None
 
     version = payload.get("version") if isinstance(payload, dict) else None
@@ -251,6 +426,266 @@ def load_snapshot(
     _validate_session_plan(session, canonical)
     _validate_plan_matches_tools(session, tools, canonical)
     return session, tools
+
+
+def _ensure_private_directory(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        directory_stat = directory.lstat()
+    except OSError as exc:
+        raise SessionSnapshotError("Session storage is unavailable.") from exc
+    if not stat.S_ISDIR(directory_stat.st_mode) or directory.is_symlink():
+        raise SessionSnapshotError("Session storage is unavailable.")
+    if os.name != "nt":
+        os.chmod(directory, 0o700)
+
+
+def prepare_snapshot_storage(co_dir: Path) -> Path:
+    """Create and validate every controlled directory in a bounded store."""
+
+    root = Path(co_dir)
+    _ensure_private_directory(root)
+    _ensure_private_directory(root / "ai")
+    directory = root / "ai" / "sessions"
+    _ensure_private_directory(directory)
+    return directory
+
+
+def _open_regular_lock(path: Path, *, message: str):
+    flags = os.O_RDWR | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags, 0o600)
+    except OSError:
+        raise SessionSnapshotError(message) from None
+    handle = None
+    try:
+        handle = os.fdopen(descriptor, "a+b")
+        descriptor = -1
+        if not stat.S_ISREG(os.fstat(handle.fileno()).st_mode):
+            raise OSError("lock is not a regular file")
+        if hasattr(os, "fchmod"):
+            os.fchmod(handle.fileno(), 0o600)
+        if os.name == "nt":
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle, fcntl.LOCK_EX)
+        return handle
+    except OSError:
+        if handle is not None:
+            handle.close()
+        raise SessionSnapshotError(message) from None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+@contextmanager
+def _snapshot_storage_lock(co_dir: Path):
+    """Serialize principal-wide snapshot accounting across processes."""
+
+    root = Path(co_dir)
+    prepare_snapshot_storage(root)
+    handle = _open_regular_lock(
+        root / "sessions.lock",
+        message="Session storage is unavailable.",
+    )
+    try:
+        yield
+    finally:
+        handle.close()
+
+
+def _snapshot_storage_usage(
+    directory: Path,
+    target_session_id: str,
+    *,
+    max_sessions: int,
+    max_total_bytes: int,
+) -> tuple[int, int, int | None, bool]:
+    """Return exact committed usage and remove only abandoned writer temp files."""
+
+    stored_session_ids: set[str] = set()
+    stored_bytes = 0
+    target_bytes = None
+    try:
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                name = entry.name
+                if _is_snapshot_temporary(name):
+                    entry_stat = entry.stat(follow_symlinks=False)
+                    if not stat.S_ISREG(entry_stat.st_mode):
+                        raise OSError("unexpected session snapshot temporary")
+                    Path(entry.path).unlink()
+                    continue
+                suffix = Path(name).suffix
+                if suffix not in {".json", ".lock"}:
+                    raise OSError("unexpected session storage entry")
+                session_id = name[:-5]
+                try:
+                    canonical = _canonical_id(session_id)
+                except SessionSnapshotError:
+                    raise OSError("unexpected session storage name") from None
+                if canonical != session_id:
+                    raise OSError("unexpected session storage name")
+                entry_stat = entry.stat(follow_symlinks=False)
+                if not stat.S_ISREG(entry_stat.st_mode):
+                    raise OSError("session storage entry is not a regular file")
+                stored_session_ids.add(session_id)
+                if len(stored_session_ids) > max_sessions:
+                    logger.warning(
+                        "ACP session storage quota exceeded during scan: "
+                        "sessions>%d",
+                        max_sessions,
+                    )
+                    raise SessionSnapshotError("Session storage quota exceeded.")
+                if suffix == ".json":
+                    stored_bytes += entry_stat.st_size
+                    if stored_bytes > max_total_bytes:
+                        logger.warning(
+                            "ACP session storage quota exceeded during scan: "
+                            "bytes>%d",
+                            max_total_bytes,
+                        )
+                        raise SessionSnapshotError("Session storage quota exceeded.")
+                    if session_id == target_session_id:
+                        target_bytes = entry_stat.st_size
+    except SessionSnapshotError:
+        raise
+    except OSError:
+        raise SessionSnapshotError("Session storage is unavailable.") from None
+    return (
+        len(stored_session_ids),
+        stored_bytes,
+        target_bytes,
+        target_session_id in stored_session_ids,
+    )
+
+
+def acquire_bounded_new_session_lease(
+    co_dir: Path,
+    session_id: str,
+    storage_limits: SnapshotStorageLimits,
+) -> SessionLease:
+    """Atomically reserve one new network session against principal quota."""
+
+    canonical = _canonical_id(session_id)
+    _validate_storage_limits(storage_limits)
+    directory = prepare_snapshot_storage(co_dir)
+    with _snapshot_storage_lock(co_dir):
+        stored_sessions, stored_bytes, _target_bytes, target_counted = (
+            _snapshot_storage_usage(
+                directory,
+                canonical,
+                max_sessions=storage_limits.max_sessions,
+                max_total_bytes=storage_limits.max_total_bytes,
+            )
+        )
+        if target_counted:
+            raise SessionSnapshotError("Session storage is unavailable.")
+        if (
+            stored_sessions >= storage_limits.max_sessions
+            or stored_bytes >= storage_limits.max_total_bytes
+        ):
+            logger.warning(
+                "ACP session storage quota exceeded during admission: "
+                "sessions=%d/%d bytes=%d/%d",
+                stored_sessions,
+                storage_limits.max_sessions,
+                stored_bytes,
+                storage_limits.max_total_bytes,
+            )
+            raise SessionSnapshotError("Session storage quota exceeded.")
+        # Creating the canonical lease while the namespace lock is held makes
+        # this reservation visible before a competing admission can scan.
+        return acquire_session_lease(
+            co_dir,
+            canonical,
+            exclusive_create=True,
+        )
+
+
+def _is_snapshot_temporary(name: str) -> bool:
+    if not name.startswith("."):
+        return False
+    session_id, separator, suffix = name[1:].partition(".")
+    if not separator or not suffix:
+        return False
+    try:
+        return _canonical_id(session_id) == session_id
+    except SessionSnapshotError:
+        return False
+
+
+def _read_snapshot(
+    path: Path,
+    session_id: str,
+    *,
+    max_bytes: int | None = None,
+    require_stable_identity: bool = False,
+) -> bytes:
+    """Read one regular snapshot without following a symbolic link."""
+
+    try:
+        before = path.lstat()
+    except FileNotFoundError:
+        raise SessionSnapshotError(f"Session {session_id} was not found.") from None
+    except OSError:
+        raise SessionSnapshotError(f"Session {session_id} is unreadable.") from None
+    if not stat.S_ISREG(before.st_mode):
+        raise SessionSnapshotError(f"Session {session_id} is unreadable.")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as file:
+            opened = os.fstat(file.fileno())
+            before_identity = (before.st_dev, before.st_ino)
+            opened_identity = (opened.st_dev, opened.st_ino)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or before_identity != opened_identity
+                or (
+                    require_stable_identity
+                    and (0 in before_identity or 0 in opened_identity)
+                )
+            ):
+                raise OSError("session snapshot changed during open")
+            if max_bytes is not None and opened.st_size > max_bytes:
+                raise SessionSnapshotError("Session snapshot exceeds the storage limit.")
+            encoded = file.read(None if max_bytes is None else max_bytes + 1)
+    except SessionSnapshotError:
+        raise
+    except OSError:
+        raise SessionSnapshotError(f"Session {session_id} is unreadable.") from None
+    if max_bytes is not None and len(encoded) > max_bytes:
+        raise SessionSnapshotError("Session snapshot exceeds the storage limit.")
+    return encoded
+
+
+def _validate_storage_limits(limits: SnapshotStorageLimits) -> None:
+    if (
+        isinstance(limits.max_sessions, bool)
+        or not isinstance(limits.max_sessions, int)
+        or limits.max_sessions <= 0
+        or isinstance(limits.max_total_bytes, bool)
+        or not isinstance(limits.max_total_bytes, int)
+        or limits.max_total_bytes <= 0
+        or isinstance(limits.max_snapshot_bytes, bool)
+        or not isinstance(limits.max_snapshot_bytes, int)
+        or limits.max_snapshot_bytes <= 0
+        or limits.max_snapshot_bytes > limits.max_total_bytes
+    ):
+        raise ValueError("Snapshot storage limits must be positive and consistent.")
 
 
 def _validate_tool_state(

--- a/connectonion/network/host/config.py
+++ b/connectonion/network/host/config.py
@@ -30,6 +30,9 @@ DEFAULT_FILE_LIMITS = {
     "max_files_per_request": 10,               # Max files in one request
     "max_acp_upload_storage": 100,             # MB retained per ACP principal
     "max_acp_upload_files": 100,               # Files retained per ACP principal
+    "max_acp_sessions": 100,                   # Durable sessions per ACP principal
+    "max_acp_session_storage": 100,            # MB of snapshots per ACP principal
+    "max_acp_snapshot_size": 32,               # MB in one ACP session snapshot
 }
 
 

--- a/connectonion/network/host/host.yaml
+++ b/connectonion/network/host/host.yaml
@@ -12,6 +12,9 @@ reload: false
 # max_files_per_request: 10         # Max number of files in one request
 # max_acp_upload_storage: 100       # MB retained per authenticated ACP principal
 # max_acp_upload_files: 100         # Files retained per authenticated ACP principal
+# max_acp_sessions: 100             # Durable snapshots per authenticated ACP principal
+# max_acp_session_storage: 100      # MB of snapshots per authenticated ACP principal
+# max_acp_snapshot_size: 32         # MB in one durable ACP snapshot
 
 # Auto-approve tool permissions
 # Default permissions for safe read-only commands

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -52,6 +52,13 @@ retained for resumable sessions under a per-authenticated-principal quota
 default). Reaching either cumulative limit fails before the Agent turn without
 writing another file.
 
+Durable native-network ACP sessions have a separate authenticated-principal
+quota: 100 snapshots, 100 MiB total serialized state, and 32 MiB for one
+snapshot by default. Operators can lower these with `max_acp_sessions`,
+`max_acp_session_storage`, and `max_acp_snapshot_size`. Quota exhaustion keeps
+the previous resumable snapshot unchanged; it never truncates conversation
+state. Local stdio ACP is not charged to a remote principal quota.
+
 ### One-Shot Mode
 
 ```bash

--- a/docs/design-decisions/049-bounded-network-acp-session-storage.md
+++ b/docs/design-decisions/049-bounded-network-acp-session-storage.md
@@ -1,0 +1,79 @@
+# DD-049: Bound durable network ACP session storage
+
+**Status:** Accepted
+
+**Date:** 2026-08-13
+
+**Related:** [DD-029 Persistent ACP Session Ownership](029-acp-persistent-session-ownership.md), [DD-045 Authenticated ACP WebSocket Gateway](045-authenticated-acp-websocket-gateway.md), [DD-047 Network ACP Virtual Workspace](047-network-acp-virtual-workspace.md), [DD-048 Native ACP Browser Attachments](048-native-acp-browser-attachments.md), [Issue #921](https://github.com/openonion/connectonion/issues/921)
+
+## Context
+
+An authenticated network principal can create many resumable ACP sessions. A
+successful prompt replaces its session snapshot with the complete private Agent
+continuation state. Inline image data remains inside that state. DD-048 bounds
+retained files, but its quota does not count snapshot files or inline message
+data. Small successful requests could therefore consume Host disk without
+reaching the attachment quota.
+
+ACP `session/close` only releases the runtime-long lease. DD-029 deliberately
+keeps the snapshot resumable, so close cannot be reinterpreted as deletion or
+automatic eviction.
+
+## Decision
+
+Each authenticated-principal namespace has three independent network limits:
+
+- 100 durable session snapshots;
+- 100 MiB of cumulative serialized snapshot bytes;
+- 32 MiB for one serialized snapshot.
+
+Operators may lower these with `max_acp_sessions`,
+`max_acp_session_storage`, and `max_acp_snapshot_size`. The single-snapshot
+limit cannot exceed the cumulative limit. Local stdio ACP keeps the existing
+operator-owned storage behavior and is not charged to a remote principal.
+
+The complete JSON candidate is encoded to UTF-8 and measured before commit.
+One OS-backed lock serializes accounting across every connection and process in
+the principal namespace. While holding it, the writer scans canonical snapshot
+files as the only source of truth, counts the union of snapshot and lease IDs,
+subtracts the current target bytes on replacement,
+enforces all three limits, writes a private temporary file, calls `fsync`, and
+atomically replaces the target. Quota failure never changes the previous file;
+the ACP prompt transaction restores its last-good in-memory checkpoint.
+
+New-session admission creates its provisional lease ID while holding the same
+principal lock. Concurrent admissions therefore reserve remaining slots in a
+stable order: one excess request cannot make every otherwise-valid request fail.
+
+Bounded resume scans and opens only canonical regular snapshot files without
+following symbolic links. It rejects a store already beyond its configured
+limits before decoding JSON and caps the read to the single-snapshot limit.
+Unknown entries and scan, stat, lock, or pathname races fail closed. Network
+errors remain generic and contain no private content or Host path.
+
+A caller-supplied unknown resume UUID is checked before a lease file is
+created. A server-minted new session whose initial snapshot fails is removed
+with its uncommitted lease. If request cancellation occurs after initial commit
+but before the ID can be returned, that unpublished snapshot and lease are also
+removed. A normal returned session, including one later closed, is retained.
+
+## Retention
+
+The 1.7 preview has no silent expiry, LRU eviction, history truncation, or file
+reference guessing. Exhaustion fails closed. Removing the whole private
+principal namespace while the Host is stopped remains the explicit destructive
+operator boundary. A future authenticated delete/expiry method must separately
+define attachment references and race-safe reclamation.
+
+## Rejected alternatives
+
+- **A mutable usage manifest:** introduces a second crash-recovery truth that
+  can drift from the atomically committed files. A locked scan of at most 100
+  snapshots is simpler.
+- **Delete on `session/close`:** breaks the accepted resume lifecycle.
+- **Truncate old messages or inline images:** makes private continuation state
+  inconsistent and silently changes model behavior.
+- **Use session IDs as quota authority:** they are routing values; the
+  authenticated principal namespace is the authority boundary.
+- **Count only retained files:** inline images and all other serialized session
+  state would remain unbounded.

--- a/docs/network/host-config.md
+++ b/docs/network/host-config.md
@@ -208,6 +208,11 @@ max_files_per_request: 10
 # Native ACP files retained for resumable sessions, per authenticated principal
 max_acp_upload_storage: 100      # MB across successful prompts
 max_acp_upload_files: 100        # Files across successful prompts
+
+# Durable native ACP snapshots, per authenticated principal
+max_acp_sessions: 100            # Number of resumable snapshots
+max_acp_session_storage: 100     # MB across serialized snapshots
+max_acp_snapshot_size: 32        # MB in one durable snapshot
 ```
 
 **Error Messages:**

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -465,6 +465,14 @@ def test_acp_rejects_invalid_attachment_count_limits(count):
         ("max_acp_upload_storage", 1e308, "at least one byte"),
         ("max_acp_upload_files", 0, "positive numbers"),
         ("max_acp_upload_files", 1.5, "positive numbers"),
+        ("max_acp_sessions", 0, "positive numbers"),
+        ("max_acp_sessions", 1.5, "positive numbers"),
+        ("max_acp_session_storage", 0, "positive numbers"),
+        ("max_acp_session_storage", 1e-308, "at least one byte"),
+        ("max_acp_session_storage", 1e308, "at least one byte"),
+        ("max_acp_snapshot_size", 0, "positive numbers"),
+        ("max_acp_snapshot_size", 1e-308, "at least one byte"),
+        ("max_acp_snapshot_size", 1e308, "at least one byte"),
     ],
 )
 def test_acp_rejects_invalid_principal_storage_limits(key, value, message):
@@ -476,6 +484,21 @@ def test_acp_rejects_invalid_principal_storage_limits(key, value, message):
             yolo_turns=2,
             agent_factory=lambda **_kwargs: _FakeAgent(),
             input_limits={key: value},
+        )
+
+
+def test_acp_rejects_single_snapshot_limit_above_total_storage():
+    with pytest.raises(ValueError, match="consistent"):
+        ConnectOnionACPAgent(
+            model="test",
+            max_iterations=2,
+            yolo=False,
+            yolo_turns=2,
+            agent_factory=lambda **_kwargs: _FakeAgent(),
+            input_limits={
+                "max_acp_session_storage": 1,
+                "max_acp_snapshot_size": 2,
+            },
         )
 
 

--- a/tests/unit/test_co_ai_acp_resume.py
+++ b/tests/unit/test_co_ai_acp_resume.py
@@ -16,7 +16,10 @@ from acp import RequestError, text_block
 from acp.schema import CloseSessionResponse, ResumeSessionResponse
 
 from connectonion.cli.co_ai import acp_server
-from connectonion.cli.co_ai.acp_server import ConnectOnionACPAgent
+from connectonion.cli.co_ai.acp_server import (
+    ConnectOnionACPAgent,
+    capture_network_workspace,
+)
 from connectonion.cli.co_ai.one_shot_sessions import (
     SessionSnapshotError,
     acquire_session_lease,
@@ -161,6 +164,21 @@ def _server(
         agent_factory=factory,
         session_co_dir=state_dir,
     )
+
+
+def _network_server(state_dir, project, factory, **limits):
+    workspace = capture_network_workspace(project)
+    server = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+        session_co_dir=state_dir,
+        network_workspace=workspace,
+        input_limits=limits,
+    )
+    return server, workspace
 
 
 def _project(tmp_path, monkeypatch):
@@ -320,6 +338,227 @@ async def test_runtime_lease_blocks_a_second_server_until_close(
     await owner.close_session(session.session_id)
     await contender.resume_session(session.session_id, str(project), mcp_servers=[])
     await contender.close_session(session.session_id)
+
+
+@pytest.mark.asyncio
+async def test_network_session_count_quota_is_shared_across_connections(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    first, first_workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+        max_acp_sessions=1,
+    )
+    second, second_workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+        max_acp_sessions=1,
+    )
+    try:
+        created = await first.new_session("/", mcp_servers=[])
+
+        with pytest.raises(RequestError, match="Unable to create"):
+            await second.new_session("/", mcp_servers=[])
+
+        snapshots = list((state_dir / "ai" / "sessions").glob("*.json"))
+        assert [path.stem for path in snapshots] == [created.session_id]
+        locks = list((state_dir / "ai" / "sessions").glob("*.lock"))
+        assert [path.stem for path in locks] == [created.session_id]
+        await first.close_session(created.session_id)
+    finally:
+        first_workspace.close()
+        second_workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_network_admission_fills_last_slot_once(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    first, first_workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+        max_acp_sessions=1,
+    )
+    second, second_workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+        max_acp_sessions=1,
+    )
+    try:
+        results = await asyncio.gather(
+            first.new_session("/", mcp_servers=[]),
+            second.new_session("/", mcp_servers=[]),
+            return_exceptions=True,
+        )
+
+        created = [result for result in results if not isinstance(result, BaseException)]
+        rejected = [result for result in results if isinstance(result, RequestError)]
+        assert len(created) == 1
+        assert len(rejected) == 1
+        assert len(list((state_dir / "ai" / "sessions").glob("*.json"))) == 1
+        await (first if results[0] is created[0] else second).close_session(
+            created[0].session_id
+        )
+    finally:
+        first_workspace.close()
+        second_workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_network_admission_removes_provisional_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    server, workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+        max_acp_sessions=1,
+    )
+    reserved = threading.Event()
+    release_admission = threading.Event()
+    real_load = server._load_owned_session
+
+    def pause_after_reservation(*args, **kwargs):
+        ownership = real_load(*args, **kwargs)
+        reserved.set()
+        assert release_admission.wait(timeout=1)
+        return ownership
+
+    monkeypatch.setattr(server, "_load_owned_session", pause_after_reservation)
+    try:
+        request = asyncio.create_task(server.new_session("/", mcp_servers=[]))
+        assert await asyncio.to_thread(reserved.wait, 1)
+        request.cancel()
+        release_admission.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await request
+        directory = state_dir / "ai" / "sessions"
+        assert list(directory.glob("*.json")) == []
+        assert list(directory.glob("*.lock")) == []
+    finally:
+        release_admission.set()
+        workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_network_prompt_snapshot_quota_rolls_back_disk_and_runtime(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    agent = _PersistentFakeAgent()
+    server, workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: agent,
+        max_acp_snapshot_size=1 / 1024,
+        max_acp_session_storage=1,
+    )
+    server.on_connect(_Client())
+    try:
+        created = await server.new_session("/", mcp_servers=[])
+        path = state_dir / "ai" / "sessions" / f"{created.session_id}.json"
+        before = path.read_bytes()
+
+        with pytest.raises(RequestError, match="co ai prompt failed"):
+            await server.prompt(created.session_id, [text_block("x" * 2000)])
+
+        assert path.read_bytes() == before
+        stored, _ = load_snapshot(
+            state_dir,
+            created.session_id,
+            virtual_cwd="/",
+        )
+        assert stored["turn"] == 0
+        assert agent.current_session["turn"] == 0
+        await server.close_session(created.session_id)
+    finally:
+        workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_network_unknown_resume_does_not_create_a_durable_lock_file(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    server, workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+    )
+    unknown = "cfb44753-f6da-47b3-9281-a0e9f664dd3c"
+    try:
+        with pytest.raises(RequestError, match="Unable to resume"):
+            await server.resume_session(unknown, "/", mcp_servers=[])
+
+        assert list((state_dir / "ai" / "sessions").glob("*.lock")) == []
+    finally:
+        workspace.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_network_new_session_removes_unpublished_snapshot_and_lease(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "principal"
+    server, workspace = _network_server(
+        state_dir,
+        project,
+        lambda **_: _PersistentFakeAgent(),
+    )
+    committed = threading.Event()
+    release_constructor = threading.Event()
+    cleanup_threads = []
+    real_open = server._open_session_runtime
+    real_discard = acp_server.discard_unpublished_session
+
+    def pause_after_initial_commit(*args, **kwargs):
+        runtime = real_open(*args, **kwargs)
+        committed.set()
+        assert release_constructor.wait(timeout=1)
+        return runtime
+
+    def track_discard(*args, **kwargs):
+        cleanup_threads.append(threading.get_ident())
+        return real_discard(*args, **kwargs)
+
+    monkeypatch.setattr(server, "_open_session_runtime", pause_after_initial_commit)
+    monkeypatch.setattr(acp_server, "discard_unpublished_session", track_discard)
+    try:
+        request = asyncio.create_task(server.new_session("/", mcp_servers=[]))
+        assert await asyncio.to_thread(committed.wait, 1)
+        request.cancel()
+        release_constructor.set()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+        directory = state_dir / "ai" / "sessions"
+        assert list(directory.glob("*.json")) == []
+        assert list(directory.glob("*.lock")) == []
+        assert cleanup_threads
+        assert cleanup_threads != [threading.get_ident()]
+    finally:
+        release_constructor.set()
+        workspace.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -135,7 +135,10 @@ def test_network_acp_sessions_are_principal_scoped_and_full_access_is_admin_only
         "max_file_size: 2\n"
         "max_files_per_request: 4\n"
         "max_acp_upload_storage: 20\n"
-        "max_acp_upload_files: 40\n",
+        "max_acp_upload_files: 40\n"
+        "max_acp_sessions: 12\n"
+        "max_acp_session_storage: 24\n"
+        "max_acp_snapshot_size: 6\n",
         encoding="utf-8",
     )
 
@@ -175,6 +178,10 @@ def test_network_acp_sessions_are_principal_scoped_and_full_access_is_admin_only
     assert contact._max_attachments == 4
     assert contact._max_upload_storage_bytes == 20 * 1024 * 1024
     assert contact._max_upload_files == 40
+    assert contact._snapshot_storage_limits.max_sessions == 12
+    assert contact._snapshot_storage_limits.max_total_bytes == 24 * 1024 * 1024
+    assert contact._snapshot_storage_limits.max_snapshot_bytes == 6 * 1024 * 1024
+    assert contact._snapshot_storage_limits is not same_contact._snapshot_storage_limits
     assert admin._yolo is True
     assert admin._yolo_turns == 7
 

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -2,14 +2,19 @@
 
 import json
 import os
+from contextlib import contextmanager
 
 import pytest
 import typer
 
+import connectonion.cli.co_ai.one_shot_sessions as session_storage
 import connectonion.cli.commands.ai_commands as ai_commands
 from connectonion.cli.co_ai.agent import create_agent
 from connectonion.cli.co_ai.one_shot_sessions import (
+    SessionLease,
     SessionSnapshotError,
+    SnapshotStorageLimits,
+    acquire_bounded_new_session_lease,
     load_snapshot,
     new_session_id,
     save_snapshot,
@@ -34,6 +39,14 @@ def _plan(*contents):
         {"content": content, "priority": "medium", "status": "pending"}
         for content in contents
     ]
+
+
+def _snapshot_limits(*, sessions=2, total=4096, single=2048):
+    return SnapshotStorageLimits(
+        max_sessions=sessions,
+        max_total_bytes=total,
+        max_snapshot_bytes=single,
+    )
 
 
 class _ToolRegistry:
@@ -364,6 +377,446 @@ def test_failed_atomic_replace_leaves_the_previous_snapshot(tmp_path, monkeypatc
     loaded, _ = load_snapshot(tmp_path, session_id)
     assert loaded["turn"] == 1
     assert not list((tmp_path / "ai" / "sessions").glob(f".{session_id}.*"))
+
+
+def test_bounded_snapshot_replacement_charges_only_the_new_exact_bytes(tmp_path):
+    session_id = new_session_id()
+    limits = _snapshot_limits(sessions=1, total=900, single=900)
+    original = {
+        "session_id": session_id,
+        "messages": [{"role": "user", "content": "short"}],
+        "trace": [],
+        "turn": 1,
+    }
+    replacement = {
+        **original,
+        "messages": [{"role": "user", "content": "x" * 400}],
+        "turn": 2,
+    }
+
+    save_snapshot(tmp_path, original, storage_limits=limits)
+    save_snapshot(tmp_path, replacement, storage_limits=limits)
+
+    assert load_snapshot(tmp_path, session_id, storage_limits=limits)[0] == replacement
+
+
+def test_bounded_snapshot_count_rejection_preserves_every_committed_file(tmp_path):
+    limits = _snapshot_limits(sessions=1)
+    first_id = new_session_id()
+    second_id = new_session_id()
+    first = {
+        "session_id": first_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+    second = {**first, "session_id": second_id}
+    save_snapshot(tmp_path, first, storage_limits=limits)
+    directory = tmp_path / "ai" / "sessions"
+    before = (directory / f"{first_id}.json").read_bytes()
+
+    with pytest.raises(SessionSnapshotError, match="quota exceeded"):
+        save_snapshot(tmp_path, second, storage_limits=limits)
+
+    assert (directory / f"{first_id}.json").read_bytes() == before
+    assert not (directory / f"{second_id}.json").exists()
+
+
+def test_bounded_snapshot_count_includes_orphan_lease_ids(tmp_path):
+    first_id = new_session_id()
+    second_id = new_session_id()
+    directory = tmp_path / "ai" / "sessions"
+    directory.mkdir(parents=True)
+    (directory / f"{first_id}.lock").write_bytes(b"")
+    session = {
+        "session_id": second_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    with pytest.raises(SessionSnapshotError, match="quota exceeded"):
+        save_snapshot(
+            tmp_path,
+            session,
+            storage_limits=_snapshot_limits(sessions=1),
+        )
+
+    assert not (directory / f"{second_id}.json").exists()
+
+
+def test_oversized_snapshot_rejection_preserves_last_good_bytes(tmp_path):
+    session_id = new_session_id()
+    original = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 1,
+    }
+    wide_limits = _snapshot_limits(single=4096)
+    narrow_limits = _snapshot_limits(single=400)
+    save_snapshot(tmp_path, original, storage_limits=wide_limits)
+    path = tmp_path / "ai" / "sessions" / f"{session_id}.json"
+    before = path.read_bytes()
+
+    with pytest.raises(SessionSnapshotError, match="exceeds the storage limit"):
+        save_snapshot(
+            tmp_path,
+            {
+                **original,
+                "messages": [{"role": "user", "content": "x" * 1000}],
+                "turn": 2,
+            },
+            storage_limits=narrow_limits,
+        )
+
+    assert path.read_bytes() == before
+
+
+def test_bounded_snapshot_total_rejection_preserves_last_good_bytes(tmp_path):
+    first_id = new_session_id()
+    second_id = new_session_id()
+    first = {
+        "session_id": first_id,
+        "messages": [{"role": "user", "content": "x" * 300}],
+        "trace": [],
+        "turn": 1,
+    }
+    second = {
+        **first,
+        "session_id": second_id,
+        "messages": [{"role": "user", "content": "y" * 300}],
+    }
+    save_snapshot(tmp_path, first, storage_limits=_snapshot_limits())
+    path = tmp_path / "ai" / "sessions" / f"{first_id}.json"
+    before = path.read_bytes()
+
+    with pytest.raises(SessionSnapshotError, match="quota exceeded"):
+        save_snapshot(
+            tmp_path,
+            second,
+            storage_limits=_snapshot_limits(
+                total=len(before) + 10,
+                single=len(before) + 10,
+            ),
+        )
+
+    assert path.read_bytes() == before
+    assert not (path.parent / f"{second_id}.json").exists()
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="no O_NOFOLLOW")
+def test_bounded_snapshot_load_rejects_symlink_without_reading_target(tmp_path):
+    session_id = new_session_id()
+    target = tmp_path / "private"
+    target.write_text("secret", encoding="utf-8")
+    directory = tmp_path / "ai" / "sessions"
+    directory.mkdir(parents=True)
+    (directory / f"{session_id}.json").symlink_to(target)
+
+    with pytest.raises(SessionSnapshotError, match="storage is unavailable"):
+        load_snapshot(tmp_path, session_id, storage_limits=_snapshot_limits())
+
+    assert target.read_text(encoding="utf-8") == "secret"
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="no O_NOFOLLOW")
+def test_bounded_snapshot_store_rejects_symlinked_control_directory(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    state = tmp_path / "state"
+    state.mkdir()
+    (state / "ai").symlink_to(target, target_is_directory=True)
+    session_id = new_session_id()
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    with pytest.raises(SessionSnapshotError, match="storage is unavailable"):
+        save_snapshot(state, session, storage_limits=_snapshot_limits())
+
+    assert list(target.iterdir()) == []
+
+
+def test_unpublished_cleanup_releases_lease_when_storage_lock_cannot_open(
+    tmp_path,
+    monkeypatch,
+):
+    session_id = new_session_id()
+    lease = SessionLease(session_id, open(tmp_path / "lease", "a+", encoding="utf-8"))
+
+    @contextmanager
+    def fail_before_enter(_co_dir):
+        raise SessionSnapshotError("Session storage is unavailable.")
+        yield
+
+    monkeypatch.setattr(session_storage, "_snapshot_storage_lock", fail_before_enter)
+
+    with pytest.raises(SessionSnapshotError, match="storage is unavailable"):
+        session_storage.discard_unpublished_session(tmp_path, session_id, lease)
+
+    assert lease.closed is True
+
+
+def test_bounded_snapshot_read_rejects_zero_file_identity(tmp_path, monkeypatch):
+    session_id = new_session_id()
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+    limits = _snapshot_limits()
+    save_snapshot(tmp_path, session, storage_limits=limits)
+    real_fstat = session_storage.os.fstat
+
+    class ZeroIdentity:
+        def __init__(self, source):
+            self.st_mode = source.st_mode
+            self.st_size = source.st_size
+            self.st_dev = 0
+            self.st_ino = 0
+
+    monkeypatch.setattr(
+        session_storage.os,
+        "fstat",
+        lambda descriptor: ZeroIdentity(real_fstat(descriptor)),
+    )
+
+    path = tmp_path / "ai" / "sessions" / f"{session_id}.json"
+    with pytest.raises(SessionSnapshotError, match="is unreadable"):
+        session_storage._read_snapshot(
+            path,
+            session_id,
+            max_bytes=limits.max_snapshot_bytes,
+            require_stable_identity=True,
+        )
+
+
+def test_bounded_scan_stops_at_legacy_orphan_lock_limit(tmp_path, monkeypatch):
+    directory = tmp_path / "ai" / "sessions"
+    directory.mkdir(parents=True)
+    for _ in range(4):
+        (directory / f"{new_session_id()}.lock").write_bytes(b"")
+    real_scandir = session_storage.os.scandir
+
+    class GuardedScan:
+        def __init__(self, path):
+            self._entries = real_scandir(path)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            self._entries.close()
+
+        def __iter__(self):
+            for index, entry in enumerate(self._entries, start=1):
+                if index > 3:
+                    raise AssertionError("scan continued beyond the quota boundary")
+                yield entry
+
+    monkeypatch.setattr(session_storage.os, "scandir", GuardedScan)
+    session = {
+        "session_id": new_session_id(),
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    with pytest.raises(SessionSnapshotError, match="quota exceeded"):
+        save_snapshot(
+            tmp_path,
+            session,
+            storage_limits=_snapshot_limits(sessions=2),
+        )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX flock failure injection")
+def test_failed_bounded_admission_does_not_consume_a_session_slot(
+    tmp_path,
+    monkeypatch,
+):
+    import fcntl
+
+    failed_id = new_session_id()
+    real_flock = fcntl.flock
+
+    def fail_session_lease(handle, operation):
+        if operation & fcntl.LOCK_NB:
+            raise OSError("injected lease failure")
+        return real_flock(handle, operation)
+
+    with monkeypatch.context() as failure:
+        failure.setattr(fcntl, "flock", fail_session_lease)
+        with pytest.raises(SessionSnapshotError, match="already running"):
+            acquire_bounded_new_session_lease(
+                tmp_path,
+                failed_id,
+                _snapshot_limits(sessions=1),
+            )
+
+    directory = tmp_path / "ai" / "sessions"
+    assert list(directory.glob("*.lock")) == []
+    replacement_id = new_session_id()
+    lease = acquire_bounded_new_session_lease(
+        tmp_path,
+        replacement_id,
+        _snapshot_limits(sessions=1),
+    )
+    try:
+        assert lease.session_id == replacement_id
+    finally:
+        session_storage.discard_unpublished_session(
+            tmp_path,
+            replacement_id,
+            lease,
+        )
+
+
+@pytest.mark.parametrize("failure", ["fstat", "fdopen"])
+def test_bounded_admission_failure_never_unlinks_a_replacement(
+    tmp_path,
+    monkeypatch,
+    failure,
+):
+    session_id = new_session_id()
+    directory = tmp_path / "ai" / "sessions"
+    replacement = b"replacement owned by another actor"
+    real_fstat = session_storage.os.fstat
+    real_fdopen = session_storage.os.fdopen
+    fstat_calls = 0
+    fdopen_calls = 0
+
+    def replace_path():
+        path = directory / f"{session_id}.lock"
+        path.unlink()
+        path.write_bytes(replacement)
+
+    def fail_second_fstat(descriptor):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        if fstat_calls == 2:
+            replace_path()
+            raise OSError("injected fstat failure")
+        return real_fstat(descriptor)
+
+    def fail_second_fdopen(*args, **kwargs):
+        nonlocal fdopen_calls
+        fdopen_calls += 1
+        if fdopen_calls == 2:
+            replace_path()
+            raise OSError("injected fdopen failure")
+        return real_fdopen(*args, **kwargs)
+
+    monkeypatch.setattr(
+        session_storage.os,
+        "fstat",
+        fail_second_fstat if failure == "fstat" else real_fstat,
+    )
+    monkeypatch.setattr(
+        session_storage.os,
+        "fdopen",
+        fail_second_fdopen if failure == "fdopen" else real_fdopen,
+    )
+
+    with pytest.raises(SessionSnapshotError, match="lock is unavailable"):
+        acquire_bounded_new_session_lease(
+            tmp_path,
+            session_id,
+            _snapshot_limits(sessions=1),
+        )
+
+    assert (directory / f"{session_id}.lock").read_bytes() == replacement
+
+
+def test_bounded_admission_rejects_zero_file_identity_without_unlink(
+    tmp_path,
+    monkeypatch,
+):
+    session_id = new_session_id()
+    real_fstat = session_storage.os.fstat
+    fstat_calls = 0
+
+    class ZeroIdentity:
+        def __init__(self, source):
+            self.st_mode = source.st_mode
+            self.st_dev = 0
+            self.st_ino = 0
+
+    def zero_second_identity(descriptor):
+        nonlocal fstat_calls
+        fstat_calls += 1
+        source = real_fstat(descriptor)
+        return ZeroIdentity(source) if fstat_calls == 2 else source
+
+    monkeypatch.setattr(session_storage.os, "fstat", zero_second_identity)
+
+    with pytest.raises(SessionSnapshotError, match="lock is unavailable"):
+        acquire_bounded_new_session_lease(
+            tmp_path,
+            session_id,
+            _snapshot_limits(sessions=1),
+        )
+
+    assert (
+        tmp_path / "ai" / "sessions" / f"{session_id}.lock"
+    ).is_file()
+
+
+def test_bounded_snapshot_scan_removes_only_canonical_stale_temporary(tmp_path):
+    session_id = new_session_id()
+    directory = tmp_path / "ai" / "sessions"
+    directory.mkdir(parents=True)
+    stale = directory / f".{session_id}.stale"
+    stale.write_bytes(b"partial")
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    save_snapshot(tmp_path, session, storage_limits=_snapshot_limits())
+
+    assert not stale.exists()
+    assert load_snapshot(tmp_path, session_id, storage_limits=_snapshot_limits())[0] == session
+
+
+@pytest.mark.parametrize("name", ["unknown", "not-a-uuid.json", "not-a-uuid.lock"])
+def test_bounded_snapshot_scan_fails_closed_on_unexpected_entries(tmp_path, name):
+    session_id = new_session_id()
+    directory = tmp_path / "ai" / "sessions"
+    directory.mkdir(parents=True)
+    (directory / name).write_bytes(b"unexpected")
+    session = {
+        "session_id": session_id,
+        "messages": [],
+        "trace": [],
+        "turn": 0,
+    }
+
+    with pytest.raises(SessionSnapshotError, match="storage is unavailable"):
+        save_snapshot(tmp_path, session, storage_limits=_snapshot_limits())
+
+    assert not (directory / f"{session_id}.json").exists()
+
+
+def test_unbounded_stdio_snapshot_behavior_remains_explicit(tmp_path):
+    session_id = new_session_id()
+    session = {
+        "session_id": session_id,
+        "messages": [{"role": "user", "content": "x" * 4096}],
+        "trace": [],
+        "turn": 1,
+    }
+
+    save_snapshot(tmp_path, session)
+
+    assert load_snapshot(tmp_path, session_id)[0] == session
 
 
 def test_atomic_replace_is_the_last_fallible_commit_step(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- bound durable native-network ACP sessions per authenticated principal by session count, cumulative serialized bytes, and one-snapshot bytes
- serialize quota accounting across connections and processes with a principal-scoped OS lock
- reserve new-session lease IDs atomically with admission, while keeping resume IDs as routing values rather than authority
- keep snapshot replacement transactional and preserve the last-good disk and in-memory state on quota failure
- fail closed on symlinks, non-regular or unexpected entries, unstable file identity, scan races, lock failures, and already-over-limit stores
- remove unpublished snapshots and provisional leases through cancellation-resistant off-thread cleanup
- keep local stdio ACP unbounded and keep `session/close` resumable
- document the decision in DD-049 and expose operator configuration defaults

## Why

DD-048 bounds retained browser files, but inline image data and the rest of a resumable Agent session live in the JSON snapshot. An authenticated principal could therefore grow Host storage without reaching the upload quota. The fix treats the authenticated principal namespace as the authority and accounting boundary, with no silent truncation, eviction, or close-as-delete semantic change.

Defaults:

- 100 durable sessions
- 100 MiB total serialized snapshots
- 32 MiB for one snapshot

## Review notes

The implementation was independently reviewed through repeated adversarial passes. Findings around duplicate lease counting, event-loop blocking cleanup, unbounded legacy-orphan scans, concurrent admission fairness, provisional lease leakage, and pathname/identity races were fixed before opening this PR. Both final reviewers reported zero actionable findings.

## Validation

- `312 passed` across ACP lifecycle, persistence, gateway, Host routing, Agent transaction, and official SDK e2e suites
- Ruff passed on every changed Python file
- `git diff --check` passed

Closes #921
