### PR TITLE
fix: honor shell timeouts and surface timeout failures

### DIFF
--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -5,8 +5,8 @@ LLM-Note:
   Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() with shell=True → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
   Integration: exposes bash(command, description="", cwd, timeout) function | used as agent tool | description is OPTIONAL (defaults "") — an LLM is prompted to fill it for the approval UI, but direct/programmatic callers (remote.call, co call, scripts) can pass command alone | not passed to shell | Unix/Mac only (raises ValueError on Windows)
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
-  Errors: raises ValueError on Windows | returns formatted error on timeout | non-zero exit codes included in output | stderr merged with stdout
+  Performance: timeout default 120s; explicit caller values are honored | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
+  Errors: raises ValueError on Windows | propagates subprocess.TimeoutExpired so callers can distinguish timeout from success | non-zero exit codes included in output | stderr merged with stdout
 
 Bash tool for executing terminal commands (Unix/Mac only).
 
@@ -23,8 +23,8 @@ Usage:
 Note: This tool is for Unix/Mac systems. For cross-platform usage, use Shell class instead.
 """
 
-import subprocess
 import platform
+import subprocess
 
 
 def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120) -> str:
@@ -36,17 +36,17 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             — an LLM should fill it in so the approval UI can show intent, but direct
             callers (scripts, remote.call, co call) may pass just the command.
         cwd: Working directory (default: current directory)
-        timeout: Seconds before timeout (default: 120, max: 600)
+        timeout: Seconds before timeout (default: 120)
 
     Returns:
         Command output (stdout + stderr)
+
+    Raises:
+        subprocess.TimeoutExpired: If the command exceeds ``timeout``.
     """
     # Check platform
     if platform.system() == "Windows":
         return "Error: bash tool is for Unix/Mac only. Use Shell class for Windows."
-
-    # Cap timeout at 10 minutes
-    timeout = min(timeout, 600)
 
     try:
         result = subprocess.run(
@@ -60,8 +60,6 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             cwd=cwd,
             timeout=timeout
         )
-    except subprocess.TimeoutExpired:
-        return f"Error: Command timed out after {timeout} seconds"
     except FileNotFoundError:
         return "Error: /bin/bash not found. This tool requires bash shell."
 

--- a/connectonion/useful_tools/shell.py
+++ b/connectonion/useful_tools/shell.py
@@ -5,8 +5,8 @@ LLM-Note:
   Data flow: Shell() creates instance → .run(command, timeout) or .run_in_dir(command, directory, timeout) → subprocess.run(shell=True) in cwd → captures stdout+stderr → _format_output() truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | stores default cwd in self.cwd | no file persistence | side effects depend on executed commands (file I/O, network calls, etc.)
   Integration: exposes Shell class with .run(command, timeout), .run_in_dir(command, directory, timeout) | used as agent tool | class methods extracted to tools via extract_methods_from_instance() | instance accessible via agent.tools.shell
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
-  Errors: returns "Error: Command timed out" on TimeoutExpired | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
+  Performance: timeout default 120s; explicit caller values are honored | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
+  Errors: propagates subprocess.TimeoutExpired so callers can distinguish timeout from success | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
 
 Shell tool for executing terminal commands (cross-platform).
 
@@ -55,27 +55,25 @@ class Shell:
 
         Args:
             command: Shell command to execute (e.g., "ls -la", "git status")
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120)
 
         Returns:
             Command output (stdout + stderr)
-        """
-        timeout = min(timeout, 600)
 
-        try:
-            result = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=self.cwd,
-                timeout=timeout,
-                env=_utf8_env(),
-            )
-        except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+        Raises:
+            subprocess.TimeoutExpired: If the command exceeds ``timeout``.
+        """
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=self.cwd,
+            timeout=timeout,
+            env=_utf8_env(),
+        )
 
         return self._format_output(result)
 
@@ -85,27 +83,25 @@ class Shell:
         Args:
             command: Shell command to execute
             directory: Directory to run the command in
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120)
 
         Returns:
             Command output (stdout + stderr)
-        """
-        timeout = min(timeout, 600)
 
-        try:
-            result = subprocess.run(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=directory,
-                timeout=timeout,
-                env=_utf8_env(),
-            )
-        except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+        Raises:
+            subprocess.TimeoutExpired: If the command exceeds ``timeout``.
+        """
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            cwd=directory,
+            timeout=timeout,
+            env=_utf8_env(),
+        )
 
         return self._format_output(result)
 

--- a/docs/blog/2026-08-15-ten-minutes-was-not-a-timeout-policy.md
+++ b/docs/blog/2026-08-15-ten-minutes-was-not-a-timeout-policy.md
@@ -1,0 +1,46 @@
+# Ten minutes was not a timeout policy
+
+*2026-08-15*
+
+An agent asked ConnectOnion to let a shell command run for two hours. Ten
+minutes later, the command stopped. Worse, the tool reported the stop as an
+ordinary string result, so the agent believed the command had completed.
+
+Both behaviours came from a small convenience that had outgrown its original
+context. The shell tools accepted a `timeout` argument but silently replaced
+every value above 600 seconds with 600. When `subprocess` raised its timeout
+exception, the tools caught it and returned text beginning with `Error:`.
+Humans could read that text as a failure; the tool executor could not. From its
+perspective the Python function returned normally, so the trace status was
+`success`.
+
+## Nested agents changed the scale
+
+Ten minutes may sound generous for a command typed at a terminal. It is not
+generous for an agent that launches another agent. The child may inspect a
+repository, edit several files, run a test suite, and wait for a remote build.
+That work can legitimately exceed the old ceiling, and the parent already has
+the context needed to choose an appropriate bound.
+
+The fix makes the public argument truthful: the default remains 120 seconds,
+but an explicit caller-supplied timeout now reaches `subprocess.run` unchanged.
+There is no hidden second policy inside the tool.
+
+## Failure needs structure
+
+The shell tools also no longer consume `TimeoutExpired`. A direct Python caller
+can catch that exception normally. When the same function runs as an Agent
+tool, ConnectOnion's existing executor catches it at the orchestration boundary
+and records a tool result with `status: error` and `error_type:
+TimeoutExpired`. The model still receives a useful error message, while the
+trace, events, and clients can reliably tell that the command did not finish.
+
+Tests cover both halves of the contract. A 7,200-second timeout must be passed
+through unchanged for `bash`, `Shell.run`, and `Shell.run_in_dir`; a simulated
+timeout must raise from the direct API and become an error in an Agent trace.
+No test needs to wait two hours to prove it.
+
+The broader lesson is that limits are part of an API even when they are hidden.
+If a caller is allowed to request a value, silently substituting another value
+creates false confidence. And once a failure crosses a tool boundary, it must
+remain a failure—not merely look like one in a string.

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -3,8 +3,7 @@
 Tests cover:
 - Shell class: cross-platform shell execution
 - bash function: Unix/Mac specific bash execution
-"""
-"""
+
 LLM-Note: Tests for shell tool
 
 What it tests:
@@ -15,14 +14,15 @@ Components under test:
 """
 
 
-import pytest
+import platform
 import subprocess
 import tempfile
-import platform
 from pathlib import Path
-from connectonion.useful_tools.shell import Shell
-from connectonion.useful_tools.bash import bash
 
+import pytest
+
+from connectonion.useful_tools.bash import bash
+from connectonion.useful_tools.shell import Shell
 
 # =============================================================================
 # Shell Class Tests (Cross-Platform)
@@ -128,10 +128,11 @@ class TestShellIntegration:
 
     def test_shell_can_be_used_as_agent_tool(self):
         """Test that Shell can be registered with agent."""
+        from unittest.mock import Mock
+
         from connectonion import Agent
         from connectonion.core.llm import LLMResponse
         from connectonion.core.usage import TokenUsage
-        from unittest.mock import Mock
 
         mock_llm = Mock()
         mock_llm.model = "test-model"
@@ -261,10 +262,11 @@ class TestBashIntegration:
 
     def test_bash_can_be_used_as_agent_tool(self):
         """Test that bash can be registered with agent."""
+        from unittest.mock import Mock
+
         from connectonion import Agent
         from connectonion.core.llm import LLMResponse
         from connectonion.core.usage import TokenUsage
-        from unittest.mock import Mock
 
         mock_llm = Mock()
         mock_llm.model = "test-model"
@@ -297,6 +299,27 @@ class TestBashIntegration:
         assert "command" in schema["parameters"]["properties"]
         assert "cwd" in schema["parameters"]["properties"]
         assert "timeout" in schema["parameters"]["properties"]
+
+    def test_bash_timeout_is_an_agent_tool_error(self, monkeypatch):
+        """The Agent trace exposes a timeout as an error instead of success."""
+        from unittest.mock import Mock
+
+        from connectonion import Agent
+
+        def expired(*args, **kwargs):
+            raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "run", expired)
+
+        mock_llm = Mock()
+        mock_llm.model = "test-model"
+        agent = Agent("test", llm=mock_llm, tools=[bash], log=False, quiet=True)
+
+        result = agent.execute_tool("bash", {"command": "long-running-agent", "timeout": 7200})
+
+        assert result["status"] == "error"
+        assert "timed out after 7200 seconds" in result["result"]
+        assert agent.current_session["trace"][-1]["error_type"] == "TimeoutExpired"
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -16,6 +16,7 @@ Components under test:
 
 
 import pytest
+import subprocess
 import tempfile
 import platform
 from pathlib import Path
@@ -67,11 +68,29 @@ class TestShellRun:
             result = shell.run("pwd")
             assert tmpdir in result
 
-    def test_run_timeout(self):
-        """Test that timeout returns error message."""
+    def test_run_timeout_raises(self, monkeypatch):
+        """A killed command is an error boundary, not successful tool output."""
+        def expired(*args, **kwargs):
+            raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "run", expired)
         shell = Shell()
-        result = shell.run("sleep 5", timeout=1)
-        assert "timed out" in result
+        with pytest.raises(subprocess.TimeoutExpired):
+            shell.run("long-running-agent", timeout=1)
+
+    def test_run_honours_a_long_timeout(self, monkeypatch):
+        """Agent-sized timeouts must reach subprocess.run unchanged."""
+        seen = {}
+
+        def completed(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            return subprocess.CompletedProcess(args[0], 0, stdout="done", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", completed)
+
+        shell = Shell()
+        assert shell.run("long-running-agent", timeout=7200) == "done"
+        assert seen["timeout"] == 7200
 
 
 class TestShellRunInDir:
@@ -90,6 +109,18 @@ class TestShellRunInDir:
         with tempfile.TemporaryDirectory() as tmpdir:
             shell.run_in_dir("touch test_file.txt", tmpdir)
             assert (Path(tmpdir) / "test_file.txt").exists()
+
+    def test_run_in_dir_honours_a_long_timeout(self, monkeypatch, tmp_path):
+        seen = {}
+
+        def completed(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            return subprocess.CompletedProcess(args[0], 0, stdout="done", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", completed)
+
+        assert Shell().run_in_dir("long-running-agent", str(tmp_path), timeout=7200) == "done"
+        assert seen["timeout"] == 7200
 
 
 class TestShellIntegration:
@@ -202,10 +233,26 @@ class TestBashWithCwd:
 class TestBashWithTimeout:
     """Tests for bash timeout handling."""
 
-    def test_bash_timeout_returns_error(self):
-        """Test that timeout returns error message."""
-        result = bash("sleep 5", "Sleep command", timeout=1)
-        assert "timed out" in result
+    def test_bash_timeout_raises(self, monkeypatch):
+        """The tool executor must be able to distinguish timeout from success."""
+        def expired(*args, **kwargs):
+            raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "run", expired)
+        with pytest.raises(subprocess.TimeoutExpired):
+            bash("long-running-agent", "Long-running command", timeout=1)
+
+    def test_bash_honours_a_long_timeout(self, monkeypatch):
+        seen = {}
+
+        def completed(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            return subprocess.CompletedProcess(args[0], 0, stdout="done", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", completed)
+
+        assert bash("long-running-agent", timeout=7200) == "done"
+        assert seen["timeout"] == 7200
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="bash is Unix/Mac only")


### PR DESCRIPTION
## Summary
- honor caller-supplied timeouts in `bash`, `Shell.run`, and `Shell.run_in_dir` instead of silently clamping them to 600 seconds
- propagate `subprocess.TimeoutExpired` so direct callers can catch it and Agent execution records a structured error status
- add regression coverage for 7,200-second agent workloads and Agent trace error classification
- document why hidden limits and string-shaped errors broke nested agents

## Tests
- `pytest -q tests/unit/test_shell_tool.py tests/unit/test_tool_executor.py` (44 passed, 1 skipped)
- `python -m ruff check connectonion/useful_tools/bash.py connectonion/useful_tools/shell.py tests/unit/test_shell_tool.py`
- `git diff --check`

Closes #1037