### PR TITLE
fix(permissions): align bounded yolo with Full access

### DIFF
--- a/connectonion/useful_plugins/ulw.py
+++ b/connectonion/useful_plugins/ulw.py
@@ -77,6 +77,12 @@ def handle_ulw_mode_change(agent: 'Agent', turns: int = None) -> None:
 
     # Set ULW state
     agent.current_session['mode'] = 'ulw'
+    # The versioned approval policy is the authority consumed immediately
+    # before every tool. Keep the legacy ULW compatibility fields, but update
+    # that profile in the same transition so `--yolo` cannot announce Full
+    # access while the policy still enforces Safe/Default underneath it.
+    from .tool_approval.policy import set_approval_profile
+    set_approval_profile(agent, 'full_access', source='bounded-yolo')
     agent.current_session['ulw_turns'] = turns
     agent.current_session['ulw_turns_used'] = 0
     agent.current_session['skip_tool_approval'] = True

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -15,6 +15,7 @@ from connectonion.useful_plugins.tool_approval.policy import (
     evaluate_auto_approve,
     set_approval_profile,
 )
+from connectonion.useful_plugins.ulw import handle_yolo_mode_change
 
 
 def test_new_session_advertises_versioned_default_without_trusting_client_state():
@@ -283,3 +284,14 @@ def test_full_access_is_still_bounded_by_control_files(tmp_path, monkeypatch):
     instance = agent(tmp_path, profile="full_access")
     with pytest.raises(ValueError, match="decides what this agent may do"):
         call(instance, "write", {"path": str(tmp_path / ".co" / "host.yaml")})
+
+
+def test_bounded_yolo_updates_the_versioned_policy_before_its_first_tool(tmp_path):
+    instance = agent(tmp_path, io=False, profile="safe")
+    handle_yolo_mode_change(instance, turns=30)
+
+    result = call(instance, "add", {"content": "compile", "active_form": "compiling"})
+
+    assert instance.current_session["approval_profile"]["id"] == "full_access"
+    assert result["decision"] == "allow"
+    assert result["reason"] == "Full access was explicitly selected"

--- a/tests/unit/test_ulw.py
+++ b/tests/unit/test_ulw.py
@@ -44,6 +44,11 @@ def test_mode_change_defaults_to_100_turns():
     agent = FakeAgent()
     handle_ulw_mode_change(agent)
     assert agent.current_session['mode'] == 'ulw'
+    assert agent.current_session['approval_profile'] == {
+        'id': 'full_access',
+        'version': 1,
+        'source': 'bounded-yolo',
+    }
     assert agent.current_session['ulw_turns'] == ULW_DEFAULT_TURNS
     assert agent.current_session['ulw_turns_used'] == 0
     assert agent.current_session['skip_tool_approval'] is True


### PR DESCRIPTION
## Outcome

Makes bounded --yolo / ULW and the versioned approval policy perform one atomic Full access transition. A one-shot run can no longer announce Full access while Auto Approve still enforces Safe or Default.

Control-file protection remains earlier than any Full access allow.

Closes #1113

## Real E2E reproduction

The 1.6.11 C algorithm release run entered safe -> ulw (30 turns), then connectonion.auto-approve denied TodoList add and general bash calls because no approval channel exists.

## Verification

- 113 focused permission, ULW, and tool-approval tests passed
- new regression exercises the exact unattended add call after handle_yolo_mode_change
- the long real C E2E will be rerun after this PR