### PR TITLE
fix(bash,shell): honour the caller's timeout, and make a timeout unmistakable (#1037)

### DIFF
--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -5,7 +5,7 @@ LLM-Note:
   Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() with shell=True → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
   Integration: exposes bash(command, description="", cwd, timeout) function | used as agent tool | description is OPTIONAL (defaults "") — an LLM is prompted to fill it for the approval UI, but direct/programmatic callers (remote.call, co call, scripts) can pass command alone | not passed to shell | Unix/Mac only (raises ValueError on Windows)
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
+  Performance: timeout default 120s, caller's value honoured | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
   Errors: raises ValueError on Windows | returns formatted error on timeout | non-zero exit codes included in output | stderr merged with stdout
 
 Bash tool for executing terminal commands (Unix/Mac only).
@@ -36,7 +36,10 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             — an LLM should fill it in so the approval UI can show intent, but direct
             callers (scripts, remote.call, co call) may pass just the command.
         cwd: Working directory (default: current directory)
-        timeout: Seconds before timeout (default: 120, max: 600)
+        timeout: Seconds before timeout (default: 120). Honoured as given —
+            an agent invoking another agent over bash routinely needs more than
+            ten minutes, and a silently clamped value is indistinguishable from
+            a respected one.
 
     Returns:
         Command output (stdout + stderr)
@@ -45,8 +48,6 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
     if platform.system() == "Windows":
         return "Error: bash tool is for Unix/Mac only. Use Shell class for Windows."
 
-    # Cap timeout at 10 minutes
-    timeout = min(timeout, 600)
 
     try:
         result = subprocess.run(
@@ -61,7 +62,14 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             timeout=timeout
         )
     except subprocess.TimeoutExpired:
-        return f"Error: Command timed out after {timeout} seconds"
+        # Callers must be able to tell a killed command from a finished one.
+        # This string is the only signal they get, so it leads with TIMEOUT and
+        # says the work is incomplete rather than reading like ordinary output.
+        return (
+            f"TIMEOUT: command was killed after {timeout} seconds and did NOT complete. "
+            f"Any work it was part-way through is unfinished. "
+            f"Do not treat this as success; re-run with a larger timeout or smaller scope."
+        )
     except FileNotFoundError:
         return "Error: /bin/bash not found. This tool requires bash shell."
 

--- a/connectonion/useful_tools/shell.py
+++ b/connectonion/useful_tools/shell.py
@@ -5,8 +5,8 @@ LLM-Note:
   Data flow: Shell() creates instance → .run(command, timeout) or .run_in_dir(command, directory, timeout) → subprocess.run(shell=True) in cwd → captures stdout+stderr → _format_output() truncates if >10000 chars → returns formatted output: str
   State/Effects: executes system commands via subprocess.run(shell=True) | stores default cwd in self.cwd | no file persistence | side effects depend on executed commands (file I/O, network calls, etc.)
   Integration: exposes Shell class with .run(command, timeout), .run_in_dir(command, directory, timeout) | used as agent tool | class methods extracted to tools via extract_methods_from_instance() | instance accessible via agent.tools.shell
-  Performance: timeout default 120s, max 600s | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
-  Errors: returns "Error: Command timed out" on TimeoutExpired | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
+  Performance: timeout default 120s, caller's value honoured | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes) | uses system default shell (bash/sh on Unix, cmd.exe on Windows)
+  Errors: returns a "TIMEOUT: ... did NOT complete" string on TimeoutExpired | includes stderr in output | includes exit code for non-zero returns | handles empty output gracefully
 
 Shell tool for executing terminal commands (cross-platform).
 
@@ -55,12 +55,11 @@ class Shell:
 
         Args:
             command: Shell command to execute (e.g., "ls -la", "git status")
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120), honoured as given
 
         Returns:
             Command output (stdout + stderr)
         """
-        timeout = min(timeout, 600)
 
         try:
             result = subprocess.run(
@@ -75,7 +74,11 @@ class Shell:
                 env=_utf8_env(),
             )
         except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+            return (
+                f"TIMEOUT: command was killed after {timeout} seconds and did NOT complete. "
+                f"Any work it was part-way through is unfinished. "
+                f"Do not treat this as success; re-run with a larger timeout or smaller scope."
+            )
 
         return self._format_output(result)
 
@@ -85,12 +88,11 @@ class Shell:
         Args:
             command: Shell command to execute
             directory: Directory to run the command in
-            timeout: Seconds before timeout (default: 120, max: 600)
+            timeout: Seconds before timeout (default: 120), honoured as given
 
         Returns:
             Command output (stdout + stderr)
         """
-        timeout = min(timeout, 600)
 
         try:
             result = subprocess.run(
@@ -105,7 +107,11 @@ class Shell:
                 env=_utf8_env(),
             )
         except subprocess.TimeoutExpired:
-            return f"Error: Command timed out after {timeout} seconds"
+            return (
+                f"TIMEOUT: command was killed after {timeout} seconds and did NOT complete. "
+                f"Any work it was part-way through is unfinished. "
+                f"Do not treat this as success; re-run with a larger timeout or smaller scope."
+            )
 
         return self._format_output(result)
 

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -18,6 +18,7 @@ Components under test:
 import pytest
 import tempfile
 import platform
+import subprocess
 from pathlib import Path
 from connectonion.useful_tools.shell import Shell
 from connectonion.useful_tools.bash import bash
@@ -71,7 +72,11 @@ class TestShellRun:
         """Test that timeout returns error message."""
         shell = Shell()
         result = shell.run("sleep 5", timeout=1)
-        assert "timed out" in result
+        # A timeout must be unmistakable to the caller: a killed command and a
+        # finished one arriving as similar-looking strings is how orchestrators
+        # come to mark truncated steps complete.
+        assert "TIMEOUT" in result
+        assert "did NOT complete" in result
 
 
 class TestShellRunInDir:
@@ -205,7 +210,8 @@ class TestBashWithTimeout:
     def test_bash_timeout_returns_error(self):
         """Test that timeout returns error message."""
         result = bash("sleep 5", "Sleep command", timeout=1)
-        assert "timed out" in result
+        assert "TIMEOUT" in result
+        assert "did NOT complete" in result
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="bash is Unix/Mac only")
@@ -260,3 +266,40 @@ class TestBashOnWindows:
         """Test that bash returns error on Windows."""
         result = bash("echo test", "Echo test")
         assert "Unix/Mac only" in result
+
+
+class TestTimeoutNotClamped:
+    """The caller's timeout must be honoured, not silently reduced.
+
+    Regression for #1037: `timeout = min(timeout, 600)` capped every call at ten
+    minutes without telling anyone. Agents invoking other agents over bash need
+    longer than that, and a clamped value is indistinguishable from a respected
+    one — so a step killed at 600s was reported as complete and whole pipelines
+    exited 0 having produced nothing.
+    """
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="bash is Unix/Mac only")
+    def test_bash_passes_timeout_through_unchanged(self, monkeypatch):
+        seen = {}
+
+        def fake_run(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            raise subprocess.TimeoutExpired(cmd="sleep", timeout=kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = bash("sleep 9000", "long agent run", timeout=7200)
+
+        assert seen["timeout"] == 7200, "timeout was clamped instead of passed through"
+        assert "7200" in result, "the reported timeout must be the one actually used"
+
+    def test_shell_run_passes_timeout_through_unchanged(self, monkeypatch):
+        seen = {}
+
+        def fake_run(*args, **kwargs):
+            seen["timeout"] = kwargs["timeout"]
+            raise subprocess.TimeoutExpired(cmd="sleep", timeout=kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        Shell().run("sleep 9000", timeout=7200)
+
+        assert seen["timeout"] == 7200, "timeout was clamped instead of passed through"


### PR DESCRIPTION
Closes #1037.

## What was wrong

`bash()` and `Shell.run()` / `run_in_dir()` clamped every call with `timeout = min(timeout, 600)` and reported nothing. `co call` and `co ai` make bash the transport for *whole agent runs*, so a ten-minute ceiling is a ceiling on what an agent can ask another agent to do — and the caller could not tell its parameter had been discarded.

## Evidence

A five-step pipeline passing `timeout=7200` on every call:

```
bash(timeout=7200, ...)  [OK] 600.0s
bash(timeout=7200, ...)  [OK] 600.0s
bash(timeout=7200, ...)  [OK] 600.0s
bash(timeout=7200, ...)  [OK] 600.0s
```

One sub-skill writes its output file at around minute 11. Through the pipeline it produced **zero files, every run**; run standalone it finishes in 63 iterations and writes 6. The clamp also silently swallowed a separate `-i` fix — iteration ceilings really were raised to 200, but nothing could reach one because wall-clock killed the process first. **Two limits, and the invisible one won.**

## Changes

1. **Remove the clamp** in `bash.py` and both `shell.py` sites. The caller's value is used as given; the default stays 120s.
2. **Make a timeout unmistakable.** It previously returned `"Error: Command timed out after N seconds"` — an ordinary successful tool result as far as the caller is concerned, which is how orchestrators came to mark killed steps complete while the run exited 0. It now leads with `TIMEOUT:` and states plainly that the work did not complete.

Kept as a returned string rather than a raised exception: the existing tests pin the return contract, and other failure paths in this tool (Windows, missing bash) return strings too.

## Tests

Two regression tests assert the timeout reaches `subprocess.run` unchanged. **Both fail on the unpatched code** (`assert 600 == 7200`) — verified by stashing the fix and running them — and 25 pass with it.

Existing timeout assertions were updated to the new wording.