### PR TITLE
test: unblock and speed the 1.6.8 release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Verify and audit the exact dependency lock
         run: |
@@ -44,6 +48,10 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |
@@ -83,6 +91,10 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |
@@ -95,8 +107,8 @@ jobs:
           pytest tests/unit/test_transport.py tests/e2e/cli/test_browser_daemon.py -v --tb=short
 
   # Simulate a REAL Windows user end-to-end: install from the wheel (exactly what
-  # PyPI ships — not an editable checkout), discover the CLI from the shell, run the
-  # documented patchright step, exercise paths with spaces + non-ASCII characters,
+  # PyPI ships — not an editable checkout), discover the CLI from the shell,
+  # validate the patchright CLI, exercise paths with spaces + non-ASCII characters,
   # then drive a REAL Chrome through `co browser` (daemon spawn → named pipe →
   # launch → navigate → close). This is the "it installs but co/patchright won't
   # run on my machine" class of failure, caught before release.
@@ -112,6 +124,10 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Build the wheel (what PyPI ships)
         run: |
@@ -162,17 +178,10 @@ jobs:
             Write-Error "keypair was not created on first run"; exit 1
           }
 
-      - name: patchright CLI runs and can install a browser (the documented user step)
+      - name: patchright CLI is included and runnable
         run: |
           python -m patchright --version
           if ($LASTEXITCODE -ne 0) { Write-Error "patchright module not runnable"; exit 1 }
-          # Retry once: this downloads a browser and can flake on network hiccups.
-          python -m patchright install chrome
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "patchright install chrome failed once - retrying"
-            python -m patchright install chrome
-            if ($LASTEXITCODE -ne 0) { exit 1 }
-          }
 
       - name: Package data survives the wheel — skills copy in a path with spaces + CJK
         run: |

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -267,8 +267,12 @@ New tests in `tests/unit/test_windows_compat.py`:
 - ✅ Subprocess pipe decodes UTF-8/emoji even when the locale reports GBK/cp936
 - ✅ Subprocess survives non-UTF-8 bytes (`errors="replace"`, no crash)
 
-A real Windows E2E job (`.github/workflows/tests.yml` → `windows-e2e`) also runs the
-shipped `Shell` + background runner under an actual `chcp 936` (GBK) console.
+A real Windows E2E job (`.github/workflows/tests.yml` → `windows-e2e`) installs the
+wheel like a user, verifies the Patchright CLI, launches the preinstalled Chrome,
+then hides Chrome and proves `co browser` can download per-user Chromium and drive
+it on a truly fresh setup. It also runs the shipped `Shell` + background runner
+under an actual `chcp 936` (GBK) console. The fresh-setup journey is the single
+browser-download check, avoiding a second redundant network installation.
 
 ## Supported Characters
 

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -10,23 +10,22 @@ exits 0. Asking for a specific email that does not exist is one — the command
 did not deliver what was asked.
 """
 
-import sys
+from importlib import import_module
 from unittest.mock import patch
 
 import pytest
 import typer
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
+# The package __init__ re-exports the functions under the same names as their
+# modules, so a dotted patch target resolves to the function. Import the real
+# modules explicitly so collection never depends on another test's import order.
 from connectonion.cli.commands import email_commands
 from connectonion.cli.main import app
-# The package __init__ re-exports the functions under the same names as their
-# modules, so a dotted patch target resolves to the function; go through
-# sys.modules to reach the real modules the handlers import from.
-import connectonion.useful_tools.send_email
-import connectonion.useful_tools.get_emails
 
-_send_module = sys.modules["connectonion.useful_tools.send_email"]
-_get_module = sys.modules["connectonion.useful_tools.get_emails"]
+_send_module = import_module("connectonion.useful_tools.send_email")
+_get_module = import_module("connectonion.useful_tools.get_emails")
 runner = CliRunner()
 
 
@@ -66,8 +65,9 @@ def test_inbox_rejects_more_than_one_backend_page_before_calling_it():
         result = runner.invoke(app, ["email", "inbox", "--last", "1001"])
 
     assert result.exit_code == 2
-    assert "--last" in result.output
-    assert "1000" in result.output
+    output = strip_ansi(result.output)
+    assert "--last" in output
+    assert "1000" in output
     get_emails.assert_not_called()
 
 

--- a/tests/unit/test_compaction_does_not_eat_a_write.py
+++ b/tests/unit/test_compaction_does_not_eat_a_write.py
@@ -37,6 +37,19 @@ def _expired(storage, n=10):
                              created=past - 1000, expires=past))
 
 
+def _append_while_compactor_has_the_lock(storage, session):
+    """Model an append after the compactor's read without waiting 30 seconds.
+
+    The size guard is deliberately a second defence beyond the lock. Calling
+    ``save`` here from the same thread cannot model another process: it waits
+    for the lock held by ``compact`` until the production timeout expires.
+    Appending the same JSONL payload directly isolates the guard this test is
+    about and keeps three tests from each paying that 30-second timeout.
+    """
+    with storage.path.open("a", encoding="utf-8") as stream:
+        stream.write(session.model_dump_json() + "\n")
+
+
 class TestAWriteDuringCompactionSurvives:
 
     def test_a_session_saved_mid_compaction_is_not_lost(self, storage, monkeypatch):
@@ -49,8 +62,11 @@ class TestAWriteDuringCompactionSurvives:
 
         def read_then_someone_writes():
             records = original()
-            storage.save(Session(session_id="mid", status="done", prompt="a real turn",
-                                 created=now, expires=now + 3600))
+            _append_while_compactor_has_the_lock(
+                storage,
+                Session(session_id="mid", status="done", prompt="a real turn",
+                        created=now, expires=now + 3600),
+            )
             return records
 
         monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)
@@ -70,8 +86,11 @@ class TestAWriteDuringCompactionSurvives:
 
         def read_then_someone_writes():
             records = original()
-            storage.save(Session(session_id="mid", status="done", prompt="p",
-                                 created=now, expires=now + 3600))
+            _append_while_compactor_has_the_lock(
+                storage,
+                Session(session_id="mid", status="done", prompt="p",
+                        created=now, expires=now + 3600),
+            )
             return records
 
         monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)
@@ -123,8 +142,11 @@ class TestStartupDoesNotHingeOnIt:
 
         def read_then_someone_writes():
             records = original()
-            storage.save(Session(session_id="mid", status="done", prompt="p",
-                                 created=now, expires=now + 3600))
+            _append_while_compactor_has_the_lock(
+                storage,
+                Session(session_id="mid", status="done", prompt="p",
+                        created=now, expires=now + 3600),
+            )
             return records
 
         monkeypatch.setattr(storage, '_latest_by_id', read_then_someone_writes)


### PR DESCRIPTION
Closes #1048

## What changed

- strips Rich ANSI codes before asserting the visible `--last` validation message
- imports patch targets deterministically instead of depending on test collection order
- models the compaction size-guard race directly, removing three 30-second same-thread lock waits
- caches pip downloads for Linux and Windows CI jobs
- removes the redundant 43-second branded-Chrome install from Windows E2E while retaining:
  - wheel installation as a real user
  - Patchright CLI verification
  - preinstalled Chrome launch/navigation
  - fresh-laptop per-user Chromium auto-install, launch, and navigation
  - named-pipe, parallel-agent, CJK path, GBK console, stale-PID, and authkey recovery journeys
- documents the exact Windows browser coverage

## Measured result

The three compaction tests fell from ~30.5 seconds each to ~0.01–0.05 seconds. This saves ~90 seconds per Python job (~6 runner-minutes across 3.10–3.13). Windows E2E removes another 43 seconds from its critical path.

## Verification

- `14 passed` focused tests, repeated in both file orders
- Ruff clean for changed Python tests
- workflow YAML parsed successfully
- `git diff --check` clean
- prior release run passed Windows E2E and 6,206 tests per Python version except the one ANSI assertion fixed here

Full PR CI is the authoritative cross-version/Windows verification.