### PR TITLE
co email failures exit 1 instead of 0

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -11,6 +11,7 @@ LLM-Note:
 import os
 
 import requests
+import typer
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -27,11 +28,11 @@ def _print_no_auth():
 
 
 def _require_auth() -> bool:
-    """Ensure OPENONION_API_KEY (and the .env it lives next to) are loaded. Returns False if missing."""
+    """Ensure OPENONION_API_KEY (and the .env it lives next to) are loaded. Exits 1 if missing."""
     if load_api_key():
         return True
     _print_no_auth()
-    return False
+    raise typer.Exit(1)
 
 
 def _err(response) -> str:
@@ -63,6 +64,7 @@ def handle_email_send(to: str, subject: str, message: str, idempotency_key: str 
             console.print(f"  Safe retry key: {result['idempotency_key']}")
             console.print("  [dim]Retry the same command with --idempotency-key <key>[/dim]")
         console.print()
+        raise typer.Exit(1)
 
 
 def handle_email_inbox(last: int = 10, unread: bool = False):
@@ -119,10 +121,10 @@ def handle_email_sent(last: int = 10, to: str = None):
         else:
             status = response.status_code if response is not None else "unknown"
             console.print(f"\n[red]✗ Could not load sent mail (HTTP {status}).[/red]\n")
-        return
+        raise typer.Exit(1)
     except requests.RequestException:
         console.print("\n[red]✗ Could not reach the email service.[/red] Try again later.\n")
-        return
+        raise typer.Exit(1)
 
     if not emails:
         scope = f" to {to}" if to else ""
@@ -168,15 +170,15 @@ def handle_email_sent_read(email_id: str):
         else:
             status = response.status_code if response is not None else "unknown"
             console.print(f"\n[red]✗ Could not load sent mail (HTTP {status}).[/red]\n")
-        return
+        raise typer.Exit(1)
     except requests.RequestException:
         console.print("\n[red]✗ Could not reach the email service.[/red] Try again later.\n")
-        return
+        raise typer.Exit(1)
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
     if not match:
         console.print(f"\n[yellow]No sent email with id {email_id} in your recent sent mail.[/yellow]\n")
-        return
+        raise typer.Exit(1)
 
     header = (
         f"[cyan]To:[/cyan]         {match.get('to', '')}\n"
@@ -204,7 +206,7 @@ def handle_email_read(email_id: str):
 
     if not match:
         console.print(f"\n[yellow]No email with id {email_id} in your recent inbox.[/yellow]\n")
-        return
+        raise typer.Exit(1)
 
     header = (
         f"[cyan]From:[/cyan]    {match.get('from', '')}\n"
@@ -225,7 +227,7 @@ def handle_email_name(name: str, buy: bool = False):
     token = load_api_key()
     if not token:
         _print_no_auth()
-        return
+        raise typer.Exit(1)
 
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -233,7 +235,7 @@ def handle_email_name(name: str, buy: bool = False):
         r = requests.get(f"{backend_url()}/api/v1/email/check-name", params={"name": name}, headers=headers, timeout=10)
         if not r.ok:
             console.print(f"\n[red]✗ {_err(r)}[/red]\n")
-            return
+            raise typer.Exit(1)
         data = r.json()
         if data.get("available"):
             console.print(f"\n[green]✓ {data['email']} is available[/green] — [bold]${data['price']:.2f}[/bold] one-time, from credits")
@@ -245,7 +247,7 @@ def handle_email_name(name: str, buy: bool = False):
     r = requests.post(f"{backend_url()}/api/v1/email/purchase-name", json={"name": name}, headers=headers, timeout=15)
     if not r.ok:
         console.print(f"\n[red]✗ {_err(r)}[/red]\n")
-        return
+        raise typer.Exit(1)
     data = r.json()
     console.print(f"\n[green]✓ {data['message']}[/green]")
     console.print(f"  Your address: [cyan]{data['email']}[/cyan]\n")
@@ -261,7 +263,7 @@ def handle_email_upgrade(
     token = load_api_key()
     if not token:
         _print_no_auth()
-        return
+        raise typer.Exit(1)
 
     headers = {"Authorization": f"Bearer {token}"}
     payload = {"tier": tier}
@@ -275,7 +277,7 @@ def handle_email_upgrade(
     r = requests.post(f"{backend_url()}/api/v1/email/upgrade", json=payload, headers=headers, timeout=15)
     if not r.ok:
         console.print(f"\n[red]✗ {_err(r)}[/red]\n")
-        return
+        raise typer.Exit(1)
     data = r.json()
     console.print(f"\n[green]✓ {data['message']}[/green]")
     console.print(f"  Address: [cyan]{data['email_address']}[/cyan]")

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -1,0 +1,65 @@
+"""Every co email failure must exit non-zero, like its gmail/outlook siblings.
+
+Every failure path in email_commands printed an error and returned normally,
+so the process exited 0 and `co email send … && next` ran `next` after a
+failed send. `co gmail`/`co outlook` exit 1 in the same situations — two
+sibling command groups disagreed about what a failure is (#1012).
+
+A legitimately empty result is not a failure: an empty inbox listing still
+exits 0. Asking for a specific email that does not exist is one — the command
+did not deliver what was asked.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands
+# The package __init__ re-exports the functions under the same names as their
+# modules, so a dotted patch target resolves to the function; go through
+# sys.modules to reach the real modules the handlers import from.
+import connectonion.useful_tools.send_email
+import connectonion.useful_tools.get_emails
+
+_send_module = sys.modules["connectonion.useful_tools.send_email"]
+_get_module = sys.modules["connectonion.useful_tools.get_emails"]
+
+
+def test_missing_auth_exits_nonzero():
+    with patch.object(email_commands, "load_api_key", return_value=None):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_send("a@b.com", "s", "m")
+    assert exc_info.value.exit_code == 1
+
+
+def test_failed_send_exits_nonzero():
+    failed = {"success": False, "error": "insufficient credits"}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_send_module, "send_email", return_value=failed):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_send("a@b.com", "s", "m")
+    assert exc_info.value.exit_code == 1
+
+
+def test_reading_a_missing_email_exits_nonzero():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_get_module, "get_emails", return_value=[]):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_read("999")
+    assert exc_info.value.exit_code == 1
+
+
+def test_an_empty_inbox_is_not_a_failure():
+    """Listing nothing is an answer, not an error — must NOT raise."""
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_get_module, "get_emails", return_value=[]):
+        email_commands.handle_email_inbox()
+
+
+def test_a_successful_send_does_not_raise():
+    ok = {"success": True, "message_id": "m1", "from": "x@mail.openonion.ai"}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_send_module, "send_email", return_value=ok):
+        email_commands.handle_email_send("a@b.com", "s", "m")


### PR DESCRIPTION
Closes #1012.

Every failure path in `email_commands.py` printed an error and `return`ed normally, so the process exited 0 and `co email send … && next` ran `next` after a failed send. `co gmail`/`co outlook` exit 1 in the same situations — two sibling command groups disagreed about what a failure is.

**The line drawn**: a legitimately empty result is not a failure. `co email inbox` with nothing in it still exits 0 — that is an answer. Asking for a specific email that does not exist (`co email read 999`) is a failure — the command did not deliver what was asked. 13 failure paths now `raise typer.Exit(1)`: missing auth (×3 entry points), failed send, both sent-mail HTTP/network branches (×2 functions), missing id on read/sent-read, and the three HTTP-error branches in name/upgrade.

**Red-first**: the three failure-path tests fail on unmodified `main` (handler returns normally, no exception), pass here. The two no-raise tests (empty inbox, successful send) pin unchanged behavior and pass on both sides. Process-level: `HOME=$(mktemp -d) co email inbox` exits 1 now, was 0.

**Target release**: v1.6.5. The rewritten mail skill (#1010, merged) links #1012 from its exit-0 caveat; that caveat text should be updated to past tense when this ships — noted for the release PR.