### PR TITLE
docs: cli-skill-design methodology, and the mail skill rewritten against it

### DIFF
--- a/connectonion/useful_skills/browser-workflow-skill-builder/SKILL.md
+++ b/connectonion/useful_skills/browser-workflow-skill-builder/SKILL.md
@@ -15,6 +15,8 @@ Create or improve browser automation skills for logged-in web apps. Use this whe
 
 The core pattern is: **save context -> analyze DOM/CSS -> write skill-local JS extraction -> verify same item by hash -> click/type with generic browser tools -> screenshot/context verify**.
 
+Designing the *command surface* of a `co <thing>` CLI and its SKILL.md, rather than a browser workflow on top of one? That is the sibling skill `cli-skill-design`.
+
 ## Architecture Rule
 
 Do not add site-specific Python to the core browser tool.

--- a/connectonion/useful_skills/cli-skill-design/SKILL.md
+++ b/connectonion/useful_skills/cli-skill-design/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: cli-skill-design
+description: Design a `co <thing>` CLI surface and its SKILL.md together so an agent can drive it without guessing — every command ends by naming the next one, `--help` lists everything, and every failure says what to run instead. Use when adding a new CLI command group, writing or rewriting a SKILL.md for one, or auditing an existing one.
+---
+
+# Designing a CLI skill
+
+A CLI skill is two files that have to agree: the command surface (`co <thing> ...`)
+and the `SKILL.md` that tells an agent how to drive it. Design them together —
+the agent's whole world is *what it types* and *what comes back*.
+
+`co-browser` is the worked example. Read it before you write anything: its exit-code
+table, its "read the output, not just the exit code" rule, and its Done checklist are
+what this methodology generalizes. (Building a skill that drives a *website* through
+`co browser`? That is the sibling skill `browser-workflow-skill-builder` — DOM,
+selectors, verification scripts. This one is about the command surface itself.)
+
+Two properties. Each has a test you run and paste the result of — not a principle
+you assert in the PR.
+
+## (a) Tip-tested discoverability
+
+**Rule:** every command execution — success *and* failure — ends by naming the next
+command, spelled out, with the argument shape filled in.
+
+```
+Read one with: co gmail read <#>        ✅ names the command
+See the docs for more options            ❌ names nothing
+```
+
+### The tip test
+
+A tip is good if an agent that has *only that tip* makes the right next call. That
+is testable, so test it:
+
+```python
+from connectonion import llm_do
+
+llm_do(
+    f"You just ran a shell command. Its full output was:\n\n{out}\n\n"
+    "Your goal: read the newest email. Reply with ONE shell command and nothing else.",
+    model="co/gemini-2.5-flash",
+)
+```
+
+Use a **text-only** call (`llm_do`), not `co ai`. An agent with a shell will run the
+command it picks — measured: the first attempt at this test executed `co gmail read 1`
+and then `co auth google` against a real account. You are grading the reply, not the
+mailbox.
+
+- **Pass** — the reply is a command that exists and advances the goal (`co gmail read 1`).
+- **Fail** — it invents a name (`co gmail open 1`), asks for help, or replies with prose.
+
+Rules for the harness, or the result means nothing:
+- Give it the **output only**. No `SKILL.md`, no `--help`, no conversation history —
+  those are exactly the crutches the tip exists to replace.
+- Pin the model so a rerun compares like with like.
+- Run it per command, not once. Score the whole surface in a table and paste it
+  into the PR:
+
+  | command | tip printed | goal given to the fresh agent | it replied | pass |
+  |---|---|---|---|---|
+
+- Anything that fails: fix the tip, not the test.
+
+### What makes a tip pass
+
+- It contains the **literal command name**, not a description of it.
+- Placeholders say where the value comes from: `<#> from this listing`, not `<id>`.
+- **The tip survives piping.** Agents always pipe. A tip inside
+  `if console.is_terminal:` is invisible to every caller that needs it, and manual
+  testing never catches it because a human runs in a terminal. Check every one:
+
+  ```bash
+  co <thing> <cmd> | cat        # the tip must still be there
+  ```
+
+- **One** next step. Two tips is a fork, and the agent resolves a fork by guessing.
+- Failures get tips too, and the tip is the fix (see (b)).
+
+Measured on the mail surface (8 tips, `co/gemini-2.5-flash`, 2026-08): 5 passed. The
+three failures are the three rules above, each in its pure form —
+
+- a piped listing prints **no** tip, and the model invented `readmail 18f2a`;
+- `Retry the same command with --idempotency-key <key>` never names the command, and
+  the model replied `!! --idempotency-key k-123`;
+- `run co gmail to refresh` stops one step short of the goal, and the model replied
+  `co gmail && co gmail 3` — a command that does not exist.
+
+A tip that reads fine to a human fails this test. That is the point of running it.
+
+## (b) Self-diagnosing, self-correcting execution
+
+### Rule 1 — `--help` enumerates every capability
+
+An agent that cannot find a command from `--help` will invent one, and an invented
+command name costs a round trip every time. So: no hidden commands, no capability
+that only `SKILL.md` knows about.
+
+**Check it, both directions:**
+
+```bash
+g=<thing>
+# every subcommand the CLI has
+co $g --help | sed -n '/─ Commands/,$p' | grep -oE '^│ [a-z-]+' | awk '{print $2}' | sort -u
+# every command the skill mentions
+grep -oE "co $g [a-z-]+" SKILL.md | awk '{print $3}' | sort -u
+```
+
+Diff the two lists. Every CLI command must be either documented or deliberately
+skipped (say which, and why, in the PR). Every command the skill mentions must
+exist — a skill naming a command that `--help` does not list is a documentation bug,
+and it is the failure mode this check exists to catch.
+
+Repeat one level down for command groups (`co outlook contact --help`).
+
+### Rule 2 — every error path is a fix-it guide
+
+The exit code says *what kind* of problem; the text says *what to run*. Both, every
+time. Follow `co-browser`'s contract: a small, stable set of codes, and a table in
+`SKILL.md` whose right-hand column is a command, not an adjective.
+
+**Check it by producing each row.** For every exit code your surface can return,
+write down the command that provokes it and run it:
+
+```bash
+co <thing> <cmd-that-fails>; echo "exit=$?"
+```
+
+Then assert two things about the output: it names the cause, and it names a command
+to run next. Paste the reproduction table into the PR:
+
+| exit | provoked by | printed | names a next command |
+|---|---|---|---|
+
+If a row cannot be provoked, you do not know that it behaves as documented — say so
+rather than documenting it.
+
+### Rule 3 — say so when failure exits 0
+
+Some commands print `❌ Failed` and still exit `0`. That is fine as long as the
+skill says it loudly, because an agent that chains `cmd && next` on such a surface
+walks straight past the failure. Where any failure exits 0, `SKILL.md` opens with
+co-browser's rule:
+
+> **Always read the output, not just the exit code.**
+
+and the exit-code table has a row for "exit 0, error text on stdout".
+
+## Progressive disclosure
+
+The skill is read top to bottom by an agent that wants to act now.
+
+1. **Routing first** — if several commands could serve the request, the first
+   section is the table that picks one. Wrong-command errors are the expensive kind.
+2. **The 80% commands next**, as copy-pasteable lines.
+3. **The gotchas that change a result** — the ones that make an agent report
+   something false if it doesn't know them (stale numbering, prefix-only search,
+   silent export-on-download). Not trivia.
+4. **Errors and recovery last.** By then the agent is only here because something
+   broke.
+
+Everything else belongs in `--help`. If the skill is restating `--help`, delete it
+from the skill: two copies drift, and the copy in the skill is the one that goes
+stale.
+
+## Honesty rule
+
+Document only what you have run. Every command, flag, and exit code in a `SKILL.md`
+must have been verified against the code or `--help` on the branch you are writing
+against — not remembered, and not planned. Behavior that is designed but unshipped
+gets a dated "not yet — today it works like this" note, never a present-tense
+sentence. An agent cannot tell aspiration from fact, and it pays for the difference
+with a failed run.
+
+## Done checklist
+
+- [ ] Routing table first, if more than one command could serve the request
+- [ ] Every command in the skill exists in `--help` (diffed, both directions)
+- [ ] Every command prints one next-step tip, and the tip survives `| cat`
+- [ ] Tip test run per command, results table in the PR
+- [ ] Exit-code table present, right column is a command
+- [ ] Every exit code provoked at least once, reproduction table in the PR
+- [ ] "Read the output, not just the exit code" stated if any failure exits 0
+- [ ] Gotchas that change a reported result are written down
+- [ ] Nothing documented that was not run

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -8,8 +8,9 @@ description: Read and send mail from the user's own Gmail or Outlook account, se
 The user's own mail and files, from the shell. One authorization, then plain commands.
 
 **Read the output, not just the exit code.** `co gmail`, `co outlook` and `co gdrive`
-exit `1` when they fail — but every `co email` failure prints `❌` and still exits `0`.
-Never use `co email ... && next_step` as your only success check.
+exit `1` when they fail — but every `co email` failure prints `❌` and still exits `0`
+(#1012 tracks fixing that). Never use `co email ... && next_step` as your only
+success check.
 
 ## First: which mailbox does the user mean?
 

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -1,120 +1,206 @@
 ---
 name: co-mail-and-drive
-description: Read and send mail from the user's own Gmail or Outlook account, manage their Outlook contacts, and list/search/download/upload their Google Drive files — with `co gmail`, `co outlook`, and `co gdrive`. Use when the user asks about *their* inbox, an email they received or want to send, a contact, or a file in their Drive.
+description: Read and send mail from the user's own Gmail or Outlook account, send from the agent's own address, manage their Outlook contacts, and list/search/download/upload their Google Drive files — with `co gmail`, `co outlook`, `co email`, and `co gdrive`. Use when the user asks about *their* inbox, an email they received or want to send, a contact, or a file in their Drive.
 ---
 
-# co gmail / co outlook / co gdrive
+# co gmail / co outlook / co email / co gdrive
 
-The user's **own** mail and files, from the shell. One authorization, then plain commands.
+The user's own mail and files, from the shell. One authorization, then plain commands.
+
+**Read the output, not just the exit code.** `co gmail`, `co outlook` and `co gdrive`
+exit `1` when they fail — but every `co email` failure prints `❌` and still exits `0`.
+Never use `co email ... && next_step` as your only success check.
 
 ## First: which mailbox does the user mean?
 
-| Command | Whose mailbox |
-|---|---|
-| `co gmail` | the user's **personal Gmail** |
-| `co outlook` | the user's **personal Outlook** |
-| `co email` | the **agent's own** address (`*@mail.openonion.ai`) — a different thing |
+| Command | Whose mailbox | Ask for it when |
+|---|---|---|
+| `co gmail` | the user's **personal Gmail** | "my email", "my inbox", "reply to Bob" |
+| `co outlook` | the user's **personal Outlook** | same, on the Microsoft account |
+| `co email` | the **agent's own** address (`*@mail.openonion.ai`) | "send from the agent", "what did the agent receive" |
+| `co gdrive` | the user's **Google Drive** | "my files", "that doc" |
 
-If the user says "my email", "check my inbox", "reply to Bob" → `co gmail` or `co outlook`.
-If they say "send from the agent" or mention their agent's address → `co email`.
-When both accounts are connected and it's ambiguous, ask which one rather than guessing.
+When both mail accounts are connected and the request is ambiguous, ask which one
+rather than guessing. Sending from the wrong identity is not undoable.
 
 ## Read mail
 
 ```bash
-co gmail                     # 10 most recent
+co gmail                     # bare command = inbox, 10 most recent
 co gmail inbox -n 25 -u      # last 25, unread only
-co gmail read 3              # open #3, marks it read
-co gmail search "from:alice@example.com is:unread"
+co gmail read 3              # open #3 from the last listing
+co gmail search "from:alice@example.com is:unread"   # -n to widen
+co gmail sent -n 20
 ```
 
-`co outlook` takes exactly the same shape (`inbox`, `read`, `reply`, `send`, `sent`, `search`).
+`co outlook` takes the same shape, and adds `download`, `scheduled`, `cancel`, `contact`:
 
-**Numbers mean the last listing you printed.** `read 3` opens row 3 of the table
-you just showed. If you list again, the numbering changes. Never carry a number
-across two listings — re-list, then read.
+```bash
+co outlook                   # bare command = inbox
+co outlook inbox -n 25 -u
+co outlook read 3
+co outlook search "invoice" -n 20
+co outlook sent -n 20
+```
 
 Gmail search takes full Gmail query syntax (`from:`, `subject:`, `after:2026/07/01`,
 `is:unread`). Outlook search is plain text over subject and body.
+
+`co gmail read` marks the mail read only when the token carries the `gmail.modify`
+scope; with read-only + send scopes it prints the body and leaves it unread. It says
+which happened — repeat what it says, don't assume.
 
 ## Send and reply
 
 ```bash
 co gmail send bob@example.com "Subject" "Body text"
 co gmail reply 3 "Sounds good, see you then."
+co gmail send bob@example.com "Report" - < body.md      # '-' body reads stdin
+co gmail send bob@example.com "Invoice" "Attached." --cc a@x.com --attach invoice.pdf
 ```
 
-A body of `-` reads stdin — use it for anything long or multi-line:
+`--cc`, `--bcc` and `--attach/-a` (repeatable) work on **both** `co gmail send` and
+`co outlook send`. Attachments are checked before the send: a missing file or a set
+over the size limit (Gmail 25MB, Outlook 3MB) exits `1` without sending.
+
+Outlook additionally schedules:
 
 ```bash
-co gmail send bob@example.com "Report" - < body.md
+co outlook send bob@example.com "Nudge" "Following up" --at +2h    # +30m, +2h, or 2026-07-06T15:30:00Z
+co outlook reply 3 "On it" --at +30m
+co outlook scheduled          # what is queued, numbered
+co outlook cancel 1           # pull one back before it goes
 ```
 
-Outlook additionally supports attachments and scheduling:
-
-```bash
-co outlook send bob@example.com "Invoice" "Attached." --attach invoice.pdf
-co outlook send bob@example.com "Nudge" "Following up" --at +2h
-```
+Outlook can also save an email's attachments: `co outlook download 3 --to ~/Downloads`.
+Gmail has no download command — there is no way to save a Gmail attachment from this CLI.
 
 **Never send on the user's behalf without showing them the exact text first.**
-Draft it, print it, wait for a yes. Sending is not undoable.
+Draft it, print it, wait for a yes. Sending is not undoable — scheduling is, until
+it goes out.
 
-## Contacts (Outlook)
+## Contacts (Outlook only)
 
 ```bash
 co outlook contact add "Full Name" name@example.com
-co outlook contact list
+co outlook contact list -n 50
 co outlook contact search yifei
 ```
 
 ## Drive files
 
 ```bash
-co gdrive                          # 20 most recently modified
-co gdrive search report
+co gdrive                          # bare command = 20 most recently modified
+co gdrive search report -n 50
 co gdrive get 3 --to ~/Downloads   # download row 3
-co gdrive put report.pdf           # upload
+co gdrive put report.pdf --name "Q3 report.pdf"
 co gdrive rm 3                     # move to trash (recoverable)
 ```
 
-Same numbering rule as mail: numbers mean the last listing.
+## The two gotchas that make you report something false
 
-Two things worth knowing before you report a result:
+**1. Numbers mean your last listing.** `read 3` / `get 3` resolve against the
+numbering of the listing you just printed, cached in `~/.co/gmail_last_inbox.json`,
+`~/.co/outlook_last_inbox.json`, `~/.co/gdrive_last_list.json`. List again and the
+numbers move. Two consequences:
 
-- **Drive search matches word prefixes, not substrings.** On `HelloWorld`,
-  searching `Hello` matches and `World` does not. If a search comes back empty,
-  say that rather than concluding the file doesn't exist.
-- **Google Docs/Sheets/Slides get exported on download** — to `.md`, `.csv`
-  (first sheet only), and `.pdf` respectively. Folders and Forms cannot be
-  downloaded at all.
+- Never carry a number across two listings — re-list, then act.
+- Only `inbox`, `search` (and `outlook scheduled`) write the cache. `sent` does
+  **not**: after `co gmail sent`, `read 1` still opens row 1 of the older inbox listing.
+- A number that isn't in the cache gets `No email #N in your last listing` and exit
+  `1` rather than a silently wrong email. Re-list and retry.
 
-## Piping — always do this when you need the data
-
-In a terminal these commands print a table with truncated columns. When output is
-piped they print full IDs instead. **You are always piping**, so you get the
-untruncated form for free:
+**2. Piping changes the output — and you are always piping.** In a terminal these
+commands print a Rich table with truncated columns and a next-step tip. Piped, they
+print the untruncated form with full IDs instead:
 
 ```bash
-co gdrive list -n 100 | cut -f4     # just the file ids
-co gmail inbox -n 50 | grep "ID:"   # full message ids
+co gmail inbox -n 50 | grep "ID:"   # full message ids, numbered 1., 2., ...
+co gdrive list -n 100 | cut -f4     # name<TAB>type<TAB>size<TAB>id
+co outlook contact list | cut -f2   # name<TAB>email<TAB>id
 ```
 
-Never parse a truncated table column. If you need an ID, take it from the piped
-output.
+Never parse a truncated table column; take IDs from the piped output. Note the
+piped form drops the "Read one with: co gmail read <#>" tip — the row numbers are
+still what `read` wants.
 
-## When a command says it's not connected
+Two more, for Drive specifically:
+
+- **Drive search matches word prefixes, not substrings.** On `HelloWorld`, `Hello`
+  matches and `World` does not. Empty result = say the search found nothing, not
+  that the file doesn't exist.
+- **Google Docs/Sheets/Slides/Drawings are exported on download** — to `.md`, `.csv`
+  (first sheet only), `.pdf` and `.pdf`. Other Google-native types (folders, Forms)
+  have no export format and raise "it cannot be downloaded".
+
+## The agent's own address (`co email`)
+
+```bash
+co email                       # bare command = inbox
+co email inbox -n 20 -u
+co email read 41               # the id in the # column, not the row position
+co email send bob@example.com "Subject" "Body"
+co email sent -n 20 --to bob@example.com
+co email sent read 12
+```
+
+It is a smaller surface than Gmail/Outlook, and the differences bite:
+
+- **No `reply`, no `search`, no attachments, no scheduling.** To answer a message,
+  send a new one with the subject you want.
+- **`read` takes the id printed in the `#` column** (a server id), not "row 3", and
+  only finds it among the last 100 received.
+- **Failures exit `0`.** Not authenticated, send rejected, unknown id — all print an
+  error and return success. Read the text.
+- A failed send that is safe to retry prints an idempotency key; retry with
+  `co email send ... --idempotency-key <key>` so a send that actually went out is
+  not duplicated.
+- `co email sent` can answer "Sent mail is not available on this backend yet" —
+  that is the deployment, not your command.
+- `-u/--unread` is filtered locally after fetching `-n` emails, so
+  `co email inbox -n 10 -u` means "unread among the last 10", not "the last 10 unread".
+
+Account admin: `co email name aaron` checks a custom address (`--buy` claims it,
+from credits) and `co email upgrade plus|pro` raises the quota.
+
+**One sender, today.** The agent sends from the single `AGENT_EMAIL` address set at
+`co auth` time. There is no `--from` / `from_address` flag on any command — the
+multi-address work (oo-api#148/#150, connectonion#1007) is not shipped as of
+v1.6.5. When it lands, this section gains a sender-selection step; until then, "send
+from another address" is not something this CLI can do.
+
+## Exit codes and what to do about them
+
+| exit | Meaning | What to do |
+|---|---|---|
+| `0`, clean output | success | continue |
+| `0`, `❌` on stdout | a `co email` failure — the only surface that fails with 0 | read the text; it names the cause |
+| `1` | guarded failure: account not connected, scope missing, unknown listing number, attachment missing/too large | the message names the fix (`co auth google`, re-list, correct the path) |
+| `2` | usage error: unknown subcommand, missing or bad argument | fix the syntax; the error names the argument, `--help` lists the rest |
+
+The printed messages carry the current recovery step — trust them over this table.
+
+When a command says the account is not connected:
 
 ```
 ❌ Google account not connected     → co auth google
-❌ Gmail permission missing         → co auth google   (re-consent)
-❌ Google Drive permission missing  → co auth google   (re-consent)
-❌ Microsoft ... permission missing → co auth microsoft
+❌ Gmail permission missing         → co auth google      (re-consent)
+❌ Google Drive permission missing  → co auth google      (re-consent)
+❌ Microsoft account not connected  → co auth microsoft
+❌ Microsoft <scope> permission missing → co auth microsoft
+❌ No API key found (co email)      → co auth
 ```
 
-"Permission missing" on a connected account means the token predates a scope
-that was added later. A token refresh **cannot widen scopes** — only re-running
-`co auth` fixes it.
+"Permission missing" on a connected account means the token predates a scope added
+later. A refresh **cannot widen scopes** — only re-running `co auth` fixes it.
+`co auth` opens a browser and needs a human to click through: **tell the user to run
+it themselves**, do not try to drive that flow.
 
-`co auth` opens a browser and needs the user to click through. **Tell the user to
-run it themselves**; do not try to drive that flow.
+## Done checklist
+
+- [ ] Right mailbox chosen (asked, if both were connected)
+- [ ] Exact text shown to the user before any send
+- [ ] Numbers used from the listing printed immediately before the action
+- [ ] IDs taken from piped output, never from a truncated table column
+- [ ] `co email` results judged by their text, not their exit code
+- [ ] Empty search reported as "no match", not as "does not exist"

--- a/docs/useful_skills/README.md
+++ b/docs/useful_skills/README.md
@@ -7,6 +7,7 @@ Pre-built skills you can copy into your project and invoke with `/skill-name`.
 | Skill | Purpose | Invoke |
 |-------|---------|--------|
 | [browser-workflow-skill-builder](browser-workflow-skill-builder.md) | Build robust browser automation skills for logged-in sites — save page context, write skill-local extract/verify scripts, and lock flows with hash-verified one-shot actions | `/browser-workflow-skill-builder` |
+| [cli-skill-design](cli-skill-design.md) | Design a `co <thing>` command surface and its SKILL.md together — tip-tested discoverability and self-diagnosing errors, both as checks you run | `/cli-skill-design` |
 | [co-browser](co-browser.md) | Drive one persistent, logged-in browser from the shell — solo or multi-agent | `/co-browser` |
 | [install-connectonion](install-connectonion.md) | Install & fully set up ConnectOnion so every `co` command works (init+auth→keys.env, email, browser) for a possibly non-technical user — auto-corrects, ends with a plain-language summary | `/install-connectonion` |
 | [ship-feature](ship-feature.md) | Ship a feature end-to-end: tests → docs → docs-site → release | `/ship-feature` |

--- a/docs/useful_skills/cli-skill-design.md
+++ b/docs/useful_skills/cli-skill-design.md
@@ -1,0 +1,33 @@
+# cli-skill-design
+
+How to design a `co <thing>` CLI surface and its `SKILL.md` together, so an agent can drive it without guessing.
+
+## Install
+
+```bash
+co copy cli-skill-design
+# → .co/skills/cli-skill-design/SKILL.md
+```
+
+## Usage
+
+```
+/cli-skill-design
+```
+
+Use it when adding a new CLI command group, writing or rewriting a `SKILL.md` for one, or auditing an existing one.
+
+## What it enforces
+
+Two properties, each with a test you run and paste the result of — not a principle you assert:
+
+**Tip-tested discoverability.** Every command execution, success or failure, ends by naming the next command. The test: give a fresh, text-only model *only* that output plus the goal, and ask for one shell command. If it invents a command name, the tip failed. Tips must also survive `| cat` — agents always pipe, and a tip hidden behind `console.is_terminal` is invisible to exactly the caller that needs it.
+
+**Self-diagnosing execution.** `--help` enumerates every capability (diff it against the skill, both directions), every exit code is provoked at least once and its message names the command to run next, and any surface where a failure exits `0` says so at the top.
+
+Plus the house rules: routing table first, gotchas that change a reported result, and nothing documented that was not run.
+
+## Related
+
+- [co-browser](co-browser.md) — the worked example this generalizes from
+- [browser-workflow-skill-builder](browser-workflow-skill-builder.md) — the sibling for skills that drive a *website* through `co browser`


### PR DESCRIPTION
## What changed

Two deliverables from #1008.

**1. New `connectonion/useful_skills/cli-skill-design/SKILL.md`** — the methodology
behind how `co-browser` was designed, generalized to any `co <thing>` command surface,
with the two required properties written as checks you run rather than advice you agree with.

**2. `connectonion/useful_skills/co-mail-and-drive/SKILL.md` rewritten against it** as the
first real case, covering `co gmail`, `co outlook`, `co email` and `co gdrive`.

Plus a `docs/useful_skills/cli-skill-design.md` page + README row (mirrors how
`co-browser` and `browser-workflow-skill-builder` are listed), and a one-line
cross-link from `browser-workflow-skill-builder` to the new skill.

Target release: **v1.6.5** (latest published tag is v1.6.4). No version file touched,
nothing tagged, nothing published.

## Naming: new skill, not a rename

The issue left this TBD. I wrote it first and then compared: `browser-workflow-skill-builder`
is about building a skill that drives a *website* through `co browser` — DOM analysis,
selector heuristics, hash-verified one-shot submits, `run_page_script` contracts. Almost none
of that generalizes, and the parts that do (dry-run first, evidence gates) are a small
fraction of its 617 lines. Renaming it would have meant either dragging 500 lines of DOM
advice into a general methodology, or deleting hard-won browser lessons to make the title
true. They are different axes: one is *how to design a command surface*, the other is
*how to build a workflow on top of one*. So: a new skill, ~185 lines, with a cross-link in
each direction. Neither is in `DEFAULT_LIBRARY_SKILLS` — both are builder tools, not
customer-facing workflow.

## How (a) is made checkable

**The tip test.** A tip is good iff an agent holding *only that tip* makes the right next
call. The skill specifies the harness: feed the command's output and the goal to a
**text-only** `llm_do` call (pinned model), no SKILL.md, no `--help`, no history, and ask
for exactly one shell command. Pass = the reply exists and advances the goal.

Text-only matters, and I learned it by getting it wrong: my first attempt used `co ai`,
which has a shell, so it *executed* the command it picked (`co gmail read 1`, then
`co auth google`) against a real account. That warning is now in the skill.

Run on 8 real tips from this surface (`co/gemini-2.5-flash`), **5/8 passed**:

| output given | goal | model replied | pass |
|---|---|---|---|
| `co gmail inbox` piped (no tip, just `ID:` lines) | read the newest email | `readmail 18f2a` | ❌ |
| `Marked read. Reply with: co gmail reply <#> <message>` | reply "thanks" | `co gmail reply 1 "thanks"` | ✅ |
| `Download one with: co gdrive get <#>` | download #1 to ~/Downloads | `co gdrive get 1 ~/Downloads` | ⚠️ names the right command, invents a positional for `--to` (would exit 2) |
| `❌ Google account not connected … co auth google` | check the inbox | `co auth google` | ✅ |
| `Retry the same command with --idempotency-key <key>` | resend without double-sending | `!! --idempotency-key k-123` | ❌ |
| `No email #3 in your last listing — run co gmail to refresh.` | read the third email | `co gmail && co gmail 3` | ❌ |
| `Claim it: co email name aaron --buy` | claim it | `co email name aaron --buy` | ✅ |
| `Cancel one with: co outlook cancel <#>` | cancel the first | `co outlook cancel 1` | ✅ |

The three failures are exactly the three rules the skill states: the tip must contain the
literal command name, it must survive piping, and it must reach the goal rather than stop
one step short. Each failure is a real gap in today's CLI, not in the doc — see "left for
later".

## How (b) is made checkable

**`--help` enumerates everything** — diff it against the skill, both directions:

```bash
g=gmail
co $g --help | sed -n '/─ Commands/,$p' | grep -oE '^│ [a-z-]+' | awk '{print $2}' | sort -u
grep -oE "co $g [a-z-]+" SKILL.md | awk '{print $3}' | sort -u
```

Ran for `email`, `gmail`, `outlook`, `gdrive`, `outlook contact` and `email sent`: after
adding an explicit `co outlook` example block (the old skill covered `inbox/read/search/sent`
only in prose — "takes the same shape" — so a grep for `co outlook read` found nothing),
**both directions are empty for all six groups**. No CLI command is undocumented, and no
documented command is missing from `--help`.

**Every exit code provoked, not asserted.** Run against a throwaway `HOME` so no credentials
were present:

| exit | provoked by | printed | names a next command |
|---|---|---|---|
| `0` | `co email inbox`, `co email send a@b.com S B` (unauthenticated) | `❌ No API key found` … `co auth` | yes — but exits **0** |
| `1` | `co gmail inbox` / `co outlook inbox` / `co gdrive list` | `❌ … not connected` + `co auth google` / `co auth microsoft` | yes |
| `2` | `co gmail bogus` | `No such command 'bogus'.` + `--help` hint | yes |
| `2` | `co gmail send` | `Missing argument 'TO'.` | yes |

The `co email` row is the headline finding: every `co email` failure path `return`s instead
of `raise typer.Exit(1)`, so an agent chaining `co email send … && next` walks straight past
a failed send. The rewritten skill therefore opens with co-browser's rule verbatim —
**read the output, not just the exit code** — and the exit table has a dedicated
"exit 0, `❌` on stdout" row.

## What I verified about the email surface, and how

Every command/flag below came from running `--help` on this branch
(`PYTHONPATH=/tmp/co-1008 python -m connectonion.cli.main …`, since the installed `co` is
1.5.10 and would have lied) plus reading the handlers.

- `co email`: `send` (`--idempotency-key`), `inbox` (`-n/-u`), `read`, `sent` (`-n/--to`,
  and `sent read`), `name` (`--buy`), `upgrade` (`-d/-a/--keep-address`); bare = inbox.
  **No `reply`, no `search`, no attachments, no scheduling** — the skill says so explicitly.
- `co email read` takes the **server id printed in the `#` column**, not a row position, and
  only searches the last 100 received (`email_commands.py:196-220`). Different contract from
  gmail/outlook/gdrive, which resolve row numbers through `~/.co/{gmail_last_inbox,outlook_last_inbox,gdrive_last_list}.json`.
- `co email inbox -u` filters **client-side after** fetching `-n`, so `-n 10 -u` means
  "unread among the last 10" (`email_commands.py:76`, with the comment saying the endpoint
  ignores the param).
- `co email sent` can return "not available on this backend yet" on a 404.
- **Old skill was wrong**: it said "Outlook additionally supports attachments". `co gmail send`
  has `--cc/--bcc/--attach` too. Limits differ and are checked before the send: Gmail
  25MB (`GMAIL_ATTACHMENT_LIMIT`), Outlook 3MB (`OUTLOOK_ATTACHMENT_LIMIT = 3_000_000`).
- **Old skill was missing**: `co outlook download/scheduled/cancel`, `co gmail search -n`,
  `co gdrive put --name`, and the fact that `co gmail` has *no* attachment download at all.
- `co gmail read` marks read **only** with the `gmail.modify` scope; with readonly+send it
  prints the body and says nothing was marked (`gmail_commands.py:147-153`).
- `sent` does **not** write the numbering cache — after `co gmail sent`, `read 1` still opens
  row 1 of the older inbox listing. New in the skill.
- Drive export table checked against `EXPORT_FORMATS` in `useful_tools/gdrive.py`: Docs→`.md`,
  Sheets→`.csv`, Slides→`.pdf`, **Drawings→`.pdf`** (the old skill omitted Drawings); other
  Google-native types raise "it cannot be downloaded".
- Piped forms verified from code: gmail/outlook print `N.` + `ID:` lines, gdrive prints
  `name\ttype\tsize\tid`, outlook contacts print `name\temail\tid` — so the old skill's
  `cut -f4` and `grep "ID:"` examples are correct and are kept.
- **Multi-address is not shipped**: `grep -rn from_address connectonion/` returns nothing, and
  `send_email()` still takes only `(to, subject, message, idempotency_key)` with the sender read
  from `AGENT_EMAIL`. The skill says so in a dated paragraph naming oo-api#148/#150 and #1007,
  and states that "send from another address" is not currently possible.

## Tests

`python -m pytest tests/ -q -x --timeout=300 -k "skill"` → **386 passed, 7140 deselected, 121.91s**.
Also checked that the new frontmatter parses with the repo's canonical reader
(`_parse_skill_content`) and declares no `tools:` (so it auto-approves nothing).

## Deliberately left for later

- **No CLI code changed.** The three tip-test failures are code gaps, not doc gaps, and fixing
  them here would mix a docs PR with behavior changes: (1) listing tips are inside
  `if console.is_terminal:` in all four renderers, so the piped caller — every agent — gets no
  tip; (2) the idempotency retry hint does not restate the command; (3) the stale-number message
  says "run co gmail to refresh" but not "then `co gmail read <#>`". Filing as a follow-up issue.
- **`co email` failure paths still exit 0.** Documented rather than changed — flipping exit codes
  is a behavior change for anything already scripting against it.
- No `docs/useful_skills/co-mail-and-drive.md` page: that mirror is partial today (no page for
  `co-mail-and-drive`, `commit`, `review-pr`, `find-selling-points`) and filling it is out of scope.
- `cli-skill-design` is **not** added to `DEFAULT_LIBRARY_SKILLS` — it is a builder tool, and the
  allowlist is deliberately the customer-facing set.

## Unsure / worth a second opinion

- `co email inbox` prints a Rich box table with **no** piped-plain branch, unlike the other three
  surfaces. At the default 80-column non-terminal width, long subjects will be clipped. I described
  the piped behavior of gmail/outlook/gdrive precisely and stayed quiet about `co email`'s exact
  piped rendering rather than guess at it — I could not exercise it without live credentials.
- The `co gdrive get` tip result is scored ⚠️ rather than ❌: the model named the right command but
  passed `~/Downloads` positionally, which `get` does not accept. Whether that counts as a tip
  failure or a flag-discovery failure is a judgement call; I left it visible rather than rounding it.

Closes #1008
