### PR TITLE
fix: honor ACP resume capability

### DIFF
--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -216,16 +216,31 @@ async def run_agent(
             resumed = False
             metadata = session_metadata(engine)
             if session_id:
-                if not initialized.agent_capabilities.load_session:
-                    raise RuntimeError(f"{engine} does not advertise session/load")
                 client.active_session = session_id
-                session = await _before_deadline(
-                    connection.load_session(
-                        str(cwd), session_id, mcp_servers=[], **metadata
-                    ),
-                    startup_deadline,
-                    timeout,
+                session_capabilities = (
+                    initialized.agent_capabilities.session_capabilities
                 )
+                resume_capability = getattr(session_capabilities, "resume", None)
+                if resume_capability is not None:
+                    session = await _before_deadline(
+                        connection.resume_session(
+                            session_id, str(cwd), mcp_servers=[], **metadata
+                        ),
+                        startup_deadline,
+                        timeout,
+                    )
+                elif initialized.agent_capabilities.load_session:
+                    session = await _before_deadline(
+                        connection.load_session(
+                            str(cwd), session_id, mcp_servers=[], **metadata
+                        ),
+                        startup_deadline,
+                        timeout,
+                    )
+                else:
+                    raise RuntimeError(
+                        f"{engine} does not advertise session/resume or session/load"
+                    )
                 active_session = session_id
                 resumed = True
             else:
@@ -574,7 +589,7 @@ class ToolClient:
             self._message_truncated = True
 
     def begin_prompt(self) -> None:
-        """Discard history replayed by session/load before this turn starts."""
+        """Discard updates received before this delegated turn starts."""
         self._reset_message()
         self._message_chunks = 0
         self._tool_titles.clear()

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -57,8 +57,12 @@ explicit parent identity, privacy, replay, and rendering semantics.
 Named Claude sessions ignore persistent interactive CLI allow rules and
 explicitly select Manual, Auto, or Don't Ask through advertised ACP session
 modes. Gemini likewise must advertise the required mode. Missing modes fail
-closed. Claude and Codex resume reapply the same policy and never silently
-create a fresh session after load failure.
+closed. For a supplied session ID, the generic client prefers an advertised
+`sessionCapabilities.resume` because it needs continuation without transcript
+replay. It retains `loadSession` as the compatibility path when resume is not
+advertised. Once one method is selected, its failure is final: the client does
+not try the other lifecycle method or silently create a fresh session. Claude
+and Codex continuation reapply the same permission policy on either path.
 
 Gemini CLI 0.55.1 advertises `session/load`, but real new-process conformance
 testing could not load the session created by the preceding process. The named
@@ -135,6 +139,9 @@ present; it does not retain an import-time working directory as a wider root.
 
 - Claude Code, Codex, and Gemini share one typed protocol client without
   replacing the preferred native Claude/Codex tools.
+- A resume-only ACP agent can continue a session, while load-only adapters keep
+  their proven compatibility path and agents advertising both avoid replaying
+  history the outer tool will discard.
 - Browser tool cards show bounded child activity without copying arbitrary
   command arguments, file contents, provider output, thoughts, or plans.
 - The generic Codex ACP route remains available for explicit Full Access, while
@@ -163,6 +170,11 @@ present; it does not retain an import-time working directory as a wider root.
 - **Use unpinned `npx` packages:** executes unreviewed adapter updates.
 - **Silently start a new session after resume failure:** loses continuity while
   falsely reporting successful delegation.
+- **Require `session/load` for every continuation:** rejects agents that expose
+  the narrower ACP `session/resume` capability and asks dual-capability agents
+  to replay history that this adapter deliberately does not consume.
+- **Retry through the other lifecycle method after a request failure:** can
+  duplicate accepted work and hides the selected continuation contract.
 
 ## Related decisions
 

--- a/docs/useful_tools/acp_agent.md
+++ b/docs/useful_tools/acp_agent.md
@@ -48,6 +48,12 @@ does not persist its advertised ACP session across these one-process-per-turn
 invocations. A named Gemini turn therefore returns an empty `session_id`, and
 supplying one fails before launch instead of pretending to resume.
 
+For custom ACP agents, continuation follows the capabilities returned by
+`initialize`. The client prefers `sessionCapabilities.resume` because it does
+not need transcript replay, and otherwise uses `loadSession` for compatibility.
+It sends exactly one selected lifecycle request; a failure never triggers a
+fallback request through the other method.
+
 ## Permissions
 
 The public tool uses manual approval. A model can choose only a named engine;

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -139,6 +139,61 @@ FAKE_AGENT = textwrap.dedent(
     """
 )
 
+CAPABILITY_AGENT = textwrap.dedent(
+    """
+    import json
+    import sys
+
+    def send(message):
+        sys.stdout.write(json.dumps(message) + "\\n")
+        sys.stdout.flush()
+
+    mode = sys.argv[1]
+    selected_method = ""
+    for line in sys.stdin:
+        message = json.loads(line)
+        method, message_id = message.get("method"), message.get("id")
+        if method == "initialize":
+            capabilities = {
+                "loadSession": mode in {"load-only", "both", "resume-fails"}
+            }
+            if mode in {"resume-only", "both", "resume-fails"}:
+                capabilities["sessionCapabilities"] = {"resume": {}}
+            elif mode == "null":
+                capabilities["sessionCapabilities"] = None
+            send({"jsonrpc": "2.0", "id": message_id, "result": {
+                "protocolVersion": 1,
+                "agentCapabilities": capabilities,
+                "agentInfo": {"name": "capability-agent", "version": "1"}}})
+        elif method == "session/resume":
+            assert message["params"] == {
+                "sessionId": "sess-known",
+                "cwd": message["params"]["cwd"],
+                "mcpServers": [],
+            }
+            if mode == "resume-fails":
+                send({"jsonrpc": "2.0", "id": message_id,
+                      "error": {"code": -32002, "message": "resume failed"}})
+            else:
+                selected_method = "RESUME"
+                send({"jsonrpc": "2.0", "id": message_id, "result": {}})
+        elif method == "session/load":
+            selected_method = "LOAD"
+            send({"jsonrpc": "2.0", "id": message_id, "result": {}})
+        elif method == "session/prompt":
+            send({"jsonrpc": "2.0", "method": "session/update", "params": {
+                "sessionId": "sess-known",
+                "update": {"sessionUpdate": "agent_message_chunk",
+                           "messageId": "answer-1",
+                           "content": {"type": "text", "text": selected_method}}}})
+            send({"jsonrpc": "2.0", "id": message_id,
+                  "result": {"stopReason": "end_turn"}})
+        else:
+            send({"jsonrpc": "2.0", "id": message_id,
+                  "error": {"code": -32601, "message": method or "response"}})
+    """
+)
+
 
 class RecordingIO:
     def __init__(self, approve: bool = True, cancelled: bool = False) -> None:
@@ -173,6 +228,17 @@ def fake_command(tmp_path):
     script = tmp_path / "fake_acp.py"
     script.write_text(FAKE_AGENT, encoding="utf-8")
     return [sys.executable, str(script)]
+
+
+@pytest.fixture
+def capability_command(tmp_path):
+    script = tmp_path / "capability_acp.py"
+    script.write_text(CAPABILITY_AGENT, encoding="utf-8")
+
+    def command(mode):
+        return [sys.executable, str(script), mode]
+
+    return command
 
 
 def runner(fake_command, *, approval="auto") -> ACPAgent:
@@ -476,6 +542,62 @@ class TestTypedRun:
         assert output["resumed"] is True
         assert output["session_id"] == "sess-known"
         assert output["result"] == "Fixing the tests — done."
+
+    @pytest.mark.parametrize(
+        ("mode", "expected_method"),
+        [
+            ("resume-only", "RESUME"),
+            ("both", "RESUME"),
+            ("load-only", "LOAD"),
+        ],
+    )
+    def test_continuation_selects_one_advertised_method(
+        self, capability_command, mode, expected_method
+    ):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command(mode),
+                name=mode,
+                approval="auto",
+            ).acp_agent("continue", session_id="sess-known")
+        )
+
+        assert output == {
+            "engine": mode,
+            "session_id": "sess-known",
+            "resumed": True,
+            "stop_reason": "end_turn",
+            "result": expected_method,
+        }
+
+    @pytest.mark.parametrize("mode", ["neither", "null"])
+    def test_missing_continuation_capability_fails_before_request(
+        self, capability_command, mode
+    ):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command(mode),
+                name=mode,
+                approval="auto",
+            ).acp_agent("continue", session_id="sess-known")
+        )
+
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert "does not advertise session/resume or session/load" in output["error"]
+
+    def test_resume_failure_does_not_fall_back_to_load(self, capability_command):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command("resume-fails"),
+                name="resume-fails",
+                approval="auto",
+            ).acp_agent("continue", session_id="sess-known")
+        )
+
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert "resume failed" in output["error"]
 
     def test_child_meta_cannot_shadow_visible_update_session(self, fake_command):
         output = json.loads(runner(fake_command).acp_agent("shadow update"))


### PR DESCRIPTION
## Summary

- prefer advertised `sessionCapabilities.resume` when continuing an ACP child session
- retain `loadSession` as the compatibility path when resume is absent
- fail before a lifecycle request when neither capability is advertised
- never retry through the other method or silently create a replacement session after failure
- record the capability-selection decision in DD-052 and the `acp_agent` documentation

## Why

`acp_agent` previously required `loadSession` for every supplied session ID. A conforming resume-only agent was rejected even though the pinned official client provides typed `session/resume` support. The outer adapter does not consume transcript replay, so resume is the narrower correct primitive when the agent advertises it.

## Stack

This Draft is stacked on #976 (`fix/acp-response-envelope-975`). Review only this branch diff. After its parent chain is reviewed and merged, retarget this PR to `main` and rerun the full matrix.

## Verification

- red-first real stdio fixture reproduced rejection of a resume-only agent
- resume-only, load-only, dual-capability, absent, explicit-null, and failed-resume cases pass
- `tests/unit/test_acp_agent.py`: 68 passed
- ACP unit + CLI selection: 626 passed
- authenticated direct Claude Code/Codex first-turn + continuation and both `co ai -> acp_agent` routes: 4 passed
- Ruff and `git diff --check`: clean
- package wheel/sdist build and Twine checks: passed
- frozen production dependency audit: no known vulnerabilities
- simplicity/security self-review: no retry ambiguity, schema copy, new abstraction, React/O Chat change, or retired TypeScript SDK work

Closes #977

Related: #838, #894, #900, #976; DD-032, DD-052

No merge, tag, or release is part of this PR.