### PR TITLE
fix: make ignored Claude skill permissions explicit

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -421,8 +421,14 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
     if not match:
         return None
 
-    import yaml
     yaml_text = match.group(1)
+    top_level_keys = {
+        line.split(':', 1)[0].strip()
+        for line in yaml_text.splitlines()
+        if ':' in line and not line.startswith((' ', '\t'))
+    }
+
+    import yaml
     try:
         yaml.safe_load(yaml_text)
     except yaml.YAMLError as e:
@@ -440,24 +446,26 @@ def _why_the_skill_cannot_be_read(skill_md: Path) -> Optional[str]:
         # it grants permissions, so a file that declares one is the real problem:
         # the declaration does nothing and the author cannot tell.
         recovered = _read_frontmatter(yaml_text)
-        # `tools:` only. `allowed-tools:` is another tool's key and _tool_patterns
-        # never reads it, so it is ignored whether or not the YAML parses —
-        # blaming the bad quoting for that would be a false claim, and most of
-        # these files declare allowed-tools rather than tools.
-        declares_tools = any(
-            line.split(':', 1)[0].strip() == 'tools'
-            for line in yaml_text.splitlines()
-            if ':' in line and not line.startswith((' ', '\t'))
-        )
+        # ConnectOnion's `tools:` is lost specifically because YAML cannot read
+        # it. Claude Code's `allowed-tools:` is unsupported even in valid YAML,
+        # so name that compatibility problem without blaming the parse failure.
+        declares_tools = 'tools' in top_level_keys
         if declares_tools:
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— its tools: declaration is being ignored')
+        if 'allowed-tools' in top_level_keys:
+            return (f'SKILL.md frontmatter is not valid YAML{where}: {detail}; '
+                    'allowed-tools is a Claude Code key and ConnectOnion does '
+                    'not grant it — add a tools: list for ConnectOnion permissions')
         if recovered.get('description'):
             return (f'SKILL.md frontmatter is not valid YAML{where}: {detail} '
                     f'— name and description were still read')
         return f'SKILL.md frontmatter is not valid YAML{where}: {detail}'
 
     frontmatter = _read_frontmatter(yaml_text)
+    if 'allowed-tools' in frontmatter:
+        return ('declares Claude Code allowed-tools, which ConnectOnion does not '
+                'grant — add a tools: list for ConnectOnion permissions')
     skill_name = frontmatter.get('name') or skill_md.parent.name
     try:
         parse_skill_requirements(frontmatter, str(skill_name))
@@ -502,6 +510,31 @@ def _tool_patterns(frontmatter: dict) -> list:
     if isinstance(declared, str):
         return [declared]
     return list(declared)
+
+
+def _warn_unsupported_allowed_tools(agent: 'Agent', skill_name: str,
+                                    frontmatter: dict) -> None:
+    """Name Claude's ignored permission key once per agent session.
+
+    Treating ``allowed-tools`` as ``tools`` would silently widen authority and
+    the two tool vocabularies are not identical. The skill instructions remain
+    portable; only the auto-approval declaration needs an explicit ConnectOnion
+    ``tools:`` list.
+    """
+    if 'allowed-tools' not in frontmatter:
+        return
+
+    warnings = agent.current_session.setdefault('_skill_warnings', {})
+    warning_key = f'{skill_name}:allowed-tools'
+    if warnings.get(warning_key):
+        return
+
+    agent.logger.print(
+        f"[yellow]⚠ Skill '{skill_name}' declares Claude Code allowed-tools; "
+        "ConnectOnion does not grant it. Add a tools: list for ConnectOnion "
+        "permissions.[/yellow]"
+    )
+    warnings[warning_key] = True
 
 
 def _grant_skill_permissions(agent: 'Agent', skill_name: str, patterns: List[str]) -> None:
@@ -663,6 +696,7 @@ def handle_skill_invocation(agent: 'Agent') -> None:
 
     frontmatter = skill['frontmatter']
     instructions = skill['instructions']
+    _warn_unsupported_allowed_tools(agent, skill_name, frontmatter)
 
     from ..skill_preflight import format_preflight_report, preflight_skills
 

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -88,6 +88,12 @@ directly:
 co ai --yolo "/deploy-oo-chat" --yolo-turns 10
 ```
 
+Claude Code's `allowed-tools` frontmatter is not a ConnectOnion permission
+grant: the tool names and authority rules are not identical. Add the equivalent
+`tools:` list when you want turn-scoped auto-approval in ConnectOnion. Skill
+invocation and `co doctor` both warn when `allowed-tools` would otherwise be
+silently ignored.
+
 YOLO deliberately reuses the existing ULW session and frontend protocol.
 Persisted fields such as `mode: ulw`, `ulw_turns`, and
 `skip_tool_approval` remain unchanged for compatibility.

--- a/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
+++ b/tests/unit/test_doctor_says_what_the_bad_yaml_costs.py
@@ -116,14 +116,8 @@ class TestABrokenFileWithoutToolsSaysWhatSurvived:
         assert frontmatter["description"].startswith("Rework the outline")
 
 
-class TestAllowedToolsIsNotOurKey:
-    """`allowed-tools:` belongs to another tool and _tool_patterns never reads it.
-
-    The first version of this message counted it, so a file declaring only
-    `allowed-tools` was told its tools were being ignored *because of* the bad
-    quoting. They are ignored either way — most of the real files on this machine
-    declare exactly that, so the wrong claim would have been the common case.
-    """
+class TestAllowedToolsIsNamedInsteadOfSilentlyIgnored:
+    """Claude's permission key stays non-authoritative, but is never silent."""
 
     ALLOWED_TOOLS_ONLY = """---
 allowed-tools: Read, Edit, Glob
@@ -133,22 +127,27 @@ description: Rework the outline: from the pain.
 # Outline
 """
 
-    def test_it_does_not_blame_the_quoting_for_them(self, tmp_path):
+    def test_bad_yaml_still_names_the_unsupported_key(self, tmp_path):
         reason = _why_the_skill_cannot_be_read(
             _write(tmp_path, self.ALLOWED_TOOLS_ONLY)
         )
 
-        assert "ignored" not in reason
+        assert "allowed-tools" in reason
+        assert "tools:" in reason
 
-    def test_it_says_what_did_survive(self, tmp_path):
+    def test_valid_yaml_is_also_reported(self, tmp_path):
+        body = self.ALLOWED_TOOLS_ONLY.replace(
+            "description: Rework the outline: from the pain.",
+            "description: 'Rework the outline: from the pain.'",
+        )
         reason = _why_the_skill_cannot_be_read(
-            _write(tmp_path, self.ALLOWED_TOOLS_ONLY)
+            _write(tmp_path, body)
         )
 
-        assert "description" in reason
+        assert reason.startswith("declares Claude Code allowed-tools")
 
     def test_the_loader_never_grants_from_allowed_tools(self, tmp_path):
-        """Even in a well-formed file, so the message is right to ignore it."""
+        """A warning must not quietly become a permission alias."""
         from connectonion.useful_plugins.skills import _tool_patterns
 
         assert _tool_patterns({"allowed-tools": "Read, Edit"}) == []

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -319,6 +319,31 @@ class TestSkillInvocation:
         )
 
     @patch.object(skills_module, '_load_skill')
+    def test_allowed_tools_warns_once_and_grants_nothing(self, mock_load):
+        agent = FakeAgent()
+        mock_load.return_value = {
+            'frontmatter': {'allowed-tools': 'Bash(git *)'},
+            'instructions': 'Review the repository',
+            'requirements': None,
+        }
+
+        for _ in range(2):
+            agent.current_session['messages'] = [
+                {'role': 'user', 'content': '/review'}
+            ]
+            handle_skill_invocation(agent)
+
+        assert 'Bash(git *)' not in agent.current_session['permissions']
+        assert agent.current_session['_skill_warnings'] == {
+            'review:allowed-tools': True,
+        }
+        warnings = [
+            call for call in agent.logger.print.call_args_list
+            if 'allowed-tools' in call.args[0]
+        ]
+        assert len(warnings) == 1
+
+    @patch.object(skills_module, '_load_skill')
     def test_handle_skill_invocation_ignores_non_slash(self, mock_load):
         """Test that non-slash messages are ignored."""
         agent = FakeAgent()


### PR DESCRIPTION
Closes #967. Keeps the stable permission boundary unchanged: Claude Code allowed-tools is not treated as ConnectOnion tools because their tool vocabularies and authority rules are not identical. Instead, co doctor reports every affected skill and invocation emits one warning per skill/session with the exact tools: migration. This avoids both silent failure and silent permission widening. Focused result: 91 skill/frontmatter/subscription tests passed. Docs now state the compatibility boundary.