### PR TITLE
Terminate cancelled Bash process trees

### DIFF
--- a/connectonion/useful_tools/bash.py
+++ b/connectonion/useful_tools/bash.py
@@ -2,8 +2,8 @@
 Purpose: Execute bash commands on Unix/Mac systems with timeout and output truncation
 LLM-Note:
   Dependencies: imports from [subprocess, platform] | imported by [useful_tools/__init__.py, useful_prompts/coding_agent/assembler.py] | tested by command execution
-  Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() with shell=True → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
-  State/Effects: executes system commands via subprocess.run(shell=True) | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
+  Data flow: receives command: str, description: str, cwd: str, timeout: int → subprocess.run() locally or cancellable Popen in hosted mode → captures stdout+stderr → truncates if >10000 chars → returns formatted output: str
+  State/Effects: executes shell commands | hosted runs use an isolated process group so OIP Stop terminates descendants | no persistent state | reads/writes filesystem based on command | can have any side effect depending on command (network calls, file operations, etc.)
   Integration: exposes bash(command, description="", cwd, timeout) function | used as agent tool | description is OPTIONAL (defaults "") — an LLM is prompted to fill it for the approval UI, but direct/programmatic callers (remote.call, co call, scripts) can pass command alone | not passed to shell | Unix/Mac only (raises ValueError on Windows)
   Performance: timeout default 120s; explicit caller values are honored | truncates output >10000 chars to prevent token overflow | synchronous execution (blocks until command completes)
   Errors: raises ValueError on Windows | propagates subprocess.TimeoutExpired so callers can distinguish timeout from success | non-zero exit codes included in output | stderr merged with stdout
@@ -23,11 +23,22 @@ Usage:
 Note: This tool is for Unix/Mac systems. For cross-platform usage, use Shell class instead.
 """
 
+import os
 import platform
+import signal
 import subprocess
+import time
+
+from ..core.interrupt import UserInterrupt
 
 
-def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120) -> str:
+def bash(
+    command: str,
+    description: str = "",
+    cwd: str = ".",
+    timeout: int = 120,
+    agent=None,
+) -> str:
     """Execute a bash command, returns output (Unix/Mac only).
 
     Args:
@@ -37,6 +48,7 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
             callers (scripts, remote.call, co call) may pass just the command.
         cwd: Working directory (default: current directory)
         timeout: Seconds before timeout (default: 120)
+        agent: Runtime-injected Agent used only for hosted cancellation.
 
     Returns:
         Command output (stdout + stderr)
@@ -48,18 +60,22 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
     if platform.system() == "Windows":
         return "Error: bash tool is for Unix/Mac only. Use Shell class for Windows."
 
+    cancelled = getattr(getattr(agent, "io", None), "is_cancelled", None)
     try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            executable="/bin/bash",
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=cwd,
-            timeout=timeout
-        )
+        if callable(cancelled):
+            result = _run_cancellable(command, cwd, timeout, cancelled)
+        else:
+            result = subprocess.run(
+                command,
+                shell=True,
+                executable="/bin/bash",
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=cwd,
+                timeout=timeout,
+            )
     except FileNotFoundError:
         return "Error: /bin/bash not found. This tool requires bash shell."
 
@@ -79,3 +95,52 @@ def bash(command: str, description: str = "", cwd: str = ".", timeout: int = 120
         output = output[:max_chars] + f"\n... (truncated, {len(output):,} total chars)"
 
     return output
+
+
+def _run_cancellable(command, cwd, timeout, cancelled):
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        executable="/bin/bash",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=cwd,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + timeout
+    while True:
+        if cancelled():
+            _terminate_process_group(process)
+            raise UserInterrupt()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            _terminate_process_group(process)
+            raise subprocess.TimeoutExpired(command, timeout)
+        try:
+            stdout, stderr = process.communicate(timeout=min(0.05, remaining))
+            return subprocess.CompletedProcess(
+                command, process.returncode, stdout, stderr
+            )
+        except subprocess.TimeoutExpired:
+            continue
+
+
+def _terminate_process_group(process):
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=0.5)
+        return
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+    process.wait(timeout=1)

--- a/docs/blog/2026-08-16-stop-is-a-process-tree-operation.md
+++ b/docs/blog/2026-08-16-stop-is-a-process-tree-operation.md
@@ -1,0 +1,40 @@
+# Stop Is a Process-Tree Operation
+
+The browser said the command had stopped. The Host disagreed.
+
+In a real OIP test, an operator approved `sleep 120` and then pressed **Stop**.
+O Chat promptly rendered an interrupted tool with `exit 1`. A process-tree check
+afterward still found both `/bin/bash -c ...` and its `sleep 120` child. The UI
+had cancelled ownership of the result, but the operating system was still doing
+the work.
+
+ConnectOnion's general interrupt boundary deliberately runs arbitrary blocking
+Python on an abandonable daemon thread. Python cannot safely kill an arbitrary
+thread, so the Agent revokes that worker's IO lease, ignores late output, and
+continues. This protects conversation state, but it cannot undo external side
+effects. Tools that own cancellable external work must cooperate.
+
+The built-in `bash` tool did not. It used blocking `subprocess.run()` and had no
+runtime Agent parameter, so it could not observe the revocable IO lease. Killing
+only the shell would not have been enough either: shell commands routinely spawn
+children, and those children can outlive their parent.
+
+Hosted Bash runs now take the cooperative path. The tool receives the Agent as a
+runtime-only parameter that is absent from the model-visible schema. It launches
+the shell in a new process session, polls the lease while collecting output, and
+terminates the entire process group on Stop or timeout. A short grace period uses
+`SIGTERM`; a surviving group receives `SIGKILL`. Direct local calls keep the
+existing `subprocess.run()` behavior.
+
+The regression test does not stop at checking an `interrupted` trace. It launches
+a real child process, records its PID, sends the same interrupt used by OIP, and
+then proves that the PID no longer exists. That distinction matters: protocol
+state can say “cancelled” while resource state says “running.”
+
+Cancellation therefore has two separate contracts. The framework owns result
+isolation: cancelled work cannot commit late Agent state or emit late UI events.
+The tool owns resource termination: processes, sockets, browser jobs, and provider
+sessions must expose a cooperative stop path when they can safely do so.
+
+The practical rule is simple: if a tool starts an external resource, its Stop test
+must inspect that resource, not just the card rendered in the browser.

--- a/tests/unit/test_shell_tool.py
+++ b/tests/unit/test_shell_tool.py
@@ -14,9 +14,13 @@ Components under test:
 """
 
 
+import os
 import platform
+import signal
 import subprocess
 import tempfile
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -186,6 +190,8 @@ class TestBashBasic:
         assert "description" in schema["properties"]
         assert "command" in schema["required"]
         assert "description" not in schema["required"]
+        assert "agent" not in schema["properties"]
+        assert tool._needs_agent is True
 
     def test_bash_returns_stdout(self):
         """Test that stdout is captured."""
@@ -300,6 +306,38 @@ class TestBashIntegration:
         assert "cwd" in schema["parameters"]["properties"]
         assert "timeout" in schema["parameters"]["properties"]
 
+    def test_host_interrupt_terminates_bash_process_group(self, tmp_path):
+        """OIP Stop must not abandon the shell or its child process."""
+        from connectonion import Agent
+        from connectonion.network.io.websocket import WebSocketIO
+
+        child_pid_file = tmp_path / "child.pid"
+        command = f"sleep 30 & child=$!; echo $child > {child_pid_file}; wait $child"
+        agent = Agent("cancel-bash", tools=[bash], log=False, quiet=True)
+        agent.io = WebSocketIO()
+
+        def interrupt_after_child_starts():
+            deadline = time.monotonic() + 3
+            while not child_pid_file.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert child_pid_file.exists()
+            agent.io.send_to_agent({"type": "INTERRUPT"})
+
+        interrupter = threading.Thread(target=interrupt_after_child_starts)
+        interrupter.start()
+        trace = agent.execute_tool("bash", {"command": command})
+        interrupter.join(timeout=1)
+
+        assert trace["status"] == "interrupted"
+        child_pid = int(child_pid_file.read_text())
+        deadline = time.monotonic() + 2
+        while _process_exists(child_pid) and time.monotonic() < deadline:
+            time.sleep(0.02)
+        survived = _process_exists(child_pid)
+        if survived:
+            os.kill(child_pid, signal.SIGKILL)
+        assert not survived
+
     def test_bash_timeout_is_an_agent_tool_error(self, monkeypatch):
         """The Agent trace exposes a timeout as an error instead of success."""
         from unittest.mock import Mock
@@ -320,6 +358,14 @@ class TestBashIntegration:
         assert result["status"] == "error"
         assert "timed out after 7200 seconds" in result["result"]
         assert agent.current_session["trace"][-1]["error_type"] == "TimeoutExpired"
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")


### PR DESCRIPTION
Closes #1092

## What changed

- make the built-in `bash` tool accept the runtime-injected Agent without exposing it in the model schema
- use an isolated process session for hosted Bash invocations
- poll the revocable IO lease and terminate the full process group on Stop
- terminate the process group on hosted timeout as well
- preserve the existing `subprocess.run()` path for direct/local callers
- add a real-process regression and a public design-journal entry

## Root cause

The Agent interrupt boundary correctly abandoned and isolated the result of arbitrary blocking Python, but `bash()` used blocking `subprocess.run()` and did not cooperate with cancellation. The UI could therefore report an interrupted turn while the shell and child process continued on the Host.

## Validation

- `python -m pytest tests/unit/test_shell_tool.py tests/unit/test_agent.py tests/unit/test_tool_executor.py -q` — 80 passed, 1 Windows-only skipped
- `python -m ruff check connectonion/useful_tools/bash.py tests/unit/test_shell_tool.py`
- `git diff --check`
- real public oo-chat/OIP/relay E2E: approve `sleep 120`, press Stop, card reports interrupted, unique output marker absent, and `ps` finds no matching shell or child process

## User impact

Pressing Stop on an in-flight hosted Bash command now stops its operating-system work instead of only cancelling the visible Agent result.
