### PR TITLE
fix: validate ACP error responses

### DIFF
--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -64,6 +64,21 @@ def acp_request_id(message: Any) -> str | int | None:
     return request_id if is_acp_request_id(request_id) else None
 
 
+def is_acp_json_rpc_response_candidate(message: Any) -> bool:
+    """Return whether an invalid envelope is recognizably a response.
+
+    A JSON-RPC peer must never answer a response. Keeping this classification
+    separate lets transports fail a malformed response without creating an
+    error-response loop.
+    """
+
+    return (
+        isinstance(message, dict)
+        and "method" not in message
+        and ("result" in message or "error" in message)
+    )
+
+
 def acp_meta_shadows_request_params(message: Any) -> bool:
     """Detect metadata keys that the pinned SDK would promote over ACP fields."""
 
@@ -108,4 +123,24 @@ def is_acp_json_rpc_message(message: Any) -> bool:
     if "id" not in message or has_result == has_error:
         return False
     expected = {"jsonrpc", "id", "result" if has_result else "error"}
-    return set(message) == expected and is_acp_request_id(message["id"])
+    if set(message) != expected:
+        return False
+    if has_result:
+        return is_acp_request_id(message["id"])
+    return (
+        (message["id"] is None or is_acp_request_id(message["id"]))
+        and _is_json_rpc_error_object(message["error"])
+    )
+
+
+def _is_json_rpc_error_object(value: Any) -> bool:
+    if not isinstance(value, dict) or not set(value).issubset(
+        {"code", "message", "data"}
+    ):
+        return False
+    code = value.get("code")
+    return (
+        isinstance(code, int)
+        and not isinstance(code, bool)
+        and isinstance(value.get("message"), str)
+    )

--- a/connectonion/core/acp_transport.py
+++ b/connectonion/core/acp_transport.py
@@ -17,6 +17,7 @@ from .acp_jsonrpc import (
     acp_params_use_protocol_field_names,
     acp_request_id,
     is_acp_json_rpc_message,
+    is_acp_json_rpc_response_candidate,
     is_acp_request_id,
 )
 
@@ -64,6 +65,8 @@ class StrictACPTransport:
                 await self._send_error(None, RequestError.parse_error())
                 continue
             if not self._is_json_rpc_message(message):
+                if is_acp_json_rpc_response_candidate(message):
+                    return None
                 request_id = self._request_id(message)
                 await self._send_error(request_id, RequestError.invalid_request())
                 continue

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -39,6 +39,7 @@ from ...core.acp_jsonrpc import (
     acp_params_use_protocol_field_names,
     acp_request_id,
     is_acp_json_rpc_message,
+    is_acp_json_rpc_response_candidate,
     is_acp_request_id,
 )
 from .auth import _authenticate_signed, request_from_http_headers
@@ -263,6 +264,9 @@ class _ACPTransport:
         if self._closed:
             raise ConnectionError("ACP WebSocket transport is closed")
         if not is_acp_json_rpc_message(message):
+            if is_acp_json_rpc_response_candidate(message):
+                await self.close()
+                return
             await self.send(
                 {
                     "jsonrpc": "2.0",

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -121,6 +121,13 @@ aliases and custom root fields receive `InvalidParams`. Put implementation data
 inside `_meta`. The pinned official ACP SDK continues to validate nested method
 data, optional/null values, enums, results, and extension methods.
 
+Error responses use the JSON-RPC `code`, `message`, and optional `data` shape.
+An error may use `id: null` only when the sender could not recover a request ID;
+requests and successful responses still require a string or integer ID. Native
+transports never answer a response. A malformed response closes the connection
+so pending work fails through the existing disconnect path instead of creating
+an error-response loop.
+
 Each ACP session owns one in-memory `co ai` Agent, so later prompts in that
 session reuse its conversation and tool state. The working directory supplied
 by the client must be an existing absolute directory. Additional workspace

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -50,6 +50,14 @@ dropped without a response. Nested values, types, nullability, enums, and
 results remain validated by the official SDK rather than a copied
 ConnectOnion schema.
 
+The shared classifier distinguishes response candidates before deciding
+whether an error reply is legal. Requests and successful responses keep their
+string/non-boolean-integer correlation IDs. A structurally valid error may use
+`id=null` when its sender could not recover the request ID, and its `error`
+object requires an integer `code`, string `message`, and optional arbitrary
+`data`. A malformed response fails the transport and is never answered; this
+prevents two strict peers from turning one protocol error into a response loop.
+
 ### State the tested version contract
 
 The package supports `agent-client-protocol>=0.12.0,<0.13.0` and negotiates

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -71,6 +71,13 @@ order. The pinned SDK continues to own parameter values, nested types, results,
 and extensions such as `_meta`; envelope validation does not replace ACP
 schema validation.
 
+That error reply applies to invalid request candidates, not responses. A
+response has exactly one result or error; the error object has an integer code,
+string message, and optional arbitrary data. An error response may carry a null
+ID when its sender could not identify the request. A malformed response closes
+the transport without a reply, because replying to a response can create a
+protocol loop between strict peers.
+
 One pinned-router compatibility guard runs before both native transports hand
 messages to the SDK. The SDK promotes `_meta` entries to Python handler keyword
 arguments after parsing official fields, so metadata whose key matches an

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -121,6 +121,28 @@ def _isolate_project_lookup(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_acp_subprocess_does_not_answer_its_own_null_id_error(tmp_path):
+    async with _server(tmp_path / "home") as process:
+        assert process.stdin is not None
+        process.stdin.write(b"{not json}\n")
+        await process.stdin.drain()
+        parse_error = await _read_frame(process)
+
+        assert parse_error["id"] is None
+        assert parse_error["error"]["code"] == -32700
+        await _send(process, parse_error)
+
+        initialized, unexpected = await _request(
+            process,
+            1,
+            "initialize",
+            {"protocolVersion": 1, "clientCapabilities": {}},
+        )
+        assert initialized["result"]["protocolVersion"] == 1
+        assert unexpected == []
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
     state_root = tmp_path / "home"
     async with _server(state_root) as process:

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -25,6 +25,7 @@ from connectonion.network.host.acp_gateway import (
     ACPPrincipal,
     ACPTicketRegistry,
     AuthenticatedACPApp,
+    _ACPTransport,
 )
 from connectonion.network.host.auth import sign_http_request
 from connectonion.network.host.session import ActiveSessionRegistry
@@ -234,6 +235,49 @@ def _initialize():
         "method": "initialize",
         "params": {"protocolVersion": PROTOCOL_VERSION},
     }
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"jsonrpc": "2.0", "id": None, "result": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {"code": True, "message": "failed"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {},
+            "params": {},
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_websocket_transport_closes_without_replying_to_malformed_response(
+    message,
+):
+    transport = _ACPTransport()
+
+    await transport.feed(message)
+
+    assert await transport.next_outgoing() is None
+
+
+@pytest.mark.asyncio
+async def test_websocket_transport_accepts_a_null_id_error_without_replying():
+    transport = _ACPTransport()
+    message = {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "Invalid Request"},
+    }
+
+    await transport.feed(message)
+
+    assert await transport.receive() == message
+    assert transport._to_client.empty()
 
 
 def test_ticket_registry_hashes_binds_and_consumes_once():
@@ -1020,12 +1064,6 @@ async def test_malformed_initialize_never_creates_an_agent(first):
             "method": "session/resume",
             "result": {},
         },
-        {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "result": {},
-            "params": {},
-        },
     ],
 )
 async def test_mixed_post_initialize_envelope_has_no_side_effect(mixed):
@@ -1050,6 +1088,39 @@ async def test_mixed_post_initialize_envelope_has_no_side_effect(mixed):
     assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
     assert rejected["error"]["code"] == -32600
     assert not hasattr(agents[0][1], "resumed")
+
+
+@pytest.mark.asyncio
+async def test_malformed_response_after_initialize_is_never_answered():
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    malformed = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {},
+        "params": {},
+    }
+
+    sent = await _websocket(
+        app,
+        headers=signed,
+        frames=[_initialize(), malformed],
+    )
+
+    responses = [
+        json.loads(item["text"])
+        for item in sent
+        if item["type"] == "websocket.send"
+    ]
+    assert all(item.get("id") != malformed["id"] for item in responses)
+    assert not hasattr(agents[0][1], "resumed")
+    assert agents[0][1].cancelled is True
+    assert agents[0][1].closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -41,6 +41,7 @@ from connectonion.cli.co_ai.one_shot_sessions import save_snapshot
 from connectonion.core.acp_jsonrpc import (
     acp_meta_shadows_request_params,
     acp_params_use_protocol_field_names,
+    is_acp_json_rpc_message,
 )
 from connectonion.core.llm import LLMResponse
 from connectonion.core.usage import TokenUsage
@@ -1932,11 +1933,6 @@ def test_wire_name_guard_rejects_unknown_and_duplicate_root_fields():
     [
         {"jsonrpc": "2.0", "id": None, "method": "initialize", "params": {}},
         {"jsonrpc": "2.0", "id": None, "result": {}},
-        {
-            "jsonrpc": "2.0",
-            "id": None,
-            "error": {"code": -32603, "message": "failed"},
-        },
         {"jsonrpc": "2.0", "id": True, "result": {}},
         {"jsonrpc": "2.0", "id": 1.5, "result": {}},
     ],
@@ -2003,11 +1999,83 @@ def test_strict_ndjson_rejects_mixed_request_and_response_envelopes(message):
             "id": "request-1",
             "error": {"code": -32603, "message": "failed"},
         },
+        {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32603, "message": "failed"},
+        },
         {"jsonrpc": "2.0", "method": "session/cancel", "params": {}},
     ],
 )
 def test_strict_ndjson_keeps_supported_ids_and_notifications(message):
     assert _StrictNDJSONTransport._is_json_rpc_message(message) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        None,
+        [],
+        {},
+        {"code": True, "message": "failed"},
+        {"code": -32603, "message": 42},
+        {"code": -32603, "message": "failed", "extra": True},
+    ],
+)
+def test_strict_ndjson_rejects_malformed_error_response_objects(error):
+    assert not is_acp_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 1, "error": error}
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"jsonrpc": "2.0", "id": None, "result": {}},
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "error": {"code": True, "message": "failed"},
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_strict_ndjson_does_not_reply_to_a_malformed_response(message):
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    reader.feed_data(json.dumps(message).encode() + b"\n")
+    reader.feed_eof()
+
+    assert await transport.receive() is None
+    assert writer.buffer == b""
+
+
+@pytest.mark.asyncio
+async def test_strict_ndjson_accepts_a_null_id_error_without_replying():
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    message = {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "Invalid Request"},
+    }
+    reader.feed_data(json.dumps(message).encode() + b"\n")
+
+    assert await transport.receive() == message
+    assert writer.buffer == b""
+
+
+@pytest.mark.parametrize("data", [None, True, 42, "detail", [], {}, {"x": 1}])
+def test_strict_ndjson_preserves_arbitrary_error_data(data):
+    assert is_acp_json_rpc_message(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32000, "message": "failed", "data": data},
+        }
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- validate JSON-RPC error responses as `{code, message, data?}` and reject boolean/non-integer codes or non-string messages
- accept `id: null` only for error responses while keeping request and success IDs restricted to strings/non-boolean integers
- distinguish malformed response candidates from invalid requests so stdio and WebSocket fail the connection without ever answering a response
- document the response-loop boundary in DD-032, DD-045, and the `co ai --acp` guide

Addresses #975.

## Why

Before this change, ConnectOnion rejected the null-ID Parse Error it emitted itself, but accepted malformed error values such as `code: true` and `message: 42`. Echoing one emitted Parse Error into another strict transport produced a new `-32600`, which can become a response loop between strict peers.

The boundary now follows the narrow JSON-RPC rule: invalid request candidates may receive errors; response candidates never receive responses. A malformed response closes/fails the transport so existing disconnect cleanup settles pending work.

## Design

- one shared response-candidate predicate; no transport-specific protocol dialect
- one small error-object validator; ACP method/result schemas remain owned by the pinned official SDK
- no broadened null request IDs
- no React or O Chat conversion; the retired TypeScript SDK is untouched
- request/notification, `_meta`, official field aliases, arbitrary error `data`, and underscore extension behavior remain unchanged

## Verification

- red evidence on parent commit `9f172a69`: own null-ID error rejected, malformed error object accepted, and real stdio subprocess echoed a second `-32600`
- focused response matrix: 25 passed
- complete ACP unit + CLI E2E selection: 614 passed, 6261 deselected
- Ruff: passed
- `git diff --check`: passed
- `uv lock --check`: passed
- wheel and sdist build: passed
- Twine checks: passed
- wheel contains both shared ACP boundary modules
- frozen production dependency audit: no known vulnerabilities

## Author review

No blocking finding. Production behavior adds one shared classifier, one error-object validator, and the same short fail-closed branch in both transports. No new class, config layer, copied protocol schema, authority expansion, or raw peer value is exposed.

## Stack

This Draft is based on #974 (`fix/acp-wire-alias-973`). It should remain Draft until the parent chain lands, then be retargeted to `main` and run through the full main CI/reviewer gate. No merge, tag, or publish action is part of this PR.