### PR TITLE
backport to 1.6.12: co server new --region + co email share/unshare

### DIFF
--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
   Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread) → Rich table | handle_email_read() → get_emails() → find by id → print body → optionally mark_read(id)
   State/Effects: no local state | network calls happen inside the engine tools | only read --mark-read flips server-side read status | writes to stdout via rich.Console
-  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
+  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses(), handle_email_share()/handle_email_unshare() (connectonion#1137) for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py, share/unshare hit /api/v1/email/share directly like addresses/name do | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
 """
 
@@ -297,6 +297,108 @@ def handle_email_addresses():
     console.print()
     console.print(table)
     console.print('\n[dim]Send as one with:[/dim] [bold]co email send <to> "<subject>" "<body>" --from <address>[/bold]\n')
+
+
+_CAPABILITIES = {"send": "can_send", "read": "can_read"}
+
+
+def _parse_capabilities(can: str) -> dict:
+    """'send,read' -> {'can_send': True, 'can_read': True}. Rejects a typo rather
+    than silently granting nothing, which the server would also refuse but
+    only after a round trip."""
+    flags = {"can_send": False, "can_read": False}
+    for word in can.split(","):
+        word = word.strip().lower()
+        if not word:
+            continue
+        key = _CAPABILITIES.get(word)
+        if not key:
+            console.print(f"\n[red]✗ Unknown capability: '{word}'.[/red] Use send, read, or both.\n")
+            raise typer.Exit(1)
+        flags[key] = True
+    if not flags["can_send"] and not flags["can_read"]:
+        console.print("\n[red]✗ --can needs at least one of: send, read[/red]\n")
+        raise typer.Exit(1)
+    return flags
+
+
+def _print_shares_table(title: str, rows: list, other_key: str):
+    if not rows:
+        console.print(f"[cyan]{title}:[/cyan] none\n")
+        return
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("Address")
+    table.add_column("With" if other_key == "grantee_public_key" else "Owner")
+    table.add_column("Can")
+    for row in rows:
+        capabilities = ",".join(
+            name for name, key in _CAPABILITIES.items() if row.get(key)
+        )
+        table.add_row(str(row.get("address", "")), str(row.get(other_key, "")), capabilities)
+    console.print(table)
+    console.print()
+
+
+def handle_email_share(
+    address: str = None, *, with_: str = None, can: str = None, list_: bool = False,
+):
+    """Grant, or list, access to one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    if list_:
+        r = requests.get(f"{backend_url()}/api/v1/email/share", headers=headers, timeout=10)
+        if not r.ok:
+            console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+            raise typer.Exit(1)
+        data = r.json()
+        console.print()
+        _print_shares_table("📤 Shared by you", data.get("granted_by_me", []), "grantee_public_key")
+        _print_shares_table("📥 Shared with you", data.get("granted_to_me", []), "owner_public_key")
+        return
+
+    if not address or not with_ or not can:
+        console.print(
+            "\n[red]✗ Usage:[/red] co email share <address> --with <who> --can send,read"
+            "\n         co email share --list\n"
+        )
+        raise typer.Exit(1)
+
+    payload = {"address": address, "grantee": with_, **_parse_capabilities(can)}
+    r = requests.post(f"{backend_url()}/api/v1/email/share", json=payload, headers=headers, timeout=15)
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    data = r.json()
+    granted = ",".join(name for name, key in _CAPABILITIES.items() if data.get(key))
+    console.print(f"\n[green]✓ Shared {address}[/green] with [cyan]{with_}[/cyan] ({granted})")
+    console.print("[dim]Revoke it with:[/dim]")
+    # Plain print, not console.print: Rich wraps at the console width, and a
+    # line-broken command is no longer copy-pasteable.
+    print(f"  co email unshare {address} --with {with_}\n")
+
+
+def handle_email_unshare(address: str, *, with_: str):
+    """Revoke a grant on one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+
+    r = requests.delete(
+        f"{backend_url()}/api/v1/email/share/{address}/{with_}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]✓ Revoked {with_}'s access to {address}[/green]\n")
 
 
 def handle_email_name(name: str, buy: bool = False):

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -663,7 +663,8 @@ def _fetch_pricing() -> Optional[dict]:
     return response.json() if response.status_code == 200 else None
 
 
-def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[float]) -> bool:
+def _confirm(name: str, machine_type: str, region: str, pricing: dict,
+            balance: Optional[float]) -> bool:
     """Show what this costs and what is left, then ask.
 
     Every other `co` command is either free or spends metered credit in
@@ -695,7 +696,7 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
 
     console.print()
     console.print(f"  [cyan]name[/cyan]          {name}")
-    console.print(f"  [cyan]region[/cyan]        {pricing['region']}")
+    console.print(f"  [cyan]region[/cyan]        {region}")
     console.print(f"  [cyan]machine[/cyan]       {machine_type} [dim]— {entry['description']}[/dim]")
     console.print(f"  [cyan]cost[/cyan]          [bold]${monthly:.0f} / month[/bold] "
                   f"[dim]— ${price:.2f} for {months} months, charged now[/dim]")
@@ -871,7 +872,7 @@ def handle_server_fix_key(name: str) -> bool:
 
 
 def handle_server_new(name: str, machine_type: Optional[str] = None,
-                      yes: bool = False) -> bool:
+                      region: Optional[str] = None, yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""
     import requests
 
@@ -914,8 +915,14 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
         console.print(f"[dim]Available: {', '.join(sorted(pricing['machine_types']))}[/dim]\n")
         return False
 
+    region = region or pricing["default_region"]
+    if region not in pricing["regions"]:
+        console.print(f"\n[red]Unknown region: {region}[/red]")
+        console.print(f"[dim]Available: {', '.join(sorted(pricing['regions']))}[/dim]\n")
+        return False
+
     if not yes:
-        if not _confirm(name, machine_type, pricing, _fetch_balance(api_key)):
+        if not _confirm(name, machine_type, region, pricing, _fetch_balance(api_key)):
             console.print("[dim]Nothing was created or charged.[/dim]\n")
             return False
 
@@ -925,7 +932,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
             f"{backend_url()}/api/v1/servers",
             headers={"Authorization": f"Bearer {api_key}"},
             json={"name": name, "ssh_public_key": ssh_public_line,
-                  "machine_type": machine_type},
+                  "machine_type": machine_type, "region": region},
             timeout=300,
         )
     except requests.RequestException as exc:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -468,11 +468,13 @@ def server_check(
 def server_new(
     name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
     machine: Optional[str] = typer.Option(None, "--machine", help="Machine type (default: the smallest)"),
+    region: Optional[str] = typer.Option(None, "--region",
+                                         help="Where to provision (default: australia-southeast1)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the price confirmation"),
 ):
     """Have a server created for you. Charges 12 months of credit up front."""
     from .commands.server_commands import handle_server_new
-    if not handle_server_new(name=name, machine_type=machine, yes=yes):
+    if not handle_server_new(name=name, machine_type=machine, region=region, yes=yes):
         raise typer.Exit(1)
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -770,6 +770,28 @@ def email_name(
     handle_email_name(name, buy=buy)
 
 
+@email_app.command("share")
+def email_share(
+    address: Optional[str] = typer.Argument(None, help="One of your addresses (omit with --list)"),
+    with_: Optional[str] = typer.Option(None, "--with", help="Grantee: public key or one of their addresses"),
+    can: Optional[str] = typer.Option(None, "--can", help="Comma-separated capabilities: send,read"),
+    list_: bool = typer.Option(False, "--list", help="Show what you've shared, and what's shared with you"),
+):
+    """Let another account send and/or read as one of your addresses, without moving it."""
+    from .commands.email_commands import handle_email_share
+    handle_email_share(address, with_=with_, can=can, list_=list_)
+
+
+@email_app.command("unshare")
+def email_unshare(
+    address: str = typer.Argument(..., help="One of your addresses"),
+    with_: str = typer.Option(..., "--with", help="Grantee to revoke: public key or one of their addresses"),
+):
+    """Revoke a grant. No key rotation — the address was never shared, only access to it."""
+    from .commands.email_commands import handle_email_unshare
+    handle_email_unshare(address, with_=with_)
+
+
 @email_app.command("upgrade")
 def email_upgrade(
     tier: str = typer.Argument(..., help="Tier: plus or pro"),

--- a/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
+++ b/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
@@ -1,0 +1,35 @@
+# A Server Quota Is Not a Ceiling
+
+`co server new` had exactly one region. It said so in the pricing response —
+`"region": "australia-southeast1"` — as a fact, not a choice. That was fine
+until the fourth server: the fifth request came back refunded, with GCE naming
+the exact wall it hit — `Quota 'IN_USE_ADDRESSES' exceeded. Limit: 4.0 in
+region australia-southeast1` — and nothing in the product to do about it. Not
+another region, not a smaller machine. The only moves left were outside the
+CLI entirely: raise the quota by hand, or destroy a server still in use.
+
+The honest fix wasn't a bigger number. A quota that size is a routine ceiling
+on one region, not a statement about how many servers an operator should ever
+have. What was missing was a second place to stand.
+
+`REGIONS` is now a dict of region name to its zones, not a single fixed pair.
+Sydney stays the default — an Australian company keeps a customer's machine
+and data in the country unless they ask otherwise — but it is a default now,
+not the only value that exists. Zones within a region are still tried in
+order, because capacity was always a per-zone accident, never a regional
+verdict; that logic didn't change, it just runs inside whichever region was
+asked for.
+
+The part worth noticing is what *didn't* need to change: a server's region.
+It's read off the `zone` column it already had — `"australia-southeast1-a"`
+split on its last hyphen — rather than stored a second time next to it. Two
+copies of the same fact drift; one, derived, cannot.
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server new` validates `--region` against a list the backend actually
+publishes, the same way `--machine` is checked against real machine types —
+never a value hardcoded on the client side of a line that used to have only
+one value to be right about.

--- a/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
+++ b/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
@@ -1,0 +1,42 @@
+# Sharing a Mailbox Is Not the Same as Giving It Away
+
+A rental-outreach pipeline had a mailbox with a history: `rental@mail.openonion.ai`
+had been the sender for months, replies landed there, and a CRM's dedupe rules
+were written around that one address being the one identity. A newly deployed
+agent needed to send the first-touch enquiries from that same address, and
+ownership in the email system was exclusive — one account, one address, no
+exceptions.
+
+Every workaround was a worse trade than the problem. Moving the address to
+the agent took it away from the person who still needed it. A new address for
+the agent split the conversation across two inboxes that nothing reconciled,
+and looked, to anyone replying, like mail from a stranger. Sharing the
+private key solved the technical problem and created a real one: one
+identity now sat on two machines, with no way to tell which had sent what,
+and revoking access meant rotating the key for everyone who held it.
+
+The system already had a mechanism for moving an address between accounts —
+two signatures, a fixed-order message, one irreversible transaction. It's the
+right tool for handing a mailbox over for good. It was the wrong tool here,
+because nothing was ending: the person kept using the address exactly as
+before, and the agent needed to use it too, starting now and stopping the
+moment anyone changed their mind.
+
+What was missing sat in between owning an address and losing it: a grant.
+Revocable, and checked on every request rather than proven once with a
+signature — the natural shape once you notice the server already sits in the
+middle of every send. Nobody has to sign anything offline for a permission
+the server can just look up. `co email share rental@mail.openonion.ai --with
+<agent> --can send` writes one row; `co email unshare` deletes it. Attribution
+falls out of the existing schema for free: every sent-mail record already
+carried the identity of whoever actually sent it, so a shared address stays
+one conversation, sent by two accounts, with no ambiguity about which one did
+what.
+
+The design question worth naming: not every "let account A act as account B"
+problem needs cryptography. A signed, offline-verifiable grant is for the
+case where nobody trustworthy is online to ask — a proxy dialing out through
+a home connection at 3am, say. A mailbox share is answered on every request
+by a server that was already the arbiter. Reaching for the stronger tool
+there wouldn't have made the feature more correct. It would have solved a
+problem this one doesn't have.

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -53,14 +53,26 @@ $ co server new prod
 is free or costs fractions of a cent, so the prompt says the price, what your balance
 becomes, and when the term ends. `--yes` skips it; nothing else does.
 
-The machine is created in **Sydney**, boots Ubuntu 24.04, and carries the SSH key
-derived from your recovery phrase — nothing else is installed. The first
+The machine is created in **Sydney** by default, boots Ubuntu 24.04, and carries the
+SSH key derived from your recovery phrase — nothing else is installed. The first
 `co deploy --to` sets up python, the venv, systemd and Caddy.
 
 | Flag | |
 |---|---|
 | `--machine e2-medium` | 4 GB, for browser agents |
+| `--region asia-southeast1` | provision somewhere other than Sydney |
 | `--yes` | skip the price confirmation |
+
+Each region has its own quota — Sydney's runs out after 4 live servers (a GCE
+external-address ceiling, not ours) — so `--region` is also the way out once you hit
+it:
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server ls` shows an unfamiliar `region` from `co server new`'s own output if you
+forget which one you picked; there is no separate lookup for it yet.
 
 ---
 

--- a/tests/cli/test_email_share.py
+++ b/tests/cli/test_email_share.py
@@ -1,0 +1,178 @@
+"""co email share/unshare: let another account act as one of your addresses,
+without moving it (connectonion#1137). Companion to openonion/oo-api#167.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    return r
+
+
+# --- _parse_capabilities ------------------------------------------------
+
+
+def test_parses_both_capabilities():
+    assert email_commands._parse_capabilities("send,read") == {
+        "can_send": True, "can_read": True,
+    }
+
+
+def test_parses_one_capability():
+    assert email_commands._parse_capabilities("send") == {
+        "can_send": True, "can_read": False,
+    }
+
+
+def test_an_unknown_capability_exits_before_any_request(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("delete")
+    assert "Unknown capability" in capsys.readouterr().out
+
+
+def test_an_empty_capability_list_exits(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("")
+    assert "at least one of" in capsys.readouterr().out
+
+
+# --- handle_email_share: granting ---------------------------------------
+
+
+def test_sharing_posts_the_parsed_capabilities():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "grantee_public_key": "0x" + "b" * 64,
+                          "can_send": True, "can_read": False,
+                      })) as post:
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+        )
+
+    payload = post.call_args.kwargs["json"]
+    assert payload == {
+        "address": "rental@mail.openonion.ai",
+        "grantee": "0x" + "b" * 64,
+        "can_send": True,
+        "can_read": False,
+    }
+
+
+def test_sharing_prints_the_unshare_command(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "can_send": True, "can_read": False,
+                      })):
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="alice@mail.openonion.ai", can="send",
+        )
+    out = capsys.readouterr().out
+    assert "co email unshare rental@mail.openonion.ai --with alice@mail.openonion.ai" in out
+
+
+def test_missing_arguments_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share("rental@mail.openonion.ai")
+    post.assert_not_called()
+
+
+def test_share_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(ok=False, status=403,
+                                         json_data={"detail": "not one of your email addresses."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    assert exc_info.value.exit_code == 1
+    assert "not one of your" in capsys.readouterr().out
+
+
+def test_no_auth_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value=None), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    post.assert_not_called()
+
+
+# --- handle_email_share: --list -----------------------------------------
+
+
+def test_list_shows_both_directions(capsys):
+    body = {
+        "granted_by_me": [{
+            "address": "rental@mail.openonion.ai",
+            "grantee_public_key": "0x" + "b" * 64,
+            "can_send": True, "can_read": False,
+        }],
+        "granted_to_me": [{
+            "address": "leads@mail.openonion.ai",
+            "owner_public_key": "0x" + "c" * 64,
+            "can_send": False, "can_read": True,
+        }],
+    }
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(json_data=body)) as get:
+        email_commands.handle_email_share(list_=True)
+
+    out = capsys.readouterr().out
+    assert "rental@mail.openonion.ai" in out
+    assert "leads@mail.openonion.ai" in out
+    assert get.call_args.args[0].endswith("/api/v1/email/share")
+
+
+def test_list_with_nothing_shared_either_way_is_not_an_error(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get",
+                      return_value=_resp(json_data={"granted_by_me": [], "granted_to_me": []})):
+        email_commands.handle_email_share(list_=True)  # must NOT raise
+    out = capsys.readouterr().out
+    assert "none" in out
+
+
+# --- handle_email_unshare -------------------------------------------------
+
+
+def test_unshare_deletes_the_grant():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(json_data={"success": True, "revoked": True})) as delete:
+        email_commands.handle_email_unshare(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+        )
+    url = delete.call_args.args[0]
+    assert url.endswith(f"/api/v1/email/share/rental@mail.openonion.ai/0x{'b' * 64}")
+
+
+def test_unshare_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(ok=False, status=404,
+                                         json_data={"detail": "No active grant."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_unshare(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+            )
+    assert exc_info.value.exit_code == 1
+    assert "No active grant" in capsys.readouterr().out

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -301,7 +301,8 @@ class TestServerForget:
 
 PRICING = {
     "term_months": 12,
-    "region": "asia-southeast1",
+    "regions": ["asia-southeast1", "australia-southeast1"],
+    "default_region": "asia-southeast1",
     "default": "e2-small",
     "machine_types": {"e2-small": {"usd_12mo": 180.0, "description": "2 vCPU, 2 GB"}},
 }
@@ -406,6 +407,52 @@ class TestServerNewSuccess:
             sc.handle_server_new("prod")
 
         assert post.call_args.kwargs["json"]["ssh_public_key"] == line
+
+
+class TestServerNewRegion:
+    """openonion/connectonion#713 — a region nobody could pick from the CLI."""
+
+    def test_the_chosen_region_is_sent(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod", region="australia-southeast1")
+
+        assert post.call_args.kwargs["json"]["region"] == "australia-southeast1"
+
+    def test_no_region_falls_back_to_the_backends_default(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod")
+
+        assert post.call_args.kwargs["json"]["region"] == PRICING["default_region"]
+
+    def test_an_unknown_region_is_rejected_before_charging(self, servers_file, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod", region="mars-central1") is False
+
+        post.assert_not_called()
+        assert "mars-central1" in capsys.readouterr().out
 
 
 class TestServerNewFailureReporting:
@@ -799,7 +846,8 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     instead of it."""
 
     PRICING = {
-        "term_months": 12, "region": "australia-southeast1", "default": "e2-small",
+        "term_months": 12, "regions": ["australia-southeast1"],
+        "default_region": "australia-southeast1", "default": "e2-small",
         "machine_types": {"e2-small": {"usd_month": 30.0, "usd_12mo": 360.0,
                                        "description": "2 vCPU (shared), 2 GB"}},
     }
@@ -807,7 +855,7 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     def _prompt(self, pricing):
         with patch("questionary.confirm") as confirm:
             confirm.return_value.ask.return_value = False
-            sc._confirm("prod", "e2-small", pricing, 500.0)
+            sc._confirm("prod", "e2-small", pricing["default_region"], pricing, 500.0)
 
     def test_both_the_month_and_the_year_are_shown(self, capsys):
         self._prompt(self.PRICING)
@@ -867,6 +915,8 @@ class TestARecreatedServerDoesNotLookLikeAnAttack:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \
@@ -920,6 +970,8 @@ class TestReadyMeansYouCanLogIn:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \

--- a/tests/unit/test_server_new_without_a_terminal.py
+++ b/tests/unit/test_server_new_without_a_terminal.py
@@ -16,7 +16,8 @@ from connectonion.cli.commands import server_commands as sc
 
 
 PRICING = {
-    "region": "australia-southeast1",
+    "regions": ["australia-southeast1"],
+    "default_region": "australia-southeast1",
     "term_months": 12,
     "machine_types": {
         "e2-small": {
@@ -31,7 +32,7 @@ PRICING = {
 def confirm_without_a_tty(capsys):
     with patch.object(sys.stdin, "isatty", return_value=False):
         with patch("questionary.confirm") as prompt:
-            answer = sc._confirm("my-box", "e2-small", PRICING, balance=1000.0)
+            answer = sc._confirm("my-box", "e2-small", "australia-southeast1", PRICING, balance=1000.0)
     return answer, prompt, capsys.readouterr().out
 
 


### PR DESCRIPTION
First slice of the revised #1125 scope (Aaron, 2026-08-19: 1.6.12 takes the
stable features; browser stays 1.8, Codex stays 1.7).

Clean cherry-picks from main, no conflicts, no 1.7+ ancestry:

- `f04ab649` — co server new --region (#713, main PR #1136)
- `d9effb98` — its design-journal post
- `b2bc9942` — co email share/unshare (#1137, main PR #1138)

Both backends are already deployed to production (oo-api#166 region,
oo-api#167 email grants incl. the resolve_email_owner multi-address fix), so
these CLI slices go live against a backend that already answers them.

## Testing on this exact lineage

- Targeted: `tests/unit/test_server_commands.py`, `test_server_new_without_a_terminal.py`, `tests/cli/test_email_share.py`, `test_email_addresses.py` — **105 passed**
- Full: `pytest tests/unit -q` — **5801 passed, 13 skipped, 0 failed**
- Editable install from this branch: `co server new --help` shows `--region`, `co email --help` shows `share`/`unshare` — wiring verified, not assumed