### PR TITLE
fix(codex): pause turn budget during approvals

### DIFF
--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -177,7 +177,7 @@ class CodexPlugin(_CodingAgentPlugin):
         cwd: str = "",
         session_id: str = "",
         model: str = "",
-        timeout: int = 600,
+        timeout: int = 1800,
         agent=None,
     ) -> str:
         """Run, open, or resume Codex inside the operator-configured workspace."""

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -654,6 +654,12 @@ class CodexAppServer:
         self._stderr_tail = ""
         self._stderr_thread = None
         self._exit_error = None
+        # A human deciding on a nested approval is not active Codex execution.
+        # Keep that wall time separate from the bounded turn budget so a careful
+        # review cannot make the next provider step time out immediately.
+        self._approval_lock = threading.Lock()
+        self._approval_wait_seconds = 0.0
+        self._approval_started_at = None
 
     # ── lifecycle ────────────────────────────────────────────────
 
@@ -755,13 +761,20 @@ class CodexAppServer:
 
     def run_turn(self, thread_id, prompt, cwd="", timeout=600):
         deadline = time.monotonic() + timeout
+        approval_pause_mark = self._approval_pause_mark()
         self._turn_done.clear()
         self._turn_result = {}
         self.request("turn/start", {
             "threadId": thread_id, "cwd": cwd or self.cwd or ".",
             "input": [{"type": "text", "text": prompt}],
         }, timeout=_remaining(deadline))
-        self._wait_for(self._turn_done, deadline, "turn", timeout)
+        self._wait_for_turn(
+            self._turn_done,
+            deadline,
+            approval_pause_mark,
+            "turn",
+            timeout,
+        )
         return self._turn_result
 
     # ── JSON-RPC plumbing ────────────────────────────────────────
@@ -799,6 +812,29 @@ class CodexAppServer:
             if self.cancelled():
                 raise _ProviderCancelled(f"{operation} interrupted")
             remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"{operation} timed out after {timeout}s")
+            if event.wait(min(0.1, remaining)):
+                return
+
+    def _approval_pause_mark(self):
+        with self._approval_lock:
+            return self._approval_wait_seconds
+
+    def _approval_pause_since(self, mark, now):
+        with self._approval_lock:
+            paused = self._approval_wait_seconds - mark
+            if self._approval_started_at is not None:
+                paused += now - self._approval_started_at
+        return max(0.0, paused)
+
+    def _wait_for_turn(self, event, deadline, approval_pause_mark, operation, timeout):
+        """Wait for a turn without charging an operator's approval review time."""
+        while True:
+            if self.cancelled():
+                raise _ProviderCancelled(f"{operation} interrupted")
+            now = time.monotonic()
+            remaining = deadline + self._approval_pause_since(approval_pause_mark, now) - now
             if remaining <= 0:
                 raise TimeoutError(f"{operation} timed out after {timeout}s")
             if event.wait(min(0.1, remaining)):
@@ -870,10 +906,18 @@ class CodexAppServer:
 
     def _handle_server_request(self, req_id, method, params):
         if method in _APPROVAL_METHODS:
+            started_at = time.monotonic()
+            with self._approval_lock:
+                self._approval_started_at = started_at
             try:
                 allowed = bool(self.on_approval(method, params))
             except Exception:
                 allowed = False
+            finally:
+                finished_at = time.monotonic()
+                with self._approval_lock:
+                    self._approval_wait_seconds += max(0.0, finished_at - started_at)
+                    self._approval_started_at = None
             self._send(
                 {
                     "id": req_id,

--- a/docs/blog/2026-08-16-an-approval-is-not-execution-time.md
+++ b/docs/blog/2026-08-16-an-approval-is-not-execution-time.md
@@ -1,0 +1,48 @@
+# An approval is not execution time
+
+*2026-08-16*
+
+A Work Room test asked Codex to create and test a small Dijkstra program. The
+first action was deliberately harmless: inspect the workspace. The operator
+read the approval, allowed it, and expected the coding run to continue.
+
+Instead, the native app-server reported a turn timeout just under ten minutes
+after the invocation began. The problem was not that Codex had spent ten
+minutes computing. Our timer had spent the operator's review time as though it
+were provider execution time.
+
+That distinction matters most in a Work Room. The point of a manual approval
+is to let a person stop and understand an action. Treating that pause as a
+penalty turns careful review into a hidden failure mode: the next safe command
+can inherit almost no time to run.
+
+## Two clocks, one authority boundary
+
+The Codex adapter still has a bounded active-execution budget. A genuinely hung
+app-server can still time out, and an interrupt can still stop its process
+tree. The change only separates the period spent waiting in the nested approval
+callback from that active budget.
+
+The adapter measures each approval callback and extends the turn wait by the
+measured duration. It does not grant an action automatically, widen the
+sandbox, or add a new protocol path. An approval remains an operator decision;
+it just no longer erases the time needed to act on that decision.
+
+For hosted co ai Codex runs, the default active budget is now thirty minutes.
+That is still finite, but it reflects the scale of a coding agent that may
+inspect a repository, edit files, run checks, and return a result rather than a
+single shell command.
+
+## Measure the pause without making the test slow
+
+The regression test does not wait for a human. It advances a deterministic
+clock through one hundred seconds of simulated approval review, then proves
+that the following execution slice still has the full configured budget. A
+second test verifies that the approval callback records exactly its measured
+duration. Existing cancellation and hosted-routing tests cover the boundary
+around it.
+
+The lesson is small but reusable: a timeout is a statement about what work is
+allowed to consume. Human review is not the same work as provider execution.
+When a product asks someone to approve an action, the system must make room for
+them to do that thoughtfully.

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -603,6 +603,47 @@ class TestResumeProtocol:
         assert request.call_args.kwargs["timeout"] == 10
         done.wait.assert_called_once_with(0.1)
 
+    def test_turn_wait_preserves_the_full_budget_after_manual_approval(self):
+        client = codex_module.CodexAppServer(["codex", "app-server"])
+
+        class ApprovalDelayEvent:
+            def __init__(self):
+                self.waits = []
+
+            def clear(self):
+                pass
+
+            def wait(self, seconds):
+                self.waits.append(seconds)
+                if len(self.waits) == 1:
+                    # Simulate 100 seconds of operator review between two
+                    # active execution slices without sleeping in the test.
+                    client._approval_wait_seconds = 100
+                    return False
+                return True
+
+        done = ApprovalDelayEvent()
+        client._turn_done = done
+        with patch.object(client, "request", return_value={}), patch.object(
+            codex_module.time, "monotonic", side_effect=[0, 0, 1, 101]
+        ):
+            client.run_turn("thread-1", "continue", timeout=10)
+
+        assert done.waits == [0.1, 0.1]
+
+    def test_approval_request_records_operator_review_time(self):
+        client = codex_module.CodexAppServer(
+            ["codex", "app-server"], on_approval=lambda *_: True
+        )
+        with patch.object(client, "_send"), patch.object(
+            codex_module.time, "monotonic", side_effect=[10, 35]
+        ):
+            client._handle_server_request(
+                1, "item/commandExecution/requestApproval", {"command": "pytest -q"}
+            )
+
+        assert client._approval_wait_seconds == 25
+
     def test_close_reaps_the_process_tree_and_closes_every_pipe(self):
         client = codex_module.CodexAppServer(["codex", "app-server"])
         process = MagicMock()

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -210,6 +210,10 @@ def test_public_signature_matches_the_provider_contract(tmp_path):
             "prompt", "cwd", "session_id", "model", "timeout", "agent"
         ]
 
+    assert inspect.signature(CodexPlugin(workspace=tmp_path).codex).parameters[
+        "timeout"
+    ].default == 1800
+
 
 def test_codex_prompt_is_optional_so_open_does_not_invent_a_task(tmp_path):
     signature = inspect.signature(CodexPlugin(workspace=tmp_path).codex)


### PR DESCRIPTION
Closes #1104.

Manual nested-approval review no longer consumes the native Codex turn's active
execution budget. The hosted Codex plugin now starts with a bounded 30-minute
budget for multi-step coding work; a hung server remains subject to that active
budget and the existing cancellation path.

The adapter records the duration of each approval callback and only extends the
turn wait by that measured duration. It does not change the sandbox or approval
authority model.

Verification:

- 75 focused Codex/provider-plugin unit tests passed.
- 58 routing, hosted-agent, and interruption tests passed.
- Ruff passed on all changed files.

The new deterministic regression simulates 100 seconds of manual review without
sleeping and verifies the full post-approval active execution budget remains.
This is OIP-native only; no ACP path is added.
