### PR TITLE
Fix fresh co ai owner onboarding

### DIFF
--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -18,10 +18,14 @@ Used by:
 
 import hashlib
 import logging
+import os
 import threading
 import time
 import webbrowser
+from contextlib import contextmanager
 from pathlib import Path
+
+from dotenv import dotenv_values
 
 from connectonion import address, host
 
@@ -32,6 +36,70 @@ logging.basicConfig(level=logging.WARNING, format="[%(levelname)s] %(name)s: %(m
 # 1. Current directory .env
 # 2. Global ~/.co/keys.env
 # No need to load again here (load_dotenv doesn't override existing env vars)
+
+
+@contextmanager
+def _owner_invite_lock(co_dir: Path):
+    """Serialize the one-time invite mint across simultaneous ``co ai`` starts."""
+    co_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = co_dir / "owner-invite.lock"
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt
+
+            if lock_file.tell() == 0:
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            lock_path.chmod(0o600)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _ensure_owner_invite(co_dir: Path) -> bool:
+    """Load or mint the private invite used by the careful onboarding policy.
+
+    The process environment wins because it may have come from the current
+    project's ``.env``. Otherwise the global value is loaded into this process
+    (dotenv loading happened before ``co ai`` reached this module), or one is
+    minted once and written with owner-only permissions.
+    """
+    if os.environ.get("CO_INVITE_CODE"):
+        return False
+
+    from ..commands.project_cmd_lib import mint_invite_code, upsert_env
+
+    with _owner_invite_lock(co_dir):
+        keys_env = co_dir / "keys.env"
+        existing = dotenv_values(keys_env, interpolate=False).get("CO_INVITE_CODE")
+        if existing:
+            os.environ["CO_INVITE_CODE"] = existing
+            return False
+
+        invite = mint_invite_code()
+        upsert_env(keys_env, {"CO_INVITE_CODE": invite})
+        os.environ["CO_INVITE_CODE"] = invite
+        return True
+
+
+def _prepare_owner_onboarding(co_dir: Path) -> bool:
+    """Ensure the global identity and its private owner invite exist."""
+    from ..commands.project_cmd_lib import ensure_global_config
+
+    ensure_global_config()
+    return _ensure_owner_invite(co_dir)
 
 
 def start_server(
@@ -69,6 +137,12 @@ def start_server(
     try:
         # Use global ~/.co/ for consistent identity across all co ai sessions
         co_dir = Path.home() / ".co"
+        if _prepare_owner_onboarding(co_dir):
+            from ..commands.project_cmd_lib import console
+
+            console.print(
+                "[green]Owner invite created.[/green] Run [bold]co keys --reveal[/bold] when onboarding your client."
+            )
         input_limits = load_host_config(co_dir)
         addr_data = address.load(co_dir)
 

--- a/connectonion/cli/commands/keys_commands.py
+++ b/connectonion/cli/commands/keys_commands.py
@@ -63,6 +63,7 @@ def _load_env_vars(
 
     names = (
         "OPENONION_API_KEY",
+        "CO_INVITE_CODE",
         "GOOGLE_EMAIL",
         "GOOGLE_ACCESS_TOKEN",
         "GOOGLE_REFRESH_TOKEN",
@@ -210,6 +211,13 @@ def handle_keys(reveal: bool = False, ssh: bool = False, write: bool = False):
             )
     else:
         sec_table.add_row("API Key", "[dim]not set — run 'co auth'[/dim]")
+
+    owner_invite = env_vars.get("CO_INVITE_CODE")
+    if owner_invite:
+        sec_table.add_row(
+            "Owner Invite",
+            owner_invite if reveal else _mask(owner_invite, secret=True),
+        )
 
     telegram_token = env_vars.get("TELEGRAM_BOT_TOKEN")
     if telegram_token:

--- a/connectonion/cli/commands/status_commands.py
+++ b/connectonion/cli/commands/status_commands.py
@@ -81,7 +81,10 @@ def _is_configured(value: object) -> bool:
     )
 
 
-def _read_credential_file(path: Path) -> dict[str, str]:
+def _read_credential_file(
+    path: Path,
+    supported_names: set[str] | None = None,
+) -> dict[str, str]:
     """Read supported key entries without mutating ``os.environ``."""
     if not path.is_file():
         return {}
@@ -89,7 +92,11 @@ def _read_credential_file(path: Path) -> dict[str, str]:
         values = dotenv_values(path, interpolate=False)
     except (OSError, UnicodeError):
         return {}
-    supported = {name for name, _provider in CREDENTIAL_ENV_VARS} | _OAUTH_ENV_VARS
+    supported = (
+        {name for name, _provider in CREDENTIAL_ENV_VARS} | _OAUTH_ENV_VARS
+        if supported_names is None
+        else supported_names
+    )
     return {
         name: str(value)
         for name, value in values.items()
@@ -102,6 +109,7 @@ def _credential_sources(
     project_dir: Path | None = None,
     home: Path | None = None,
     environ: Mapping[str, str] | None = None,
+    supported_names: set[str] | None = None,
 ) -> tuple[tuple[str, Mapping[str, str]], ...]:
     """Return supported credential values grouped by privacy-safe source."""
     project_dir = (
@@ -115,8 +123,14 @@ def _credential_sources(
 
     return (
         ("process environment", environ),
-        (project_source, _read_credential_file(project_dir / ".env")),
-        ("~/.co/keys.env", _read_credential_file(home / ".co" / "keys.env")),
+        (
+            project_source,
+            _read_credential_file(project_dir / ".env", supported_names),
+        ),
+        (
+            "~/.co/keys.env",
+            _read_credential_file(home / ".co" / "keys.env", supported_names),
+        ),
     )
 
 
@@ -132,6 +146,7 @@ def _selected_credential_values(
         project_dir=project_dir,
         home=home,
         environ=environ,
+        supported_names=set(names),
     )
     return {
         name: next(

--- a/docs/blog/2026-08-15-the-owner-needs-a-door.md
+++ b/docs/blog/2026-08-15-the-owner-needs-a-door.md
@@ -1,0 +1,75 @@
+# The Owner Needs a Door
+
+`co ai` was secure on a fresh install. It was also unusable.
+
+The default careful policy admits known contacts and lets a stranger become a
+contact by presenting `CO_INVITE_CODE`. We deliberately stopped shipping a
+literal invite in that policy: a password committed to a public repository is
+one password shared by every installation, not an access-control mechanism.
+`co init` and `co create` replaced it with a unique per-project code.
+
+But the shortest path in the documentation is simply:
+
+```bash
+pip install connectonion
+co ai
+```
+
+That path creates and hosts the global identity directly. It does not run
+either project command, so there was no invite in the environment. The host
+correctly advertised no onboarding method. The person sitting at the machine
+had started their agent and then had no credential with which to connect their
+own client.
+
+## Why printing a code is not a fix
+
+The tempting patch is to generate a code at startup and include it in the host
+banner. It makes the demo work, but turns every captured terminal, CI log,
+screen share, and support paste into a credential leak. Masking part of the
+code is no improvement: the owner still cannot use it, while the output still
+reveals secret material for no operational benefit.
+
+The other tempting patch is to use a fixed fallback whenever the variable is
+missing. That recreates the original universal-password defect under a new
+name.
+
+The useful distinction is between *creating* a recovery path and *displaying*
+its credential. Creation should be automatic; disclosure should be deliberate.
+
+## One code, minted once
+
+The web-server path now ensures the global identity has one owner invite in
+`~/.co/keys.env`. The file is owner-readable on POSIX. A cross-process lock
+protects the first write, so two simultaneous cold starts cannot mint two
+different answers and silently invalidate the first one handed to a client.
+
+Precedence remains ordinary and unsurprising. A code already loaded from the
+process or current project wins. Otherwise an existing global code is loaded
+into the server process. Only when all three are absent is a new value minted,
+stored, and used. Restarting preserves it.
+
+Startup says only that an owner invite was created and points to:
+
+```bash
+co keys --reveal
+```
+
+Plain `co keys` confirms the credential exists with a fixed-width mask. The
+explicit reveal command shows it when the operator is actually onboarding a
+client. That matches how recovery phrases and provider tokens already work:
+safe inspection by default, full material only after an intentional flag.
+
+## The invariant
+
+A careful default needs two properties at once: an unrelated stranger cannot
+walk in, and the owner has a private way back in. We had tested the first half
+and assumed the project scaffolding covered the second. It did not cover the
+product's shortest entry point.
+
+The regression tests now begin from an empty home, exercise the real careful
+rule with the minted value, reject an unrelated value, preserve an existing
+invite across restart, and check that normal key output never contains it.
+
+Security defaults are not complete when they deny the wrong person. They are
+complete when the right person can recover access without teaching logs the
+secret.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -24,6 +24,18 @@ co ai
 - Agent runs in your project directory
 - Starts an authenticated ACP v1 WebSocket at `/acp` for compatible clients
 
+On its first web-server start, `co ai` creates a private owner invite in
+`~/.co/keys.env`. The code is never printed in startup logs. When you are ready
+to connect your own client, reveal it intentionally:
+
+```bash
+co keys --reveal
+```
+
+Restarting `co ai` keeps the same invite, so clients already given the code are
+not locked out. An explicit `CO_INVITE_CODE` in the current project or process
+continues to take precedence.
+
 The published `@connectonion/react@0.4.2-alpha.2` package owns browser transport
 selection, and O Chat pins it. An exact supported discovery descriptor selects
 authenticated `/acp`;

--- a/docs/features/trust.md
+++ b/docs/features/trust.md
@@ -787,6 +787,14 @@ repository. A literal in a shipped policy would be one password for every
 deployment (#561), and a shipped price would charge for every agent whose
 operator never asked to (#672).
 
+The default local `co ai` host is the exception that makes first-owner setup
+usable without weakening that rule: on its first web-server start it mints one
+unique `CO_INVITE_CODE` in the owner-only `~/.co/keys.env`. Startup names the
+command to retrieve it but never prints the secret. Use `co keys` to confirm
+that an owner invite exists, then `co keys --reveal` only in a private terminal
+when you are ready to enter it in your client. Existing project, process, or
+global values are preserved.
+
 Writing the number in your own policy still works, and is the right thing when
 the price is part of what you are publishing:
 

--- a/tests/e2e/cli/test_cli_keys.py
+++ b/tests/e2e/cli/test_cli_keys.py
@@ -210,6 +210,25 @@ class TestLoadEnvVars:
             finally:
                 os.chdir(original_cwd)
 
+    def test_loads_the_owner_invite_without_mutating_the_environment(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        (home / ".co").mkdir(parents=True)
+        (home / ".co" / "keys.env").write_text(
+            "CO_INVITE_CODE=OWNER-INVIT-CODE2\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+
+        from connectonion.cli.commands.keys_commands import _load_env_vars
+
+        before = dict(os.environ)
+        result = _load_env_vars(project_dir=tmp_path / "project", home=home)
+
+        assert result["CO_INVITE_CODE"] == "OWNER-INVIT-CODE2"
+        assert dict(os.environ) == before
+
     def test_uses_canonical_sources_from_a_deep_directory_without_mutation(
         self, tmp_path, monkeypatch
     ):
@@ -479,6 +498,35 @@ class TestHandleKeysSuccess:
         assert "*" * 16 in output
         assert token not in output
         assert token[:8] not in output
+
+    def test_owner_invite_is_masked_until_reveal(self, monkeypatch, capsys):
+        from connectonion import address
+        from connectonion.cli.commands import keys_commands
+        from rich.console import Console
+
+        invite = "OWNER-INVIT-CODE2"
+        monkeypatch.setattr(
+            keys_commands,
+            "console",
+            Console(width=200, color_system=None),
+        )
+        monkeypatch.setattr(keys_commands, "_find_co_dir", lambda: Path(".co"))
+        monkeypatch.setattr(address, "load", lambda _path: self.MOCK_ADDR)
+        monkeypatch.setattr(
+            keys_commands,
+            "_load_env_vars",
+            lambda: {"OPENONION_API_KEY": None, "CO_INVITE_CODE": invite},
+        )
+
+        keys_commands.handle_keys(reveal=False)
+        masked = capsys.readouterr().out
+        keys_commands.handle_keys(reveal=True)
+        revealed = capsys.readouterr().out
+
+        assert "Owner Invite" in masked
+        assert invite not in masked
+        assert "*" * 16 in masked
+        assert invite in revealed
 
 
 class TestHandleKeysOAuth:

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -26,6 +26,12 @@ from connectonion.useful_plugins import eval as eval_plugin
 from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
 
 
+@pytest.fixture(autouse=True)
+def avoid_real_global_owner_setup(monkeypatch):
+    """Server tests exercise hosting without writing to the developer's home."""
+    monkeypatch.setattr(main_mod, "_prepare_owner_onboarding", lambda _co_dir: False)
+
+
 def test_managed_delegation_permissions_are_explicit(tmp_path):
     """Nested coding agents own inner approval without reopening unknown tools."""
     agent = SimpleNamespace(current_session={'permissions': {}})
@@ -141,6 +147,32 @@ def test_start_server_hosts_provided_agent(monkeypatch):
     assert called["relay_url"] is None
     assert called["agent"] is agent
     assert callable(called["acp_agent_factory"])
+
+
+def test_start_server_prepares_owner_invite_without_printing_it(monkeypatch):
+    agent = SimpleNamespace(name="agent")
+    printed = []
+    prepared = []
+    secret = "NEVER-PRINT-THIS2"
+
+    def prepare(co_dir):
+        prepared.append(co_dir)
+        return True
+
+    monkeypatch.setattr(main_mod, "_prepare_owner_onboarding", prepare)
+    monkeypatch.setattr(main_mod, "host", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "connectonion.cli.commands.project_cmd_lib.console.print",
+        lambda message: printed.append(message),
+    )
+    monkeypatch.setenv("CO_INVITE_CODE", secret)
+
+    main_mod.start_server(agent)
+
+    assert prepared == [Path.home() / ".co"]
+    output = " ".join(printed)
+    assert "co keys --reveal" in output
+    assert secret not in output
 
 
 def test_network_acp_sessions_are_principal_scoped_and_full_access_is_admin_only(

--- a/tests/unit/test_co_ai_owner_invite.py
+++ b/tests/unit/test_co_ai_owner_invite.py
@@ -1,0 +1,65 @@
+"""A fresh ``co ai`` owner always has one private way back in."""
+
+import os
+import re
+
+from connectonion.cli.co_ai.main import _ensure_owner_invite
+from connectonion.network.trust.fast_rules import evaluate_request
+
+
+def test_a_fresh_install_mints_one_private_invite(tmp_path, monkeypatch):
+    co_dir = tmp_path / ".co"
+    co_dir.mkdir()
+    (co_dir / "keys.env").write_text("AGENT_ADDRESS=0xowner\n", encoding="utf-8")
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+
+    created = _ensure_owner_invite(co_dir)
+
+    code = os.environ["CO_INVITE_CODE"]
+    assert created is True
+    assert re.fullmatch(r"[A-HJ-NP-Z2-9]{5}(?:-[A-HJ-NP-Z2-9]{5}){2}", code)
+    assert f"CO_INVITE_CODE={code}\n" in (co_dir / "keys.env").read_text()
+    if os.name != "nt":
+        assert (co_dir / "keys.env").stat().st_mode & 0o777 == 0o600
+
+
+def test_restart_keeps_the_invite_people_already_hold(tmp_path, monkeypatch):
+    co_dir = tmp_path / ".co"
+    co_dir.mkdir()
+    keys_env = co_dir / "keys.env"
+    keys_env.write_text("CO_INVITE_CODE=KEPT2-KEPT3-KEPT4\n", encoding="utf-8")
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+
+    created = _ensure_owner_invite(co_dir)
+
+    assert created is False
+    assert os.environ["CO_INVITE_CODE"] == "KEPT2-KEPT3-KEPT4"
+    assert keys_env.read_text().count("CO_INVITE_CODE=") == 1
+
+
+def test_an_explicit_project_invite_wins_without_copying_it_global(tmp_path, monkeypatch):
+    co_dir = tmp_path / ".co"
+    co_dir.mkdir()
+    keys_env = co_dir / "keys.env"
+    keys_env.write_text("AGENT_ADDRESS=0xowner\n", encoding="utf-8")
+    monkeypatch.setenv("CO_INVITE_CODE", "LOCAL-OWNER-CODE2")
+
+    created = _ensure_owner_invite(co_dir)
+
+    assert created is False
+    assert "CO_INVITE_CODE" not in keys_env.read_text()
+
+
+def test_the_new_invite_opens_only_for_the_client_who_knows_it(tmp_path, monkeypatch):
+    co_dir = tmp_path / ".co"
+    co_dir.mkdir()
+    (co_dir / "keys.env").touch()
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    _ensure_owner_invite(co_dir)
+    policy = {
+        "onboard": {"invite_code": ["$CO_INVITE_CODE"]},
+        "default": "deny",
+    }
+
+    assert evaluate_request(policy, "0xowner-client", {"invite_code": os.environ["CO_INVITE_CODE"]}) == "allow"
+    assert evaluate_request(policy, "0xunrelated", {"invite_code": "SOMEONE-ELSES-CODE2"}) == "deny"


### PR DESCRIPTION
## Summary

- bootstrap one unique owner invite when a fresh `co ai` web host has no project, process, or global invite
- serialize simultaneous cold starts so they cannot mint competing credentials
- keep startup output secret-free and expose the invite only through the intentional `co keys --reveal` path
- preserve existing project/process/global invite precedence and retain the same code across restarts

## Security model

The careful policy remains closed to unrelated strangers. The invite is stored in owner-only `~/.co/keys.env`, masked by default, and never included in startup logs. Fresh setup creates a private recovery path without restoring a universal fallback password.

## Tests

- `110 passed` across the owner-invite, key display, trust policy, `co ai`, eval-factory, and status regression suites
- broad CI selection reached `1,449 passed` locally before stopping; three Unix-socket tests blocked by the workspace sandbox pass `5/5` with socket permission
- design-journal story check: passed
- GitHub’s full Python and Windows matrices are the merge gate

Closes #1043
