### PR TITLE
test: make Windows E2E faster without dropping coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,14 +214,11 @@ jobs:
           Write-Host $cur
           if ($cur -notmatch "test.html") { Write-Error "navigation did not land on the test page"; exit 1 }
 
-          co browser close
-          if ($LASTEXITCODE -ne 0) { exit 1 }
-
       - name: Parallel agents — three tabs opened concurrently (multi-agent contention)
         run: |
-          co browser --headless go_to about:blank
-          if ($LASTEXITCODE -ne 0) { Write-Error "daemon cold-start failed"; exit 1 }
-
+          # Reuse the real daemon from the preceding step. Cold start is already
+          # covered there; restarting it here spent ~7 seconds without testing a
+          # different path. This step is about simultaneous named-pipe clients.
           $jobs = 1..3 | ForEach-Object {
             Start-Job -ScriptBlock {
               param($i)
@@ -242,11 +239,11 @@ jobs:
           foreach ($who in "agent1", "agent2", "agent3") {
             if ($status -notmatch $who) { Write-Error "status is missing $who's tab"; exit 1 }
           }
-          co browser close
-          if ($LASTEXITCODE -ne 0) { exit 1 }
 
-      - name: Second run — warm daemon lifecycle (spawn again after close)
+      - name: Restart after close — a second daemon lifecycle stays healthy
         run: |
+          co browser close
+          if ($LASTEXITCODE -ne 0) { Write-Error "first daemon did not close cleanly"; exit 1 }
           co browser --headless go_to about:blank
           if ($LASTEXITCODE -ne 0) { Write-Error "second daemon cold-start failed"; exit 1 }
           co browser close


### PR DESCRIPTION
Closes #1068. Reuses the already-live real browser daemon for the three-client contention test, then explicitly closes and restarts it in the lifecycle test. This removes redundant process launches while preserving wheel installation, first cold start, named-pipe contention, restart-after-close, fresh-laptop download, CJK paths, PowerShell 5.1, GBK, stale-pid, and authkey recovery coverage. The previous measured baseline was 3m17s on PR #1065.