### PR TITLE
Paginate received inbox beyond 100 messages

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -2,7 +2,7 @@
 Purpose: CLI surface for the agent mailbox — send, list (inbox), and read emails from the terminal
 LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
-  Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread) → Rich table | handle_email_read() → get_emails() → find by id → print body → mark_read(id)
+  Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread, offset) → Rich table | handle_email_read() → get_emails() → find by id → print body → mark_read(id)
   State/Effects: no local state | network calls happen inside the engine tools | mark_read() flips server-side read status | writes to stdout via rich.Console
   Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
@@ -85,13 +85,13 @@ def handle_email_send(
         raise typer.Exit(1)
 
 
-def handle_email_inbox(last: int = 10, unread: bool = False):
+def handle_email_inbox(last: int = 10, unread: bool = False, offset: int = 0):
     """List recent emails received at the agent's address."""
     if not _require_auth():
         return
 
     from ...useful_tools.get_emails import get_emails
-    emails = get_emails(last=last)
+    emails = get_emails(last=last, offset=offset)
     if unread:
         # The /received endpoint ignores the unread param, so filter here to keep the flag honest.
         emails = [e for e in emails if not e.get("read")]
@@ -219,7 +219,7 @@ def handle_email_read(email_id: str):
         return
 
     from ...useful_tools.get_emails import get_emails, mark_read
-    emails = get_emails(last=100)
+    emails = get_emails(last=1000)
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
     if not match:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -728,14 +728,20 @@ def email_inbox(
         "--last",
         "-n",
         min=1,
-        max=100,
-        help="How many received emails to show (1-100)",
+        max=1000,
+        help="How many received emails to show in this page (1-1000)",
+    ),
+    offset: int = typer.Option(
+        0,
+        "--offset",
+        min=0,
+        help="Skip this many newer emails",
     ),
     unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
 ):
     """List recent received emails."""
     from .commands.email_commands import handle_email_inbox
-    handle_email_inbox(last=last, unread=unread)
+    handle_email_inbox(last=last, offset=offset, unread=unread)
 
 
 @email_app.command("read")

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -723,7 +723,14 @@ def email_send(
 
 @email_app.command("inbox")
 def email_inbox(
-    last: int = typer.Option(10, "--last", "-n", help="How many emails to show"),
+    last: int = typer.Option(
+        10,
+        "--last",
+        "-n",
+        min=1,
+        max=100,
+        help="How many received emails to show (1-100)",
+    ),
     unread: bool = typer.Option(False, "--unread", "-u", help="Only unread emails"),
 ):
     """List recent received emails."""

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -146,6 +146,10 @@ co email sent -n 20 --to bob@example.com
 co email sent read 12
 ```
 
+Received inbox pages accept `-n/--last` from 1 through 100. A larger request is
+rejected locally; never treat it as a complete mailbox scan. Sent mail uses a
+separate endpoint and may accept a larger page.
+
 It is a smaller surface than Gmail/Outlook, and the differences bite:
 
 - **No `reply`, no `search`, no attachments, no scheduling.** To answer a message,

--- a/connectonion/useful_skills/co-mail-and-drive/SKILL.md
+++ b/connectonion/useful_skills/co-mail-and-drive/SKILL.md
@@ -138,6 +138,7 @@ Two more, for Drive specifically:
 ```bash
 co email                       # bare command = inbox
 co email inbox -n 20 -u
+co email inbox -n 1000 --offset 1000  # the next page of older mail
 co email read 41               # the id in the # column, not the row position
 co email send bob@example.com "Subject" "Body"
 co email send bob@example.com "Subject" "Body" --from aaron@openonion.ai
@@ -146,16 +147,16 @@ co email sent -n 20 --to bob@example.com
 co email sent read 12
 ```
 
-Received inbox pages accept `-n/--last` from 1 through 100. A larger request is
-rejected locally; never treat it as a complete mailbox scan. Sent mail uses a
-separate endpoint and may accept a larger page.
+Received inbox pages accept `-n/--last` from 1 through 1000. Use `--offset` to
+skip newer rows and continue through older mail; for example, page through
+offsets 0, 1000, 2000 until the command returns no rows.
 
 It is a smaller surface than Gmail/Outlook, and the differences bite:
 
 - **No `reply`, no `search`, no attachments, no scheduling.** To answer a message,
   send a new one with the subject you want.
 - **`read` takes the id printed in the `#` column** (a server id), not "row 3", and
-  only finds it among the last 100 received.
+  currently finds it among the latest 1000 received.
 - A failed send that is safe to retry prints the **full retry command**
   (`co email send ... --idempotency-key <key>`) — run it as printed so a send
   that actually went out is not duplicated.

--- a/connectonion/useful_tools/get_emails.py
+++ b/connectonion/useful_tools/get_emails.py
@@ -4,9 +4,9 @@ LLM-Note:
   Dependencies: imports from [requests, typing, backend, credentials] | imported by [__init__.py, useful_tools/__init__.py] | tested by [tests/unit/test_email_functions.py, tests/unit/test_credentials.py, tests/test_real_email.py]
   Data flow: Agent calls a mailbox function → require_ambient_api_key() checks the already-loaded environment token against the canonical project identity → request to the configured backend → normalized result
   State/Effects: reads the ambient token and local identity keys | makes HTTP GET/POST requests | no local caching | mark_read()/mark_unread() modify server-side read status
-  Integration: exposes get_emails(last, unread), mark_read(email_id) | used as agent tool functions | requires 'co auth' setup | API endpoints: GET /api/v1/email/received?last=N&unread=true, PUT /api/v1/email/s/mark-read
-  Performance: one HTTP request per call | no pagination (uses 'last' param, received range 1..100) | synchronous blocking | no local cache
-  Errors: received limits outside 1..100 raise ValueError before auth/network | missing/mismatched ambient credentials and HTTP failures raise | no credential value is included in errors
+  Integration: exposes get_emails(last, unread, offset), mark_read(email_id) | used as agent tool functions | requires 'co auth' setup | API endpoints: GET /api/v1/email/received?limit=N&offset=N, PUT /api/v1/email/s/mark-read
+  Performance: one HTTP request per call | received pages contain 1..1000 messages and offset selects older pages | synchronous blocking | no local cache
+  Errors: invalid received page sizes or offsets raise ValueError before auth/network | missing/mismatched ambient credentials and HTTP failures raise | no credential value is included in errors
 """
 
 from typing import Dict, List, Union
@@ -17,15 +17,16 @@ from ..backend import backend_url
 from ..credentials import require_ambient_api_key
 
 MIN_RECEIVED_EMAILS = 1
-MAX_RECEIVED_EMAILS = 100
+MAX_RECEIVED_EMAILS = 1000
 
 
-def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
+def get_emails(last: int = 10, unread: bool = False, offset: int = 0) -> List[Dict]:
     """Get emails sent to the agent's address.
 
     Args:
-        last: Number of emails to retrieve (default: 10, range: 1..100)
+        last: Number of emails to retrieve (default: 10, range: 1..1000)
         unread: Only get unread emails (default: False)
+        offset: Number of newer emails to skip (default: 0)
 
     Returns:
         List of email dictionaries containing:
@@ -46,6 +47,9 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
             f"{MAX_RECEIVED_EMAILS} for received email"
         )
 
+    if isinstance(offset, bool) or not isinstance(offset, int) or offset < 0:
+        raise ValueError("offset must be a non-negative integer")
+
     token = require_ambient_api_key()
 
     # Fetch emails from backend API
@@ -58,6 +62,7 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
 
     params = {
         "limit": last,
+        "offset": offset,
         "unread_only": unread
     }
 
@@ -72,6 +77,11 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
     response.raise_for_status()
 
     data = response.json()
+    if offset and data.get("offset") != offset:
+        raise RuntimeError(
+            "This backend does not support received email pagination yet; "
+            "upgrade the backend before using offset"
+        )
     emails = data.get("emails", [])
 
     # Ensure consistent format

--- a/connectonion/useful_tools/get_emails.py
+++ b/connectonion/useful_tools/get_emails.py
@@ -5,21 +5,26 @@ LLM-Note:
   Data flow: Agent calls a mailbox function → require_ambient_api_key() checks the already-loaded environment token against the canonical project identity → request to the configured backend → normalized result
   State/Effects: reads the ambient token and local identity keys | makes HTTP GET/POST requests | no local caching | mark_read()/mark_unread() modify server-side read status
   Integration: exposes get_emails(last, unread), mark_read(email_id) | used as agent tool functions | requires 'co auth' setup | API endpoints: GET /api/v1/email/received?last=N&unread=true, PUT /api/v1/email/s/mark-read
-  Performance: one HTTP request per call | no pagination (uses 'last' param) | synchronous blocking | no local cache
-  Errors: missing/mismatched ambient credentials and HTTP failures raise | no credential value is included in errors
+  Performance: one HTTP request per call | no pagination (uses 'last' param, received range 1..100) | synchronous blocking | no local cache
+  Errors: received limits outside 1..100 raise ValueError before auth/network | missing/mismatched ambient credentials and HTTP failures raise | no credential value is included in errors
 """
 
+from typing import Dict, List, Union
+
 import requests
-from typing import List, Dict, Union
+
 from ..backend import backend_url
 from ..credentials import require_ambient_api_key
+
+MIN_RECEIVED_EMAILS = 1
+MAX_RECEIVED_EMAILS = 100
 
 
 def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
     """Get emails sent to the agent's address.
 
     Args:
-        last: Number of emails to retrieve (default: 10)
+        last: Number of emails to retrieve (default: 10, range: 1..100)
         unread: Only get unread emails (default: False)
 
     Returns:
@@ -31,8 +36,18 @@ def get_emails(last: int = 10, unread: bool = False) -> List[Dict]:
             - timestamp: ISO format timestamp
             - read: Boolean read status
     """
+    if (
+        isinstance(last, bool)
+        or not isinstance(last, int)
+        or not MIN_RECEIVED_EMAILS <= last <= MAX_RECEIVED_EMAILS
+    ):
+        raise ValueError(
+            f"last must be between {MIN_RECEIVED_EMAILS} and "
+            f"{MAX_RECEIVED_EMAILS} for received email"
+        )
+
     token = require_ambient_api_key()
-    
+
     # Fetch emails from backend API
     endpoint = f"{backend_url()}/api/v1/email/received"
 
@@ -135,7 +150,7 @@ def mark_read(email_ids: Union[str, List[str]]) -> bool:
         raise ValueError("No email IDs provided to mark as read")
 
     token = require_ambient_api_key()
-    
+
     # Mark emails as read via backend API
     endpoint = f"{backend_url()}/api/v1/email/s/mark-read"
 

--- a/docs/blog/2026-08-15-one-mailbox-two-limits.md
+++ b/docs/blog/2026-08-15-one-mailbox-two-limits.md
@@ -1,0 +1,30 @@
+# One Mailbox, Two Limits
+
+The two calls look interchangeable:
+
+```python
+get_emails(last=1000)
+get_sent(last=1000)
+```
+
+They are not. Production accepts a thousand sent messages, while received mail
+accepts 100 and answers HTTP 422 at 101. The SDK and CLI exposed both through
+the same `last` idea without documenting that asymmetry, so the only way to
+learn the received limit was to cross it.
+
+The tempting repair is to clamp 1000 down to 100. That would make the request
+green while making its meaning false: a reconciliation job would believe it
+had asked for—and received—a thousand messages. Silent incompleteness is worse
+than a loud limit.
+
+ConnectOnion 1.6.7 therefore states the production contract at the client
+boundary. `get_emails(last=...)` accepts 1 through 100 and rejects anything else
+before it reads credentials or makes a request. `co email inbox --last` exposes
+the same range as a usage constraint. The sent endpoint remains independent and
+continues to accept 1000.
+
+This does not pretend that a page of 100 is mailbox history. Complete
+reconciliation still needs backend cursor pagination, and sender filtering
+belongs on the server rather than after downloading a global inbox window. The
+patch makes today's finite contract honest while leaving that larger API work
+visible.

--- a/docs/blog/2026-08-15-one-mailbox-two-limits.md
+++ b/docs/blog/2026-08-15-one-mailbox-two-limits.md
@@ -1,4 +1,4 @@
-# One Mailbox, Two Limits
+# A Page Should Not Become a Wall
 
 The two calls look interchangeable:
 
@@ -7,24 +7,27 @@ get_emails(last=1000)
 get_sent(last=1000)
 ```
 
-They are not. Production accepts a thousand sent messages, while received mail
-accepts 100 and answers HTTP 422 at 101. The SDK and CLI exposed both through
-the same `last` idea without documenting that asymmetry, so the only way to
-learn the received limit was to cross it.
+They used to behave differently. Production accepted a thousand sent messages,
+while received mail stopped at 100 and answered HTTP 422 at 101. The SDK and
+CLI exposed both through the same `last` idea, so the only way to learn the
+received limit was to cross it.
 
 The tempting repair is to clamp 1000 down to 100. That would make the request
 green while making its meaning false: a reconciliation job would believe it
 had asked for—and received—a thousand messages. Silent incompleteness is worse
 than a loud limit.
 
-ConnectOnion 1.6.7 therefore states the production contract at the client
-boundary. `get_emails(last=...)` accepts 1 through 100 and rejects anything else
-before it reads credentials or makes a request. `co email inbox --last` exposes
-the same range as a usage constraint. The sent endpoint remains independent and
-continues to accept 1000.
+The first repair made the hidden limit explicit at the client boundary. That
+was honest, but it preserved the wrong product behaviour: users still could not
+reconcile an inbox larger than one hundred messages. A page boundary had become
+a mailbox boundary.
 
-This does not pretend that a page of 100 is mailbox history. Complete
-reconciliation still needs backend cursor pagination, and sender filtering
-belongs on the server rather than after downloading a global inbox window. The
-patch makes today's finite contract honest while leaving that larger API work
-visible.
+The final repair aligns received and sent page sizes at 1000 and adds an offset
+to every received-mail page. `get_emails(last=1000, offset=2000)` and `co email
+inbox -n 1000 --offset 2000` now address the third page of an inbox. The backend
+orders equal timestamps by message id as well, so rows do not swap positions
+inside a page merely because their timestamps match.
+
+A service still needs a finite page size to protect itself. The important
+difference is that the boundary is now traversable. Callers can continue until
+a page is empty instead of mistaking the newest slice for complete history.

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -36,6 +36,7 @@ co email
 ```bash
 co email inbox                 # last 10
 co email inbox --last 25       # last 25  (alias: -n 25)
+co email inbox --last 100      # largest received-mail page
 co email inbox --unread        # only unread  (alias: -u)
 ```
 
@@ -43,11 +44,16 @@ Unread messages are marked with a green `●`. The leftmost `#` is the email's
 id — pass it to `co email read`.
 
 **Options**
-- `--last, -n` — how many to show (default: 10)
+- `--last, -n` — how many to show (default: 10, range: 1–100)
 - `--unread, -u` — only unread messages
 
 > Note: `--unread` filters the fetched page locally, so `--last 10 --unread`
 > means "unread among your 10 most recent," not "your 10 most recent unread."
+
+The received-mail service currently exposes one page of at most 100 messages.
+Values outside 1–100 fail locally instead of being silently clamped or sent to
+the backend as a generic HTTP 422. Sent mail has a separate endpoint and is not
+subject to this received-mail maximum.
 
 ### `co email read <#>` — Read one message
 

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -36,7 +36,8 @@ co email
 ```bash
 co email inbox                 # last 10
 co email inbox --last 25       # last 25  (alias: -n 25)
-co email inbox --last 100      # largest received-mail page
+co email inbox --last 1000     # largest received-mail page
+co email inbox -n 1000 --offset 1000  # next page of older mail
 co email inbox --unread        # only unread  (alias: -u)
 ```
 
@@ -44,16 +45,17 @@ Unread messages are marked with a green `●`. The leftmost `#` is the email's
 id — pass it to `co email read`.
 
 **Options**
-- `--last, -n` — how many to show (default: 10, range: 1–100)
+- `--last, -n` — how many to show (default: 10, range: 1–1000)
+- `--offset` — how many newer emails to skip (default: 0)
 - `--unread, -u` — only unread messages
 
 > Note: `--unread` filters the fetched page locally, so `--last 10 --unread`
 > means "unread among your 10 most recent," not "your 10 most recent unread."
 
-The received-mail service currently exposes one page of at most 100 messages.
-Values outside 1–100 fail locally instead of being silently clamped or sent to
-the backend as a generic HTTP 422. Sent mail has a separate endpoint and is not
-subject to this received-mail maximum.
+Each received-mail page can contain up to 1000 messages. Continue through a
+larger inbox with offsets 0, 1000, 2000, and so on until a page is empty. Page
+sizes outside 1–1000 and negative offsets fail locally instead of becoming a
+generic backend validation error.
 
 ### `co email read <#>` — Read one message
 

--- a/docs/useful_tools/get_emails.md
+++ b/docs/useful_tools/get_emails.md
@@ -42,12 +42,16 @@ emails = get_emails()
 Three functions. That's all:
 
 ```python
-get_emails(last=10, unread=False)  # Get emails
+get_emails(last=10, unread=False)  # Get 1–100 received emails
 send_email(to, subject, message)   # Send email (already done)
 mark_read(email_id)                # Mark as read after processing
 ```
 
 **Important**: Emails are NOT auto-marked as read. You control when to mark them.
+
+`last` must be between 1 and 100. The received-mail endpoint does not paginate
+yet, so requesting more raises `ValueError` rather than returning a silently
+incomplete result.
 
 ---
 

--- a/docs/useful_tools/get_emails.md
+++ b/docs/useful_tools/get_emails.md
@@ -42,16 +42,16 @@ emails = get_emails()
 Three functions. That's all:
 
 ```python
-get_emails(last=10, unread=False)  # Get 1–100 received emails
+get_emails(last=10, unread=False, offset=0)  # Get one received-mail page
 send_email(to, subject, message)   # Send email (already done)
 mark_read(email_id)                # Mark as read after processing
 ```
 
 **Important**: Emails are NOT auto-marked as read. You control when to mark them.
 
-`last` must be between 1 and 100. The received-mail endpoint does not paginate
-yet, so requesting more raises `ValueError` rather than returning a silently
-incomplete result.
+`last` must be between 1 and 1000, and `offset` must be non-negative. To scan a
+larger inbox, request successive pages such as `get_emails(last=1000,
+offset=0)`, then offsets 1000, 2000, and so on until the result is empty.
 
 ---
 

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -62,15 +62,27 @@ def test_an_empty_inbox_is_not_a_failure():
         email_commands.handle_email_inbox()
 
 
-def test_inbox_rejects_more_than_the_backend_can_return_before_calling_it():
+def test_inbox_rejects_more_than_one_backend_page_before_calling_it():
     with patch.object(_get_module, "get_emails") as get_emails:
-        result = runner.invoke(app, ["email", "inbox", "--last", "101"])
+        result = runner.invoke(app, ["email", "inbox", "--last", "1001"])
 
     assert result.exit_code == 2
     output = strip_ansi(result.output)
     assert "--last" in output
-    assert "1<=x<=100" in output
+    assert "1<=x<=1000" in output
     get_emails.assert_not_called()
+
+
+def test_inbox_forwards_the_page_size_and_offset():
+    with patch.object(email_commands, "_require_auth", return_value=True), \
+         patch.object(_get_module, "get_emails", return_value=[]) as get_emails:
+        result = runner.invoke(
+            app,
+            ["email", "inbox", "--last", "1000", "--offset", "2000"],
+        )
+
+    assert result.exit_code == 0
+    get_emails.assert_called_once_with(last=1000, offset=2000)
 
 
 def test_a_successful_send_does_not_raise():

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -15,16 +15,20 @@ from unittest.mock import patch
 
 import pytest
 import typer
+from click.utils import strip_ansi
+from typer.testing import CliRunner
 
-from connectonion.cli.commands import email_commands
 # The package __init__ re-exports the functions under the same names as their
 # modules, so a dotted patch target resolves to the function; go through
 # sys.modules to reach the real modules the handlers import from.
-import connectonion.useful_tools.send_email
-import connectonion.useful_tools.get_emails
+import connectonion.useful_tools.get_emails  # noqa: F401
+import connectonion.useful_tools.send_email  # noqa: F401
+from connectonion.cli.commands import email_commands
+from connectonion.cli.main import app
 
 _send_module = sys.modules["connectonion.useful_tools.send_email"]
 _get_module = sys.modules["connectonion.useful_tools.get_emails"]
+runner = CliRunner()
 
 
 def test_missing_auth_exits_nonzero():
@@ -56,6 +60,17 @@ def test_an_empty_inbox_is_not_a_failure():
     with patch.object(email_commands, "load_api_key", return_value="tok"), \
          patch.object(_get_module, "get_emails", return_value=[]):
         email_commands.handle_email_inbox()
+
+
+def test_inbox_rejects_more_than_the_backend_can_return_before_calling_it():
+    with patch.object(_get_module, "get_emails") as get_emails:
+        result = runner.invoke(app, ["email", "inbox", "--last", "101"])
+
+    assert result.exit_code == 2
+    output = strip_ansi(result.output)
+    assert "--last" in output
+    assert "1<=x<=100" in output
+    get_emails.assert_not_called()
 
 
 def test_a_successful_send_does_not_raise():

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -373,11 +373,11 @@ def test_get_emails_unread_only(mock_get):
     assert call_args[1]["params"]["unread_only"] is True
 
 
-@pytest.mark.parametrize("last", [0, 101, 1000, -1, True, 1.5, "10"])
+@pytest.mark.parametrize("last", [0, 1001, -1, True, 1.5, "10"])
 @patch.dict('os.environ', {}, clear=True)
 @patch('requests.get')
 def test_get_emails_rejects_an_unsupported_limit_before_auth_or_network(mock_get, last):
-    with pytest.raises(ValueError, match="last must be between 1 and 100"):
+    with pytest.raises(ValueError, match="last must be between 1 and 1000"):
         get_emails(last=last)
 
     mock_get.assert_not_called()
@@ -385,13 +385,35 @@ def test_get_emails_rejects_an_unsupported_limit_before_auth_or_network(mock_get
 
 @patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
 @patch('requests.get')
-def test_get_emails_accepts_the_received_mail_maximum(mock_get):
+def test_get_emails_accepts_the_received_mail_maximum_and_offset(mock_get):
+    response = MagicMock()
+    response.json.return_value = {"emails": [], "offset": 2000}
+    mock_get.return_value = response
+
+    assert get_emails(last=1000, offset=2000) == []
+    assert mock_get.call_args.kwargs["params"]["limit"] == 1000
+    assert mock_get.call_args.kwargs["params"]["offset"] == 2000
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
+@patch('requests.get')
+def test_get_emails_refuses_to_silently_ignore_an_offset(mock_get):
     response = MagicMock()
     response.json.return_value = {"emails": []}
     mock_get.return_value = response
 
-    assert get_emails(last=100) == []
-    assert mock_get.call_args.kwargs["params"]["limit"] == 100
+    with pytest.raises(RuntimeError, match="does not support received email pagination"):
+        get_emails(offset=100)
+
+
+@pytest.mark.parametrize("offset", [-1, True, 1.5, "10"])
+@patch.dict('os.environ', {}, clear=True)
+@patch('requests.get')
+def test_get_emails_rejects_an_invalid_offset_before_auth_or_network(mock_get, offset):
+    with pytest.raises(ValueError, match="offset must be a non-negative integer"):
+        get_emails(offset=offset)
+
+    mock_get.assert_not_called()
 
 
 @patch.dict('os.environ', {}, clear=True)

--- a/tests/unit/test_email_functions.py
+++ b/tests/unit/test_email_functions.py
@@ -373,6 +373,27 @@ def test_get_emails_unread_only(mock_get):
     assert call_args[1]["params"]["unread_only"] is True
 
 
+@pytest.mark.parametrize("last", [0, 101, 1000, -1, True, 1.5, "10"])
+@patch.dict('os.environ', {}, clear=True)
+@patch('requests.get')
+def test_get_emails_rejects_an_unsupported_limit_before_auth_or_network(mock_get, last):
+    with pytest.raises(ValueError, match="last must be between 1 and 100"):
+        get_emails(last=last)
+
+    mock_get.assert_not_called()
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
+@patch('requests.get')
+def test_get_emails_accepts_the_received_mail_maximum(mock_get):
+    response = MagicMock()
+    response.json.return_value = {"emails": []}
+    mock_get.return_value = response
+
+    assert get_emails(last=100) == []
+    assert mock_get.call_args.kwargs["params"]["limit"] == 100
+
+
 @patch.dict('os.environ', {}, clear=True)
 def test_get_emails_no_project():
     """Test getting emails without OPENONION_API_KEY."""
@@ -416,6 +437,17 @@ def test_get_sent_returns_what_was_sent(mock_get):
     call_args = mock_get.call_args
     assert call_args[0][0].endswith("/api/v1/email/sent")
     assert call_args[1]["params"] == {"limit": 5}
+
+
+@patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})
+@patch('requests.get')
+def test_get_sent_still_accepts_one_thousand(mock_get):
+    response = MagicMock()
+    response.json.return_value = {"emails": []}
+    mock_get.return_value = response
+
+    assert get_sent(last=1000) == []
+    assert mock_get.call_args.kwargs["params"]["limit"] == 1000
 
 
 @patch.dict('os.environ', {'OPENONION_API_KEY': TEST_JWT_TOKEN})


### PR DESCRIPTION
## Summary

- allow received-mail pages from 1 through 1000 instead of stopping users at 100
- add `offset` to `get_emails()` and `co email inbox`, so users can continue through older pages
- fail closed when a non-zero offset is sent to an older backend that silently ignores pagination
- update mailbox documentation, agent skill guidance, and CLI help
- expand `co email read` lookup from the newest 100 to the newest 1000 messages

## Backend

[openonion/oo-api#164](https://github.com/openonion/oo-api/pull/164) raises the server page size, accepts `offset`, echoes the applied offset, and gives equal timestamps a deterministic ID tie-breaker.

## Usage

```bash
co email inbox -n 1000 --offset 0
co email inbox -n 1000 --offset 1000
co email inbox -n 1000 --offset 2000
```

```python
get_emails(last=1000, offset=2000)
```

Continue until a page is empty.

## Checks

- client/CLI regression batch — 91 passed
- focused Ruff fatal-error checks
- `git diff --check`
- real CLI help verified `1<=x<=1000` and `offset >= 0`
- browser inspection of backend Swagger verified both public constraints and no horizontal overflow

**Dev Blog (required)**
> `docs/blog/2026-08-15-one-mailbox-two-limits.md`

Fixes #1027
