### PR TITLE
[1.9 Deferred] discord: post from the terminal and from an agent

### DIFF
--- a/connectonion/cli/commands/discord_commands.py
+++ b/connectonion/cli/commands/discord_commands.py
@@ -1,0 +1,30 @@
+"""
+Purpose: `co discord send` — post to Discord from the terminal
+LLM-Note:
+  Dependencies: imports from [sys, rich.console, rich.text, useful_tools.discord.send_discord] | imported by [cli/main.py via discord_send()] | tested by [tests/unit/test_discord.py]
+  Data flow: handle_discord_send(channel, message) → send_discord() → prints the outcome → exit 0 on success, 1 on failure
+  State/Effects: one HTTP POST via the tool | no local state
+  Integration: same shape as handle_telegram_send — a thin handler over the tool an agent already has
+  Errors: a refused post or a missing token prints Discord's own reason and exits 1
+"""
+
+import sys
+
+from rich.console import Console
+from rich.text import Text
+
+from ...useful_tools.discord import send_discord
+
+console = Console()
+
+
+def handle_discord_send(channel: str, message: str) -> int:
+    """Post one message and say what happened."""
+    result = send_discord(channel, message)
+
+    if not result["success"]:
+        console.print(Text(str(result["error"]), style="red"))
+        sys.exit(1)
+
+    console.print(Text(f"Posted to {result['channel']}", style="green"))
+    return 0

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -158,6 +158,7 @@ def _show_help():
     console.print("  [green]email[/green]             Send and read agent email")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]telegram[/green]          Send a message from your Telegram bot")
+    console.print("  [green]discord[/green]           Post to Discord, as your bot or via a webhook")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
     console.print("  [green]syno[/green]              Browse and transfer Synology NAS files (co syno login)")
     console.print("  [green]outlook[/green]           Manage Outlook email and contacts (co auth microsoft)")
@@ -779,6 +780,22 @@ def email_upgrade(
 
 # Telegram command group. The bot is the user's own (@BotFather), so the token
 # lives in their keys.env -- no OpenOnion credential and nothing billed.
+# Discord command group. The bot is the user's own application, so the token
+# lives in their keys.env -- same as Telegram. A webhook URL needs no token.
+discord_app = _typer_app(help="Post a message to Discord, as your bot or through a webhook.")
+app.add_typer(discord_app, name="discord")
+
+
+@discord_app.command("send")
+def discord_send(
+    channel: str = typer.Argument(..., help="Channel id, or a webhook URL"),
+    message: str = typer.Argument(..., help="The text to post (max 2000 chars)"),
+):
+    """Post a message to Discord."""
+    from .commands.discord_commands import handle_discord_send
+    handle_discord_send(channel, message)
+
+
 telegram_app = _typer_app(help="Send a message from your Telegram bot.")
 app.add_typer(telegram_app, name="telegram")
 

--- a/connectonion/useful_tools/__init__.py
+++ b/connectonion/useful_tools/__init__.py
@@ -30,6 +30,7 @@ from .todo_list import TodoList
 from .slash_command import SlashCommand
 from .ask_user import ask_user
 from .telegram import send_telegram
+from .discord import send_discord
 
 # Claude Code-style file tools
 from .file_tools import (
@@ -78,6 +79,7 @@ __all__ = [
     "SlashCommand",
     "ask_user",
     "send_telegram",
+    "send_discord",
     # Claude Code-style file tools
     "FileTools",
     "read_file",

--- a/connectonion/useful_tools/discord.py
+++ b/connectonion/useful_tools/discord.py
@@ -1,0 +1,119 @@
+"""
+Purpose: Post a Discord message — as your bot to a channel, or through a webhook URL
+LLM-Note:
+  Dependencies: imports from [os, requests] | imported by [useful_tools/__init__.py, cli/commands/discord_commands.py] | tested by [tests/unit/test_discord.py]
+  Data flow: send_discord(channel, message) → webhook URL posts straight to it | channel id reads DISCORD_BOT_TOKEN → POST discord.com/api/v10/channels/<id>/messages → returns {success, message_id, channel, error}
+  State/Effects: one HTTP POST per message | no local state | no credential of ours is involved — the bot is the user's own
+  Integration: exposed as an agent tool and as `co discord send` | the token is from the user's own Discord application, like Telegram's bot token rather than a carrier account
+  Errors: returns {success: False, error, channel} for setup, transport and Discord refusals, without echoing the token or a webhook URL
+"""
+
+import os
+
+import requests
+
+
+API = "https://discord.com/api/v10"
+
+# Discord caps a message at 2000 characters and rejects the whole thing above
+# it, so a long release note fails at the API rather than being truncated.
+MAX_MESSAGE = 2000
+
+NO_TOKEN = (
+    "DISCORD_BOT_TOKEN is not set, and the target is not a webhook URL. Either "
+    "pass a webhook URL, or create a bot at "
+    "https://discord.com/developers/applications and put its token in "
+    "~/.co/keys.env as DISCORD_BOT_TOKEN. The bot is yours — nothing is billed to it."
+)
+
+
+def send_discord(channel: str, message: str) -> dict[str, object]:
+    """Post a message to Discord.
+
+    Args:
+        channel: A channel id (posts as your bot), or a webhook URL (posts as
+            the webhook). Webhooks need no bot and no token.
+        message: The text to post. Discord's limit is 2000 characters.
+
+    Returns:
+        dict: {success, message_id, channel, error}
+    """
+    if not message:
+        return _failure(channel, "Discord rejects an empty message.")
+    if len(message) > MAX_MESSAGE:
+        return _failure(
+            channel,
+            f"Discord rejects messages over {MAX_MESSAGE} characters; this one is "
+            f"{len(message)}. Split it rather than letting the API refuse the whole post.",
+        )
+
+    if channel.startswith("https://"):
+        return _post(channel, {"content": message}, headers={}, channel=channel)
+
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    if not token:
+        return _failure(channel, NO_TOKEN)
+
+    return _post(
+        f"{API}/channels/{channel}/messages",
+        {"content": message},
+        headers={"Authorization": f"Bot {token}"},
+        channel=channel,
+        token=token,
+    )
+
+
+def _post(url, payload, *, headers, channel, token=None) -> dict[str, object]:
+    """One POST, with the message carried as JSON.
+
+    `json=` is the whole point of this function. The release path hand-built
+    the body with `curl -d "{...}"`, and a backtick or a backslash in a release
+    note broke the quoting and came back as Discord error 50109, invalid JSON.
+    Serialising in the library cannot make that mistake.
+    """
+    try:
+        response = requests.post(
+            url, json=payload, headers={**headers, "User-Agent": "connectonion"}, timeout=15
+        )
+    except requests.RequestException as exc:
+        # A webhook URL is itself a secret, and it appears in the exception's
+        # string form. The class names the failure without leaking it.
+        return _failure(channel, f"Discord request failed ({type(exc).__name__}).")
+
+    return _read(response, channel=channel, token=token)
+
+
+def _read(response, *, channel, token) -> dict[str, object]:
+    """Discord's own reason, kept — 50109 and "unknown channel" need different fixes."""
+    if response.status_code in (200, 204):
+        return {"success": True, "message_id": _message_id(response), "channel": channel}
+
+    try:
+        body = response.json()
+    except ValueError:
+        return _failure(channel, f"Discord returned HTTP {response.status_code} without JSON.")
+
+    reason = body.get("message") if isinstance(body, dict) else None
+    code = body.get("code") if isinstance(body, dict) else None
+    detail = f"{reason} (code {code})" if reason and code else (reason or str(body)[:200])
+    if token:
+        detail = detail.replace(token, "[redacted]")
+    return _failure(channel, f"Discord refused the message: {detail}")
+
+
+def _message_id(response):
+    """Webhooks answer 204 with no body; a bot post answers 200 with the message."""
+    try:
+        body = response.json()
+    except ValueError:
+        return None
+    return body.get("id") if isinstance(body, dict) else None
+
+
+def _failure(channel: str, error: str) -> dict[str, object]:
+    return {"success": False, "error": error, "channel": _safe(channel)}
+
+
+def _safe(channel: str) -> str:
+    """A webhook URL carries its own token, so it never goes back in a result."""
+    return "webhook" if channel.startswith("https://") else channel

--- a/connectonion/useful_tools/discord.py
+++ b/connectonion/useful_tools/discord.py
@@ -13,8 +13,6 @@ import os
 import requests
 
 
-API = "https://discord.com/api/v10"
-
 # Discord caps a message at 2000 characters and rejects the whole thing above
 # it, so a long release note fails at the API rather than being truncated.
 MAX_MESSAGE = 2000
@@ -55,7 +53,7 @@ def send_discord(channel: str, message: str) -> dict[str, object]:
         return _failure(channel, NO_TOKEN)
 
     return _post(
-        f"{API}/channels/{channel}/messages",
+        f"https://discord.com/api/v10/channels/{channel}/messages",
         {"content": message},
         headers={"Authorization": f"Bot {token}"},
         channel=channel,
@@ -86,7 +84,7 @@ def _post(url, payload, *, headers, channel, token=None) -> dict[str, object]:
 def _read(response, *, channel, token) -> dict[str, object]:
     """Discord's own reason, kept — 50109 and "unknown channel" need different fixes."""
     if response.status_code in (200, 204):
-        return {"success": True, "message_id": _message_id(response), "channel": channel}
+        return {"success": True, "message_id": _message_id(response), "channel": _safe(channel)}
 
     try:
         body = response.json()

--- a/tests/unit/test_discord.py
+++ b/tests/unit/test_discord.py
@@ -1,0 +1,222 @@
+"""Unit tests for the Discord outbound tool.
+
+LLM-Note: Tests for send_discord and `co discord send`
+
+What it tests:
+- Posting as a bot and through a webhook, and every way it can fail
+
+Components under test:
+- Module: useful_tools/discord, cli/commands/discord_commands
+"""
+
+import sys
+
+import pytest
+
+from connectonion.useful_tools.discord import send_discord
+
+discord = sys.modules["connectonion.useful_tools.discord"]
+
+WEBHOOK = "https://discord.com/api/webhooks/123/abcSECRETtoken"
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None, raises=False):
+        self.status_code = status_code
+        self._payload = payload
+        self._raises = raises
+
+    def json(self):
+        if self._raises:
+            raise ValueError("no json")
+        return self._payload
+
+
+@pytest.fixture
+def bot(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "botTOKEN123")
+
+
+def test_a_channel_id_posts_as_the_bot(bot, monkeypatch):
+    posted = {}
+
+    def fake_post(url, json, headers, timeout):
+        posted.update(url=url, json=json, headers=headers)
+        return FakeResponse(200, {"id": "999"})
+
+    monkeypatch.setattr(discord.requests, "post", fake_post)
+
+    result = send_discord("42", "1.6.0 is out")
+
+    assert result == {"success": True, "message_id": "999", "channel": "42"}
+    assert posted["url"] == "https://discord.com/api/v10/channels/42/messages"
+    assert posted["headers"]["Authorization"] == "Bot botTOKEN123"
+
+
+def test_a_webhook_url_posts_without_a_token(monkeypatch):
+    """The release path uses a webhook, and a webhook needs no bot at all."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    posted = {}
+
+    def fake_post(url, json, headers, timeout):
+        posted.update(url=url, headers=headers)
+        return FakeResponse(204, raises=True)
+
+    monkeypatch.setattr(discord.requests, "post", fake_post)
+
+    result = send_discord(WEBHOOK, "1.6.0 is out")
+
+    assert result["success"] is True
+    assert posted["url"] == WEBHOOK
+    assert "Authorization" not in posted["headers"]
+
+
+def test_the_release_note_that_broke_the_1_6_0_announcement_goes_through(monkeypatch):
+    """#816: `curl -d "{...}"` broke on backtick and backslash quoting and Discord
+    answered 50109 invalid JSON. Serialising in the library cannot make that
+    mistake — the characters must reach Discord unmangled."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    posted = {}
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: (posted.update(json=json),
+                                             FakeResponse(204, raises=True))[1],
+    )
+
+    nasty = 'Run `co discord send` with a path C:\\Users\\x and a "quote" — 100% done'
+    send_discord(WEBHOOK, nasty)
+
+    assert posted["json"]["content"] == nasty
+
+
+def test_a_user_agent_is_always_sent(monkeypatch):
+    """#816: python urllib got 403 because Discord rejects its default
+    User-Agent. Ours must never be the default."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    posted = {}
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: (posted.update(headers=headers),
+                                             FakeResponse(204, raises=True))[1],
+    )
+
+    send_discord(WEBHOOK, "hello")
+
+    assert posted["headers"]["User-Agent"] == "connectonion"
+
+
+def test_discords_own_reason_and_code_survive(bot, monkeypatch):
+    """50109 and "Unknown Channel" are different problems with different fixes."""
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(
+            404, {"message": "Unknown Channel", "code": 10003}),
+    )
+
+    result = send_discord("42", "hello")
+
+    assert result["success"] is False
+    assert "Unknown Channel" in result["error"]
+    assert "10003" in result["error"]
+
+
+def test_a_webhook_url_never_comes_back_in_the_result(monkeypatch):
+    """The URL is itself the credential. It must not land in a log line or an
+    error an agent might repeat."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(400, {"message": "Bad", "code": 50109}),
+    )
+
+    result = send_discord(WEBHOOK, "hello")
+
+    assert "abcSECRETtoken" not in str(result)
+    assert result["channel"] == "webhook"
+
+
+def test_a_transport_error_does_not_leak_the_webhook(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    def blow_up(url, json, headers, timeout):
+        raise discord.requests.ConnectionError(f"failed connecting to {WEBHOOK}")
+
+    monkeypatch.setattr(discord.requests, "post", blow_up)
+
+    result = send_discord(WEBHOOK, "hello")
+
+    assert result["success"] is False
+    assert "abcSECRETtoken" not in str(result)
+    assert "ConnectionError" in result["error"]
+
+
+def test_the_bot_token_is_never_echoed_back(bot, monkeypatch):
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(
+            401, {"message": "Invalid token botTOKEN123", "code": 50014}),
+    )
+
+    result = send_discord("42", "hello")
+
+    assert "botTOKEN123" not in result["error"]
+    assert "[redacted]" in result["error"]
+
+
+def test_a_message_over_the_limit_is_refused_here_not_by_discord(monkeypatch):
+    """Discord rejects the whole post above 2000 characters rather than
+    truncating, so a long release note would silently not appear."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("sent an over-length message to Discord")
+
+    monkeypatch.setattr(discord.requests, "post", must_not_run)
+
+    result = send_discord(WEBHOOK, "x" * 2001)
+
+    assert result["success"] is False
+    assert "2000" in result["error"]
+    assert "2001" in result["error"]
+
+
+def test_no_token_and_no_webhook_says_how_to_get_one(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("called Discord with no credential")
+
+    monkeypatch.setattr(discord.requests, "post", must_not_run)
+
+    result = send_discord("42", "hello")
+
+    assert result["success"] is False
+    assert "DISCORD_BOT_TOKEN" in result["error"]
+    assert "developers/applications" in result["error"]
+
+
+class TestTheCommand:
+    def test_a_refused_post_exits_nonzero(self, monkeypatch):
+        """The release path has to be able to tell the announcement did not go out
+        — #300 shipped a post with a blank download count and nobody noticed."""
+        from connectonion.cli.commands import discord_commands
+
+        monkeypatch.setattr(
+            discord_commands, "send_discord",
+            lambda channel, message: {"success": False, "error": "Discord refused", "channel": "42"},
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            discord_commands.handle_discord_send("42", "hello")
+
+        assert exc.value.code == 1
+
+    def test_a_successful_post_exits_zero(self, monkeypatch):
+        from connectonion.cli.commands import discord_commands
+
+        monkeypatch.setattr(
+            discord_commands, "send_discord",
+            lambda channel, message: {"success": True, "message_id": "9", "channel": "42"},
+        )
+
+        assert discord_commands.handle_discord_send("42", "hello") == 0

--- a/tests/unit/test_discord.py
+++ b/tests/unit/test_discord.py
@@ -135,6 +135,23 @@ def test_a_webhook_url_never_comes_back_in_the_result(monkeypatch):
     assert result["channel"] == "webhook"
 
 
+def test_a_successful_webhook_post_does_not_echo_the_url_either(monkeypatch):
+    """The failure path redacts it; so must the success path. A result gets
+    logged, printed, and repeated back by an agent — success is the case that
+    happens most often."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        discord.requests, "post",
+        lambda url, json, headers, timeout: FakeResponse(204, raises=True),
+    )
+
+    result = send_discord(WEBHOOK, "1.6.0 is out")
+
+    assert result["success"] is True
+    assert "abcSECRETtoken" not in str(result)
+    assert result["channel"] == "webhook"
+
+
 def test_a_transport_error_does_not_leak_the_webhook(monkeypatch):
     monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
 


### PR DESCRIPTION
Closes #1003. Third of the outbound chat commands in #816, after Telegram (#866).

```
co discord send <channel-id> "message"
co discord send https://discord.com/api/webhooks/... "message"
```

plus `send_discord(channel, message)` as an agent tool.

## Scoped to notification, deliberately

**This PR is the outbound notification channel and nothing more.** A webhook and a bot are not two ways of saying the same thing — a webhook is a one-way pipe with no identity and no ears, while a bot can read, reply, be @-mentioned, join voice, and hold a role in a server. They overlap on exactly one verb: post a message.

For notification, **the webhook is not a compromise — it is the complete answer.** No bot, no developer application, no permission scopes, no token to leak: a URL is the whole configuration. The channel-id path is here because the release process and a general agent both benefit from posting as a real bot identity, and it is one branch on whether the target starts with `https://`.

Everything else a bot can do is a larger surface with a different setup cost and belongs in its own issue. #1003 has the capability table and a review of `discli`, an existing MIT-licensed Discord CLI aimed at agents that already covers much of that surface — worth reading before designing it, and too young (27 stars) to depend on.

## The two incidents this is built around

#816 recorded both, and both are pinned by a test rather than a comment:

**Escaping.** `curl -d "{…}"` broke on backtick and backslash quoting and Discord answered **50109 invalid JSON**, so the release skill accumulated a `json.dumps → file → curl` workaround. The test feeds the shape that broke it — backticks, `C:\Users\x`, quotes, a percent sign — and asserts it arrives byte-for-byte. Serialising in the library cannot make that mistake.

**403.** python urllib was rejected because Discord refuses its default User-Agent. There is a test asserting ours is never the default.

And the reason exit codes matter here: **#300 shipped a release post reading `• downloads` with no number and nobody noticed.** A refused post exits non-zero so the release path can tell.

## Three things the API will not do for us

- **A webhook URL is itself the credential.** It never appears in a result, in an error, or in a transport exception's string form — `requests` puts the URL in the exception, so the failure is reported by exception class instead. Tested with a URL containing a recognisable secret.
- **A bot token appearing in Discord's own error text is redacted.**
- **Over 2000 characters is refused here.** Discord rejects the whole post rather than truncating, so a long release note would silently not appear. The error names both the limit and the actual length.

## Where the credential lives

Local, in `keys.env`, same as Telegram in #866. The bot is the user's own Discord application, costs nothing, and a leak reaches only their bot.

That is the opposite of `openonion/oo-api#136`, where the Twilio account is ours and a leaked credential reaches every user's call logs. **Third channel in a row on the same rule: blast radius plus whether a policy exists that only we can enforce — not what the channel looks like.**

## Not in scope

- **Inbound** (a Discord message triggering `agent.input()`) is #341
- **Voice.** Discord bots genuinely can hold live voice conversations in a channel, and people already run Gemini Live that way — it is the only free live-voice option available to us. It cannot ring anyone, so it does not replace #938. Noted in #1003 as deserving its own issue.

## Tests

12 unit tests, no live Discord. `471 passed` across these, the Telegram tests, the import-cost guard, and the full `tests/e2e/cli` suite.
