### PR TITLE
fix(auth): keep OAuth URLs on one line

### DIFF
--- a/connectonion/cli/commands/auth_commands.py
+++ b/connectonion/cli/commands/auth_commands.py
@@ -237,6 +237,13 @@ def _save_google_to_env(env_file: Path, credentials: dict) -> None:
     }, strip_prefix="GOOGLE_")
 
 
+def _print_oauth_url(auth_url: str) -> None:
+    """Print a copyable URL without Rich inserting terminal-width newlines."""
+    console.print("    URL:", style="dim")
+    console.print(auth_url, soft_wrap=True, markup=False, highlight=False)
+    console.print()
+
+
 def handle_google_auth():
     """Authenticate with Google OAuth for Gmail/Calendar access."""
 
@@ -281,8 +288,8 @@ def handle_google_auth():
     auth_url = response.json()['auth_url']
 
     # Open browser
-    console.print(f"\n🌐 Opening browser for Google authentication...")
-    console.print(f"    URL: {auth_url}\n", style="dim")
+    console.print("\n🌐 Opening browser for Google authentication...")
+    _print_oauth_url(auth_url)
 
     webbrowser.open(auth_url)
 
@@ -467,8 +474,8 @@ def handle_microsoft_auth():
         expected_state["value"] = state
 
         # Open browser
-        console.print(f"\n🌐 Opening browser for Microsoft authentication...")
-        console.print(f"    URL: {auth_url}\n", style="dim")
+        console.print("\n🌐 Opening browser for Microsoft authentication...")
+        _print_oauth_url(auth_url)
 
         webbrowser.open(auth_url)
 

--- a/docs/blog/2026-08-21-a-url-is-one-piece-of-data.md
+++ b/docs/blog/2026-08-21-a-url-is-one-piece-of-data.md
@@ -1,0 +1,29 @@
+# A URL Is One Piece of Data
+
+An operator ran `co auth google` on a headless server. There was no browser to
+finish the handoff, so the terminal URL was the only path forward. They copied
+what looked like the URL, pasted it elsewhere, and Google rejected it. Rich had
+wrapped the 786-character value at the terminal edge, turning one URL into
+several physical lines. When a spinner followed, terminal control sequences
+made the copied text even harder to repair.
+
+The tempting answer was to improve the instructions around the link. That did
+not change the actual interface: on a remote box, stdout is not decoration. It
+is the transport between the CLI and the browser on another machine. A value
+that needs hand-editing before use is a broken value.
+
+The complication was that the friendly output still matters. The command
+should explain why a browser is opening, and a human should be able to spot the
+link. Dropping Rich for the entire flow would solve wrapping by discarding the
+rest of the presentation.
+
+The turn was smaller. The label remains styled, while the URL gets its own raw
+line with Rich soft wrapping enabled and markup and syntax highlighting
+disabled. The same path now serves Google and Microsoft, so the next long OAuth
+query cannot rediscover the bug under a different provider name. A regression
+test renders a deliberately long URL through a 24-column console and proves
+the output still contains exactly one URL line.
+
+The lesson is that terminal output can be both prose and data, but each part
+needs its own rendering contract. Labels may wrap. Tokens, URLs, IDs, and shell
+commands must survive copying byte for byte.

--- a/tests/unit/test_oauth_url_output.py
+++ b/tests/unit/test_oauth_url_output.py
@@ -1,0 +1,22 @@
+"""OAuth URLs remain one copyable line even in a narrow terminal."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from rich.console import Console
+
+from connectonion.cli.commands.auth_commands import _print_oauth_url
+
+
+def test_a_long_oauth_url_is_not_hard_wrapped():
+    auth_url = "https://accounts.google.com/o/oauth2/v2/auth?" + "scope=x&" * 100
+    output = StringIO()
+    narrow_console = Console(file=output, width=24, color_system=None)
+
+    with patch(
+        "connectonion.cli.commands.auth_commands.console", narrow_console
+    ):
+        _print_oauth_url(auth_url)
+
+    lines = output.getvalue().splitlines()
+    assert lines == ["    URL:", auth_url, ""]


### PR DESCRIPTION
## Description

Prints Google and Microsoft OAuth URLs as one copyable, unwrapped line even when the terminal is narrow. The explanatory label remains styled; the URL disables Rich markup/highlighting and uses soft wrapping.

## Related Issue

Fixes #1131

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5.6 via Codex.

The least certain part is interaction with unusual real terminal emulators. I verified Rich rendering at 24 columns and the complete mocked Google/Microsoft CLI flows, but did not complete a live OAuth authorization or test a headless SSH session. If this is wrong, the first thing to break is copy/paste of the printed URL; browser opening and token storage are unchanged.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-21-a-url-is-one-piece-of-data.md

## Changes Made

- Add one OAuth URL renderer that preserves the URL as a single physical line.
- Use the same renderer for Google and Microsoft flows, which shared the defect.
- Add a 24-column regression test proving a long URL remains byte-for-byte on one line.

No dependencies were added. `--no-browser` and OAuth scope redesign are intentionally outside this bug fix.

## Testing

```text
$ uv run pytest -q tests/unit/test_oauth_url_output.py tests/e2e/cli/test_cli_auth_google.py tests/e2e/cli/test_cli_auth_microsoft.py
23 passed in 1.09s

$ uv run ruff check tests/unit/test_oauth_url_output.py
All checks passed!

$ git diff --check
(no output)
```

- [x] I have added tests for new functionality

## Scope

- `auth_commands.py`: centralizes raw OAuth URL rendering and calls it from both provider flows.
- `test_oauth_url_output.py`: locks down narrow-terminal behavior.
- one dev-blog post: records the headless-server failure and rendering boundary.

## Example Usage

```text
    URL:
https://accounts.google.com/o/oauth2/v2/auth?client_id=...&redirect_uri=...&scope=...
```

The second line remains one physical line regardless of terminal width.

## Checklist

- [x] My code follows the project code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

Not applicable; terminal behavior is covered with exact captured output.

## Additional Notes

The URL is printed separately from the styled label so it remains machine-readable when piped and directly selectable on a terminal.