### PR TITLE
fix: normalize null ACP capabilities

### DIFF
--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -13,6 +13,7 @@ from typing import Any
 import acp
 from acp.client.connection import ClientSideConnection
 from acp.schema import (
+    AgentCapabilities,
     AgentMessageChunk,
     AllowedOutcome,
     ClientCapabilities,
@@ -219,13 +220,14 @@ async def run_agent(
                     f"{initialized.protocol_version}; client supports "
                     f"{acp.PROTOCOL_VERSION}"
                 )
+            agent_capabilities = (
+                initialized.agent_capabilities or AgentCapabilities()
+            )
             resumed = False
             metadata = session_metadata(engine)
             if session_id:
                 client.active_session = session_id
-                session_capabilities = (
-                    initialized.agent_capabilities.session_capabilities
-                )
+                session_capabilities = agent_capabilities.session_capabilities
                 resume_capability = getattr(session_capabilities, "resume", None)
                 if resume_capability is not None:
                     session = await _before_deadline(
@@ -235,7 +237,7 @@ async def run_agent(
                         startup_deadline,
                         timeout,
                     )
-                elif initialized.agent_capabilities.load_session:
+                elif agent_capabilities.load_session:
                     session = await _before_deadline(
                         connection.load_session(
                             str(cwd), session_id, mcp_servers=[], **metadata

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -65,7 +65,10 @@ ID, the generic client prefers an advertised
 replay. It retains `loadSession` as the compatibility path when resume is not
 advertised. Once one method is selected, its failure is final: the client does
 not try the other lifecycle method or silently create a fresh session. Claude
-and Codex continuation reapply the same permission policy on either path.
+and Codex continuation reapply the same permission policy on either path. The
+typed schema permits `agentCapabilities: null`; the client treats that as an
+empty capability set and fails continuation before a lifecycle request instead
+of leaking an internal attribute error or guessing an unsupported method.
 
 Gemini CLI 0.55.1 advertises `session/load`, but real new-process conformance
 testing could not load the session created by the preceding process. The named
@@ -183,6 +186,9 @@ present; it does not retain an import-time working directory as a wider root.
 - **Keep sending v1 messages after an agent selects another major:** confuses a
   well-typed version value with an agreed protocol and can execute under the
   wrong wire semantics.
+- **Reject or guess around a null agent capability object:** the pinned schema
+  permits null. Treating it as no optional capabilities preserves negotiation;
+  blindly trying a lifecycle method does not.
 
 ## Related decisions
 

--- a/docs/useful_tools/acp_agent.md
+++ b/docs/useful_tools/acp_agent.md
@@ -52,7 +52,10 @@ For custom ACP agents, continuation follows the capabilities returned by
 `initialize`. The client prefers `sessionCapabilities.resume` because it does
 not need transcript replay, and otherwise uses `loadSession` for compatibility.
 It sends exactly one selected lifecycle request; a failure never triggers a
-fallback request through the other method.
+fallback request through the other method. An explicitly null
+`agentCapabilities` value means that no optional capability was advertised, so
+continuation fails with the same capability error before sending a lifecycle
+request.
 
 This adapter implements ACP protocol major version 1. If an agent selects a
 different major during `initialize`, the tool reports the incompatibility and

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -165,7 +165,9 @@ CAPABILITY_AGENT = textwrap.dedent(
                 capabilities["sessionCapabilities"] = None
             send({"jsonrpc": "2.0", "id": message_id, "result": {
                 "protocolVersion": 2 if mode == "version-two" else 1,
-                "agentCapabilities": capabilities,
+                "agentCapabilities": (
+                    None if mode == "agent-null" else capabilities
+                ),
                 "agentInfo": {"name": "capability-agent", "version": "1"}}})
         elif method == "session/new":
             selected_method = "NEW"
@@ -576,7 +578,7 @@ class TestTypedRun:
             "result": expected_method,
         }
 
-    @pytest.mark.parametrize("mode", ["neither", "null"])
+    @pytest.mark.parametrize("mode", ["neither", "null", "agent-null"])
     def test_missing_continuation_capability_fails_before_request(
         self, capability_command, mode
     ):


### PR DESCRIPTION
## Summary

- normalize a schema-valid `agentCapabilities: null` initialize result to the pinned SDK's empty `AgentCapabilities` model
- preserve capability-driven continuation: prefer advertised `session/resume`, otherwise `session/load`, and never guess or fall back after a request
- extend the real stdio capability matrix and document the null-as-empty decision in DD-052 and the public tool guide

## Root cause

The official typed schema accepts an explicitly null `agentCapabilities` value. The continuation path assumed the decoded object was always present and dereferenced `.session_capabilities`, leaking a `NoneType` implementation error before it could issue the existing clear capability error.

The fix uses the existing pinned ACP model as the default. It does not add a local schema, exception catch, lifecycle retry, or new-session fallback.

## Design review

- **Chosen:** treat null as an empty optional-capability set and fail closed before a lifecycle request.
- **Rejected:** declare the valid initialize response malformed.
- **Rejected:** try resume/load without an advertisement.
- **Rejected:** catch `AttributeError` at the public envelope boundary.

Full alternatives and acceptance criteria are recorded in #981 before implementation.

## Validation

- reproduced red against the previous exact head: `ACP agent-null: 'NoneType' object has no attribute 'session_capabilities'`
- focused continuation/version matrix: 8 passed
- ACP unit + CLI selection: 628 passed, 6678 deselected
- authenticated real provider E2E: 4 passed
  - Claude Code first turn + cross-process resume
  - Codex first turn + cross-process resume
  - `co ai -> acp_agent -> Claude Code`
  - `co ai -> acp_agent -> Codex`
- `git diff --check` and Ruff lint pass
- `uv lock --check` passes
- wheel + sdist build as `1.7.0a1`; Twine checks both artifacts
- frozen production dependency audit: no known vulnerabilities
- Linus-style review: no helper, catch-all, fallback, or duplicate schema introduced

## Stack

Draft stacked on #980. Keep this Draft and do not merge directly until its parent stack has been reviewed, merged, and this PR is retargeted to `main` for full CI.

Closes #981
