### PR TITLE
fix(acp): validate load capability wire type

### DIFF
--- a/connectonion/useful_tools/_acp_agent_client.py
+++ b/connectonion/useful_tools/_acp_agent_client.py
@@ -225,6 +225,15 @@ async def run_agent(
                     f"{client.raw_protocol_version}; client supports "
                     f"{acp.PROTOCOL_VERSION}"
                 )
+            if (
+                client.raw_load_session is not None
+                and type(client.raw_load_session) is not bool
+            ):
+                raise RuntimeError(
+                    f"{engine} returned ACP loadSession as "
+                    f"{type(client.raw_load_session).__name__}; "
+                    "expected boolean or null"
+                )
             agent_capabilities = (
                 initialized.agent_capabilities or AgentCapabilities()
             )
@@ -430,6 +439,7 @@ class ToolClient:
         self._updates_handled = 0
         self._initialize_request_id: str | int | None = None
         self.raw_protocol_version: Any = None
+        self.raw_load_session: Any = None
 
     def observe_stream(self, event) -> None:
         """Count updates before their independently scheduled callbacks run."""
@@ -445,6 +455,9 @@ class ToolClient:
             result = message.get("result")
             if isinstance(result, dict):
                 self.raw_protocol_version = result.get("protocolVersion")
+                capabilities = result.get("agentCapabilities")
+                if isinstance(capabilities, dict):
+                    self.raw_load_session = capabilities.get("loadSession")
         if direction == "incoming" and message.get("method") == "session/update":
             self._updates_seen += 1
 

--- a/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
+++ b/docs/design-decisions/052-bounded-downward-acp-agent-adapter.md
@@ -70,7 +70,10 @@ not try the other lifecycle method or silently create a fresh session. Claude
 and Codex continuation reapply the same permission policy on either path. The
 typed schema permits `agentCapabilities: null`; the client treats that as an
 empty capability set and fails continuation before a lifecycle request instead
-of leaking an internal attribute error or guessing an unsupported method.
+of leaking an internal attribute error or guessing an unsupported method. The
+legacy `loadSession` field is consumed only when its correlated raw value is a
+JSON boolean; null and omission remain unadvertised, while strings and numbers
+fail before lifecycle instead of becoming truthy through schema coercion.
 
 Gemini CLI 0.55.1 advertises `session/load`, but real new-process conformance
 testing could not load the session created by the preceding process. The named
@@ -191,6 +194,8 @@ present; it does not retain an import-time working directory as a wider root.
 - **Trust only the SDK's coerced protocol-version field:** accepts strings and
   booleans as v1. Making every ACP model globally strict or copying the full
   initialize schema would widen this focused compatibility fix unnecessarily.
+- **Trust a coerced `loadSession` capability:** a string or number can become
+  true and trigger a lifecycle request the peer did not validly advertise.
 - **Reject or guess around a null agent capability object:** the pinned schema
   permits null. Treating it as no optional capabilities preserves negotiation;
   blindly trying a lifecycle method does not.

--- a/docs/useful_tools/acp_agent.md
+++ b/docs/useful_tools/acp_agent.md
@@ -55,7 +55,8 @@ It sends exactly one selected lifecycle request; a failure never triggers a
 fallback request through the other method. An explicitly null
 `agentCapabilities` value means that no optional capability was advertised, so
 continuation fails with the same capability error before sending a lifecycle
-request.
+request. The legacy `loadSession` flag must be a JSON boolean or null; strings
+and numbers fail initialization instead of being coerced into a capability.
 
 This adapter implements ACP protocol major version 1. The initialize response
 must carry `protocolVersion` as a JSON integer, not a string or boolean. An

--- a/tests/unit/test_acp_agent.py
+++ b/tests/unit/test_acp_agent.py
@@ -154,11 +154,17 @@ CAPABILITY_AGENT = textwrap.dedent(
         message = json.loads(line)
         method, message_id = message.get("method"), message.get("id")
         if method == "initialize":
-            capabilities = {
-                "loadSession": mode in {
+            if mode == "load-string":
+                load_session = "true"
+            elif mode == "load-int":
+                load_session = 1
+            elif mode == "load-null":
+                load_session = None
+            else:
+                load_session = mode in {
                     "load-only", "both", "resume-fails", "version-two"
                 }
-            }
+            capabilities = {"loadSession": load_session}
             if mode in {"resume-only", "both", "resume-fails"}:
                 capabilities["sessionCapabilities"] = {"resume": {}}
             elif mode == "null":
@@ -679,6 +685,83 @@ class TestTypedRun:
         assert client.raw_protocol_version is None
         client.observe_stream(matching)
         assert client.raw_protocol_version == "1"
+
+    @pytest.mark.parametrize(
+        ("mode", "wire_type"),
+        [("load-string", "str"), ("load-int", "int")],
+    )
+    def test_coerced_load_capability_stops_before_lifecycle(
+        self, capability_command, mode, wire_type
+    ):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command(mode),
+                name=mode,
+                approval="auto",
+            ).acp_agent("continue", session_id="sess-known")
+        )
+
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert (
+            f"returned ACP loadSession as {wire_type}; expected boolean or null"
+            in output["error"]
+        )
+
+    def test_null_load_capability_is_not_advertised(self, capability_command):
+        output = json.loads(
+            ACPAgent(
+                command=capability_command("load-null"),
+                name="load-null",
+                approval="auto",
+            ).acp_agent("continue", session_id="sess-known")
+        )
+
+        assert output["resumed"] is False
+        assert output["result"] == ""
+        assert "does not advertise session/resume or session/load" in output["error"]
+
+    def test_raw_load_capability_uses_initialize_request_id(self):
+        client = ToolClient(None, "deny")
+        client.observe_stream(
+            SimpleNamespace(
+                direction=SimpleNamespace(value="outgoing"),
+                message={
+                    "jsonrpc": "2.0",
+                    "id": "init-8",
+                    "method": "initialize",
+                },
+            )
+        )
+        client.observe_stream(
+            SimpleNamespace(
+                direction=SimpleNamespace(value="incoming"),
+                message={
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {"loadSession": 1},
+                    },
+                },
+            )
+        )
+        assert client.raw_load_session is None
+
+        client.observe_stream(
+            SimpleNamespace(
+                direction=SimpleNamespace(value="incoming"),
+                message={
+                    "jsonrpc": "2.0",
+                    "id": "init-8",
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {"loadSession": "true"},
+                    },
+                },
+            )
+        )
+        assert client.raw_load_session == "true"
 
     def test_child_meta_cannot_shadow_visible_update_session(self, fake_command):
         output = json.loads(runner(fake_command).acp_agent("shadow update"))


### PR DESCRIPTION
Closes #985

## Decision

- reuse the initialize response already correlated to the actual request ID;
- require a present non-null `loadSession` wire value to be a JSON boolean;
- keep null, omission, and false unadvertised; keep true as the legacy `session/load` capability;
- validate only this consumed field and leave all other optional/extension schema ownership with the pinned ACP SDK.

## Stack

- base: #984 (strict raw `protocolVersion` negotiation)
- this PR contains only the `loadSession` wire-type delta and its docs/tests

## Validation

- red proof: the parent accepted both `"true"` and `1`, executed `session/load`, and reported a resumed turn;
- focused valid/invalid/correlation/precedence matrix: 7 passed;
- complete adapter unit file: 77 passed;
- full ACP selection: 635 passed, 6935 deselected;
- authenticated real-provider E2E: 5 passed (Claude first/resume, Codex first/resume, `co ai` to both, Gemini one turn);
- `uv lock --check`, Ruff, and `git diff --check` pass;
- 1.7.0a1 wheel and sdist build and both pass Twine;
- frozen production dependency audit: no known vulnerabilities.

Draft only. No merge or release is requested.