### PR TITLE
run the NL agent in the caller, not inside the daemon

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -181,6 +181,38 @@ def _ensure_browser_ready(line: str) -> bool:
     return True
 
 
+def run_verb(line: str, headless: bool = False, tab: str = None) -> str:
+    """Send one verb and return the daemon's reply text instead of printing it.
+
+    This is what makes the NL agent a *client* of the daemon rather than a
+    resident of it (#933). The agent needs each tool result back as a string to
+    feed its next turn; `send()` prints and returns an exit code, which is right
+    for a shell caller and useless to a caller that has to read the answer.
+
+    One request per tool call is the whole point: each is a short queue slot, so
+    other sessions interleave between the agent's steps instead of waiting out
+    its entire run.
+    """
+    # send() is the one place that knows the envelope, the transport, the
+    # cold-start provisioning and the old-daemon diagnostics. Reimplementing
+    # that here would mean two wire clients, and the one that drifts is the one
+    # nobody tests. So call it and capture what it writes.
+    #
+    # redirect_std*, not a patched builtins.print: patching the builtin would
+    # also swallow output from anything else running in this process, and the
+    # agent's own UI stream is running in it.
+    import contextlib
+    import io
+
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        exit_code = send(line, headless=headless, tab=tab)
+    body = out.getvalue().strip() or err.getvalue().strip()
+    if exit_code != 0 and not body:
+        body = f"command failed with exit code {exit_code}"
+    return body
+
+
 def send(line: str, headless: bool = False, tab: str = None,
          _provisioned: bool = False) -> int:
     """Send one request; print the reply; return the process exit code.

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -1,11 +1,11 @@
 """
 Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI requests to it over the platform transport (POSIX Unix socket / Windows named pipe), arbitrating concurrent agents through per-tab ownership.
 LLM-Note:
-  Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.agent (resolve_api_key, build_browser_agent), browser_agent.transport] | imported by [browser_agent/client.py (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
+  Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.transport] | imported by [browser_agent/client.py (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
   Data flow: client sends wire-v1 JSON {v,caller,account,tab,line} (or a legacy plain line) → page verbs stay shared; model-backed `do` runs only when both public account addresses are present and equal (legacy/missing/mismatched payer data fails closed) → reply includes process exit code (2 usage, 3 unknown tab, 4 busy, 5 payer mismatch)
   State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | the tab REGISTRY + claims live on browser._tab_meta[key] (key None = shared 'main'): who/purpose/opened_at/caller/claim_at/last_line/last_at | tracks last_command for `status` | binds the endpoint at default_sock_path() via `transport` — POSIX: a raw AF_UNIX socket (unchanged); Windows: a native named pipe (multiprocessing.connection) with an HMAC authkey — under a lifetime OS lock (transport.lock_path: fcntl.flock POSIX / msvcrt Windows, released by the OS on any death, so simultaneous cold-starts can't both bind) and records its owner pid in transport.pid_path so a refused probe can tell busy from stale; 120s per-connection recv timeout | _cleanup closes the listener (POSIX also unlinks the socket) + pidfile only while the pidfile still names this process (browser teardown is the driver pipe closing on process death — the executor is already gone when atexit runs) | serve() exits (releasing the endpoint) when browser._context_is_alive() goes false or _launch_failed()
   Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]` | module helpers _key()/_tab_label()/_held_by_other()/_owner_alive() define the None↔main aliasing, the shared claim-expiry predicate (dispatch, _tab_open, _closetab), and the socket-owner liveness check (client + _bind)
-  Performance: one request at a time | browser launch overhead on first page verb (1-3s) | `do` builds a fresh Agent per call | tab lifecycle/status verbs never launch Chrome
+  Performance: one request at a time | browser launch overhead on first page verb (1-3s) | `do` no longer runs here — the NL agent is a CLIENT (cli/browser_agent/nl_client.py) that sends one ordinary verb per tool call, so its model latency holds nothing and other callers interleave between its steps (#933); the trade-off is that a `do` run is no longer atomic, which is what makes the per-tab claim load-bearing rather than advisory | tab lifecycle/status verbs never launch Chrome
   Errors: dispatch/handler exceptions are caught at the request boundary in serve() and returned to THAT client (never unwind the loop and kill the shared browser) | a client that vanishes mid-reply is logged to ~/.co/browser.log, not fatal | bind race with a second daemon → loser exits
 """
 
@@ -27,7 +27,7 @@ from connectonion.useful_tools.browser_tools import BrowserAutomation
 from connectonion.useful_tools.browser_tools.browser import (
     driver_stealth_status, installed_browser_path,
 )
-from .agent import resolve_api_key, build_browser_agent
+# The NL agent moved to the client (#933); nothing here builds one any more.
 from . import transport
 
 
@@ -638,15 +638,23 @@ class BrowserDaemon:
         return True, f"Closed tab {_tab_label(key)}. {message}"
 
     def _run_nl(self, command: str) -> tuple:
-        """Hand the command to the NL agent driving the same live browser."""
-        api_key = resolve_api_key()
-        if not api_key:
-            return False, "Browser agent requires authentication. Run: co auth"
-        try:
-            result = build_browser_agent(self.browser, api_key).input(command)
-        except Exception as exc:
-            return False, f"{type(exc).__name__}: {exc}"
-        return True, _stringify(result)
+        """`do` is a client-side agent now; this daemon no longer runs the loop.
+
+        It used to: `.input(command)` ran up to 200 steps -- each one an LLM call
+        -- inside this single request, and serve() is serial, so no other caller
+        was served for the whole run. Three sessions were starved for ~40 minutes
+        by one such run while the browser sat idle (#933).
+
+        The verb still exists here only to tell an old client where the agent
+        went. A new client never sends `do` over the wire; it runs the loop in
+        its own process and sends the individual verbs.
+        """
+        return False, (
+            "`do` now runs in the calling process, not in the browser daemon, so "
+            "one agent run no longer blocks every other session (#933).\n"
+            "This client is older than the daemon it is talking to. Upgrade it:  "
+            "pip install -U connectonion"
+        )
 
     def serve(self):
         self._bind()

--- a/connectonion/cli/browser_agent/nl_client.py
+++ b/connectonion/cli/browser_agent/nl_client.py
@@ -1,0 +1,101 @@
+"""
+Purpose: Run the natural-language browser agent in the CALLER's process, issuing one ordinary daemon request per tool call, so a `do` never holds the single execution lane for its whole run.
+LLM-Note:
+  Dependencies: imports from [inspect, connectonion Agent, browser_agent.agent (PROMPT_PATH, resolve_api_key), browser_agent.client (run_verb), useful_tools.browser_tools.BrowserAutomation (signatures only, never instantiated)] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_daemon.py, tests/unit/test_nl_client.py]
+  Data flow: run(instruction, tab, headless) → builds an Agent whose tools are generated proxies, one per BrowserAutomation verb → each proxy call formats a shell line and sends it through client.run_verb() as a normal request → the daemon serves it in a few-second slot and replies → the reply string is the tool result the model reads
+  State/Effects: holds NO browser and NO page — the daemon owns those | model latency happens here, holding nothing | the caller's own environment pays for the model, so the payer is whoever ran the command
+  Integration: exposes run() | replaces daemon._run_nl, which ran the same loop inside one daemon request (#933)
+  Performance: one short daemon request per tool call instead of one request per run | the browser is free between the agent's steps, so other sessions interleave
+  Errors: a failed verb returns the daemon's own message as the tool result, which is what the model needs to correct itself | authentication is checked once before the loop starts
+"""
+
+import inspect
+
+from connectonion import Agent
+
+from .agent import PROMPT_PATH, resolve_api_key
+from . import client
+
+
+# Verbs the agent must never call. `do` would recurse into another agent, and
+# the lifecycle verbs belong to the human or the orchestrating skill -- an agent
+# that can close the browser can end another session's work mid-task.
+_NOT_FOR_THE_AGENT = {
+    "do", "close", "close_tab", "closetab", "open_browser", "newtab", "tab",
+    "save_state", "tab_status",
+}
+
+
+def _format(verb: str, args: dict) -> str:
+    """One shell line for a verb call, quoted so the daemon's shlex sees it whole."""
+    import shlex
+
+    parts = [verb]
+    for name, value in args.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            # The daemon coerces --flag=true/false by the annotation, so send the
+            # value rather than bare presence: `--headless` and `--headless=false`
+            # must not mean the same thing.
+            parts.append(f"--{name}={'true' if value else 'false'}")
+        else:
+            parts.append(f"--{name}={shlex.quote(str(value))}"
+                         if " " in str(value) else f"--{name}={value}")
+    return " ".join(parts)
+
+
+def _make_proxy(verb: str, signature, doc: str, tab, headless: bool):
+    """Build one tool that sends `verb` to the daemon and returns its reply.
+
+    The generated function carries the real verb's signature and docstring, so
+    the schema the model sees is the same one it saw when these were bound
+    methods -- the agent's prompt and habits keep working unchanged.
+    """
+    params = [p for name, p in signature.parameters.items() if name != "self"]
+
+    def proxy(**kwargs):
+        return client.run_verb(_format(verb, kwargs), headless=headless, tab=tab)
+
+    proxy.__name__ = verb
+    proxy.__doc__ = doc or f"Run the browser verb {verb}."
+    proxy.__signature__ = inspect.Signature(params)
+    return proxy
+
+
+def build_tools(tab, headless: bool):
+    """A proxy per public BrowserAutomation verb, each one a daemon request."""
+    from connectonion.useful_tools.browser_tools import BrowserAutomation
+
+    tools = []
+    for name, member in inspect.getmembers(BrowserAutomation, inspect.isfunction):
+        if name.startswith("_") or name in _NOT_FOR_THE_AGENT:
+            continue
+        tools.append(_make_proxy(name, inspect.signature(member),
+                                 inspect.getdoc(member), tab, headless))
+    return tools
+
+
+def run(instruction: str, tab=None, headless: bool = False) -> int:
+    """Run the NL agent here, in the caller's process. Returns an exit code.
+
+    The loop, and every model call in it, happens in this process. The daemon
+    sees only the individual verbs -- each a short request it can serve between
+    other callers' requests. That is the whole fix for #933: the browser is idle
+    and available while this agent is thinking, which is most of the time.
+    """
+    api_key = resolve_api_key()
+    if not api_key:
+        print("Browser agent requires authentication. Run: co auth")
+        return 1
+
+    agent = Agent(
+        name="browser_cli",
+        model="co/gemini-3.6-flash",
+        api_key=api_key,
+        system_prompt=PROMPT_PATH,
+        tools=build_tools(tab, headless),
+        max_iterations=200,
+    )
+    print(agent.input(instruction))
+    return 0

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -103,7 +103,17 @@ def handle_browser(args, headless: bool = False) -> int:
     if args[0] in ("help", "--list", "list"):  # after -t extraction: `-t x help` is still help
         print(USAGE + "\n\nFunctions:\n" + list_functions())
         return 0
-    code = send(shlex.join(args), headless=headless, tab=tab)
+    if args[0] == "do":
+        # The agent loop runs HERE, not in the daemon. Inside the daemon it was
+        # one request for the whole run -- up to 200 steps, each waiting on the
+        # model -- and serve() is serial, so nothing else was served until it
+        # finished (#933). Out here, each of its tool calls is an ordinary
+        # request the daemon can slot between other callers' work.
+        from ..browser_agent.nl_client import run as run_nl_agent
+
+        code = run_nl_agent(" ".join(args[1:]), tab=tab, headless=headless)
+    else:
+        code = send(shlex.join(args), headless=headless, tab=tab)
     if code == 0 and sys.stdout.isatty():
         print(f"\n\033[2m💡 {_next_tip()}\033[0m", file=sys.stderr)
     return code

--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -38,6 +38,17 @@ works but gets **no contention protection**.
 
 **One task = one tab.** Before touching the browser, see what's already happening:
 
+> **`do` is interruptible, so its tab claim is what protects it.**
+> A `do` run is no longer one indivisible daemon request: the agent runs in
+> your process and sends each browser action separately, which is what stops
+> one run from blocking every other session. The cost is that another caller
+> **can act on the same page between the agent's steps**.
+>
+> The tab claim is what prevents that, so it went from good manners to
+> load-bearing. **A `do` that must not be interleaved has to hold its own
+> tab** — `-t <name>` on the `do` itself, not just on the verbs around it.
+> On the shared `main` tab, assume someone else may touch the page mid-run.
+
 ```bash
 co browser status      # browser state, headless flag, last command, the board
 co browser tab ls      # every tab: who owns it, purpose, last command (--json for scripting)

--- a/docs/useful_skills/co-browser.md
+++ b/docs/useful_skills/co-browser.md
@@ -22,7 +22,7 @@ to open its own tab), but a skill front-loads the lifecycle so the agent gets it
 right on the first command instead of learning from collisions:
 
 1. **Identity** — attach `CO_WHO` to every command (shell state doesn't survive between tool calls)
-2. **The board** — check `status` / `tab ls` before claiming; one task = one tab; `-t <name>` on every command when concurrent; declare `--needs 10m` so peers know whether to wait or clean up
+2. **The board** — check `status` / `tab ls` before claiming; one task = one tab; `-t <name>` on every command when concurrent; declare `--needs 10m` so peers know whether to wait or clean up. `do` runs its agent loop in your own process and queues each browser action separately, so it no longer blocks other sessions — but it is interruptible, and **its tab claim is what keeps another caller off the page between steps**
 3. **Right verb** — direct functions for deterministic steps (free, instant), `do "<end state>"` only for judgment, text probes before screenshot probes
 4. **Evidence** — read output text (soft failures return exit 0 with the error on stdout), screenshots at irreversible-action gates only, one-shot submits
 5. **Login** — human logs in in the visible window; the agent polls with short bounded waits and never touches credentials

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -238,26 +238,28 @@ def test_dispatch_empty(tmp_path):
     assert ok == 2
 
 
-def test_dispatch_do_routes_to_nl(tmp_path, monkeypatch):
-    """`do` must go to the NL agent, not function dispatch."""
-    captured = {}
+def test_dispatch_do_tells_an_old_client_where_the_agent_went(tmp_path, monkeypatch):
+    """`do` over the wire is an upgrade prompt now, not an agent run.
 
-    class FakeAgent:
-        def input(self, command):
-            captured["command"] = command
-            return "agent says hi"
+    This test used to assert the opposite -- that dispatch built an Agent and
+    ran its loop right here. That is the #933 defect: the loop held the single
+    execution lane for its whole run, up to 200 model calls, while every other
+    caller waited and the browser sat idle.
 
-    monkeypatch.setattr(d, "resolve_api_key", lambda: "key")
-    monkeypatch.setattr(d, "build_browser_agent", lambda browser, key: FakeAgent())
+    A current client never sends `do`; it runs the loop in its own process and
+    sends the individual verbs. Only an older client still sends it, so the
+    reply's job is to say so rather than to fail obscurely.
+    """
     monkeypatch.setattr(d, "_daemon_account", lambda: "0xsame-account")
 
     daemon = make_daemon(str(tmp_path / "s.sock"))
     ok, payload = daemon.dispatch(_env(
         "do find the cheapest flight", account="0xsame-account"
     ))
-    assert ok is True
-    assert payload == "agent says hi"
-    assert captured["command"] == "find the cheapest flight"
+    assert ok is False
+    assert "runs in the calling process" in payload
+    assert "pip install -U connectonion" in payload, (
+        "an old client has to be told what to do about it")
 
 
 # ---- status + tab accountability ----------------------------------------
@@ -575,7 +577,14 @@ def test_page_commands_remain_shared_across_billing_accounts(tmp_path, monkeypat
     assert daemon.browser.calls == [("go_to", "example.com")]
 
 
-def test_do_runs_when_caller_and_daemon_accounts_match(tmp_path, monkeypatch):
+def test_do_passes_the_payer_check_before_reaching_the_agent(tmp_path, monkeypatch):
+    """A matching payer still gets past the billing gate.
+
+    What lies beyond it changed with #933 -- the daemon answers with the
+    upgrade notice instead of running a loop -- but the gate itself must keep
+    letting a matching account through, or the mismatch tests below would pass
+    for the wrong reason.
+    """
     daemon = make_daemon(str(tmp_path / "s.sock"))
     daemon._run_nl = Mock(return_value=(True, "done"))
     monkeypatch.setattr(d, "_daemon_account", lambda: "0xsame-account")
@@ -1224,3 +1233,126 @@ def test_duration_parsing():
     assert d._parse_duration("90") == 90
     assert d._parse_duration("") == 0
     assert d._parse_duration("garbage") == 0
+
+
+
+# ---- #933: a long `do` must not hold the lane for its whole agent loop -----
+
+def _tool_call(name, arguments):
+    from connectonion.core.llm import ToolCall
+
+    return ToolCall(name=name, arguments=arguments, id=f"call_{name}")
+
+
+def _llm_response(content=None, tool_calls=()):
+    from connectonion.core.llm import LLMResponse
+    from connectonion.core.usage import TokenUsage
+
+    # A real usage object: the console logs every response and reads fields off
+    # it, so None here fails in the logger rather than in the code under test.
+    return LLMResponse(content=content, tool_calls=list(tool_calls),
+                       raw_response=None, usage=TokenUsage())
+
+def test_a_running_do_does_not_block_another_clients_verb(short_sock, monkeypatch):
+    """The property the #933 fix has to deliver.
+
+    `do` used to run its whole agent loop -- up to 200 steps, each an LLM call
+    -- inside ONE daemon request. serve() is strictly serial, so no other caller
+    was served until the entire run finished; three sessions were starved for
+    ~40 minutes by one run while the browser itself sat idle.
+
+    So this drives the real `do` entry point with a model that is slow and a
+    tool call that is real, and asserts that an ordinary verb from a second
+    caller completes *while the agent is still thinking*. It is the thinking
+    time that used to be stolen, so that is the moment the second client has to
+    get through.
+
+    Before the fix the loop runs inside the daemon and the second client cannot
+    be answered at all; the assertion below is what fails.
+    """
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    daemon = make_daemon(short_sock)
+    threading.Thread(target=daemon.serve, daemon=True).start()
+    _wait_until_listening(short_sock)
+
+    c.send("tab open agenttab --who runner --for 'long run'", headless=True)
+    c.send("tab open peertab --who peer --for 'ordinary verb'", headless=True)
+
+    thinking = threading.Event()
+    release = threading.Event()
+    calls = {"n": 0}
+
+    class SlowModel:
+        """One tool call, then a long think, then finish.
+
+        The pause stands in for model latency, which is where a real run spends
+        nearly all of its time and holds nothing it needs.
+        """
+        model = "fake"
+
+        def complete(self, messages, tools=None, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _llm_response(tool_calls=[_tool_call("get_current_url", {})])
+            thinking.set()
+            release.wait(timeout=30)
+            return _llm_response(content="finished")
+
+    monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *a, **k: SlowModel())
+    # Both sides of the payer check, and both places the key is resolved: the
+    # daemon path reads one, the client path the other, and this test must reach
+    # the agent loop down whichever path the code takes.
+    monkeypatch.setattr(c, "_caller_account", lambda: "0xpayer")
+    monkeypatch.setattr(d, "_daemon_account", lambda: "0xpayer")
+    monkeypatch.setattr("connectonion.cli.browser_agent.agent.resolve_api_key",
+                        lambda: "test-key")
+    # nl_client did `from .agent import resolve_api_key`, so it holds its own
+    # binding and patching the source module alone would miss it. Guarded
+    # because the module does not exist before the fix, which is the state this
+    # test has to be able to run in.
+    try:
+        monkeypatch.setattr(
+            "connectonion.cli.browser_agent.nl_client.resolve_api_key",
+            lambda: "test-key")
+    except (ImportError, AttributeError, ModuleNotFoundError):
+        pass
+
+    agent_done = threading.Event()
+
+    def run_agent():
+        # Through the CLI entry point, NOT by importing the new module: the
+        # question is what `co browser do` does, and a test that reaches past
+        # the dispatcher into the new implementation passes before the fix as
+        # happily as after it -- which is no test at all.
+        from connectonion.cli.commands.browser_commands import handle_browser
+
+        try:
+            handle_browser(["-t", "agenttab", "do", "look at the page"],
+                           headless=True)
+        finally:
+            agent_done.set()
+
+    threading.Thread(target=run_agent, daemon=True).start()
+
+    assert thinking.wait(timeout=20), (
+        "the agent never reached its thinking phase; the run did not start")
+
+    # THE assertion: a different caller, a different tab, an ordinary verb,
+    # served while the agent above is mid-run.
+    served = {}
+
+    def peer():
+        served["code"] = c.send("go_to example.com", headless=True, tab="peertab")
+
+    t = threading.Thread(target=peer, daemon=True)
+    t.start()
+    t.join(timeout=10)
+
+    blocked = t.is_alive()
+    release.set()
+    agent_done.wait(timeout=20)
+
+    assert not blocked, (
+        "a second client was not served while a `do` was mid-run -- the agent "
+        "loop is still holding the single execution lane for its whole run")
+    assert served.get("code") == 0


### PR DESCRIPTION
Closes #933.

## The problem

`co browser do` ran its **entire agent loop inside one daemon request**:

```python
def _run_nl(self, command: str) -> tuple:
    result = build_browser_agent(self.browser, api_key).input(command)   # whole loop
```

`serve()` is strictly serial (`accept → dispatch → reply → close`), so up to 200 steps — each an LLM call — completed before any other client was served. Three sessions were starved for ~40 minutes by one run, and the browser being held sat idle for nearly all of it, because most of each step is spent waiting on the model, which needs no browser.

## The change

The loop moves to the calling process. Each tool call becomes an ordinary `co browser <verb>` request carrying the same `caller`/`tab` envelope.

- Each browser action is a short queue slot, so other sessions interleave between the agent's steps.
- Model latency happens in the client and holds nothing.
- **The daemon's concurrency model is untouched** — no threads, no async, still one short request at a time.

New `cli/browser_agent/nl_client.py` builds the agent with one generated proxy per `BrowserAutomation` verb; each proxy sends a request and returns the reply as the tool result. The proxies carry the real verbs' signatures and docstrings, so the schema the model sees is unchanged.

## The trade-off, stated plainly

**A `do` run is no longer atomic.** Another caller can act on the same page between the agent's steps.

That is what the `GUARD_WINDOW` tab claim is for, and this change makes it **load-bearing rather than advisory**: a `do` that must not be interleaved has to hold its own tab (`-t <name>` on the `do` itself). Both `useful_skills/co-browser/SKILL.md` and `docs/useful_skills/co-browser.md` now say this outright, since the previous wording implied a `do` was indivisible.

## A problem that dissolves

`do` used to spend whatever key the *daemon's* environment held — the directory whoever started the browser happened to be in — which is why dispatch had to refuse callers whose account did not match (#728). Running in the caller's process, the caller pays. The guard stays for old clients; the class of bug it worked around is gone.

The daemon still accepts `do` and answers with an upgrade notice, because only a client older than the daemon still sends it over the wire.

## Verification

A test that **fails before the change and passes after** — it drives the real `co browser do` entry point with a slow stubbed model and asserts a second client's ordinary verb is served *while the agent is still thinking*, which is the moment that used to be stolen.

Before (with `nl_client.py` removed and sources reverted, so the loop really is in the daemon):

```
E   AssertionError: a second client was not served while a `do` was mid-run --
    the agent loop is still holding the single execution lane for its whole run
1 failed
```

After:

```
1 passed
```

Full suite: **7080 passed, 13 skipped, 2 failed**. Both failures are pre-existing on `main`, confirmed by running them there — a changelog-entry check and a CJK stealth test that needs a real browser.

`test_dispatch_do_routes_to_nl` asserted the old behaviour directly; it is rewritten to assert the new contract rather than deleted.

## Note for reviewers

Landing this needs a daemon restart to take effect, and a restart interrupts every session currently using the browser. Worth announcing before it goes out.
