### PR TITLE
fix: allow safe command output redirects

### DIFF
--- a/connectonion/useful_plugins/prefer_write_tool.py
+++ b/connectonion/useful_plugins/prefer_write_tool.py
@@ -14,7 +14,9 @@ AI models often use bash commands for file operations:
 - Creating: `cat <<EOF > file.py`, `echo > file.py` → BLOCKED
 - Reading: `cat file.txt`, `head file.txt`, `tail file.txt` → SOFT REMINDER
 
-File creation is blocked because it bypasses tool UI/diffs/approval flow.
+Explicit shell authoring is blocked because it bypasses tool UI/diffs/approval
+flow. Output redirects, append-only logs, and `tee` are allowed because the
+shell command is not authoring the redirected content.
 File reading is allowed but a system reminder suggests using read_file tool instead.
 
 Usage:
@@ -33,15 +35,12 @@ if TYPE_CHECKING:
     from ..core.agent import Agent
 
 
-# Patterns that indicate bash is being used to create/write files (hard blocked)
+# Patterns that indicate bash is explicitly authoring file content (hard blocked)
 FILE_CREATION_PATTERNS = [
     re.compile(r"cat\s+<<"),              # cat <<EOF, cat <<'EOF', cat << 'EOF'
     re.compile(r">\s*\S+\.\w+\s*<<"),     # > file.py <<EOF
     re.compile(r"echo\s+.*[^2]>\s*\S+"),  # echo "..." > file (but not 2>)
     re.compile(r"printf\s+.*[^2]>\s*\S+"),# printf "..." > file (but not 2>)
-    re.compile(r"tee\s+\S+"),             # tee file.py
-    re.compile(r"(?<!\d)>\s*[~\.]"),      # > ./file, > ~/file (not 2>/dev/null)
-    re.compile(r"(?<!\d)>>\s*[~\.]"),     # >> ./file, >> ~/file
 ]
 
 # Patterns that indicate bash is being used to read files (standalone, not in pipelines)

--- a/docs/blog/2026-08-15-redirects-are-not-authoring.md
+++ b/docs/blog/2026-08-15-redirects-are-not-authoring.md
@@ -1,0 +1,19 @@
+# Redirects are not authoring
+
+An agent running a five-step pipeline spent all 100 iterations on each step and
+still wrote zero bytes. The commands were not trying to author source files:
+one appended a JSONL record, another redirected browser output, and a third used
+`tee` to keep a log. The `prefer_write_tool` plugin treated all three spellings
+as file creation, then told the agent to use `Write`, which cannot append safely
+to a shared log without first reading and rewriting it.
+
+The guard now keeps its narrow job: it blocks commands that visibly manufacture
+content with `cat <<EOF`, `echo >`, or `printf >`. It allows append redirects,
+`tee`, and redirects whose content comes from another command. That distinction
+preserves the reviewable path for source authoring while leaving operational
+state and command output to the shell tools that produce them.
+
+The regression tests exercise both sides of the boundary. In particular, an
+`echo` redirect remains blocked, while a browser-output redirect, an append, and
+a `tee` pipeline are allowed. The change does not inspect the destination path:
+the important signal is whether the command itself is generating the content.

--- a/tests/unit/test_prefer_write_tool.py
+++ b/tests/unit/test_prefer_write_tool.py
@@ -28,14 +28,13 @@ class TestFileCreationDetection:
     def test_printf_redirect(self):
         assert _is_file_creation_command("printf 'test' > file.txt")
 
-    def test_tee(self):
-        assert _is_file_creation_command("echo hello | tee file.txt")
-        assert _is_file_creation_command("ls -la | tee output.txt")
+    def test_command_output_redirects_are_allowed(self):
+        """Redirecting another command's output is not file authoring."""
+        assert not _is_file_creation_command("co browser get_text > ~/out.txt")
+        assert not _is_file_creation_command("co browser get_text >> ~/.co/ledger.jsonl")
 
-    def test_path_redirect(self):
-        assert _is_file_creation_command("echo test > ./file.txt")
-        assert _is_file_creation_command("echo test > ~/notes.txt")
-        assert _is_file_creation_command("echo test >> ./log.txt")
+    def test_tee_is_allowed_for_logging(self):
+        assert not _is_file_creation_command("co run task | tee run.log")
 
     def test_not_stderr_redirect(self):
         """2>/dev/null should NOT be flagged as file creation."""


### PR DESCRIPTION
## Description
Fixes #1028.

The `prefer_write_tool` plugin currently blocks append redirects, `tee`, and ordinary command stdout redirects as if the model were authoring file contents. This causes agents to retry harmless logging/state commands until the iteration budget is exhausted.

This change keeps explicit `cat <<EOF`, `echo >`, and `printf >` authoring blocked, while allowing append redirects, `tee`, and redirects from other commands. It also adds regression coverage and the required design journal.

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5 via Codex.

The least confident part is the intentionally narrow command classification: it distinguishes explicit content-producing commands from command-output redirects, but does not attempt shell parsing. I did not run the full suite or Windows CLI integration paths; the full repository fixture setup is blocked in this environment by an incompatible `acp` module and a permission error in the default temporary directory. If the classification is wrong, a shell command that explicitly authors content without `echo`, `printf`, or heredoc could bypass this guard.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Dev Blog

Blog file in this PR:

> docs/blog/2026-08-15-redirects-are-not-authoring.md

## Changes Made

- Remove broad `tee` and path-based redirect patterns from file-creation detection.
- Add tests proving append redirects, command output redirects, and `tee` logging are allowed.
- Add the required design journal post.

## Testing

```text
$ $env:PYTHONUTF8='1'; $env:TEMP='D:\project\tscodex\connectonion-pr\.tmp'; $env:TMP=$env:TEMP; python -m pytest -o addopts='' --confcutdir=tests/unit tests/unit/test_prefer_write_tool.py -q
30 passed, 1 warning in 0.71s

$ git diff --check
passed

$ python -m compileall -q connectonion/useful_plugins/prefer_write_tool.py
passed
```

- [x] I have added tests for the changed behavior

## Scope

Only `connectonion/useful_plugins/prefer_write_tool.py`, its focused unit test, and the required `docs/blog/` post are changed.

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding documentation changes
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

This is intentionally scoped to the false-positive guard described in #1028; it does not redesign shell command parsing or add path-specific policy.