### PR TITLE
fix: prevent Outlook attachment overwrites

### DIFF
--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -523,7 +523,6 @@ class Outlook:
             )
             if name in {"", ".", ".."}:
                 name = "attachment"
-            path = destination / name
             data = base64.b64decode(content, validate=True)
             flags = (
                 os.O_WRONLY
@@ -532,17 +531,24 @@ class Outlook:
                 | getattr(os, "O_BINARY", 0)
                 | getattr(os, "O_NOFOLLOW", 0)
             )
-            try:
-                descriptor_number = os.open(path, flags, 0o600)
-            except FileExistsError as exc:
-                raise FileExistsError(f"Refusing to overwrite existing attachment: {path}") from exc
+            original = destination / name
+            stem = original.stem
+            suffix = original.suffix
+            attempt = 0
+            while True:
+                candidate = original if attempt == 0 else destination / f"{stem}-{attempt}{suffix}"
+                try:
+                    descriptor_number = os.open(candidate, flags, 0o600)
+                    break
+                except FileExistsError:
+                    attempt += 1
             try:
                 with os.fdopen(descriptor_number, "wb") as handle:
                     handle.write(data)
             except Exception:
-                path.unlink(missing_ok=True)
+                candidate.unlink(missing_ok=True)
                 raise
-            saved.append(str(path))
+            saved.append(str(candidate))
         return saved
 
     # === Sending ===

--- a/docs/blog/2026-08-15-outlook-attachment-collisions.md
+++ b/docs/blog/2026-08-15-outlook-attachment-collisions.md
@@ -1,0 +1,7 @@
+# When “Download” Quietly Meant “Replace”
+
+The dangerous version of this bug looked ordinary. An agent downloaded an email, saved the first `cover.jpg`, then saved another attachment with the same sender-chosen name. The command reported both downloads, but the second write replaced the first. The same thing happened when a local file already had that name.
+
+The downloader already treated attachment names as untrusted input: it stripped directory components and kept writes inside the selected destination. The missing piece was treating an existing filename as occupied data rather than an invitation to overwrite it. The fix keeps the first `cover.jpg`, then selects `cover-1.jpg`, `cover-2.jpg`, and so on, preserving the extension and returning the paths that were actually written.
+
+The useful lesson is that safe path handling is more than preventing `../../` escapes. A path can stay inside the right directory and still destroy the wrong file. Regression tests now download duplicate names with different payloads and start with an existing local file; both original payloads remain readable, and the returned paths expose the disambiguation.

--- a/docs/superpowers/plans/2026-08-15-outlook-download-no-overwrite.md
+++ b/docs/superpowers/plans/2026-08-15-outlook-download-no-overwrite.md
@@ -1,0 +1,108 @@
+# Outlook Attachment Download Collision Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans (recommended inline) to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Make Outlook attachment downloads preserve existing files and duplicate attachment payloads by choosing unique suffixed filenames.
+
+**Architecture:** Keep filename sanitisation in `Outlook.download_attachments()`, add a small local collision-selection loop before each write, and return the actual written paths. Extend the existing unit tests and add the required narrative blog entry.
+
+**Tech Stack:** Python 3.10+, pytest, pathlib, existing Outlook/Graph test fixtures.
+
+## Global Constraints
+
+- Modify only the Outlook downloader, its focused tests, the required design journal, and this implementation documentation.
+- Preserve existing path sanitisation and directory-boundary behavior.
+- Do not add dependencies or change the public method signature.
+- Follow conventional commits and disclose AI assistance in the PR.
+
+---
+
+### Task 1: Add regression coverage for filename collisions
+
+**Files:**
+- Modify: `tests/unit/test_outlook.py` near the existing `download_attachments()` tests
+
+**Interfaces:**
+- Consumes: existing Outlook fixtures and mocked Graph attachment responses.
+- Produces: tests that fail against the current overwrite behavior and specify exact returned paths and payload preservation.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test with two file attachments named `cover.jpg`, assert `download_attachments()` returns `cover.jpg` and `cover-1.jpg`, and assert both file contents remain distinct. Add a second test with a pre-existing `cover.jpg`, assert the original bytes remain and the download is written to `cover-1.jpg`.
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_outlook.py -k "duplicate or existing" -q`
+
+Expected: failures showing the second write overwrites `cover.jpg` and the returned path list contains duplicate/original paths instead of a suffixed path.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add tests/unit/test_outlook.py
+git commit -m "test: cover outlook attachment name collisions"
+```
+
+### Task 2: Implement unique attachment paths
+
+**Files:**
+- Modify: `connectonion/useful_tools/outlook.py:488-510`
+
+**Interfaces:**
+- Consumes: sanitised attachment names and the existing `Path` destination.
+- Produces: the same `list[str]` return type containing actual unique paths.
+
+- [ ] **Step 1: Write minimal collision handling**
+
+After sanitisation, choose the original path when unused. If it exists, split the name with `Path.stem` and `Path.suffix`, then increment an integer suffix until the candidate does not exist. Write bytes only to the selected candidate and append that candidate to `saved`.
+
+- [ ] **Step 2: Run the focused tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_outlook.py -k "duplicate or existing" -q`
+
+Expected: all selected collision tests pass.
+
+- [ ] **Step 3: Run the full Outlook unit test file**
+
+Run: `python -m pytest tests/unit/test_outlook.py -q`
+
+Expected: exit code 0 with no failures.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add connectonion/useful_tools/outlook.py
+git commit -m "fix: prevent outlook attachment overwrites"
+```
+
+### Task 3: Add the required design journal and verify the branch
+
+**Files:**
+- Create: `docs/blog/2026-08-15-outlook-attachment-collisions.md`
+
+**Interfaces:**
+- Consumes: Issue #923 behavior and test evidence.
+- Produces: a concise narrative explaining the data-loss scenario, the collision fix, and what was measured.
+
+- [ ] **Step 1: Write the blog entry**
+
+Describe a user downloading two attachments with the same sender-provided name, explain why the previous direct write was lossy, describe preserving the first path and suffixing later paths, and mention the regression tests.
+
+- [ ] **Step 2: Run focused and full non-real-API verification**
+
+Run: `python -m pytest tests/unit/test_outlook.py -q`
+
+Run: `python -m pytest -m "not real_api" -q`
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Inspect the final diff and commit the blog entry**
+
+Run: `git diff HEAD~3..HEAD --check; git diff HEAD~3..HEAD --stat; git status --short`
+
+Expected: only the planned files are changed, no whitespace errors, and the worktree is clean after commit.
+
+```bash
+git add docs/blog/2026-08-15-outlook-attachment-collisions.md
+git commit -m "docs: explain safe outlook attachment downloads"
+```

--- a/docs/superpowers/specs/2026-08-15-outlook-download-no-overwrite-design.md
+++ b/docs/superpowers/specs/2026-08-15-outlook-download-no-overwrite-design.md
@@ -1,0 +1,19 @@
+# Outlook Attachment Downloads Must Not Overwrite Existing Files
+
+## Goal
+
+Fix Issue #923 so `download_attachments()` never loses an attachment or clobbers an existing local file when attachment names collide.
+
+## Design
+
+Keep the current sender-controlled filename sanitisation and destination-directory boundary checks. After sanitising each attachment name, select the first unused path: the original filename, then `stem-1.suffix`, `stem-2.suffix`, and so on. This preserves the original name whenever possible and keeps extensions intact.
+
+The method continues returning the paths actually written, so the CLI's existing output reports the disambiguated filenames without an interface change. The selection and write happen in the same method, using the existing local filesystem behavior; no dependencies or public API changes are needed.
+
+## Verification
+
+Add unit tests proving that two attachments with the same name produce two files with both payloads preserved, and that an existing destination file is preserved while the attachment is written to a suffixed path. Run the focused Outlook unit tests and the repository's non-real-API test suite.
+
+## Scope
+
+Only `connectonion/useful_tools/outlook.py`, its Outlook unit tests, and a required `docs/blog/` design journal entry are changed. No unrelated refactoring or documentation restructuring is included.

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1060,10 +1060,11 @@ class TestDownloadAttachments:
             {"name": "cover.jpg", "contentBytes": base64.b64encode(b"replace me").decode()},
         ])
 
-        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
-            outlook.download_attachments("msg-id", out_dir)
+        saved = outlook.download_attachments("msg-id", out_dir)
 
         assert outside.read_bytes() == b"keep me"
+        assert saved == [str(out_dir / "cover-1.jpg")]
+        assert (out_dir / "cover-1.jpg").read_bytes() == b"replace me"
 
     def test_replaces_control_characters_in_sender_filename(self, monkeypatch, tmp_path):
         import base64

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1000,6 +1000,24 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"pixels"
         assert saved == [str(tmp_path / "out" / "cover.jpg")]
 
+    def test_preserves_duplicate_attachment_names(self, monkeypatch, tmp_path):
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": encoded(b"first")},
+            {"name": "cover.jpg", "contentBytes": encoded(b"second")},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [
+            str(tmp_path / "out" / "cover.jpg"),
+            str(tmp_path / "out" / "cover-1.jpg"),
+        ]
+        assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"first"
+        assert (tmp_path / "out" / "cover-1.jpg").read_bytes() == b"second"
+
     def test_sender_cannot_escape_the_directory_with_a_relative_name(self, monkeypatch, tmp_path):
         """A sender names the attachment '../../owned.txt'; it must stay put."""
         import base64
@@ -1013,7 +1031,7 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "owned.txt").exists()
         assert not (tmp_path.parent / "owned.txt").exists()
 
-    def test_refuses_to_overwrite_an_existing_file(self, monkeypatch, tmp_path):
+    def test_preserves_an_existing_file(self, monkeypatch, tmp_path):
         import base64
 
         out_dir = tmp_path / "out"
@@ -1024,10 +1042,11 @@ class TestDownloadAttachments:
             {"name": "pyproject.toml", "contentBytes": base64.b64encode(b"replace me").decode()},
         ])
 
-        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
-            outlook.download_attachments("msg-id", out_dir)
+        saved = outlook.download_attachments("msg-id", out_dir)
 
         assert existing.read_bytes() == b"keep me"
+        assert saved == [str(out_dir / "pyproject-1.toml")]
+        assert (out_dir / "pyproject-1.toml").read_bytes() == b"replace me"
 
     def test_refuses_to_follow_an_existing_symlink(self, monkeypatch, tmp_path):
         import base64


### PR DESCRIPTION
## Description
Prevent Outlook attachment downloads from overwriting an existing local file or an earlier attachment with the same sender-provided filename. Collisions now receive `-1`, `-2`, and later suffixes while preserving the original extension.

## Related Issue
Fixes #923

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5 via Codex.

**If AI was involved at all, answer these in prose.**

The least confident area is the Windows filesystem behavior around symlink collisions, because this environment does not grant symlink creation privileges. I did not run real Microsoft Graph/API paths or complete the full non-real-API suite. If the behavior is wrong, the first break would be a platform-specific collision or symlink edge case; the implementation still uses exclusive creation and preserves the existing no-follow protection.

## Type of Change
- [x] Bug fix (non-breaking change which fixes functionality)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Dev Blog

Blog file in this PR: `docs/blog/2026-08-15-outlook-attachment-collisions.md`

## Changes Made
- Select a unique suffixed destination before exclusive creation.
- Preserve duplicate attachment payloads and pre-existing files.
- Update collision and symlink regression tests.
- Add the required design journal entry.

## Testing

Focused command:

```text
$env:PYTHONUTF8='1'; $env:TEMP='D:\project\tscodex\github_pr\_codex_work_37599\pytest-temp'; $env:TMP=$env:TEMP; python -m pytest tests/unit/test_outlook.py -k "saves_file_attachment_bytes or preserves_duplicate_attachment_names or sender_cannot_escape or preserves_an_existing_file or replaces_control_characters or rejects_malformed_base64 or refuses_a_destination_outside or skips_attachments" -q
8 passed, 38 deselected
```

The full `tests/unit/test_outlook.py` run reached 43 passed and 1 skipped, with two environment/baseline failures: one existing parent-directory replacement assertion had a Windows message mismatch, and the symlink test could not create a symlink because Windows Developer Mode/privilege was unavailable. The full `python -m pytest -m "not real_api" -q` run was stopped after an unrelated existing E2E deploy failure appeared; it was not completed.

- [x] I have added tests for new functionality

## Scope

- `connectonion/useful_tools/outlook.py`: choose a unique path before exclusive write.
- `tests/unit/test_outlook.py`: verify duplicate, existing-file, and symlink collision preservation.
- `docs/blog/2026-08-15-outlook-attachment-collisions.md`: required narrative design journal.
- `docs/superpowers/`: implementation design and plan records.

## Checklist
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] This PR ships its dev-blog post under docs/blog/
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Additional Notes

The branch is based on the latest `main` fetched by a clean clone. No production API calls were made.