### PR TITLE
proxy: signed grants and delegations, verified at the presenter (#1036)

### DIFF
--- a/connectonion/network/proxy/__init__.py
+++ b/connectonion/network/proxy/__init__.py
@@ -1,0 +1,5 @@
+"""Proxy capability: signed egress authorisation between agents (#1036)."""
+
+from .grants import GrantError, issue_grant, issue_delegation, renew_grant, verify
+
+__all__ = ["GrantError", "issue_grant", "issue_delegation", "renew_grant", "verify"]

--- a/connectonion/network/proxy/grants.py
+++ b/connectonion/network/proxy/grants.py
@@ -1,0 +1,168 @@
+"""
+Purpose: Signed proxy grants and delegations — the authorisation objects that let one agent egress through another agent's network, decided in advance so nobody has to be online at 3am
+LLM-Note:
+  Dependencies: imports from [json, secrets, datetime, nacl.signing, ...address (sign)] | imported by [network/proxy/__init__.py] | tested by [tests/unit/test_proxy_grants.py]
+  Data flow: P calls issue_grant(keys, holder=..., delegable_to=[...]) → signed grant dict | D calls issue_delegation(keys, grant, delegate=B) → signed delegation dict | B presents both to P → P calls verify(grant, delegation, presenter=<authenticated address>, now=...) → verified claims or GrantError
+  State/Effects: pure functions over dicts — no files, no network, no clock reads (callers pass `now`)
+  Integration: design record is issue #1036; the chain is P→D→B with a direct grant being the same object with holder == presenter and no delegation | signatures follow host/auth.py's canonicalisation (sorted-keys compact JSON) and address.sign()
+  Errors: every verification failure raises GrantError naming exactly which check refused — an unauthorised proxy use must fail loudly, never fall through
+
+The one check that carries the design (#1036): the delegate identity must equal
+the *presenter* — the authenticated identity of whoever is USING the credential —
+not whoever opened the TCP connection. In the reverse-tunnel topology the proxy
+dials the browser, so "connecting endpoint" would make P verify itself and the
+chain would protect nothing. Who dials is an accident of NAT; who authorises is
+the design.
+"""
+
+import json
+import secrets
+from datetime import datetime, timezone
+
+from ... import address as _address
+
+
+class GrantError(ValueError):
+    """A grant or delegation failed verification; the message names the check."""
+
+
+def _canonical(payload: dict) -> bytes:
+    """The bytes that get signed. Same shape as host/auth.py's."""
+    unsigned = {key: value for key, value in payload.items() if key != "signature"}
+    return json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _parse_time(value: str, field: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise GrantError(f"{field} must carry a timezone: {value!r}")
+    return parsed
+
+
+def _verify_signature(payload: dict, signer: str, kind: str) -> None:
+    from nacl.exceptions import BadSignatureError
+    from nacl.signing import VerifyKey
+
+    try:
+        VerifyKey(bytes.fromhex(signer[2:])).verify(
+            _canonical(payload), bytes.fromhex(payload["signature"])
+        )
+    except (BadSignatureError, ValueError) as refused:
+        raise GrantError(f"{kind} signature does not verify against {signer}") from refused
+
+
+def issue_grant(
+    keys: dict,
+    *,
+    holder: str,
+    expires_at: str,
+    delegable_to: list | None = None,
+    scope: str = "public_internet",
+    renewable_until: str | None = None,
+    max_bytes: int | None = None,
+) -> dict:
+    """P's decision, signed by P: `holder` may use this egress.
+
+    A direct grant to the machine that will connect is simply holder == that
+    machine and no delegable_to — the chain of length one (#1036).
+    """
+    grant = {
+        "type": "proxy_grant",
+        "grant_id": "pxg_" + secrets.token_urlsafe(12),
+        "grantor": keys["address"],
+        "holder": holder,
+        "delegable_to": list(delegable_to or []),
+        "scope": scope,
+        "expires_at": expires_at,
+        "renewable_until": renewable_until,
+        "max_bytes": max_bytes,
+    }
+    if renewable_until is not None and _parse_time(renewable_until, "renewable_until") < _parse_time(expires_at, "expires_at"):
+        raise GrantError("renewable_until is earlier than expires_at")
+    grant["signature"] = _address.sign(keys, _canonical(grant)).hex()
+    return grant
+
+
+def issue_delegation(keys: dict, grant: dict, *, delegate: str, expires_at: str | None = None) -> dict:
+    """D naming the machine that will actually connect — signed in advance, so D
+    can be offline when it is used."""
+    delegation = {
+        "type": "proxy_delegation",
+        "grant_id": grant["grant_id"],
+        "delegator": keys["address"],
+        "delegate": delegate,
+        "expires_at": expires_at or grant["expires_at"],
+    }
+    delegation["signature"] = _address.sign(keys, _canonical(delegation)).hex()
+    return delegation
+
+
+def renew_grant(keys: dict, grant: dict, *, expires_at: str) -> dict:
+    """A fresh signature with a later expiry — allowed only inside the ceiling P
+    pre-authorised. This is what keeps a 3am schedule alive without letting any
+    party extend an authorisation on its own (#1036: renewal model)."""
+    if keys["address"] != grant["grantor"]:
+        raise GrantError("only the grantor renews a grant")
+    ceiling = grant.get("renewable_until")
+    if ceiling is None:
+        raise GrantError("grant was issued without renewable_until; issue a new one")
+    if _parse_time(expires_at, "expires_at") > _parse_time(ceiling, "renewable_until"):
+        raise GrantError(f"renewal past renewable_until ({ceiling})")
+    renewed = {**grant, "expires_at": expires_at}
+    del renewed["signature"]
+    renewed["signature"] = _address.sign(keys, _canonical(renewed)).hex()
+    return renewed
+
+
+def verify(grant: dict, delegation: dict | None, *, presenter: str, now: datetime) -> dict:
+    """Accept or refuse a presented credential chain.
+
+    `presenter` is the authenticated identity of the party USING the credential
+    (the browser), never the party that happened to open the connection.
+
+    Returns the verified claims a proxy needs: who egresses, under which grant,
+    with which scope, until when, and within what byte budget.
+    """
+    if now.tzinfo is None:
+        raise GrantError("now must be timezone-aware")
+    if grant.get("type") != "proxy_grant":
+        raise GrantError(f"not a proxy_grant: {grant.get('type')!r}")
+    _verify_signature(grant, grant["grantor"], "grant")
+    grant_expiry = _parse_time(grant["expires_at"], "grant expires_at")
+    if now >= grant_expiry:
+        raise GrantError(f"grant expired at {grant['expires_at']}")
+
+    if delegation is None:
+        if presenter != grant["holder"]:
+            raise GrantError("presenter is not the grant holder and no delegation was presented")
+        effective_expiry = grant_expiry
+    else:
+        if delegation.get("type") != "proxy_delegation":
+            raise GrantError(f"not a proxy_delegation: {delegation.get('type')!r}")
+        if delegation["grant_id"] != grant["grant_id"]:
+            raise GrantError("delegation names a different grant")
+        if delegation["delegator"] != grant["holder"]:
+            raise GrantError("delegation is not signed by the grant holder")
+        _verify_signature(delegation, delegation["delegator"], "delegation")
+        if delegation["delegate"] not in grant["delegable_to"]:
+            raise GrantError("delegate is not in the grant's delegable_to list")
+        delegation_expiry = _parse_time(delegation["expires_at"], "delegation expires_at")
+        if delegation_expiry > grant_expiry:
+            raise GrantError("delegation outlives the grant")
+        if now >= delegation_expiry:
+            raise GrantError(f"delegation expired at {delegation['expires_at']}")
+        # The check the whole design rests on: bind to who is USING the
+        # credential, not who dialed. See the module docstring.
+        if presenter != delegation["delegate"]:
+            raise GrantError("presenter is not the delegate this chain authorises")
+        effective_expiry = min(grant_expiry, delegation_expiry)
+
+    return {
+        "egress_for": presenter,
+        "grant_id": grant["grant_id"],
+        "grantor": grant["grantor"],
+        "accountable": grant["holder"],
+        "scope": grant["scope"],
+        "expires_at": effective_expiry.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "max_bytes": grant.get("max_bytes"),
+    }

--- a/docs/blog/2026-08-19-authorise-in-advance-so-nobody-signs-at-3am.md
+++ b/docs/blog/2026-08-19-authorise-in-advance-so-nobody-signs-at-3am.md
@@ -1,0 +1,47 @@
+# Authorise in Advance, So Nobody Signs at 3am
+
+The question behind ConnectOnion's remote-browser design was ordinary for
+anyone who has run something overnight: a laptop that's sometimes on, a home
+desktop that's always on but sits behind a residential NAT, and a server with
+a real address that runs the browser. Route the browser's traffic through the
+desktop's connection, and a scheduled task can survive the laptop being
+closed. The awkward part was never the routing — it was who gets to say yes,
+and when.
+
+The obvious shape is a live handshake: the browser asks, the desktop is
+online, the desktop signs, off it goes. That shape breaks the moment the task
+is scheduled. Nobody is required to be at a keyboard at 3am, so nothing that
+happens at 3am should require a decision made at 3am. The three parties are
+better described by role than by machine: **P**, who owns the egress and
+decides who may use it; **D**, the developer's agent, who holds an
+authorisation and can go offline; and **B**, the browser, who shows up later
+and presents it.
+
+A direct grant — P signs a credential naming B — covers the simple case: a
+chain of length one, holder equal to presenter, no delegation in the middle.
+The chain gets interesting where the topology forces P and B to never meet as
+peers. In a reverse tunnel, P is the one behind NAT, so P dials out to B, not
+the other way round. That inverts the naive rule "trust whoever connected" —
+under that rule P would be verifying itself, and the credential would protect
+nothing. The check that actually matters binds to the identity *using* the
+credential, the one B can independently authenticate, never to whichever side
+happened to open the socket. Who dials is an accident of NAT topology; who is
+authorised is the design.
+
+The rest follows from taking "in advance" seriously. `delegable_to` is a
+pinned list signed at issuance — an empty list refuses every delegation
+rather than defaulting open. `renewable_until` sets a ceiling nobody, not
+even the grantor at renewal time, can push past — the pre-authorised decision
+is the one that's allowed to move, not a fresh one made under time pressure.
+And verification returns two identities on purpose: `egress_for`, whoever is
+actually using the network right now, and `accountable`, whoever is on the
+hook for it — because a worker rotates in a way an account never should, and
+conflating the two would make usage untraceable to a person the moment the
+worker changed.
+
+Fifteen tests carry the design, and the one that matters most is named for
+the failure it prevents: `test_presenter_binding_refuses_the_dialing_party`.
+It hands P the chain that authorises B, has P present it — since P is the one
+making the connection — and asserts that this fails. If that test ever turns
+green, the reverse tunnel has quietly become a way for the proxy to grant
+itself its own egress.

--- a/tests/unit/test_proxy_grants.py
+++ b/tests/unit/test_proxy_grants.py
@@ -1,0 +1,179 @@
+"""The grant chain from #1036: P authorises in advance, nobody signs at 3am.
+
+Three parties throughout, named as in the design record:
+
+    P — proxy agent, owns the egress, signs grants
+    D — developer's agent, holds a grant, signs delegations, then goes offline
+    B — remote browser, presents the chain and egresses
+
+The one test that carries the design is
+test_presenter_binding_refuses_the_dialing_party: in the reverse-tunnel
+topology P dials B, so binding to "whoever connected" would have P verify
+itself. The chain binds to whoever PRESENTS the credential.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from connectonion import address
+from connectonion.network.proxy import (
+    GrantError,
+    issue_delegation,
+    issue_grant,
+    renew_grant,
+    verify,
+)
+
+NOW = datetime(2026, 8, 18, 3, 0, tzinfo=timezone.utc)  # 3am, the design's test hour
+LATER = (NOW + timedelta(hours=24)).isoformat().replace("+00:00", "Z")
+CEILING = (NOW + timedelta(days=30)).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture(scope="module")
+def parties():
+    return {"P": address.generate(), "D": address.generate(), "B": address.generate()}
+
+
+def _direct(parties, **overrides):
+    kwargs = {"holder": parties["B"]["address"], "expires_at": LATER, **overrides}
+    return issue_grant(parties["P"], **kwargs)
+
+
+def _chain(parties, **grant_overrides):
+    grant = issue_grant(
+        parties["P"],
+        holder=parties["D"]["address"],
+        delegable_to=[parties["B"]["address"]],
+        expires_at=LATER,
+        **grant_overrides,
+    )
+    delegation = issue_delegation(parties["D"], grant, delegate=parties["B"]["address"])
+    return grant, delegation
+
+
+# --- the direct grant: chain of length one -------------------------------------
+
+
+def test_direct_grant_verifies_for_its_holder(parties):
+    claims = verify(_direct(parties), None, presenter=parties["B"]["address"], now=NOW)
+    assert claims["egress_for"] == parties["B"]["address"]
+    assert claims["accountable"] == parties["B"]["address"]
+
+
+def test_direct_grant_refuses_anyone_else(parties):
+    with pytest.raises(GrantError, match="not the grant holder"):
+        verify(_direct(parties), None, presenter=parties["D"]["address"], now=NOW)
+
+
+def test_a_tampered_grant_does_not_verify(parties):
+    grant = _direct(parties)
+    grant["max_bytes"] = 10**12  # quota raised after signing
+    with pytest.raises(GrantError, match="signature"):
+        verify(grant, None, presenter=parties["B"]["address"], now=NOW)
+
+
+def test_a_grant_signed_by_the_wrong_key_names_the_grantor(parties):
+    forged = issue_grant(parties["D"], holder=parties["B"]["address"], expires_at=LATER)
+    forged["grantor"] = parties["P"]["address"]  # claims to be P's network
+    with pytest.raises(GrantError, match="signature"):
+        verify(forged, None, presenter=parties["B"]["address"], now=NOW)
+
+
+def test_an_expired_grant_is_refused(parties):
+    grant = _direct(parties)
+    with pytest.raises(GrantError, match="expired"):
+        verify(grant, None, presenter=parties["B"]["address"], now=NOW + timedelta(days=2))
+
+
+# --- the delegated chain: P → D → B --------------------------------------------
+
+
+def test_the_full_chain_verifies_and_attributes_to_the_holder(parties):
+    grant, delegation = _chain(parties)
+    claims = verify(grant, delegation, presenter=parties["B"]["address"], now=NOW)
+    assert claims["egress_for"] == parties["B"]["address"]
+    # every byte attributes to D, the account — not to the worker machine
+    assert claims["accountable"] == parties["D"]["address"]
+
+
+def test_presenter_binding_refuses_the_dialing_party(parties):
+    """P dials B in the reverse tunnel; P presenting the chain must still fail."""
+    grant, delegation = _chain(parties)
+    with pytest.raises(GrantError, match="presenter"):
+        verify(grant, delegation, presenter=parties["P"]["address"], now=NOW)
+
+
+def test_a_delegate_outside_the_pinned_list_is_refused(parties):
+    grant = issue_grant(
+        parties["P"], holder=parties["D"]["address"], delegable_to=[], expires_at=LATER
+    )
+    delegation = issue_delegation(parties["D"], grant, delegate=parties["B"]["address"])
+    with pytest.raises(GrantError, match="delegable_to"):
+        verify(grant, delegation, presenter=parties["B"]["address"], now=NOW)
+
+
+def test_a_delegation_signed_by_a_non_holder_is_refused(parties):
+    grant, _ = _chain(parties)
+    stranger = address.generate()
+    forged = issue_delegation(stranger, grant, delegate=parties["B"]["address"])
+    forged["delegator"] = parties["D"]["address"]  # claims D signed it
+    with pytest.raises(GrantError, match="signature"):
+        verify(grant, forged, presenter=parties["B"]["address"], now=NOW)
+
+
+def test_a_delegation_for_a_different_grant_is_refused(parties):
+    grant, _ = _chain(parties)
+    other_grant, other_delegation = _chain(parties)
+    assert other_grant["grant_id"] != grant["grant_id"]
+    with pytest.raises(GrantError, match="different grant"):
+        verify(grant, other_delegation, presenter=parties["B"]["address"], now=NOW)
+
+
+def test_a_delegation_cannot_outlive_its_grant(parties):
+    grant, _ = _chain(parties)
+    stretched = issue_delegation(
+        parties["D"],
+        grant,
+        delegate=parties["B"]["address"],
+        expires_at=(NOW + timedelta(days=365)).isoformat().replace("+00:00", "Z"),
+    )
+    with pytest.raises(GrantError, match="outlives"):
+        verify(grant, stretched, presenter=parties["B"]["address"], now=NOW)
+
+
+# --- renewal: the pre-authorised ceiling ---------------------------------------
+
+
+def test_renewal_inside_the_ceiling_keeps_the_schedule_alive(parties):
+    grant = _direct(parties, renewable_until=CEILING)
+    renewed = renew_grant(
+        parties["P"],
+        grant,
+        expires_at=(NOW + timedelta(days=2)).isoformat().replace("+00:00", "Z"),
+    )
+    later = NOW + timedelta(hours=30)  # past the original expiry
+    claims = verify(renewed, None, presenter=parties["B"]["address"], now=later)
+    assert claims["grant_id"] == grant["grant_id"]
+
+
+def test_renewal_past_the_ceiling_is_refused(parties):
+    grant = _direct(parties, renewable_until=CEILING)
+    with pytest.raises(GrantError, match="renewable_until"):
+        renew_grant(
+            parties["P"],
+            grant,
+            expires_at=(NOW + timedelta(days=60)).isoformat().replace("+00:00", "Z"),
+        )
+
+
+def test_only_the_grantor_renews(parties):
+    grant = _direct(parties, renewable_until=CEILING)
+    with pytest.raises(GrantError, match="grantor"):
+        renew_grant(parties["B"], grant, expires_at=LATER)
+
+
+def test_a_grant_without_a_ceiling_cannot_be_renewed_at_all(parties):
+    grant = _direct(parties)  # no renewable_until: an authorisation with a hard end
+    with pytest.raises(GrantError, match="renewable_until"):
+        renew_grant(parties["P"], grant, expires_at=LATER)


### PR DESCRIPTION
First implementation slice of the 1.8 proxy capability. Part of #1036; design rationale in #1034.

## Scope — deliberately only the authorisation objects

`connectonion/network/proxy/grants.py`: `issue_grant` / `issue_delegation` / `renew_grant` / `verify`. Pure functions over dicts — no transport, no CLI, no clock reads (callers pass `now`), no new dependencies. The reverse tunnel, SOCKS listener, preflight and CLI land as separate slices on top of this.

## The design, in code

- **Nobody signs at request time.** P signs a grant and D signs a delegation *in advance*; at 3am B presents both and every human is asleep. This is the availability requirement #1036 exists for.
- **A direct grant is a chain of length one** — same object, `holder == presenter`, no delegation, same verification path. The three-machine deployment uses exactly this.
- **Verification binds to the presenter, not the connector.** In the reverse-tunnel topology P dials B, so binding to "whoever opened the connection" would have P verify itself and the chain would protect nothing. This is the check the whole design rests on, and it has the test with the design's name on it: `test_presenter_binding_refuses_the_dialing_party`.
- **`delegable_to` is a pinned list.** An empty list refuses every delegation; there is no boolean that makes a grant transitively assignable.
- **Renewal happens only inside a pre-authorised ceiling** (`renewable_until`), and only by the grantor. Neither holder nor delegate can extend an authorisation — an authorisation that extends itself has no expiry.
- **Attribution:** verified claims name `accountable` (the holder) separately from `egress_for` (the presenter) — the account vs the worker, which is what a shared or public proxy bills and revokes by.

## Conventions

Signatures follow `host/auth.py`: sorted-keys compact JSON canonicalisation, `address.sign()`, hex signatures, `VerifyKey` from the 0x-hex address. Failures raise `GrantError` naming exactly which check refused — an unauthorised proxy use fails loudly, never falls through.

## Tests

15 tests, all green locally. Forgery cases mint real keys and re-sign (a grant signed by the wrong key claiming P's network; a delegation signed by a stranger claiming D); expiry, ceiling, cross-grant and out-of-list cases each pin one named check.