### PR TITLE
fix(acp): reject coerced protocol versions

### DIFF
--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -214,10 +214,15 @@ async def run_agent(
                 startup_deadline,
                 timeout,
             )
-            if initialized.protocol_version != acp.PROTOCOL_VERSION:
+            if type(client.raw_protocol_version) is not int:
+                raise RuntimeError(
+                    f"{engine} returned ACP protocolVersion as "
+                    f"{type(client.raw_protocol_version).__name__}; expected integer"
+                )
+            if client.raw_protocol_version != acp.PROTOCOL_VERSION:
                 raise RuntimeError(
                     f"{engine} selected unsupported ACP protocol version "
-                    f"{initialized.protocol_version}; client supports "
+                    f"{client.raw_protocol_version}; client supports "
                     f"{acp.PROTOCOL_VERSION}"
                 )
             agent_capabilities = (
@@ -423,13 +428,24 @@ class ToolClient:
         self._in_prompt = False
         self._updates_seen = 0
         self._updates_handled = 0
+        self._initialize_request_id: str | int | None = None
+        self.raw_protocol_version: Any = None
 
     def observe_stream(self, event) -> None:
         """Count updates before their independently scheduled callbacks run."""
-        if (
-            getattr(event.direction, "value", "") == "incoming"
-            and event.message.get("method") == "session/update"
+        direction = getattr(event.direction, "value", "")
+        message = event.message
+        if direction == "outgoing" and message.get("method") == "initialize":
+            self._initialize_request_id = message.get("id")
+        elif (
+            direction == "incoming"
+            and self._initialize_request_id is not None
+            and message.get("id") == self._initialize_request_id
         ):
+            result = message.get("result")
+            if isinstance(result, dict):
+                self.raw_protocol_version = result.get("protocolVersion")
+        if direction == "incoming" and message.get("method") == "session/update":
             self._updates_seen += 1
 
     async def drain_updates(self, deadline: float, timeout: int) -> None:

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -58,9 +58,11 @@ Named Claude sessions ignore persistent interactive CLI allow rules and
 explicitly select Manual, Auto, or Don't Ask through advertised ACP session
 modes. Gemini likewise must advertise the required mode. Missing modes fail
 closed. After `initialize`, the generic client requires the agent-selected
-protocol version to equal the v1 major it implements; an unsupported selection
-closes the child before any session lifecycle request. For a supplied session
-ID, the generic client prefers an advertised
+protocol version to be a JSON integer equal to the v1 major it implements. It
+observes the raw response correlated to the actual initialize request ID so a
+schema library cannot quietly coerce `"1"` or `true` into version 1. An invalid
+type or unsupported selection closes the child before any session lifecycle
+request. For a supplied session ID, the generic client prefers an advertised
 `sessionCapabilities.resume` because it needs continuation without transcript
 replay. It retains `loadSession` as the compatibility path when resume is not
 advertised. Once one method is selected, its failure is final: the client does
@@ -186,6 +188,9 @@ present; it does not retain an import-time working directory as a wider root.
 - **Keep sending v1 messages after an agent selects another major:** confuses a
   well-typed version value with an agreed protocol and can execute under the
   wrong wire semantics.
+- **Trust only the SDK's coerced protocol-version field:** accepts strings and
+  booleans as v1. Making every ACP model globally strict or copying the full
+  initialize schema would widen this focused compatibility fix unnecessarily.
 - **Reject or guess around a null agent capability object:** the pinned schema
   permits null. Treating it as no optional capabilities preserves negotiation;
   blindly trying a lifecycle method does not.

--- a/docs/useful_tools/acp_agent.md
+++ b/docs/useful_tools/acp_agent.md
@@ -57,9 +57,10 @@ fallback request through the other method. An explicitly null
 continuation fails with the same capability error before sending a lifecycle
 request.
 
-This adapter implements ACP protocol major version 1. If an agent selects a
-different major during `initialize`, the tool reports the incompatibility and
-closes the child before creating or resuming a session.
+This adapter implements ACP protocol major version 1. The initialize response
+must carry `protocolVersion` as a JSON integer, not a string or boolean. An
+invalid type or different major closes the child before creating or resuming a
+session.
 
 ## Permissions
 

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -163,8 +163,16 @@ CAPABILITY_AGENT = textwrap.dedent(
                 capabilities["sessionCapabilities"] = {"resume": {}}
             elif mode == "null":
                 capabilities["sessionCapabilities"] = None
+            if mode == "version-string":
+                protocol_version = "1"
+            elif mode == "version-bool":
+                protocol_version = True
+            elif mode == "version-two":
+                protocol_version = 2
+            else:
+                protocol_version = 1
             send({"jsonrpc": "2.0", "id": message_id, "result": {
-                "protocolVersion": 2 if mode == "version-two" else 1,
+                "protocolVersion": protocol_version,
                 "agentCapabilities": (
                     None if mode == "agent-null" else capabilities
                 ),
@@ -623,6 +631,54 @@ class TestTypedRun:
         assert output["result"] == ""
         assert "selected unsupported ACP protocol version 2" in output["error"]
         assert "client supports 1" in output["error"]
+
+    @pytest.mark.parametrize(
+        ("mode", "wire_type"),
+        [("version-string", "str"), ("version-bool", "bool")],
+    )
+    def test_coerced_protocol_version_stops_before_session(
+        self, capability_command, mode, wire_type
+    ):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command(mode),
+                name=mode,
+                approval="auto",
+            ).acp_agent("continue")
+        )
+
+        assert output["session_id"] == ""
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert (
+            f"returned ACP protocolVersion as {wire_type}; expected integer"
+            in output["error"]
+        )
+
+    def test_raw_protocol_version_uses_initialize_request_id(self):
+        client = ToolClient(None, "deny")
+        outgoing = SimpleNamespace(
+            direction=SimpleNamespace(value="outgoing"),
+            message={"jsonrpc": "2.0", "id": "init-7", "method": "initialize"},
+        )
+        unrelated = SimpleNamespace(
+            direction=SimpleNamespace(value="incoming"),
+            message={"jsonrpc": "2.0", "id": 0, "result": {"protocolVersion": True}},
+        )
+        matching = SimpleNamespace(
+            direction=SimpleNamespace(value="incoming"),
+            message={
+                "jsonrpc": "2.0",
+                "id": "init-7",
+                "result": {"protocolVersion": "1"},
+            },
+        )
+
+        client.observe_stream(outgoing)
+        client.observe_stream(unrelated)
+        assert client.raw_protocol_version is None
+        client.observe_stream(matching)
+        assert client.raw_protocol_version == "1"
 
     def test_child_meta_cannot_shadow_visible_update_session(self, fake_command):
         output = json.loads(runner(fake_command).acp_agent("shadow update"))


### PR DESCRIPTION
Closes #983

## Decision

- capture the raw `protocolVersion` from the response correlated to the actual initialize request ID;
- require the wire value to be a JSON integer before comparing it with ACP v1;
- fail closed before `session/new`, `session/resume`, or `session/load`;
- keep the pinned official ACP models instead of copying the initialize schema or enabling global strict coercion.

## Stack

- base: #982 (`agentCapabilities: null` normalization)
- this PR contains only the protocol-version wire-type delta and its docs/tests

## Validation

- red proof: the parent accepted both `"1"` and `true`, created `sess-known`, and completed a prompt;
- focused version/correlation matrix: 4 passed;
- complete `test_acp_agent.py`: 73 passed;
- full ACP selection: 631 passed, 6935 deselected;
- authenticated real provider E2E: 5 passed (Claude first/resume, Codex first/resume, `co ai` to Claude, `co ai` to Codex, Gemini one turn);
- `uv lock --check`, Ruff, and `git diff --check` pass;
- 1.7.0a1 wheel and sdist build; both pass Twine;
- frozen production dependency audit: no known vulnerabilities.

Draft only. No merge or release is requested.