### PR TITLE
fix(skills): warn when Claude grants are ignored

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -495,14 +495,15 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
         return f'SKILL.md frontmatter is not valid YAML{where}: {detail}'
 
     frontmatter = _read_frontmatter(yaml_text)
-    if 'allowed-tools' in frontmatter and 'tools' not in frontmatter:
-        return ('Claude Code allowed-tools permissions are not auto-approved by '
-                'ConnectOnion 1.6.9; review the tool names and add tools: if intended')
     skill_name = frontmatter.get('name') or skill_md.parent.name
     try:
         parse_skill_requirements(frontmatter, str(skill_name))
     except SkillManifestError as exc:
         return str(exc)
+
+    if 'allowed-tools' in frontmatter and 'tools' not in frontmatter:
+        return ('Claude Code allowed-tools permissions are not auto-approved by '
+                'ConnectOnion 1.6.9; review the tool names and add tools: if intended')
 
     return None
 

--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -119,6 +119,10 @@ PUBLISHED_SKILL_LOCATIONS = ("project", "claude-project")
 # and not one — travelling and being publishable are different questions.
 TRAVELS_ON_DEPLOY = ("project", "claude-project", "builtin")
 
+# A Claude Code skill may be invoked more than once in a process. Keep the
+# compatibility warning useful instead of printing it on every turn.
+_WARNED_ALLOWED_TOOLS = set()
+
 
 # =============================================================================
 # SKILL DISCOVERY
@@ -175,6 +179,7 @@ def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
         if path.exists():
             content = path.read_text(encoding="utf-8")
             frontmatter, instructions = _parse_skill_content(content)
+            _warn_ignored_allowed_tools(path, frontmatter)
             manifest_name = frontmatter.get('name') or skill_name
             requirements = parse_skill_requirements(frontmatter, str(manifest_name))
             return {
@@ -185,6 +190,32 @@ def _load_skill(skill_name: str) -> Optional[Dict[str, Any]]:
             }
 
     return None
+
+
+def _warn_ignored_allowed_tools(path: Path, frontmatter: dict) -> None:
+    """Warn once when a Claude permission declaration cannot be honored safely.
+
+    Claude Code accepts a space-delimited scalar with Claude tool names as well
+    as newer YAML lists. ConnectOnion's ``tools:`` field uses its own registered
+    tool names and parser. Treating the fields as aliases in a stable patch
+    would therefore either grant the wrong capability or silently grant
+    nothing. Keep failing closed, but make that compatibility boundary visible.
+    """
+    if 'allowed-tools' not in frontmatter or 'tools' in frontmatter:
+        return
+    key = str(path.resolve())
+    if key in _WARNED_ALLOWED_TOOLS:
+        return
+    _WARNED_ALLOWED_TOOLS.add(key)
+
+    import warnings
+    warnings.warn(
+        f"Skill {path} declares Claude Code allowed-tools; those permissions "
+        "are not auto-approved by ConnectOnion 1.6.9. Review the tool names "
+        "and add a ConnectOnion tools: declaration if the grants are intended.",
+        UserWarning,
+        stacklevel=2,
+    )
 
 
 # ---\n<yaml>\n---\n<instructions>.  Shared with the reader that diagnoses a
@@ -440,24 +471,33 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
         # it grants permissions, so a file that declares one is the real problem:
         # the declaration does nothing and the author cannot tell.
         recovered = _read_frontmatter(yaml_text)
-        # `tools:` only. `allowed-tools:` is another tool's key and _tool_patterns
-        # never reads it, so it is ignored whether or not the YAML parses —
-        # blaming the bad quoting for that would be a false claim, and most of
-        # these files declare allowed-tools rather than tools.
-        declares_tools = any(
-            line.split(':', 1)[0].strip() == 'tools'
+        # Neither permission spelling is recovered from malformed YAML. The
+        # doctor names `allowed-tools` separately because valid declarations are
+        # also deliberately fail-closed in 1.6.9, rather than guessed into a
+        # different tool vocabulary.
+        declared_keys = {
+            line.split(':', 1)[0].strip()
             for line in yaml_text.splitlines()
             if ':' in line and not line.startswith((' ', '\t'))
-        )
-        if declares_tools:
+        }
+        if 'tools' in declared_keys:
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— its tools: declaration is being ignored')
+        if 'allowed-tools' in declared_keys:
+            survived = ('; name and description were still read'
+                        if recovered.get('description') else '')
+            return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
+                    '— its Claude Code allowed-tools declaration is ignored by '
+                    f'ConnectOnion 1.6.9{survived}')
         if recovered.get('description'):
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— name and description were still read')
         return f'SKILL.md frontmatter is not valid YAML{where}: {detail}'
 
     frontmatter = _read_frontmatter(yaml_text)
+    if 'allowed-tools' in frontmatter and 'tools' not in frontmatter:
+        return ('Claude Code allowed-tools permissions are not auto-approved by '
+                'ConnectOnion 1.6.9; review the tool names and add tools: if intended')
     skill_name = frontmatter.get('name') or skill_md.parent.name
     try:
         parse_skill_requirements(frontmatter, str(skill_name))

--- a/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
+++ b/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
@@ -133,12 +133,13 @@ description: Rework the outline: from the pain.
 # Outline
 """
 
-    def test_it_does_not_blame_the_quoting_for_them(self, tmp_path):
+    def test_it_says_the_permission_declaration_is_ignored(self, tmp_path):
         reason = _why_the_skill_cannot_be_read(
             _write(tmp_path, self.ALLOWED_TOOLS_ONLY)
         )
 
-        assert "ignored" not in reason
+        assert "allowed-tools" in reason
+        assert "ignored" in reason
 
     def test_it_says_what_did_survive(self, tmp_path):
         reason = _why_the_skill_cannot_be_read(
@@ -152,6 +153,46 @@ description: Rework the outline: from the pain.
         from connectonion.useful_plugins.skills import _tool_patterns
 
         assert _tool_patterns({"allowed-tools": "Read, Edit"}) == []
+
+    def test_valid_yaml_is_still_reported_by_doctor(self, tmp_path):
+        skill = _write(tmp_path, """---
+name: claude-helper
+description: A valid Claude Code skill
+allowed-tools: Bash(git status) Read
+---
+
+# Helper
+""")
+
+        reason = _why_the_skill_cannot_be_read(skill)
+
+        assert "allowed-tools" in reason
+        assert "not auto-approve" in reason
+
+    def test_invoking_the_skill_warns_once(self, tmp_path, monkeypatch):
+        import importlib
+
+        skills = importlib.import_module("connectonion.useful_plugins.skills")
+
+        skill_dir = tmp_path / "claude-helper"
+        skill_dir.mkdir()
+        skill = skill_dir / "SKILL.md"
+        skill.write_text("""---
+name: claude-helper
+description: A valid Claude Code skill
+allowed-tools: Bash(git status) Read
+---
+
+# Helper
+""", encoding="utf-8")
+        monkeypatch.setattr(skills, "_get_skill_paths", lambda _: [skill])
+        skills._WARNED_ALLOWED_TOOLS.clear()
+
+        with pytest.warns(UserWarning, match="allowed-tools.*not auto-approved") as seen:
+            skills._load_skill("claude-helper")
+            skills._load_skill("claude-helper")
+
+        assert len(seen) == 1
 
 
 class TestTheGenuinelyUnreadableStaysUnreadable:

--- a/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
+++ b/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
@@ -169,6 +169,22 @@ allowed-tools: Bash(git status) Read
         assert "allowed-tools" in reason
         assert "not auto-approve" in reason
 
+    def test_manifest_errors_are_not_hidden_by_the_compatibility_warning(self, tmp_path):
+        skill = _write(tmp_path, """---
+name: broken-requirements
+description: A skill with two problems
+allowed-tools: Read
+requirements: definitely-not-a-mapping
+---
+
+# Helper
+""")
+
+        reason = _why_the_skill_cannot_be_read(skill)
+
+        assert "requirements" in reason
+        assert "allowed-tools" not in reason
+
     def test_invoking_the_skill_warns_once(self, tmp_path, monkeypatch):
         import importlib
 


### PR DESCRIPTION
## Outcome

Claude Code `allowed-tools` declarations are no longer silently ignored in the 1.6.9 stable line. ConnectOnion keeps them fail-closed, warns once when the skill is invoked, and reports both valid and malformed declarations in `co doctor`.

## Why warning instead of an alias

Claude Code accepts legacy space-delimited scalars and newer YAML lists using Claude tool names such as `Read`, `Edit`, and `Glob`. ConnectOnion's stable `tools:` grammar uses different registered names (for example `read_file` and `write`) and has no equivalent workspace-trust migration in this patch train.

Treating the keys as aliases would therefore either silently grant nothing, map to the wrong capability, or import a previously inert foreign permission field into auto-approval. The conditional release requirement explicitly permits an honest warning when compatibility cannot be guaranteed.

## Behavior

- `allowed-tools` remains inert and cannot widen permissions;
- each skill path warns at most once per process when invoked;
- the warning tells the operator to review names and add native `tools:` only if intended;
- `co doctor` reports valid declarations as unsupported and malformed declarations as ignored;
- native `tools:` remains authoritative when both keys exist;
- no global permission matcher or 1.7 vocabulary changes.

## Verification

- 107 focused skill parsing, permission lifecycle, sync-authority, and doctor tests passed;
- Python compilation passed;
- `git diff --check` passed.

Fixes #967
Tracks #1056.