### PR TITLE
fix: fail closed for headless Auto

### DIFF
--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -553,7 +553,9 @@ def check_approval(agent: 'Agent') -> None:
     if 'stop_signal' in agent.current_session:
         raise ValueError("User rejected this batch of tools. They want to provide input for the correct direction.")
 
-    # No IO = not web mode, skip
+    # No IO cannot open a dialog. The deterministic policy hook immediately
+    # before this one has already allowed safe calls or denied anything that
+    # would have needed a person, so there is nothing interactive left to do.
     if not agent.io:
         return
 

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -240,11 +240,6 @@ def _operator(agent: "Agent") -> bool:
 
 def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
     """Return an Auto decision only for an authorized Workspace session."""
-    # Local CLI agents retain their established no-IO behavior.  This policy
-    # defines the hosted Auto UI boundary, where a human approval channel is
-    # available for an ``ask`` result.
-    if not agent.io:
-        return None
     if ensure_approval_profile(agent) != WORKSPACE_PERMISSION_PROFILE or not _operator(agent):
         return None
     try:
@@ -256,6 +251,13 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             f"authorization policy failed closed ({type(exc).__name__})",
             "call",
             requires_human=bool(agent.io),
+        )
+    if not agent.io and result["decision"] == "ask":
+        result = decision(
+            result["effect_class"],
+            "deny",
+            f"{result['reason']}; no approval channel is available",
+            result["scope"],
         )
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)

--- a/docs/blog/2026-08-21-no-dialog-is-not-approval.md
+++ b/docs/blog/2026-08-21-no-dialog-is-not-approval.md
@@ -1,0 +1,30 @@
+# No Dialog Is Not Approval
+
+A headless `co ai` run was asked to write one canary outside its project. It
+started in Auto, had no browser or other approval channel, and wrote the file
+without asking. The same operation in O Chat was correctly classified as an
+outside-workspace write and denied. The permission mode had one name but two
+boundaries.
+
+The split came from an old shortcut. The deterministic Auto policy only ran
+when `agent.io` existed, because its `ask` decisions were designed to open a
+dialog. Without IO, the older approval hook simply returned. That kept local
+library calls noninteractive, but it also meant that one-shot `co ai` skipped
+the path and effect checks that made Auto safe.
+
+Treating every headless call as denied would have fixed the escape by making
+Auto unusable. Workspace reads, reversible workspace edits, and focused
+verification are the operations Auto is meant to perform unattended. The
+correct boundary is the policy decision itself: run the same classifier with
+or without a UI, preserve its allow and deny results, and turn only `ask` into
+deny when nobody can answer.
+
+Full access remains separate. An operator can explicitly select its bounded
+turn grant for trusted unattended work, and protected control files still
+cannot be rewritten. A missing dialog is now the absence of consent, not an
+implicit grant.
+
+The regression covers both sides of the boundary: headless Auto allows an
+inside-workspace edit, rejects outside reads and writes plus unknown tools,
+and bounded Full access retains its explicit bypass. Permission policy should
+not depend on whether the product happened to render a button.

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -24,7 +24,7 @@ class IO:
         return self.response
 
 
-def agent(*, mode=":workspace", permissions=None, requester=None):
+def agent(*, mode=":workspace", permissions=None, requester=None, io=True):
     session = {
         "messages": [],
         "trace": [],
@@ -33,7 +33,12 @@ def agent(*, mode=":workspace", permissions=None, requester=None):
     }
     if requester:
         session["requester"] = requester
-    return SimpleNamespace(current_session=session, io=IO(), storage=None, logger=None)
+    return SimpleNamespace(
+        current_session=session,
+        io=IO() if io else None,
+        storage=None,
+        logger=None,
+    )
 
 
 def call(instance, name, arguments):
@@ -179,3 +184,46 @@ def test_contact_cannot_use_auto_without_host_authorization():
 
     assert result is None
     assert instance.io.sent[0]["type"] == "approval_needed"
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments", "effect"),
+    [
+        ("write", {"path": "../outside.txt"}, "write_outside_workspace"),
+        ("read_file", {"path": "../outside.txt"}, "read_outside_workspace"),
+        ("new_plugin_tool", {}, "unknown"),
+    ],
+)
+def test_headless_auto_fails_closed_without_an_approval_channel(
+    tmp_path, monkeypatch, name, arguments, effect
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {
+        "name": name,
+        "arguments": arguments,
+    }
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny"
+    assert result["effect_class"] == effect
+    with pytest.raises(ValueError, match="denied by connectonion.workspace-auto-approve"):
+        check_approval(instance)
+
+
+def test_headless_auto_still_allows_a_reversible_workspace_edit(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False)
+    instance.current_session["pending_tool"] = {
+        "name": "write",
+        "arguments": {"path": str(tmp_path / "inside.txt")},
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"


### PR DESCRIPTION
## Summary

Forward-port the release/1.7 headless Auto boundary fix from #1169 to main.

- apply the deterministic workspace Auto classifier even when no interactive IO channel exists
- fail closed when the classifier would otherwise require human approval
- preserve safe workspace edits and main's existing `:workspace` permission vocabulary
- keep contact/requester authorization behavior unchanged

This deliberately adapts the runtime fix to main instead of importing the 1.7 canonical permission IDs.

## Validation

- `pytest -q tests/unit/test_auto_approve_policy.py tests/unit/test_tool_approval.py tests/unit/test_full_access.py tests/unit/test_co_ai_agent_main.py` (145 passed)
- `uv run ruff check connectonion/useful_plugins/tool_approval/approval.py connectonion/useful_plugins/tool_approval/policy.py tests/unit/test_auto_approve_policy.py`
- `git diff origin/main...HEAD --check`

Release evidence and exact headless E2E are recorded in #1169 and #1126.