### PR TITLE
fix: report max-iteration runs as incomplete

### DIFF
--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -52,7 +52,7 @@ def handle_ai(
     if not prompt and (json_output or resume):
         message = "--json and --resume require a one-shot prompt"
         if json_output:
-            _print_envelope(None, None, message)
+            _print_envelope(None, None, "error", message)
         else:
             console.print(f"[red]{message}[/red]")
         raise typer.Exit(2)
@@ -135,7 +135,10 @@ def _handle_plain_one_shot(agent, prompt: str) -> None:
     except LLMProviderError as exc:
         console.print(f"\n[red]✗ Model request failed:[/red] {exc}\n")
         raise typer.Exit(1) from None
+    outcome = _completed_outcome(agent)
     print("\n" + result)
+    if outcome == "max_iterations":
+        raise typer.Exit(1)
 
 
 def _handle_json_one_shot(
@@ -193,9 +196,12 @@ def _handle_json_one_shot(
                     )
     except Exception as exc:
         error_session_id = resume if persist_session else None
-        _print_envelope(error_session_id, None, str(exc))
+        _print_envelope(error_session_id, None, "error", str(exc))
         raise typer.Exit(1) from None
-    _print_envelope(session_id, result, None)
+    outcome = _completed_outcome(agent)
+    _print_envelope(session_id, result, outcome, None)
+    if outcome == "max_iterations":
+        raise typer.Exit(1)
 
 
 def _fresh_session(agent, session_id: str) -> dict:
@@ -208,6 +214,24 @@ def _fresh_session(agent, session_id: str) -> dict:
     }
 
 
-def _print_envelope(session_id, result, error) -> None:
-    envelope = {"session_id": session_id, "result": result, "error": error}
+def _completed_outcome(agent) -> str:
+    """Return the canonical terminal reason for the latest completed turn."""
+
+    for event in reversed(agent.current_session["trace"]):
+        if event.get("type") != "turn_result":
+            continue
+        outcome = event.get("reason")
+        if outcome not in {"natural", "max_iterations"}:
+            raise RuntimeError(f"Unexpected completed turn outcome: {outcome!r}")
+        return outcome
+    raise RuntimeError("Completed Agent turn has no turn_result outcome")
+
+
+def _print_envelope(session_id, result, outcome, error) -> None:
+    envelope = {
+        "session_id": session_id,
+        "result": result,
+        "outcome": outcome,
+        "error": error,
+    }
     print(json.dumps(envelope, ensure_ascii=False, separators=(",", ":")))

--- a/docs/blog/2026-08-21-an-iteration-limit-is-not-success.md
+++ b/docs/blog/2026-08-21-an-iteration-limit-is-not-success.md
@@ -1,23 +1,31 @@
-# An iteration limit is not success
+# The pipeline that succeeded without doing the work
 
-Automation needs a truthful process outcome. Until now, `co ai "..."` could
-reach `--max-iterations`, print that the task was incomplete, and still exit
-with status zero. A person could read the warning; a shell pipeline could not
-distinguish it from completed work.
+Four agent jobs ran in sequence overnight. The first was supposed to finish a
+LinkedIn workflow before the next job started. It did not finish: the Agent
+used every allowed iteration and printed `Task incomplete`. The shell saw exit
+zero, marked the step green, and launched the other three anyway.
 
-ConnectOnion 1.7 preserves the partial result but reports the boundary
-honestly. Human-readable one-shot runs exit nonzero after printing the result.
-JSON mode adds one stable `outcome` field:
+By morning, the run log looked healthy. Only the English sentence buried in
+stdout revealed that the first job had stopped halfway through. The later jobs
+had inherited an assumption that was never true, and the scheduler had no
+signal it could use to halt or retry. Raising the iteration limit made the run
+more expensive, but did not make that signal any more honest.
+
+The important turn was realizing that the partial answer was not the problem.
+It was useful evidence and, for a resumable session, worth preserving. The lie
+was the process status. We changed one-shot execution so it commits the partial
+session and prints the result, then exits nonzero when the terminal reason is
+`max_iterations`. JSON mode makes the same distinction explicit:
 
 ```json
 {"session_id":"...","result":"...","outcome":"max_iterations","error":null}
 ```
 
-The other values are `natural` for a completed turn and `error` for execution
-failure. Resumable state is committed before an incomplete run exits, so an
-orchestrator can decide whether to resume without losing evidence.
+A naturally completed turn reports `outcome: "natural"` and exits zero; an
+execution failure reports `outcome: "error"`. An orchestrator can now stop,
+alert, or resume based on data instead of grepping prose.
 
-This change deliberately does not add a cost-budget system. Cost ceilings and
-in-context budget guidance require a separate product contract and remain a
-1.8 concern; the bounded 1.7 fix is simply that incomplete work is never
-reported as process success.
+The lesson was smaller than a new budgeting system: a safety limit is not a
+success criterion. Cost ceilings and in-context budget guidance need their own
+design, but no future budget feature can compensate for reporting unfinished
+work as green.

--- a/docs/blog/2026-08-21-an-iteration-limit-is-not-success.md
+++ b/docs/blog/2026-08-21-an-iteration-limit-is-not-success.md
@@ -1,0 +1,23 @@
+# An iteration limit is not success
+
+Automation needs a truthful process outcome. Until now, `co ai "..."` could
+reach `--max-iterations`, print that the task was incomplete, and still exit
+with status zero. A person could read the warning; a shell pipeline could not
+distinguish it from completed work.
+
+ConnectOnion 1.7 preserves the partial result but reports the boundary
+honestly. Human-readable one-shot runs exit nonzero after printing the result.
+JSON mode adds one stable `outcome` field:
+
+```json
+{"session_id":"...","result":"...","outcome":"max_iterations","error":null}
+```
+
+The other values are `natural` for a completed turn and `error` for execution
+failure. Resumable state is committed before an incomplete run exits, so an
+orchestrator can decide whether to resume without losing evidence.
+
+This change deliberately does not add a cost-budget system. Cost ceilings and
+in-context budget guidance require a separate product contract and remain a
+1.8 concern; the bounded 1.7 fix is simply that incomplete work is never
+reported as process success.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -57,14 +57,16 @@ For scripts and other coding agents, request one stable JSON object:
 
 ```bash
 co ai "Fix the failing tests" --json
-# {"session_id":"...","result":"...","error":null}
+# {"session_id":"...","result":"...","outcome":"natural","error":null}
 
 co ai "Now update the docs" --resume <session-id> --json
 ```
 
 Human-oriented progress moves to stderr in JSON mode, so stdout is safe to
-parse. A successful run exits `0`; invalid sessions and execution failures put
-a concise message in `error` and exit non-zero. Resume never silently starts a
+parse. `outcome` is `natural`, `max_iterations`, or `error`. A naturally
+completed run exits `0`; hitting the iteration cap preserves the result with
+`outcome: "max_iterations"` and exits non-zero. Invalid sessions and execution
+failures put a concise message in `error` and exit non-zero. Resume never silently starts a
 new conversation when the requested session is missing or invalid. Resume must
 run from the same project directory, and concurrent turns for one session fail
 fast instead of overwriting each other.

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -64,6 +64,9 @@ def test_handle_ai_enables_eval_only_when_requested(monkeypatch, capsys):
 
     class FakeAgent:
         def input(self, prompt):
+            self.current_session = {
+                "trace": [{"type": "turn_result", "reason": "natural"}]
+            }
             return "done"
 
     def fake_create_agent(**kwargs):
@@ -87,6 +90,9 @@ def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
     class FakeAgent:
         def input(self, prompt):
             created["prompt"] = prompt
+            self.current_session = {
+                "trace": [{"type": "turn_result", "reason": "natural"}]
+            }
             return "done"
 
     def fake_create_agent(**kwargs):
@@ -103,6 +109,30 @@ def test_handle_ai_one_shot_keeps_plain_mode_unchanged(monkeypatch, capsys):
     assert created["prompt"] == "task"
     assert created["yolo_turns"] is None
     assert capsys.readouterr().out.endswith("done\n")
+
+
+def test_plain_one_shot_exits_nonzero_when_iterations_are_exhausted(
+    monkeypatch, capsys
+):
+    class IncompleteAgent:
+        def input(self, prompt):
+            self.current_session = {
+                "trace": [
+                    {"type": "turn_result", "reason": "max_iterations"}
+                ]
+            }
+            return "Task incomplete: Maximum iterations (1) reached."
+
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent",
+        lambda **_: IncompleteAgent(),
+    )
+
+    with pytest.raises(typer.Exit) as caught:
+        ai_mod.handle_ai(prompt="task", max_iterations=1)
+
+    assert caught.value.exit_code == 1
+    assert "Task incomplete" in capsys.readouterr().out
 
 
 def test_isolated_agent_keeps_global_config_and_redirects_only_state(

--- a/tests/unit/test_co_ai_one_shot_sessions.py
+++ b/tests/unit/test_co_ai_one_shot_sessions.py
@@ -76,8 +76,9 @@ class _Todo:
 class _Agent:
     system_prompt = "system"
 
-    def __init__(self, noise="progress"):
+    def __init__(self, noise="progress", outcome="natural"):
         self.noise = noise
+        self.outcome = outcome
         self.current_session = None
         self.received_session = None
         self.tools = _ToolRegistry(_Todo())
@@ -94,7 +95,10 @@ class _Agent:
         self.current_session = {
             **base,
             "messages": messages,
-            "trace": list(base.get("trace", [])),
+            "trace": [
+                *base.get("trace", []),
+                {"type": "turn_result", "reason": self.outcome},
+            ],
             "turn": base.get("turn", 0) + 1,
             "mode": ":danger-full-access",
         }
@@ -870,6 +874,7 @@ def test_json_mode_emits_one_stdout_object_and_saves_resume_state(
     assert envelope == {
         "session_id": envelope["session_id"],
         "result": "done",
+        "outcome": "natural",
         "error": None,
     }
     assert captured.out.count("\n") == 1
@@ -881,6 +886,30 @@ def test_json_mode_emits_one_stdout_object_and_saves_resume_state(
     assert stored["mode"] == ":danger-full-access"
     assert stored["turn"] == 1
     assert tools == {"todolist": [_todo("first")]}
+
+
+def test_json_max_iterations_preserves_result_and_exits_nonzero(
+    tmp_path, monkeypatch, capsys
+):
+    agent = _Agent(outcome="max_iterations")
+    monkeypatch.setattr("connectonion.cli.co_ai.agent.GLOBAL_CO_DIR", tmp_path)
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.agent.create_agent", lambda **_: agent
+    )
+
+    with pytest.raises(typer.Exit) as caught:
+        ai_commands.handle_ai(prompt="unfinished", json_output=True)
+
+    assert caught.value.exit_code == 1
+    envelope = json.loads(capsys.readouterr().out)
+    assert envelope == {
+        "session_id": envelope["session_id"],
+        "result": "done",
+        "outcome": "max_iterations",
+        "error": None,
+    }
+    stored, _ = load_snapshot(tmp_path, envelope["session_id"])
+    assert stored["trace"][-1]["reason"] == "max_iterations"
 
 
 def test_resume_restores_messages_plugin_state_and_todos(tmp_path, monkeypatch, capsys):
@@ -947,6 +976,7 @@ def test_failed_resume_preserves_the_last_atomic_snapshot(
     assert envelope == {
         "session_id": session_id,
         "result": None,
+        "outcome": "error",
         "error": "follow-up failed",
     }
     stored, tools = load_snapshot(tmp_path, session_id)
@@ -973,6 +1003,7 @@ def test_json_failure_is_structured_and_nonzero(tmp_path, monkeypatch, capsys):
     assert json.loads(captured.out) == {
         "session_id": None,
         "result": None,
+        "outcome": "error",
         "error": "our bug",
     }
     assert "before failure" in captured.err
@@ -994,6 +1025,7 @@ def test_transient_one_shot_rejects_resume_without_echoing_the_session_id(capsys
     assert json.loads(capsys.readouterr().out) == {
         "session_id": None,
         "result": None,
+        "outcome": "error",
         "error": "A transient one-shot run cannot resume a session.",
     }
 

--- a/tests/unit/test_github_action.py
+++ b/tests/unit/test_github_action.py
@@ -46,6 +46,7 @@ def test_json_review_uses_the_333_agent_factory_seam(tmp_path, monkeypatch):
                 **session,
                 "messages": session["messages"]
                 + [{"role": "user", "content": prompt}],
+                "trace": [{"type": "turn_result", "reason": "natural"}],
                 "turn": 1,
             }
             return "review result"
@@ -64,6 +65,7 @@ def test_json_review_uses_the_333_agent_factory_seam(tmp_path, monkeypatch):
     assert json.loads(stdout) == {
         "session_id": None,
         "result": "review result",
+        "outcome": "natural",
         "error": None,
     }
     assert calls == [(("co/test", 4, True, 1), {"resumable": True})]


### PR DESCRIPTION
Closes the stable-1.7 portion of #1150. Cost ceilings and in-context cost guidance remain explicitly deferred to 1.8.

## Contract

- a natural one-shot turn exits 0
- a one-shot turn ending at `max_iterations` preserves and prints its partial result, but exits 1
- JSON output always includes `outcome`: `natural`, `max_iterations`, or `error`
- resumable state is committed before an incomplete JSON run exits
- library `Agent.input()` keeps its existing string return API; the CLI reads the already-recorded canonical `turn_result` event
- missing/malformed terminal outcome is an invariant failure, not silently converted to success

## Examples

Natural completion:

```json
{"session_id":"...","result":"done","outcome":"natural","error":null}
```

Iteration cap:

```json
{"session_id":"...","result":"Task incomplete: Maximum iterations (1) reached.","outcome":"max_iterations","error":null}
```

The second envelope exits 1.

## Verification

- focused CLI / resumable-session / agent-server tests: 67 passed
- Ruff on changed Python files: passed
- `git diff --check`: passed
- regression coverage for both plain and JSON max-iteration outcomes

Release control: #792