### PR TITLE
fix: allow append and command-output redirects

### DIFF
--- a/connectonion/useful_plugins/prefer_write_tool.py
+++ b/connectonion/useful_plugins/prefer_write_tool.py
@@ -37,11 +37,8 @@ if TYPE_CHECKING:
 FILE_CREATION_PATTERNS = [
     re.compile(r"cat\s+<<"),              # cat <<EOF, cat <<'EOF', cat << 'EOF'
     re.compile(r">\s*\S+\.\w+\s*<<"),     # > file.py <<EOF
-    re.compile(r"echo\s+.*[^2]>\s*\S+"),  # echo "..." > file (but not 2>)
-    re.compile(r"printf\s+.*[^2]>\s*\S+"),# printf "..." > file (but not 2>)
-    re.compile(r"tee\s+\S+"),             # tee file.py
-    re.compile(r"(?<!\d)>\s*[~\.]"),      # > ./file, > ~/file (not 2>/dev/null)
-    re.compile(r"(?<!\d)>>\s*[~\.]"),     # >> ./file, >> ~/file
+    re.compile(r"echo\s+.*(?<![2>])>(?!>)\s*\S+"),   # echo "..." > file (but not 2> or >>)
+    re.compile(r"printf\s+.*(?<![2>])>(?!>)\s*\S+"), # printf "..." > file (but not 2> or >>)
 ]
 
 # Patterns that indicate bash is being used to read files (standalone, not in pipelines)

--- a/docs/blog/2026-08-15-when-logging-looked-like-authoring.md
+++ b/docs/blog/2026-08-15-when-logging-looked-like-authoring.md
@@ -1,0 +1,9 @@
+# When logging looked like authoring
+
+The failure was easy to miss because nothing crashed. An agent tried to append a JSONL record with `>>`, then tried `tee`, then tried another shell spelling. The write policy rejected every spelling, the step kept retrying, and the pipeline eventually exited successfully with an empty ledger.
+
+The rule had been written for a useful distinction: model-authored source should go through the Write or Edit tools so a reviewer can see a diff. But append-only state and command output are different operations. Replacing an entire ledger is not equivalent to appending one row, especially when two workers may write at the same time. Likewise, redirecting a subprocess's stdout is logging, not the model authoring a file.
+
+The fix narrows the block to the dangerous case: `echo` and `printf` with a single overwrite redirect, plus heredocs. Append redirects, `tee`, and ordinary command-output redirects are now allowed. The regression tests make the boundary explicit, including `>>` next to the existing `2>` stderr exemption.
+
+The practical lesson is that a safety rule needs to distinguish the effect it is protecting against, not just the shell punctuation used to spell it. A blocked operation without a viable alternative is not a guardrail; it is a retry loop with a bill attached.

--- a/tests/unit/test_prefer_write_tool.py
+++ b/tests/unit/test_prefer_write_tool.py
@@ -23,19 +23,24 @@ class TestFileCreationDetection:
 
     def test_echo_redirect(self):
         assert _is_file_creation_command("echo hello > file.txt")
-        assert _is_file_creation_command("echo hello >> file.txt")
+
+    def test_append_redirect_is_allowed(self):
+        assert not _is_file_creation_command("echo hello >> file.txt")
 
     def test_printf_redirect(self):
         assert _is_file_creation_command("printf 'test' > file.txt")
 
     def test_tee(self):
-        assert _is_file_creation_command("echo hello | tee file.txt")
-        assert _is_file_creation_command("ls -la | tee output.txt")
+        assert not _is_file_creation_command("echo hello | tee file.txt")
+        assert not _is_file_creation_command("ls -la | tee output.txt")
+
+    def test_command_output_redirect_is_allowed(self):
+        assert not _is_file_creation_command("co browser get_text > ~/.co/out.txt")
 
     def test_path_redirect(self):
         assert _is_file_creation_command("echo test > ./file.txt")
         assert _is_file_creation_command("echo test > ~/notes.txt")
-        assert _is_file_creation_command("echo test >> ./log.txt")
+        assert not _is_file_creation_command("echo test >> ./log.txt")
 
     def test_not_stderr_redirect(self):
         """2>/dev/null should NOT be flagged as file creation."""


### PR DESCRIPTION
## Description
Allow append redirects, `tee`, and ordinary command-output redirects in `prefer_write_tool` while continuing to block model-authored overwrite redirects and heredocs.

## Related Issue
Fixes #1028

## How this was written
- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5 via Codex.

The least confident area is shell syntax outside the covered patterns; this change intentionally keeps the existing heuristic rather than introducing a shell parser. I did not run the full suite because this Windows environment has unrelated dependency/configuration issues. If the rule is still too broad, the first breakage would be a legitimate command-output or append operation being blocked again.

## Type of Change
- [x] Bug fix (non-breaking change which fixes the issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Dev Blog
`docs/blog/2026-08-15-when-logging-looked-like-authoring.md`

## Changes Made
- Restrict hard blocking to heredocs and single `echo`/`printf` overwrite redirects.
- Allow `>>`, `tee`, and command stdout redirects.
- Add regression coverage for append, logging, output redirection, and stderr redirect boundaries.
- Add the required design-journal post.

## Testing

`PYTHONUTF8=1 python -m pytest -o addopts='' --basetemp=.pytest-tmp tests/unit/test_prefer_write_tool.py -q`

Result: `32 passed, 1 warning`.

The warning is the local pytest 7.4.4 environment reporting the repository's `asyncio_default_fixture_loop_scope` option as unknown. The default configured command initially could not collect because the environment lacked `textual`; after installing project dependencies, the focused suite ran successfully. The full suite was not run.

## Scope
Only the plugin, its focused unit tests, and the required dev-blog are touched.

## Checklist
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] This PR ships its dev-blog under `docs/blog/`
- [x] My changes generate no new test failures
- [ ] Full test suite run (not run; see Testing)

## Additional Notes
Commit: `dd57b31a`