### PR TITLE
fix: preserve ACP error code semantics

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -101,6 +101,7 @@ PermissionRequester = Callable[
     Awaitable[RequestPermissionResponse],
 ]
 ACP_EVENT_BUFFER_SIZE = 64
+ACP_SESSION_CONFLICT_ERROR_CODE = -32001
 logger = logging.getLogger(__name__)
 
 _UPLOAD_URI_SCHEME = "connectonion-upload"
@@ -862,7 +863,9 @@ class ConnectOnionACPAgent:
 
     def _require_initialized(self) -> None:
         if not self._initialized:
-            raise RequestError(-32000, "Connection is not initialized")
+            raise RequestError.invalid_request(
+                {"details": "Connection is not initialized"}
+            )
 
     async def initialize(
         self,
@@ -873,7 +876,9 @@ class ConnectOnionACPAgent:
     ) -> InitializeResponse:
         del client_capabilities, client_info
         if self._initialized:
-            raise RequestError(-32000, "Connection is already initialized")
+            raise RequestError.invalid_request(
+                {"details": "Connection is already initialized"}
+            )
         # ACP asks an agent to return its latest supported version when it does
         # not support the client's version. The client then decides whether it
         # can continue (v1 initialization, "Version Negotiation").
@@ -952,7 +957,7 @@ class ConnectOnionACPAgent:
         project_dir = self._session_cwd(cwd)
         if session_id in self._sessions:
             raise RequestError(
-                -32000,
+                ACP_SESSION_CONFLICT_ERROR_CODE,
                 "Session is already open",
                 {"sessionId": session_id},
             )
@@ -1013,7 +1018,7 @@ class ConnectOnionACPAgent:
             )
         if runtime.prompt_lock.locked() or runtime.prompt_active.is_set():
             raise RequestError(
-                -32000,
+                ACP_SESSION_CONFLICT_ERROR_CODE,
                 "Session is busy",
                 {"sessionId": session_id},
             )
@@ -1091,7 +1096,7 @@ class ConnectOnionACPAgent:
             )
         if runtime.prompt_lock.locked() or runtime.prompt_active.is_set():
             raise RequestError(
-                -32000,
+                ACP_SESSION_CONFLICT_ERROR_CODE,
                 "Session is busy",
                 {"sessionId": session_id},
             )

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -107,6 +107,10 @@ sent before initialization fail without constructing an Agent or allocating
 session state, and a second `initialize` request on the same connection is
 rejected. Clients may continue with session requests after either rejection
 only when the connection has already completed one successful initialization.
+Connection-order violations return JSON-RPC `-32600`; an already-open or busy
+session returns the ConnectOnion `-32001` conflict code with its `sessionId`.
+ACP `-32000` remains reserved for `Authentication required` and is never used
+for ordinary lifecycle contention.
 
 Use `--acp` when another local process launches `co ai` and owns its stdio.
 Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -34,6 +34,16 @@ production code.
 Both suites are isolated from user state, credentials, and the network. Client
 permission callbacks reject by default.
 
+### Preserve ACP error-code semantics
+
+Wire tests treat an error code as a protocol enum, not an arbitrary server
+number. In particular, ACP reserves `-32000` for `Authentication required`, so
+connection-order violations use standard `-32600 Invalid request`. The one
+ConnectOnion extension in this lifecycle is `-32001` for an already-open or
+busy session, with the owned `sessionId` in bounded error data. This keeps
+retryable session contention distinct from authentication and internal errors
+on both stdio and authenticated WebSocket transports.
+
 ### State the tested version contract
 
 The package supports `agent-client-protocol>=0.12.0,<0.13.0` and negotiates
@@ -57,6 +67,7 @@ as clients that launch ConnectOnion.
 
 - Schema or router drift fails in the official SDK client before release.
 - Framing regressions remain visible instead of being hidden by SDK helpers.
+- Raw lifecycle tests catch standard error codes reused with the wrong meaning.
 - Interoperability claims say exactly which layer and version were exercised.
 - The deterministic fixture is shared by raw and typed subprocess suites.
 - GUI integration can still change independently and must not be overstated.

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -132,9 +132,9 @@ async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
         )
 
         assert rejected["error"] == {
-            "code": -32000,
-            "message": "Connection is not initialized",
-            "data": None,
+            "code": -32600,
+            "message": "Invalid request",
+            "data": {"details": "Connection is not initialized"},
         }
         assert not (state_root / ".co" / "ai" / "sessions").exists()
 
@@ -178,9 +178,9 @@ async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
         assert initialized["result"]["protocolVersion"] == 1
         assert pre_initialize_output == []
         assert repeated["error"] == {
-            "code": -32000,
-            "message": "Connection is already initialized",
-            "data": None,
+            "code": -32600,
+            "message": "Invalid request",
+            "data": {"details": "Connection is already initialized"},
         }
         assert created["result"]["sessionId"]
         assert prompted["result"]["stopReason"] == "end_turn"

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -287,16 +287,20 @@ async def test_acp_requires_initialize_before_creating_session(tmp_path):
     with pytest.raises(RequestError) as exc_info:
         await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
-    assert exc_info.value.code == -32000
-    assert "Connection is not initialized" in str(exc_info.value)
+    assert exc_info.value.code == -32600
+    assert exc_info.value.data == {"details": "Connection is not initialized"}
     for operation in (
         lambda: acp_agent.resume_session("missing", str(tmp_path), mcp_servers=[]),
         lambda: acp_agent.set_session_mode("missing", ":read-only"),
         lambda: acp_agent.close_session("missing"),
         lambda: acp_agent.prompt("missing", [text_block("hello")]),
     ):
-        with pytest.raises(RequestError, match="Connection is not initialized"):
+        with pytest.raises(RequestError) as operation_error:
             await operation()
+        assert operation_error.value.code == -32600
+        assert operation_error.value.data == {
+            "details": "Connection is not initialized"
+        }
     await acp_agent.cancel("missing")
     assert constructed == 0
     assert acp_agent._sessions == {}
@@ -319,9 +323,47 @@ async def test_acp_rejects_repeated_initialize_without_resetting_connection(tmp_
     session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
 
     assert initialized.protocol_version == PROTOCOL_VERSION
-    assert exc_info.value.code == -32000
-    assert "Connection is already initialized" in str(exc_info.value)
+    assert exc_info.value.code == -32600
+    assert exc_info.value.data == {"details": "Connection is already initialized"}
     assert session.session_id in acp_agent._sessions
+
+
+@pytest.mark.asyncio
+async def test_acp_session_conflicts_never_emit_auth_required(tmp_path):
+    acp_agent = ConnectOnionACPAgent(
+        model="test",
+        max_iterations=2,
+        yolo=False,
+        yolo_turns=2,
+        agent_factory=lambda **_kwargs: _FakeAgent(),
+    )
+    await _initialize_agent(acp_agent)
+    session = await acp_agent.new_session(str(tmp_path), mcp_servers=[])
+
+    with pytest.raises(RequestError) as already_open:
+        await acp_agent.resume_session(
+            session.session_id,
+            str(tmp_path),
+            mcp_servers=[],
+        )
+
+    runtime = acp_agent._sessions[session.session_id]
+    async with runtime.prompt_lock:
+        operations = (
+            lambda: acp_agent.set_session_mode(session.session_id, ":read-only"),
+            lambda: acp_agent.prompt(session.session_id, [text_block("hello")]),
+        )
+        conflict_errors = []
+        for operation in operations:
+            with pytest.raises(RequestError) as conflict:
+                await operation()
+            conflict_errors.append(conflict.value)
+
+    for error in (already_open.value, *conflict_errors):
+        assert error.code == acp_server.ACP_SESSION_CONFLICT_ERROR_CODE == -32001
+        assert error.data == {"sessionId": session.session_id}
+    assert str(already_open.value) == "Session is already open"
+    assert {str(error) for error in conflict_errors} == {"Session is busy"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop using ACP `-32000 Authentication required` for ordinary lifecycle failures
- use standard `-32600 Invalid request` with bounded details for connection-order violations
- use one documented `-32001` ConnectOnion session-conflict code for already-open and busy sessions
- keep stdio and authenticated WebSocket behavior aligned through the shared Agent lifecycle

## Why

The pinned official `agent-client-protocol==0.12.0` reserves `-32000` for `RequestError.auth_required()`. ConnectOnion used that value for five non-authentication paths. Strict clients could therefore treat an initialization-order error or retryable session conflict as a credential challenge.

Network admission still happens before ACP Agent construction. This PR changes no credential, authentication, Origin, identity, or trust behavior.

## Wire behavior

- session method before initialize: `-32600`, `data.details = "Connection is not initialized"`
- repeated initialize: `-32600`, `data.details = "Connection is already initialized"`
- already-open resume: `-32001`, owned `sessionId`
- busy prompt/set-mode: `-32001`, owned `sessionId`
- no non-authentication path in `ConnectOnionACPAgent` emits `-32000`

## Verification

- red-first: 4 focused unit/raw-stdio cases failed before implementation and passed after it
- 280/280 ACP, Gateway, stdio, and official-SDK tests passed
- Ruff lint and `uv lock --check` passed
- locked production dependency audit found no known vulnerabilities
- `1.7.0a1` wheel and sdist built; Twine checks passed
- local Linus-style simplicity/security review found no blocking issue

## Design

DD-032 now records that ACP error codes are semantic enums, not arbitrary server numbers. The implementation adds one constant reused at three conflict sites and uses the official SDK helper for standard invalid requests; it adds no error class or schema fork.

## Scope

No merge, tag, release, React/O Chat change, retired TypeScript SDK change, or `-32002 ResourceNotFound` redesign is included.

Closes #962
Related to #838 and #894
