### PR TITLE
[1.9 Deferred] phone: give the endpoint a caller — co phone and notify_owner

### DIFF
--- a/connectonion/cli/commands/phone_commands.py
+++ b/connectonion/cli/commands/phone_commands.py
@@ -1,0 +1,55 @@
+"""
+Purpose: `co phone` — set the number your agents reach you on, and send a notification to it
+LLM-Note:
+  Dependencies: imports from [sys, rich.console, useful_tools.phone] | imported by [cli/main.py via phone_*()] | tested by [tests/unit/test_phone.py]
+  Data flow: handle_phone_number(phone) → set/get_owner_phone() | handle_phone_notify(message, urgent) → notify_owner() → prints the outcome
+  State/Effects: one HTTP call per command via the tool | no local state
+  Integration: same shape as handle_email_send — a thin handler over the tool an agent already has
+  Errors: any failure prints the server's own reason and exits 1
+"""
+
+import sys
+
+from rich.console import Console
+
+from ...useful_tools.phone import get_owner_phone, notify_owner, set_owner_phone
+
+console = Console()
+
+
+def handle_phone_number(phone: str = None) -> int:
+    """Show the configured number, or set it."""
+    result = set_owner_phone(phone) if phone else get_owner_phone()
+
+    if not result["success"]:
+        console.print(f"[red]{result['error']}[/red]")
+        sys.exit(1)
+
+    if phone:
+        console.print(f"[green]Your agents will reach you on {result['phone']}[/green]")
+        return 0
+
+    if not result.get("configured"):
+        console.print(
+            "No number set. [dim]co phone number +61435525634[/dim]\n"
+            "Until then your agents can only reach you by email."
+        )
+        return 0
+
+    console.print(f"Your agents reach you on [cyan]{result['phone']}[/cyan]")
+    return 0
+
+
+def handle_phone_notify(message: str, urgent: bool = False) -> int:
+    """Send yourself a notification, the way an agent would."""
+    result = notify_owner(message, urgent=urgent)
+
+    if not result["success"]:
+        console.print(f"[red]{result['error']}[/red]")
+        sys.exit(1)
+
+    console.print(
+        f"[green]{'Calling' if urgent else 'Texted'} {result['to']}[/green] "
+        f"[dim](${result['cost_usd']:.2f})[/dim]"
+    )
+    return 0

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -158,6 +158,7 @@ def _show_help():
     console.print("  [green]email[/green]             Send and read agent email")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]telegram[/green]          Send a message from your Telegram bot")
+    console.print("  [green]phone[/green]             Reach yourself on your phone when email is too slow")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
@@ -785,6 +786,37 @@ def telegram_send(
     """Send a Telegram message."""
     from .commands.telegram_commands import handle_telegram_send
     handle_telegram_send(chat, message)
+# Phone command group. The carrier account is ours and billed to us, so the
+# credential never comes down here -- these call oo-api, which holds it.
+phone_app = _typer_app(help="Reach yourself on your phone. Bare 'co phone' shows the number.")
+app.add_typer(phone_app, name="phone")
+
+
+@phone_app.callback(invoke_without_command=True)
+def phone_callback(ctx: typer.Context):
+    """With no subcommand, show the number agents will reach you on."""
+    if ctx.invoked_subcommand is None:
+        from .commands.phone_commands import handle_phone_number
+        handle_phone_number()
+
+
+@phone_app.command("number")
+def phone_number(
+    phone: Optional[str] = typer.Argument(None, help="E.164, e.g. +61435525634. Omit to show the current one."),
+):
+    """Show or set the number your agents reach you on."""
+    from .commands.phone_commands import handle_phone_number
+    handle_phone_number(phone)
+
+
+@phone_app.command("notify")
+def phone_notify(
+    message: str = typer.Argument(..., help="What to tell yourself"),
+    urgent: bool = typer.Option(False, "--urgent", help="Place a call that speaks it, instead of an SMS"),
+):
+    """Send a notification to your own phone."""
+    from .commands.phone_commands import handle_phone_notify
+    handle_phone_notify(message, urgent=urgent)
 
 
 # Gmail command group. `co gmail` (no args) shows the Gmail inbox.

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -29,6 +29,7 @@ from .todo_list import TodoList
 from .slash_command import SlashCommand
 from .ask_user import ask_user
 from .telegram import send_telegram
+from .phone import notify_owner
 
 # Claude Code-style file tools
 from .file_tools import (
@@ -74,6 +75,7 @@ __all__ = [
     "SlashCommand",
     "ask_user",
     "send_telegram",
+    "notify_owner",
     # Claude Code-style file tools
     "FileTools",
     "read_file",

--- a/connectonion/useful_tools/phone.py
+++ b/connectonion/useful_tools/phone.py
@@ -1,0 +1,102 @@
+"""
+Purpose: Reach the owner on their phone when email will not be read in time
+LLM-Note:
+  Dependencies: imports from [os, requests, backend.backend_url] | imported by [useful_tools/__init__.py, cli/commands/phone_commands.py] | tested by [tests/unit/test_phone.py]
+  Data flow: notify_owner(message, urgent) → POST {backend}/api/v1/phone/notify with OPENONION_API_KEY → returns {success, channel, error}
+  State/Effects: one HTTP POST per notification | no local state | no carrier credential is held here — the backend owns it
+  Integration: exposed as an agent tool and as `co phone notify` | set_owner_phone/get_owner_phone back `co phone number`
+  Errors: returns {success: False, error} — a rate-limited or unconfigured account is a normal outcome the caller must read, not an exception
+"""
+
+import os
+from typing import Dict
+
+import requests
+
+from ..backend import backend_url
+
+
+NO_AUTH = (
+    "OPENONION_API_KEY not found. Run 'co auth login' first — the phone "
+    "channel is billed to your account, so it needs one."
+)
+
+
+def notify_owner(message: str, urgent: bool = False) -> Dict:
+    """Get the owner's attention on their phone.
+
+    Use this when a run cannot continue without a human and email would not be
+    read in time — an overnight run, a deploy that needs a decision now. The
+    answer still comes back by email; this only makes someone look.
+
+    Args:
+        message: What to tell them. Say which agent you are and what you need.
+        urgent: True places a call that speaks the message; False sends an SMS.
+
+    Returns:
+        dict: {success, channel, error}
+    """
+    token = os.getenv("OPENONION_API_KEY")
+    if not token:
+        return {"success": False, "error": NO_AUTH}
+
+    response = requests.post(
+        f"{backend_url()}/api/v1/phone/notify",
+        json={"message": message, "channel": "voice" if urgent else "sms"},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+
+    if response.status_code == 200:
+        return {"success": True, **response.json()}
+
+    # The backend's reasons are all actionable and all different: no number
+    # configured, inside the cooldown, out of credit. Flattening them to
+    # "failed" would throw away what the agent should do next.
+    return {"success": False, "error": _reason(response)}
+
+
+def set_owner_phone(phone: str) -> Dict:
+    """Set the number your agents should reach you on. E.164, e.g. +61435525634."""
+    token = os.getenv("OPENONION_API_KEY")
+    if not token:
+        return {"success": False, "error": NO_AUTH}
+
+    response = requests.put(
+        f"{backend_url()}/api/v1/phone/number",
+        json={"phone": phone},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        return {"success": True, **response.json()}
+    return {"success": False, "error": _reason(response)}
+
+
+def get_owner_phone() -> Dict:
+    """What number your agents will reach you on, if any."""
+    token = os.getenv("OPENONION_API_KEY")
+    if not token:
+        return {"success": False, "error": NO_AUTH}
+
+    response = requests.get(
+        f"{backend_url()}/api/v1/phone/number",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if response.status_code == 200:
+        return {"success": True, **response.json()}
+    return {"success": False, "error": _reason(response)}
+
+
+def _reason(response) -> str:
+    """The server's own explanation, with the retry delay kept attached."""
+    detail = response.json().get("detail") if response.headers.get(
+        "content-type", ""
+    ).startswith("application/json") else None
+    reason = detail if isinstance(detail, str) else response.text[:300]
+
+    retry_after = response.headers.get("Retry-After")
+    if retry_after and str(retry_after) not in reason:
+        reason = f"{reason} (retry in {retry_after}s)"
+    return reason

--- a/tests/unit/test_phone.py
+++ b/tests/unit/test_phone.py
@@ -1,0 +1,168 @@
+"""Unit tests for the phone notification tool and `co phone`.
+
+LLM-Note: Tests for notify_owner / set_owner_phone / get_owner_phone
+
+What it tests:
+- Reaching the owner's phone through oo-api, and every way it can fail
+
+Components under test:
+- Module: useful_tools/phone, cli/commands/phone_commands
+"""
+
+import sys
+
+import pytest
+
+from connectonion.useful_tools.phone import get_owner_phone, notify_owner, set_owner_phone
+
+phone = sys.modules["connectonion.useful_tools.phone"]
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, headers=None, text=""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.headers = headers or {"content-type": "application/json"}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def authed(monkeypatch):
+    monkeypatch.setenv("OPENONION_API_KEY", "test-key")
+
+
+def test_a_normal_notification_goes_out_as_a_text(authed, monkeypatch):
+    posted = {}
+
+    def fake_post(url, json, headers, timeout):
+        posted.update(url=url, json=json, headers=headers)
+        return FakeResponse(200, {"sid": "SM1", "to": "+61435525634",
+                                  "channel": "sms", "cost_usd": 0.06})
+
+    monkeypatch.setattr(phone.requests, "post", fake_post)
+
+    result = notify_owner("Stuck on AllEvents verification")
+
+    assert result["success"] is True
+    assert posted["json"] == {"message": "Stuck on AllEvents verification", "channel": "sms"}
+    assert posted["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_urgent_escalates_to_a_voice_call(authed, monkeypatch):
+    """The whole reason phone exists is the case email cannot cover, and a
+    ringing phone is the only thing that gets through a silent one."""
+    posted = {}
+    monkeypatch.setattr(
+        phone.requests, "post",
+        lambda url, json, headers, timeout: (posted.update(json=json),
+                                             FakeResponse(200, {"channel": "voice"}))[1],
+    )
+
+    notify_owner("Deploy is blocked and I cannot continue", urgent=True)
+
+    assert posted["json"]["channel"] == "voice"
+
+
+def test_no_number_configured_says_so_rather_than_failing_vaguely(authed, monkeypatch):
+    monkeypatch.setattr(
+        phone.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(
+            400, {"detail": "No phone number is set for this account."}),
+    )
+
+    result = notify_owner("hello")
+
+    assert result["success"] is False
+    assert "No phone number is set" in result["error"]
+
+
+def test_a_rate_limited_notification_keeps_the_retry_delay(authed, monkeypatch):
+    """The agent has to know it was throttled AND for how long, or it will
+    either loop or give up — the two failure modes the cooldown exists to stop."""
+    monkeypatch.setattr(
+        phone.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(
+            429,
+            {"detail": "A notification was already sent to this account less than 5 minutes ago."},
+            headers={"content-type": "application/json", "Retry-After": "240"},
+        ),
+    )
+
+    result = notify_owner("again")
+
+    assert result["success"] is False
+    assert "240" in result["error"]
+
+
+def test_no_api_key_points_at_co_auth_instead_of_calling(monkeypatch):
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("called the backend with no key")
+
+    monkeypatch.setattr(phone.requests, "post", must_not_run)
+
+    result = notify_owner("hello")
+
+    assert result["success"] is False
+    assert "co auth login" in result["error"]
+
+
+def test_setting_a_number_returns_what_the_server_stored(authed, monkeypatch):
+    put = {}
+    monkeypatch.setattr(
+        phone.requests, "put",
+        lambda url, json, headers, timeout: (put.update(json=json),
+                                             FakeResponse(200, {"phone": "+61435525634"}))[1],
+    )
+
+    result = set_owner_phone("+61435525634")
+
+    assert result["success"] is True
+    assert put["json"] == {"phone": "+61435525634"}
+
+
+def test_an_unset_number_reads_as_not_configured(authed, monkeypatch):
+    monkeypatch.setattr(
+        phone.requests, "get",
+        lambda url, headers, timeout: FakeResponse(200, {"phone": None, "configured": False}),
+    )
+
+    result = get_owner_phone()
+
+    assert result["success"] is True
+    assert result["configured"] is False
+
+
+class TestTheCommand:
+    def test_a_failed_notify_exits_nonzero(self, monkeypatch):
+        from connectonion.cli.commands import phone_commands
+
+        monkeypatch.setattr(
+            phone_commands, "notify_owner",
+            lambda message, urgent: {"success": False, "error": "No phone number is set."},
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            phone_commands.handle_phone_notify("hello")
+
+        assert exc.value.code == 1
+
+    def test_no_number_set_tells_you_the_command_to_set_one(self, monkeypatch, capsys):
+        """A person running `co phone` with nothing configured should leave with
+        the next command, not with a blank."""
+        from connectonion.cli.commands import phone_commands
+
+        monkeypatch.setattr(
+            phone_commands, "get_owner_phone",
+            lambda: {"success": True, "phone": None, "configured": False},
+        )
+
+        phone_commands.handle_phone_number()
+
+        printed = capsys.readouterr().out
+        assert "co phone number" in printed
+        assert "email" in printed


### PR DESCRIPTION
Draft. The framework half of `openonion/oo-api#136` — that PR built `POST /api/v1/phone/notify` and **nothing in the framework could reach it.** The backend half of a channel is not a channel.

## What this adds

```
co phone                        what number your agents reach you on
co phone number +61435525634    set it
co phone notify "..." [--urgent]
```

and `notify_owner(message, urgent)` as an agent tool — so an agent blocked at 2am can make someone look, instead of dying quietly with its question unasked (#843).

`--urgent` places a call that speaks the message; without it you get an SMS. That is the whole distinction, because it is the only one that matters: a text is seen when someone next looks, a ringing phone gets through a silent one.

## Where the credential lives, and why it differs from #866

**No carrier credential comes down here.** These call oo-api, which holds it. The Telegram tool in #866 does the opposite — the bot is the user's own from @BotFather and the token sits in their `keys.env`.

Both are right, and the rule that decides it is **whose account it is and who pays** — not what the channel looks like. Twilio is our account and our bill, so a deployed agent must never hold that key. A Telegram bot is the user's and costs nothing, exactly like the Google OAuth token `co gmail` uses.

Worth writing down because "chat and phone are both messaging, put them together" is a plausible-sounding mistake, and the next channel added will face the same fork.

## The refusals are passed through, not flattened

The backend refuses for three different reasons and every one has a different fix: no number configured, inside the cooldown, out of credit. They come back with the server's own wording **and the `Retry-After` delay still attached**.

An agent that cannot tell *"wait 240 seconds"* from *"you have no number"* will either loop or give up — the two behaviours the cooldown in `openonion/oo-api#136` exists to prevent. Collapsing them into "failed" would throw away the instruction the agent needs.

## Tests

9 unit tests, no live backend:

- a normal notification goes out as a text, with the exact payload and bearer token asserted
- **`--urgent` escalates to voice** — the case the whole feature exists for
- **a rate-limited notification keeps the retry delay** (429 + `Retry-After: 240` → "240" survives into the error the agent reads)
- no number configured says so, rather than failing vaguely
- **no API key points at `co auth login` and never calls the backend**
- `co phone` with nothing configured prints the command to set one and says agents can only reach you by email until then — a person should leave with the next command, not a blank
- a failed notify exits non-zero, so a script can tell

`431 passed` across these, the import-cost guard, and the full `tests/e2e/cli` suite.

## Not yet real

`openonion/oo-api#136` has never talked to a live carrier — no Twilio account, no number bought. Until that exists and `scripts/add_phone_columns.py` has run, `co phone notify` will fail against production. **The first real call is the actual test of both PRs.**
