### PR TITLE
Require ACP initialization before session methods

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -855,9 +855,14 @@ class ConnectOnionACPAgent:
         self._mcp_connector = mcp_connector
         self._client: Client | None = None
         self._sessions: dict[str, _SessionRuntime] = {}
+        self._initialized = False
 
     def on_connect(self, client: Client) -> None:
         self._client = client
+
+    def _require_initialized(self) -> None:
+        if not self._initialized:
+            raise RequestError(-32000, "Connection is not initialized")
 
     async def initialize(
         self,
@@ -867,11 +872,13 @@ class ConnectOnionACPAgent:
         **_kwargs: Any,
     ) -> InitializeResponse:
         del client_capabilities, client_info
+        if self._initialized:
+            raise RequestError(-32000, "Connection is already initialized")
         # ACP asks an agent to return its latest supported version when it does
         # not support the client's version. The client then decides whether it
         # can continue (v1 initialization, "Version Negotiation").
         selected_version = PROTOCOL_VERSION
-        return InitializeResponse(
+        response = InitializeResponse(
             protocol_version=selected_version,
             agent_capabilities=AgentCapabilities(
                 load_session=False,
@@ -891,6 +898,8 @@ class ConnectOnionACPAgent:
             ),
             auth_methods=[],
         )
+        self._initialized = True
+        return response
 
     async def new_session(
         self,
@@ -899,6 +908,7 @@ class ConnectOnionACPAgent:
         mcp_servers: list[Any] | None = None,
         **_kwargs: Any,
     ) -> NewSessionResponse:
+        self._require_initialized()
         self._validate_session_inputs(additional_directories, mcp_servers)
         project_dir = self._session_cwd(cwd)
         session_id = new_session_id()
@@ -937,6 +947,7 @@ class ConnectOnionACPAgent:
     ) -> ResumeSessionResponse:
         """Resume one persisted session without replaying its transcript."""
 
+        self._require_initialized()
         self._validate_session_inputs(additional_directories, mcp_servers)
         project_dir = self._session_cwd(cwd)
         if session_id in self._sessions:
@@ -982,6 +993,7 @@ class ConnectOnionACPAgent:
     ) -> SetSessionModeResponse:
         """Persist one idle mode change without exceeding launch authority."""
 
+        self._require_initialized()
         runtime = self._sessions.get(session_id)
         if runtime is None:
             raise RequestError(
@@ -1045,6 +1057,7 @@ class ConnectOnionACPAgent:
     ) -> CloseSessionResponse:
         """Close one live runtime and release its exclusive disk lease."""
 
+        self._require_initialized()
         runtime = self._sessions.get(session_id)
         if runtime is None:
             raise RequestError(
@@ -1068,6 +1081,7 @@ class ConnectOnionACPAgent:
         prompt: list[Any],
         **_kwargs: Any,
     ) -> PromptResponse:
+        self._require_initialized()
         runtime = self._sessions.get(session_id)
         if runtime is None:
             raise RequestError(
@@ -1224,6 +1238,8 @@ class ConnectOnionACPAgent:
     async def cancel(self, session_id: str, **_kwargs: Any) -> None:
         """Cooperatively stop the active turn for an ACP session."""
 
+        if not self._initialized:
+            return
         runtime = self._sessions.get(session_id)
         if runtime is not None and runtime.prompt_active.is_set():
             runtime.prompt_cancelled.set()

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -102,6 +102,12 @@ CLI can create a session and drive the real `co ai` coding agent. ACP messages
 are newline-delimited JSON-RPC on stdin/stdout; human-readable diagnostics stay
 on stderr.
 
+The first request on each connection must be `initialize`. Session requests
+sent before initialization fail without constructing an Agent or allocating
+session state, and a second `initialize` request on the same connection is
+rejected. Clients may continue with session requests after either rejection
+only when the connection has already completed one successful initialization.
+
 Use `--acp` when another local process launches `co ai` and owns its stdio.
 Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a
 network endpoint and therefore keeps ConnectOnion authentication and trust in

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -121,6 +121,78 @@ def _isolate_project_lookup(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
+    state_root = tmp_path / "home"
+    async with _server(state_root) as process:
+        rejected, _ = await _request(
+            process,
+            1,
+            "session/new",
+            {"cwd": str(tmp_path), "mcpServers": []},
+        )
+
+        assert rejected["error"] == {
+            "code": -32000,
+            "message": "Connection is not initialized",
+            "data": None,
+        }
+        assert not (state_root / ".co" / "ai" / "sessions").exists()
+
+        await _send(
+            process,
+            {
+                "jsonrpc": "2.0",
+                "method": "session/cancel",
+                "params": {"sessionId": "missing"},
+            },
+        )
+
+        initialized, pre_initialize_output = await _request(
+            process,
+            2,
+            "initialize",
+            {"protocolVersion": 1, "clientCapabilities": {}},
+        )
+        repeated, _ = await _request(
+            process,
+            3,
+            "initialize",
+            {"protocolVersion": 1, "clientCapabilities": {}},
+        )
+        created, _ = await _request(
+            process,
+            4,
+            "session/new",
+            {"cwd": str(tmp_path), "mcpServers": []},
+        )
+        prompted, prompt_notifications = await _request(
+            process,
+            5,
+            "session/prompt",
+            {
+                "sessionId": created["result"]["sessionId"],
+                "prompt": [{"type": "text", "text": "after initialize"}],
+            },
+        )
+
+        assert initialized["result"]["protocolVersion"] == 1
+        assert pre_initialize_output == []
+        assert repeated["error"] == {
+            "code": -32000,
+            "message": "Connection is already initialized",
+            "data": None,
+        }
+        assert created["result"]["sessionId"]
+        assert prompted["result"]["stopReason"] == "end_turn"
+        assert [item["method"] for item in prompt_notifications] == [
+            "session/update"
+        ]
+        assert prompt_notifications[0]["params"]["update"]["content"]["text"] == (
+            "answer: after initialize"
+        )
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_path):
     async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -263,6 +263,67 @@ def _isolate_acp_session_state(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
 
+async def _initialize_agent(agent: ConnectOnionACPAgent) -> None:
+    await agent.initialize(protocol_version=PROTOCOL_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_acp_requires_initialize_before_creating_session(tmp_path):
+    constructed = 0
+
+    def factory(**_kwargs: Any) -> _FakeAgent:
+        nonlocal constructed
+        constructed += 1
+        return _FakeAgent()
+
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=factory,
+    )
+
+    with pytest.raises(RequestError) as exc_info:
+        await acp_agent.new_session(str(tmp_path), mcp_servers=[])
+
+    assert exc_info.value.code == -32000
+    assert "Connection is not initialized" in str(exc_info.value)
+    for operation in (
+        lambda: acp_agent.resume_session("missing", str(tmp_path), mcp_servers=[]),
+        lambda: acp_agent.set_session_mode("missing", ":read-only"),
+        lambda: acp_agent.close_session("missing"),
+        lambda: acp_agent.prompt("missing", [text_block("hello")]),
+    ):
+        with pytest.raises(RequestError, match="Connection is not initialized"):
+            await operation()
+    await acp_agent.cancel("missing")
+    assert constructed == 0
+    assert acp_agent._sessions == {}
+    assert not (tmp_path / "acp-state" / "ai" / "sessions").exists()
+
+
+@pytest.mark.asyncio
+async def test_acp_rejects_repeated_initialize_without_resetting_connection(tmp_path):
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+
+    initialized = await acp_agent.initialize(protocol_version=PROTOCOL_VERSION)
+    with pytest.raises(RequestError) as exc_info:
+        await acp_agent.initialize(protocol_version=PROTOCOL_VERSION)
+    session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
+
+    assert initialized.protocol_version == PROTOCOL_VERSION
+    assert exc_info.value.code == -32000
+    assert "Connection is already initialized" in str(exc_info.value)
+    assert session.session_id in acp_agent._sessions
+
+
 @pytest.mark.asyncio
 async def test_acp_lifecycle_reuses_agent_and_exits_on_eof(tmp_path, capsys):
     created: list[_FakeAgent] = []
@@ -318,7 +379,14 @@ async def test_acp_lifecycle_reuses_agent_and_exits_on_eof(tmp_path, capsys):
 
 @pytest.mark.asyncio
 async def test_acp_reports_its_supported_version_for_any_client_version():
-    acp_agent = ConnectOnionACPAgent(
+    older_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+    newer_agent = ConnectOnionACPAgent(
         model="test",
         max_iterations=2,
         yolo=False,
@@ -326,8 +394,8 @@ async def test_acp_reports_its_supported_version_for_any_client_version():
         agent_factory=lambda **_kwargs: _FakeAgent(),
     )
 
-    older = await acp_agent.initialize(protocol_version=0)
-    newer = await acp_agent.initialize(protocol_version=PROTOCOL_VERSION + 1)
+    older = await older_agent.initialize(protocol_version=0)
+    newer = await newer_agent.initialize(protocol_version=PROTOCOL_VERSION + 1)
 
     assert older.protocol_version == PROTOCOL_VERSION
     assert newer.protocol_version == PROTOCOL_VERSION
@@ -348,6 +416,7 @@ async def test_acp_passes_official_image_and_embedded_file_blocks_to_agent(tmp_p
         input_limits={"max_file_size": 1, "max_files_per_request": 3},
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
     response = await acp_agent.prompt(
@@ -466,6 +535,7 @@ async def test_acp_rejects_unsafe_attachment_blocks_before_turn_mutation(
         yolo_turns=2,
         agent_factory=lambda **_kwargs: fake_agent,
     )
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     runtime = acp_agent._sessions[session.session_id]
     before = deepcopy(runtime.last_good_session)
@@ -491,6 +561,7 @@ async def test_acp_rejects_oversized_or_excess_attachments_before_turn(tmp_path)
             "max_files_per_request": 1,
         },
     )
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     image = ImageContentBlock(
         type="image",
@@ -623,6 +694,7 @@ async def test_acp_real_agent_uses_existing_image_and_safe_file_path(tmp_path):
         agent_factory=lambda **_kwargs: real_agent,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
     response = await acp_agent.prompt(
@@ -698,6 +770,7 @@ async def test_network_acp_stages_files_in_the_authenticated_principal_namespace
         network_workspace=workspace,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     try:
         session = await acp_agent.new_session("/", mcp_servers=[])
 
@@ -775,6 +848,7 @@ async def test_network_acp_rejects_sequential_prompts_at_principal_storage_quota
         input_limits=limits,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     try:
         session = await acp_agent.new_session("/", mcp_servers=[])
 
@@ -849,6 +923,7 @@ async def test_network_acp_releases_upload_quota_before_model_work(tmp_path):
         network_workspace=workspace,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     try:
         session = await acp_agent.new_session("/", mcp_servers=[])
         prompt = acp_agent.prompt(
@@ -1051,6 +1126,7 @@ async def test_acp_failed_real_agent_removes_new_upload_before_snapshot_restore(
         agent_factory=lambda **_kwargs: real_agent,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     runtime = acp_agent._sessions[session.session_id]
     before = deepcopy(runtime.last_good_session)
@@ -1085,6 +1161,7 @@ async def test_acp_rejects_unknown_session():
         agent_factory=lambda **_kwargs: _FakeAgent(),
     )
 
+    await _initialize_agent(acp_agent)
     with pytest.raises(RequestError, match="Session not found"):
         await acp_agent.prompt("missing", [text_block("hello")])
 
@@ -1100,6 +1177,7 @@ async def test_acp_cancel_stops_an_active_prompt(tmp_path):
         agent_factory=lambda **_kwargs: fake_agent,
     )
     acp_agent.on_connect(_RecordingClient())
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
         acp_agent.prompt(session.session_id, [text_block("wait")])
@@ -1134,6 +1212,7 @@ async def test_acp_cancel_while_waiting_for_upload_quota_never_starts_agent(tmp_
         **kwargs,
     )
     contender.on_connect(_RecordingClient())
+    await _initialize_agent(contender)
     (principal_co_dir / "uploads").mkdir(parents=True)
     parsed = holder._parse_prompt(
         [
@@ -1203,6 +1282,7 @@ async def test_acp_close_while_waiting_for_upload_quota_never_starts_agent(tmp_p
         **kwargs,
     )
     contender.on_connect(_RecordingClient())
+    await _initialize_agent(contender)
     (principal_co_dir / "uploads").mkdir(parents=True)
     parsed = holder._parse_prompt(
         [
@@ -1306,6 +1386,7 @@ async def test_acp_errors_do_not_echo_agent_exception_details(tmp_path):
         yolo_turns=2,
         agent_factory=lambda **_kwargs: _FailingAgent(),
     )
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
     with pytest.raises(RequestError) as exc_info:
@@ -1325,6 +1406,7 @@ async def test_acp_rejects_unsupported_session_inputs(tmp_path):
         agent_factory=lambda **_kwargs: _FakeAgent(),
     )
 
+    await _initialize_agent(acp_agent)
     with pytest.raises(RequestError, match="Invalid params"):
         await acp_agent.new_session(
             str(tmp_path),
@@ -1355,6 +1437,7 @@ async def test_network_acp_maps_only_virtual_root_to_host_workspace(tmp_path):
         network_workspace=capture_network_workspace(workspace),
     )
 
+    await _initialize_agent(acp_agent)
     session = await acp_agent.new_session(
         "/",
         mcp_servers=[],
@@ -1385,6 +1468,7 @@ async def test_network_acp_rejects_host_paths_before_agent_construction(tmp_path
         network_workspace=capture_network_workspace(workspace),
     )
 
+    await _initialize_agent(acp_agent)
     for cwd in (str(workspace), "/./", "/tmp"):
         with pytest.raises(RequestError, match="Invalid params") as exc_info:
             await acp_agent.new_session(cwd, mcp_servers=[])
@@ -1432,6 +1516,7 @@ async def test_network_acp_resume_does_not_disclose_saved_host_workspace(tmp_pat
         network_workspace=capture_network_workspace(new_workspace),
     )
 
+    await _initialize_agent(acp_agent)
     with pytest.raises(RequestError, match="Unable to resume session") as exc_info:
         await acp_agent.resume_session(session_id, "/", mcp_servers=[])
 
@@ -1470,6 +1555,7 @@ async def test_network_acp_workspace_does_not_follow_replaced_launch_path(tmp_pa
         network_workspace=workspace,
     )
 
+    await _initialize_agent(acp_agent)
     if hasattr(os, "fchdir"):
         await acp_agent.new_session("/", mcp_servers=[])
         assert observed == ["original"]
@@ -1515,6 +1601,8 @@ async def test_acp_adapters_share_one_process_context_lock(tmp_path):
         agent_factory=second_factory,
     )
 
+    await _initialize_agent(first)
+    await _initialize_agent(second)
     first_task = asyncio.create_task(first.new_session(str(first_dir), mcp_servers=[]))
     await asyncio.wait_for(asyncio.to_thread(first_started.wait), timeout=1)
     second_task = asyncio.create_task(second.new_session(str(second_dir), mcp_servers=[]))

--- a/tests/unit/test_co_ai_acp_approval.py
+++ b/tests/unit/test_co_ai_acp_approval.py
@@ -7,7 +7,7 @@ from collections import deque
 from typing import Any
 
 import pytest
-from acp import RequestError, text_block
+from acp import PROTOCOL_VERSION, RequestError, text_block
 from acp.schema import PermissionOption, RequestPermissionResponse, ToolCallUpdate
 
 from connectonion import Agent
@@ -132,8 +132,8 @@ def _agent(
     )
 
 
-def _server(state_dir, factory) -> ConnectOnionACPAgent:
-    return ConnectOnionACPAgent(
+async def _initialized_server(state_dir, factory) -> ConnectOnionACPAgent:
+    server = ConnectOnionACPAgent(
         model="test",
         max_iterations=4,
         yolo=False,
@@ -141,6 +141,8 @@ def _server(state_dir, factory) -> ConnectOnionACPAgent:
         agent_factory=factory,
         session_co_dir=state_dir,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
+    return server
 
 
 def _project(tmp_path, monkeypatch):
@@ -162,7 +164,7 @@ async def test_allow_once_uses_exact_acp_schema_without_persisting_grant(
     project = _project(tmp_path, monkeypatch)
     executed: list[str] = []
     client = _ApprovalClient(_selected("allow_once"))
-    server = _server(
+    server = await _initialized_server(
         tmp_path / "state",
         lambda **_: _agent(project, executed, ["same-call-id"]),
     )
@@ -212,7 +214,7 @@ async def test_allow_session_commits_once_and_survives_resume(
     state_dir = tmp_path / "state"
     first_executed: list[str] = []
     first_client = _ApprovalClient(_selected("allow_session"))
-    first = _server(
+    first = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, first_executed, ["call-1"]),
     )
@@ -229,7 +231,7 @@ async def test_allow_session_commits_once_and_survives_resume(
 
     resumed_executed: list[str] = []
     resumed_client = _ApprovalClient(RuntimeError("must not ask again"))
-    resumed = _server(
+    resumed = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, resumed_executed, ["call-3"]),
     )
@@ -264,7 +266,7 @@ async def test_cancelled_unknown_and_reject_outcomes_execute_no_tool(
     project = _project(tmp_path, monkeypatch)
     executed: list[str] = []
     client = _ApprovalClient(decision)
-    server = _server(
+    server = await _initialized_server(
         tmp_path / "state",
         lambda **_: _agent(project, executed, ["call-reject"]),
     )
@@ -288,7 +290,7 @@ async def test_permission_transport_failure_rolls_back_without_private_details(
     state_dir = tmp_path / "state"
     executed: list[str] = []
     client = _ApprovalClient(RuntimeError("private transport marker"))
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, executed, ["call-fail"]),
     )
@@ -315,7 +317,7 @@ async def test_session_grant_rolls_back_when_atomic_persistence_fails(
     state_dir = tmp_path / "state"
     executed: list[str] = []
     client = _ApprovalClient(_selected("allow_session"))
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, executed, ["call-save-fail"]),
     )
@@ -347,7 +349,7 @@ async def test_session_grant_rolls_back_when_a_later_acp_update_fails(
     state_dir = tmp_path / "state"
     executed: list[str] = []
     client = _FailAfterSessionGrantClient()
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, executed, ["call-update-fail"]),
     )
@@ -374,7 +376,7 @@ async def test_cancel_while_permission_is_pending_is_bounded_and_fail_closed(
     project = _project(tmp_path, monkeypatch)
     executed: list[str] = []
     client = _BlockingApprovalClient()
-    server = _server(
+    server = await _initialized_server(
         tmp_path / "state",
         lambda **_: _agent(project, executed, ["call-blocked"]),
     )
@@ -402,7 +404,7 @@ async def test_close_while_permission_is_pending_waits_then_releases_lease(
     state_dir = tmp_path / "state"
     executed: list[str] = []
     client = _BlockingApprovalClient()
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, executed, ["call-close"]),
     )
@@ -432,7 +434,7 @@ async def test_eof_cleanup_while_permission_is_pending_releases_lease(
     state_dir = tmp_path / "state"
     executed: list[str] = []
     client = _BlockingApprovalClient()
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _agent(project, executed, ["call-eof"]),
     )
@@ -480,7 +482,7 @@ async def test_identical_tool_ids_in_two_sessions_cannot_cross_decisions(
             return RequestPermissionResponse.model_validate(_selected(option))
 
     client = SessionClient()
-    server = _server(tmp_path / "state", factory)
+    server = await _initialized_server(tmp_path / "state", factory)
     server.on_connect(client)
     first = await server.new_session(str(project), mcp_servers=[])
     second = await server.new_session(str(project), mcp_servers=[])

--- a/tests/unit/test_co_ai_acp_events.py
+++ b/tests/unit/test_co_ai_acp_events.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 from uuid import UUID, uuid4
 
 import pytest
-from acp import RequestError, text_block
+from acp import PROTOCOL_VERSION, RequestError, text_block
 from acp.schema import (
     AgentMessageChunk,
     AgentPlanUpdate,
@@ -281,14 +281,16 @@ def _isolate_acp_session_state(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 
 
-def _server(agent: _ScriptedAgent) -> ConnectOnionACPAgent:
-    return ConnectOnionACPAgent(
+async def _initialized_server(agent: _ScriptedAgent) -> ConnectOnionACPAgent:
+    server = ConnectOnionACPAgent(
         model="test",
         max_iterations=2,
         yolo=False,
         yolo_turns=2,
         agent_factory=lambda **_kwargs: agent,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
+    return server
 
 
 @pytest.mark.asyncio
@@ -336,7 +338,7 @@ async def test_multi_tool_stream_is_ordered_and_prompt_response_is_terminal(tmp_
         return "finished"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -412,6 +414,7 @@ async def test_real_agent_streams_structured_tool_events_through_acp(tmp_path):
         agent_factory=lambda **_kwargs: agent,
     )
     acp_agent.on_connect(client)
+    await acp_agent.initialize(protocol_version=PROTOCOL_VERSION)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
     response = await acp_agent.prompt(
@@ -458,7 +461,7 @@ async def test_prompt_waits_until_the_last_session_update_is_drained(tmp_path):
         return "done"
 
     client = BlockingClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -518,7 +521,7 @@ async def test_parallel_event_detachment_preserves_entry_order(monkeypatch, tmp_
         return "done"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -569,7 +572,7 @@ async def test_terminal_barrier_waits_for_an_event_already_being_detached(
         return "done"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -621,7 +624,7 @@ async def test_slow_client_applies_bounded_backpressure_to_agent_events(tmp_path
         return "done"
 
     client = BlockingClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -677,7 +680,7 @@ async def test_cancelling_slow_client_wakes_backpressured_producer(tmp_path):
         return f"{prompt} answer"
 
     client = BlockingOnceClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     first = asyncio.create_task(
@@ -739,7 +742,7 @@ async def test_protocol_cancel_wakes_backpressured_producer(tmp_path):
         return "cancelled"
 
     client = BlockingClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -775,7 +778,7 @@ async def test_cancel_after_natural_terminal_keeps_final_assistant(tmp_path):
         return "completed answer"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -846,7 +849,7 @@ async def test_cancelled_generation_bounds_forged_completion_events(tmp_path):
         return "cancelled"
 
     client = BlockingClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -892,7 +895,7 @@ async def test_forged_terminal_cannot_override_canonical_turn_outcome(tmp_path):
         return "cancelled"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -947,7 +950,7 @@ async def test_slow_detachment_does_not_block_event_loop_retirement(
         })
         return "done"
 
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(_Client())
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     prompt_task = asyncio.create_task(
@@ -1002,6 +1005,7 @@ async def test_different_sessions_keep_their_event_streams_isolated(tmp_path):
     )
     client = _Client()
     acp_agent.on_connect(client)
+    await acp_agent.initialize(protocol_version=PROTOCOL_VERSION)
     first = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     second = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -1044,7 +1048,7 @@ async def test_same_session_rejects_an_overlapping_prompt(tmp_path):
         })
         return "cancelled"
 
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(_Client())
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     active = asyncio.create_task(
@@ -1086,7 +1090,7 @@ async def test_cancelling_prompt_task_retires_worker_and_allows_next_turn(tmp_pa
         return "second answer"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     first = asyncio.create_task(
@@ -1126,7 +1130,7 @@ async def test_max_iterations_returns_the_protocol_stop_reason(tmp_path):
         return "Task incomplete: iteration limit reached."
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
@@ -1182,7 +1186,7 @@ async def test_cancelled_generation_drops_late_events_from_the_next_turn(tmp_pat
         return "second answer"
 
     client = _Client()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
     first = asyncio.create_task(
@@ -1248,7 +1252,7 @@ async def test_session_update_failure_interrupts_and_retires_the_generation(tmp_
         return "recovered"
 
     client = FailingClient()
-    acp_agent = _server(_ScriptedAgent(script))
+    acp_agent = await _initialized_server(_ScriptedAgent(script))
     acp_agent.on_connect(client)
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 

--- a/tests/unit/test_co_ai_acp_mcp.py
+++ b/tests/unit/test_co_ai_acp_mcp.py
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from acp import RequestError, text_block
+from acp import PROTOCOL_VERSION, RequestError, text_block
 from acp.schema import (
     EnvVariable,
     McpServerStdio,
@@ -132,6 +132,7 @@ async def test_mcp_is_rejected_before_connect_without_launch_authority(tmp_path)
         mcp_connector=connector,
     )
 
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     with pytest.raises(RequestError, match="Invalid params"):
         await server.new_session(str(tmp_path), mcp_servers=[_server_spec()])
 
@@ -161,6 +162,7 @@ async def test_authorized_mcp_tools_are_session_scoped_and_closed(tmp_path):
         mcp_connector=connector,
     )
 
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     session = await server.new_session(str(tmp_path), mcp_servers=[_server_spec()])
 
     assert connection["servers"] == [_server_spec()]
@@ -194,6 +196,7 @@ async def test_runtime_construction_failure_closes_connected_mcp_pool(tmp_path):
         mcp_connector=connector,
     )
 
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     with pytest.raises(RequestError, match="Unable to create"):
         await server.new_session(str(tmp_path), mcp_servers=[_server_spec()])
 
@@ -220,6 +223,7 @@ async def test_existing_tool_name_collision_closes_connected_mcp_pool(tmp_path):
         mcp_connector=connector,
     )
 
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     with pytest.raises(RequestError, match="Unable to create"):
         await server.new_session(str(tmp_path), mcp_servers=[_server_spec()])
 
@@ -236,6 +240,7 @@ async def test_locked_resume_is_rejected_before_connecting_mcp(tmp_path):
         agent_factory=lambda **_kwargs: _Agent(),
         session_co_dir=tmp_path / "state",
     )
+    await owner.initialize(protocol_version=PROTOCOL_VERSION)
     created = await owner.new_session(str(tmp_path), mcp_servers=[])
     connected = False
 
@@ -255,6 +260,7 @@ async def test_locked_resume_is_rejected_before_connecting_mcp(tmp_path):
         mcp_connector=connector,
     )
 
+    await contender.initialize(protocol_version=PROTOCOL_VERSION)
     with pytest.raises(RequestError, match="Unable to resume"):
         await contender.resume_session(
             created.session_id,
@@ -560,6 +566,7 @@ async def test_acp_session_teardown_reaps_real_mcp_process(tmp_path, cleanup):
         session_co_dir=tmp_path / "state",
         allow_mcp=True,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     created = await server.new_session(str(tmp_path), mcp_servers=[spec])
     pid = int(pid_file.read_text(encoding="utf-8"))
 
@@ -626,6 +633,7 @@ async def test_resume_reconnects_mcp_without_persisting_launch_data(tmp_path):
         session_co_dir=tmp_path / "state",
         allow_mcp=True,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     first = await server.new_session(str(tmp_path), mcp_servers=[spec])
     first_runtime = server._sessions[first.session_id]
     first_tool = next(
@@ -754,6 +762,7 @@ async def test_real_mcp_side_effect_waits_for_acp_permission(
         allow_mcp=True,
     )
     server.on_connect(client)  # type: ignore[arg-type]
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     session = await server.new_session(str(project), mcp_servers=[spec])
 
     response = await server.prompt(session.session_id, [text_block("write")])
@@ -843,6 +852,7 @@ async def test_mcp_session_approval_is_not_reused_after_resume(
     )
     first_client = ApprovalClient("allow_session")
     server.on_connect(first_client)  # type: ignore[arg-type]
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     first_spec = McpServerStdio(
         name="context",
         command=sys.executable,
@@ -958,6 +968,7 @@ async def test_operator_mcp_permission_remains_configured_after_resume(
         allow_mcp=True,
     )
     server.on_connect(Client())  # type: ignore[arg-type]
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     created = await server.new_session(str(project), mcp_servers=[spec])
 
     first_response = await server.prompt(created.session_id, [text_block("write")])
@@ -1029,6 +1040,7 @@ async def test_failed_restore_reaps_mcp_process_before_releasing_session(
         allow_mcp=True,
     )
     server.on_connect(Client())  # type: ignore[arg-type]
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     created = await server.new_session(str(project), mcp_servers=[spec])
     runtime = server._sessions[created.session_id]
     pid = int(pid_file.read_text(encoding="utf-8"))

--- a/tests/unit/test_co_ai_acp_modes.py
+++ b/tests/unit/test_co_ai_acp_modes.py
@@ -9,7 +9,7 @@ import time
 from typing import Any
 
 import pytest
-from acp import RequestError, text_block
+from acp import PROTOCOL_VERSION, RequestError, text_block
 from acp.schema import CurrentModeUpdate, SetSessionModeResponse
 
 from connectonion import Agent
@@ -115,14 +115,14 @@ class _ModeAgent:
         return prompt
 
 
-def _server(
+async def _initialized_server(
     state_dir,
     factory,
     *,
     yolo: bool = False,
     yolo_turns: int = 7,
 ) -> ConnectOnionACPAgent:
-    return ConnectOnionACPAgent(
+    server = ConnectOnionACPAgent(
         model="test",
         max_iterations=2,
         yolo=yolo,
@@ -130,6 +130,8 @@ def _server(
         agent_factory=factory,
         session_co_dir=state_dir,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
+    return server
 
 
 def _project(tmp_path, monkeypatch):
@@ -155,7 +157,7 @@ async def test_new_default_session_returns_exact_modes_and_persists_default(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _ModeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
 
     created = await server.new_session(str(project), mcp_servers=[])
 
@@ -189,7 +191,7 @@ async def test_yolo_launch_advertises_and_persists_bounded_full_access(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _ModeAgent(),
         yolo=True,
@@ -219,7 +221,7 @@ async def test_idle_auto_change_commits_memory_disk_and_resume(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    first = _server(state_dir, lambda **_: _ModeAgent())
+    first = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     created = await first.new_session(str(project), mcp_servers=[])
 
     changed = await first.set_session_mode(created.session_id, ":workspace")
@@ -232,7 +234,7 @@ async def test_idle_auto_change_commits_memory_disk_and_resume(
     assert stored["mode"] == ":workspace"
     await first.close_session(created.session_id)
 
-    resumed_server = _server(state_dir, lambda **_: _ModeAgent())
+    resumed_server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     resumed = await resumed_server.resume_session(
         created.session_id,
         str(project),
@@ -249,7 +251,7 @@ async def test_unknown_and_unauthorized_full_access_do_not_mutate_session(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _ModeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     created = await server.new_session(str(project), mcp_servers=[])
 
     for mode in ("future", ":danger-full-access"):
@@ -270,7 +272,7 @@ async def test_authorized_full_access_upgrade_and_downgrade_clean_bypass_state(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _ModeAgent(),
         yolo=True,
@@ -334,7 +336,7 @@ async def test_auto_mode_drives_the_existing_tool_approval_policy(
             co_dir=project / ".co",
         )
 
-    server = _server(state_dir, factory)
+    server = await _initialized_server(state_dir, factory)
     server.on_connect(_Client())
     created = await server.new_session(str(project), mcp_servers=[])
     await server.set_session_mode(created.session_id, ":workspace")
@@ -386,7 +388,7 @@ async def test_default_downgrade_disarms_real_agent_full_access_activation(
         return agent
 
     client = _Client()
-    server = _server(state_dir, factory, yolo=True, yolo_turns=7)
+    server = await _initialized_server(state_dir, factory, yolo=True, yolo_turns=7)
     server.on_connect(client)
     created = await server.new_session(str(project), mcp_servers=[])
     runtime = server._sessions[created.session_id]
@@ -411,7 +413,7 @@ async def test_busy_prompt_rejects_mode_change_without_policy_race(
 ):
     project = _project(tmp_path, monkeypatch)
     agent = _ModeAgent(block=True)
-    server = _server(tmp_path / "state", lambda **_: agent)
+    server = await _initialized_server(tmp_path / "state", lambda **_: agent)
     server.on_connect(_Client())
     created = await server.new_session(str(project), mcp_servers=[])
     prompting = asyncio.create_task(
@@ -437,7 +439,7 @@ async def test_persistence_failure_leaves_mode_unchanged_without_private_details
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _ModeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     created = await server.new_session(str(project), mcp_servers=[])
 
     def fail_save(*_args: Any, **_kwargs: Any) -> None:
@@ -465,7 +467,7 @@ async def test_internal_mode_update_is_published_only_after_commit(
     state_dir = tmp_path / "state"
     agent = _ModeAgent(internal_mode=":workspace")
     client = _Client()
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(client)
     created = await server.new_session(str(project), mcp_servers=[])
 
@@ -491,7 +493,7 @@ async def test_failed_prompt_commit_does_not_publish_internal_mode(
     state_dir = tmp_path / "state"
     agent = _ModeAgent(internal_mode=":workspace")
     client = _Client()
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(client)
     created = await server.new_session(str(project), mcp_servers=[])
 
@@ -518,7 +520,7 @@ async def test_mode_notification_failure_cannot_roll_back_durable_commit(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _ModeAgent(internal_mode=":workspace")
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client(fail_mode_update=True))
     created = await server.new_session(str(project), mcp_servers=[])
     runtime = server._sessions[created.session_id]
@@ -546,7 +548,7 @@ async def test_cancelled_mode_notification_quarantines_committed_runtime(
     state_dir = tmp_path / "state"
     agent = _ModeAgent(internal_mode=":workspace")
     client = _BlockingModeClient()
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(client)
     created = await server.new_session(str(project), mcp_servers=[])
     prompting = asyncio.create_task(
@@ -574,7 +576,7 @@ async def test_cancelled_mode_request_settles_atomic_commit(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _ModeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     created = await server.new_session(str(project), mcp_servers=[])
     real_save = acp_server.save_snapshot
     started = threading.Event()
@@ -608,7 +610,7 @@ async def test_close_waits_for_mode_commit_then_releases_lease(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _ModeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _ModeAgent())
     created = await server.new_session(str(project), mcp_servers=[])
     real_save = acp_server.save_snapshot
     started = threading.Event()
@@ -656,7 +658,7 @@ async def test_resume_preserves_committed_full_access_budget_without_reset(
         "skip_tool_approval": True,
     }
     save_snapshot(state_dir, saved, {}, cwd=project)
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _ModeAgent(),
         yolo=True,
@@ -691,7 +693,7 @@ async def test_resume_rejects_full_access_budget_above_current_launch_ceiling(
         "skip_tool_approval": True,
     }
     save_snapshot(state_dir, saved, {}, cwd=project)
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _ModeAgent(),
         yolo=True,
@@ -742,7 +744,7 @@ async def test_resume_rejects_unknown_or_over_authorized_mode_state(
         **mode_state,
     }
     save_snapshot(state_dir, saved, {}, cwd=project)
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: _ModeAgent(),
         yolo=yolo,

--- a/tests/unit/test_co_ai_acp_resume.py
+++ b/tests/unit/test_co_ai_acp_resume.py
@@ -12,7 +12,7 @@ from typing import Any
 from uuid import UUID
 
 import pytest
-from acp import RequestError, text_block
+from acp import PROTOCOL_VERSION, RequestError, text_block
 from acp.schema import CloseSessionResponse, ResumeSessionResponse
 
 from connectonion.cli.co_ai import acp_server
@@ -152,11 +152,11 @@ class _GateAgent(_PersistentFakeAgent):
         return super().input(prompt, session=session)
 
 
-def _server(
+async def _initialized_server(
     state_dir,
     factory,
 ) -> ConnectOnionACPAgent:
-    return ConnectOnionACPAgent(
+    server = ConnectOnionACPAgent(
         model="test",
         max_iterations=2,
         yolo=False,
@@ -164,9 +164,11 @@ def _server(
         agent_factory=factory,
         session_co_dir=state_dir,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
+    return server
 
 
-def _network_server(state_dir, project, factory, **limits):
+async def _initialized_network_server(state_dir, project, factory, **limits):
     workspace = capture_network_workspace(project)
     server = ConnectOnionACPAgent(
         model="test",
@@ -178,6 +180,7 @@ def _network_server(state_dir, project, factory, **limits):
         network_workspace=workspace,
         input_limits=limits,
     )
+    await server.initialize(protocol_version=PROTOCOL_VERSION)
     return server, workspace
 
 
@@ -227,7 +230,14 @@ def test_session_lease_rejects_a_symlink_lock_without_touching_target(tmp_path):
 
 @pytest.mark.asyncio
 async def test_initialize_advertises_resume_and_close_but_not_load(tmp_path):
-    server = _server(tmp_path / "state", lambda **_: _PersistentFakeAgent())
+    server = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_: _PersistentFakeAgent(),
+        session_co_dir=tmp_path / "state",
+    )
 
     initialized = await server.initialize(protocol_version=1)
 
@@ -244,7 +254,7 @@ async def test_new_session_persists_canonical_snapshot_and_holds_lease(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
 
     created = await server.new_session(str(project), mcp_servers=[])
 
@@ -293,7 +303,7 @@ async def test_resume_restores_session_and_tool_state_without_replay(
         created_with.append(kwargs)
         return agent
 
-    server = _server(state_dir, factory)
+    server = await _initialized_server(state_dir, factory)
     client = _Client()
     server.on_connect(client)
 
@@ -324,8 +334,8 @@ async def test_runtime_lease_blocks_a_second_server_until_close(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    owner = _server(state_dir, lambda **_: _PersistentFakeAgent())
-    contender = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    owner = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
+    contender = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
     session = await owner.new_session(str(project), mcp_servers=[])
 
     with pytest.raises(RequestError, match="Unable to resume session"):
@@ -347,13 +357,13 @@ async def test_network_session_count_quota_is_shared_across_connections(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
-    first, first_workspace = _network_server(
+    first, first_workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
         max_acp_sessions=1,
     )
-    second, second_workspace = _network_server(
+    second, second_workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
@@ -382,13 +392,13 @@ async def test_concurrent_network_admission_fills_last_slot_once(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
-    first, first_workspace = _network_server(
+    first, first_workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
         max_acp_sessions=1,
     )
-    second, second_workspace = _network_server(
+    second, second_workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
@@ -421,7 +431,7 @@ async def test_cancelled_network_admission_removes_provisional_lease(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
-    server, workspace = _network_server(
+    server, workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
@@ -462,7 +472,7 @@ async def test_network_prompt_snapshot_quota_rolls_back_disk_and_runtime(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
     agent = _PersistentFakeAgent()
-    server, workspace = _network_server(
+    server, workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: agent,
@@ -498,7 +508,7 @@ async def test_network_unknown_resume_does_not_create_a_durable_lock_file(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
-    server, workspace = _network_server(
+    server, workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
@@ -520,7 +530,7 @@ async def test_cancelled_network_new_session_removes_unpublished_snapshot_and_le
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "principal"
-    server, workspace = _network_server(
+    server, workspace = await _initialized_network_server(
         state_dir,
         project,
         lambda **_: _PersistentFakeAgent(),
@@ -578,7 +588,7 @@ async def test_resume_rejects_wrong_cwd_before_agent_construction(
         "turn": 0,
     })
     constructed = []
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: constructed.append(True) or _PersistentFakeAgent(),
     )
@@ -628,7 +638,7 @@ async def test_resume_rejects_unusable_snapshots_before_agent_construction(
             encoding="utf-8",
         )
     constructed = []
-    server = _server(
+    server = await _initialized_server(
         state_dir,
         lambda **_: constructed.append(True) or _PersistentFakeAgent(),
     )
@@ -658,7 +668,7 @@ async def test_cancelled_runtime_construction_settles_and_releases_lease(
             "trace": [],
             "turn": 0,
         })
-    server = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    server = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
     real_open = server._open_session_runtime
     started = threading.Event()
     release = threading.Event()
@@ -699,7 +709,7 @@ async def test_successful_turns_commit_in_order(tmp_path, monkeypatch):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _PersistentFakeAgent(["natural", "max_iterations"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
 
@@ -735,7 +745,7 @@ async def test_unsuccessful_turn_rolls_back_disk_and_runtime(
     state_dir = tmp_path / "state"
     action = "natural" if failure == "update" else failure
     agent = _PersistentFakeAgent([action, "natural"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     client = _Client(fail_updates=failure == "update")
     server.on_connect(client)
     session = await server.new_session(str(project), mcp_servers=[])
@@ -774,7 +784,7 @@ async def test_persistence_failure_restores_last_good_state(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _PersistentFakeAgent(["natural"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     before, _ = load_snapshot(state_dir, session.session_id)
@@ -802,7 +812,7 @@ async def test_atomic_replace_is_the_last_fallible_commit_step(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _PersistentFakeAgent(["natural"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     real_save = acp_server.save_snapshot
@@ -840,7 +850,7 @@ async def test_commit_uses_explicit_cwd_without_a_fallible_context_exit(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _PersistentFakeAgent()
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     session = await server.new_session(str(project), mcp_servers=[])
     runtime = server._sessions[session.session_id]
     runtime.agent.current_session = copy.deepcopy(runtime.last_good_session)
@@ -879,7 +889,9 @@ async def test_failed_rollback_quarantines_runtime_and_releases_lease(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _PersistentFakeAgent(["natural"]))
+    server = await _initialized_server(
+        state_dir, lambda **_: _PersistentFakeAgent(["natural"])
+    )
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
 
@@ -908,7 +920,7 @@ async def test_close_interrupts_active_prompt_then_releases_ownership(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _PersistentFakeAgent(["block"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     prompt = asyncio.create_task(
@@ -934,7 +946,7 @@ async def test_repeated_prompt_cancellation_cannot_release_a_live_worker(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _GateAgent(["natural"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     before, _ = load_snapshot(state_dir, session.session_id)
@@ -973,7 +985,7 @@ async def test_cancelled_close_still_finishes_before_releasing_ownership(
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
     agent = _GateAgent(["block"])
-    server = _server(state_dir, lambda **_: agent)
+    server = await _initialized_server(state_dir, lambda **_: agent)
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     prompting = asyncio.create_task(
@@ -1006,8 +1018,10 @@ async def test_cancelled_commit_and_eof_wait_for_the_atomic_writer(
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
-    server = _server(state_dir, lambda **_: _PersistentFakeAgent(["natural"]))
-    contender = _server(state_dir, lambda **_: _PersistentFakeAgent())
+    server = await _initialized_server(
+        state_dir, lambda **_: _PersistentFakeAgent(["natural"])
+    )
+    contender = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
     server.on_connect(_Client())
     session = await server.new_session(str(project), mcp_servers=[])
     real_save = acp_server.save_snapshot


### PR DESCRIPTION
## Summary

- require one successful ACP `initialize` before any session request
- reject a second `initialize` without changing the negotiated connection
- keep pre-initialization `session/cancel` side-effect free and silent
- document the lifecycle and make direct adapter tests perform a real handshake

## Why and design

ACP v1 requires initialization before session creation. The previous production stdio adapter allowed a raw client to allocate an Agent, lease, and durable snapshot before negotiating protocol version and capabilities.

The fix keeps one connection-local boolean in `ConnectOnionACPAgent`. Session entry points check it before validation, construction, leases, or snapshots. `initialize` has no suspension point, so the state transition is atomic in the adapter event loop. Framing remains in `_StrictNDJSONTransport`; session ownership remains under DD-029. This follows DD-032's typed-client plus raw-subprocess evidence rule. The design alternatives were discussed in #958 before implementation.

## Exact-head verification (`a61aef5d`)

- focused lifecycle tests: **3 passed**
- modified adapter + raw stdio suite: **227 passed**
- complete ACP typed SDK/raw stdio/Gateway suite: **496 passed**
- independent Codex commit review: **no findings**, and it reran **227 passed**
- Linus-style simplicity review: **no findings**; production delta is one bit, one guard, and one check per entry point
- Ruff: passed
- `uv lock --check`: passed
- exact frozen production-lock audit: no known vulnerabilities
- wheel + sdist build and `twine check`: passed
- `git diff --check`: passed

The raw production subprocess proves correlated rejection without Agent/session allocation, silent pre-init cancel, successful later initialize/new/prompt, and repeated-initialize rejection without disrupting the valid connection.

Closes #958

Related: #838, #894