### PR TITLE
chore: forward-port owned Codex Work Room continuation

### DIFF
--- a/connectonion/network/host/provider_workroom.py
+++ b/connectonion/network/host/provider_workroom.py
@@ -168,6 +168,11 @@ def _direct_session(
         # invocation. Keep that exact durable revision so only a successful
         # native ``turn/start`` can acknowledge the original request.
         "_provider_direct_state_revision": state_revision,
+        # Ownership and the terminal source revision were validated while the
+        # durable session lock was held.  Let the approval plugin consume this
+        # one-shot capability for the outer Codex wrapper only; Codex-native
+        # command and file approvals still travel through ``agent.io``.
+        "_provider_direct_approved_tool": "codex",
     }
 
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -443,6 +443,24 @@ def check_approval(agent: 'Agent') -> None:
         tool_name = pending['name']
         tool_args = pending['arguments']
 
+        # A completed Work Room continuation has already passed the Host's
+        # owner + durable revision checks.  Consume its internal capability at
+        # the first tool boundary and bypass only the outer Codex wrapper.  It
+        # cannot authorize an arbitrary tool, cannot survive for a later call,
+        # and does not affect Codex's own command/file approval protocol.
+        direct_tool = agent.current_session.pop(
+            '_provider_direct_approved_tool', None
+        )
+        if direct_tool == tool_name == 'codex':
+            if getattr(getattr(agent, 'logger', None), 'console', None):
+                agent.logger.console.log_permission_granted(
+                    tool_name,
+                    tool_args,
+                    'host',
+                    'owned Work Room continuation',
+                )
+            return
+
         # Before the whitelist, and before the mode: these decide what this
         # agent may do and who may command it, so no configuration grants them.
         # is_tool_permitted has the same guard, but this is the path the agent's

--- a/docs/blog/2026-08-22-the-approval-belonged-to-the-wrong-room.md
+++ b/docs/blog/2026-08-22-the-approval-belonged-to-the-wrong-room.md
@@ -1,0 +1,36 @@
+# The Approval Belonged to the Wrong Room
+
+The Codex Work Room finished a real Rust task, then failed on the smallest
+possible follow-up. The browser kept the draft and eventually reported that
+the Host had not confirmed it. The Host log said the message had arrived. No
+file changed, and Codex never showed a new turn.
+
+The message had stopped at an approval dialog, but not one the Work Room could
+answer. A terminal follow-up resumes Codex by calling the framework's `codex`
+tool directly. That call still passed through the ordinary agent approval
+plugin, which opened an outer tool approval before the native Codex adapter
+could start its turn. The focused Work Room owns native Codex approvals; the
+outer conversation owns generic tool approvals. We had asked one room to
+answer a decision rendered in another.
+
+Making Codex automatic would have hidden the symptom by removing decisions we
+want people to see. Letting every direct tool call through would have weakened
+the Host boundary. The useful fact was narrower: while holding the durable
+session lock, the Host had already verified the requester, the terminal Codex
+invocation, and its exact state revision.
+
+The runner now turns that fact into a one-shot capability for one operation:
+the outer `codex` wrapper. The approval plugin consumes it at the first tool
+boundary. A different tool consumes nothing useful and still asks; a later
+Codex call still asks. Once the native adapter starts, its command and file
+approvals continue through the Work Room exactly as before.
+
+The regression uses a real Agent with the real approval plugin, not a fake that
+jumps straight to the adapter. Negative cases prove the capability cannot
+approve another tool or survive for a later call. The focused provider tests
+and approval tests pass together, so the boundary is checked from both sides.
+
+An approval is not just a yes-or-no question. It also has an owner and a
+surface. When execution crosses from an outer agent into a focused native
+provider session, preserving every approval layer can be just as wrong as
+removing one. The right question must appear in the room that can answer it.

--- a/tests/unit/test_provider_workroom.py
+++ b/tests/unit/test_provider_workroom.py
@@ -1,9 +1,12 @@
 """Owned native Codex Work Room continuation tests."""
 
+from connectonion import Agent
 from connectonion.network.host.provider_workroom import (
     prepare_provider_workroom_turn,
 )
 from connectonion.network.host.session import Session, SessionStorage
+from connectonion.useful_plugins import tool_approval
+from tests.utils.mock_helpers import MockLLM
 
 
 def _stored_codex_session(*, owner="0xowner"):
@@ -103,6 +106,7 @@ def test_owned_terminal_codex_thread_runs_only_the_native_tool_and_persists_safe
         "Please add a reverse-order fixture."
     )
     assert agent.current_session["_provider_direct_state_revision"] == 7
+    assert agent.current_session["_provider_direct_approved_tool"] == "codex"
 
     stored = storage.get("session-1")
     assert stored.status == "done"
@@ -144,3 +148,55 @@ def test_workroom_continuation_fails_closed_for_another_owner_or_live_source(tmp
         "input-2",
         "0xowner",
     ) == {"reason": "not_active"}
+
+
+def test_owned_continuation_reaches_codex_through_the_real_approval_plugin(tmp_path):
+    storage = SessionStorage(tmp_path / "sessions.jsonl")
+    storage.save(Session(
+        session_id="session-1",
+        status="done",
+        prompt="original outer prompt",
+        session=_stored_codex_session(),
+    ))
+    calls = []
+
+    def codex(prompt: str, cwd: str, session_id: str) -> str:
+        """Continue a Codex thread."""
+        calls.append((prompt, cwd, session_id))
+        return "continued"
+
+    class NoOuterApprovalIO:
+        def __init__(self):
+            self.sent = []
+
+        def send(self, event):
+            self.sent.append(event)
+
+        def receive(self):
+            raise AssertionError("the outer Codex wrapper must not ask")
+
+    def create_agent():
+        return Agent(
+            "direct-codex-test",
+            llm=MockLLM(),
+            tools=[codex],
+            plugins=[tool_approval],
+            log=False,
+            quiet=True,
+        )
+
+    prepared = prepare_provider_workroom_turn(
+        create_agent,
+        storage,
+        "session-1",
+        "codex:current",
+        "Please continue.",
+        "input-1",
+        "0xowner",
+    )
+    io = NoOuterApprovalIO()
+
+    prepared["run"](io)
+
+    assert calls == [("Please continue.", "", "thread-42")]
+    assert all(event.get("type") != "approval_needed" for event in io.sent)

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -185,6 +185,42 @@ class TestDangerousTools:
         assert io.sent[0]['arguments'] == {'command': 'npm install', 'description': 'Install dependencies'}
         assert io.sent[0]['description'] == 'Install dependencies'
 
+    def test_owned_workroom_continuation_skips_only_outer_codex_approval(self):
+        io = FakeIO()
+        agent = FakeAgent(io=io)
+        agent.current_session['_provider_direct_approved_tool'] = 'codex'
+        agent.current_session['pending_tool'] = {
+            'name': 'codex',
+            'arguments': {'prompt': 'Continue the owned thread'},
+        }
+
+        check_approval(agent)
+
+        assert io.sent == []
+        assert '_provider_direct_approved_tool' not in agent.current_session
+
+    def test_workroom_capability_cannot_approve_another_tool_or_later_call(self):
+        io = FakeIO(responses=[
+            {'approved': True, 'scope': 'once'},
+            {'approved': True, 'scope': 'once'},
+        ])
+        agent = FakeAgent(io=io)
+        agent.current_session['_provider_direct_approved_tool'] = 'codex'
+        agent.current_session['pending_tool'] = {
+            'name': 'bash',
+            'arguments': {'command': 'pwd'},
+        }
+
+        check_approval(agent)
+        agent.current_session['pending_tool'] = {
+            'name': 'codex',
+            'arguments': {'prompt': 'A later unrelated call'},
+        }
+        check_approval(agent)
+
+        assert [event['tool'] for event in io.sent] == ['bash', 'codex']
+        assert '_provider_direct_approved_tool' not in agent.current_session
+
     def test_approved_once_continues(self):
         """Approved with scope=once should continue without saving."""
         io = FakeIO(responses=[{'approved': True, 'scope': 'once'}])


### PR DESCRIPTION
## Summary

Forward-port the exact release/1.7 fix from #1178 to `main` so the provider Work Room contract does not diverge after 1.7.

- source merge: `efd701cfd795a0dc9facd2a1096449487f99cf7c`
- cherry-pick: `34dd5b51`
- no conflict or semantic rewrite

## Verification

- focused provider, approval, truthful-ACK, and Codex matrix: 155 passed
- `git diff --check`

Tracks #1177, #1109, and #792.