### PR TITLE
fix(acp): verify native payment onboarding

### DIFF
--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -502,7 +502,6 @@ class AuthenticatedACPApp:
                 ],
             },
             origin=origin,
-            extra_headers=[(b"cache-control", b"no-store")],
         )
 
     async def _handle_websocket(
@@ -1055,7 +1054,14 @@ class AuthenticatedACPApp:
         origin: str | None = None,
         extra_headers: list[tuple[bytes, bytes]] | None = None,
     ) -> None:
-        headers = [(b"content-type", b"application/json")]
+        # Every gateway answer is dynamic admission/transport state. In
+        # particular, caching a trust refusal would keep rejecting a caller
+        # after they completed onboarding. DD-045 requires all authorization
+        # responses, not only successful tickets, to be non-cacheable.
+        headers = [
+            (b"content-type", b"application/json"),
+            (b"cache-control", b"no-store"),
+        ]
         if origin is not None and self._origin_allowed(origin):
             headers.extend(self._cors_headers(origin))
         if extra_headers:

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -463,7 +463,7 @@ class AuthenticatedACPApp:
             await self._send_json(send, 400, {"error": "Invalid payment"}, origin=origin)
             return
 
-        principal, error, status = self._admit_signed(
+        principal, error, status = await self._admit_signed(
             scope,
             method="POST",
             path=ACP_AUTHORIZE_PATH,
@@ -560,7 +560,7 @@ class AuthenticatedACPApp:
                     }
                 )
                 return
-            principal, error, status = self._admit_websocket(scope)
+            principal, error, status = await self._admit_websocket(scope)
             if error:
                 close_code = 4403 if status == 403 else 4429 if status == 429 else 4401
                 await send(
@@ -697,7 +697,7 @@ class AuthenticatedACPApp:
                 else:
                     self._active_principals.pop(principal_key, None)
 
-    def _admit_websocket(
+    async def _admit_websocket(
         self,
         scope: dict,
     ) -> tuple[ACPPrincipal | None, str | None, int]:
@@ -716,7 +716,7 @@ class AuthenticatedACPApp:
                 return None, "Invalid or expired ACP ticket", 401
             return replace(principal, auth_method="browser_ticket"), None, 200
 
-        return self._admit_signed(
+        return await self._admit_signed(
             scope,
             method="GET",
             path=ACP_PATH,
@@ -725,7 +725,7 @@ class AuthenticatedACPApp:
             request_data={"prompt": "Open an ACP WebSocket connection"},
         )
 
-    def _admit_signed(
+    async def _admit_signed(
         self,
         scope: dict,
         *,
@@ -755,21 +755,13 @@ class AuthenticatedACPApp:
         except ReplayProtectionError:
             return None, "misconfigured: replay protection unavailable", 503
 
-        if caller not in self._whitelist:
-            try:
-                decision = self._trust_agent.should_allow(caller, request_data)
-            except (OSError, UnicodeDecodeError) as exc:
-                return None, f"misconfigured: {exc}", 503
-            if not decision.allow:
-                return None, f"forbidden: {decision.reason}", 403
-
-        try:
-            level = "admin" if self._trust_agent.is_admin(caller) else self._trust_agent.get_level(caller)
-        except (OSError, UnicodeDecodeError) as exc:
-            return None, f"misconfigured: {exc}", 503
+        # Count every verified, replay-safe attempt before trust evaluation or
+        # payment-provider IO. Previously only successful admissions reached
+        # the limiter, so an authenticated stranger could create unbounded
+        # rejected policy/payment work while never consuming a slot.
         principal = ACPPrincipal(
             address=caller,
-            level=level,
+            level="",
             recipient=self._recipient_address,
             origin=origin,
             auth_method="signed_headers",
@@ -777,7 +769,43 @@ class AuthenticatedACPApp:
         )
         if not self._rate_limiter.allow(principal):
             return None, "too many ACP admission attempts", 429
-        return principal, None, 200
+
+        if caller not in self._whitelist:
+            try:
+                decision = self._trust_agent.should_allow(caller, request_data)
+            except (OSError, UnicodeDecodeError) as exc:
+                return None, f"misconfigured: {exc}", 503
+            if not decision.allow:
+                payment = request_data.get("payment", 0)
+                if _payment_is_valid(payment) and payment > 0:
+                    # A number in the signed body is still only a claim. The
+                    # existing verifier resolves the operator's configured
+                    # minimum and confirms a real recent transfer from this
+                    # authenticated caller to this Host before promotion. It
+                    # performs bounded network IO, so keep it off the ASGI loop.
+                    try:
+                        paid = await asyncio.to_thread(
+                            self._trust_agent.verify_payment,
+                            caller,
+                            payment,
+                        )
+                    except Exception:
+                        logger.exception("ACP payment verification failed")
+                        return None, "misconfigured: payment verification unavailable", 503
+                    if not paid:
+                        return None, f"forbidden: {decision.reason}", 403
+                else:
+                    return None, f"forbidden: {decision.reason}", 403
+
+        try:
+            level = "admin" if self._trust_agent.is_admin(caller) else self._trust_agent.get_level(caller)
+        except (OSError, UnicodeDecodeError) as exc:
+            return None, f"misconfigured: {exc}", 503
+        return replace(
+            principal,
+            level=level,
+            authenticated_at=time.time(),
+        ), None, 200
 
     async def _pump_inbound(
         self,

--- a/docs/design-decisions/050-verified-native-acp-payment-onboarding.md
+++ b/docs/design-decisions/050-verified-native-acp-payment-onboarding.md
@@ -1,0 +1,65 @@
+# DD-050: Verify payment inside native ACP browser admission
+
+**Status:** Accepted
+
+**Date:** 2026-08-13
+
+**Related:** [DD-045 Authenticated ACP WebSocket Gateway](045-authenticated-acp-websocket-gateway.md), [Issue #928](https://github.com/openonion/connectonion/issues/928)
+
+## Context
+
+The native browser ACP gateway accepts a signed JSON body at
+`POST /acp/authorize`. Public discovery can advertise invite-code and payment
+onboarding, but the original admission path passed both fields only through
+the normal trust decision. Invite codes work there. Payment deliberately does
+not: a number written by the caller is not evidence of a transfer, so the fast
+trust rules refuse to grant access from it.
+
+Legacy `/ws` verifies payment in a later signed `ONBOARD_SUBMIT` frame. React
+cannot use that path after native ACP was selected without creating an
+error-driven downgrade and a second transport lifecycle.
+
+## Decision
+
+Native payment onboarding completes inside the existing signed authorization
+exchange. After exact signature, recipient, Origin, request-body digest, and
+one-use request-ID verification, the Host rate-limits the verified principal.
+Rejected attempts consume the same bounded admission budget as successful
+ones, before trust evaluation or payment-provider work.
+
+The ordinary trust decision runs first. If it refuses and the signed request
+contains a positive payment claim, the Host calls the existing
+`TrustAgent.verify_payment()` outside the ASGI event loop. That verifier, not
+the caller's number, resolves the operator-configured minimum and confirms a
+recent transfer from the authenticated caller to the Host's own address. It
+promotes the caller only after verification. A successful admission then
+issues the normal origin-bound, one-use browser ticket.
+
+Verification refusal returns the same generic trust error. Provider failures
+fail closed without exposing provider details. Blocked, malformed, replayed,
+wrong-recipient, wrong-Origin, and rate-limited requests never reach payment
+verification. React never opens `/ws` to finish native onboarding.
+
+The payment recipient displayed by React is the requested Agent address. The
+same address must match `/info.address` during transport discovery and is the
+Host identity used by the payment verifier, so no second public identity field
+is introduced.
+
+## Rejected alternatives
+
+- **Trust the signed `payment` number:** signatures prove who made a claim, not
+  that money moved. This would restore the historical pay-nothing bypass.
+- **Open legacy `/ws` for `ONBOARD_SUBMIT`:** native selection would no longer
+  be atomic and failures could create duplicate connections or prompts.
+- **Run payment verification on the ASGI loop:** provider timeouts would stall
+  unrelated ACP connections.
+- **Rate-limit only successful tickets:** rejected callers could create
+  unbounded trust and external-verification work.
+- **Publish a separate payment address:** the public Agent identity already is
+  the verified recipient; another field could drift from it.
+
+## Compatibility and rollback
+
+Invite onboarding and already-trusted callers are unchanged. Removing this
+slice makes payment-only native onboarding fail closed again; it does not
+weaken admission or redirect the client to legacy transport.

--- a/docs/design-decisions/050-verified-native-acp-payment-onboarding.md
+++ b/docs/design-decisions/050-verified-native-acp-payment-onboarding.md
@@ -38,7 +38,9 @@ issues the normal origin-bound, one-use browser ticket.
 Verification refusal returns the same generic trust error. Provider failures
 fail closed without exposing provider details. Blocked, malformed, replayed,
 wrong-recipient, wrong-Origin, and rate-limited requests never reach payment
-verification. React never opens `/ws` to finish native onboarding.
+verification. Every gateway response, including a refusal, is `no-store` so a
+completed onboarding cannot remain hidden behind a cached denial. React never
+opens `/ws` to finish native onboarding.
 
 The payment recipient displayed by React is the requested Agent address. The
 same address must match `/info.address` during transport discovery and is the

--- a/docs/network/acp-websocket.md
+++ b/docs/network/acp-websocket.md
@@ -85,6 +85,15 @@ transport limitations; it does not replace ConnectOnion identity or trust.
 The preflight accepts only the documented signing headers and supports Private
 Network Access when an HTTPS page reaches a loopback Agent.
 
+When the Host advertises onboarding, the same signed authorization body may
+carry an invite code or payment claim. An invite is checked against the Host's
+configured codes. A payment claim never grants access by itself: the Host
+resolves its configured price and verifies a recent transfer from the signed
+caller to the Agent address before it promotes the caller and issues a ticket.
+This bounded provider check runs outside the ASGI event loop. Rejected
+onboarding remains on this native path and never falls back to `/ws`. See
+[DD-050](../design-decisions/050-verified-native-acp-payment-onboarding.md).
+
 Before admission, an ACP-enabled Host advertises the transport in its public
 `/info` response:
 

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -32,10 +33,12 @@ ORIGIN = "https://chat.openonion.ai"
 
 
 class _Trust:
-    def __init__(self, *, allow=True, level="contact"):
+    def __init__(self, *, allow=True, level="contact", payment_verified=False):
         self.allow = allow
         self.level = level
+        self.payment_verified = payment_verified
         self.requests = []
+        self.payment_requests = []
 
     def should_allow(self, address, request):
         self.requests.append((address, request))
@@ -46,6 +49,10 @@ class _Trust:
 
     def get_level(self, _address):
         return self.level
+
+    def verify_payment(self, caller, amount):
+        self.payment_requests.append((caller, amount, threading.get_ident()))
+        return self.payment_verified
 
 
 class _Replay:
@@ -589,6 +596,94 @@ async def test_verified_principal_admission_is_rate_limited():
     assert second[0] == 429
     assert second[2] == {"error": "too many ACP admission attempts"}
     assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_native_payment_onboarding_verifies_transfer_off_the_event_loop():
+    trust = _Trust(allow=False, payment_verified=True)
+    app, caller, recipient, agents = _app(trust=trust)
+    event_loop_thread = threading.get_ident()
+
+    status, headers, response = await _authorize(
+        app,
+        caller,
+        recipient,
+        body=b'{"payment":10}',
+    )
+
+    assert status == 201
+    assert headers[b"cache-control"] == b"no-store"
+    assert response["protocols"][0] == "acp"
+    assert len(trust.payment_requests) == 1
+    payment_caller, payment_amount, worker_thread = trust.payment_requests[0]
+    assert (payment_caller, payment_amount) == (caller["address"], 10)
+    assert worker_thread != event_loop_thread
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_claimed_native_payment_without_verified_transfer_stays_forbidden():
+    tickets = ACPTicketRegistry()
+    trust = _Trust(allow=False, payment_verified=False)
+    app, caller, recipient, agents = _app(trust=trust, tickets=tickets)
+
+    status, _, response = await _authorize(
+        app,
+        caller,
+        recipient,
+        body=b'{"payment":999}',
+    )
+
+    assert status == 403
+    assert response == {"error": "forbidden: test policy"}
+    assert trust.payment_requests[0][:2] == (caller["address"], 999)
+    assert tickets._records == {}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_native_payment_provider_failure_is_generic_and_issues_no_ticket():
+    tickets = ACPTicketRegistry()
+    trust = _Trust(allow=False)
+    trust.verify_payment = Mock(side_effect=RuntimeError("private provider detail"))
+    app, caller, recipient, agents = _app(trust=trust, tickets=tickets)
+
+    status, _, response = await _authorize(
+        app,
+        caller,
+        recipient,
+        body=b'{"payment":10}',
+    )
+
+    assert status == 503
+    assert response == {"error": "misconfigured: payment verification unavailable"}
+    assert "private provider detail" not in response["error"]
+    assert tickets._records == {}
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_signed_attempts_are_limited_before_payment_verification():
+    limiter = ACPAdmissionRateLimiter(limit=1)
+    trust = _Trust(allow=False, payment_verified=False)
+    caller = address.generate()
+    recipient = address.generate()
+    app = AuthenticatedACPApp(
+        lambda _principal: _Agent(),
+        trust_agent=trust,
+        recipient_address=recipient["address"],
+        replay_check=_Replay(),
+        allowed_origins=[ORIGIN],
+        rate_limiter=limiter,
+    )
+
+    first = await _authorize(app, caller, recipient, body=b'{"payment":10}')
+    second = await _authorize(app, caller, recipient, body=b'{"payment":10}')
+
+    assert first[0] == 403
+    assert second[0] == 429
+    assert second[2] == {"error": "too many ACP admission attempts"}
+    assert len(trust.payment_requests) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -627,7 +627,7 @@ async def test_claimed_native_payment_without_verified_transfer_stays_forbidden(
     trust = _Trust(allow=False, payment_verified=False)
     app, caller, recipient, agents = _app(trust=trust, tickets=tickets)
 
-    status, _, response = await _authorize(
+    status, headers, response = await _authorize(
         app,
         caller,
         recipient,
@@ -635,6 +635,7 @@ async def test_claimed_native_payment_without_verified_transfer_stays_forbidden(
     )
 
     assert status == 403
+    assert headers[b"cache-control"] == b"no-store"
     assert response == {"error": "forbidden: test policy"}
     assert trust.payment_requests[0][:2] == (caller["address"], 999)
     assert tickets._records == {}


### PR DESCRIPTION
## What changed

- verify native browser ACP payment onboarding through the existing `TrustAgent.verify_payment()` boundary instead of trusting a caller-provided amount
- run the bounded provider check off the ASGI event loop
- charge every verified, replay-safe admission attempt to the per-principal rate limiter before trust or provider work
- keep invite onboarding and already-trusted admission unchanged
- return generic fail-closed errors and issue no browser ticket when verification fails
- document the security and rollback decision in DD-050 and the ACP WebSocket guide

## Why

`/info` could advertise payment onboarding and `/acp/authorize` accepted a signed `payment` field, but the secure trust rules intentionally ignore that self-reported number. Only the legacy `/ws` onboarding frame called the real transfer verifier, so a payment-only native ACP Host advertised a door that could never open. React cannot fall back to `/ws` after selecting native ACP without creating downgrade and duplicate-lifecycle risk.

The signed amount remains only a request to check. The Host-configured minimum and a recent transfer from the authenticated caller to the Agent address remain authoritative.

## Review

The final simplicity/security review kept the logic in the existing admission boundary, rejected a second onboarding endpoint, and added explicit evidence that provider exceptions are logged internally but never returned or converted into tickets.

## Validation

- `178 passed` across ACP gateway, discovery, legacy onboarding, Host routes, and trust/payment policy suites
- final gateway suite: `42 passed`
- Ruff passed on changed Python files
- `git diff --check` passed

Closes #928
