### PR TITLE
release process: permanent visual evidence per release (#1124)

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -117,9 +117,10 @@ When releasing a new version:
 - [ ] Update `VERSION` in the docs site's `lib/version.ts`
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
 - [ ] Record the release's visual evidence: `python scripts/check_release_visuals.py vX.Y.Z`
-      must pass — a reviewed image set under `docs/releases/assets/vX.Y.Z/` for
-      user-visible changes, or an explicit `no_visual_change` reason for a
-      backend-only patch (see docs/releases/README.md, #1124)
+      must pass — a reviewed image set under docs/releases/assets/vX.Y.Z/ (a
+      per-release directory; the contract lives in `docs/releases/README.md`)
+      for user-visible changes, or an explicit `no_visual_change` reason for a
+      backend-only patch (#1124)
 - [ ] Commit changes: `git commit -m "Release vX.Y.Z: Description"`
 - [ ] Create git tag: `git tag vX.Y.Z`
 - [ ] Push commits: `git push`

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -116,6 +116,10 @@ When releasing a new version:
 - [ ] Update `## Current Version:` and add the release line in this file
 - [ ] Update `VERSION` in the docs site's `lib/version.ts`
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
+- [ ] Record the release's visual evidence: `python scripts/check_release_visuals.py vX.Y.Z`
+      must pass — a reviewed image set under `docs/releases/assets/vX.Y.Z/` for
+      user-visible changes, or an explicit `no_visual_change` reason for a
+      backend-only patch (see docs/releases/README.md, #1124)
 - [ ] Commit changes: `git commit -m "Release vX.Y.Z: Description"`
 - [ ] Create git tag: `git tag vX.Y.Z`
 - [ ] Push commits: `git push`

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,72 @@
+# Release Visual Evidence
+
+Screenshots proving a release's user-visible changes are part of the release,
+not an expiring CI artifact (#1124). A user opening a GitHub Release or a
+Design Journal entry must be able to see what visibly changed without
+starting O Chat or downloading an Actions artifact that died two weeks ago.
+
+## The manifest
+
+Every release **with user-visible changes** commits a reviewed set under:
+
+```text
+docs/releases/assets/vX.Y.Z/
+  manifest.yml
+  control-center-desktop.webp
+  work-room-approval-mobile.webp
+  cli-template-to-deploy.webp
+```
+
+A backend-only patch commits a manifest with an explicit exemption instead —
+absence of the directory is a failed release check, never a shrug.
+
+### manifest.yml shape
+
+```yaml
+version: v1.6.12
+# EITHER an explicit reviewed exemption:
+no_visual_change: "backend-only patch: LLM network bounds and Outlook CLI fixes"
+# OR the image set:
+images:
+  - file: control-center-desktop.webp
+    alt: "Control Center showing three permission profiles"
+    caption: "The Control Center now names the active permission profile."
+    scenario: "operator opens dashboard after co deploy --to prod"
+    viewport: "1440x900, light"
+    commit: 25fefdf8
+    source_run: "https://github.com/openonion/oo-chat/actions/runs/<id>"
+```
+
+Required per image: `file`, `alt`, `caption`, `scenario`, `viewport`,
+`commit`, `source_run`. The file must exist beside the manifest, be
+non-empty, and stay under 2 MB — optimize without making text unreadable.
+
+### What the set contains
+
+1. **Hero** — the main outcome.
+2. **Narrow/mobile** (375–390 px) where applicable.
+3. **Critical interaction** — approval, reconnect, running state — when one changed.
+4. **Before / After** — required when an existing surface changes materially.
+5. **CLI/terminal capture** — only when the release's primary change is a CLI workflow.
+
+Never publish raw prompts, credentials, invite codes, private local paths,
+reasoning traces, or customer data. The reviewer of the release PR reviews
+the captions and the images, not just the code.
+
+## Validation
+
+```bash
+python scripts/check_release_visuals.py vX.Y.Z
+```
+
+Run it before tagging (it is part of the release checklist in
+VERSIONING.md). It fails when the directory is missing, when a listed file
+is absent/empty/oversized, when required metadata is missing, and when a
+manifest claims both `no_visual_change` and `images`.
+
+## Immutability
+
+A published version's evidence is append-only: retrying a release run may
+repair a missing asset, but replacing reviewed images with unrelated output
+is a review failure, the same as force-pushing a tag. CI artifacts remain
+the full QA record; this directory is the small, reviewed, permanent subset.

--- a/scripts/check_release_visuals.py
+++ b/scripts/check_release_visuals.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate a release's visual-evidence manifest (#1124).
+
+Usage: python scripts/check_release_visuals.py vX.Y.Z
+
+Exit 0 when docs/releases/assets/vX.Y.Z/manifest.yml is a valid reviewed
+set (or a valid explicit exemption); exit 1 with the reason named otherwise.
+Absence is a failure on purpose: "we forgot" and "nothing visible changed"
+must not look the same — the second one is spelled no_visual_change with a
+reviewed reason.
+
+Run by the release checklist (VERSIONING.md), not by CI on every push:
+whether a release has user-visible changes is a human judgement this script
+checks the *recording* of, not one it can make itself.
+"""
+
+import sys
+from pathlib import Path
+
+MAX_IMAGE_BYTES = 2_000_000
+REQUIRED_IMAGE_FIELDS = ("file", "alt", "caption", "scenario", "viewport",
+                         "commit", "source_run")
+
+
+def fail(reason: str) -> "None":
+    print(f"FAIL: {reason}")
+    sys.exit(1)
+
+
+def check(version: str, root: Path = None) -> None:
+    import yaml
+
+    root = root or Path(__file__).resolve().parent.parent
+    asset_dir = root / "docs" / "releases" / "assets" / version
+    manifest_path = asset_dir / "manifest.yml"
+
+    if not manifest_path.exists():
+        fail(f"{manifest_path} does not exist. Every release records its "
+             f"visual evidence — a backend-only patch records "
+             f"no_visual_change with a reviewed reason instead.")
+
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+
+    if manifest.get("version") != version:
+        fail(f"manifest says version {manifest.get('version')!r}, "
+             f"checking {version!r}")
+
+    exemption = manifest.get("no_visual_change")
+    images = manifest.get("images")
+
+    if exemption and images:
+        fail("manifest claims BOTH no_visual_change and images — pick one")
+    if not exemption and not images:
+        fail("manifest has neither images nor a no_visual_change reason")
+
+    if exemption:
+        if not isinstance(exemption, str) or len(exemption.strip()) < 10:
+            fail("no_visual_change must be a real reviewed reason, not a nod")
+        print(f"OK: {version} exempt — {exemption.strip()}")
+        return
+
+    for entry in images:
+        missing = [f for f in REQUIRED_IMAGE_FIELDS if not entry.get(f)]
+        if missing:
+            fail(f"image entry {entry.get('file', '<unnamed>')!r} missing: "
+                 f"{', '.join(missing)}")
+        image = asset_dir / entry["file"]
+        if not image.exists():
+            fail(f"{image} is listed but does not exist")
+        size = image.stat().st_size
+        if size == 0:
+            fail(f"{image} is empty")
+        if size > MAX_IMAGE_BYTES:
+            fail(f"{image} is {size} bytes; optimize below {MAX_IMAGE_BYTES}")
+
+    print(f"OK: {version} — {len(images)} reviewed image(s)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or not sys.argv[1].startswith("v"):
+        print(__doc__)
+        sys.exit(2)
+    check(sys.argv[1])

--- a/tests/unit/test_release_visuals.py
+++ b/tests/unit/test_release_visuals.py
@@ -1,0 +1,97 @@
+"""The release-visual manifest check (#1124): a UI release cannot skip
+evidence, and a backend-only patch can use the explicit exemption — the
+dry-run pair the issue's workflow requirements name.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from check_release_visuals import check  # noqa: E402
+
+
+def _write_manifest(root: Path, version: str, text: str) -> Path:
+    asset_dir = root / "docs" / "releases" / "assets" / version
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "manifest.yml").write_text(text)
+    return asset_dir
+
+
+def test_a_missing_manifest_fails_instead_of_shrugging(tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "does not exist" in capsys.readouterr().out
+
+
+def test_a_backend_only_patch_uses_the_explicit_exemption(tmp_path):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\n'
+                    'no_visual_change: "backend-only patch: network bounds"\n')
+    check("v9.9.9", root=tmp_path)  # must not raise
+
+
+def test_a_nod_is_not_a_reviewed_exemption(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\nno_visual_change: "n/a"\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "reviewed reason" in capsys.readouterr().out
+
+
+def test_claiming_both_exemption_and_images_fails(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\n'
+                    'no_visual_change: "backend-only patch: nothing visible"\n'
+                    'images:\n  - file: x.webp\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "pick one" in capsys.readouterr().out
+
+
+def test_a_ui_release_needs_every_field_and_a_real_file(tmp_path, capsys):
+    asset_dir = _write_manifest(tmp_path, "v9.9.9",
+                                'version: v9.9.9\n'
+                                'images:\n'
+                                '  - file: hero.webp\n'
+                                '    alt: "the hero"\n'
+                                '    caption: "what changed"\n'
+                                '    scenario: "operator opens dashboard"\n'
+                                '    viewport: "1440x900, light"\n'
+                                '    commit: abc123\n'
+                                '    source_run: "https://example.com/run/1"\n')
+    # listed but absent
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "does not exist" in capsys.readouterr().out
+
+    # empty file is as bad as no file
+    (asset_dir / "hero.webp").write_bytes(b"")
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "empty" in capsys.readouterr().out
+
+    # a real file passes
+    (asset_dir / "hero.webp").write_bytes(b"RIFF....WEBP")
+    check("v9.9.9", root=tmp_path)
+
+
+def test_missing_metadata_names_the_fields(tmp_path, capsys):
+    asset_dir = _write_manifest(tmp_path, "v9.9.9",
+                                'version: v9.9.9\n'
+                                'images:\n  - file: hero.webp\n')
+    (asset_dir / "hero.webp").write_bytes(b"RIFF")
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    out = capsys.readouterr().out
+    for field in ("alt", "caption", "scenario", "viewport", "commit", "source_run"):
+        assert field in out
+
+
+def test_the_version_in_the_manifest_must_match(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v1.0.0\nno_visual_change: "backend-only patch"\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "v1.0.0" in capsys.readouterr().out


### PR DESCRIPTION
Fifth slice of the #1125 merge order — the lean, stable-branch-appropriate
version of #1124.

## What's in it

- **`docs/releases/README.md`** — the contract: every release commits either
  a reviewed image set under `docs/releases/assets/vX.Y.Z/` (with
  alt/caption/scenario/viewport/commit/source_run per image, ≤2 MB each) or
  an explicit reviewed `no_visual_change` reason. Absence fails — "we
  forgot" and "nothing visible changed" must not be indistinguishable.
- **`scripts/check_release_visuals.py`** — the validator, added to
  VERSIONING.md's release checklist before the tag step.
- **`tests/unit/test_release_visuals.py`** — 7 tests, including the two
  dry-runs the issue's workflow requirements name explicitly: a backend-only
  patch passes via the exemption; a UI release cannot skip evidence (missing
  manifest, missing file, empty file, missing metadata, both-claims, and
  version-mismatch all fail with the reason named).

## Deliberately out of scope on this branch

- `.github/workflows/` changes (release-body fragment generation from the
  manifest): the workflow-scope wall applies to pushes touching workflows,
  and per the check's own docstring, whether a release has user-visible
  changes is a human judgement made at release time — the validator runs
  from the checklist the releaser walks, not on every push. Automating the
  release-body fragment can follow on main.
- The O Chat / react manifests: owned by their repositories per the issue's
  cross-repository flow.

`pytest tests/unit/test_release_visuals.py` — 7 passed.