### PR TITLE
feat: add first-class Codex and Claude Code plugins

### DIFF
--- a/connectonion/__init__.py
+++ b/connectonion/__init__.py
@@ -60,7 +60,7 @@ for _env_file in (_Path.cwd() / ".env", _Path.home() / ".co" / "keys.env"):
 # because accessing any one of them imports the others and hides the gap.
 _SUBMODULES = ("address", "console", "core", "debug", "derive", "logger",
                "network", "prompts", "tui", "useful_events_handlers",
-               "useful_plugins", "useful_tools")
+               "useful_plugins", "useful_tools", "plugins")
 
 _FROM = {
     **{name: ".core" for name in (
@@ -77,6 +77,7 @@ _FROM = {
     "transcribe": ".transcribe",
     "load_system_prompt": ".prompts",
     **{name: ".debug" for name in ("xray", "auto_debug_exception", "replay", "xray_replay")},
+    **{name: ".plugins" for name in ("CodexPlugin", "ClaudeCodePlugin", "PermissionMode")},
     **{name: ".useful_tools" for name in (
         "send_email", "get_emails", "mark_read", "mark_unread", "send_telegram",
         "Memory", "Gmail", "GDrive", "Synology", "GoogleCalendar", "Outlook",
@@ -156,6 +157,9 @@ __all__ = [
     "replay",
     "xray_replay",
     "auto_debug_exception",
+    "CodexPlugin",
+    "ClaudeCodePlugin",
+    "PermissionMode",
     # Email tools
     "send_email",
     "get_emails",

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -443,6 +443,7 @@ def execute_single_tool(
             except BaseException as error:
                 return False, error
 
+        tool_agent.current_session['_active_tool_call_id'] = tool_id
         outcome, interrupted = run_interruptible(
             capture_tool_outcome,
             poll_io,
@@ -470,6 +471,7 @@ def execute_single_tool(
                 if instance is tool_instance:
                     tool_tools._instances[name] = original_instance
 
+        tool_agent.current_session.pop('_active_tool_call_id', None)
         if tool_session is not None:
             original_session.clear()
             original_session.update(tool_session)
@@ -546,6 +548,10 @@ def execute_single_tool(
         # after_tool fires later, after the LLM tool message is added.
 
     finally:
+        if getattr(agent, 'current_session', None):
+            agent.current_session.pop('_active_tool_call_id', None)
+        if tool_session is not None:
+            tool_session.pop('_active_tool_call_id', None)
         if tool_io:
             tool_io.cancel()
         # No `tool_args.pop('agent')` here any more: nothing was ever put in.

--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -337,6 +337,7 @@ def execute_single_tool(
     original_tools = None
     tool_tools = None
     invoke_func = tool_func
+    tool_agent = agent
     original_instance = None
     tool_instance = None
 

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -63,6 +63,12 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
             'kind': entry.get('kind'),
         }
 
+    if entry_type == 'provider_invocation':
+        return {
+            key: value for key, value in entry.items()
+            if key not in {'ts'}
+        }
+
     # tool_executor.py records two trace entries per tool: 'tool_call' (placeholder before
     # execute, no result) then 'tool_result' (final state, has status/result/timing_ms).
     # Emit one ChatItem per tool from the 'tool_result' so we don't double-render. Match
@@ -77,7 +83,7 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
         ui_status = (
             'done' if raw in ('success', 'done', 'completed') else 'error'
         )
-        return {
+        item = {
             'id': entry.get('tool_id') or f"tool-{idx}",
             'type': 'tool_call',
             'name': name,
@@ -86,6 +92,10 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
             'result': entry.get('result'),
             'timing_ms': entry.get('timing_ms'),
         }
+        for key in ('provider', 'invocationId', 'parentToolCallId'):
+            if key in entry:
+                item[key] = entry[key]
+        return item
 
     return None
 
@@ -158,4 +168,53 @@ def session_to_chat_items(session: dict) -> list[dict]:
             if item_ui:
                 items_ui.append(item_ui)
 
-    return items_ui
+    return _nest_provider_invocations(items_ui)
+
+
+def _nest_provider_invocations(items: list[dict]) -> list[dict]:
+    """Rebuild the same single provider card produced by the live mapper."""
+    invocations: dict[str, dict] = {}
+    parent_ids: set[str] = set()
+    for item in items:
+        if item.get('type') != 'provider_invocation':
+            continue
+        invocation_id = item.get('invocationId') or item.get('id')
+        parent_id = item.get('parentToolCallId')
+        if not isinstance(invocation_id, str) or not isinstance(parent_id, str):
+            continue
+        parent_ids.add(parent_id)
+        existing = invocations.get(invocation_id)
+        if existing is None:
+            existing = {**item, 'id': invocation_id, 'activities': []}
+            invocations[invocation_id] = existing
+        else:
+            activities = existing['activities']
+            existing.update(item)
+            existing['id'] = invocation_id
+            existing['activities'] = activities
+
+    if not invocations:
+        return items
+
+    output: list[dict] = []
+    emitted: set[str] = set()
+    for item in items:
+        invocation_id = item.get('invocationId')
+        parent_id = item.get('parentToolCallId')
+        if item.get('type') == 'provider_invocation' and invocation_id in invocations:
+            if invocation_id not in emitted:
+                output.append(invocations[invocation_id])
+                emitted.add(invocation_id)
+            continue
+        if (
+            item.get('type') == 'tool_call'
+            and isinstance(parent_id, str)
+            and isinstance(invocation_id, str)
+            and invocation_id in invocations
+        ):
+            invocations[invocation_id]['activities'].append(item)
+            continue
+        if item.get('type') == 'tool_call' and item.get('id') in parent_ids:
+            continue
+        output.append(item)
+    return output

--- a/connectonion/plugins/__init__.py
+++ b/connectonion/plugins/__init__.py
@@ -1,0 +1,5 @@
+"""First-class, operator-configured plugins for ConnectOnion Agents."""
+
+from .coding_agents import ClaudeCodePlugin, CodexPlugin, PermissionMode
+
+__all__ = ["ClaudeCodePlugin", "CodexPlugin", "PermissionMode"]

--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -1,0 +1,252 @@
+"""Provider plugins for bounded Codex and Claude Code delegation."""
+
+from __future__ import annotations
+
+import json
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ..core.events import on_agent_ready
+from ..useful_tools.claude_code import _run_claude_code
+from ..useful_tools.codex import codex as _run_codex
+
+
+class PermissionMode(str, Enum):
+    """The three authority choices exposed to operators and user interfaces."""
+
+    MANUAL = "manual"
+    AUTO_APPROVE = "auto_approve"
+    FULL_ACCESS = "full_access"
+
+
+_COMPATIBILITY_MODES = {
+    ":read-only": PermissionMode.MANUAL,
+    ":workspace": PermissionMode.AUTO_APPROVE,
+    ":danger-full-access": PermissionMode.FULL_ACCESS,
+}
+
+
+def _permission_mode(value: PermissionMode | str) -> PermissionMode:
+    if isinstance(value, PermissionMode):
+        return value
+    compatibility = _COMPATIBILITY_MODES.get(value)
+    if compatibility is not None:
+        return compatibility
+    try:
+        return PermissionMode(value)
+    except ValueError as exc:
+        choices = ", ".join(mode.value for mode in PermissionMode)
+        raise ValueError(f"Unknown permission mode {value!r}; use {choices}.") from exc
+
+
+class _CodingAgentPlugin(list):
+    """Event-plugin lifecycle plus a model-callable provider tool.
+
+    Subclassing ``list`` preserves the existing event-plugin protocol while
+    making installation explicit and configurable. The registered tool is a
+    bound method, so operator state never appears in its model-visible schema.
+    """
+
+    provider: str
+    display_name: str
+
+    def __init__(
+        self,
+        *,
+        permission_mode: PermissionMode | str = PermissionMode.MANUAL,
+        workspace: str | Path | None = None,
+    ) -> None:
+        self.permission_mode = _permission_mode(permission_mode)
+        self.workspace = Path(workspace or Path.cwd()).expanduser().resolve()
+        if not self.workspace.is_dir():
+            raise ValueError(f"Plugin workspace is not a directory: {self.workspace}")
+        super().__init__([self._install])
+
+    @on_agent_ready
+    def _install(self, agent) -> None:
+        agent.add_tool(getattr(self, self.provider))
+        installed = getattr(agent, "installed_plugins", None)
+        if installed is None:
+            installed = []
+            agent.installed_plugins = installed
+        installed.append(self)
+
+    def _cwd(self, cwd: str) -> tuple[Path | None, str]:
+        try:
+            candidate = Path(cwd).expanduser() if cwd else self.workspace
+            if not candidate.is_absolute():
+                candidate = self.workspace / candidate
+            candidate = candidate.resolve(strict=True)
+            candidate.relative_to(self.workspace)
+        except (OSError, RuntimeError, ValueError):
+            return None, f"Working directory must stay inside workspace {self.workspace}."
+        if not candidate.is_dir():
+            return None, f"Working directory is not a directory: {candidate}."
+        return candidate, ""
+
+    def _invoke(self, agent, prompt: str, run) -> str:
+        started = time.monotonic()
+        parent_id = _parent_tool_call_id(agent)
+        invocation_id = f"{self.provider}:{parent_id}" if parent_id else f"{self.provider}:untracked"
+        _emit(
+            agent,
+            "provider_invocation",
+            invocationId=invocation_id,
+            parentToolCallId=parent_id,
+            provider=self.provider,
+            providerDisplayName=self.display_name,
+            taskSummary=_bounded(prompt, 500),
+            permissionMode=self.permission_mode.value,
+            status="running",
+        )
+        try:
+            result = run()
+        except BaseException as exc:
+            _emit(
+                agent,
+                "provider_invocation",
+                invocationId=invocation_id,
+                parentToolCallId=parent_id,
+                provider=self.provider,
+                providerDisplayName=self.display_name,
+                status="cancelled" if exc.__class__.__name__ == "UserInterrupt" else "failed",
+                elapsedMs=round((time.monotonic() - started) * 1000),
+                error=_bounded(exc, 1000),
+            )
+            raise
+        envelope = _envelope(result)
+        error = envelope.get("error")
+        status = envelope.get("status")
+        if status == "cancelled" or (isinstance(error, str) and "interrupt" in error.lower()):
+            terminal = "cancelled"
+        elif error or envelope.get("exit_code") not in (None, 0):
+            terminal = "failed"
+        else:
+            terminal = "completed"
+        _emit(
+            agent,
+            "provider_invocation",
+            invocationId=invocation_id,
+            parentToolCallId=parent_id,
+            provider=self.provider,
+            providerDisplayName=self.display_name,
+            status=terminal,
+            sessionId=_bounded(envelope.get("session_id", ""), 512),
+            elapsedMs=round((time.monotonic() - started) * 1000),
+            result=_bounded(envelope.get("result", envelope.get("last_message", "")), 4000),
+            error=_bounded(error or "", 1000),
+        )
+        return result
+
+
+class CodexPlugin(_CodingAgentPlugin):
+    """Install a Codex tool whose workspace and authority are operator-owned."""
+
+    provider = "codex"
+    display_name = "Codex"
+
+    def codex(
+        self,
+        prompt: str,
+        cwd: str = "",
+        session_id: str = "",
+        model: str = "",
+        timeout: int = 600,
+        agent=None,
+    ) -> str:
+        """Run or resume Codex inside the operator-configured workspace."""
+        working_directory, error = self._cwd(cwd)
+        if error:
+            return json.dumps({"provider": "codex", "session_id": session_id, "error": error})
+        sandbox, approval = {
+            PermissionMode.MANUAL: ("workspace-write", "manual"),
+            PermissionMode.AUTO_APPROVE: ("workspace-write", "auto"),
+            PermissionMode.FULL_ACCESS: ("danger-full-access", "auto"),
+        }[self.permission_mode]
+        return self._invoke(
+            agent,
+            prompt,
+            lambda: _run_codex(
+                prompt=prompt,
+                cwd=str(working_directory),
+                session_id=session_id,
+                model=model,
+                timeout=timeout,
+                sandbox=sandbox,
+                approval=approval,
+                agent=agent,
+            ),
+        )
+
+
+class ClaudeCodePlugin(_CodingAgentPlugin):
+    """Install a Claude Code tool with an operator-owned permission ceiling."""
+
+    provider = "claude_code"
+    display_name = "Claude Code"
+
+    def claude_code(
+        self,
+        prompt: str,
+        cwd: str = "",
+        session_id: str = "",
+        model: str = "",
+        timeout: int = 600,
+        agent=None,
+    ) -> str:
+        """Run or resume Claude Code inside the configured workspace."""
+        working_directory, error = self._cwd(cwd)
+        if error:
+            return json.dumps({"provider": "claude_code", "session_id": session_id, "error": error})
+        provider_mode = {
+            PermissionMode.MANUAL: "manual",
+            PermissionMode.AUTO_APPROVE: "acceptEdits",
+            PermissionMode.FULL_ACCESS: "auto",
+        }[self.permission_mode]
+        return self._invoke(
+            agent,
+            prompt,
+            lambda: _run_claude_code(
+                prompt=prompt,
+                cwd=str(working_directory),
+                session_id=session_id,
+                permission_mode=provider_mode,
+                model=model,
+                timeout=timeout,
+                agent=agent,
+                workspace=self.workspace,
+            ),
+        )
+
+
+def _parent_tool_call_id(agent) -> str | None:
+    session = getattr(agent, "current_session", None)
+    value = session.get("_active_tool_call_id") if isinstance(session, dict) else None
+    return value if isinstance(value, str) and value else None
+
+
+def _emit(agent, event_type: str, **fields: Any) -> None:
+    record = getattr(agent, "_record_trace", None)
+    if callable(record) and isinstance(getattr(agent, "current_session", None), dict):
+        record({"type": event_type, **fields})
+        return
+    io = getattr(agent, "io", None)
+    if io is not None:
+        io.log(event_type, **fields)
+
+
+def _envelope(result: Any) -> dict[str, Any]:
+    if isinstance(result, str):
+        try:
+            parsed = json.loads(result)
+            return parsed if isinstance(parsed, dict) else {"result": result}
+        except json.JSONDecodeError:
+            return {"result": result}
+    return result if isinstance(result, dict) else {"result": str(result)}
+
+
+def _bounded(value: Any, limit: int) -> str:
+    text = value if isinstance(value, str) else str(value)
+    return text if len(text) <= limit else text[: limit - 1] + "…"

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -354,7 +354,17 @@ class _ClaudeStreamForwarder:
     """Translate Claude stream-json messages into native live tool events."""
 
     def __init__(self, agent) -> None:
+        self._agent = agent
         self._io = getattr(agent, "io", None) if agent is not None else None
+        session = getattr(agent, "current_session", None)
+        self._parent_tool_call_id = (
+            session.get("_active_tool_call_id") if isinstance(session, dict) else None
+        )
+        self._correlation = (
+            {"invocationId": f"claude_code:{self._parent_tool_call_id}",
+             "parentToolCallId": self._parent_tool_call_id}
+            if self._parent_tool_call_id else {}
+        )
         self._tools: dict[str, dict[str, Any]] = {}
         self._event_count = 0
 
@@ -394,6 +404,7 @@ class _ClaudeStreamForwarder:
                 provider="claude_code",
                 child_session_id=metadata["session_id"],
                 parent_tool_id=metadata["parent_tool_id"],
+                **self._correlation,
             )
             self._tools[tool_id] = metadata
 
@@ -418,6 +429,7 @@ class _ClaudeStreamForwarder:
                 provider="claude_code",
                 child_session_id=metadata["session_id"],
                 parent_tool_id=metadata["parent_tool_id"],
+                **self._correlation,
             )
             self._tools.pop(tool_id, None)
 
@@ -431,13 +443,18 @@ class _ClaudeStreamForwarder:
             provider="claude_code",
             child_session_id=metadata["session_id"],
             parent_tool_id=metadata["parent_tool_id"],
+            **self._correlation,
         )
 
     def _emit(self, event_type: str, **fields: Any) -> None:
         if self._event_count >= _MAX_LIVE_EVENTS:
             return
         self._event_count += 1
-        self._io.log(event_type, **fields)
+        record = getattr(self._agent, "_record_trace", None)
+        if callable(record) and isinstance(getattr(self._agent, "current_session", None), dict):
+            record({"type": event_type, **fields})
+        else:
+            self._io.log(event_type, **fields)
 
 
 def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -198,14 +198,37 @@ def _forward_ui(agent, event):
     if agent is None or getattr(agent, "io", None) is None:
         return
     kind = event.get("kind", "")
+    parent_id = _active_parent_tool_call_id(agent)
+    correlation = ({"invocationId": f"codex:{parent_id}",
+                    "parentToolCallId": parent_id} if parent_id else {})
     if kind == "tool_start":
-        agent.io.log("tool_call", tool_id=event.get("id", ""),
-                     name=event.get("name", "codex"), args={},
-                     status="in_progress")
+        _emit_provider_event(agent, "tool_call", tool_id=event.get("id", ""),
+                             name=event.get("name", "codex"), args={},
+                             status="in_progress", provider="codex",
+                             **correlation)
     elif kind == "tool_end":
-        agent.io.log("tool_result", tool_id=event.get("id", ""),
-                     status="failed" if event.get("failed") else "completed",
-                     result=event.get("name", ""))
+        _emit_provider_event(agent, "tool_result", tool_id=event.get("id", ""),
+                             name=event.get("name", "codex"), args={},
+                             status="failed" if event.get("failed") else "completed",
+                             result=event.get("name", ""), provider="codex",
+                             **correlation)
+
+
+def _active_parent_tool_call_id(agent):
+    session = getattr(agent, "current_session", None)
+    value = session.get("_active_tool_call_id") if isinstance(session, dict) else None
+    return value if isinstance(value, str) and value else None
+
+
+def _emit_provider_event(agent, event_type, **fields):
+    record = getattr(agent, "_record_trace", None)
+    if callable(record) and isinstance(getattr(agent, "current_session", None), dict):
+        record({"type": event_type, **fields})
+    else:
+        if event_type == "tool_result":
+            fields.pop("name", None)
+            fields.pop("args", None)
+        agent.io.log(event_type, **fields)
 
 
 def _approval_allowed(method, params, approval, agent):

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@
 ├── vibe-coding-guide.md   # Coding-assistant workflow and prompts
 ├── cli/                   # CLI commands documentation
 ├── concepts/              # Core concepts (agents, tools, trust)
+│   └── coding-agent-plugins.md # Codex/Claude delegation and live invocation contract
 ├── debug/                 # Debugging and @xray documentation
 ├── design-decisions/      # Why things are built this way
 ├── integrations/          # Third-party integrations

--- a/docs/codex-tool-frontend-contract.md
+++ b/docs/codex-tool-frontend-contract.md
@@ -1,9 +1,9 @@
 # Codex tool ↔ frontend integration contract
 
-**TL;DR — oo-chat needs no component changes.** The backend `codex` tool
-converts Codex's steps into the events the SDK already renders. The SDK accepts
-both historical and ACP-aligned lifecycle statuses during rolling upgrades.
-This note records the research behind that and the exact contract.
+**Historical note.** The backend `codex` tool originally flattened Codex steps
+into generic tool cards. Alpha.2 keeps those events as the compatibility
+fallback and additionally emits the parented provider-invocation contract
+described in [Coding-agent plugins](concepts/coding-agent-plugins.md).
 
 ## How the `codex` tool drives Codex
 
@@ -27,7 +27,7 @@ app-server wins on every axis for a Python framework: one dependency, official
 protocol, our own client, and it still gives session/resume, live streaming, and
 interactive approval requests when the selected Codex policy requires them.
 
-## The frontend contract (why no frontend change is needed)
+## The original generic frontend contract
 
 The connection layer bundled in `@connectonion/react`
 (`connectonion-react/src/connect/chat-item-mapper.ts`) maps a **fixed set of
@@ -48,9 +48,10 @@ Key points:
 - **ACP-aligned live status**: provider events use `in_progress`, `completed`,
   and `failed`. The SDK also accepts the historical success/failure values;
   canonical session traces keep their existing statuses.
-- **No custom event type.** An earlier draft emitted `io.log("codex_event", …)`,
-  which matched nothing in the mapper and would not render — that was the bug to
-  fix. The fix is emitting the native `tool_call` / `tool_result` vocabulary.
+- **Generic compatibility remains.** `tool_call` / `tool_result` are still
+  emitted, now with optional provider-invocation correlation fields. Clients
+  that understand `provider_invocation` nest them; older clients render them
+  as ordinary cards.
 - **Approval is already wired.** When Codex requests permission,
   `agent.io.request_approval` sends `approval_needed`
   and blocks for the user's answer over the same channel oo-chat already uses for
@@ -61,12 +62,9 @@ Key points:
 
 ## What the frontend team should know
 
-- Nothing to implement to make Codex render. Codex's inner command runs and file
-  edits show up as ordinary tool cards; its permission prompts as ordinary
-  approval cards.
-- Optional polish (not required): a Codex-specific icon/label on tool cards whose
-  origin is the codex tool. This is cosmetic — the generic tool-card rendering
-  already works.
+- The React package owns normalization and child correlation. O Chat consumes
+  its typed `provider_invocation` item and renders the shared coding-agent card.
+- Generic tool cards remain the rolling-upgrade fallback.
 
 ## Validation
 

--- a/docs/concepts/coding-agent-plugins.md
+++ b/docs/concepts/coding-agent-plugins.md
@@ -1,0 +1,50 @@
+# Coding-agent plugins
+
+`CodexPlugin` and `ClaudeCodePlugin` let any ConnectOnion Agent delegate one
+task to a locally installed coding agent while keeping authority in operator
+configuration.
+
+```python
+from connectonion import Agent, ClaudeCodePlugin, CodexPlugin
+
+agent = Agent(
+    "developer",
+    plugins=[
+        CodexPlugin(permission_mode="manual", workspace="."),
+        ClaudeCodePlugin(permission_mode="manual", workspace="."),
+    ],
+)
+```
+
+Each plugin registers one model-callable tool:
+
+- `codex(prompt, cwd, session_id?, model?, timeout?)`
+- `claude_code(prompt, cwd, session_id?, model?, timeout?)`
+
+The model cannot select the permission mode, provider command, or workspace
+root. Relative `cwd` values resolve below the configured root; traversal and
+symlink escapes fail closed.
+
+## Permission modes
+
+| Mode | Boundary |
+| --- | --- |
+| `manual` | The provider asks when its automation interface supports the action; unsupported prompts fail closed. |
+| `auto_approve` | Work may proceed within the configured workspace and provider sandbox. |
+| `full_access` | Per-action prompts are disabled inside the explicit Host launch ceiling. Configure this only for a trusted workspace. |
+
+The compatibility names `:read-only`, `:workspace`, and
+`:danger-full-access` normalize to these three modes. Resuming a provider
+session reapplies the plugin's current operator-owned mode.
+
+## Live invocation contract
+
+The parent tool call becomes one `provider_invocation` with a stable
+`invocationId` and `parentToolCallId`. Provider tool/file/command activity
+carries the same correlation and is nested by compatible clients. Every
+invocation ends as `completed`, `failed`, or `cancelled`; bounded result and
+error text remain available after reconnect/replay. Unknown providers and old
+clients retain the generic tool-card fallback.
+
+The provider session ID can be passed back to the tool to resume work. It is
+not a browser or navigation API.

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -2,6 +2,9 @@
 
 Plugins are reusable event handlers. Package capabilities and reuse them across agents.
 
+Configured lifecycle plugins can also install tools while keeping operator
+state out of the model schema. See [Coding-agent plugins](coding-agent-plugins.md).
+
 ## Quick Start
 
 ```python
@@ -65,6 +68,7 @@ agent = Agent("a", plugins=[re_act, logger])
 | `yolo` | Familiar shorthand for Full access | [yolo.md](../useful_plugins/yolo.md) |
 | `gmail_plugin` | Gmail OAuth flow | [gmail_plugin.md](../useful_plugins/gmail_plugin.md) |
 | `calendar_plugin` | Google Calendar OAuth flow | [calendar_plugin.md](../useful_plugins/calendar_plugin.md) |
+| `CodexPlugin` / `ClaudeCodePlugin` | Bounded coding-agent delegation with live child activity | [coding-agent-plugins.md](coding-agent-plugins.md) |
 
 ```python
 from connectonion.useful_plugins import skills, re_act, eval, image_result_formatter, tool_approval

--- a/docs/design-decisions/044-first-class-coding-agent-plugins.md
+++ b/docs/design-decisions/044-first-class-coding-agent-plugins.md
@@ -1,0 +1,44 @@
+# DD-044: One operator-owned plugin per coding provider
+
+**Status:** Accepted for Alpha.2
+
+**Date:** 2026-08-14
+
+**Related:** [DD-043](043-claude-code-live-tool-events.md), [GitHub issue #986](https://github.com/openonion/connectonion/issues/986)
+
+## Problem
+
+Codex and Claude Code existed as useful tools and COAI wrappers, but installation,
+authority, and frontend identity were split across those surfaces. Flattening
+child activity also made the parent conversation hard to follow.
+
+## Decision
+
+Each provider has one configurable plugin which installs its public tool. The
+plugin binds workspace and permission state before the model sees the schema.
+The existing native transports remain replaceable implementation details.
+
+One invocation emits a provider-neutral lifecycle parented to the outer tool
+call. Child activity carries the same correlation, remains bounded/redacted,
+and is persisted for replay. React owns normalization; O Chat renders one
+inline expandable card and retains generic fallback behavior.
+
+## Alternatives
+
+- COAI-only wrappers were rejected because third-party Agents would need to
+  duplicate provider policy.
+- A provider session browser was rejected as broader than a linear Alpha.2
+  delegation.
+- Raw terminal embedding was rejected because it leaks provider detail and
+  weakens transcript ownership.
+
+## Tradeoffs and limits
+
+Claude Code's current headless stream cannot round-trip every interactive
+permission request, so unsupported Manual actions fail closed. A configured
+workspace is a launch boundary, not an OS container. Alpha.2 supports ordinary
+linear delegation and one or two expanded cards, not a persistent agent graph.
+
+Revisit the transport when Claude exposes a compatible approval-aware API, or
+revisit the UI contract when concurrent persistent provider sessions become a
+real product requirement.

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -1,0 +1,102 @@
+"""Contract tests for first-class coding-agent plugins."""
+
+import inspect
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion import Agent, ClaudeCodePlugin, CodexPlugin, PermissionMode
+from connectonion.network.host.session.ui import session_to_chat_items
+
+
+class _LLM:
+    model = "test"
+
+
+@pytest.mark.parametrize(
+    ("plugin", "tool_name"),
+    [(CodexPlugin, "codex"), (ClaudeCodePlugin, "claude_code")],
+)
+def test_plugin_registers_provider_tool_without_model_owned_authority(tmp_path, plugin, tool_name):
+    agent = Agent("developer", plugins=[plugin(workspace=tmp_path)], llm=_LLM(), quiet=True)
+    assert tool_name in agent.list_tools()
+    parameters = agent.tools.get(tool_name).get_parameters_schema()["properties"]
+    assert "permission_mode" not in parameters
+    assert "workspace" not in parameters
+    assert "sandbox" not in parameters
+    assert "approval" not in parameters
+
+
+def test_compatibility_permission_names_are_normalized(tmp_path):
+    assert CodexPlugin(permission_mode=":read-only", workspace=tmp_path).permission_mode is PermissionMode.MANUAL
+    assert CodexPlugin(permission_mode=":workspace", workspace=tmp_path).permission_mode is PermissionMode.AUTO_APPROVE
+    assert CodexPlugin(permission_mode=":danger-full-access", workspace=tmp_path).permission_mode is PermissionMode.FULL_ACCESS
+
+
+def test_workspace_traversal_and_symlink_escape_fail_closed(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    link = workspace / "escape"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    result = json.loads(CodexPlugin(workspace=workspace).codex("inspect", cwd="escape"))
+    assert "must stay inside workspace" in result["error"]
+
+
+def test_invocation_lifecycle_is_parented_and_terminal(monkeypatch, tmp_path):
+    import connectonion.plugins.coding_agents as module
+
+    monkeypatch.setattr(
+        module,
+        "_run_codex",
+        lambda **kwargs: json.dumps({"provider": "codex", "session_id": "s1", "exit_code": 0, "last_message": "done"}),
+    )
+    io = SimpleNamespace(log=MagicMock())
+    agent = SimpleNamespace(io=io, current_session={"_active_tool_call_id": "call-7"})
+    result = CodexPlugin(workspace=tmp_path).codex("fix it", agent=agent)
+    assert json.loads(result)["last_message"] == "done"
+    start, finish = io.log.call_args_list
+    assert start.args == ("provider_invocation",)
+    assert start.kwargs["invocationId"] == "codex:call-7"
+    assert start.kwargs["parentToolCallId"] == "call-7"
+    assert start.kwargs["status"] == "running"
+    assert finish.kwargs["status"] == "completed"
+    assert finish.kwargs["sessionId"] == "s1"
+
+
+def test_public_signature_matches_the_provider_contract(tmp_path):
+    for method in (
+        CodexPlugin(workspace=tmp_path).codex,
+        ClaudeCodePlugin(workspace=tmp_path).claude_code,
+    ):
+        assert list(inspect.signature(method).parameters) == [
+            "prompt", "cwd", "session_id", "model", "timeout", "agent"
+        ]
+
+
+def test_replay_reconstructs_one_parent_card_with_nested_activity():
+    session = {
+        "messages": [{"role": "user", "content": "fix it"}],
+        "trace": [
+            {"type": "user_input"},
+            {"type": "tool_call", "tool_id": "parent", "name": "codex", "args": {}},
+            {"type": "provider_invocation", "invocationId": "codex:parent", "parentToolCallId": "parent", "provider": "codex", "providerDisplayName": "Codex", "status": "running"},
+            {"type": "tool_result", "tool_id": "child", "name": "Bash", "args": {}, "status": "completed", "result": "ok", "provider": "codex", "invocationId": "codex:parent", "parentToolCallId": "parent"},
+            {"type": "provider_invocation", "invocationId": "codex:parent", "parentToolCallId": "parent", "provider": "codex", "providerDisplayName": "Codex", "status": "completed"},
+            {"type": "tool_result", "tool_id": "parent", "name": "codex", "args": {}, "status": "success", "result": "done"},
+        ],
+    }
+    items = session_to_chat_items(session)
+    assert [item["type"] for item in items] == ["user", "provider_invocation"]
+    assert items[1]["status"] == "completed"
+    assert items[1]["activities"] == [{
+        "id": "child", "type": "tool_call", "name": "Bash", "args": {},
+        "status": "done", "result": "ok", "timing_ms": None,
+        "provider": "codex", "invocationId": "codex:parent", "parentToolCallId": "parent",
+    }]


### PR DESCRIPTION
## Outcome

Adds the Core slice of #986: operator-configured `CodexPlugin` and `ClaudeCodePlugin`, the three public permission modes, canonical parented provider-invocation events, nested/replay-safe child activity, and SDK documentation.

## Boundary

- plugin owns workspace and authority; neither appears in the model schema
- existing Codex app-server and Claude stream-json transports remain the implementation
- traversal and symlink escape fail closed
- provider lifecycle and child activity are bounded, parent-correlated, and persisted for replay
- legacy generic tool events remain compatible

## Validation

- 202 focused Core tests passed (plugins, providers, session replay, import surface)
- Ruff passed on changed Python
- `git diff --check` passed

## Release impact

Next minor preview (`1.7.0a2`). This PR does not bump or publish a package.

Advances #986
