### PR TITLE
fix: a deployed agent runs on its own account, not its author's

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -22,6 +22,7 @@ import yaml
 from dotenv import dotenv_values
 from rich.console import Console
 
+from .env_inheritance import is_operator_identity
 from .server_commands import SSH_TIMEOUT_SECONDS, derived_agent_identity, load_server
 
 console = Console()
@@ -640,7 +641,55 @@ RSYNC_FILTERS = [
 ]
 
 
-def _env_for_server(env_vars: dict, agent: str) -> dict:
+def _agent_account(agent_identity: dict) -> Optional[dict]:
+    """Authenticate as the agent, so the server bills the agent.
+
+    `/api/v1/auth` creates an account for any key that authenticates, so this
+    both mints a token and, on a first deploy, opens the agent's account. The
+    email comes from the response rather than being computed here: the backend
+    is authoritative about the mailbox it actually routes, and the local
+    fallback format has not always agreed with it.
+    """
+    import time
+
+    import requests
+    from nacl.signing import SigningKey
+
+    from ...backend import backend_url
+
+    public_key = agent_identity["address"]
+    timestamp = int(time.time())
+    message = f"ConnectOnion-Auth-{public_key}-{timestamp}"
+    signature = SigningKey(agent_identity["key_bytes"]).sign(
+        message.encode()).signature.hex()
+
+    try:
+        response = requests.post(
+            f"{backend_url()}/api/v1/auth",
+            json={"public_key": public_key, "signature": signature,
+                  "message": message},
+            timeout=15,
+        )
+    except requests.exceptions.RequestException:
+        return None
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+    token = data.get("token")
+    if not token:
+        return None
+    email = ((data.get("user") or {}).get("email") or {}).get("address")
+    return {
+        "OPENONION_API_KEY": token,
+        "AGENT_ADDRESS": public_key,
+        "AGENT_EMAIL": email or f"{public_key[:10]}@mail.openonion.ai",
+        "IS_EMAIL_ACTIVE": "true",
+    }
+
+
+def _env_for_server(env_vars: dict, agent: str,
+                    agent_account: Optional[dict] = None) -> dict:
     """The project's `.env`, corrected for the machine it is going to.
 
     `AGENT_CONFIG_PATH` is written by `co init` as an absolute path to the
@@ -649,14 +698,24 @@ def _env_for_server(env_vars: dict, agent: str) -> dict:
     and `google_calendar.py` all build their `keys.env` path from it — so those
     tools fail there rather than falling back. The Cloud path already rewrites
     it to `/app/.co`; this is the same correction for `/srv/<agent>/.co`.
+
+    The identity lines are dropped for a different reason: they are true of the
+    developer, and `co init` puts them there on purpose so the project runs as
+    its author locally. The server has its own key, so shipping them makes the
+    deployed agent send mail as its author and bill its author's account, with
+    nothing failing. `agent_account` is the replacement, derived from the key
+    the server will actually hold.
     """
-    out = dict(env_vars)
+    out = {k: v for k, v in env_vars.items() if not is_operator_identity(k)}
     if out.get("AGENT_CONFIG_PATH"):
         out["AGENT_CONFIG_PATH"] = f"{SRV}/{agent}/.co"
+    if agent_account:
+        out.update(agent_account)
     return out
 
 
-def _sync_env(target: str, agent: str, project_dir: Path) -> bool:
+def _sync_env(target: str, agent: str, project_dir: Path,
+              agent_account: Optional[dict] = None) -> bool:
     """Write the project's secrets where systemd can read them and nobody else.
 
     Sent over ssh rather than rsync, to a path outside the rsync root: the file
@@ -665,10 +724,9 @@ def _sync_env(target: str, agent: str, project_dir: Path) -> bool:
     key that was rotated on the server.
     """
     env_path = project_dir / ".env"
-    if not env_path.exists():
-        return True
-
-    env_vars = _env_for_server(dotenv_values(env_path), agent)
+    env_vars = _env_for_server(
+        dotenv_values(env_path) if env_path.exists() else {},
+        agent, agent_account)
 
     # A newline inside a value would end the KEY=VALUE line and turn the rest
     # into junk entries. Say so rather than write a file that looks fine.
@@ -1023,7 +1081,23 @@ def handle_deploy_to(server: str, project_dir: Optional[Path] = None,
         return False
     if not _sync_code(target, agent, project_dir):
         return False
-    if not _sync_env(target, agent, project_dir):
+
+    # The account the agent runs on. Derived identities can be authenticated
+    # from here, because this machine holds the key the server was given; an
+    # `--own-identity` agent cannot be, by construction, so say what is missing
+    # rather than fall back to the operator's account — which is the bug this
+    # replaces, and it is silent.
+    agent_account = _agent_account(agent_identity) if agent_identity else None
+    if agent_account:
+        console.print(f"  [dim]account {agent_account['AGENT_EMAIL']} — "
+                      f"the agent's own[/dim]")
+    elif agent_identity:
+        console.print("[yellow]  could not authenticate as the agent — "
+                      "deploying without an account[/yellow]")
+    if not agent_account:
+        console.print(f"[dim]  run [cyan]co auth[/cyan] in {SRV}/{agent} to give "
+                      f"it one; co/* models need it[/dim]")
+    if not _sync_env(target, agent, project_dir, agent_account):
         return False
     if not _install_deps_if_changed(target, agent, project_dir, skill_requirements):
         return False

--- a/connectonion/cli/commands/env_inheritance.py
+++ b/connectonion/cli/commands/env_inheritance.py
@@ -41,3 +41,25 @@ def describes_this_machine(key: str) -> bool:
     return key in MACHINE_LOCAL_KEYS
 
 
+# Who the agent is and who pays for it. `co init` and `co create` copy these
+# from ~/.co/keys.env deliberately: a project you are developing should run as
+# you, on your account, without a second setup step. That is right on a laptop.
+#
+# It is wrong on a server. A deployed agent has its own key in .co/keys/, so
+# these lines describe someone else — and they are not inert. AGENT_EMAIL
+# overrides the mailbox the agent derives from its own address, and
+# OPENONION_API_KEY decides which account every model call is billed to. The
+# agent ends up cryptographically itself and financially its author, with
+# nothing reporting an error. AGENT_ADDRESS sets nothing (address.load() reads
+# the keypair) but a stale value there is what people read when they want to
+# know who an agent is, so it travels with the other three rather than being
+# left behind to contradict them.
+AGENT_IDENTITY_KEYS = ('AGENT_ADDRESS', 'AGENT_EMAIL', 'IS_EMAIL_ACTIVE',
+                       'OPENONION_API_KEY')
+
+
+def is_operator_identity(key: str) -> bool:
+    """Whether this entry names the operator rather than the agent that runs it."""
+    return key in AGENT_IDENTITY_KEYS
+
+

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -174,7 +174,8 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # Authenticate to get OPENONION_API_KEY (always, for everyone)
     auth_success = authenticate(global_co_dir, save_to_project=False)
 
-    from .env_inheritance import describes_this_machine, is_personal_account_credential
+    from .env_inheritance import (AGENT_IDENTITY_KEYS, describes_this_machine,
+                                  is_personal_account_credential)
 
     # Handle .env file - append API keys from global config
     env_path = Path(current_dir) / ".env"
@@ -185,8 +186,11 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # AGENT_CONFIG_PATH is not one of them — it describes the machine, not the
     # identity, and copying an absolute home directory into a file that travels
     # is what made a project only work where it was made (#438).
-    IDENTITY_KEYS = {'AGENT_ADDRESS', 'OPENONION_API_KEY',
-                     'AGENT_EMAIL', 'IS_EMAIL_ACTIVE'}
+    #
+    # Shared with `co deploy --to`, which withholds exactly this set: propagating
+    # the operator's identity into a project is the point here and a bug there,
+    # so the two must be reading one definition.
+    IDENTITY_KEYS = set(AGENT_IDENTITY_KEYS)
 
     # Read global keys.env into a dict
     global_keys = {}  # key -> "KEY=value" line

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -313,6 +313,39 @@ The rsync carries the project tree and **excludes `.co/`**, with one exception:
 A change you make over ssh survives the next deploy, as long as it is not a file the
 sync owns.
 
+### The agent runs as itself, not as you
+
+Your project `.env` names *you*. `co init` puts `AGENT_ADDRESS`, `AGENT_EMAIL`,
+`IS_EMAIL_ACTIVE` and `OPENONION_API_KEY` there on purpose, so the project runs on
+your account while you are developing it.
+
+On the server those four are wrong, and not inertly so: `AGENT_EMAIL` overrides the
+mailbox the agent derives from its own address, and `OPENONION_API_KEY` decides whose
+credits every model call spends. So the deploy **withholds them** and substitutes the
+agent's own, authenticated from the key the server holds:
+
+```
+myagent → prod (co@1.2.3.4)
+  …
+  writing secrets … (5 keys)
+  account 0xcf1619cb4c… — the agent's own
+```
+
+Everything else in `.env` — your Gemini key, your database URL — travels unchanged.
+
+`--own-identity` mints the key on the machine, so this laptop cannot authenticate as
+that agent and no account is written. The deploy says so and the agent has no access
+to `co/*` models until you run `co auth` in `/srv/<agent>`:
+
+```
+  run co auth in /srv/myagent to give it one; co/* models need it
+```
+
+That is deliberate. An agent with no account fails visibly on its first model call;
+an agent quietly spending its author's credits does not fail at all — and the spend
+cannot be separated afterwards, because usage records carry no column naming the
+machine that made the call.
+
 ### https and the hostname
 
 A server created by `co server new` gets a DNS record of its own, and the deploy

--- a/tests/unit/test_a_deploy_runs_as_the_agent.py
+++ b/tests/unit/test_a_deploy_runs_as_the_agent.py
@@ -1,0 +1,213 @@
+"""A deployed agent runs as itself, not as whoever deployed it.
+
+`co init` copies AGENT_ADDRESS, AGENT_EMAIL, IS_EMAIL_ACTIVE and
+OPENONION_API_KEY from ~/.co/keys.env into the project `.env` on purpose — a
+project you are developing should run as you, locally, with no second setup
+step.
+
+`co deploy --to` then wrote that same file to /etc/connectonion/<agent>.env
+verbatim. The server already has its own key in .co/keys/, so the deployed agent
+was cryptographically itself and financially its author: AGENT_EMAIL overrode
+the mailbox it derives from its own address, and OPENONION_API_KEY billed every
+model call to the operator. Nothing failed. One agent ran for nine days that
+way, and the spend cannot be split back out afterwards because usage_logs
+records no column naming the machine.
+
+These tests look at what the deploy actually sends, not at how it is spelled.
+"""
+
+import base64
+import subprocess
+from unittest.mock import Mock, patch
+
+import pytest
+
+from connectonion.cli.commands import deploy_to_server as dts
+
+
+OPERATOR = "0x10e68f6dff39ab1c50cc48ea1c74e7fd6ce7269aa6e8123829b344e57d005508"
+AGENT = "0xcf1619cb4cd96c6d5bcb8f8a0cac4e7e0091c511fbce329e3acb6b8d4fb0c8c6"
+
+# What `co init` leaves in a project .env, plus the app's own secrets.
+PROJECT_ENV = {
+    "OPENONION_API_KEY": "eyJ-operators-token",
+    "AGENT_ADDRESS": OPERATOR,
+    "AGENT_EMAIL": "aaron.xie@mail.openonion.ai",
+    "IS_EMAIL_ACTIVE": "true",
+    "AGENT_CONFIG_PATH": "/Users/someone/.co",
+    "GEMINI_API_KEY": "AIza-app-secret",
+    "DATABASE_URL": "postgres://app",
+}
+
+AGENT_ACCOUNT = {
+    "OPENONION_API_KEY": "eyJ-agents-token",
+    "AGENT_ADDRESS": AGENT,
+    "AGENT_EMAIL": "0xcf1619cb4c@mail.openonion.ai",
+    "IS_EMAIL_ACTIVE": "true",
+}
+
+
+def _ok():
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _env_written_over_ssh(tmp_path, agent_account):
+    """Run the real _sync_env and return the file body it sent to the server."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".env").write_text(
+        "".join(f"{k}={v}\n" for k, v in PROJECT_ENV.items()))
+
+    sent = {}
+
+    def fake_ssh(target, script, **kwargs):
+        for token in script.split():
+            try:
+                decoded = base64.b64decode(token.strip("'"), validate=True)
+            except Exception:
+                continue
+            if b"=" in decoded and b"\n" in decoded:
+                sent["body"] = decoded.decode()
+        return _ok()
+
+    with patch.object(dts, "_ssh", side_effect=fake_ssh):
+        assert dts._sync_env("prod", "myagent", project, agent_account)
+
+    return dict(
+        line.split("=", 1) for line in sent["body"].strip().splitlines() if line)
+
+
+def test_the_operators_account_does_not_reach_the_server(tmp_path):
+    """The regression. Every one of these four described the operator."""
+    written = _env_written_over_ssh(tmp_path, AGENT_ACCOUNT)
+
+    assert OPERATOR not in written.values(), "operator's address was shipped"
+    assert "aaron.xie@mail.openonion.ai" not in written.values(), \
+        "operator's mailbox was shipped — the agent would send mail as them"
+    assert written["OPENONION_API_KEY"] != "eyJ-operators-token", \
+        "operator's token was shipped — every model call bills them"
+
+
+def test_the_agents_own_account_reaches_the_server_instead(tmp_path):
+    written = _env_written_over_ssh(tmp_path, AGENT_ACCOUNT)
+
+    assert written["AGENT_ADDRESS"] == AGENT
+    assert written["AGENT_EMAIL"] == "0xcf1619cb4c@mail.openonion.ai"
+    assert written["OPENONION_API_KEY"] == "eyJ-agents-token"
+    assert written["IS_EMAIL_ACTIVE"] == "true"
+
+
+def test_the_applications_own_secrets_still_travel(tmp_path):
+    """Dropping identity must not drop the keys the agent needs to work."""
+    written = _env_written_over_ssh(tmp_path, AGENT_ACCOUNT)
+
+    assert written["GEMINI_API_KEY"] == "AIza-app-secret"
+    assert written["DATABASE_URL"] == "postgres://app"
+    assert written["AGENT_CONFIG_PATH"] == "/srv/myagent/.co", \
+        "still corrected for the machine it is going to"
+
+
+def test_without_an_account_the_operators_identity_is_still_dropped(tmp_path):
+    """`--own-identity`, or an auth that failed.
+
+    An agent with no account cannot call co/* models, which is visible and
+    fixable. An agent quietly spending someone else's credits is neither.
+    """
+    written = _env_written_over_ssh(tmp_path, None)
+
+    assert "OPENONION_API_KEY" not in written
+    assert "AGENT_EMAIL" not in written
+    assert OPERATOR not in written.values()
+    assert written["GEMINI_API_KEY"] == "AIza-app-secret"
+
+
+def test_a_project_with_no_env_still_gets_its_account(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    sent = {}
+
+    def fake_ssh(target, script, **kwargs):
+        for token in script.split():
+            try:
+                decoded = base64.b64decode(token.strip("'"), validate=True)
+            except Exception:
+                continue
+            if b"=" in decoded and b"\n" in decoded:
+                sent["body"] = decoded.decode()
+        return _ok()
+
+    with patch.object(dts, "_ssh", side_effect=fake_ssh):
+        assert dts._sync_env("prod", "myagent", project, AGENT_ACCOUNT)
+
+    assert "eyJ-agents-token" in sent["body"]
+
+
+class TestAgentAccount:
+    """Authenticating as the agent, from the key this machine derived."""
+
+    IDENTITY = {"address": AGENT, "key_bytes": bytes(32)}
+
+    def _response(self, status=200, payload=None):
+        response = Mock()
+        response.status_code = status
+        response.json.return_value = payload or {}
+        return response
+
+    def test_it_signs_as_the_agent_not_the_operator(self):
+        with patch("requests.post") as post:
+            post.return_value = self._response(payload={
+                "token": "eyJ-agents-token",
+                "user": {"email": {"address": "0xcf1619cb4c@mail.openonion.ai"}},
+            })
+            dts._agent_account(self.IDENTITY)
+
+        body = post.call_args.kwargs["json"]
+        assert body["public_key"] == AGENT
+        assert body["message"].startswith(f"ConnectOnion-Auth-{AGENT}-")
+
+    def test_the_mailbox_comes_from_the_backend(self):
+        """The backend routes the mail, so it decides the address.
+
+        The local fallback format (`address[:10]`) has not always agreed with
+        what the backend issues, and a computed-but-wrong mailbox fails by
+        silently not receiving.
+        """
+        with patch("requests.post") as post:
+            post.return_value = self._response(payload={
+                "token": "t",
+                "user": {"email": {"address": "0xcf1619cb4c@mail.openonion.ai"}},
+            })
+            account = dts._agent_account(self.IDENTITY)
+
+        assert account["AGENT_EMAIL"] == "0xcf1619cb4c@mail.openonion.ai"
+
+    def test_a_refused_auth_yields_no_account(self):
+        """Rather than falling back to whatever was in the project .env."""
+        with patch("requests.post") as post:
+            post.return_value = self._response(status=401)
+            assert dts._agent_account(self.IDENTITY) is None
+
+    def test_an_unreachable_backend_yields_no_account(self):
+        import requests as requests_module
+
+        with patch("requests.post",
+                   side_effect=requests_module.exceptions.ConnectionError()):
+            assert dts._agent_account(self.IDENTITY) is None
+
+
+def test_init_and_deploy_read_one_definition_of_identity():
+    """`co init` propagates exactly the keys `co deploy --to` withholds.
+
+    Two lists of "what counts as identity" drift, and the one that drifts is the
+    one nobody is looking at. Restating them separately is how this bug would
+    come back with a fifth key.
+    """
+    import inspect
+
+    from connectonion.cli.commands import init as init_module
+    from connectonion.cli.commands.env_inheritance import AGENT_IDENTITY_KEYS
+
+    source = inspect.getsource(init_module.handle_init)
+    assert "AGENT_IDENTITY_KEYS" in source, \
+        "co init should use the shared constant, not its own copy"
+    assert dts.is_operator_identity(AGENT_IDENTITY_KEYS[0])

--- a/tests/unit/test_deploy_env_is_secret.py
+++ b/tests/unit/test_deploy_env_is_secret.py
@@ -68,10 +68,12 @@ def test_local_config_path_is_rewritten_for_the_server():
     verbatim it points at a directory that cannot exist on Linux, and the OAuth
     tools that build their keys.env path from it fail there."""
     out = dts._env_for_server({"AGENT_CONFIG_PATH": "/Users/someone/.co",
-                               "OPENONION_API_KEY": "jwt"}, "myagent")
+                               "GEMINI_API_KEY": "AIza"}, "myagent")
 
     assert out["AGENT_CONFIG_PATH"] == f"{dts.SRV}/myagent/.co"
-    assert out["OPENONION_API_KEY"] == "jwt"
+    # Everything that is not identity passes through untouched. The identity
+    # keys are withheld deliberately — see test_a_deploy_runs_as_the_agent.py.
+    assert out["GEMINI_API_KEY"] == "AIza"
 
 
 def test_a_project_without_config_path_gains_nothing():


### PR DESCRIPTION
Fixes #994. Target release: **1.6.5** (patch on the stable line — not 1.7 preview work). Based on `main` because there is no 1.6.x maintenance branch; needs cherry-picking for the tag.

## The bug

`co deploy --to` wrote the project `.env` to `/etc/connectonion/<agent>.env` verbatim. That file carries four lines describing the **operator**, put there deliberately by `co init` so a project runs as its author locally:

| | effect on the server |
|---|---|
| `AGENT_EMAIL` | overrides the mailbox `address.load()` derives — the agent sends mail as its author |
| `OPENONION_API_KEY` | billing keys off the JWT's `public_key`, so every model call charges its author |
| `AGENT_ADDRESS` | sets nothing, but it is what people read to learn who an agent is |
| `IS_EMAIL_ACTIVE` | travels with the above |

The agent was cryptographically itself and financially its author, with nothing failing. One ran that way for nine days; `usage_logs` has no column naming the machine, so the spend cannot be separated afterwards.

## The fix

`_env_for_server` withholds the identity keys and substitutes the agent's own, from `_agent_account()` — which signs `ConnectOnion-Auth-…` with the key the deploy already derived (`derived_agent_identity`, SLIP-0013 `agent://<name>`) and calls `POST /api/v1/auth`.

- **The mailbox comes from the auth response**, not from `address[:10]`. The backend routes the mail and the local fallback has not always matched what it issues — a computed-but-wrong mailbox fails by silently not receiving.
- **`--own-identity` writes no account and says so**, naming `co auth` in `/srv/<agent>`. The operator cannot sign as an agent whose key was minted on the machine, and falling back to their own account is the bug being fixed.
- **The key set is named once** in `env_inheritance.py`; `co init` and `co deploy --to` both read it. Propagating it is the point in one and a bug in the other, so neither keeps its own copy.

Third-party keys and database URLs travel unchanged.

## Tests

`tests/unit/test_a_deploy_runs_as_the_agent.py` — 10 tests that intercept the real `_sync_env` and decode the base64 body actually sent over ssh, rather than asserting on argv:

- the operator's address, mailbox and token do not reach the server
- the agent's own do
- application secrets and the `AGENT_CONFIG_PATH` rewrite are untouched
- **with no account, the operator's identity is still dropped** — this is the shipped bug's exact path
- `_agent_account` signs as the agent, takes the mailbox from the response, and returns `None` on a refused or unreachable backend instead of falling back
- `co init` and the deploy read one definition of identity

**Verified red first.** With `is_operator_identity` stubbed to `return False`, `test_without_an_account_the_operators_identity_is_still_dropped` fails with the operator's address and `aaron.xie@…` present in what was sent.

```
$ pytest tests/unit -k "deploy or env or init" -q
455 passed
```

One pre-existing test changed: `test_local_config_path_is_rewritten_for_the_server` asserted `OPENONION_API_KEY` survived `_env_for_server`. That was incidental to what it tests — that only `AGENT_CONFIG_PATH` is rewritten — so it now uses an application key, which still does pass through.

## Docs

`docs/network/deploy.md` gains "The agent runs as itself, not as you", including the `--own-identity` path and why a missing account is the safer failure. The concept doc is in #993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)