### PR TITLE
Add co deploy and chain-aware permission checking to the selling points

### DIFF
--- a/docs/SELLING_POINTS.md
+++ b/docs/SELLING_POINTS.md
@@ -19,7 +19,7 @@ just fixing the number — a moved line is often a changed behaviour.
 `connectonion/cli/main.py`, `connectonion/useful_skills/`, `connectonion/useful_tools/`,
 `connectonion/cli/browser_agent/`, `connectonion/cli/co_ai/`, and the front end at `../oo-chat`.
 
-**Survived:** 13. **Cut:** 10 (see the bottom — that list is the more useful half).
+**Survived:** 15. **Cut:** 10 (see the bottom — that list is the more useful half).
 
 ---
 
@@ -40,6 +40,40 @@ answer (`ai_commands.py:40-43`).
 is no terminal TUI — the interface is the web chat.
 **Why it is unusual.** The install does not give you a library to build a product
 with. It gives you the product, and the address to share it.
+
+### `co deploy` takes it off your laptop
+
+**Claim.** When the agent needs to outlive your laptop lid, one command packages
+the project, uploads it, and gives you back a hosted agent URL.
+**Proof.** `cli/main.py:207` wires the command; `cli/commands/deploy_commands.py`
+validates `.co/host.yaml`, packages git-tracked files into a tarball (merging any
+`--skills` paths into `.co/skills/`), POSTs to `/api/v1/deploy`, polls
+`/api/v1/deploy/{id}/status` until running, and prints the agent URL.
+**Default or opt-in.** Opt-in. Needs `.co/host.yaml` and an `OPENONION_API_KEY`.
+**Limit.** It deploys to ConnectOnion Cloud, not to your own infrastructure, and
+the relay caveat above still applies to the hosted agent. Build budget is up to
+about 20 minutes.
+**Why it is unusual.** Nothing here — hosting an app is ordinary. It is on this
+list because **every reviewer asked "what happens when I close the laptop?"
+before any other question**, and a page that shows a laptop-hosted agent without
+answering it reads as a toy. This is the answer, and it was missing from both the
+site and this file.
+
+### Permission patterns are checked per subcommand, not against the whole string
+
+**Claim.** A permission for `git *` does not let a chained command through.
+`git log; curl evil.com` is rejected, because every subcommand in a chain must be
+independently permitted.
+**Proof.** `useful_plugins/tool_approval/bash_parser.py:162-202` —
+`check_bash_chain_permitted()` calls `_extract_subcommands()` and requires a match
+for each one; any unpermitted subcommand rejects the whole chain.
+**Default or opt-in.** Default, wherever the approval plugin is loaded.
+**Limit.** Matching within a subcommand is still fnmatch rather than a full shell
+parser, so patterns should be written tightly.
+**Why it is unusual.** It is here because a reviewing engineer named the opposite
+as a dealbreaker — "fnmatch against a command string is a bypass waiting to
+happen" — and was wrong, but only findably wrong. If a careful reader assumes the
+naive implementation, the page should say which one we built.
 
 ### It is reachable from anywhere, not just the tab that opened
 


### PR DESCRIPTION
Two entries, both surfaced by a reviewer panel scoring the existing list, and both missing for the same reason: they answer questions rather than announce features, so nobody thought to write them down.

## `co deploy`

Every one of three reviewers asked **"what happens when I close the laptop?"** before asking anything else — an OSS launch marketer, a sceptical infra engineer, and an agency owner. The engineer:

> Everything in this file is downstream of that. Either there's a hosted path, or this is a very good local dev toy that should stop using the word "customer".

The agency owner was more specific: it kills the *second* contract, the profitable one.

`co deploy` is the answer, and it appeared neither in this file nor on any site. `cli/main.py:207` wires it; `cli/commands/deploy_commands.py` validates `.co/host.yaml`, packages git-tracked files into a tarball, POSTs to `/api/v1/deploy`, polls for status and prints the agent URL.

It is not unusual — hosting an app is ordinary. It is on the list because a page showing a laptop-hosted agent that never answers this reads as a toy.

## Chain-aware permission checking

This one is here because a reviewer named its **opposite** as a dealbreaker:

> fnmatch, not a shell parser. `Bash(git *)` matched by glob against a command string is a bypass waiting to happen — `git log; curl evil` matches. This is filed as a footnote and it is a dealbreaker dressed as one.

He was wrong. `useful_plugins/tool_approval/bash_parser.py:162-202` — `check_bash_chain_permitted()` calls `_extract_subcommands()` and requires every subcommand in a chain to match independently; any unpermitted one rejects the whole chain. `git log; curl evil` does not get through.

But he was only *findably* wrong — the naive implementation is what a careful reader assumes when they see fnmatch mentioned. So the page has to say which one we built. The stated limit stays honest: matching *within* a subcommand is still fnmatch, so patterns want writing tightly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjWtif58mkmvFB7EEPfVR3)_