### PR TITLE
Make co/gemini-3.7-flash the default model everywhere (#1002)

### DIFF
--- a/.github/workflows/co-ai-review.yml
+++ b/.github/workflows/co-ai-review.yml
@@ -10,7 +10,7 @@ on:
       model:
         description: co ai model
         required: false
-        default: co/gemini-3.6-flash
+        default: co/gemini-3.7-flash
         type: string
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,7 +431,7 @@ the matching docs-site channel, then publishes only from the reviewed exact tag.
 - Example:
   ```python
   try:
-      agent = Agent("my_agent", model="co/gemini-3.6-flash")
+      agent = Agent("my_agent", model="co/gemini-3.7-flash")
       response = agent.input("Hello")
   except InsufficientCreditsError as e:
       print(f"Need ${e.shortfall:.4f} more credits")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ connectonion/
 - Session persists across turns for multi-turn conversations
 - `tools`: ToolRegistry with O(1) lookup via `.get()` or attribute access (`agent.tools.tool_name`)
 - Class instances accessible via `agent.tools.instance_name` (e.g., `agent.tools.gmail`)
-- Default model: `co/gemini-3.6-flash` (managed keys via OpenOnion proxy)
+- Default model: `co/gemini-3.7-flash` (managed keys via OpenOnion proxy)
 
 ### LLM Provider Routing (`connectonion/core/llm.py:create_llm()`)
 - Model prefix determines provider:
@@ -451,7 +451,7 @@ the matching docs-site channel, then publishes only from the reviewed exact tag.
 - Example:
   ```python
   try:
-      agent = Agent("my_agent", model="co/gemini-3.6-flash")
+      agent = Agent("my_agent", model="co/gemini-3.7-flash")
       response = agent.input("Hello")
   except InsufficientCreditsError as e:
       print(f"Need ${e.shortfall:.4f} more credits")
@@ -486,7 +486,7 @@ the matching docs-site channel, then publishes only from the reviewed exact tag.
 
 ### Code Organization Preferences
 - Avoid `utils.py` - keep helper functions with their features
-- Default model for agents: `co/gemini-3.6-flash` (managed keys)
+- Default model for agents: `co/gemini-3.7-flash` (managed keys)
 - No Co-Authored-By lines in commit messages (no Claude, Happy, or other brand attribution)
 - Function-based tools over class-based tools
 - Events/plugins over subclassing Agent

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ agent = Agent(name="test", api_key="your-api-key-here")
 
 ### Model Selection
 ```python
-agent = Agent(name="test", model="gpt-5")  # Default: co/gemini-3.6-flash
+agent = Agent(name="test", model="gpt-5")  # Default: co/gemini-3.7-flash
 ```
 
 ### Iteration Control

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   model:
     description: Model passed to co ai
     required: false
-    default: co/gemini-3.6-flash
+    default: co/gemini-3.7-flash
   python-version:
     description: Python version used to run ConnectOnion
     required: false

--- a/connectonion/cli/browser_agent/agent.py
+++ b/connectonion/cli/browser_agent/agent.py
@@ -3,7 +3,7 @@
 Purpose: Wrap BrowserAutomation with a ConnectOnion Agent so the `co browser` CLI can run natural-language browser commands end-to-end.
 LLM-Note:
   Dependencies: imports from [pathlib, connectonion.Agent, connectonion.useful_plugins (image_result_formatter, ui_stream), connectonion.useful_tools.browser_tools.BrowserAutomation, cli.commands.project_cmd_lib.load_api_key (lazy)] | imported by [cli/browser_agent/__init__.py (re-exported), cli/commands/browser_commands.py (lazy import), cli/browser_agent/daemon.py] | tested by [tests/unit/test_the_browser_agent_bills_this_account.py]
-  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → resolves OPENONION_API_KEY through load_api_key(), which verifies the token belongs to this machine's account → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3.6-flash", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
+  Data flow: receives command: str (+ headless: bool) from browser_commands.handle_browser() → resolves OPENONION_API_KEY through load_api_key(), which verifies the token belongs to this machine's account → builds BrowserAutomation context → spins up Agent("browser_cli", model="co/gemini-3.7-flash", system_prompt=PROMPT_PATH, tools=[browser], plugins=[image_result_formatter, ui_stream], max_iterations=200) → returns agent.input(command) raw string
   State/Effects: launches Playwright browser process via BrowserAutomation context manager (auto-closes on exit) | resolves OPENONION_API_KEY via load_api_key() (env, ./.env, ~/.co/keys.env; re-authenticates if the token names another account) | may create screenshots/files inside the BrowserAutomation tool calls | streams UI events via ui_stream plugin
   Integration: exposes execute_browser_command(command, headless=False) -> str | PROMPT_PATH points to ./prompts/agent.md (sibling to this file)
   Performance: synchronous, blocks for full agent loop (up to 200 iterations) | one browser session per call (no pooling)
@@ -41,7 +41,7 @@ def build_browser_agent(browser, api_key: str) -> Agent:
     """Build the natural-language browser Agent driving an existing BrowserAutomation."""
     return Agent(
         name="browser_cli",
-        model="co/gemini-3.6-flash",
+        model="co/gemini-3.7-flash",
         api_key=api_key,
         system_prompt=PROMPT_PATH,
         tools=[browser],

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -36,6 +36,7 @@ from pathlib import Path
 
 from connectonion import Agent, TodoList, bash
 from connectonion.core.events import after_user_input
+from connectonion.core.usage import DEFAULT_MODEL
 from connectonion.useful_plugins import (
     auto_compact,
     enable_yolo,
@@ -112,7 +113,7 @@ def agent_name(co_dir: Path = Path(".co")) -> str:
 
 
 def create_agent(
-    model: str = "co/gemini-3.6-flash",
+    model: str = DEFAULT_MODEL,
     max_iterations: int = 100,
     co_dir: Path = Path(".co"),
     yolo_turns: int | None = None,

--- a/connectonion/cli/co_ai/agents/registry.py
+++ b/connectonion/cli/co_ai/agents/registry.py
@@ -27,13 +27,13 @@ SUBAGENTS: Dict[str, Dict[str, Any]] = {
     "explore": {
         "description": "Fast agent for exploring codebases. Find files, search code, answer questions about structure.",
         "tools": [FileTools],
-        "model": "co/gemini-3.6-flash",  # Fast model for exploration
+        "model": "co/gemini-3.7-flash",  # Fast model for exploration
         "max_iterations": 15,
     },
     "plan": {
         "description": "Design implementation plans. Analyze architecture, identify files to change, plan steps.",
         "tools": [FileTools],
-        "model": "co/gemini-3.6-flash",  # Smarter model for planning
+        "model": "co/gemini-3.7-flash",  # Smarter model for planning
         "max_iterations": 10,
     },
 }

--- a/connectonion/cli/co_ai/commands/compact.py
+++ b/connectonion/cli/co_ai/commands/compact.py
@@ -15,7 +15,7 @@ Compaction strategy:
 - Replaces old messages with single summary message
 
 Summarization:
-- Uses fast model: co/gemini-3.6-flash
+- Uses fast model: co/gemini-3.7-flash
 - Prompt asks for concise summary preserving key decisions/facts
 - Summary becomes new "assistant" message in conversation
 - Reduces token count while maintaining continuity
@@ -164,7 +164,7 @@ Keep the summary under 1000 words but preserve all critical technical details.""
 
     summary = llm_do(
         summary_prompt,
-        model="co/gemini-3.6-flash",  # Fast model for summarization
+        model="co/gemini-3.7-flash",  # Fast model for summarization
     )
 
     # Create compacted messages

--- a/connectonion/cli/co_ai/commands/export.py
+++ b/connectonion/cli/co_ai/commands/export.py
@@ -11,7 +11,7 @@ Key function:
 Export format:
 - Markdown file with conversation metadata header
 - Date and timestamp
-- Model name (e.g., co/gemini-3.6-flash)
+- Model name (e.g., co/gemini-3.7-flash)
 - Formatted message history (user/assistant/tool)
 - Tool calls displayed with formatting
 - Tool results in code blocks

--- a/connectonion/cli/co_ai/commands/help.py
+++ b/connectonion/cli/co_ai/commands/help.py
@@ -57,7 +57,7 @@ oo "fix the bug in auth.py"
 oo
 
 # With options
-oo -m co/gemini-3.6-flash "task"   # Use different model
+oo -m co/gemini-3.7-flash "task"   # Use different model
 oo -y "task"                      # Auto-approve file changes
 ```
 

--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -195,7 +195,7 @@ def detect_intent(agent: 'Agent') -> None:
     try:
         analysis = llm_do(
             INTENT_PROMPT.format(user_prompt=user_prompt),
-            model=getattr(agent, "model", None) or "co/gemini-3.6-flash",
+            model=getattr(agent, "model", None) or "co/gemini-3.7-flash",
             output=IntentAnalysis,
             temperature=0,
         )

--- a/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3.6-flash" | Model to use |
+| `model` | str | "co/gemini-3.7-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,8 +110,8 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3.6-flash")
-transcribe("audio.mp3", model="co/gemini-3.6-flash")
+transcribe("audio.mp3", model="co/gemini-3.7-flash")
+transcribe("audio.mp3", model="co/gemini-3.7-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
 transcribe("audio.mp3", model="gemini-3.5-flash")

--- a/connectonion/cli/co_ai/prompts/connectonion/index.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/index.md
@@ -18,7 +18,7 @@ agent = Agent(
     name="my_bot",                        # Required: identifier
     tools=[func1, func2],                 # Functions or class instances
     system_prompt="You are helpful",      # String or file path
-    model="co/gemini-3.6-flash",            # Default model
+    model="co/gemini-3.7-flash",            # Default model
     max_iterations=10,                    # Tool call limit per task
     plugins=[plugin1, plugin2],           # Event handlers
 )

--- a/connectonion/cli/commands/create.py
+++ b/connectonion/cli/commands/create.py
@@ -371,7 +371,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
         # describes the machine it is on rather than the one that made the file.
         lines_to_add = []
         if "# Default model:" not in env_content:
-            lines_to_add.append("# Default model: co/gemini-3.6-flash (managed keys with free credits)\n")
+            lines_to_add.append("# Default model: co/gemini-3.7-flash (managed keys with free credits)\n")
 
         if lines_to_add:
             # Add blank line after comments if we're adding any
@@ -380,7 +380,7 @@ def handle_create(name: Optional[str], ai: Optional[bool], key: Optional[str],
     else:
         # Fallback - create minimal .env with detected keys
         env_lines = [
-            "# Default model: co/gemini-3.6-flash (managed keys with free credits)",
+            "# Default model: co/gemini-3.7-flash (managed keys with free credits)",
             "",
         ]
 

--- a/connectonion/cli/commands/init.py
+++ b/connectonion/cli/commands/init.py
@@ -256,7 +256,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
     # Write .env
     if not env_existed:
         if keys_to_add or global_keys:
-            env_content = "# Default model: co/gemini-3.6-flash (managed keys with free credits)\n\n"
+            env_content = "# Default model: co/gemini-3.7-flash (managed keys with free credits)\n\n"
             # Add all global keys + detected keys
             all_keys = list(global_keys.values()) + [k for k in keys_to_add if k not in global_keys.values()]
             env_content += '\n'.join(all_keys) + '\n'
@@ -272,7 +272,7 @@ def handle_init(ai: Optional[bool], key: Optional[str], template: Optional[str],
 # OPENROUTER_API_KEY=
 
 # Optional: Override default model
-# MODEL=co/gemini-3.6-flash
+# MODEL=co/gemini-3.7-flash
 """
             env_path.write_text(env_content, encoding='utf-8')
         files_created.append(".env")

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -644,7 +644,7 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         },
         'connectonion': {
             'var': 'CONNECTONION_API_KEY',
-            'model': 'co/gemini-3.6-flash'  # Prefixed models for managed keys
+            'model': 'co/gemini-3.7-flash'  # Prefixed models for managed keys
         }
     }
 
@@ -659,8 +659,8 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
 # Same pricing as OpenAI/Anthropic
 
 # Model Configuration (use co/ prefix for managed models)
-MODEL=co/gemini-3.6-flash
-# Available models: co/gemini-3.6-flash, co/gemini-3.5-flash, co/gemini-2.5-pro, co/gemini-2.5-flash
+MODEL=co/gemini-3.7-flash
+# Available models: co/gemini-3.7-flash, co/gemini-3.6-flash, co/gemini-3.5-flash, co/gemini-2.5-pro, co/gemini-2.5-flash
 # With purchased credits: co/gpt-5, co/o4-mini, co/claude-sonnet-4
 
 # No API key needed - authentication handled via JWT token from 'co auth'
@@ -676,7 +676,7 @@ MODEL=co/gemini-3.6-flash
 # 3. Your GitHub star will be verified automatically
 
 # Model Configuration (use co/ prefix for managed models)
-MODEL=co/gemini-3.6-flash
+MODEL=co/gemini-3.7-flash
 
 # No API key needed - authentication handled via JWT token from 'co auth'
 
@@ -703,7 +703,7 @@ def generate_custom_template_with_name(description: str, api_key: str, model: st
     Args:
         description: What the agent should do
         api_key: API key or token for LLM
-        model: Optional model to use (e.g., "co/gemini-3.6-flash")
+        model: Optional model to use (e.g., "co/gemini-3.7-flash")
         loading_animation: Optional LoadingAnimation instance to update
 
     Returns:
@@ -719,8 +719,8 @@ def generate_custom_template_with_name(description: str, api_key: str, model: st
         try:
             from ...core.llm import create_llm
 
-            # Use the model specified or default to co/gemini-3.6-flash
-            llm_model = model if model else "co/gemini-3.6-flash"
+            # Use the model specified or default to co/gemini-3.7-flash
+            llm_model = model if model else "co/gemini-3.7-flash"
 
             if loading_animation:
                 loading_animation.update(f"Connecting to {llm_model}...")
@@ -805,7 +805,7 @@ def process_request(query: str) -> str:
 # Create agent
 agent = Agent(
     name="{suggested_name.replace('-', '_')}",
-    model="{model if model and model.startswith('co/') else 'co/gemini-3.6-flash'}",
+    model="{model if model and model.startswith('co/') else 'co/gemini-3.7-flash'}",
     system_prompt=\"\"\"You are an AI agent designed to: {description}
 
     Provide helpful, accurate, and concise responses.\"\"\",

--- a/connectonion/cli/github_action.py
+++ b/connectonion/cli/github_action.py
@@ -14,6 +14,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
+from ..core.usage import DEFAULT_MODEL
+
 COMMENT_MARKER = "<!-- connectonion-pr-review -->"
 MAX_COMMENT_BYTES = 60_000
 MAX_GITHUB_RESPONSE_BYTES = 5_000_000
@@ -430,7 +432,7 @@ def main() -> int:
         pr_number = resolve_pr_number(
             os.getenv("CO_ACTION_PR_NUMBER"), os.getenv("GITHUB_EVENT_PATH")
         )
-        model = os.getenv("CO_ACTION_MODEL", "co/gemini-3.6-flash").strip()
+        model = os.getenv("CO_ACTION_MODEL", DEFAULT_MODEL).strip()
         if not model:
             raise ActionError("Provide a model name.")
         token = os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -33,6 +33,7 @@ from rich.console import Console
 # the OpenAI and Anthropic SDKs before the CLI had parsed an argument, which
 # is what every command handler being imported inside its function was for.
 from .._version import __version__
+from ..core.usage import DEFAULT_MODEL
 
 # Load both env files for all CLI commands. keys.env stays first — that is
 # already the CLI's effective precedence, since commands that load .env do so
@@ -347,7 +348,7 @@ def call(
 def ai(
     prompt: Optional[str] = typer.Argument(None, help="One-shot prompt (runs and exits)"),
     port: int = typer.Option(8000, "--port", "-p", help="Port for web server"),
-    model: str = typer.Option("co/gemini-3.6-flash", "--model", "-m", help="Model to use"),
+    model: str = typer.Option(DEFAULT_MODEL, "--model", "-m", help="Model to use"),
     max_iterations: int = typer.Option(100, "--max-iterations", "-i", help="Max iterations"),
     yolo: bool = typer.Option(False, "--yolo", help="Skip approvals and keep working autonomously"),
     yolo_turns: int = typer.Option(

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -27,7 +27,7 @@ from .provider_messages import messages_for_provider
 from .tool_executor import execute_and_record_tools, execute_single_tool
 from .tool_factory import create_tool_from_function, extract_methods_from_instance, is_class_instance
 from .tool_registry import ToolRegistry
-from .usage import get_context_limit, turn_usage_from_trace
+from .usage import DEFAULT_MODEL, get_context_limit, turn_usage_from_trace
 from .wire_events import normalize_wire_event
 
 
@@ -67,7 +67,7 @@ class Agent:
         tools: Optional[Union[List[Callable], Callable, Any]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-3.6-flash",
+        model: str = DEFAULT_MODEL,
         max_iterations: int = 100,
         log: Optional[Union[bool, str, Path]] = None,
         quiet: bool = False,

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -187,7 +187,7 @@ class ToolCall:
 
 
 # Import TokenUsage from usage module
-from .usage import TokenUsage, calculate_cost
+from .usage import DEFAULT_MODEL, TokenUsage, calculate_cost
 from ..backend import backend_url
 from .exceptions import (
     InsufficientCreditsError,
@@ -614,7 +614,7 @@ class GeminiLLM(LLM):
 
     # gemini-2.0-flash-exp was the default and Google has retired it: a bare
     # GeminiLLM(api_key=...) answered 404 for every call.
-    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-3.6-flash", **kwargs):
+    def __init__(self, api_key: Optional[str] = None, model: str = "gemini-3.7-flash", **kwargs):
         import openai
         self.api_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
         if not self.api_key:
@@ -1027,6 +1027,7 @@ MODEL_REGISTRY = {
     "claude-3-7-sonnet-20250219": "anthropic",
     
     # Google Gemini models
+    "gemini-3.7-flash": "google",
     "gemini-3.6-flash": "google",
     "gemini-3.5-flash": "google",
     "gemini-3-pro-image-preview": "google",
@@ -1052,7 +1053,7 @@ MODEL_REGISTRY = {
 class OpenOnionLLM(LLM):
     """OpenOnion managed keys LLM implementation using OpenAI-compatible API."""
 
-    def __init__(self, api_key: Optional[str] = None, model: str = "co/gemini-3.6-flash", **kwargs):
+    def __init__(self, api_key: Optional[str] = None, model: str = DEFAULT_MODEL, **kwargs):
         # For co/ models, api_key is actually the auth token
         # Framework auto-loads .env, so OPENONION_API_KEY will be in environment
         import openai

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -92,6 +92,11 @@ MODEL_PRICING = {
     # Standard paid tier, per million tokens: input $1.50, output $7.50,
     # context-cached input $0.15 (Google pricing page, checked 2026-08-08).
     "gemini-3.6-flash": {"input": 1.50, "output": 7.50, "cached": 0.15},
+    # 3.7 Flash: introductory rate published by Google through 2026-12-31
+    # (standard pricing from 2027-01-01 is input $1.50 / output $7.50). Cached
+    # follows the common 25% rule; not yet reconciled against real backend
+    # charges.
+    "gemini-3.7-flash": {"input": 0.75, "output": 3.75, "cached": 0.1875},
     "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cached": 0.375},
     # Solved from real charges, two calls: (in=4, total=28, $0.000074) and
     # (in=2006, total=2101, $0.001288) give input 0.50 / output 3.00 and both
@@ -125,6 +130,7 @@ MODEL_CONTEXT_LIMITS = {
     "claude-3-7-sonnet": 200000,
 
     # Gemini
+    "gemini-3.7-flash": 1000000,
     "gemini-3.6-flash": 1000000,
     "gemini-3.5-flash": 1000000,
     # Without this row it took the 128,000 default, so `% ctx` read 7.8x high and
@@ -144,6 +150,13 @@ MODEL_CONTEXT_LIMITS = {
 DEFAULT_PRICING = {"input": 1.00, "output": 3.00, "cached": 0.50}
 DEFAULT_CONTEXT_LIMIT = 128000
 
+# The model every entry point uses when the user configures nothing. One
+# constant, imported by Agent, llm_do, transcribe, and the CLI — because
+# "what is the default model" was previously answered by separate literals
+# that drifted apart. The previous default stays on FREE_MANAGED_MODELS
+# below as the rollback (issue #1002).
+DEFAULT_MODEL = "co/gemini-3.7-flash"
+
 # Which managed models a free account can call. The backend refuses the rest
 # with error='paid_account_required': "Your free $5 credits work with
 # Google-routed models."
@@ -155,6 +168,7 @@ DEFAULT_CONTEXT_LIMIT = 128000
 # completing a real call per model; see
 # tests/unit/test_the_models_we_advertise_answer.py.
 FREE_MANAGED_MODELS = (
+    "co/gemini-3.7-flash",
     "co/gemini-3.6-flash",
     "co/gemini-3.5-flash",
     "co/gemini-2.5-pro",

--- a/connectonion/llm_do.py
+++ b/connectonion/llm_do.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [typing, pathlib, pydantic, dotenv, prompts.py, llm.py] | imported by [debug_explainer/explain_context.py, user code, examples] | tested by [tests/unit/test_llm_do.py, tests/e2e/real_api/]
   Data flow: user calls llm_do(input, output, system_prompt, model, api_key, **kwargs) → validates input non-empty → loads system_prompt via load_system_prompt() → builds messages [system, user] → calls create_llm(model, api_key) factory → calls llm.complete(messages, **kwargs) OR llm.structured_complete(messages, output, **kwargs) → returns string OR Pydantic model instance
   State/Effects: loads .env via dotenv.load_dotenv() | reads system_prompt files if Path provided | makes one LLM API request | no caching or persistence | stateless
-  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-3.6-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
+  Integration: exposes llm_do(input, output, system_prompt, model, api_key, **kwargs) | default model="co/gemini-3.7-flash" (managed keys) | default temperature=0.1 | supports all create_llm() providers | **kwargs pass through to provider (max_tokens, temperature, etc.)
   Performance: minimal overhead (no agent loop, no tool calling, no conversation history) | one LLM call per invocation | no caching | synchronous blocking
   Errors: raises ValueError if input empty | provider errors from create_llm() and llm.complete() bubble up | Pydantic ValidationError if structured output doesn't match schema
 
@@ -43,7 +43,7 @@ Key Design Decisions
 -------------------
 - **Stateless**: No conversation history, each call is independent
 - **Simple API**: Minimal parameters, sensible defaults
-- **Default Model**: Uses "co/gemini-3.6-flash" (ConnectOnion managed keys) for zero-setup
+- **Default Model**: Uses "co/gemini-3.7-flash" (ConnectOnion managed keys) for zero-setup
 - **Structured Output**: Native Pydantic support via provider-specific APIs
 - **Flexible Parameters**: **kwargs pass through to underlying LLM (temperature, max_tokens, etc.)
 
@@ -95,7 +95,7 @@ All providers from llm.py module:
    - Structured output via response_schema
    - Good balance of speed and quality
 
-4. **ConnectOnion**: co/gemini-3.6-flash (DEFAULT), co/gpt-5
+4. **ConnectOnion**: co/gemini-3.7-flash (DEFAULT), co/gpt-5
    - Managed API keys (no env vars needed!)
    - Proxies to OpenAI with usage tracking
    - Requires: run `co auth` first
@@ -134,7 +134,7 @@ Parameters
 - input (str): The text/question to send to the LLM
 - output (Type[BaseModel], optional): Pydantic model for structured output
 - system_prompt (str | Path, optional): System instructions (inline or file path)
-- model (str): Model name (default: "co/gemini-3.6-flash")
+- model (str): Model name (default: "co/gemini-3.7-flash")
 - temperature (float): Sampling temperature (default: 0.1 for consistency)
 - api_key (str, optional): Override API key (uses env vars by default)
 - **kwargs: Additional parameters passed to LLM (max_tokens, top_p, etc.)
@@ -223,6 +223,7 @@ from pathlib import Path
 from pydantic import BaseModel
 from .prompts import load_system_prompt
 from .core.llm import create_llm
+from .core.usage import DEFAULT_MODEL
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -231,7 +232,7 @@ def llm_do(
     input: str,
     output: Optional[Type[T]] = None,
     system_prompt: Optional[Union[str, Path]] = None,
-    model: str = "co/gemini-3.6-flash",
+    model: str = DEFAULT_MODEL,
     api_key: Optional[str] = None,
     **kwargs
 ) -> Union[str, T]:
@@ -242,13 +243,13 @@ def llm_do(
     - OpenAI: "o4-mini", "o3-mini"
     - Anthropic: "claude-sonnet-4-20250514", "claude-opus-4-20250514"
     - Google: "gemini-2.5-pro", "gemini-2.5-flash"
-    - ConnectOnion Managed: "co/gemini-3.6-flash", "co/gpt-5" (no API keys needed!)
+    - ConnectOnion Managed: "co/gemini-3.7-flash", "co/gpt-5" (no API keys needed!)
 
     Args:
         input: The input text/question to send to the LLM
         output: Optional Pydantic model class for structured output
         system_prompt: Optional system prompt (string or file path)
-        model: Model name (default: "co/gemini-3.6-flash")
+        model: Model name (default: "co/gemini-3.7-flash")
         api_key: Optional API key (uses environment variable if not provided)
         **kwargs: Additional parameters (temperature, max_tokens, etc.)
 
@@ -261,7 +262,7 @@ def llm_do(
         >>> print(answer)  # "4"
 
         >>> # With ConnectOnion managed keys (no API key needed!)
-        >>> answer = llm_do("What's 2+2?", model="co/gemini-3.6-flash")
+        >>> answer = llm_do("What's 2+2?", model="co/gemini-3.7-flash")
 
         >>> # With Claude
         >>> answer = llm_do("Explain quantum physics", model="claude-sonnet-4-20250514")

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -108,7 +108,7 @@ class TrustAgent:
     """
 
     def __init__(self, trust: str = "careful", *, api_key: str = None,
-                 model: str = "co/gemini-3.6-flash", co_dir: Path = None):
+                 model: str = "co/gemini-3.7-flash", co_dir: Path = None):
         """
         Create a TrustAgent.
 

--- a/connectonion/transcribe.py
+++ b/connectonion/transcribe.py
@@ -23,7 +23,7 @@ Usage:
     >>> text = transcribe("meeting.mp3", prompt="Technical AI discussion, speakers: Aaron, Lisa")
 
     # Different model
-    >>> text = transcribe("meeting.mp3", model="co/gemini-3.6-flash")
+    >>> text = transcribe("meeting.mp3", model="co/gemini-3.7-flash")
 
 Supported formats: WAV, MP3, AIFF, AAC, OGG, FLAC
 Token cost: 32 tokens per second of audio (1 minute = 1,920 tokens)
@@ -37,6 +37,7 @@ from typing import Optional
 import httpx
 from connectonion.backend import backend_url
 from connectonion.credentials import require_ambient_api_key
+from connectonion.core.usage import DEFAULT_MODEL
 
 
 # MIME type mapping for audio formats
@@ -82,7 +83,7 @@ def _get_api_key(model: str) -> str:
 def transcribe(
     audio: str,
     prompt: Optional[str] = None,
-    model: str = "co/gemini-3.6-flash",
+    model: str = DEFAULT_MODEL,
     timestamps: bool = False,
 ) -> str:
     """
@@ -92,7 +93,7 @@ def transcribe(
         audio: Path to audio file (WAV, MP3, AIFF, AAC, OGG, FLAC)
         prompt: Optional context hints for better accuracy
                 (e.g., "Technical AI discussion, speakers: Aaron, Lisa")
-        model: Model to use (default: co/gemini-3.6-flash)
+        model: Model to use (default: co/gemini-3.7-flash)
         timestamps: If True, include timestamps in output
 
     Returns:

--- a/connectonion/tui/__init__.py
+++ b/connectonion/tui/__init__.py
@@ -15,7 +15,7 @@ Usage:
 
     # Status bar with model/context/git info
     status = StatusBar([
-        ("🤖", "co/gemini-3.6-flash", "magenta"),
+        ("🤖", "co/gemini-3.7-flash", "magenta"),
         ("📊", "50%", "green"),
         ("", "main", "blue"),
     ])

--- a/connectonion/tui/status_bar.py
+++ b/connectonion/tui/status_bar.py
@@ -38,7 +38,7 @@ class ProgressSegment:
         from connectonion.tui import StatusBar, ProgressSegment
 
         status = StatusBar([
-            ("🤖", "co/gemini-3.6-flash", "magenta"),
+            ("🤖", "co/gemini-3.7-flash", "magenta"),
             ProgressSegment(percent=78, bg_color="green"),
         ])
     """
@@ -68,19 +68,19 @@ class StatusBar:
 
         # Text segments only
         bar = StatusBar([
-            ("🤖", "co/gemini-3.6-flash", "magenta"),
+            ("🤖", "co/gemini-3.7-flash", "magenta"),
             ("", "main", "blue"),
         ])
 
         # With progress bar for context window
         bar = StatusBar([
-            ("🤖", "co/gemini-3.6-flash", "magenta"),
+            ("🤖", "co/gemini-3.7-flash", "magenta"),
             ProgressSegment(percent=78, bg_color="green"),
         ])
         console.print(bar.render())
 
     Output (with powerline font):
-        🤖 co/gemini-3.6-flash  ███████░░░ 78%
+        🤖 co/gemini-3.7-flash  ███████░░░ 78%
     """
 
     def __init__(
@@ -144,13 +144,13 @@ class SimpleStatusBar:
 
     Usage:
         bar = SimpleStatusBar([
-            ("🤖", "co/gemini-3.6-flash", "magenta"),
+            ("🤖", "co/gemini-3.7-flash", "magenta"),
             ("📊", "50%", "green"),
         ])
         console.print(bar.render())
 
     Output:
-        [🤖 co/gemini-3.6-flash] [📊 50%]
+        [🤖 co/gemini-3.7-flash] [📊 50%]
     """
 
     def __init__(self, segments: list[tuple[str, str, str]]):

--- a/connectonion/useful_events_handlers/reflect.py
+++ b/connectonion/useful_events_handlers/reflect.py
@@ -112,7 +112,7 @@ Error: {error}"""
 
     reasoning = llm_do(
         prompt,
-        model="co/gemini-3.6-flash",
+        model="co/gemini-3.7-flash",
         temperature=0.2,
         system_prompt=REFLECT_PROMPT
     )

--- a/connectonion/useful_plugins/auto_compact.py
+++ b/connectonion/useful_plugins/auto_compact.py
@@ -137,7 +137,7 @@ Keep the summary under 800 words but preserve all critical technical details."""
 
     summary = llm_do(
         summary_prompt,
-        model="co/gemini-3.6-flash",
+        model="co/gemini-3.7-flash",
         temperature=0,
     )
 

--- a/connectonion/useful_plugins/builtin_agents/explore/AGENT.md
+++ b/connectonion/useful_plugins/builtin_agents/explore/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast codebase exploration agent - find files, search code, answer questions
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob

--- a/connectonion/useful_plugins/builtin_agents/plan/AGENT.md
+++ b/connectonion/useful_plugins/builtin_agents/plan/AGENT.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Implementation planning agent - analyze requirements and design actionable plans
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 10
 tools:
   - glob

--- a/connectonion/useful_plugins/eval.py
+++ b/connectonion/useful_plugins/eval.py
@@ -62,7 +62,7 @@ Focus on the USER'S INTENT, not exact text matching:
 Be lenient - if the core task was done, mark it passed."""
 
 
-DEFAULT_SCORING_MODEL = "co/gemini-3.6-flash"
+DEFAULT_SCORING_MODEL = "co/gemini-3.7-flash"
 
 
 def _scoring_model(agent: 'Agent') -> str:

--- a/connectonion/useful_plugins/re_act.py
+++ b/connectonion/useful_plugins/re_act.py
@@ -134,7 +134,7 @@ Current user input: {user_prompt}
 
 Acknowledge this request (1-2 sentences):"""
 
-    model = "co/gemini-3.6-flash"
+    model = "co/gemini-3.7-flash"
     agent.logger.print(f"[dim]/understanding ({model})...[/dim]")
 
     ack = llm_do(

--- a/connectonion/useful_plugins/subagents.py
+++ b/connectonion/useful_plugins/subagents.py
@@ -18,7 +18,7 @@ AGENT.md Format:
 ---
 name: explore
 description: Fast codebase exploration agent
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob
@@ -163,7 +163,7 @@ def task(agent, prompt: str, agent_type: str) -> str:
     # Extract configuration
     frontmatter = config['frontmatter']
     system_prompt = config['system_prompt']
-    model = frontmatter.get('model', 'co/gemini-3.6-flash')
+    model = frontmatter.get('model', 'co/gemini-3.7-flash')
     max_iterations = frontmatter.get('max_iterations', 10)
     tool_names = frontmatter.get('tools', [])
 

--- a/connectonion/useful_tools/browser_tools/element_finder.py
+++ b/connectonion/useful_tools/browser_tools/element_finder.py
@@ -208,7 +208,7 @@ def find_element(
     result = llm_do(
         prompt,
         output=ElementMatch,
-        model="co/gemini-3.6-flash",
+        model="co/gemini-3.7-flash",
         temperature=0.1
     )
 

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -107,7 +107,7 @@ def _ai_scroll(page, times: int, description: str):
     strategy = llm_do(
         _PROMPT.format(description=description, scrollable_elements=scrollable, simplified_html=html),
         output=ScrollStrategy,
-        model="co/gemini-3.6-flash",
+        model="co/gemini-3.7-flash",
         temperature=0.1
     )
     print(f"    AI: {strategy.explanation}")

--- a/connectonion/useful_tools/file_tools/README.md
+++ b/connectonion/useful_tools/file_tools/README.md
@@ -195,7 +195,7 @@ from connectonion.useful_tools import FileTools
 
 agent = Agent(
     "code-reviewer",
-    model="co/gemini-3.6-flash",
+    model="co/gemini-3.7-flash",
     tools=[FileTools()],
     instructions="Review and fix code. Always read files before editing."
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -314,7 +314,7 @@ class Agent:
         tools: Optional[List[Callable]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-3.6-flash",
+        model: str = "co/gemini-3.7-flash",
         max_iterations: int = 100
     )
     

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,7 +13,7 @@ Agent(
     tools: Optional[List[Callable]] = None,
     system_prompt: Union[str, Path, None] = None,
     api_key: Optional[str] = None,
-    model: str = "co/gemini-3.6-flash"
+    model: str = "co/gemini-3.7-flash"
 )
 ```
 
@@ -27,9 +27,9 @@ Agent(
   - `Path`: Path object pointing to a prompt file
   - `None`: Uses default prompt
 - **api_key** (`Optional[str]`): OpenAI API key (if not using custom LLM)
-- **model** (`str`): Model to use (default: "co/gemini-3.6-flash")
-  - Managed keys: `co/gemini-3.6-flash`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
-  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-3.6-flash`
+- **model** (`str`): Model to use (default: "co/gemini-3.7-flash")
+  - Managed keys: `co/gemini-3.7-flash`, `co/gpt-4o-mini`, `co/claude-sonnet-4-5`
+  - Your own key: `gpt-4o-mini`, `claude-sonnet-4-5`, `gemini-3.7-flash`
 
 ### System Prompt Options
 
@@ -239,11 +239,11 @@ llm = create_llm("o4-mini")          # → OpenAILLM
 llm = create_llm("claude-sonnet-4-5") # → AnthropicLLM
 
 # Google Gemini models
-llm = create_llm("gemini-3.6-flash")  # → GeminiLLM
+llm = create_llm("gemini-3.7-flash")  # → GeminiLLM
 
 # ConnectOnion managed keys (co/ prefix)
 llm = create_llm("co/gpt-4o-mini")    # → OpenOnionLLM
-llm = create_llm("co/gemini-3.6-flash") # → OpenOnionLLM
+llm = create_llm("co/gemini-3.7-flash") # → OpenOnionLLM
 ```
 
 ### co/ Models (Managed Keys)
@@ -254,7 +254,7 @@ Models prefixed with `co/` use ConnectOnion's managed API keys through the OpenO
 from connectonion import Agent
 
 # Uses OpenOnion managed keys - no API key needed
-agent = Agent(name="bot", model="co/gemini-3.6-flash")
+agent = Agent(name="bot", model="co/gemini-3.7-flash")
 ```
 
 **How it works:**
@@ -265,7 +265,7 @@ agent = Agent(name="bot", model="co/gemini-3.6-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-3.6-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- `co/gemini-3.7-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - `co/claude-opus-4-5`, `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)
@@ -310,7 +310,7 @@ from connectonion.core.llm import GeminiLLM
 
 llm = GeminiLLM(
     api_key="your-key",  # or GEMINI_API_KEY env var
-    model="gemini-3.6-flash"
+    model="gemini-3.7-flash"
 )
 
 agent = Agent("bot", llm=llm)
@@ -325,7 +325,7 @@ from connectonion.core.llm import OpenOnionLLM
 
 llm = OpenOnionLLM(
     api_key="your-token",  # or OPENONION_API_KEY env var
-    model="co/gemini-3.6-flash"
+    model="co/gemini-3.7-flash"
 )
 
 agent = Agent("bot", llm=llm)

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -308,7 +308,7 @@ co auth
 
 ```python
 # After co auth, just use co/ prefix
-agent = Agent("bot", model="co/gemini-3.6-flash")
+agent = Agent("bot", model="co/gemini-3.7-flash")
 agent = Agent("bot", model="co/gpt-5")
 ```
 
@@ -498,10 +498,10 @@ print(result.sentiment)  # Type-safe!
 
 ```python
 # ✅ Default: Fast and cheap
-llm_do("Quick task")  # Uses co/gemini-3.6-flash
+llm_do("Quick task")  # Uses co/gemini-3.7-flash
 
 # ✅ For complex reasoning
-llm_do("Complex analysis", model="co/gemini-3.6-flash")
+llm_do("Complex analysis", model="co/gemini-3.7-flash")
 
 # ✅ For structured output (Anthropic 4.5+ only)
 from pydantic import BaseModel

--- a/docs/blog/2026-08-15-one-default-five-answers.md
+++ b/docs/blog/2026-08-15-one-default-five-answers.md
@@ -1,0 +1,93 @@
+# One Default, Five Answers
+
+The issue was one sentence: make Gemini 3.7 the default model.
+
+I expected a one-line diff. Find the constant, bump the version, done. So I did
+what you do — grep for the current default:
+
+```
+grep -rn "co/gemini" --include='*.py' --include='*.yml' .
+```
+
+Fifty-nine lines came back. Not fifty-nine mentions of a constant. Fifty-nine
+separate, hand-typed copies of the string `co/gemini-3.6-flash`, each one
+independently claiming to be *the* default.
+
+## Where "the default" actually lived
+
+Once you stop skimming and start reading the hits, they sort into places, and
+each place is its own small story:
+
+1. **`connectonion/core/agent.py`** — the `Agent` class signature. The one
+   everybody would name if you asked "where is the default model defined?"
+2. **`connectonion/llm_do.py`** — the one-shot call helper, with its own copy
+   in the signature and four more in its docstring.
+3. **`connectonion/core/llm.py`** — twice, actually: `OpenOnionLLM` for the
+   managed route, and `GeminiLLM` with the bare `gemini-3.6-flash` for people
+   bringing their own Google key.
+4. **`connectonion/cli/main.py`** — the `co ai --model` option default, typed
+   out again inside a `typer.Option(...)` call.
+5. **`action.yml`** — the GitHub Action's `model` input, in YAML, where no
+   Python constant can reach. Plus its twin fallback in
+   `cli/github_action.py`, reading `CO_ACTION_MODEL` with — you guessed it —
+   another literal.
+
+And that's just the headline five. Keep reading the grep and the default also
+lived in the subagent frontmatter loaders (`useful_plugins/subagents.py`,
+`subagents/loader.py`, `cli/co_ai/agents/registry.py`), the project
+scaffolding that writes `.env` files for new users
+(`cli/commands/init.py`, `create.py`, `project_cmd_lib.py`), the eval plugin's
+scoring model, the TUI status bar's example renders, the transcribe helper,
+and about forty documentation lines that confidently told readers what the
+default was.
+
+## Why defaults drift
+
+None of this happened because anyone was careless. It happened because every
+one of those places was written on a different day, and on each of those days
+the author did the reasonable thing: they looked at what the default was *that
+day* and typed it in. A new plugin copies the current default at birth. Then
+the default moves on, and the copy doesn't.
+
+We had already paid for this once. The free-models list in this repo used to
+exist as two copies in two branches of the same auth flow, and the test that
+guards it now carries the scar in its docstring: "both copies naming the
+retired model — the shape that has caused most of this release's bugs."
+Defaults drift for exactly the same reason lists drift. A literal is a
+snapshot; nobody schedules the snapshot's refresh.
+
+The tell was right there in the grep output. If the repo had one source of
+truth, the search would have returned one definition and fifty-eight
+references. It returned fifty-nine definitions.
+
+## The fix is a name, not a sed
+
+Running `sed 's/3.6/3.7/'` would have closed the issue and re-armed the trap.
+The next default change would face the same fifty-nine-line grep, minus
+whatever new copies had accumulated by then.
+
+So the actual change is one new line in `core/usage.py`, next to the pricing
+and context tables where the other model facts already live:
+
+```python
+DEFAULT_MODEL = "co/gemini-3.7-flash"
+```
+
+`Agent`, `llm_do`, `transcribe`, both LLM classes, `co ai`, and the GitHub
+Action fallback now import that name. The next time the default moves, the
+diff is the one-liner I originally expected — plus the places that genuinely
+cannot import Python and have to stay prose: `action.yml`, the scaffolded
+`.env` templates, the docs. Those still exist, but they went from
+fifty-something down to a handful, and the test suite now asserts that the
+three entry points agree with each other, so a partial edit fails loudly
+instead of shipping quietly.
+
+Two things deliberately did *not* change. Anything a user configured
+explicitly stays theirs — the defaults only apply when you configured nothing,
+and the tests pin that. And `co/gemini-3.6-flash` stays on the free-models
+list, priced and reachable, as the rollback: if 3.7 misbehaves, reverting is
+one constant, no user migration.
+
+What changing one number everywhere teaches you is that "everywhere" is the
+bug. A default you have to change in fifty-nine places isn't a default — it's
+fifty-nine opinions that currently happen to agree.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -171,13 +171,13 @@ from connectonion import llm_do
 # Use co/ prefix
 response = llm_do("Hello", model="co/gpt-4o")
 response = llm_do("Hello", model="co/claude-sonnet-4-5")
-response = llm_do("Hello", model="co/gemini-3.6-flash")
+response = llm_do("Hello", model="co/gemini-3.7-flash")
 ```
 
 **Available models:**
 - OpenAI: `co/gpt-4o`, `co/gpt-4o-mini`, `co/o4-mini`
 - Anthropic: `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- Google: `co/gemini-3.6-flash` (default), `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- Google: `co/gemini-3.7-flash` (default), `co/gemini-3.6-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - And more...
 
 **Benefits:**

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -191,7 +191,7 @@ operator choice at process launch.
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--port` | `-p` | `8000` | Port for web server |
-| `--model` | `-m` | `co/gemini-3.6-flash` | LLM model to use |
+| `--model` | `-m` | `co/gemini-3.7-flash` | LLM model to use |
 | `--max-iterations` | `-i` | `100` | Max tool iterations per turn |
 | `--yolo` | | off | Skip tool approvals and keep working across turns |
 | `--yolo-turns` | | `100` | Autonomous turns before a checkpoint; must be positive |
@@ -203,7 +203,7 @@ operator choice at process launch.
 
 ```bash
 co ai --port 9000
-co ai --model co/gemini-3.6-flash
+co ai --model co/gemini-3.7-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 co ai --yolo "Fix the failing suite" --yolo-turns 20
 co ai --acp
@@ -421,7 +421,7 @@ co ai "Add rate limiting to the API endpoint in oo-api/routes/llm.py"
 co ai "The test test_agent_loop is failing, investigate and fix it"
 
 # Use a different model
-co ai --model co/gemini-3.6-flash
+co ai --model co/gemini-3.7-flash
 
 # Run on a different port
 co ai --port 9000

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -36,7 +36,7 @@ response = llm_do("Hello", model="co/gpt-4o")
 Works across providers:
 - `co/gpt-4o`, `co/gpt-4o-mini`
 - `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- `co/gemini-3.6-flash` (default), `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- `co/gemini-3.7-flash` (default), `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 
 ## Troubleshooting
 

--- a/docs/co-directory-structure.md
+++ b/docs/co-directory-structure.md
@@ -126,7 +126,7 @@ Detailed per-session logs for eval and replay, one file per unique first input:
 ```yaml
 # evals/what_is_2_2.yaml
 agent: assistant
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 started_at: "2025-01-15T10:30:00Z"
 turns:
   - input: "What is 2+2?"

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -42,7 +42,7 @@ Agent(
     name="my_bot",                        # Required: agent identifier
     tools=[func1, func2],                 # Optional: functions agent can call
     system_prompt="You are helpful",      # Optional: personality/behavior
-    model="co/gemini-3.6-flash",            # Optional: LLM model (default: co/gemini-3.6-flash)
+    model="co/gemini-3.7-flash",            # Optional: LLM model (default: co/gemini-3.7-flash)
     max_iterations=100,                   # Optional: how many tool calls allowed (default: 100)
     api_key="sk-...",                     # Optional: override environment variable
     llm=custom_llm,                       # Optional: bring your own LLM instance
@@ -448,7 +448,7 @@ See [max_iterations.md](max_iterations.md) for detailed guide.
 
 ### Supported Providers
 
-Default model is `co/gemini-3.6-flash`. You can use:
+Default model is `co/gemini-3.7-flash`. You can use:
 
 ```python
 # OpenAI models
@@ -463,8 +463,8 @@ agent = Agent("bot", model="claude-haiku-4-5")
 agent = Agent("bot", model="claude-opus-4")
 
 # Google Gemini
-agent = Agent("bot", model="gemini-3.6-flash")
-agent = Agent("bot", model="gemini-3.6-flash")
+agent = Agent("bot", model="gemini-3.7-flash")
+agent = Agent("bot", model="gemini-3.7-flash")
 agent = Agent("bot", model="gemini-2.5-flash")
 ```
 
@@ -593,7 +593,7 @@ Token usage is automatically shown in console logs after each LLM call:
 Cost tracking works with all supported providers:
 - OpenAI (gpt-4o, gpt-4o-mini, o1, o3-mini, o4-mini)
 - Anthropic Claude (claude-sonnet-4, claude-opus-4, claude-3-5-sonnet, claude-3-5-haiku)
-- Google Gemini (gemini-3.6-flash, gemini-3.5-flash, gemini-2.5-pro, gemini-2.5-pro, gemini-2.5-flash)
+- Google Gemini (gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash, gemini-2.5-pro, gemini-2.5-pro, gemini-2.5-flash)
 
 Models not in the pricing table fall back to default pricing estimates ($1/M input, $3/M output).
 
@@ -895,7 +895,7 @@ import pytest
 @pytest.mark.real_api
 def test_real_agent():
     """Requires OPENONION_API_KEY or GEMINI_API_KEY in environment."""
-    agent = Agent("test", tools=[search], model="co/gemini-3.6-flash")
+    agent = Agent("test", tools=[search], model="co/gemini-3.7-flash")
     result = agent.input("Search for Python")
     assert "Python" in result
 

--- a/docs/concepts/llm_do.md
+++ b/docs/concepts/llm_do.md
@@ -7,12 +7,12 @@ Make direct LLM calls with optional structured output. Supports OpenAI, Google G
 ```python
 from connectonion import llm_do
 
-# Default: co/gemini-3.6-flash (managed key, no setup needed)
+# Default: co/gemini-3.7-flash (managed key, no setup needed)
 answer = llm_do("What's 2+2?")  
 print(answer)  # "4"
 
 # Google Gemini (your own key)
-answer = llm_do("What's 2+2?", model="gemini-3.6-flash")  
+answer = llm_do("What's 2+2?", model="gemini-3.7-flash")  
 
 # Anthropic Claude
 answer = llm_do("What's 2+2?", model="claude-haiku-4-5")
@@ -120,8 +120,8 @@ llm_do("Hello", model="co/gpt-4o-mini")
 llm_do("Hello", model="co/o4-mini")
 
 # Google Gemini models (via managed keys)
-llm_do("Hello", model="co/gemini-3.6-flash")
-llm_do("Hello", model="co/gemini-3.6-flash")
+llm_do("Hello", model="co/gemini-3.7-flash")
+llm_do("Hello", model="co/gemini-3.7-flash")
 
 # Anthropic Claude models (via managed keys)
 llm_do("Hello", model="co/claude-sonnet-4-5")
@@ -146,7 +146,7 @@ class Answer(BaseModel):
 
 # Works with all providers
 llm_do("What is 2+2?", output=Answer, model="co/gpt-4o-mini")      # ✅
-llm_do("What is 2+2?", output=Answer, model="co/gemini-3.6-flash") # ✅
+llm_do("What is 2+2?", output=Answer, model="co/gemini-3.7-flash") # ✅
 llm_do("What is 2+2?", output=Answer, model="co/claude-sonnet-4-5") # ✅
 
 # Legacy Claude models do NOT support structured output
@@ -160,7 +160,7 @@ llm_do("What is 2+2?", output=Answer, model="co/claude-sonnet-4-5") # ✅
 | `input` | str | required | The input text/question |
 | `output` | BaseModel | None | Pydantic model for structured output |
 | `system_prompt` | str\|Path | None | System prompt (string or file path) |
-| `model` | str | "co/gemini-3.6-flash" | Model to use (supports OpenAI, Gemini, Claude) |
+| `model` | str | "co/gemini-3.7-flash" | Model to use (supports OpenAI, Gemini, Claude) |
 | `temperature` | float | 0.1 | Randomness (0=deterministic, 2=creative) |
 
 ## What You Get

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -84,8 +84,8 @@ agent = Agent("assistant", model="co/gemini-2.5-pro")  # Managed
 agent = Agent("assistant", model="gemini-2.5-pro")     # Your key
 
 # Newest Flash workhorse - frontier intelligence built for speed
-agent = Agent("assistant", model="co/gemini-3.6-flash")  # Managed
-agent = Agent("assistant", model="gemini-3.6-flash")     # Your key
+agent = Agent("assistant", model="co/gemini-3.7-flash")  # Managed
+agent = Agent("assistant", model="gemini-3.7-flash")     # Your key
 
 # Fastest Gemini 3 model
 agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
@@ -178,7 +178,8 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | Model | Provider | Key Strengths | Multimodal |
 |-------|----------|---------------|------------|
 | gpt-5 | OpenAI | Best for coding and agentic tasks | ✅ |
-| gemini-3.6-flash | Google | Default model, newest fast Gemini | ✅ |
+| gemini-3.7-flash | Google | Default model, newest fast Gemini | ✅ |
+| gemini-3.6-flash | Google | Previous default, fast Gemini | ✅ |
 | gemini-2.5-pro | Google | Strong multimodal model for agents | ✅ |
 | claude-sonnet-4-5 | Anthropic | Best balance of intelligence and speed | ✅ |
 | mistral-large-latest | Mistral | High performance European model | ✅ |
@@ -194,6 +195,7 @@ agent = Agent("assistant", model="mistral/mistral-medium-latest")
 | gpt-4o | 128K tokens |
 | o4-mini | 128K tokens |
 | **Google** | |
+| gemini-3.7-flash | 1M tokens |
 | gemini-3.6-flash | 1M tokens |
 | gemini-2.5-pro | 1M tokens |
 | gemini-3.5-flash | 1M tokens |
@@ -222,7 +224,8 @@ All prices are **per 1M tokens** and match official provider pricing:
 
 | Model | Input | Output | Notes |
 |-------|-------|--------|-------|
-| gemini-3.6-flash | $1.50 | $7.50 | **Default model** - newest fast Gemini |
+| gemini-3.7-flash | $0.75 | $3.75 | **Default model** - intro pricing through 2026-12-31, then $1.50/$7.50 |
+| gemini-3.6-flash | $1.50 | $7.50 | Previous default, fast Gemini |
 | gemini-3.5-flash | $1.50 | $9.00 | Previous fast Gemini |
 | gemini-3-pro-image-preview | $2.00 | $0.134 | Image generation |
 | gemini-2.5-pro | $1.25 | $10.00 | Strong multimodal model for agents |

--- a/docs/connectonion.md
+++ b/docs/connectonion.md
@@ -298,7 +298,7 @@ class Agent:
         tools: Optional[List[Callable]] = None,
         system_prompt: Union[str, Path, None] = None,
         api_key: Optional[str] = None,
-        model: str = "co/gemini-3.6-flash",
+        model: str = "co/gemini-3.7-flash",
         max_iterations: int = 100
     )
     

--- a/docs/debug/auto_debug.md
+++ b/docs/debug/auto_debug.md
@@ -59,7 +59,7 @@ Type your message to the agent:
 ────────────────────────────────────────────────────
 
 Iteration 1/10
-→ LLM Request (co/gemini-3.6-flash)
+→ LLM Request (co/gemini-3.7-flash)
 ← LLM Response (234ms): 2 tool calls
 
 → Tool: search_emails({"query": "John"})
@@ -324,7 +324,7 @@ Conversation Messages:
 
 Agent State:
   Name: email_assistant
-  Model: co/gemini-3.6-flash
+  Model: co/gemini-3.7-flash
   Iteration: 1/10
   Tools available: [search_emails, send_email]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/debug/console.md
+++ b/docs/debug/console.md
@@ -19,14 +19,14 @@ When you run an agent, you'll see the onion stack banner and execution flow:
  ◎    my-assistant
 ●     ────────────────────
       connectonion v0.5.1
-      co/gemini-3.6-flash · 3 tools
+      co/gemini-3.7-flash · 3 tools
       .co/logs/ · .co/evals/
       ────────────────────
 
 [co] > "Generate a Python function"
 
-[co] ○ gemini-3.6-flash                                    1/100
-[co] ● gemini-3.6-flash · 1 tool · 150 tok · $0.0012       ⚡ 1.2s
+[co] ○ gemini-3.7-flash                                    1/100
+[co] ● gemini-3.7-flash · 1 tool · 150 tok · $0.0012       ⚡ 1.2s
 [co]   ▸ generate_code(language="python")         ✓ 0.12s
 
 [co] ═══════════════════════════════════════════════

--- a/docs/debug/eval-format.md
+++ b/docs/debug/eval-format.md
@@ -22,7 +22,7 @@ name: say_hello_to_alice
 created: '2025-12-25 11:56:26'
 updated: '2025-12-25 11:56:56'
 runs: 2
-model: gemini-3.6-flash
+model: gemini-3.7-flash
 turns:
 - input: Say hello to Alice
   run: 2

--- a/docs/debug/eval.md
+++ b/docs/debug/eval.md
@@ -124,7 +124,7 @@ from connectonion import Agent
 agent = Agent(
     name="my_agent",
     tools=[...],
-    model="co/gemini-3.6-flash"
+    model="co/gemini-3.7-flash"
 )
 
 if __name__ == "__main__":

--- a/docs/debug/log.md
+++ b/docs/debug/log.md
@@ -45,7 +45,7 @@ Session started: 2024-12-02 10:32:14
 ============================================================
 
 [10:32:14] INPUT: Generate a Python function...
-[10:32:14] -> LLM Request (co/gemini-3.6-flash) • 2 msgs • 3 tools
+[10:32:14] -> LLM Request (co/gemini-3.7-flash) • 2 msgs • 3 tools
 [10:32:15] <- LLM Response (1.1s) • 1 tools • 1.2k tokens • $0.0012
 [10:32:15] -> Tool: generate_code({"language": "python"})
 [10:32:15] <- Result (0.05s): def hello(): print("Hi")...
@@ -62,7 +62,7 @@ timestamp: 2024-12-02 10:32:14
 
 turns:
   - input: "Generate a Python function"
-    model: "co/gemini-3.6-flash"
+    model: "co/gemini-3.7-flash"
     duration_ms: 2300
     tokens: 1234
     cost: 0.0012

--- a/docs/features/transcribe.md
+++ b/docs/features/transcribe.md
@@ -97,7 +97,7 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 |-----------|------|---------|-------------|
 | `audio` | str | required | Path to audio file |
 | `prompt` | str | None | Context hints for accuracy |
-| `model` | str | "co/gemini-3.6-flash" | Model to use |
+| `model` | str | "co/gemini-3.7-flash" | Model to use |
 | `timestamps` | bool | False | Include timestamps in output |
 
 ## Supported Formats
@@ -110,12 +110,12 @@ result = agent.input("Transcribe the file meeting.mp3 and summarize it")
 
 ```python
 # OpenOnion managed keys (default - no API key needed)
-transcribe("audio.mp3", model="co/gemini-3.6-flash")
-transcribe("audio.mp3", model="co/gemini-3.6-flash")
+transcribe("audio.mp3", model="co/gemini-3.7-flash")
+transcribe("audio.mp3", model="co/gemini-3.7-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
 transcribe("audio.mp3", model="gemini-3.5-flash")
-transcribe("audio.mp3", model="gemini-3.6-flash")
+transcribe("audio.mp3", model="gemini-3.7-flash")
 ```
 
 ## Error Handling

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -140,8 +140,8 @@ llm_do("Hello", model="co/claude-haiku-4-5")
 ### Google Models
 ```python
 llm_do("Hello", model="co/gemini-2.5-pro")
-llm_do("Hello", model="co/gemini-3.6-flash")
-llm_do("Hello", model="co/gemini-3.6-flash")
+llm_do("Hello", model="co/gemini-3.7-flash")
+llm_do("Hello", model="co/gemini-3.7-flash")
 ```
 
 ## Real-World Examples
@@ -189,7 +189,7 @@ response = agent.input("Help me write a Python function")
 
 ```python
 # Compare responses from different models
-models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-3.6-flash"]
+models = ["co/gpt-4o", "co/claude-sonnet-4-5", "co/gemini-3.7-flash"]
 
 for model in models:
     response = llm_do("What's the meaning of life?", model=model)
@@ -242,7 +242,7 @@ def test_all_models(prompt):
     models = {
         "OpenAI": "co/gpt-4o",
         "Anthropic": "co/claude-sonnet-4-5",
-        "Google": "co/gemini-3.6-flash"
+        "Google": "co/gemini-3.7-flash"
     }
     
     results = {}

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -28,7 +28,7 @@ INFO: Loaded global keys: /Users/you/.co/keys.env
 
 [agent] ─────────────────────────────────────
         translator
-        co/gemini-3.6-flash • 12 tools
+        co/gemini-3.7-flash • 12 tools
 
 [host]  ─────────────────────────────────────
         http://localhost:8000
@@ -439,7 +439,7 @@ curl http://localhost:8000/info
   "name": "translator",
   "address": "0x3d4017c3...",
   "tools": ["translate", "detect_language"],
-  "model": "co/gemini-3.6-flash",
+  "model": "co/gemini-3.7-flash",
   "trust": "careful",
   "version": "0.4.1",
   "accepted_inputs": {

--- a/docs/network/session-websocket-lifecycle.md
+++ b/docs/network/session-websocket-lifecycle.md
@@ -98,7 +98,7 @@ def _record_trace(self, entry: dict):
 {
   type: "llm_call",
   id: "uuid-1",
-  model: "gemini-3.6-flash",
+  model: "gemini-3.7-flash",
   iteration: 1,
   status: "running",
   ts: 1234567890
@@ -119,7 +119,7 @@ def _record_trace(self, entry: dict):
 {
   type: "llm_result",
   id: "uuid-1",
-  model: "gemini-3.6-flash",
+  model: "gemini-3.7-flash",
   duration_ms: 1500,
   tool_calls_count: 1,
   iteration: 1,

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -684,7 +684,7 @@ managed-key agents. Sent once, right after `CONNECTED`.
   "session_id": "550e8400-...",
   "name": "my-agent",
   "address": "0x3d4017c3...",
-  "model": "co/gemini-3.6-flash",
+  "model": "co/gemini-3.7-flash",
   "tools": ["search", "shell"],
   "skills": [
     {"name": "co-browser", "description": "drive a browser", "location": "project"},

--- a/docs/subagent-definition-format.md
+++ b/docs/subagent-definition-format.md
@@ -28,7 +28,7 @@ Each file has:
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob
@@ -166,7 +166,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
         ---
         name: explore
         description: Fast codebase exploration
-        model: co/gemini-3.6-flash
+        model: co/gemini-3.7-flash
         max_iterations: 15
         tools: [glob, grep, read_file]
         plugins: []
@@ -210,7 +210,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
     return SubAgentDefinition(
         name=config.get('name', file_path.stem),
         description=config.get('description', ''),
-        model=config.get('model', 'co/gemini-3.6-flash'),
+        model=config.get('model', 'co/gemini-3.7-flash'),
         max_iterations=config.get('max_iterations', 15),
         tools=config.get('tools', []),
         plugins=config.get('plugins', []),
@@ -376,7 +376,7 @@ __all__ = ["task", "load_subagents", "get_available_agent_types"]
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools: [glob, grep, read_file]
 plugins: []
@@ -396,7 +396,7 @@ You are a read-only exploration agent specialized in quickly understanding codeb
 ---
 name: plan
 description: Design implementation plans and architecture strategies
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 10
 tools: [glob, grep, read_file]
 plugins: []
@@ -416,7 +416,7 @@ You are a planning agent specialized in designing implementation strategies.
 ---
 name: debug
 description: Analyze errors and suggest fixes
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tools: [glob, grep, read_file, bash]
 plugins: []
@@ -471,7 +471,7 @@ How to verify the fix works
 ---
 name: research
 description: Research topics using web search and documentation
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tools: [WebFetch]
 plugins: []
@@ -591,7 +591,7 @@ class SubAgentSchema(BaseModel):
 
     name: str = Field(..., description="Unique agent identifier")
     description: str = Field(..., description="One-line description")
-    model: str = Field(default="co/gemini-3.6-flash", description="LLM model")
+    model: str = Field(default="co/gemini-3.7-flash", description="LLM model")
     max_iterations: int = Field(default=15, ge=1, le=100)
     tools: List[str] = Field(default_factory=list)
     plugins: List[str] = Field(default_factory=list)

--- a/docs/subagent-function-assembly.md
+++ b/docs/subagent-function-assembly.md
@@ -84,7 +84,7 @@ Agent(
     tools=[FileTools(permission="read")],  # ← Class instance
     plugins=[],
     system_prompt="# Explore Agent...",
-    model="co/gemini-3.6-flash",
+    model="co/gemini-3.7-flash",
     max_iterations=15
 )
                 ↓

--- a/docs/subagent-mechanism.md
+++ b/docs/subagent-mechanism.md
@@ -41,13 +41,13 @@
 │  │   "explore": {                                                │  │
 │  │     "description": "Fast codebase exploration",               │  │
 │  │     "tools": [FileTools],  # glob, grep, read_file only      │  │
-│  │     "model": "co/gemini-3.6-flash",  # Fast & cheap          │  │
+│  │     "model": "co/gemini-3.7-flash",  # Fast & cheap          │  │
 │  │     "max_iterations": 15,                                     │  │
 │  │   },                                                          │  │
 │  │   "plan": {                                                   │  │
 │  │     "description": "Design implementation plans",             │  │
 │  │     "tools": [FileTools],  # Read-only                       │  │
-│  │     "model": "co/gemini-3.6-flash",  # Smart                   │  │
+│  │     "model": "co/gemini-3.7-flash",  # Smart                   │  │
 │  │     "max_iterations": 10,                                     │  │
 │  │   },                                                          │  │
 │  │ }                                                             │  │
@@ -84,7 +84,7 @@
 │  │   └────────────────────────────────────────────────────────┘  │  │
 │  │                                                               │  │
 │  │ Tools: [glob, grep, read_file]  # Read-only                  │  │
-│  │ Model: co/gemini-3.6-flash                                    │  │
+│  │ Model: co/gemini-3.7-flash                                    │  │
 │  │ Plugins: []  # None                                           │  │
 │  │ Max Iterations: 15                                            │  │
 │  │ Session: FRESH - no memory of parent conversation            │  │
@@ -297,14 +297,14 @@ Main Agent (co/claude-opus-4-5)
 ├─ Context: 200k tokens
 └─ Use case: Complex reasoning, code generation
 
-Explore Sub-Agent (co/gemini-3.6-flash)
+Explore Sub-Agent (co/gemini-3.7-flash)
 ├─ Input cost: $0.15 / 1M tokens  (100x cheaper!)
 ├─ Output cost: $0.60 / 1M tokens  (125x cheaper!)
 ├─ Speed: ~2000 tokens/sec  (4x faster!)
 ├─ Context: 1M tokens
 └─ Use case: Fast file finding, simple searches
 
-Plan Sub-Agent (co/gemini-3.6-flash)
+Plan Sub-Agent (co/gemini-3.7-flash)
 ├─ Input cost: $2.50 / 1M tokens  (6x cheaper)
 ├─ Output cost: $10 / 1M tokens   (7.5x cheaper)
 ├─ Speed: ~1000 tokens/sec  (2x faster)

--- a/docs/subagent-tool-naming.md
+++ b/docs/subagent-tool-naming.md
@@ -79,7 +79,7 @@ email
 ---
 name: explore
 description: Fast codebase exploration
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - file_read      # ← Clear: only reading files
@@ -91,7 +91,7 @@ tools:
 ---
 name: plan
 description: Design implementation plans
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 10
 tools:
   - file_read      # ← Same: only reading
@@ -103,7 +103,7 @@ tools:
 ---
 name: debug
 description: Analyze errors and suggest fixes
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tools:
   - file_read      # Read files
@@ -129,7 +129,7 @@ tools:
 ---
 name: scraper
 description: Web scraping with browser automation
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 25
 tools:
   - browser        # Navigate, click, screenshot
@@ -143,7 +143,7 @@ tools:
 ---
 name: research
 description: Research topics and save findings
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tools:
   - web            # Fetch documentation
@@ -156,7 +156,7 @@ tools:
 ---
 name: email_assistant
 description: Manage emails and drafts
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - email          # Send, read, organize

--- a/docs/subagent-tool-resolution.md
+++ b/docs/subagent-tool-resolution.md
@@ -164,7 +164,7 @@ agent.tools = {
 ---
 name: browser
 description: Web scraping and browser automation
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tools:
   - browser_navigate
@@ -224,7 +224,7 @@ Instead of listing individual tools, use **tool groups**:
 ---
 name: scraper
 description: Web scraping agent
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 20
 tool_groups:
   - file_read      # FileTools(permission="read")
@@ -329,7 +329,7 @@ def _resolve_tools(tool_names: List[str]) -> List:
 ---
 name: scraper
 description: Web scraping with browser automation and file storage
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 25
 tools:
   - browser        # BrowserAutomation (navigate, click, screenshot)

--- a/docs/tui/status_bar.md
+++ b/docs/tui/status_bar.md
@@ -11,7 +11,7 @@ from rich.console import Console
 console = Console()
 
 status = StatusBar([
-    ("🤖", "co/gemini-3.6-flash", "magenta"),
+    ("🤖", "co/gemini-3.7-flash", "magenta"),
     ("📊", "50%", "green"),
     ("", "main", "blue"),
 ])
@@ -63,5 +63,5 @@ ProgressSegment(
 ## Example Output
 
 ```
-🤖 co/gemini-3.6-flash  📊 50%   main
+🤖 co/gemini-3.7-flash  📊 50%   main
 ```

--- a/docs/useful_plugins/auto_compact.md
+++ b/docs/useful_plugins/auto_compact.md
@@ -14,7 +14,7 @@ agent = Agent("assistant", plugins=[auto_compact])
 ## What it does
 
 When the context window hits 90% full:
-1. Summarizes old messages into a single compact message using `co/gemini-3.6-flash`
+1. Summarizes old messages into a single compact message using `co/gemini-3.7-flash`
 2. Replaces old messages with the summary (keeps system prompt + summary + last 5 messages)
 3. Continues the session without interruption
 
@@ -32,7 +32,7 @@ A long research session that would normally hit token limits:
 from connectonion import Agent
 from connectonion.useful_plugins import auto_compact
 
-agent = Agent("researcher", plugins=[auto_compact], model="co/gemini-3.6-flash")
+agent = Agent("researcher", plugins=[auto_compact], model="co/gemini-3.7-flash")
 
 # Works even on very long sessions
 for topic in topics:

--- a/docs/useful_plugins/subagents.md
+++ b/docs/useful_plugins/subagents.md
@@ -38,7 +38,7 @@ builtin/{name}/AGENT.md         # Built-in agents
 ---
 name: explore
 description: Fast codebase exploration agent
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -226,7 +226,7 @@ from connectonion import Agent
 from connectonion.useful_tools.browser_tools import BrowserAutomation
 
 browser = BrowserAutomation(headless=False)  # Visible for debugging
-agent = Agent("scraper", tools=[browser], model="co/gemini-3.6-flash")
+agent = Agent("scraper", tools=[browser], model="co/gemini-3.7-flash")
 
 agent.input("Go to news.ycombinator.com, get the top 5 story titles")
 agent.input("Navigate to github.com/trending and screenshot the page")

--- a/docs/useful_tools/file_tools.md
+++ b/docs/useful_tools/file_tools.md
@@ -141,7 +141,7 @@ from connectonion.useful_tools import FileTools
 
 agent = Agent(
     "code-reviewer",
-    model="co/gemini-3.6-flash",
+    model="co/gemini-3.7-flash",
     tools=[FileTools()],
     instructions="Review and fix code. Always read files before editing."
 )

--- a/subagents/README.md
+++ b/subagents/README.md
@@ -12,7 +12,7 @@ Create a `.md` file in `subagents/`:
 ---
 name: explore
 description: Fast agent for exploring codebases
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob
@@ -43,7 +43,7 @@ result = task("Find all API endpoints", "explore")
 ---
 name: explore                          # Required: unique identifier
 description: Fast codebase exploration  # Required: one-line description
-model: co/gemini-3.6-flash             # Required: LLM model
+model: co/gemini-3.7-flash             # Required: LLM model
 max_iterations: 15                      # Required: max iteration limit
 tools:                                  # Required: list of tool names
   - glob
@@ -70,7 +70,7 @@ Everything after `---` is the system prompt sent to the agent.
 class SubAgentDefinition:
     name: str               # "explore"
     description: str        # "Fast codebase exploration"
-    model: str             # "co/gemini-3.6-flash"
+    model: str             # "co/gemini-3.7-flash"
     max_iterations: int    # 15
     tools: List[str]       # ["glob", "grep", "read_file"]
     system_prompt: str     # Full markdown body
@@ -126,7 +126,7 @@ Fast, cheap exploration agent using Flash model:
 ```yaml
 ---
 name: explore
-model: co/gemini-3.6-flash  # 100x cheaper than Opus
+model: co/gemini-3.7-flash  # 100x cheaper than Opus
 max_iterations: 15
 tools: [glob, grep, read_file]
 read_only: true
@@ -140,7 +140,7 @@ Smart planning agent using Pro model:
 ```yaml
 ---
 name: plan
-model: co/gemini-3.6-flash    # Smart but still 6x cheaper than Opus
+model: co/gemini-3.7-flash    # Smart but still 6x cheaper than Opus
 max_iterations: 10
 tools: [glob, grep, read_file]
 read_only: true

--- a/subagents/explore.md
+++ b/subagents/explore.md
@@ -1,7 +1,7 @@
 ---
 name: explore
 description: Fast agent for exploring codebases and finding files
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - file_read

--- a/subagents/loader.py
+++ b/subagents/loader.py
@@ -7,7 +7,7 @@ File format:
     ---
     name: explore
     description: Fast codebase exploration
-    model: co/gemini-3.6-flash
+    model: co/gemini-3.7-flash
     max_iterations: 15
     tools:
       - glob
@@ -146,7 +146,7 @@ def parse_subagent_file(file_path: Path) -> Optional[SubAgentDefinition]:
     return SubAgentDefinition(
         name=config.get('name', file_path.stem),
         description=config.get('description', ''),
-        model=config.get('model', 'co/gemini-3.6-flash'),
+        model=config.get('model', 'co/gemini-3.7-flash'),
         max_iterations=config.get('max_iterations', 15),
         tools=config.get('tools', []),
         system_prompt=system_prompt,

--- a/subagents/plan.md
+++ b/subagents/plan.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Design implementation plans and architecture strategies
-model: co/gemini-3.6-flash
+model: co/gemini-3.7-flash
 max_iterations: 10
 tools:
   - file_read

--- a/tests/e2e/cli/test_cli_create.py
+++ b/tests/e2e/cli/test_cli_create.py
@@ -286,7 +286,7 @@ class TestCliCreate:
             assert os.path.exists(env_file)
             with open(env_file) as f:
                 content = f.read()
-                assert "# Default model: co/gemini-3.6-flash" in content
+                assert "# Default model: co/gemini-3.7-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_create_adds_agent_address_explanation_to_global_keys(self):

--- a/tests/e2e/cli/test_cli_init.py
+++ b/tests/e2e/cli/test_cli_init.py
@@ -326,7 +326,7 @@ class TestCliInit:
             assert os.path.exists(".env")
             with open(".env") as f:
                 content = f.read()
-                assert "# Default model: co/gemini-3.6-flash" in content
+                assert "# Default model: co/gemini-3.7-flash" in content
                 assert "managed keys with free credits" in content
 
     def test_init_creates_agent_address_explanation_in_global_keys(self, tmp_path, monkeypatch):

--- a/tests/unit/test_subagents.py
+++ b/tests/unit/test_subagents.py
@@ -62,7 +62,7 @@ class TestSubagentsPlugin:
         # Verify frontmatter
         fm = config['frontmatter']
         assert fm['name'] == 'explore'
-        assert fm['model'] == 'co/gemini-3.6-flash'
+        assert fm['model'] == 'co/gemini-3.7-flash'
         assert fm['max_iterations'] == 15
         assert 'glob' in fm['tools']
         assert 'grep' in fm['tools']
@@ -81,7 +81,7 @@ class TestSubagentsPlugin:
         # Verify frontmatter
         fm = config['frontmatter']
         assert fm['name'] == 'plan'
-        assert fm['model'] == 'co/gemini-3.6-flash'
+        assert fm['model'] == 'co/gemini-3.7-flash'
         assert fm['max_iterations'] == 10
         assert 'glob' in fm['tools']
         assert 'grep' in fm['tools']

--- a/tests/unit/test_the_default_model_is_gemini_3_7.py
+++ b/tests/unit/test_the_default_model_is_gemini_3_7.py
@@ -1,0 +1,64 @@
+"""The product default is Gemini 3.7 everywhere a model can be omitted.
+
+Issue #1002: when the user configures nothing, Agent, llm_do, and `co ai`
+must all pick co/gemini-3.7-flash — the exact ID the managed backend
+registered in oo-api#146. An explicitly chosen model is the user's and
+stays untouched; the previous default remains available as the rollback.
+
+Signature defaults are asserted directly: that is the value that applies
+when the caller omits `model`, checked without a network or a home
+directory in play.
+"""
+
+import inspect
+
+from connectonion import Agent, llm_do
+from connectonion.cli.co_ai.agent import create_agent
+from connectonion.core.usage import FREE_MANAGED_MODELS
+
+DEFAULT = "co/gemini-3.7-flash"
+ROLLBACK = "co/gemini-3.6-flash"
+
+
+def _model_default(fn):
+    return inspect.signature(fn).parameters["model"].default
+
+
+class TestOmittedModelSelectsGemini37:
+
+    def test_agent(self):
+        assert _model_default(Agent.__init__) == DEFAULT
+
+    def test_llm_do(self):
+        assert _model_default(llm_do) == DEFAULT
+
+    def test_co_ai(self):
+        assert _model_default(create_agent) == DEFAULT
+
+    def test_the_three_agree(self):
+        """The defaults drifted apart once; one constant now feeds them all."""
+        assert (
+            _model_default(Agent.__init__)
+            == _model_default(llm_do)
+            == _model_default(create_agent)
+        )
+
+
+class TestAnExplicitModelIsPreserved:
+
+    def test_agent_keeps_what_the_user_chose(self):
+        agent = Agent("t", api_key="fake_key", model="o4-mini")
+        assert agent.llm.model == "o4-mini"
+
+    def test_the_previous_default_is_still_accepted(self):
+        # The managed route strips its co/ prefix; the model itself must
+        # remain the one the user pinned, not the new default.
+        agent = Agent("t", api_key="fake_key", model=ROLLBACK)
+        assert agent.llm.model == ROLLBACK.removeprefix("co/")
+
+
+class TestTheRollbackStaysAdvertised:
+
+    def test_both_ids_are_on_the_free_list(self):
+        assert DEFAULT in FREE_MANAGED_MODELS
+        assert ROLLBACK in FREE_MANAGED_MODELS

--- a/tests/unit/test_the_models_we_advertise_answer.py
+++ b/tests/unit/test_the_models_we_advertise_answer.py
@@ -48,9 +48,11 @@ class TestTheListIsUsable:
         assert all(m.startswith("co/") for m in MANAGED_MODELS)
 
     def test_the_default_model_is_offered(self):
-        # co/gemini-3.6-flash is what a new project is created with, so it has
-        # to be one of the names the same flow tells the user about.
-        assert "co/gemini-3.6-flash" in MANAGED_MODELS
+        # The default is what a new project is created with, so it has to be
+        # one of the names the same flow tells the user about.
+        from connectonion.core.usage import DEFAULT_MODEL
+
+        assert DEFAULT_MODEL in MANAGED_MODELS
 
     def test_there_is_only_one_copy_of_the_list(self):
         """Both call sites must render the tuple, not their own literal."""


### PR DESCRIPTION
Makes `co/gemini-3.7-flash` the default model everywhere a model can be omitted, per #1002. The exact upstream ID `gemini-3.7-flash` (GA, verified live against Google's API) is the one oo-api registers.

**Merge ordering: do NOT merge until openonion/oo-api#146 is deployed to production.** The client default must not ship before the backend accepts the same exact model ID. `co/gemini-3.6-flash` stays priced, routed, and on the free-models list as the rollback — reverting is one constant, no user-config migration.

Explicit user configuration is untouched: only signature/option defaults changed; nothing rewrites a stored `MODEL=` or a pinned `model=` argument, and tests pin that.

## One source of truth

`DEFAULT_MODEL = "co/gemini-3.7-flash"` now lives in `connectonion/core/usage.py` next to the other model-fact tables, and every runtime default imports it. Previously "the default" was answered by independent literals that drifted.

## Default sites changed

Now importing `DEFAULT_MODEL`:
- `connectonion/core/agent.py:70` — `Agent` signature default
- `connectonion/llm_do.py:235` — `llm_do` signature default
- `connectonion/transcribe.py:86` — `transcribe` signature default
- `connectonion/core/llm.py:1056` — `OpenOnionLLM` (managed route)
- `connectonion/cli/main.py:351` — `co ai --model` option default
- `connectonion/cli/co_ai/agent.py:116` — `create_agent` default
- `connectonion/cli/github_action.py:435` — `CO_ACTION_MODEL` fallback

Literals updated (cannot import Python, or are frontmatter/templates):
- `action.yml:11` and `.github/workflows/co-ai-review.yml:13` — GitHub Action `model` input default
- `connectonion/core/llm.py:617` — `GeminiLLM` bring-your-own-Google-key default (`gemini-3.7-flash`, bare ID)
- `connectonion/core/llm.py:1030` — `gemini-3.7-flash` added to the provider routing map (3.6 kept)
- `connectonion/cli/co_ai/agents/registry.py:30,36` — explore/plan subagent models
- `connectonion/useful_plugins/subagents.py:21,166`, `subagents/loader.py:10,149` — subagent frontmatter default
- `connectonion/useful_plugins/builtin_agents/{explore,plan}/AGENT.md` — shipped frontmatter
- `connectonion/useful_plugins/eval.py:65` — `DEFAULT_SCORING_MODEL`
- `connectonion/useful_plugins/re_act.py:137`, `auto_compact.py`, `useful_events_handlers/reflect.py`, `useful_tools/browser_tools/{scroll,element_finder}.py`, `network/trust/trust_agent.py`, `cli/browser_agent/agent.py`, `cli/co_ai/plugins/system_reminder.py`, `cli/co_ai/commands/{compact,export,help}.py`
- `connectonion/cli/commands/{init,create,project_cmd_lib}.py` — scaffolding that writes `MODEL=` into new projects (`co/gemini-3.6-flash` kept in the "Available models" comment as rollback)
- `connectonion/tui/status_bar.py`, `tui/__init__.py` — example renders

Model registration (rollback preserved):
- `connectonion/core/usage.py` — `DEFAULT_MODEL` constant; `gemini-3.7-flash` added to `MODEL_PRICING` (intro rate $0.75/$3.75 per 1M through 2026-12-31, then $1.50/$7.50; cached at the 25% rule, not yet reconciled against real charges), `MODEL_CONTEXT_LIMITS` (1M), and `FREE_MANAGED_MODELS` (3.6 kept)

Deliberately unchanged (feature-specific model choices, not the product default):
- `connectonion/debug/auto_debug_exception.py` (`o4-mini`), `connectonion/debug/debug_explainer/explain_agent.py` (`co/gpt-5`), `connectonion/cli/commands/ai_commands.py` + `cli/co_ai/main.py` ACP path (`co/claude-opus-4-5`)
- `connectonion/core/usage.py` 3.6 pricing rows/comments — measured facts about 3.6, still true

## Docs

Every doc naming the old default as *the* default now says 3.7 (the `cli/co_ai/prompts/connectonion/` tree symlinks into `docs/`, so the co-ai prompt files follow automatically): `docs/README.md`, `api.md`, `best-practices.md`, `connectonion.md`, `co-directory-structure.md`, `cli/README.md`, `cli/ai.md`, `cli/auth.md`, `concepts/{agent,llm_do,models}.md`, `debug/{auto_debug,console,eval,eval-format,log}.md`, `features/transcribe.md`, `integrations/auth.md`, `network/{host,websocket-protocol,session-websocket-lifecycle}.md`, `subagent-*.md`, `tui/status_bar.md`, `useful_plugins/{auto_compact,subagents}.md`, `useful_tools/{browser_tools,file_tools}.md`, plus `README.md`, `AGENTS.md`, `CLAUDE.md`, `subagents/{README,explore,plan}.md`. `docs/concepts/models.md` gains 3.7 rows (flagship/context/pricing tables) with 3.6 kept as "previous default".

Dev-blog post (blog gate): `docs/blog/2026-08-15-one-default-five-answers.md`.

## docs-site (separate repo — NOT touched here)

Pages the maintainer should sync with the same change: models, concepts/agent, concepts/llm_do, cli/ai, cli/auth, api reference, transcribe, debug console/eval, network host + websocket pages, tui status bar, subagents/useful-plugins/useful-tools pages — i.e. the mirror of every docs/ file listed above.

## Red-first evidence

The new test `tests/unit/test_the_default_model_is_gemini_3_7.py` was run on unmodified origin/main (2229df12) first:

```
FAILED ...::TestOmittedModelSelectsGemini37::test_agent - assert 'co/gemini-3.6-flash' == 'co/gemini-3.7-flash'
FAILED ...::TestOmittedModelSelectsGemini37::test_llm_do
FAILED ...::TestOmittedModelSelectsGemini37::test_co_ai
FAILED ...::TestOmittedModelSelectsGemini37::test_the_three_agree
FAILED ...::TestTheRollbackStaysAdvertised::test_both_ids_are_on_the_free_list
5 failed, 2 passed in 12.74s
```

(the 2 passes are the explicit-model-preservation tests, which must hold on both sides). After the change: all pass.

## Test suites

- `python -m pytest tests/unit/ tests/cli/ -q --timeout=300` — 6 failed, 6825 passed, 13 skipped (18m24s). The 6 failures: 2 were stale collection of `test_subagents.py` (assertions updated mid-run; re-run green), the other 4 (`test_email_cli_errors.py` x3, `test_every_release_has_an_entry.py`) reproduce identically on unmodified origin/main (verified in a clean baseline worktree at 2229df12) — pre-existing, unrelated to this change
- `python -m pytest tests/ -q -k "default or model" --timeout=300` — 431 passed, 7119 deselected (1m22s) — fully green after updating the two e2e scaffolding tests that track the default `.env` comment

Closes #1002
