### PR TITLE
Update main's copy of the error-output tests to the exit-1 contract

### DIFF
--- a/tests/unit/test_email_cli_errors.py
+++ b/tests/unit/test_email_cli_errors.py
@@ -3,7 +3,9 @@
 import importlib
 from unittest.mock import MagicMock
 
+import pytest
 import requests
+import typer
 
 from connectonion.cli.commands import email_commands
 
@@ -22,7 +24,8 @@ def test_sent_list_explains_an_old_backend(monkeypatch, capsys):
         get_emails, "get_sent", lambda **kwargs: (_ for _ in ()).throw(_http_error(404))
     )
 
-    email_commands.handle_email_sent(last=0)
+    with pytest.raises(typer.Exit):
+        email_commands.handle_email_sent(last=0)
 
     output = capsys.readouterr().out
     assert "not available on this backend yet" in output
@@ -38,7 +41,8 @@ def test_sent_read_hides_transport_tracebacks(monkeypatch, capsys):
         lambda **kwargs: (_ for _ in ()).throw(requests.ConnectionError("secret host detail")),
     )
 
-    email_commands.handle_email_sent_read("7")
+    with pytest.raises(typer.Exit):
+        email_commands.handle_email_sent_read("7")
 
     output = capsys.readouterr().out
     assert "Could not reach the email service" in output
@@ -55,7 +59,8 @@ def test_send_does_not_call_a_non_retryable_key_safe(monkeypatch, capsys):
         "retryable": False,
     })
 
-    email_commands.handle_email_send("to@example.com", "subject", "body")
+    with pytest.raises(typer.Exit):
+        email_commands.handle_email_send("to@example.com", "subject", "body")
 
     output = capsys.readouterr().out
     assert "provider retry window expired" in output


### PR DESCRIPTION
Three tests in `tests/unit/test_email_cli_errors.py` have been red on `main` since #1016 merged: they pinned the old print-and-return-normally contract, #1016's handlers now also `raise typer.Exit(1)`, and #1016's verification ran `tests/cli/` but missed this file. Found by the #1002 agent's clean-baseline run (a red test on main is exactly what a baseline run exists to surface).

The identical update already shipped on `release/1.6.5` — this applies it where it was forgotten. The printed explanations are still asserted; only the exit expectation changes. 8/8 green locally (`test_email_cli_errors.py` + `test_email_failures_exit_nonzero.py`).

An always-red test on main trains everyone to ignore red — this restores the meaning of the color.