### PR TITLE
Preserve multimodal skill input

### DIFF
--- a/connectonion/useful_plugins/skills.py
+++ b/connectonion/useful_plugins/skills.py
@@ -704,6 +704,29 @@ def _close_out_a_turn_that_never_finished(agent: 'Agent') -> None:
     _restore_permissions(agent)
 
 
+def _message_text(content):
+    if isinstance(content, str):
+        return content, None
+    if isinstance(content, list):
+        for index, part in enumerate(content):
+            if (
+                isinstance(part, dict)
+                and part.get('type') == 'text'
+                and isinstance(part.get('text'), str)
+            ):
+                return part['text'], index
+    return '', None
+
+
+def _replace_message_text(message, text_index, text):
+    if text_index is None:
+        message['content'] = text
+        return
+    content = list(message['content'])
+    content[text_index] = {**content[text_index], 'text': text}
+    message['content'] = content
+
+
 @after_user_input
 def handle_skill_invocation(agent: 'Agent') -> None:
     """Detect /command and load skill with permission scope.
@@ -721,7 +744,7 @@ def handle_skill_invocation(agent: 'Agent') -> None:
     if last_msg.get('role') != 'user':
         return
 
-    content = last_msg.get('content', '')
+    content, text_index = _message_text(last_msg.get('content', ''))
     if not content.startswith('/'):
         return
 
@@ -745,7 +768,11 @@ def handle_skill_invocation(agent: 'Agent') -> None:
 
     preflight = preflight_skills([(skill_name, skill.get('requirements'))])
     if preflight.missing_required:
-        messages[-1]['content'] = format_preflight_report(preflight) + "\nSkill did not start."
+        _replace_message_text(
+            last_msg,
+            text_index,
+            format_preflight_report(preflight) + "\nSkill did not start.",
+        )
         return
 
     # Grant skill permissions (with snapshot)
@@ -755,7 +782,7 @@ def handle_skill_invocation(agent: 'Agent') -> None:
     # Replace user message with skill instructions, preserving slash-command args.
     if skill_args:
         instructions = f"{instructions}\n\n---\n## Arguments\n{skill_args}"
-    messages[-1]['content'] = instructions
+    _replace_message_text(last_msg, text_index, instructions)
 
     if agent.logger.console:
         description = frontmatter.get('description', '')

--- a/docs/blog/2026-08-16-a-user-message-is-not-always-a-string.md
+++ b/docs/blog/2026-08-16-a-user-message-is-not-always-a-string.md
@@ -1,0 +1,33 @@
+# A User Message Is Not Always a String
+
+Text-file attachments worked. Image attachments crashed before the model ran.
+
+The browser rendered an image preview and OIP delivered one image to the Host.
+Then the skills plugin called `.startswith('/')` on the newest user message and
+raised `AttributeError: 'list' object has no attribute 'startswith'`.
+
+The assumption was easy to miss because ordinary user content is a string. A
+multimodal user message is an ordered list of content parts: one text part plus
+one or more image parts. The Agent already supported that representation, but an
+`after_user_input` plugin at the edge of the execution loop still assumed the old
+shape.
+
+Returning early for every list would have stopped the crash. It would also have
+made `/skill` commands silently stop working whenever the user attached an image.
+Replacing the entire list with skill instructions would be worse: the command
+would run, but the attachment it was meant to inspect would disappear.
+
+The skills plugin now locates the text part without flattening the message. A
+normal image prompt passes through untouched. A multimodal slash command replaces
+only its text part with the loaded instructions and arguments, preserving the
+remaining image parts and their order. Plain string behavior is unchanged.
+
+The regression covers both sides of that boundary: a non-command image prompt
+must not load a skill or raise, and a slash command with an image must load the
+skill while keeping the exact image part. The real browser retest then confirmed
+the stronger result: OIP reported one image, the LLM completed, and the chat
+remained live.
+
+The lesson applies to every message event handler. Plugins should reason about
+message semantics — text, images, files, tool calls — rather than treating the
+wire representation as permanently scalar.

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -332,6 +332,49 @@ class TestSkillInvocation:
         mock_load.assert_not_called()
 
     @patch.object(skills_module, '_load_skill')
+    def test_handle_skill_invocation_ignores_multimodal_non_slash(self, mock_load):
+        """Image prompts are ordinary input, not malformed slash commands."""
+        agent = FakeAgent()
+        content = [
+            {'type': 'text', 'text': 'What is in this image?'},
+            {'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,abc'}},
+        ]
+        agent.current_session['messages'] = [{'role': 'user', 'content': content}]
+
+        handle_skill_invocation(agent)
+
+        mock_load.assert_not_called()
+        assert agent.current_session['messages'][-1]['content'] == content
+
+    @patch.object(skills_module, '_load_skill')
+    def test_multimodal_slash_command_preserves_image(self, mock_load):
+        """A slash command may replace its text without dropping attachments."""
+        agent = FakeAgent()
+        image = {
+            'type': 'image_url',
+            'image_url': {'url': 'data:image/png;base64,abc'},
+        }
+        agent.current_session['messages'] = [{
+            'role': 'user',
+            'content': [{'type': 'text', 'text': '/inspect focus'}, image],
+        }]
+        mock_load.return_value = {
+            'frontmatter': {},
+            'instructions': 'Inspect the image',
+        }
+
+        handle_skill_invocation(agent)
+
+        mock_load.assert_called_once_with('inspect')
+        assert agent.current_session['messages'][-1]['content'] == [
+            {
+                'type': 'text',
+                'text': 'Inspect the image\n\n---\n## Arguments\nfocus',
+            },
+            image,
+        ]
+
+    @patch.object(skills_module, '_load_skill')
     def test_handle_skill_invocation_skill_not_found(self, mock_load):
         """Test that missing skills are handled gracefully."""
         agent = FakeAgent()


### PR DESCRIPTION
Closes #1094

## What changed

- teach the skills `after_user_input` handler to read the text part of multimodal user content
- pass ordinary image prompts through unchanged
- replace only the text part for multimodal slash commands, preserving image parts and order
- apply the same shape-preserving replacement to skill preflight errors
- add regression coverage and a design-journal entry

## Root cause

`Agent.input(..., images=[...])` stores the user message as a list of OpenAI-style text/image parts. The skills plugin assumed `content` was always a string and called `.startswith('/')`, crashing every `co ai` image prompt before the LLM ran.

## Validation

- `python -m pytest tests/unit/test_skills.py tests/unit/test_agent.py -q` — 55 passed
- `git diff --check`
- `python -m py_compile connectonion/useful_plugins/skills.py tests/unit/test_skills.py`
- real public oo-chat/OIP/relay E2E: non-sensitive SVG preview rendered; Host logged `↑ 1 images`; LLM completed; chat remained live with no `Unable to run agent`

The two touched legacy modules have pre-existing broad Ruff findings unrelated to this diff; syntax, diff checks, focused tests, and CI remain the acceptance gates.

## User impact

Image attachments now reach the model instead of crashing `co ai`, and `/skill` commands can retain attached images.
