### PR TITLE
fix(eval): scope evidence to current turn

### DIFF
--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -105,6 +105,8 @@ def generate_expected(agent: 'Agent') -> None:
 
     Skips if already set or no user prompt.
     """
+    _prepare_turn_state(agent)
+
     user_prompt = agent.current_session.get('user_prompt', '')
     if not user_prompt:
         return
@@ -120,7 +122,9 @@ def generate_expected(agent: 'Agent') -> None:
     # Losing the expectation costs the score and nothing else, which is why
     # this one call earns a catch that most do not.
     try:
-        agent.current_session['expected'] = _generate_expected(agent)
+        expected = _generate_expected(agent)
+        agent.current_session['expected'] = expected
+        agent.current_session['_eval_expected'] = expected
     except Exception as exc:
         agent.logger.print(f"[dim]/expected unavailable ({exc})[/dim]")
 
@@ -139,6 +143,37 @@ def _summarize_trace(trace: List[Dict]) -> str:
             else:
                 actions.append(f"- {tool}: failed ({entry.get('error', 'unknown')})")
     return "\n".join(actions) if actions else "No tools were used."
+
+
+def _prepare_turn_state(agent: 'Agent') -> None:
+    """Keep transient eval values scoped to the current Agent turn.
+
+    Sessions are cumulative, so ``expected`` and ``evaluation`` otherwise
+    survive into the next user input.  Preserve a value another plugin wrote
+    for this turn, but discard the value last produced by this plugin.
+    """
+    session = agent.current_session
+    turn = session.get('turn')
+    if session.get('_eval_turn') == turn:
+        return
+
+    previous_expected = session.get('expected')
+    if previous_expected == session.get('_eval_expected'):
+        session.pop('expected', None)
+    session.pop('evaluation', None)
+    session['_eval_turn'] = turn
+
+
+def _current_turn_trace(agent: 'Agent') -> List[Dict]:
+    """Return the canonical trace slice that belongs to the current turn."""
+    trace = agent.current_session.get('trace', [])
+    turn = agent.current_session.get('turn')
+    for index in range(len(trace) - 1, -1, -1):
+        entry = trace[index]
+        if entry.get('type') == 'user_input' and entry.get('turn') == turn:
+            return trace[index:]
+    # Hand-built and legacy session shapes may not contain turn markers.
+    return trace
 
 
 @on_complete
@@ -160,11 +195,13 @@ def evaluate_completion(agent: 'Agent') -> None:
     if profile == DANGER_FULL_ACCESS_PERMISSION_PROFILE:
         return
 
+    _prepare_turn_state(agent)
+
     user_prompt = agent.current_session.get('user_prompt', '')
     if not user_prompt:
         return
 
-    trace = agent.current_session.get('trace', [])
+    trace = _current_turn_trace(agent)
     actions_summary = _summarize_trace(trace)
     result = agent.current_session.get('result', 'No response generated.')
 
@@ -173,6 +210,7 @@ def evaluate_completion(agent: 'Agent') -> None:
     if not expected:
         expected = _generate_expected(agent)
         agent.current_session['expected'] = expected
+    agent.current_session['_eval_expected'] = expected
 
     # Build prompt based on whether expected is available
     if expected:

--- a/docs/design-decisions/017-session-logging-and-eval-format.md
+++ b/docs/design-decisions/017-session-logging-and-eval-format.md
@@ -61,6 +61,11 @@ turns:
 - No second user input within a turn
 - Second user input = next turn
 
+The stored session and message history remain cumulative, but evaluation is
+turn-local. An evaluator uses the current turn's `user_input` trace boundary,
+tool results, final response, expected outcome, and verdict. Earlier turns are
+conversation context, not evidence that the current request passed or failed.
+
 ## Field Reference
 
 | Field | Type | Description |

--- a/docs/useful_plugins/eval.md
+++ b/docs/useful_plugins/eval.md
@@ -25,7 +25,10 @@ The plugin hooks into two lifecycle events:
 
 ### Why `on_complete`?
 
-The evaluation needs to see the **entire execution** - all iterations, all tool calls, and the final response.
+The evaluation needs to see the **entire current turn** - all iterations and
+tool calls after the current `user_input`, plus that turn's final response. A
+continued session keeps earlier messages and trace entries for conversation
+context, but they are not evaluation evidence for the new request.
 
 ```
 User Input
@@ -63,8 +66,11 @@ agent = Agent("assistant", tools=[search], plugins=[re_act, eval])
 ## Session Data
 
 The plugin stores:
-- `agent.current_session['expected']` - Expected outcome
-- `agent.current_session['evaluation']` - Evaluation result
+- `agent.current_session['expected']` - Expected outcome for the current turn
+- `agent.current_session['evaluation']` - Evaluation result for the current turn
+
+Both values are refreshed when a new turn starts. This prevents a tool used in
+an earlier request from causing a false pass or failure in a later request.
 
 ## When to Use
 

--- a/tests/unit/test_eval_plugin.py
+++ b/tests/unit/test_eval_plugin.py
@@ -6,18 +6,6 @@ Tests cover:
 - _summarize_trace: summarizing tool execution trace
 - Plugin registration with correct events
 """
-"""
-LLM-Note: Tests for eval plugin
-
-What it tests:
-- Eval Plugin functionality
-
-Components under test:
-- Module: eval_plugin
-"""
-
-
-import pytest
 import importlib
 from unittest.mock import Mock, patch
 
@@ -100,6 +88,32 @@ class TestGenerateExpected:
 
             call_args = mock_llm_do.call_args[0][0]
             assert 'tool1, tool2' in call_args
+
+    def test_generate_expected_regenerates_once_for_each_turn(self):
+        """A cumulative session must not reuse the previous turn's expectation."""
+        agent = FakeAgent()
+        agent.current_session.update({
+            'turn': 1,
+            'user_prompt': 'Use Claude Code',
+            'expected': 'Claude Code should run',
+            '_eval_expected': 'Claude Code should run',
+            '_eval_turn': 1,
+            'evaluation': {'passed': True, 'summary': 'Done'},
+        })
+
+        agent.current_session['turn'] = 2
+        agent.current_session['user_prompt'] = 'Use Codex'
+
+        with patch.object(eval_module, 'llm_do') as mock_llm_do:
+            mock_llm_do.return_value = 'Codex should run'
+
+            generate_expected(agent)
+            generate_expected(agent)
+
+            mock_llm_do.assert_called_once()
+            assert agent.current_session['expected'] == 'Codex should run'
+            assert agent.current_session['_eval_turn'] == 2
+            assert 'evaluation' not in agent.current_session
 
 
 class TestSummarizeTrace:
@@ -204,6 +218,45 @@ class TestEvaluateCompletion:
 
             call_args = mock_llm_do.call_args[0][0]
             assert '- search:' in call_args
+
+    def test_evaluate_completion_excludes_tools_from_previous_turns(self):
+        """Only the current turn's canonical trace slice is evaluation evidence."""
+        agent = FakeAgent()
+        agent.current_session.update({
+            'turn': 2,
+            'user_prompt': 'Use Codex once',
+            'expected': 'Codex should run once',
+            '_eval_expected': 'Codex should run once',
+            '_eval_turn': 2,
+            'result': 'CODEX_READ_OK',
+            'trace': [
+                {'type': 'user_input', 'turn': 1, 'content': 'Use Claude Code once'},
+                {
+                    'type': 'tool_result',
+                    'name': 'claude_code',
+                    'status': 'success',
+                    'result': 'CLAUDE_READ_OK',
+                },
+                {'type': 'turn_result', 'turn': 1, 'reason': 'natural'},
+                {'type': 'user_input', 'turn': 2, 'content': 'Use Codex once'},
+                {
+                    'type': 'tool_result',
+                    'name': 'codex',
+                    'status': 'success',
+                    'result': 'CODEX_READ_OK',
+                },
+            ],
+        })
+
+        with patch.object(eval_module, 'llm_do') as mock_llm_do:
+            mock_llm_do.return_value = 'Complete'
+
+            evaluate_completion(agent)
+
+            evaluation_prompt = mock_llm_do.call_args[0][0]
+            assert '- codex: CODEX_READ_OK' in evaluation_prompt
+            assert 'claude_code' not in evaluation_prompt
+            assert 'CLAUDE_READ_OK' not in evaluation_prompt
 
     def test_evaluate_completion_prints_status(self):
         """Test that evaluate_completion prints evaluation status."""


### PR DESCRIPTION
## Summary

- scope eval tool evidence to the current Agent turn's canonical `user_input` boundary
- refresh eval-owned expected outcomes and verdicts when the turn changes
- document the per-turn contract in DD-017 and the eval guide

Closes #940.

## Design

This reuses the turn identity and trace source of truth established by DD-017 and DD-026. It does not add a second lifecycle ledger. Hand-built/legacy sessions without `user_input.turn` retain the previous whole-trace fallback.

## Verification

- `pytest -q tests/unit/test_eval_plugin.py tests/unit/test_eval_plugin_is_not_load_bearing.py tests/unit/test_turn_outcome.py tests/unit/test_events.py` — 78 passed
- `ruff check connectonion/useful_plugins/eval.py tests/unit/test_eval_plugin.py` — passed
- `git diff --check` — passed
- real pre-fix E2E: Claude Code succeeded in turn 1; Codex read `README.md` and returned `CODEX_READ_OK` in turn 2, while eval falsely cited turn 1's Claude tool

## Full-suite note

The local full suite was stopped after environment-level failures began: a live E2E Host/browser occupied shared ports, and the sibling docs checkout advertised stable `1.6.0` while this core checkout is preview `1.7.0a1`. The focused lifecycle/ACP-adjacent suites above pass; CI provides the isolated full matrix.

## Docs site

Companion PR: https://github.com/wu-changxing/connectonion-docs-site/pull/55
