### PR TITLE
fix(browser): merge 1.6.10 CJK input fix into main

### DIFF
--- a/connectonion/useful_tools/browser_tools/humanize.py
+++ b/connectonion/useful_tools/browser_tools/humanize.py
@@ -287,6 +287,14 @@ def _clipboard_get() -> str:
     return out.decode("utf-8", errors="replace").rstrip("\r\n")
 
 
+def _active_text_len(page) -> int:
+    """Return the current focused editor length for paste acceptance checks."""
+    return page.evaluate(
+        "() => { const e = document.activeElement;"
+        " return e ? ((e.value != null ? e.value : e.textContent) || '').length : 0; }"
+    )
+
+
 def _paste(page, text):
     """Put `text` on the OS clipboard and Ctrl/Cmd+V it into the focused field, then restore
     the user's clipboard. Returns True only if the field actually took the paste — some

--- a/tests/unit/test_browser_humanize.py
+++ b/tests/unit/test_browser_humanize.py
@@ -36,6 +36,9 @@ class FakeKeyboard:
     def type(self, text):
         self._log.append(("type", text))
 
+    def press(self, key):
+        self._log.append(("press", key))
+
 
 class FakePage:
     """Records every low-level input call humanize makes."""
@@ -179,6 +182,20 @@ def test_type_text_latin_still_per_character_keystroke():
     page = FakePage()
     humanize.type_text(page, "hi")
     assert [e[1] for e in page.log if e[0] == "type"] == ["h", "i"]
+
+
+def test_type_text_cjk_paste_checks_the_active_field_without_crashing(monkeypatch):
+    page = FakePage()
+    lengths = iter((0, 2))
+    page.evaluate = lambda _script: next(lengths)
+    monkeypatch.setattr(humanize, "_clipboard_set_argv", lambda _text: ["pbcopy"])
+    monkeypatch.setattr(humanize, "_clipboard_get", lambda: "saved")
+    monkeypatch.setattr(humanize, "_clipboard_set", lambda _text: True)
+    monkeypatch.setattr(humanize.platform, "system", lambda: "Darwin")
+
+    humanize.type_text(page, "你好")
+
+    assert ("press", "Meta+v") in page.log
 
 
 def test_cursor_position_is_remembered_between_actions():


### PR DESCRIPTION
Ports the exact v1.6.10 CJK browser input fix onto the 1.7 preview train without downgrading main version metadata. The stable commit already passed all nine Linux and Windows gates and the built wheel passed a real Chrome CJK input test. Supersedes the version-conflicting main merge in #1084. Fixes #1078.