### PR TITLE
Honor caller timeouts for long-running shell commands

### DIFF
--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -5,8 +5,8 @@ LLM-Note:
   Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() with shell=True → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
   Integration: exposes bash(command, description="", cwd, timeout) function | used as agent tool | description is OPTIONAL (defaults "") — an LLM is prompted to fill it for the approval UI, but direct/programmatic callers (remote.call, co call, scripts) can pass command alone | not passed to shell | Unix/Mac only (raises ValueError on Windows)
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
-  Errors: raises ValueError on Windows | returns formatted error on timeout | non-zero exit codes included in output | stderr merged with stdout
+  Performance: timeout default 120s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
+  Errors: raises ValueError on Windows | raises subprocess.TimeoutExpired on timeout | non-zero exit codes included in output | stderr merged with stdout
 
 Bash tool for executing terminal commands (Unix/Mac only).
 
@@ -23,8 +23,8 @@ Usage:
 Note: This tool is for Unix/Mac systems. For cross-platform usage, use Shell class instead.
 """
 
-import subprocess
 import platform
+import subprocess
 
 
 def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120) -> str:
@@ -36,7 +36,7 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             — an LLM should fill it in so the approval UI can show intent, but direct
             callers (scripts, remote.call, co call) may pass just the command.
         cwd: Working directory (default: current directory)
-        timeout: Seconds before timeout (default: 120, max: 600)
+        timeout: Seconds before timeout (default: 120)
 
     Returns:
         Command output (stdout + stderr)
@@ -44,9 +44,6 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
     # Check platform
     if platform.system() == "Windows":
         return "Error: bash tool is for Unix/Mac only. Use Shell class for Windows."
-
-    # Cap timeout at 10 minutes
-    timeout = min(timeout, 600)
 
     try:
         result = subprocess.run(
@@ -60,8 +57,6 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             cwd=cwd,
             timeout=timeout
         )
-    except subprocess.TimeoutExpired:
-        return f"Error: Command timed out after {timeout} seconds"
     except FileNotFoundError:
         return "Error: /bin/bash not found. This tool requires bash shell."
 

--- a/connectonion/useful_tools/shell.py
+++ b/connectonion/useful_tools/shell.py
@@ -5,8 +5,8 @@ LLM-Note:
   Data flow: Shell() creates instance → .run(command, timeout) or .run_in_dir(command, directory, timeout) → subprocess.run(shell=True) in cwd → captures stdout+stderr → _format_output() truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | stores default cwd in self.cwd | no file persistence | side effects depend on executed commands (file I/O, network calls, etc.)
   Integration: exposes Shell class with .run(command, timeout), .run_in_dir(command, directory, timeout) | used as agent tool | class methods extracted to tools via extract_methods_from_instance() | instance accessible via agent.tools.shell
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
-  Errors: returns "Error: Command timed out" on TimeoutExpired | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
+  Performance: timeout default 120s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
+  Errors: raises subprocess.TimeoutExpired on timeout | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
 
 Shell tool for executing terminal commands (cross-platform).
 
@@ -55,27 +55,22 @@ class Shell:
 
         Args:
             command: Shell command to execute (e.g., "ls -la", "git status")
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120)
 
         Returns:
             Command output (stdout + stderr)
         """
-        timeout = min(timeout, 600)
-
-        try:
-            result = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=self.cwd,
-                timeout=timeout,
-                env=_utf8_env(),
-            )
-        except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=self.cwd,
+            timeout=timeout,
+            env=_utf8_env(),
+        )
 
         return self._format_output(result)
 
@@ -85,27 +80,22 @@ class Shell:
         Args:
             command: Shell command to execute
             directory: Directory to run the command in
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120)
 
         Returns:
             Command output (stdout + stderr)
         """
-        timeout = min(timeout, 600)
-
-        try:
-            result = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=directory,
-                timeout=timeout,
-                env=_utf8_env(),
-            )
-        except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=directory,
+            timeout=timeout,
+            env=_utf8_env(),
+        )
 
         return self._format_output(result)
 

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -15,12 +15,20 @@ Components under test:
 """
 
 
-import pytest
-import tempfile
+import importlib
 import platform
+import subprocess
+import tempfile
 from pathlib import Path
-from connectonion.useful_tools.shell import Shell
+from unittest.mock import patch
+
+import pytest
+
 from connectonion.useful_tools.bash import bash
+from connectonion.useful_tools.shell import Shell
+
+
+bash_module = importlib.import_module("connectonion.useful_tools.bash")
 
 
 # =============================================================================
@@ -67,11 +75,23 @@ class TestShellRun:
             result = shell.run("pwd")
             assert tmpdir in result
 
-    def test_run_timeout(self):
-        """Test that timeout returns error message."""
+    def test_run_timeout_raises(self):
+        """A timeout is an error outcome, not successful prose output."""
         shell = Shell()
-        result = shell.run("sleep 5", timeout=1)
-        assert "timed out" in result
+        expired = subprocess.TimeoutExpired(cmd="slow command", timeout=7200)
+        with patch("connectonion.useful_tools.shell.subprocess.run", side_effect=expired):
+            with pytest.raises(subprocess.TimeoutExpired) as raised:
+                shell.run("slow command", timeout=7200)
+
+        assert raised.value is expired
+
+    def test_run_honors_timeout_above_ten_minutes(self):
+        """The caller's timeout reaches subprocess.run unchanged."""
+        completed = subprocess.CompletedProcess("long command", 0, "done\n", "")
+        with patch("connectonion.useful_tools.shell.subprocess.run", return_value=completed) as run:
+            assert Shell().run("long command", timeout=7200) == "done"
+
+        assert run.call_args.kwargs["timeout"] == 7200
 
 
 class TestShellRunInDir:
@@ -90,6 +110,16 @@ class TestShellRunInDir:
         with tempfile.TemporaryDirectory() as tmpdir:
             shell.run_in_dir("touch test_file.txt", tmpdir)
             assert (Path(tmpdir) / "test_file.txt").exists()
+
+    def test_run_in_dir_honors_timeout_and_raises(self):
+        shell = Shell()
+        expired = subprocess.TimeoutExpired(cmd="slow command", timeout=7200)
+        with patch("connectonion.useful_tools.shell.subprocess.run", side_effect=expired) as run:
+            with pytest.raises(subprocess.TimeoutExpired) as raised:
+                shell.run_in_dir("slow command", "/tmp", timeout=7200)
+
+        assert raised.value is expired
+        assert run.call_args.kwargs["timeout"] == 7200
 
 
 class TestShellIntegration:
@@ -202,10 +232,23 @@ class TestBashWithCwd:
 class TestBashWithTimeout:
     """Tests for bash timeout handling."""
 
-    def test_bash_timeout_returns_error(self):
-        """Test that timeout returns error message."""
-        result = bash("sleep 5", "Sleep command", timeout=1)
-        assert "timed out" in result
+    def test_bash_timeout_raises(self):
+        """A timeout is an error outcome, not successful prose output."""
+        expired = subprocess.TimeoutExpired(cmd="slow command", timeout=7200)
+        with patch.object(bash_module.subprocess, "run", side_effect=expired) as run:
+            with pytest.raises(subprocess.TimeoutExpired) as raised:
+                bash("slow command", "Run a long agent", timeout=7200)
+
+        assert raised.value is expired
+        assert run.call_args.kwargs["timeout"] == 7200
+
+    def test_bash_honors_timeout_above_ten_minutes(self):
+        """The caller's timeout reaches subprocess.run unchanged."""
+        completed = subprocess.CompletedProcess("long command", 0, "done\n", "")
+        with patch.object(bash_module.subprocess, "run", return_value=completed) as run:
+            assert bash("long command", timeout=7200) == "done"
+
+        assert run.call_args.kwargs["timeout"] == 7200
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="bash is Unix/Mac only")


### PR DESCRIPTION
## Summary

- honor the caller-supplied timeout in `bash()`, `Shell.run()`, and `Shell.run_in_dir()` instead of silently capping it at 600 seconds
- let `subprocess.TimeoutExpired` propagate so agent tool execution and remote EXEC report an error status instead of successful prose output
- add regression coverage for 7,200-second timeouts and timeout exceptions across all three entry points

## Why

The shell tools accepted values such as `timeout=7200` but replaced them with 600 without telling the caller. When the command reached that hidden ceiling, they caught `TimeoutExpired` and returned an error-looking string as a successful tool result. Long-running agents were therefore killed after ten minutes while orchestrators recorded the step as complete.

## Impact

Agents invoking agents can now run beyond ten minutes when the caller explicitly allows it. If a real timeout is reached, the existing tool executor turns the exception into an error trace and remote EXEC exposes it as a failed result, so callers can distinguish truncation from completion.

## Release

Planned for the ConnectOnion 1.6.7 stable release. The stable release branch should carry this fix from `v1.6.6` when 1.6.7 is cut.

## Checks

- `pytest -q tests/unit/test_shell_tool.py tests/unit/test_ws_exec.py` — 48 passed, 1 skipped (Windows-only)
- `ruff check connectonion/useful_tools/bash.py connectonion/useful_tools/shell.py`
- `git diff --check`

Fixes #1037
