### PR TITLE
fix(logger): scope metrics to the current turn

### DIFF
--- a/connectonion/core/trace.py
+++ b/connectonion/core/trace.py
@@ -1,0 +1,22 @@
+"""
+Purpose: Select canonical per-turn slices from the cumulative Agent trace
+LLM-Note:
+  Dependencies: none | imported by [logger.py, useful_plugins/eval.py] | tested by [tests/unit/test_logger.py, tests/unit/test_eval_plugin.py]
+  Data flow: cumulative trace + current turn number -> trace beginning at that turn's user_input marker
+  State/Effects: pure; never mutates the trace
+  Errors: legacy or hand-built traces without a matching marker remain unchanged
+"""
+
+
+def current_turn_trace(trace: list[dict], turn: object) -> list[dict]:
+    """Return the canonical trace slice for one Agent turn.
+
+    Agent sessions retain earlier turns.  The latest matching ``user_input``
+    marker is the source-of-truth boundary; legacy traces without that marker
+    stay usable by falling back to the complete trace.
+    """
+    for index in range(len(trace) - 1, -1, -1):
+        entry = trace[index]
+        if entry.get("type") == "user_input" and entry.get("turn") == turn:
+            return trace[index:]
+    return trace

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -272,17 +272,25 @@ class Logger:
         if self.eval_data is None:
             self._init_eval_file(user_input)
 
-        # Aggregate from trace
+        # Messages and the session trace stay cumulative across turns.  Eval
+        # metrics do not: the current user_input marker is the canonical turn
+        # boundary, with a whole-trace fallback for legacy session shapes.
         trace = session.get('trace', [])
-        tool_calls = [t for t in trace if t.get('type') == 'tool_result']
-        # Imported here, not at module level: `.core.usage` runs
-        # `connectonion.core.__init__`, which imports Agent, which imports
+        # Imported here, not at module level: importing a `.core` submodule
+        # runs `connectonion.core.__init__`, which imports Agent, which imports
         # Logger from this module -- so `import connectonion.logger` in a
         # process that has not already loaded core died on the cycle. The
         # eager imports used to hide it; #631 removed them.
+        from .core.trace import current_turn_trace
         from .core.usage import totals_from_trace
 
-        total_tokens, total_cost = totals_from_trace(trace)
+        turn_trace = current_turn_trace(trace, session.get('turn'))
+        tool_calls = [
+            entry
+            for entry in turn_trace
+            if entry.get('type') == 'tool_result'
+        ]
+        total_tokens, total_cost = totals_from_trace(turn_trace)
 
         # Build metadata as compact JSON string
         meta = json.dumps({

--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -35,6 +35,7 @@ from ..core.approval_modes import (
     legacy_permission_profile_id,
 )
 from ..core.events import after_user_input, on_complete
+from ..core.trace import current_turn_trace
 from ..llm_do import llm_do
 
 if TYPE_CHECKING:
@@ -164,18 +165,6 @@ def _prepare_turn_state(agent: 'Agent') -> None:
     session['_eval_turn'] = turn
 
 
-def _current_turn_trace(agent: 'Agent') -> List[Dict]:
-    """Return the canonical trace slice that belongs to the current turn."""
-    trace = agent.current_session.get('trace', [])
-    turn = agent.current_session.get('turn')
-    for index in range(len(trace) - 1, -1, -1):
-        entry = trace[index]
-        if entry.get('type') == 'user_input' and entry.get('turn') == turn:
-            return trace[index:]
-    # Hand-built and legacy session shapes may not contain turn markers.
-    return trace
-
-
 @on_complete
 def evaluate_completion(agent: 'Agent') -> None:
     """Evaluate if the task completed correctly.
@@ -201,7 +190,10 @@ def evaluate_completion(agent: 'Agent') -> None:
     if not user_prompt:
         return
 
-    trace = _current_turn_trace(agent)
+    trace = current_turn_trace(
+        agent.current_session.get('trace', []),
+        agent.current_session.get('turn'),
+    )
     actions_summary = _summarize_trace(trace)
     result = agent.current_session.get('result', 'No response generated.')
 

--- a/docs/debug/eval-format.md
+++ b/docs/debug/eval-format.md
@@ -43,6 +43,9 @@ turns:
 ```
 
 The `meta` field is a compact JSON string containing tokens, cost, duration, and timestamp.
+For a continued Agent session, each turn's `tools_called`, tokens, and cost come
+only from trace entries beginning at that turn's matching `user_input` marker.
+The full message history remains cumulative so the run can still be replayed.
 
 ## Run YAML Format
 
@@ -69,7 +72,7 @@ messages: |
 - `system_prompt`: The agent's system prompt (easy to access)
 - `model`: Which model was used
 - `cwd`: Working directory (for re-execution)
-- `tokens`, `cost`, `duration_ms`: Performance metrics
+- `tokens`, `cost`, `duration_ms`: Performance metrics for this turn
 - `messages`: Full message history as multi-line JSON (API format)
 
 ## Design Rationale

--- a/docs/debug/log.md
+++ b/docs/debug/log.md
@@ -71,6 +71,10 @@ turns:
     messages: '[{"role":"system",...}]'
 ```
 
+In a multi-turn session, `tools_called`, `tokens`, and `cost` describe only the
+current turn, bounded by its `user_input` trace entry. `messages` can still
+contain the cumulative conversation needed for replay.
+
 Use cases:
 - **Session replay**: Restore context from saved sessions
 - **Regression testing**: Compare expected vs actual results

--- a/docs/design-decisions/017-session-logging-and-eval-format.md
+++ b/docs/design-decisions/017-session-logging-and-eval-format.md
@@ -61,10 +61,16 @@ turns:
 - No second user input within a turn
 - Second user input = next turn
 
-The stored session and message history remain cumulative, but evaluation is
-turn-local. An evaluator uses the current turn's `user_input` trace boundary,
-tool results, final response, expected outcome, and verdict. Earlier turns are
-conversation context, not evidence that the current request passed or failed.
+The stored session, trace, and message history remain cumulative, but
+evaluation and per-turn metrics are turn-local. The matching `user_input`
+trace entry is the canonical boundary. Evaluation evidence, `tools_called`,
+tokens, and cost come only from entries at or after that boundary. Earlier
+turns remain conversation context; they are neither evidence that the current
+request passed nor work and usage that the current turn can claim again.
+
+Legacy or hand-built sessions may not have `user_input` turn markers. They keep
+their historical whole-trace behavior rather than losing all metrics. New Agent
+sessions always write the marker.
 
 ## Field Reference
 
@@ -73,9 +79,9 @@ conversation context, not evidence that the current request passed or failed.
 | `input` | string | User input for this turn |
 | `model` | string | LLM model used |
 | `duration_ms` | int | How long the turn took |
-| `tokens` | int | Total tokens used |
-| `cost` | float | Cost in USD |
-| `tools_called` | list | Tools that were called |
+| `tokens` | int | Tokens used in this turn |
+| `cost` | float | Cost in USD for this turn |
+| `tools_called` | list | Tools called in this turn |
 | `result` | string | Agent's final response |
 | `messages` | JSON string | Message context window |
 | `eval` | object | Optional expectations |
@@ -123,3 +129,5 @@ messages = json.loads(turn['messages'])
 - **Pure YAML** - Prompts break format (colons, quotes)
 - **Multi-line JSON** - Unnecessary complexity
 - **Separate message files** - Too complex
+- **Cumulative trace for each turn** - Double-counts earlier tools, tokens, and cost
+- **Subtract the previous YAML entry** - Saved files are output, not the runtime source of truth

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -390,6 +390,88 @@ class TestEvalLogging:
         assert data["turns"][0]["input"] == "turn 1"
         assert data["turns"][1]["input"] == "turn 2"
 
+    def test_log_turn_scopes_tools_and_usage_to_current_trace_boundary(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A cumulative session must not bill or credit an earlier turn twice."""
+        monkeypatch.chdir(tmp_path)
+
+        logger = Logger("test-agent", quiet=True)
+        logger.start_session()
+
+        turn_one_trace = [
+            {'type': 'user_input', 'turn': 1, 'content': 'Use Claude Code'},
+            {
+                'type': 'llm_result',
+                'usage': {
+                    'input_tokens': 100,
+                    'output_tokens': 50,
+                    'cost': 0.01,
+                },
+            },
+            {
+                'type': 'tool_result',
+                'name': 'claude_code',
+                'args': {'prompt': 'read README'},
+            },
+            {'type': 'turn_result', 'turn': 1, 'reason': 'natural'},
+        ]
+        turn_two_trace = [
+            *turn_one_trace,
+            {'type': 'user_input', 'turn': 2, 'content': 'Use Codex'},
+            {
+                'type': 'llm_result',
+                'usage': {
+                    'input_tokens': 20,
+                    'output_tokens': 5,
+                    'cost': 0.002,
+                },
+            },
+            {
+                'type': 'tool_result',
+                'name': 'codex',
+                'args': {'prompt': 'read README'},
+            },
+            {'type': 'turn_result', 'turn': 2, 'reason': 'natural'},
+        ]
+
+        logger.log_turn(
+            "Use Claude Code",
+            "CLAUDE_READ_OK",
+            100,
+            {'turn': 1, 'trace': turn_one_trace, 'messages': []},
+            "gpt-5",
+        )
+        logger.log_turn(
+            "Use Codex",
+            "CODEX_READ_OK",
+            200,
+            {'turn': 2, 'trace': turn_two_trace, 'messages': []},
+            "gpt-5",
+        )
+
+        with open(logger.eval_file) as f:
+            data = yaml.safe_load(f)
+
+        first_turn, second_turn = data['turns']
+        assert first_turn['tools_called'] == [
+            "claude_code(prompt='read README')",
+        ]
+        assert json.loads(first_turn['meta'])['tokens'] == 150
+        assert json.loads(first_turn['meta'])['cost'] == 0.01
+        assert second_turn['tools_called'] == [
+            "codex(prompt='read README')",
+        ]
+        assert json.loads(second_turn['meta'])['tokens'] == 25
+        assert json.loads(second_turn['meta'])['cost'] == 0.002
+
+        with open(logger.eval_dir / 'run_1.yaml') as f:
+            latest_run = yaml.safe_load(f)
+        assert latest_run['tokens'] == 25
+        assert latest_run['cost'] == 0.002
+
     def test_log_turn_without_start_session(self, tmp_path, monkeypatch):
         """Test log_turn does nothing if enable_sessions is False."""
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## What changed

- centralize the canonical current-turn trace slice used by both evaluation and logging
- scope `tools_called`, tokens, and cost to the matching `user_input` boundary
- preserve whole-trace behavior for legacy or hand-built sessions without turn markers
- document the per-turn metric contract in DD-017 and the logging/eval guides

## Root cause

`Logger.log_turn()` read the cumulative session trace directly. On turn 2 it therefore credited turn 1's tools again and added turn 1's usage to the new turn. The evaluator had already learned the correct boundary in #941, but the invariant was private to that plugin.

## Impact

Multi-turn YAML now reports work and usage for the turn that owns it. Full messages remain cumulative for replay and conversation context.

## Validation

- `pytest -q tests/unit/test_logger.py tests/unit/test_eval_plugin.py tests/unit/test_the_token_count_matches_what_was_billed.py tests/unit/test_turn_outcome.py` — 88 passed
- regression proved red before the implementation and now verifies both eval summary and run YAML metrics
- `ruff check connectonion/core/trace.py`
- `ruff format --check connectonion/core/trace.py`
- `git diff --check`

Closes #942
