### PR TITLE
fix(shell): backport corrected safe redirects for 1.6.9

### DIFF
--- a/connectonion/useful_plugins/prefer_write_tool.py
+++ b/connectonion/useful_plugins/prefer_write_tool.py
@@ -37,11 +37,8 @@ if TYPE_CHECKING:
 FILE_CREATION_PATTERNS = [
     re.compile(r"cat\s+<<"),              # cat <<EOF, cat <<'EOF', cat << 'EOF'
     re.compile(r">\s*\S+\.\w+\s*<<"),     # > file.py <<EOF
-    re.compile(r"echo\s+.*[^2]>\s*\S+"),  # echo "..." > file (but not 2>)
-    re.compile(r"printf\s+.*[^2]>\s*\S+"),# printf "..." > file (but not 2>)
-    re.compile(r"tee\s+\S+"),             # tee file.py
-    re.compile(r"(?<!\d)>\s*[~\.]"),      # > ./file, > ~/file (not 2>/dev/null)
-    re.compile(r"(?<!\d)>>\s*[~\.]"),     # >> ./file, >> ~/file
+    re.compile(r"echo\s+.*(?<![2>])>(?!>)\s*\S+"),   # echo "..." > file (but not 2> or >>)
+    re.compile(r"printf\s+.*(?<![2>])>(?!>)\s*\S+"), # printf "..." > file (but not 2> or >>)
 ]
 
 # Patterns that indicate bash is being used to read files (standalone, not in pipelines)

--- a/docs/blog/2026-08-15-when-logging-looked-like-authoring.md
+++ b/docs/blog/2026-08-15-when-logging-looked-like-authoring.md
@@ -1,0 +1,9 @@
+# When logging looked like authoring
+
+The failure was easy to miss because nothing crashed. An agent tried to append a JSONL record with `>>`, then tried `tee`, then tried another shell spelling. The write policy rejected every spelling, the step kept retrying, and the pipeline eventually exited successfully with an empty ledger.
+
+The rule had been written for a useful distinction: model-authored source should go through the Write or Edit tools so a reviewer can see a diff. But append-only state and command output are different operations. Replacing an entire ledger is not equivalent to appending one row, especially when two workers may write at the same time. Likewise, redirecting a subprocess's stdout is logging, not the model authoring a file.
+
+The fix narrows the block to the dangerous case: `echo` and `printf` with a single overwrite redirect, plus heredocs. Append redirects, `tee`, and ordinary command-output redirects are now allowed. The regression tests make the boundary explicit, including `>>` next to the existing `2>` stderr exemption.
+
+The practical lesson is that a safety rule needs to distinguish the effect it is protecting against, not just the shell punctuation used to spell it. A blocked operation without a viable alternative is not a guardrail; it is a retry loop with a bill attached.

--- a/tests/unit/test_prefer_write_tool.py
+++ b/tests/unit/test_prefer_write_tool.py
@@ -23,19 +23,24 @@ class TestFileCreationDetection:
 
     def test_echo_redirect(self):
         assert _is_file_creation_command("echo hello > file.txt")
-        assert _is_file_creation_command("echo hello >> file.txt")
+
+    def test_append_redirect_is_allowed(self):
+        assert not _is_file_creation_command("echo hello >> file.txt")
 
     def test_printf_redirect(self):
         assert _is_file_creation_command("printf 'test' > file.txt")
 
     def test_tee(self):
-        assert _is_file_creation_command("echo hello | tee file.txt")
-        assert _is_file_creation_command("ls -la | tee output.txt")
+        assert not _is_file_creation_command("echo hello | tee file.txt")
+        assert not _is_file_creation_command("ls -la | tee output.txt")
+
+    def test_command_output_redirect_is_allowed(self):
+        assert not _is_file_creation_command("co browser get_text > ~/.co/out.txt")
 
     def test_path_redirect(self):
         assert _is_file_creation_command("echo test > ./file.txt")
         assert _is_file_creation_command("echo test > ~/notes.txt")
-        assert _is_file_creation_command("echo test >> ./log.txt")
+        assert not _is_file_creation_command("echo test >> ./log.txt")
 
     def test_not_stderr_redirect(self):
         """2>/dev/null should NOT be flagged as file creation."""


### PR DESCRIPTION
## Outcome

Backports the reviewed commit from #1032 onto the exact 1.6.9 stable base. It allows append redirects, `tee`, and ordinary command-output redirects while continuing to block heredocs and explicit `echo`/`printf` overwrite authoring.

## Why a backport PR

PR #1032 is based on current `main`. Retargeting it would include roughly 49,000 lines of 1.7 alpha work across 421 files. This branch cherry-picks only commit `dd57b31a`, preserving the original author.

PR #1031 remains incorrect for append redirects: its unchanged `echo.*[^2]>` expression still matches the second `>` in `>>`.

## Verification

- exact diff: 3 files, 20 additions, 9 deletions
- 32 focused tests passed with fixed seed 1028
- `git diff --check` passed

Stable backport of #1032. Closes #1028.