### PR TITLE
fix: reject mixed ACP JSON-RPC envelopes

### DIFF
--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -172,13 +172,23 @@ class _StrictNDJSONTransport:
         if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
             return False
         if "method" in message:
+            # Generated ACP models ignore unknown fields, so reject mixed
+            # request/response envelopes before authority-bearing routing.
+            if not set(message).issubset({"jsonrpc", "id", "method", "params"}):
+                return False
             if not isinstance(message["method"], str):
                 return False
             if "id" in message and not cls._is_request_id(message["id"]):
                 return False
-            params = message.get("params")
-            return params is None or isinstance(params, (dict, list))
-        if "id" not in message or (("result" in message) == ("error" in message)):
+            return "params" not in message or isinstance(
+                message["params"], (dict, list)
+            )
+        has_result = "result" in message
+        has_error = "error" in message
+        if "id" not in message or has_result == has_error:
+            return False
+        expected = {"jsonrpc", "id", "result" if has_result else "error"}
+        if set(message) != expected:
             return False
         return cls._is_request_id(message["id"])
 

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -342,3 +342,49 @@ async def test_acp_subprocess_sets_and_resumes_the_official_mode_state(tmp_path)
         )
         assert resumed["result"]["modes"]["currentModeId"] == ":workspace"
         assert notifications == []
+
+
+@pytest.mark.asyncio
+async def test_acp_subprocess_rejects_a_mixed_envelope_without_changing_mode(
+    tmp_path,
+):
+    state_root = tmp_path / "home"
+    async with _server(state_root) as first:
+        session_id = await _initialize_and_create_session(first, tmp_path)
+        await _send(
+            first,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/set_mode",
+                "params": {
+                    "sessionId": session_id,
+                    "modeId": ":workspace",
+                },
+                "result": {},
+            },
+        )
+
+        rejected = await _read_frame(first)
+        assert rejected["id"] == 3
+        assert rejected["error"]["code"] == -32600
+
+        closed, _ = await _request(
+            first,
+            4,
+            "session/close",
+            {"sessionId": session_id},
+        )
+        assert closed["result"] == {}
+
+    async with _server(state_root) as second:
+        await _initialize(second)
+        resumed, notifications = await _request(
+            second,
+            2,
+            "session/resume",
+            {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
+        )
+
+        assert resumed["result"]["modes"]["currentModeId"] == ":read-only"
+        assert notifications == []

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1602,6 +1602,54 @@ def test_strict_ndjson_rejects_unsupported_correlation_ids(message):
 @pytest.mark.parametrize(
     "message",
     [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/set_mode",
+            "params": {},
+            "result": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/set_mode",
+            "params": {},
+            "error": {"code": -32603, "message": "failed"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/set_mode",
+            "result": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {},
+            "params": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/set_mode",
+            "params": None,
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "session/set_mode",
+            "params": {},
+            "extra": True,
+        },
+    ],
+)
+def test_strict_ndjson_rejects_mixed_request_and_response_envelopes(message):
+    assert _StrictNDJSONTransport._is_json_rpc_message(message) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
         {"jsonrpc": "2.0", "id": "request-1", "method": "initialize"},
         {"jsonrpc": "2.0", "id": 1, "result": {}},
         {


### PR DESCRIPTION
Closes #956
Related: #838, #894

## Problem

The native `co ai --acp` stdio classifier selected request handling whenever `method` existed, even if the same object also contained response-only `result` or `error`. Responses likewise accepted request-only members. A real production-stdio red test proved that a mixed `session/set_mode` + `result` frame was executed and persisted `:workspace` instead of returning Invalid Request.

## Decision

DD-032 assigns raw JSON-RPC framing facts to the transport boundary. Classify exact envelope families there before generated ACP models route them:

- requests/notifications: `jsonrpc`, `method`, optional `id`, optional structured `params`;
- responses: `jsonrpc`, `id`, exactly one of `result` or `error`;
- explicit null params and unknown envelope fields are invalid;
- nested ACP `_meta` remains untouched.

This does not fork SDK models, change persisted sessions, or touch React, O Chat, or the retired standalone TypeScript SDK.

## Red-first evidence

Before the implementation, all six unit vectors were accepted and the production subprocess performed the mixed mode change. After the implementation, the frame receives `-32600`, the server keeps reading, and close/resume proves the mode remained `:read-only`.

## Verification

- focused red/green boundary: 7/7
- ACP unit + Gateway + raw/official-SDK stdio suite: 493/493
- Ruff and diff check
- `uv lock --check`
- wheel build and Twine check
- locked production dependency audit: no known vulnerabilities

No merge, tag, publication, or deployment performed.