### PR TITLE
feat: add versioned Auto Approve policy

### DIFF
--- a/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
+++ b/connectonion/cli/co_ai/prompts/connectonion/useful_plugins/tool_approval.md
@@ -9,10 +9,12 @@ The plugin is the same in every mode; what moves is the gate.
 
 | mode | behaviour |
 |---|---|
-| `safe` | dangerous tool calls are confirmed one at a time |
-| `plan` | the agent proposes a plan and waits for review before doing anything |
-| `accept_edits` | file edits land without asking; other dangerous calls still ask |
-| `ulw` | runs unattended for a bounded number of turns — see `useful_plugins/ulw` |
+| `default` | deterministic Auto Approve for workspace work; higher-impact calls ask or deny |
+| `safe` | every call without an explicit permission asks |
+| `full_access` | explicit local/Host-admin access, bounded by Host controls |
+
+`accept_edits`, `ulw`, and `yolo` remain compatibility aliases. Plan is stored
+as workflow state and does not change the approval profile.
 
 Mode changes arrive over the WebSocket, so a client can move between them
 mid-session without restarting the agent.
@@ -25,8 +27,8 @@ temporary grants are snapshotted and restored around the skill rather than
 merged into it — a permission the user gave for one turn must not survive
 into the next.
 
-## What it does not do
+## Policy decisions
 
-It does not decide what is dangerous. That comes from the tool's own
-declaration and the permission patterns, so adding a tool does not mean editing
-this plugin.
+The Default policy emits a versioned `allow`, `ask`, or `deny` decision with a
+reason, effect class, and scope. Unknown tools ask rather than running silently.
+An `ask` reuses the same human approval protocol and permission state as before.

--- a/connectonion/cli/co_ai/tools/plan_mode.py
+++ b/connectonion/cli/co_ai/tools/plan_mode.py
@@ -26,17 +26,19 @@ Agent can enter plan mode via enter_plan_mode().
 User can switch modes via WebSocket mode_change message.
 
 State management:
-- Mode stored in agent.current_session['mode']
+- Workflow state stored in agent.current_session['workflow_mode']
 - Plan path stored in agent.current_session['plan_path']
 - Previous mode stored in agent.current_session['previous_mode']
 - Plan file at .co/PLAN.md
 """
 
 from pathlib import Path
-from ....project import project_co_dir
+
 from rich.console import Console
-from rich.panel import Panel
 from rich.markdown import Markdown
+from rich.panel import Panel
+
+from ....project import project_co_dir
 
 # Note: The `agent` parameter in tool functions has no type hint.
 #
@@ -65,7 +67,7 @@ def get_plan_file_path(session_id: str = None) -> Path:
 
 def is_plan_mode_active(agent) -> bool:
     """Check if plan mode is currently active."""
-    return agent.current_session.get('mode') == 'plan'
+    return agent.current_session.get('workflow_mode') == 'plan'
 
 
 def enter_plan_mode(agent=None) -> str:
@@ -93,13 +95,12 @@ def enter_plan_mode(agent=None) -> str:
         4. exit_plan_and_implement() - Get user approval, then implement
     """
     # Check if already in plan mode
-    if agent and agent.current_session.get('mode') == 'plan':
+    if agent and agent.current_session.get('workflow_mode') == 'plan':
         return "Already in plan mode. Use exit_plan_and_implement() when ready for user approval."
 
     # Save previous mode and set plan path in session
     if agent:
-        agent.current_session['previous_mode'] = agent.current_session.get('mode', 'safe')
-        agent.current_session['mode'] = 'plan'
+        agent.current_session['workflow_mode'] = 'plan'
         if agent.io:
             agent.io.send({'type': 'mode_changed', 'mode': 'plan', 'triggered_by': 'agent'})
 
@@ -150,7 +151,7 @@ def enter_plan_mode(agent=None) -> str:
         border_style="green"
     ))
 
-    return f"Entered plan mode. Write your plan with write_plan(), then call exit_plan_and_implement() when ready for user approval."
+    return "Entered plan mode. Write your plan with write_plan(), then call exit_plan_and_implement() when ready for user approval."
 
 
 def exit_plan_and_implement(agent=None) -> str:
@@ -164,7 +165,7 @@ def exit_plan_and_implement(agent=None) -> str:
     Returns:
         User's response message (raw from io.receive)
     """
-    if agent and agent.current_session.get('mode') != 'plan':
+    if agent and agent.current_session.get('workflow_mode') != 'plan':
         return "Not in plan mode. Use enter_plan_mode() first."
 
     plan_path = agent.current_session.get('plan_path') if agent else None
@@ -191,16 +192,18 @@ def exit_plan_and_implement(agent=None) -> str:
         ))
         response = {"message": f"Plan approved. Implement now. Do NOT re-enter plan mode.\n\n---\n\n{plan_content}"}
 
-    # Restore previous mode
+    # Planning is workflow state, not authority. Leaving it does not change the
+    # user's Default/Safe/Full access approval profile.
     if agent:
-        previous_mode = agent.current_session.get('previous_mode', 'safe')
-        agent.current_session['mode'] = previous_mode
+        agent.current_session.pop('workflow_mode', None)
+        from connectonion.useful_plugins.tool_approval import get_current_mode
+        current_mode = get_current_mode(agent)
         if agent.io:
-            agent.io.send({'type': 'mode_changed', 'mode': previous_mode})
+            agent.io.send({'type': 'mode_changed', 'mode': current_mode})
 
         # Clean up session state
         agent.current_session.pop('plan_path', None)
-        agent.current_session.pop('previous_mode', None)
+        agent.current_session.pop('previous_mode', None)  # legacy sessions
 
     return response.get("message", "")
 

--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -268,7 +268,11 @@ class Agent:
             self.current_session = {
                 'messages': [{"role": "system", "content": self.system_prompt}],
                 'trace': [],
-                'turn': 0  # Track conversation turns
+                'turn': 0,  # Track conversation turns
+                # Consumed by the approval plugin. Persisted sessions without a
+                # versioned profile migrate to Safe; only an actual new session
+                # receives the Default Auto Approve profile.
+                '_new_session': True,
             }
             # Start YAML session logging
             self.logger.start_session(self.system_prompt)

--- a/connectonion/network/host/http_router.py
+++ b/connectonion/network/host/http_router.py
@@ -33,7 +33,7 @@ from .session import Session, SessionStorage, merge_sessions, session_to_chat_it
 # survives the round trip without the client being able to invent it.
 SERVER_OWNED_SESSION_KEYS = (
     'mode', 'ulw_turns', 'ulw_turns_used', 'skip_tool_approval',
-    'permissions', 'approval', 'requester',
+    'permissions', 'approval', 'approval_profile', 'requester',
 )
 
 
@@ -90,6 +90,13 @@ def input_handler(create_agent: Callable, storage: SessionStorage, prompt: str, 
         session.pop(key, None)
         if key in stored_session:
             session[key] = stored_session[key]
+
+    # A client cannot declare itself new to obtain a more permissive default.
+    # The server knows whether this id has stored state, and the approval plugin
+    # consumes this one-shot marker before the session is checkpointed.
+    session.pop('_new_session', None)
+    if stored is None:
+        session['_new_session'] = True
 
     # After the merge, and overwriting whatever arrived. The session dict
     # round-trips through the client, so anything read out of it is their

--- a/connectonion/network/host/ws_router/connect.py
+++ b/connectonion/network/host/ws_router/connect.py
@@ -11,6 +11,7 @@ LLM-Note:
 import uuid
 
 from rich.console import Console
+
 from ...trust.ws_admin import get_onboard_requirements
 from .agent_io import resume_forwarding
 
@@ -85,6 +86,7 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     conn["session_id"] = session_id
     conn["session"] = data.get("session")
     server_newer = False
+    stored = None
 
     if conn["session"]:
         msg_count = len(conn["session"].get("messages", []))
@@ -119,7 +121,7 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
             client = conn["session"] or {}
             conn["session"], server_newer = merge_sessions(client_session=client, server_session=stored.session)
             if server_newer:
-                console.print(f"  [dim]↕ merged sessions (server newer)[/dim]")
+                console.print("  [dim]↕ merged sessions (server newer)[/dim]")
 
     # The live half, and the worse one: resume_forwarding rewinds and streams
     # the output of a turn already in progress. A caller who does not own it was
@@ -136,6 +138,16 @@ async def establish_connection(data, agent_address, send_msg, conn, storage, reg
     console.print(f"[green]✓ CONNECT[/green] agent_address={agent_address[:16]}... session={session_id[:8]}... status={status}{' (server_newer)' if server_newer else ''}")
 
     connected_msg = {"type": "CONNECTED", "session_id": session_id, "status": status}
+    from ....useful_plugins.tool_approval.policy import advertised_profile_state
+
+    trust_agent = route_handlers and route_handlers.get("trust_agent")
+    is_admin = getattr(trust_agent, "is_admin", None)
+    allow_full_access = bool(is_admin and is_admin(agent_address))
+    connected_msg["session_modes"] = advertised_profile_state(
+        conn["session"] if stored else None,
+        new_session=stored is None,
+        allow_full_access=allow_full_access,
+    )
     if server_newer and conn["session"]:
         from ..session import session_to_chat_items
         connected_msg["server_newer"] = True

--- a/connectonion/useful_plugins/tool_approval/__init__.py
+++ b/connectonion/useful_plugins/tool_approval/__init__.py
@@ -192,10 +192,17 @@ from .approval import (
     get_current_mode,
 )
 from .constants import VALID_MODES, DEFAULT_MODE
+from .policy import apply_auto_approve_policy
 
 # Export as plugin (list of event handlers)
 # Usage: Agent("name", plugins=[tool_approval])
-tool_approval = [load_config_permissions, poll_mode_changes, poll_interrupt, check_approval]
+tool_approval = [
+    load_config_permissions,
+    poll_mode_changes,
+    poll_interrupt,
+    apply_auto_approve_policy,
+    check_approval,
+]
 
 # Export mode functions for external use
 __all__ = [

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -199,13 +199,13 @@ File Relationships:
                                     → raise ValueError or return
 """
 
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from ...core.events import before_each_tool, before_iteration, after_iteration, after_user_input
-from .constants import VALID_MODES, DEFAULT_MODE, DANGEROUS_TOOLS, FILE_EDIT_TOOLS, COMMAND_TOOLS
+from ...core.events import after_iteration, after_user_input, before_each_tool, before_iteration
 from ...project import project_co_dir
-from .bash_parser import extract_commands_from_bash, check_bash_chain_permitted
+from .bash_parser import check_bash_chain_permitted
+from .constants import DANGEROUS_TOOLS, DEFAULT_MODE, VALID_MODES
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -328,14 +328,19 @@ def _get_mode(agent: 'Agent') -> str:
         'plan': Read-only tools only, exit_plan_and_implement needs approval
         'accept_edits': No approvals, agent runs freely
     """
-    return agent.current_session.get('mode', DEFAULT_MODE)
+    from .policy import ensure_approval_profile
+
+    return ensure_approval_profile(agent)
 
 
 def _set_mode(agent: 'Agent', mode: str) -> None:
     """Set approval mode in session and notify frontend."""
-    if mode not in VALID_MODES:
-        mode = DEFAULT_MODE
-    agent.current_session['mode'] = mode
+    from .policy import set_approval_profile
+
+    try:
+        mode = set_approval_profile(agent, mode)
+    except ValueError:
+        mode = set_approval_profile(agent, DEFAULT_MODE)
     # Notify frontend of mode change
     if agent.io:
         agent.io.send({'type': 'mode_changed', 'mode': mode, 'triggered_by': 'agent'})
@@ -426,8 +431,36 @@ def check_approval(agent: 'Agent') -> None:
         if refusal:
             raise ValueError(refusal)
 
+        # The deterministic policy plugin runs immediately before this human
+        # approval hook. Its result is transient call state, not a second
+        # approval store: session-scoped human grants still live only in the
+        # unified permissions dict below.
+        policy = pending.get('approval_policy')
+        if policy:
+            verdict = policy.get('decision')
+            if verdict == 'deny':
+                raise ValueError(
+                    f"Tool '{tool_name}' denied by {policy.get('policy_id')}: "
+                    f"{policy.get('reason', 'policy denied the call')}"
+                )
+            if verdict == 'allow':
+                if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
+                    agent.logger.console.log_permission_granted(
+                        tool_name, tool_args, 'policy', policy.get('reason', 'auto-approved')
+                    )
+                return
+
         # Get permissions from session (includes safe tools from template)
         permissions = agent.current_session.get('permissions', {})
+        if policy and policy.get('decision') == 'ask' and policy.get('requires_human'):
+            # High-impact/unknown calls may only reuse an approval a person
+            # already granted in this session. Broad template, config, or skill
+            # rules cannot turn the policy's mandatory human decision into a
+            # silent allow (for example Bash(co *) must not imply co deploy).
+            permissions = {
+                key: value for key, value in permissions.items()
+                if value.get('source') == 'user'
+            }
 
         if permissions:
             # matches_permission_pattern is from skills plugin - handles pattern matching
@@ -481,7 +514,7 @@ def check_approval(agent: 'Agent') -> None:
     # =================================================================
     # Check if another plugin requested to skip approvals (e.g., ulw)
     # =================================================================
-    if agent.current_session.get('mode') == 'ulw':
+    if _get_mode(agent) == 'full_access':
         pending = agent.current_session.get('pending_tool')
         tool_name = pending['name'] if pending else 'unknown'
         tool_args = pending.get('arguments', {}) if pending else {}
@@ -509,17 +542,7 @@ def check_approval(agent: 'Agent') -> None:
     # =================================================================
     # MODE: accept_edits - File edits auto-approved, others need approval
     # =================================================================
-    if mode == 'accept_edits':
-        if tool_name in FILE_EDIT_TOOLS:
-            if hasattr(agent, 'logger') and agent.logger and hasattr(agent.logger, 'console'):
-                agent.logger.console.log_permission_granted(tool_name, tool_args, 'mode', 'accept_edits mode')
-            return
-        # Other dangerous tools fall through to approval logic
-
-    # =================================================================
-    # MODE: plan - Read-only tools only, exit_plan_and_implement needs approval
-    # =================================================================
-    if mode == 'plan':
+    if agent.current_session.get('workflow_mode') == 'plan':
         # Block dangerous tools in plan mode (exit_plan_and_implement handles its own io.send/receive)
         if tool_name in DANGEROUS_TOOLS:
             raise ValueError(
@@ -532,10 +555,12 @@ def check_approval(agent: 'Agent') -> None:
             return
 
     # =================================================================
-    # MODE: safe - Dangerous tools need approval
+    # Safe and Default calls not allowed by policy require human approval.
     # =================================================================
-    # Unknown tools (not in SAFE or DANGEROUS) are treated as safe
-    if tool_name not in DANGEROUS_TOOLS:
+    # Compatibility for callers invoking this handler without the exported
+    # plugin chain. In normal use the policy result is always present, and an
+    # unknown tool receives ``ask`` rather than reaching this branch.
+    if not pending.get('approval_policy') and tool_name not in DANGEROUS_TOOLS:
         return
 
     # =================================================================
@@ -576,6 +601,8 @@ def check_approval(agent: 'Agent') -> None:
         'arguments': tool_args,
         'description': tool_args.get('description', ''),
     }
+    if pending.get('approval_policy'):
+        approval_msg['policy'] = pending['approval_policy']
     if batch_remaining:
         approval_msg['batch_remaining'] = batch_remaining
 
@@ -878,11 +905,13 @@ def poll_mode_changes(agent: 'Agent') -> None:
 
     for msg in agent.io.receive_all('mode_change'):
         new_mode = msg.get('mode')
-        if new_mode in VALID_MODES:
+        if new_mode == 'plan':
+            agent.current_session['workflow_mode'] = 'plan'
+            agent.io.send({'type': 'mode_changed', 'mode': 'plan', 'triggered_by': 'user'})
+        elif new_mode in VALID_MODES:
+            if new_mode in {'ulw', 'yolo', 'full_access'} and msg.get('turns') is not None:
+                agent.current_session['ulw_turns'] = msg['turns']
             handle_mode_change(agent, new_mode)
-        elif new_mode == 'ulw':
-            from ..ulw import handle_ulw_mode_change
-            handle_ulw_mode_change(agent, msg.get('turns'))
 
 
 @after_iteration
@@ -917,19 +946,41 @@ def handle_mode_change(agent: 'Agent', mode: str) -> None:
         agent: Agent instance
         mode: New mode ('safe', 'plan', 'accept_edits')
     """
-    if mode not in VALID_MODES:
-        # Unknown mode - might be handled by another plugin (e.g., ulw)
+    from .policy import canonical_profile, set_approval_profile
+
+    if mode == 'plan':
+        agent.current_session['workflow_mode'] = 'plan'
+        if agent.io:
+            agent.io.send({'type': 'mode_changed', 'mode': 'plan', 'triggered_by': 'user'})
+        return
+
+    canonical = canonical_profile(mode)
+    if canonical is None:
+        return
+    requester = agent.current_session.get('requester')
+    if canonical == 'full_access' and requester and requester.get('level') != 'admin':
+        set_approval_profile(agent, 'safe', source='host-boundary')
+        _log(agent, "[yellow]Only the local or Host admin operator can enable Full access[/yellow]")
         return
 
     old_mode = _get_mode(agent)
-    if old_mode == mode:
+    if old_mode == canonical:
         return  # No change
 
     # Clear skip_tool_approval when switching to a mode we handle
     agent.current_session.pop('skip_tool_approval', None)
 
-    _set_mode(agent, mode)
-    _log(agent, f"[cyan]Mode changed: {old_mode} → {mode}[/cyan]")
+    set_approval_profile(agent, canonical)
+    if canonical == 'full_access':
+        turns = agent.current_session.get('ulw_turns')
+        from ..ulw import handle_ulw_mode_change
+        handle_ulw_mode_change(agent, turns)
+        # ULW keeps its established wire/session fields; the versioned profile
+        # remains the authority source for new clients.
+        set_approval_profile(agent, canonical)
+    elif agent.io:
+        agent.io.send({'type': 'mode_changed', 'mode': canonical, 'triggered_by': 'user'})
+    _log(agent, f"[cyan]Mode changed: {old_mode} → {canonical}[/cyan]")
 
 
 def get_current_mode(agent: 'Agent') -> str:

--- a/connectonion/useful_plugins/tool_approval/constants.py
+++ b/connectonion/useful_plugins/tool_approval/constants.py
@@ -41,8 +41,12 @@ Tool Classification:
 #   - Agent: via enter_plan_mode() tool (safe/accept_edits → plan)
 # =============================================================================
 
-VALID_MODES = {'safe', 'plan', 'accept_edits'}
-DEFAULT_MODE = 'safe'
+VALID_MODES = {
+    'default', 'safe', 'full_access',
+    # Compatibility wire aliases retained for older clients.
+    'accept_edits', 'ulw', 'yolo', 'plan',
+}
+DEFAULT_MODE = 'default'
 
 
 # Tools that need approval in 'safe' mode

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -1,0 +1,369 @@
+"""Deterministic authorization policy for the Default approval profile.
+
+The policy answers one narrow question before the interactive approval hook:
+may this exact tool call run without asking a person?  It does not persist
+approvals.  Human session grants remain in ``session['permissions']``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ...core.events import before_each_tool
+from ...project import project_root
+from .approval import _is_control_file
+from .bash_parser import _extract_subcommands
+
+if TYPE_CHECKING:
+    from ...core.agent import Agent
+
+
+POLICY_ID = "connectonion.auto-approve"
+POLICY_VERSION = 1
+PROFILE_VERSION = 1
+
+DEFAULT_PROFILE = "default"
+SAFE_PROFILE = "safe"
+FULL_ACCESS_PROFILE = "full_access"
+
+PROFILE_ALIASES = {
+    "default": DEFAULT_PROFILE,
+    "auto": DEFAULT_PROFILE,
+    "auto_approve": DEFAULT_PROFILE,
+    "accept_edits": DEFAULT_PROFILE,
+    "safe": SAFE_PROFILE,
+    "manual": SAFE_PROFILE,
+    "full_access": FULL_ACCESS_PROFILE,
+    "full-access": FULL_ACCESS_PROFILE,
+    "ulw": FULL_ACCESS_PROFILE,
+    "yolo": FULL_ACCESS_PROFILE,
+}
+
+READ_TOOLS = {
+    "read", "read_file", "glob", "grep", "search", "list", "ls",
+    "list_files", "get_file_info", "task_output", "get_emails", "get_events",
+    "screenshot", "load_guide",
+}
+WORKFLOW_TOOLS = {"task", "ask_user", "skill", "enter_plan_mode", "exit_plan_and_implement", "write_plan"}
+WORKSPACE_EDIT_TOOLS = {"write", "edit", "multi_edit"}
+DELETE_TOOLS = {"delete", "remove", "unlink", "rmdir", "delete_file"}
+EXTERNAL_EFFECT_TOOLS = {
+    "send_email", "post", "publish", "deploy", "transfer", "pay",
+    "create_payment", "delete_event", "send_message",
+}
+
+_FOCUSED_COMMANDS = {
+    "pytest", "ruff", "mypy", "pyright", "eslint", "tsc", "vitest",
+    "jest", "cargo", "go", "make",
+}
+_PACKAGE_RUNNERS = {"npm", "pnpm", "yarn", "bun"}
+_DESTRUCTIVE_COMMANDS = {
+    "rm", "rmdir", "shred", "truncate", "del", "erase", "format",
+}
+_EXTERNAL_COMMANDS = {
+    "curl", "wget", "ssh", "scp", "rsync", "mail", "sendmail",
+}
+_SENSITIVE_COMMANDS = {
+    "env", "printenv", "security", "keychain", "gcloud", "aws", "az",
+}
+
+
+def decision(
+    effect: str, verdict: str, reason: str, scope: str, *, requires_human: bool = False
+) -> dict:
+    """Return the versioned decision shape exposed to logs and clients."""
+    return {
+        "decision": verdict,
+        "policy_id": POLICY_ID,
+        "policy_version": POLICY_VERSION,
+        "source": "built-in",
+        "reason": reason,
+        "effect_class": effect,
+        "scope": scope,
+        "requires_human": requires_human,
+    }
+
+
+def canonical_profile(value: object) -> str | None:
+    """Map current and forward-compatible wire aliases to a stable profile."""
+    if not isinstance(value, str):
+        return None
+    return PROFILE_ALIASES.get(value.strip().lower().replace(" ", "_"))
+
+
+def _profile(profile_id: str, source: str) -> dict:
+    return {"id": profile_id, "version": PROFILE_VERSION, "source": source}
+
+
+def advertised_profile_state(
+    session: dict | None, *, new_session: bool, allow_full_access: bool
+) -> dict:
+    """Build the authenticated, versioned profile capability sent on CONNECTED.
+
+    Browser-provided session fields are never authority. Callers must derive
+    ``new_session`` from Host storage, never from a client marker.
+    """
+    stored = (session or {}).get("approval_profile")
+    profile_id = None
+    if isinstance(stored, dict) and stored.get("version") == PROFILE_VERSION:
+        profile_id = canonical_profile(stored.get("id"))
+    if new_session:
+        profile_id = DEFAULT_PROFILE
+    elif profile_id is None:
+        raw_mode = (session or {}).get("mode")
+        legacy = canonical_profile(raw_mode)
+        profile_id = (
+            legacy
+            if raw_mode not in (None, "default") and legacy is not None
+            else SAFE_PROFILE
+        )
+    if profile_id == FULL_ACCESS_PROFILE and not allow_full_access:
+        profile_id = SAFE_PROFILE
+
+    available = [
+        {
+            "id": SAFE_PROFILE,
+            "name": "Safe",
+            "description": "Read normally; ask before unresolved effects.",
+        },
+        {
+            "id": DEFAULT_PROFILE,
+            "name": "Default",
+            "description": "Automatically allow low-risk workspace work; ask or deny otherwise.",
+            "recommended": True,
+        },
+    ]
+    if allow_full_access:
+        available.append({
+            "id": FULL_ACCESS_PROFILE,
+            "name": "Full access",
+            "description": "Bypass per-action approval within the Host-defined bound.",
+            "dangerous": True,
+            "bound": "host-configured",
+        })
+    return {
+        "schemaVersion": PROFILE_VERSION,
+        "currentModeId": profile_id,
+        "availableModes": available,
+        "policy": {"id": POLICY_ID, "version": POLICY_VERSION},
+    }
+
+
+def ensure_approval_profile(agent: "Agent") -> str:
+    """Restore a versioned profile, conservatively migrating older sessions.
+
+    Only sessions explicitly marked as new receive Default/Auto Approve.  An
+    old session containing the historical ``mode: default`` (or no mode at
+    all) migrates to Safe, so an upgrade cannot silently add authority.
+    """
+    session = agent.current_session
+    stored = session.get("approval_profile")
+    if (isinstance(stored, dict) and stored.get("version") == PROFILE_VERSION
+            and canonical_profile(stored.get("id"))):
+        profile_id = canonical_profile(stored["id"])
+        stored["id"] = profile_id
+        return profile_id
+
+    raw_mode = session.get("mode")
+    legacy_alias = canonical_profile(raw_mode)
+    if session.pop("_new_session", False):
+        profile_id = DEFAULT_PROFILE
+        source = "new-session-default"
+    elif raw_mode not in (None, "default") and legacy_alias is not None:
+        profile_id = legacy_alias
+        source = "legacy-alias-migration"
+    else:
+        profile_id = SAFE_PROFILE
+        source = "legacy-session-migration"
+
+    session["approval_profile"] = _profile(profile_id, source)
+    session["mode"] = profile_id
+    return profile_id
+
+
+def set_approval_profile(agent: "Agent", profile_id: str, source: str = "user") -> str:
+    """Persist a canonical profile while retaining old wire aliases."""
+    canonical = canonical_profile(profile_id)
+    if canonical is None:
+        raise ValueError(f"Unknown approval profile: {profile_id}")
+    agent.current_session["approval_profile"] = _profile(canonical, source)
+    agent.current_session["mode"] = "ulw" if canonical == FULL_ACCESS_PROFILE else canonical
+    return canonical
+
+
+def _workspace_path(args: dict) -> Path | None:
+    raw = next((args.get(key) for key in ("file_path", "path", "target", "filename")
+                if args.get(key)), None)
+    if raw is None:
+        return None
+    return Path(str(raw)).expanduser().resolve(strict=False)
+
+
+def _inside_workspace(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _command_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command, posix=True)
+    except (TypeError, ValueError):
+        return []
+
+
+def _classify_single_command(command: str) -> dict:
+    words = _command_words(command)
+    if not words:
+        return decision("command", "ask", "command could not be parsed safely", "call", requires_human=True)
+
+    lowered = [word.lower() for word in words]
+    first = Path(words[0]).name.lower()
+    if first in _DESTRUCTIVE_COMMANDS:
+        return decision("deletion", "deny", "destructive command requires an explicit safer workflow", "call")
+    if any(token in lowered for token in ("publish", "deploy", "release", "push")):
+        return decision("publication", "ask", "publishing and deployment require human approval", "call", requires_human=True)
+    if first in _EXTERNAL_COMMANDS:
+        return decision("external_network", "ask", "external network access requires human approval", "call", requires_human=True)
+    if first in _SENSITIVE_COMMANDS or any(
+        ".env" in token or "credential" in token or "secret" in token
+        for token in lowered
+    ):
+        return decision("credentials", "deny", "credential access is never auto-approved", "call")
+
+    focused = first in _FOCUSED_COMMANDS
+    focused = focused or (first in {"python", "python3"} and words[1:3] == ["-m", "pytest"])
+    focused = focused or (first == "uv" and len(words) > 2 and words[1] == "run"
+                          and Path(words[2]).name in _FOCUSED_COMMANDS)
+    if first in _PACKAGE_RUNNERS:
+        focused = any(token in lowered[1:4] for token in ("test", "lint", "build", "check", "typecheck"))
+    if first == "cargo":
+        focused = len(words) > 1 and words[1] in {"test", "check", "clippy", "build"}
+    if first == "go":
+        focused = len(words) > 1 and words[1] == "test"
+
+    if focused:
+        return decision("verification", "allow", "focused test, lint, or build command", "workspace")
+    return decision("command", "ask", "command is outside the focused verification allowlist", "call")
+
+
+def _classify_command(command: str) -> dict:
+    """All parts of a shell chain must independently qualify for auto approval."""
+    try:
+        subcommands = _extract_subcommands(command)
+    except Exception:
+        return decision("command", "ask", "command could not be parsed safely", "call", requires_human=True)
+
+    results = [_classify_single_command(full) for _, full in subcommands]
+    denied = next((item for item in results if item["decision"] == "deny"), None)
+    if denied:
+        return denied
+    asked = next((item for item in results if item["decision"] == "ask"), None)
+    if asked:
+        return asked
+    return decision(
+        "verification", "allow",
+        f"focused verification chain ({len(results)} command{'s' if len(results) != 1 else ''})",
+        "workspace",
+    )
+
+
+def evaluate_auto_approve(tool_name: str, args: dict, root: Path | None = None) -> dict:
+    """Classify one exact tool call without model judgment or side effects."""
+    root = (root or project_root()).resolve()
+    name = str(tool_name).lower()
+
+    if name in READ_TOOLS:
+        path = _workspace_path(args)
+        if path is not None and not _inside_workspace(path, root):
+            return decision("read_outside_workspace", "ask", "reading outside the workspace requires approval", "call", requires_human=True)
+        return decision("read", "allow", "read-only workspace operation", "workspace")
+
+    if name in WORKFLOW_TOOLS:
+        return decision("workflow", "allow", "built-in planning or user-interaction workflow", "session")
+
+    if name in WORKSPACE_EDIT_TOOLS:
+        path = _workspace_path(args)
+        if path is None:
+            return decision("workspace_edit", "ask", "edit target is missing or ambiguous", "call", requires_human=True)
+        if _is_control_file(str(path)):
+            return decision("authorization_control", "deny", "agents cannot rewrite authorization control files", "call")
+        if not _inside_workspace(path, root):
+            return decision("write_outside_workspace", "deny", "writes outside the workspace are not auto-approved", "call")
+        return decision("workspace_edit", "allow", "reversible edit inside the workspace", "workspace")
+
+    if name in DELETE_TOOLS:
+        return decision("deletion", "deny", "deletion is never auto-approved", "call")
+    if name in EXTERNAL_EFFECT_TOOLS:
+        return decision("external_effect", "ask", "external side effects require human approval", "call", requires_human=True)
+    if name in {"bash", "shell", "run", "run_in_dir", "run_background"}:
+        return _classify_command(str(args.get("command", "")))
+    if name == "kill_task":
+        return decision("task_control", "ask", "stopping a running task requires approval", "call", requires_human=True)
+    return decision("unknown", "ask", "unknown tools never run silently", "call", requires_human=True)
+
+
+@before_each_tool
+def apply_auto_approve_policy(agent: "Agent") -> None:
+    """Attach a transient decision before the existing human approval hook."""
+    pending = agent.current_session.get("pending_tool")
+    if not pending:
+        return
+
+    profile_id = ensure_approval_profile(agent)
+    if profile_id == FULL_ACCESS_PROFILE:
+        requester = agent.current_session.get("requester")
+        if requester and requester.get("level") != "admin":
+            set_approval_profile(agent, SAFE_PROFILE, source="host-boundary")
+            pending["approval_policy"] = decision(
+                "authority", "ask", "only the local or Host admin operator can select Full access", "call",
+                requires_human=True,
+            )
+            _record_decision(agent, pending)
+            return
+        pending["approval_policy"] = decision(
+            "unbounded", "allow", "Full access was explicitly selected", "host"
+        )
+        _record_decision(agent, pending)
+        return
+    if profile_id == SAFE_PROFILE:
+        pending["approval_policy"] = decision(
+            "manual", "ask", "Safe profile requires manual approval", "call", requires_human=True
+        )
+        _record_decision(agent, pending)
+        return
+
+    try:
+        result = evaluate_auto_approve(pending["name"], pending.get("arguments") or {})
+    except Exception as exc:  # Policy failure is authority failure, never a bypass.
+        verdict = "ask" if agent.io else "deny"
+        result = decision(
+            "policy_failure", verdict,
+            f"authorization policy failed closed ({type(exc).__name__})", "call",
+            requires_human=verdict == "ask",
+        )
+    if result["decision"] == "ask" and not agent.io:
+        result = {**result, "decision": "deny", "reason": result["reason"] + "; no approval channel is available"}
+    pending["approval_policy"] = result
+    _record_decision(agent, pending)
+
+
+def _record_decision(agent: "Agent", pending: dict) -> None:
+    """Attach the decision to the existing tool trace for durable auditing."""
+    tool_id = pending.get("id")
+    for entry in reversed(agent.current_session.get("trace", [])):
+        if entry.get("type") == "tool_call" and (not tool_id or entry.get("id") == tool_id):
+            entry["approval_policy"] = dict(pending["approval_policy"])
+            return
+
+
+__all__ = [
+    "DEFAULT_PROFILE", "FULL_ACCESS_PROFILE", "POLICY_ID", "POLICY_VERSION",
+    "PROFILE_VERSION", "SAFE_PROFILE", "apply_auto_approve_policy",
+    "advertised_profile_state", "canonical_profile", "ensure_approval_profile",
+    "evaluate_auto_approve", "set_approval_profile",
+]

--- a/docs/features/permissions.md
+++ b/docs/features/permissions.md
@@ -2,6 +2,31 @@
 
 ConnectOnion provides multiple permission mechanisms to balance safety and automation. This guide explains how they work together.
 
+## Approval profiles
+
+New sessions use the versioned **Default** profile. Default runs a deterministic
+Auto Approve policy before the human approval hook:
+
+- workspace reads and reversible workspace edits are allowed;
+- focused test, lint, type-check, and build commands are allowed;
+- deletions and credential access are denied;
+- deployment, publishing, external communication, payments, outside-workspace
+  reads, and unknown tools ask a person.
+
+Every policy result contains `allow`, `ask`, or `deny` plus a policy ID,
+version, reason, effect class, and scope. An `ask` uses the existing
+`approval_needed` protocol and the existing `session['permissions']` store; the
+policy does not maintain a second approval cache.
+
+**Safe** asks for every call that is not already explicitly permitted. **Full
+access** is an explicit local/Host-admin choice and remains bounded by Host
+authorization controls. The old names `accept_edits`, `ulw`, and `yolo` remain
+wire aliases. Old or unversioned sessions whose mode was `default` migrate to
+Safe so upgrading cannot silently grant more authority.
+
+Plan is a workflow state, not an approval profile. Entering or leaving a plan
+does not change Default, Safe, or Full access.
+
 ## Unified Permission System
 
 **Core Concept**: All permissions use a single, consistent data structure at runtime. Whether from config files, skills, or user approvals, every permission is stored the same way in `session['permissions']`.
@@ -52,9 +77,9 @@ session['permissions'] = {
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. Tool Approval - Ask user for dangerous operations       │
-│    bash, edit, write → require explicit user approval      │
-│    If no permission in unified dict → ask user             │
+│ 5. Auto Approve policy + Tool Approval                     │
+│    deterministic allow/ask/deny for the exact call         │
+│    ask reuses the existing human approval path             │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -132,14 +157,12 @@ agent.input("Update the docs")
 # → Turn ends, permissions cleared ✓
 
 # Session memory - remember decisions
-agent.input("Run tests")
-# → bash("pytest") approval needed (first time, not in config)
-# → User approves for "session"
-# → Future pytest calls auto-approved for this session ✓
+agent.input("Run focused tests")
+# → bash("pytest tests/unit/test_api.py") is auto-approved by Default ✓
 
-# Dangerous operations - always ask
+# Destructive operations fail closed
 agent.input("Delete all files")
-# → User approval required (destructive operation)
+# → deletion denied by the built-in policy
 ```
 
 ## Unified Permission Format

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -1,6 +1,19 @@
 # tool_approval
 
-Web-based approval for dangerous tools via WebSocket. Requires user confirmation before executing tools that can modify files or run commands.
+Versioned authorization profiles plus WebSocket approval for calls that need a
+human decision.
+
+## Profiles
+
+| Profile | Behaviour |
+|---|---|
+| `default` | Auto-approves workspace reads/edits and focused verification; asks or denies higher-impact calls |
+| `safe` | Manual approval for every call not explicitly permitted |
+| `full_access` | Explicit local/Host-admin bypass, still bounded by Host control files |
+
+`accept_edits` maps to Default. `ulw` and `yolo` map to Full access. Persisted
+old/unversioned `default` sessions migrate to Safe. Planning uses
+`workflow_mode: plan` and never changes the approval profile.
 
 ## Quick Start
 
@@ -29,8 +42,8 @@ LLM returns tool_calls batch: [bash("npm install"), write("config.json"), bash("
 tool_executor iterates sequentially:
     ↓
 ┌─ Tool #1: bash("npm install")
-│   before_each_tool fires → check_approval()
-│   → Is it safe? No (bash is DANGEROUS)
+│   before_each_tool fires → deterministic policy → check_approval()
+│   → Policy result: ask (package installation is not focused verification)
 │   → Already approved for session? No
 │   → Send to client:
 │       {
@@ -138,7 +151,8 @@ send_email, post, delete, remove
 
 ### Unknown Tools
 
-Tools not in either list are treated as safe (no approval needed).
+Unknown tools are never silently allowed. Default and Safe ask through the
+existing approval protocol; without an approval channel they fail closed.
 
 ## Config-Based Auto-Approval
 

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -1,0 +1,285 @@
+"""Default Auto Approve is deterministic, scoped, versioned, and fail closed."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from connectonion.useful_plugins.tool_approval import check_approval, tool_approval
+from connectonion.useful_plugins.tool_approval.policy import (
+    DEFAULT_PROFILE,
+    POLICY_ID,
+    SAFE_PROFILE,
+    advertised_profile_state,
+    apply_auto_approve_policy,
+    ensure_approval_profile,
+    evaluate_auto_approve,
+    set_approval_profile,
+)
+
+
+def test_new_session_advertises_versioned_default_without_trusting_client_state():
+    state = advertised_profile_state(
+        {"approval_profile": {"id": "full_access", "version": 1}},
+        new_session=True,
+        allow_full_access=False,
+    )
+    assert state["schemaVersion"] == 1
+    assert state["currentModeId"] == "default"
+    assert state["policy"] == {
+        "id": "connectonion.auto-approve",
+        "version": 1,
+    }
+    assert [mode["id"] for mode in state["availableModes"]] == ["safe", "default"]
+
+
+def test_unversioned_default_advertises_safe_and_admin_alone_sees_full_access():
+    safe = advertised_profile_state(
+        {"mode": "default"}, new_session=False, allow_full_access=False
+    )
+    admin = advertised_profile_state(
+        {"mode": "accept_edits"}, new_session=False, allow_full_access=True
+    )
+    assert safe["currentModeId"] == "safe"
+    assert admin["currentModeId"] == "default"
+    assert [mode["id"] for mode in admin["availableModes"]] == [
+        "safe", "default", "full_access",
+    ]
+
+
+class IO:
+    def __init__(self, response=None):
+        self.sent = []
+        self.response = response or {"approved": True, "scope": "once"}
+
+    def send(self, message):
+        self.sent.append(message)
+
+    def receive(self):
+        return self.response
+
+
+@pytest.fixture(autouse=True)
+def _workspace_is_the_test_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+
+def agent(tmp_path, *, io=True, profile=DEFAULT_PROFILE, requester=None):
+    session = {
+        "messages": [],
+        "trace": [],
+        "permissions": {},
+        "approval_profile": {"id": profile, "version": 1, "source": "test"},
+        "mode": profile,
+    }
+    if requester:
+        session["requester"] = requester
+    return SimpleNamespace(
+        current_session=session,
+        io=IO() if io else None,
+        storage=None,
+        logger=None,
+    )
+
+
+def call(agent, name, arguments):
+    agent.current_session["pending_tool"] = {"name": name, "arguments": arguments}
+    apply_auto_approve_policy(agent)
+    check_approval(agent)
+    return agent.current_session["pending_tool"]["approval_policy"]
+
+
+def test_every_decision_has_stable_audit_fields(tmp_path):
+    result = evaluate_auto_approve("read_file", {"path": str(tmp_path / "README.md")}, tmp_path)
+    assert result == {
+        "decision": "allow",
+        "policy_id": POLICY_ID,
+        "policy_version": 1,
+        "source": "built-in",
+        "reason": "read-only workspace operation",
+        "effect_class": "read",
+        "scope": "workspace",
+        "requires_human": False,
+    }
+
+
+def test_policy_plugin_runs_immediately_before_human_approval():
+    assert tool_approval[-2:] == [apply_auto_approve_policy, check_approval]
+
+
+def test_decision_is_written_to_existing_trace_and_approval_message(tmp_path):
+    instance = agent(tmp_path)
+    instance.current_session["trace"] = [{"type": "tool_call", "id": "call-1", "name": "send_email"}]
+    instance.current_session["pending_tool"] = {
+        "id": "call-1",
+        "name": "send_email",
+        "arguments": {"to": "person@example.com"},
+    }
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert instance.current_session["trace"][0]["approval_policy"] == result
+    assert instance.io.sent[0]["policy"] == result
+
+
+@pytest.mark.parametrize("name", ["read", "read_file", "glob", "grep", "search"])
+def test_workspace_reads_are_auto_approved(tmp_path, name):
+    instance = agent(tmp_path)
+    result = call(instance, name, {"path": str(tmp_path / "file.txt")})
+    assert result["decision"] == "allow"
+    assert instance.io.sent == []
+
+
+@pytest.mark.parametrize("name", ["write", "edit", "multi_edit"])
+def test_workspace_edits_are_auto_approved(tmp_path, name):
+    instance = agent(tmp_path)
+    result = call(instance, name, {"path": str(tmp_path / "src.py")})
+    assert result["decision"] == "allow"
+    assert instance.io.sent == []
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pytest -q tests/unit/test_one.py",
+        "python -m pytest tests/unit/test_one.py",
+        "uv run pytest -q tests/unit/test_one.py",
+        "npm run lint",
+        "cargo test --lib",
+        "pytest -q && ruff check src",
+    ],
+)
+def test_focused_verification_commands_are_auto_approved(tmp_path, command):
+    instance = agent(tmp_path)
+    result = call(instance, "bash", {"command": command})
+    assert result["decision"] == "allow"
+    assert instance.io.sent == []
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments", "effect"),
+    [
+        ("delete", {"path": "src.py"}, "deletion"),
+        ("write", {"path": "../outside.txt"}, "write_outside_workspace"),
+        ("bash", {"command": "rm -rf build"}, "deletion"),
+        ("bash", {"command": "cat .env"}, "credentials"),
+    ],
+)
+def test_hard_denies_never_open_the_human_prompt(tmp_path, monkeypatch, name, arguments, effect):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(tmp_path)
+    with pytest.raises(ValueError, match="denied by"):
+        call(instance, name, arguments)
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny"
+    assert result["effect_class"] == effect
+    assert instance.io.sent == []
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments"),
+    [
+        ("new_plugin_tool", {}),
+        ("send_email", {"to": "person@example.com"}),
+        ("bash", {"command": "git push origin main"}),
+        ("bash", {"command": "co deploy"}),
+        ("read_file", {"path": "/etc/hosts"}),
+    ],
+)
+def test_ambiguous_or_external_calls_reuse_the_human_approval_path(tmp_path, name, arguments):
+    instance = agent(tmp_path)
+    result = call(instance, name, arguments)
+    assert result["decision"] == "ask"
+    assert instance.io.sent[0]["type"] == "approval_needed"
+
+
+def test_broad_config_cannot_silently_turn_co_deploy_into_a_safe_command(tmp_path):
+    instance = agent(tmp_path)
+    instance.current_session["permissions"] = {
+        "Bash(co *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "legacy broad CLI permission",
+            "when": {"command": "co *"},
+        }
+    }
+    result = call(instance, "bash", {"command": "co deploy"})
+    assert result["decision"] == "ask"
+    assert result["requires_human"] is True
+    assert instance.io.sent[0]["type"] == "approval_needed"
+
+
+def test_human_session_grant_is_still_the_single_reusable_approval_store(tmp_path):
+    instance = agent(tmp_path)
+    instance.io.response = {"approved": True, "scope": "session"}
+    call(instance, "send_email", {"to": "person@example.com"})
+    assert instance.current_session["permissions"]["send_email"]["source"] == "user"
+
+    instance.io.sent.clear()
+    call(instance, "send_email", {"to": "second@example.com"})
+    assert instance.io.sent == []
+
+
+def test_unknown_tool_fails_closed_when_unattended(tmp_path):
+    instance = agent(tmp_path, io=False)
+    instance.current_session["pending_tool"] = {"name": "new_plugin_tool", "arguments": {}}
+    apply_auto_approve_policy(instance)
+    with pytest.raises(ValueError, match="denied by"):
+        check_approval(instance)
+
+
+def test_policy_exception_asks_interactively_and_denies_unattended(tmp_path, monkeypatch):
+    import importlib
+
+    policy = importlib.import_module("connectonion.useful_plugins.tool_approval.policy")
+
+    def broken(*args, **kwargs):
+        raise RuntimeError("details must not become authority")
+
+    monkeypatch.setattr(policy, "evaluate_auto_approve", broken)
+    interactive = agent(tmp_path)
+    result = call(interactive, "read", {})
+    assert result["decision"] == "ask"
+    assert result["effect_class"] == "policy_failure"
+
+    unattended = agent(tmp_path, io=False)
+    unattended.current_session["pending_tool"] = {"name": "read", "arguments": {}}
+    apply_auto_approve_policy(unattended)
+    with pytest.raises(ValueError, match="denied by"):
+        check_approval(unattended)
+
+
+def test_new_session_gets_versioned_default_but_legacy_default_migrates_safe(tmp_path):
+    new = SimpleNamespace(current_session={"_new_session": True}, io=None)
+    old = SimpleNamespace(current_session={"mode": "default"}, io=None)
+    assert ensure_approval_profile(new) == DEFAULT_PROFILE
+    assert new.current_session["approval_profile"]["version"] == 1
+    assert ensure_approval_profile(old) == SAFE_PROFILE
+    assert old.current_session["approval_profile"]["source"] == "legacy-session-migration"
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [("safe", "safe"), ("accept_edits", "default"), ("ulw", "full_access"),
+     ("full-access", "full_access"), ("auto", "default")],
+)
+def test_mode_aliases_persist_a_versioned_profile(tmp_path, alias, expected):
+    instance = agent(tmp_path, profile="safe")
+    assert set_approval_profile(instance, alias) == expected
+    assert instance.current_session["approval_profile"]["id"] == expected
+
+
+def test_contact_cannot_restore_full_access(tmp_path):
+    requester = {"address": "0x" + "a" * 64, "level": "contact"}
+    instance = agent(tmp_path, profile="full_access", requester=requester)
+    instance.current_session["pending_tool"] = {"name": "bash", "arguments": {"command": "pytest -q"}}
+    apply_auto_approve_policy(instance)
+    assert instance.current_session["approval_profile"]["id"] == "safe"
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "ask"
+
+
+def test_full_access_is_still_bounded_by_control_files(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".co").mkdir()
+    instance = agent(tmp_path, profile="full_access")
+    with pytest.raises(ValueError, match="decides what this agent may do"):
+        call(instance, "write", {"path": str(tmp_path / ".co" / "host.yaml")})

--- a/tests/unit/test_host_routes.py
+++ b/tests/unit/test_host_routes.py
@@ -168,6 +168,47 @@ class TestInputHandler:
 
         assert mock_agent.storage == storage
 
+    def test_server_marks_only_an_unstored_session_as_new(self, tmp_path):
+        storage = SessionStorage(str(tmp_path / "sessions.jsonl"))
+        mock_agent = Mock()
+        mock_agent.input.return_value = "Response"
+        mock_agent.current_session = {}
+
+        input_handler(
+            Mock(return_value=mock_agent), storage, "Hello", result_ttl=3600,
+            session={
+                "session_id": "fresh",
+                "_new_session": False,
+                "approval_profile": {"id": "full_access", "version": 1},
+            },
+        )
+
+        passed = mock_agent.input.call_args.kwargs["session"]
+        assert passed["_new_session"] is True
+        assert "approval_profile" not in passed
+
+    def test_client_cannot_mark_a_stored_legacy_session_as_new(self, tmp_path):
+        storage = SessionStorage(str(tmp_path / "sessions.jsonl"))
+        storage.save(Session(
+            session_id="legacy",
+            status="done",
+            prompt="Earlier turn",
+            created=time.time(),
+            session={"session_id": "legacy", "mode": "default", "messages": []},
+        ))
+        mock_agent = Mock()
+        mock_agent.input.return_value = "Response"
+        mock_agent.current_session = {}
+
+        input_handler(
+            Mock(return_value=mock_agent), storage, "Continue", result_ttl=3600,
+            session={"session_id": "legacy", "_new_session": True},
+        )
+
+        passed = mock_agent.input.call_args.kwargs["session"]
+        assert "_new_session" not in passed
+        assert passed["mode"] == "default"
+
 
 class TestSessionHandler:
     """Test session_handler route."""

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -672,7 +672,8 @@ class TestPollModeChanges:
 
         poll_mode_changes(agent)
 
-        assert agent.current_session['mode'] == 'plan'
+        assert agent.current_session['workflow_mode'] == 'plan'
+        assert agent.current_session['mode'] == 'safe'
 
     def test_poll_mode_changes_handles_accept_edits_mode(self):
         """poll_mode_changes should handle mode_change to accept_edits."""
@@ -682,7 +683,8 @@ class TestPollModeChanges:
 
         poll_mode_changes(agent)
 
-        assert agent.current_session['mode'] == 'accept_edits'
+        assert agent.current_session['mode'] == 'default'
+        assert agent.current_session['approval_profile']['id'] == 'default'
 
     def test_poll_mode_changes_handles_ulw_mode(self):
         """poll_mode_changes should handle mode_change to ulw."""
@@ -721,7 +723,8 @@ class TestPollModeChanges:
 
         poll_mode_changes(agent)
 
-        assert agent.current_session['mode'] == 'plan'
+        assert agent.current_session['workflow_mode'] == 'plan'
+        assert agent.current_session['mode'] == 'safe'
         # Other signal should still be in pending
         assert len(io.pending_signals) == 1
         assert io.pending_signals[0]['type'] == 'other_signal'


### PR DESCRIPTION
## Summary
- add Default, Safe, and Full access approval profiles with a versioned policy
- automatically allow workspace reads, edits, and focused verification while keeping destructive, credential, deployment, publication, and external effects gated
- prevent clients from forging new-session or approval-profile state and preserve Plan as a workflow mode

## Verification
- 253 focused permission, shell, config, Host, and Plan tests passed
- full unit run: 5,779 passed; 11 socket failures passed outside the filesystem sandbox; one known external checkout mismatch remains because docs-site still advertises 1.6.6 and will be synchronized for 1.6.11
- ruff and git diff checks passed

Closes #1098