### PR TITLE
fix: block ACP metadata parameter shadowing

### DIFF
--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -3,22 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import platform
 import sys
-from contextlib import suppress
 from typing import Any
 
-from acp import RequestError, stdio_streams
+from acp import stdio_streams
 from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
 
-from ...core.acp_jsonrpc import (
-    ACP_META_SHADOW_ERROR_DETAILS,
-    acp_meta_shadows_request_params,
-    acp_request_id,
-    is_acp_json_rpc_message,
-    is_acp_request_id,
-)
+from ...core.acp_transport import StrictACPTransport
+
+_StrictNDJSONTransport = StrictACPTransport
 
 
 class _BoundStdoutWriter:
@@ -56,140 +50,6 @@ class _BoundStdoutWriter:
 
     async def wait_closed(self) -> None:
         pass
-
-
-class _StrictNDJSONTransport:
-    """Add deterministic malformed-frame errors around the SDK transport seam."""
-
-    def __init__(
-        self,
-        reader: asyncio.StreamReader,
-        writer: Any,
-        *,
-        max_frame_bytes: int = DEFAULT_STDIO_BUFFER_LIMIT_BYTES,
-    ) -> None:
-        self._reader = reader
-        self._writer = writer
-        self._max_frame_bytes = max_frame_bytes
-        self._write_lock = asyncio.Lock()
-        self._closed = False
-
-    async def receive(self) -> dict[str, Any] | None:
-        while True:
-            try:
-                line = await self._read_line()
-            except _FrameTooLarge:
-                await self._send_error(
-                    None,
-                    RequestError.parse_error(
-                        {
-                            "details": (
-                                "ACP frame exceeds the configured "
-                                f"{self._max_frame_bytes}-byte limit"
-                            )
-                        }
-                    ),
-                )
-                return None
-            if not line:
-                return None
-            if not line.strip():
-                continue
-            try:
-                message = json.loads(line, parse_constant=_reject_json_constant)
-            except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
-                await self._send_error(None, RequestError.parse_error())
-                continue
-            if not self._is_json_rpc_message(message):
-                request_id = self._request_id(message)
-                await self._send_error(request_id, RequestError.invalid_request())
-                continue
-            if acp_meta_shadows_request_params(message):
-                if "id" in message:
-                    await self._send_error(
-                        self._request_id(message),
-                        RequestError.invalid_params(
-                            {"details": ACP_META_SHADOW_ERROR_DETAILS}
-                        ),
-                    )
-                continue
-            return message
-
-    async def send(self, message: dict[str, Any]) -> None:
-        if self._closed:
-            raise ConnectionError("ACP stdio transport is closed")
-        payload = json.dumps(
-            message,
-            ensure_ascii=False,
-            allow_nan=False,
-            separators=(",", ":"),
-        ).encode("utf-8") + b"\n"
-        async with self._write_lock:
-            self._writer.write(payload)
-            await self._writer.drain()
-
-    async def close(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        self._writer.close()
-        with suppress(Exception):
-            await self._writer.wait_closed()
-
-    async def _send_error(self, request_id: Any, error: RequestError) -> None:
-        await self.send(
-            {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": error.to_error_obj(),
-            }
-        )
-
-    async def _read_line(self) -> bytes:
-        """Read one frame even when it exceeds StreamReader's chunk limit."""
-
-        chunks: list[bytes] = []
-        total_bytes = 0
-        try:
-            while True:
-                try:
-                    line = await self._reader.readuntil(b"\n")
-                except asyncio.LimitOverrunError as exc:
-                    if total_bytes + exc.consumed > self._max_frame_bytes:
-                        raise _FrameTooLarge from None
-                    chunk = await self._reader.readexactly(exc.consumed)
-                    chunks.append(chunk)
-                    total_bytes += len(chunk)
-                else:
-                    if total_bytes + len(line) > self._max_frame_bytes:
-                        raise _FrameTooLarge
-                    chunks.append(line)
-                    return b"".join(chunks)
-        except asyncio.IncompleteReadError as exc:
-            if total_bytes + len(exc.partial) > self._max_frame_bytes:
-                raise _FrameTooLarge from None
-            chunks.append(exc.partial)
-            return b"".join(chunks)
-
-    @classmethod
-    def _request_id(cls, message: Any) -> str | int | None:
-        return acp_request_id(message)
-
-    @staticmethod
-    def _is_request_id(value: Any) -> bool:
-        return is_acp_request_id(value)
-
-    @classmethod
-    def _is_json_rpc_message(cls, message: Any) -> bool:
-        return is_acp_json_rpc_message(message)
-
-
-def _reject_json_constant(value: str) -> None:
-    raise ValueError(f"invalid JSON constant: {value}")
-
-
-class _FrameTooLarge(Exception):
-    pass
 
 
 async def open_stdio_transport() -> _StrictNDJSONTransport:

--- a/connectonion/cli/co_ai/acp_transport.py
+++ b/connectonion/cli/co_ai/acp_transport.py
@@ -13,6 +13,8 @@ from acp import RequestError, stdio_streams
 from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
 
 from ...core.acp_jsonrpc import (
+    ACP_META_SHADOW_ERROR_DETAILS,
+    acp_meta_shadows_request_params,
     acp_request_id,
     is_acp_json_rpc_message,
     is_acp_request_id,
@@ -101,6 +103,15 @@ class _StrictNDJSONTransport:
             if not self._is_json_rpc_message(message):
                 request_id = self._request_id(message)
                 await self._send_error(request_id, RequestError.invalid_request())
+                continue
+            if acp_meta_shadows_request_params(message):
+                if "id" in message:
+                    await self._send_error(
+                        self._request_id(message),
+                        RequestError.invalid_params(
+                            {"details": ACP_META_SHADOW_ERROR_DETAILS}
+                        ),
+                    )
                 continue
             return message
 

--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -1,13 +1,38 @@
-"""Exact JSON-RPC envelope rules shared by native ACP transports.
+"""JSON-RPC boundary rules shared by native ACP transports.
 
-Method-specific ACP schemas remain owned by the pinned SDK. This module only
-keeps stdio and WebSocket from disagreeing about request, notification, and
-response envelope families before those schemas run.
+Method-specific validation remains owned by the pinned SDK. This module keeps
+stdio and WebSocket aligned on envelope families and blocks metadata keys that
+the pinned SDK router would otherwise promote over validated request fields.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from acp import AGENT_METHODS
+from acp.schema import (
+    CancelNotification,
+    CloseSessionRequest,
+    InitializeRequest,
+    NewSessionRequest,
+    PromptRequest,
+    ResumeSessionRequest,
+    SetSessionModeRequest,
+)
+
+_AGENT_REQUEST_PARAM_NAMES = {
+    AGENT_METHODS[method]: frozenset(model.model_fields) - {"field_meta"}
+    for method, model in (
+        ("initialize", InitializeRequest),
+        ("session_new", NewSessionRequest),
+        ("session_resume", ResumeSessionRequest),
+        ("session_set_mode", SetSessionModeRequest),
+        ("session_prompt", PromptRequest),
+        ("session_close", CloseSessionRequest),
+        ("session_cancel", CancelNotification),
+    )
+}
+ACP_META_SHADOW_ERROR_DETAILS = "ACP _meta cannot override request parameters"
 
 
 def is_acp_request_id(value: Any) -> bool:
@@ -23,6 +48,19 @@ def acp_request_id(message: Any) -> str | int | None:
         return None
     request_id = message.get("id")
     return request_id if is_acp_request_id(request_id) else None
+
+
+def acp_meta_shadows_request_params(message: Any) -> bool:
+    """Detect metadata keys that the pinned SDK would promote over ACP fields."""
+
+    if not isinstance(message, dict):
+        return False
+    reserved = _AGENT_REQUEST_PARAM_NAMES.get(message.get("method"))
+    params = message.get("params")
+    if reserved is None or not isinstance(params, dict):
+        return False
+    metadata = params.get("_meta")
+    return isinstance(metadata, dict) and not reserved.isdisjoint(metadata)
 
 
 def is_acp_json_rpc_message(message: Any) -> bool:

--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -9,28 +9,32 @@ from __future__ import annotations
 
 from typing import Any
 
-from acp import AGENT_METHODS
+from acp import AGENT_METHODS, CLIENT_METHODS
 from acp.schema import (
     CancelNotification,
     CloseSessionRequest,
     InitializeRequest,
     NewSessionRequest,
     PromptRequest,
+    RequestPermissionRequest,
     ResumeSessionRequest,
+    SessionNotification,
     SetSessionModeRequest,
 )
 
-_AGENT_REQUEST_PARAM_NAMES = {
-    AGENT_METHODS[method]: frozenset(model.model_fields) - {"field_meta"}
-    for method, model in (
-        ("initialize", InitializeRequest),
-        ("session_new", NewSessionRequest),
-        ("session_resume", ResumeSessionRequest),
-        ("session_set_mode", SetSessionModeRequest),
-        ("session_prompt", PromptRequest),
-        ("session_close", CloseSessionRequest),
-        ("session_cancel", CancelNotification),
-    )
+_ROUTED_PARAM_NAMES = {
+    method: frozenset(model.model_fields) - {"field_meta"}
+    for method, model in {
+        AGENT_METHODS["initialize"]: InitializeRequest,
+        AGENT_METHODS["session_new"]: NewSessionRequest,
+        AGENT_METHODS["session_resume"]: ResumeSessionRequest,
+        AGENT_METHODS["session_set_mode"]: SetSessionModeRequest,
+        AGENT_METHODS["session_prompt"]: PromptRequest,
+        AGENT_METHODS["session_close"]: CloseSessionRequest,
+        AGENT_METHODS["session_cancel"]: CancelNotification,
+        CLIENT_METHODS["session_update"]: SessionNotification,
+        CLIENT_METHODS["session_request_permission"]: RequestPermissionRequest,
+    }.items()
 }
 ACP_META_SHADOW_ERROR_DETAILS = "ACP _meta cannot override request parameters"
 
@@ -55,7 +59,7 @@ def acp_meta_shadows_request_params(message: Any) -> bool:
 
     if not isinstance(message, dict):
         return False
-    reserved = _AGENT_REQUEST_PARAM_NAMES.get(message.get("method"))
+    reserved = _ROUTED_PARAM_NAMES.get(message.get("method"))
     params = message.get("params")
     if reserved is None or not isinstance(params, dict):
         return False

--- a/connectonion/core/acp_transport.py
+++ b/connectonion/core/acp_transport.py
@@ -1,0 +1,153 @@
+"""Strict newline-delimited ACP transport shared by both process roles."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import suppress
+from typing import Any
+
+from acp import RequestError
+from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
+
+from .acp_jsonrpc import (
+    ACP_META_SHADOW_ERROR_DETAILS,
+    acp_meta_shadows_request_params,
+    acp_request_id,
+    is_acp_json_rpc_message,
+    is_acp_request_id,
+)
+
+
+class StrictACPTransport:
+    """Validate framing and routing invariants before the pinned SDK router."""
+
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: Any,
+        *,
+        max_frame_bytes: int = DEFAULT_STDIO_BUFFER_LIMIT_BYTES,
+    ) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._max_frame_bytes = max_frame_bytes
+        self._write_lock = asyncio.Lock()
+        self._closed = False
+
+    async def receive(self) -> dict[str, Any] | None:
+        while True:
+            try:
+                line = await self._read_line()
+            except _FrameTooLarge:
+                await self._send_error(
+                    None,
+                    RequestError.parse_error(
+                        {
+                            "details": (
+                                "ACP frame exceeds the configured "
+                                f"{self._max_frame_bytes}-byte limit"
+                            )
+                        }
+                    ),
+                )
+                return None
+            if not line:
+                return None
+            if not line.strip():
+                continue
+            try:
+                message = json.loads(line, parse_constant=_reject_json_constant)
+            except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+                await self._send_error(None, RequestError.parse_error())
+                continue
+            if not self._is_json_rpc_message(message):
+                request_id = self._request_id(message)
+                await self._send_error(request_id, RequestError.invalid_request())
+                continue
+            if acp_meta_shadows_request_params(message):
+                if "id" in message:
+                    await self._send_error(
+                        self._request_id(message),
+                        RequestError.invalid_params(
+                            {"details": ACP_META_SHADOW_ERROR_DETAILS}
+                        ),
+                    )
+                continue
+            return message
+
+    async def send(self, message: dict[str, Any]) -> None:
+        if self._closed:
+            raise ConnectionError("ACP stdio transport is closed")
+        payload = json.dumps(
+            message,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8") + b"\n"
+        async with self._write_lock:
+            self._writer.write(payload)
+            await self._writer.drain()
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._writer.close()
+        with suppress(Exception):
+            await self._writer.wait_closed()
+
+    async def _send_error(self, request_id: Any, error: RequestError) -> None:
+        await self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": error.to_error_obj(),
+            }
+        )
+
+    async def _read_line(self) -> bytes:
+        """Read one frame even when it exceeds StreamReader's chunk limit."""
+
+        chunks: list[bytes] = []
+        total_bytes = 0
+        try:
+            while True:
+                try:
+                    line = await self._reader.readuntil(b"\n")
+                except asyncio.LimitOverrunError as exc:
+                    if total_bytes + exc.consumed > self._max_frame_bytes:
+                        raise _FrameTooLarge from None
+                    chunk = await self._reader.readexactly(exc.consumed)
+                    chunks.append(chunk)
+                    total_bytes += len(chunk)
+                else:
+                    if total_bytes + len(line) > self._max_frame_bytes:
+                        raise _FrameTooLarge
+                    chunks.append(line)
+                    return b"".join(chunks)
+        except asyncio.IncompleteReadError as exc:
+            if total_bytes + len(exc.partial) > self._max_frame_bytes:
+                raise _FrameTooLarge from None
+            chunks.append(exc.partial)
+            return b"".join(chunks)
+
+    @classmethod
+    def _request_id(cls, message: Any) -> str | int | None:
+        return acp_request_id(message)
+
+    @staticmethod
+    def _is_request_id(value: Any) -> bool:
+        return is_acp_request_id(value)
+
+    @classmethod
+    def _is_json_rpc_message(cls, message: Any) -> bool:
+        return is_acp_json_rpc_message(message)
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+class _FrameTooLarge(Exception):
+    pass

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -33,6 +33,8 @@ from acp.schema import InitializeRequest
 from pydantic import ValidationError
 
 from ...core.acp_jsonrpc import (
+    ACP_META_SHADOW_ERROR_DETAILS,
+    acp_meta_shadows_request_params,
     acp_request_id,
     is_acp_json_rpc_message,
     is_acp_request_id,
@@ -266,6 +268,18 @@ class _ACPTransport:
                     "error": RequestError.invalid_request().to_error_obj(),
                 }
             )
+            return
+        if acp_meta_shadows_request_params(message):
+            if "id" in message:
+                await self.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": acp_request_id(message),
+                        "error": RequestError.invalid_params(
+                            {"details": ACP_META_SHADOW_ERROR_DETAILS}
+                        ).to_error_obj(),
+                    }
+                )
             return
         await self._to_agent.put(message)
 
@@ -978,6 +992,7 @@ class AuthenticatedACPApp:
         request_id = payload.get("id")
         envelope_valid = (
             is_acp_json_rpc_message(payload)
+            and not acp_meta_shadows_request_params(payload)
             and payload.get("method") == "initialize"
             and isinstance(payload.get("params"), dict)
             and is_acp_request_id(request_id)

--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -6,11 +6,12 @@ import asyncio
 import hashlib
 import json
 import os
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
 import acp
+from acp.client.connection import ClientSideConnection
 from acp.schema import (
     AgentMessageChunk,
     AllowedOutcome,
@@ -26,6 +27,7 @@ from acp.schema import (
 )
 
 from .._version import __version__
+from ..core.acp_transport import StrictACPTransport
 
 APPROVAL_MODES = ("manual", "auto", "deny")
 _STDIO_LIMIT = 10 * 1024 * 1024
@@ -135,6 +137,38 @@ def required_mode(engine: str, approval: str) -> str | None:
     return None
 
 
+@asynccontextmanager
+async def _spawn_guarded_agent_process(
+    command: tuple[str, ...],
+    cwd: Path,
+    client: "ToolClient",
+    environment: dict[str, str],
+):
+    """Put child callbacks through the same strict boundary as native ACP."""
+
+    async with acp.spawn_stdio_transport(
+        command[0],
+        *command[1:],
+        env=environment,
+        cwd=cwd,
+        limit=_STDIO_LIMIT,
+        shutdown_timeout=2.0,
+    ) as (reader, writer, process):
+        connection = ClientSideConnection(
+            client,
+            StrictACPTransport(
+                reader,
+                writer,
+                max_frame_bytes=_STDIO_LIMIT,
+            ),
+            observers=[client.observe_stream],
+        )
+        try:
+            yield connection, process
+        finally:
+            await connection.close()
+
+
 async def run_agent(
     command: tuple[str, ...],
     engine: str,
@@ -158,14 +192,11 @@ async def run_agent(
     stderr_signals = {"authentication": False}
 
     try:
-        async with acp.spawn_agent_process(
+        async with _spawn_guarded_agent_process(
+            command,
+            cwd,
             client,
-            command[0],
-            *command[1:],
-            env=environment,
-            cwd=cwd,
-            transport_kwargs={"limit": _STDIO_LIMIT, "shutdown_timeout": 2.0},
-            observers=[client.observe_stream],
+            environment,
         ) as (connection, process):
             if process.stderr is not None:
                 stderr_task = asyncio.create_task(

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -34,6 +34,14 @@ production code.
 Both suites are isolated from user state, credentials, and the network. Client
 permission callbacks reject by default.
 
+The pinned Python SDK expands request `_meta` entries into handler keyword
+arguments. Native transports therefore share a narrow pre-router guard: a
+metadata key cannot use the generated Python name of an official request field
+and replace that field after validation. Other metadata remains untouched.
+Requests with a collision receive `InvalidParams`; invalid notifications are
+dropped without a response. This is a compatibility guard around the pinned
+router, not a second ACP parameter validator.
+
 ### State the tested version contract
 
 The package supports `agent-client-protocol>=0.12.0,<0.13.0` and negotiates
@@ -56,6 +64,8 @@ as clients that launch ConnectOnion.
 ## Consequences
 
 - Schema or router drift fails in the official SDK client before release.
+- Raw clients cannot use `_meta` to make executed handler arguments disagree
+  with the visible request fields.
 - Framing regressions remain visible instead of being hidden by SDK helpers.
 - Interoperability claims say exactly which layer and version were exercised.
 - The deterministic fixture is shared by raw and typed subprocess suites.

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -35,12 +35,15 @@ Both suites are isolated from user state, credentials, and the network. Client
 permission callbacks reject by default.
 
 The pinned Python SDK expands request `_meta` entries into handler keyword
-arguments. Native transports therefore share a narrow pre-router guard: a
-metadata key cannot use the generated Python name of an official request field
-and replace that field after validation. Other metadata remains untouched.
-Requests with a collision receive `InvalidParams`; invalid notifications are
-dropped without a response. This is a compatibility guard around the pinned
-router, not a second ACP parameter validator.
+arguments. Every ConnectOnion-owned router therefore uses the same narrow
+pre-router rule: a metadata key cannot use the generated Python name of an
+official request or implemented callback field and replace that field after
+validation. Native stdio/WebSocket apply it before Agent routing; the generic
+`acp_agent` child process uses the shared strict stdio transport before
+`ToolClient` callback routing. Other metadata remains untouched. Requests with
+a collision receive `InvalidParams`; invalid notifications are dropped without
+a response. This is a compatibility guard around the pinned router, not a
+second ACP parameter validator.
 
 ### State the tested version contract
 

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -71,6 +71,15 @@ order. The pinned SDK continues to own method parameters, results, and
 extensions such as `_meta`; envelope validation does not replace ACP schema
 validation.
 
+One pinned-router compatibility guard runs before both native transports hand
+messages to the SDK. The SDK promotes `_meta` entries to Python handler keyword
+arguments after parsing official fields, so metadata whose key matches an
+official generated parameter name could otherwise shadow the visible field.
+Such requests receive `-32602` with fixed public details, while invalid
+notifications are dropped without a response. Unrelated `_meta` entries and
+extension methods remain available. A shadowed first WebSocket `initialize`
+fails the existing pre-Agent admission rule and closes with `4400`.
+
 ### Browsers exchange a signed request for a one-use ticket
 
 Browser JavaScript cannot add `X-Co-*` headers to a WebSocket upgrade. It first

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -106,6 +106,14 @@ turn's total deadline. Timeout or interruption revokes the lease so a pending
 approval cannot leave the ACP subprocess alive. The client may select only an
 `allow_once` response; it never converts one prompt into a persistent rule.
 
+The child process uses ConnectOnion's strict ACP stdio transport before the
+pinned SDK client router. The SDK otherwise promotes `_meta` entries over typed
+callback arguments after validation. Metadata cannot therefore replace the
+visible `sessionId`, permission options, tool call, or update delivered to
+`ToolClient`; shadowed requests receive `InvalidParams`, and shadowed
+notifications are dropped. Unrelated metadata remains an ACP extension and is
+not interpreted as authority.
+
 The operator also binds a launch workspace root. Model-selected `cwd` values
 may choose only that directory or a resolved descendant; symlink escapes fail
 closed. This constrains working-directory selection, not every engine's
@@ -128,6 +136,8 @@ present; it does not retain an import-time working directory as a wider root.
   ephemeral process-local ID as durable state.
 - A timed-out approval is revoked with the same child turn instead of leaving
   a blocked worker or live subprocess behind.
+- A child cannot use `_meta` to make the session or permission callback checked
+  by `ToolClient` disagree with its visible ACP fields.
 - Re-enabling Codex `manual` or `deny` requires a pinned adapter plus a real
   conformance test covering file writes, shell commands, and outbound network.
 

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -193,6 +193,40 @@ async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_acp_subprocess_rejects_meta_parameter_shadowing(tmp_path):
+    visible = tmp_path / "visible"
+    hidden = tmp_path / "hidden"
+    visible.mkdir()
+    hidden.mkdir()
+    async with _server(tmp_path / "home") as process:
+        await _initialize(process)
+
+        rejected, _ = await _request(
+            process,
+            2,
+            "session/new",
+            {
+                "cwd": str(visible),
+                "mcpServers": [],
+                "_meta": {"cwd": str(hidden)},
+            },
+        )
+        created, _ = await _request(
+            process,
+            3,
+            "session/new",
+            {"cwd": str(visible), "mcpServers": []},
+        )
+
+        assert rejected["error"] == {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {"details": "ACP _meta cannot override request parameters"},
+        }
+        assert created["result"]["sessionId"]
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_path):
     async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -87,20 +87,32 @@ FAKE_AGENT = textwrap.dedent(
             update({"sessionUpdate": "agent_message_chunk",
                     "messageId": "answer-1",
                     "content": {"type": "text", "text": "Fixing the tests"}})
+            if text == "shadow update":
+                send({"jsonrpc": "2.0", "method": "session/update",
+                      "params": {
+                          "sessionId": "visible-wrong-session",
+                          "update": {"sessionUpdate": "agent_message_chunk",
+                                     "messageId": "answer-1",
+                                     "content": {"type": "text",
+                                                 "text": "SHADOWED"}},
+                          "_meta": {"session_id": active_session}}})
             update({"sessionUpdate": "tool_call", "toolCallId": "call-1",
                     "title": "Run pytest", "kind": "execute",
                     "status": "pending", "rawInput": {"command": "pytest"}})
             permission_id = 900
+            permission_params = {
+                "sessionId": "sess-1",
+                "toolCall": {"toolCallId": "call-1", "title": "Run pytest"},
+                "options": [
+                    {"optionId": "ok", "name": "Allow", "kind": "allow_once"},
+                    {"optionId": "no", "name": "Reject", "kind": "reject_once"}],
+            }
+            if text == "shadow permission":
+                permission_params["sessionId"] = "visible-wrong-session"
+                permission_params["_meta"] = {"session_id": active_session}
             send({"jsonrpc": "2.0", "id": permission_id,
                   "method": "session/request_permission",
-                  "params": {"sessionId": "sess-1",
-                             "toolCall": {"toolCallId": "call-1",
-                                          "title": "Run pytest"},
-                             "options": [
-                                 {"optionId": "ok", "name": "Allow",
-                                  "kind": "allow_once"},
-                                 {"optionId": "no", "name": "Reject",
-                                  "kind": "reject_once"}]}})
+                  "params": permission_params})
         elif method is None and message_id == permission_id:
             allowed = (message.get("result", {}).get("outcome", {})
                        .get("optionId") == "ok")
@@ -454,6 +466,11 @@ class TestTypedRun:
         assert output["session_id"] == "sess-known"
         assert output["result"] == "Fixing the tests — done."
 
+    def test_child_meta_cannot_shadow_visible_update_session(self, fake_command):
+        output = json.loads(runner(fake_command).acp_agent("shadow update"))
+
+        assert output["result"] == "Fixing the tests — done."
+
     def test_failed_resume_does_not_silently_start_another_session(
         self, fake_command
     ):
@@ -502,6 +519,18 @@ class TestPermissionBoundary:
             "tool_call_id": "call-1",
             "input_preview": "null",
         }]
+
+    def test_child_meta_cannot_shadow_visible_permission_session(
+        self, fake_command
+    ):
+        io = RecordingIO(approve=True)
+        runner(fake_command, approval="manual").acp_agent(
+            "shadow permission", agent=FakeAgent(io)
+        )
+
+        assert io.approvals == []
+        result = next(event for event in io.events if event["type"] == "tool_result")
+        assert result["status"] == "failed"
 
     def test_operator_refusal_reaches_engine(self, fake_command):
         io = RecordingIO(approve=False)

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -1053,6 +1053,69 @@ async def test_mixed_post_initialize_envelope_has_no_side_effect(mixed):
 
 
 @pytest.mark.asyncio
+async def test_meta_cannot_shadow_websocket_request_parameters():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    shadowed = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "session/resume",
+        "params": {
+            "sessionId": "visible-session",
+            "cwd": "/",
+            "_meta": {
+                "session_id": "hidden-session",
+                "cwd": "/hidden",
+            },
+        },
+    }
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[_initialize(), shadowed],
+        expected_sends=2,
+    )
+
+    responses = [
+        json.loads(item["text"])
+        for item in sent
+        if item["type"] == "websocket.send"
+    ]
+    rejected = next(item for item in responses if item["id"] == shadowed["id"])
+    assert rejected["error"] == {
+        "code": -32602,
+        "message": "Invalid params",
+        "data": {"details": "ACP _meta cannot override request parameters"},
+    }
+    assert not hasattr(agents[0][1], "resumed")
+
+
+@pytest.mark.asyncio
+async def test_shadowed_initialize_never_creates_an_agent():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    first = _initialize()
+    first["params"]["_meta"] = {"protocol_version": 0}
+
+    sent = await _websocket(app, headers=signed, frames=[first])
+
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 4400
+    assert agents == []
+
+
+@pytest.mark.asyncio
 async def test_non_standard_json_constant_is_rejected_before_agent_creation():
     app, caller, recipient, agents = _app()
     signed = sign_http_request(

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -38,6 +38,7 @@ from connectonion.cli.co_ai.acp_transport import (
     _StrictNDJSONTransport,
 )
 from connectonion.cli.co_ai.one_shot_sessions import save_snapshot
+from connectonion.core.acp_jsonrpc import acp_meta_shadows_request_params
 from connectonion.core.llm import LLMResponse
 from connectonion.core.usage import TokenUsage
 from connectonion.useful_plugins.tool_approval import check_approval
@@ -1667,6 +1668,119 @@ async def test_strict_ndjson_returns_errors_and_keeps_reading():
     errors = [json.loads(line) for line in writer.buffer.splitlines()]
     assert [item["error"]["code"] for item in errors] == [-32700, -32600]
     assert [item["id"] for item in errors] == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_rejects_meta_parameter_shadowing_and_keeps_reading():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "shadowed",
+                "method": "session/resume",
+                "params": {
+                    "sessionId": "visible-session",
+                    "cwd": "/visible",
+                    "_meta": {
+                        "session_id": "hidden-session",
+                        "cwd": "/hidden",
+                    },
+                },
+            }
+        ).encode()
+        + b"\n"
+    )
+    valid = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"protocolVersion": PROTOCOL_VERSION},
+    }
+    reader.feed_data(json.dumps(valid).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == valid
+    error = json.loads(writer.buffer)
+    assert error == {
+        "jsonrpc": "2.0",
+        "id": "shadowed",
+        "error": {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {"details": "ACP _meta cannot override request parameters"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_drops_shadowed_meta_notification_without_response():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/cancel",
+                "params": {
+                    "sessionId": "visible-session",
+                    "_meta": {"session_id": "hidden-session"},
+                },
+            }
+        ).encode()
+        + b"\n"
+    )
+    valid = {
+        "jsonrpc": "2.0",
+        "method": "session/cancel",
+        "params": {"sessionId": "visible-session", "_meta": {"trace": "ok"}},
+    }
+    reader.feed_data(json.dumps(valid).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == valid
+    assert writer.buffer == b""
+
+
+@pytest.mark.parametrize(
+    ("method", "parameter"),
+    [
+        ("initialize", "protocol_version"),
+        ("session/new", "additional_directories"),
+        ("session/resume", "mcp_servers"),
+        ("session/set_mode", "mode_id"),
+        ("session/prompt", "prompt"),
+        ("session/close", "session_id"),
+        ("session/cancel", "session_id"),
+    ],
+)
+def test_meta_shadow_guard_tracks_pinned_sdk_handler_parameters(method, parameter):
+    assert acp_meta_shadows_request_params(
+        {
+            "method": method,
+            "params": {"_meta": {parameter: "shadowed"}},
+        }
+    )
+
+
+def test_meta_shadow_guard_preserves_unrelated_and_extension_metadata():
+    assert not acp_meta_shadows_request_params(
+        {
+            "method": "session/prompt",
+            "params": {"_meta": {"trace": "kept"}},
+        }
+    )
+    assert not acp_meta_shadows_request_params(
+        {
+            "method": "_connectonion/custom",
+            "params": {"_meta": {"session_id": "extension-owned"}},
+        }
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1757,6 +1757,8 @@ async def test_strict_ndjson_drops_shadowed_meta_notification_without_response()
         ("session/prompt", "prompt"),
         ("session/close", "session_id"),
         ("session/cancel", "session_id"),
+        ("session/update", "update"),
+        ("session/request_permission", "options"),
     ],
 )
 def test_meta_shadow_guard_tracks_pinned_sdk_handler_parameters(method, parameter):


### PR DESCRIPTION
## Summary

- reject ACP `_meta` keys that the pinned Python SDK router would promote over official request parameters
- share the same model-derived guard between native stdio, authenticated WebSocket, and generic `acp_agent` child callbacks
- preserve unrelated metadata and extension methods
- return fixed `InvalidParams` responses for requests, drop invalid notifications without a response, and keep the WebSocket first-frame gate fail closed before Agent construction

## Design

`agent-client-protocol==0.12.0` validates the official request/callback model, then expands `_meta` into Python handler kwargs. Because metadata is applied last, a raw peer can replace values such as `session_id`, `cwd`, `mode_id`, `prompt`, `update`, or permission options after validation.

The guard derives reserved names from the pinned official models. The strict NDJSON transport now lives once in `core` and is used for both Agent and downward Client process roles. It does not duplicate camelCase aliases, inspect metadata values, reject unrelated metadata, or patch the SDK. DD-032, DD-045, and DD-052 record the compatibility boundary and rollback.

This PR is stacked on #961 because that PR introduces the shared native JSON-RPC boundary module. Retarget it to `main` after #961 merges.

## Verification

- red-first reproduction proved both stdio and WebSocket executed shadowed values before the guard
- 294 native ACP/Gateway/official-SDK/real-stdio tests passed
- 66 generic child-agent/tool tests passed, including real subprocess permission and update shadow attempts
- method matrix covers the supported Agent methods plus `session/update` and `session/request_permission`
- Ruff and `git diff --check` passed
- exact lock check passed; locked production dependency audit found no vulnerabilities
- `connectonion-1.7.0a1` wheel and sdist built; both passed Twine validation
- author-side protocol/security/simplicity review found no blocking issue

Closes #971
Related: #838, #894, #960, #961
