### PR TITLE
cli: co transfer, co email addresses, and tips that survive piping

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -4,11 +4,12 @@ LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
   Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread) → Rich table | handle_email_read() → get_emails() → find by id → print body → mark_read(id)
   State/Effects: no local state | network calls happen inside the engine tools | mark_read() flips server-side read status | writes to stdout via rich.Console
-  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
+  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
 """
 
 import os
+import shlex
 
 import requests
 import typer
@@ -61,14 +62,25 @@ def handle_email_send(
     if result.get("success"):
         console.print(f"\n[green]✓ Sent[/green] to [cyan]{to}[/cyan]")
         console.print(f"  From:       {result.get('from', '')}")
-        console.print(f"  Message ID: {result.get('message_id', '')}\n")
+        console.print(f"  Message ID: {result.get('message_id', '')}")
+        console.print("\n[dim]See it in your sent mail:[/dim] [bold]co email sent[/bold]\n")
     else:
-        console.print(f"\n❌ [bold red]Failed:[/bold red] {result.get('error', 'Unknown error')}")
+        error = result.get("error", "Unknown error")
+        console.print(f"\n❌ [bold red]Failed:[/bold red] {error}")
         if result.get("request_id"):
             console.print(f"  Request ID: {result['request_id']}")
         if result.get("retryable") and result.get("idempotency_key"):
-            console.print(f"  Safe retry key: {result['idempotency_key']}")
-            console.print("  [dim]Retry the same command with --idempotency-key <key>[/dim]")
+            # The full command, restated — "the same command" is not in the
+            # output, so an agent reading only this output could not retry.
+            retry = ["co", "email", "send", shlex.quote(to), shlex.quote(subject), shlex.quote(message)]
+            if from_address:
+                retry += ["--from", shlex.quote(from_address)]
+            retry += ["--idempotency-key", shlex.quote(result["idempotency_key"])]
+            # Plain print, not console.print: Rich wraps at the console width,
+            # and a line-broken command is no longer copy-pasteable.
+            print("  Retry safely with: " + " ".join(retry))
+        if "not one of this account's email addresses" in error:
+            console.print("  See your addresses: [bold]co email addresses[/bold]")
         console.print()
         raise typer.Exit(1)
 
@@ -183,7 +195,7 @@ def handle_email_sent_read(email_id: str):
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
     if not match:
-        console.print(f"\n[yellow]No sent email with id {email_id} in your recent sent mail.[/yellow]\n")
+        console.print(f"\n[yellow]No sent email with id {email_id} in your recent sent mail — run co email sent, then co email sent read <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     header = (
@@ -211,7 +223,7 @@ def handle_email_read(email_id: str):
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
     if not match:
-        console.print(f"\n[yellow]No email with id {email_id} in your recent inbox.[/yellow]\n")
+        console.print(f"\n[yellow]No email with id {email_id} in your recent inbox — run co email inbox, then co email read <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     header = (
@@ -226,6 +238,53 @@ def handle_email_read(email_id: str):
     console.print()
 
     mark_read(str(email_id))
+
+
+def handle_email_addresses():
+    """List every email address this account owns, marking the default sender."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+
+    r = requests.get(
+        f"{backend_url()}/api/v1/email/addresses",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    addresses = r.json().get("addresses", [])
+    if not addresses:
+        console.print("\n[cyan]Addresses:[/cyan] none owned yet")
+        console.print("\n[dim]Get one with:[/dim] [bold]co email name <name>[/bold]\n")
+        return
+
+    if not console.is_terminal:
+        # Scripts and agents get tab-separated rows: address, default flag.
+        # Plain print, not console.print: Rich expands \t into spaces.
+        for a in addresses:
+            print(f"{a['address']}\t{'default' if a.get('is_default') else ''}")
+        print('Send as one with: co email send <to> "<subject>" "<body>" --from <address>')
+        return
+
+    table = Table(title="📧 Your addresses", show_header=True, header_style="bold cyan")
+    table.add_column("Address")
+    table.add_column("Default")
+    table.add_column("Since")
+
+    for a in addresses:
+        table.add_row(
+            str(a["address"]),
+            "[green]✓[/green]" if a.get("is_default") else "",
+            str(a.get("created_at") or "")[:10],
+        )
+
+    console.print()
+    console.print(table)
+    console.print('\n[dim]Send as one with:[/dim] [bold]co email send <to> "<subject>" "<body>" --from <address>[/bold]\n')
 
 
 def handle_email_name(name: str, buy: bool = False):

--- a/connectonion/cli/commands/gdrive_commands.py
+++ b/connectonion/cli/commands/gdrive_commands.py
@@ -92,6 +92,9 @@ def _print_listing(files: list, title: str):
         # silently turns tab-separated output into something cut -f can't read.
         for item in files:
             print(f"{item['name']}\t{item['type']}\t{item['size']}\t{item['id']}")
+        # Same next-step tip as the terminal table: piped callers are exactly
+        # the AI audience the tip exists for.
+        print("Download one with: co gdrive get <#>")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -148,7 +151,7 @@ def handle_gdrive_get(file_id: str, dest: str = "."):
     drive = _gdrive()
     resolved = _resolve_file_id(file_id)
     if not resolved:
-        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive, then co gdrive get <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     console.print(drive.download(resolved, dest=dest).replace("Downloaded to", "\n[green]✓ Downloaded[/green]"))
@@ -174,7 +177,7 @@ def handle_gdrive_rm(file_id: str):
     drive = _gdrive()
     resolved = _resolve_file_id(file_id)
     if not resolved:
-        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No file #{file_id} in your last listing — run co gdrive, then co gdrive rm <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     drive.delete(resolved)

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -74,8 +74,11 @@ def _print_listing(gmail, emails: list, title: str):
     INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}), encoding="utf-8")
 
     if not console.is_terminal:
-        # Scripts and agents get the untruncated format with full message ids.
+        # Scripts and agents get the untruncated format with full message ids —
+        # and the same next-step tip: piped callers are exactly the AI audience
+        # the tip exists for.
         console.print(gmail._format_dicts(emails), markup=False, highlight=False)
+        print("Read one with: co gmail read <#>")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -130,7 +133,7 @@ def handle_gmail_read(email_id: str):
     gmail = _gmail()
     resolved = _resolve_email_id(gmail, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail, then co gmail read <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     body = gmail.get_email_body(resolved)
@@ -161,7 +164,7 @@ def handle_gmail_reply(email_id: str, message: str):
     gmail = _gmail()
     resolved = _resolve_email_id(gmail, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co gmail, then co gmail reply <#> <message>.[/yellow]\n")
         raise typer.Exit(1)
 
     gmail.reply(resolved, message)

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -65,8 +65,11 @@ def _print_listing(outlook, emails: list, title: str):
     INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(emails, 1)}), encoding="utf-8")
 
     if not console.is_terminal:
-        # Scripts and agents get the untruncated format with full message ids.
+        # Scripts and agents get the untruncated format with full message ids —
+        # and the same next-step tip: piped callers are exactly the AI audience
+        # the tip exists for.
         console.print(outlook._format_dicts(emails), markup=False, highlight=False)
+        print("Read one with: co outlook read <#>")
         return
 
     table = Table(title=title, show_header=True, header_style="bold cyan")
@@ -186,7 +189,7 @@ def handle_outlook_read(email_id: str):
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook read <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     body = outlook.get_email_body(resolved)
@@ -214,7 +217,7 @@ def handle_outlook_download(email_id: str, out_dir: str = "."):
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook download <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     saved = outlook.download_attachments(resolved, out_dir)
@@ -237,7 +240,7 @@ def handle_outlook_reply(email_id: str, message: str, at: str = None):
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook reply <#> <message>.[/yellow]\n")
         raise typer.Exit(1)
 
     outlook.reply(resolved, message, send_at=send_at)
@@ -330,10 +333,12 @@ def handle_outlook_scheduled():
     INBOX_CACHE.write_text(json.dumps({str(i): e["id"] for i, e in enumerate(scheduled, 1)}), encoding="utf-8")
 
     if not console.is_terminal:
-        # Scripts and agents get one plain line per email with the full id.
+        # Scripts and agents get one plain line per email with the full id —
+        # and the same next-step tip as the terminal table.
         for email in scheduled:
             console.print(f"{email['send_at']}  {email['to']}  {email['subject']}  {email['id']}",
                           markup=False, highlight=False)
+        print("Cancel one with: co outlook cancel <#>")
         return
 
     table = Table(title="⏰ Outlook — scheduled sends", show_header=True, header_style="bold cyan")
@@ -355,7 +360,7 @@ def handle_outlook_cancel(email_id: str):
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
-        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook scheduled first.[/yellow]\n")
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook scheduled, then co outlook cancel <#>.[/yellow]\n")
         raise typer.Exit(1)
 
     outlook.cancel_scheduled(resolved)

--- a/connectonion/cli/commands/transfer_commands.py
+++ b/connectonion/cli/commands/transfer_commands.py
@@ -1,0 +1,137 @@
+"""
+Purpose: CLI surface for peer-to-peer credit transfers — send credits to another agent address and list transfer history
+LLM-Note:
+  Dependencies: imports from [requests, typer, rich.console, rich.table, ...backend.backend_url, .project_cmd_lib.load_api_key, .email_commands._err/_print_no_auth] | imported by [cli/main.py via handle_transfer_send()/handle_transfer_list()] | backend endpoints [POST/GET /api/v1/transfers, GET /api/v1/tokens/balance]
+  Data flow: handle_transfer_send(address, amount) → print what will happen → typer.confirm unless --yes → POST /api/v1/transfers {to, amount, memo} → print sent amount + remaining balance (GET /api/v1/tokens/balance) + next-step tip | handle_transfer_list() → GET /api/v1/transfers?type=… → table (terminal) or tab-separated rows (piped), tip in both
+  State/Effects: no local state | POST moves real money server-side — guarded by explicit confirmation | declined confirm exits 1 before anything is sent
+  Integration: registered in cli/main.py as `co transfer <address> <amount>` and `co transfer list [--sent|--received]` | requires prior 'co auth'
+  Errors: exit 1 with the server's message on any API failure | exit 1 on declined confirmation | exit 2 on missing/invalid amount | 'run co auth' hint when no API key
+"""
+
+import requests
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from ...backend import backend_url
+from .email_commands import _err, _print_no_auth
+from .project_cmd_lib import load_api_key
+
+console = Console()
+
+
+def _require_token() -> str:
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+    return token
+
+
+def _balance(token: str):
+    """Remaining balance in USD, or None when the balance endpoint is unavailable."""
+    r = requests.get(
+        f"{backend_url()}/api/v1/tokens/balance",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if not r.ok:
+        return None
+    data = r.json()
+    return data.get("credits_usd", 0.0) - data.get("total_spent_usd", 0.0)
+
+
+def handle_transfer_send(address: str, amount: float, memo: str = None, yes: bool = False):
+    """Send credits to another agent address. Irreversible — confirms before posting."""
+    if amount is None:
+        console.print("\n[red]✗ Amount missing.[/red] Usage: [bold]co transfer <address> <amount>[/bold]\n")
+        raise typer.Exit(2)
+    if amount <= 0:
+        console.print("\n[red]✗ Amount must be positive.[/red] Usage: [bold]co transfer <address> <amount>[/bold]\n")
+        raise typer.Exit(2)
+
+    token = _require_token()
+
+    console.print(f"\nTransfer [bold]${amount:.2f}[/bold] of your credits to [cyan]{address}[/cyan].")
+    console.print("[yellow]This cannot be undone.[/yellow]\n")
+    if not yes and not typer.confirm(f"Send ${amount:.2f}?"):
+        console.print("\nCancelled — nothing was sent.\n")
+        raise typer.Exit(1)
+
+    payload = {"to": address, "amount": amount}
+    if memo:
+        payload["memo"] = memo
+    r = requests.post(
+        f"{backend_url()}/api/v1/transfers",
+        json=payload,
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ Transfer failed: {_err(r)}[/red]")
+        console.print("[dim]Check your balance with:[/dim] [bold]co status[/bold]\n")
+        raise typer.Exit(1)
+
+    data = r.json()
+    console.print(f"\n[green]✓ Sent[/green] [bold]${data['amount']:.2f}[/bold] to [cyan]{data['to_address']}[/cyan]  (transfer #{data['id']})")
+    balance = _balance(token)
+    if balance is not None:
+        console.print(f"  Balance: [bold]${balance:.2f}[/bold]")
+    console.print("\n[dim]See it in your history:[/dim] [bold]co transfer list[/bold]\n")
+
+
+def handle_transfer_list(sent: bool = False, received: bool = False, last: int = 50):
+    """List transfers this account sent and/or received."""
+    if sent and received:
+        console.print("\n[red]✗ Choose one of --sent or --received[/red] (neither shows both).\n")
+        raise typer.Exit(2)
+
+    token = _require_token()
+    transfer_type = "sent" if sent else "received" if received else "all"
+    r = requests.get(
+        f"{backend_url()}/api/v1/transfers",
+        params={"type": transfer_type, "limit": last},
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=15,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ Could not load transfers: {_err(r)}[/red]")
+        console.print("[dim]Check your account with:[/dim] [bold]co status[/bold]\n")
+        raise typer.Exit(1)
+
+    transfers = r.json()
+    if not transfers:
+        scope = {"sent": "sent ", "received": "received ", "all": ""}[transfer_type]
+        console.print(f"\n[cyan]Transfers:[/cyan] no {scope}transfers yet")
+        console.print("\n[dim]Send credits with:[/dim] [bold]co transfer <address> <amount>[/bold]\n")
+        return
+
+    if not console.is_terminal:
+        # Scripts and agents get full addresses in tab-separated rows.
+        # Plain print, not console.print: Rich expands \t into spaces.
+        for t in transfers:
+            print(f"{t['id']}\t{t['from_address']}\t{t['to_address']}\t{t['amount']}\t{t.get('memo') or ''}\t{t['created_at']}")
+        print("Send credits with: co transfer <address> <amount>")
+        return
+
+    table = Table(title=f"💸 Transfers — {transfer_type}", show_header=True, header_style="bold cyan")
+    table.add_column("#", justify="right")
+    table.add_column("From", max_width=16, no_wrap=True)
+    table.add_column("To", max_width=16, no_wrap=True)
+    table.add_column("Amount", justify="right")
+    table.add_column("Memo", overflow="ellipsis", no_wrap=True)
+    table.add_column("When")
+
+    for t in transfers:
+        table.add_row(
+            str(t["id"]),
+            str(t["from_address"]),
+            str(t["to_address"]),
+            f"${t['amount']:.2f}",
+            t.get("memo") or "",
+            str(t.get("created_at") or "")[:19],
+        )
+
+    console.print()
+    console.print(table)
+    console.print("\n[dim]Send credits with:[/dim] [bold]co transfer <address> <amount>[/bold]\n")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -157,6 +157,7 @@ def _show_help():
     console.print("  [green]deploy[/green]            Deploy to ConnectOnion Cloud")
     console.print("  [green]auth[/green]              Authenticate for managed keys")
     console.print("  [green]email[/green]             Send and read agent email")
+    console.print("  [green]transfer[/green]          Send credits to another agent address")
     console.print("  [green]gmail[/green]             Send and read Gmail (co auth google)")
     console.print("  [green]telegram[/green]          Send a message from your Telegram bot")
     console.print("  [green]gdrive[/green]            List and transfer Google Drive files (co auth google)")
@@ -760,6 +761,13 @@ def email_sent_read(email_id: str = typer.Argument(..., help="Email # from the s
     handle_email_sent_read(email_id)
 
 
+@email_app.command("addresses")
+def email_addresses():
+    """List every email address this account owns, marking the default sender."""
+    from .commands.email_commands import handle_email_addresses
+    handle_email_addresses()
+
+
 @email_app.command("name")
 def email_name(
     name: str = typer.Argument(..., help="Desired name, e.g. 'aaron' → aaron@openonion.ai"),
@@ -784,6 +792,27 @@ def email_upgrade(
     """Upgrade email tier — deducts the monthly price from your credits."""
     from .commands.email_commands import handle_email_upgrade
     handle_email_upgrade(tier, domain=domain, alias=alias, keep_address=keep_address)
+
+
+# One command, not a group: a group callback with positional arguments would
+# swallow "list" as the address ('co transfer list' parses the group args
+# first), so the listing mode is the literal address "list" instead.
+@app.command("transfer")
+def transfer(
+    address: str = typer.Argument(..., help="Recipient 0x… address, or 'list' for your transfer history"),
+    amount: Optional[float] = typer.Argument(None, help="Amount in USD credits, e.g. 5.00"),
+    memo: Optional[str] = typer.Option(None, "--memo", help="Note stored with the transfer"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Send without the interactive confirmation"),
+    sent: bool = typer.Option(False, "--sent", help="With list: only transfers you sent"),
+    received: bool = typer.Option(False, "--received", help="With list: only transfers you received"),
+    last: int = typer.Option(50, "--last", "-n", help="With list: how many to show"),
+):
+    """Send credits to another agent address (irreversible, confirms first), or list transfers."""
+    from .commands.transfer_commands import handle_transfer_list, handle_transfer_send
+    if address == "list":
+        handle_transfer_list(sent=sent, received=received, last=last)
+    else:
+        handle_transfer_send(address, amount, memo=memo, yes=yes)
 
 
 # Telegram command group. The bot is the user's own (@BotFather), so the token

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -7,10 +7,9 @@ description: Read and send mail from the user's own Gmail or Outlook account, se
 
 The user's own mail and files, from the shell. One authorization, then plain commands.
 
-**Read the output, not just the exit code.** `co gmail`, `co outlook` and `co gdrive`
-exit `1` when they fail — but every `co email` failure prints `❌` and still exits `0`
-(#1012 tracks fixing that). Never use `co email ... && next_step` as your only
-success check.
+**Read the output, not just the exit code.** All four surfaces — `co gmail`,
+`co outlook`, `co email` and `co gdrive` — exit `1` when they fail (#1012 fixed
+the `co email` exception). The output still carries the recovery step; read it.
 
 ## First: which mailbox does the user mean?
 
@@ -121,9 +120,9 @@ co gdrive list -n 100 | cut -f4     # name<TAB>type<TAB>size<TAB>id
 co outlook contact list | cut -f2   # name<TAB>email<TAB>id
 ```
 
-Never parse a truncated table column; take IDs from the piped output. Note the
-piped form drops the "Read one with: co gmail read <#>" tip — the row numbers are
-still what `read` wants.
+Never parse a truncated table column; take IDs from the piped output. The piped
+form keeps the "Read one with: co gmail read <#>" tip (#1011) — the row numbers
+are still what `read` wants.
 
 Two more, for Drive specifically:
 
@@ -141,6 +140,8 @@ co email                       # bare command = inbox
 co email inbox -n 20 -u
 co email read 41               # the id in the # column, not the row position
 co email send bob@example.com "Subject" "Body"
+co email send bob@example.com "Subject" "Body" --from aaron@openonion.ai
+co email addresses             # every address this account owns; default marked
 co email sent -n 20 --to bob@example.com
 co email sent read 12
 ```
@@ -151,32 +152,30 @@ It is a smaller surface than Gmail/Outlook, and the differences bite:
   send a new one with the subject you want.
 - **`read` takes the id printed in the `#` column** (a server id), not "row 3", and
   only finds it among the last 100 received.
-- **Failures exit `0`.** Not authenticated, send rejected, unknown id — all print an
-  error and return success. Read the text.
-- A failed send that is safe to retry prints an idempotency key; retry with
-  `co email send ... --idempotency-key <key>` so a send that actually went out is
-  not duplicated.
+- A failed send that is safe to retry prints the **full retry command**
+  (`co email send ... --idempotency-key <key>`) — run it as printed so a send
+  that actually went out is not duplicated.
 - `co email sent` can answer "Sent mail is not available on this backend yet" —
   that is the deployment, not your command.
 - `-u/--unread` is filtered locally after fetching `-n` emails, so
   `co email inbox -n 10 -u` means "unread among the last 10", not "the last 10 unread".
 
+**Choosing the sender.** The account can own several addresses. `co email addresses`
+lists them (piped: `address<TAB>default`) and marks the default; `--from` on
+`co email send` picks one. Sending as an address the account does not own is a
+guarded failure: the server answers 403, nothing is sent, and the message ends with
+`See your addresses: co email addresses`. An account with no owned addresses gets an
+empty listing (exit `0`) and the pointer `co email name <name>` to claim one.
+
 Account admin: `co email name aaron` checks a custom address (`--buy` claims it,
 from credits) and `co email upgrade plus|pro` raises the quota.
-
-**One sender, today.** The agent sends from the single `AGENT_EMAIL` address set at
-`co auth` time. There is no `--from` / `from_address` flag on any command — the
-multi-address work (oo-api#148/#150, connectonion#1007) is not shipped as of
-v1.6.5. When it lands, this section gains a sender-selection step; until then, "send
-from another address" is not something this CLI can do.
 
 ## Exit codes and what to do about them
 
 | exit | Meaning | What to do |
 |---|---|---|
-| `0`, clean output | success | continue |
-| `0`, `❌` on stdout | a `co email` failure — the only surface that fails with 0 | read the text; it names the cause |
-| `1` | guarded failure: account not connected, scope missing, unknown listing number, attachment missing/too large | the message names the fix (`co auth google`, re-list, correct the path) |
+| `0`, clean output | success — including legitimately empty listings | continue |
+| `1` | guarded failure: account not connected, scope missing, unknown listing number, rejected send, unowned `--from` address, attachment missing/too large | the message names the fix (`co auth google`, `co email addresses`, re-list, correct the path) |
 | `2` | usage error: unknown subcommand, missing or bad argument | fix the syntax; the error names the argument, `--help` lists the rest |
 
 The printed messages carry the current recovery step — trust them over this table.
@@ -203,5 +202,5 @@ it themselves**, do not try to drive that flow.
 - [ ] Exact text shown to the user before any send
 - [ ] Numbers used from the listing printed immediately before the action
 - [ ] IDs taken from piped output, never from a truncated table column
-- [ ] `co email` results judged by their text, not their exit code
+- [ ] `--from` address taken from `co email addresses`, never guessed
 - [ ] Empty search reported as "no match", not as "does not exist"

--- a/docs/blog/2026-08-15-the-cli-is-the-product.md
+++ b/docs/blog/2026-08-15-the-cli-is-the-product.md
@@ -1,0 +1,101 @@
+# The CLI is the product
+
+*2026-08-15 · Design Journal*
+
+For several months, ConnectOnion accounts have been able to send credits to each
+other. `POST /api/v1/transfers` worked in production. `GET /api/v1/transfers`
+returned clean history. Onboard verification was built on top of it. The
+feature was live, tested, and billing real money.
+
+It also, for every user we have, did not exist.
+
+Nothing in `co --help` mentioned transfers. No command called the endpoint. The
+only way to move credits was to hand-sign a request against the API — which is
+to say, the only users of the feature were the people who built it. A working
+backend with no CLI in front of it is not a shipped feature; it is a rehearsal
+for one. The library is the engine, but the skill and the CLI are the
+interface, and users — human or AI — live entirely on the interface side.
+
+This release closes three gaps of exactly that shape. Each one is small. What
+makes them worth a journal entry is that all three were invisible from where we
+usually stand.
+
+## An error that names a problem no command can answer
+
+When multi-address accounts shipped, `co email send --from` gained a guard: try
+to send as an address you don't own and the server answers 403 with
+
+```
+❌ Failed: nobody@mail.openonion.ai is not one of this account's email addresses.
+```
+
+That message is accurate, specific — and a dead end. It names a category
+("this account's email addresses") that no command in existence could list.
+The backend's `list_email_addresses()` was live; the CLI never called it. An
+agent hitting that error had nowhere to go but guessing, and an agent that
+guesses email addresses is an agent you eventually have to apologize for.
+
+The fix is `co email addresses`, and one sentence appended to the 403: `See
+your addresses: co email addresses`. The error is now a fix-it guide. That is
+the whole standard we're trying to hold: every failure message should read as
+the first line of its own recovery procedure.
+
+## Tips that hid from the callers who needed them
+
+Our listing commands end with a next-step tip — `Read one with: co gmail read
+<#>`. The tip lived inside `if console.is_terminal:`, so piped output didn't
+get it. That guard felt reasonable when it was written: pipes are for scripts,
+scripts don't read prose.
+
+Except the callers who pipe are AI agents, and they do read prose — it is the
+only thing they read. A human in a terminal has habits, history, and the
+memory of yesterday's session. A fresh agent has the output in front of it and
+nothing else. We had built discoverability for the audience that needs it
+least and stripped it from the audience that needs it most, and no manual test
+could ever catch it, because a human tester is by definition in a terminal.
+
+## Measuring the tips instead of admiring them
+
+The `cli-skill-design` methodology gives tips an actual test: hand a fresh,
+text-only model one command's output and a goal, and ask for the single next
+shell command. No SKILL.md, no `--help`, no history — those are the crutches
+the tip exists to replace.
+
+The first run across the mail surface scored **5 of 8**. The three failures:
+
+- A piped inbox printed no tip at all, and the model invented `readmail 18f2a`.
+- A failed send said `Retry the same command with --idempotency-key <key>` —
+  but "the same command" is not in the output, so there was nothing to
+  reconstruct the retry from. The model replied `!! --idempotency-key k-123`.
+- The stale-number message said `run co gmail to refresh` and stopped one step
+  short of the goal. The model replied `co gmail && co gmail 3`, the second
+  half of which does not exist.
+
+None of these tips looked wrong in review. All of them read fine to a human,
+because a human silently fills the gap with context the tip was supposed to
+carry. That is precisely why the test uses a model with no context: it can't
+be polite about a missing step.
+
+The fixes are one line each. Tips now survive piping. The retry hint restates
+the entire command, quoted and copy-pasteable. The stale-number message names
+the step after the refresh. On the re-run, all eight tips — plus the new
+transfer and addresses tips — produced a correct next command.
+
+## What this teaches
+
+The three gaps share one anatomy: **the engine was done and the interface was
+not, and from the engine room everything looked finished.** The transfer API
+passed its tests. The ownership 403 was correct. The terminal tips worked for
+everyone who tried them by hand. Every instrument we normally read said green,
+because every instrument we normally read measures the engine.
+
+The interface has its own instruments, and they are unforgiving in a useful
+way: does `--help` name the capability? Does the failure name the next
+command? Does the output, alone, carry a fresh agent to the right next call?
+Those questions have runnable answers, and running them found real defects
+that review had blessed.
+
+So the rule we're keeping: a feature ships when the CLI exposes it, the errors
+route around themselves, and the tips pass the test — not when the endpoint
+returns 200. The skill and CLI are the interface; the library is the engine.
+Nobody buys an engine.

--- a/tests/cli/test_email_addresses.py
+++ b/tests/cli/test_email_addresses.py
@@ -1,0 +1,69 @@
+"""co email addresses: the account can finally see what it owns (#1019).
+
+The ownership 403 on `co email send --from` named a problem no command could
+answer. Now the listing exists, the empty case is not an error, and the 403
+message ends by naming the command that answers it.
+"""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands
+import connectonion.useful_tools.send_email  # noqa: F401 — the real module, past the package re-exports
+
+_send_module = sys.modules["connectonion.useful_tools.send_email"]
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    return r
+
+
+ADDRESSES = {
+    "addresses": [
+        {"id": 1, "address": "0xabc123@mail.openonion.ai", "is_default": True, "created_at": "2026-07-01T00:00:00"},
+        {"id": 2, "address": "aaron@openonion.ai", "is_default": False, "created_at": "2026-08-01T00:00:00"},
+    ]
+}
+
+
+def test_lists_addresses_and_marks_the_default(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(json_data=ADDRESSES)):
+        email_commands.handle_email_addresses()
+    out = capsys.readouterr().out
+    assert "0xabc123@mail.openonion.ai\tdefault" in out
+    assert "aaron@openonion.ai\t" in out
+    assert "co email send" in out and "--from <address>" in out  # next step named
+
+
+def test_no_addresses_is_an_answer_not_an_error(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(json_data={"addresses": []})):
+        email_commands.handle_email_addresses()  # must NOT raise
+    assert "co email name <name>" in capsys.readouterr().out
+
+
+def test_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(ok=False, status=500, json_data={"detail": "boom"})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_addresses()
+    assert exc_info.value.exit_code == 1
+
+
+def test_ownership_403_names_the_addresses_command(capsys):
+    failed = {"success": False, "error": "nobody@mail.openonion.ai is not one of this account's email addresses."}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_send_module, "send_email", return_value=failed):
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_send("a@b.com", "s", "m", from_address="nobody@mail.openonion.ai")
+    assert "See your addresses: co email addresses" in capsys.readouterr().out

--- a/tests/cli/test_tips_survive_piping.py
+++ b/tests/cli/test_tips_survive_piping.py
@@ -1,0 +1,100 @@
+"""The three tip gaps found by the cli-skill-design tip test (#1011).
+
+1. Piped listings printed no tip — the `if console.is_terminal:` guard hid the
+   next step from exactly the AI/script callers who need it.
+2. The idempotency retry hint said "the same command" without restating it, so
+   there was nothing in the output to reconstruct the retry from.
+3. The stale-number message stopped one step short of the goal ("run co gmail
+   to refresh" — then what?).
+
+Under pytest the Rich console is not a terminal, so calling the handlers here
+exercises the piped branch — the branch a human tester never sees.
+"""
+
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands, gdrive_commands, gmail_commands, outlook_commands
+import connectonion.useful_tools.send_email  # noqa: F401 — the real modules, past the package re-exports
+import connectonion.useful_tools.get_emails  # noqa: F401
+
+_send_module = sys.modules["connectonion.useful_tools.send_email"]
+_get_module = sys.modules["connectonion.useful_tools.get_emails"]
+
+EMAILS = [{"id": "18f2a", "from": "a@x.com", "subject": "hi", "date": "Unknown", "unread": False}]
+
+
+def test_gmail_piped_listing_still_names_the_next_step(tmp_path, capsys):
+    gmail = Mock()
+    gmail._format_dicts.return_value = "1. a@x.com  hi  ID: 18f2a"
+    with patch.object(gmail_commands, "INBOX_CACHE", tmp_path / "gmail.json"):
+        gmail_commands._print_listing(gmail, EMAILS, "inbox")
+    assert "Read one with: co gmail read <#>" in capsys.readouterr().out
+
+
+def test_outlook_piped_listing_still_names_the_next_step(tmp_path, capsys):
+    outlook = Mock()
+    outlook._format_dicts.return_value = "1. a@x.com  hi  ID: 18f2a"
+    with patch.object(outlook_commands, "INBOX_CACHE", tmp_path / "outlook.json"):
+        outlook_commands._print_listing(outlook, EMAILS, "inbox")
+    assert "Read one with: co outlook read <#>" in capsys.readouterr().out
+
+
+def test_outlook_piped_scheduled_still_names_the_next_step(tmp_path, capsys):
+    outlook = Mock()
+    outlook.get_scheduled.return_value = [
+        {"id": "s1", "to": "a@x.com", "subject": "hi", "send_at": "2026-08-15T10:00:00Z"},
+    ]
+    with patch.object(outlook_commands, "INBOX_CACHE", tmp_path / "outlook.json"), \
+         patch.object(outlook_commands, "_outlook", return_value=outlook):
+        outlook_commands.handle_outlook_scheduled()
+    assert "Cancel one with: co outlook cancel <#>" in capsys.readouterr().out
+
+
+def test_gdrive_piped_listing_still_names_the_next_step(tmp_path, capsys):
+    files = [{"id": "f1", "name": "report.pdf", "type": "application/pdf", "size": "10", "modified": ""}]
+    with patch.object(gdrive_commands, "LIST_CACHE", tmp_path / "gdrive.json"):
+        gdrive_commands._print_listing(files, "drive")
+    assert "Download one with: co gdrive get <#>" in capsys.readouterr().out
+
+
+def test_retry_hint_restates_the_full_command(capsys):
+    failed = {
+        "success": False, "error": "Request timed out.",
+        "retryable": True, "idempotency_key": "k-123", "request_id": "r-1",
+    }
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_send_module, "send_email", return_value=failed):
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_send("bob@example.com", "Hello", "Body text")
+    out = capsys.readouterr().out
+    # The whole command, not just the flag — the output is all a fresh agent has.
+    assert "co email send bob@example.com Hello 'Body text' --idempotency-key k-123" in out
+
+
+def test_stale_gmail_number_names_the_step_after_the_refresh(capsys):
+    with patch.object(gmail_commands, "_gmail", return_value=Mock()), \
+         patch.object(gmail_commands, "_resolve_email_id", return_value=""):
+        with pytest.raises(typer.Exit):
+            gmail_commands.handle_gmail_read("3")
+    assert "run co gmail, then co gmail read <#>" in capsys.readouterr().out
+
+
+def test_stale_email_id_names_the_step_after_the_refresh(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_get_module, "get_emails", return_value=[]):
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_read("999")
+    out = " ".join(capsys.readouterr().out.split())  # Rich wraps at 80 columns
+    assert "run co email inbox, then co email read <#>" in out
+
+
+def test_send_success_names_the_sent_listing(capsys):
+    ok = {"success": True, "message_id": "m1", "from": "x@mail.openonion.ai"}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_send_module, "send_email", return_value=ok):
+        email_commands.handle_email_send("a@b.com", "s", "m")
+    assert "co email sent" in capsys.readouterr().out

--- a/tests/cli/test_transfer_command.py
+++ b/tests/cli/test_transfer_command.py
@@ -1,0 +1,89 @@
+"""co transfer: sending money is irreversible, so the CLI confirms before posting.
+
+A declined confirmation exits 1 with nothing sent; server failures exit 1 with
+the server's message; success prints the new balance and names the next step
+(`co transfer list`); listings carry their tip even when piped (#1018).
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import transfer_commands
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    return r
+
+
+TRANSFER = {
+    "id": 7,
+    "from_address": "0xaaa",
+    "to_address": "0xbbb",
+    "amount": 5.0,
+    "memo": None,
+    "created_at": "2026-08-15T10:00:00",
+}
+
+
+def test_declined_confirm_exits_1_and_sends_nothing():
+    with patch.object(transfer_commands, "load_api_key", return_value="tok"), \
+         patch.object(transfer_commands.typer, "confirm", return_value=False), \
+         patch.object(transfer_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit) as exc_info:
+            transfer_commands.handle_transfer_send("0xbbb", 5.0)
+    assert exc_info.value.exit_code == 1
+    post.assert_not_called()
+
+
+def test_yes_posts_and_prints_balance_and_tip(capsys):
+    balance = _resp(json_data={"credits_usd": 10.0, "total_spent_usd": 3.0})
+    with patch.object(transfer_commands, "load_api_key", return_value="tok"), \
+         patch.object(transfer_commands.requests, "post", return_value=_resp(json_data=TRANSFER)) as post, \
+         patch.object(transfer_commands.requests, "get", return_value=balance):
+        transfer_commands.handle_transfer_send("0xbbb", 5.0, yes=True)
+    out = capsys.readouterr().out
+    assert post.call_args.kwargs["json"] == {"to": "0xbbb", "amount": 5.0}
+    assert "$7.00" in out                    # 10 credited - 3 spent
+    assert "co transfer list" in out         # next step named
+
+
+def test_server_failure_exits_1_with_server_message(capsys):
+    failed = _resp(ok=False, status=500, json_data={"detail": "Insufficient balance. Have $0.10, need $5.00"})
+    with patch.object(transfer_commands, "load_api_key", return_value="tok"), \
+         patch.object(transfer_commands.requests, "post", return_value=failed):
+        with pytest.raises(typer.Exit) as exc_info:
+            transfer_commands.handle_transfer_send("0xbbb", 5.0, yes=True)
+    assert exc_info.value.exit_code == 1
+    assert "Insufficient balance" in capsys.readouterr().out
+
+
+def test_missing_amount_is_a_usage_error():
+    with pytest.raises(typer.Exit) as exc_info:
+        transfer_commands.handle_transfer_send("0xbbb", None)
+    assert exc_info.value.exit_code == 2
+
+
+def test_list_carries_its_tip_when_piped(capsys):
+    with patch.object(transfer_commands, "load_api_key", return_value="tok"), \
+         patch.object(transfer_commands.requests, "get", return_value=_resp(json_data=[TRANSFER])):
+        transfer_commands.handle_transfer_list()
+    out = capsys.readouterr().out
+    assert "0xbbb" in out
+    assert "co transfer <address> <amount>" in out
+
+
+def test_list_sent_asks_the_server_for_sent(capsys):
+    with patch.object(transfer_commands, "load_api_key", return_value="tok"), \
+         patch.object(transfer_commands.requests, "get", return_value=_resp(json_data=[])) as get:
+        transfer_commands.handle_transfer_list(sent=True)
+    assert get.call_args.kwargs["params"]["type"] == "sent"
+    # Empty history is an answer, not an error — and it still names the next step.
+    assert "co transfer <address> <amount>" in capsys.readouterr().out


### PR DESCRIPTION
Three gaps found by applying the cli-skill-design methodology (#1008) to our own surface.

**`co transfer` (#1018)** — the credit-transfer API has been live in production for months with no CLI: for every user and AI, the feature did not exist. `co transfer <address> <amount>` states what will happen and requires `--yes` or an interactive confirm (a declined confirm exits 1 **before** anything is posted — test pins this); `co transfer list [--sent|--received]` shows history, tab-separated with full addresses when piped. Request/response fields verified against `transfers/routes.py` line by line: `{to, amount, memo}` out, `id/from_address/to_address/amount/memo/created_at` back, `type`+`limit` params, balance from `credits_usd - total_spent_usd`.

**`co email addresses` (#1019)** — the ownership 403 on `send --from` named a problem no command could answer. Now lists every owned address, marks the default, and the 403 ends with `See your addresses: co email addresses`. Empty list is an answer (exit 0) pointing at `co email name`.

**Tips that survive piping (#1011)** — the `is_terminal` guard hid next-step tips from exactly the AI/script callers who need them; gmail/outlook/gdrive listings now tip in both modes, the idempotency hint restates the full retry command, stale-number messages name the refresh step, and a successful send points at `co email sent`.

**Live verification against production** (not mocks): `co email addresses` returned this account's real address with the default marker and tip in piped mode; `co transfer list` returned the two real historical transfers. No real money sent — the send path's live test was confirm-then-decline only.

**Suite**: tests/cli/ + the email error-contract file: 28 passed. Blog-gate story check on the shipped post: STORY.

**Dev Blog (required)**
> docs/blog/2026-08-15-the-cli-is-the-product.md

Supersedes the stale #912 (an earlier `co transfer` attempt predating the methodology and the current backend contract).

Closes #1018
Closes #1019
Closes #1011