### PR TITLE
fix: enforce ACP version negotiation

### DIFF
--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -213,6 +213,12 @@ async def run_agent(
                 startup_deadline,
                 timeout,
             )
+            if initialized.protocol_version != acp.PROTOCOL_VERSION:
+                raise RuntimeError(
+                    f"{engine} selected unsupported ACP protocol version "
+                    f"{initialized.protocol_version}; client supports "
+                    f"{acp.PROTOCOL_VERSION}"
+                )
             resumed = False
             metadata = session_metadata(engine)
             if session_id:

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -57,7 +57,10 @@ explicit parent identity, privacy, replay, and rendering semantics.
 Named Claude sessions ignore persistent interactive CLI allow rules and
 explicitly select Manual, Auto, or Don't Ask through advertised ACP session
 modes. Gemini likewise must advertise the required mode. Missing modes fail
-closed. For a supplied session ID, the generic client prefers an advertised
+closed. After `initialize`, the generic client requires the agent-selected
+protocol version to equal the v1 major it implements; an unsupported selection
+closes the child before any session lifecycle request. For a supplied session
+ID, the generic client prefers an advertised
 `sessionCapabilities.resume` because it needs continuation without transcript
 replay. It retains `loadSession` as the compatibility path when resume is not
 advertised. Once one method is selected, its failure is final: the client does
@@ -142,6 +145,8 @@ present; it does not retain an import-time working directory as a wider root.
 - A resume-only ACP agent can continue a session, while load-only adapters keep
   their proven compatibility path and agents advertising both avoid replaying
   history the outer tool will discard.
+- An agent selecting an unsupported protocol major cannot receive a v1 session
+  or prompt request after initialization.
 - Browser tool cards show bounded child activity without copying arbitrary
   command arguments, file contents, provider output, thoughts, or plans.
 - The generic Codex ACP route remains available for explicit Full Access, while
@@ -175,6 +180,9 @@ present; it does not retain an import-time working directory as a wider root.
   to replay history that this adapter deliberately does not consume.
 - **Retry through the other lifecycle method after a request failure:** can
   duplicate accepted work and hides the selected continuation contract.
+- **Keep sending v1 messages after an agent selects another major:** confuses a
+  well-typed version value with an agreed protocol and can execute under the
+  wrong wire semantics.
 
 ## Related decisions
 

--- a/docs/useful_tools/acp_agent.md
+++ b/docs/useful_tools/acp_agent.md
@@ -54,6 +54,10 @@ not need transcript replay, and otherwise uses `loadSession` for compatibility.
 It sends exactly one selected lifecycle request; a failure never triggers a
 fallback request through the other method.
 
+This adapter implements ACP protocol major version 1. If an agent selects a
+different major during `initialize`, the tool reports the incompatibility and
+closes the child before creating or resuming a session.
+
 ## Permissions
 
 The public tool uses manual approval. A model can choose only a named engine;

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -155,16 +155,22 @@ CAPABILITY_AGENT = textwrap.dedent(
         method, message_id = message.get("method"), message.get("id")
         if method == "initialize":
             capabilities = {
-                "loadSession": mode in {"load-only", "both", "resume-fails"}
+                "loadSession": mode in {
+                    "load-only", "both", "resume-fails", "version-two"
+                }
             }
             if mode in {"resume-only", "both", "resume-fails"}:
                 capabilities["sessionCapabilities"] = {"resume": {}}
             elif mode == "null":
                 capabilities["sessionCapabilities"] = None
             send({"jsonrpc": "2.0", "id": message_id, "result": {
-                "protocolVersion": 1,
+                "protocolVersion": 2 if mode == "version-two" else 1,
                 "agentCapabilities": capabilities,
                 "agentInfo": {"name": "capability-agent", "version": "1"}}})
+        elif method == "session/new":
+            selected_method = "NEW"
+            send({"jsonrpc": "2.0", "id": message_id,
+                  "result": {"sessionId": "sess-known"}})
         elif method == "session/resume":
             assert message["params"] == {
                 "sessionId": "sess-known",
@@ -598,6 +604,23 @@ class TestTypedRun:
         assert output["resumed"] is False
         assert output["result"] == ""
         assert "resume failed" in output["error"]
+
+    def test_incompatible_protocol_version_stops_before_session(
+        self, capability_command
+    ):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command("version-two"),
+                name="version-two",
+                approval="auto",
+            ).acp_agent("continue")
+        )
+
+        assert output["session_id"] == ""
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert "selected unsupported ACP protocol version 2" in output["error"]
+        assert "client supports 1" in output["error"]
 
     def test_child_meta_cannot_shadow_visible_update_session(self, fake_command):
         output = json.loads(runner(fake_command).acp_agent("shadow update"))


### PR DESCRIPTION
## Summary

- compare the agent-selected protocol major immediately after `initialize`
- stop and close the child when the selected major is not ACP v1
- send no session or prompt request under incompatible wire semantics
- document the negotiated-version boundary in DD-052 and the `acp_agent` guide

## Why

The client sent `protocolVersion=1` but ignored the version returned by the agent. A typed fixture selecting version 2 therefore received a v1 `session/new` request. ACP requires both peers to agree on a protocol major before continuing.

## Stack

This Draft is stacked on #978 (`fix/acp-resume-capability-977`), which is stacked on #976. Review only this branch diff. After the parent chain is independently reviewed and merged, retarget this PR to `main` and rerun the full matrix.

## Verification

- red-first real stdio fixture proved version 2 reached `session/new` before the fix
- the fixed fixture stops after initialize and reports selected/supported versions
- `tests/unit/test_acp_agent.py`: 69 passed
- ACP unit + CLI selection: 627 passed
- authenticated direct Claude Code/Codex first-turn + continuation and both `co ai -> acp_agent` routes: 4 passed
- Ruff and `git diff --check`: clean
- package wheel/sdist build and Twine checks: passed
- lock check and frozen production dependency audit: passed; no known vulnerabilities
- simplicity/security review: six production lines, no version converter, retry, schema copy, hidden exception, React/O Chat change, or retired TypeScript SDK work

Closes #979

Related: #838, #894, #900, #977, #978; DD-032, DD-052

No merge, tag, or release is part of this PR.