### PR TITLE
templates: the AI implementation contract (#1123)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,3 +40,36 @@ from connectonion import Agent
 
 **Additional context**
 Add any other context about the problem here.
+## AI implementation contract
+
+<!-- The bug-sized subset. Full guidance, repository defaults, and
+     guardrails: docs/ai-implementation-contract.md -->
+
+### Scope and release line
+- Target: [ ] stable patch [ ] preview [ ] main-only
+- Exact base/tag:
+- Owning repositories:
+- Explicitly out of scope:
+- Release action authorized by this issue:
+  [ ] test only
+  [ ] prepare Draft release PR
+  [ ] publish approved Preview
+  [ ] publish stable
+  [ ] no publication
+
+### Plan before code
+- Reproduce first: a regression test must fail on the unpatched code before
+  the fix has any claim to work.
+- Inspect the current implementation, tests, and related PRs/issues before editing.
+- Do not merge a preview `main` wholesale into a stable branch.
+
+### Required verification
+- Focused red/green regression test:
+- Full suite on the exact candidate commit:
+- Real journey exercising the fixed path (browser/CLI as applicable):
+- Commands and exact output to record:
+
+### Evidence
+- [ ] The regression test's red run (pre-patch) is recorded in the PR.
+- [ ] Before/After behavior is shown, not asserted.
+- [ ] If user-visible: screenshots attached directly to the PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -33,3 +33,69 @@ Add any other context, screenshots, or examples about the feature request here.
 - [ ] Yes, I can submit a PR
 - [ ] Yes, but I would need guidance
 - [ ] No, but I can help test it
+## AI implementation contract
+
+<!-- Fill this in so an AI session can execute without the owner repeating
+     the operating contract every round. Full guidance, repository defaults,
+     and guardrails: docs/ai-implementation-contract.md -->
+
+### Scope and release line
+- Target: [ ] stable patch [ ] preview [ ] main-only [ ] docs/process only
+- Exact base/tag:
+- Owning repositories:
+- Related issues/design decisions:
+- Explicitly out of scope:
+- Release action authorized by this issue:
+  [ ] test only
+  [ ] prepare Draft release PR
+  [ ] publish approved Preview
+  [ ] publish stable
+  [ ] no publication
+
+### Plan before code
+- Inspect the current implementation, tests, AGENTS/CLAUDE guidance, protocol docs,
+  related PRs/issues, and released package behavior.
+- Write the implementation/compatibility/test plan before editing.
+- Identify security authority, migration, rollback, and old/new version boundaries.
+- Do not merge a preview `main` wholesale into a stable branch.
+
+### Required verification
+- Unit/component/contract tests:
+- Cross-repository fixtures:
+- Real browser journey:
+- Required desktop/mobile widths:
+- Required failure/reconnect/approval states:
+- Complex acceptance task:
+- Commands and exact output to record:
+
+### UI and interaction review
+- [ ] Capture the current baseline before implementation.
+- [ ] Hide raw code/terminal detail behind progressive disclosure by default.
+- [ ] Run an expert UI/interaction audit after each UI implementation round.
+- [ ] Record the ten highest-impact findings and the disposition of each.
+- [ ] Re-run the journey after fixes until no release-blocking finding remains.
+
+### Screenshot evidence
+- [ ] Attach Before / After screenshots directly to the PR.
+- [ ] Attach desktop and narrow/mobile screenshots.
+- [ ] Include approval, error/reconnect, running, and completed states when applicable.
+- [ ] Link the complete browser artifact/trace.
+- [ ] Select permanent release screenshots; do not rely only on expiring CI artifacts.
+
+### Documentation and code knowledge
+- [ ] Update user documentation and exact release/version guidance.
+- [ ] Update protocol/design decisions and compatibility matrix when a boundary changes.
+- [ ] Add concise "why" comments around non-obvious invariants.
+- [ ] Boundary files link to their Core writer, React normalizer, O Chat renderer,
+      contract fixture, and design decision.
+- [ ] Do not add boilerplate headers to unrelated files.
+
+### Release and forward integration
+- [ ] Test the reviewed package/artifact, not only a source checkout.
+- [ ] Publish only through the protected GitHub Preview/Release workflow explicitly
+      authorized above.
+- [ ] Re-test the public artifact and deployed Preview.
+- [ ] After a stable 1.6.x release is verified, forward-merge that stable line into
+      `main`; preserve newer OIP authority and resolve conflicts explicitly.
+- [ ] Link rollback instructions, immutable versions/hashes, PRs, screenshots, and
+      public release.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -71,6 +71,9 @@ from connectonion import Agent
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
+- [ ] Every piece of evidence the linked issue's **AI implementation contract**
+      requires is attached or linked here (tests, journeys, screenshots,
+      exact commands) — see docs/ai-implementation-contract.md
 
 ## Screenshots (if applicable)
 Add screenshots to help explain your changes.

--- a/docs/ai-implementation-contract.md
+++ b/docs/ai-implementation-contract.md
@@ -1,0 +1,92 @@
+# The AI Implementation Contract
+
+An issue that describes only the code change makes an AI session guess the
+operating contract: which release line owns the work, whether a real browser
+journey is required, what evidence must be attached, whether publication is
+authorized. Guessed contracts fail in the same places every time — backend
+unit tests pass while invitation onboarding, Host ↔ React ↔ O Chat
+integration, mobile UI, approvals, reconnect, release artifacts, or
+documentation were never exercised.
+
+The fix is a scoped, configurable section embedded in each feature/bug
+issue. It is not a prompt asking an AI to "finish everything"; it is the
+contract the session executes against. The canonical section lives in
+`.github/ISSUE_TEMPLATE/feature_request.md` (the bug template carries the
+smaller relevant subset). Repository-specific templates may add detail but
+must retain the same vocabulary. Tracked in #1123.
+
+## Repository-specific defaults
+
+### ConnectOnion Core
+
+- Start stable work from the exact stable tag; never back-merge preview `main`.
+- Test protocol writers, permission authority, migration, packaging,
+  Windows/Linux, and installed artifacts.
+- If a change can alter browser-visible behavior, Core unit tests are
+  insufficient: require the React/O Chat consumer journey.
+- After verified stable publication, forward-merge the stable line into `main`.
+
+### `@connectonion/react`
+
+- Own typed OIP normalization, compatibility, acknowledgement, reconnect,
+  and browser authority.
+- Pack the exact candidate tarball and install it as a consumer would.
+- Run the O Chat journey against that tarball before publication.
+- No browser storage or optimistic UI state can increase Host authority.
+
+### O Chat
+
+- Begin at invite-code onboarding and continue through a real connected prompt.
+- Exercise Default/Safe/Full access, approvals, reconnect/error, Work Room,
+  Stop, resume, and Control Center when relevant.
+- Run desktop and phone layouts with no overflow or hidden essential controls.
+- Attach changed-surface screenshots directly to the PR in addition to CI
+  artifacts.
+
+## Default complex acceptance task
+
+For native Codex/Claude Code Work Room changes, use a task long enough to
+exercise multiple states:
+
+1. inspect a clean workspace;
+2. design a C sorting algorithm;
+3. write `sort.c` and a non-trivial `test_sort.c`;
+4. compile with strict warnings;
+5. run normal, duplicate, sorted, reverse, empty, and large inputs;
+6. trigger at least one genuine approval when the selected profile requires it;
+7. fix a discovered issue;
+8. rerun compilation/tests;
+9. finish with a concise result.
+
+The purpose is UI/state coverage — not artificial step inflation. The
+evidence should include several meaningful provider activities, approval,
+terminal success/failure, files, reconnect/Stop where in scope, and the
+final result.
+
+## Upstream UI learning
+
+For coding-agent UI work, perform a fresh audit of the current public Codex
+UI and other explicitly named references at implementation time. Extract
+transferable interaction principles — progressive disclosure, semantic
+summaries, approval placement, status hierarchy — not private assets,
+branding, or provider protocol.
+
+Happy Coder may inform the native-provider → normalized-event → frontend
+translation pattern. OIP remains our protocol and authority boundary.
+
+## Guardrails
+
+- A template checkbox does not authorize a release, deployment, destructive
+  action, or repository-setting change; the issue must select the exact
+  allowed release action.
+- "Fix all issues" means all issues in the named acceptance scope, not
+  unrelated repository backlog.
+- Do not claim an expert audit occurred without recording findings and
+  evidence.
+- Do not hide failures by replacing real integrations with mocks; mocks
+  support deterministic coverage, and a named real journey supplies
+  acceptance.
+- Do not put raw prompts, secrets, credentials, private local paths, or
+  reasoning traces in screenshots or protocol fixtures.
+- Comments and file headers explain non-obvious boundaries; they must not
+  restate the code or become stale duplicate documentation.


### PR DESCRIPTION
Third slice of the #1125 merge order. Implements #1123's Core-repository
deliverables:

- `feature_request.md` — the canonical configurable contract section,
  verbatim vocabulary from the issue (scope/release-line + release-action
  authorization, plan-before-code, required verification, UI audit loop,
  screenshot evidence, docs, release & forward integration).
- `bug_report.md` — the smaller bug-sized subset; its first plan item is
  red-before-green (a regression test must fail on unpatched code first).
- `pull_request_template.md` — checklist row requiring the linked issue's
  contract evidence to be attached (the "PR-body check" deliverable).
- `docs/ai-implementation-contract.md` — repository defaults
  (Core / @connectonion/react / O Chat), the default complex acceptance
  task (the C-sorting journey), upstream-UI-learning note, and guardrails.

Out of scope here, per the issue's own delivery list: the O Chat and
connectonion-react variants live in their own repositories
(openonion/oo-chat#191, openonion/connectonion-react#80), and the
worked-example migration of a real cross-repo issue is a follow-up.

Docs/templates only — no code, no tests to run. Markdown proofread; the
templates keep their existing front-matter untouched.