### PR TITLE
test(relay): wait for reconnect behavior

### DIFF
--- a/tests/unit/test_relay.py
+++ b/tests/unit/test_relay.py
@@ -477,9 +477,12 @@ class TestRelaySupervisorResilience:
         from connectonion.network.host.server import _create_relay_lifespan
 
         calls = {"connect": 0}
+        second_attempt = asyncio.Event()
 
         async def boom(*args, **kwargs):
             calls["connect"] += 1
+            if calls["connect"] == 2:
+                second_attempt.set()
             raise OSError("simulated network blip")
 
         monkeypatch.setattr(relay_module, "connect", boom)
@@ -491,8 +494,10 @@ class TestRelaySupervisorResilience:
         )
 
         await on_startup()
-        await asyncio.sleep(1.3)   # initial attempt + at least one retry after the 1s backoff
-        await on_shutdown()
+        try:
+            await asyncio.wait_for(second_attempt.wait(), timeout=5)
+        finally:
+            await on_shutdown()
 
         assert calls["connect"] >= 2, (
             "supervisor died after the first error instead of reconnecting"


### PR DESCRIPTION
## Outcome

Make the relay supervisor resilience regression synchronize on the second connection attempt instead of guessing that CI scheduled it within a fixed 1.3-second sleep.

## Change

- the fake relay connection sets an `asyncio.Event` on attempt two
- the test waits for that observable behavior with a bounded `asyncio.wait_for`
- shutdown remains in `finally`, so a timeout or assertion cannot leak the supervisor task
- the production one-second first retry and later exponential backoff are unchanged

This keeps the test about its real contract: a non-`ConnectionClosed` exception does not kill the long-lived supervisor.

## Validation

- focused regression: passed
- focused regression repeated five consecutive times: 5/5 passed
- complete `tests/unit/test_relay.py`: 23 passed
- `git diff --check`: passed
- self-review: one test-only change; no production behavior or timing change

Fixes #914
