### PR TITLE
Fix OIP reattach trust-policy race

### DIFF
--- a/connectonion/network/host/auth.py
+++ b/connectonion/network/host/auth.py
@@ -397,6 +397,32 @@ def authenticate_connect(
     replay_check=signature_already_used,
 ):
     """Authenticate CONNECT in security order: signature, claim, then policy."""
+    prompt, agent_address, sig_valid, error = authenticate_connect_identity(
+        data,
+        blacklist=blacklist,
+        recipient_address=recipient_address,
+        replay_check=replay_check,
+    )
+    if error:
+        return prompt, agent_address, sig_valid, error
+
+    return _authorize_authenticated(data, prompt, agent_address, trust, whitelist)
+
+
+def authenticate_connect_identity(
+    data: dict,
+    *,
+    blacklist=None,
+    recipient_address=None,
+    replay_check=signature_already_used,
+):
+    """Verify a fresh CONNECT signature and replay claim without trust policy.
+
+    This is the cryptographic half of ``authenticate_connect``. It is also the
+    right gate for an equivalent relay reattach: that socket must prove the same
+    caller, recipient, capability and session again, but the already-authorized
+    live connection must not repeat mutable onboarding/contact policy.
+    """
     if "payload" not in data or "signature" not in data:
         return None, None, False, "unauthorized: signed request required"
 
@@ -423,7 +449,7 @@ def authenticate_connect(
             "unauthorized: this CONNECT was already used",
         )
 
-    return _authorize_authenticated(data, prompt, agent_address, trust, whitelist)
+    return prompt, agent_address, True, None
 
 
 def authenticated_command_payload(

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -40,6 +40,32 @@ def authenticate_connect_frame(data, route_handlers, trust, blacklist, whitelist
     return connect_auth(data, trust, **auth_kwargs)
 
 
+def authenticate_reattach_frame(data, route_handlers, trust, blacklist, whitelist):
+    """Re-authenticate an equivalent live connection without repeating policy."""
+    from ..auth import authenticate_connect_identity, signature_already_used
+
+    metadata = route_handlers.get("agent_metadata") or {}
+    auth_kwargs = {"blacklist": blacklist}
+    if metadata.get("address"):
+        auth_kwargs["recipient_address"] = metadata["address"]
+
+    # A custom connection verifier may carry authentication semantics that the
+    # standard Ed25519 verifier cannot reproduce. Let deployments provide the
+    # narrow reattach half explicitly; otherwise preserve their existing gate.
+    reattach_auth = route_handlers.get("reattach_auth")
+    if reattach_auth is not None:
+        return reattach_auth(data, trust, whitelist=whitelist, **auth_kwargs)
+    connect_auth = route_handlers.get("connect_auth")
+    if connect_auth is not None:
+        return connect_auth(data, trust, whitelist=whitelist, **auth_kwargs)
+
+    return authenticate_connect_identity(
+        data,
+        replay_check=route_handlers.get("replay", signature_already_used),
+        **auth_kwargs,
+    )
+
+
 async def handle_connect(data, send_msg, conn, route_handlers, storage, registry, trust, blacklist, whitelist):
     """Handle CONNECT message: auth + merge + optional running reattach."""
     _, agent_address, _, err = authenticate_connect_frame(
@@ -99,7 +125,7 @@ async def handle_authenticated_reconnect(data, send_msg, conn, route_handlers,
         })
         return
 
-    _, agent_address, _, err = authenticate_connect_frame(
+    _, agent_address, _, err = authenticate_reattach_frame(
         data, route_handlers, trust, blacklist, whitelist
     )
 

--- a/docs/blog/2026-08-16-the-second-connection-was-still-the-first.md
+++ b/docs/blog/2026-08-16-the-second-connection-was-still-the-first.md
@@ -32,12 +32,30 @@ OIP protocol, and application session. If all of those are equal, it republishes
 for a running agent. If any field differs, the old rejection remains. Reusing
 the same signature still fails the replay guard.
 
+The first public alpha taught us that “verifies the fresh signature again” was
+still too broad. The implementation reused the whole first-connect gate, so it
+also repeated the mutable trust decision: read the contact lists, decide whether
+the caller must onboard, and consult policy. A brand-new session connected, but
+its first Send raced another equivalent `CONNECT` through that second policy
+read. A local missing-file error became `misconfigured: [Errno 2]` in the browser,
+and the actual `INPUT` never reached the Host.
+
+That was not a reason to weaken reauthentication. It was a reason to name its
+two halves. A first connection proves the signed identity and authorizes it under
+current policy. An equivalent reattach must prove the signed identity, recipient,
+freshness, replay claim and current blacklist again, then show that every bound
+connection field is unchanged. It must not ask onboarding/contact policy to
+authorize the same still-live connection twice. Custom verifiers retain their
+existing gate unless they explicitly provide the same narrow reattach half.
+
 The tests make the boundary visible. One session-loop test puts two freshly
 signed, equivalent `CONNECT` frames into the same logical stream and expects two
 `CONNECTED` replies for the same session. Six negative cases try to change the
 identity, recipient, capability, session, protocol, or reuse a signature. Every
-one is rejected. Together with the existing Host, relay, and command-signing
-coverage, 77 focused tests passed.
+one is rejected. A regression makes trust policy raise the exact missing-file
+error and proves reattach never calls it; another proves a newly blacklisted
+caller is still refused. Together with the existing Host, relay, replay, and
+command-signing coverage, 70 focused tests passed in the follow-up run.
 
 The production screenshot was the important measurement. Before this change,
 the transcript proved that Codex had finished while a red authentication error

--- a/tests/unit/test_relay_authenticated_reattach.py
+++ b/tests/unit/test_relay_authenticated_reattach.py
@@ -10,6 +10,7 @@ from connectonion import address
 from connectonion.network.connect import RemoteAgent
 from connectonion.network.host import auth
 from connectonion.network.host.ws_router.connect import handle_authenticated_reconnect
+from connectonion.network.trust.trust_agent import TrustAgent
 
 
 RECIPIENT = "0x" + "12" * 20
@@ -56,7 +57,7 @@ def authenticated_conn(keys):
     }
 
 
-async def reattach(frame, conn):
+async def reattach(frame, conn, trust="open", blacklist=None):
     sent = []
     storage = MagicMock()
     storage.get.return_value = None
@@ -73,11 +74,34 @@ async def reattach(frame, conn):
         {"agent_metadata": {"address": RECIPIENT}},
         storage,
         registry,
-        "open",
-        None,
+        trust,
+        blacklist,
         None,
     )
     return sent
+
+
+@pytest.mark.asyncio
+async def test_reattach_does_not_repeat_mutable_trust_policy(keys, monkeypatch):
+    """A live connection was already authorized; reattach only re-authenticates it."""
+    trust = TrustAgent("open")
+    should_allow = MagicMock(side_effect=FileNotFoundError(2, "No such file or directory"))
+    monkeypatch.setattr(trust, "should_allow", should_allow)
+    sent = await reattach(connect_frame(keys), authenticated_conn(keys), trust=trust)
+
+    assert sent[0]["type"] == "CONNECTED"
+    should_allow.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reattach_still_enforces_current_blacklist(keys):
+    sent = await reattach(
+        connect_frame(keys),
+        authenticated_conn(keys),
+        blacklist=[keys["address"]],
+    )
+
+    assert sent == [{"type": "ERROR", "message": "forbidden: blacklisted"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1079

## Problem
A public alpha9 fresh-session browser test proved that eager CONNECT could succeed, then first Send could race a second equivalent CONNECT into the live relay queue. Re-running mutable TrustAgent policy on that already-authorized connection surfaced a local FileNotFoundError as a client-visible misconfigured error and prevented INPUT.

## Fix
- split fresh CONNECT identity/replay verification from trust authorization
- on an equivalent live reattach, reverify Ed25519 signature, recipient, replay claim, blacklist, caller, capability, protocol, and session
- do not repeat onboarding/contact policy already granted to the live connection
- preserve custom verifier behavior unless a deployment supplies a dedicated reattach verifier

## Tests
- regression: trust policy raising FileNotFoundError is not called during equivalent reattach
- current blacklist is still enforced
- existing identity/recipient/capability/session/protocol/replay rejection coverage remains green
- 70 focused auth, replay, and reattach tests pass