### PR TITLE
Add find-selling-points skill, and the first run's findings

### DIFF
--- a/connectonion/useful_skills/find-selling-points/SKILL.md
+++ b/connectonion/useful_skills/find-selling-points/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: find-selling-points
+description: Mine the codebase for capabilities worth telling people about — the surprising, user-facing ones — and prove each against source before it may be published. Use when writing or auditing marketing copy, a landing page, a README, a launch post, or when asked "what is actually good about this" / "找卖点" / "提炼宣传点".
+tools:
+  - read_file
+  - glob
+  - grep
+  - write_file
+  - edit_file
+  - Bash(git *)
+  - Bash(ls *)
+  - Bash(cat *)
+---
+
+# Find Selling Points
+
+Find what is genuinely unusual about this project, prove it, and write it down in a
+form someone can publish without lying.
+
+This skill exists because the failure mode is not "we could not think of anything".
+It is the opposite: it is easy to generate plausible marketing sentences, and
+plausible marketing sentences about software are wrong most of the time. Everything
+below is built to make a claim expensive to assert and cheap to check.
+
+## The two rules
+
+**Rule 1 — a claim you cannot cite does not exist.** Every point ends in
+`file:line`. If you cannot cite it, you delete it. Not soften it, not hedge it —
+delete it. A missing selling point costs nothing. A false one costs a customer.
+
+**Rule 2 — say what someone can DO, not how the code looks.** "Functions become
+tools automatically" is a fact about our source. "You can hand a client a link and
+they talk to the agent in a browser with nothing installed" is a fact about their
+day. Only the second kind ships.
+
+## What does not count
+
+Reject these on sight. They are the reflexes to suppress, not options to weigh:
+
+- **Comparisons to other frameworks.** "Fewer lines than LangChain", "unlike
+  AutoGPT", any table with a competitor column. Comparing files us in their
+  category and dates instantly. We are not a better framework; we are not a
+  framework.
+- **Line counts.** "2 lines", "3 lines", "8 lines". Nobody writes those lines —
+  the CLI writes the project. The number was retired on purpose; do not
+  resurrect it in a new costume.
+- **Developer ergonomics as the headline.** Type hints, decorators, no
+  boilerplate, clean API. Real, and nobody outside the repo cares. These are
+  supporting detail at best.
+- **Anything an LLM could write about any agent library.** If the sentence
+  survives find-and-replacing our name with a competitor's, it says nothing.
+- **Adjectives standing in for facts.** "Powerful", "seamless", "production-ready",
+  "enterprise-grade". Replace with the specific thing, or cut.
+
+## What counts
+
+A point qualifies when it passes all four:
+
+1. **True** — cited to `file:line`.
+2. **Surprising** — someone who has evaluated three agent libraries this year did
+   not expect it.
+3. **User-facing** — it changes what a person can do, see, sell, or hand over.
+   Prefer things the *end customer* experiences over things the *developer*
+   experiences.
+4. **Not available elsewhere** — or not available without assembling four
+   services.
+
+The strongest points usually answer one of:
+
+- What do you get **before writing anything**?
+- What can you use **standalone**, without adopting the rest?
+- What does the **person you are selling to** see?
+- What would normally require a **backend, a frontend, a deploy pipeline, and an
+  auth provider** — and here does not?
+- What is **on the machine** rather than in someone's cloud?
+
+## Procedure
+
+### Step 1 — Read the ground
+
+Do not start from memory or from existing marketing copy; existing copy is the
+thing most likely to be wrong. Start from source.
+
+Cover at minimum, and in parallel where possible:
+
+- `connectonion/cli/main.py` — the whole command surface. Every command is a
+  capability someone can use with no Python at all.
+- `connectonion/cli/co_ai/` — the agent that ships ready to run.
+- `connectonion/useful_skills/`, `connectonion/useful_plugins/skills.py` — what a
+  skill is and where skills can come from.
+- `connectonion/useful_tools/` — what is usable on its own.
+- `connectonion/network/` — hosting, addressing, relay, trust, dashboard delivery.
+- `connectonion/cli/templates/` — what lands on disk at `co create`.
+- The front end, if present in a sibling checkout (`../oo-chat`) — this is what
+  the end customer actually sees, and it is routinely the most under-sold part.
+
+### Step 2 — Generate wide, then cut hard
+
+List every candidate, including ones you expect to fail. Twenty candidates that
+get cut to five is the intended shape. Five candidates that all survive means you
+did not look hard enough.
+
+### Step 3 — Falsify each candidate
+
+For each one, actively try to kill it:
+
+- Grep for the mechanism. Does the code do what the sentence says?
+- Is it **on by default**, or does it need configuration? Say which. "Ships with"
+  and "can be configured to" are different products.
+- Is it **complete**, or a stub with a TODO?
+- Is there a **limit** a buyer would feel misled by if they found it later?
+  Write the limit down next to the claim. A claim with its limit stated is
+  stronger than a claim without, because it survives contact.
+
+This step has caught real, shipped, public falsehoods on our own sites. Keep the
+bar where it is:
+
+| Claim that shipped | What was actually true |
+|---|---|
+| "MIT licensed" | Apache-2.0, wrong in six places at once |
+| "End-to-end encrypted" | No payload encryption exists. TLS to a relay that terminates it |
+| "Migration tools connect your existing agents in minutes" | No migration tool in the package |
+| "Agents test collaboration with dummy data first" | No such mechanism anywhere |
+| "Developers report 75% more time for building features" | An invented statistic |
+
+Every one of those was written by someone confident and helpful.
+
+### Step 4 — Write each survivor in this shape
+
+```markdown
+### <the capability, as a thing a person can do>
+
+**Claim.** One sentence, plain, no adjectives.
+**Proof.** `path/to/file.py:123` — what is there.
+**Default or opt-in.** Which, and what turns it on.
+**Limit.** The thing a buyer would otherwise discover later and feel misled by.
+**Why it is unusual.** One sentence. If you cannot write this one, cut the point.
+```
+
+### Step 5 — Rank for a launch post
+
+Order by *how hard it is for a competitor to answer*, not by how much engineering
+went in. The point we are proudest of and the point that sells are rarely the
+same, and when they differ, the buyer is right.
+
+Then write the top three as they would appear:
+
+- one sentence a person would actually say out loud;
+- one screenshot or terminal transcript that proves it — name which, and if it
+  does not exist yet, say so, because a claim with a picture beats three without.
+
+### Step 6 — Record it
+
+Write results to `docs/SELLING_POINTS.md` in this repo. If it exists, update it
+rather than replacing it, and keep a dated entry per run so drift is visible:
+a point that stops being true is itself important news, and the diff is the only
+place anyone will notice.
+
+For each run record: date, what was read, what survived, **what was cut and why**.
+The cut list is the more valuable half — it stops the same false claim being
+rediscovered and shipped every quarter.
+
+## A note on tone
+
+The audience for the output is a person deciding whether to spend twenty minutes
+on this. They are tired of agent frameworks. They have read the same launch post
+nine times.
+
+Write for the sceptic, not the enthusiast. The sentence that works on them is
+almost always a concrete fact stated flatly, with the limit attached — not
+enthusiasm. If a point needs excitement to land, it is not a point.

--- a/docs/SELLING_POINTS.md
+++ b/docs/SELLING_POINTS.md
@@ -1,0 +1,241 @@
+# Selling points
+
+What is genuinely unusual about ConnectOnion, with the proof attached.
+
+Produced by the `find-selling-points` skill. Read that skill before adding to this
+file — the rules are the point. In short: every claim ends in `file:line` or it
+gets deleted, no framework comparisons, no line counts, and each entry states the
+limit a buyer would otherwise discover later and feel misled by.
+
+Line numbers drift. If one no longer matches, re-verify the claim rather than
+just fixing the number — a moved line is often a changed behaviour.
+
+---
+
+## Run 2026-08-13
+
+**Read:** `connectonion/network/host/ws_router/`, `connectonion/network/host/server.py`,
+`connectonion/useful_plugins/skills.py`, `connectonion/cli/commands/skills_commands.py`,
+`connectonion/cli/main.py`, `connectonion/useful_skills/`, `connectonion/useful_tools/`,
+`connectonion/cli/browser_agent/`, `connectonion/cli/co_ai/`, and the front end at `../oo-chat`.
+
+**Survived:** 13. **Cut:** 10 (see the bottom — that list is the more useful half).
+
+---
+
+### `co ai` is the product. One command, and a chat opens in your browser.
+
+**Claim.** You do not build an agent to get an agent. Type `co ai` and a browser
+opens onto a working chat — with the dashboard beside it — talking to an agent
+running on your own machine. Nothing is written, nothing is deployed.
+**Proof.** `cli/commands/ai_commands.py:33-46` builds the agent and calls
+`start_server()`; `cli/co_ai/main.py:59-69` opens
+`https://chat.openonion.ai/{your 0x address}` and calls
+`host(agent, port=port, trust="careful", co_dir=~/.co)`. `host()` serves
+`POST /input`, `WS /ws`, `/health`, `/info` and joins the relay at
+`wss://oo.openonion.ai` by default (`network/host/server.py:415-449`).
+**Default or opt-in.** Default. `co ai "do X"` instead runs once and prints the
+answer (`ai_commands.py:40-43`).
+**Limit.** The agent runs on your machine; close the laptop and it stops. There
+is no terminal TUI — the interface is the web chat.
+**Why it is unusual.** The install does not give you a library to build a product
+with. It gives you the product, and the address to share it.
+
+### It is reachable from anywhere, not just the tab that opened
+
+**Claim.** Because `co ai` hosts the agent on the relay with its own address, the
+chat link works for other people, on other machines — while it runs on yours.
+**Proof.** `host()` joins `wss://oo.openonion.ai` and the opened URL is keyed by
+the agent's `0x` address (`cli/co_ai/main.py:59-69`, `network/host/server.py:415-449`).
+**Default or opt-in.** Default.
+**Limit.** The relay is an intermediary and terminates TLS, so traffic is
+encrypted in transit and readable at the relay. This is **not** end-to-end
+encryption and must never be described as such.
+**Why it is unusual.** Handing someone a working link to software running on your
+laptop normally means a tunnel, a deploy, or both.
+
+### Your existing Claude Code setup is picked up as-is
+
+**Claim.** Point `co ai` at a repo you already work in and it reads the context you
+already wrote — `CLAUDE.md`, `README.md`, git status, and the skills in
+`.claude/skills/`.
+**Proof.** `cli/co_ai/context.py:57-95` for the project context;
+`useful_plugins/skills.py:123-130` for the `.claude/skills/` load path.
+**Default or opt-in.** Default.
+**Limit.** As above, Claude Code's `allowed-tools` key is not read, so a skill's
+auto-approvals do not carry over.
+**Why it is unusual.** Adoption cost is usually a migration. Here the setup someone
+already did counts.
+
+### You can talk to it while it is working
+
+**Claim.** You do not have to wait for the agent to finish to redirect it. Type
+mid-run and the message is folded in at the next iteration.
+**Proof.** `useful_plugins/runtime_input.py:22-28`.
+**Default or opt-in.** Default in `co ai` (`cli/co_ai/agent.py:107-118`).
+**Limit.** It lands at the next iteration boundary, not instantly.
+**Why it is unusual.** The normal choice is to let a wrong run finish or kill it.
+
+### The agent redraws its own interface, mid-conversation
+
+**Claim.** The agent changes what its users see by writing an HTML file. The new
+version is in their browser at the end of that run — no deploy, no build, no release.
+**Proof.** The agent edits `dashboard.html` with the same file tools it uses for
+anything else — `connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md:9-16`.
+The host notices by mtime+size (`ws_router/dashboard.py:77-99`) and pushes a
+`DASHBOARD_SNAPSHOT` after any run that changed it (`ws_router/agent_io.py:70-74`);
+the pane re-renders (`../oo-chat/components/dashboard/dashboard-pane.tsx:52-53`).
+There is no polling and no fetch.
+**Default or opt-in.** Default.
+**Limit.** 2 MB. Over that, no dashboard is sent at all rather than a truncated one
+(`dashboard.py:22-31,57-63`). Images must be inlined as `data:` URIs.
+**Why it is unusual.** Changing a normal product's UI is a pull request. Here it is
+something the agent can do because a customer asked it to, while they are talking.
+
+### Every agent has a dashboard on day zero, with its skills already as buttons
+
+**Claim.** You do not build the dashboard. If the agent has no `dashboard.html`,
+one is written for it — the agent's name, and up to four of its skills as working
+buttons.
+**Proof.** `ensure_dashboard()` and `render_starter()` —
+`ws_router/dashboard.py:102-155,136-207`; wired in at `network/host/server.py:494-496,616-618`.
+**Default or opt-in.** Default, on first connect.
+**Limit.** Four skills, and only ones published as `project`/`claude-project`;
+personal and builtin skills are deliberately not exposed (`useful_plugins/skills.py:96`,
+`server.py:155-167`).
+**Why it is unusual.** The starting point is a working control panel, not an empty one.
+
+### A button on the dashboard runs a real skill, and you can see it happen
+
+**Claim.** Dashboard buttons are wired to the agent's actual skills. Clicking one
+produces a visible turn in the chat next to it, so there is no hidden action.
+**Proof.** `<button data-ochat-skill="daily-brief" data-ochat-args="today">` →
+bridge `postMessage` (`../oo-chat/components/dashboard/build-srcdoc.ts:64-82`) →
+parent validates and sends `/daily-brief today` as an ordinary chat message
+(`dashboard-pane.tsx:55-71`, `../oo-chat/app/[address]/[sessionId]/page.tsx:174-177`).
+**Default or opt-in.** Default.
+**Limit.** The click is untrusted intent, and is treated that way: source-frame
+check, name must match `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$`, must be in the agent's
+published skill list, **fails closed while that list is loading**, args collapsed
+and cut to 500 chars (`dashboard-pane.tsx:26,56-67`).
+**Why it is unusual.** Most dashboards report. This one is the remote control, and
+every press leaves an auditable line in the conversation.
+
+### Agent-written HTML runs with no network access at all
+
+**Claim.** The agent authors the page, and that page cannot phone anywhere,
+cannot run the agent's own scripts, and cannot navigate away.
+**Proof.** `sandbox="allow-scripts"` without `allow-same-origin`, so an opaque
+origin with no access to the host page's storage or keys (`dashboard-pane.tsx:110`).
+CSP `default-src 'none'; style-src 'unsafe-inline'; img-src data:; font-src data:;
+script-src 'nonce-…'` (`build-srcdoc.ts:52-62,107-111`) — the agent's `<script>`
+and inline `onclick` never execute. Non-fragment `<a href>` clicks are cancelled
+and a second iframe load is treated as navigation-away and blocked
+(`build-srcdoc.ts:78-79`, `dashboard-pane.tsx:40-48,77-88`).
+**Default or opt-in.** Default, not configurable.
+**Limit.** This is also a real constraint on what you can build: no external
+images, fonts, stylesheets, or API calls from the dashboard.
+**Why it is unusual.** "LLM-generated UI" normally means trusting generated markup.
+Here the HTML is wrapped in a document we own rather than edited or sanitised
+(`build-srcdoc.ts:92-105`), because string-matching someone else's `<head>` is
+defeatable and a sanitiser that is wrong once is wrong forever.
+
+### There is no account. A link is the whole onboarding.
+
+**Claim.** The person you send it to installs nothing and signs up for nothing.
+They open a link — or scan a QR code — and start talking.
+**Proof.** Shareable `https://chat.openonion.ai/{address}` plus a client-side QR
+(`../oo-chat/components/qr-share.tsx:9,30,70`). Identity is generated silently on
+first load: BIP39 phrase → Ed25519 keypair in localStorage, signed for a JWT
+(`../oo-chat/hooks/use-identity.ts:107-141,16-40`). No email, no password.
+**Default or opt-in.** Default.
+**Limit.** Because the key is in that browser's localStorage, a different browser
+is a different identity unless the recovery phrase is imported
+(`use-identity.ts:159-176`). The phrase is shown once and re-exportable from
+Settings (`:104-118,197-207`).
+**Why it is unusual.** No signup form is a conversion story, but the sharper part
+is that the *credential* is generated locally and never handed to us.
+
+### Strangers can be gated by an invite code or a payment — not a login
+
+**Claim.** An agent exposed to the public can require something before it will
+work for someone new, and that something can be money.
+**Proof.** `onboard_required` card offering invite code or payment
+(`../oo-chat/components/chat/messages/onboard-required.tsx:19-31`); server side,
+`invite_code` and `payment` onboard methods, with payment verified against
+oo-api `/api/v1/onboard/verify`.
+**Default or opt-in.** Opt-in, configured per agent.
+**Limit.** Payment verification depends on the OpenOnion API.
+**Why it is unusual.** The usual answer to "how do I stop strangers draining my
+credits" is an auth provider and a billing integration. Here it is a setting.
+
+### Skills written in Claude Code or Codex are the same files
+
+**Claim.** A skill is a `SKILL.md`. ConnectOnion reads the ones already in
+`.claude/skills/`, and `co skills discover` also finds Codex, Cursor and Kiro ones.
+`co skills link` pushes ours the other way, into Claude Code and Codex.
+**Proof.** Runtime load path includes `.claude/skills/<name>/SKILL.md` and
+`~/.claude/skills/…` (`useful_plugins/skills.py:117-136`, tagged at `:207-212`).
+Discovery additionally scans `~/.codex/skills`, `~/.cursor/rules` (`.mdc`),
+`~/.kiro/steering` (`skills_commands.py:36-43,95-139`). `link` symlinks bundled
+skills into `~/.claude/skills` and `~/.codex/skills` (`:334-391`).
+**Default or opt-in.** The `.claude/` runtime paths are default. Codex/Cursor/Kiro
+are `co skills discover` + `copy`, not the runtime path.
+**Limit — state this one.** Permissions come from the `tools:` key
+(`skills.py:346,393`). Claude Code's `allowed-tools` is **not** read — grepping
+`connectonion/` for it returns nothing. So a Claude Code skill runs its
+instructions unchanged but grants no auto-approvals. Say **"reads the same
+SKILL.md files"**, never "runs identically".
+**Why it is unusual.** The work someone already did in another tool is not thrown
+away, and it is a file rather than an export.
+
+### A skill's extra permissions expire when the turn ends
+
+**Claim.** A skill can widen what the agent may do while it runs, and the widening
+is withdrawn automatically afterwards.
+**Proof.** On invocation the plugin snapshots `session['permissions']`, grants each
+pattern with `source: 'skill'` and `expires: {'type': 'turn_end'}` — `Bash(git *)`
+becoming `when: {'command': 'git *'}` (`skills.py:246-287`). `cleanup_scope`
+restores the snapshot at `on_complete` (`:290-296,359-362`).
+**Default or opt-in.** Default, for any agent loading the skills plugin.
+**Limit.** Patterns are fnmatch, not a shell parser
+(`useful_plugins/tool_approval/__init__.py:104-132,146`). Write them tightly.
+**Why it is unusual.** The usual choice is a permanent allowlist or approving the
+same command forever. This is neither.
+
+### A logged-in browser that stays logged in, driven from the terminal
+
+**Claim.** `co browser` runs a persistent daemon that owns one real browser. Log in
+once by hand; every later command reuses that session. No Python.
+**Proof.** Daemon over a Unix socket / named pipe, browser stays open until
+`co browser close` (`cli/commands/browser_commands.py:20-40`,
+`cli/browser_agent/daemon.py:2-8`). ~40 operations including
+`wait_for_manual_login`, `upload_file_by_selector`, `extract_items_by_selector`,
+`take_screenshot`, `run_page_script` (`useful_tools/browser_tools/browser.py:667-2002`).
+`co browser do "<instruction>"` puts an LLM agent on that same live browser
+(`daemon.py:6`).
+**Default or opt-in.** Available immediately after install.
+**Limit.** One browser, with multi-agent tab contention signalled by exit code 4
+(`browser_commands.py:24-41`).
+**Why it is unusual.** It dissolves the usual blocker for automating a customer's
+internal system: the login. You do it yourself, once, and hand the session over.
+
+---
+
+## What was cut, and why
+
+Keeping this list is the point. It stops the same false claim being rediscovered
+and shipped next quarter.
+
+| Candidate | Why it was cut |
+|---|---|
+| "Calendar from the command line" | No `co calendar` command exists. Calendar is Python-only (`useful_tools/google_calendar.py`, `microsoft_calendar.py`). `co auth google` unlocks Gmail/Drive/Outlook on the CLI, not calendar. |
+| "Claude Code skills run identically" | `allowed-tools` is not read, so auto-approvals do not carry. Downgraded to "reads the same SKILL.md files" and kept with the limit attached. |
+| "Native mobile apps" | Responsive web only. No native client, and no PWA manifest in `../oo-chat/public/`. |
+| "We list the OAuth scopes we request" | Scope list is server-supplied and not in this repo (`commands/auth_commands.py:191,285`). Cannot cite it, so cannot claim it. |
+| "End-to-end encrypted" | Still false, still worth repeating. No payload encryption exists anywhere. Transport is TLS to a relay that terminates it — encrypted in transit, plaintext to the relay. |
+| Anything counting lines of code | Retired on purpose. Nobody writes those lines; the CLI writes the project. |
+| "`co ai` has slash commands `/init /help /cost /compact /tasks /export /sessions /new /resume /undo /redo`" | Defined in `cli/co_ai/commands/__init__.py:39-52`, but `BUILTIN_COMMANDS` is imported nowhere at runtime. **Not wired today.** The slash commands that do work are skill names — `/commit`, `/review-pr`, `/ship-feature`, `/dashboard`. |
+| "`co ai` keeps a session history you can resume" | `cli/co_ai/sessions.py` (SQLite at `~/.co-ai/sessions.db`) is only used by those unwired commands. What is real is host-side `SessionStorage` and `GET /sessions/{id}` (`network/host/server.py:445-447,514`), plus logs and evals under `~/.co`. |
+| "`co ai` can send email" | Email is not a wired tool on that agent. It is reachable as a CLI command (`co email send`, `co gmail`) after `co auth google` — a separate, opt-in path. |
+| "`co ai` ships explore and plan subagents from its own registry" | The live subagents come from `useful_plugins/builtin_agents/`. `cli/co_ai/agents/registry.py:26-39` defines the same two but is imported only by its own `__init__` and tests — the running agent never imports it. Claim the capability, not that file. |


### PR DESCRIPTION
Two files, no code changes.

## The problem this addresses

Writing marketing copy for this project keeps producing claims that are false. Not through carelessness — through fluency. Plausible sentences about software are easy to generate, and a helpful person writing from a directory listing will confidently describe things that do not exist.

Recent examples, all of which were live on our own public sites:

| Claim that shipped | What was actually true |
|---|---|
| "MIT licensed" | Apache-2.0 — wrong in six places at once |
| "End-to-end encrypted" | No payload encryption exists anywhere. TLS to a relay that terminates it |
| "Migration tools connect your existing agents in minutes" | No migration tool in the package |
| "Agents test collaboration with dummy data first" | No such mechanism |
| "Developers report 75% more time for building features" | An invented statistic |

## `connectonion/useful_skills/find-selling-points/SKILL.md`

Makes a claim expensive to assert and cheap to check. Every point ends in `file:line` or gets deleted — not softened, deleted. A missing selling point costs nothing; a false one costs a customer.

It also bans on sight the things we keep reaching for: framework comparisons, line counts, developer ergonomics as the headline, and any sentence that survives find-and-replacing our name with a competitor's. And it requires each point to state the **limit** a buyer would otherwise discover later and feel misled by — a claim with its limit attached is stronger, because it survives contact.

The table above lives in the skill's falsification step, so the bar stays where it is.

No packaging change needed; `connectonion/**/*.md` already ships.

## `docs/SELLING_POINTS.md` — first run

Three parallel investigations over `cli/co_ai/`, `network/host/ws_router/`, `useful_plugins/skills.py`, `cli/commands/skills_commands.py`, `useful_tools/`, `cli/browser_agent/` and the front end at `../oo-chat`. **13 claims survived, 10 were cut.**

The strongest surviving point appears nowhere in our current marketing: **`co ai` hosts the agent and opens `chat.openonion.ai` against your own machine** (`cli/co_ai/main.py:59-69`, `network/host/server.py:415-449`) — one command produces a working chat UI, a dashboard beside it, and a shareable address, with nothing written and nothing deployed.

Others include the agent rewriting its own dashboard mid-conversation and the change reaching the browser with no deploy (`ws_router/agent_io.py:70-74`), dashboard buttons wired to real skills producing auditable chat turns (`build-srcdoc.ts:64-82`), `.claude/skills/` being read directly (`skills.py:123-130`), and skill permissions that expire at `turn_end` (`skills.py:246-287`).

**The cut list is the more valuable half.** Four of the ten are things that look shipped and are not:

- `cli/co_ai/commands/__init__.py:39-52` defines `/init /help /cost /compact /tasks /export /sessions /new /resume /undo /redo`, but `BUILTIN_COMMANDS` is imported nowhere at runtime. The slash commands that work are skill names.
- `cli/co_ai/sessions.py` and its SQLite store are only reachable from those unwired commands.
- `cli/co_ai/agents/registry.py:26-39` duplicates the explore and plan subagents; the running agent never imports it.
- Email is not a wired tool on the `co ai` agent — CLI only.

Anyone writing copy from a directory listing would have claimed all four.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjWtif58mkmvFB7EEPfVR3)_