### PR TITLE
Sweep user-visible surfaces to gemini-3.7-flash

### DIFF
--- a/.github/scripts/check_blog_story.py
+++ b/.github/scripts/check_blog_story.py
@@ -31,7 +31,7 @@ def main() -> int:
             continue
         verdict = llm_do(
             RUBRIC + "\n---\n" + path.read_text(),
-            model="co/gemini-2.5-flash",
+            model="co/gemini-3.7-flash",
         ).strip()
         print(f"{name}: {verdict}")
         if not verdict.startswith("STORY"):

--- a/connectonion/cli/co_ai/agents/registry.py
+++ b/connectonion/cli/co_ai/agents/registry.py
@@ -10,8 +10,8 @@ Key components:
 
 Architecture:
 - Each sub-agent config includes: description, tools, model, max_iterations
-- "explore": Fast codebase exploration (gemini-2.5-flash, glob/grep/read)
-- "plan": Implementation planning (gemini-2.5-pro, glob/grep/read)
+- "explore": Fast codebase exploration (gemini-3.7-flash, glob/grep/read)
+- "plan": Implementation planning (gemini-3.7-flash, glob/grep/read)
 - System prompts loaded from co_ai/prompts/agents/{type}.md
 - Falls back to description if prompt file not found
 """

--- a/connectonion/cli/co_ai/plugins/system_reminder.py
+++ b/connectonion/cli/co_ai/plugins/system_reminder.py
@@ -12,7 +12,7 @@ Key components:
 
 Architecture:
 - Dual-trigger system: Intent detection on user input + reminder injection after tools
-- Uses llm_do with gemini-2.5-flash for fast intent analysis (structured output)
+- Uses llm_do with gemini-3.7-flash for fast intent analysis (structured output)
 - Stores detected intent in agent.current_session['intent'] as {ack, is_build}
 - Reminder files in prompts/system-reminders/ directory with YAML frontmatter
 - Only injects reminders when intent matches (build tasks) or tool usage matches

--- a/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md
@@ -12,7 +12,7 @@ text = transcribe("meeting.mp3")
 print(text)
 
 # With your own Gemini API key
-text = transcribe("meeting.mp3", model="gemini-3.5-flash")
+text = transcribe("meeting.mp3", model="gemini-3.7-flash")
 ```
 
 That's it! One function for audio-to-text.
@@ -114,8 +114,7 @@ transcribe("audio.mp3", model="co/gemini-3.7-flash")
 transcribe("audio.mp3", model="co/gemini-3.7-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
-transcribe("audio.mp3", model="gemini-3.5-flash")
-transcribe("audio.mp3", model="gemini-2.5-flash")
+transcribe("audio.mp3", model="gemini-3.7-flash")
 ```
 
 ## Error Handling

--- a/connectonion/cli/commands/project_cmd_lib.py
+++ b/connectonion/cli/commands/project_cmd_lib.py
@@ -628,7 +628,7 @@ def configure_env_for_provider(provider: str, api_key: str) -> str:
         },
         'google': {
             'var': 'GEMINI_API_KEY',
-            'model': 'gemini-2.5-flash'
+            'model': 'gemini-3.7-flash'
         },
         'groq': {
             'var': 'GROQ_API_KEY',

--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -523,7 +523,7 @@ class Console:
     def print_llm_request(self, model: str, session: Dict[str, Any], max_iterations: int) -> None:
         """Print LLM request with violet empty circle (AI thinking).
 
-        [co] ○ gemini-2.5-flash                              1/10
+        [co] ○ gemini-3.7-flash                              1/10
 
         Args:
             model: Model name
@@ -545,7 +545,7 @@ class Console:
     def log_llm_response(self, model: str, duration_ms: float, tool_count: int, usage, context_percent: int = None) -> None:
         """Log LLM response with violet filled circle (AI done thinking).
 
-        [co] ● gemini-2.5-flash · 1 tools · 66 tok (42 cached) · $0.00 · 45% ctx   ✓ 1.8s
+        [co] ● gemini-3.7-flash · 1 tools · 66 tok (42 cached) · $0.00 · 45% ctx   ✓ 1.8s
 
         Args:
             model: Model name

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1264,7 +1264,7 @@ def create_llm(model: str, api_key: Optional[str] = None, **kwargs) -> LLM:
     """Factory function to create the appropriate LLM based on model name.
     
     Args:
-        model: The model name (e.g., "o4-mini", "claude-sonnet-4-20250514", "gemini-2.5-pro")
+        model: The model name (e.g., "o4-mini", "claude-sonnet-4-20250514", "gemini-3.7-flash")
         api_key: Optional API key to override environment variable
         **kwargs: Additional arguments to pass to the LLM constructor
     

--- a/connectonion/llm_do.py
+++ b/connectonion/llm_do.py
@@ -91,7 +91,7 @@ All providers from llm.py module:
    - Structured output via forced tool calling
    - Requires max_tokens parameter (default: 8192)
 
-3. **Google Gemini**: gemini-2.5-flash, gemini-2.5-pro
+3. **Google Gemini**: gemini-3.7-flash
    - Structured output via response_schema
    - Good balance of speed and quality
 
@@ -242,7 +242,7 @@ def llm_do(
     Supports multiple LLM providers:
     - OpenAI: "o4-mini", "o3-mini"
     - Anthropic: "claude-sonnet-4-20250514", "claude-opus-4-20250514"
-    - Google: "gemini-2.5-pro", "gemini-2.5-flash"
+    - Google: "gemini-3.7-flash"
     - ConnectOnion Managed: "co/gemini-3.7-flash", "co/gpt-5" (no API keys needed!)
 
     Args:
@@ -268,7 +268,7 @@ def llm_do(
         >>> answer = llm_do("Explain quantum physics", model="claude-sonnet-4-20250514")
 
         >>> # With Gemini
-        >>> answer = llm_do("Write a poem", model="gemini-2.5-flash")
+        >>> answer = llm_do("Write a poem", model="gemini-3.7-flash")
 
         >>> # With structured output
         >>> class Analysis(BaseModel):

--- a/connectonion/useful_plugins/auto_compact.py
+++ b/connectonion/useful_plugins/auto_compact.py
@@ -2,10 +2,10 @@
 Purpose: Automatically compress conversation context when usage >= 90% to prevent overflow
 LLM-Note:
   Dependencies: imports from [typing, core.events, llm_do, pathlib, uuid] | imported by [useful_plugins/__init__.py, cli/co_ai/agent.py] | tested via after_llm event firing
-  Data flow: after_llm event fires → check_and_compact() checks context_percent → if >= 90% and len(messages) >= 8: _do_compact() → llm_do() with gemini-2.5-flash summarizes old messages → replaces old messages with summary → keeps system + summary + last 5 messages → returns "{old_count} → {new_count} messages"
+  Data flow: after_llm event fires → check_and_compact() checks context_percent → if >= 90% and len(messages) >= 8: _do_compact() → llm_do() with gemini-3.7-flash summarizes old messages → replaces old messages with summary → keeps system + summary + last 5 messages → returns "{old_count} → {new_count} messages"
   State/Effects: modifies agent.current_session['messages'] by replacing old messages with LLM-generated summary | sends compact events via agent.io if connected | logs to console via agent.logger | no file I/O except loading summarization.md prompt
   Integration: exposes auto_compact=[check_and_compact] plugin | fires on after_llm event | uses _do_compact(), _format_messages_for_summary() helper functions | COMPACT_THRESHOLD=90 constant | reads cli/co_ai/prompts/summarization.md for instructions
-  Performance: only fires when context >= 90% | minimum 8 messages required | keeps last 5 messages (recent_count) + system + summary | llm_do() call to gemini-2.5-flash (fast/cheap) | summary prompt limited to 800 words
+  Performance: only fires when context >= 90% | minimum 8 messages required | keeps last 5 messages (recent_count) + system + summary | llm_do() call to gemini-3.7-flash (fast/cheap) | summary prompt limited to 800 words
   Errors: catches all exceptions in _do_compact() and sends error event | prints red ✗ on failure | gracefully handles missing summarization.md (empty instructions)
 
 Auto-compact plugin - Automatically compresses context when running low.

--- a/connectonion/useful_skills/cli-skill-design/SKILL.md
+++ b/connectonion/useful_skills/cli-skill-design/SKILL.md
@@ -39,7 +39,7 @@ from connectonion import llm_do
 llm_do(
     f"You just ran a shell command. Its full output was:\n\n{out}\n\n"
     "Your goal: read the newest email. Reply with ONE shell command and nothing else.",
-    model="co/gemini-2.5-flash",
+    model="co/gemini-3.7-flash",
 )
 ```
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -47,10 +47,10 @@ glob, grep, bash, plan mode, a todo list, background tasks, subagents, skills, a
 `ask_user`. Browsing is via bash calling `co browser`. Email is **not** a wired tool
 on this agent — it is a separate CLI path (§3).
 
-**Default model** for `co ai` is `co/gemini-3.6-flash` (`cli/main.py:224`; note
+**Default model** for `co ai` is `co/gemini-3.7-flash` (`cli/main.py:224`; note
 `ai_commands.py:13` carries `co/claude-opus-4-5` as a Python-level default that the
 CLI always overrides — do not quote that one). `Agent()` and the `co create`
-template also default to `co/gemini-3.6-flash` (`core/agent.py:41`).
+template also default to `co/gemini-3.7-flash` (`core/agent.py:41`).
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@ agent = Agent(name="bot", model="co/gemini-3.7-flash")
 
 **Available co/ models:**
 - `co/gpt-4o-mini`, `co/gpt-4o`, `co/gpt-5`, `co/gpt-5-mini`, `co/gpt-5-nano`, `co/o4-mini`
-- `co/gemini-3.7-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- `co/gemini-3.7-flash` (default), `co/gemini-3.6-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - `co/claude-opus-4-5`, `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
 
 **Environment variable:** `OPENONION_API_KEY` (auto-loaded from `.env`)

--- a/docs/blog/2026-08-16-the-long-tail-of-a-default.md
+++ b/docs/blog/2026-08-16-the-long-tail-of-a-default.md
@@ -1,0 +1,60 @@
+# The Long Tail of a Default
+
+We changed the default model three times. The constant, once. The rumor took
+three passes.
+
+Pass one was #1021: `DEFAULT_MODEL = "co/gemini-3.7-flash"`, one constant,
+imported everywhere the code needs an answer to "what model do I use when the
+user says nothing." That PR even told this story — fifty-nine hand-typed
+copies of the old default, collapsed into one name. We shipped it and felt
+done.
+
+Pass two was the stable line. The same change, ported, released. Done again.
+
+Then someone read the docs.
+
+`docs/concepts/models.md` recommended `gemini-2.5-pro` as the flagship — twice
+in a row, on consecutive lines, because at some point a copy-paste stuttered
+and nobody reads a model catalog closely enough to notice. The transcribe
+guide showed `gemini-3.5-flash`. The browser-agent example — the one we point
+new users at — was pinned to `co/gemini-3.5-flash` in its `Agent(...)` call.
+The subagent registry's code said 3.7 while its own docstring, six lines up,
+still said the explore agent runs on 2.5-flash. The docstring wasn't lying
+when it was written. It just never heard the news.
+
+My favorite one: `.github/scripts/check_blog_story.py`. That's the CI gate
+that judges whether a dev-blog post reads like a story — the gate this very
+post has to pass. It calls `llm_do` with an explicit model, because a gate
+should be pinned, not drift with the default. Reasonable. Except the pin was
+`co/gemini-2.5-flash`. For two releases, every post announcing that 3.7 is
+the new default was quality-checked by a 2.5 model. The gatekeeper for the
+news was the last one to receive it.
+
+So pass three was a sweep: grep for every 2.5-, 3.5-, 3.6-era name outside
+the tests, and read each hit. Not replace each hit — read it. Because about
+a third of them turned out to be true.
+
+The pricing table's row for `gemini-2.5-flash` at $0.15/$0.60 is not stale;
+it's what Google charges for a model they still sell. The free-models list
+keeps `co/gemini-3.6-flash` on purpose — it's the rollback if 3.7 misbehaves,
+and a rollback you deleted from the docs is a rollback nobody can find. The
+skill file that says "measured on 8 tips with co/gemini-2.5-flash, 2026-08"
+records a measurement; rewriting the model name would forge the lab notebook.
+And yesterday's blog post about the 3.6-to-3.7 switch has to keep saying 3.6,
+because that's what it was. A sweep that can't tell an example from a fact
+doesn't clean the docs — it launders them.
+
+Here's the lesson I keep relearning. A default is not a constant. The
+constant is the smallest part of it. A default is a rumor: every docstring
+that mentions it, every example that hardcodes it because autocomplete
+offered it, every scaffold comment, every CI script whose author pinned
+"whatever the default was that day." The constant updates atomically. The
+rumor updates the way rumors do — one correction at a time, and only where
+someone bothers to go look.
+
+The fix for the constant was #1021. The fix for the rumor is this PR, three
+hundred-odd mentions later. And the honest ending is that there is no fix,
+only a lower steady state: the next default change will leave a tail too.
+The best we did for future-us is make the tail greppable — old model names
+now appear only where they're facts, so the next sweep can read the diff of
+truth instead of the whole repo.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -177,7 +177,7 @@ response = llm_do("Hello", model="co/gemini-3.7-flash")
 **Available models:**
 - OpenAI: `co/gpt-4o`, `co/gpt-4o-mini`, `co/o4-mini`
 - Anthropic: `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- Google: `co/gemini-3.7-flash` (default), `co/gemini-3.6-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- Google: `co/gemini-3.7-flash` (default), `co/gemini-3.6-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 - And more...
 
 **Benefits:**

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -36,7 +36,7 @@ response = llm_do("Hello", model="co/gpt-4o")
 Works across providers:
 - `co/gpt-4o`, `co/gpt-4o-mini`
 - `co/claude-sonnet-4-5`, `co/claude-haiku-4-5`
-- `co/gemini-3.7-flash` (default), `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
+- `co/gemini-3.7-flash` (default), `co/gemini-3.6-flash`, `co/gemini-3.5-flash`, `co/gemini-2.5-pro`, `co/gemini-2.5-flash`
 
 ## Troubleshooting
 

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -464,8 +464,6 @@ agent = Agent("bot", model="claude-opus-4")
 
 # Google Gemini
 agent = Agent("bot", model="gemini-3.7-flash")
-agent = Agent("bot", model="gemini-3.7-flash")
-agent = Agent("bot", model="gemini-2.5-flash")
 ```
 
 ### Managed Keys (After `co auth`)
@@ -593,7 +591,7 @@ Token usage is automatically shown in console logs after each LLM call:
 Cost tracking works with all supported providers:
 - OpenAI (gpt-4o, gpt-4o-mini, o1, o3-mini, o4-mini)
 - Anthropic Claude (claude-sonnet-4, claude-opus-4, claude-3-5-sonnet, claude-3-5-haiku)
-- Google Gemini (gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash, gemini-2.5-pro, gemini-2.5-pro, gemini-2.5-flash)
+- Google Gemini (gemini-3.7-flash and other gemini-* names)
 
 Models not in the pricing table fall back to default pricing estimates ($1/M input, $3/M output).
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -79,34 +79,17 @@ agent = Agent("assistant", model="o4-mini")         # Your key
 
 #### Gemini 3 (Newest - State-of-the-Art Reasoning)
 ```python
-# Most intelligent model family with state-of-the-art reasoning
-agent = Agent("assistant", model="co/gemini-2.5-pro")  # Managed
-agent = Agent("assistant", model="gemini-2.5-pro")     # Your key
-
-# Newest Flash workhorse - frontier intelligence built for speed
+# Newest Flash workhorse - frontier intelligence built for speed (the default)
 agent = Agent("assistant", model="co/gemini-3.7-flash")  # Managed
 agent = Agent("assistant", model="gemini-3.7-flash")     # Your key
-
-# Fastest Gemini 3 model
-agent = Agent("assistant", model="co/gemini-3.5-flash")  # Managed
-agent = Agent("assistant", model="gemini-3.5-flash")     # Your key
 
 # Image generation model with grounded generation
 agent = Agent("assistant", model="co/gemini-3-pro-image-preview")  # Managed
 agent = Agent("assistant", model="gemini-3-pro-image-preview")     # Your key
 ```
 
-#### Gemini 2.5
+#### Gemini 2.5 (Previous generation)
 ```python
-# Enhanced thinking and reasoning, multimodal understanding, advanced coding
-# Supports: Audio, images, videos, text, and PDF
-agent = Agent("assistant", model="co/gemini-2.5-flash")  # Managed
-agent = Agent("assistant", model="gemini-2.5-flash")     # Your key
-
-# Best price-performance ratio
-agent = Agent("assistant", model="co/gemini-2.5-flash")  # Managed
-agent = Agent("assistant", model="gemini-2.5-flash")     # Your key
-
 # Ultra fast, cheapest Gemini option
 agent = Agent("assistant", model="co/gemini-2.5-flash-lite")  # Managed
 agent = Agent("assistant", model="gemini-2.5-flash-lite")     # Your key
@@ -252,12 +235,12 @@ All prices are **per 1M tokens** and match official provider pricing:
 ```python
 # Typical conversation (~1000 input, ~500 output tokens)
 # gpt-5:           $0.00125 + $0.005 = $0.00625 (~$6.25 per 1000 requests)
-# gemini-2.5-flash: $0.00015 + $0.0003 = $0.00045 (~$0.45 per 1000 requests)
+# gemini-3.7-flash: $0.00075 + $0.001875 = $0.002625 (~$2.63 per 1000 requests)
 # claude-sonnet-4-5: $0.003 + $0.0075 = $0.0105 (~$10.50 per 1000 requests)
 
 # With 100K free tokens, you can make approximately:
 # - 66 requests with gpt-5 (1500 tokens each)
-# - 66 requests with gemini-2.5-pro
+# - 66 requests with gemini-3.7-flash
 # - 66 requests with claude-sonnet-4-5
 ```
 
@@ -283,7 +266,7 @@ class Result(BaseModel):
 
 # Works with all OpenAI and Gemini models
 result = llm_do("What is 2+2?", output=Result, model="co/gpt-4o-mini")
-result = llm_do("What is 2+2?", output=Result, model="co/gemini-2.5-flash")
+result = llm_do("What is 2+2?", output=Result, model="co/gemini-3.7-flash")
 
 # Works with Claude 4.5/4.1 models only
 result = llm_do("What is 2+2?", output=Result, model="co/claude-sonnet-4-5")  # ✅
@@ -308,7 +291,7 @@ def calculate(expression: str) -> float:
 tools = [search, calculate]
 
 agent_openai = Agent("assistant", model="gpt-5", tools=tools)
-agent_google = Agent("assistant", model="gemini-2.5-pro", tools=tools)
+agent_google = Agent("assistant", model="gemini-3.7-flash", tools=tools)
 agent_claude = Agent("assistant", model="claude-sonnet-4-5", tools=tools)
 ```
 
@@ -328,7 +311,7 @@ from connectonion import Agent
 
 # Use any model with co/ prefix
 agent = Agent("assistant", model="co/gpt-5")
-agent = Agent("assistant", model="co/gemini-2.5-pro")
+agent = Agent("assistant", model="co/gemini-3.7-flash")
 agent = Agent("assistant", model="co/claude-sonnet-4-5")
 ```
 
@@ -384,7 +367,7 @@ from connectonion import Agent
 
 # Use models without co/ prefix
 agent = Agent("assistant", model="gpt-5")
-agent = Agent("assistant", model="gemini-2.5-pro")
+agent = Agent("assistant", model="gemini-3.7-flash")
 agent = Agent("assistant", model="claude-opus-4.1")
 agent = Agent("assistant", model="groq/llama-3.3-70b-versatile")
 agent = Agent("assistant", model="openrouter/openai/gpt-4o-mini")
@@ -426,7 +409,7 @@ agent = Agent("assistant", model="mistral/mistral-large-latest")
 ```python
 # Top tier models from each provider
 agent = Agent("assistant", model="gpt-5")             # OpenAI flagship
-agent = Agent("assistant", model="gemini-2.5-pro")    # Google flagship
+agent = Agent("assistant", model="gemini-3.7-flash")  # Google flagship
 agent = Agent("assistant", model="claude-sonnet-4-5") # Anthropic flagship
 ```
 
@@ -443,7 +426,7 @@ agent = Agent("coder", model="claude-sonnet-4-5")
 ```python
 # Fastest options from each provider
 agent = Agent("quick", model="gpt-5-nano")       # OpenAI fastest
-agent = Agent("quick", model="gemini-2.5-flash") # Google fast
+agent = Agent("quick", model="gemini-3.7-flash") # Google fast
 agent = Agent("quick", model="claude-haiku-4-5") # Anthropic fast
 ```
 
@@ -457,14 +440,13 @@ agent = Agent("budget", model="gemini-2.5-flash-lite") # Google cheapest
 **Long Context (>200K tokens)**
 ```python
 # Models with longest context windows
-agent = Agent("reader", model="gemini-2.5-pro")        # 1M tokens
-agent = Agent("reader", model="gemini-2.5-pro")  # 1M tokens
+agent = Agent("reader", model="gemini-3.7-flash")      # 1M tokens
 ```
 
 **Multimodal (Images, Audio, Video)**
 ```python
-# Gemini 2.5 Pro supports the most modalities
-agent = Agent("multimodal", model="gemini-2.5-pro")  # Audio, video, images, PDF
+# Gemini Flash models are fully multimodal
+agent = Agent("multimodal", model="gemini-3.7-flash")  # Audio, video, images, PDF
 
 # Alternatives
 agent = Agent("multimodal", model="gpt-5")           # Images, text
@@ -480,12 +462,12 @@ from connectonion import Agent
 
 # With managed keys (easiest)
 agent_openai = Agent("assistant", model="co/gpt-5")
-agent_google = Agent("assistant", model="co/gemini-2.5-pro")
+agent_google = Agent("assistant", model="co/gemini-3.7-flash")
 agent_claude = Agent("assistant", model="co/claude-opus-4.1")
 
 # OR with your own API keys
 agent_openai = Agent("assistant", model="gpt-5")
-agent_google = Agent("assistant", model="gemini-2.5-pro")
+agent_google = Agent("assistant", model="gemini-3.7-flash")
 agent_claude = Agent("assistant", model="claude-opus-4.1")
 
 # Same interface for all
@@ -498,7 +480,7 @@ response = agent_claude.input("Explain quantum computing")
 
 ```python
 # Compare responses from top models (using managed keys)
-models = ["co/gpt-5", "co/gemini-2.5-pro", "co/claude-sonnet-4-5"]
+models = ["co/gpt-5", "co/gemini-3.7-flash", "co/claude-sonnet-4-5"]
 prompt = "Write a Python implementation of binary search"
 
 for model in models:
@@ -518,16 +500,16 @@ def select_model(task_type: str, speed_priority: bool = False) -> str:
         return {
             "code": "gpt-5-mini",
             "chat": "gpt-5-nano",
-            "analysis": "gemini-2.5-flash",
+            "analysis": "gemini-3.7-flash",
             "creative": "claude-haiku-4-5"
         }.get(task_type, "gpt-5-nano")
     else:
         # Best quality models
         return {
             "code": "gpt-5",
-            "reasoning": "gemini-2.5-pro",
+            "reasoning": "gemini-3.7-flash",
             "analysis": "claude-opus-4.1",
-            "multimodal": "gemini-2.5-pro"
+            "multimodal": "gemini-3.7-flash"
         }.get(task_type, "gpt-5")
 
 # Use appropriate model
@@ -547,7 +529,7 @@ def create_agent_with_fallback(name: str):
     model_chain = [
         "gpt-5",              # Best overall
         "claude-sonnet-4-5",  # Strong alternative
-        "gemini-2.5-pro",     # Multimodal option
+        "gemini-3.7-flash",   # Multimodal option
         "gpt-5-mini",         # Faster fallback
         "gpt-4o"              # Legacy fallback
     ]
@@ -635,7 +617,7 @@ def create_robust_agent(name: str, model: str, max_retries: int = 3):
                 # Try alternative model
                 alternatives = {
                     "gpt-5": "gpt-5-mini",
-                    "gemini-2.5-pro": "gemini-2.5-flash",
+                    "gemini-3.7-flash": "gemini-2.5-flash",
                     "claude-sonnet-4-5": "claude-sonnet-4"
                 }
                 alt_model = alternatives.get(model)
@@ -670,7 +652,7 @@ agent = Agent("assistant", model="gpt-4o-mini")
 ```python
 # Any provider, any model
 agent = Agent("assistant", model="gpt-5")
-agent = Agent("assistant", model="gemini-2.5-pro")
+agent = Agent("assistant", model="gemini-3.7-flash")
 agent = Agent("assistant", model="claude-sonnet-4-5")
 ```
 

--- a/docs/design-decisions/017-session-logging-and-eval-format.md
+++ b/docs/design-decisions/017-session-logging-and-eval-format.md
@@ -23,7 +23,7 @@ timestamp: 2024-11-27 11:39:58
 
 turns:
   - input: "check my emails"
-    model: "gemini-2.5-pro"
+    model: "gemini-3.7-flash"
     duration_ms: 11200
     tokens: 1234
     cost: 0.01
@@ -35,7 +35,7 @@ turns:
       expect_result: "shows email list"
 
   - input: "reply to first saying thanks"
-    model: "gemini-2.5-pro"
+    model: "gemini-3.7-flash"
     duration_ms: 8500
     tokens: 2345
     cost: 0.02

--- a/docs/design-decisions/019-agent-lifecycle-design.md
+++ b/docs/design-decisions/019-agent-lifecycle-design.md
@@ -494,7 +494,7 @@ def reflect(agent):
 
     reflection = llm_do(
         f"What did we learn from: {last_tools}? One sentence.",
-        model="co/gemini-2.5-flash"
+        model="co/gemini-3.7-flash"
     )
 
     agent.current_session['messages'].append({

--- a/docs/design-decisions/023-expose-decorator.md
+++ b/docs/design-decisions/023-expose-decorator.md
@@ -113,7 +113,7 @@ room = connect("0xGameRoom")
 player = Agent(
     "poker-player",
     tools=[room.tools],        # exposed functions become remote tools
-    model="co/gemini-2.5-pro"
+    model="co/gemini-3.7-flash"
 )
 player.input("It's your turn. Check the game state and make a bid.")
 # → LLM sees get_state, make_bid as available tools

--- a/docs/design-decisions/024-subagent-system-design.md
+++ b/docs/design-decisions/024-subagent-system-design.md
@@ -59,7 +59,7 @@ def create_explore_agent():
         system_prompt="""
         You are an exploration agent...
         """,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.7-flash",
         max_iterations=15,
     )
 ```
@@ -84,7 +84,7 @@ def create_explore_agent():
 {
   "name": "explore",
   "description": "Fast codebase exploration",
-  "model": "co/gemini-2.5-flash",
+  "model": "co/gemini-3.7-flash",
   "max_iterations": 15,
   "tools": ["glob", "grep", "read_file"],
   "system_prompt_file": "prompts/explore.txt"
@@ -110,7 +110,7 @@ def create_explore_agent():
 [explore]
 name = "explore"
 description = "Fast codebase exploration"
-model = "co/gemini-2.5-flash"
+model = "co/gemini-3.7-flash"
 max_iterations = 15
 tools = ["glob", "grep", "read_file"]
 
@@ -139,7 +139,7 @@ You are an exploration agent...
 ---
 name: explore
 description: Fast agent for exploring codebases
-model: co/gemini-2.5-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools:
   - glob
@@ -212,7 +212,7 @@ class SubAgentDefinition:
     """Sub-agent configuration and prompt."""
     name: str               # Unique identifier
     description: str        # One-line description
-    model: str             # LLM model (e.g., "co/gemini-2.5-flash")
+    model: str             # LLM model (e.g., "co/gemini-3.7-flash")
     max_iterations: int    # Max iteration limit
     tools: List[str]       # Tool names ["glob", "grep", "read_file"]
     system_prompt: str     # Full markdown body
@@ -393,7 +393,7 @@ Easy to add new fields without breaking changes:
 ```yaml
 # Current
 name: explore
-model: co/gemini-2.5-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 tools: [glob, grep, read_file]
 
@@ -418,7 +418,7 @@ Easy to test in isolation:
 def test_parse_explore_definition():
     definition = parse_subagent_file("subagents/explore.md")
     assert definition.name == "explore"
-    assert definition.model == "co/gemini-2.5-flash"
+    assert definition.model == "co/gemini-3.7-flash"
     assert "glob" in definition.tools
 
 # Integration test
@@ -443,7 +443,7 @@ Before (Python):
 ```python
 # subagents/explore.py
 EXPLORE_CONFIG = {
-    "model": "co/gemini-2.5-flash",
+    "model": "co/gemini-3.7-flash",
     "max_iterations": 15,
 }
 EXPLORE_PROMPT = "You are an explorer..."
@@ -453,7 +453,7 @@ After (Markdown):
 ```markdown
 ---
 name: explore
-model: co/gemini-2.5-flash
+model: co/gemini-3.7-flash
 max_iterations: 15
 ---
 

--- a/docs/features/transcribe.md
+++ b/docs/features/transcribe.md
@@ -12,7 +12,7 @@ text = transcribe("meeting.mp3")
 print(text)
 
 # With your own Gemini API key
-text = transcribe("meeting.mp3", model="gemini-3.5-flash")
+text = transcribe("meeting.mp3", model="gemini-3.7-flash")
 ```
 
 That's it! One function for audio-to-text.
@@ -114,7 +114,6 @@ transcribe("audio.mp3", model="co/gemini-3.7-flash")
 transcribe("audio.mp3", model="co/gemini-3.7-flash")
 
 # Your own Gemini API key (set GEMINI_API_KEY)
-transcribe("audio.mp3", model="gemini-3.5-flash")
 transcribe("audio.mp3", model="gemini-3.7-flash")
 ```
 

--- a/docs/integrations/auth.md
+++ b/docs/integrations/auth.md
@@ -139,8 +139,6 @@ llm_do("Hello", model="co/claude-haiku-4-5")
 
 ### Google Models
 ```python
-llm_do("Hello", model="co/gemini-2.5-pro")
-llm_do("Hello", model="co/gemini-3.7-flash")
 llm_do("Hello", model="co/gemini-3.7-flash")
 ```
 

--- a/examples/browser-agent/CLAUDE.md
+++ b/examples/browser-agent/CLAUDE.md
@@ -18,7 +18,7 @@ This is a **natural language browser automation agent** built with ConnectOnion 
 
 2. **Agent Layer** (`agent.py`):
    - ConnectOnion Agent orchestrates tool calls
-   - Natural language understanding via LLM (gemini-2.5-flash by default)
+   - Natural language understanding via LLM (gemini-3.7-flash by default)
    - System prompt defines agent personality (`prompt.md`)
    - Interactive CLI and automated task modes
 
@@ -170,7 +170,7 @@ From global CLAUDE.md: Try-except is sometimes over-engineering. Only catch exce
 
 ### Model Selection
 
-- Default: `gemini-2.5-flash` (fast, cost-effective)
+- Default: `gemini-3.7-flash` (fast, cost-effective)
 - For complex HTML analysis: `co/gpt-4o` (higher accuracy)
 - For testing: `co/o4-mini` (cheapest option)
 - All models use ConnectOnion managed keys (`co/` prefix)

--- a/examples/browser-agent/agent.py
+++ b/examples/browser-agent/agent.py
@@ -2,7 +2,7 @@
 Purpose: Main entry point for natural language browser automation agent
 LLM-Note:
   Dependencies: imports from [pathlib, dotenv, connectonion.Agent, web_automation.WebAutomation] | imported by [README.md examples] | tested by [tests/test_all.py]
-  Data flow: receives natural language command string from __main__ → agent.input() routes to LLM (gemini-2.5-flash) → LLM calls web.* tools → returns execution result string
+  Data flow: receives natural language command string from __main__ → agent.input() routes to LLM (gemini-3.7-flash) → LLM calls web.* tools → returns execution result string
   State/Effects: creates global web=WebAutomation() instance | loads .env with OPENONION_API_KEY | reads prompt.md system instructions | web tools mutate browser state (open/navigate/click/close)
   Integration: exposes agent.input(str) → str API | uses ConnectOnion Agent with tools=web (all WebAutomation methods become callable tools) | max_iterations=20 for complex multi-step workflows
   Performance: agent orchestrates sequential tool calls based on LLM decisions | browser operations are synchronous (blocking) | screenshot I/O writes to screenshots/ folder
@@ -27,7 +27,7 @@ web = WebAutomation(use_chrome_profile=True)
 # ui_stream sends real-time activity events to connected UI clients via WebSocket
 agent = Agent(
     name="browser_agent",
-    model="co/gemini-3.5-flash",
+    model="co/gemini-3.7-flash",
     system_prompt=Path(__file__).parent / "prompts" / "agent.md",
     tools=web,
     plugins=[image_result_formatter, ui_stream],  # Vision + real-time streaming

--- a/examples/browser-agent/web_automation.py
+++ b/examples/browser-agent/web_automation.py
@@ -561,7 +561,7 @@ def analyze_page(html_content: str, question: str) -> str:
     """Ask a question about page content using AI."""
     return llm_do(
         f"Based on this HTML content, {question}\n\n {html_content}",
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.7-flash",
         temperature=0.3
     )
 
@@ -584,7 +584,7 @@ def smart_fill_form(fields: List[FormField], user_info: str) -> Dict[str, str]:
     result = llm_do(
         prompt,
         output=FormData,
-        model="co/gemini-2.5-flash",
+        model="co/gemini-3.7-flash",
         temperature=0.7
     )
 


### PR DESCRIPTION
Finishes the model sweep that #1021 started. #1021 changed the *defaults*; this pass updates every user-visible surface — docs, examples, prompts, scaffolding comments, help text — to `co/gemini-3.7-flash` (bare `gemini-3.7-flash` where the `co/` prefix isn't used), and keeps old model names only where they state facts.

## Files changed

**Code / prompts / scripts**
- `.github/scripts/check_blog_story.py` — the blog-quality gate itself was judging posts with `co/gemini-2.5-flash`; now 3.7
- `connectonion/console.py`, `llm_do.py`, `core/llm.py` (docstring example) — example strings and model lists
- `connectonion/useful_plugins/auto_compact.py`, `cli/co_ai/plugins/system_reminder.py`, `cli/co_ai/agents/registry.py` — header comments that still described the code as running 2.5 models (the code already ran 3.7)
- `connectonion/cli/co_ai/prompts/connectonion/concepts/transcribe.md`, `cli/commands/project_cmd_lib.py` (google `.env` template model), `useful_skills/cli-skill-design/SKILL.md` (test snippet)
- `examples/browser-agent/agent.py` (was pinned to `co/gemini-3.5-flash`), `web_automation.py`, `CLAUDE.md`

**Docs**
- `docs/api.md`, `docs/cli/README.md`, `docs/cli/auth.md` — managed-model lists normalized to the exact `FREE_MANAGED_MODELS` tuple (see exceptions)
- `docs/PRODUCT.md` — stated 3.6 as the *current* default; corrected
- `docs/features/transcribe.md`, `docs/integrations/auth.md`, `docs/concepts/agent.md`, `docs/concepts/models.md` — examples to 3.7, duplicated lines collapsed, mislabeled sections fixed (2.5-pro was listed under "Gemini 3"), cost-estimation math recomputed for 3.7 ($0.75/$3.75)
- `docs/design-decisions/017`, `019`, `023`, `024` — copy-pasteable example configs updated; no historical claims were altered

**Blog (merge gate)**
- `docs/blog/2026-08-16-the-long-tail-of-a-default.md` — the three-pass story of changing "the default"

## Kept exceptions (final residual grep, non-test files)

`grep -rn "gemini-2\.5\|gemini-3\.5\|gemini-3\.6\|gemini-3-flash" --include='*.py' --include='*.md' --include='*.yml' . | grep -v tests` leaves exactly these, each intentional:

| Location | Why kept |
|---|---|
| `connectonion/core/usage.py:86-145` (MODEL_PRICING / MODEL_CONTEXT_LIMITS rows incl. `gemini-3-flash-preview`) | price/limit facts for real, still-offered models |
| `connectonion/core/usage.py:172-175` (FREE_MANAGED_MODELS) | 3.6 is the designated rollback (#1002); the rest are still callable on free accounts |
| `connectonion/core/usage.py:188, 200, 215-216, 264` | docstrings recording real pricing bugs and real model names (`-lite`, `-preview-05-06`, `-preview-tts`) the parsing rules exist for |
| `connectonion/core/llm.py:1031-1035` (MODEL_REGISTRY) | routing facts — these models still answer |
| `connectonion/useful_plugins/eval.py:72` | record of bug #543; the literal model name is the evidence |
| `connectonion/cli/commands/project_cmd_lib.py:663` | scaffold comment mirroring FREE_MANAGED_MODELS (availability fact) |
| `connectonion/useful_skills/cli-skill-design/SKILL.md:81` | measured result ("8 tips, co/gemini-2.5-flash, 2026-08") — rewriting it would falsify the measurement |
| `docs/api.md:268`, `docs/cli/README.md:180`, `docs/cli/auth.md:39` | docs mirror of FREE_MANAGED_MODELS, normalized to the exact five-model tuple |
| `docs/blog/2026-08-15-one-default-five-answers.md:13,26,87` | historical record of the 3.6→3.7 switch and the rollback |
| `docs/concepts/models.md:94-95,437` (`gemini-2.5-flash-lite`) | it is factually the cheapest Google option per the pricing table |
| `docs/concepts/models.md:165-166,182-185,211-216` | availability/context/pricing tables (rows explicitly labeled "Previous default" / "Previous fast Gemini") |
| `docs/concepts/models.md:620` (`"gemini-3.7-flash": "gemini-2.5-flash"`) | fallback-map example needs a genuinely cheaper target; 2.5-flash is it |

## Verification

- `python -m pytest tests/unit/ tests/cli/ -q --timeout=300`: **6853 passed, 13 skipped, 15 deselected, 1 failed** — the one failure is `tests/unit/test_every_release_has_an_entry.py::test_every_released_tag_is_documented` ("released with no entry in VERSIONING.md: ['1.6.5', '1.6.6']"), pre-existing on `main` and untouched by this PR (it reads git tags and VERSIONING.md, neither changed here). Left alone per the never-loosen rule.
- `python3 .github/scripts/check_blog_story.py` run with its bumped model on both the 08-15 post and the new post: both return `STORY:` — the gate still works after its own model change.

Blog post: `docs/blog/2026-08-16-the-long-tail-of-a-default.md`
