### PR TITLE
fix(deploy): preserve gitignored runtime state on owned servers

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -639,6 +639,21 @@ RSYNC_FILTERS = [
 ]
 
 
+def _rsync_filters(project_dir: Path) -> list[str]:
+    """Framework safety rules plus the project's own deploy boundary.
+
+    A path in the root ``.gitignore`` is neither transferred nor deleted on
+    the server. That gives authors one familiar place to name generated caches
+    and runtime state, and matches the cloud deploy path. Framework-owned
+    secrets and state remain protected first, regardless of project rules.
+    """
+    filters = list(RSYNC_FILTERS)
+    gitignore = project_dir / ".gitignore"
+    if gitignore.is_file():
+        filters.extend(["--exclude-from", str(gitignore)])
+    return filters
+
+
 def _agent_account(agent_identity: dict) -> Optional[dict]:
     """Authenticate as the agent, so the server bills the agent.
 
@@ -775,7 +790,11 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     template defaults behind a proxy pointed at the wrong port, and reports
     success either way.
 
-    See RSYNC_FILTERS for the two rules and why the default is now "carry".
+    The project's root `.gitignore` is also authoritative: ignored paths are
+    neither copied from the laptop nor deleted on the server. Put generated
+    runtime state there when it lives inside the project root.
+
+    See RSYNC_FILTERS for the framework rules and why the default is "carry".
     """
     from .server_commands import _identity as _ssh_identity
 
@@ -783,7 +802,7 @@ def _sync_code(target: str, agent: str, project_dir: Path) -> bool:
     result = subprocess.run(
         [
             "rsync", "-az", "--delete",
-            *RSYNC_FILTERS,
+            *_rsync_filters(project_dir),
             "-e", " ".join(["ssh", "-o", "BatchMode=yes",
                             "-o", "StrictHostKeyChecking=accept-new",
                             *_ssh_identity(target)]),

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -150,10 +150,13 @@ $150.41 of $360.00 refunded to your credit — the unused part of the term.
 ```
 /srv/<agent>/            code, rsynced each deploy
 /srv/<agent>/.venv       dependencies
-/srv/<agent>/.co/        identity, logs, evals — a deploy never touches this
+/srv/<agent>/.co/        identity/logs preserved; project config and skills synced
 /etc/systemd/system/<agent>.service
 /etc/caddy/Caddyfile     the hostname, proxied to the agent
 ```
+
+Paths listed in the project's root `.gitignore` are also preserved. Use that for
+runtime-generated directories inside the project, such as `work/` or `state/`.
 
 `systemctl` gives what the container was for: `Restart=always` for crash recovery,
 `enable` for start-on-boot, journald for logs.

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -57,11 +57,10 @@ Home vanished on upgrade would be a worse bug than an inconsistent path. Move it
 
 #### It travels
 
-`co deploy --to` rsyncs the project **excluding `.co/*`**, because that directory
-holds the agent's identity, logs and evals — that exclusion is why a redeploy doesn't
-reissue your agent's address. Two things are included back in: `.co/skills/` and
-`.co/dashboard.html`. Same reason for both. A deploy that dropped your Home page would
-regenerate a starter over it, and the agent would look fine.
+`co deploy --to` protects server-owned `.co/` state such as identity, logs and evals,
+while syncing project-authored files such as `.co/host.yaml`, `.co/skills/` and
+`.co/dashboard.html`. A deploy that dropped the Home page could regenerate a starter
+over it and still look successful, so the page travels as ordinary project content.
 
 #### It isn't scaffolded
 

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -290,7 +290,7 @@ myagent → prod (co@1.2.3.4)
 ### What a deploy does
 
 ```
-ensure(setup) → sync code → install deps if changed → write unit if changed → restart
+ensure(setup) → sync code → install deps if changed → authenticate live identity → write unit if changed → restart
 ```
 
 `ensure(setup)` is idempotent and a no-op once the server is converged, which is why a
@@ -300,7 +300,8 @@ decide whether to spend seconds or tens of seconds.
 
 ### What survives, and what does not
 
-The rsync carries the project tree and **excludes `.co/`**, with one exception:
+The rsync carries the project tree. Framework-owned state under `.co/` is
+protected, while project-authored configuration and skills still travel:
 
 | | |
 |---|---|
@@ -309,8 +310,19 @@ The rsync carries the project tree and **excludes `.co/`**, with one exception:
 | `.co/skills/` | **synced** — skills are what the agent *is*, not state it accumulated |
 | everything else in the project | synced, with `--delete`, so a deleted file goes away |
 
-A change you make over ssh survives the next deploy, as long as it is not a file the
-sync owns.
+The project's root `.gitignore` is the boundary for its own generated state too.
+An ignored path is neither uploaded nor deleted on the server. For example, an agent
+that writes a cache under `work/` should include:
+
+```gitignore
+work/
+```
+
+The live `/srv/<agent>/work/` then survives every deploy, including files that exist
+only on the server. Non-ignored source still follows the laptop and `--delete`, so a
+source file removed locally is removed remotely. Keep large or irreplaceable state
+outside `/srv/<agent>/` when possible; otherwise list it in `.gitignore` before the
+first deploy.
 
 ### The agent runs as itself, not as you
 

--- a/tests/unit/test_deploy_sync_filters.py
+++ b/tests/unit/test_deploy_sync_filters.py
@@ -13,7 +13,7 @@ import subprocess
 
 import pytest
 
-from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
+from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS, _rsync_filters
 
 
 pytestmark = pytest.mark.skipif(
@@ -88,6 +88,31 @@ def test_server_owned_state_survives_the_delete(synced, relpath):
 def test_deleted_code_still_goes_away(synced):
     """The protection must not turn `--delete` off for the rest of the tree."""
     assert not (synced / "stale.py").exists()
+
+
+def test_gitignored_runtime_state_is_neither_replaced_nor_deleted(tmp_path):
+    """The project names its state once; a deploy must leave the live copy alone."""
+    local, server = tmp_path / "local", tmp_path / "server"
+    local.mkdir()
+    (local / ".gitignore").write_text("work/\n")
+    (local / "work").mkdir()
+    (local / "work" / "cache.json").write_text("STALE LAPTOP COPY")
+    (local / "agent.py").write_text("print('new code')\n")
+
+    (server / "work").mkdir(parents=True)
+    (server / "work" / "cache.json").write_text("LIVE SERVER STATE")
+    (server / "work" / "sentinel.json").write_text("SERVER ONLY")
+    (server / "stale.py").write_text("deleted source")
+
+    subprocess.run(
+        ["rsync", "-a", "--delete", *_rsync_filters(local),
+         f"{local}/", f"{server}/"],
+        check=True, capture_output=True,
+    )
+
+    assert (server / "work" / "cache.json").read_text() == "LIVE SERVER STATE"
+    assert (server / "work" / "sentinel.json").read_text() == "SERVER ONLY"
+    assert not (server / "stale.py").exists(), "non-ignored deleted code lingered"
 
 
 @pytest.mark.parametrize("relpath, server_value", [

--- a/tests/unit/test_deploy_to_server.py
+++ b/tests/unit/test_deploy_to_server.py
@@ -110,6 +110,22 @@ class TestSyncNeverTouchesState:
         assert ("--exclude", ".venv/") in pairs
         assert ("--exclude", ".git/") in pairs
 
+    def test_rsync_honours_the_projects_gitignore(self, project):
+        (project / ".gitignore").write_text("work/\n")
+
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        argv = self._rsync_argv(run)
+        assert "--exclude-from" in argv
+        assert str(project / ".gitignore") in argv
+
+    def test_a_project_without_gitignore_needs_no_fake_filter_file(self, project):
+        with patch.object(dts.subprocess, "run", return_value=_ok()) as run:
+            dts._sync_code("user@host", "myagent", project)
+
+        assert "--exclude-from" not in self._rsync_argv(run)
+
     def test_setup_never_writes_inside_the_state_directory(self, project):
         """ensure(setup) may create .co/ but must not write files into it.
 


### PR DESCRIPTION
## Outcome

`co deploy --to` now honors the project root `.gitignore`, matching the cloud deploy boundary. Ignored runtime state is neither uploaded from the laptop nor deleted from the server, while non-ignored source still follows `--delete`.

## Regression covered

A real-rsync test creates:

- stale `work/cache.json` on the laptop
- live `work/cache.json` plus a server-only sentinel remotely
- deleted non-ignored source remotely

After sync, both live state files are unchanged and the deleted source is gone.

## Safety

- framework secret/state filters still run first
- `.co` identity, logs, admin state, and provision metadata stay protected
- local copies cannot overwrite server-owned state
- projects without `.gitignore` add no fake filter path
- documentation now explains the exact state boundary and recommended `work/`/`state/` rule

## Verification

- 136 deploy/filter/dashboard/address tests passed
- real rsync outcome tests passed
- `git diff --check` passed

Closes #911