### PR TITLE
Fix OIP relay session reload reattach

### DIFF
--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -2,9 +2,9 @@
 Purpose: Authenticate CONNECT, bind session ownership, initialize durable Host mode policy, advertise capabilities, and optionally reattach running work
 LLM-Note:
   Dependencies: imports from [..session (merge_sessions, session_to_chat_items via lazy local import), ...trust.ws_admin (get_onboard_requirements), .agent_io (resume_forwarding), uuid, rich.console] | imported by [.session as part of CONNECT dispatch]
-  Data flow: verify identity/trust → bind/replace session ID by owner → merge conversation → ensure durable Safe/current policy → derive identity-bounded SessionModeState → CONNECTED → optional running-agent rewind/resume
+  Data flow: verify identity/trust → bind/replace session ID by owner → merge conversation → ensure durable Safe/current policy → derive identity-bounded SessionModeState → CONNECTED → optional running-agent rewind/resume | equivalent authenticated relay CONNECT → reverify → republish CONNECTED without another forwarder
   State/Effects: mutates authenticated connection state; may append initial/normalized durable session; refreshes registry ping when reattaching
-  Integration: handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist) → returns (io, forward_task) for reattach or None
+  Integration: handle_connect(...) handles the first CONNECT; handle_authenticated_reconnect(...) handles a matching fresh relay reload; establish_connection(..., resume_running=False) republishes authority without a second forwarder
   Performance: one ownership read plus one atomic mode-state initialization and registry checks per CONNECT
   Errors: auth/policy/storage initialization failures surface as bounded ERROR frames; private storage exceptions are not sent
 """
@@ -22,8 +22,8 @@ console = Console()
 logger = logging.getLogger(__name__)
 
 
-async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
-    """Handle CONNECT message: auth, session merge, send CONNECTED. Returns (io, task) for reattach or None."""
+def authenticate_connect_frame(data, route_handlers, trust, blacklist, whitelist):
+    """Authenticate one CONNECT with the Host's configured verifier."""
     from ..auth import authenticate_connect, signature_already_used
 
     metadata = route_handlers.get("agent_metadata") or {}
@@ -32,15 +32,19 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
         auth_kwargs["recipient_address"] = metadata["address"]
     connect_auth = route_handlers.get("connect_auth")
     if connect_auth is None:
-        _, agent_address, sig_valid, err = authenticate_connect(
+        return authenticate_connect(
             data, trust,
             replay_check=route_handlers.get("replay", signature_already_used),
             **auth_kwargs,
         )
-    else:
-        _, agent_address, sig_valid, err = connect_auth(
-            data, trust, **auth_kwargs
-        )
+    return connect_auth(data, trust, **auth_kwargs)
+
+
+async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
+    """Handle CONNECT message: auth + merge + optional running reattach."""
+    _, agent_address, _, err = authenticate_connect_frame(
+        data, route_handlers, trust, blacklist, whitelist
+    )
 
     if err and "forbidden" in err.lower():
         trust_agent = route_handlers["trust_agent"]
@@ -71,8 +75,52 @@ async def handle_connect(data, send_msg, conn, route_handlers, storage, registry
     )
 
 
+async def handle_authenticated_reconnect(data, send_msg, conn, route_handlers,
+                                         storage, registry, trust, blacklist,
+                                         whitelist):
+    """Accept only an equivalent, freshly authenticated relay reattach.
+
+    The relay multiplexes by application session id. A browser reload can put a
+    new CONNECT into the old logical queue before its close frame is observed.
+    Treat that narrow case as idempotent without allowing an authenticated
+    socket to change caller, recipient, capability level, or session.
+    """
+    payload = data.get("payload") or {}
+    equivalent = (
+        data.get("session_id") == conn.get("session_id")
+        and (payload.get("signed_commands") == 1) == bool(conn.get("signed_commands"))
+        and payload.get("to") == conn.get("recipient_address")
+        and supports_oip(data.get("protocol"))
+    )
+    if not equivalent:
+        await send_msg({
+            "type": "ERROR",
+            "message": "already authenticated: open a new connection",
+        })
+        return
+
+    _, agent_address, _, err = authenticate_connect_frame(
+        data, route_handlers, trust, blacklist, whitelist
+    )
+
+    if err:
+        await send_msg({"type": "ERROR", "message": err})
+        return
+    if agent_address != conn.get("agent_address"):
+        await send_msg({
+            "type": "ERROR",
+            "message": "already authenticated: open a new connection",
+        })
+        return
+
+    await establish_connection(
+        data, agent_address, send_msg, conn, storage, registry, route_handlers,
+        resume_running=False,
+    )
+
+
 async def establish_connection(data, agent_address, send_msg, conn, storage, registry,
-                               route_handlers=None):
+                               route_handlers=None, resume_running=True):
     """Post-auth half of CONNECT: populate conn, merge sessions, send CONNECTED.
 
     Called by handle_connect and, after a successful onboard, with the stashed
@@ -261,6 +309,6 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     from .dashboard import send_dashboard
     await send_dashboard(send_msg, session_id, conn)
 
-    if status == "running":
+    if status == "running" and resume_running:
         active.io.rewind_to(data.get("last_msg_id"))
         return resume_forwarding(send_msg, active, registry, session_id, storage, conn)

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -2,7 +2,7 @@
 Purpose: Run one client session — read loop, per-type dispatch, lifecycle of forward + ping tasks
 LLM-Note:
   Dependencies: imports from [.connect, .agent_io, .exec, .mode, .ping, ...trust.ws_admin, asyncio, uuid, rich.console] | imported by [.__init__ as the only public symbol]
-  Data flow: recv → verify every v2 application command → dispatch CONNECT/INPUT/EXEC/mode_change/INTERRUPT/admin/runtime frames → bounded response → cancel spawned tasks on close
+  Data flow: recv → verify every v2 application command → first CONNECT auth or equivalent authenticated relay reattach → dispatch INPUT/EXEC/mode_change/INTERRUPT/admin/runtime frames → bounded response → cancel spawned tasks on close
   State/Effects: per-call local state — conn dict, active_io, forward_task, ping_task | mutates conn via handle_connect | spawns asyncio Tasks (forward + ping) cancelled in finally
   Integration: OIP mode_change uses .mode durable authority; interrupt requires registered active IO; signed-command clients execute only verified payload copies
   Performance: single-reader of recv_msg | O(1) per-message dispatch | bounded local state
@@ -15,7 +15,7 @@ from rich.console import Console
 
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
 from .agent_io import start_agent
-from .connect import establish_connection, handle_connect
+from .connect import establish_connection, handle_authenticated_reconnect, handle_connect
 from .exec import run_exec
 from .mode import handle_mode_change
 from .ping import ping_loop
@@ -52,10 +52,10 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
             # and then inject unsigned commands. Reauthentication belongs on a
             # fresh transport, with fresh per-connection state.
             if msg_type == "CONNECT" and conn.get("authenticated"):
-                await send_msg({
-                    "type": "ERROR",
-                    "message": "already authenticated: open a new connection",
-                })
+                await handle_authenticated_reconnect(
+                    data, send_msg, conn, route_handlers, storage, registry,
+                    trust, blacklist, whitelist,
+                )
                 continue
 
             # A v2 CONNECT signs the capability that enables this gate. Keep the

--- a/docs/blog/2026-08-16-the-second-connection-was-still-the-first.md
+++ b/docs/blog/2026-08-16-the-second-connection-was-still-the-first.md
@@ -1,0 +1,57 @@
+# The Second Connection Was Still the First
+
+The Codex run had succeeded. The Work Room showed the same provider session,
+the follow-up returned the exact confirmation string, and the parent transcript
+contained both completed cards. Then we reloaded the page and the Host said:
+
+`already authenticated: open a new connection`
+
+That answer sounded reasonable. The browser had opened a new WebSocket. The
+surprise was that, from the Host's point of view, it had not opened a new
+connection at all.
+
+OIP sessions commonly travel through the relay. The relay multiplexes browser
+traffic to a Host using the application session ID. On reload, the new browser
+socket can send its signed `CONNECT` before the close from the old socket has
+been delivered and processed. Both frames briefly occupy the same logical
+relay queue. The second physical connection therefore arrives inside the first
+`run_ws_session` loop, where the connection is already authenticated.
+
+The existing rule rejected every second `CONNECT`. It was added for a good
+reason: an authenticated socket must not replace its caller, downgrade signed
+commands, point at another recipient, or switch sessions. Removing that guard
+would fix reload by reopening a security boundary.
+
+The useful distinction was not first versus second. It was change versus
+reattach.
+
+A reload now gets one narrow path. The Host verifies the fresh signature again,
+then requires the same caller, recipient, signed-command capability, supported
+OIP protocol, and application session. If all of those are equal, it republishes
+`CONNECTED` and the authenticated profile. It does not start a second forwarder
+for a running agent. If any field differs, the old rejection remains. Reusing
+the same signature still fails the replay guard.
+
+The tests make the boundary visible. One session-loop test puts two freshly
+signed, equivalent `CONNECT` frames into the same logical stream and expects two
+`CONNECTED` replies for the same session. Six negative cases try to change the
+identity, recipient, capability, session, protocol, or reuse a signature. Every
+one is rejected. Together with the existing Host, relay, and command-signing
+coverage, 77 focused tests passed.
+
+The production screenshot was the important measurement. Before this change,
+the transcript proved that Codex had finished while a red authentication error
+claimed the page was broken. That contradiction exposed two different bugs:
+O Chat held on to a cleared error, and the Host created a new error during
+reload. Fixing only the banner would have made the first screenshot cleaner and
+the next refresh fail again.
+
+Connection identity is a stack of names: physical WebSocket, relay route,
+authenticated caller, OIP application session, and provider session. In the
+simple case they begin and end together, so it is tempting to treat them as one
+thing. Reload is where they separate. The browser connection can be new while
+the relay route and application session are deliberately old. A correct
+reconnect policy preserves that continuity without letting any authority move.
+
+The lesson is small enough to reuse: idempotence is not the absence of a
+security check. It is the security check that proves nothing changed.

--- a/tests/unit/test_relay_authenticated_reattach.py
+++ b/tests/unit/test_relay_authenticated_reattach.py
@@ -1,0 +1,159 @@
+"""A relay reload may reattach to the still-live logical OIP session."""
+
+import copy
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from connectonion import address
+from connectonion.network.connect import RemoteAgent
+from connectonion.network.host import auth
+from connectonion.network.host.ws_router.connect import handle_authenticated_reconnect
+
+
+RECIPIENT = "0x" + "12" * 20
+SESSION_ID = "relay-session"
+
+
+@pytest.fixture(autouse=True)
+def clean_replay_cache():
+    auth._seen_signatures.clear()
+    yield
+    auth._seen_signatures.clear()
+
+
+@pytest.fixture
+def keys():
+    return address.generate()
+
+
+def connect_frame(keys, recipient=RECIPIENT, session_id=SESSION_ID):
+    frame = RemoteAgent(recipient, keys=keys)._build_connect_message()
+    frame["session_id"] = session_id
+    return frame
+
+
+def freshly_resign(frame, keys):
+    fresh = copy.deepcopy(frame)
+    fresh["payload"]["timestamp"] += 1
+    fresh["timestamp"] = fresh["payload"]["timestamp"]
+    canonical = json.dumps(
+        fresh["payload"], sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    fresh["signature"] = address.sign(keys, canonical.encode()).hex()
+    return fresh
+
+
+def authenticated_conn(keys):
+    return {
+        "authenticated": True,
+        "agent_address": keys["address"],
+        "session_id": SESSION_ID,
+        "session": None,
+        "signed_commands": True,
+        "recipient_address": RECIPIENT,
+    }
+
+
+async def reattach(frame, conn):
+    sent = []
+    storage = MagicMock()
+    storage.get.return_value = None
+    registry = MagicMock()
+    registry.get.return_value = None
+
+    async def send(message):
+        sent.append(message)
+
+    await handle_authenticated_reconnect(
+        frame,
+        send,
+        conn,
+        {"agent_metadata": {"address": RECIPIENT}},
+        storage,
+        registry,
+        "open",
+        None,
+        None,
+    )
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_equivalent_fresh_connect_reattaches(keys):
+    sent = await reattach(connect_frame(keys), authenticated_conn(keys))
+
+    assert sent[0]["type"] == "CONNECTED"
+    assert sent[0]["session_id"] == SESSION_ID
+    assert sent[0]["status"] == "new"
+    assert sent[0]["protocol"]["name"] == "oip"
+
+
+@pytest.mark.asyncio
+async def test_session_loop_treats_a_fresh_equivalent_connect_as_reattach(keys):
+    from connectonion.network.host.ws_router.session import run_ws_session
+
+    first = connect_frame(keys)
+    queue = [first, freshly_resign(first, keys)]
+    sent = []
+    storage = MagicMock()
+    storage.get.return_value = None
+    registry = MagicMock()
+    registry.get.return_value = None
+
+    async def recv():
+        return queue.pop(0) if queue else None
+
+    async def send(message):
+        sent.append(message)
+
+    await run_ws_session(
+        send,
+        recv,
+        route_handlers={"agent_metadata": {"address": RECIPIENT}},
+        storage=storage,
+        registry=registry,
+        trust="open",
+        enable_ping=False,
+    )
+
+    connected = [message for message in sent if message["type"] == "CONNECTED"]
+    assert [message["session_id"] for message in connected] == [SESSION_ID, SESSION_ID]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change", ["identity", "recipient", "capability", "session", "protocol"]
+)
+async def test_reattach_cannot_change_authenticated_connection(keys, change):
+    frame = connect_frame(keys)
+    if change == "identity":
+        frame = connect_frame(address.generate())
+    elif change == "recipient":
+        frame = connect_frame(keys, recipient="0x" + "34" * 20)
+    elif change == "capability":
+        frame["payload"]["signed_commands"] = 0
+    elif change == "session":
+        frame["session_id"] = "other-session"
+    else:
+        frame["protocol"] = {"name": "legacy", "version": "1"}
+
+    sent = await reattach(frame, authenticated_conn(keys))
+
+    assert sent == [{
+        "type": "ERROR",
+        "message": "already authenticated: open a new connection",
+    }]
+
+
+@pytest.mark.asyncio
+async def test_reattach_connect_signature_cannot_be_replayed(keys):
+    frame = connect_frame(keys)
+    conn = authenticated_conn(keys)
+
+    assert (await reattach(frame, conn))[0]["type"] == "CONNECTED"
+    replay = await reattach(frame, conn)
+
+    assert replay[0]["type"] == "ERROR"
+    assert "already used" in replay[0]["message"]


### PR DESCRIPTION
Fixes #1079.

Public alpha8 browser E2E reproduced a successful Codex Work Room whose page failed on reload with `already authenticated: open a new connection`. The relay can route a new browser CONNECT into the still-live logical session queue before the previous close is observed.

This adds a narrow reattach path that re-authenticates a fresh signature and requires the same caller, recipient, signed-command capability, supported OIP protocol, and application session. Any mismatch remains rejected; signature replay remains rejected. Reattach republishes CONNECTED without starting a duplicate running-session forwarder.

Checks:
- 77 focused Host/relay/signing tests passed
- new end-to-end session-loop regression passed
- identity, recipient, capability, protocol, session, and replay negative tests passed
- browser-daemon sandbox-only failures passed when run with temporary socket permission