### PR TITLE
fix: reject mixed ACP WebSocket envelopes

### DIFF
--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -12,6 +12,12 @@ from typing import Any
 from acp import RequestError, stdio_streams
 from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
 
+from ...core.acp_jsonrpc import (
+    acp_request_id,
+    is_acp_json_rpc_message,
+    is_acp_request_id,
+)
+
 
 class _BoundStdoutWriter:
     """Windows writer bound to original stdout with blocking write-all drain."""
@@ -156,41 +162,15 @@ class _StrictNDJSONTransport:
 
     @classmethod
     def _request_id(cls, message: Any) -> str | int | None:
-        if not isinstance(message, dict):
-            return None
-        request_id = message.get("id")
-        return request_id if cls._is_request_id(request_id) else None
+        return acp_request_id(message)
 
     @staticmethod
     def _is_request_id(value: Any) -> bool:
-        return isinstance(value, str) or (
-            isinstance(value, int) and not isinstance(value, bool)
-        )
+        return is_acp_request_id(value)
 
     @classmethod
     def _is_json_rpc_message(cls, message: Any) -> bool:
-        if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
-            return False
-        if "method" in message:
-            # Generated ACP models ignore unknown fields, so reject mixed
-            # request/response envelopes before authority-bearing routing.
-            if not set(message).issubset({"jsonrpc", "id", "method", "params"}):
-                return False
-            if not isinstance(message["method"], str):
-                return False
-            if "id" in message and not cls._is_request_id(message["id"]):
-                return False
-            return "params" not in message or isinstance(
-                message["params"], (dict, list)
-            )
-        has_result = "result" in message
-        has_error = "error" in message
-        if "id" not in message or has_result == has_error:
-            return False
-        expected = {"jsonrpc", "id", "result" if has_result else "error"}
-        if set(message) != expected:
-            return False
-        return cls._is_request_id(message["id"])
+        return is_acp_json_rpc_message(message)
 
 
 def _reject_json_constant(value: str) -> None:

--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -1,0 +1,47 @@
+"""Exact JSON-RPC envelope rules shared by native ACP transports.
+
+Method-specific ACP schemas remain owned by the pinned SDK. This module only
+keeps stdio and WebSocket from disagreeing about request, notification, and
+response envelope families before those schemas run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_acp_request_id(value: Any) -> bool:
+    """Return whether value is a supported ACP correlation ID."""
+
+    return isinstance(value, str) or (isinstance(value, int) and not isinstance(value, bool))
+
+
+def acp_request_id(message: Any) -> str | int | None:
+    """Return a reflectable correlation ID from an arbitrary message."""
+
+    if not isinstance(message, dict):
+        return None
+    request_id = message.get("id")
+    return request_id if is_acp_request_id(request_id) else None
+
+
+def is_acp_json_rpc_message(message: Any) -> bool:
+    """Validate one exact JSON-RPC envelope family, not method semantics."""
+
+    if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+        return False
+    if "method" in message:
+        if not set(message).issubset({"jsonrpc", "id", "method", "params"}):
+            return False
+        if not isinstance(message["method"], str):
+            return False
+        if "id" in message and not is_acp_request_id(message["id"]):
+            return False
+        return "params" not in message or isinstance(message["params"], (dict, list))
+
+    has_result = "result" in message
+    has_error = "error" in message
+    if "id" not in message or has_result == has_error:
+        return False
+    expected = {"jsonrpc", "id", "result" if has_result else "error"}
+    return set(message) == expected and is_acp_request_id(message["id"])

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -27,11 +27,16 @@ from dataclasses import dataclass, replace
 from typing import Any, Callable, Iterable
 from urllib.parse import urlsplit
 
-from acp import PROTOCOL_VERSION
+from acp import PROTOCOL_VERSION, RequestError
 from acp.agent.connection import AgentSideConnection
 from acp.schema import InitializeRequest
 from pydantic import ValidationError
 
+from ...core.acp_jsonrpc import (
+    acp_request_id,
+    is_acp_json_rpc_message,
+    is_acp_request_id,
+)
 from .auth import _authenticate_signed, request_from_http_headers
 from .replay import ReplayProtectionError
 
@@ -253,6 +258,15 @@ class _ACPTransport:
     async def feed(self, message: dict[str, Any]) -> None:
         if self._closed:
             raise ConnectionError("ACP WebSocket transport is closed")
+        if not is_acp_json_rpc_message(message):
+            await self.send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": acp_request_id(message),
+                    "error": RequestError.invalid_request().to_error_obj(),
+                }
+            )
+            return
         await self._to_agent.put(message)
 
     async def next_outgoing(self) -> dict[str, Any] | None:
@@ -963,10 +977,10 @@ class AuthenticatedACPApp:
     def _is_initialize_request(payload: dict[str, Any]) -> bool:
         request_id = payload.get("id")
         envelope_valid = (
-            payload.get("jsonrpc") == "2.0"
+            is_acp_json_rpc_message(payload)
             and payload.get("method") == "initialize"
             and isinstance(payload.get("params"), dict)
-            and (isinstance(request_id, str) or (isinstance(request_id, int) and not isinstance(request_id, bool)))
+            and is_acp_request_id(request_id)
         )
         if not envelope_valid:
             return False

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -113,6 +113,11 @@ Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a
 network endpoint and therefore keeps ConnectOnion authentication and trust in
 front of ACP initialization.
 
+The stdio and authenticated WebSocket entry points share exact JSON-RPC
+envelope validation. Mixed request/response envelopes are rejected before ACP
+routing, while method data and extensions such as `_meta` remain validated by
+the pinned official ACP SDK.
+
 Each ACP session owns one in-memory `co ai` Agent, so later prompts in that
 session reuse its conversation and tool state. The working directory supplied
 by the client must be an existing absolute directory. Additional workspace

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -61,6 +61,16 @@ coding Agent is constructed. The upgrade response
 carries an `Acp-Connection-Id`; it and every ACP session ID are routing values,
 never credentials.
 
+Native stdio and WebSocket transports apply the same exact JSON-RPC envelope
+classifier before SDK routing. A message cannot be both a request and a
+response, and response envelopes cannot contain request members. Once a valid
+first `initialize` frame is admitted, an invalid later envelope receives
+JSON-RPC `-32600` through the existing bounded outbound queue and is never
+delivered to the Agent. Responses remain correlated by ID rather than arrival
+order. The pinned SDK continues to own method parameters, results, and
+extensions such as `_meta`; envelope validation does not replace ACP schema
+validation.
+
 ### Browsers exchange a signed request for a one-use ticket
 
 Browser JavaScript cannot add `X-Co-*` headers to a WebSocket upgrade. It first
@@ -147,6 +157,8 @@ provenance role after #898 decides it.
   rate-limited, and insecure non-loopback admissions fail before Agent creation.
 - Binary frames are ignored as required by the upstream RFD unless they exceed
   the transport limit. Malformed text and oversized frames close the connection.
+  Syntactically valid JSON with a mixed or otherwise invalid JSON-RPC envelope
+  receives `-32600` after first-frame admission and is not routed to the Agent.
   Each direction has a bounded eight-message queue and applies backpressure
   rather than dropping protocol messages.
 - `initialize` has a bounded deadline. Disconnect and Host shutdown cancel

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -928,7 +928,11 @@ async def test_remote_transport_keeps_resume_route_enabled():
         expected_sends=2,
     )
 
-    responses = [json.loads(item["text"]) for item in sent if item["type"] == "websocket.send"]
+    responses = [
+        json.loads(item["text"])
+        for item in sent
+        if item["type"] == "websocket.send"
+    ]
     assert [response["id"] for response in responses] == [1, 2]
     assert responses[1]["result"] == {}
     assert agents[0][1].resumed == ("saved-session", "/tmp")
@@ -969,6 +973,11 @@ async def test_first_frame_must_initialize_before_agent_creation():
             "method": "initialize",
             "params": {"protocolVersion": "not-an-integer"},
         },
+        {**_initialize(), "result": {"foreign": True}},
+        {
+            **_initialize(),
+            "error": {"code": -32000, "message": "foreign"},
+        },
     ],
 )
 async def test_malformed_initialize_never_creates_an_agent(first):
@@ -985,6 +994,62 @@ async def test_malformed_initialize_never_creates_an_agent(first):
     assert sent[-1]["type"] == "websocket.close"
     assert sent[-1]["code"] == 4400
     assert agents == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mixed",
+    [
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/resume",
+            "params": {"sessionId": "saved-session", "cwd": "/tmp"},
+            "result": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/resume",
+            "params": {"sessionId": "saved-session", "cwd": "/tmp"},
+            "error": {"code": -32000, "message": "foreign"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/resume",
+            "result": {},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {},
+            "params": {},
+        },
+    ],
+)
+async def test_mixed_post_initialize_envelope_has_no_side_effect(mixed):
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[_initialize(), mixed],
+        expected_sends=2,
+    )
+
+    responses = [json.loads(item["text"]) for item in sent if item["type"] == "websocket.send"]
+    initialized = next(item for item in responses if item["id"] == 1)
+    rejected = next(item for item in responses if item["id"] == mixed["id"])
+    assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert rejected["error"]["code"] == -32600
+    assert not hasattr(agents[0][1], "resumed")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- share one exact JSON-RPC envelope classifier between ACP stdio and native WebSocket transports
- reject mixed request/response envelopes before SDK routing
- return `-32600` through the existing bounded WebSocket outbound queue after first-frame admission
- keep ACP method schemas and `_meta` extensions owned by the pinned official SDK

## Security behavior

Before this change, generated SDK models could ignore foreign envelope members on the native WebSocket path. A mixed `session/resume` request could therefore execute even when it also carried a response `error` or `result` member. Mixed `initialize` frames could construct an Agent.

After this change:

- a mixed first `initialize` frame closes with `4400` before Agent construction
- a mixed later envelope returns JSON-RPC `-32600`
- the mixed message is never delivered to `AgentSideConnection`
- error responses use the same bounded queue and backpressure as normal ACP output
- valid responses, notifications, method payloads, and SDK-owned `_meta` remain supported

## Design

This follows DD-032's rule that raw framing owns facts hidden by generated SDK models and extends DD-045 so stdio and WebSocket cannot drift again. The shared module validates envelope families only; it intentionally does not duplicate ACP method schemas.

## Verification

- red-first reproduction: 6 focused cases failed before implementation, then passed
- `143 passed`: full Gateway, stdio, and official-SDK ACP suites
- original end-to-end reproduction now reports no Agent for mixed initialize and no resume side effect for mixed resume
- Ruff lint passed on every changed Python file
- `uv lock --check` passed
- locked production dependency audit: no known vulnerabilities
- wheel and sdist built as `1.7.0a1`; Twine checks passed
- local Linus-style simplicity/security review completed with no blocking findings
- external-model review was not run because the environment's data-egress policy rejected sending the unpublished security diff

## Scope

No merge, release, tag, React/O Chat change, or retired TypeScript SDK change is included.

Closes #960
Related to #838 and #894
