### PR TITLE
feat(acp): isolate mutable CLI state

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -2287,6 +2287,7 @@ def create_acp_agent(
     max_iterations: int,
     yolo: bool,
     yolo_turns: int,
+    agent_factory: AgentFactory | None = None,
     session_co_dir: Path | None = None,
     network_workspace: _BoundNetworkWorkspace | None = None,
     input_limits: Mapping[str, int | float] | None = None,
@@ -2299,6 +2300,7 @@ def create_acp_agent(
         max_iterations=max_iterations,
         yolo=yolo,
         yolo_turns=yolo_turns,
+        agent_factory=agent_factory,
         session_co_dir=session_co_dir,
         network_workspace=network_workspace,
         input_limits=input_limits,
@@ -2313,8 +2315,16 @@ async def serve_acp(
     yolo: bool,
     yolo_turns: int,
     allow_mcp: bool = False,
+    state_dir: Path | None = None,
 ) -> None:
     """Serve ``co ai`` as an ACP v1 Agent until the client closes stdin."""
+
+    agent_factory = None
+    if state_dir is not None:
+        from ..commands.ai_commands import _create_agent
+
+        def agent_factory(**kwargs: Any) -> Any:
+            return _create_agent(**kwargs, state_dir=state_dir)
 
     transport = await open_stdio_transport()
     agent = create_acp_agent(
@@ -2322,6 +2332,8 @@ async def serve_acp(
         max_iterations=max_iterations,
         yolo=yolo,
         yolo_turns=yolo_turns,
+        agent_factory=agent_factory,
+        session_co_dir=state_dir,
         allow_mcp=allow_mcp,
     )
     try:

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -117,6 +117,7 @@ def create_agent(
     yolo_turns: int | None = None,
     role: str | None = "coding",
     background_tools: bool = True,
+    state_dir: Path | None = None,
 ) -> Agent:
     """Build the co-ai agent.
 
@@ -182,6 +183,7 @@ def create_agent(
         model=model,
         max_iterations=max_iterations,
         co_dir=co_dir,
+        state_dir=state_dir,
     )
     agent._delegation_workspace = Path.cwd().resolve()
     # This browser helper blocks on stdin, which is wrong for co ai's websocket

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import sys
 from contextlib import nullcontext, redirect_stdout
+from pathlib import Path
 
 import typer
 from rich.console import Console
@@ -29,6 +30,7 @@ def handle_ai(
     resume: str = None,
     acp: bool = False,
     acp_mcp: bool = False,
+    state_dir: Path | None = None,
 ):
     """Start AI coding agent or run one-shot prompt.
 
@@ -43,6 +45,7 @@ def handle_ai(
         resume: Continue a prior one-shot session ID
         acp: Serve the coding agent over ACP v1 on stdio
         acp_mcp: Allow ACP clients to launch session-scoped stdio MCP servers
+        state_dir: ACP-only root for mutable session, log, and eval state
 
     Examples:
         co ai                                    # Start web server
@@ -54,6 +57,10 @@ def handle_ai(
 
     if acp_mcp and not acp:
         console.print("[red]--acp-mcp requires --acp[/red]")
+        raise typer.Exit(2)
+
+    if state_dir is not None and not acp:
+        console.print("[red]--state-dir requires --acp[/red]")
         raise typer.Exit(2)
 
     if not prompt and (json_output or resume):
@@ -77,6 +84,10 @@ def handle_ai(
     if acp:
         from ..co_ai.acp_server import serve_acp
 
+        prepared_state_dir = (
+            _prepare_acp_state_dir(state_dir) if state_dir is not None else None
+        )
+
         asyncio.run(
             serve_acp(
                 model=model,
@@ -84,6 +95,7 @@ def handle_ai(
                 yolo=yolo,
                 yolo_turns=yolo_turns,
                 allow_mcp=acp_mcp,
+                state_dir=prepared_state_dir,
             )
         )
         return
@@ -103,13 +115,39 @@ def handle_ai(
         )
 
 
-def _create_agent(model, max_iterations, yolo, yolo_turns, *, resumable=False):
+def _prepare_acp_state_dir(state_dir: Path) -> Path:
+    """Create one private root for an isolated ACP process."""
+
+    from ..co_ai.one_shot_sessions import (
+        SessionSnapshotError,
+        prepare_snapshot_storage,
+    )
+
+    selected = Path(state_dir).expanduser()
+    try:
+        prepare_snapshot_storage(selected)
+        return selected.resolve(strict=True)
+    except (OSError, SessionSnapshotError):
+        console.print(f"[red]ACP state directory is unavailable: {selected}[/red]")
+        raise typer.Exit(2) from None
+
+
+def _create_agent(
+    model,
+    max_iterations,
+    yolo,
+    yolo_turns,
+    *,
+    resumable=False,
+    state_dir: Path | None = None,
+):
     from ..co_ai.agent import GLOBAL_CO_DIR, create_agent
 
     return create_agent(
         model=model,
         max_iterations=max_iterations,
         co_dir=GLOBAL_CO_DIR,
+        state_dir=state_dir,
         yolo_turns=yolo_turns if yolo else None,
         background_tools=not resumable,
     )

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -370,6 +370,11 @@ def ai(
         "--acp-mcp",
         help="Allow ACP clients to launch session-scoped stdio MCP servers",
     ),
+    state_dir: Optional[Path] = typer.Option(
+        None,
+        "--state-dir",
+        help="With --acp, isolate mutable session and eval state",
+    ),
 ):
     """Start AI coding agent or run one-shot prompt."""
     from .commands.ai_commands import handle_ai
@@ -384,6 +389,7 @@ def ai(
         resume=resume,
         acp=acp,
         acp_mcp=acp_mcp,
+        state_dir=state_dir,
     )
 
 

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -73,7 +73,8 @@ class Agent:
         quiet: bool = False,
         plugins: Optional[List[List[EventHandler]]] = None,
         on_events: Optional[List[EventHandler]] = None,
-        co_dir: Optional[Union[str, Path]] = None
+        co_dir: Optional[Union[str, Path]] = None,
+        state_dir: Optional[Union[str, Path]] = None,
     ):
         self.name = name
         self.co_dir = Path(co_dir) if co_dir else Path(".co")
@@ -99,7 +100,12 @@ class Agent:
         if os.getenv('CONNECTONION_LOG'):
             effective_log = Path(os.getenv('CONNECTONION_LOG'))
 
-        self.logger = Logger(agent_name=name, quiet=quiet, log=effective_log, co_dir=co_dir)
+        self.logger = Logger(
+            agent_name=name,
+            quiet=quiet,
+            log=effective_log,
+            co_dir=state_dir if state_dir is not None else co_dir,
+        )
 
         # Initialize event registry
         # Note: before_each_tool/after_each_tool fire for EACH tool

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -95,9 +95,11 @@ class Agent:
         self.last_usage: Optional[TokenUsage] = None  # From most recent LLM call
 
         # Initialize logger (unified: terminal + file + YAML evals)
-        # Environment variable override (highest priority)
+        # Environment override stays highest priority for the legacy path. An
+        # explicit state root is an isolation boundary, so hidden process state
+        # must not redirect its file log outside that root.
         effective_log = log
-        if os.getenv('CONNECTONION_LOG'):
+        if state_dir is None and os.getenv('CONNECTONION_LOG'):
             effective_log = Path(os.getenv('CONNECTONION_LOG'))
 
         self.logger = Logger(

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -112,6 +112,21 @@ session reuse its conversation and tool state. The working directory supplied
 by the client must be an existing absolute directory. Additional workspace
 roots are not accepted yet.
 
+Automation and concurrent acceptance tests can give one ACP process a private
+mutable-state root:
+
+```bash
+co ai --acp --state-dir /private/tmp/co-acp-test
+```
+
+This roots that process's durable ACP snapshots, Agent logs, and eval files
+under the selected directory. It does not copy credentials or create another
+ConnectOnion identity: the Agent name and configured provider credentials still
+come from the normal global configuration. On POSIX, the selected directory is
+created or tightened to mode `0700`; a symlink is rejected. The default remains
+`~/.co`, and `--state-dir` without `--acp` exits with an error. This first slice
+does not change web-server or network Host storage semantics.
+
 The stdio adapter advertises image and embedded-context prompt capabilities
 with the same validated content-block mapping as the network endpoint. Audio is
 not advertised. Invalid MIME types, base64, counts, sizes, or unsafe upload
@@ -175,6 +190,7 @@ operator choice at process launch.
 | `--resume` | | | With `--json`, continue a one-shot session by ID |
 | `--acp` | | off | Serve stable ACP v1 over stdin/stdout |
 | `--acp-mcp` | | off | With `--acp`, allow session-scoped stdio MCP launches |
+| `--state-dir` | | `~/.co` | With `--acp`, isolate mutable session, log, and eval state |
 
 ```bash
 co ai --port 9000
@@ -183,6 +199,7 @@ co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 co ai --yolo "Fix the failing suite" --yolo-turns 20
 co ai --acp
 co ai --acp --acp-mcp
+co ai --acp --state-dir /private/tmp/co-acp-test
 ```
 
 ## Full access (`--yolo`)

--- a/docs/design-decisions/051-explicit-acp-state-isolation.md
+++ b/docs/design-decisions/051-explicit-acp-state-isolation.md
@@ -1,0 +1,87 @@
+# DD-051: Isolate local ACP state with an explicit CLI root
+
+**Status:** Accepted
+
+**Date:** 2026-08-13
+
+**Related:** [DD-011 Global Config and Identity](011-global-config-identity-management.md), [DD-029 Persistent ACP Session Ownership](029-acp-persistent-session-ownership.md), [Issue #945](https://github.com/openonion/connectonion/issues/945)
+
+## Context
+
+Local `co ai --acp` stores durable session snapshots and every Agent's logs and
+eval records under `~/.co`. That default is useful for one operator, but it is
+not a safe acceptance-test boundary when another Agent may be active on the
+same machine. Concurrent runs can contend for a session lease or write mutable
+evidence into the operator's ordinary state directory.
+
+The final acceptance test must run the real `co ai` command. A unit-test-only
+monkeypatch would prove a different entry point, while changing `HOME` would
+also redirect unrelated configuration and credential discovery.
+
+## Decision
+
+Add an explicit ACP-only option:
+
+```bash
+co ai --acp --state-dir PATH
+```
+
+The CLI prepares `PATH` as a private state root and passes the same resolved
+directory to both owners of mutable state:
+
+- the ACP lifecycle adapter, for leases and durable snapshots;
+- the Agent factory, for Logger and eval output.
+
+The normal default remains `~/.co`. Using `--state-dir` without `--acp` is an
+exit-2 usage error. Web-server and network Host storage are unchanged because
+they also carry identity, relay, and authenticated-principal semantics that
+need a separate decision.
+
+## Keep configuration separate from state
+
+`Agent.co_dir` is configuration as well as a filesystem path: the coding Agent
+uses it for its name and skill discovery. Redirecting that value would silently
+rename the Agent and make its configured skills disappear.
+
+The Agent therefore accepts a separate Logger state directory. An isolated ACP
+Agent keeps its normal global `co_dir` for name and configuration while Logger
+and eval output use `PATH`. Provider credentials keep their existing
+environment and global-config lookup; no key, token, skill, or identity file is
+copied into the state directory.
+
+## Security boundary
+
+The selected root reuses the durable-session store's existing validation:
+
+- create controlled directories with private permissions;
+- enforce mode `0700` on POSIX;
+- reject a symlink as the selected root;
+- fail before opening the ACP protocol when the directory is unavailable.
+
+The flag isolates ConnectOnion's mutable process state. It does not sandbox the
+workspace, provider CLIs, environment, or effects authorized by an ACP session
+mode.
+
+## Alternatives considered
+
+- **Override `HOME`:** rejected because it changes unrelated tools, shell
+  conventions, identity, and credential lookup.
+- **Copy `~/.co`:** rejected because it duplicates private credentials and
+  creates a second identity copy.
+- **Monkeypatch `GLOBAL_CO_DIR`:** retained for narrow unit tests, but rejected
+  as final acceptance evidence because it does not run the public CLI contract.
+- **Add an environment variable:** rejected for this slice because invisible
+  process state is harder to audit than an explicit launch argument.
+- **Change every mode at once:** rejected because web and network modes have
+  additional storage ownership and authentication boundaries.
+
+## Consequences
+
+Real Claude Code and Codex ACP acceptance can run beside other local Agents
+without sharing session, log, or eval files. Callers must deliberately manage
+and remove their test directory. Existing users see no behavior change unless
+they provide the new flag.
+
+Revisit the ACP-only boundary when web Host mode gains a separately designed
+runtime-state root that preserves its global identity and per-principal network
+storage guarantees.

--- a/docs/design-decisions/051-explicit-acp-state-isolation.md
+++ b/docs/design-decisions/051-explicit-acp-state-isolation.md
@@ -47,7 +47,9 @@ The Agent therefore accepts a separate Logger state directory. An isolated ACP
 Agent keeps its normal global `co_dir` for name and configuration while Logger
 and eval output use `PATH`. Provider credentials keep their existing
 environment and global-config lookup; no key, token, skill, or identity file is
-copied into the state directory.
+copied into the state directory. The explicit state root also takes precedence
+over the implicit `CONNECTONION_LOG` file override, so process environment
+cannot make an isolated CLI run write its ordinary log elsewhere.
 
 ## Security boundary
 

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -29,6 +29,7 @@ def test_ai_forwards_yolo_options():
         resume=None,
         acp=False,
         acp_mcp=False,
+        state_dir=None,
     )
 
 
@@ -51,6 +52,7 @@ def test_ai_forwards_json_and_resume_options():
         resume="session-id",
         acp=False,
         acp_mcp=False,
+        state_dir=None,
     )
 
 
@@ -70,7 +72,21 @@ def test_ai_forwards_acp_mode():
         resume=None,
         acp=True,
         acp_mcp=False,
+        state_dir=None,
     )
+
+
+def test_ai_forwards_explicit_acp_state_dir(tmp_path):
+    state_dir = tmp_path / "acp-state"
+    with patch("connectonion.cli.commands.ai_commands.handle_ai") as handler:
+        result = runner.invoke(
+            app,
+            ["ai", "--acp", "--state-dir", str(state_dir)],
+        )
+
+    assert result.exit_code == 0
+    assert handler.call_args.kwargs["acp"] is True
+    assert handler.call_args.kwargs["state_dir"] == state_dir
 
 
 def test_ai_forwards_explicit_acp_mcp_authority():
@@ -94,6 +110,16 @@ def test_ai_rejects_acp_mcp_without_acp():
 
     assert result.exit_code == 2
     assert "--acp-mcp requires --acp" in strip_ansi(result.output)
+
+
+def test_ai_rejects_state_dir_without_acp(tmp_path):
+    result = runner.invoke(
+        app,
+        ["ai", "--state-dir", str(tmp_path / "state")],
+    )
+
+    assert result.exit_code == 2
+    assert "--state-dir requires --acp" in strip_ansi(result.output)
 
 
 def test_ai_rejects_non_positive_yolo_turns():

--- a/tests/unit/test_agent_state_dir.py
+++ b/tests/unit/test_agent_state_dir.py
@@ -4,9 +4,13 @@ from connectonion import Agent
 from tests.utils.mock_helpers import MockLLM
 
 
-def test_state_dir_redirects_logger_without_moving_agent_configuration(tmp_path):
+def test_state_dir_redirects_logger_without_moving_agent_configuration(
+    tmp_path,
+    monkeypatch,
+):
     config_dir = tmp_path / "config"
     state_dir = tmp_path / "state"
+    monkeypatch.setenv("CONNECTONION_LOG", str(tmp_path / "outside.log"))
 
     agent = Agent(
         name="isolated",

--- a/tests/unit/test_agent_state_dir.py
+++ b/tests/unit/test_agent_state_dir.py
@@ -1,0 +1,21 @@
+"""Agent configuration and mutable Logger state can have separate roots."""
+
+from connectonion import Agent
+from tests.utils.mock_helpers import MockLLM
+
+
+def test_state_dir_redirects_logger_without_moving_agent_configuration(tmp_path):
+    config_dir = tmp_path / "config"
+    state_dir = tmp_path / "state"
+
+    agent = Agent(
+        name="isolated",
+        llm=MockLLM(),
+        log=False,
+        co_dir=config_dir,
+        state_dir=state_dir,
+    )
+
+    assert agent.co_dir == config_dir
+    assert agent.logger.co_dir == state_dir
+    assert agent.logger.log_file_path == state_dir / "logs" / "isolated.log"

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -1,5 +1,5 @@
-"""Tests for CLI ai and trust command handlers."""
-"""
+"""Tests for CLI ai and trust command handlers.
+
 LLM-Note: Tests for cli commands ai trust
 
 What it tests:
@@ -9,11 +9,13 @@ Components under test:
 - Module: cli_commands_ai_trust
 """
 
+import os
+
+import pytest
+import typer
 
 import connectonion.cli.commands.ai_commands as ai_mod
 import connectonion.cli.commands.trust_commands as trust_mod
-import pytest
-import typer
 from connectonion.cli.co_ai.agent import GLOBAL_CO_DIR
 from connectonion.core.exceptions import LLMAuthenticationError
 
@@ -79,6 +81,80 @@ def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
     assert capsys.readouterr().out.endswith("done\n")
 
 
+def test_handle_ai_prepares_private_acp_state_dir(tmp_path, monkeypatch):
+    selected = tmp_path / "isolated" / "acp-state"
+    called = {}
+
+    async def fake_serve_acp(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.acp_server.serve_acp",
+        fake_serve_acp,
+    )
+
+    ai_mod.handle_ai(acp=True, state_dir=selected)
+
+    assert called["state_dir"] == selected.resolve()
+    assert selected.is_dir()
+    if os.name != "nt":
+        assert selected.stat().st_mode & 0o777 == 0o700
+
+
+def test_isolated_agent_keeps_global_config_and_redirects_only_state(
+    tmp_path,
+    monkeypatch,
+):
+    created = {}
+
+    def fake_create_agent(**kwargs):
+        created.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent",
+        fake_create_agent,
+    )
+
+    state_dir = tmp_path / "state"
+    ai_mod._create_agent(
+        "test",
+        2,
+        False,
+        2,
+        resumable=True,
+        state_dir=state_dir,
+    )
+
+    assert created["co_dir"] == GLOBAL_CO_DIR
+    assert created["state_dir"] == state_dir
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows symlink creation needs privileges")
+def test_handle_ai_rejects_a_symlink_state_dir(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "target"
+    target.mkdir()
+    selected = tmp_path / "state"
+    selected.symlink_to(target, target_is_directory=True)
+    served = False
+
+    async def fake_serve_acp(**_kwargs):
+        nonlocal served
+        served = True
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.acp_server.serve_acp",
+        fake_serve_acp,
+    )
+
+    with pytest.raises(typer.Exit) as caught:
+        ai_mod.handle_ai(acp=True, state_dir=selected)
+
+    assert caught.value.exit_code == 2
+    assert served is False
+    assert "state directory is unavailable" in capsys.readouterr().out
+
+
 def test_handle_ai_reports_a_provider_failure_without_a_traceback(monkeypatch, capsys):
     class FakeAgent:
         def input(self, prompt):
@@ -116,7 +192,8 @@ def test_handle_ai_does_not_hide_programmer_errors(monkeypatch):
 
 def test_trust_commands_list_and_actions(tmp_path, monkeypatch):
     # Point CO_DIR at temp path and create lists
-    co = tmp_path / ".co"; co.mkdir()
+    co = tmp_path / ".co"
+    co.mkdir()
     monkeypatch.chdir(tmp_path)
     (co / "contacts.txt").write_text("c1\n", encoding="utf-8")
     (co / "whitelist.txt").write_text("w1\n", encoding="utf-8")

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -116,6 +116,100 @@ class _FakeAgent:
         return f"answer {len(self.prompts)}: {prompt}"
 
 
+class _ServedACPAdapter:
+    def __init__(self) -> None:
+        self.cancelled = False
+        self.closed = False
+
+    def cancel_all(self) -> None:
+        self.cancelled = True
+
+    async def close_all(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_serve_acp_routes_explicit_state_to_sessions_and_agent(
+    tmp_path,
+    monkeypatch,
+):
+    state_dir = (tmp_path / "acp-state").resolve()
+    adapter = _ServedACPAdapter()
+    captured = {}
+
+    async def fake_open_stdio_transport():
+        return object()
+
+    def fake_create_acp_agent(**kwargs):
+        captured["adapter_kwargs"] = kwargs
+        return adapter
+
+    def fake_create_runtime_agent(**kwargs):
+        captured["runtime_kwargs"] = kwargs
+        return object()
+
+    async def fake_run_agent(agent, **_kwargs):
+        assert agent is adapter
+        captured["adapter_kwargs"]["agent_factory"](
+            model="test",
+            max_iterations=2,
+            yolo=False,
+            yolo_turns=2,
+            resumable=True,
+        )
+
+    monkeypatch.setattr(acp_server, "open_stdio_transport", fake_open_stdio_transport)
+    monkeypatch.setattr(acp_server, "create_acp_agent", fake_create_acp_agent)
+    monkeypatch.setattr(acp_server, "run_agent", fake_run_agent)
+    monkeypatch.setattr(
+        "connectonion.cli.commands.ai_commands._create_agent",
+        fake_create_runtime_agent,
+    )
+
+    await acp_server.serve_acp(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        state_dir=state_dir,
+    )
+
+    assert captured["adapter_kwargs"]["session_co_dir"] == state_dir
+    assert captured["runtime_kwargs"]["state_dir"] == state_dir
+    assert adapter.cancelled is True
+    assert adapter.closed is True
+
+
+@pytest.mark.asyncio
+async def test_serve_acp_keeps_the_global_default(monkeypatch):
+    adapter = _ServedACPAdapter()
+    captured = {}
+
+    async def fake_open_stdio_transport():
+        return object()
+
+    def fake_create_acp_agent(**kwargs):
+        captured.update(kwargs)
+        return adapter
+
+    async def fake_run_agent(agent, **_kwargs):
+        assert agent is adapter
+
+    monkeypatch.setattr(acp_server, "open_stdio_transport", fake_open_stdio_transport)
+    monkeypatch.setattr(acp_server, "create_acp_agent", fake_create_acp_agent)
+    monkeypatch.setattr(acp_server, "run_agent", fake_run_agent)
+
+    await acp_server.serve_acp(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+    )
+
+    assert captured["session_co_dir"] is None
+    assert captured["agent_factory"] is None
+
+
 class _BlockingFakeAgent(_FakeAgent):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
## Summary

- add explicit `co ai --acp --state-dir PATH`
- route one resolved private root to ACP snapshots and Agent Logger/eval output
- keep global Agent configuration, identity name, credentials, and skills unchanged
- reject non-ACP use and symlink roots before protocol startup
- record the decision in DD-051 and update the CLI reference

## Design

Issue #945 discusses and rejects overriding HOME, copying ~/.co, monkeypatch-only acceptance, and a hidden environment variable. The implementation reuses the existing private snapshot-directory validation and adds no second storage system.

A review found that Agent.co_dir also drives name and skill discovery. The final design therefore adds a separate Logger state directory instead of redirecting Agent configuration.

## Validation

- 89 focused CLI, Agent, ACP, and security tests passed
- 62 ACP stdio, Agent factory, and snapshot regressions passed
- Ruff passed for every changed Python file
- git diff --check passed
- docs-site ESLint passed
- docs-site production build generated 121/121 pages

Closes #945