### PR TITLE
send_email: choose which owned address to send as

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -43,13 +43,19 @@ def _err(response) -> str:
     return response.text.strip() or f"HTTP {response.status_code}"
 
 
-def handle_email_send(to: str, subject: str, message: str, idempotency_key: str = None):
+def handle_email_send(
+    to: str, subject: str, message: str,
+    idempotency_key: str = None, from_address: str = None,
+):
     """Send an email from the agent's address."""
     if not _require_auth():
         return
 
     from ...useful_tools.send_email import send_email
-    result = send_email(to, subject, message, idempotency_key=idempotency_key)
+    result = send_email(
+        to, subject, message,
+        idempotency_key=idempotency_key, from_address=from_address,
+    )
 
     if result.get("success"):
         console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -705,10 +705,18 @@ def email_send(
         "--idempotency-key",
         help="Reuse a failed send's key to retry without sending twice",
     ),
+    from_address: Optional[str] = typer.Option(
+        None,
+        "--from",
+        help="Send as one of your owned addresses (server checks ownership)",
+    ),
 ):
     """Send an email from the agent's address."""
     from .commands.email_commands import handle_email_send
-    handle_email_send(to, subject, message, idempotency_key=idempotency_key)
+    handle_email_send(
+        to, subject, message,
+        idempotency_key=idempotency_key, from_address=from_address,
+    )
 
 
 @email_app.command("inbox")

--- a/connectonion/useful_tools/send_email.py
+++ b/connectonion/useful_tools/send_email.py
@@ -27,6 +27,7 @@ def send_email(
     subject: str,
     message: str,
     idempotency_key: Optional[str] = None,
+    from_address: Optional[str] = None,
 ) -> Dict:
     """Send an email using the agent's email address.
 
@@ -37,6 +38,9 @@ def send_email(
         idempotency_key: Reuse the key from a failed result to retry without
             sending the same email twice while the provider retry window is
             still active. A new key is generated when omitted.
+        from_address: Send as one of this account's owned addresses instead of
+            the default. The server verifies ownership and answers 403 for an
+            address this account does not hold.
 
     Returns:
         dict: Success status and details
@@ -103,6 +107,8 @@ def send_email(
         # backend's decision, and nothing here influences it.
         "body": message
     }
+    if from_address:
+        payload["from_address"] = from_address
     
     # Send email via backend API
     endpoint = f"{backend_url()}/api/v1/email/send"

--- a/tests/cli/test_send_email_from_address.py
+++ b/tests/cli/test_send_email_from_address.py
@@ -1,0 +1,36 @@
+"""send_email carries the caller's chosen sender to the API (#1007).
+
+The backend half (oo-api#150) verifies the address belongs to the caller and
+answers 403 otherwise; the client's whole job is to put the choice in the
+payload — and to leave the payload alone when no choice was made, so every
+existing caller keeps the server-derived default.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import connectonion.useful_tools.send_email
+
+_send_module = sys.modules["connectonion.useful_tools.send_email"]
+
+
+def _sent_payload(monkeypatch, **kwargs):
+    response = MagicMock(status_code=200)
+    response.json.return_value = {"message_id": "m1", "from": "x@mail.openonion.ai"}
+    monkeypatch.setenv("OPENONION_API_KEY", "tok")
+    monkeypatch.setenv("AGENT_EMAIL", "x@mail.openonion.ai")
+    with patch.object(_send_module.requests, "post", return_value=response) as post:
+        result = _send_module.send_email("a@b.com", "s", "m", **kwargs)
+    assert result["success"], result
+    return post.call_args.kwargs["json"]
+
+
+def test_a_chosen_from_address_reaches_the_api(monkeypatch):
+    payload = _sent_payload(monkeypatch, from_address="rental@mail.openonion.ai")
+    assert payload["from_address"] == "rental@mail.openonion.ai"
+
+
+def test_no_choice_leaves_the_payload_unchanged(monkeypatch):
+    """Omitted must mean absent — not null — so old servers see the old body."""
+    payload = _sent_payload(monkeypatch)
+    assert "from_address" not in payload


### PR DESCRIPTION
Closes #1007. Client half of oo-api#150, which is **already live in production** (deployed and verified today), so this ships second per the degrade-gracefully order — an old client simply never sends the field.

- `send_email()` gains `from_address`; `co email send` gains `--from`
- omitted → the payload is byte-identical to before (asserted: key absent, not null), so old servers and all existing callers see no change
- provided → the server verifies ownership and refuses cleanly

**Red-first**: fails on `main` with `TypeError: send_email() got an unexpected keyword argument 'from_address'`, passes here.

**Live production check**: `co email send … --from rental@mail.openonion.ai` (an address this account does not own) → `❌ Failed: rental@mail.openonion.ai is not one of this account's email addresses.` with a request ID, and nothing sent. The full chain — CLI flag → payload → server ownership check → clean refusal — exercised against the real deployed backend, not a mock.

**Target release**: v1.6.5, together with #1016 (exit codes) and #1010 (already merged).