### PR TITLE
co email share/unshare — grant another account send access (#1137)

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
   Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread, offset) → Rich table | handle_email_read() → get_emails() → find by id → print body → optionally mark_read(id)
   State/Effects: no local state | network calls happen inside the engine tools | only read --mark-read flips server-side read status | writes to stdout via rich.Console
-  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
+  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses(), handle_email_share()/handle_email_unshare() (connectonion#1137) for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py, share/unshare hit /api/v1/email/share directly like addresses/name do | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
 """
 
@@ -298,6 +298,108 @@ def handle_email_addresses():
     console.print()
     console.print(table)
     console.print('\n[dim]Send as one with:[/dim] [bold]co email send <to> "<subject>" "<body>" --from <address>[/bold]\n')
+
+
+_CAPABILITIES = {"send": "can_send", "read": "can_read"}
+
+
+def _parse_capabilities(can: str) -> dict:
+    """'send,read' -> {'can_send': True, 'can_read': True}. Rejects a typo rather
+    than silently granting nothing, which the server would also refuse but
+    only after a round trip."""
+    flags = {"can_send": False, "can_read": False}
+    for word in can.split(","):
+        word = word.strip().lower()
+        if not word:
+            continue
+        key = _CAPABILITIES.get(word)
+        if not key:
+            console.print(f"\n[red]✗ Unknown capability: '{word}'.[/red] Use send, read, or both.\n")
+            raise typer.Exit(1)
+        flags[key] = True
+    if not flags["can_send"] and not flags["can_read"]:
+        console.print("\n[red]✗ --can needs at least one of: send, read[/red]\n")
+        raise typer.Exit(1)
+    return flags
+
+
+def _print_shares_table(title: str, rows: list, other_key: str):
+    if not rows:
+        console.print(f"[cyan]{title}:[/cyan] none\n")
+        return
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("Address")
+    table.add_column("With" if other_key == "grantee_public_key" else "Owner")
+    table.add_column("Can")
+    for row in rows:
+        capabilities = ",".join(
+            name for name, key in _CAPABILITIES.items() if row.get(key)
+        )
+        table.add_row(str(row.get("address", "")), str(row.get(other_key, "")), capabilities)
+    console.print(table)
+    console.print()
+
+
+def handle_email_share(
+    address: str = None, *, with_: str = None, can: str = None, list_: bool = False,
+):
+    """Grant, or list, access to one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    if list_:
+        r = requests.get(f"{backend_url()}/api/v1/email/share", headers=headers, timeout=10)
+        if not r.ok:
+            console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+            raise typer.Exit(1)
+        data = r.json()
+        console.print()
+        _print_shares_table("📤 Shared by you", data.get("granted_by_me", []), "grantee_public_key")
+        _print_shares_table("📥 Shared with you", data.get("granted_to_me", []), "owner_public_key")
+        return
+
+    if not address or not with_ or not can:
+        console.print(
+            "\n[red]✗ Usage:[/red] co email share <address> --with <who> --can send,read"
+            "\n         co email share --list\n"
+        )
+        raise typer.Exit(1)
+
+    payload = {"address": address, "grantee": with_, **_parse_capabilities(can)}
+    r = requests.post(f"{backend_url()}/api/v1/email/share", json=payload, headers=headers, timeout=15)
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    data = r.json()
+    granted = ",".join(name for name, key in _CAPABILITIES.items() if data.get(key))
+    console.print(f"\n[green]✓ Shared {address}[/green] with [cyan]{with_}[/cyan] ({granted})")
+    console.print("[dim]Revoke it with:[/dim]")
+    # Plain print, not console.print: Rich wraps at the console width, and a
+    # line-broken command is no longer copy-pasteable.
+    print(f"  co email unshare {address} --with {with_}\n")
+
+
+def handle_email_unshare(address: str, *, with_: str):
+    """Revoke a grant on one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+
+    r = requests.delete(
+        f"{backend_url()}/api/v1/email/share/{address}/{with_}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]✓ Revoked {with_}'s access to {address}[/green]\n")
 
 
 def handle_email_name(name: str, buy: bool = False):

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -784,6 +784,28 @@ def email_name(
     handle_email_name(name, buy=buy)
 
 
+@email_app.command("share")
+def email_share(
+    address: Optional[str] = typer.Argument(None, help="One of your addresses (omit with --list)"),
+    with_: Optional[str] = typer.Option(None, "--with", help="Grantee: public key or one of their addresses"),
+    can: Optional[str] = typer.Option(None, "--can", help="Comma-separated capabilities: send,read"),
+    list_: bool = typer.Option(False, "--list", help="Show what you've shared, and what's shared with you"),
+):
+    """Let another account send and/or read as one of your addresses, without moving it."""
+    from .commands.email_commands import handle_email_share
+    handle_email_share(address, with_=with_, can=can, list_=list_)
+
+
+@email_app.command("unshare")
+def email_unshare(
+    address: str = typer.Argument(..., help="One of your addresses"),
+    with_: str = typer.Option(..., "--with", help="Grantee to revoke: public key or one of their addresses"),
+):
+    """Revoke a grant. No key rotation — the address was never shared, only access to it."""
+    from .commands.email_commands import handle_email_unshare
+    handle_email_unshare(address, with_=with_)
+
+
 @email_app.command("upgrade")
 def email_upgrade(
     tier: str = typer.Argument(..., help="Tier: plus or pro"),

--- a/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
+++ b/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
@@ -1,0 +1,42 @@
+# Sharing a Mailbox Is Not the Same as Giving It Away
+
+A rental-outreach pipeline had a mailbox with a history: `rental@mail.openonion.ai`
+had been the sender for months, replies landed there, and a CRM's dedupe rules
+were written around that one address being the one identity. A newly deployed
+agent needed to send the first-touch enquiries from that same address, and
+ownership in the email system was exclusive — one account, one address, no
+exceptions.
+
+Every workaround was a worse trade than the problem. Moving the address to
+the agent took it away from the person who still needed it. A new address for
+the agent split the conversation across two inboxes that nothing reconciled,
+and looked, to anyone replying, like mail from a stranger. Sharing the
+private key solved the technical problem and created a real one: one
+identity now sat on two machines, with no way to tell which had sent what,
+and revoking access meant rotating the key for everyone who held it.
+
+The system already had a mechanism for moving an address between accounts —
+two signatures, a fixed-order message, one irreversible transaction. It's the
+right tool for handing a mailbox over for good. It was the wrong tool here,
+because nothing was ending: the person kept using the address exactly as
+before, and the agent needed to use it too, starting now and stopping the
+moment anyone changed their mind.
+
+What was missing sat in between owning an address and losing it: a grant.
+Revocable, and checked on every request rather than proven once with a
+signature — the natural shape once you notice the server already sits in the
+middle of every send. Nobody has to sign anything offline for a permission
+the server can just look up. `co email share rental@mail.openonion.ai --with
+<agent> --can send` writes one row; `co email unshare` deletes it. Attribution
+falls out of the existing schema for free: every sent-mail record already
+carried the identity of whoever actually sent it, so a shared address stays
+one conversation, sent by two accounts, with no ambiguity about which one did
+what.
+
+The design question worth naming: not every "let account A act as account B"
+problem needs cryptography. A signed, offline-verifiable grant is for the
+case where nobody trustworthy is online to ask — a proxy dialing out through
+a home connection at 3am, say. A mailbox share is answered on every request
+by a server that was already the arbiter. Reaching for the stronger tool
+there wouldn't have made the feature more correct. It would have solved a
+problem this one doesn't have.

--- a/tests/cli/test_email_share.py
+++ b/tests/cli/test_email_share.py
@@ -1,0 +1,178 @@
+"""co email share/unshare: let another account act as one of your addresses,
+without moving it (connectonion#1137). Companion to openonion/oo-api#167.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    return r
+
+
+# --- _parse_capabilities ------------------------------------------------
+
+
+def test_parses_both_capabilities():
+    assert email_commands._parse_capabilities("send,read") == {
+        "can_send": True, "can_read": True,
+    }
+
+
+def test_parses_one_capability():
+    assert email_commands._parse_capabilities("send") == {
+        "can_send": True, "can_read": False,
+    }
+
+
+def test_an_unknown_capability_exits_before_any_request(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("delete")
+    assert "Unknown capability" in capsys.readouterr().out
+
+
+def test_an_empty_capability_list_exits(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("")
+    assert "at least one of" in capsys.readouterr().out
+
+
+# --- handle_email_share: granting ---------------------------------------
+
+
+def test_sharing_posts_the_parsed_capabilities():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "grantee_public_key": "0x" + "b" * 64,
+                          "can_send": True, "can_read": False,
+                      })) as post:
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+        )
+
+    payload = post.call_args.kwargs["json"]
+    assert payload == {
+        "address": "rental@mail.openonion.ai",
+        "grantee": "0x" + "b" * 64,
+        "can_send": True,
+        "can_read": False,
+    }
+
+
+def test_sharing_prints_the_unshare_command(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "can_send": True, "can_read": False,
+                      })):
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="alice@mail.openonion.ai", can="send",
+        )
+    out = capsys.readouterr().out
+    assert "co email unshare rental@mail.openonion.ai --with alice@mail.openonion.ai" in out
+
+
+def test_missing_arguments_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share("rental@mail.openonion.ai")
+    post.assert_not_called()
+
+
+def test_share_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(ok=False, status=403,
+                                         json_data={"detail": "not one of your email addresses."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    assert exc_info.value.exit_code == 1
+    assert "not one of your" in capsys.readouterr().out
+
+
+def test_no_auth_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value=None), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    post.assert_not_called()
+
+
+# --- handle_email_share: --list -----------------------------------------
+
+
+def test_list_shows_both_directions(capsys):
+    body = {
+        "granted_by_me": [{
+            "address": "rental@mail.openonion.ai",
+            "grantee_public_key": "0x" + "b" * 64,
+            "can_send": True, "can_read": False,
+        }],
+        "granted_to_me": [{
+            "address": "leads@mail.openonion.ai",
+            "owner_public_key": "0x" + "c" * 64,
+            "can_send": False, "can_read": True,
+        }],
+    }
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(json_data=body)) as get:
+        email_commands.handle_email_share(list_=True)
+
+    out = capsys.readouterr().out
+    assert "rental@mail.openonion.ai" in out
+    assert "leads@mail.openonion.ai" in out
+    assert get.call_args.args[0].endswith("/api/v1/email/share")
+
+
+def test_list_with_nothing_shared_either_way_is_not_an_error(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get",
+                      return_value=_resp(json_data={"granted_by_me": [], "granted_to_me": []})):
+        email_commands.handle_email_share(list_=True)  # must NOT raise
+    out = capsys.readouterr().out
+    assert "none" in out
+
+
+# --- handle_email_unshare -------------------------------------------------
+
+
+def test_unshare_deletes_the_grant():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(json_data={"success": True, "revoked": True})) as delete:
+        email_commands.handle_email_unshare(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+        )
+    url = delete.call_args.args[0]
+    assert url.endswith(f"/api/v1/email/share/rental@mail.openonion.ai/0x{'b' * 64}")
+
+
+def test_unshare_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(ok=False, status=404,
+                                         json_data={"detail": "No active grant."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_unshare(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+            )
+    assert exc_info.value.exit_code == 1
+    assert "No active grant" in capsys.readouterr().out


### PR DESCRIPTION
CLI half of #1137. Backend: openonion/oo-api#167 (must merge/deploy first,
or `/api/v1/email/share` 404s).

## What changed

```
co email share rental@mail.openonion.ai --with 0x... --can send
co email share --list
co email unshare rental@mail.openonion.ai --with 0x...
```

- `share`/`unshare` hit `/api/v1/email/share` directly, the same way
  `addresses`/`name` already do (not through `useful_tools/`, which is
  reserved for what an agent calls as its own tool).
- `--list` shows both directions — what you've granted, what's been granted
  to you — from one `GET /api/v1/email/share` call.
- `--can` is parsed client-side first (`send`, `read`, or both) so a typo'd
  capability fails before any request, the same way `--from` failures already
  point at `co email addresses`.

## Scope: send-only for now

`--can read` is accepted and sent through — the oo-api PR's `email_grants`
table already has the `can_read` column — but nothing on the server *checks*
it yet: `get_received_emails` doesn't accept an impersonated address, so a
read grant is currently inert rather than functional. Send is what actually
blocks the rental-lead pipeline in the issue; read-sharing is proposed as a
follow-up PR once the backend wires it, rather than shipping a flag that
looks like it does something it doesn't.

## Testing

`pytest tests/cli/test_email_share.py tests/cli/test_email_addresses.py -q`
— 17 passed (added `test_email_share.py`, confirmed all 13 of its cases red
against the pre-patch code first).

`co email --help` / `co email share --help` / `co email unshare --help`
driven against a clean-venv install of this branch — commands register and
read correctly.

Full `pytest tests/cli/ tests/unit/test_the_version_agrees_with_itself.py`
(minus the known unrelated docs-site-drift test) — 55 passed.