### PR TITLE
fix(trust): let contacts approve their own session work

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -553,28 +553,29 @@ def check_approval(agent: 'Agent') -> None:
         return
 
     # =================================================================
-    # The dialog belongs to the operator, not to whoever is connected
+    # The dialog belongs to the authenticated user of this session
     # =================================================================
-    # Placed here, at the one line that is about to prompt — not earlier. An
-    # earlier check refused `read_file` for a contact, which gates access
-    # rather than approval and makes the agent useless to the people it was
-    # shared with. Only a call that would have opened the dialog is affected.
+    # An invite grants normal agent use. A contact therefore needs to be able
+    # to approve the edits and commands required by their own request. Admin is
+    # reserved for control-plane operations; those remain separately guarded
+    # by the signed /admin and /superadmin routes and by the control-file check
+    # above.
     #
-    # The host knows who is on this socket: CONNECT is signed and the trust
-    # layer classified them before the session existed. That answer used to be
-    # dropped, so a contact saw the owner's "Allow" button and an invite code
-    # carried command execution.
+    # The host derives this level from the signed CONNECT identity on every
+    # turn. It is server-owned session state, so a client cannot promote itself
+    # by editing the session JSON. Unknown, blocked, and stranger levels still
+    # fail closed here as defence in depth, even though the trust gate should
+    # stop them before a session begins.
     #
-    # No requester recorded means the session did not arrive through the host —
-    # a local `co ai` run — and behaves as before.
+    # No requester recorded means the session is local (`co ai`) and behaves as
+    # before.
     requester = agent.current_session.get('requester')
-    if requester and requester.get('level') != 'admin':
+    user_levels = {'contact', 'whitelist', 'whitelisted', 'admin'}
+    if requester and requester.get('level') not in user_levels:
         raise ValueError(
-            f"{tool_name} needs the operator's approval, and you are "
-            f"{requester.get('level', 'not the operator')}. Only they can "
-            f"answer that prompt. Ask them to allow it in .co/host.yaml under "
-            f"`permissions` — the entry for this call is "
-            f"`{_permission_line(pending)}`."
+            f"{tool_name} needs approval from an authenticated contact, and "
+            f"you are {requester.get('level', 'unknown')}. Ask the agent owner "
+            "for an invite or access."
         )
 
     # Get approval key for this tool

--- a/tests/unit/test_only_the_owner_approves.py
+++ b/tests/unit/test_only_the_owner_approves.py
@@ -5,13 +5,9 @@ layer classifies the caller as admin / whitelisted / contact / blocked before
 the session exists. That answer was computed and dropped — `approval.py` had
 zero references to the requester.
 
-So the dialog went to whoever was connected. A contact — anyone who typed the
-invite code — was shown the owner's dialog and could click "Allow". An invite
-code carried command execution.
-
-The dialog is the operator's. Anyone else gets a refusal that names what the
-operator would have to pre-authorise, which is a thing they can paste into a
-message and ask for.
+An invite is the normal B2B user grant. Its contact may use the agent and
+approve work in their own authenticated session. Admin remains the control-
+plane role; it is not required for ordinary agent work.
 """
 
 import pytest
@@ -51,50 +47,31 @@ DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
                                            'description': 'clean'}}
 
 
-class TestOnlyAnAdminIsAsked:
+class TestAuthenticatedUsersApproveTheirOwnWork:
 
-    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'stranger'])
-    def test_a_non_admin_is_not_shown_the_dialog(self, level):
-        io = FakeIO()
+    @pytest.mark.parametrize("level", ['contact', 'whitelist', 'whitelisted', 'admin'])
+    def test_an_authenticated_user_is_shown_the_dialog(self, level):
+        io = FakeIO(responses=[{'approved': True}])
         agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
                                             'level': level})
-        agent.current_session['pending_tool'] = DANGEROUS
-
-        with pytest.raises(ValueError):
-            check_approval(agent)
-
-        assert io.sent == [], (
-            f"a {level} was offered the operator's approval dialog and could "
-            "have clicked Allow"
-        )
-
-    def test_the_refusal_names_what_to_ask_for(self):
-        """The requester cannot fix this themselves, so tell them what to ask.
-
-        A refusal that just says no turns into a message to the operator
-        saying 'it did not work', which costs a round trip to learn nothing.
-        """
-        agent = FakeAgent(io=FakeIO(), requester={'address': '0x' + 'e' * 64,
-                                                  'level': 'contact'})
-        agent.current_session['pending_tool'] = DANGEROUS
-
-        with pytest.raises(ValueError) as exc:
-            check_approval(agent)
-
-        message = str(exc.value)
-        assert 'host.yaml' in message
-        assert 'bash' in message
-
-    def test_an_admin_is_still_asked(self):
-        io = FakeIO(responses=[{'approved': True}])
-        agent = FakeAgent(io=io, requester={'address': '0x' + 'f' * 64,
-                                            'level': 'admin'})
         agent.current_session['pending_tool'] = DANGEROUS
 
         check_approval(agent)
 
         assert len(io.sent) == 1
         assert io.sent[0]['type'] == 'approval_needed'
+
+    @pytest.mark.parametrize("level", ['stranger', 'blocked', 'unknown'])
+    def test_a_non_user_is_not_shown_the_dialog(self, level):
+        io = FakeIO()
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': level})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        with pytest.raises(ValueError, match='authenticated contact'):
+            check_approval(agent)
+
+        assert io.sent == []
 
     def test_a_safe_tool_is_unaffected_for_everyone(self):
         """This gates approval, not access. A contact may still use the agent."""


### PR DESCRIPTION
## Outcome

An invited contact can now approve edits, commands, and delegation tools in their own authenticated session. Admin remains a control-plane role.

## Security boundary

- allows approval prompts for contact, whitelist, and admin session users
- keeps stranger, blocked, and unknown identities fail-closed
- keeps requester identity/level server-owned and signature-derived
- keeps cross-session ownership checks intact
- keeps `.co` control files protected
- keeps direct `EXEC` restricted to admin/whitelist because it has no approval hook
- keeps signed admin/super-admin routes unchanged

## Verification

- 82 focused approval/control-plane/session tests passed
- 143 broader approval/trust/EXEC/session tests passed
- `git diff --check` passed

Closes #1054