### PR TITLE
fix: let contacts approve their own sessions

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -553,28 +553,22 @@ def check_approval(agent: 'Agent') -> None:
         return
 
     # =================================================================
-    # The dialog belongs to the operator, not to whoever is connected
+    # Only a trusted caller may approve work in their own session
     # =================================================================
-    # Placed here, at the one line that is about to prompt — not earlier. An
-    # earlier check refused `read_file` for a contact, which gates access
-    # rather than approval and makes the agent useless to the people it was
-    # shared with. Only a call that would have opened the dialog is affected.
+    # CONNECT authenticates the socket, and the host writes that verified
+    # identity into this session on every turn. Contacts and explicitly
+    # whitelisted callers are ordinary users of the shared agent: they may
+    # approve work in the session they own. Admin status is reserved for the
+    # separate control-plane routes; it is not required to use the agent.
     #
-    # The host knows who is on this socket: CONNECT is signed and the trust
-    # layer classified them before the session existed. That answer used to be
-    # dropped, so a contact saw the owner's "Allow" button and an invite code
-    # carried command execution.
-    #
-    # No requester recorded means the session did not arrive through the host —
-    # a local `co ai` run — and behaves as before.
+    # Missing requester data means a local `co ai` run and keeps the local
+    # approval flow working. An unexpected network trust level fails closed.
     requester = agent.current_session.get('requester')
-    if requester and requester.get('level') != 'admin':
+    if requester and requester.get('level') not in {'admin', 'contact', 'whitelist'}:
         raise ValueError(
-            f"{tool_name} needs the operator's approval, and you are "
-            f"{requester.get('level', 'not the operator')}. Only they can "
-            f"answer that prompt. Ask them to allow it in .co/host.yaml under "
-            f"`permissions` — the entry for this call is "
-            f"`{_permission_line(pending)}`."
+            f"{tool_name} needs approval from a trusted contact. Your current "
+            f"access level is {requester.get('level', 'unknown')}. Ask the "
+            "agent owner for an invite or whitelist access."
         )
 
     # Get approval key for this tool

--- a/tests/unit/test_trusted_callers_approve.py
+++ b/tests/unit/test_trusted_callers_approve.py
@@ -1,17 +1,14 @@
 """Who is allowed to answer an approval prompt.
 
 The host knows exactly who is on the socket: CONNECT is signed, and the trust
-layer classifies the caller as admin / whitelisted / contact / blocked before
-the session exists. That answer was computed and dropped — `approval.py` had
-zero references to the requester.
+layer classifies the caller as admin / whitelist / contact / blocked before
+the session exists. Approval uses that server-computed level, never a level
+claimed by the client.
 
-So the dialog went to whoever was connected. A contact — anyone who typed the
-invite code — was shown the owner's dialog and could click "Allow". An invite
-code carried command execution.
-
-The dialog is the operator's. Anyone else gets a refusal that names what the
-operator would have to pre-authorise, which is a thing they can paste into a
-message and ask for.
+An authenticated contact owns their session and must be able to approve its
+ordinary work. Stranger and blocked identities still fail before a prompt is
+shown. Admin remains a control-plane role, not a prerequisite for using the
+agent.
 """
 
 import pytest
@@ -51,10 +48,22 @@ DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
                                            'description': 'clean'}}
 
 
-class TestOnlyAnAdminIsAsked:
+class TestTrustedCallersApproveTheirOwnSession:
 
-    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'stranger'])
-    def test_a_non_admin_is_not_shown_the_dialog(self, level):
+    @pytest.mark.parametrize("level", ['contact', 'whitelist', 'admin'])
+    def test_a_trusted_caller_is_shown_the_dialog(self, level):
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
+                                            'level': level})
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert len(io.sent) == 1
+        assert io.sent[0]['type'] == 'approval_needed'
+
+    @pytest.mark.parametrize("level", ['stranger', 'blocked', 'unexpected'])
+    def test_an_untrusted_caller_is_not_shown_the_dialog(self, level):
         io = FakeIO()
         agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
                                             'level': level})
@@ -63,38 +72,17 @@ class TestOnlyAnAdminIsAsked:
         with pytest.raises(ValueError):
             check_approval(agent)
 
-        assert io.sent == [], (
-            f"a {level} was offered the operator's approval dialog and could "
-            "have clicked Allow"
-        )
+        assert io.sent == []
 
-    def test_the_refusal_names_what_to_ask_for(self):
-        """The requester cannot fix this themselves, so tell them what to ask.
-
-        A refusal that just says no turns into a message to the operator
-        saying 'it did not work', which costs a round trip to learn nothing.
-        """
+    def test_the_refusal_explains_how_to_get_access(self):
         agent = FakeAgent(io=FakeIO(), requester={'address': '0x' + 'e' * 64,
-                                                  'level': 'contact'})
+                                                  'level': 'stranger'})
         agent.current_session['pending_tool'] = DANGEROUS
 
         with pytest.raises(ValueError) as exc:
             check_approval(agent)
 
-        message = str(exc.value)
-        assert 'host.yaml' in message
-        assert 'bash' in message
-
-    def test_an_admin_is_still_asked(self):
-        io = FakeIO(responses=[{'approved': True}])
-        agent = FakeAgent(io=io, requester={'address': '0x' + 'f' * 64,
-                                            'level': 'admin'})
-        agent.current_session['pending_tool'] = DANGEROUS
-
-        check_approval(agent)
-
-        assert len(io.sent) == 1
-        assert io.sent[0]['type'] == 'approval_needed'
+        assert 'invite or whitelist access' in str(exc.value)
 
     def test_a_safe_tool_is_unaffected_for_everyone(self):
         """This gates approval, not access. A contact may still use the agent."""
@@ -216,6 +204,24 @@ class TestTheLevelTheHostActuallyComputes:
 
         check_approval(agent)
 
+        assert len(io.sent) == 1
+
+    def test_a_real_contact_is_shown_their_approval_dialog(self, tmp_path, monkeypatch):
+        from connectonion.network.trust import TrustAgent
+
+        contact = '0x' + '2' * 64
+        (tmp_path / '.co').mkdir()
+        monkeypatch.chdir(tmp_path)
+        trust = TrustAgent('careful')
+        trust.promote_to_contact(contact)
+
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester=self._resolve(contact, tmp_path))
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert agent.current_session['requester']['level'] == 'contact'
         assert len(io.sent) == 1
 
     def test_someone_not_in_admins_txt_is_not_admin(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- allow authenticated contacts and whitelisted callers to approve ordinary work in the session they own
- keep stranger, blocked, and unexpected trust levels fail-closed before any approval UI is shown
- preserve local `co ai` approvals and owner/admin approvals
- keep admin routes, trust mutation, deploy/config access, protected `.co` control files, and cross-session ownership unchanged
- rename the regression test so the intended policy is readable at a glance

## Why

An invite promotes a caller to `contact`, but the stable approval gate required `admin`. The invited user could chat yet every useful tool call stopped at an approval they were forbidden to answer. Admin should be a control-plane role, not a prerequisite for ordinary use.

## Verification

`pytest -q tests/unit/test_trusted_callers_approve.py tests/unit/test_tool_approval.py tests/unit/test_host_auth.py tests/unit/test_host_session.py tests/unit/test_co_ai_owner_invite.py tests/unit/test_invite_code_is_not_a_constant.py tests/unit/test_invite_startup_line.py tests/e2e/test_host_ws.py`

196 passed in 12.12s.

Fixes #1054