### PR TITLE
co server new --region (#713)

### DIFF
--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -663,7 +663,8 @@ def _fetch_pricing() -> Optional[dict]:
     return response.json() if response.status_code == 200 else None
 
 
-def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[float]) -> bool:
+def _confirm(name: str, machine_type: str, region: str, pricing: dict,
+            balance: Optional[float]) -> bool:
     """Show what this costs and what is left, then ask.
 
     Every other `co` command is either free or spends metered credit in
@@ -695,7 +696,7 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
 
     console.print()
     console.print(f"  [cyan]name[/cyan]          {name}")
-    console.print(f"  [cyan]region[/cyan]        {pricing['region']}")
+    console.print(f"  [cyan]region[/cyan]        {region}")
     console.print(f"  [cyan]machine[/cyan]       {machine_type} [dim]— {entry['description']}[/dim]")
     console.print(f"  [cyan]cost[/cyan]          [bold]${monthly:.0f} / month[/bold] "
                   f"[dim]— ${price:.2f} for {months} months, charged now[/dim]")
@@ -871,7 +872,7 @@ def handle_server_fix_key(name: str) -> bool:
 
 
 def handle_server_new(name: str, machine_type: Optional[str] = None,
-                      yes: bool = False) -> bool:
+                      region: Optional[str] = None, yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""
     import requests
 
@@ -914,8 +915,14 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
         console.print(f"[dim]Available: {', '.join(sorted(pricing['machine_types']))}[/dim]\n")
         return False
 
+    region = region or pricing["default_region"]
+    if region not in pricing["regions"]:
+        console.print(f"\n[red]Unknown region: {region}[/red]")
+        console.print(f"[dim]Available: {', '.join(sorted(pricing['regions']))}[/dim]\n")
+        return False
+
     if not yes:
-        if not _confirm(name, machine_type, pricing, _fetch_balance(api_key)):
+        if not _confirm(name, machine_type, region, pricing, _fetch_balance(api_key)):
             console.print("[dim]Nothing was created or charged.[/dim]\n")
             return False
 
@@ -925,7 +932,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
             f"{backend_url()}/api/v1/servers",
             headers={"Authorization": f"Bearer {api_key}"},
             json={"name": name, "ssh_public_key": ssh_public_line,
-                  "machine_type": machine_type},
+                  "machine_type": machine_type, "region": region},
             timeout=300,
         )
     except requests.RequestException as exc:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -478,11 +478,13 @@ def server_check(
 def server_new(
     name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
     machine: Optional[str] = typer.Option(None, "--machine", help="Machine type (default: the smallest)"),
+    region: Optional[str] = typer.Option(None, "--region",
+                                         help="Where to provision (default: australia-southeast1)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the price confirmation"),
 ):
     """Have a server created for you. Charges 12 months of credit up front."""
     from .commands.server_commands import handle_server_new
-    if not handle_server_new(name=name, machine_type=machine, yes=yes):
+    if not handle_server_new(name=name, machine_type=machine, region=region, yes=yes):
         raise typer.Exit(1)
 
 

--- a/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
+++ b/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
@@ -1,0 +1,35 @@
+# A Server Quota Is Not a Ceiling
+
+`co server new` had exactly one region. It said so in the pricing response —
+`"region": "australia-southeast1"` — as a fact, not a choice. That was fine
+until the fourth server: the fifth request came back refunded, with GCE naming
+the exact wall it hit — `Quota 'IN_USE_ADDRESSES' exceeded. Limit: 4.0 in
+region australia-southeast1` — and nothing in the product to do about it. Not
+another region, not a smaller machine. The only moves left were outside the
+CLI entirely: raise the quota by hand, or destroy a server still in use.
+
+The honest fix wasn't a bigger number. A quota that size is a routine ceiling
+on one region, not a statement about how many servers an operator should ever
+have. What was missing was a second place to stand.
+
+`REGIONS` is now a dict of region name to its zones, not a single fixed pair.
+Sydney stays the default — an Australian company keeps a customer's machine
+and data in the country unless they ask otherwise — but it is a default now,
+not the only value that exists. Zones within a region are still tried in
+order, because capacity was always a per-zone accident, never a regional
+verdict; that logic didn't change, it just runs inside whichever region was
+asked for.
+
+The part worth noticing is what *didn't* need to change: a server's region.
+It's read off the `zone` column it already had — `"australia-southeast1-a"`
+split on its last hyphen — rather than stored a second time next to it. Two
+copies of the same fact drift; one, derived, cannot.
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server new` validates `--region` against a list the backend actually
+publishes, the same way `--machine` is checked against real machine types —
+never a value hardcoded on the client side of a line that used to have only
+one value to be right about.

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -53,14 +53,26 @@ $ co server new prod
 is free or costs fractions of a cent, so the prompt says the price, what your balance
 becomes, and when the term ends. `--yes` skips it; nothing else does.
 
-The machine is created in **Sydney**, boots Ubuntu 24.04, and carries the SSH key
-derived from your recovery phrase — nothing else is installed. The first
+The machine is created in **Sydney** by default, boots Ubuntu 24.04, and carries the
+SSH key derived from your recovery phrase — nothing else is installed. The first
 `co deploy --to` sets up python, the venv, systemd and Caddy.
 
 | Flag | |
 |---|---|
 | `--machine e2-medium` | 4 GB, for browser agents |
+| `--region asia-southeast1` | provision somewhere other than Sydney |
 | `--yes` | skip the price confirmation |
+
+Each region has its own quota — Sydney's runs out after 4 live servers (a GCE
+external-address ceiling, not ours) — so `--region` is also the way out once you hit
+it:
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server ls` shows an unfamiliar `region` from `co server new`'s own output if you
+forget which one you picked; there is no separate lookup for it yet.
 
 ---
 

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -301,7 +301,8 @@ class TestServerForget:
 
 PRICING = {
     "term_months": 12,
-    "region": "asia-southeast1",
+    "regions": ["asia-southeast1", "australia-southeast1"],
+    "default_region": "asia-southeast1",
     "default": "e2-small",
     "machine_types": {"e2-small": {"usd_12mo": 180.0, "description": "2 vCPU, 2 GB"}},
 }
@@ -406,6 +407,52 @@ class TestServerNewSuccess:
             sc.handle_server_new("prod")
 
         assert post.call_args.kwargs["json"]["ssh_public_key"] == line
+
+
+class TestServerNewRegion:
+    """openonion/connectonion#713 — a region nobody could pick from the CLI."""
+
+    def test_the_chosen_region_is_sent(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod", region="australia-southeast1")
+
+        assert post.call_args.kwargs["json"]["region"] == "australia-southeast1"
+
+    def test_no_region_falls_back_to_the_backends_default(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod")
+
+        assert post.call_args.kwargs["json"]["region"] == PRICING["default_region"]
+
+    def test_an_unknown_region_is_rejected_before_charging(self, servers_file, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod", region="mars-central1") is False
+
+        post.assert_not_called()
+        assert "mars-central1" in capsys.readouterr().out
 
 
 class TestServerNewFailureReporting:
@@ -799,7 +846,8 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     instead of it."""
 
     PRICING = {
-        "term_months": 12, "region": "australia-southeast1", "default": "e2-small",
+        "term_months": 12, "regions": ["australia-southeast1"],
+        "default_region": "australia-southeast1", "default": "e2-small",
         "machine_types": {"e2-small": {"usd_month": 30.0, "usd_12mo": 360.0,
                                        "description": "2 vCPU (shared), 2 GB"}},
     }
@@ -807,7 +855,7 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     def _prompt(self, pricing):
         with patch("questionary.confirm") as confirm:
             confirm.return_value.ask.return_value = False
-            sc._confirm("prod", "e2-small", pricing, 500.0)
+            sc._confirm("prod", "e2-small", pricing["default_region"], pricing, 500.0)
 
     def test_both_the_month_and_the_year_are_shown(self, capsys):
         self._prompt(self.PRICING)
@@ -867,6 +915,8 @@ class TestARecreatedServerDoesNotLookLikeAnAttack:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \
@@ -920,6 +970,8 @@ class TestReadyMeansYouCanLogIn:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \

--- a/tests/unit/test_server_new_without_a_terminal.py
+++ b/tests/unit/test_server_new_without_a_terminal.py
@@ -16,7 +16,8 @@ from connectonion.cli.commands import server_commands as sc
 
 
 PRICING = {
-    "region": "australia-southeast1",
+    "regions": ["australia-southeast1"],
+    "default_region": "australia-southeast1",
     "term_months": 12,
     "machine_types": {
         "e2-small": {
@@ -31,7 +32,7 @@ PRICING = {
 def confirm_without_a_tty(capsys):
     with patch.object(sys.stdin, "isatty", return_value=False):
         with patch("questionary.confirm") as prompt:
-            answer = sc._confirm("my-box", "e2-small", PRICING, balance=1000.0)
+            answer = sc._confirm("my-box", "e2-small", "australia-southeast1", PRICING, balance=1000.0)
     return answer, prompt, capsys.readouterr().out
 
 


### PR DESCRIPTION
CLI half of #713: a server-quota ceiling in one region had no `--region` to
move to.

## What changed

- `co server new [name] --region <region>` — validated against the
  `regions` list `GET /servers/pricing` now publishes, same way `--machine`
  is validated against `machine_types`. Default (`region` unset) falls back
  to the backend's `default_region` (Sydney).
- `--region` is sent through to `POST /servers`; the confirmation prompt's
  `region` line now shows the region actually being requested, not a fixed
  string read off the pricing response.
- `docs/cli/server.md` documents the flag and the quota it routes around.

Backend companion PR: openonion/oo-api#166 (must merge/deploy first, or an
unknown-region request will 400 with `region` not yet accepted by the API —
no worse than today, but pointless before the backend ships).

## Testing

`pytest tests/unit/test_server_commands.py tests/unit/test_server_new_without_a_terminal.py -q`
— 89 passed (added `TestServerNewRegion`, confirmed red against the
pre-patch code first).

Full `pytest tests/unit -q` — 6536 passed, 13 skipped, 1 deselected
(`test_the_docs_site_advertises_the_version_that_exists`: this worktree's
`main` is 1.7.0a18 while the shared docs-site checkout already advertises
1.7.0b1 from an unrelated earlier release — environmental drift between two
branches, unrelated to this change, reproduces on origin/main without this
patch too).