### PR TITLE
fix: preserve open Codex thread for first Work Room task

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,9 +43,10 @@ Stable users remain on the 1.6.x line while the 1.7.0 feature train is exercised
 alpha, beta, and release-candidate builds. Pre-releases are opt-in and must be
 marked as pre-releases on PyPI and GitHub.
 
-## Current Version: 1.7.0a7
+## Current Version: 1.7.0a8
 
 ### Version History
+- 1.7.0a8 (**an open Codex Work Room keeps its exact provider thread for the first real task**: because Codex does not persist a rollout until its first turn, open-only app-server processes now remain alive behind a bounded, expiring registry. The first Work Room follow-up claims that same thread ID, streams normally through OIP, persists the rollout, and then closes the process; real-Codex and browser acceptance cover the path that alpha 7 exposed.)
 - 1.7.0a7 (**an explicit Codex request always opens the native Codex adapter**: `run`, `use`, `start`, `open`, slash-command, delegation, and Chinese Codex requests are routed deterministically before the model chooses a tool. Opening Codex without a task creates or resumes the native session without inventing a prompt; an OIP-visible guard rejects direct Codex launches through shell tools while leaving ordinary shell mentions alone. The same provider session, activity, approval, terminal status, and Work Room card remain correlated through OIP.)
 - 1.7.0a6 (**the latest stable fixes move forward without reopening the browser boundary**: merges the exact `v1.6.9` stable line into the OIP-only preview, including authenticated-contact approvals, consistent deploy identity and runtime-state preservation, safe redirects, non-mutating mail reads, and explicit Claude Code grant reporting. Codex and Claude Code remain native adapters translated into OIP at the provider edge.)
 - 1.7.0a5 (**one OIP browser protocol and two native coding adapters**: the abandoned alternate transport, generic coding-agent edge, SDK dependency, CLI flags, gateway, exports, tests, fixtures, and product docs are removed. `co ai` serves OIP 0.1 over `/ws`; `@connectonion/react@0.4.2-alpha.4` owns the browser client; Codex and Claude Code remain native provider adapters. Fresh installations mint one private owner invite and reveal it only through `co keys --reveal`.)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.7.0a7"
+__version__ = "1.7.0a8"

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -1,11 +1,11 @@
 """
 Purpose: Run Codex via its native app-server protocol, stream steps and permission requests to the frontend, and resume sessions
 LLM-Note:
-  Dependencies: imports from [json, os, shutil, subprocess, threading, time] | imported by [useful_tools/__init__.py] | tested by [tests/unit/test_codex_tool.py, tests/e2e/real_api/test_real_codex.py]
+  Dependencies: imports from [atexit, json, os, shutil, subprocess, threading, time] | imported by [useful_tools/__init__.py] | tested by [tests/unit/test_codex_tool.py, tests/e2e/real_api/test_real_codex.py]
   Data flow: codex(prompt, session_id, cwd, sandbox, model, timeout, approval, agent) → spawns `codex app-server` → CodexAppServer speaks newline-delimited JSON-RPC 2.0 → initialize/initialized → thread/start or thread/resume with the requested policy reapplied → turn/start → item/started+item/completed notifications converted to OIP-aligned frontend events via agent.io.log → method-specific approval responses are answered by the approval gate → waits for turn/completed → returns JSON envelope: str
-  State/Effects: spawns `codex app-server` subprocess | reader thread parses stdout | streams live events to agent.io using the tool_call/tool_result/approval_needed events that @connectonion/react already renders (NO frontend changes) | Codex persists threads under ~/.codex; file writes depend on sandbox + granted approvals
+  State/Effects: spawns `codex app-server` subprocess | reader thread parses stdout | open-only threads remain in a process-local registry for at most 15 minutes (maximum 8) until their first turn persists the rollout | streams live events to agent.io using the tool_call/tool_result/approval_needed events that @connectonion/react already renders (NO frontend changes) | Codex persists threads under ~/.codex; file writes depend on sandbox + granted approvals
   Integration: exposes codex(...) and CodexAppServer | this is the native adapter: ConnectOnion's Python client drives Codex app-server directly | agent injected by tool_executor (hidden from LLM) | codex binary overridable via $CODEX_CMD | session_id resumes via thread/resume; envelope's resumed flag reports it
-  Performance: long-lived process per call | streams incrementally | requests + turn wait have timeouts so a hung server can't block forever
+  Performance: one process per active call; open-only keeps its initialized process until first follow-up/expiry | streams incrementally | requests + turn wait have timeouts so a hung server can't block forever
   Errors: returns envelope with error on missing binary, JSON-RPC failure/timeout, or exception | never raises to the agent loop
 
 Codex tool. ConnectOnion drives the codex CLI's built-in `app-server` (OpenAI's
@@ -33,6 +33,7 @@ Requires the `codex` CLI (npm install -g @openai/codex) and Codex auth. Set
 $CODEX_CMD to override the binary path/command.
 """
 
+import atexit
 import json
 import os
 import shutil
@@ -54,6 +55,16 @@ _APPROVAL_METHODS = (
 )
 # Thread items that represent a discrete step worth showing as a tool card.
 _TOOL_ITEM_TYPES = ("commandExecution", "fileChange", "mcpToolCall", "webSearch")
+
+# A newly started Codex thread is not written to ~/.codex until its first turn.
+# Keep an open-only app-server alive so the Work Room's first message can use
+# the exact provider thread id that was shown to the user.  Once that first
+# turn completes, Codex has persisted the rollout and ordinary thread/resume
+# works across later tool calls and Host restarts.
+_OPEN_THREAD_TTL_SECONDS = 15 * 60
+_MAX_OPEN_THREADS = 8
+_open_threads = {}
+_open_threads_lock = threading.Lock()
 
 
 def codex(prompt: str = "", session_id: str = "", cwd: str = "",
@@ -107,40 +118,72 @@ def codex(prompt: str = "", session_id: str = "", cwd: str = "",
         return _approval_allowed(method, params, approval, agent)
 
     cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
-    client = CodexAppServer(
-        command=command,
-        cwd=cwd or ".",
-        on_event=on_event,
-        on_approval=on_approval,
-        cancelled=cancelled if callable(cancelled) else None,
-    )
+    working_directory = cwd or "."
+    cancellation_check = cancelled if callable(cancelled) else None
+    client = None
     deadline = time.monotonic() + timeout
     force_close = False
+    keep_open = False
     try:
-        client.start()
-        client.initialize(timeout=_remaining(deadline))
         has_prompt = bool(prompt.strip())
-        if has_prompt:
-            client.refresh_account(timeout=_remaining(deadline))
         approval_policy = "untrusted" if approval == "manual" else "never"
-        if session_id:
-            sid = client.resume_thread(
+        if session_id and has_prompt:
+            client = _take_open_thread(
                 session_id,
+                cwd=working_directory,
                 sandbox=sandbox,
                 model=model,
                 approval_policy=approval_policy,
-                timeout=_remaining(deadline),
             )
+        reused_open_thread = client is not None
+        if client is not None:
+            client.on_event = on_event
+            client.on_approval = on_approval
+            client.cancelled = cancellation_check or (lambda: False)
+            client.refresh_account(timeout=_remaining(deadline))
+            sid = session_id
             resumed = True
         else:
-            sid = client.start_thread(
-                sandbox=sandbox,
-                model=model,
-                approval_policy=approval_policy,
-                timeout=_remaining(deadline),
+            client = CodexAppServer(
+                command=command,
+                cwd=working_directory,
+                on_event=on_event,
+                on_approval=on_approval,
+                cancelled=cancellation_check,
             )
-            resumed = False
+            client.start()
+            client.initialize(timeout=_remaining(deadline))
+            if has_prompt:
+                client.refresh_account(timeout=_remaining(deadline))
+        if not reused_open_thread:
+            if session_id:
+                sid = client.resume_thread(
+                    session_id,
+                    sandbox=sandbox,
+                    model=model,
+                    approval_policy=approval_policy,
+                    timeout=_remaining(deadline),
+                )
+                resumed = True
+            else:
+                sid = client.start_thread(
+                    sandbox=sandbox,
+                    model=model,
+                    approval_policy=approval_policy,
+                    timeout=_remaining(deadline),
+                )
+                resumed = False
         if not has_prompt:
+            if not session_id:
+                _store_open_thread(
+                    sid,
+                    client,
+                    cwd=working_directory,
+                    sandbox=sandbox,
+                    model=model,
+                    approval_policy=approval_policy,
+                )
+                keep_open = True
             return _envelope(
                 sid, resumed=resumed, exit_code=0, opened=True
             )
@@ -153,10 +196,11 @@ def codex(prompt: str = "", session_id: str = "", cwd: str = "",
     except Exception as e:
         return _envelope(session_id, error=f"codex app-server: {e}")
     finally:
-        if force_close:
-            client.close(force=True)
-        else:
-            client.close()
+        if client is not None and not keep_open:
+            if force_close:
+                client.close(force=True)
+            else:
+                client.close()
 
     turn = turn or {}
     status = turn.get("status", "")
@@ -165,6 +209,95 @@ def codex(prompt: str = "", session_id: str = "", cwd: str = "",
                          usage=turn.get("usage", {}), exit_code=0)
     return _envelope(sid, resumed=resumed, last_message="".join(chunks),
                      usage=turn.get("usage", {}), exit_code=1, error=f"turn {status}: {_turn_error(turn)}")
+
+
+def _thread_config(cwd, sandbox, model, approval_policy):
+    return cwd, sandbox, model, approval_policy
+
+
+def _store_open_thread(
+    thread_id, client, *, cwd, sandbox, model, approval_policy
+):
+    """Keep a no-turn thread alive until its first Work Room message."""
+    record = {
+        "client": client,
+        "config": _thread_config(cwd, sandbox, model, approval_policy),
+        "opened_at": time.monotonic(),
+    }
+    timer = threading.Timer(
+        _OPEN_THREAD_TTL_SECONDS, _expire_open_thread, (thread_id, client)
+    )
+    timer.daemon = True
+    record["timer"] = timer
+    with _open_threads_lock:
+        previous = _open_threads.pop(thread_id, None)
+        _open_threads[thread_id] = record
+        evicted = []
+        while len(_open_threads) > _MAX_OPEN_THREADS:
+            oldest = min(
+                _open_threads,
+                key=lambda key: _open_threads[key]["opened_at"],
+            )
+            evicted.append(_open_threads.pop(oldest))
+    _close_thread_records([previous] if previous is not None else [])
+    _close_thread_records(evicted)
+    timer.start()
+
+
+def _take_open_thread(
+    thread_id, *, cwd, sandbox, model, approval_policy
+):
+    """Claim a matching live open-only thread for its first provider turn."""
+    _close_expired_open_threads()
+    expected = _thread_config(cwd, sandbox, model, approval_policy)
+    with _open_threads_lock:
+        record = _open_threads.get(thread_id)
+        if record is None:
+            return None
+        _open_threads.pop(thread_id, None)
+    record["timer"].cancel()
+    if record["config"] != expected:
+        record["client"].close()
+        return None
+    return record["client"]
+
+
+def _close_expired_open_threads(now=None):
+    now = time.monotonic() if now is None else now
+    with _open_threads_lock:
+        expired = [
+            thread_id
+            for thread_id, record in _open_threads.items()
+            if now - record["opened_at"] >= _OPEN_THREAD_TTL_SECONDS
+        ]
+        records = [_open_threads.pop(thread_id) for thread_id in expired]
+    _close_thread_records(records)
+
+
+def _expire_open_thread(thread_id, client):
+    with _open_threads_lock:
+        record = _open_threads.get(thread_id)
+        if record is None or record["client"] is not client:
+            return
+        _open_threads.pop(thread_id, None)
+    record["client"].close()
+
+
+def _close_thread_records(records):
+    for record in records:
+        record["timer"].cancel()
+        record["client"].close()
+
+
+def _close_open_threads():
+    """Reap open-only app-servers when the Host process exits."""
+    with _open_threads_lock:
+        records = list(_open_threads.values())
+        _open_threads.clear()
+    _close_thread_records(records)
+
+
+atexit.register(_close_open_threads)
 
 
 def _turn_error(turn):

--- a/docs/blog/2026-08-16-a-name-is-not-an-adapter.md
+++ b/docs/blog/2026-08-16-a-name-is-not-an-adapter.md
@@ -32,10 +32,20 @@ the user supplied no work. The returned session ID is still the handle for the
 next real task. Opening a work room and asking someone to work are different
 actions, even when the same API supports both.
 
+The first public browser run exposed one more lifecycle detail: Codex does not
+write a resumable rollout until a thread receives its first turn. Alpha 7 could
+therefore display a real open-only thread ID and still fail when the Work Room
+tried to resume it in a new app-server process. Alpha 8 keeps that initial
+app-server alive behind a bounded, fifteen-minute registry. The first follow-up
+claims the exact thread, persists it by completing a real turn, and closes the
+process. Expiry and a hard registry limit prevent abandoned rooms from becoming
+an unbounded process leak.
+
 The useful measurement was not one happy mocked call. The focused suite now
 covers 101 routing, adapter, plugin, and co-ai cases, including false positives
-and wrapped shell launches. Three authenticated Codex app-server tests exercise
-open-without-turn, a real turn, and session resume. The installed wheel is then
+and wrapped shell launches. Four authenticated Codex app-server tests exercise
+open-without-turn, its same-thread first follow-up, a real turn, and session
+resume. The installed wheel is then
 tested in a fresh environment so a source checkout cannot accidentally supply
 the new plugin. The final browser acceptance remains the most human test: the
 same words from the original screenshot must produce a Codex card and an

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,7 +11,7 @@ Preview releases never replace the stable recommendation. Install one with
 ## Current release work
 
 - Stable release: `1.6.9`
-- Preview target: `1.7.0a7`
+- Preview target: `1.7.0a8`
 - Browser client: `@connectonion/react@0.4.2-alpha.7`
 
 The preview uses OIP 0.1 as the only first-party browser protocol. The Python
@@ -27,11 +27,18 @@ the provider session without inventing a prompt, and an OIP-visible guard blocks
 direct Codex launches through shell tools without affecting ordinary shell text.
 The browser continues to use OIP 0.1 and the same shared Work Room card.
 
+Alpha 8 closes the open-only lifecycle found by public browser acceptance.
+Codex writes a rollout only after its first turn, so an open-only app-server now
+stays alive in a bounded, expiring registry. The first Work Room message claims
+that exact provider thread, completes the real turn, persists the rollout, and
+then closes the process. The session ID shown when Codex opens is therefore the
+same one used by the first task.
+
 Normal upgrades stay on stable. Preview testers opt in explicitly:
 
 ```bash
 python -m pip install --pre --upgrade connectonion
-python -m pip install connectonion==1.7.0a7
+python -m pip install connectonion==1.7.0a8
 ```
 
 ## Design Journal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.7.0a7"
+version = "1.7.0a8"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/e2e/real_api/test_real_codex.py
+++ b/tests/e2e/real_api/test_real_codex.py
@@ -78,6 +78,32 @@ def test_real_codex_open_without_prompt_creates_thread_without_model_turn():
     assert "error" not in result
 
 
+@pytest.mark.skipif(
+    not HAS_AUTH, reason="needs Codex credentials for an open-only follow-up"
+)
+@requires_codex
+def test_real_codex_open_only_thread_accepts_its_first_follow_up():
+    """The exact thread id shown by open-only must accept the first real turn."""
+    opened = json.loads(
+        codex(prompt="", cwd=".", approval="deny", timeout=30)
+    )
+
+    follow_up = json.loads(
+        codex(
+            "Reply with exactly: opened-thread-ok",
+            session_id=opened["session_id"],
+            cwd=".",
+            approval="deny",
+            timeout=120,
+        )
+    )
+
+    assert follow_up["session_id"] == opened["session_id"]
+    assert follow_up["resumed"] is True
+    assert "error" not in follow_up
+    assert "opened-thread-ok" in follow_up["last_message"].lower()
+
+
 @requires_codex
 def test_real_codex_app_server_handshake_and_reporting():
     """Drives the real `codex app-server` end-to-end. initialize + thread/start

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -20,6 +20,13 @@ from connectonion.useful_tools.codex import codex
 codex_module = importlib.import_module("connectonion.useful_tools.codex")
 
 
+@pytest.fixture(autouse=True)
+def _reap_open_only_clients():
+    codex_module._close_open_threads()
+    yield
+    codex_module._close_open_threads()
+
+
 class FakeServer:
     """Stand-in CodexAppServer that simulates one turn via callbacks."""
     last = None
@@ -122,6 +129,87 @@ class TestCodexRun:
             isinstance(call, tuple) and call[0] == "run_turn"
             for call in FakeServer.last.calls
         )
+        assert "close" not in FakeServer.last.calls
+
+    def test_first_prompt_reuses_the_exact_open_only_thread(self):
+        with (
+            patch.object(codex_module, "CodexAppServer", FakeServer),
+            patch.object(
+                codex_module,
+                "_base_command",
+                return_value=["codex", "app-server"],
+            ),
+        ):
+            opened = json.loads(
+                codex(prompt="", cwd=".", approval="auto", agent=_Agent(_IO()))
+            )
+            server = FakeServer.last
+            result = json.loads(
+                codex(
+                    prompt="inspect",
+                    session_id=opened["session_id"],
+                    cwd=".",
+                    approval="auto",
+                    agent=_Agent(_IO()),
+                )
+            )
+
+        assert FakeServer.last is server
+        assert result["session_id"] == opened["session_id"]
+        assert result["resumed"] is True
+        assert ("run_turn", "thread-1", "inspect") in server.calls
+        assert not any(
+            isinstance(call, tuple) and call[0] == "resume_thread"
+            for call in server.calls
+        )
+        assert server.calls[-1] == "close"
+
+    def test_expired_open_only_thread_is_closed(self):
+        opened = _run(
+            prompt="", cwd=".", approval="auto", agent=_Agent(_IO())
+        )
+        server = FakeServer.last
+
+        codex_module._close_expired_open_threads(
+            now=codex_module.time.monotonic()
+            + codex_module._OPEN_THREAD_TTL_SECONDS
+        )
+
+        assert opened["session_id"] not in codex_module._open_threads
+        assert server.calls[-1] == "close"
+
+    def test_open_only_registry_evicts_the_oldest_process(self):
+        servers = []
+        for index in range(codex_module._MAX_OPEN_THREADS + 1):
+            server = FakeServer(["codex", "app-server"])
+            servers.append(server)
+            codex_module._store_open_thread(
+                f"thread-{index}",
+                server,
+                cwd=".",
+                sandbox="read-only",
+                model="",
+                approval_policy="never",
+            )
+
+        assert len(codex_module._open_threads) == codex_module._MAX_OPEN_THREADS
+        assert "thread-0" not in codex_module._open_threads
+        assert servers[0].calls[-1] == "close"
+
+    def test_changed_policy_refuses_and_closes_an_open_only_process(self):
+        _run(prompt="", cwd=".", approval="auto", agent=_Agent(_IO()))
+        server = FakeServer.last
+
+        claimed = codex_module._take_open_thread(
+            "thread-1",
+            cwd=".",
+            sandbox="workspace-write",
+            model="",
+            approval_policy="untrusted",
+        )
+
+        assert claimed is None
+        assert server.calls[-1] == "close"
 
     def test_open_existing_session_without_prompt_resumes_without_turn(self):
         result = _run(

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.7.0a7"
+version = "1.7.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Problem

Public 1.7.0a7 browser acceptance proved that `Open Codex` used the native adapter, but the first Work Room follow-up failed with `thread/resume ... no rollout found`. Codex does not persist a rollout until the first turn, while open-only intentionally submits no turn.

Closes the remaining same-session acceptance gap in #1052.

## Change

- retain a brand-new open-only app-server until its first real prompt
- claim the exact provider thread ID for that first prompt
- close after the turn persists the rollout
- expire abandoned threads after 15 minutes and cap the registry at 8
- refuse policy/cwd/model mismatches instead of silently escalating
- add unit lifecycle/resource-bound tests and a real Codex same-thread regression
- prepare `1.7.0a8` preview notes and design-journal correction

## Evidence

- focused native routing/plugin/co-ai: 103 passed
- Codex unit suite: 55 passed
- real Codex open-only -> same-thread first follow-up: passed
- full local non-real/non-network/non-slow: 6903 passed; 25 sandbox-restricted tests all passed when rerun with normal local socket/filesystem permissions
- built wheel/sdist + twine check: passed
- installed-wheel E2E: 8 passed
- docs-site lint: 0 errors (existing warnings); production build: 124 pages

## Release

Protected tag workflow only; no workstation upload. Target preview: `1.7.0a8`.