### PR TITLE
fix: classify ACP resume failures

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -81,7 +81,10 @@ from .acp_events import (
 from .acp_transport import open_stdio_transport
 from .agent import GLOBAL_CO_DIR
 from .one_shot_sessions import (
+    InvalidSessionIdError,
     SessionLease,
+    SessionLeaseConflictError,
+    SessionNotFoundError,
     SessionSnapshotError,
     SnapshotStorageLimits,
     acquire_bounded_new_session_lease,
@@ -974,12 +977,25 @@ class ConnectOnionACPAgent:
                 True,
                 mcp_servers or [],
             )
-        except SessionSnapshotError as exc:
-            details = None if self._network_workspace is not None else str(exc)
+        except InvalidSessionIdError:
+            raise RequestError.invalid_params(
+                {"details": "Session ID must be a canonical UUID"}
+            ) from None
+        except SessionNotFoundError:
             raise RequestError(
                 -32002,
-                "Unable to resume session",
-                {"details": details} if details is not None else None,
+                "Session not found",
+                {"sessionId": session_id},
+            ) from None
+        except SessionLeaseConflictError:
+            raise RequestError(
+                ACP_SESSION_CONFLICT_ERROR_CODE,
+                "Session is busy",
+                {"sessionId": session_id},
+            ) from None
+        except SessionSnapshotError:
+            raise RequestError.internal_error(
+                {"details": "Unable to restore session state"}
             ) from None
         except Exception:
             logger.exception("Failed to resume co ai ACP session")

--- a/connectonion/cli/co_ai/one_shot_sessions.py
+++ b/connectonion/cli/co_ai/one_shot_sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import os
@@ -24,6 +25,18 @@ class SessionSnapshotError(ValueError):
     """A one-shot session cannot be safely saved or resumed."""
 
 
+class InvalidSessionIdError(SessionSnapshotError):
+    """A session ID is not a canonical UUID."""
+
+
+class SessionNotFoundError(SessionSnapshotError):
+    """A valid session ID has no stored snapshot."""
+
+
+class SessionLeaseConflictError(SessionSnapshotError):
+    """Another process currently owns a session lease."""
+
+
 @dataclass(frozen=True)
 class SnapshotStorageLimits:
     """Hard bounds for one authenticated principal's durable ACP snapshots."""
@@ -42,10 +55,14 @@ def _canonical_id(session_id: str) -> str:
     try:
         parsed = uuid.UUID(session_id)
     except (AttributeError, TypeError, ValueError):
-        raise SessionSnapshotError("Provide a valid session ID from a previous run.") from None
+        raise InvalidSessionIdError(
+            "Provide a valid session ID from a previous run."
+        ) from None
     canonical = str(parsed)
     if session_id != canonical:
-        raise SessionSnapshotError("Provide a valid session ID from a previous run.")
+        raise InvalidSessionIdError(
+            "Provide a valid session ID from a previous run."
+        )
     return canonical
 
 
@@ -118,7 +135,15 @@ def acquire_session_lease(
         flags |= os.O_NOFOLLOW
     try:
         descriptor = os.open(lock_path, flags, 0o600)
-    except OSError:
+    except OSError as exc:
+        if (
+            exclusive_create
+            and exc.errno == errno.EEXIST
+            and _is_regular_lock_path(lock_path)
+        ):
+            raise SessionLeaseConflictError(
+                f"Session {canonical} is already running in another process."
+            ) from None
         raise SessionSnapshotError(
             f"Session {canonical} lock is unavailable."
         ) from None
@@ -155,14 +180,36 @@ def acquire_session_lease(
             import fcntl
 
             fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
+    except OSError as exc:
         handle.close()
         if exclusive_create:
             _unlink_created_lock(lock_path, opened_identity)
+        if _is_lock_conflict(exc):
+            raise SessionLeaseConflictError(
+                f"Session {canonical} is already running in another process."
+            ) from None
         raise SessionSnapshotError(
-            f"Session {canonical} is already running in another process."
+            f"Session {canonical} lock is unavailable."
         ) from None
     return SessionLease(canonical, handle)
+
+
+def _is_lock_conflict(error: OSError) -> bool:
+    conflict_errnos = {errno.EACCES, errno.EAGAIN}
+    if hasattr(errno, "EDEADLK"):
+        conflict_errnos.add(errno.EDEADLK)
+    return (
+        isinstance(error, BlockingIOError)
+        or error.errno in conflict_errnos
+        or getattr(error, "winerror", None) in {32, 33, 36}
+    )
+
+
+def _is_regular_lock_path(path: Path) -> bool:
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
 
 
 def _unlink_created_lock(
@@ -367,7 +414,9 @@ def load_snapshot(
                 )
             )
             if target_bytes is None:
-                raise SessionSnapshotError(f"Session {canonical} was not found.")
+                raise SessionNotFoundError(
+                    f"Session {canonical} was not found."
+                )
             if (
                 stored_sessions > storage_limits.max_sessions
                 or stored_bytes > storage_limits.max_total_bytes
@@ -635,7 +684,9 @@ def _read_snapshot(
     try:
         before = path.lstat()
     except FileNotFoundError:
-        raise SessionSnapshotError(f"Session {session_id} was not found.") from None
+        raise SessionNotFoundError(
+            f"Session {session_id} was not found."
+        ) from None
     except OSError:
         raise SessionSnapshotError(f"Session {session_id} is unreadable.") from None
     if not stat.S_ISREG(before.st_mode):

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -111,6 +111,9 @@ Connection-order violations return JSON-RPC `-32600`; an already-open or busy
 session returns the ConnectOnion `-32001` conflict code with its `sessionId`.
 ACP `-32000` remains reserved for `Authentication required` and is never used
 for ordinary lifecycle contention.
+Resume further distinguishes invalid session IDs (`-32602`), absent snapshots
+(`-32002`), and unusable private state (`-32603`). Authenticated network errors
+never include Host paths or raw snapshot exceptions.
 
 Use `--acp` when another local process launches `co ai` and owns its stdio.
 Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a

--- a/docs/design-decisions/029-acp-persistent-session-ownership.md
+++ b/docs/design-decisions/029-acp-persistent-session-ownership.md
@@ -20,6 +20,12 @@ directory before constructing an Agent or granting it filesystem tools. The
 lease remains held across every prompt until `session/close`, stdio EOF, or
 failed runtime construction. Lock files are private regular files and symbolic
 links are not followed where the operating system supports that guarantee.
+Resume failures preserve the distinction required at the ACP boundary: an
+invalid canonical ID is invalid parameters, an absent snapshot is resource not
+found, a held lease is the shared session-conflict extension, and every other
+integrity, workspace, quota, or storage failure is internal error. Wire error
+data is fixed and bounded; raw exception text and Host paths never reach a
+network peer.
 The current tool contract accepts only TodoList items with string `content` and
 `active_form` fields plus a known `status`; unknown tools or malformed items
 fail before Agent construction.
@@ -78,6 +84,8 @@ Only one process or runtime can own a session ID at a time. Explicit close and
 normal EOF make it immediately resumable elsewhere without deleting its
 snapshot. A worker that ignores cooperative interruption can delay close: this
 is preferable to releasing a lease while that worker can still mutate state.
+Lease contention is reported as retryable session conflict rather than missing
+state, so a client retains the valid session identity while waiting for release.
 Because commit is non-cancellable once started, a client that disconnects at
 that boundary must resume before deciding whether to retry its prompt.
 

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -44,6 +44,11 @@ busy session, with the owned `sessionId` in bounded error data. This keeps
 retryable session contention distinct from authentication and internal errors
 on both stdio and authenticated WebSocket transports.
 
+Resume error tests classify the storage boundary without matching presentation
+strings: invalid IDs use `-32602`, absent valid sessions use `-32002`, held
+leases reuse `-32001`, and corrupt or unavailable state uses `-32603`. Only
+fixed details and the caller-owned `sessionId` cross the wire.
+
 ### State the tested version contract
 
 The package supports `agent-client-protocol>=0.12.0,<0.13.0` and negotiates

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -314,7 +314,11 @@ async def test_acp_subprocess_lease_blocks_a_second_process_until_close(tmp_path
             "session/resume",
             {"sessionId": session_id, "cwd": str(tmp_path), "mcpServers": []},
         )
-        assert rejected["error"]["code"] == -32002
+        assert rejected["error"] == {
+            "code": -32001,
+            "message": "Session is busy",
+            "data": {"sessionId": session_id},
+        }
 
         closed, _ = await _request(
             owner,

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1559,9 +1559,11 @@ async def test_network_acp_resume_does_not_disclose_saved_host_workspace(tmp_pat
     )
 
     await _initialize_agent(acp_agent)
-    with pytest.raises(RequestError, match="Unable to resume session") as exc_info:
+    with pytest.raises(RequestError, match="Internal error") as exc_info:
         await acp_agent.resume_session(session_id, "/", mcp_servers=[])
 
+    assert exc_info.value.code == -32603
+    assert exc_info.value.data == {"details": "Unable to restore session state"}
     error = str(exc_info.value)
     assert str(old_workspace) not in error
     assert str(new_workspace) not in error

--- a/tests/unit/test_co_ai_acp_mcp.py
+++ b/tests/unit/test_co_ai_acp_mcp.py
@@ -261,13 +261,15 @@ async def test_locked_resume_is_rejected_before_connecting_mcp(tmp_path):
     )
 
     await contender.initialize(protocol_version=PROTOCOL_VERSION)
-    with pytest.raises(RequestError, match="Unable to resume"):
+    with pytest.raises(RequestError, match="Session is busy") as conflict:
         await contender.resume_session(
             created.session_id,
             str(tmp_path),
             mcp_servers=[_server_spec()],
         )
 
+    assert conflict.value.code == acp_server.ACP_SESSION_CONFLICT_ERROR_CODE
+    assert conflict.value.data == {"sessionId": created.session_id}
     assert connected is False
     await owner.close_session(created.session_id)
 

--- a/tests/unit/test_co_ai_acp_modes.py
+++ b/tests/unit/test_co_ai_acp_modes.py
@@ -700,9 +700,11 @@ async def test_resume_rejects_full_access_budget_above_current_launch_ceiling(
         yolo_turns=4,
     )
 
-    with pytest.raises(RequestError, match="Unable to resume session"):
+    with pytest.raises(RequestError, match="Internal error") as error:
         await server.resume_session(session_id, str(project), mcp_servers=[])
 
+    assert error.value.code == -32603
+    assert error.value.data == {"details": "Unable to restore session state"}
     with session_lock(state_dir, session_id):
         pass
 
@@ -750,8 +752,10 @@ async def test_resume_rejects_unknown_or_over_authorized_mode_state(
         yolo=yolo,
     )
 
-    with pytest.raises(RequestError, match="Unable to resume session"):
+    with pytest.raises(RequestError, match="Internal error") as error:
         await server.resume_session(session_id, str(project), mcp_servers=[])
 
+    assert error.value.code == -32603
+    assert error.value.data == {"details": "Unable to restore session state"}
     with session_lock(state_dir, session_id):
         pass

--- a/tests/unit/test_co_ai_acp_resume.py
+++ b/tests/unit/test_co_ai_acp_resume.py
@@ -338,12 +338,14 @@ async def test_runtime_lease_blocks_a_second_server_until_close(
     contender = await _initialized_server(state_dir, lambda **_: _PersistentFakeAgent())
     session = await owner.new_session(str(project), mcp_servers=[])
 
-    with pytest.raises(RequestError, match="Unable to resume session"):
+    with pytest.raises(RequestError, match="Session is busy") as conflict:
         await contender.resume_session(
             session.session_id,
             str(project),
             mcp_servers=[],
         )
+    assert conflict.value.code == acp_server.ACP_SESSION_CONFLICT_ERROR_CODE
+    assert conflict.value.data == {"sessionId": session.session_id}
 
     await owner.close_session(session.session_id)
     await contender.resume_session(session.session_id, str(project), mcp_servers=[])
@@ -515,9 +517,11 @@ async def test_network_unknown_resume_does_not_create_a_durable_lock_file(
     )
     unknown = "cfb44753-f6da-47b3-9281-a0e9f664dd3c"
     try:
-        with pytest.raises(RequestError, match="Unable to resume"):
+        with pytest.raises(RequestError, match="Session not found") as error:
             await server.resume_session(unknown, "/", mcp_servers=[])
 
+        assert error.value.code == -32002
+        assert error.value.data == {"sessionId": unknown}
         assert list((state_dir / "ai" / "sessions").glob("*.lock")) == []
     finally:
         workspace.close()
@@ -593,9 +597,11 @@ async def test_resume_rejects_wrong_cwd_before_agent_construction(
         lambda **_: constructed.append(True) or _PersistentFakeAgent(),
     )
 
-    with pytest.raises(RequestError):
+    with pytest.raises(RequestError, match="Internal error") as error:
         await server.resume_session(session_id, str(other), mcp_servers=[])
 
+    assert error.value.code == -32603
+    assert error.value.data == {"details": "Unable to restore session state"}
     assert constructed == []
     with session_lock(state_dir, session_id):
         pass
@@ -604,13 +610,20 @@ async def test_resume_rejects_wrong_cwd_before_agent_construction(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "snapshot",
-    ["missing", "corrupt", "old-version", "malformed-tool"],
+    ("snapshot", "expected_code", "expected_message"),
+    [
+        ("missing", -32002, "Session not found"),
+        ("corrupt", -32603, "Internal error"),
+        ("old-version", -32603, "Internal error"),
+        ("malformed-tool", -32603, "Internal error"),
+    ],
 )
 async def test_resume_rejects_unusable_snapshots_before_agent_construction(
     tmp_path,
     monkeypatch,
     snapshot,
+    expected_code,
+    expected_message,
 ):
     project = _project(tmp_path, monkeypatch)
     state_dir = tmp_path / "state"
@@ -643,12 +656,42 @@ async def test_resume_rejects_unusable_snapshots_before_agent_construction(
         lambda **_: constructed.append(True) or _PersistentFakeAgent(),
     )
 
-    with pytest.raises(RequestError, match="Unable to resume session"):
+    with pytest.raises(RequestError, match=expected_message) as error:
         await server.resume_session(session_id, str(project), mcp_servers=[])
 
+    assert error.value.code == expected_code
+    assert error.value.data == (
+        {"sessionId": session_id}
+        if snapshot == "missing"
+        else {"details": "Unable to restore session state"}
+    )
     assert constructed == []
     with session_lock(state_dir, session_id):
         pass
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_invalid_session_id_as_invalid_params(
+    tmp_path,
+    monkeypatch,
+):
+    project = _project(tmp_path, monkeypatch)
+    state_dir = tmp_path / "state"
+    constructed = []
+    server = await _initialized_server(
+        state_dir,
+        lambda **_: constructed.append(True) or _PersistentFakeAgent(),
+    )
+
+    with pytest.raises(RequestError, match="Invalid params") as error:
+        await server.resume_session("not-a-uuid", str(project), mcp_servers=[])
+
+    assert error.value.code == -32602
+    assert error.value.data == {
+        "details": "Session ID must be a canonical UUID"
+    }
+    assert constructed == []
+    assert not state_dir.exists()
 
 
 @pytest.mark.asyncio
@@ -1047,12 +1090,14 @@ async def test_cancelled_commit_and_eof_wait_for_the_atomic_writer(
 
     assert not prompting.done()
     assert not eof_cleanup.done()
-    with pytest.raises(RequestError, match="Unable to resume session"):
+    with pytest.raises(RequestError, match="Session is busy") as conflict:
         await contender.resume_session(
             session.session_id,
             str(project),
             mcp_servers=[],
         )
+    assert conflict.value.code == acp_server.ACP_SESSION_CONFLICT_ERROR_CODE
+    assert conflict.value.data == {"sessionId": session.session_id}
 
     allow_save.set()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -652,7 +652,7 @@ def test_failed_bounded_admission_does_not_consume_a_session_slot(
 
     with monkeypatch.context() as failure:
         failure.setattr(fcntl, "flock", fail_session_lease)
-        with pytest.raises(SessionSnapshotError, match="already running"):
+        with pytest.raises(SessionSnapshotError, match="lock is unavailable"):
             acquire_bounded_new_session_lease(
                 tmp_path,
                 failed_id,


### PR DESCRIPTION
## Summary

- classify ACP `resumeSession` failures by their actual JSON-RPC meaning
- reserve `ResourceNotFound` (`-32002`) for a missing, valid session snapshot
- return `InvalidParams` for malformed session IDs, the shared session-conflict code for lease contention, and fixed `InternalError` details for corrupt or inaccessible state
- keep raw filesystem errors and host paths out of network responses
- document the classification in DD-029, DD-032, and the CLI reference

## Design

The implementation uses explicit storage-layer exception types instead of matching exception strings:

- invalid/non-canonical ID -> `-32602`
- missing snapshot -> `-32002` with `sessionId`
- active lease -> `-32001` with `sessionId`
- corrupt, incompatible, wrong-workspace, quota, or storage failure -> `-32603` with fixed public details

This PR is stacked on #963 and should be retargeted to `main` after #963 is merged.

## Verification

- 327 ACP/Gateway/stdio/official-SDK tests passed
- Ruff passed for all changed Python files
- `uv lock --check` passed
- locked production dependency audit found no vulnerabilities
- wheel and sdist built as `connectonion-1.7.0a1`; both passed Twine validation
- local security/simplicity review found no blocking issue

Closes #964
Related: #838, #894, #962, #963
