### PR TITLE
test_cli_ai pins DEFAULT_MODEL, not a model string

### DIFF
--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -6,6 +6,7 @@ from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from connectonion.cli.main import app
+from connectonion.core.usage import DEFAULT_MODEL
 
 runner = CliRunner()
 
@@ -21,7 +22,7 @@ def test_ai_forwards_yolo_options():
     handler.assert_called_once_with(
         prompt="task",
         port=8000,
-        model="co/gemini-3.6-flash",
+        model=DEFAULT_MODEL,
         max_iterations=100,
         yolo=True,
         yolo_turns=4,
@@ -44,7 +45,7 @@ def test_ai_forwards_json_and_resume_options():
     handler.assert_called_once_with(
         prompt="task",
         port=8000,
-        model="co/gemini-3.6-flash",
+        model=DEFAULT_MODEL,
         max_iterations=100,
         yolo=False,
         yolo_turns=100,
@@ -64,7 +65,7 @@ def test_ai_forwards_acp_mode():
     handler.assert_called_once_with(
         prompt=None,
         port=8000,
-        model="co/gemini-3.6-flash",
+        model=DEFAULT_MODEL,
         max_iterations=100,
         yolo=False,
         yolo_turns=100,


### PR DESCRIPTION
Main's Tests workflow went red after #1025: three `co ai` forwarding tests asserted the forwarded kwargs against the literal `co/gemini-3.6-flash` and the default is now 3.7. e2e isn't in the per-PR test selection that was run before merging, which is how it slipped.

Fix asserts `model=DEFAULT_MODEL` — the test's real claim is "the CLI forwards the default", not "the default is 3.6" — so the next default change cannot rot it. 9/9 green locally.

Bookkeeping-scale test fix — requesting `no-blog`.