### PR TITLE
feat(tools): stream concise action summaries

### DIFF
--- a/connectonion/core/tool_executor.py
+++ b/connectonion/core/tool_executor.py
@@ -275,6 +275,15 @@ def execute_single_tool(
     Returns:
         Dict trace entry with: type, tool_name, arguments, call_id, result, status, timing, iteration, timestamp
     """
+    # Detach the model's presentation sentence from ordinary implementation
+    # arguments. Old sessions and third-party callers may omit it; execution
+    # remains compatible and readers provide a deterministic fallback.
+    tool_args = dict(tool_args)
+    tool_func = tools.get(tool_name)
+    summary = _bounded_tool_summary(tool_args.get("summary"))
+    if not getattr(tool_func, "_summary_is_function_argument", False):
+        tool_args.pop("summary", None)
+
     # Log tool call before execution
     logger.log_tool_call(tool_name, tool_args)
 
@@ -287,19 +296,23 @@ def execute_single_tool(
         "result": None,
         "timing_ms": 0,
     }
+    if summary:
+        trace_entry["summary"] = summary
 
     # Every result must have a preceding start with the same stable ID.  This
     # is required by streaming clients and also avoids a completion that cannot be
     # correlated by ConnectOnion clients when the requested tool is unknown.
-    agent._record_trace({
+    start_entry = {
         "type": "tool_call",
         "tool_id": tool_id,
         "name": tool_name,
         "args": tool_args,
-    })
+    }
+    if summary:
+        start_entry["summary"] = summary
+    agent._record_trace(start_entry)
 
     # Check if tool exists
-    tool_func = tools.get(tool_name)
     if tool_func is None:
         error_msg = f"Tool '{tool_name}' not found"
 
@@ -560,6 +573,16 @@ def execute_single_tool(
         clear_xray_context()
 
     return trace_entry
+
+
+def _bounded_tool_summary(value: Any) -> str | None:
+    """Return a bounded action summary or no summary for old callers."""
+    if not isinstance(value, str):
+        return None
+    value = " ".join(value.split())
+    if not value:
+        return None
+    return value[:240]
 
 
 def _add_assistant_message(messages: List[Dict], tool_calls: List) -> None:

--- a/connectonion/core/tool_factory.py
+++ b/connectonion/core/tool_factory.py
@@ -206,6 +206,21 @@ def create_tool_from_function(func: Callable) -> Callable:
         if param.default is inspect.Parameter.empty:
             required.append(param_name)
 
+    # The calling model supplies a short, user-facing description of the action.
+    # This is presentation metadata, not an argument to ordinary tool functions.
+    # If a tool already owns ``summary`` as a real parameter, it keeps receiving it.
+    properties["summary"] = {
+        "type": "string",
+        "description": (
+            "A short action phrase describing what this call is doing, written "
+            "for the person watching. Do not explain why."
+        ),
+        "minLength": 1,
+        "maxLength": 240,
+    }
+    if "summary" not in required:
+        required.append("summary")
+
     parameters_schema = {
         "type": "object",
         "properties": properties,
@@ -241,6 +256,7 @@ def create_tool_from_function(func: Callable) -> Callable:
     # Cache whether this tool needs agent injection (checked by tool_executor)
     # Convention: if the original function has 'agent' in its signature, the executor provides it.
     tool_func._needs_agent = 'agent' in sig.parameters
+    tool_func._summary_is_function_argument = 'summary' in sig.parameters
 
     # Preserve the exact owner of a bound method. The executor must not infer
     # ownership by scanning registered instances for a matching method name:

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -1015,6 +1015,8 @@ class RemoteAgent:
                 "args": event.get("args"),
                 "status": _tool_ui_status(event.get("status")),
             }
+            if isinstance(event.get("summary"), str) and event["summary"]:
+                tool_item["summary"] = event["summary"]
             if existing is None:
                 self._add_ui_event(tool_item)
             else:
@@ -1030,7 +1032,7 @@ class RemoteAgent:
             if existing is not None:
                 if event.get("status") is not None:
                     existing["status"] = _tool_ui_status(event["status"])
-                for field in ("name", "args", "result", "timing_ms"):
+                for field in ("name", "args", "summary", "result", "timing_ms"):
                     if field in event:
                         existing[field] = event[field]
 

--- a/connectonion/network/host/session/ui.py
+++ b/connectonion/network/host/session/ui.py
@@ -102,6 +102,8 @@ def _trace_entry_to_item_ui(entry: dict, idx: int) -> dict | None:
             'result': entry.get('result'),
             'timing_ms': entry.get('timing_ms'),
         }
+        if isinstance(entry.get('summary'), str) and entry['summary']:
+            item['summary'] = entry['summary']
         for key in ('provider', 'invocationId', 'parentToolCallId'):
             if key in entry:
                 item[key] = entry[key]

--- a/docs/blog/2026-08-22-an-action-is-not-a-reason.md
+++ b/docs/blog/2026-08-22-an-action-is-not-a-reason.md
@@ -1,29 +1,39 @@
 # An Action Is Not a Reason
 
-A tool implementation knows what its function does. A model can also supply a
-short description of the concrete action it is taking. Neither fact gives a
-reader permission to claim why that action was chosen.
+We asked an agent whether a machine was ready for release. It called
+`inspect_system` with `uname -a`, and the first version of the interface put a
+field named `reason` above the call.
 
-The first draft of the 1.7 tool contract called its presentation field
-`reason`. That name made a simple activity line carry too much meaning. It
-encouraged explanations, squeezed longer prose into the transcript, and risked
-turning a model's guess about motivation into a statement of fact.
+That small name changed what the model wrote. Instead of a crisp activity such
+as “Check the operating system,” the transcript began explaining itself: “I
+need to inspect the operating system because the user asked me to verify release
+readiness.” The sentence was longer than the useful result, repeated the user's
+request, and presented a generated account of motivation as though it were an
+observable fact. On a phone, it also turned one quiet tool event into a block of
+prose.
 
-The contract now asks for a short `summary` instead: an action phrase such as
-“Check the operating system” or “Search the order table.” Core carries it beside
-the executable arguments in both the live start event and the durable result
-trace. Readers show it as the primary activity line while keeping tool names,
-arguments, and raw output available on demand.
+The failure was not in the tool. The function still received the right command
+and returned the right kernel version. The failure was in the contract we had
+given the model: ask for a reason, and it will try to justify itself.
 
-The field is required in schemas presented to current models, but optional on
-the wire. That distinction preserves replay and third-party compatibility. An
-old call without a summary still executes; its reader derives a deterministic
-action label from the tool name and does not invent intent.
+The useful line was already hiding inside that explanation. “Check the
+operating system” says exactly what a person watching the run needs to know. So
+the 1.7 contract now calls the field `summary` and describes it as a short action
+phrase. The reader places that phrase beside the status and duration, then keeps
+the tool name, arguments, and raw result behind an expandable detail row.
 
-Presentation metadata is removed before an ordinary function runs. If a tool
-already owns a real `summary` parameter, tool creation marks that collision and
-the executor preserves it. In both cases the trace receives the same
-whitespace-normalised, bounded phrase.
+Changing the name also forced us to decide what happens outside the happy path.
+Old recordings and third-party clients do not have a summary, so they still run
+and receive a deterministic label derived from the tool name. Ordinary tools do
+not receive presentation metadata as an unexpected argument. A tool that
+already declares a real `summary` parameter keeps its own value, while the trace
+still records the bounded activity phrase shown to the reader.
 
-The distinction keeps the interface honest: show what is happening, expose the
-details when requested, and leave “why” to the surrounding conversation.
+When we replayed the same release check, the transcript finally read like an
+activity log: “Check the operating system · 1.2s.” The command and its output
+were still one click away, but the default view no longer pretended to know the
+agent's inner motivation.
+
+That is the distinction worth keeping: report what is happening, reveal the
+evidence on demand, and leave “why” to the conversation where it can be examined
+rather than asserted.

--- a/docs/blog/2026-08-22-an-action-is-not-a-reason.md
+++ b/docs/blog/2026-08-22-an-action-is-not-a-reason.md
@@ -1,0 +1,29 @@
+# An Action Is Not a Reason
+
+A tool implementation knows what its function does. A model can also supply a
+short description of the concrete action it is taking. Neither fact gives a
+reader permission to claim why that action was chosen.
+
+The first draft of the 1.7 tool contract called its presentation field
+`reason`. That name made a simple activity line carry too much meaning. It
+encouraged explanations, squeezed longer prose into the transcript, and risked
+turning a model's guess about motivation into a statement of fact.
+
+The contract now asks for a short `summary` instead: an action phrase such as
+“Check the operating system” or “Search the order table.” Core carries it beside
+the executable arguments in both the live start event and the durable result
+trace. Readers show it as the primary activity line while keeping tool names,
+arguments, and raw output available on demand.
+
+The field is required in schemas presented to current models, but optional on
+the wire. That distinction preserves replay and third-party compatibility. An
+old call without a summary still executes; its reader derives a deterministic
+action label from the tool name and does not invent intent.
+
+Presentation metadata is removed before an ordinary function runs. If a tool
+already owns a real `summary` parameter, tool creation marks that collision and
+the executor preserves it. In both cases the trace receives the same
+whitespace-normalised, bounded phrase.
+
+The distinction keeps the interface honest: show what is happening, expose the
+details when requested, and leave “why” to the surrounding conversation.

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -84,8 +84,9 @@ def test_create_coding_agent(monkeypatch, tmp_path):
         "cwd",
         "model",
         "timeout",
+        "summary",
     }
-    assert codex_schema.get("required", []) == []
+    assert codex_schema.get("required", []) == ["summary"]
     assert "claude_code" in agent.tools._tools
     claude_plugins = [
         plugin for plugin in agent.installed_plugins
@@ -100,8 +101,9 @@ def test_create_coding_agent(monkeypatch, tmp_path):
         "cwd",
         "model",
         "timeout",
+        "summary",
     }
-    assert claude_schema["required"] == ["prompt", "cwd"]
+    assert claude_schema["required"] == ["prompt", "cwd", "summary"]
     assert "acp_agent" not in agent.tools._tools
     # agent.py removes this stdin-blocking helper; it must not come back
     assert "wait_for_manual_login" not in agent.tools._tools

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -15,6 +15,26 @@ class _LLM:
     model = "test"
 
 
+def test_replayed_tool_card_keeps_the_model_written_summary():
+    items = session_to_chat_items({
+        "messages": [{"role": "user", "content": "inspect it"}],
+        "trace": [{
+            "type": "tool_result",
+            "tool_id": "call-1",
+            "name": "read_file",
+            "args": {"path": "README.md"},
+            "summary": "Reading the project guide to find the documented behavior",
+            "status": "success",
+            "result": "contents",
+        }],
+    })
+
+    tool = next(item for item in items if item["type"] == "tool_call")
+    assert tool["summary"] == (
+        "Reading the project guide to find the documented behavior"
+    )
+
+
 @pytest.mark.parametrize(
     ("plugin", "tool_name"),
     [(CodexPlugin, "codex"), (ClaudeCodePlugin, "claude_code")],

--- a/tests/unit/test_connect.py
+++ b/tests/unit/test_connect.py
@@ -213,6 +213,21 @@ class TestUIEventTransformation:
         assert agent.ui[0]["id"] == "tc1"
         assert agent.ui[0]["status"] == "running"
 
+    def test_handle_tool_call_keeps_the_model_written_summary(self):
+        agent = RemoteAgent("0x123")
+
+        agent._handle_stream_event({
+            "type": "tool_call",
+            "id": "tc1",
+            "name": "search",
+            "args": {"q": "duplicates"},
+            "summary": "Searching the order table to find duplicate rows",
+        })
+
+        assert agent.ui[0]["summary"] == (
+            "Searching the order table to find duplicate rows"
+        )
+
     def test_handle_tool_result_updates_existing_tool_call(self):
         """Test tool_result event updates existing tool_call item."""
         agent = RemoteAgent("0x123")

--- a/tests/unit/test_tool_executor.py
+++ b/tests/unit/test_tool_executor.py
@@ -70,6 +70,96 @@ class TestToolExecutor:
         # execute_single_tool stores the raw result as string in trace['result']
         assert "10" in str(trace["result"])
 
+    def test_summary_is_recorded_but_not_passed_to_an_ordinary_tool(self):
+        received = {}
+
+        def sample_tool(x: int) -> int:
+            received["x"] = x
+            return x * 2
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(sample_tool))
+        agent = FakeAgent()
+
+        trace = execute_single_tool(
+            tool_name="sample_tool",
+            tool_args={"x": 5, "summary": "Double the sample value"},
+            tool_id="call-summary",
+            tools=tools,
+            agent=agent,
+            logger=Logger("test-agent", log=False),
+        )
+
+        assert received == {"x": 5}
+        assert trace["summary"] == "Double the sample value"
+        assert trace["args"] == {"x": 5}
+        assert agent.current_session["trace"][0]["summary"] == trace["summary"]
+
+    def test_missing_summary_keeps_old_and_third_party_calls_working(self):
+        def sample_tool(x: int) -> int:
+            return x * 2
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(sample_tool))
+
+        trace = execute_single_tool(
+            "sample_tool",
+            {"x": 5},
+            "call-without-summary",
+            tools,
+            FakeAgent(),
+            Logger("test-agent", log=False),
+        )
+
+        assert trace["status"] == "success"
+        assert "summary" not in trace
+
+    def test_summary_is_normalised_and_bounded_before_it_reaches_the_trace(self):
+        def sample_tool() -> str:
+            return "ok"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(sample_tool))
+
+        trace = execute_single_tool(
+            "sample_tool",
+            {"summary": f"  Inspect\n\tfiles {'x' * 300}  "},
+            "call-bounded-summary",
+            tools,
+            FakeAgent(),
+            Logger("test-agent", log=False),
+        )
+
+        assert trace["summary"].startswith("Inspect files ")
+        assert "\n" not in trace["summary"]
+        assert len(trace["summary"]) == 240
+
+    def test_a_tools_own_summary_parameter_is_not_stripped(self):
+        received = {}
+
+        def block(client_id: str, summary: str = "") -> str:
+            received.update(client_id=client_id, summary=summary)
+            return "blocked"
+
+        tools = ToolRegistry()
+        tools.add(create_tool_from_function(block))
+
+        trace = execute_single_tool(
+            "block",
+            {"client_id": "client-1", "summary": "Stopping abusive traffic"},
+            "call-owned-summary",
+            tools,
+            FakeAgent(),
+            Logger("test-agent", log=False),
+        )
+
+        assert received == {
+            "client_id": "client-1",
+            "summary": "Stopping abusive traffic",
+        }
+        assert trace["summary"] == "Stopping abusive traffic"
+        assert trace["args"]["summary"] == "Stopping abusive traffic"
+
     def test_execute_tool_not_found(self):
         """Unknown tool returns not_found status."""
         tools = ToolRegistry()

--- a/tests/unit/test_tool_factory.py
+++ b/tests/unit/test_tool_factory.py
@@ -70,6 +70,33 @@ class TestToolFactory:
         assert "y" in schema["parameters"]["properties"]
         assert "operation" in schema["parameters"]["properties"]
 
+    def test_every_tool_schema_requires_a_short_model_written_summary(self):
+        def calculate(x: int) -> int:
+            return x * 2
+
+        schema = create_tool_from_function(calculate).to_function_schema()["parameters"]
+
+        assert schema["properties"]["summary"] == {
+            "type": "string",
+            "description": "A short action phrase describing what this call is doing, written for the person watching. Do not explain why.",
+            "minLength": 1,
+            "maxLength": 240,
+        }
+        assert schema["required"] == ["x", "summary"]
+
+    def test_an_existing_summary_parameter_remains_a_real_function_argument(self):
+        def block(client_id: str, summary: str = "") -> str:
+            return f"{client_id}: {summary}"
+
+        tool = create_tool_from_function(block)
+        schema = tool.to_function_schema()["parameters"]
+
+        assert "summary" in schema["required"]
+        assert tool._summary_is_function_argument is True
+        assert tool.run(client_id="client-1", summary="Stop abusive traffic") == (
+            "client-1: Stop abusive traffic"
+        )
+
     def test_tool_with_no_docstring(self):
         """Test tool creation with function that has no docstring."""
         def no_doc(x: int) -> int:


### PR DESCRIPTION
## Summary
- require a short model-written `summary` action phrase in every generic tool schema
- keep summary metadata out of ordinary function arguments while preserving real parameter collisions
- carry the bounded summary through live and replayed tool activity
- keep old and third-party calls without summaries executable
- document why an action summary must not be modeled as a reason

Closes #1153. Coordinated reader work: openonion/connectonion-react#89 and openonion/oo-chat#196.

## Rollout order
This writer must merge only after the React beta.2 reader and O Chat summary UI are merged/deployed.

## Verification
- focused tool/agent/wire/connect regression: 320 passed, 1 Windows-only skipped
- full local suite before the terminology correction: 7,118 passed, 18 skipped; the sole failure was the intentionally stale local docs-site checkout (`1.7.0b1`) while production already advertises `1.7.0b5`
- `git diff --check`