### PR TITLE
[1.7] Define the canonical permission mode contract

### DIFF
--- a/connectonion/core/mode.py
+++ b/connectonion/core/mode.py
@@ -1,0 +1,123 @@
+"""Canonical permission-mode state for ConnectOnion 1.7.
+
+Purpose: define the public mode vocabulary and keep every state transition in
+one place. Host/OIP, provider adapters, plugins, React, and O Chat use these
+same three IDs; provider-private permission values are translated only at the
+provider boundary.
+
+There is deliberately no legacy alias reader. Unknown stored values degrade
+to ``auto`` and a malformed Full access grant never skips approval.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Mapping
+
+Mode = Literal["read-only", "auto", "full-access"]
+
+READ_ONLY: Mode = "read-only"
+AUTO: Mode = "auto"
+FULL_ACCESS: Mode = "full-access"
+MODES: tuple[Mode, ...] = (READ_ONLY, AUTO, FULL_ACCESS)
+DEFAULT_MODE: Mode = AUTO
+
+
+def mode_id(value: Any) -> Mode:
+    """Return one exact public mode ID or reject it."""
+
+    if value in MODES and isinstance(value, str):
+        return value  # type: ignore[return-value]
+    raise ValueError(f"Unsupported mode: {value!r}")
+
+
+def full_access_turns_left(session: Mapping[str, Any]) -> int:
+    """Return a valid remaining Full access budget, otherwise zero."""
+
+    value = session.get("turns_left")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return 0
+    return value
+
+
+def mode_of(session: Mapping[str, Any]) -> Mode:
+    """Read canonical state, degrading unknown or incomplete state to Auto."""
+
+    try:
+        mode = mode_id(session.get("mode", DEFAULT_MODE))
+    except ValueError:
+        return DEFAULT_MODE
+    if mode == FULL_ACCESS and full_access_turns_left(session) == 0:
+        return DEFAULT_MODE
+    return mode
+
+
+def set_mode(
+    session: dict[str, Any],
+    mode: Mode | str,
+    *,
+    turns_left: int | None = None,
+) -> Mode:
+    """Write one canonical state.
+
+    This is the only function allowed to assign ``mode`` or ``turns_left``.
+    Full access requires a positive bounded budget; the other modes reject a
+    budget and remove any stale countdown.
+    """
+
+    canonical = mode_id(mode)
+    if canonical == FULL_ACCESS:
+        if (
+            isinstance(turns_left, bool)
+            or not isinstance(turns_left, int)
+            or turns_left <= 0
+        ):
+            raise ValueError("full-access requires a positive turns_left budget")
+        session["turns_left"] = turns_left
+    else:
+        if turns_left is not None:
+            raise ValueError("turns_left is only valid for full-access")
+        session.pop("turns_left", None)
+    session["mode"] = canonical
+    return canonical
+
+
+def skips_approval(session: Mapping[str, Any]) -> bool:
+    """Return whether the current bounded mode bypasses routine approval."""
+
+    return mode_of(session) == FULL_ACCESS
+
+
+def consume_full_access_turn(session: dict[str, Any]) -> Mode:
+    """Consume one completed user-driven turn and atomically apply expiry.
+
+    Non-Full-access modes are unchanged. A malformed stored Full access value
+    is repaired to Auto. A valid countdown either remains Full access with one
+    fewer turn or expires to Auto at zero.
+    """
+
+    current = mode_of(session)
+    if current != FULL_ACCESS:
+        if session.get("mode") == FULL_ACCESS:
+            return set_mode(session, AUTO)
+        return current
+
+    remaining = full_access_turns_left(session) - 1
+    if remaining == 0:
+        return set_mode(session, AUTO)
+    return set_mode(session, FULL_ACCESS, turns_left=remaining)
+
+
+__all__ = [
+    "AUTO",
+    "DEFAULT_MODE",
+    "FULL_ACCESS",
+    "MODES",
+    "Mode",
+    "READ_ONLY",
+    "consume_full_access_turn",
+    "full_access_turns_left",
+    "mode_id",
+    "mode_of",
+    "set_mode",
+    "skips_approval",
+]

--- a/docs/blog/2026-08-21-three-labels-were-one-decision.md
+++ b/docs/blog/2026-08-21-three-labels-were-one-decision.md
@@ -1,0 +1,33 @@
+# Three Labels Were One Decision
+
+The same coding session could be called **Default** in one client,
+`:workspace` on the wire, and `auto_approve` inside a provider. Each name made
+sense where it was introduced. Together they made a user answer an impossible
+question: what authority does the agent have right now?
+
+This was more than inconsistent copy. The old vocabulary had accumulated
+aliases, participant-specific defaults, and a Plan value beside permission
+values. A reader could translate one spelling into another, but every
+translation became a second policy engine. During reconnects and rolling
+upgrades, an old browser and a new Host could therefore agree on a label while
+disagreeing about its authority.
+
+The 1.7 contract makes the public decision intentionally small. There are only
+three exact identifiers: `read-only`, `auto`, and `full-access`. Every
+participant starts in Auto. Unknown stored values are discarded to Auto rather
+than translated, because stale authority must never become current authority
+through a helpful compatibility layer.
+
+Plan is gone from this schema. Planning work still exists as Todo List progress,
+but it does not grant or remove permission. Full access is also narrower than
+its old name suggested: it bypasses approval only for a bounded number of
+completed user-driven turns, then expires to Auto. It never invents another
+turn.
+
+The contract fixture is shared byte for byte by Core, React, and O Chat. That
+gives the release train one question to test at every boundary: did this value
+come from the authoritative Host, and is it one of the three values the user
+can actually see?
+
+The lesson is simple. Permission vocabulary is part of the security boundary.
+If one choice has three names, it will eventually have three meanings.

--- a/docs/design-decisions/044-canonical-approval-mode-vocabulary.md
+++ b/docs/design-decisions/044-canonical-approval-mode-vocabulary.md
@@ -1,81 +1,113 @@
-# DD-044: Align collaboration and permissions with Codex
+# DD-044: One permission-mode contract
 
 **Status:** Accepted
 
-**Date:** 2026-08-12
+**Date:** 2026-08-21
 
-**Related:** [053 One browser protocol, native coding adapters](053-oip-only-browser-and-native-coding-adapters.md), [Issue #903](https://github.com/openonion/connectonion/issues/903)
+**Related:** [Issue #1142](https://github.com/openonion/connectonion/issues/1142),
+[Issue #1140](https://github.com/openonion/connectonion/issues/1140),
+[053 One browser protocol, native coding adapters](053-oip-only-browser-and-native-coding-adapters.md)
 
 ## Context
 
-ConnectOnion historically mixed `safe`, `plan`, and `ulw` in one selector.
-That combined two different questions: how the agent collaborates with the
-user, and what the agent may do without asking. It also required
-ConnectOnion-specific vocabulary across Host, React, O Chat, and delegated
-coding tools.
+The 1.7 preview mixed collaboration state, permission policy, provider-private
+settings, and autonomous continuation in one selector. Core, Host/OIP, React,
+O Chat, Codex, and Claude Code consequently used overlapping vocabularies and
+could disagree about which component held authority.
 
-Codex keeps those concerns independent. Its app-server collaboration mode has
-`default` and `plan`; its built-in permission profiles are `:read-only`,
-`:workspace`, and `:danger-full-access`.
+Plan Mode also conflated planning with permission. A Todo List is useful
+progress data, but neither planning nor a completed todo may authorize a tool.
+Likewise, Full access is a bounded permission grant; it is not an instruction
+to continue generating Agent turns.
 
 ## Decision
 
-Connect uses the same two-layer model:
+ConnectOnion 1.7 has exactly three public permission modes:
 
-| Layer | Canonical ID | Display name |
+| Canonical ID | Display name | Meaning |
 |---|---|---|
-| Collaboration | `default` | Default |
-| Collaboration | `plan` | Plan |
-| Permission | `:read-only` | Read only |
-| Permission | `:workspace` | Auto |
-| Permission | `:danger-full-access` | Full access |
+| `read-only` | Read only | Reads may run; every effectful operation asks. |
+| `auto` | Auto | The default. Deterministic policy allows safe reversible workspace work and asks or denies higher-risk work. |
+| `full-access` | Full access | Routine approvals are skipped for a positive, bounded number of user-driven turns. |
 
-Collaboration is client workflow state. Plan never grants or rewrites Host
-authority. Permission profiles are authenticated Host state and change only
-after the matching OIP `mode_changed` response is acknowledged.
+Core owns the authoritative state:
 
-`Auto` is the product label for the workspace profile, not a canonical
-`auto_approve` identifier. `--yolo` remains a recognizable CLI shorthand for
-Full access; it is not a fourth mode or the primary UI/code identifier.
+```python
+{"mode": "read-only" | "auto" | "full-access", "turns_left": int | None}
+```
 
-The exact permission profiles are emitted on OIP and persisted in session
-state. Full access remains operator-only and requires ConnectOnion's complete,
-current Host grant and turn ceiling. This vocabulary alignment does not claim
-that every provider implements Codex's operating-system sandbox.
+`turns_left` exists only for Full access. Completing a user-driven Agent turn
+decrements it; zero atomically returns the mode to Auto. The public state does
+not cache derived authority such as `skip_tool_approval`, and it does not keep
+total/used counter pairs that can disagree.
 
-Provider adapters translate the permission profile at their boundary. Codex
-receives `read-only`, `workspace-write`, or `danger-full-access`; Claude Code
-receives its own provider-specific permission value. Those terms do not leak
-back into Connect's public contract.
+`connectonion/core/mode.py` defines the IDs, validation, safe reads, the only
+writer, approval-bypass derivation, and countdown transition. Host/OIP and
+provider lifecycle events use the same IDs. Provider-private values are
+translated only inside their adapters and never appear in public events or
+persisted session state.
 
-## Migration
+Every new session starts in Auto regardless of whether the participant is a
+local operator, administrator, invited user, or contact. Administrative
+control-plane authorization remains separate from ordinary session mode.
 
-Compatibility readers accept old persisted or wire values only at the
-boundary, normalize immediately, and never newly emit them:
+Plan is not a permission mode. Plan-mode protocol fields, permission behavior,
+UI controls, and prompts are removed. Todo List remains ordinary
+`pending` / `in_progress` / `completed` progress data with no authority.
 
-| Previous value | Canonical result |
-|---|---|
-| `safe`, `default` | `:read-only` |
-| `accept_edits`, `auto_approve` | `:workspace` |
-| `ulw`, `full_access` | `:danger-full-access` |
-| `plan` in an old permission field | collaboration `plan` plus permission `:read-only` |
+`--yolo` may remain a CLI convenience that selects bounded Full access. Full
+access never synthesizes a follow-up prompt or recursively calls
+`agent.input(...)`. Structured continue-until-complete execution belongs to the
+separate Goal plugin planned for 1.9.
 
-Unknown or incomplete authority fails closed. A malformed Full access label
-without its bounded grant is downgraded before any tool can run.
+## Compatibility
 
-## References
+There is no legacy vocabulary compatibility layer in 1.7. The following are
+not accepted, translated, emitted, persisted, documented as modes, or tested
+as supported values:
 
-- [Codex agent approvals and security](https://learn.chatgpt.com/codex/agent-approvals-security)
-- [Codex permissions](https://learn.chatgpt.com/codex/permissions)
-- [Codex configuration reference](https://learn.chatgpt.com/codex/config-file/config-reference)
+```text
+:read-only  :workspace  :danger-full-access
+safe  default  manual  accept_edits  auto_approve
+ulw  full_access  plan  planning
+```
+
+An old, unknown, or incomplete stored value is discarded at the 1.7 schema
+boundary and initialized to Auto. It is never translated into authority. A
+Full access label without a valid positive countdown cannot skip approval.
+
+This intentional contract correction requires coordinated Core, React, and O
+Chat releases. The exact package versions and shared fixture SHA are recorded
+in the 1.7 release-control issue before a Beta or RC is promoted.
+
+## Consequences
+
+- one state owner replaces compatibility aliases and duplicated authority;
+- reconnect and replay carry the same three IDs as live requests;
+- frontend labels and backend values cannot drift;
+- Full access expiry is deterministic and bounded;
+- Todo List and planning remain useful without becoming authorization;
+- rolling old/new combinations fail safely instead of entering reconnect loops
+  or guessing authority.
+
+## Release evidence
+
+1. Focused Core mode and policy unit tests.
+2. Host transaction, reconnect, replay, and invalid-state fixtures.
+3. Real Codex and Claude Code permission/Stop/resume smokes.
+4. React typecheck, unit tests, build, and packed-artifact audit.
+5. O Chat desktop and 320–390 px mode-control journeys.
+6. A clean wheel plus exact published React prerelease in O Chat.
+7. Direct and Relay old/new pair tests proving safe failure and rollback.
 
 ## Rejected alternatives
 
-- **One selector containing Plan and Full access:** still conflates workflow
-  intent with authority.
-- **Public `auto_approve` / `full_access` IDs:** resembles common wording but
-  does not match Codex's profile contract.
-- **YOLO as a fourth protocol value:** duplicates Full access and complicates
-  every client.
-- **Silent unknown-value fallback in Host authority:** can hide corrupt or
-  over-authorized persisted state.
+- **Keep Codex colon-prefixed profiles as the public contract:** leaks one
+  provider's vocabulary into every client and does not match the product IDs.
+- **Retain legacy aliases for rolling compatibility:** prolongs multiple
+  authorities; the release decision is one synchronized vocabulary.
+- **Keep Plan as a fourth mode:** confuses workflow progress with permission.
+- **Make Full access mean continue until completion:** combines approval with
+  execution control and permits runaway work.
+- **Role-specific ordinary defaults:** makes identical user actions receive
+  different permission semantics; control-plane roles are handled separately.

--- a/tests/unit/test_mode.py
+++ b/tests/unit/test_mode.py
@@ -1,0 +1,123 @@
+import pytest
+
+from connectonion.core.mode import (
+    AUTO,
+    DEFAULT_MODE,
+    FULL_ACCESS,
+    MODES,
+    READ_ONLY,
+    consume_full_access_turn,
+    full_access_turns_left,
+    mode_id,
+    mode_of,
+    set_mode,
+    skips_approval,
+)
+
+
+def test_public_mode_vocabulary_has_exactly_three_values_and_defaults_to_auto():
+    assert MODES == ("read-only", "auto", "full-access")
+    assert DEFAULT_MODE == AUTO
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test_mode_id_accepts_only_exact_public_values(mode):
+    assert mode_id(mode) == mode
+
+
+@pytest.mark.parametrize(
+    "legacy",
+    [
+        ":read-only",
+        ":workspace",
+        ":danger-full-access",
+        "safe",
+        "default",
+        "manual",
+        "accept_edits",
+        "auto_approve",
+        "ulw",
+        "full_access",
+        "plan",
+        "planning",
+        None,
+    ],
+)
+def test_mode_id_rejects_legacy_unknown_and_missing_values(legacy):
+    with pytest.raises(ValueError, match="Unsupported mode"):
+        mode_id(legacy)
+
+
+@pytest.mark.parametrize(
+    "session",
+    [
+        {},
+        {"mode": "future"},
+        {"mode": ":read-only"},
+        {"mode": "ulw", "turns_left": 10},
+        {"mode": FULL_ACCESS},
+        {"mode": FULL_ACCESS, "turns_left": 0},
+        {"mode": FULL_ACCESS, "turns_left": True},
+    ],
+)
+def test_mode_of_degrades_unknown_or_incomplete_stored_state_to_auto(session):
+    assert mode_of(session) == AUTO
+    assert not skips_approval(session)
+
+
+def test_set_mode_is_the_single_canonical_writer():
+    session = {"turns_left": 99, "unrelated": "kept"}
+
+    assert set_mode(session, READ_ONLY) == READ_ONLY
+    assert session == {"mode": READ_ONLY, "unrelated": "kept"}
+
+    assert set_mode(session, AUTO) == AUTO
+    assert session == {"mode": AUTO, "unrelated": "kept"}
+
+    assert set_mode(session, FULL_ACCESS, turns_left=3) == FULL_ACCESS
+    assert session == {
+        "mode": FULL_ACCESS,
+        "turns_left": 3,
+        "unrelated": "kept",
+    }
+    assert skips_approval(session)
+
+
+@pytest.mark.parametrize("turns_left", [None, 0, -1, True, 1.5, "3"])
+def test_full_access_rejects_an_invalid_or_unbounded_budget(turns_left):
+    with pytest.raises(ValueError, match="positive turns_left"):
+        set_mode({}, FULL_ACCESS, turns_left=turns_left)
+
+
+@pytest.mark.parametrize("mode", [READ_ONLY, AUTO])
+def test_non_full_access_modes_reject_a_turn_budget(mode):
+    with pytest.raises(ValueError, match="only valid for full-access"):
+        set_mode({}, mode, turns_left=2)
+
+
+def test_full_access_countdown_expires_atomically_to_auto():
+    session = {}
+    set_mode(session, FULL_ACCESS, turns_left=2)
+
+    assert consume_full_access_turn(session) == FULL_ACCESS
+    assert session == {"mode": FULL_ACCESS, "turns_left": 1}
+    assert full_access_turns_left(session) == 1
+
+    assert consume_full_access_turn(session) == AUTO
+    assert session == {"mode": AUTO}
+    assert not skips_approval(session)
+
+
+def test_consuming_a_malformed_full_access_grant_repairs_it_to_auto():
+    session = {"mode": FULL_ACCESS, "turns_left": "unbounded"}
+
+    assert consume_full_access_turn(session) == AUTO
+    assert session == {"mode": AUTO}
+
+
+@pytest.mark.parametrize("mode", [READ_ONLY, AUTO])
+def test_consuming_an_ordinary_mode_is_a_noop(mode):
+    session = {"mode": mode, "unrelated": 1}
+
+    assert consume_full_access_turn(session) == mode
+    assert session == {"mode": mode, "unrelated": 1}


### PR DESCRIPTION
## Purpose

Foundation for #1142 on the frozen `release/1.7` line. It defines the one public mode vocabulary and state transition authority shared by Core/Host, React, and O Chat:

- `read-only`
- `auto` (default)
- `full-access` with positive `turns_left`

Unknown/legacy stored values degrade to Auto without translation. A malformed Full access state cannot bypass approval. The single writer owns the countdown and atomically returns an exhausted grant to Auto. DD-044 is replaced with the final 1.7 decision, including the separation of Todo List, permissions, and the 1.9 Goal plugin.

## Verification

- `uv run pytest tests/unit/test_mode.py tests/unit/test_approval_modes.py -q` — 47 passed
- `uv run ruff check connectonion/core/mode.py tests/unit/test_mode.py`
- `git diff --check`
- GitHub Linux 3.10–3.13 and Windows checks green

## Stack gate

Review this together with the adoption stack; do not merge it alone:

1. runtime/Core/Host adoption: #1159
2. React consumer: openonion/connectonion-react#85
3. O Chat consumer: openonion/oo-chat#197

The coordinated fixture is byte-identical across all three repositories. Merge #1158 immediately before #1159; publish the reviewed React beta before updating O Chat #197 to the exact registry package.

Release control: #792
Contract: #1142
Continuation removal: #1140