### PR TITLE
Every PR ships its dev-blog post, enforced by CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,16 +32,18 @@ A PR that says *"I didn't test the Windows path and I'm unsure the retry logic i
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 
-## Design Journal Impact
+## Dev Blog (required)
 
-- [ ] Release notes only — maintenance change with no reusable design lesson
-- [ ] Update an existing Design Journal post
-- [ ] Add a new Design Journal post for a feature train, phase promotion, stable release, or material design decision
-- [ ] Not applicable
+**Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`): a PR that touches no `docs/blog/` file fails the check. The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
 
-Link the draft or explain the choice:
+What the post is: a short Design Journal piece telling the story of this change — the problem as a user or AI hit it, what the fix teaches, what was measured. Written for a reader, not a robot.
+What it is not: a changelog entry, a list of commits, or marketing copy.
 
->
+Blog file in this PR:
+
+> docs/blog/YYYY-MM-DD-<slug>.md
+
+Genuinely trivial change (typo, lockfile, CI plumbing)? A maintainer can apply the `no-blog` label to waive the gate — that is the maintainer's call, not the author's.
 
 ## Changes Made
 - List the main changes
@@ -80,7 +82,7 @@ from connectonion import Agent
 - [ ] I have read every line of this diff and can defend each change
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
-- [ ] I have handled the Design Journal impact described above
+- [ ] This PR ships its dev-blog post under docs/blog/ (or a maintainer applied `no-blog`)
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,8 +36,10 @@ A PR that says *"I didn't test the Windows path and I'm unsure the retry logic i
 
 **Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`): a PR that touches no `docs/blog/` file fails the check. The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
 
-What the post is: a short Design Journal piece telling the story of this change — the problem as a user or AI hit it, what the fix teaches, what was measured. Written for a reader, not a robot.
+What the post is: a short Design Journal piece telling the **story** of this change — the problem as someone actually hit it, a turn or complication, what the fix teaches, what was measured. Written for a reader who could stop reading at any point.
 What it is not: a changelog entry, a list of commits, or marketing copy.
+
+The gate reviews the writing, not just the file: a post without a narrative arc — a changelog wearing prose — fails the check, with the model's one concrete fix in the error. A merged PR means its story was worth reading.
 
 Blog file in this PR:
 

--- a/.github/scripts/check_blog_story.py
+++ b/.github/scripts/check_blog_story.py
@@ -1,0 +1,49 @@
+"""blog-gate's second door: the post must read like a story.
+
+The existence check proves a post shipped; this proves someone would want
+to read it. A changelog wearing prose — "we added X, we fixed Y" — fails.
+A story has a problem someone actually hit, a turn, and a lesson.
+"""
+
+import sys
+from pathlib import Path
+
+from connectonion import llm_do
+
+RUBRIC = (
+    "You are the quality gate for a team's dev blog. Judge ONLY whether this "
+    "post reads like a story a person would want to read: it has a narrative "
+    "arc (a problem someone actually hit, a turn or complication, a "
+    "resolution or lesson), it flows, and it is not a changelog, commit "
+    "list, or feature enumeration wearing prose. Imperfect grammar is fine; "
+    "honesty about mistakes is a virtue. Reply with exactly one line:\n"
+    "  STORY: <what makes it work, one clause>\n"
+    "or\n"
+    "  NOT_STORY: <the single biggest fix, one sentence, concrete>\n"
+)
+
+
+def main() -> int:
+    failed = False
+    for name in sys.argv[1:]:
+        path = Path(name)
+        if not path.is_file():  # deleted in this PR
+            continue
+        verdict = llm_do(
+            RUBRIC + "\n---\n" + path.read_text(),
+            model="co/gemini-2.5-flash",
+        ).strip()
+        print(f"{name}: {verdict}")
+        if not verdict.startswith("STORY"):
+            fix = verdict.split(":", 1)[-1].strip()
+            print(
+                "::error::The dev-blog post does not read as a story yet. "
+                "It needs a problem someone hit, a turn, and a lesson — not "
+                f"a list of changes. Model's one fix: {fix}"
+            )
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/blog-gate.yml
+++ b/.github/workflows/blog-gate.yml
@@ -1,0 +1,42 @@
+name: blog-gate
+
+# Every PR ships a dev-blog post under docs/blog/ in the same diff.
+# The posts sync to the docs site, so the gate is what keeps the site
+# current without a human having to ask each time.
+#
+# Waiver: a maintainer applies the `no-blog` label for genuinely trivial
+# changes (typo, lockfile, CI plumbing). The label is the maintainer's
+# call, not the author's.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  blog-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a docs/blog/ file in the diff (or the no-blog label)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if gh api "repos/$REPO/pulls/$PR" --jq '.labels[].name' | grep -qx "no-blog"; then
+            echo "no-blog label present — gate waived by a maintainer."
+            exit 0
+          fi
+          if gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' | grep -q "^docs/blog/"; then
+            echo "dev-blog post found in the diff."
+            exit 0
+          fi
+          echo "::error::This PR ships no dev-blog post."
+          echo ""
+          echo "Every PR adds or updates a file under docs/blog/ in the same diff:"
+          echo "  docs/blog/$(date -u +%F)-<slug>.md"
+          echo ""
+          echo "Write a short Design Journal piece — the problem as a user or AI hit it,"
+          echo "what the fix teaches, what was measured. A story, not a changelog."
+          echo ""
+          echo "Genuinely trivial change? Ask a maintainer to apply the 'no-blog' label."
+          exit 1

--- a/.github/workflows/blog-gate.yml
+++ b/.github/workflows/blog-gate.yml
@@ -40,3 +40,25 @@ jobs:
           echo ""
           echo "Genuinely trivial change? Ask a maintainer to apply the 'no-blog' label."
           exit 1
+
+      - name: Checkout PR head for the blog files
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: The post must read like a story, not a changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          OPENONION_API_KEY: ${{ secrets.OPENONION_API_KEY }}
+        run: |
+          if [ -z "$OPENONION_API_KEY" ]; then
+            # Fork PRs get no secrets; the existence gate above still applied.
+            echo "no model credential in this context — quality check skipped."
+            exit 0
+          fi
+          pip -q install connectonion
+          gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' \
+            | grep "^docs/blog/" \
+            | xargs python3 .github/scripts/check_blog_story.py

--- a/docs/blog/2026-08-15-every-pr-tells-its-story.md
+++ b/docs/blog/2026-08-15-every-pr-tells-its-story.md
@@ -1,0 +1,42 @@
+# Every PR tells its story
+
+*2026-08-15*
+
+We shipped a credit-transfer API months ago. It worked — production traffic,
+onboard verification, the lot. This week we noticed that as far as any user or
+any AI driving our CLI could tell, **the feature did not exist**. No command
+exposed it, no help text mentioned it, no doc described it.
+
+The code was fine. The story was missing.
+
+That failure has a shape we keep meeting. A feature ships; the doc site lags;
+someone asks "can it do X?" and the honest answer is "yes, but nothing will
+tell you that." Documentation written *after* the fact is documentation that
+loses a race, every time, forever.
+
+## The fix is structural, not motivational
+
+Telling people (or AIs) "please remember to write docs" does not work — we
+know because we are the ones it did not work on. So the requirement moves into
+the path where work already flows:
+
+**Every PR ships a dev-blog post in the same diff.** A file under
+`docs/blog/`, checked by CI (`blog-gate`). No post, no merge. The posts sync
+to the docs site, so the site stays current as a side effect of merging —
+nobody has to ask, nobody has to remember.
+
+A maintainer can waive the gate with a `no-blog` label for a typo or a
+lockfile bump. The label is the maintainer's call, not the author's — a
+requirement the author can waive is a suggestion.
+
+## What a post is
+
+Not a changelog. The PR description already lists what changed; repeating it
+here would be noise wearing a hat.
+
+A post tells the story a reader would want: the problem as someone actually
+hit it, what the fix teaches, what was measured. It is allowed to be three
+paragraphs. It is allowed to say "we got this wrong first." The best ones
+will say exactly that.
+
+This post is the first one through its own gate.


### PR DESCRIPTION
## What

A credit-transfer API ran in production for months while no CLI, no help text, and no doc mentioned it — for every user and every AI driving the CLI, the feature did not exist (#1018 is the catch-up). Docs written after the fact lose the race, so the requirement moves into the merge path:

- **`.github/workflows/blog-gate.yml`** — a PR must add or update a file under `docs/blog/` or the check fails. The failure message tells the author exactly what to write and where, so an AI opening a PR self-corrects without a human asking. A maintainer waives it with the `no-blog` label (author cannot self-waive — a requirement the author can waive is a suggestion).
- **PR template** — the old "Design Journal Impact" section had a "Not applicable" checkbox, which made it optional in practice. Replaced with the enforced contract and the file-naming convention.
- **`docs/blog/2026-08-15-every-pr-tells-its-story.md`** — the policy post, and the first file through its own gate. These posts are what syncs to the docs site.

## Dev Blog (required)

> docs/blog/2026-08-15-every-pr-tells-its-story.md

## Testing

The gate's own logic is a two-branch grep over the PR file list + a label check; it is exercised by this very PR (must pass: this diff contains a docs/blog/ file) and will be negatively exercised by the next PR that forgets — which is the point.