### PR TITLE
fix: align ACP JSON-RPC IDs

### DIFF
--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -154,14 +154,18 @@ class _StrictNDJSONTransport:
             chunks.append(exc.partial)
             return b"".join(chunks)
 
-    @staticmethod
-    def _request_id(message: Any) -> str | int | None:
+    @classmethod
+    def _request_id(cls, message: Any) -> str | int | None:
         if not isinstance(message, dict):
             return None
         request_id = message.get("id")
-        if isinstance(request_id, bool):
-            return None
-        return request_id if isinstance(request_id, (str, int)) else None
+        return request_id if cls._is_request_id(request_id) else None
+
+    @staticmethod
+    def _is_request_id(value: Any) -> bool:
+        return isinstance(value, str) or (
+            isinstance(value, int) and not isinstance(value, bool)
+        )
 
     @classmethod
     def _is_json_rpc_message(cls, message: Any) -> bool:
@@ -170,13 +174,13 @@ class _StrictNDJSONTransport:
         if "method" in message:
             if not isinstance(message["method"], str):
                 return False
-            if "id" in message and cls._request_id(message) != message.get("id"):
+            if "id" in message and not cls._is_request_id(message["id"]):
                 return False
             params = message.get("params")
             return params is None or isinstance(params, (dict, list))
         if "id" not in message or (("result" in message) == ("error" in message)):
             return False
-        return cls._request_id(message) == message.get("id")
+        return cls._is_request_id(message["id"])
 
 
 def _reject_json_constant(value: str) -> None:

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1581,6 +1581,41 @@ async def test_strict_ndjson_returns_errors_and_keeps_reading():
     assert [item["id"] for item in errors] == [None, None]
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"jsonrpc": "2.0", "id": None, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": None, "result": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32603, "message": "failed"},
+        },
+        {"jsonrpc": "2.0", "id": True, "result": {}},
+        {"jsonrpc": "2.0", "id": 1.5, "result": {}},
+    ],
+)
+def test_strict_ndjson_rejects_unsupported_correlation_ids(message):
+    assert _StrictNDJSONTransport._is_json_rpc_message(message) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"jsonrpc": "2.0", "id": "request-1", "method": "initialize"},
+        {"jsonrpc": "2.0", "id": 1, "result": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": "request-1",
+            "error": {"code": -32603, "message": "failed"},
+        },
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {}},
+    ],
+)
+def test_strict_ndjson_keeps_supported_ids_and_notifications(message):
+    assert _StrictNDJSONTransport._is_json_rpc_message(message) is True
+
+
 @pytest.mark.asyncio
 async def test_strict_ndjson_accepts_a_frame_larger_than_stream_chunk_limit():
     reader = asyncio.StreamReader(limit=64)


### PR DESCRIPTION
Closes #950
Related to #838 and #894.

## What changed

- give the strict stdio transport one explicit ACP JSON-RPC correlation-ID predicate;
- accept only string or integer IDs, excluding booleans;
- reject explicit null, float, boolean, array, and object IDs on inbound requests/responses;
- keep notifications without an `id` valid;
- keep invalid-request error responses able to emit `id: null` when no valid ID can be reflected.

## Why

`_request_id()` previously returned `None` both for an invalid ID and for literal JSON `null`. `_is_json_rpc_message()` compared that result back to the original value, so request, success-response, and error-response frames with `id: null` all passed the strict stdio boundary.

The authenticated WebSocket gateway already requires a non-boolean string/integer ID before `initialize` under DD-045. This makes the stdio correlation contract match it without changing the pinned ACP SDK or session identity.

## Impact

Valid ACP clients are unchanged: the official SDK generates integer request IDs, string IDs remain valid, and notifications still omit `id`. Only malformed inbound correlation IDs are rejected before they can enter SDK connection state. Persistence, Host compatibility carriers, React, and O Chat are unchanged.

## Validation

- red-first reproduction: three null-ID request/response cases failed on current `main`;
- strict transport matrix: 13 passed;
- all ACP-named unit files: 403 passed before the final two existing invalid-ID assertions were added; the focused final matrix remains green;
- official SDK and real stdio subprocess E2E: 9 passed;
- `ruff check`: passed;
- `git diff --check`: passed;
- Linus-style simplicity review: no remaining findings;
- Aaron-style contract/security review: no remaining findings.

## Review focus

- confirm inbound correlation IDs intentionally match the WebSocket string/integer rule;
- confirm absent notification IDs remain distinct from explicit null IDs;
- confirm JSON-RPC error output may still use null when the invalid input supplied no reflectable ID.

No merge, tag, package publication, or deployment is part of this Draft.
