### PR TITLE
fix: keep trust authorization bound to the hosted project

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -1171,15 +1171,22 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
     from .ws_router.dashboard import ensure_dashboard
     ensure_dashboard(agent_metadata)
 
+    # The storage directory is the project boundary available to create_app().
+    # Resolve it before trust construction so authorization and replay state
+    # cannot land in different projects when custom storage is supplied.
+    storage_path = getattr(storage, "path", None)
+    replay_dir = Path(storage_path).parent if storage_path else project_co_dir()
+
     # Create TrustAgent instance
     if isinstance(trust, TrustAgent):
         trust_agent = trust
     else:
-        trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
+        trust_agent = TrustAgent(
+            trust if isinstance(trust, str) else "careful",
+            co_dir=replay_dir,
+        )
 
     from ...useful_plugins.tool_approval.approval import load_permission_patterns
-    storage_path = getattr(storage, "path", None)
-    replay_dir = Path(storage_path).parent if storage_path else project_co_dir()
     replay_store = SignatureReplayStore(replay_dir / "replay.sqlite3")
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent,

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -1013,7 +1013,10 @@ def host(
     if isinstance(trust, TrustAgent):
         trust_agent = trust
     else:
-        trust_agent = TrustAgent(trust if isinstance(trust, str) else "careful")
+        trust_agent = TrustAgent(
+            trust if isinstance(trust, str) else "careful",
+            co_dir=co_dir,
+        )
 
     # Load the permission whitelist that gates direct execution (WS EXEC).
     # Same list the LLM approval flow reads: template safe defaults + this

--- a/connectonion/network/trust/fast_rules.py
+++ b/connectonion/network/trust/fast_rules.py
@@ -140,7 +140,8 @@ def _resolve_codes(codes) -> list:
     return out
 
 
-def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[str]:
+def evaluate_request(config: dict, client_id: str, request: dict,
+                     co_dir=None) -> Optional[str]:
     """
     Evaluate request using fast rules (no LLM).
 
@@ -177,7 +178,10 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     # 1. Check deny list first (blocked users)
     deny_list = config.get('deny', ['blocked'])
     for condition in deny_list:
-        if condition == 'blocked' and is_blocked(client_id):
+        if condition == 'blocked' and (
+            is_blocked(client_id) if co_dir is None
+            else is_blocked(client_id, co_dir)
+        ):
             logger.warning(f"[FAST_RULES] Client {client_id} is BLOCKED, returning 'deny'")
             return 'deny'
 
@@ -193,13 +197,22 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
         # Each of these says so on the way out. A log that recorded only the denials
         # left "did not grow" meaning either *allowed* or *never asked*, and those are
         # the two states an operator debugging a silent client most needs to separate.
-        if condition == 'admin' and is_admin(client_id):
+        if condition == 'admin' and (
+            is_admin(client_id) if co_dir is None
+            else is_admin(client_id, co_dir)
+        ):
             logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is admin")
             return 'allow'
-        if condition == 'whitelisted' and is_whitelisted(client_id):
+        if condition == 'whitelisted' and (
+            is_whitelisted(client_id) if co_dir is None
+            else is_whitelisted(client_id, co_dir)
+        ):
             logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is whitelisted")
             return 'allow'
-        if condition == 'contact' and is_contact(client_id):
+        if condition == 'contact' and (
+            is_contact(client_id) if co_dir is None
+            else is_contact(client_id, co_dir)
+        ):
             logger.warning(f"[FAST_RULES] Returning 'allow' — {client_id} is contact")
             return 'allow'
 
@@ -210,7 +223,10 @@ def evaluate_request(config: dict, client_id: str, request: dict) -> Optional[st
     valid_codes = _resolve_codes(onboard.get('invite_code', []))
     request_code = request.get('invite_code')
     if request_code and request_code in valid_codes:
-        promote_to_contact(client_id)
+        if co_dir is None:
+            promote_to_contact(client_id)
+        else:
+            promote_to_contact(client_id, co_dir)
         # Promotion is durable — this client is a contact from now on. That is a
         # change to who can reach the agent, so it belongs in the record. The code
         # itself does not.

--- a/connectonion/network/trust/tools.py
+++ b/connectonion/network/trust/tools.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import List, Callable
 
 
-def list_file(list_name: str) -> Path:
+def list_file(list_name: str, co_dir: Path = None) -> Path:
     """Where one of this agent's trust lists lives — beside its identity.
 
     These used to sit in a single ~/.co/ shared by every agent on the machine,
@@ -31,7 +31,7 @@ def list_file(list_name: str) -> Path:
     `admins.txt` was moved for exactly this reason. These three are the rest of
     the same list, and whitelist is the one that grants.
     """
-    return _project_co_dir() / f"{list_name}.txt"
+    return (Path(co_dir) if co_dir else _project_co_dir()) / f"{list_name}.txt"
 
 
 # One line per list per process. The entries in the old global file are not read
@@ -41,7 +41,7 @@ def list_file(list_name: str) -> Path:
 _announced_legacy = set()
 
 
-def _mention_a_legacy_list(list_name: str) -> None:
+def _mention_a_legacy_list(list_name: str, co_dir: Path = None) -> None:
     legacy = Path.home() / ".co" / f"{list_name}.txt"
     if list_name in _announced_legacy or not legacy.exists():
         return
@@ -50,7 +50,7 @@ def _mention_a_legacy_list(list_name: str) -> None:
         return
     print(f"[trust] {legacy} is no longer read — these lists now live beside "
           f"each agent, in its own .co/. Copy the lines you still want into "
-          f"{list_file(list_name)}.")
+          f"{list_file(list_name, co_dir)}.")
 
 
 # The `.co/` that belongs to this agent. A blocked address read from the wrong
@@ -69,7 +69,7 @@ def _admins_file(co_dir: Path = None) -> Path:
     return (Path(co_dir) if co_dir else _project_co_dir()) / "admins.txt"
 
 
-def _check_list(list_name: str, agent_id: str) -> bool:
+def _check_list(list_name: str, agent_id: str, co_dir: Path = None) -> bool:
     """Check if agent_id is in a list file. Supports `*` wildcards.
 
     A line matches the whole identifier, not part of it. `trusted-*` used to be
@@ -82,9 +82,9 @@ def _check_list(list_name: str, agent_id: str) -> bool:
     but an admin pastes what a UI showed them, and `block("0xABCDEF…")` that
     silently blocks nobody is worse than one that errors — it reported success.
     """
-    list_path = list_file(list_name)
+    list_path = list_file(list_name, co_dir)
     if not list_path.exists():
-        _mention_a_legacy_list(list_name)
+        _mention_a_legacy_list(list_name, co_dir)
         return False
     # An unreadable file is not an empty file.
     #
@@ -162,14 +162,14 @@ def check_blocklist(agent_id: str) -> str:
     return f"{agent_id} is not blocked"
 
 
-def is_whitelisted(agent_id: str) -> bool:
+def is_whitelisted(agent_id: str, co_dir: Path = None) -> bool:
     """Check if agent is whitelisted. Returns bool for fast rules."""
-    return _check_list("whitelist", agent_id)
+    return _check_list("whitelist", agent_id, co_dir)
 
 
-def is_blocked(agent_id: str) -> bool:
+def is_blocked(agent_id: str, co_dir: Path = None) -> bool:
     """Check if agent is blocked. Returns bool for fast rules."""
-    return _check_list("blocklist", agent_id)
+    return _check_list("blocklist", agent_id, co_dir)
 
 
 def test_capability(agent_id: str, test: str, expected: str) -> str:
@@ -201,13 +201,13 @@ def verify_agent(agent_id: str, agent_info: str = "") -> str:
     return f"Verifying agent: {agent_id}. Info: {agent_info}"
 
 
-def _add_to_list(list_name: str, client_id: str) -> bool:
+def _add_to_list(list_name: str, client_id: str, co_dir: Path = None) -> bool:
     """Add client_id to a list file."""
-    list_path = list_file(list_name)
+    list_path = list_file(list_name, co_dir)
     list_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Check if already in list
-    if _check_list(list_name, client_id):
+    if _check_list(list_name, client_id, co_dir):
         return True
 
     # Append to file
@@ -216,9 +216,9 @@ def _add_to_list(list_name: str, client_id: str) -> bool:
     return True
 
 
-def _remove_from_list(list_name: str, client_id: str) -> bool:
+def _remove_from_list(list_name: str, client_id: str, co_dir: Path = None) -> bool:
     """Remove client_id from a list file."""
-    list_path = list_file(list_name)
+    list_path = list_file(list_name, co_dir)
     if not list_path.exists():
         return True
 
@@ -269,69 +269,69 @@ def verify_payment(client_id: str, amount: float, required_amount: float) -> str
 
 # === Promotion ===
 
-def promote_to_contact(client_id: str) -> str:
+def promote_to_contact(client_id: str, co_dir: Path = None) -> str:
     """Stranger → Contact"""
-    _add_to_list("contacts", client_id)
+    _add_to_list("contacts", client_id, co_dir)
     return f"{client_id} promoted to contact."
 
 
-def promote_to_whitelist(client_id: str) -> str:
+def promote_to_whitelist(client_id: str, co_dir: Path = None) -> str:
     """Contact → Whitelist"""
-    _add_to_list("whitelist", client_id)
+    _add_to_list("whitelist", client_id, co_dir)
     return f"{client_id} promoted to whitelist."
 
 
 # === Demotion ===
 
-def demote_to_contact(client_id: str) -> str:
+def demote_to_contact(client_id: str, co_dir: Path = None) -> str:
     """Whitelist → Contact"""
-    _remove_from_list("whitelist", client_id)
-    _add_to_list("contacts", client_id)
+    _remove_from_list("whitelist", client_id, co_dir)
+    _add_to_list("contacts", client_id, co_dir)
     return f"{client_id} demoted to contact."
 
 
-def demote_to_stranger(client_id: str) -> str:
+def demote_to_stranger(client_id: str, co_dir: Path = None) -> str:
     """Contact → Stranger"""
-    _remove_from_list("contacts", client_id)
-    _remove_from_list("whitelist", client_id)
+    _remove_from_list("contacts", client_id, co_dir)
+    _remove_from_list("whitelist", client_id, co_dir)
     return f"{client_id} demoted to stranger."
 
 
 # === Blocking ===
 
-def block(client_id: str, reason: str = "") -> str:
+def block(client_id: str, reason: str = "", co_dir: Path = None) -> str:
     """Add to blocklist."""
-    _add_to_list("blocklist", client_id)
+    _add_to_list("blocklist", client_id, co_dir)
     return f"{client_id} blocked. Reason: {reason}"
 
 
-def unblock(client_id: str) -> str:
+def unblock(client_id: str, co_dir: Path = None) -> str:
     """Remove from blocklist."""
-    _remove_from_list("blocklist", client_id)
+    _remove_from_list("blocklist", client_id, co_dir)
     return f"{client_id} unblocked."
 
 
 # === Queries ===
 
-def get_level(client_id: str) -> str:
+def get_level(client_id: str, co_dir: Path = None) -> str:
     """Returns: stranger, contact, whitelist, or blocked."""
-    if is_blocked(client_id):
+    if is_blocked(client_id, co_dir):
         return "blocked"
-    if is_whitelisted(client_id):
+    if is_whitelisted(client_id, co_dir):
         return "whitelist"
-    if _check_list("contacts", client_id):
+    if _check_list("contacts", client_id, co_dir):
         return "contact"
     return "stranger"
 
 
-def is_contact(client_id: str) -> bool:
+def is_contact(client_id: str, co_dir: Path = None) -> bool:
     """Check if client is a contact."""
-    return _check_list("contacts", client_id)
+    return _check_list("contacts", client_id, co_dir)
 
 
-def is_stranger(client_id: str) -> bool:
+def is_stranger(client_id: str, co_dir: Path = None) -> bool:
     """Check if client is a stranger (not contact, whitelist, or blocked)."""
-    return get_level(client_id) == "stranger"
+    return get_level(client_id, co_dir) == "stranger"
 
 
 def get_trust_verification_tools() -> List[Callable]:

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -107,7 +107,8 @@ class TrustAgent:
         authentication backends, or business logic. See module docstring.
     """
 
-    def __init__(self, trust: str = "careful", *, api_key: str = None, model: str = "co/gemini-3.6-flash"):
+    def __init__(self, trust: str = "careful", *, api_key: str = None,
+                 model: str = "co/gemini-3.6-flash", co_dir: Path = None):
         """
         Create a TrustAgent.
 
@@ -115,10 +116,13 @@ class TrustAgent:
             trust: Trust level ("open", "careful", "strict") or path to policy file
             api_key: Optional API key for LLM (only needed if using 'ask' default)
             model: Model to use for LLM decisions
+            co_dir: Project .co directory. Bound at construction so trust state
+                does not move with, or disappear with, the process cwd.
         """
         self.trust = trust
         self.api_key = api_key
         self.model = model
+        self._co_dir = Path(co_dir).resolve() if co_dir else project_co_dir()
 
         # Load policy and parse config
         self._config, self._prompt = self._load_policy(trust)
@@ -170,7 +174,7 @@ class TrustAgent:
         request = request or {}
 
         # Fast rules (no LLM)
-        result = evaluate_request(self._config, client_id, request)
+        result = evaluate_request(self._config, client_id, request, self._co_dir)
 
         if result == 'allow':
             return Decision(allow=True, reason="Allowed by fast rules")
@@ -334,7 +338,7 @@ justify admitting them, it is not enough."""
         from ... import address as addr
         from ...project import project_identity
 
-        keys = project_identity()
+        keys = project_identity(self._co_dir)
         if not keys:
             return False
 
@@ -388,31 +392,31 @@ justify admitting them, it is not enough."""
 
     def promote_to_contact(self, client_id: str) -> str:
         """Stranger -> Contact"""
-        return _promote_to_contact(client_id)
+        return _promote_to_contact(client_id, self._co_dir)
 
     def promote_to_whitelist(self, client_id: str) -> str:
         """Contact -> Whitelist"""
-        return _promote_to_whitelist(client_id)
+        return _promote_to_whitelist(client_id, self._co_dir)
 
     # === Demotion ===
 
     def demote_to_contact(self, client_id: str) -> str:
         """Whitelist -> Contact"""
-        return _demote_to_contact(client_id)
+        return _demote_to_contact(client_id, self._co_dir)
 
     def demote_to_stranger(self, client_id: str) -> str:
         """Contact -> Stranger"""
-        return _demote_to_stranger(client_id)
+        return _demote_to_stranger(client_id, self._co_dir)
 
     # === Blocking ===
 
     def block(self, client_id: str, reason: str = "") -> str:
         """Add to blocklist."""
-        return _block(client_id, reason)
+        return _block(client_id, reason, self._co_dir)
 
     def unblock(self, client_id: str) -> str:
         """Remove from blocklist."""
-        return _unblock(client_id)
+        return _unblock(client_id, self._co_dir)
 
     # === Queries ===
 
@@ -422,23 +426,23 @@ justify admitting them, it is not enough."""
 
         Returns: "stranger", "contact", "whitelist", or "blocked"
         """
-        return _get_level(client_id)
+        return _get_level(client_id, self._co_dir)
 
     def is_whitelisted(self, client_id: str) -> bool:
         """Check if client is whitelisted."""
-        return _is_whitelisted(client_id)
+        return _is_whitelisted(client_id, self._co_dir)
 
     def is_blocked(self, client_id: str) -> bool:
         """Check if client is blocked."""
-        return _is_blocked(client_id)
+        return _is_blocked(client_id, self._co_dir)
 
     def is_contact(self, client_id: str) -> bool:
         """Check if client is a contact."""
-        return _is_contact(client_id)
+        return _is_contact(client_id, self._co_dir)
 
     def is_stranger(self, client_id: str) -> bool:
         """Check if client is a stranger."""
-        return _is_stranger(client_id)
+        return _is_stranger(client_id, self._co_dir)
 
     # === Admin Management ===
     # Instance methods for easy subclass overloading.
@@ -446,23 +450,23 @@ justify admitting them, it is not enough."""
 
     def is_admin(self, client_id: str) -> bool:
         """Check if client is an admin. Override for custom admin logic."""
-        return _is_admin(client_id)
+        return _is_admin(client_id, self._co_dir)
 
     def is_super_admin(self, client_id: str) -> bool:
         """Check if client is super admin (self address). Override for custom logic."""
-        return _is_super_admin(client_id)
+        return _is_super_admin(client_id, self._co_dir)
 
     def get_self_address(self) -> str | None:
         """Get self address (super admin)."""
-        return _get_self_address()
+        return _get_self_address(self._co_dir)
 
     def add_admin(self, admin_id: str) -> str:
         """Add an admin. Super admin only. Override for custom storage."""
-        return _add_admin(admin_id)
+        return _add_admin(admin_id, self._co_dir)
 
     def remove_admin(self, admin_id: str) -> str:
         """Remove an admin. Super admin only. Override for custom storage."""
-        return _remove_admin(admin_id)
+        return _remove_admin(admin_id, self._co_dir)
 
     # === Config Access ===
 

--- a/tests/unit/test_trust_survives_a_lost_working_directory.py
+++ b/tests/unit/test_trust_survives_a_lost_working_directory.py
@@ -7,6 +7,7 @@ which surfaced to O Chat as ``Agent error: misconfigured``.
 """
 
 import os
+from unittest.mock import MagicMock
 
 from connectonion.network.trust import TrustAgent
 
@@ -70,3 +71,36 @@ def test_explicit_host_directory_wins_over_the_startup_working_directory(
 
     assert not decision.allow
     assert decision.reason == "Denied by fast rules"
+
+
+def test_create_app_binds_trust_beside_custom_storage(tmp_path, monkeypatch):
+    """External ASGI hosting keeps trust and replay state in one project."""
+    from connectonion.network.host import server
+    from connectonion.network.host.session.storage import SessionStorage
+
+    launcher = tmp_path / "launcher"
+    launcher.mkdir()
+    hosted_co_dir = tmp_path / "hosted" / ".co"
+    hosted_co_dir.mkdir(parents=True)
+    monkeypatch.chdir(launcher)
+
+    captured = {}
+    real_trust_agent = server.TrustAgent
+
+    class CapturingTrustAgent(real_trust_agent):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["co_dir"] = self._co_dir
+
+    monkeypatch.setattr(server, "TrustAgent", CapturingTrustAgent)
+
+    def create_agent():
+        agent = MagicMock()
+        agent.name = "test-agent"
+        agent.tools.names.return_value = []
+        return agent
+
+    storage = SessionStorage(hosted_co_dir / "session_results.jsonl")
+    server.create_app(create_agent, storage=storage, trust="open")
+
+    assert captured["co_dir"] == hosted_co_dir.resolve()

--- a/tests/unit/test_trust_survives_a_lost_working_directory.py
+++ b/tests/unit/test_trust_survives_a_lost_working_directory.py
@@ -51,3 +51,22 @@ def test_authorization_does_not_follow_a_tool_into_another_project(tmp_path,
 
     assert not decision.allow
     assert decision.reason == "Denied by fast rules"
+
+
+def test_explicit_host_directory_wins_over_the_startup_working_directory(
+        tmp_path, monkeypatch):
+    hosted = tmp_path / "hosted"
+    hosted_co_dir = hosted / ".co"
+    hosted_co_dir.mkdir(parents=True)
+    blocked = "0x" + "c" * 64
+    (hosted_co_dir / "blocklist.txt").write_text(blocked + "\n")
+
+    launcher = tmp_path / "launcher"
+    launcher.mkdir()
+    monkeypatch.chdir(launcher)
+    trust = TrustAgent("open", co_dir=hosted_co_dir)
+
+    decision = trust.should_allow(blocked, {"prompt": "hello"})
+
+    assert not decision.allow
+    assert decision.reason == "Denied by fast rules"

--- a/tests/unit/test_trust_survives_a_lost_working_directory.py
+++ b/tests/unit/test_trust_survives_a_lost_working_directory.py
@@ -1,0 +1,53 @@
+"""Trust state belongs to the hosted project, not the process' current cwd.
+
+An agent tool may change into a temporary directory and remove it.  Calling
+``Path.cwd()`` after that raises ``FileNotFoundError: [Errno 2] No such file or
+directory``.  The host used to do exactly that on the next authorization check,
+which surfaced to O Chat as ``Agent error: misconfigured``.
+"""
+
+import os
+
+from connectonion.network.trust import TrustAgent
+
+
+def test_authorization_uses_the_project_bound_when_the_host_started(tmp_path,
+                                                                   monkeypatch):
+    project = tmp_path / "agent"
+    (project / ".co").mkdir(parents=True)
+    monkeypatch.chdir(project)
+
+    trust = TrustAgent("open")
+
+    abandoned = tmp_path / "tool-work"
+    abandoned.mkdir()
+    original_cwd = os.open(".", os.O_RDONLY)
+    try:
+        os.chdir(abandoned)
+        abandoned.rmdir()
+
+        decision = trust.should_allow("0x" + "a" * 64, {"prompt": "hello"})
+    finally:
+        os.fchdir(original_cwd)
+        os.close(original_cwd)
+
+    assert decision.allow
+
+
+def test_authorization_does_not_follow_a_tool_into_another_project(tmp_path,
+                                                                   monkeypatch):
+    hosted = tmp_path / "hosted"
+    (hosted / ".co").mkdir(parents=True)
+    blocked = "0x" + "b" * 64
+    (hosted / ".co" / "blocklist.txt").write_text(blocked + "\n")
+    monkeypatch.chdir(hosted)
+    trust = TrustAgent("open")
+
+    unrelated = tmp_path / "unrelated"
+    (unrelated / ".co").mkdir(parents=True)
+    monkeypatch.chdir(unrelated)
+
+    decision = trust.should_allow(blocked, {"prompt": "hello"})
+
+    assert not decision.allow
+    assert decision.reason == "Denied by fast rules"


### PR DESCRIPTION
## Problem

A long-running host resolves trust files from `Path.cwd()` on every request. If an agent tool changes into a temporary directory and that directory is later removed, the next authorization check raises `[Errno 2] No such file or directory`. The client then receives `Agent error: misconfigured`, matching the production screenshot.

The same ambient-cwd lookup also lets a tool switch authorization to another project's `.co` directory.

## Fix

- bind the hosted project's `.co` directory when `TrustAgent` is constructed
- thread that directory through fast rules, trust-list mutations, admin checks, identity lookup, and payment verification
- keep standalone trust helper behavior backwards-compatible when no directory is supplied
- add regressions for a deleted cwd and cross-project cwd changes

## Verification

- `pytest -q tests/unit/test_acp_transport_discovery.py tests/unit/test_trust_survives_a_lost_working_directory.py tests/unit/test_fast_rules.py tests/unit/test_trust_agent_class.py tests/unit/test_a_broken_list_still_answers.py tests/unit/test_the_trust_layer_knows_who_it_is.py` — 77 passed
- `python -m build` — sdist and wheel built
- broader unit run reached 777 passed; 3 unrelated AF_UNIX tests were blocked by the macOS sandbox before the intentionally stopped run

## Issue #996 audit

This is separate from #996. The published PyPI 1.7.0a1 wheel was downloaded and inspected: its `/info` implementation contains neither the ACP `transports` descriptor nor the `Cache-Control: no-store` response header. Therefore the released artifact does not contain the half-contract described by #996 and cannot explain this server-side authorization error.
