### PR TITLE
fix(co-ai): expose Claude provider lifecycle

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -34,7 +34,7 @@ Debug:
 
 from pathlib import Path
 
-from connectonion import Agent, CodexPlugin, TodoList, bash
+from connectonion import Agent, ClaudeCodePlugin, CodexPlugin, TodoList, bash
 from connectonion.core.events import after_user_input
 from connectonion.core.usage import DEFAULT_MODEL
 from connectonion.useful_plugins import (
@@ -56,7 +56,6 @@ from .skills import skill
 from .tools import (
     FileTools,
     ask_user,
-    claude_code,
     kill_task,
     load_guide,
     run_background,
@@ -131,6 +130,10 @@ def create_agent(
         workspace=Path.cwd(),
         use_host_permissions=True,
     )
+    claude_plugin = ClaudeCodePlugin(
+        workspace=Path.cwd(),
+        use_host_permissions=True,
+    )
 
     tools = [
         file_tools,
@@ -141,12 +144,11 @@ def create_agent(
         *([run_background, task_output, kill_task] if background_tools else []),
         load_guide,
         ask_user,
-        claude_code,
     ]
 
     base_prompt = assemble_prompt(
         prompts_dir=str(PROMPTS_DIR),
-        tools=[*tools, codex_plugin.codex],
+        tools=[*tools, codex_plugin.codex, claude_plugin.claude_code],
         role=role,
     )
 
@@ -162,6 +164,7 @@ def create_agent(
     # back into an image the model and the user can actually see.
     plugins = [
         codex_plugin,
+        claude_plugin,
         native_coding_agent_routing,
         skills_plugin,
         subagents,

--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -244,24 +244,32 @@ class ClaudeCodePlugin(_CodingAgentPlugin):
     provider = "claude_code"
     display_name = "Claude Code"
 
+    def __init__(
+        self,
+        *,
+        permission_mode: PermissionMode | str = PermissionMode.MANUAL,
+        workspace: str | Path | None = None,
+        use_host_permissions: bool = False,
+    ) -> None:
+        self.use_host_permissions = use_host_permissions
+        super().__init__(permission_mode=permission_mode, workspace=workspace)
+
     def claude_code(
         self,
         prompt: str,
-        cwd: str = "",
+        cwd: str,
         session_id: str = "",
         model: str = "",
         timeout: int = 600,
         agent=None,
     ) -> str:
         """Run or resume Claude Code inside the configured workspace."""
+        provider_mode, effective_mode = self._policy(agent)
+        if provider_mode is None:
+            return _hosted_claude_refusal(session_id)
         working_directory, error = self._cwd(cwd)
         if error:
             return json.dumps({"provider": "claude_code", "session_id": session_id, "error": error})
-        provider_mode = {
-            PermissionMode.MANUAL: "manual",
-            PermissionMode.AUTO_APPROVE: "acceptEdits",
-            PermissionMode.FULL_ACCESS: "auto",
-        }[self.permission_mode]
         return self._invoke(
             agent,
             prompt,
@@ -275,7 +283,60 @@ class ClaudeCodePlugin(_CodingAgentPlugin):
                 agent=agent,
                 workspace=self.workspace,
             ),
+            permission_mode=effective_mode,
         )
+
+    def _policy(self, agent) -> tuple[str | None, PermissionMode]:
+        if not self.use_host_permissions:
+            return {
+                PermissionMode.MANUAL: "manual",
+                PermissionMode.AUTO_APPROVE: "acceptEdits",
+                PermissionMode.FULL_ACCESS: "auto",
+            }[self.permission_mode], self.permission_mode
+
+        session = getattr(agent, "current_session", {}) or {}
+        requester = session.get("requester")
+        if requester and requester.get("level") != "admin":
+            return None, PermissionMode.MANUAL
+        try:
+            profile = legacy_permission_profile_id(
+                session.get("mode", READ_ONLY_PERMISSION_PROFILE)
+            )
+        except ValueError:
+            profile = READ_ONLY_PERMISSION_PROFILE
+        if (
+            profile == DANGER_FULL_ACCESS_PERMISSION_PROFILE
+            and not has_valid_full_access_grant(session)
+        ):
+            profile = READ_ONLY_PERMISSION_PROFILE
+        return {
+            READ_ONLY_PERMISSION_PROFILE: ("manual", PermissionMode.MANUAL),
+            WORKSPACE_PERMISSION_PROFILE: (
+                "acceptEdits", PermissionMode.AUTO_APPROVE
+            ),
+            DANGER_FULL_ACCESS_PERMISSION_PROFILE: (
+                "auto", PermissionMode.FULL_ACCESS
+            ),
+        }[profile]
+
+
+def _hosted_claude_refusal(session_id: str) -> str:
+    return json.dumps(
+        {
+            "provider": "claude_code",
+            "session_id": session_id,
+            "resumed": bool(session_id),
+            "status": "error",
+            "result": "",
+            "error": (
+                "Claude Code delegation is available only to the operator "
+                "in a hosted session."
+            ),
+            "exit_code": -1,
+            "usage": {},
+            "total_cost_usd": None,
+        }
+    )
 
 
 def _parent_tool_call_id(agent) -> str | None:

--- a/docs/blog/2026-08-16-a-session-id-is-not-a-work-room.md
+++ b/docs/blog/2026-08-16-a-session-id-is-not-a-work-room.md
@@ -1,0 +1,59 @@
+# A Session ID Is Not a Work Room
+
+The first Claude Code browser test appeared to pass. O Chat showed a
+`claude_code` tool card, the tool ran for six seconds, and the assistant returned
+the requested text. Expanding the card revealed an even stronger signal: a real
+Claude provider envelope with `status: completed`, `exit_code: 0`, and a UUID
+session ID.
+
+There was still no **Open Work Room** button.
+
+The temptation was to fix that in React. The browser had the tool name and the
+JSON result, so it could parse the envelope, recognize `claude_code`, manufacture
+a provider card, and infer which later calls belonged to it. That would make one
+screenshot look right. It would also put protocol reconstruction in the least
+authoritative layer.
+
+Codex showed the intended boundary. `co ai` installed `CodexPlugin`, which owns a
+provider invocation from start to finish. It emits a stable invocation ID, the
+parent tool-call ID, provider name, permission mode, terminal status, elapsed
+time, result, error, and resumable session ID. Child commands carry the same
+correlation. React normalizes those events, and O Chat only presents them.
+
+Claude had all the difficult pieces — a bounded streaming reader, structured
+results, cancellation, nested tool activity, and session resume — but `co ai`
+registered it as a plain function. The streaming reader could correlate child
+activity with the outer tool call. No owner existed to emit the parent provider
+lifecycle, so the browser correctly rendered the only contract it received: a
+generic tool card.
+
+The fix was not a Claude-shaped frontend exception. `co ai` now installs
+`ClaudeCodePlugin` beside `CodexPlugin`. Both adapters emit the same provider
+lifecycle while keeping their provider-specific transports and policies. The
+model-visible Claude signature remains `prompt`, explicit `cwd`, optional
+`session_id`, model, and timeout. OIP still carries normalized events rather
+than provider CLI output.
+
+That symmetry could not weaken the hosted security boundary. Claude's `plan`
+mode is provider behavior, not a process sandbox, so an invited contact still
+cannot start the operator's local Claude CLI. The plugin checks the
+signature-verified requester before resolving `cwd`; a non-admin therefore
+cannot launch Claude or probe operator paths. An admin's Read only, workspace,
+or bounded Full access choice maps to Claude manual, Accept Edits, or Auto mode.
+The browser never chooses those modes, and resuming reapplies the current Host
+ceiling.
+
+The acceptance test measured the whole path, not just the presence of a button.
+A real admin browser sent one OIP request through the production relay. The card
+rendered **Claude Code · Completed · Open Work Room**. Opening the room showed the
+provider UUID as its target. A follow-up typed inside that room reached the same
+outer OIP session, caused `co ai` to call Claude with that exact UUID, and returned
+the second requested result. Ninety focused unit and security tests passed before
+the browser run.
+
+The lesson is the same one that makes protocol adapters worth having: data being
+available is not the same as semantics being owned. A session ID inside an
+opaque result can be displayed. A Work Room needs a lifecycle — identity,
+parentage, status, authority, continuation, and replay — emitted by the layer
+that actually controls the provider.
+

--- a/docs/concepts/coding-agent-plugins.md
+++ b/docs/concepts/coding-agent-plugins.md
@@ -53,9 +53,15 @@ For Codex, omitting `prompt` creates or resumes the native provider thread
 without starting a model turn. This is the backend half of O Chat's “Open Work
 Room” behavior: the room can exist before it has a task.
 
-`co ai` also installs a routing interceptor. Explicit run/use/start/open Codex
-intent receives a hidden native-route reminder, and any attempt to execute the
-Codex CLI through bash, shell, command substitution, a background wrapper, or a
-package runner is rejected with `codex()` as the required next action. The
+`co ai` installs both plugins, so Codex and Claude Code share the same native
+provider-card and Work Room lifecycle. In hosted sessions, Claude Code remains
+operator-only: a signature-verified non-admin is rejected before workspace
+resolution or process launch. Admin permission profiles select the provider
+mode again on every first turn and resume.
+
+`co ai` also installs a Codex routing interceptor. Explicit run/use/start/open
+Codex intent receives a hidden native-route reminder, and any attempt to execute
+the Codex CLI through bash, shell, command substitution, a background wrapper,
+or a package runner is rejected with `codex()` as the required next action. The
 interceptor parses command positions, so documentation searches and strings
 that merely contain “codex” are not blocked.

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -9,6 +9,7 @@ Components under test:
 - Module: co_ai_agent_main
 """
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -16,7 +17,7 @@ import pytest
 
 import connectonion.cli.co_ai.agent as agent_mod
 import connectonion.cli.co_ai.main as main_mod
-from connectonion import CodexPlugin
+from connectonion import ClaudeCodePlugin, CodexPlugin
 from connectonion.cli.co_ai.plugins.native_coding_agent_routing import (
     reject_raw_codex_launch,
     route_explicit_codex_request,
@@ -86,6 +87,12 @@ def test_create_coding_agent(monkeypatch, tmp_path):
     }
     assert codex_schema.get("required", []) == []
     assert "claude_code" in agent.tools._tools
+    claude_plugins = [
+        plugin for plugin in agent.installed_plugins
+        if isinstance(plugin, ClaudeCodePlugin)
+    ]
+    assert len(claude_plugins) == 1
+    assert agent.tools.get("claude_code")._bound_instance is claude_plugins[0]
     claude_schema = agent.tools.get("claude_code").to_function_schema()["parameters"]
     assert set(claude_schema["properties"]) == {
         "prompt",
@@ -160,6 +167,42 @@ def test_co_ai_codex_uses_the_plugin_invocation_lifecycle(monkeypatch, tmp_path)
     ]
     assert [entry["status"] for entry in lifecycle] == ["running", "completed"]
     assert all(entry["parentToolCallId"] == "call-1" for entry in lifecycle)
+
+
+def test_co_ai_claude_uses_the_plugin_invocation_lifecycle(monkeypatch, tmp_path):
+    class FakeLLM:
+        model = "fake-model"
+
+    import connectonion.plugins.coding_agents as coding_agents
+
+    monkeypatch.setattr("connectonion.core.agent.create_llm", lambda *a, **k: FakeLLM())
+    monkeypatch.setattr(agent_mod, "assemble_prompt", lambda *a, **k: "BASE")
+    monkeypatch.setattr(agent_mod, "load_project_context", lambda *a, **k: "")
+    monkeypatch.setattr(
+        coding_agents,
+        "_run_claude_code",
+        lambda **kwargs: json.dumps({
+            "provider": "claude_code",
+            "session_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "exit_code": 0,
+        }),
+    )
+    monkeypatch.chdir(tmp_path)
+    agent = agent_mod.create_agent(model="fake", max_iterations=1)
+    agent.current_session = {
+        "trace": [],
+        "mode": ":read-only",
+        "_active_tool_call_id": "call-2",
+    }
+
+    agent.tools.claude_code("inspect", cwd=".", agent=agent)
+
+    lifecycle = [
+        entry for entry in agent.current_session["trace"]
+        if entry["type"] == "provider_invocation"
+    ]
+    assert [entry["status"] for entry in lifecycle] == ["running", "completed"]
+    assert all(entry["parentToolCallId"] == "call-2" for entry in lifecycle)
 
 
 def test_start_server_hosts_provided_agent(monkeypatch):

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -122,6 +122,85 @@ def test_codex_plugin_can_follow_the_authenticated_host_permission_ceiling(
     assert seen["approval"] == approval
 
 
+@pytest.mark.parametrize(
+    ("session", "permission_mode"),
+    [
+        ({"mode": ":read-only"}, "manual"),
+        ({"mode": ":workspace"}, "acceptEdits"),
+        (
+            {
+                "mode": ":danger-full-access",
+                "full_access_turns": 2,
+                "full_access_turns_used": 0,
+                "skip_tool_approval": True,
+            },
+            "auto",
+        ),
+    ],
+)
+def test_claude_plugin_can_follow_the_authenticated_host_permission_ceiling(
+    monkeypatch,
+    tmp_path,
+    session,
+    permission_mode,
+):
+    import connectonion.plugins.coding_agents as module
+
+    seen = {}
+
+    def fake_claude(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({
+            "provider": "claude_code",
+            "session_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "exit_code": 0,
+        })
+
+    monkeypatch.setattr(module, "_run_claude_code", fake_claude)
+    agent = SimpleNamespace(
+        current_session={"_active_tool_call_id": "call-9", **session},
+        io=SimpleNamespace(log=MagicMock()),
+    )
+
+    ClaudeCodePlugin(
+        workspace=tmp_path,
+        use_host_permissions=True,
+    ).claude_code("inspect", cwd=str(tmp_path), agent=agent)
+
+    assert seen["permission_mode"] == permission_mode
+
+
+def test_hosted_contact_cannot_launch_claude_plugin(monkeypatch, tmp_path):
+    import connectonion.plugins.coding_agents as module
+
+    monkeypatch.setattr(module, "_run_claude_code", pytest.fail)
+    io = SimpleNamespace(log=MagicMock())
+    agent = SimpleNamespace(
+        current_session={
+            "_active_tool_call_id": "call-10",
+            "mode": ":danger-full-access",
+            "requester": {"address": "0xcontact", "level": "contact"},
+        },
+        io=io,
+    )
+
+    result = json.loads(
+        ClaudeCodePlugin(
+            workspace=tmp_path,
+            use_host_permissions=True,
+        ).claude_code(
+            "change it",
+            cwd=str(tmp_path.parent / "private-repository-name"),
+            session_id="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            agent=agent,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "only to the operator" in result["error"]
+    io.log.assert_not_called()
+
+
 def test_public_signature_matches_the_provider_contract(tmp_path):
     for method in (
         CodexPlugin(workspace=tmp_path).codex,


### PR DESCRIPTION
Fixes #1089.

Stacked on #1088 because the real browser acceptance needs its macOS Claude-auth fix. Retarget to `main` after #1088 merges.

## What changed

- install `ClaudeCodePlugin` in `co ai` beside `CodexPlugin`
- preserve the existing model-visible `claude_code(prompt, cwd, session_id?, model?, timeout?)` contract
- emit one parented running/terminal `provider_invocation`, including the exact resumable session ID
- derive admin Claude modes from the authenticated Host session
- reject hosted non-admins before cwd inspection or local CLI launch

No OChat presentation change and no ACP surface is added.

## Verification

- red-first: Claude was a plain tool, no lifecycle, no Work Room
- 90 related unit/security tests passed
- Ruff and `git diff --check` passed
- real admin OIP + deployed OChat acceptance passed:
  - native Claude first turn: `CLAUDE-WORKROOM-FIRST-OK`
  - card: `Claude Code`, `Completed`, `Open Work Room`
  - Work Room target contained the provider session ID
  - follow-up resumed that exact ID and returned `CLAUDE-WORKROOM-RESUME-OK`

Screenshots in the acceptance workspace:

- `/tmp/frontend-test-screenshots/claude-workroom-card-completed.png`
- `/tmp/frontend-test-screenshots/claude-workroom-resume-completed.png`

Public-wheel verification remains required after the next protected preview release.
