### PR TITLE
fix(mail): preserve unread state unless explicitly consumed

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -2,8 +2,8 @@
 Purpose: CLI surface for the agent mailbox — send, list (inbox), and read emails from the terminal
 LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
-  Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread) → Rich table | handle_email_read() → get_emails() → find by id → print body → mark_read(id)
-  State/Effects: no local state | network calls happen inside the engine tools | mark_read() flips server-side read status | writes to stdout via rich.Console
+  Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread) → Rich table | handle_email_read() → get_emails() → find by id → print body → optionally mark_read(id)
+  State/Effects: no local state | network calls happen inside the engine tools | only read --mark-read flips server-side read status | writes to stdout via rich.Console
   Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
 """
@@ -220,12 +220,12 @@ def handle_email_sent_read(email_id: str):
     console.print()
 
 
-def handle_email_read(email_id: str):
-    """Show a single email's body and mark it read."""
+def handle_email_read(email_id: str, mark_read: bool = False):
+    """Show a single email's body; mutate its read state only when requested."""
     if not _require_auth():
         return
 
-    from ...useful_tools.get_emails import get_emails, mark_read
+    from ...useful_tools.get_emails import get_emails
     emails = get_emails(last=1000)
     match = next((e for e in emails if str(e.get("id")) == str(email_id)), None)
 
@@ -244,7 +244,12 @@ def handle_email_read(email_id: str):
     console.print(match.get("message", "") or "[dim](empty body)[/dim]")
     console.print()
 
-    mark_read(str(email_id))
+    if mark_read:
+        from ...useful_tools.get_emails import mark_read as mark_email_read
+        mark_email_read(str(email_id))
+        console.print("[dim]Marked read.[/dim]")
+    else:
+        console.print("[dim]Unread state unchanged. Use --mark-read to change it.[/dim]")
 
 
 def handle_email_addresses():

--- a/connectonion/cli/commands/gmail_commands.py
+++ b/connectonion/cli/commands/gmail_commands.py
@@ -3,7 +3,7 @@ Purpose: CLI surface for the user's Gmail mailbox — send, list (inbox/sent), r
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.gmail.Gmail] | imported by [cli/main.py via handle_gmail_*()] | hits the Gmail API through the Gmail tool
   Data flow: _gmail() loads GOOGLE_* from .env / ~/.co/keys.env → Gmail() instance | inbox/search: list_inbox()/list_search() → numbered Rich table (plain ID-bearing text when piped) → saves {#: message_id} to ~/.co/gmail_last_inbox.json | read/reply: resolve short numbers via that cache → get_email_body()/reply() | send: '-' body reads stdin
-  State/Effects: writes ~/.co/gmail_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read marks emails read server-side | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  State/Effects: writes ~/.co/gmail_last_inbox.json (last listing's # → message id map; "numbers mean your last listing" — only inbox and search write it) | read changes mailbox state only with --mark-read | Gmail refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
   Integration: exposes handle_gmail_send(), handle_gmail_inbox(), handle_gmail_read(), handle_gmail_reply(), handle_gmail_sent(), handle_gmail_search() for cli/main.py | presentation mirrors outlook_commands.py (table shape, ● unread mark, ✉️ panel, '✓ Sent' wording) | Gmail API logic lives in useful_tools/gmail.py | requires prior 'co auth google'
   Errors: every guarded failure prints a hint and exits 1 (typer.Exit) so scripts can detect it — missing auth/scopes, unresolvable email # | Gmail API errors propagate from the Gmail tool
 """
@@ -126,8 +126,8 @@ def _resolve_email_id(gmail, email_id: str) -> str:
     return emails[int(email_id) - 1]["id"]
 
 
-def handle_gmail_read(email_id: str):
-    """Show one Gmail email's full body and mark it read. Accepts the listing # or a full message id."""
+def handle_gmail_read(email_id: str, mark_read: bool = False):
+    """Show one Gmail message; mark it read only with explicit opt-in."""
     gmail = _gmail()
     resolved = _resolve_email_id(gmail, email_id)
     if not resolved:
@@ -145,12 +145,14 @@ def handle_gmail_read(email_id: str):
     console.print()
     console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
 
-    marked = ""
-    if "gmail.modify" in os.getenv("GOOGLE_SCOPES", ""):
+    marked = "Unread state unchanged. "
+    if mark_read and "gmail.modify" in os.getenv("GOOGLE_SCOPES", ""):
         # Marking read is a mailbox write — the API rejects it on tokens that
         # only carry gmail.readonly + gmail.send.
         gmail.mark_read(resolved)
         marked = "Marked read. "
+    elif mark_read:
+        marked = "Not marked read: run co auth google to grant gmail.modify. "
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co gmail reply <#> <message>[/bold]\n")
 
 

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -3,7 +3,7 @@ Purpose: CLI surface for Outlook email and contacts — send/read/search mail an
 LLM-Note:
   Dependencies: imports from [os, sys, json, pathlib, datetime, typer, dotenv, rich.console, rich.panel, rich.table, ...useful_tools.outlook.Outlook] | imported by [cli/main.py via handle_outlook_*()] | hits Microsoft Graph API through the Outlook tool
   Data flow: _outlook() loads MICROSOFT_* from .env / ~/.co/keys.env and checks the operation scope → Outlook() instance | mail commands use list/read/send methods and the numbered inbox cache | contact commands use add_contact()/list_contacts()/search_contacts() and render Rich tables or tab-separated plain output
-  State/Effects: writes ~/.co/outlook_last_inbox.json for mail numbering | mutates Outlook mail/contact data through the library | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
+  State/Effects: writes ~/.co/outlook_last_inbox.json for mail numbering | read changes mailbox state only with --mark-read; send/reply/contact commands mutate their named data | Outlook auto-refreshes expired tokens via oo-api and rewrites ~/.co/keys.env
   Integration: exposes handle_outlook_* functions for cli/main.py, including handle_outlook_contact_add/list/search | presentation mirrors existing mail tables | Graph logic lives in useful_tools/outlook.py | requires prior 'co auth microsoft'
   Errors: guarded failures print a hint and exit 1 (typer.Exit) — missing auth/Mail/Contacts.ReadWrite scopes, invalid files/times/ids | Graph API errors propagate from Outlook
 """
@@ -185,8 +185,8 @@ def _resolve_email_id(outlook, email_id: str) -> str:
     return emails[int(email_id) - 1]["id"]
 
 
-def handle_outlook_read(email_id: str):
-    """Show one Outlook email's full body and mark it read. Accepts the listing # or a full message id."""
+def handle_outlook_read(email_id: str, mark_read: bool = False):
+    """Show one Outlook message; mark it read only with explicit opt-in."""
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
     if not resolved:
@@ -204,12 +204,14 @@ def handle_outlook_read(email_id: str):
     console.print()
     console.print(content.strip() or "[dim](empty body)[/dim]", markup=False, highlight=False)
 
-    marked = ""
-    if "Mail.ReadWrite" in os.getenv("MICROSOFT_SCOPES", ""):
+    marked = "Unread state unchanged. "
+    if mark_read and "Mail.ReadWrite" in os.getenv("MICROSOFT_SCOPES", ""):
         # Marking read is a mailbox write — Graph rejects it with 403 on
         # tokens that only carry Mail.Read + Mail.Send.
         outlook.mark_read(resolved)
         marked = "Marked read. "
+    elif mark_read:
+        marked = "Not marked read: run co auth microsoft to grant Mail.ReadWrite. "
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -719,10 +719,13 @@ def email_inbox(
 
 
 @email_app.command("read")
-def email_read(email_id: str = typer.Argument(..., help="Email # from the inbox list")):
-    """Show one email's body and mark it read."""
+def email_read(
+    email_id: str = typer.Argument(..., help="Email # from the inbox list"),
+    mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
+):
+    """Show one email's body without changing its unread state."""
     from .commands.email_commands import handle_email_read
-    handle_email_read(email_id)
+    handle_email_read(email_id, mark_read=mark_read)
 
 
 sent_app = _typer_app(help="List and read emails the agent has sent")
@@ -845,10 +848,11 @@ def gmail_inbox(
 @gmail_app.command("read")
 def gmail_read(
     email_id: str = typer.Argument(..., help="Email # from the last listing, or a full message id"),
+    mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
 ):
-    """Show one email's full body and mark it read."""
+    """Show one email's full body without changing its unread state."""
     from .commands.gmail_commands import handle_gmail_read
-    handle_gmail_read(email_id)
+    handle_gmail_read(email_id, mark_read=mark_read)
 
 
 @gmail_app.command("reply")
@@ -1106,10 +1110,13 @@ def outlook_inbox(
 
 
 @outlook_app.command("read")
-def outlook_read(email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing (re-run to refresh numbers)")):
-    """Show one email's body and mark it read."""
+def outlook_read(
+    email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing (re-run to refresh numbers)"),
+    mark_read: bool = typer.Option(False, "--mark-read", help="Mark the email as read after showing it"),
+):
+    """Show one email's body without changing its unread state."""
     from .commands.outlook_commands import handle_outlook_read
-    handle_outlook_read(email_id)
+    handle_outlook_read(email_id, mark_read=mark_read)
 
 
 @outlook_app.command("reply")

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -207,13 +207,14 @@ activated by `co auth`. Manage it from the terminal.
 ```bash
 co email                                          # show inbox (default)
 co email inbox --unread                           # only unread (alias: -u)
-co email read 42                                  # read message #42, mark read
+co email read 42                                  # read #42, preserve unread state
+co email read 42 --mark-read                      # explicitly mark it read
 co email send bob@example.com "Hi" "Body text"    # send (HTML auto-detected)
 ```
 
 **Subcommands:**
 - `co email` / `co email inbox` - list received email (`--last/-n`, `--unread/-u`)
-- `co email read <#>` - print one message's body and mark it read
+- `co email read <#>` - print one message's body; add `--mark-read` to consume it
 - `co email send <to> <subject> <message>` - send from your agent address
 - `co email sent` - list sent email (`--last/-n`, `--to`)
 - `co email sent read <#>` - print one sent message's body and status
@@ -236,7 +237,8 @@ Your personal Gmail account from the terminal, via the Gmail API. Requires
 ```bash
 co gmail                                            # inbox (10 most recent)
 co gmail inbox -n 25 -u                             # last 25, unread only
-co gmail read 3                                     # read #3 from the listing, mark read
+co gmail read 3                                     # read #3, preserve unread state
+co gmail read 3 --mark-read                         # explicitly mark it read
 co gmail send bob@example.com "Hi" "Body text"      # send now
 co gmail search "from:alice@example.com is:unread"  # full Gmail query syntax
 #### `co gdrive` - Google Drive Files
@@ -255,7 +257,7 @@ co gdrive put report.pdf               # upload
 **Subcommands:**
 
 - `co gmail` / `co gmail inbox` - list recent emails (`--last/-n`, `--unread/-u`)
-- `co gmail read <#>` - show one email and mark it read
+- `co gmail read <#>` - show one email; add `--mark-read` to consume it
 - `co gmail reply <#> <message>` - threaded reply (`-` reads stdin)
 - `co gmail send <to> <subject> <message>` - send, with `--cc` and `--bcc`
 - `co gmail sent` - list recently sent emails
@@ -313,7 +315,8 @@ Requires `co auth microsoft` once (Mail/Contacts scopes; saved as `MICROSOFT_*` 
 ```bash
 co outlook                                            # show inbox (default)
 co outlook inbox -n 25 -u                             # last 25, unread only
-co outlook read 3                                     # read #3 from the listing, mark read
+co outlook read 3                                     # read #3, preserve unread state
+co outlook read 3 --mark-read                         # explicitly mark it read
 co outlook send bob@example.com "Hi" "Body text"      # send now
 co outlook send bob@example.com "Hi" - < body.txt     # body from stdin
 co outlook contact add "Zhou Yifei" zhou@example.com  # save contact
@@ -322,7 +325,7 @@ co outlook contact search yifei                       # find by name/email
 
 **Subcommands:**
 - `co outlook` / `co outlook inbox` - numbered inbox table (`--last/-n`, `--unread/-u`)
-- `co outlook read <#>` - print one message's body and mark it read (inbox # or full Graph ID)
+- `co outlook read <#>` - print one message's body; add `--mark-read` to consume it
 - `co outlook send <to> <subject> <message>` - send, with `--cc`, `--bcc`, repeatable `--attach FILE` (~3MB Graph limit), and `--at` to schedule (`+30m`, `+2h`, or UTC ISO time — Exchange holds delivery)
 - `co outlook sent` - list recently sent emails
 - `co outlook search <query>` - search subject and body

--- a/docs/cli/email.md
+++ b/docs/cli/email.md
@@ -17,6 +17,7 @@ co email send alice@example.com "Hello" "Thanks for trying ConnectOnion!"
 
 # Read message #42 from the inbox list
 co email read 42
+co email read 42 --mark-read      # opt in to changing mailbox state
 ```
 
 That's the whole surface. Everything below is detail.
@@ -59,9 +60,11 @@ next page. Continue until the command returns no rows.
 
 ```bash
 co email read 42
+co email read 42 --mark-read
 ```
 
-Prints the sender, subject, date, and body, then marks the message read.
+Prints the sender, subject, date, and body without changing unread state. Add
+`--mark-read` only after you intend to consume the message.
 
 > Reads from your 1000 most recent messages. An email older than that won't be
 > found by id yet (see [Limitations](#limitations)).

--- a/docs/cli/gmail.md
+++ b/docs/cli/gmail.md
@@ -60,9 +60,11 @@ A green ● marks unread.
 ```bash
 co gmail read 3                    # by listing number
 co gmail read 18f2c9d0a1b2c3d4     # by full message id
+co gmail read 3 --mark-read         # explicitly consume it
 ```
 
-Prints headers in a panel and the body below it, then marks the email read
+Prints headers in a panel and the body below it. Unread state is preserved by
+default; `--mark-read` opts into changing it
 (only when your token carries `gmail.modify` — a read-only token skips it).
 
 ### `co gmail reply <#> <message>` — Reply

--- a/docs/cli/outlook.md
+++ b/docs/cli/outlook.md
@@ -15,6 +15,7 @@ co outlook
 
 # Read message #3 from the inbox list
 co outlook read 3
+co outlook read 3 --mark-read
 
 # Send a message
 co outlook send alice@example.com "Hello" "Thanks for the meeting today!"
@@ -99,12 +100,13 @@ in a later shell session.
 
 ```bash
 co outlook read 3
+co outlook read 3 --mark-read
 ```
 
 Prints the full body (sender, subject, date, content). Accepts the `#` from
-your last listing (inbox or search) or a full Graph message ID. If your
-Microsoft auth includes the `Mail.ReadWrite` scope, the message is also
-marked read.
+your last listing (inbox or search) or a full Graph message ID. The message is
+left unread by default. Use `--mark-read` when opening it should consume it;
+that opt-in needs the `Mail.ReadWrite` scope.
 
 ### `co outlook reply <#> <message>` — Reply
 

--- a/docs/useful_tools/gmail.md
+++ b/docs/useful_tools/gmail.md
@@ -163,7 +163,8 @@ you can do by hand:
 
 ```bash
 co gmail                                            # inbox
-co gmail read 3                                     # open #3, mark read
+co gmail read 3                                     # open #3, preserve unread state
+co gmail read 3 --mark-read                         # explicitly mark read
 co gmail send bob@example.com "Hi" "Body text"
 co gmail search "from:alice@example.com is:unread"
 ```

--- a/tests/cli/test_email_failures_exit_nonzero.py
+++ b/tests/cli/test_email_failures_exit_nonzero.py
@@ -53,6 +53,30 @@ def test_reading_a_missing_email_exits_nonzero():
     assert exc_info.value.exit_code == 1
 
 
+def test_reading_preserves_unread_state_by_default(capsys):
+    email = {"id": "7", "from": "a@b.com", "subject": "Hi",
+             "timestamp": "now", "message": "body"}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_get_module, "get_emails", return_value=[email]), \
+         patch.object(_get_module, "mark_read") as mark_read:
+        email_commands.handle_email_read("7")
+
+    mark_read.assert_not_called()
+    assert "Unread state unchanged" in capsys.readouterr().out
+
+
+def test_explicit_mark_read_mutates_the_agent_mailbox(capsys):
+    email = {"id": "7", "from": "a@b.com", "subject": "Hi",
+             "timestamp": "now", "message": "body"}
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(_get_module, "get_emails", return_value=[email]), \
+         patch.object(_get_module, "mark_read") as mark_read:
+        email_commands.handle_email_read("7", mark_read=True)
+
+    mark_read.assert_called_once_with("7")
+    assert "Marked read" in capsys.readouterr().out
+
+
 def test_an_empty_inbox_is_not_a_failure():
     """Listing nothing is an answer, not an error — must NOT raise."""
     with patch.object(email_commands, "load_api_key", return_value="tok"), \

--- a/tests/e2e/cli/test_cli_gmail.py
+++ b/tests/e2e/cli/test_cli_gmail.py
@@ -46,7 +46,15 @@ def test_gmail_read_routes_id():
         result = runner.invoke(app, ["gmail", "read", "3"])
 
     assert result.exit_code == 0
-    handler.assert_called_once_with("3")
+    handler.assert_called_once_with("3", mark_read=False)
+
+
+def test_gmail_read_routes_explicit_mark_read():
+    with patch("connectonion.cli.commands.gmail_commands.handle_gmail_read") as handler:
+        result = runner.invoke(app, ["gmail", "read", "3", "--mark-read"])
+
+    assert result.exit_code == 0
+    handler.assert_called_once_with("3", mark_read=True)
 
 
 def test_gmail_send_routes_arguments():

--- a/tests/e2e/cli/test_cli_mail_read_flags.py
+++ b/tests/e2e/cli/test_cli_mail_read_flags.py
@@ -1,0 +1,35 @@
+"""Every mailbox uses the same safe-by-default read contract."""
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from connectonion.cli.main import app
+
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(("command", "handler"), [
+    ("email", "connectonion.cli.commands.email_commands.handle_email_read"),
+    ("outlook", "connectonion.cli.commands.outlook_commands.handle_outlook_read"),
+])
+def test_read_preserves_unread_state_by_default(command, handler):
+    with patch(handler) as read:
+        result = runner.invoke(app, [command, "read", "3"])
+
+    assert result.exit_code == 0
+    read.assert_called_once_with("3", mark_read=False)
+
+
+@pytest.mark.parametrize(("command", "handler"), [
+    ("email", "connectonion.cli.commands.email_commands.handle_email_read"),
+    ("outlook", "connectonion.cli.commands.outlook_commands.handle_outlook_read"),
+])
+def test_mark_read_is_explicit_and_uniform(command, handler):
+    with patch(handler) as read:
+        result = runner.invoke(app, [command, "read", "3", "--mark-read"])
+
+    assert result.exit_code == 0
+    read.assert_called_once_with("3", mark_read=True)

--- a/tests/unit/test_gmail_commands.py
+++ b/tests/unit/test_gmail_commands.py
@@ -292,7 +292,7 @@ class TestResolveEmailId:
 
 
 class TestHandleGmailRead:
-    """Read shows the body and only marks read when the scope allows it."""
+    """Read is non-destructive unless both the flag and scope allow mutation."""
 
     def _gmail_mock(self):
         gmail = MagicMock()
@@ -329,7 +329,7 @@ class TestHandleGmailRead:
 
         with patch.dict(os.environ, CONNECTED_ENV, clear=False):
             with patch.object(gmail_commands, "_gmail", return_value=gmail):
-                handle_gmail_read("18f2c9d0a1b2c3d4")
+                handle_gmail_read("18f2c9d0a1b2c3d4", mark_read=True)
 
         gmail.mark_read.assert_called_once_with("18f2c9d0a1b2c3d4")
         assert "Marked read" in plain(capsys.readouterr().out)
@@ -340,10 +340,22 @@ class TestHandleGmailRead:
 
         with patch.dict(os.environ, READONLY_ENV, clear=False):
             with patch.object(gmail_commands, "_gmail", return_value=gmail):
+                handle_gmail_read("18f2c9d0a1b2c3d4", mark_read=True)
+
+        gmail.mark_read.assert_not_called()
+        output = plain(capsys.readouterr().out)
+        assert "Marked read" not in output
+        assert "co auth google" in output
+
+    def test_default_read_preserves_unread_state_even_with_modify_scope(self, capsys):
+        gmail = self._gmail_mock()
+
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False):
+            with patch.object(gmail_commands, "_gmail", return_value=gmail):
                 handle_gmail_read("18f2c9d0a1b2c3d4")
 
         gmail.mark_read.assert_not_called()
-        assert "Marked read" not in plain(capsys.readouterr().out)
+        assert "Unread state unchanged" in plain(capsys.readouterr().out)
 
     def test_resolves_listing_number_through_cache(self, capsys):
         gmail_commands.INBOX_CACHE.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/test_outlook_commands.py
+++ b/tests/unit/test_outlook_commands.py
@@ -248,6 +248,44 @@ class TestHandleOutlookInbox:
         assert "no unread emails" in capsys.readouterr().out
 
 
+class TestHandleOutlookRead:
+    """Opening a message preserves unread state unless --mark-read was chosen."""
+
+    def _outlook_mock(self):
+        outlook = MagicMock()
+        outlook.get_email_body.return_value = (
+            "From: alice@example.com\nSubject: Hello\n--- Email Body ---\nThe body text"
+        )
+        return outlook
+
+    def test_default_read_is_non_destructive(self, capsys):
+        outlook = self._outlook_mock()
+        with patch.dict(os.environ, CONNECTED_CONTACT_ENV, clear=False), \
+             patch.object(outlook_commands, "_outlook", return_value=outlook):
+            outlook_commands.handle_outlook_read("msg-123")
+
+        outlook.mark_read.assert_not_called()
+        assert "Unread state unchanged" in capsys.readouterr().out
+
+    def test_explicit_mark_read_mutates_with_write_scope(self, capsys):
+        outlook = self._outlook_mock()
+        with patch.dict(os.environ, CONNECTED_CONTACT_ENV, clear=False), \
+             patch.object(outlook_commands, "_outlook", return_value=outlook):
+            outlook_commands.handle_outlook_read("msg-123", mark_read=True)
+
+        outlook.mark_read.assert_called_once_with("msg-123")
+        assert "Marked read" in capsys.readouterr().out
+
+    def test_explicit_mark_read_explains_missing_scope(self, capsys):
+        outlook = self._outlook_mock()
+        with patch.dict(os.environ, CONNECTED_ENV, clear=False), \
+             patch.object(outlook_commands, "_outlook", return_value=outlook):
+            outlook_commands.handle_outlook_read("msg-123", mark_read=True)
+
+        outlook.mark_read.assert_not_called()
+        assert "co auth microsoft" in capsys.readouterr().out
+
+
 class TestHandleOutlookSend:
     """handle_outlook_send sends via the Outlook tool."""
 


### PR DESCRIPTION
## Outcome

`co email read`, `co gmail read`, and `co outlook read` are now non-destructive by default. Each uses the same explicit `--mark-read` opt-in.

## CLI behavior

```text
co gmail read 3              # body shown; unread state unchanged
co gmail read 3 --mark-read  # body shown; marked read
```

The Gmail and Outlook commands explain how to reconnect when the requested mutation lacks write scope.

## Verification

- shared routing matrix covers safe default and `--mark-read` for all mailboxes
- handler regressions cover mutation, non-mutation, and missing-scope diagnostics
- 113 CLI/handler tests passed
- 125 underlying agent-mail/Gmail/Outlook tool tests passed
- docs and CLI help updated for all three surfaces
- `git diff --check` passed

Closes #849