### PR TITLE
Fix Gemini 3.7 cache pricing and expose cache usage

### DIFF
--- a/connectonion/cli/co_ai/commands/cost.py
+++ b/connectonion/cli/co_ai/commands/cost.py
@@ -99,7 +99,10 @@ def cmd_cost(args: str = "") -> str:
         # they are. billed_tokens, not the sum of the two rows above it: the cost
         # comes from the server and covers reasoning tokens those fields never
         # name, so the sum would be 29x off the cost in the same table.
-        table.add_row("Last Call", f"{last_usage.input_tokens:,} in · "
+        cached = last_usage.cached_tokens
+        uncached = max(0, last_usage.input_tokens - cached)
+        table.add_row("Last Call", f"{uncached:,} new · "
+                                   f"{cached:,} cached · "
                                    f"{last_usage.output_tokens:,} out · "
                                    f"{last_usage.billed_tokens:,} billed")
 

--- a/connectonion/console.py
+++ b/connectonion/console.py
@@ -565,8 +565,8 @@ class Console:
         total_tokens = usage.billed_tokens
         tokens_str = f"{total_tokens/1000:.1f}k tok" if total_tokens >= 1000 else f"{total_tokens} tok"
         cached = getattr(usage, 'cached_tokens', 0)
-        if cached:
-            tokens_str = f"{tokens_str} ({cached} cached)"
+        uncached = max(0, usage.input_tokens - cached)
+        tokens_str = f"{tokens_str} ({uncached} new · {cached} cached)"
 
         # Format cost. A `~` when the model is not in the pricing table, because
         # the figure is then a generic fallback rather than a looked-up price —

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -92,11 +92,9 @@ MODEL_PRICING = {
     # Standard paid tier, per million tokens: input $1.50, output $7.50,
     # context-cached input $0.15 (Google pricing page, checked 2026-08-08).
     "gemini-3.6-flash": {"input": 1.50, "output": 7.50, "cached": 0.15},
-    # 3.7 Flash: introductory rate published by Google through 2026-12-31
-    # (standard pricing from 2027-01-01 is input $1.50 / output $7.50). Cached
-    # follows the common 25% rule; not yet reconciled against real backend
-    # charges.
-    "gemini-3.7-flash": {"input": 0.75, "output": 3.75, "cached": 0.1875},
+    # 3.7 Flash introductory rates through 2026-12-31: input $0.75, output
+    # $3.75, cached input $0.075 per million. Standard rates double in 2027.
+    "gemini-3.7-flash": {"input": 0.75, "output": 3.75, "cached": 0.075},
     "gemini-3.5-flash": {"input": 1.50, "output": 9.00, "cached": 0.375},
     # Solved from real charges, two calls: (in=4, total=28, $0.000074) and
     # (in=2006, total=2101, $0.001288) give input 0.50 / output 3.00 and both

--- a/connectonion/tui/chat.py
+++ b/connectonion/tui/chat.py
@@ -56,6 +56,8 @@ class ChatStatusBar(Static):
 
     status = reactive("Ready")
     tokens = reactive(0)
+    cached_tokens = reactive(0)
+    uncached_input_tokens = reactive(0)
     cost = reactive(0.0)
 
     def __init__(
@@ -101,6 +103,11 @@ class ChatStatusBar(Static):
             right.append(self.model, style="dim")
         if self.tokens > 0:
             right.append(f"  {self.tokens:,} tok", style="dim")
+            right.append(
+                f" ({self.uncached_input_tokens:,} new · "
+                f"{self.cached_tokens:,} cached)",
+                style="dim",
+            )
         if self.cost > 0:
             right.append(f"  ${self.cost:.4f}", style="dim")
 
@@ -476,7 +483,15 @@ class Chat(App):
                     # and the sum of these two fields does not account for that
                     # cost on a reasoning model (see TokenUsage.billed_tokens).
                     total_tokens = agent.last_usage.billed_tokens
-                    chat.call_from_thread(chat._update_tokens, total_tokens, agent.total_cost)
+                    cached = agent.last_usage.cached_tokens
+                    uncached = max(0, agent.last_usage.input_tokens - cached)
+                    chat.call_from_thread(
+                        chat._update_tokens,
+                        total_tokens,
+                        agent.total_cost,
+                        uncached,
+                        cached,
+                    )
 
             @on_complete
             def _on_done(agent):
@@ -545,10 +560,18 @@ class Chat(App):
         status_bar = self.query_one(ChatStatusBar)
         status_bar.status = status
 
-    def _update_tokens(self, tokens: int, cost: float) -> None:
+    def _update_tokens(
+        self,
+        tokens: int,
+        cost: float,
+        uncached_input_tokens: int = 0,
+        cached_tokens: int = 0,
+    ) -> None:
         """Update status bar token/cost display (called from worker thread)."""
         status_bar = self.query_one(ChatStatusBar)
         status_bar.tokens = tokens
+        status_bar.uncached_input_tokens = uncached_input_tokens
+        status_bar.cached_tokens = cached_tokens
         status_bar.cost = cost
 
     def _set_input_enabled(self, enabled: bool) -> None:

--- a/docs/blog/2026-08-15-the-cache-was-invisible.md
+++ b/docs/blog/2026-08-15-the-cache-was-invisible.md
@@ -1,0 +1,52 @@
+# The cache was invisible
+
+*2026-08-15*
+
+The model provider said a request had reused thousands of tokens. Our bill and
+our terminal said nothing about it.
+
+That disagreement made every repeated agent turn look more expensive than it
+really was. It also made the cache impossible to reason about: a developer
+could send the same large prefix twice, see no cached-token count, and conclude
+that the provider had missed the cache entirely. In reality, the provider had
+reported the hit. We had flattened the response into input and output totals
+before the useful detail reached the user.
+
+## A total is not an explanation
+
+`prompt_tokens` includes both newly processed input and cached input. Treating
+the whole number as fresh input is therefore wrong twice: it overcharges the
+cached portion, and it hides the evidence needed to verify the charge.
+
+The useful accounting identity is small:
+
+```text
+new input = prompt tokens - cached tokens
+cost = new input × input rate
+     + cached input × cached rate
+     + output × output rate
+```
+
+The fix keeps those quantities intact across the managed proxy, Python usage
+object, console output, `/cost`, and the chat status line. A turn can now say
+how many tokens were new, how many were cached, how many came back as output,
+and what was finally charged. Zero is also reported explicitly; absence no
+longer masquerades as a cache miss.
+
+## Cache hits are observations, not promises
+
+Implicit provider caching is opportunistic. Similar prompts sent close
+together are good candidates, but an application cannot honestly promise that
+every turn will hit. Our tests therefore check the contract we control: when a
+provider reports cached tokens, the same number survives every layer and uses
+the cached rate. They do not invent a hit when the provider reports none.
+
+We exercised that path with a repeated Gemini prompt large enough to qualify
+for implicit caching. The warm response reported cached tokens through the
+OpenAI-compatible API, which ruled out the tempting but unnecessary solution
+of replacing the whole transport. The bug was local accounting, not missing
+provider capability.
+
+The lesson is broader than one model or one price. Usage metadata is part of
+the product contract. If an optimization changes what a request costs, users
+must be able to see both the optimization and the resulting charge.

--- a/tests/unit/test_the_cached_rate_follows_its_stated_rule.py
+++ b/tests/unit/test_the_cached_rate_follows_its_stated_rule.py
@@ -8,7 +8,7 @@ from connectonion.core.usage import MODEL_PRICING
 GOOGLE_ROWS = {name: row for name, row in MODEL_PRICING.items()
                if name.startswith("gemini")}
 
-PUBLISHED_EXCEPTIONS = {"gemini-3.6-flash"}
+PUBLISHED_EXCEPTIONS = {"gemini-3.6-flash", "gemini-3.7-flash"}
 
 
 class TestTheCommonGoogleRowsUseTheSeventyFivePercentDiscount:
@@ -36,6 +36,10 @@ class TestTheProviderPublishedException:
         row = MODEL_PRICING["gemini-3.6-flash"]
         assert row["cached"] == pytest.approx(row["input"] * 0.10)
         assert row["cached"] == 0.15
+
+    def test_gemini_3_7_flash_is_ten_percent_of_promotional_input(self):
+        row = MODEL_PRICING["gemini-3.7-flash"]
+        assert row == {"input": 0.75, "output": 3.75, "cached": 0.075}
 
 
 class TestTheConfirmedRatesStay:

--- a/tests/unit/test_the_managed_route_reports_what_it_charged.py
+++ b/tests/unit/test_the_managed_route_reports_what_it_charged.py
@@ -34,9 +34,10 @@ import pytest
 from connectonion.core.llm import OpenOnionLLM
 
 
-def _response(cost_usd=None, prompt=3, completion=9, total=114):
+def _response(cost_usd=None, prompt=3, completion=9, total=114, cached=0):
     usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion,
-                            total_tokens=total, prompt_tokens_details=None)
+                            total_tokens=total,
+                            prompt_tokens_details=SimpleNamespace(cached_tokens=cached))
     if cost_usd is not None:
         usage.cost_usd = cost_usd
     message = SimpleNamespace(content="hi", tool_calls=None)
@@ -82,6 +83,15 @@ class TestTheServersFigureWins:
 
         assert result.usage.input_tokens == 3
         assert result.usage.output_tokens == 9
+
+    def test_cached_prompt_tokens_reach_the_trace_contract(self, llm):
+        result = _complete(
+            llm,
+            _response(cost_usd=0.000837, prompt=100, cached=80),
+        )
+
+        assert result.usage.input_tokens == 100
+        assert result.usage.cached_tokens == 80
 
 
 class TestWithoutOneNothingChanges:


### PR DESCRIPTION
Companion to openonion/oo-api#162.

## What changed
- fixes Gemini 3.7 cached-input price from $0.1875 to the published $0.075 per 1M
- shows new, cached, output, billed tokens, and final cost in co ai surfaces
- verifies managed co/ responses propagate cached tokens into traces and ACP usage

## Verification
- 74 focused cache/usage/console tests passed
- broader unit run reached 2,224 passed; six unrelated Unix-socket/browser-daemon tests were blocked by sandbox bind permissions