### PR TITLE
backport to 1.6.12: Outlook attachment downloads — #815 + #923 + #924

### DIFF
--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -215,7 +215,7 @@ def handle_outlook_read(email_id: str, mark_read: bool = False):
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 
-def handle_outlook_download(email_id: str, out_dir: str = "."):
+def handle_outlook_download(email_id: str, out_dir: str = ".", include_inline: bool = False):
     """Save an email's attachments to disk. Accepts the listing # or a full message id."""
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
@@ -223,9 +223,10 @@ def handle_outlook_download(email_id: str, out_dir: str = "."):
         console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
         raise typer.Exit(1)
 
-    saved = outlook.download_attachments(resolved, out_dir)
+    saved = outlook.download_attachments(resolved, out_dir, include_inline=include_inline)
     if not saved:
-        console.print("\n[yellow]No file attachments on that email.[/yellow]\n")
+        console.print("\n[yellow]No file attachments on that email.[/yellow]")
+        console.print("[dim]Embedded signature images are skipped — --include-inline saves them too.[/dim]\n")
         return
 
     console.print()

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -215,6 +215,25 @@ def handle_outlook_read(email_id: str, mark_read: bool = False):
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 
+def handle_outlook_download(email_id: str, out_dir: str = "."):
+    """Save an email's attachments to disk. Accepts the listing # or a full message id."""
+    outlook = _outlook()
+    resolved = _resolve_email_id(outlook, email_id)
+    if not resolved:
+        console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook to refresh.[/yellow]\n")
+        raise typer.Exit(1)
+
+    saved = outlook.download_attachments(resolved, out_dir)
+    if not saved:
+        console.print("\n[yellow]No file attachments on that email.[/yellow]\n")
+        return
+
+    console.print()
+    for path in saved:
+        console.print(f"[green]✓[/green] {path}")
+    console.print()
+
+
 def handle_outlook_reply(email_id: str, message: str, at: str = None):
     """Reply to an email from the last listing (threaded via Graph). A message of '-' reads stdin."""
     if message == "-":

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1143,6 +1143,16 @@ def outlook_read(
     handle_outlook_read(email_id, mark_read=mark_read)
 
 
+@outlook_app.command("download")
+def outlook_download(
+    email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
+    out_dir: str = typer.Option(".", "--to", help="Directory to save attachments into"),
+):
+    """Save an email's attachments to disk."""
+    from .commands.outlook_commands import handle_outlook_download
+    handle_outlook_download(email_id, out_dir)
+
+
 @outlook_app.command("reply")
 def outlook_reply(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1147,10 +1147,14 @@ def outlook_read(
 def outlook_download(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     out_dir: str = typer.Option(".", "--to", help="Directory to save attachments into"),
+    include_inline: bool = typer.Option(
+        False, "--include-inline",
+        help="Also save embedded signature images and logos (skipped by default)",
+    ),
 ):
     """Save an email's attachments to disk."""
     from .commands.outlook_commands import handle_outlook_download
-    handle_outlook_download(email_id, out_dir)
+    handle_outlook_download(email_id, out_dir, include_inline=include_inline)
 
 
 @outlook_app.command("reply")

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -2,8 +2,8 @@
 Purpose: Outlook integration tool for email and contact management via Microsoft Graph API
 LLM-Note:
   Dependencies: imports from [os, html, httpx] | imported by [useful_tools/__init__.py] | requires OAuth tokens from 'co auth microsoft' | tested by [tests/unit/test_outlook.py]
-  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
-  State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails) and create contacts | token refresh rewrites ~/.co/keys.env | no other local file persistence
+  Data flow: Agent calls Outlook methods → _get_access_token() loads MICROSOFT_ACCESS_TOKEN from env (auto-refresh via oo-api) → HTTP calls to Graph API (https://graph.microsoft.com/v1.0) → returns email/contact data or confirmations | download_attachments() decodes Graph fileAttachment bytes into a caller-selected project directory without overwriting existing paths | send()/reply() with send_at attach deferred-send extended property (SystemTime 0x3FEF) so Exchange holds delivery | reply() escapes bodies (html.escape) and converts to HTML <p> paragraphs (blank-line splits, \n → <br>) since Graph renders the comment as HTML | get_scheduled() and contacts page through Graph collections
+  State/Effects: reads MICROSOFT_* env vars for OAuth tokens/scopes | makes HTTP calls to Microsoft Graph API | can modify mailbox state (mark read, archive, send emails), create contacts, and write downloaded attachments inside the project boundary | token refresh rewrites ~/.co/keys.env
   Integration: exposes Outlook class with email methods plus add_contact(), list_contacts(), search_contacts() | structured list methods feed cli/commands/outlook_commands.py | used as agent tool via Agent(tools=[Outlook()])
   Performance: network I/O per API call | batch fetching for list operations | email body fetched separately
   Errors: raises ValueError if OAuth not configured | HTTP errors from Graph API propagate | deferred drafts cannot be deleted via API (Exchange 403) — cancel via Outlook's own Cancel Send | returns error strings for display to user
@@ -483,7 +483,7 @@ class Outlook:
 
         return "\n".join(output)
 
-    def download_attachments(self, email_id: str, out_dir: str = ".") -> list:
+    def download_attachments(self, email_id: str, out_dir: str = ".") -> list[str]:
         """Save an email's file attachments to disk.
 
         Args:
@@ -513,9 +513,33 @@ class Outlook:
                 continue
             # The name is sender-controlled: keep the last path segment only, so
             # "../../.ssh/authorized_keys" cannot escape the chosen directory.
-            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/")) or "attachment"
+            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/"))
+            # Control characters can forge CLI output (including ANSI escapes).
+            name = "".join(
+                "_" if ord(character) < 32 or ord(character) == 127 else character
+                for character in name
+            )
+            if name in {"", ".", ".."}:
+                name = "attachment"
             path = destination / name
-            path.write_bytes(base64.b64decode(content))
+            data = base64.b64decode(content, validate=True)
+            flags = (
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_BINARY", 0)
+                | getattr(os, "O_NOFOLLOW", 0)
+            )
+            try:
+                descriptor_number = os.open(path, flags, 0o600)
+            except FileExistsError as exc:
+                raise FileExistsError(f"Refusing to overwrite existing attachment: {path}") from exc
+            try:
+                with os.fdopen(descriptor_number, "wb") as handle:
+                    handle.write(data)
+            except Exception:
+                path.unlink(missing_ok=True)
+                raise
             saved.append(str(path))
         return saved
 

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -521,7 +521,6 @@ class Outlook:
             )
             if name in {"", ".", ".."}:
                 name = "attachment"
-            path = destination / name
             data = base64.b64decode(content, validate=True)
             flags = (
                 os.O_WRONLY
@@ -530,17 +529,24 @@ class Outlook:
                 | getattr(os, "O_BINARY", 0)
                 | getattr(os, "O_NOFOLLOW", 0)
             )
-            try:
-                descriptor_number = os.open(path, flags, 0o600)
-            except FileExistsError as exc:
-                raise FileExistsError(f"Refusing to overwrite existing attachment: {path}") from exc
+            original = destination / name
+            stem = original.stem
+            suffix = original.suffix
+            attempt = 0
+            while True:
+                candidate = original if attempt == 0 else destination / f"{stem}-{attempt}{suffix}"
+                try:
+                    descriptor_number = os.open(candidate, flags, 0o600)
+                    break
+                except FileExistsError:
+                    attempt += 1
             try:
                 with os.fdopen(descriptor_number, "wb") as handle:
                     handle.write(data)
             except Exception:
-                path.unlink(missing_ok=True)
+                candidate.unlink(missing_ok=True)
                 raise
-            saved.append(str(path))
+            saved.append(str(candidate))
         return saved
 
     # === Sending ===

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -483,6 +483,42 @@ class Outlook:
 
         return "\n".join(output)
 
+    def download_attachments(self, email_id: str, out_dir: str = ".") -> list:
+        """Save an email's file attachments to disk.
+
+        Args:
+            email_id: Outlook message ID
+            out_dir: Directory to write the files into
+
+        Returns:
+            List of saved file paths
+        """
+        import base64
+
+        destination = Path(out_dir).expanduser().resolve()
+        if not self._allow_external_attachments:
+            try:
+                destination.relative_to(self._attachment_root)
+            except ValueError:
+                raise PermissionError(f"Download directory is outside the project: {out_dir}") from None
+        destination.mkdir(parents=True, exist_ok=True)
+
+        attachments = self._request("GET", f"/me/messages/{email_id}/attachments").get("value", [])
+
+        saved = []
+        for attachment in attachments:
+            content = attachment.get("contentBytes")
+            if not content:
+                # itemAttachment and referenceAttachment carry no bytes to write.
+                continue
+            # The name is sender-controlled: keep the last path segment only, so
+            # "../../.ssh/authorized_keys" cannot escape the chosen directory.
+            name = os.path.basename(str(attachment.get("name", "")).replace("\\", "/")) or "attachment"
+            path = destination / name
+            path.write_bytes(base64.b64decode(content))
+            saved.append(str(path))
+        return saved
+
     # === Sending ===
 
     def _file_attachment(self, file_path: str) -> dict:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -50,6 +50,7 @@ from pathlib import Path
 
 import httpx
 from ..backend import backend_url
+from ..project import project_root
 
 
 class Outlook:
@@ -57,7 +58,7 @@ class Outlook:
 
     GRAPH_API_URL = "https://graph.microsoft.com/v1.0"
 
-    def __init__(self):
+    def __init__(self, allow_external_attachments: bool = False):
         """Initialize Outlook tool.
 
         Validates that Microsoft OAuth is configured.
@@ -78,6 +79,8 @@ class Outlook:
             )
 
         self._access_token = None
+        self._attachment_root = project_root().resolve()
+        self._allow_external_attachments = allow_external_attachments
 
     def _require_scope(self, required_scope: str) -> None:
         """Raise a re-consent hint when an operation's OAuth scope is absent."""
@@ -483,12 +486,17 @@ class Outlook:
 
         return "\n".join(output)
 
-    def download_attachments(self, email_id: str, out_dir: str = ".") -> list[str]:
+    def download_attachments(self, email_id: str, out_dir: str = ".",
+                             include_inline: bool = False) -> list[str]:
         """Save an email's file attachments to disk.
 
         Args:
             email_id: Outlook message ID
             out_dir: Directory to write the files into
+            include_inline: Also save attachments Graph marks ``isInline`` —
+                embedded signature images and logos. Off by default: a mail
+                with one real PDF and a corporate signature otherwise saves
+                four decorative PNGs beside it (#924).
 
         Returns:
             List of saved file paths
@@ -510,6 +518,9 @@ class Outlook:
             content = attachment.get("contentBytes")
             if not content:
                 # itemAttachment and referenceAttachment carry no bytes to write.
+                continue
+            if attachment.get("isInline") and not include_inline:
+                # Embedded signature images and logos, not documents (#924).
                 continue
             # The name is sender-controlled: keep the last path segment only, so
             # "../../.ssh/authorized_keys" cannot escape the chosen directory.

--- a/docs/blog/2026-08-15-outlook-attachment-collisions.md
+++ b/docs/blog/2026-08-15-outlook-attachment-collisions.md
@@ -1,0 +1,7 @@
+# When “Download” Quietly Meant “Replace”
+
+The dangerous version of this bug looked ordinary. An agent downloaded an email, saved the first `cover.jpg`, then saved another attachment with the same sender-chosen name. The command reported both downloads, but the second write replaced the first. The same thing happened when a local file already had that name.
+
+The downloader already treated attachment names as untrusted input: it stripped directory components and kept writes inside the selected destination. The missing piece was treating an existing filename as occupied data rather than an invitation to overwrite it. The fix keeps the first `cover.jpg`, then selects `cover-1.jpg`, `cover-2.jpg`, and so on, preserving the extension and returning the paths that were actually written.
+
+The useful lesson is that safe path handling is more than preventing `../../` escapes. A path can stay inside the right directory and still destroy the wrong file. Regression tests now download duplicate names with different payloads and start with an existing local file; both original payloads remain readable, and the returned paths expose the disambiguation.

--- a/docs/superpowers/plans/2026-08-15-outlook-download-no-overwrite.md
+++ b/docs/superpowers/plans/2026-08-15-outlook-download-no-overwrite.md
@@ -1,0 +1,108 @@
+# Outlook Attachment Download Collision Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans (recommended inline) to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** Make Outlook attachment downloads preserve existing files and duplicate attachment payloads by choosing unique suffixed filenames.
+
+**Architecture:** Keep filename sanitisation in `Outlook.download_attachments()`, add a small local collision-selection loop before each write, and return the actual written paths. Extend the existing unit tests and add the required narrative blog entry.
+
+**Tech Stack:** Python 3.10+, pytest, pathlib, existing Outlook/Graph test fixtures.
+
+## Global Constraints
+
+- Modify only the Outlook downloader, its focused tests, the required design journal, and this implementation documentation.
+- Preserve existing path sanitisation and directory-boundary behavior.
+- Do not add dependencies or change the public method signature.
+- Follow conventional commits and disclose AI assistance in the PR.
+
+---
+
+### Task 1: Add regression coverage for filename collisions
+
+**Files:**
+- Modify: `tests/unit/test_outlook.py` near the existing `download_attachments()` tests
+
+**Interfaces:**
+- Consumes: existing Outlook fixtures and mocked Graph attachment responses.
+- Produces: tests that fail against the current overwrite behavior and specify exact returned paths and payload preservation.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test with two file attachments named `cover.jpg`, assert `download_attachments()` returns `cover.jpg` and `cover-1.jpg`, and assert both file contents remain distinct. Add a second test with a pre-existing `cover.jpg`, assert the original bytes remain and the download is written to `cover-1.jpg`.
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run: `python -m pytest tests/unit/test_outlook.py -k "duplicate or existing" -q`
+
+Expected: failures showing the second write overwrites `cover.jpg` and the returned path list contains duplicate/original paths instead of a suffixed path.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add tests/unit/test_outlook.py
+git commit -m "test: cover outlook attachment name collisions"
+```
+
+### Task 2: Implement unique attachment paths
+
+**Files:**
+- Modify: `connectonion/useful_tools/outlook.py:488-510`
+
+**Interfaces:**
+- Consumes: sanitised attachment names and the existing `Path` destination.
+- Produces: the same `list[str]` return type containing actual unique paths.
+
+- [ ] **Step 1: Write minimal collision handling**
+
+After sanitisation, choose the original path when unused. If it exists, split the name with `Path.stem` and `Path.suffix`, then increment an integer suffix until the candidate does not exist. Write bytes only to the selected candidate and append that candidate to `saved`.
+
+- [ ] **Step 2: Run the focused tests to verify they pass**
+
+Run: `python -m pytest tests/unit/test_outlook.py -k "duplicate or existing" -q`
+
+Expected: all selected collision tests pass.
+
+- [ ] **Step 3: Run the full Outlook unit test file**
+
+Run: `python -m pytest tests/unit/test_outlook.py -q`
+
+Expected: exit code 0 with no failures.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add connectonion/useful_tools/outlook.py
+git commit -m "fix: prevent outlook attachment overwrites"
+```
+
+### Task 3: Add the required design journal and verify the branch
+
+**Files:**
+- Create: `docs/blog/2026-08-15-outlook-attachment-collisions.md`
+
+**Interfaces:**
+- Consumes: Issue #923 behavior and test evidence.
+- Produces: a concise narrative explaining the data-loss scenario, the collision fix, and what was measured.
+
+- [ ] **Step 1: Write the blog entry**
+
+Describe a user downloading two attachments with the same sender-provided name, explain why the previous direct write was lossy, describe preserving the first path and suffixing later paths, and mention the regression tests.
+
+- [ ] **Step 2: Run focused and full non-real-API verification**
+
+Run: `python -m pytest tests/unit/test_outlook.py -q`
+
+Run: `python -m pytest -m "not real_api" -q`
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Inspect the final diff and commit the blog entry**
+
+Run: `git diff HEAD~3..HEAD --check; git diff HEAD~3..HEAD --stat; git status --short`
+
+Expected: only the planned files are changed, no whitespace errors, and the worktree is clean after commit.
+
+```bash
+git add docs/blog/2026-08-15-outlook-attachment-collisions.md
+git commit -m "docs: explain safe outlook attachment downloads"
+```

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -872,3 +872,57 @@ class TestOutlookContacts:
             outlook = Outlook()
             with pytest.raises(ValueError, match="Contacts.ReadWrite"):
                 outlook.list_contacts()
+
+
+class TestDownloadAttachments:
+    """Saving attachments to disk, including the sender-controlled filename."""
+
+    def _outlook(self, monkeypatch, tmp_path, attachments):
+        from connectonion.useful_tools import outlook as outlook_module
+
+        monkeypatch.setenv("MICROSOFT_SCOPES", "Mail.ReadWrite Mail.Send")
+        monkeypatch.setenv("MICROSOFT_ACCESS_TOKEN", "token")
+        monkeypatch.setenv("MICROSOFT_REFRESH_TOKEN", "refresh")
+        monkeypatch.setattr(outlook_module, "project_root", lambda: tmp_path)
+
+        instance = outlook_module.Outlook()
+        monkeypatch.setattr(instance, "_request", lambda *a, **k: {"value": attachments})
+        return instance
+
+    def test_saves_file_attachment_bytes(self, monkeypatch, tmp_path):
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": base64.b64encode(b"pixels").decode()},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"pixels"
+        assert saved == [str(tmp_path / "out" / "cover.jpg")]
+
+    def test_sender_cannot_escape_the_directory_with_a_relative_name(self, monkeypatch, tmp_path):
+        """A sender names the attachment '../../owned.txt'; it must stay put."""
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "../../owned.txt", "contentBytes": base64.b64encode(b"x").decode()},
+        ])
+
+        outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert (tmp_path / "out" / "owned.txt").exists()
+        assert not (tmp_path.parent / "owned.txt").exists()
+
+    def test_refuses_a_destination_outside_the_project(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [])
+
+        with pytest.raises(PermissionError):
+            outlook.download_attachments("msg-id", tmp_path.parent / "elsewhere")
+
+    def test_skips_attachments_without_bytes(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "linked.docx", "@odata.type": "#microsoft.graph.referenceAttachment"},
+        ])
+
+        assert outlook.download_attachments("msg-id", tmp_path / "out") == []

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -901,6 +901,24 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"pixels"
         assert saved == [str(tmp_path / "out" / "cover.jpg")]
 
+    def test_preserves_duplicate_attachment_names(self, monkeypatch, tmp_path):
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": encoded(b"first")},
+            {"name": "cover.jpg", "contentBytes": encoded(b"second")},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [
+            str(tmp_path / "out" / "cover.jpg"),
+            str(tmp_path / "out" / "cover-1.jpg"),
+        ]
+        assert (tmp_path / "out" / "cover.jpg").read_bytes() == b"first"
+        assert (tmp_path / "out" / "cover-1.jpg").read_bytes() == b"second"
+
     def test_sender_cannot_escape_the_directory_with_a_relative_name(self, monkeypatch, tmp_path):
         """A sender names the attachment '../../owned.txt'; it must stay put."""
         import base64
@@ -914,7 +932,7 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "owned.txt").exists()
         assert not (tmp_path.parent / "owned.txt").exists()
 
-    def test_refuses_to_overwrite_an_existing_file(self, monkeypatch, tmp_path):
+    def test_preserves_an_existing_file(self, monkeypatch, tmp_path):
         import base64
 
         out_dir = tmp_path / "out"
@@ -925,10 +943,11 @@ class TestDownloadAttachments:
             {"name": "pyproject.toml", "contentBytes": base64.b64encode(b"replace me").decode()},
         ])
 
-        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
-            outlook.download_attachments("msg-id", out_dir)
+        saved = outlook.download_attachments("msg-id", out_dir)
 
         assert existing.read_bytes() == b"keep me"
+        assert saved == [str(out_dir / "pyproject-1.toml")]
+        assert (out_dir / "pyproject-1.toml").read_bytes() == b"replace me"
 
     def test_refuses_to_follow_an_existing_symlink(self, monkeypatch, tmp_path):
         import base64

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -914,6 +914,61 @@ class TestDownloadAttachments:
         assert (tmp_path / "out" / "owned.txt").exists()
         assert not (tmp_path.parent / "owned.txt").exists()
 
+    def test_refuses_to_overwrite_an_existing_file(self, monkeypatch, tmp_path):
+        import base64
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        existing = out_dir / "pyproject.toml"
+        existing.write_bytes(b"keep me")
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "pyproject.toml", "contentBytes": base64.b64encode(b"replace me").decode()},
+        ])
+
+        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+            outlook.download_attachments("msg-id", out_dir)
+
+        assert existing.read_bytes() == b"keep me"
+
+    def test_refuses_to_follow_an_existing_symlink(self, monkeypatch, tmp_path):
+        import base64
+
+        outside = tmp_path / "outside.txt"
+        outside.write_bytes(b"keep me")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        (out_dir / "cover.jpg").symlink_to(outside)
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover.jpg", "contentBytes": base64.b64encode(b"replace me").decode()},
+        ])
+
+        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+            outlook.download_attachments("msg-id", out_dir)
+
+        assert outside.read_bytes() == b"keep me"
+
+    def test_replaces_control_characters_in_sender_filename(self, monkeypatch, tmp_path):
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "cover\n\x1b[31m.jpg", "contentBytes": base64.b64encode(b"pixels").decode()},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [str(tmp_path / "out" / "cover__[31m.jpg")]
+        assert (tmp_path / "out" / "cover__[31m.jpg").read_bytes() == b"pixels"
+
+    def test_rejects_malformed_base64_without_creating_a_file(self, monkeypatch, tmp_path):
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "broken.pdf", "contentBytes": "not base64!"},
+        ])
+
+        with pytest.raises(ValueError):
+            outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert not (tmp_path / "out" / "broken.pdf").exists()
+
     def test_refuses_a_destination_outside_the_project(self, monkeypatch, tmp_path):
         outlook = self._outlook(monkeypatch, tmp_path, [])
 

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -961,10 +961,11 @@ class TestDownloadAttachments:
             {"name": "cover.jpg", "contentBytes": base64.b64encode(b"replace me").decode()},
         ])
 
-        with pytest.raises(FileExistsError, match="Refusing to overwrite"):
-            outlook.download_attachments("msg-id", out_dir)
+        saved = outlook.download_attachments("msg-id", out_dir)
 
         assert outside.read_bytes() == b"keep me"
+        assert saved == [str(out_dir / "cover-1.jpg")]
+        assert (out_dir / "cover-1.jpg").read_bytes() == b"replace me"
 
     def test_replaces_control_characters_in_sender_filename(self, monkeypatch, tmp_path):
         import base64

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1001,3 +1001,49 @@ class TestDownloadAttachments:
         ])
 
         assert outlook.download_attachments("msg-id", tmp_path / "out") == []
+
+    def test_inline_signature_images_are_skipped_by_default(self, monkeypatch, tmp_path):
+        """One real PDF and a corporate signature must save one file, not five (#924)."""
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "invoice.pdf", "contentBytes": encoded(b"pdf")},
+            {"name": "logo.png", "contentBytes": encoded(b"png"), "isInline": True},
+            {"name": "banner.png", "contentBytes": encoded(b"png"), "isInline": True},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [str(tmp_path / "out" / "invoice.pdf")]
+        assert not (tmp_path / "out" / "logo.png").exists()
+
+    def test_include_inline_saves_the_embedded_images_too(self, monkeypatch, tmp_path):
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "invoice.pdf", "contentBytes": encoded(b"pdf")},
+            {"name": "logo.png", "contentBytes": encoded(b"png"), "isInline": True},
+        ])
+
+        saved = outlook.download_attachments(
+            "msg-id", tmp_path / "out", include_inline=True
+        )
+
+        assert saved == [
+            str(tmp_path / "out" / "invoice.pdf"),
+            str(tmp_path / "out" / "logo.png"),
+        ]
+
+    def test_an_inline_only_mail_reports_no_attachments(self, monkeypatch, tmp_path):
+        """The signature-only mail is the everyday case the default protects."""
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "logo.png",
+             "contentBytes": base64.b64encode(b"png").decode(),
+             "isInline": True},
+        ])
+
+        assert outlook.download_attachments("msg-id", tmp_path / "out") == []


### PR DESCRIPTION
Second slice of the #1125 merge order.

## What's in it

- **#815** (`co outlook download <email> [--to DIR]`): cherry-picks `5737f223` + `5adf7f96` — the exact four-file tool/CLI/test slice the tracker names, no 1.7 ancestry.
- **#923** (never overwrite): cherry-picks `3498e02e` + `a95464bd` from the open main PR #1075 — collisions get `-1`/`-2` suffixes, existing files and duplicate names in one message are preserved, symlink targets untouched. **Note: #1075 is still open on main** — main should land it too, or pick these back when stable merges forward.
- **#924** (new work): attachments Graph marks `isInline` — signature logos, banners — are skipped by default; `--include-inline` saves them. The empty-result CLI message names the flag so a signature-only mail explains itself.
- Plus the `__init__` wiring (`project_root` attachment boundary, `allow_external_attachments`) the cherry-picked code references but which lived in a separate main commit — the picks alone left 9 tests failing on this lineage until it was ported.

## Testing on this lineage

- `tests/unit/test_outlook.py` — **44 passed** (3 new #924 tests confirmed red against the pre-patch source first)
- CLI wiring driven via typer's CliRunner: `co outlook download --help` shows `--to` and `--include-inline`
- Full suite: **5818 passed, 13 skipped, 0 failed**

The tracker's remaining Outlook checklist rows (Windows-safe paths, mocked Graph journey, control characters, malformed base64, traversal) are covered by the cherry-picked tests themselves — they came across with the fix commits.