### PR TITLE
fix: reject ambiguous ACP authority payloads

### DIFF
--- a/connectonion/core/acp_wire.py
+++ b/connectonion/core/acp_wire.py
@@ -562,13 +562,27 @@ def legacy_approval_response_from_acp(
     if frame.get("sessionId") != expected_session_id:
         raise ValueError("ACP permission response belongs to another session")
     message = _required_mapping(frame, "message")
+    _require_exact_fields(
+        message,
+        {"jsonrpc", "id", "result"},
+        "ACP permission response",
+    )
     if message.get("jsonrpc") != "2.0":
         raise ValueError("ACP response jsonrpc must be '2.0'")
     if message.get("id") != expected_request_id:
         raise ValueError("ACP permission response belongs to another request")
-    result = RequestPermissionResponse.model_validate(
-        _required_mapping(message, "result")
+    raw_result = _required_mapping(message, "result")
+    _require_exact_fields(
+        raw_result, {"outcome", "_meta"}, "ACP permission result"
     )
+    raw_outcome = _required_mapping(raw_result, "outcome")
+    outcome_fields = {"outcome"}
+    if raw_outcome.get("outcome") == "selected":
+        outcome_fields.update({"optionId", "_meta"})
+    _require_exact_fields(
+        raw_outcome, outcome_fields, "ACP permission outcome"
+    )
+    result = RequestPermissionResponse.model_validate(raw_result)
     outcome = result.outcome
     if outcome.outcome == "cancelled":
         return _hard_rejection()
@@ -609,6 +623,9 @@ def legacy_interrupt_from_acp_cancel(
     if message.get("method") != ACP_CANCEL_METHOD:
         raise ValueError("Unsupported ACP client notification method")
     params = _required_mapping(message, "params")
+    _require_exact_fields(
+        params, {"sessionId", "_meta"}, "ACP cancel params"
+    )
     if not isinstance(params.get("sessionId"), str):
         raise ValueError("ACP cancel sessionId must be a string")
     cancel = CancelNotification.model_validate(params)
@@ -782,6 +799,13 @@ def _required_mapping(
     if not isinstance(item, Mapping):
         raise ValueError(f"ACP notification field {field!r} must be an object")
     return item
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any], allowed: set[str], context: str
+) -> None:
+    if not set(value).issubset(allowed):
+        raise ValueError(f"{context} contains unsupported fields")
 
 
 def _required_string(value: Mapping[str, Any], field: str) -> str:

--- a/tests/unit/test_acp_host_cancel.py
+++ b/tests/unit/test_acp_host_cancel.py
@@ -33,6 +33,15 @@ def test_exact_cancel_maps_to_the_existing_interrupt_lifecycle():
     ) == {"type": "INTERRUPT"}
 
 
+def test_cancel_keeps_standard_meta_opaque():
+    frame = cancel_frame()
+    frame["message"]["params"]["_meta"] = {"vendor": {"hint": True}}
+
+    assert legacy_interrupt_from_acp_cancel(
+        frame, expected_session_id=SESSION_ID
+    ) == {"type": "INTERRUPT"}
+
+
 @pytest.mark.parametrize(
     "mutate, message",
     [
@@ -42,6 +51,7 @@ def test_exact_cancel_maps_to_the_existing_interrupt_lifecycle():
         (lambda frame: frame["message"].update(id="request-not-notification"), "notification"),
         (lambda frame: frame["message"]["params"].update(sessionId="other"), "another session"),
         (lambda frame: frame["message"]["params"].update(sessionId=7), "string"),
+        (lambda frame: frame["message"]["params"].update(unexpected=True), "fields"),
     ],
 )
 def test_malformed_or_cross_session_cancel_fails_closed(mutate, message):

--- a/tests/unit/test_acp_host_permission.py
+++ b/tests/unit/test_acp_host_permission.py
@@ -203,6 +203,16 @@ def test_wrong_request_or_session_cannot_cross_into_the_mailbox():
         lambda frame: frame["message"]["result"]["outcome"].update(
             optionId="manufactured_allow"
         ),
+        lambda frame: frame["message"].update(
+            error={"code": -32603, "message": "contradictory response"}
+        ),
+        lambda frame: frame["message"].update(unexpected="ignored"),
+        lambda frame: frame["message"]["result"].update(
+            unexpected="ignored"
+        ),
+        lambda frame: frame["message"]["result"]["outcome"].update(
+            unexpected="ignored"
+        ),
         lambda frame: frame["message"].update(jsonrpc="1.0"),
         lambda frame: frame["message"].pop("result"),
     ],
@@ -233,6 +243,21 @@ def test_cancelled_response_is_a_hard_rejection():
     assert io.receive_all() == [
         {"approved": False, "scope": "once", "mode": "reject_hard"}
     ]
+
+
+def test_permission_response_keeps_standard_meta_opaque():
+    io = WebSocketIO()
+    event = approval_event()
+    frame = acp_permission_request_frame(event, SESSION_ID)
+    io.register_permission_request(event, SESSION_ID, frame)
+    response = selected_response("allow_once")
+    response["message"]["result"]["_meta"] = {"vendor": {"hint": True}}
+    response["message"]["result"]["outcome"]["_meta"] = {
+        "vendor": {"hint": True}
+    }
+
+    assert io.resolve_acp_permission(response, SESSION_ID) is True
+    assert io.receive_all() == [{"approved": True, "scope": "once"}]
 
 
 def test_legacy_response_is_bound_to_the_current_request_and_consumed_once():


### PR DESCRIPTION
Closes #948
Related to #838 and #894.

## What changed

- reject ACP permission responses unless their JSON-RPC message contains exactly one success `result` shape;
- reject unknown non-`_meta` fields in the permission result and selected/cancelled outcome;
- reject unknown non-`_meta` fields in `session/cancel` params;
- keep standard ACP `_meta` extension objects opaque and non-authoritative;
- add regression coverage proving malformed owned permission responses are consumed once and become the existing hard rejection.

## Why

The pinned generated ACP Pydantic models ignore unknown object fields by default. Before this change, a malformed Host `ACP_RESPONSE` containing both `result` and `error` could retain an `allow_once` result and reach the permission mailbox as an approval. Unknown fields inside permission outcomes and cancellation params were also silently discarded.

Authority-bearing input should not inherit permissive parser behavior. DD-037 requires malformed permission responses to fail closed, while DD-038 defines an exact generation-scoped cancellation adapter. The strict checks stay local to those two Host inputs rather than forking the official SDK models or restricting unrelated protocol surfaces.

## Impact

Valid ACP v1.19 permission and cancel messages are unchanged. Standard `_meta` remains accepted, but cannot grant authority. Legacy Host events, canonical traces, session persistence, React, O Chat, and the SDK version are unchanged.

## Validation

- red-first reproduction: 5 new cases failed on current `main` while 37 existing focused cases passed;
- focused ACP wire/permission/cancel/mode/gateway matrix: 197 passed;
- all ACP-named unit files: 404 passed;
- official SDK and real stdio subprocess E2E: 9 passed;
- `ruff check` on all changed files: passed;
- `git diff --check`: passed;
- Linus-style simplicity review: no remaining findings;
- Aaron-style ConnectOnion/security review: no remaining findings.

## Review focus

- confirm the pinned v1.19 selected outcome permits `outcome`, `optionId`, and `_meta` while cancelled permits only its schema-defined discriminator;
- confirm invalid owned permission responses continue to be one-shot hard rejection rather than an ignored/retryable request;
- confirm no compatibility surface outside the two authority-bearing adapters is narrowed.

No merge, tag, package publication, or deployment is part of this Draft.
