### PR TITLE
release: 1.8.0a1 — the first 1.8 preview

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -39,13 +39,16 @@ patch releases; the minor is the statement that it no longer needs to be.
 - Reserved for breaking changes, or for a stable release worth naming
 - Same rule as any whole number: earned, not reached
 
-Stable users remain on the 1.6.x line while the 1.7.0 feature train is exercised through
-alpha, beta, and release-candidate builds. Pre-releases are opt-in and must be
-marked as pre-releases on PyPI and GitHub.
+Stable users remain on the 1.6.x line. The 1.7.0 feature train is frozen as of
+a18 and is being exercised toward stable on its own `release/1.7` branch
+(currently `1.7.0b1`) — that branch takes stabilisation fixes only. New
+feature work now targets `main` as the 1.8 train, starting from this release.
+Pre-releases are opt-in and must be marked as pre-releases on PyPI and GitHub.
 
-## Current Version: 1.7.0a18
+## Current Version: 1.8.0a1
 
 ### Version History
+- 1.8.0a1 (**the first 1.8 preview**: cut from `main` once 1.7 was feature-frozen (see the 1.7.0b1 entry) — new feature work resumes here rather than on the stabilising 1.7 line. `co server new --region` lets an operator pick a region and route around a single region's server-address quota instead of having nowhere to go once it fills (#713); `co email share`/`unshare` let one account grant another send access to one of its addresses without transferring ownership or sharing a private key (#1137), with `resolve_email_owner` also fixed to recognise addresses added after the original multi-address work shipped; and the signed proxy-grant primitives (`connectonion.network.proxy`) that a future `co proxy` will use land as a library module with no CLI surface yet.)
 - 1.7.0a18 (**a native Work Room message is not outer-agent input**: direct Codex follow-ups now receive a successful OIP acknowledgement only after native `turn/steer` or resumed `turn/start` succeeds, so a browser retains its draft across a terminal race. Provider messages flow through the React reader without a hidden event drop, while O Chat reduces a long coding run to one current state, optional genuine preview, and one focused approval surface. A real native C11 implementation run completed through the provider lifecycle and its independently compiled six-fixture test suite passed. Pairs with `@connectonion/react` 0.4.2-alpha.16.)
 - 1.7.0a17 (**a Work Room preview is evidence for one exact state, never a decorative stale image**: OIP provider lifecycle events now carry a per-invocation monotonic `stateRevision`; a browser Stop asks for the revision it observed and receives an ACK only when the Host proves that exact live state. Core introduces the bounded `provider_artifact` contract for a Host-owned PNG/JPEG capture, validates it again during session replay, and never invents a Codex thumbnail when no capture producer exists. Pairs with `@connectonion/react` 0.4.2-alpha.15 and O Chat's compact optional current-preview renderer.)
 - 1.7.0a16 (**a Stop request is not a stopped provider**: OIP now correlates each browser Stop request to one live native provider invocation and replies with an explicit accepted/rejected acknowledgement. The browser waits for that acknowledgement, restores a clear retry action after refusal or loss, and treats the terminal provider event—not a local button press—as the authoritative stopped state. Pairs with `@connectonion/react` 0.4.2-alpha.14 and O Chat's verified Work Room Stop state.)

--- a/connectonion/_version.py
+++ b/connectonion/_version.py
@@ -8,4 +8,4 @@ is what lets the entry point keep that promise.
 Kept in step with pyproject.toml by a test.
 """
 
-__version__ = "1.7.0a18"
+__version__ = "1.8.0a1"

--- a/docs/blog/2026-08-19-new-feature-work-needs-a-new-number.md
+++ b/docs/blog/2026-08-19-new-feature-work-needs-a-new-number.md
@@ -1,0 +1,31 @@
+# New Feature Work Needs a New Number
+
+The moment 1.7 was declared feature-frozen — "everything the eighteen alphas
+built is now feature-complete, from here the line takes stabilisation fixes
+only" — three PRs were already open against `main` that were exactly what
+that sentence rules out: `co server new --region`, an authorization layer for
+sharing an email address across accounts, and the signed grant primitives a
+future proxy feature will need. None of them belonged on `release/1.7`
+anymore. All three still needed to ship somewhere.
+
+The version they landed in couldn't be another `1.7.0aN`. `main`'s
+`pyproject.toml` still said `1.7.0a18` — the exact commit the beta was cut
+from — and PEP 440 sorts `a19` before `b1`, which would have made three
+genuinely new post-freeze features look, to any tool or person reading the
+version, like they predated the beta they actually came after. The freeze
+wasn't just a policy statement; it was the boundary a version number has to
+respect once a beta exists on the other side of it.
+
+So `main` gets its own next number: `1.8.0a1`. Cutting it is mechanical in a
+way that's worth noticing — the same four files, the same test that fails if
+they disagree, the same docs-site preview channel to update, run exactly the
+way they were for every one of the eighteen 1.7 alphas before it. The only
+thing that changed is which train the number names.
+
+One of the three isn't a feature yet in the way a release note usually means
+it: `connectonion.network.proxy` ships signed grant and delegation objects — a
+real, tested authorization primitive — with no `co proxy` command anywhere
+that uses it. It's in this release because merged code ships in every wheel
+whether or not there's a command line pointed at it yet, not because there's
+something to demo. The version history entry says so plainly rather than
+implying a command exists that doesn't.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectonion"
-version = "1.7.0a18"
+version = "1.8.0a1"
 description = "A simple Python framework for creating AI agents with behavior tracking"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "connectonion"
-version = "1.7.0a18"
+version = "1.8.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
1.7 is feature-frozen (`1.7.0b1`, stabilising on `release/1.7`). New feature
work now targets `main` as the 1.8 train — this is its first preview,
bundling everything that landed on `main` since the freeze.

## What's in it

- `co server new --region` — pick a region for a new server and route around
  a single region's server-address quota once it fills (#713, connectonion#1136)
- `co email share`/`unshare` — one account grants another send access to one
  of its addresses, without transferring ownership or sharing a private key
  (#1137, connectonion#1138 + oo-api#167, already deployed to production).
  Also fixes `resolve_email_owner`, which never checked the multi-address
  table added by #148 — an address added via `add_email_address` resolved to
  no owner at all.
- `connectonion.network.proxy` — signed grant/delegation primitives (#1036,
  connectonion#1135). Library module only; no `co proxy` command yet, said
  plainly in the version history rather than implied.

## Version files

Standard four-file bump + docs-site preview channel
(wu-changxing/connectonion-docs-site#80, merged) — verified against the live
remote checkout since the local sibling repo here was on an unrelated branch.

## Testing

`pytest tests/unit -q` — 6554 passed, 13 skipped. Two transient failures on
the first run, both confirmed non-issues: the docs-site version check against
a stale *local* checkout (re-verified green against the real remote state
with `CONNECTONION_DOCS_SITE=<fresh clone>`), and one network-flaky balance
call that passed cleanly in isolation.