### PR TITLE
Release ConnectOnion 1.7.0a9

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -43,9 +43,10 @@ Stable users remain on the 1.6.x line while the 1.7.0 feature train is exercised
 alpha, beta, and release-candidate builds. Pre-releases are opt-in and must be
 marked as pre-releases on PyPI and GitHub.
 
-## Current Version: 1.7.0a8
+## Current Version: 1.7.0a9
 
 ### Version History
+- 1.7.0a9 (**reloading an OIP session keeps the authenticated relay continuity without weakening the connection boundary**: when a fresh browser WebSocket reaches the still-live logical relay queue, an equivalent freshly signed CONNECT now reattaches only if caller, recipient, signed-command capability, OIP protocol, and application session are unchanged. Any mismatch and signature replay remain rejected; CONNECTED is republished without duplicating a running-session forwarder, so a completed Codex Work Room no longer turns into `already authenticated` after refresh.)
 - 1.7.0a8 (**an open Codex Work Room keeps its exact provider thread for the first real task**: because Codex does not persist a rollout until its first turn, open-only app-server processes now remain alive behind a bounded, expiring registry. The first Work Room follow-up claims that same thread ID, streams normally through OIP, persists the rollout, and then closes the process; real-Codex and browser acceptance cover the path that alpha 7 exposed.)
 - 1.7.0a7 (**an explicit Codex request always opens the native Codex adapter**: `run`, `use`, `start`, `open`, slash-command, delegation, and Chinese Codex requests are routed deterministically before the model chooses a tool. Opening Codex without a task creates or resumes the native session without inventing a prompt; an OIP-visible guard rejects direct Codex launches through shell tools while leaving ordinary shell mentions alone. The same provider session, activity, approval, terminal status, and Work Room card remain correlated through OIP.)
 - 1.7.0a6 (**the latest stable fixes move forward without reopening the browser boundary**: merges the exact `v1.6.9` stable line into the OIP-only preview, including authenticated-contact approvals, consistent deploy identity and runtime-state preservation, safe redirects, non-mutating mail reads, and explicit Claude Code grant reporting. Codex and Claude Code remain native adapters translated into OIP at the provider edge.)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.7.0a8"
+__version__ = "1.7.0a9"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -11,7 +11,7 @@ Preview releases never replace the stable recommendation. Install one with
 ## Current release work
 
 - Stable release: `1.6.9`
-- Preview target: `1.7.0a8`
+- Preview target: `1.7.0a9`
 - Browser client: `@connectonion/react@0.4.2-alpha.7`
 
 The preview uses OIP 0.1 as the only first-party browser protocol. The Python
@@ -34,11 +34,17 @@ that exact provider thread, completes the real turn, persists the rollout, and
 then closes the process. The session ID shown when Codex opens is therefore the
 same one used by the first task.
 
+Alpha 9 makes reload an authenticated OIP reattach instead of a false second
+login. A fresh signed CONNECT that reaches the still-live relay queue is accepted
+only when caller, recipient, signed-command capability, OIP protocol, and session
+are unchanged. The Host republishes CONNECTED without duplicating a running
+forwarder; every mismatch and signature replay remains rejected.
+
 Normal upgrades stay on stable. Preview testers opt in explicitly:
 
 ```bash
 python -m pip install --pre --upgrade connectonion
-python -m pip install connectonion==1.7.0a8
+python -m pip install connectonion==1.7.0a9
 ```
 
 ## Design Journal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.7.0a8"
+version = "1.7.0a9"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.7.0a8"
+version = "1.7.0a9"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Publish the next opt-in 1.7 preview after #1080.

1.7.0a9 contains the OIP relay reload reattach fix: a fresh equivalent signed CONNECT can reclaim the same logical relay/application session, while caller, recipient, signed-command capability, protocol, session changes, and signature replay remain rejected.

Release metadata updated:
- package and lockfile: 1.7.0a9
- VERSIONING history
- preview install guidance
- stable remains 1.6.9

Verification:
- Core fix PR #1080 passed Python 3.10–3.13, all Windows browser jobs, Windows wheel E2E, CodeQL, blog gate, and lockfile
- release/version checks: 48 passed; the one local-only sibling docs checkout assertion correctly reports that the separate docs checkout must be updated after public artifacts exist
- `uv lock --check` passed