### PR TITLE
llm: explicit network bounds on every provider client (#1116)

### DIFF
--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -207,6 +207,41 @@ def _is_paid_account_required(error) -> bool:
     return isinstance(detail, dict) and detail.get('error') == 'paid_account_required'
 
 
+# Explicit network bounds for every provider client (#1116).
+#
+# A scheduled run froze mid-iteration with the upstream socket in CLOSE_WAIT:
+# the server had closed its side and the client sat in a read that nothing
+# bounded. No error, no exit, killed by hand after 15 minutes. The fix is not
+# cleverness, it is that no provider client is ever constructed on implicit
+# SDK defaults again — every one carries these numbers, visibly.
+#
+# READ is 600s because a long non-streaming generation legitimately sends no
+# bytes until it finishes; cutting that off would break exactly the runs that
+# matter (#1116: "confirm ordinary long model generations are not cut off").
+# CONNECT is 20s — generous for proxy/VPN users, far below "looks hung".
+#
+# The documented upper bound for a stalled upstream is therefore
+# (1 + max_retries) x 600s per request: ~30 minutes for the default 2 retries,
+# ~60 for OpenOnionLLM's deliberate 5 (transient relay blips used to kill
+# whole agent runs; that decision predates this and stands). Bounded and
+# typed — a stall now ends in LLMConnectionError, never a silent hang.
+LLM_CONNECT_TIMEOUT_SECONDS = 20.0
+LLM_READ_TIMEOUT_SECONDS = 600.0
+LLM_MAX_RETRIES = 2
+
+
+def _network_bounds(max_retries: int = LLM_MAX_RETRIES) -> dict:
+    """Constructor kwargs no provider client is allowed to omit."""
+    import openai
+
+    return {
+        "timeout": openai.Timeout(
+            LLM_READ_TIMEOUT_SECONDS, connect=LLM_CONNECT_TIMEOUT_SECONDS
+        ),
+        "max_retries": max_retries,
+    }
+
+
 @dataclass
 class LLMResponse:
     """Response from LLM including content and tool calls."""
@@ -294,7 +329,7 @@ class OpenAILLM(LLM):
         if not self.api_key:
             raise ValueError("OpenAI API key required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
         
-        self.client = openai.OpenAI(api_key=self.api_key)
+        self.client = openai.OpenAI(api_key=self.api_key, **_network_bounds())
         self.model = model
     
     def complete(self, messages: List[Dict[str, str]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -380,7 +415,7 @@ class AnthropicLLM(LLM):
         if not self.api_key:
             raise ValueError("Anthropic API key required. Set ANTHROPIC_API_KEY environment variable or pass api_key parameter.")
 
-        self.client = anthropic.Anthropic(api_key=self.api_key)
+        self.client = anthropic.Anthropic(api_key=self.api_key, **_network_bounds())
         self.model = model
         self.max_tokens = max_tokens  # Anthropic requires max_tokens (default 8192)
     
@@ -623,7 +658,8 @@ class GeminiLLM(LLM):
         # Use Gemini's OpenAI-compatible endpoint
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://generativelanguage.googleapis.com/v1beta/openai/"
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+            **_network_bounds(),
         )
         self.model = model
     
@@ -702,7 +738,8 @@ class GroqLLM(LLM):
         self.model = model.removeprefix("groq/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.groq.com/openai/v1"
+            base_url="https://api.groq.com/openai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -780,7 +817,8 @@ class GrokLLM(LLM):
         self.model = model.removeprefix("grok/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.x.ai/v1"
+            base_url="https://api.x.ai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -862,6 +900,7 @@ class OpenRouterLLM(LLM):
         client_kwargs = {
             "api_key": self.api_key,
             "base_url": "https://openrouter.ai/api/v1",
+            **_network_bounds(),
         }
         if default_headers:
             client_kwargs["default_headers"] = default_headers
@@ -942,7 +981,8 @@ class MistralLLM(LLM):
         self.model = model.removeprefix("mistral/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.mistral.ai/v1"
+            base_url="https://api.mistral.ai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -1078,8 +1118,7 @@ class OpenOnionLLM(LLM):
         self.client = openai.OpenAI(
             base_url=self.base_url,
             api_key=self.auth_token,
-            timeout=openai.Timeout(600.0, connect=20.0),
-            max_retries=5,
+            **_network_bounds(max_retries=5),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:

--- a/tests/unit/test_llm_network_bounds.py
+++ b/tests/unit/test_llm_network_bounds.py
@@ -1,0 +1,99 @@
+"""Every provider client carries explicit network bounds (#1116).
+
+A scheduled run froze mid-iteration with the upstream socket in CLOSE_WAIT —
+the server had closed its side and the client sat in a read nothing bounded.
+No error, no exit, killed by hand after 15 minutes.
+
+The property these tests protect is not a number, it is visibility: no
+provider client may be constructed on implicit SDK defaults. The connect
+value doubles as the tripwire — the openai SDK's implicit default is 5s, so
+an accidentally-unbounded client fails the assertion by value, not just by
+style. (Confirmed red on the pre-patch code for every provider except
+OpenOnionLLM, which had the bounds since the relay-blip fix.)
+"""
+
+import pytest
+
+from connectonion.core import llm as llm_module
+from connectonion.core.llm import (
+    LLM_CONNECT_TIMEOUT_SECONDS,
+    LLM_MAX_RETRIES,
+    LLM_READ_TIMEOUT_SECONDS,
+    LLMConnectionError,
+    _network_bounds,
+)
+
+DUMMY_KEY = "sk-test-not-a-real-key"
+
+
+def _provider_clients():
+    """(name, constructed client, expected retries) for every provider."""
+    return [
+        ("OpenAILLM", llm_module.OpenAILLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("AnthropicLLM", llm_module.AnthropicLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GeminiLLM", llm_module.GeminiLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GroqLLM", llm_module.GroqLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GrokLLM", llm_module.GrokLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("MistralLLM", llm_module.MistralLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("OpenRouterLLM", llm_module.OpenRouterLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        # Deliberately 5: transient relay blips used to kill whole agent runs.
+        ("OpenOnionLLM", llm_module.OpenOnionLLM(api_key=DUMMY_KEY).client, 5),
+    ]
+
+
+def test_every_provider_client_has_the_explicit_bounds():
+    """The whole point of #1116 in one loop.
+
+    One loop rather than parametrize so a new provider that forgets the
+    bounds fails here the moment someone adds it to the list — and the
+    list itself is checked against the module below, so it cannot silently
+    go stale either.
+    """
+    for name, client, expected_retries in _provider_clients():
+        timeout = client.timeout
+        assert timeout.connect == LLM_CONNECT_TIMEOUT_SECONDS, (
+            f"{name}: connect timeout is {timeout.connect!r} — the implicit "
+            f"SDK default, exactly what let the CLOSE_WAIT hang happen"
+        )
+        assert timeout.read == LLM_READ_TIMEOUT_SECONDS, name
+        assert client.max_retries == expected_retries, name
+
+
+def test_the_inventory_covers_every_provider_class():
+    """A provider class this file does not construct is an unchecked client."""
+    import inspect
+
+    covered = {name for name, _, _ in _provider_clients()}
+    all_providers = {
+        name
+        for name, obj in vars(llm_module).items()
+        if inspect.isclass(obj)
+        and issubclass(obj, llm_module.LLM)
+        and obj is not llm_module.LLM
+    }
+    assert covered == all_providers, (
+        f"providers without a bounds check: {sorted(all_providers - covered)}"
+    )
+
+
+def test_a_stalled_read_becomes_the_typed_connection_error():
+    """The user-facing half: a timeout ends in LLMConnectionError, not a hang
+    and not a raw SDK type the caller has to know per-provider."""
+    import openai
+
+    provider = llm_module.OpenAILLM(api_key=DUMMY_KEY)
+
+    def stalled_send():
+        raise openai.APITimeoutError(request=None)
+
+    with pytest.raises(LLMConnectionError):
+        provider._call_provider(stalled_send)
+
+
+def test_the_bounds_are_finite_and_positive():
+    """The documented upper bound — (1 + retries) x read — must be computable."""
+    bounds = _network_bounds()
+    assert 0 < LLM_CONNECT_TIMEOUT_SECONDS < LLM_READ_TIMEOUT_SECONDS
+    assert bounds["max_retries"] >= 0
+    worst_case = (1 + bounds["max_retries"]) * LLM_READ_TIMEOUT_SECONDS
+    assert worst_case <= 3600, "a stall must resolve within an hour, documented"


### PR DESCRIPTION
P0 of the #1125 tracker. Fixes #1116 — the CLOSE_WAIT hang: a scheduled run
froze mid-iteration because the upstream closed its socket and the client sat
in a read nothing bounded, for 15+ minutes until killed by hand.

## What changed

- `_network_bounds()` in `core/llm.py` — one place defining connect 20s /
  read 600s / retries 2, with the rationale and the documented worst case
  (`(1 + retries) × 600s`) in its comment block.
- Every provider constructor (`OpenAILLM`, `AnthropicLLM`, `GeminiLLM`,
  `GroqLLM`, `GrokLLM`, `MistralLLM`, `OpenRouterLLM`, `OpenOnionLLM`) now
  passes it. OpenOnionLLM keeps its deliberate 5 retries (relay-blip policy)
  but through the same helper, so the numbers cannot drift.
- Read stays 600s so long non-streaming generations are not cut off
  (#1116's explicit requirement). A stall now ends in the existing typed
  `LLMConnectionError` — the error-translation layer already existed; the
  missing piece was only the bound that lets it fire.

## Testing

- New `tests/unit/test_llm_network_bounds.py`:
  - inventory test constructs **every** `LLM` subclass and asserts the bounds
    **by value** — the SDK's implicit connect default is 5s, so an unbounded
    client fails on the number, not on style. A second test diffs the
    inventory against the module's classes so a future provider can't skip it.
  - **It caught a real gap during this patch**: OpenRouterLLM builds its
    kwargs dynamically and I'd missed it; the test failed with
    `connect timeout is 5.0` until fixed. That is the red-first proof, live.
  - stall → `LLMConnectionError` regression, and a finite-bound sanity check.
- Full suite on this lineage: **5802 passed, 13 skipped, 0 failed**.