### PR TITLE
Let real_api tests see the operator's real credential store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ load_dotenv()
 
 
 @pytest.fixture(autouse=True)
-def _never_touch_the_real_home(monkeypatch, tmp_path_factory):
+def _never_touch_the_real_home(request, monkeypatch, tmp_path_factory):
     """No test may read or write the operator's real ~/.co.
 
     `CliRunner.isolated_filesystem()` isolates the working directory and
@@ -58,7 +58,18 @@ def _never_touch_the_real_home(monkeypatch, tmp_path_factory):
     Isolating HOME is the only guard that holds: the paths are resolved deep
     inside the commands, from Path.home() and from AGENT_CONFIG_PATH, and a
     per-test patch has to be remembered by every future test.
+
+    `real_api` is the one exception, because provider CLIs keep their
+    credentials under $HOME as well: `codex` reads an OAuth session from
+    ~/.codex/auth.json, and with HOME repointed it finds none and the turn
+    dies at the provider with `401 Missing bearer`. Reaching the operator's
+    real account is the entire purpose of those tests, they are opt-in behind
+    a marker, and they are deselected from the default run — so they keep the
+    real HOME while every other test is isolated.
     """
+    if request.node.get_closest_marker("real_api"):
+        return
+
     home = tmp_path_factory.mktemp("home")
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))       # Windows

--- a/tests/unit/test_real_api_tests_can_reach_real_credentials.py
+++ b/tests/unit/test_real_api_tests_can_reach_real_credentials.py
@@ -1,0 +1,57 @@
+"""A test that must reach a real provider has to see the real credential store.
+
+`_never_touch_the_real_home` repoints HOME at a temp directory for every test.
+It earns that: a mocked-HTTP run of `co auth microsoft` once wrote fake tokens
+into the operator's real `~/.co/keys.env` and surfaced days later as "Microsoft
+session expired" — the last thing anyone traces back to a test run.
+
+But provider CLIs keep their credentials under `$HOME` too. `codex` stores an
+OAuth session in `~/.codex/auth.json`; with HOME repointed it finds nothing and
+the turn dies at the provider:
+
+    tests/e2e/real_api/test_real_codex.py::test_real_codex_session_resume
+    turn failed: unexpected status 401 Unauthorized:
+    Missing bearer or basic authentication in header
+
+Confirmed by changing one variable and nothing else: the identical `codex()`
+call succeeded with the operator's HOME (from two different working
+directories) and produced that exact 401 with HOME pointed at a temp dir.
+
+So the rule is not "isolate HOME" but "isolate HOME for tests that must not
+touch it". A `real_api` test is the stated exception: reaching the operator's
+real account is its entire purpose, it is opt-in behind a marker, and it is
+deselected from the default run.
+
+Both halves are asserted from inside real tests rather than by inspecting the
+fixture, so they exercise the contract the suite actually runs under.
+"""
+
+import os
+import pwd
+from pathlib import Path
+
+import pytest
+
+# The operator's real home, read from the password database so it is unaffected
+# by whatever HOME this test itself was given.
+OPERATOR_HOME = Path(pwd.getpwuid(os.getuid()).pw_dir)
+
+
+def test_an_ordinary_test_is_isolated_from_the_real_home():
+    """The protection every other test depends on, asserted from inside one."""
+    assert Path.home() != OPERATOR_HOME, (
+        "an ordinary test can see the operator's real home — the guard that "
+        "stopped a test from overwriting live OAuth tokens is not running"
+    )
+    assert os.environ["HOME"] != str(OPERATOR_HOME)
+
+
+@pytest.mark.real_api
+def test_a_real_api_test_keeps_the_operator_home():
+    """A provider test must find ~/.codex, ~/.claude, ~/.co as they really are."""
+    assert Path.home() == OPERATOR_HOME, (
+        "a real_api test was given a temp HOME, so a provider CLI storing its "
+        "credentials under $HOME cannot authenticate — this is the 401 that "
+        "blocked the real Codex resume gate"
+    )
+    assert os.environ["HOME"] == str(OPERATOR_HOME)


### PR DESCRIPTION
Unblocks the real-Codex hard gate on #891. **Two real Codex provider tests go from 1 failed to 2 passed.**

## The problem

`tests/conftest.py`'s autouse `_never_touch_the_real_home` repoints `HOME` / `USERPROFILE` / `Path.home()` at a temp dir for every test. That fixture earns its place — a mocked-HTTP run of `co auth microsoft` once wrote fake tokens into the operator's real `~/.co/keys.env` and surfaced days later as "Microsoft session expired".

But provider CLIs keep their credentials under `$HOME` as well. `codex` reads an OAuth session from `~/.codex/auth.json`; with HOME repointed it finds none and the turn dies at the provider:

```
tests/e2e/real_api/test_real_codex.py::test_real_codex_session_resume
turn failed: unexpected status 401 Unauthorized:
Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses
```

## Root cause, by controlled experiment

Identical `codex()` call, one variable changed:

| condition | result |
|---|---|
| operator HOME, cwd = scratchpad | ✅ inference returned `CODEX_INFER_OK` |
| operator HOME, cwd = repo root | ✅ inference returned `REPO_CWD_OK` |
| **HOME → temp dir** (what the suite does) | ❌ **the exact same 401** |

Credentials were valid throughout: `auth_mode: chatgpt`, access token good until 2026-08-24. The harness was hiding them, not the provider rejecting them.

Only the resume test trips it because it runs a genuine inference turn. The handshake test exercises protocol alone and passed either way — which is why this looked like a partial provider failure rather than a harness bug.

## The change

Five lines: `real_api`-marked tests keep the operator's HOME; everything else is isolated exactly as before.

The rule is not "isolate HOME" but **"isolate HOME for tests that must not touch it."** `real_api` is the stated exception — reaching the operator's real account is its entire purpose, it is opt-in behind a marker, and it is deselected from the default run. The alternative (seeding a fake HOME with real credentials per provider test) copies secrets around, which is strictly worse.

## Tests

`tests/unit/test_real_api_tests_can_reach_real_credentials.py` asserts **both halves from inside real tests** rather than inspecting the fixture:

- an ordinary test still cannot see the operator's home
- a `real_api` test can

Verified red-first: without the change it is **1 failed / 1 passed** — the `real_api` half fails while the isolation guard keeps passing, which is exactly the half that must not move.

Real gate result with the change: `tests/e2e/real_api/test_real_codex.py` → **2 passed**.

One implementation note worth keeping: the operator's home is read from `pwd.getpwuid(os.getuid())`, not `Path.home()`, because the test asserting the contract is itself subject to it.