### PR TITLE
fix: require ACP wire field names

### DIFF
--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -1,8 +1,9 @@
-"""JSON-RPC boundary rules shared by native ACP transports.
+"""JSON-RPC boundary rules shared by ConnectOnion ACP transports.
 
 Method-specific validation remains owned by the pinned SDK. This module keeps
-stdio and WebSocket aligned on envelope families and blocks metadata keys that
-the pinned SDK router would otherwise promote over validated request fields.
+stdio and WebSocket aligned on envelope families, preserves canonical wire
+names, and blocks metadata keys that the pinned SDK router would otherwise
+promote over validated request fields.
 """
 
 from __future__ import annotations
@@ -22,21 +23,30 @@ from acp.schema import (
     SetSessionModeRequest,
 )
 
+_ROUTED_PARAM_MODELS = {
+    AGENT_METHODS["initialize"]: InitializeRequest,
+    AGENT_METHODS["session_new"]: NewSessionRequest,
+    AGENT_METHODS["session_resume"]: ResumeSessionRequest,
+    AGENT_METHODS["session_set_mode"]: SetSessionModeRequest,
+    AGENT_METHODS["session_prompt"]: PromptRequest,
+    AGENT_METHODS["session_close"]: CloseSessionRequest,
+    AGENT_METHODS["session_cancel"]: CancelNotification,
+    CLIENT_METHODS["session_update"]: SessionNotification,
+    CLIENT_METHODS["session_request_permission"]: RequestPermissionRequest,
+}
 _ROUTED_PARAM_NAMES = {
     method: frozenset(model.model_fields) - {"field_meta"}
-    for method, model in {
-        AGENT_METHODS["initialize"]: InitializeRequest,
-        AGENT_METHODS["session_new"]: NewSessionRequest,
-        AGENT_METHODS["session_resume"]: ResumeSessionRequest,
-        AGENT_METHODS["session_set_mode"]: SetSessionModeRequest,
-        AGENT_METHODS["session_prompt"]: PromptRequest,
-        AGENT_METHODS["session_close"]: CloseSessionRequest,
-        AGENT_METHODS["session_cancel"]: CancelNotification,
-        CLIENT_METHODS["session_update"]: SessionNotification,
-        CLIENT_METHODS["session_request_permission"]: RequestPermissionRequest,
-    }.items()
+    for method, model in _ROUTED_PARAM_MODELS.items()
+}
+_ROUTED_WIRE_PARAM_NAMES = {
+    method: frozenset(
+        field.alias or name
+        for name, field in model.model_fields.items()
+    )
+    for method, model in _ROUTED_PARAM_MODELS.items()
 }
 ACP_META_SHADOW_ERROR_DETAILS = "ACP _meta cannot override request parameters"
+ACP_WIRE_PARAM_ERROR_DETAILS = "ACP params must use protocol field names"
 
 
 def is_acp_request_id(value: Any) -> bool:
@@ -65,6 +75,18 @@ def acp_meta_shadows_request_params(message: Any) -> bool:
         return False
     metadata = params.get("_meta")
     return isinstance(metadata, dict) and not reserved.isdisjoint(metadata)
+
+
+def acp_params_use_protocol_field_names(message: Any) -> bool:
+    """Return whether routed params use only pinned protocol field names."""
+
+    if not isinstance(message, dict):
+        return True
+    allowed = _ROUTED_WIRE_PARAM_NAMES.get(message.get("method"))
+    params = message.get("params")
+    if allowed is None or not isinstance(params, dict):
+        return True
+    return set(params).issubset(allowed)
 
 
 def is_acp_json_rpc_message(message: Any) -> bool:

--- a/connectonion/core/acp_transport.py
+++ b/connectonion/core/acp_transport.py
@@ -12,7 +12,9 @@ from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
 
 from .acp_jsonrpc import (
     ACP_META_SHADOW_ERROR_DETAILS,
+    ACP_WIRE_PARAM_ERROR_DETAILS,
     acp_meta_shadows_request_params,
+    acp_params_use_protocol_field_names,
     acp_request_id,
     is_acp_json_rpc_message,
     is_acp_request_id,
@@ -71,6 +73,15 @@ class StrictACPTransport:
                         self._request_id(message),
                         RequestError.invalid_params(
                             {"details": ACP_META_SHADOW_ERROR_DETAILS}
+                        ),
+                    )
+                continue
+            if not acp_params_use_protocol_field_names(message):
+                if "id" in message:
+                    await self._send_error(
+                        self._request_id(message),
+                        RequestError.invalid_params(
+                            {"details": ACP_WIRE_PARAM_ERROR_DETAILS}
                         ),
                     )
                 continue

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -34,7 +34,9 @@ from pydantic import ValidationError
 
 from ...core.acp_jsonrpc import (
     ACP_META_SHADOW_ERROR_DETAILS,
+    ACP_WIRE_PARAM_ERROR_DETAILS,
     acp_meta_shadows_request_params,
+    acp_params_use_protocol_field_names,
     acp_request_id,
     is_acp_json_rpc_message,
     is_acp_request_id,
@@ -277,6 +279,18 @@ class _ACPTransport:
                         "id": acp_request_id(message),
                         "error": RequestError.invalid_params(
                             {"details": ACP_META_SHADOW_ERROR_DETAILS}
+                        ).to_error_obj(),
+                    }
+                )
+            return
+        if not acp_params_use_protocol_field_names(message):
+            if "id" in message:
+                await self.send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": acp_request_id(message),
+                        "error": RequestError.invalid_params(
+                            {"details": ACP_WIRE_PARAM_ERROR_DETAILS}
                         ).to_error_obj(),
                     }
                 )
@@ -993,6 +1007,7 @@ class AuthenticatedACPApp:
         envelope_valid = (
             is_acp_json_rpc_message(payload)
             and not acp_meta_shadows_request_params(payload)
+            and acp_params_use_protocol_field_names(payload)
             and payload.get("method") == "initialize"
             and isinstance(payload.get("params"), dict)
             and is_acp_request_id(request_id)

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -115,8 +115,11 @@ front of ACP initialization.
 
 The stdio and authenticated WebSocket entry points share exact JSON-RPC
 envelope validation. Mixed request/response envelopes are rejected before ACP
-routing, while method data and extensions such as `_meta` remain validated by
-the pinned official ACP SDK.
+routing. Routed top-level params must use pinned ACP wire names such as
+`protocolVersion`, `sessionId`, `modeId`, and `mcpServers`; Python construction
+aliases and custom root fields receive `InvalidParams`. Put implementation data
+inside `_meta`. The pinned official ACP SDK continues to validate nested method
+data, optional/null values, enums, results, and extension methods.
 
 Each ACP session owns one in-memory `co ai` Agent, so later prompts in that
 session reuse its conversation and tool state. The working directory supplied

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -40,10 +40,15 @@ pre-router rule: a metadata key cannot use the generated Python name of an
 official request or implemented callback field and replace that field after
 validation. Native stdio/WebSocket apply it before Agent routing; the generic
 `acp_agent` child process uses the shared strict stdio transport before
-`ToolClient` callback routing. Other metadata remains untouched. Requests with
-a collision receive `InvalidParams`; invalid notifications are dropped without
-a response. This is a compatibility guard around the pinned router, not a
-second ACP parameter validator.
+`ToolClient` callback routing. Other metadata remains untouched. The same
+pinned-model registry derives each routed method's top-level wire names from
+explicit Pydantic aliases. This keeps Python construction names such as
+`session_id` and `mode_id` from becoming a second ACP dialect, and rejects
+custom root fields that ACP requires callers to place under `_meta`. Requests
+with either violation receive `InvalidParams`; invalid notifications are
+dropped without a response. Nested values, types, nullability, enums, and
+results remain validated by the official SDK rather than a copied
+ConnectOnion schema.
 
 ### State the tested version contract
 
@@ -69,6 +74,8 @@ as clients that launch ConnectOnion.
 - Schema or router drift fails in the official SDK client before release.
 - Raw clients cannot use `_meta` to make executed handler arguments disagree
   with the visible request fields.
+- Raw clients must use the pinned ACP wire aliases for routed top-level params;
+  Python SDK field names are never accepted as protocol spellings.
 - Framing regressions remain visible instead of being hidden by SDK helpers.
 - Interoperability claims say exactly which layer and version were exercised.
 - The deterministic fixture is shared by raw and typed subprocess suites.

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -67,9 +67,9 @@ response, and response envelopes cannot contain request members. Once a valid
 first `initialize` frame is admitted, an invalid later envelope receives
 JSON-RPC `-32600` through the existing bounded outbound queue and is never
 delivered to the Agent. Responses remain correlated by ID rather than arrival
-order. The pinned SDK continues to own method parameters, results, and
-extensions such as `_meta`; envelope validation does not replace ACP schema
-validation.
+order. The pinned SDK continues to own parameter values, nested types, results,
+and extensions such as `_meta`; envelope validation does not replace ACP
+schema validation.
 
 One pinned-router compatibility guard runs before both native transports hand
 messages to the SDK. The SDK promotes `_meta` entries to Python handler keyword
@@ -79,6 +79,16 @@ Such requests receive `-32602` with fixed public details, while invalid
 notifications are dropped without a response. Unrelated `_meta` entries and
 extension methods remain available. A shadowed first WebSocket `initialize`
 fails the existing pre-Agent admission rule and closes with `4400`.
+
+The guard also derives permitted top-level wire keys from explicit aliases on
+those pinned request models. Raw JSON must therefore say `protocolVersion`,
+`sessionId`, `modeId`, and `mcpServers`, never their Python-only construction
+names. Alias/name duplicates and custom root fields receive the same fixed
+`-32602` request error or notification drop. Standard optional/null values and
+arbitrary content inside `_meta` remain available; underscore extension
+methods retain their own raw payload namespace. The first WebSocket gate
+applies this rule before Agent construction, while React already emits the
+standard camelCase forms and needs no compatibility conversion.
 
 ### Browsers exchange a signed request for a one-use ticket
 

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -114,6 +114,13 @@ visible `sessionId`, permission options, tool call, or update delivered to
 notifications are dropped. Unrelated metadata remains an ACP extension and is
 not interpreted as authority.
 
+That shared guard also derives top-level callback wire keys from the pinned
+models. A child must send `sessionId` and `toolCall`, not the Python-only
+`session_id` or `tool_call` names that generated models accept for local
+construction. Non-schema root fields are rejected; opaque `_meta`, nested ACP
+validation, optional/null values, and underscore extension methods remain
+owned by the official protocol layers.
+
 The operator also binds a launch workspace root. Model-selected `cwd` values
 may choose only that directory or a resolved descendant; symlink escapes fail
 closed. This constrains working-directory selection, not every engine's
@@ -138,6 +145,8 @@ present; it does not retain an import-time working directory as a wider root.
   a blocked worker or live subprocess behind.
 - A child cannot use `_meta` to make the session or permission callback checked
   by `ToolClient` disagree with its visible ACP fields.
+- A child cannot reach `ToolClient` through a Python-specific wire alias or an
+  ignored custom root parameter.
 - Re-enabling Codex `manual` or `deny` requires a pinned adapter plus a real
   conformance test covering file writes, shell commands, and outbound network.
 

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -227,6 +227,34 @@ async def test_acp_subprocess_rejects_meta_parameter_shadowing(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_acp_subprocess_rejects_python_wire_aliases(tmp_path):
+    async with _server(tmp_path / "home") as process:
+        rejected, _ = await _request(
+            process,
+            1,
+            "initialize",
+            {
+                "protocol_version": acp_package.PROTOCOL_VERSION,
+                "client_capabilities": {},
+            },
+        )
+        await _initialize(process)
+        created, _ = await _request(
+            process,
+            3,
+            "session/new",
+            {"cwd": str(tmp_path), "mcpServers": []},
+        )
+
+        assert rejected["error"] == {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {"details": "ACP params must use protocol field names"},
+        }
+        assert created["result"]["sessionId"]
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_keeps_stdout_protocol_only_and_exits_on_eof(tmp_path):
     async with _server(tmp_path / "home") as process:
         session_id = await _initialize_and_create_session(process, tmp_path)

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -96,6 +96,14 @@ FAKE_AGENT = textwrap.dedent(
                                      "content": {"type": "text",
                                                  "text": "SHADOWED"}},
                           "_meta": {"session_id": active_session}}})
+            if text == "python alias update":
+                send({"jsonrpc": "2.0", "method": "session/update",
+                      "params": {
+                          "session_id": active_session,
+                          "update": {"sessionUpdate": "agent_message_chunk",
+                                     "messageId": "answer-1",
+                                     "content": {"type": "text",
+                                                 "text": "PYTHON_ALIAS"}}}})
             update({"sessionUpdate": "tool_call", "toolCallId": "call-1",
                     "title": "Run pytest", "kind": "execute",
                     "status": "pending", "rawInput": {"command": "pytest"}})
@@ -110,6 +118,9 @@ FAKE_AGENT = textwrap.dedent(
             if text == "shadow permission":
                 permission_params["sessionId"] = "visible-wrong-session"
                 permission_params["_meta"] = {"session_id": active_session}
+            if text == "python alias permission":
+                del permission_params["sessionId"]
+                permission_params["session_id"] = active_session
             send({"jsonrpc": "2.0", "id": permission_id,
                   "method": "session/request_permission",
                   "params": permission_params})
@@ -471,6 +482,13 @@ class TestTypedRun:
 
         assert output["result"] == "Fixing the tests — done."
 
+    def test_child_python_alias_update_is_not_dispatched(self, fake_command):
+        output = json.loads(
+            runner(fake_command).acp_agent("python alias update")
+        )
+
+        assert output["result"] == "Fixing the tests — done."
+
     def test_failed_resume_does_not_silently_start_another_session(
         self, fake_command
     ):
@@ -526,6 +544,16 @@ class TestPermissionBoundary:
         io = RecordingIO(approve=True)
         runner(fake_command, approval="manual").acp_agent(
             "shadow permission", agent=FakeAgent(io)
+        )
+
+        assert io.approvals == []
+        result = next(event for event in io.events if event["type"] == "tool_result")
+        assert result["status"] == "failed"
+
+    def test_child_python_alias_permission_is_not_dispatched(self, fake_command):
+        io = RecordingIO(approve=True)
+        runner(fake_command, approval="manual").acp_agent(
+            "python alias permission", agent=FakeAgent(io)
         )
 
         assert io.approvals == []

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -1116,6 +1116,73 @@ async def test_shadowed_initialize_never_creates_an_agent():
 
 
 @pytest.mark.asyncio
+async def test_python_alias_initialize_never_creates_an_agent():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    first = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "client_capabilities": {},
+        },
+    }
+
+    sent = await _websocket(app, headers=signed, frames=[first])
+
+    assert sent[-1]["type"] == "websocket.close"
+    assert sent[-1]["code"] == 4400
+    assert agents == []
+
+
+@pytest.mark.asyncio
+async def test_python_alias_resume_has_no_websocket_side_effect():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    non_standard = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "session/resume",
+        "params": {
+            "session_id": "saved-session",
+            "cwd": "/",
+            "mcp_servers": [],
+        },
+    }
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[_initialize(), non_standard],
+        expected_sends=2,
+    )
+
+    responses = [
+        json.loads(item["text"])
+        for item in sent
+        if item["type"] == "websocket.send"
+    ]
+    rejected = next(item for item in responses if item["id"] == 2)
+    assert rejected["error"] == {
+        "code": -32602,
+        "message": "Invalid params",
+        "data": {"details": "ACP params must use protocol field names"},
+    }
+    assert not hasattr(agents[0][1], "resumed")
+
+
+@pytest.mark.asyncio
 async def test_non_standard_json_constant_is_rejected_before_agent_creation():
     app, caller, recipient, agents = _app()
     signed = sign_http_request(

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -38,7 +38,10 @@ from connectonion.cli.co_ai.acp_transport import (
     _StrictNDJSONTransport,
 )
 from connectonion.cli.co_ai.one_shot_sessions import save_snapshot
-from connectonion.core.acp_jsonrpc import acp_meta_shadows_request_params
+from connectonion.core.acp_jsonrpc import (
+    acp_meta_shadows_request_params,
+    acp_params_use_protocol_field_names,
+)
 from connectonion.core.llm import LLMResponse
 from connectonion.core.usage import TokenUsage
 from connectonion.useful_plugins.tool_approval import check_approval
@@ -1747,6 +1750,76 @@ async def test_strict_ndjson_drops_shadowed_meta_notification_without_response()
     assert writer.buffer == b""
 
 
+@pytest.mark.asyncio
+async def test_strict_ndjson_rejects_python_field_aliases_and_keeps_reading():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "python-alias",
+                "method": "session/resume",
+                "params": {
+                    "session_id": "non-standard-session",
+                    "cwd": "/workspace",
+                    "mcp_servers": [],
+                },
+            }
+        ).encode()
+        + b"\n"
+    )
+    valid = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"protocolVersion": PROTOCOL_VERSION},
+    }
+    reader.feed_data(json.dumps(valid).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == valid
+    assert json.loads(writer.buffer) == {
+        "jsonrpc": "2.0",
+        "id": "python-alias",
+        "error": {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {"details": "ACP params must use protocol field names"},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_drops_python_alias_notification_without_response():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "session/cancel",
+                "params": {"session_id": "non-standard-session"},
+            }
+        ).encode()
+        + b"\n"
+    )
+    valid = {
+        "jsonrpc": "2.0",
+        "method": "session/cancel",
+        "params": {"sessionId": "standard-session"},
+    }
+    reader.feed_data(json.dumps(valid).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == valid
+    assert writer.buffer == b""
+
+
 @pytest.mark.parametrize(
     ("method", "parameter"),
     [
@@ -1781,6 +1854,75 @@ def test_meta_shadow_guard_preserves_unrelated_and_extension_metadata():
         {
             "method": "_connectonion/custom",
             "params": {"_meta": {"session_id": "extension-owned"}},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "python_name", "wire_name"),
+    [
+        ("initialize", "protocol_version", "protocolVersion"),
+        ("session/new", "mcp_servers", "mcpServers"),
+        ("session/resume", "additional_directories", "additionalDirectories"),
+        ("session/set_mode", "mode_id", "modeId"),
+        ("session/prompt", "session_id", "sessionId"),
+        ("session/close", "session_id", "sessionId"),
+        ("session/cancel", "session_id", "sessionId"),
+        ("session/update", "session_id", "sessionId"),
+        ("session/request_permission", "tool_call", "toolCall"),
+    ],
+)
+def test_wire_name_guard_tracks_pinned_sdk_aliases(
+    method, python_name, wire_name
+):
+    assert not acp_params_use_protocol_field_names(
+        {"method": method, "params": {python_name: "non-standard"}}
+    )
+    assert acp_params_use_protocol_field_names(
+        {"method": method, "params": {wire_name: "standard"}}
+    )
+
+
+def test_wire_name_guard_preserves_standard_meta_nulls_and_extensions():
+    assert acp_params_use_protocol_field_names(
+        {
+            "method": "session/resume",
+            "params": {
+                "sessionId": "session",
+                "cwd": "/workspace",
+                "additionalDirectories": None,
+                "mcpServers": None,
+                "_meta": {"traceparent": "opaque"},
+            },
+        }
+    )
+    assert acp_params_use_protocol_field_names(
+        {
+            "method": "_connectonion/custom",
+            "params": {"session_id": "extension-owned"},
+        }
+    )
+
+
+def test_wire_name_guard_rejects_unknown_and_duplicate_root_fields():
+    assert not acp_params_use_protocol_field_names(
+        {
+            "method": "session/set_mode",
+            "params": {
+                "sessionId": "session",
+                "modeId": "read-only",
+                "mode_id": "full-access",
+            },
+        }
+    )
+    assert not acp_params_use_protocol_field_names(
+        {
+            "method": "session/prompt",
+            "params": {
+                "sessionId": "session",
+                "prompt": [],
+                "customRootField": True,
+            },
         }
     )
 
@@ -1878,7 +2020,10 @@ async def test_strict_ndjson_accepts_a_frame_larger_than_stream_chunk_limit():
         "jsonrpc": "2.0",
         "id": 1,
         "method": "session/prompt",
-        "params": {"text": large_text},
+        "params": {
+            "sessionId": "session",
+            "prompt": [{"type": "text", "text": large_text}],
+        },
     }
     reader.feed_data(json.dumps(frame).encode() + b"\n")
 


### PR DESCRIPTION
Closes #973
Related to #838 and #894.

## What changed

- derive accepted top-level ACP wire parameter names from the explicit aliases on the pinned official request models;
- reject Python construction names such as `session_id`, `mode_id`, and `mcp_servers` before SDK routing;
- reject alias/name duplicates and non-schema root fields on the ConnectOnion-routed methods;
- apply one shared rule to native stdio, authenticated WebSocket, and guarded generic child callbacks;
- preserve standard optional/null values, opaque `_meta`, nested SDK validation, responses, and underscore extension methods.

## Why

The pinned Python SDK enables `populate_by_name` so local Python callers can construct generated models with snake_case names. Its raw JSON router validates with those same models, which unintentionally turns the Python names into a second wire dialect. A raw stdio or WebSocket peer could therefore send `session_id` instead of standard ACP `sessionId`; generic ACP children could send the same nonstandard spelling into `ToolClient`. When both spellings were present, the model silently selected the standard alias and discarded the Python-name field.

ACP reserves protocol-type root fields and requires custom data to live under `_meta`. Python construction ergonomics should not change that public wire contract.

## Impact

Standards-compliant clients are unchanged. React already emits `sessionId` and `modeId`, and O Chat remains protocol-free. No standalone TypeScript SDK work is involved. Invalid requests receive fixed JSON-RPC `-32602` details without reflecting input; invalid notifications are dropped without a response. No session, trace, or frontend-state migration is required.

## Validation

- red-first reproduction: six selected paths failed before the guard, proving stdio forwarding, WebSocket resume side effects, child result injection, and a real child permission prompt; the existing WebSocket first-frame `protocolVersion` check was already fail-closed;
- implementation-focused matrix: 18 passed;
- native ACP/Gateway/official-SDK/real-stdio matrix: 174 passed;
- all ACP-named unit and CLI E2E files: 537 passed;
- generic child/tool matrix: 68 passed;
- Ruff, `git diff --check`, and `uv lock --check`: passed;
- frozen production dependency audit: no known vulnerabilities;
- wheel and sdist built as `1.7.0a1`, Twine accepted both, and the wheel contains the shared guard modules;
- author-side protocol/security/simplicity review: no blocking finding.

## Review focus

- confirm the canonical names come from pinned model aliases rather than guessed camelCase conversion;
- confirm the registry contains exactly the methods ConnectOnion routes to implemented Agent handlers or Client callbacks;
- confirm `_meta`, extension methods, nullability, and nested validation remain owned by the official protocol layers;
- confirm invalid child permission input cannot reach the operator approval gate.

This is a stacked Draft based on #972 (`fix/acp-meta-shadow-971`). It should be retargeted to `main` only after its parent stack lands. No merge, tag, package publication, frontend release, or deployment is part of this PR.
