### PR TITLE
fix: align ACP initialize version compatibility

### DIFF
--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -48,7 +48,7 @@ _ROUTED_WIRE_PARAM_NAMES = {
 ACP_META_SHADOW_ERROR_DETAILS = "ACP _meta cannot override request parameters"
 ACP_WIRE_PARAM_ERROR_DETAILS = "ACP params must use protocol field names"
 ACP_PROTOCOL_VERSION_ERROR_DETAILS = (
-    "ACP protocolVersion must be a JSON integer from 0 to 65535"
+    "ACP protocolVersion must be a legacy string or JSON integer from 0 to 65535"
 )
 
 
@@ -108,7 +108,7 @@ def acp_params_use_protocol_field_names(message: Any) -> bool:
 
 
 def acp_initialize_protocol_version_is_valid(message: Any) -> bool:
-    """Validate the raw initialize version before SDK type coercion."""
+    """Validate raw versions while preserving official legacy strings."""
 
     if not isinstance(message, dict) or message.get("method") != "initialize":
         return True
@@ -116,6 +116,8 @@ def acp_initialize_protocol_version_is_valid(message: Any) -> bool:
     if not isinstance(params, dict) or "protocolVersion" not in params:
         return True
     protocol_version = params["protocolVersion"]
+    if isinstance(protocol_version, str):
+        return True
     return type(protocol_version) is int and 0 <= protocol_version <= 65535
 
 

--- a/connectonion/core/acp_jsonrpc.py
+++ b/connectonion/core/acp_jsonrpc.py
@@ -47,6 +47,9 @@ _ROUTED_WIRE_PARAM_NAMES = {
 }
 ACP_META_SHADOW_ERROR_DETAILS = "ACP _meta cannot override request parameters"
 ACP_WIRE_PARAM_ERROR_DETAILS = "ACP params must use protocol field names"
+ACP_PROTOCOL_VERSION_ERROR_DETAILS = (
+    "ACP protocolVersion must be a JSON integer from 0 to 65535"
+)
 
 
 def is_acp_request_id(value: Any) -> bool:
@@ -102,6 +105,18 @@ def acp_params_use_protocol_field_names(message: Any) -> bool:
     if allowed is None or not isinstance(params, dict):
         return True
     return set(params).issubset(allowed)
+
+
+def acp_initialize_protocol_version_is_valid(message: Any) -> bool:
+    """Validate the raw initialize version before SDK type coercion."""
+
+    if not isinstance(message, dict) or message.get("method") != "initialize":
+        return True
+    params = message.get("params")
+    if not isinstance(params, dict) or "protocolVersion" not in params:
+        return True
+    protocol_version = params["protocolVersion"]
+    return type(protocol_version) is int and 0 <= protocol_version <= 65535
 
 
 def is_acp_json_rpc_message(message: Any) -> bool:

--- a/connectonion/core/acp_transport.py
+++ b/connectonion/core/acp_transport.py
@@ -12,7 +12,9 @@ from acp.core import DEFAULT_STDIO_BUFFER_LIMIT_BYTES
 
 from .acp_jsonrpc import (
     ACP_META_SHADOW_ERROR_DETAILS,
+    ACP_PROTOCOL_VERSION_ERROR_DETAILS,
     ACP_WIRE_PARAM_ERROR_DETAILS,
+    acp_initialize_protocol_version_is_valid,
     acp_meta_shadows_request_params,
     acp_params_use_protocol_field_names,
     acp_request_id,
@@ -85,6 +87,15 @@ class StrictACPTransport:
                         self._request_id(message),
                         RequestError.invalid_params(
                             {"details": ACP_WIRE_PARAM_ERROR_DETAILS}
+                        ),
+                    )
+                continue
+            if not acp_initialize_protocol_version_is_valid(message):
+                if "id" in message:
+                    await self._send_error(
+                        self._request_id(message),
+                        RequestError.invalid_params(
+                            {"details": ACP_PROTOCOL_VERSION_ERROR_DETAILS}
                         ),
                     )
                 continue

--- a/connectonion/network/host/acp_gateway.py
+++ b/connectonion/network/host/acp_gateway.py
@@ -35,6 +35,7 @@ from pydantic import ValidationError
 from ...core.acp_jsonrpc import (
     ACP_META_SHADOW_ERROR_DETAILS,
     ACP_WIRE_PARAM_ERROR_DETAILS,
+    acp_initialize_protocol_version_is_valid,
     acp_meta_shadows_request_params,
     acp_params_use_protocol_field_names,
     acp_request_id,
@@ -1012,18 +1013,12 @@ class AuthenticatedACPApp:
             is_acp_json_rpc_message(payload)
             and not acp_meta_shadows_request_params(payload)
             and acp_params_use_protocol_field_names(payload)
+            and acp_initialize_protocol_version_is_valid(payload)
             and payload.get("method") == "initialize"
             and isinstance(payload.get("params"), dict)
             and is_acp_request_id(request_id)
         )
         if not envelope_valid:
-            return False
-        protocol_version = payload["params"].get("protocolVersion")
-        if (
-            isinstance(protocol_version, bool)
-            or not isinstance(protocol_version, int)
-            or not 0 <= protocol_version <= 65535
-        ):
             return False
         try:
             InitializeRequest.model_validate(payload["params"])

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -105,8 +105,9 @@ on stderr.
 The first request on each connection must be `initialize`. Session requests
 sent before initialization fail without constructing an Agent or allocating
 session state, and a second `initialize` request on the same connection is
-rejected. Clients may continue with session requests after either rejection
-only when the connection has already completed one successful initialization.
+rejected. Clients may continue with session requests after those lifecycle-order
+rejections only when the connection has already completed one successful
+initialization.
 
 Use `--acp` when another local process launches `co ai` and owns its stdio.
 Default web-server mode also exposes authenticated ACP v1 at `/acp`; it is a
@@ -119,7 +120,11 @@ routing. Routed top-level params must use pinned ACP wire names such as
 `protocolVersion`, `sessionId`, `modeId`, and `mcpServers`; Python construction
 aliases and custom root fields receive `InvalidParams`. Put implementation data
 inside `_meta`. The pinned official ACP SDK continues to validate nested method
-data, optional/null values, enums, results, and extension methods.
+data, optional/null values, enums, results, and extension methods. One shared
+pre-router rule keeps version negotiation syntactic: `protocolVersion` must be
+a JSON integer from 0 through 65535. Strings, booleans, floats, and out-of-range
+integers receive `InvalidParams` before SDK coercion; stdio then keeps reading so
+the client can send a corrected initialize request.
 
 Error responses use the JSON-RPC `code`, `message`, and optional `data` shape.
 An error may use `id: null` only when the sender could not recover a request ID;

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -121,10 +121,11 @@ routing. Routed top-level params must use pinned ACP wire names such as
 aliases and custom root fields receive `InvalidParams`. Put implementation data
 inside `_meta`. The pinned official ACP SDK continues to validate nested method
 data, optional/null values, enums, results, and extension methods. One shared
-pre-router rule keeps version negotiation syntactic: `protocolVersion` must be
-a JSON integer from 0 through 65535. Strings, booleans, floats, and out-of-range
-integers receive `InvalidParams` before SDK coercion; stdio then keeps reading so
-the client can send a corrected initialize request.
+pre-router rule keeps its documented version compatibility consistent across
+transports: legacy strings reach the SDK negotiation path, while exact JSON
+integers must be from 0 through 65535. Booleans, floats, and out-of-range raw
+integers receive `InvalidParams` before Python coercion; stdio then keeps reading
+so the client can send a corrected initialize request.
 
 Error responses use the JSON-RPC `code`, `message`, and optional `data` shape.
 An error may use `id: null` only when the sender could not recover a request ID;

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -46,11 +46,12 @@ explicit Pydantic aliases. This keeps Python construction names such as
 `session_id` and `mode_id` from becoming a second ACP dialect, and rejects
 custom root fields that ACP requires callers to place under `_meta`. Requests
 with either violation receive `InvalidParams`; invalid notifications are
-dropped without a response. The same boundary validates raw initialize
-`protocolVersion` as an integer in the SDK's published range because the pinned
-model otherwise coerces strings, booleans, and integral floats. Other nested
-values, types, nullability, enums, and results remain validated by the official
-SDK rather than a copied ConnectOnion schema.
+dropped without a response. The same boundary preserves the official SDK's
+legacy string `protocolVersion` compatibility while requiring raw numeric
+versions to be exact integers in the published range. This rejects Python-only
+boolean and integral-float coercion without breaking older editor clients. Other
+nested values, types, nullability, enums, and results remain validated by the
+official SDK rather than a copied ConnectOnion schema.
 
 The shared classifier distinguishes response candidates before deciding
 whether an error reply is legal. Requests and successful responses keep their

--- a/docs/design-decisions/032-acp-interoperability-evidence.md
+++ b/docs/design-decisions/032-acp-interoperability-evidence.md
@@ -46,9 +46,11 @@ explicit Pydantic aliases. This keeps Python construction names such as
 `session_id` and `mode_id` from becoming a second ACP dialect, and rejects
 custom root fields that ACP requires callers to place under `_meta`. Requests
 with either violation receive `InvalidParams`; invalid notifications are
-dropped without a response. Nested values, types, nullability, enums, and
-results remain validated by the official SDK rather than a copied
-ConnectOnion schema.
+dropped without a response. The same boundary validates raw initialize
+`protocolVersion` as an integer in the SDK's published range because the pinned
+model otherwise coerces strings, booleans, and integral floats. Other nested
+values, types, nullability, enums, and results remain validated by the official
+SDK rather than a copied ConnectOnion schema.
 
 The shared classifier distinguishes response candidates before deciding
 whether an error reply is legal. Requests and successful responses keep their

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -56,8 +56,9 @@ local.
 The first JSON-RPC text frame must be a JSON-RPC 2.0 request with a non-boolean
 string/integer ID, method `initialize`, and parameters accepted by the pinned
 official ACP SDK. Binary frames before it are ignored as required by the RFD.
-`protocolVersion` must be a raw JSON integer in the SDK's published range before
-a coding Agent is constructed. The upgrade response
+Raw numeric `protocolVersion` values must be JSON integers in the SDK's
+published range before a coding Agent is constructed; official legacy string
+compatibility is preserved. The upgrade response
 carries an `Acp-Connection-Id`; it and every ACP session ID are routing values,
 never credentials.
 
@@ -67,11 +68,11 @@ response, and response envelopes cannot contain request members. Once a valid
 first `initialize` frame is admitted, an invalid later envelope receives
 JSON-RPC `-32600` through the existing bounded outbound queue and is never
 delivered to the Agent. Responses remain correlated by ID rather than arrival
-order. A shared initialize guard rejects string, boolean, float, or out-of-range
-versions before the pinned SDK can coerce them; schema-valid integers still
-reach normal ACP version negotiation. The SDK continues to own other parameter
-values, nested types, results, and extensions such as `_meta`; boundary
-validation does not replace ACP schema validation.
+order. A shared initialize guard rejects boolean, float, or out-of-range raw
+integer versions before the pinned Python SDK can coerce them. Legacy strings
+and schema-valid integers still reach normal ACP version negotiation. The SDK
+continues to own other parameter values, nested types, results, and extensions
+such as `_meta`; boundary validation does not replace ACP schema validation.
 
 That error reply applies to invalid request candidates, not responses. A
 response has exactly one result or error; the error object has an integer code,

--- a/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
+++ b/docs/design-decisions/045-authenticated-acp-websocket-gateway.md
@@ -56,8 +56,8 @@ local.
 The first JSON-RPC text frame must be a JSON-RPC 2.0 request with a non-boolean
 string/integer ID, method `initialize`, and parameters accepted by the pinned
 official ACP SDK. Binary frames before it are ignored as required by the RFD.
-`protocolVersion` must also satisfy the SDK's published integer range before a
-coding Agent is constructed. The upgrade response
+`protocolVersion` must be a raw JSON integer in the SDK's published range before
+a coding Agent is constructed. The upgrade response
 carries an `Acp-Connection-Id`; it and every ACP session ID are routing values,
 never credentials.
 
@@ -67,9 +67,11 @@ response, and response envelopes cannot contain request members. Once a valid
 first `initialize` frame is admitted, an invalid later envelope receives
 JSON-RPC `-32600` through the existing bounded outbound queue and is never
 delivered to the Agent. Responses remain correlated by ID rather than arrival
-order. The pinned SDK continues to own parameter values, nested types, results,
-and extensions such as `_meta`; envelope validation does not replace ACP
-schema validation.
+order. A shared initialize guard rejects string, boolean, float, or out-of-range
+versions before the pinned SDK can coerce them; schema-valid integers still
+reach normal ACP version negotiation. The SDK continues to own other parameter
+values, nested types, results, and extensions such as `_meta`; boundary
+validation does not replace ACP schema validation.
 
 That error reply applies to invalid request candidates, not responses. A
 response has exactly one result or error; the error object has an integer code,

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -143,6 +143,51 @@ async def test_acp_subprocess_does_not_answer_its_own_null_id_error(tmp_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_version", ["1", True, 1.0, -1, 65536])
+async def test_acp_subprocess_rejects_invalid_initialize_version_and_recovers(
+    tmp_path, invalid_version
+):
+    async with _server(tmp_path / "home") as process:
+        rejected, _ = await _request(
+            process,
+            1,
+            "initialize",
+            {"protocolVersion": invalid_version, "clientCapabilities": {}},
+        )
+        initialized, _ = await _request(
+            process,
+            2,
+            "initialize",
+            {"protocolVersion": 1, "clientCapabilities": {}},
+        )
+
+        assert rejected["error"] == {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {
+                "details": "ACP protocolVersion must be a JSON integer from 0 to 65535"
+            },
+        }
+        assert initialized["result"]["protocolVersion"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protocol_version", [0, 65535])
+async def test_acp_subprocess_negotiates_schema_valid_initialize_versions(
+    tmp_path, protocol_version
+):
+    async with _server(tmp_path / "home") as process:
+        initialized, _ = await _request(
+            process,
+            1,
+            "initialize",
+            {"protocolVersion": protocol_version, "clientCapabilities": {}},
+        )
+
+        assert initialized["result"]["protocolVersion"] == 1
+
+
+@pytest.mark.asyncio
 async def test_acp_subprocess_requires_initialize_before_session(tmp_path):
     state_root = tmp_path / "home"
     async with _server(state_root) as process:

--- a/tests/e2e/cli/test_cli_ai_acp_stdio.py
+++ b/tests/e2e/cli/test_cli_ai_acp_stdio.py
@@ -143,7 +143,7 @@ async def test_acp_subprocess_does_not_answer_its_own_null_id_error(tmp_path):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_version", ["1", True, 1.0, -1, 65536])
+@pytest.mark.parametrize("invalid_version", [True, 1.0, -1, 65536])
 async def test_acp_subprocess_rejects_invalid_initialize_version_and_recovers(
     tmp_path, invalid_version
 ):
@@ -165,15 +165,15 @@ async def test_acp_subprocess_rejects_invalid_initialize_version_and_recovers(
             "code": -32602,
             "message": "Invalid params",
             "data": {
-                "details": "ACP protocolVersion must be a JSON integer from 0 to 65535"
+                "details": "ACP protocolVersion must be a legacy string or JSON integer from 0 to 65535"
             },
         }
         assert initialized["result"]["protocolVersion"] == 1
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("protocol_version", [0, 65535])
-async def test_acp_subprocess_negotiates_schema_valid_initialize_versions(
+@pytest.mark.parametrize("protocol_version", [0, 65535, "1", "2024-11-05"])
+async def test_acp_subprocess_negotiates_compatible_initialize_versions(
     tmp_path, protocol_version
 ):
     async with _server(tmp_path / "home") as process:

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -1015,18 +1015,6 @@ async def test_first_frame_must_initialize_before_agent_creation():
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
-            "params": {"protocolVersion": "not-an-integer"},
-        },
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {"protocolVersion": "1"},
-        },
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
             "params": {"protocolVersion": True},
         },
         {
@@ -1068,6 +1056,32 @@ async def test_malformed_initialize_never_creates_an_agent(first):
     assert sent[-1]["type"] == "websocket.close"
     assert sent[-1]["code"] == 4400
     assert agents == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protocol_version", ["1", "2024-11-05"])
+async def test_legacy_string_initialize_reaches_sdk_compatibility(
+    protocol_version,
+):
+    app, caller, recipient, agents = _app()
+    signed = sign_http_request(
+        caller,
+        "GET",
+        ACP_PATH,
+        recipient_address=recipient["address"],
+    )
+    initialize = _initialize()
+    initialize["params"]["protocolVersion"] = protocol_version
+
+    sent = await _websocket(app, headers=signed, frames=[initialize])
+
+    initialized = next(
+        json.loads(item["text"])
+        for item in sent
+        if item["type"] == "websocket.send"
+    )
+    assert initialized["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert len(agents) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_acp_gateway.py
+++ b/tests/unit/test_acp_gateway.py
@@ -1017,6 +1017,36 @@ async def test_first_frame_must_initialize_before_agent_creation():
             "method": "initialize",
             "params": {"protocolVersion": "not-an-integer"},
         },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "1"},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": True},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": 1.0},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": -1},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": 65536},
+        },
         {**_initialize(), "result": {"foreign": True}},
         {
             **_initialize(),

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1675,7 +1675,7 @@ async def test_strict_ndjson_returns_errors_and_keeps_reading():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_version", ["1", True, 1.0, -1, 65536])
+@pytest.mark.parametrize("invalid_version", [True, 1.0, -1, 65536])
 async def test_strict_ndjson_rejects_invalid_initialize_version_and_keeps_reading(
     invalid_version,
 ):
@@ -1707,15 +1707,15 @@ async def test_strict_ndjson_rejects_invalid_initialize_version_and_keeps_readin
             "code": -32602,
             "message": "Invalid params",
             "data": {
-                "details": "ACP protocolVersion must be a JSON integer from 0 to 65535"
+                "details": "ACP protocolVersion must be a legacy string or JSON integer from 0 to 65535"
             },
         },
     }
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("protocol_version", [0, 65535])
-async def test_strict_ndjson_preserves_schema_valid_initialize_versions(
+@pytest.mark.parametrize("protocol_version", [0, 65535, "1", "2024-11-05"])
+async def test_strict_ndjson_preserves_compatible_initialize_versions(
     protocol_version,
 ):
     reader = asyncio.StreamReader()

--- a/tests/unit/test_co_ai_acp.py
+++ b/tests/unit/test_co_ai_acp.py
@@ -1675,6 +1675,65 @@ async def test_strict_ndjson_returns_errors_and_keeps_reading():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_version", ["1", True, 1.0, -1, 65536])
+async def test_strict_ndjson_rejects_invalid_initialize_version_and_keeps_reading(
+    invalid_version,
+):
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    invalid = {
+        "jsonrpc": "2.0",
+        "id": "invalid-version",
+        "method": "initialize",
+        "params": {"protocolVersion": invalid_version},
+    }
+    valid = {
+        "jsonrpc": "2.0",
+        "id": "valid-version",
+        "method": "initialize",
+        "params": {"protocolVersion": PROTOCOL_VERSION},
+    }
+    reader.feed_data(json.dumps(invalid).encode() + b"\n")
+    reader.feed_data(json.dumps(valid).encode() + b"\n")
+
+    message = await transport.receive()
+
+    assert message == valid
+    assert json.loads(writer.buffer) == {
+        "jsonrpc": "2.0",
+        "id": "invalid-version",
+        "error": {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {
+                "details": "ACP protocolVersion must be a JSON integer from 0 to 65535"
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("protocol_version", [0, 65535])
+async def test_strict_ndjson_preserves_schema_valid_initialize_versions(
+    protocol_version,
+):
+    reader = asyncio.StreamReader()
+    writer = _BufferWriter()
+    transport = _StrictNDJSONTransport(reader, writer)  # type: ignore[arg-type]
+    message = {
+        "jsonrpc": "2.0",
+        "id": "version-boundary",
+        "method": "initialize",
+        "params": {"protocolVersion": protocol_version},
+    }
+    reader.feed_data(json.dumps(message).encode() + b"\n")
+
+    assert await transport.receive() == message
+    assert writer.buffer == b""
+
+
+@pytest.mark.asyncio
 async def test_strict_ndjson_rejects_meta_parameter_shadowing_and_keeps_reading():
     reader = asyncio.StreamReader()
     writer = _BufferWriter()


### PR DESCRIPTION
## Summary\n\n- align raw ACP initialize protocolVersion compatibility across stdio and authenticated WebSocket Host boundaries\n- preserve official SDK support for legacy string versions used by existing editors\n- reject Python-only boolean and float coercions plus out-of-range raw integers before routing\n- preserve normal SDK-owned version negotiation and every unrelated nested field\n\n## Why\n\nThe pinned official Python SDK deliberately accepts legacy string versions for clients such as Zed. Official ACP v0.12.0 Rust code also accepts strings as legacy version 0, while rejecting booleans and floats:\nhttps://github.com/agentclientprotocol/agent-client-protocol/blob/v0.12.0/src/version.rs\n\nStdio previously inherited all Python coercions, while authenticated WebSocket admission rejected all non-integers. The shared predicate keeps intended legacy compatibility and removes the unintended transport difference.\n\n## Validation\n\nValidation evidence will be refreshed at the revised exact head before this Draft is ready for maintainer review.\n\n## Stack\n\nThis Draft PR is stacked on #987 and should be reviewed and merged after it.\n\nCloses #988