### PR TITLE
chore: require labels and release targets in triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,36 +7,42 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+A clear and concise description of what is broken.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## Release planning
+- **Affected ConnectOnion version:** [e.g. 1.7.0a3]
+- **Suggested target version:** [e.g. next patch, 1.8.0, 2.x, or TBD]
+- **Estimated release window:** [e.g. urgent patch, next alpha, future roadmap, or unknown]
+- **Why this priority:** Explain the user impact and whether a workaround exists.
+
+> The reporter's target is an estimate. Maintainers confirm the release by assigning a milestone.
+
+## To reproduce
 1. Install ConnectOnion version '...'
-2. Run code '....'
+2. Run code '...'
 3. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Code Example**
+## Code example
 ```python
-# Minimal code example that reproduces the issue
 from connectonion import Agent
 
-# Your code here
+# Minimal reproduction
 ```
 
-**Error Output**
+## Error output
 ```
 # Paste the full error traceback here
 ```
 
-**Environment (please complete the following information):**
- - OS: [e.g. macOS, Ubuntu, Windows]
- - Python Version: [e.g. 3.10, 3.11, 3.12]
- - ConnectOnion Version: [e.g. 0.0.5]
- - OpenAI API Key configured: [yes/no]
+## Environment
+- OS: [e.g. macOS, Ubuntu, Windows]
+- Python version: [e.g. 3.10, 3.11, 3.12]
+- ConnectOnion version: [e.g. 1.7.0a3]
+- OpenAI API key configured: [yes/no]
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+Add any other context, screenshots, or examples.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,29 +7,35 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Problem
+What user problem does this solve? Describe the current limitation and who encounters it.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+## Proposed solution
+Describe the behavior or API you would like.
 
-**Example Usage**
-Show how the feature would be used:
+## Release planning
+- **Suggested target version:** [e.g. 1.8.0, 2.x, future roadmap, or TBD]
+- **Estimated release window:** [e.g. next alpha, next stable, future roadmap, or unknown]
+- **Why this version:** Explain dependencies, urgency, and compatibility impact.
+
+> The reporter's target is an estimate. Maintainers confirm the release by assigning a milestone.
+
+## Example usage
 ```python
 from connectonion import Agent
 
-# Example of how the feature would work
+# Show how the proposed feature would work
 agent = Agent("assistant")
-# Your proposed API usage
 ```
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Alternatives considered
+Describe any alternative solutions or workarounds.
 
-**Additional context**
-Add any other context, screenshots, or examples about the feature request here.
+## Implementation help
+- [ ] I can submit a PR
+- [ ] I can help with guidance
+- [ ] I can test the implementation
+- [ ] I am only reporting the need
 
-**Would you be willing to help implement this feature?**
-- [ ] Yes, I can submit a PR
-- [ ] Yes, but I would need guidance
-- [ ] No, but I can help test it
+## Additional context
+Add any other context, screenshots, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,16 @@ Brief description of what this PR does.
 ## Related Issue
 Fixes #(issue number)
 
+## Labels and target release (required)
+
+- **Suggested labels:** [bug, feature, documentation, tests, design, browser, platform]
+- **Proposed target version:** [e.g. next patch, 1.8.0, 2.x, or TBD]
+- **Estimated release window:** [e.g. next alpha, next stable, future roadmap, or unknown]
+- **Milestone:** [maintainer assigns the confirmed release milestone]
+- **Why this release:** Explain urgency, dependencies, compatibility, and rollback risk.
+
+> The author's target is an estimate. Maintainers confirm the release by applying labels and assigning a milestone.
+
 ## How this was written
 
 - [ ] I wrote this myself
@@ -34,7 +44,9 @@ A PR that says *"I didn't test the Windows path and I'm unsure the retry logic i
 
 ## Dev Blog (required)
 
-**Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`): a PR that touches no `docs/blog/` file fails the check. The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
+**Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`).
+
+The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
 
 What the post is: a short Design Journal piece telling the **story** of this change — the problem as someone actually hit it, a turn or complication, what the fix teaches, what was measured. Written for a reader who could stop reading at any point.
 What it is not: a changelog entry, a list of commits, or marketing copy.
@@ -58,7 +70,6 @@ Paste the actual command and its real output. The output is the evidence — a t
 
 ```
 $ pytest tests/ -m "not real_api and not network"
-
 ```
 
 - [ ] I have added tests for new functionality
@@ -73,13 +84,13 @@ Keep a PR to one concern. A change that spans several subsystems at once is hard
 
 ## Example Usage
 ```python
-# Show how to use any new features or fixes
 from connectonion import Agent
 
-# Example code
+# Show how to use any new features or fixes
 ```
 
 ## Checklist
+- [ ] I proposed at least one label and a target version above
 - [ ] My code follows the project's code style
 - [ ] I have read every line of this diff and can defend each change
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/.github/workflows/triage-metadata.yml
+++ b/.github/workflows/triage-metadata.yml
@@ -1,0 +1,71 @@
+name: triage-metadata
+
+on:
+  issues:
+    types: [opened, reopened, edited, unlabeled]
+  pull_request_target:
+    types: [opened, reopened, edited, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  labels-and-release-target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require labels and release planning metadata
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const item = context.payload.issue || context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = item.number;
+            const isPullRequest = Boolean(context.payload.pull_request);
+
+            let labels = item.labels.map(label => label.name);
+            if (labels.length === 0) {
+              const title = item.title.toLowerCase();
+              let label = 'needs-triage';
+
+              if (/^(fix|bug)(\(.+\))?:/.test(title) || title.startsWith('[bug]')) label = 'bug';
+              else if (/^(feat|feature)(\(.+\))?:/.test(title) || title.startsWith('[feature]')) label = 'feature';
+              else if (/^docs?(\(.+\))?:/.test(title)) label = 'documentation';
+              else if (/^tests?(\(.+\))?:/.test(title)) label = 'tests';
+              else if (/^(design|rfc)(\(.+\))?:/.test(title) || title.startsWith('[rfc]')) label = 'design';
+
+              if (label === 'needs-triage') {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: label });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color: 'ededed',
+                    description: 'Needs maintainer classification and release planning',
+                  });
+                }
+              }
+
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+              labels = [label];
+              core.notice(`Applied ${label} to #${issue_number}.`);
+            }
+
+            if (!isPullRequest) return;
+
+            const body = item.body || '';
+            const target = body.match(/\*\*Proposed target version:\*\*\s*([^\n\r]+)/i)?.[1]?.trim();
+            const window = body.match(/\*\*Estimated release window:\*\*\s*([^\n\r]+)/i)?.[1]?.trim();
+            const placeholder = value => !value || /^\[/.test(value) || /^(tbd|unknown)$/i.test(value);
+
+            if (placeholder(target) || placeholder(window)) {
+              core.setFailed(
+                'Fill in Proposed target version and Estimated release window in the PR template. ' +
+                'Use an honest estimate such as “1.8.0 / next alpha” or “future roadmap / unknown date”.'
+              );
+            }

--- a/docs/blog/2026-08-15-labels-need-a-release-home.md
+++ b/docs/blog/2026-08-15-labels-need-a-release-home.md
@@ -1,0 +1,15 @@
+---
+title: "A label is useful only when the work has somewhere to ship"
+date: 2026-08-15
+description: "What 64 unlabeled work items taught us about connecting community triage to release planning."
+---
+
+A new contribution arrived with working code and a clear user story, but no label and no release target. The missing label looked cosmetic. It was not: the pull request disappeared from every type-based queue, and nobody could tell whether it belonged in the next patch, the next minor release, or the longer roadmap.
+
+An audit found the same gap across 49 open issues and 15 open pull requests. The issue templates already applied `bug` or `enhancement`, but blank issues and every pull request could still arrive without classification. More importantly, none of the templates asked the author to estimate where the work should ship. That question was being postponed until review, when changing scope is most expensive.
+
+The first temptation was to invent a target version for every old item. That would make the board look complete while turning guesses into apparent commitments. Instead, existing items received only labels that could be supported by their titles and scope. Release ownership stays with milestones: authors propose a version and window, while maintainers confirm the plan by assigning the milestone.
+
+The templates now ask for the affected or proposed version, an estimated release window, and the reason for that priority. A lightweight workflow catches the remaining holes. It infers obvious labels from conventional titles, falls back to `needs-triage`, and prevents a pull request with placeholder release metadata from quietly joining the merge queue.
+
+The useful outcome is not that every card has a colored badge. It is that a contributor can see the path from report to release, and a maintainer can answer two questions without reopening the entire discussion: what kind of work is this, and where do we currently expect it to ship?


### PR DESCRIPTION
## Description

Makes labels and release planning part of the default community workflow.

- backfills reliable type/domain labels on currently unlabeled open issues and PRs;
- keeps the bug and feature templates automatically labeled;
- asks reporters and contributors for a proposed target version and estimated release window;
- adds a safe `pull_request_target` / `issues` workflow that labels unclassified items and requires PR release metadata;
- keeps milestones as the maintainer-confirmed release target.

## Related Issue

Community maintenance follow-up.

## Labels and target release

- **Suggested labels:** documentation, platform
- **Proposed target version:** next patch
- **Estimated release window:** next stable
- **Milestone:** maintainer assigns the confirmed release milestone
- **Why this release:** This prevents new community work from becoming invisible and adds planning metadata without changing runtime behavior.

## Testing

```
python -c 'import yaml; yaml.safe_load(open("triage-metadata.yml")); print("YAML OK")'
YAML OK
```

The workflow uses only webhook metadata and GitHub's API; it never checks out or executes fork code under `pull_request_target`.

## Dev Blog

> docs/blog/2026-08-15-labels-need-a-release-home.md
