### PR TITLE
Make co ai evaluation opt-in and bound session records

### DIFF
--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -2330,17 +2330,22 @@ async def serve_acp(
     max_iterations: int,
     yolo: bool,
     yolo_turns: int,
+    evaluate: bool = False,
     allow_mcp: bool = False,
     state_dir: Path | None = None,
 ) -> None:
     """Serve ``co ai`` as an ACP v1 Agent until the client closes stdin."""
 
     agent_factory = None
-    if state_dir is not None:
+    if state_dir is not None or evaluate:
         from ..commands.ai_commands import _create_agent
 
         def agent_factory(**kwargs: Any) -> Any:
-            return _create_agent(**kwargs, state_dir=state_dir)
+            return _create_agent(
+                **kwargs,
+                state_dir=state_dir,
+                evaluate=evaluate,
+            )
 
     transport = await open_stdio_transport()
     agent = create_acp_agent(

--- a/connectonion/cli/co_ai/acp_server.py
+++ b/connectonion/cli/co_ai/acp_server.py
@@ -24,6 +24,7 @@ import unicodedata
 from collections import deque
 from contextlib import contextmanager, redirect_stdout, suppress
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Mapping
 from urllib.parse import unquote_to_bytes, urlsplit
@@ -2330,22 +2331,19 @@ async def serve_acp(
     max_iterations: int,
     yolo: bool,
     yolo_turns: int,
-    evaluate: bool = False,
+    agent_factory: AgentFactory | None = None,
     allow_mcp: bool = False,
     state_dir: Path | None = None,
 ) -> None:
     """Serve ``co ai`` as an ACP v1 Agent until the client closes stdin."""
 
-    agent_factory = None
-    if state_dir is not None or evaluate:
+    if state_dir is not None:
         from ..commands.ai_commands import _create_agent
 
-        def agent_factory(**kwargs: Any) -> Any:
-            return _create_agent(
-                **kwargs,
-                state_dir=state_dir,
-                evaluate=evaluate,
-            )
+        agent_factory = partial(
+            agent_factory or _create_agent,
+            state_dir=state_dir,
+        )
 
     transport = await open_stdio_transport()
     agent = create_acp_agent(

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -13,7 +13,7 @@ Tools included:
 - Shell: bash (with approval flow)
 
 Plugins included:
-- eval: Session persistence for debugging
+- eval: Optional task scoring for debugging (`evaluate=True`)
 - system_reminder: Contextual hints
 - prefer_write_tool: Block bash file creation, soft-remind for file reading
 - tool_approval: Approval flow for dangerous operations
@@ -120,6 +120,7 @@ def create_agent(
     role: str | None = "coding",
     background_tools: bool = True,
     state_dir: Path | None = None,
+    evaluate: bool = False,
 ) -> Agent:
     """Build the co-ai agent.
 
@@ -166,7 +167,7 @@ def create_agent(
     plugins = [
         skills_plugin,
         subagents,
-        eval,
+        *([eval] if evaluate else []),
         system_reminder,
         prefer_write_tool,
         [grant_managed_delegation_permissions],

--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -13,7 +13,7 @@ Tools included:
 - Shell: bash (with approval flow)
 
 Plugins included:
-- eval: Optional task scoring for debugging (`evaluate=True`)
+- caller-supplied plugins: Explicit opt-ins such as task evaluation
 - system_reminder: Contextual hints
 - prefer_write_tool: Block bash file creation, soft-remind for file reading
 - tool_approval: Approval flow for dangerous operations
@@ -40,7 +40,6 @@ from connectonion.core.usage import DEFAULT_MODEL
 from connectonion.useful_plugins import (
     auto_compact,
     enable_yolo,
-    eval,
     image_result_formatter,
     prefer_write_tool,
     runtime_input,
@@ -120,7 +119,7 @@ def create_agent(
     role: str | None = "coding",
     background_tools: bool = True,
     state_dir: Path | None = None,
-    evaluate: bool = False,
+    extra_plugins=(),
 ) -> Agent:
     """Build the co-ai agent.
 
@@ -167,7 +166,7 @@ def create_agent(
     plugins = [
         skills_plugin,
         subagents,
-        *([eval] if evaluate else []),
+        *extra_plugins,
         system_reminder,
         prefer_write_tool,
         [grant_managed_delegation_permissions],

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -42,6 +42,7 @@ def start_server(
     max_iterations: int | None = None,
     yolo: bool = False,
     yolo_turns: int = 100,
+    evaluate: bool = False,
 ):
     """Start AI coding agent web server.
 
@@ -52,6 +53,7 @@ def start_server(
         max_iterations: Tool iteration limit for ACP coding agents
         yolo: Whether an administrator may select bounded Full access
         yolo_turns: Maximum Full access turns before a checkpoint
+        evaluate: Whether new ACP sessions include the eval debugging plugin
 
     The server will be accessible at:
     - POST http://localhost:{port}/input
@@ -103,6 +105,13 @@ def start_server(
             )
             owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()
             session_co_dir = co_dir / "acp-principals" / owner_id
+            agent_factory = None
+            if evaluate:
+                from ..commands.ai_commands import _create_agent
+
+                def agent_factory(**kwargs):
+                    return _create_agent(**kwargs, evaluate=True)
+
             return create_acp_agent(
                 model=acp_model,
                 max_iterations=acp_max_iterations,
@@ -111,6 +120,7 @@ def start_server(
                 # receive the Full access profile on this direct endpoint.
                 yolo=yolo and principal.level == "admin",
                 yolo_turns=yolo_turns,
+                agent_factory=agent_factory,
                 session_co_dir=session_co_dir,
                 network_workspace=network_workspace,
                 input_limits=input_limits,

--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -42,7 +42,7 @@ def start_server(
     max_iterations: int | None = None,
     yolo: bool = False,
     yolo_turns: int = 100,
-    evaluate: bool = False,
+    agent_factory=None,
 ):
     """Start AI coding agent web server.
 
@@ -53,7 +53,7 @@ def start_server(
         max_iterations: Tool iteration limit for ACP coding agents
         yolo: Whether an administrator may select bounded Full access
         yolo_turns: Maximum Full access turns before a checkpoint
-        evaluate: Whether new ACP sessions include the eval debugging plugin
+        agent_factory: Optional configured factory for new ACP sessions
 
     The server will be accessible at:
     - POST http://localhost:{port}/input
@@ -105,13 +105,6 @@ def start_server(
             )
             owner_id = hashlib.sha256(owner.encode("utf-8")).hexdigest()
             session_co_dir = co_dir / "acp-principals" / owner_id
-            agent_factory = None
-            if evaluate:
-                from ..commands.ai_commands import _create_agent
-
-                def agent_factory(**kwargs):
-                    return _create_agent(**kwargs, evaluate=True)
-
             return create_acp_agent(
                 model=acp_model,
                 max_iterations=acp_max_iterations,

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import sys
 from contextlib import nullcontext, redirect_stdout
+from functools import partial
 from pathlib import Path
 
 import typer
@@ -77,9 +78,17 @@ def handle_ai(
         console.print("[red]--resume requires --json[/red]")
         raise typer.Exit(2)
 
+    agent_factory = _agent_factory(evaluate=evaluate)
+
     if prompt and json_output:
         _handle_json_one_shot(
-            prompt, model, max_iterations, yolo, yolo_turns, resume, evaluate
+            prompt,
+            model,
+            max_iterations,
+            yolo,
+            yolo_turns,
+            resume,
+            agent_factory=agent_factory,
         )
         return
 
@@ -96,16 +105,14 @@ def handle_ai(
                 max_iterations=max_iterations,
                 yolo=yolo,
                 yolo_turns=yolo_turns,
-                evaluate=evaluate,
+                agent_factory=agent_factory,
                 allow_mcp=acp_mcp,
                 state_dir=prepared_state_dir,
             )
         )
         return
 
-    agent = _create_agent(
-        model, max_iterations, yolo, yolo_turns, evaluate=evaluate
-    )
+    agent = agent_factory(model, max_iterations, yolo, yolo_turns)
     if prompt:
         _handle_plain_one_shot(agent, prompt)
     else:
@@ -117,8 +124,18 @@ def handle_ai(
             max_iterations=max_iterations,
             yolo=yolo,
             yolo_turns=yolo_turns,
-            evaluate=evaluate,
+            agent_factory=agent_factory,
         )
+
+
+def _agent_factory(*, evaluate: bool):
+    """Configure optional behavior once, before selecting a runtime mode."""
+    extra_plugins = ()
+    if evaluate:
+        from ...useful_plugins import eval as eval_plugin
+
+        extra_plugins = (eval_plugin,)
+    return partial(_create_agent, extra_plugins=extra_plugins)
 
 
 def _prepare_acp_state_dir(state_dir: Path) -> Path:
@@ -146,7 +163,7 @@ def _create_agent(
     *,
     resumable=False,
     state_dir: Path | None = None,
-    evaluate: bool = False,
+    extra_plugins=(),
 ):
     from ..co_ai.agent import GLOBAL_CO_DIR, create_agent
 
@@ -157,7 +174,7 @@ def _create_agent(
         state_dir=state_dir,
         yolo_turns=yolo_turns if yolo else None,
         background_tools=not resumable,
-        evaluate=evaluate,
+        extra_plugins=extra_plugins,
     )
 
 
@@ -179,7 +196,6 @@ def _handle_json_one_shot(
     yolo,
     yolo_turns,
     resume,
-    evaluate=False,
     *,
     agent_factory=None,
     persist_session=True,
@@ -213,7 +229,6 @@ def _handle_json_one_shot(
                     yolo,
                     yolo_turns,
                     resumable=True,
-                    evaluate=evaluate,
                 )
                 restore_tool_state(agent, tools)
                 if session is None:

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -26,6 +26,7 @@ def handle_ai(
     max_iterations: int = 100,
     yolo: bool = False,
     yolo_turns: int = 100,
+    evaluate: bool = False,
     json_output: bool = False,
     resume: str = None,
     acp: bool = False,
@@ -41,6 +42,7 @@ def handle_ai(
         max_iterations: Max tool iterations
         yolo: Skip tool approvals and keep working across turns
         yolo_turns: Maximum autonomous turns before a checkpoint
+        evaluate: Score completion with the eval debugging plugin
         json_output: Emit one JSON envelope to stdout
         resume: Continue a prior one-shot session ID
         acp: Serve the coding agent over ACP v1 on stdio
@@ -77,7 +79,7 @@ def handle_ai(
 
     if prompt and json_output:
         _handle_json_one_shot(
-            prompt, model, max_iterations, yolo, yolo_turns, resume
+            prompt, model, max_iterations, yolo, yolo_turns, resume, evaluate
         )
         return
 
@@ -94,13 +96,16 @@ def handle_ai(
                 max_iterations=max_iterations,
                 yolo=yolo,
                 yolo_turns=yolo_turns,
+                evaluate=evaluate,
                 allow_mcp=acp_mcp,
                 state_dir=prepared_state_dir,
             )
         )
         return
 
-    agent = _create_agent(model, max_iterations, yolo, yolo_turns)
+    agent = _create_agent(
+        model, max_iterations, yolo, yolo_turns, evaluate=evaluate
+    )
     if prompt:
         _handle_plain_one_shot(agent, prompt)
     else:
@@ -112,6 +117,7 @@ def handle_ai(
             max_iterations=max_iterations,
             yolo=yolo,
             yolo_turns=yolo_turns,
+            evaluate=evaluate,
         )
 
 
@@ -140,6 +146,7 @@ def _create_agent(
     *,
     resumable=False,
     state_dir: Path | None = None,
+    evaluate: bool = False,
 ):
     from ..co_ai.agent import GLOBAL_CO_DIR, create_agent
 
@@ -150,6 +157,7 @@ def _create_agent(
         state_dir=state_dir,
         yolo_turns=yolo_turns if yolo else None,
         background_tools=not resumable,
+        evaluate=evaluate,
     )
 
 
@@ -171,6 +179,7 @@ def _handle_json_one_shot(
     yolo,
     yolo_turns,
     resume,
+    evaluate=False,
     *,
     agent_factory=None,
     persist_session=True,
@@ -199,7 +208,12 @@ def _handle_json_one_shot(
                 )
                 factory = agent_factory or _create_agent
                 agent = factory(
-                    model, max_iterations, yolo, yolo_turns, resumable=True
+                    model,
+                    max_iterations,
+                    yolo,
+                    yolo_turns,
+                    resumable=True,
+                    evaluate=evaluate,
                 )
                 restore_tool_state(agent, tools)
                 if session is None:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -358,6 +358,11 @@ def ai(
         min=1,
         help="Autonomous turns before a checkpoint (requires --yolo)",
     ),
+    evaluate: bool = typer.Option(
+        False,
+        "--eval",
+        help="Score task completion with two extra model calls",
+    ),
     json_output: bool = typer.Option(
         False, "--json", help="Emit one machine-readable JSON result"
     ),
@@ -387,6 +392,7 @@ def ai(
         max_iterations=max_iterations,
         yolo=yolo,
         yolo_turns=yolo_turns,
+        evaluate=evaluate,
         json_output=json_output,
         resume=resume,
         acp=acp,

--- a/connectonion/logger.py
+++ b/connectonion/logger.py
@@ -3,7 +3,7 @@ Purpose: Unified logging interface for agents - terminal output + plain text + Y
 LLM-Note:
   Dependencies: imports from [datetime, pathlib, typing, json, re, yaml, os, console.py] | imported by [agent.py, tool_executor.py] | tested by [tests/unit/test_logger.py]
   Data flow: receives from Agent/tool_executor → delegates to Console for terminal/file → writes YAML evals to .co/evals/
-  State/Effects: writes to .co/evals/{input_slug}.yaml (one file per unique first input — _slugify keeps Unicode word characters, so a Chinese, Japanese or Cyrillic prompt gets its own file; keeping only [a-zA-Z0-9] made every non-Latin prompt collapse to `default` and share one) | run data stored in .co/evals/{input_slug}/run_{n}.yaml, trimmed to KEEP_RUNS_PER_EVAL | the number of evals is not capped — `co doctor` reports the size | eval data persisted after each turn
+  State/Effects: writes to .co/evals/{input_slug}.yaml (one file per unique first input — _slugify keeps Unicode word characters, so a Chinese, Japanese or Cyrillic prompt gets its own file; keeping only [a-zA-Z0-9] made every non-Latin prompt collapse to `default` and share one) | retains KEEP_EVAL_RECORDS generated records and KEEP_RUNS_PER_EVAL runs per record | authored evals are never pruned | eval data persisted after each turn
   Integration: exposes Logger(agent_name, quiet, log), .print(), .log_tool_call(name, args), .log_tool_result(result, timing), .log_llm_response(), .start_session(), .log_turn()
   Eval format: eval.yaml (metadata + turns) | run_N.yaml (system_prompt, model, cwd, tokens, cost, duration_ms, timestamp, messages as multi-line JSON)
   Performance: YAML written after each turn (incremental) | Console delegation is direct passthrough
@@ -11,26 +11,30 @@ LLM-Note:
 """
 
 import json
-import re
-from datetime import datetime
 import os
+import re
+import shutil
 import sys
+from datetime import datetime
 from pathlib import Path
-from typing import Optional, Union, Dict, Any, List
+from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
 from .console import Console
+from .project import project_co_dir as _project_co_dir
 
 # How many run_N.yaml files to keep per eval. They hold the full message array
 # of one turn, nothing in the code reads them back, and an agent on a schedule
 # wrote 9.5 MB of them a day on the box it was deployed to.
 KEEP_RUNS_PER_EVAL = 20
 
-
-# The project's `.co/`, found by walking up -- not `Path(".co")`, which creates
-# one wherever the Agent happens to be constructed. See connectonion/project.py.
-from .project import project_co_dir as _project_co_dir
+# `co ai` names a record from each distinct first prompt. A developer measured
+# 2,311 of those records using 281 MB after six months, even though no command
+# reads generated records back automatically. Keep enough recent history for
+# debugging without turning a hidden directory into unbounded storage. Authored
+# evals (the files `co eval` runs) are identified separately and never pruned.
+KEEP_EVAL_RECORDS = 500
 
 
 def _slugify(text: str, max_length: int = 50) -> str:
@@ -144,6 +148,7 @@ class Logger:
         self.eval_data: Optional[Dict[str, Any]] = None
         self.current_run: int = 0
         self._first_input: Optional[str] = None  # Track first input for file naming
+        self._eval_was_new = False
 
     # Delegate to Console
     def print(self, message: str, style: str = None):
@@ -207,6 +212,7 @@ class Logger:
         self.eval_dir = None
         self.eval_data = None
         self.current_run = 0
+        self._eval_was_new = False
 
     def _init_eval_file(self, first_input: str):
         """Initialize or load eval file based on first input.
@@ -225,6 +231,7 @@ class Logger:
 
         # Load existing or create new
         existing = _read_eval_file(self.eval_file)
+        self._eval_was_new = existing is None
         if existing is not None:
             self.eval_data = existing
 
@@ -507,6 +514,58 @@ class Logger:
         with open(tmp, 'w', encoding='utf-8') as f:
             yaml.dump(ordered, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
         os.replace(tmp, self.eval_file)
+
+        if self._eval_was_new:
+            self._trim_old_evals(
+                self.eval_file.parent,
+                protected=self.eval_file,
+            )
+            self._eval_was_new = False
+
+    @staticmethod
+    def _trim_old_evals(
+        evals_dir: Path,
+        keep: Optional[int] = None,
+        protected: Optional[Path] = None,
+    ) -> None:
+        """Keep the newest generated session records and every authored eval.
+
+        A generated record has the logger's `created`, `runs`, and `turns`
+        fields and lacks the `agent`/`expected` fields that make a file an
+        authored test for `co eval`. Each deleted record owns the sibling
+        directory containing its full-message run files.
+
+        Retention is housekeeping, so malformed files and filesystem races are
+        preserved or ignored instead of failing the Agent turn.
+        """
+        keep = KEEP_EVAL_RECORDS if keep is None else keep
+        if not evals_dir or not evals_dir.is_dir():
+            return
+
+        generated = []
+        for path in evals_dir.glob("*.yaml"):
+            try:
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                is_generated = (
+                    isinstance(data, dict)
+                    and {"created", "runs", "turns"} <= set(data)
+                    and "agent" not in data
+                    and "expected" not in data
+                )
+                if is_generated:
+                    generated.append((path.stat().st_mtime_ns, path))
+            except (OSError, yaml.YAMLError):
+                continue
+
+        excess = max(0, len(generated) - keep)
+        for _, path in sorted(generated)[:excess]:
+            if protected is not None and path == protected:
+                continue
+            try:
+                path.unlink(missing_ok=True)
+                shutil.rmtree(evals_dir / path.stem, ignore_errors=True)
+            except OSError:
+                continue
 
     def get_eval_path(self) -> Optional[str]:
         """Get the absolute path to the current eval file.

--- a/docs/blog/2026-08-15-evaluation-is-a-choice.md
+++ b/docs/blog/2026-08-15-evaluation-is-a-choice.md
@@ -1,0 +1,39 @@
+# Evaluation Is a Choice
+
+The clue was not a dramatic bill. Across one measured five-step run, task
+evaluation cost $0.15 out of $10.73—about 1.4 percent—and another run recorded
+none. That is too small to build an argument around.
+
+The stronger evidence was on disk:
+
+```text
+~/.co/evals    2,311 records    281 MB
+```
+
+The oldest record was six months old. Nothing pruned the collection, and the
+operator had never asked `co ai` to evaluate every task.
+
+Two mechanisms had been hidden behind the same word. The `eval` plugin is a
+debugging judge: it generates an expected outcome and scores the completed task,
+using two additional model calls. The Logger independently records sessions
+under `.co/evals/`, whether or not that plugin is installed. Removing the plugin
+from the default fixes the unwanted calls, but it does not reclaim or bound a
+single byte. Treating them as one bug would have fixed only the visible half.
+
+`co ai` now leaves the judge off unless the operator passes `--eval`. Direct
+library use remains explicit as it always appeared in the documentation:
+
+```python
+Agent("assistant", plugins=[eval])
+```
+
+Session records remain available for replay and diagnosis, but generated
+records now have a count boundary: the newest 500 survive, along with their
+bounded per-record runs. Authored eval suites are a different class of data and
+are never pruned.
+
+The design lesson is modest: observability and judgment are not free merely
+because they run after the work. Debugging machinery should announce itself,
+and historical artifacts need an ownership and retention boundary on the day
+they are introduced—not after the hidden directory reaches hundreds of
+megabytes.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -195,6 +195,7 @@ operator choice at process launch.
 | `--max-iterations` | `-i` | `100` | Max tool iterations per turn |
 | `--yolo` | | off | Skip tool approvals and keep working across turns |
 | `--yolo-turns` | | `100` | Autonomous turns before a checkpoint; must be positive |
+| `--eval` | | off | Debug a task with two extra model calls that score completion |
 | `--json` | | off | Emit one JSON envelope to stdout in one-shot mode |
 | `--resume` | | | With `--json`, continue a one-shot session by ID |
 | `--acp` | | off | Serve stable ACP v1 over stdin/stdout |
@@ -206,6 +207,7 @@ co ai --port 9000
 co ai --model co/gemini-3.7-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 co ai --yolo "Fix the failing suite" --yolo-turns 20
+co ai --eval "Check whether this agent really completed the task"
 co ai --acp
 co ai --acp --acp-mcp
 co ai --acp --state-dir /private/tmp/co-acp-test
@@ -404,9 +406,12 @@ This is loaded every session, so the agent always follows your rules.
 `co ai` uses your global identity from `~/.co/`:
 
 - Logs saved to `~/.co/logs/oo.log`
-- Eval sessions saved to `~/.co/evals/`
+- Session records saved to `~/.co/evals/` (the newest 500 are retained)
 - Resumable one-shot sessions saved privately under `~/.co/ai/sessions/`
 - Same address across all `co ai` sessions
+
+Task scoring is separate from session recording. It is off by default; pass
+`--eval` when debugging to generate an expected outcome and score completion.
 
 ## Examples
 

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -26,6 +26,7 @@ def test_ai_forwards_yolo_options():
         max_iterations=100,
         yolo=True,
         yolo_turns=4,
+        evaluate=False,
         json_output=False,
         resume=None,
         acp=False,
@@ -49,6 +50,7 @@ def test_ai_forwards_json_and_resume_options():
         max_iterations=100,
         yolo=False,
         yolo_turns=100,
+        evaluate=False,
         json_output=True,
         resume="session-id",
         acp=False,
@@ -69,12 +71,21 @@ def test_ai_forwards_acp_mode():
         max_iterations=100,
         yolo=False,
         yolo_turns=100,
+        evaluate=False,
         json_output=False,
         resume=None,
         acp=True,
         acp_mcp=False,
         state_dir=None,
     )
+
+
+def test_ai_eval_is_explicit_and_forwarded():
+    with patch("connectonion.cli.commands.ai_commands.handle_ai") as handler:
+        result = runner.invoke(app, ["ai", "task", "--eval"])
+
+    assert result.exit_code == 0
+    assert handler.call_args.kwargs["evaluate"] is True
 
 
 def test_ai_forwards_explicit_acp_state_dir(tmp_path):

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -18,6 +18,7 @@ import connectonion.cli.commands.ai_commands as ai_mod
 import connectonion.cli.commands.trust_commands as trust_mod
 from connectonion.cli.co_ai.agent import GLOBAL_CO_DIR
 from connectonion.core.exceptions import LLMAuthenticationError
+from connectonion.useful_plugins import eval as eval_plugin
 
 
 def test_handle_ai_calls_start_server(monkeypatch):
@@ -50,13 +51,13 @@ def test_handle_ai_calls_start_server(monkeypatch):
     assert called["max_iterations"] == 3
     assert called["yolo"] is True
     assert called["yolo_turns"] == 7
-    assert called["evaluate"] is False
+    assert callable(called["agent_factory"])
     assert called["agent"] is created["agent"]
     assert created["model"] == "m"
     assert created["max_iterations"] == 3
     assert created["co_dir"] == GLOBAL_CO_DIR
     assert created["yolo_turns"] == 7
-    assert created["evaluate"] is False
+    assert created["extra_plugins"] == ()
 
 
 def test_handle_ai_enables_eval_only_when_requested(monkeypatch, capsys):
@@ -77,7 +78,7 @@ def test_handle_ai_enables_eval_only_when_requested(monkeypatch, capsys):
 
     ai_mod.handle_ai(prompt="task", evaluate=True)
 
-    assert created["evaluate"] is True
+    assert created["extra_plugins"] == (eval_plugin,)
     assert capsys.readouterr().out.endswith("done\n")
 
 

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -50,11 +50,35 @@ def test_handle_ai_calls_start_server(monkeypatch):
     assert called["max_iterations"] == 3
     assert called["yolo"] is True
     assert called["yolo_turns"] == 7
+    assert called["evaluate"] is False
     assert called["agent"] is created["agent"]
     assert created["model"] == "m"
     assert created["max_iterations"] == 3
     assert created["co_dir"] == GLOBAL_CO_DIR
     assert created["yolo_turns"] == 7
+    assert created["evaluate"] is False
+
+
+def test_handle_ai_enables_eval_only_when_requested(monkeypatch, capsys):
+    created = {}
+
+    class FakeAgent:
+        def input(self, prompt):
+            return "done"
+
+    def fake_create_agent(**kwargs):
+        created.update(kwargs)
+        return FakeAgent()
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent",
+        fake_create_agent,
+    )
+
+    ai_mod.handle_ai(prompt="task", evaluate=True)
+
+    assert created["evaluate"] is True
+    assert capsys.readouterr().out.endswith("done\n")
 
 
 def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -22,6 +22,7 @@ from connectonion.cli.co_ai.one_shot_sessions import (
     save_snapshot,
 )
 from connectonion.network.host.acp_gateway import ACPPrincipal
+from connectonion.useful_plugins import eval as eval_plugin
 from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
 
 
@@ -106,15 +107,15 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     # tabs itself (`-t <tab>`), so the workaround is gone.
     from connectonion.useful_plugins.bind_browser_session import _bind_browser_session
     assert _bind_browser_session not in agent.events["before_each_tool"]
-    for handler in agent_mod.eval:
+    for handler in eval_plugin:
         assert handler not in agent.events[handler._event_type]
 
     evaluated = agent_mod.create_coding_agent(
         model="fake",
         max_iterations=5,
-        evaluate=True,
+        extra_plugins=(eval_plugin,),
     )
-    for handler in agent_mod.eval:
+    for handler in eval_plugin:
         assert handler in evaluated.events[handler._event_type]
 
 

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -106,6 +106,16 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     # tabs itself (`-t <tab>`), so the workaround is gone.
     from connectonion.useful_plugins.bind_browser_session import _bind_browser_session
     assert _bind_browser_session not in agent.events["before_each_tool"]
+    for handler in agent_mod.eval:
+        assert handler not in agent.events[handler._event_type]
+
+    evaluated = agent_mod.create_coding_agent(
+        model="fake",
+        max_iterations=5,
+        evaluate=True,
+    )
+    for handler in agent_mod.eval:
+        assert handler in evaluated.events[handler._event_type]
 
 
 def test_start_server_hosts_provided_agent(monkeypatch):

--- a/tests/unit/test_eval_records_do_not_grow_without_end.py
+++ b/tests/unit/test_eval_records_do_not_grow_without_end.py
@@ -1,0 +1,91 @@
+"""Generated session records are useful history, not permanent storage.
+
+`co ai` wrote one YAML file and one run directory for every distinct first
+prompt. A developer measured 2,311 records using 281 MB after six months. The
+eval plugin did not create these files; Logger did, even without the plugin.
+
+Retention therefore belongs at the logger boundary. It removes only records
+whose shape identifies them as generated, preserves authored `co eval` tests,
+and removes the full-message directory paired with an expired record.
+"""
+
+import os
+
+import yaml
+
+from connectonion.logger import Logger
+
+
+def _generated(evals_dir, name, modified):
+    path = evals_dir / f"{name}.yaml"
+    path.write_text(
+        yaml.safe_dump({
+            "name": name,
+            "created": "2026-01-01 00:00:00",
+            "runs": 1,
+            "model": "test",
+            "turns": [],
+        }),
+        encoding="utf-8",
+    )
+    run_dir = evals_dir / name
+    run_dir.mkdir()
+    (run_dir / "run_1.yaml").write_text("messages: '[]'\n", encoding="utf-8")
+    os.utime(path, (modified, modified))
+    return path, run_dir
+
+
+def test_old_generated_records_and_their_runs_are_removed(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    oldest, oldest_runs = _generated(evals_dir, "oldest", 1)
+    middle, _ = _generated(evals_dir, "middle", 2)
+    newest, _ = _generated(evals_dir, "newest", 3)
+
+    Logger._trim_old_evals(evals_dir, keep=2)
+
+    assert not oldest.exists()
+    assert not oldest_runs.exists()
+    assert middle.exists()
+    assert newest.exists()
+
+
+def test_authored_evals_never_count_toward_retention(tmp_path):
+    evals_dir = tmp_path / "evals"
+    evals_dir.mkdir()
+    authored = evals_dir / "acceptance.yaml"
+    authored.write_text(
+        yaml.safe_dump({
+            "name": "acceptance",
+            "agent": "agent.py",
+            "turns": [{"input": "hello", "expected": "a greeting"}],
+        }),
+        encoding="utf-8",
+    )
+    old, _ = _generated(evals_dir, "old", 1)
+    recent, _ = _generated(evals_dir, "recent", 2)
+
+    Logger._trim_old_evals(evals_dir, keep=1)
+
+    assert authored.exists()
+    assert not old.exists()
+    assert recent.exists()
+
+
+def test_writing_a_new_record_enforces_the_cap(tmp_path, monkeypatch):
+    import connectonion.logger as logger_module
+
+    monkeypatch.setattr(logger_module, "KEEP_EVAL_RECORDS", 2)
+    logger = Logger("test", quiet=True, co_dir=tmp_path / ".co")
+
+    for index in range(3):
+        logger.start_session()
+        logger.log_turn(
+            f"unique prompt {index}",
+            "done",
+            1,
+            {"trace": [], "turn": 1, "messages": []},
+            "test",
+        )
+
+    assert len(list((tmp_path / ".co" / "evals").glob("*.yaml"))) == 2


### PR DESCRIPTION
## Summary

- remove the eval debugging plugin from the default `co ai` plugin bundle
- map `co ai --eval` to one configured agent factory shared by one-shot, web, JSON resume, and ACP modes
- retain only the newest 500 generated session records and their bounded run directories while preserving every authored `co eval` suite
- document the distinction between task scoring and session recording

## Why

`co ai` installed the eval plugin on every run even though the plugin documents itself as a debugging tool. Each completed task could therefore make two extra model calls without the operator opting in.

The 281 MB artifact accumulation has a separate root cause: Logger writes `.co/evals/{slug}.yaml` and its run directory independently of the eval plugin. Disabling the plugin fixes unwanted scoring cost and latency, but not disk growth, so this change also adds count-based retention at the logger boundary.

## Impact

Normal `co ai` runs no longer generate expected outcomes or score completion. Developers can restore that behavior explicitly with `co ai --eval`, and direct `Agent(plugins=[eval])` usage remains unchanged.

The CLI makes that choice once by adding eval to the factory's extra plugins. Runtime modes receive the configured factory and remain unaware of eval-specific flags or conditionals.

Generated session history stays available for the newest 500 distinct first prompts. Authored eval files—identified by their `agent` or `expected` contract—are never included in retention pruning.

## Release

Planned for the ConnectOnion 1.6.7 stable release. The stable release branch should carry this fix from `v1.6.6` when 1.6.7 is cut.

## Checks

- combined co-ai, ACP, logger, retention, and eval suites — 507 passed
- focused mode-routing suite — 158 passed
- Ruff on all changed Python implementation and new test files
- `git diff --check`

**Dev Blog (required)**
> `docs/blog/2026-08-15-evaluation-is-a-choice.md`

Fixes #1030
