### PR TITLE
fix(skills): honor Claude allowed-tools metadata

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -215,7 +215,7 @@ def _parse_skill_content(content: str) -> tuple[Dict[str, Any], str]:
 
 # The only keys worth rescuing from a frontmatter YAML refuses to parse.
 #
-# Deliberately not `tools:`. test_one_reader_for_skill_frontmatter records why
+# Deliberately not `tools:` or `allowed-tools:`. The frontmatter tests record why
 # the strict reader won: "neither invents a reading of a file that has a syntax
 # error in it", and `tools:` is fed to _grant_skill_permissions — guessing it
 # from a file that does not parse would widen an agent's permissions on the
@@ -436,22 +436,24 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
         # Say what it costs, which is no longer "everything". _read_frontmatter
         # rescues name and description from a file YAML rejects, so these skills
         # work — reporting them as unreadable teaches people to stop reading the
-        # doctor. What is genuinely lost is `tools:`, which is not rescued because
+        # doctor. What is genuinely lost is a tool permission declaration, which
+        # is not rescued because
         # it grants permissions, so a file that declares one is the real problem:
         # the declaration does nothing and the author cannot tell.
         recovered = _read_frontmatter(yaml_text)
-        # `tools:` only. `allowed-tools:` is another tool's key and _tool_patterns
-        # never reads it, so it is ignored whether or not the YAML parses —
-        # blaming the bad quoting for that would be a false claim, and most of
-        # these files declare allowed-tools rather than tools.
+        # Neither permission spelling is recovered from malformed YAML. A
+        # line-based guess must never widen what the agent may do.
         declares_tools = any(
-            line.split(':', 1)[0].strip() == 'tools'
+            line.split(':', 1)[0].strip() in {'tools', 'allowed-tools'}
             for line in yaml_text.splitlines()
             if ':' in line and not line.startswith((' ', '\t'))
         )
         if declares_tools:
+            survived = ('; name and description were still read'
+                        if recovered.get('description') else '')
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
-                    f'— its tools: declaration is being ignored')
+                    f'— its tools/allowed-tools permission declaration is being '
+                    f'ignored{survived}')
         if recovered.get('description'):
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— name and description were still read')
@@ -485,7 +487,7 @@ def skills_that_will_not_travel(co_dir: Optional[Path] = None,
 # =============================================================================
 
 def _tool_patterns(frontmatter: dict) -> list:
-    """The `tools:` declaration as a list of patterns.
+    """The `tools:` or Claude Code `allowed-tools:` declaration as a list.
 
     YAML gives a string for `tools: read_file` and a list for `tools: [a, b]`.
     The caller does `for pattern in patterns`, so the scalar form walked the
@@ -493,13 +495,21 @@ def _tool_patterns(frontmatter: dict) -> list:
     Nothing was granted that should not have been -- no single character matches
     a tool name -- but the author's declaration did nothing at all.
     """
-    declared = frontmatter.get('tools')
+    # Our native spelling is authoritative when both appear. This lets an
+    # author narrow imported Claude permissions without editing that metadata.
+    is_claude_alias = 'tools' not in frontmatter
+    declared = (frontmatter.get('allowed-tools') if is_claude_alias
+                else frontmatter.get('tools'))
     if declared is None:
         # No key at all, or `tools:` with nothing after it -- a null in YAML,
         # which the caller's `for pattern in patterns` used to trip over. That
         # runs when the skill is invoked, so it took the user's turn with it.
         return []
     if isinstance(declared, str):
+        # Claude Code commonly serialises several tools as one comma-separated
+        # YAML scalar: `allowed-tools: Read, Edit, Bash(git *)`.
+        if is_claude_alias:
+            return [pattern.strip() for pattern in declared.split(',') if pattern.strip()]
         return [declared]
     return list(declared)
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -359,7 +359,9 @@ def matches_permission_pattern(tool_name: str, tool_args: dict, pattern: str) ->
         True if tool matches pattern
     """
     # Pattern: "tool_name" - matches tool name only
-    if pattern == tool_name:
+    # Claude Code frontmatter uses title-cased names such as `Edit`; native
+    # ConnectOnion tools are lower-case. The spelling differs, the tool does not.
+    if pattern.lower() == tool_name.lower():
         return True
 
     # Pattern: "Bash(command pattern)" - matches bash commands

--- a/docs/useful_plugins/skills.md
+++ b/docs/useful_plugins/skills.md
@@ -53,6 +53,10 @@ Create a well-formatted git commit for staged changes.
 
 User types: `/commit` → git commands auto-approved → commit created → permissions cleared.
 
+Skills imported from Claude Code may use `allowed-tools` instead of `tools`.
+Both YAML lists and Claude's comma-separated form are supported. If a file
+declares both keys, ConnectOnion's native `tools` value takes precedence.
+
 ## Creating Skills
 
 ### Project-level (`.co/skills/`)

--- a/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
+++ b/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
@@ -116,14 +116,8 @@ class TestABrokenFileWithoutToolsSaysWhatSurvived:
         assert frontmatter["description"].startswith("Rework the outline")
 
 
-class TestAllowedToolsIsNotOurKey:
-    """`allowed-tools:` belongs to another tool and _tool_patterns never reads it.
-
-    The first version of this message counted it, so a file declaring only
-    `allowed-tools` was told its tools were being ignored *because of* the bad
-    quoting. They are ignored either way — most of the real files on this machine
-    declare exactly that, so the wrong claim would have been the common case.
-    """
+class TestClaudeAllowedTools:
+    """Claude permissions work when valid and fail closed when YAML is invalid."""
 
     ALLOWED_TOOLS_ONLY = """---
 allowed-tools: Read, Edit, Glob
@@ -133,12 +127,12 @@ description: Rework the outline: from the pain.
 # Outline
 """
 
-    def test_it_does_not_blame_the_quoting_for_them(self, tmp_path):
+    def test_bad_yaml_reports_that_permissions_were_lost(self, tmp_path):
         reason = _why_the_skill_cannot_be_read(
             _write(tmp_path, self.ALLOWED_TOOLS_ONLY)
         )
 
-        assert "ignored" not in reason
+        assert "permission declaration is being ignored" in reason
 
     def test_it_says_what_did_survive(self, tmp_path):
         reason = _why_the_skill_cannot_be_read(
@@ -147,11 +141,18 @@ description: Rework the outline: from the pain.
 
         assert "description" in reason
 
-    def test_the_loader_never_grants_from_allowed_tools(self, tmp_path):
-        """Even in a well-formed file, so the message is right to ignore it."""
+    def test_comma_separated_allowed_tools_are_individual_patterns(self, tmp_path):
         from connectonion.useful_plugins.skills import _tool_patterns
 
-        assert _tool_patterns({"allowed-tools": "Read, Edit"}) == []
+        assert _tool_patterns({"allowed-tools": "Read, Edit, Bash(git *)"}) == [
+            "Read", "Edit", "Bash(git *)",
+        ]
+
+    def test_native_tools_override_the_imported_alias(self):
+        from connectonion.useful_plugins.skills import _tool_patterns
+
+        frontmatter = {"tools": ["read_file"], "allowed-tools": ["write"]}
+        assert _tool_patterns(frontmatter) == ["read_file"]
 
 
 class TestTheGenuinelyUnreadableStaysUnreadable:

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -259,6 +259,7 @@ class TestPatternMatching:
         # Simple tool name
         assert matches_permission_pattern('read_file', {}, 'read_file') == True
         assert matches_permission_pattern('write', {}, 'read_file') == False
+        assert matches_permission_pattern('edit', {}, 'Edit') == True
 
         # Bash patterns
         assert matches_permission_pattern('bash', {'command': 'git status'}, 'Bash(git status)') == True
@@ -268,6 +269,21 @@ class TestPatternMatching:
 
 class TestSkillInvocation:
     """Tests for skill invocation via /command."""
+
+    @patch.object(skills_module, '_load_skill')
+    def test_claude_allowed_tools_grant_turn_scoped_permissions(self, mock_load):
+        agent = FakeAgent()
+        agent.current_session['messages'] = [{'role': 'user', 'content': '/commit'}]
+        mock_load.return_value = {
+            'frontmatter': {'allowed-tools': 'read_file, Bash(git status)'},
+            'instructions': 'Create a git commit',
+        }
+
+        handle_skill_invocation(agent)
+
+        assert 'read_file' in agent.current_session['permissions']
+        assert 'Bash(git status)' in agent.current_session['permissions']
+        assert '_permission_snapshot' in agent.current_session
 
     @patch.object(skills_module, '_load_skill')
     def test_handle_skill_invocation_detects_slash_command(self, mock_load):


### PR DESCRIPTION
## Outcome

Claude Code skills loaded from `.claude/skills` now keep their declared permissions instead of silently prompting for every gated tool.

## Compatibility contract

- native `tools:` remains authoritative when both spellings exist
- `allowed-tools:` accepts YAML lists and Claude's comma-separated scalar form
- title-cased Claude tool names such as `Edit` match the same lower-case ConnectOnion tool
- `Bash(git *)` keeps the existing command-pattern semantics
- malformed YAML never grants permissions from line-based recovery
- imported permissions remain turn-scoped and are restored after success or failure

## Verification

127 focused skill parsing, permission lifecycle, doctor, sync, and approval tests passed with seed 967. Python compilation and `git diff --check` passed. Documentation explains precedence and accepted forms.

Fixes #967
Tracks #1051 and #1056.