### PR TITLE
fix(host): survive denied adapter discovery in 1.6.11

### DIFF
--- a/connectonion/network/announce.py
+++ b/connectonion/network/announce.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: get_ips() makes HTTP request to ipify (one-time) | pure function otherwise | deterministic JSON serialization (matches server verification) | signature is hex string without 0x prefix
   Integration: exposes get_ips(), create_announce_message(address_data, summary, endpoints) | used by host() to announce agent presence to relay network | relay server verifies signature using address (public key) | heartbeat re-sends with updated timestamp
   Performance: Ed25519 signing is fast (sub-millisecond) | get_ips() ~300-500ms for ipify call (runs once at startup)
-  Errors: raises KeyError if address_data missing required keys | address.sign() errors bubble up | any ipify failure (timeout, DNS, 5xx) returns the local addresses without a public one — it used to raise out of get_endpoints() into host startup, which this line already claimed it did not
+  Errors: raises KeyError if address_data missing required keys | address.sign() errors bubble up | denied local adapter enumeration and ipify failures degrade independently, so neither optional discovery source can abort Host startup
 
 Build ANNOUNCE messages for relay registration.
 
@@ -68,11 +68,21 @@ def get_ips() -> List[str]:
     """Get all IP addresses (localhost, local network, public)."""
     ips = ["localhost"]
 
-    # Local IPs
-    for adapter in ifaddr.get_adapters():
-        for ip in adapter.ips:
-            if isinstance(ip.ip, str) and not ip.ip.startswith('127.'):
-                ips.append(ip.ip)
+    # Interface discovery is optional reachability enrichment. Sandboxed Linux
+    # processes can be allowed to bind/listen while the netlink operation used
+    # by ifaddr is denied. That must cost local endpoint discovery, not Host
+    # startup. Keep this catch around the OS boundary (including iteration), so
+    # programming errors elsewhere still surface normally.
+    try:
+        for adapter in ifaddr.get_adapters():
+            for ip in adapter.ips:
+                if isinstance(ip.ip, str) and not ip.ip.startswith("127."):
+                    ips.append(ip.ip)
+    except OSError as exc:
+        print(
+            "[announce] local network discovery unavailable "
+            f"({type(exc).__name__}); continuing with public/relay discovery."
+        )
 
     # Public IP, from a third party, which is the one address this project cannot
     # work out for itself. Everything above is already collected, and those are

--- a/docs/network/host.md
+++ b/docs/network/host.md
@@ -209,6 +209,13 @@ The relay is a pure forwarder — it doesn't parse or modify messages, just rout
 2. Relay stores agent info (now discoverable)
 3. When client calls `connect("0xaddress")`, SDK tries direct connection first, falls back to relay if needed
 
+Endpoint discovery is best-effort. `AGENT_PUBLIC_DOMAIN` bypasses automatic
+discovery. Otherwise the Host tries local interfaces and a public-IP lookup
+independently; if a container denies interface enumeration, or the public
+lookup is unavailable, the Host still starts and keeps its relay connection.
+When neither source yields a publishable address, the announcement carries no
+direct endpoint and clients use the relay.
+
 ### Heartbeat & Keep-Alive
 
 | Connection | Mechanism | Interval | Purpose |

--- a/tests/unit/test_a_host_starts_without_the_ip_service.py
+++ b/tests/unit/test_a_host_starts_without_the_ip_service.py
@@ -23,10 +23,19 @@ losing all of them costs the agent. So the call is allowed to fail and the rest
 is kept — which is what the header already claimed.
 """
 
+import asyncio
+
 import httpx
 import pytest
 
 from connectonion.network import announce
+
+
+def raise_when_called(error):
+    def fail(*args, **kwargs):
+        raise error
+
+    return fail
 
 
 class TestTheLookupIsAllowedToFail:
@@ -75,6 +84,122 @@ class TestTheLookupIsAllowedToFail:
         assert announce.get_ips()
 
 
+class TestLocalAdapterDiscoveryIsOptional:
+    class PublicResponse:
+        text = "203.0.113.7"
+
+    @staticmethod
+    def deny_adapters(monkeypatch, error):
+        monkeypatch.setattr(announce.ifaddr, "get_adapters", raise_when_called(error))
+
+    def test_permission_denial_keeps_the_public_address(self, monkeypatch):
+        self.deny_adapters(monkeypatch, PermissionError("private interface detail"))
+        monkeypatch.setattr(
+            announce.httpx, "get", lambda *a, **k: self.PublicResponse()
+        )
+
+        assert announce.get_ips() == ["localhost", "203.0.113.7"]
+
+    def test_another_os_error_is_also_a_degraded_path(self, monkeypatch):
+        self.deny_adapters(monkeypatch, OSError("netlink unavailable"))
+        monkeypatch.setattr(
+            announce.httpx, "get", lambda *a, **k: self.PublicResponse()
+        )
+
+        assert "203.0.113.7" in announce.get_ips()
+
+    def test_the_diagnostic_is_concise_and_does_not_leak_interfaces(
+        self, monkeypatch, capsys
+    ):
+        self.deny_adapters(monkeypatch, PermissionError("secret-interface-name"))
+        monkeypatch.setattr(
+            announce.httpx, "get", lambda *a, **k: self.PublicResponse()
+        )
+
+        announce.get_ips()
+        output = capsys.readouterr().out
+
+        assert "local network discovery unavailable (PermissionError)" in output
+        assert "secret-interface-name" not in output
+
+    def test_both_sources_can_fail_without_an_endpoint_or_traceback(
+        self, monkeypatch
+    ):
+        self.deny_adapters(monkeypatch, PermissionError("denied"))
+        monkeypatch.setattr(
+            announce.httpx,
+            "get",
+            raise_when_called(httpx.ConnectError("offline")),
+        )
+
+        assert announce.get_ips() == ["localhost"]
+        assert announce.get_endpoints(8000) == []
+
+    def test_a_local_address_survives_when_the_public_lookup_fails(
+        self, monkeypatch
+    ):
+        local_ip = type("IP", (), {"ip": "10.0.0.8"})()
+        adapter = type("Adapter", (), {"ips": [local_ip]})()
+        monkeypatch.setattr(announce.ifaddr, "get_adapters", lambda: [adapter])
+        monkeypatch.setattr(
+            announce.httpx,
+            "get",
+            raise_when_called(httpx.ConnectError("offline")),
+        )
+
+        assert announce.get_ips() == ["localhost", "10.0.0.8"]
+        assert "http://10.0.0.8:8000" in announce.get_endpoints(8000)
+
+    def test_loopback_addresses_are_never_announced(self, monkeypatch):
+        loopbacks = [
+            type("IP", (), {"ip": "127.0.0.2"})(),
+            type("IP", (), {"ip": "::1"})(),
+        ]
+        adapter = type("Adapter", (), {"ips": loopbacks})()
+        monkeypatch.setattr(announce.ifaddr, "get_adapters", lambda: [adapter])
+        monkeypatch.setattr(
+            announce.httpx,
+            "get",
+            raise_when_called(httpx.ConnectError("offline")),
+        )
+
+        assert announce.get_endpoints(8000) == []
+
+    @pytest.mark.asyncio
+    async def test_relay_startup_reaches_its_normal_path_when_both_sources_fail(
+        self, monkeypatch
+    ):
+        from connectonion.network import relay
+        from connectonion.network.host.server import _create_relay_lifespan
+
+        self.deny_adapters(monkeypatch, PermissionError("denied"))
+        monkeypatch.setattr(
+            announce.httpx,
+            "get",
+            raise_when_called(httpx.ConnectError("offline")),
+        )
+        serving = asyncio.Event()
+
+        async def serve_until_shutdown(*args, **kwargs):
+            serving.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(relay, "serve_once", serve_until_shutdown)
+        on_startup, on_shutdown = _create_relay_lifespan(
+            "wss://relay.example",
+            {"address": "0x" + "a" * 64},
+            "restricted host",
+            8000,
+            lambda *a, **k: None,
+        )
+
+        await on_startup()
+        try:
+            await asyncio.wait_for(serving.wait(), timeout=0.5)
+        finally:
+            await on_shutdown()
+
+
 class TestAWorkingLookupIsStillUsed:
 
     def test_the_public_address_is_included(self, monkeypatch):
@@ -110,7 +235,10 @@ class TestTheDomainOverrideSkipsItEntirely:
         called = []
         monkeypatch.setenv("AGENT_PUBLIC_DOMAIN", "agent.example.org")
         monkeypatch.setattr(
-            announce.httpx, "get", lambda *a, **k: called.append(1)
+            announce.ifaddr, "get_adapters", lambda: called.append("local")
+        )
+        monkeypatch.setattr(
+            announce.httpx, "get", lambda *a, **k: called.append("public")
         )
 
         announce.get_endpoints(8000)


### PR DESCRIPTION
## What changed

- treat local adapter enumeration as optional endpoint enrichment;
- catch only `OSError` at the `ifaddr` OS boundary, including lazy iteration;
- continue independently to public-IP and relay discovery;
- emit one concise diagnostic without interface details;
- document relay-only startup when neither source yields a direct endpoint.

## Root cause

The public-IP lookup was already guarded, but `ifaddr.get_adapters()` was not. In restricted Linux containers its netlink operation can raise `PermissionError`, aborting relay lifespan startup before the Host reaches its supported no-direct-endpoint state.

## Compatibility

`AGENT_PUBLIC_DOMAIN` still bypasses both discovery calls. Local/public endpoints retain their existing format and loopback addresses remain excluded. No 1.7/OIP code is included.

## Validation

- adapter denial + public success
- other `OSError` + public success
- local success + public failure
- both discovery sources fail
- domain override calls neither source
- no loopback publication
- real relay lifespan startup reaches its serving path with both sources unavailable
- announce/relay/Host focused suite: 62 passed
- `git diff --check`

Closes #1099
