### PR TITLE
fix: let contacts approve their own work

### DIFF
--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -67,7 +67,7 @@ from .http_router import (
 )
 
 
-EXEC_REQUIRES = ("admin", "whitelist")
+EXEC_REQUIRES = ("admin", "whitelist", "contact")
 
 
 def _make_ws_exec(create_agent, exec_permissions, trust_agent):
@@ -85,12 +85,11 @@ def _make_ws_exec(create_agent, exec_permissions, trust_agent):
     runs `whoami` as the operator. The session loop's comment said "Auth is the
     same gate as INPUT" -- the authentication was; the authorisation was not.
 
-    Admin or whitelisted, because EXEC is the terminal-style fast path: no LLM,
-    no session, and no approval hook. `before_each_tool` does not fire here, so
-    a tool invoked this way skips everything that normally sits between the
-    model deciding to call something and it running. A contact can still talk
-    to the agent through INPUT, where those checks are in the way. Driving the
-    operator's tools directly is a different act and was never gated as one.
+    EXEC is the terminal-style fast path: no LLM, no session, and no approval
+    hook. It remains limited to the operator's server-side permission whitelist.
+    An invite grants contact status, so a contact may use those pre-authorised
+    tools just like an admin; it does not grant permission to anything absent
+    from that whitelist.
     """
     def handle_ws_exec(tool_name, args, requester_address=None):
         if not requester_address:
@@ -101,7 +100,7 @@ def _make_ws_exec(create_agent, exec_permissions, trust_agent):
                  else trust_agent.get_level(requester_address))
         if level not in EXEC_REQUIRES:
             return {"status": "error",
-                    "error": f"forbidden: exec requires admin or whitelist, "
+                    "error": f"forbidden: exec requires a contact or admin, "
                              f"you are {level}"}
 
         return exec_handler(create_agent, exec_permissions, tool_name, args)

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -393,20 +393,6 @@ def matches_permission_pattern(tool_name: str, tool_args: dict, pattern: str) ->
 # Event Handlers
 # =============================================================================
 
-def _permission_line(pending: dict) -> str:
-    """The exact host.yaml key that would allow this call in future.
-
-    Capitalised `Bash(...)` because that is the form the loader matches. A
-    suggestion that pastes cleanly and then silently does nothing is worse than
-    no suggestion — the operator stops looking for the real cause.
-    """
-    name = pending['name']
-    if name.lower() not in ('bash', 'shell', 'run'):
-        return name
-    binary = (pending.get('arguments') or {}).get('command', '').strip().split(' ')[0]
-    return f"Bash({binary} *)" if binary else "Bash"
-
-
 @before_each_tool
 def check_approval(agent: 'Agent') -> None:
     """Check if tool needs approval based on current mode.
@@ -553,7 +539,7 @@ def check_approval(agent: 'Agent') -> None:
         return
 
     # =================================================================
-    # The dialog belongs to the operator, not to whoever is connected
+    # The dialog belongs to the authenticated actor running this session
     # =================================================================
     # Placed here, at the one line that is about to prompt — not earlier. An
     # earlier check refused `read_file` for a contact, which gates access
@@ -561,20 +547,18 @@ def check_approval(agent: 'Agent') -> None:
     # shared with. Only a call that would have opened the dialog is affected.
     #
     # The host knows who is on this socket: CONNECT is signed and the trust
-    # layer classified them before the session existed. That answer used to be
-    # dropped, so a contact saw the owner's "Allow" button and an invite code
-    # carried command execution.
+    # layer classified them before the session existed. An accepted invite is
+    # the normal B2B user grant, so contacts must be able to approve ordinary
+    # work in their own session. Admin status is reserved for the control plane
+    # (trust mutation, deployment/configuration and privileged inspection).
     #
     # No requester recorded means the session did not arrive through the host —
     # a local `co ai` run — and behaves as before.
     requester = agent.current_session.get('requester')
-    if requester and requester.get('level') != 'admin':
+    if requester and requester.get('level') not in {'contact', 'whitelisted', 'admin'}:
         raise ValueError(
-            f"{tool_name} needs the operator's approval, and you are "
-            f"{requester.get('level', 'not the operator')}. Only they can "
-            f"answer that prompt. Ask them to allow it in .co/host.yaml under "
-            f"`permissions` — the entry for this call is "
-            f"`{_permission_line(pending)}`."
+            f"{tool_name} needs approval from an authenticated contact or "
+            f"admin. This requester is {requester.get('level', 'unknown')}."
         )
 
     # Get approval key for this tool

--- a/tests/unit/test_exec_asks_who_is_calling.py
+++ b/tests/unit/test_exec_asks_who_is_calling.py
@@ -1,14 +1,17 @@
-"""A contact runs the operator's shell, and the gate never learns who asked.
+"""Direct EXEC is authenticated and constrained by the host whitelist.
 
-#653 measured the chain end to end against agents made by today's `co create`,
-on default settings — no capture, no replay, no attack on the protocol:
+#653 measured the original missing-caller bug end to end: EXEC did not receive
+the signed caller address, so even a stranger could drive a whitelisted tool.
+The host now passes the address and resolves its server-authoritative trust
+level before calling the tool runner.
 
     1. connect                  -> ONBOARD_REQUIRED ['invite_code']
     2. submit the invite code   -> CONNECTED           (a stranger is now a contact)
-    3. the contact ran  whoami  -> changxing           (the operator's account)
+    3. the contact ran  whoami  -> changxing
 
-Step 3 works because EXEC is gated by the permission whitelist alone. The two
-handlers sit next to each other:
+Step 3 is now expected product behavior after an operator-issued invite, but
+only for tools the operator already allowed in the server-side whitelist.
+Unlike the old bug, strangers and blocked identities remain outside this path.
 
     def handle_ws_input(storage, prompt, connection, session=None, images=None,
                         files=None, requester_address=None):
@@ -26,15 +29,12 @@ INPUT", and the authentication is — the authorisation is not.
 `conn["agent_address"]` has held the authenticated caller's address all along.
 Nothing asked it.
 
-## What this changes
+## Product boundary
 
-EXEC now requires admin or whitelisted. It is the terminal-style fast path: no
-LLM, no session, and no approval hook — `before_each_tool` does not fire, so a
-tool invoked this way skips every check that exists between the model deciding
-to call something and it running. A contact can still talk to the agent
-(INPUT), where the model and the approval flow are in the way. Driving the
-operator's tools directly is not the same act, and it was never gated as if it
-were.
+EXEC accepts contact, legacy whitelist, or admin. It is the terminal-style fast
+path: no LLM, no session, and no approval dialog. The server-side permission
+whitelist remains authoritative, including its protected-control-file guard.
+Admin remains distinct on control-plane routes rather than ordinary execution.
 
 The remaining half of #653 is the *scope* of what is whitelisted --
 `Bash(co *)` is auto-approved, and `co` is not a read-only tool -- which is
@@ -153,13 +153,13 @@ class TestWhoMayDriveToolsDirectly:
 
         assert result["status"] == "success"
 
-    def test_a_contact_may_not(self, ws_exec):
-        """The one the issue measured: an invite code bought this level."""
+    def test_a_contact_may_run_a_pre_authorised_tool(self, ws_exec):
+        """An operator-issued invite is the normal B2B user grant."""
         handler, calls = ws_exec
         result = handler("bash", {"command": "whoami"}, requester_address=CONTACT)
 
-        assert result["status"] == "error"
-        assert calls == [], "the tool ran for a contact"
+        assert result["status"] == "success"
+        assert calls == ["bash"]
 
     def test_a_stranger_may_not(self, ws_exec):
         handler, calls = ws_exec
@@ -170,9 +170,9 @@ class TestWhoMayDriveToolsDirectly:
 
     def test_the_refusal_says_what_is_needed(self, ws_exec):
         handler, _ = ws_exec
-        result = handler("bash", {"command": "whoami"}, requester_address=CONTACT)
+        result = handler("bash", {"command": "whoami"}, requester_address=STRANGER)
 
-        assert "whitelist" in result["error"].lower(), result["error"]
+        assert "contact or admin" in result["error"].lower(), result["error"]
 
     def test_no_address_is_refused(self, ws_exec):
         handler, calls = ws_exec

--- a/tests/unit/test_only_the_owner_approves.py
+++ b/tests/unit/test_only_the_owner_approves.py
@@ -5,13 +5,10 @@ layer classifies the caller as admin / whitelisted / contact / blocked before
 the session exists. That answer was computed and dropped — `approval.py` had
 zero references to the requester.
 
-So the dialog went to whoever was connected. A contact — anyone who typed the
-invite code — was shown the owner's dialog and could click "Allow". An invite
-code carried command execution.
-
-The dialog is the operator's. Anyone else gets a refusal that names what the
-operator would have to pre-authorise, which is a thing they can paste into a
-message and ask for.
+An operator-issued invite is the normal B2B user grant. A contact can approve
+ordinary work in the session authenticated as that contact. Admin status is
+reserved for control-plane routes; strangers and blocked identities cannot use
+an approval dialog to cross the trust boundary.
 """
 
 import pytest
@@ -51,50 +48,31 @@ DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
                                            'description': 'clean'}}
 
 
-class TestOnlyAnAdminIsAsked:
+class TestAuthenticatedUsersCanApproveTheirOwnWork:
 
-    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'stranger'])
-    def test_a_non_admin_is_not_shown_the_dialog(self, level):
+    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'admin'])
+    def test_a_contact_or_admin_is_shown_the_dialog(self, level):
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': level})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert [event['type'] for event in io.sent] == ['approval_needed']
+
+    @pytest.mark.parametrize("level", ['stranger', 'blocked', None])
+    def test_an_untrusted_requester_is_not_shown_the_dialog(self, level):
         io = FakeIO()
         agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
                                             'level': level})
         agent.current_session['pending_tool'] = DANGEROUS
 
-        with pytest.raises(ValueError):
-            check_approval(agent)
-
-        assert io.sent == [], (
-            f"a {level} was offered the operator's approval dialog and could "
-            "have clicked Allow"
-        )
-
-    def test_the_refusal_names_what_to_ask_for(self):
-        """The requester cannot fix this themselves, so tell them what to ask.
-
-        A refusal that just says no turns into a message to the operator
-        saying 'it did not work', which costs a round trip to learn nothing.
-        """
-        agent = FakeAgent(io=FakeIO(), requester={'address': '0x' + 'e' * 64,
-                                                  'level': 'contact'})
-        agent.current_session['pending_tool'] = DANGEROUS
-
         with pytest.raises(ValueError) as exc:
             check_approval(agent)
 
-        message = str(exc.value)
-        assert 'host.yaml' in message
-        assert 'bash' in message
-
-    def test_an_admin_is_still_asked(self):
-        io = FakeIO(responses=[{'approved': True}])
-        agent = FakeAgent(io=io, requester={'address': '0x' + 'f' * 64,
-                                            'level': 'admin'})
-        agent.current_session['pending_tool'] = DANGEROUS
-
-        check_approval(agent)
-
-        assert len(io.sent) == 1
-        assert io.sent[0]['type'] == 'approval_needed'
+        assert io.sent == []
+        assert 'authenticated contact or admin' in str(exc.value)
 
     def test_a_safe_tool_is_unaffected_for_everyone(self):
         """This gates approval, not access. A contact may still use the agent."""
@@ -107,6 +85,21 @@ class TestOnlyAnAdminIsAsked:
         check_approval(agent)
 
         assert io.sent == []
+
+    def test_a_contact_cannot_approve_rewriting_protected_policy(self):
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': 'contact'})
+        agent.current_session['pending_tool'] = {
+            'name': 'write',
+            'arguments': {'path': '.co/host.yaml', 'content': 'permissions: {}'},
+        }
+
+        with pytest.raises(ValueError) as exc:
+            check_approval(agent)
+
+        assert io.sent == []
+        assert 'does not get to write it' in str(exc.value)
 
 
 class TestAnUnknownRequester:
@@ -227,3 +220,39 @@ class TestTheLevelTheHostActuallyComputes:
         requester = self._resolve('0x' + '2' * 64, tmp_path)
 
         assert requester['level'] != 'admin'
+
+
+class TestFreshInviteJourney:
+    """An invite creates a usable contact and survives a host restart."""
+
+    POLICY = """---
+allow: [contact]
+deny: [blocked]
+onboard:
+  invite_code: [TEAM-INVITE]
+default: deny
+---
+"""
+
+    def test_invited_contact_can_approve_after_restart(self, tmp_path, monkeypatch):
+        from connectonion.network.trust import TrustAgent
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / '.co').mkdir()
+        address = '0x' + 'c' * 64
+
+        first_host = TrustAgent(self.POLICY)
+        assert first_host.verify_invite(address, 'TEAM-INVITE') is True
+        assert first_host.get_level(address) == 'contact'
+
+        # A new TrustAgent is the restart boundary. Contact state is read from
+        # the project trust files rather than kept only in process memory.
+        restarted_host = TrustAgent(self.POLICY)
+        requester = {'address': address, 'level': restarted_host.get_level(address)}
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester=requester)
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert io.sent[0]['type'] == 'approval_needed'


### PR DESCRIPTION
## What changed

- let authenticated contacts answer approval requests for ordinary tools in their own session
- let contacts use direct `EXEC` only for tools already permitted by the server-side whitelist
- retain legacy `whitelisted` behavior and existing admin behavior
- keep strangers, blocked identities, and unknown remote levels fail-closed
- keep protected policy files such as `.co/host.yaml` outside the approval path
- add an invite → contact → host restart → approval regression journey

## Why

An invite code is the normal B2B user grant. In 1.6.8 the host promoted an invited user to `contact`, then refused every dangerous-tool approval because only `admin` could see the dialog. It also rejected contacts from direct execution even when the operator had explicitly pre-authorised the tool. That made normal COAI editing, command execution, and delegated coding work unusable.

Admin remains reserved for the existing control-plane routes. Session ownership, signed-requester recomputation, and the server-side direct-execution whitelist remain authoritative and unchanged.

## Stable-line boundary

- base: `release/1.6.9`
- lineage: `v1.6.8` commit `34a7e1a842f39b422f182127b03ad3ddc1d0f54c`
- no merge from `main`
- no ACP/OIP/Workroom or other 1.7 code

## Validation

- 156 focused permission, onboarding, session-ownership, route-signature, and trust tests passed for the approval change
- the expanded run covering direct EXEC reached 144 passing tests; six pre-existing `test_ws_exec.py` cases failed during OpenAI client construction because this environment configured a SOCKS proxy without `socksio`, before exercising the changed authorization path
- `python -m compileall -q connectonion` passed
- `git diff --check` passed
- broad local runs were stopped when unrelated tests attempted an external request to `oo.openonion.ai`; the complete stable matrix remains required in GitHub Actions

Fixes #1054
Tracks #1056.