### PR TITLE
fix(claude): preserve macOS login identity

### DIFF
--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -72,6 +72,7 @@ _CLAUDE_ENVIRONMENT_KEYS = (
     "SYSTEMROOT",
     "TEMP",
     "TMP",
+    "USER",
     "USERPROFILE",
     "WINDIR",
 )

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -676,6 +676,7 @@ def test_process_runner_is_headless_and_does_not_use_a_shell(tmp_path):
 
 
 def test_provider_process_does_not_inherit_unrelated_credentials(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER", "macos-keychain-user")
     monkeypatch.setenv("OPENAI_API_KEY", "must-not-cross")
     monkeypatch.setenv("GH_TOKEN", "must-not-cross")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-auth")
@@ -690,6 +691,7 @@ def test_provider_process_does_not_inherit_unrelated_credentials(monkeypatch, tm
             ["claude"], cwd=str(tmp_path), timeout=2, on_event=lambda event: None
         )
     environment = popen.call_args.kwargs["env"]
+    assert environment["USER"] == "macos-keychain-user"
     assert "OPENAI_API_KEY" not in environment
     assert "GH_TOKEN" not in environment
     assert environment["ANTHROPIC_API_KEY"] == "provider-auth"


### PR DESCRIPTION
Fixes #1087.

## What changed

- forward `USER` through the existing explicit Claude child-process environment allowlist
- retain the security boundary that excludes unrelated credentials such as `OPENAI_API_KEY` and `GH_TOKEN`
- extend the environment regression test

## Why

On macOS, Claude Code 2.1.233 needs `USER` to resolve the existing claude.ai login in its headless streaming process. Public `connectonion==1.7.0a11` omitted it and returned `Not logged in · Please run /login` even though the same CLI was authenticated.

No token, API key, or broad environment inheritance is added.

## Verification

- red-first focused regression: failed with `KeyError: 'USER'`
- `python -m pytest tests/unit/test_claude_code_tool.py -q` — 52 passed
- real fixed streaming adapter on macOS:

```json
{"provider":"claude_code","status":"completed","result":"CLAUDE-USER-ENV-FIX-OK","error":"","exit_code":0}
```

After merge, the preview release gate still requires a public-wheel OIP/OChat first-turn and Work Room resume test.
