### PR TITLE
feat: introduce responsive Control Center

### DIFF
--- a/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
+++ b/connectonion/cli/co_ai/skills/builtin/dashboard/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: dashboard
-description: Update the agent's Home dashboard. Use when the user says "update my dashboard", "redesign my home", "put X on the dashboard", or "/dashboard".
+description: Update the agent's Control Center. Use when the user says "update my Control Center", "update my dashboard", "redesign my home", or "/dashboard".
 ---
 
-# Dashboard Skill
+# Control Center Skill
 
-The agent's Home is a single file, `.co/dashboard.html`, beside `.co/skills/`. (Older agents keep theirs in the project root — if `dashboard.html` is there, that is the one being served: edit it where it is, don't create a second one.) OChat renders it in a sandboxed iframe beside the chat and re-reads it after every run. You edit it with your normal file tools (Read, Edit, Write, Bash) — there is no special API.
+The agent's Control Center can be customized through the compatible single file `.co/dashboard.html`, beside `.co/skills/`. (Older agents keep theirs in the project root — if `dashboard.html` is there, that is the one being served: edit it where it is, don't create a second one.) OChat renders it in a sandboxed iframe beside the chat and re-reads it after every run. You edit it with your normal file tools (Read, Edit, Write, Bash) — there is no special API.
 
 ## Instructions
 
 1. **Read the file first** — `.co/dashboard.html`, or the root `dashboard.html` if that is where this agent's already is — so you preserve its structure and styles before changing anything.
 2. **Make the smallest edit that satisfies the request** — change the data or add a section; don't rewrite the whole file unless the user asks for a redesign.
-3. **Keep it visual, not textual.** Lead with big numbers, generous whitespace, and clear action buttons. A dashboard is a glanceable Home, not a document.
+3. **Keep it visual, not textual.** Lead with state, big numbers, generous whitespace, and clear action buttons. A Control Center is glanceable, not a document.
 4. **Write the file** and stop. OChat picks up the change automatically after the run.
 
 ## Action buttons — the one contract
@@ -30,7 +30,7 @@ A button that runs something MUST be a real, user-invocable skill, wired like th
 
 ## Filtering a long list
 
-A Home pane that lists thirty skills is a wall. Declare the list filterable and
+A Control Center pane that lists thirty skills is a wall. Declare the list filterable and
 the client renders the box and does the filtering:
 
 ```html
@@ -75,13 +75,14 @@ Declare the table sortable and the client makes its headers clickable:
 
 - One file: `.co/dashboard.html`. No sidecar JSON, no build step.
 - **It does not exist until you write it.** Until then the client shows a built-in
-  starter Home — name, model, skills, tools, trust, address — rendered fresh each
+  starter Control Center — identity/state, Now, quick actions, activity, schedules,
+  searchable capabilities, and diagnostics — rendered fresh each
   time, so it follows the agent as skills come and go. Writing the file replaces
   that for good: from then on it is yours, nothing regenerates it, and a skill you
   add later will not appear until you add its button.
-- Keep it under 2MB — the host won't send a larger file, and the Home pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
+- Keep it under 2MB — the host won't send a larger file, and the Control Center pane goes blank. Inline images are base64, which is ~33% bigger than the source file, so compress screenshots before embedding them.
 - Keep the responsive layout and `prefers-color-scheme` dark mode intact.
-- **A media query here measures the Home pane, not the browser window.** The page renders inside its own iframe, so `@media (max-width: 560px)` means "when the pane is narrower than 560px" — the question you wanted to ask. No container queries needed. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.
+- **A media query here measures the Control Center pane, not the browser window.** The page renders inside its own iframe. The pane is resizable, roughly 320–900px, so design for the narrow end: a four-column table needs about 500px, and below that the column the table exists for ends up off the right edge behind a scrollbar. Give wide tables a stacked form for narrow panes.
 - Do not add `<script>` tags or inline `onclick` handlers — OChat strips all scripting. Interactivity comes from the declared tags (`data-ochat-skill`, `<co-filter>`, `<co-table>`), which the client renders for you.
 - Keep styles inline in the file (external URLs are blocked in the sandbox).
-- **No links out.** A Home page is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.
+- **No links out.** A Control Center is one self-contained page. Don't add `<a href="https://…">` — the client cancels those clicks, so the link renders as dead text. Same-page anchors (`href="#section"`) work fine. If you want the user to *do* something, that's what a `data-ochat-skill` button is for.

--- a/connectonion/network/host/ws_router/dashboard.py
+++ b/connectonion/network/host/ws_router/dashboard.py
@@ -13,12 +13,13 @@ changed since this connection last saw it.
 
 import asyncio
 import re
+from functools import lru_cache
 from html import escape
 from pathlib import Path
-from functools import lru_cache
 from string import Template
 
 from ....console import Console
+from ....project import project_root
 
 DASHBOARD_FILE = "dashboard.html"
 CO_DIR = ".co"
@@ -45,10 +46,6 @@ _project_dir = None
 # What to render when the agent has not written a Home page of its own. Set once
 # at host startup, for the same reason as _project_dir.
 _agent_metadata = None
-
-
-# The directory that owns `.co/`. See connectonion/project.py.
-from ....project import project_root
 
 
 def dashboard_path():
@@ -309,6 +306,39 @@ def _skill_sections(skills):
             ).strip())
 
 
+def _quick_actions(skills):
+    """Up to three real skills, prominent without inventing unsupported actions."""
+    if not skills:
+        return ""
+    _, fragments = _starter_templates()
+    rows = "\n".join("      " + _skill_row(skill) for skill in sorted(
+        skills, key=lambda item: item["name"]
+    )[:3])
+    return "    " + fragments["quick"].safe_substitute(rows=rows).strip()
+
+
+def _diagnostics(agent_metadata, skill_count):
+    """Operator facts kept behind one disclosure, escaped and copyable."""
+    _, fragments = _starter_templates()
+    facts = []
+    for label, value, class_name in (
+        ("Model", agent_metadata.get("model"), ""),
+        ("Trust", agent_metadata.get("trust"), ""),
+        ("Tools", len(agent_metadata.get("tools") or []), ""),
+        ("Skills", skill_count, ""),
+        ("Address", agent_metadata.get("address"), "addr"),
+    ):
+        if value in (None, "", 0):
+            continue
+        facts.append(fragments["diag"].safe_substitute(
+            label=escape(str(label)), value=escape(str(value)), **{"class": class_name}
+        ).strip())
+    if not facts:
+        return ""
+    rows = "\n".join("      " + item for item in facts)
+    return "    " + fragments["diagnostics"].safe_substitute(rows=rows).strip()
+
+
 def _subtitle(agent_metadata, skill_count):
     """Model, skills, tools — the three facts that say what this agent can do.
 
@@ -367,8 +397,15 @@ def render_starter(agent_metadata):
         initial=escape(name.strip()[:1] or "A"),
         tagline=_tagline(agent_metadata),
         subtitle=_subtitle(agent_metadata, len(skills)),
+        # Compatibility for operator starter overrides written before Control
+        # Center. The bundled template uses diagnostics; old templates may
+        # still contain $address.
         address=_address_line(agent_metadata),
         activity=_activity_sections(),
+        quick_actions=_quick_actions(skills),
+        capability_count=(f"{len(skills)} skill{'s' if len(skills) != 1 else ''}"
+                          if skills else "None published"),
+        diagnostics=_diagnostics(agent_metadata, len(skills)),
         body=_skill_sections(skills),
     )
 
@@ -481,7 +518,8 @@ def scheduled_entries():
     the scheduler cannot disagree about what an entry means.
     """
     try:
-        from ..schedule import load_entries, load_state, last_run, running_entries
+        from ..schedule import last_run, load_entries, load_state, running_entries
+
         _running = running_entries()
     except Exception:
         return [], []

--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -3,231 +3,234 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>$name · Control Center</title>
 <style>
-  /* No JavaScript anywhere in this file, by contract: the client renders a
-     dashboard under a CSP that runs only its own bridge script, so an agent's
-     own script tag or inline handler is dropped. Every affordance here — the
-     disclosure groups, the hover states — is CSS or plain HTML. Images would
-     have to be inlined as data: URIs, so there are none. */
+  /* Shared Control Center tokens. The page is self-contained: no remote assets,
+     scripts, inline handlers, or navigation. The chat bridge owns declarative
+     data-ochat-* controls; plain HTML remains usable when that bridge is absent. */
   :root {
     color-scheme: light dark;
-    --bg: #fbfbfa; --fg: #171717; --muted: #6b6b6b; --faint: #8a8a8a;
-    --card: #fff; --line: #e7e7e5; --hover: #f4f4f2; --accent: #16a34a;
+    --cc-bg: #f7f8f6;
+    --cc-surface: #ffffff;
+    --cc-surface-raised: #f0f2ee;
+    --cc-text: #171a17;
+    --cc-muted: #505650;
+    --cc-subtle: #626962;
+    --cc-border: #d9ddd7;
+    --cc-accent: #14733a;
+    --cc-accent-soft: #e2f3e7;
+    --cc-danger: #b42318;
+    --cc-focus: #075985;
+    --cc-radius-sm: 10px;
+    --cc-radius-md: 14px;
+    --cc-shadow: 0 1px 2px rgba(19, 30, 21, .06), 0 8px 28px rgba(19, 30, 21, .05);
   }
   @media (prefers-color-scheme: dark) {
     :root {
-      --bg: #131313; --fg: #ededed; --muted: #a0a0a0; --faint: #8b8b8b;
-      --card: #1a1a1a; --line: #2b2b2b; --hover: #212121; --accent: #22c55e;
+      --cc-bg: #111411;
+      --cc-surface: #191d19;
+      --cc-surface-raised: #222722;
+      --cc-text: #f1f5f1;
+      --cc-muted: #bbc4bb;
+      --cc-subtle: #aeb7ae;
+      --cc-border: #343b34;
+      --cc-accent: #62d68a;
+      --cc-accent-soft: #173d25;
+      --cc-danger: #ff8a80;
+      --cc-focus: #7dd3fc;
+      --cc-shadow: 0 1px 2px rgba(0, 0, 0, .25), 0 12px 32px rgba(0, 0, 0, .18);
     }
   }
-  * { box-sizing: border-box; margin: 0; }
+  * { box-sizing: border-box; }
+  html { background: var(--cc-bg); }
   body {
+    margin: 0;
+    padding: clamp(18px, 4vw, 38px) clamp(12px, 3vw, 24px) 56px;
+    background: var(--cc-bg);
+    color: var(--cc-text);
     font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-    background: var(--bg); color: var(--fg); line-height: 1.5;
+    line-height: 1.5;
     -webkit-font-smoothing: antialiased;
-    padding: 32px 18px 56px;
   }
-  /* The Home pane is ~440px wide in oo-chat, full-width on mobile, and sometimes a
-     whole browser window. One centred column with a max-width covers all three;
-     anything that stretches turns an eight-character button into a 1400px bar.
+  main { width: min(100%, 860px); margin: 0 auto; }
+  button, input, summary { font: inherit; }
+  button, summary { min-height: 44px; }
+  :focus-visible { outline: 3px solid var(--cc-focus); outline-offset: 2px; }
 
-     A media query here measures THE PANE, not the browser window. The client
-     renders this page inside its own iframe, and a media query inside an iframe
-     evaluates against that frame's viewport — so `@media (max-width: 560px)` in a
-     dashboard means "when the pane is narrower than 560px", which is the question
-     you actually wanted to ask. Verified: with the pane at 320px the frame reports
-     innerWidth 319 and the query matches; dragged to 900px it reports 899 and does
-     not. No container queries needed — the isolation already gives you one.
-
-     This matters more now that the pane is resizable: one dashboard has to hold up
-     across the whole 320–900px range, not at the two or three widths the client
-     used to pick. Design for the narrow end first; a four-column table needs about
-     500px, so give it a stacked form below that or the column you care about ends
-     up off the right edge behind a scrollbar. */
-  main { max-width: 680px; margin: 0 auto; }
-
-  header { margin-bottom: 24px; }
-  /* Name and mark on one line. The mark is a letter, not an image: the CSP allows
-     images only as data: URIs, and an agent has no artwork anyway. It is the only
-     saturated colour above the fold, which is what makes the page feel like it
-     belongs to something rather than being a listing of a folder. */
-  .id { display: flex; align-items: center; gap: 10px; }
+  .masthead { display: grid; gap: 18px; margin-bottom: 18px; }
+  .eyebrow {
+    margin: 0 0 5px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
+    letter-spacing: .11em; text-transform: uppercase;
+  }
+  .identity { display: flex; align-items: center; gap: 12px; min-width: 0; }
   .mark {
-    flex: none; width: 34px; height: 34px; border-radius: 9px;
-    background: var(--accent); color: #fff;
-    font-size: 16px; font-weight: 650; line-height: 34px; text-align: center;
-    text-transform: uppercase; user-select: none;
+    flex: none; display: grid; place-items: center; width: 42px; height: 42px;
+    border-radius: 12px; background: var(--cc-accent); color: var(--cc-bg);
+    font-size: 18px; font-weight: 800; text-transform: uppercase; user-select: none;
   }
-  h1 { font-size: 24px; font-weight: 680; letter-spacing: -0.025em; line-height: 1.15; }
-  /* What the agent is for, in the agent's own words. The manifest below answers
-     "what is it made of", which is a different and much less interesting question. */
-  .tagline { font-size: 13.5px; line-height: 1.45; margin-top: 10px; }
+  h1 { margin: 0; font-size: clamp(23px, 6vw, 31px); line-height: 1.12; letter-spacing: -.03em; }
+  .tagline { margin: 9px 0 0; max-width: 64ch; font-size: 14px; color: var(--cc-muted); }
   .tagline:empty { display: none; }
-  .sub { color: var(--muted); font-size: 12px; margin-top: 8px; }
+  .sub { margin: 7px 0 0; color: var(--cc-subtle); font-size: 12px; }
 
-  /* 66 characters in a 440px pane. It wraps rather than truncating — an ellipsis
-     would defeat the only reason it is here (a deployed agent's address cannot be
-     known before its first boot) — and it is boxed so it reads as a value you can
-     copy rather than as a mistake in the layout. Below the skills, because you
-     read it once, on the day you deploy. */
-  .addr {
-    color: var(--muted); margin-top: 22px; padding: 8px 10px;
-    background: var(--hover); border: 1px solid var(--line); border-radius: 8px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 10.5px; line-height: 1.5; word-break: break-all;
-    user-select: all;
+  .grid { display: grid; gap: 14px; }
+  .stack { margin-top: 14px; }
+  .card {
+    border: 1px solid var(--cc-border); border-radius: var(--cc-radius-md);
+    background: var(--cc-surface); box-shadow: var(--cc-shadow);
+  }
+  .card-pad { padding: 16px; }
+  .section-title {
+    margin: 0 0 10px; color: var(--cc-subtle); font-size: 11px; font-weight: 760;
+    letter-spacing: .09em; text-transform: uppercase;
   }
 
-  /* No card around the rows. At 440px a bordered box whose background differs
-     from the page by one percent of luminance renders as its border alone, and
-     that border then duplicates the hairlines of the rows inside it — two
-     separator systems stacked. The rows carry themselves. */
-  .section {
-    font-size: 11px; font-weight: 600; letter-spacing: .06em; text-transform: uppercase;
-    color: var(--faint); margin: 0 0 8px 2px;
+  .now { display: flex; align-items: flex-start; gap: 11px; }
+  .status-dot {
+    flex: none; width: 10px; height: 10px; margin-top: 6px; border-radius: 999px;
+    background: var(--cc-accent); box-shadow: 0 0 0 5px var(--cc-accent-soft);
   }
-  .empty {
-    background: var(--card); border: 1px solid var(--line); border-radius: 12px;
-    padding: 20px 18px;
+  .now strong { display: block; font-size: 15px; }
+  .now p { margin: 2px 0 0; color: var(--cc-muted); font-size: 13px; }
+
+  .quick { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+  .quick .skill {
+    min-height: 72px; padding: 12px 30px 12px 12px;
+    border: 1px solid var(--cc-border); background: var(--cc-surface-raised);
   }
-  .empty p { color: var(--muted); font-size: 13.5px; }
-  .empty code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px;
-    background: var(--hover); padding: 1px 5px; border-radius: 4px;
-  }
+  .quick .skill::after { right: 13px; }
 
-  /* The one disclosure on the page. A details element is the only fold that
-     works with no JavaScript. It is centred and bordered so it cannot be
-     mistaken for a skill row — left-aligned, borderless, chevroned right:
-     pressing it must not feel like it might run something.
-
-     A down-chevron under a sentence, not a sideways triangle beside a slug. The
-     triangle is the file-tree idiom, and this page spent a redesign getting out
-     of the file browser. */
-  .more { margin-top: 6px; }
-  .more > summary {
-    display: flex; align-items: center; justify-content: center; gap: 7px;
-    padding: 11px 12px; cursor: pointer; list-style: none;
-    border: 1px solid var(--line); border-radius: 9px;
-    font-size: 12.5px; font-weight: 600; color: var(--muted);
-    transition: background .12s, border-color .12s, color .12s;
-  }
-  .more > summary::-webkit-details-marker { display: none; }
-  .more > summary::after {
-    content: ""; flex: none; width: 6px; height: 6px; margin-top: -3px;
-    border-right: 1.5px solid currentColor; border-bottom: 1.5px solid currentColor;
-    transform: rotate(45deg); transition: transform .15s;
-  }
-  .more[open] > summary::after { transform: rotate(-135deg); margin-top: 3px; }
-  .more > summary:hover { background: var(--hover); color: var(--fg); border-color: var(--faint); }
-  .more > summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-  .more > summary:active { background: var(--line); }
-  .more[open] > .rows { margin-top: 6px; }
-  /* <summary> text cannot change without JS; two labels and a swap can. */
-  .lbl-less { display: none; }
-  .more[open] .lbl-more { display: none; }
-  .more[open] .lbl-less { display: inline; }
-
-
-  .rows { display: flex; flex-direction: column; gap: 2px; }
-
-  /* Every row is a control, and has to look like one when nobody is hovering it.
-     Hover is the wrong place to put the only affordance: it does not exist on a
-     touch screen, and on a desktop it arrives after you have already guessed. */
   .skill {
     position: relative; display: flex; flex-direction: column; justify-content: center;
-    width: 100%; min-height: 56px; text-align: left; font: inherit; cursor: pointer;
-    background: none; border: 0; border-radius: 9px;
-    padding: 11px 34px 11px 12px; color: var(--fg);
-    transition: background .12s;
+    width: 100%; min-height: 56px; padding: 10px 34px 10px 12px;
+    border: 0; border-radius: var(--cc-radius-sm); background: transparent;
+    color: var(--cc-text); cursor: pointer; text-align: left;
   }
-  /* A chevron drawn in CSS — the CSP forbids an icon font or a remote SVG, and a
-     border-box rotated 45° costs nothing. */
   .skill::after {
-    content: ""; position: absolute; right: 14px; top: 50%;
-    width: 6px; height: 6px; margin-top: -4px;
-    border-right: 1.5px solid var(--faint); border-top: 1.5px solid var(--faint);
-    transform: rotate(45deg);
-    transition: transform .12s, border-color .12s;
+    content: ""; position: absolute; right: 14px; top: 50%; width: 7px; height: 7px;
+    border-right: 2px solid var(--cc-subtle); border-top: 2px solid var(--cc-subtle);
+    transform: translateY(-50%) rotate(45deg);
   }
-  .skill:hover, .skill:focus-visible { background: var(--hover); }
-  .skill:hover::after, .skill:focus-visible::after {
-    border-color: var(--accent); transform: rotate(45deg) translate(2px, -2px);
-  }
-  .skill:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-  .skill:active { background: var(--line); }
-  /* The name stays the literal skill name — it is what you would type — but in the
-     UI face. In monospace a hyphenated slug reads as a file path, which is most of
-     why this page used to look like a directory listing. */
-  .skill .name {
-    display: block; font-size: 14px; font-weight: 600;
-    letter-spacing: -0.006em;
-  }
-  /* One line, and the server already cut it at a sentence. Uniform row height is
-     what turns a list into something scannable; ragged two-line clamps gave every
-     row a different height and nothing for the eye to lock onto. */
+  .skill:hover, .skill:focus-visible { background: var(--cc-surface-raised); }
+  .skill:active { background: var(--cc-accent-soft); }
+  .skill .name { font-size: 13.5px; font-weight: 700; overflow-wrap: anywhere; }
   .skill .desc {
-    display: block; margin-top: 3px;
-    font-size: 12.5px; line-height: 1.4; color: var(--muted);
+    margin-top: 2px; color: var(--cc-muted); font-size: 12px;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .skill .desc:empty { display: none; }
 
-  /* A pane dragged out to a full window is one column of 56px rows with a field of
-     white either side. Past ~720px there is room for two. */
-  @media (min-width: 720px) {
-    .rows { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; }
+  details.card { overflow: clip; }
+  details.card > summary {
+    display: flex; align-items: center; justify-content: space-between; gap: 12px;
+    padding: 12px 16px; list-style: none; cursor: pointer; font-size: 13px; font-weight: 750;
   }
+  details.card > summary::-webkit-details-marker { display: none; }
+  details.card > summary::after {
+    content: ""; flex: none; width: 8px; height: 8px;
+    border-right: 2px solid var(--cc-subtle); border-bottom: 2px solid var(--cc-subtle);
+    transform: rotate(45deg) translate(-2px, 2px);
+  }
+  details[open].card > summary::after { transform: rotate(225deg) translate(-2px, 2px); }
+  .count { margin-left: auto; color: var(--cc-subtle); font-size: 12px; font-weight: 600; }
+  .details-body { padding: 0 12px 13px; border-top: 1px solid var(--cc-border); }
+  co-filter { display: block; min-height: 44px; margin-top: 12px; }
+  .rows { display: grid; gap: 2px; margin-top: 8px; }
+  .more { margin-top: 7px; }
+  .more > summary {
+    display: flex; align-items: center; justify-content: center; padding: 8px 12px;
+    border: 1px solid var(--cc-border); border-radius: var(--cc-radius-sm);
+    color: var(--cc-muted); cursor: pointer; list-style: none; font-size: 12.5px; font-weight: 680;
+  }
+  .more > summary::-webkit-details-marker { display: none; }
+  .more[open] > .rows { margin-top: 7px; }
+  .lbl-less { display: none; }
+  .more[open] .lbl-more { display: none; }
+  .more[open] .lbl-less { display: inline; }
+  .empty { margin-top: 10px; padding: 14px; border-radius: var(--cc-radius-sm); background: var(--cc-surface-raised); }
+  .empty p { margin: 0; color: var(--cc-muted); font-size: 13px; }
+  code { padding: 1px 5px; border-radius: 5px; background: var(--cc-accent-soft); font-size: .92em; }
 
-  /* Activity and schedule. Both are absent on a fresh agent — an empty box on
-     the day-zero page would be the first thing a new user sees, saying nothing. */
-  .act { display: flex; align-items: baseline; gap: 8px; padding: 7px 0;
-         border-top: 1px solid var(--line); font-size: 12.5px; }
-  .act:first-child { border-top: 0; }
-  .act .what { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis;
-               white-space: nowrap; color: var(--fg); }
-  .act .meta { flex: none; color: var(--faint); font-variant-numeric: tabular-nums;
-               font-size: 11.5px; }
-  /* Three outcomes, three weights. "failed" has to survive being read at a
-     glance in a 440px column, so it carries colour; "running" is the one that
-     means "look again in a minute", not "something is wrong". */
-  .act .bad { color: #dc2626; }
-  .act .live { color: var(--accent); }
-  @media (prefers-color-scheme: dark) { .act .bad { color: #f87171; } }
-  .sec { padding: 12px 16px 14px; }
-  .sec > h2 { font-size: 11px; font-weight: 650; letter-spacing: 0.08em;
-              text-transform: uppercase; color: var(--faint); margin-bottom: 6px; }
+  .activity { display: grid; gap: 10px; }
+  .sec { padding: 14px 16px; }
+  .sec > h2 { margin: 0 0 6px; font-size: 12px; }
+  .act { display: flex; align-items: baseline; gap: 8px; min-height: 38px; padding: 8px 0; border-top: 1px solid var(--cc-border); font-size: 12.5px; }
+  .act:first-of-type { border-top: 0; }
+  .act .what { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .act .meta { flex: none; color: var(--cc-subtle); font-size: 11.5px; font-variant-numeric: tabular-nums; }
+  .act .bad { color: var(--cc-danger); }
+  .act .live { color: var(--cc-accent); font-weight: 680; }
+
+  .diagnostics { padding: 2px 16px 14px; border-top: 1px solid var(--cc-border); }
+  .diag { display: grid; grid-template-columns: minmax(76px, .35fr) 1fr; gap: 10px; padding: 8px 0; border-top: 1px solid var(--cc-border); font-size: 12px; }
+  .diag:first-child { border-top: 0; }
+  .diag dt { color: var(--cc-subtle); }
+  .diag dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+  .addr { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; user-select: all; }
+
+  @media (min-width: 640px) {
+    .masthead { grid-template-columns: 1fr auto; align-items: end; }
+    .overview { grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); }
+    .capability-rows { grid-template-columns: 1fr 1fr; gap: 4px; }
+  }
+  @media (max-width: 520px) {
+    body { padding-inline: 10px; }
+    .quick { grid-template-columns: 1fr; }
+    .quick .skill { min-height: 56px; }
+    .act { align-items: flex-start; flex-direction: column; gap: 1px; }
+    .act .what { white-space: normal; }
+    .diag { grid-template-columns: 1fr; gap: 2px; }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .skill, summary { transition: background-color .14s ease, border-color .14s ease; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; animation: none !important; }
+  }
 </style>
 </head>
 <body>
   <main>
-    <header>
-      <div class="id"><span class="mark">$initial</span><h1>$name</h1></div>
-      <p class="tagline">$tagline</p>
-      <p class="sub">$subtitle</p>
+    <header class="masthead">
+      <div>
+        <p class="eyebrow">Control Center</p>
+        <div class="identity"><span class="mark" aria-hidden="true">$initial</span><h1>$name</h1></div>
+        <p class="tagline">$tagline</p>
+        <p class="sub">$subtitle</p>
+      </div>
     </header>
-$body
+
+    <div class="grid overview">
+      <section class="card card-pad" aria-labelledby="now-title">
+        <h2 class="section-title" id="now-title">Now</h2>
+        <div class="now"><span class="status-dot" aria-hidden="true"></span><div><strong>Ready</strong><p>Available for a new task.</p></div></div>
+      </section>
+$quick_actions
+    </div>
+
+    <div class="grid stack">
 $activity
-$address
+      <details class="card capabilities">
+        <summary><span>Capabilities</span><span class="count">$capability_count</span></summary>
+        <div class="details-body">
+          <co-filter target="#capability-list" placeholder="Search capabilities"></co-filter>
+          <div class="capability-rows" id="capability-list">
+$body
+          </div>
+        </div>
+      </details>
+$diagnostics
+    </div>
   </main>
 </body>
 </html>
 
 <!--FRAGMENTS
-
-Everything below this marker is authoring scaffolding, not part of the page: the
-repeated pieces the body is built from. Python splits the file here, so none of
-this reaches an agent's dashboard.html.
-
-They live in this file rather than in Python or in files of their own — one file
-to keep in sync, and a browser never renders template content, so the page above
-still opens and previews as the thing it renders.
-
-Placeholders are $name-style (string.Template). Do not use $ for anything else.
-
+Everything below this marker is render scaffolding and never reaches the page.
+Placeholders use string.Template syntax; do not use dollar signs elsewhere.
 -->
 
-<template id="skill"><button class="skill" data-ochat-skill="$name"><span class="name">$name</span><span class="desc">$description</span></button></template>
+<template id="skill"><button class="skill" type="button" data-ochat-skill="$name"><span class="name">$name</span><span class="desc">$description</span></button></template>
 
 <template id="list"><div class="rows">
 $rows
@@ -240,13 +243,29 @@ $rows
     </div>
   </details></template>
 
-<template id="empty"><section class="card empty">
-    <p>No skills yet. Add one to <code>.co/skills/</code> and it shows up here as a one-click action.</p>
+<template id="empty"><section class="empty">
+    <p>No published skills yet. Add one to <code>.co/skills/</code> and it appears here.</p>
+  </section></template>
+
+<template id="quick"><section class="card card-pad" aria-labelledby="quick-title">
+    <h2 class="section-title" id="quick-title">Quick actions</h2>
+    <div class="quick">
+$rows
+    </div>
   </section></template>
 
 <template id="activity"><section class="card sec">
-    <h2>$title</h2>
+    <h2 class="section-title">$title</h2>
 $rows
   </section></template>
 
 <template id="act"><div class="act"><span class="what">$what</span><span class="meta $tone">$meta</span></div></template>
+
+<template id="diagnostics"><details class="card diagnostics-card">
+    <summary><span>Diagnostics</span><span class="count">Host details</span></summary>
+    <dl class="diagnostics">
+$rows
+    </dl>
+  </details></template>
+
+<template id="diag"><div class="diag"><dt>$label</dt><dd class="$class">$value</dd></div></template>

--- a/docs/features/skills.md
+++ b/docs/features/skills.md
@@ -307,8 +307,8 @@ EOF
 ### 3. Built-in Skill (Shipped with ConnectOnion)
 
 The default set is deliberately customer-facing: `install-connectonion`, `co-browser`,
-`co-mail-and-drive`, `topup`, and `dashboard` (edit the agent's
-[Home page](../network/dashboard.md)). The first three keep their one canonical body in
+`co-mail-and-drive`, `topup`, and `dashboard` (the compatibility skill name for editing
+the agent's [Control Center](../network/dashboard.md)). The first three keep their one canonical body in
 `connectonion/useful_skills/`; an explicit allowlist loads them as defaults. `topup` and
 `dashboard` live in `connectonion/cli/co_ai/skills/builtin/`.
 
@@ -321,7 +321,7 @@ Users can override by creating same-named skill in project or user level.
 
 Built-in skills are **not published** to chat clients — only project-tree skills
 (`.co/skills/`, `.claude/skills/`) appear in an agent's public profile. This matters
-for dashboard action buttons, which a client validates against that profile: a button
+for Control Center action buttons, which a client validates against that profile: a button
 naming a built-in or user-level skill renders but never runs. The allowlist is
 `PUBLISHED_SKILL_LOCATIONS` in `connectonion/useful_plugins/skills.py`.
 

--- a/docs/network/README.md
+++ b/docs/network/README.md
@@ -9,7 +9,7 @@ Connect and collaborate between agents with automatic reliability and recovery.
 - [remote-call.md](remote-call.md) - Run a remote agent's tools directly with `remote.call()`, gated by the host.yaml whitelist
 - [io.md](io.md) - Stream events and communicate with clients
 - [session-reconnect.md](session-reconnect.md) - WebSocket reconnection and session recovery
-- [dashboard.md](dashboard.md) - Give your agent a Home page with `dashboard.html`
+- [dashboard.md](dashboard.md) - Understand and customize your agent's Control Center
 
 ## Key Features
 

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -1,14 +1,15 @@
-# Dashboard — your agent's Home page
+# Control Center
 
-Every hosted agent can have a **Home page**: a single file, `.co/dashboard.html`. A
-chat client renders it beside the conversation, so opening your agent shows something
-useful before you type anything.
+Every hosted agent has a **Control Center** beside the conversation. The Host renders
+a current day-zero view—identity and state, Now, quick actions, recent activity,
+schedules, searchable capabilities, and diagnostics—before you type anything.
+Custom pages keep the stable filename `.co/dashboard.html` for compatibility.
 
 ```
 my-agent/
 ├── agent.py
 └── .co/
-    ├── dashboard.html   ← the Home page
+    ├── dashboard.html   ← optional custom Control Center (compatible filename)
     └── skills/          ← and the skills it offers
 ```
 
@@ -18,19 +19,18 @@ on. There's no extra endpoint, no build step, and no sidecar JSON.
 
 ## It starts working on its own
 
-The first time you run `host()`, if there's no `dashboard.html`, ConnectOnion writes a
-starter one: your agent's name, what it runs on, and **every** skill it publishes as a
-one-click button with its description underneath.
+When there is no `dashboard.html`, ConnectOnion renders the bundled starter fresh.
+It writes no file, so improvements and newly published skills appear after upgrades.
 
 ```python
 from connectonion import Agent
 from connectonion.network import host
 
 host(lambda: Agent("lisa", tools=[...]))
-# → Created dashboard.html — your agent's Home page.
+# → The client receives Lisa's current Control Center.
 ```
 
-After that the file is yours. ConnectOnion never overwrites it.
+If you create `.co/dashboard.html`, the file is yours and ConnectOnion never overwrites it.
 
 ### Where it lives, and how it's found
 
@@ -45,31 +45,29 @@ found. So it doesn't matter which directory you start the agent from:
 my-agent/           ← found, because .co/ is here
 ├── .co/dashboard.html
 └── src/
-    └── run.py      ← `python run.py` from in here still serves the same Home
+    └── run.py      ← `python run.py` from here still serves the same Control Center
 ```
 
-With no `.co/` above you, the Home lands where the agent was started.
+With no `.co/` above you, the custom-file lookup starts where the agent was started.
 
 **An older `dashboard.html` in the project root still works.** If one is there it is
 the file being served, and nothing moves, copies, or overwrites it — an agent whose
-Home vanished on upgrade would be a worse bug than an inconsistent path. Move it to
+Control Center vanished on upgrade would be a worse bug than an inconsistent path. Move it to
 `.co/` yourself when you feel like it. If both exist, `.co/` wins.
 
 #### It travels
 
 `co deploy --to` protects server-owned `.co/` state such as identity, logs and evals,
 while syncing project-authored files such as `.co/host.yaml`, `.co/skills/` and
-`.co/dashboard.html`. A deploy that dropped the Home page could regenerate a starter
-over it and still look successful, so the page travels as ordinary project content.
+`.co/dashboard.html`. A deploy that dropped a custom Control Center would silently
+replace it with the starter, so the page travels as ordinary project content.
 
 #### It isn't scaffolded
 
 `co create` and `co init` deliberately do not write one. At create time the project has
 no skills yet, and the starter is never written over an existing file — scaffolding
-then would freeze an empty Home forever. It is written on the first `host()`, the first
-moment the agent's skills are actually known. On a server the same rule applies: an
-agent deployed without a dashboard gets one built from the skills that actually made it
-onto the server, rather than a copy of what your laptop had.
+then would freeze an empty Control Center forever. Instead the Host renders from the
+skills and activity that are present on that server at read time.
 
 ### One starter for all your agents
 
@@ -78,7 +76,7 @@ bundled template.
 
 It replaces the **template**, not the page: each agent still renders its own name and
 its own skills. That matters — a client validates every button against the skills
-*that* agent published, so serving one agent's finished Home for another gives a page
+*that* agent published, so serving one agent's finished Control Center for another gives a page
 of buttons that silently do nothing.
 
 An override only needs the parts you want to change. Its `<template>` fragments are
@@ -99,13 +97,13 @@ not "Lark Base".
 ### Where the markup lives
 
 One file: `connectonion/network/host/ws_router/starter.html`. It is a complete page —
-open it in a browser and you see what a starter dashboard looks like — followed by a
+open it in a browser and you see what the starter Control Center looks like — followed by a
 `<!--FRAGMENTS` marker and the repeated pieces (a skill row, a group, a flat list, the
 empty state) as `<template>` tags. Python splits on the marker, fills in the
 placeholders, and contains no HTML of its own. Everything below the marker, including
 its notes, is stripped before anything is written.
 
-Edit that file to change how a starter dashboard looks.
+Edit that file to change how the starter Control Center looks.
 
 Anything you write there has to survive the client's contract: **no JavaScript** (the
 CSP runs only the client's own bridge script, so an agent's script tag or inline
@@ -115,11 +113,11 @@ which is the one thing that works without scripting.
 
 ## Editing it
 
-`.co/dashboard.html` is a plain HTML file — edit it with any editor. Or ask the agent: the
-built-in `dashboard` skill teaches it the file's contract.
+`.co/dashboard.html` is a plain HTML file — edit it with any editor. Or ask the agent:
+the built-in `dashboard` skill (name preserved for compatibility) teaches the contract.
 
 ```
-/dashboard put this week's numbers on my home page
+/dashboard put this week's numbers in my Control Center
 ```
 
 Write plain HTML and inline CSS. Two constraints, both enforced by the client's
@@ -130,12 +128,12 @@ sandbox rather than by convention:
   happen.
 - **No external URLs.** No CDN stylesheets, no remote images, no fonts from the
   network. Inline your styles and use `data:` URIs for images.
-- **No links out.** A Home page is one self-contained page. A client cancels clicks
+- **No links out.** A Control Center is one self-contained page. A client cancels clicks
   on `<a href="https://…">`, so such a link renders as dead text — use a
   `data-ochat-skill` button when you want the user to *do* something. Same-page
   anchors (`href="#section"`) work normally.
 
-Keep it under **2MB**. The Host won't send a larger file, and the Home pane goes
+Keep it under **2MB**. The Host won't send a larger file, and the Control Center pane goes
 blank. Inline images are base64, which is ~33% larger than the source file — compress
 screenshots before embedding them.
 
@@ -143,7 +141,7 @@ screenshots before embedding them.
 
 The same sandbox that locks the page down also gives you something useful for free.
 Your page renders inside its own iframe, and a media query inside an iframe evaluates
-against **that frame's** viewport — so this means "when the Home pane is narrower than
+against **that frame's** viewport — so this means "when the Control Center pane is narrower than
 560px", which is the question you actually wanted to ask:
 
 ```css
@@ -163,7 +161,7 @@ behind a horizontal scrollbar, which nobody scrolls to find a number they came f
 > **Why so locked down?** The client renders your `dashboard.html` in a sandboxed
 > iframe with a strict Content-Security-Policy, because from its side the file is
 > untrusted, agent-authored HTML. Everything above follows from that: nothing loads
-> from the network, nothing scripts, and nothing navigates away. A Home page is a
+> from the network, nothing scripts, and nothing navigates away. A Control Center is a
 > glanceable, self-contained page whose one action is running a skill.
 >
 > Supporting external links later is a deliberate change to that contract, not a
@@ -203,15 +201,15 @@ The Host sends the file at two moments:
 
 | When | Why |
 |------|-----|
-| On connect, right after `CONNECTED` | Home paints before the first message |
+| On connect, right after `CONNECTED` | Control Center paints before the first message |
 | After each run, right after `OUTPUT` | A run that rewrote the dashboard shows the new version |
 
 The post-run send is skipped when the file hasn't changed since that connection last
-saw it, so an unchanged Home costs nothing per turn. Nothing is polled and nothing
+saw it, so an unchanged Control Center costs nothing per turn. Nothing is polled and nothing
 watches the filesystem — if you edit it by hand while a client is
 connected, the change shows up after the next run.
 
-An agent with no dashboard file sends nothing, and clients simply show no Home pane.
+An agent with no custom file receives the freshly rendered starter.
 
 ## Wire format
 
@@ -235,7 +233,7 @@ See [websocket-protocol.md](websocket-protocol.md) for the full frame reference.
 |----------|---------|
 | `read_dashboard_snapshot(session_id=None)` | Build the frame, or `None` if the file is missing, too large, unreadable, or not UTF-8 |
 | `send_dashboard(send_msg, session_id, conn=None)` | Send it unless this connection already has the current file; reads off the event loop |
-| `ensure_dashboard(agent_metadata, project_dir=None)` | Write the starter if absent, and anchor the directory later reads resolve against |
+| `ensure_dashboard(agent_metadata, project_dir=None)` | Anchor the project and metadata used to render the starter; writes no file |
 | `project_root(start=None)` | Walk up for `.co/`; the project, not the cwd |
 | `dashboard_path()` | `.co/dashboard.html`, or a legacy root one if that is what exists |
 | `render_starter(agent_metadata)` | The day-zero HTML, from `starter.html` |

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -533,8 +533,9 @@ contract is documented in `oo-api/docs/relay-announce-profile.md`.
 
 #### DASHBOARD_SNAPSHOT
 
-The agent's `dashboard.html` — its Home page — for the client to render beside the
-chat. Sent right after `CONNECTED` so Home paints before any input, and again after
+The agent's Control Center HTML (customized through the compatible
+`dashboard.html` filename) for the client to render beside chat. Sent right after
+`CONNECTED` so the Control Center paints before any input, and again after
 `OUTPUT` when the run changed the file. Agents without a `dashboard.html` never send
 it, and the frame is skipped when the file hasn't changed since this connection last
 saw it.

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,14 +1,16 @@
 """Unit tests for the Host-side dashboard delivery (network/host/ws_router/dashboard.py)."""
 
-import pytest
 from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
 
 from connectonion.network.host.ws_router import dashboard as dashboard_module
 from connectonion.network.host.ws_router.dashboard import (
     MAX_DASHBOARD_BYTES,
-    read_dashboard_snapshot,
     ensure_dashboard,
     published_skills,
+    read_dashboard_snapshot,
     render_starter,
     send_dashboard,
 )
@@ -91,7 +93,7 @@ def test_ensure_dashboard_does_not_clobber_existing(in_tmp):
 
 def test_render_starter_empty_skills_has_no_invalid_buttons():
     html = render_starter({"name": "Bare", "skills": []})
-    assert "data-ochat-skill" not in html
+    assert 'data-ochat-skill="' not in html
     assert ".co/skills/" in html  # tells the operator how to get one
 
 
@@ -100,13 +102,16 @@ def test_every_published_skill_is_reachable():
     111 skills the Home page silently pretended did not exist."""
     skills = [{"name": f"skill-{i:03d}", "description": "", "location": "project"} for i in range(115)]
     html = render_starter({"name": "Many", "skills": skills})
-    assert html.count("data-ochat-skill") == 115
+    # The first three are repeated as Quick actions; every capability remains
+    # in the searchable disclosure for a predictable complete index.
+    assert html.count('data-ochat-skill="') == 118
 
 
 def test_a_short_list_is_not_hidden_behind_a_disclosure():
     skills = [{"name": f"skill-{i}", "description": "", "location": "project"} for i in range(6)]
     html = render_starter({"name": "Few", "skills": skills})
-    assert "<details" not in html
+    assert '<details class="card capabilities">' in html
+    assert '<details class="more">' not in html
 
 
 def test_a_long_list_shows_the_first_few_and_folds_the_rest():
@@ -117,7 +122,7 @@ def test_a_long_list_shows_the_first_few_and_folds_the_rest():
     skills += [{"name": f"x-{i}", "description": "", "location": "project"} for i in range(5)]
     html = render_starter({"name": "Many", "skills": skills})
 
-    assert html.count("<details") == 1
+    assert html.count('<details class="more">') == 1
     assert "17 more skills" in html          # 25 total, 8 shown
     assert "other" not in html.lower()
 
@@ -170,6 +175,65 @@ def test_the_starter_carries_no_javascript():
     assert "onclick" not in html
 
 
+def test_control_center_semantic_golden_layout_is_present():
+    html = render_starter({
+        "name": "Operations",
+        "model": "co/example",
+        "trust": "careful",
+        "address": ADDRESS,
+        "tools": ["read", "write"],
+        "skills": [
+            {"name": "daily-brief", "description": "Prepare the day.", "location": "project"},
+            {"name": "invoice", "description": "Create an invoice.", "location": "project"},
+        ],
+    })
+
+    for landmark in (
+        "Control Center", 'id="now-title"', "Quick actions", "Capabilities",
+        "Recent", "Diagnostics", "Host details",
+    ):
+        # Recent is allowed to be absent without history; all other day-zero
+        # landmarks are stable. Test the explicit activity implementation name
+        # separately rather than rendering a dishonest empty card.
+        if landmark != "Recent":
+            assert landmark in html
+    assert '<co-filter target="#capability-list"' in html
+    assert 'id="capability-list"' in html
+    assert "co/example" in html and "careful" in html and ADDRESS in html
+
+
+def test_control_center_accessibility_contract_is_in_the_shipped_template():
+    template = (Path(dashboard_module.__file__).parent / "starter.html").read_text()
+    assert "min-height: 44px" in template
+    assert "prefers-reduced-motion: reduce" in template
+    assert ":focus-visible" in template
+    assert "@media (max-width: 520px)" in template
+    assert "@media (min-width: 640px)" in template
+    assert "https://" not in template and "http://" not in template
+
+
+def _contrast(hex_a, hex_b):
+    def luminance(value):
+        rgb = [int(value[index:index + 2], 16) / 255 for index in (1, 3, 5)]
+        linear = [part / 12.92 if part <= .04045 else ((part + .055) / 1.055) ** 2.4
+                  for part in rgb]
+        return .2126 * linear[0] + .7152 * linear[1] + .0722 * linear[2]
+    high, low = sorted((luminance(hex_a), luminance(hex_b)), reverse=True)
+    return (high + .05) / (low + .05)
+
+
+def test_control_center_text_tokens_meet_wcag_aa_in_light_and_dark():
+    for foreground, background in (
+        ("#171a17", "#f7f8f6"),
+        ("#505650", "#f7f8f6"),
+        ("#626962", "#ffffff"),
+        ("#f1f5f1", "#111411"),
+        ("#bbc4bb", "#111411"),
+        ("#aeb7ae", "#191d19"),
+    ):
+        assert _contrast(foreground, background) >= 4.5
+
+
 def test_render_starter_escapes_a_hostile_skill_name():
     html = render_starter({"name": "X", "skills": [
         {"name": "<img src=x>", "description": "<script>y</script>", "location": "project"},
@@ -186,19 +250,18 @@ def test_render_starter_escapes_agent_name():
 
 # --- Integration: the two emit points actually send DASHBOARD_SNAPSHOT ---
 
-import pytest as _pytest
-from unittest.mock import AsyncMock, Mock
 
-
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_establish_connection_sends_snapshot_after_connected(in_tmp):
     from connectonion.network.host.ws_router.connect import establish_connection
     (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
 
     sent = []
     send_msg = AsyncMock(side_effect=lambda m: sent.append(m))
-    storage = Mock(); storage.get.return_value = None
-    registry = Mock(); registry.get.return_value = None
+    storage = Mock()
+    storage.get.return_value = None
+    registry = Mock()
+    registry.get.return_value = None
     conn = {}
 
     await establish_connection({}, "0xabc", send_msg, conn, storage, registry)
@@ -211,18 +274,20 @@ async def test_establish_connection_sends_snapshot_after_connected(in_tmp):
     assert snap["html"] == "<h1>home</h1>" and "session_id" in snap
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_establish_connection_no_snapshot_when_no_file(in_tmp):
     from connectonion.network.host.ws_router.connect import establish_connection
     sent = []
     send_msg = AsyncMock(side_effect=lambda m: sent.append(m))
-    storage = Mock(); storage.get.return_value = None
-    registry = Mock(); registry.get.return_value = None
+    storage = Mock()
+    storage.get.return_value = None
+    registry = Mock()
+    registry.get.return_value = None
     await establish_connection({}, "0xabc", send_msg, {}, storage, registry)
     assert [m["type"] for m in sent] == ["CONNECTED"]  # no dashboard.html → no snapshot
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_forward_sends_snapshot_after_output(in_tmp):
     from connectonion.network.host.ws_router.agent_io import forward_agent_msgs_to_client
     (in_tmp / "dashboard.html").write_text("<h1>after run</h1>", encoding="utf-8")
@@ -267,7 +332,7 @@ def test_read_snapshot_survives_an_unreadable_path(in_tmp, capsys):
 # --- Per-connection dedup: an unchanged Home shouldn't re-ship every turn ---
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_send_dashboard_sends_to_a_fresh_connection(in_tmp):
     (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
     sent = []
@@ -278,7 +343,7 @@ async def test_send_dashboard_sends_to_a_fresh_connection(in_tmp):
     assert [m["type"] for m in sent] == ["DASHBOARD_SNAPSHOT"]
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_send_dashboard_skips_an_unchanged_file(in_tmp):
     (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
     sent = []
@@ -291,7 +356,7 @@ async def test_send_dashboard_skips_an_unchanged_file(in_tmp):
     assert len(sent) == 1
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_send_dashboard_resends_after_the_agent_rewrites_it(in_tmp):
     path = in_tmp / "dashboard.html"
     path.write_text("<h1>before</h1>", encoding="utf-8")
@@ -306,7 +371,7 @@ async def test_send_dashboard_resends_after_the_agent_rewrites_it(in_tmp):
     assert [m["html"] for m in sent] == ["<h1>before</h1>", "<h1>after the run</h1>"]
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_send_dashboard_gives_each_connection_its_own_snapshot(in_tmp):
     (in_tmp / "dashboard.html").write_text("<h1>home</h1>", encoding="utf-8")
     sent = []
@@ -318,7 +383,7 @@ async def test_send_dashboard_gives_each_connection_its_own_snapshot(in_tmp):
     assert len(sent) == 2  # dedup is per connection, never global
 
 
-@_pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_send_dashboard_sends_nothing_when_there_is_no_file(in_tmp):
     sent = []
     await send_dashboard(AsyncMock(side_effect=lambda m: sent.append(m)), "sid", {})
@@ -347,7 +412,7 @@ def test_starter_has_no_buttons_for_unpublished_skills(in_tmp):
         {"name": "dashboard", "description": "", "location": "builtin"},
     ]})
     html = read_dashboard_snapshot()["html"]
-    assert "data-ochat-skill" not in html
+    assert 'data-ochat-skill="' not in html
     assert ".co/skills/" in html  # falls back to the empty state
 
 
@@ -355,7 +420,7 @@ def test_starter_lists_published_skills_past_unpublished_ones():
     skills = [{"name": f"personal-{i}", "description": "", "location": "user"} for i in range(5)]
     skills += [{"name": f"shipped-{i}", "description": "", "location": "project"} for i in range(6)]
     html = render_starter({"name": "Many", "skills": skills})
-    assert html.count("data-ochat-skill") == 6
+    assert html.count('data-ochat-skill="') == 9
     assert "personal-" not in html
 
 
@@ -520,6 +585,7 @@ def test_the_deploy_rsync_carries_the_dashboard(tmp_path):
     """
     import shutil
     import subprocess
+
     from connectonion.cli.commands.deploy_to_server import RSYNC_FILTERS
 
     if shutil.which("rsync") is None:


### PR DESCRIPTION
## Summary
- replace the starter dashboard surface with a user-facing Control Center
- add identity and state, Now, quick actions, scheduled and recent activity, searchable capabilities, and diagnostics
- preserve dashboard.html, protocol frames, custom starter overrides, and internal APIs for compatibility
- add high-contrast light and dark tokens, 44px targets, visible focus, reduced motion, and responsive 320–900px layouts

## Verification
- 105 dashboard, activity, recent, and schedule tests passed
- semantic golden, accessibility, and WCAG contrast coverage added
- ruff and git diff checks passed
- real Chrome QA at 320, 440, and 900px: no overflow and no console warnings or errors; Capabilities and Diagnostics expand correctly

Closes #1100
Closes #1046