### PR TITLE
fix(deploy): report the real invite env path

### DIFF
--- a/connectonion/cli/commands/deploy_to_server.py
+++ b/connectonion/cli/commands/deploy_to_server.py
@@ -262,6 +262,13 @@ def _unit_text(agent: str, entrypoint: str, hostname: Optional[str] = None,
         # is how a second agent on this machine avoids 8000 without its author
         # knowing anything about what else runs here.
         environment += f"Environment=AGENT_PORT={port}\n"
+    # Host startup diagnostics must name the file systemd actually loaded.
+    # Without this marker the generic host layer sends an operator to the
+    # project's .env even though deploy keeps secrets outside the rsync root.
+    environment += (
+        "Environment=CONNECTONION_ENV_FILE="
+        f"{ENV_FILE_TEMPLATE.format(agent=agent)}\n"
+    )
     return f"""[Unit]
 Description=ConnectOnion agent {agent}
 After=network-online.target

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -596,6 +596,10 @@ def _invite_line(trust_config) -> str | None:
     from_env = [str(c)[1:] for c in declared if str(c).startswith("$")]
     literals = [c for c in declared if not str(c).startswith("$")]
     live = _resolve_codes(declared)
+    # `co deploy --to` loads secrets from a root-owned systemd EnvironmentFile,
+    # not from the project tree. Its unit sets this non-secret marker so the
+    # generic Host diagnostic can send the operator to the file actually read.
+    env_file = os.environ.get("CONNECTONION_ENV_FILE", "").strip() or ".env"
 
     if live:
         # Say *where* the code is, not just that there is one. Telling an
@@ -603,9 +607,12 @@ def _invite_line(trust_config) -> str | None:
         # sends them looking for something that is not there.
         resolved_from_env = [n for n in from_env if os.environ.get(n, "").strip()]
         if resolved_from_env and literals:
-            where = f"{', '.join(resolved_from_env)} in .env, and one in the trust policy"
+            where = (
+                f"{', '.join(resolved_from_env)} in {env_file}, "
+                "and one in the trust policy"
+            )
         elif resolved_from_env:
-            where = f"{', '.join(resolved_from_env)} in .env"
+            where = f"{', '.join(resolved_from_env)} in {env_file}"
         else:
             where = "in the trust policy"
         dead = [n for n in from_env if not os.environ.get(n, "").strip()]
@@ -614,7 +621,7 @@ def _invite_line(trust_config) -> str | None:
 
     if from_env:
         return (f"Invite: no one can onboard — {', '.join(from_env)} is not set. "
-                f"Add it to .env, or run `co init` to mint one.")
+                f"Add it to {env_file}, or run `co init` to mint one.")
     return None
 
 

--- a/docs/blog/2026-08-21-the-log-sent-us-to-the-wrong-file.md
+++ b/docs/blog/2026-08-21-the-log-sent-us-to-the-wrong-file.md
@@ -1,0 +1,29 @@
+# The Log Sent Us to the Wrong File
+
+An operator deployed an agent with `co deploy --to`, opened its journal, and
+saw a reassuring line: the invite was set in `.env`. They went to
+`/srv/<agent>`, looked for that file, and found nothing useful. The agent was
+running and invitations worked, yet the one diagnostic meant to explain the
+door had sent them to a file the service did not read.
+
+The first instinct was to make the deployment copy its secrets into the
+project directory. That would have made the log literally true, but it would
+also have undone an important boundary. The project tree belongs to rsync and
+`--delete`; the real deployment secrets live in a root-owned file at
+`/etc/connectonion/<agent>.env`, outside that tree, with mode `0600`.
+
+The complication was that Host is also used locally. It can describe an
+environment variable, but normally it cannot know which file populated the
+process environment. Hard-coding the server path in Host would make local
+diagnostics wrong in the opposite direction.
+
+The turn was to let the systemd unit state the fact it already knows. Alongside
+its `EnvironmentFile`, the unit now supplies a non-secret marker naming that
+file. Host uses the marker only in its diagnostic. A deployed agent says
+`CO_INVITE_CODE` is in `/etc/connectonion/<agent>.env`; a local agent continues
+to name its local `.env`. Missing-code guidance follows the same source.
+
+The secret did not need to move. The diagnostic did. The reusable lesson is
+that when one layer loads configuration for another, it should pass provenance
+along with values—otherwise a perfectly secure storage design can still become
+an operational trap.

--- a/docs/features/trust.md
+++ b/docs/features/trust.md
@@ -781,13 +781,14 @@ onboard:
 | `CO_INVITE_CODE` | no invite door; nothing is advertised | strangers who type that code become contacts |
 | `CO_PAYMENT` | no payment door | strangers who transfer at least that much to the agent's address become contacts |
 
-On a deployed agent these live in the root-owned env file `co deploy` writes,
-the same channel as every other secret — not in the project, and not in this
-repository. A literal in a shipped policy would be one password for every
-deployment (#561), and a shipped price would charge for every agent whose
+On an agent deployed with `co deploy --to`, these live in the root-owned
+`/etc/connectonion/<agent>.env` file (`0600`), the same channel as every other
+secret — not in the project, not in the server user's `~/.co/keys.env`, and not
+in this repository. A literal in a shipped policy would be one password for
+every deployment (#561), and a shipped price would charge for every agent whose
 operator never asked to (#672).
 
-The default local `co ai` host is the exception that makes first-owner setup
+The default **local** `co ai` host is the exception that makes first-owner setup
 usable without weakening that rule: on its first web-server start it mints one
 unique `CO_INVITE_CODE` in the owner-only `~/.co/keys.env`. Startup names the
 command to retrieve it but never prints the secret. Use `co keys` to confirm

--- a/docs/network/deploy.md
+++ b/docs/network/deploy.md
@@ -344,6 +344,11 @@ myagent → prod (co@1.2.3.4)
 ```
 
 Everything else in `.env` — your Gemini key, your database URL — travels unchanged.
+Deploy stores those values in the root-owned
+`/etc/connectonion/<agent>.env` (`0600`) and systemd loads that file. It is
+outside `/srv/<agent>/`, so rsync cannot expose or overwrite it. When Host
+startup reports an invite setting such as `CO_INVITE_CODE`, it names this exact
+file; edit it with root privileges, then restart the agent service.
 
 `--own-identity` mints the key on the machine, so this laptop cannot authenticate as
 that agent and no account is written. The deploy says so and the agent has no access

--- a/tests/unit/test_deploy_env_is_secret.py
+++ b/tests/unit/test_deploy_env_is_secret.py
@@ -52,7 +52,9 @@ def test_the_unit_reads_the_env_file_systemd_owns():
     and that must not be a boot failure.
     """
     unit = dts._unit_text("myagent", "agent.py")
-    assert f"EnvironmentFile=-{dts.ENV_FILE_TEMPLATE.format(agent='myagent')}" in unit
+    env_file = dts.ENV_FILE_TEMPLATE.format(agent="myagent")
+    assert f"EnvironmentFile=-{env_file}" in unit
+    assert f"Environment=CONNECTONION_ENV_FILE={env_file}" in unit
 
 
 def test_the_env_file_lives_outside_the_rsync_root(tmp_path):

--- a/tests/unit/test_invite_startup_line.py
+++ b/tests/unit/test_invite_startup_line.py
@@ -10,8 +10,6 @@ refuses every invite code — correct direction, but the operator sees only that
 nobody can get in.
 """
 
-import pytest
-
 from connectonion.network.host.server import _invite_line
 
 
@@ -57,6 +55,24 @@ class TestWhatItPrints:
         from_env = _invite_line({"onboard": {"invite_code": ["$CO_INVITE_CODE"]}})
         assert ".env" in from_env
         assert "CO_INVITE_CODE" in from_env
+
+    def test_a_deployed_agent_names_the_systemd_env_file(self, monkeypatch):
+        """The server has no project .env: deploy writes a root-owned file
+        outside the rsync tree, and that is where the operator must look."""
+        env_file = "/etc/connectonion/myagent.env"
+        monkeypatch.setenv("CONNECTONION_ENV_FILE", env_file)
+        monkeypatch.setenv("CO_INVITE_CODE", "U262R-7WA6E")
+
+        configured = _invite_line(
+            {"onboard": {"invite_code": ["$CO_INVITE_CODE"]}}
+        )
+        assert f"CO_INVITE_CODE in {env_file}" in configured
+
+        monkeypatch.delenv("CO_INVITE_CODE")
+        missing = _invite_line(
+            {"onboard": {"invite_code": ["$CO_INVITE_CODE"]}}
+        )
+        assert f"Add it to {env_file}" in missing
 
     def test_a_dead_declaration_beside_a_live_one_is_still_mentioned(self, monkeypatch):
         """One working code does not make an unset variable stop mattering —


### PR DESCRIPTION
## Description

Makes deployed Host startup diagnostics name the root-owned systemd environment file that actually contains `CO_INVITE_CODE`, instead of the misleading generic `.env` path. Secrets remain in `/etc/connectonion/<agent>.env`; this PR does not copy or move them.

## Related Issue

Fixes #1152

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5.6 via Codex.

The least certain part is behavior on a real Linux systemd host: I verified the generated unit text and Host diagnostics in tests, but did not perform a live server deployment. If this is wrong, the first visible failure is either systemd rejecting the generated marker line or the journal continuing to name `.env`; the secret storage path itself is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-21-the-log-sent-us-to-the-wrong-file.md

## Changes Made

- Add `CONNECTONION_ENV_FILE=/etc/connectonion/<agent>.env` to generated systemd units as non-secret provenance.
- Use that provenance in configured and missing invite-code startup diagnostics.
- Document the exact deploy secret location and distinguish it from local `co ai` storage.
- Add regression coverage for both generated unit and journal text.

No dependencies were added.

## Testing

```text
$ uv run pytest -q tests/unit/test_invite_startup_line.py tests/unit/test_deploy_env_is_secret.py tests/unit/test_deploy_to_server.py tests/unit/test_a_created_project_can_admit_someone.py tests/unit/test_an_agent_only_offers_a_door_that_opens.py
109 passed in 2.65s

$ uv run ruff check connectonion/cli/commands/deploy_to_server.py tests/unit/test_deploy_env_is_secret.py tests/unit/test_invite_startup_line.py
All checks passed!

$ git diff --check
(no output)
```

- [x] I have added tests for new functionality

## Scope

- `deploy_to_server.py`: publishes the exact systemd `EnvironmentFile` path as provenance.
- `server.py`: renders that provenance without exposing the invite secret.
- two unit test files: lock down unit generation and both diagnostic states.
- trust/deploy docs and one dev-blog post: correct the operator-facing storage story.

## Example Usage

```text
Invite: set — CO_INVITE_CODE in /etc/connectonion/myagent.env, not printed here
```

## Checklist

- [x] My code follows the project code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; this is a CLI journal diagnostic.

## Additional Notes

The marker is deliberately non-secret. The generated `Environment=` directive follows `EnvironmentFile=`, so an identically named project key cannot override the deployment-owned provenance.