### PR TITLE
fix: use the real whitelist approval level

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -555,7 +555,7 @@ def check_approval(agent: 'Agent') -> None:
     # No requester recorded means the session did not arrive through the host —
     # a local `co ai` run — and behaves as before.
     requester = agent.current_session.get('requester')
-    if requester and requester.get('level') not in {'contact', 'whitelisted', 'admin'}:
+    if requester and requester.get('level') not in {'contact', 'whitelist', 'admin'}:
         raise ValueError(
             f"{tool_name} needs approval from an authenticated contact or "
             f"admin. This requester is {requester.get('level', 'unknown')}."

--- a/tests/unit/test_only_the_owner_approves.py
+++ b/tests/unit/test_only_the_owner_approves.py
@@ -1,7 +1,7 @@
 """Who is allowed to answer an approval prompt.
 
 The host knows exactly who is on the socket: CONNECT is signed, and the trust
-layer classifies the caller as admin / whitelisted / contact / blocked before
+layer classifies the caller as admin / whitelist / contact / blocked before
 the session exists. That answer was computed and dropped — `approval.py` had
 zero references to the requester.
 
@@ -50,7 +50,7 @@ DANGEROUS = {'name': 'bash', 'arguments': {'command': 'rm -rf build',
 
 class TestAuthenticatedUsersCanApproveTheirOwnWork:
 
-    @pytest.mark.parametrize("level", ['contact', 'whitelisted', 'admin'])
+    @pytest.mark.parametrize("level", ['contact', 'whitelist', 'admin'])
     def test_a_contact_or_admin_is_shown_the_dialog(self, level):
         io = FakeIO(responses=[{'approved': True}])
         agent = FakeAgent(io=io, requester={'address': '0x' + 'e' * 64,
@@ -220,6 +220,25 @@ class TestTheLevelTheHostActuallyComputes:
         requester = self._resolve('0x' + '2' * 64, tmp_path)
 
         assert requester['level'] != 'admin'
+
+    def test_the_real_whitelist_level_can_approve(self, tmp_path, monkeypatch):
+        from connectonion.network.trust import TrustAgent
+
+        address = '0x' + '3' * 64
+        (tmp_path / '.co').mkdir()
+        monkeypatch.chdir(tmp_path)
+        trust = TrustAgent('careful')
+        trust.promote_to_whitelist(address)
+
+        requester = self._resolve(address, tmp_path)
+        io = FakeIO(responses=[{'approved': True}])
+        agent = FakeAgent(io=io, requester=requester)
+        agent.current_session['pending_tool'] = DANGEROUS
+
+        check_approval(agent)
+
+        assert requester['level'] == 'whitelist'
+        assert io.sent[0]['type'] == 'approval_needed'
 
 
 class TestFreshInviteJourney:


### PR DESCRIPTION
## Outcome

Correct the self-review defect in merged PR #1058: session approval now accepts the authoritative `whitelist` value returned by `TrustAgent.get_level()`, rather than the non-existent `whitelisted` spelling.

## Boundaries preserved

- contact, whitelist, and admin can approve ordinary work in their own authenticated sessions
- stranger, blocked, and unknown levels fail closed
- direct EXEC remains restricted to server-pre-authorised tools
- admin routes and protected control files are unchanged

## Verification

The regression constructs a real `TrustAgent`, promotes an address, asserts its resolved level is `whitelist`, and completes an approval.

117 focused approval, trust, EXEC, and authentication tests passed with seed 1063. `git diff --check` passed.

Fixes #1063
Tracks #1054 and #1056.