### PR TITLE
release: 1.6.1 — the CLI stops acting as the wrong account

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, 'release/**' ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, 'release/**' ]
   workflow_call:
 
 jobs:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -38,9 +38,10 @@ patch releases; the minor is the statement that it no longer needs to be.
 - Reserved for breaking changes, or for a stable release worth naming
 - Same rule as any whole number: earned, not reached
 
-## Current Version: 1.6.0
+## Current Version: 1.6.1
 
 ### Version History
+- 1.6.1 (**the CLI stops acting as the wrong account**: it refuses an `OPENONION_API_KEY` that belongs to an account this machine does not hold the signing key for — a stray `.env` in the working directory could shadow the real identity in `~/.co/keys.env`, so a command run from the wrong directory silently read that other account's mailbox and spent its credit; now it re-authenticates or fails closed instead. `co outlook read` keeps the URLs in HTML mail rather than stripping `<a href>` down to its link text, which had made per-recipient links unrecoverable; a malformed JWT claim no longer crashes every CLI command.)
 - 1.6.0 (**safer remote agents and a cleaner credential boundary**: host identity and temporary session-status probes are signed consistently; relay profile updates reject stale or conflicting state; Microsoft OAuth credentials and refresh-token rotation stay on the CLI machine instead of being stored by the backend; project invite credentials are private and no shared default invite code is documented; email sending has traceable, tenant-scoped idempotency and resilient provider-error handling; paid mailbox upgrades can preserve the existing address and are charged atomically; portable skills, dependency floors, cross-platform tests, and exact-artifact release verification are hardened for a stable release.)
 - 0.0.1b1 → 0.0.1b8 (Beta releases)
 - 0.0.2 → 0.0.9 (Early production releases)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -1046,13 +1046,20 @@ def load_api_key() -> Optional[str]:
     2. Local .env file
     3. Global ~/.co/keys.env file
 
+    Every source goes through `_token_for_this_account()`. The environment used
+    to skip it, which made the check dead code in practice: `connectonion/
+    __init__.py` calls `load_dotenv(Path.cwd() / ".env")` at import time, so by
+    the time any command runs the variable is already set and the early return
+    always fired. A `.env` in whatever directory you happened to be standing in
+    could then bill and read another agent's account in silence.
+
     Returns:
         API key if found, None otherwise
     """
     from dotenv import load_dotenv
 
     if api_key := os.getenv("OPENONION_API_KEY"):
-        return api_key
+        return _token_for_this_account(api_key)
 
     for env_path in [Path(".env"), Path.home() / ".co" / "keys.env"]:
         if env_path.exists():
@@ -1075,12 +1082,16 @@ def account_in_token(token: str) -> Optional[str]:
     payload = parts[1]
     payload += "=" * (-len(payload) % 4)          # base64url, padding stripped
     try:
-        return json.loads(base64.urlsafe_b64decode(payload)).get("public_key")
+        decoded = json.loads(base64.urlsafe_b64decode(payload))
     except (ValueError, binascii.Error):
         return None
+    if not isinstance(decoded, dict):
+        return None
+    public_key = decoded.get("public_key")
+    return public_key if isinstance(public_key, str) and public_key else None
 
 
-def _token_for_this_account(token: str) -> str:
+def _token_for_this_account(token: str) -> Optional[str]:
     """Re-authenticate when the stored token names an account we are not.
 
     `co server new` and `co deploy` bill whatever the token says; `co status`
@@ -1111,8 +1122,19 @@ def _token_for_this_account(token: str) -> str:
     if authenticate(co_dir, save_to_project=False, quiet=True):
         from dotenv import load_dotenv
         load_dotenv(co_dir / "keys.env", override=True)
-        return os.getenv("OPENONION_API_KEY", token)
-    return token
+        refreshed = os.getenv("OPENONION_API_KEY")
+        if refreshed and account_in_token(refreshed) == identity["address"]:
+            return refreshed
+
+    # Re-authentication did not produce a token for this machine. Returning the
+    # mismatched one anyway is the failure this function exists to prevent — it
+    # reads another account's mailbox and spends another account's credit while
+    # looking like an ordinary working session. No key at all is recoverable:
+    # callers say "run co auth", and the operator knows something is wrong.
+    console.print("[yellow]Could not get a token for this machine's key. "
+                  "Not using the one on hand — it bills another account. "
+                  "Run [bold]co auth[/bold].[/yellow]")
+    return None
 
 
 def upsert_env(env_path: Path, updates: dict, *, strip_prefix: str = None) -> None:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -446,7 +446,29 @@ class Outlook:
             import re
             from html import unescape
             body_content = re.sub(r'<style[^>]*>.*?</style>', '', body_content, flags=re.DOTALL | re.IGNORECASE)
-            body_content = re.sub(r'<[^>]+>', '', body_content)
+            # Keep the address before the tags go. Stripping <a href="..."> as
+            # markup leaves the words and loses the link, and a URL carrying a
+            # per-recipient token is not one the reader can reconstruct.
+            def anchor_as_text(match) -> str:
+                url = match.group(1)
+                text = re.sub(r'<[^>]+>', '', match.group(2)).strip()
+                # Clients often use the URL as its own link text; printing it
+                # twice reads as two different links.
+                if not text or unescape(text) == unescape(url):
+                    return url
+                return f"{text} <{url}>"
+
+            body_content = re.sub(
+                r'<a\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+                anchor_as_text,
+                body_content,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+            # Everything that is markup, but not the `<scheme://…>` the step
+            # above just wrote — `<[^>]+>` cannot tell those apart and ate the
+            # very addresses it was meant to preserve.
+            body_content = re.sub(r'<(?![a-zA-Z][a-zA-Z0-9+.-]*://)[^>]+>', '',
+                                  body_content)
             body_content = unescape(body_content)
             body_content = re.sub(r'\s+', ' ', body_content).strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.6.0"
+version = "1.6.1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/unit/test_a_read_email_keeps_its_links.py
+++ b/tests/unit/test_a_read_email_keeps_its_links.py
@@ -1,0 +1,129 @@
+"""`co outlook read` used to drop every URL in an HTML mail.
+
+`get_email_body()` renders HTML by deleting every tag:
+
+    body_content = re.sub(r'<[^>]+>', '', body_content)
+
+For `<a href="https://…">Complete the questionnaire</a>` that keeps the words
+and throws away the address. The reader is left with an instruction to click
+something that is no longer there.
+
+On 2026-08-11 that cost two reference-check questionnaires. Their links carried
+a per-recipient token:
+
+    https://forms.example.com/r/AbC123?t=9f2c…
+
+which is not a URL anyone can reconstruct from the anchor text, the sender, or
+the subject — unlike a bare marketing link, where you can just visit the site.
+The mail was readable, looked complete, and the one thing it existed to deliver
+was gone.
+
+So: the words stay where they are, and the address follows in angle brackets —
+the convention plain-text mail has used for decades, and one an agent reading
+the output can pick up without being taught a new format.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_token_refresh(monkeypatch):
+    from connectonion.useful_tools.outlook import Outlook
+    monkeypatch.setattr(Outlook, "_refresh_via_backend", lambda self, rt: "test-token")
+
+
+def body_rendered_from(html: str) -> str:
+    """Whatever `co outlook read` would print for this HTML mail."""
+    from connectonion.useful_tools.outlook import Outlook
+
+    with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read,Mail.Send"}, clear=False):
+        outlook = Outlook()
+        with patch.object(outlook, "_request", return_value={
+            "from": {"emailAddress": {"name": "HR", "address": "hr@example.com"}},
+            "toRecipients": [{"emailAddress": {"address": "me@example.com"}}],
+            "subject": "Reference check",
+            "receivedDateTime": "2026-08-11T00:00:00Z",
+            "body": {"contentType": "html", "content": html},
+        }):
+            return outlook.get_email_body("msg-id")
+
+
+class TestALinkSurvives:
+
+    def test_the_url_is_kept(self):
+        url = "https://forms.example.com/r/AbC123?t=9f2c"
+        out = body_rendered_from(f'<p>Please <a href="{url}">complete it</a>.</p>')
+
+        assert url in out, (
+            "the anchor's href was dropped; this URL carries a per-recipient "
+            "token and cannot be reconstructed from the text around it"
+        )
+
+    def test_the_link_text_is_kept_too(self):
+        url = "https://forms.example.com/r/AbC123?t=9f2c"
+        out = body_rendered_from(f'<p>Please <a href="{url}">complete it</a>.</p>')
+
+        assert "complete it" in out, "the sentence lost its words"
+
+    def test_several_links_each_keep_their_own_url(self):
+        out = body_rendered_from(
+            '<a href="https://a.example/1">first</a> and '
+            '<a href="https://b.example/2">second</a>'
+        )
+
+        assert "https://a.example/1" in out
+        assert "https://b.example/2" in out
+
+    def test_single_quoted_href_works(self):
+        out = body_rendered_from("<a href='https://a.example/1'>x</a>")
+
+        assert "https://a.example/1" in out
+
+    def test_other_attributes_do_not_hide_the_href(self):
+        out = body_rendered_from(
+            '<a class="btn" href="https://a.example/1" target="_blank">x</a>'
+        )
+
+        assert "https://a.example/1" in out
+
+
+class TestNothingElseChanges:
+
+    def test_a_bare_url_as_link_text_is_not_printed_twice(self):
+        """Mail clients often render the URL as its own anchor text."""
+        url = "https://a.example/1"
+        out = body_rendered_from(f'<a href="{url}">{url}</a>')
+
+        assert out.count(url) == 1, f"printed twice: {out!r}"
+
+    def test_plain_text_mail_is_untouched(self):
+        from connectonion.useful_tools.outlook import Outlook
+
+        with patch.dict(os.environ, {"MICROSOFT_SCOPES": "Mail.Read"}, clear=False):
+            outlook = Outlook()
+            with patch.object(outlook, "_request", return_value={
+                "from": {"emailAddress": {"name": "A", "address": "a@example.com"}},
+                "toRecipients": [],
+                "subject": "s",
+                "receivedDateTime": "2026-08-11T00:00:00Z",
+                "body": {"contentType": "text",
+                         "content": "see <https://a.example/1>"},
+            }):
+                out = outlook.get_email_body("id")
+
+        assert "see <https://a.example/1>" in out
+
+    def test_styles_are_still_stripped(self):
+        out = body_rendered_from("<style>a {color: red}</style><p>hello</p>")
+
+        assert "color: red" not in out
+        assert "hello" in out
+
+    def test_markup_is_still_stripped(self):
+        out = body_rendered_from('<p class="x">hello <b>there</b></p>')
+
+        assert "<p" not in out and "<b>" not in out
+        assert "hello" in out and "there" in out

--- a/tests/unit/test_the_key_in_hand_is_this_machines.py
+++ b/tests/unit/test_the_key_in_hand_is_this_machines.py
@@ -1,0 +1,167 @@
+"""Whose account does the token in `OPENONION_API_KEY` actually bill?
+
+`_token_for_this_account()` exists to answer that. Its docstring names the cost
+of getting it wrong — "One $180 server was bought that way" — and it works: a
+local JWT decode, and a re-authentication only when the token names an account
+this machine does not hold the key for.
+
+It just never runs. `load_api_key()` returns at the top:
+
+    if api_key := os.getenv("OPENONION_API_KEY"):
+        return api_key                          # <- guard skipped
+
+and `connectonion/__init__.py` guarantees that variable is always set, because
+it calls `load_dotenv(Path.cwd() / ".env")` at import time, before any command
+starts. So the guard protects only the path nothing takes.
+
+What that costs, observed on this operator's machine on 2026-08-11:
+
+    ~/.co/keys.env   0x10e68f6d…   the real account, $408 balance
+    ~/.env           0x561605f3…   a different agent, drained to $0.001
+
+    cd ~           && co email inbox   ->  1 email    (0x5616…)
+    cd ~/project/… && co email inbox   ->  full inbox (0x10e6…)
+
+Same command, same machine, two mailboxes — and the empty one is indistinguishable
+from a quiet week. Both files carried the same `AGENT_EMAIL=aaron.xie@…`, so the
+declared identity agreed everywhere; only the key differed, and the key is what
+picks the mailbox. It reads as "no mail arrived", never as "you are someone else".
+
+The rule this pins: a token that names an account whose key this machine does not
+hold must not be handed to a caller, whichever source it arrived from. Reaching
+the environment first is not evidence that it is ours.
+"""
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from connectonion.cli.commands import project_cmd_lib
+from connectonion.cli.commands.project_cmd_lib import load_api_key
+
+THIS_MACHINE = "0x" + "10e68f6d" * 8
+SOMEONE_ELSE = "0x" + "561605f3" * 8
+
+
+def token_with_payload(payload_value) -> str:
+    """A JWT-shaped value; its signature is not checked by the local decoder."""
+    payload = base64.urlsafe_b64encode(
+        json.dumps(payload_value).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+
+def token_for(public_key: str) -> str:
+    """A JWT shaped like the server's, signature not checked by the decoder."""
+    return token_with_payload({"public_key": public_key})
+
+
+@pytest.fixture
+def this_machine(monkeypatch, tmp_path):
+    """A machine holding the key for THIS_MACHINE, and nothing in the env."""
+    # Own project dir, so the walk-up for `.co` stops here instead of escaping
+    # to whatever shared parent the tmp dir happens to sit under.
+    (tmp_path / ".co").mkdir()
+    monkeypatch.chdir(tmp_path)          # no .env above the test
+    monkeypatch.setattr(
+        project_cmd_lib.address, "load",
+        lambda co_dir: {"address": THIS_MACHINE},
+    )
+    monkeypatch.delenv("OPENONION_API_KEY", raising=False)
+
+
+class TestTheTokenNamesAnotherAccount:
+    """`~/.env` shadowing `~/.co/keys.env` — the 2026-08-11 incident."""
+
+    def test_the_foreign_token_is_not_returned(self, this_machine, monkeypatch):
+        monkeypatch.setenv("OPENONION_API_KEY", token_for(SOMEONE_ELSE))
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate",
+            lambda *a, **k: False,
+        )
+
+        returned = load_api_key()
+
+        assert returned != token_for(SOMEONE_ELSE), (
+            "load_api_key() handed back a token billing "
+            f"{SOMEONE_ELSE[:14]}… while this machine holds the key for "
+            f"{THIS_MACHINE[:14]}… — every command downstream now reads that "
+            "account's mailbox and spends its credit, with no error shown"
+        )
+
+    def test_re_authentication_is_attempted(self, this_machine, monkeypatch):
+        """The mismatch is recoverable — the signing key is right here."""
+        monkeypatch.setenv("OPENONION_API_KEY", token_for(SOMEONE_ELSE))
+        attempts = []
+
+        def authenticate(*args, **kwargs):
+            attempts.append(kwargs)
+            return False
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        load_api_key()
+
+        assert attempts, (
+            "no re-authentication was attempted; the CLI holds the key that "
+            "would have produced a correct token"
+        )
+
+
+class TestTheOrdinaryCaseIsUndisturbed:
+    """The guard costs one local base64 decode when the token is ours."""
+
+    def test_our_own_token_is_returned_unchanged(self, this_machine, monkeypatch):
+        ours = token_for(THIS_MACHINE)
+        monkeypatch.setenv("OPENONION_API_KEY", ours)
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated for a token already ours")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == ours
+
+    def test_a_token_with_no_account_is_left_alone(self, this_machine, monkeypatch):
+        """Not every token is a JWT we can read; an unreadable one is not a mismatch."""
+        monkeypatch.setenv("OPENONION_API_KEY", "not-a-jwt")
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated over an undecodable token")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == "not-a-jwt"
+
+    @pytest.mark.parametrize(
+        "payload",
+        [[], "text", 7, None, {}, {"public_key": []}, {"public_key": 7}],
+    )
+    def test_a_non_string_account_claim_is_unreadable(
+        self, this_machine, monkeypatch, payload
+    ):
+        """A syntactically valid JSON payload must not crash every CLI call."""
+        token = token_with_payload(payload)
+        monkeypatch.setenv("OPENONION_API_KEY", token)
+
+        def authenticate(*args, **kwargs):
+            raise AssertionError("re-authenticated over an unreadable token")
+
+        monkeypatch.setattr(
+            "connectonion.cli.commands.auth_commands.authenticate", authenticate
+        )
+
+        assert load_api_key() == token
+
+    def test_no_key_anywhere_still_returns_none(self, this_machine, monkeypatch, tmp_path):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+        assert load_api_key() is None

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
First patch on the **1.6 stable line**. `main` is the 1.7 preview train (ACP), so this is cut from `v1.6.0` and cherry-picks fixes only — no feature train, per VERSIONING.md.

## What ships (PR #845, verified end-to-end this session)

- **The CLI refuses an `OPENONION_API_KEY` that belongs to an account this machine does not hold the signing key for.** A stray `.env` in the working directory could shadow the real identity in `~/.co/keys.env`, so a command run from the wrong directory silently read *that other account's* mailbox and spent its credit — the root of the wrong-sender / wrong-mailbox class of reports. Now it re-authenticates, or fails closed and says `co auth`.
- **`co outlook read` keeps the URLs in HTML mail** instead of stripping `<a href>` down to its link text, which had made per-recipient links (with tokens) unrecoverable.
- **A malformed JWT claim no longer crashes every CLI command** (`{"public_key": []}` etc. hit `.get()` on a non-dict).

## Why 1.6.1 and not 1.7

VERSIONING.md: patch releases carry "bug, security, documentation, compatibility fixes; they do not carry the next feature train." The ACP subsystem on `main` is that train and matures in `1.7.0aN`. This is the stabilised, non-ACP safety fix, so it belongs on the 1.6 line.

## Release checklist

```
Version
  [x] number chosen; patch (fixes only), reason above
  [x] pyproject.toml, connectonion/_version.py, VERSIONING.md (current + history), uv.lock
  [ ] docs-site/lib/version.ts — separate repo on another branch; bump on its own main (CI skips it here; does not block PyPI)
Gates
  [x] cherry-pick applied clean onto v1.6.0; feature tests green (21 passed)
  [x] release PR opened for the CI gate (8 jobs incl. Windows + e2e)
  [ ] CI green → merge
  [ ] build FROM THE MERGED COMMIT, twine check, wheel inspected, clean-venv `co --version` + `co outlook read --help`
Publish
  [ ] tag v1.6.1 (IRREVERSIBLE beyond here)
  [ ] twine upload, reinstall from PyPI, version confirmed
  [ ] GitHub release with artifacts
After
  [ ] Discord announce (feature framing)
```

Cut as the first of several small patches — subsequent fixes (project-root boundary #846/#852, the rest of the credential-guard cluster, gmail HTML #790, attachment boundaries) ship as 1.6.2 / 1.6.3, 1–2 verified per release.