### PR TITLE
fix: keep Claude workspace paths private on main

### DIFF
--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -262,9 +262,9 @@ def _resolve_workspace(workspace: str | Path | None) -> Path:
     try:
         resolved = root.expanduser().resolve(strict=True)
     except (OSError, RuntimeError, ValueError) as exc:
-        raise ValueError(f"Claude Code workspace is unavailable: {exc}") from exc
+        raise ValueError("Claude Code workspace is unavailable.") from exc
     if not resolved.is_dir():
-        raise ValueError(f"Claude Code workspace is not a directory: {resolved}")
+        raise ValueError("Claude Code workspace is not a directory.")
     return resolved
 
 
@@ -273,16 +273,19 @@ def _working_directory(
 ) -> tuple[Path | None, str]:
     try:
         root = _resolve_workspace(workspace) if workspace is not None else None
+    except (OSError, RuntimeError, ValueError):
+        return None, "Claude Code workspace is unavailable."
+    try:
         requested = Path(cwd).expanduser() if cwd else (root or Path.cwd())
         if not requested.is_absolute():
             requested = (root or Path.cwd()) / requested
         directory = requested.resolve(strict=True)
-    except (OSError, RuntimeError, ValueError) as exc:
-        return None, f"Working directory is unavailable: {exc}"
+    except (OSError, RuntimeError, ValueError):
+        return None, "Working directory is unavailable."
     if not directory.is_dir():
-        return None, f"Working directory is not a directory: {directory}"
+        return None, "Working directory is not a directory."
     if root is not None and not directory.is_relative_to(root):
-        return None, f"Working directory must stay inside workspace: {root}"
+        return None, "Working directory must stay inside the configured workspace."
     return directory, ""
 
 

--- a/docs/blog/2026-08-22-a-workspace-boundary-is-not-a-path.md
+++ b/docs/blog/2026-08-22-a-workspace-boundary-is-not-a-path.md
@@ -1,0 +1,39 @@
+# A Workspace Boundary Is Not a Path
+
+The first public Beta 7 Claude failure test did exactly what a boundary test
+should do: it asked the owned adapter to work one directory outside its
+workspace. Claude Code never launched. The tool rejected the request in less
+than a millisecond.
+
+Then the browser printed the Host's absolute workspace path.
+
+The rejection was correct, but its explanation crossed the boundary it was
+describing. The adapter had formatted the resolved root into its JSON error,
+and the parent agent faithfully repeated that error in O Chat. No credential
+was exposed, yet a private machine path had become browser data. A safe action
+with an unsafe description is still an information leak.
+
+Keeping the absolute path seemed useful for debugging. It was not useful to
+the person who could act on the error: the browser user cannot change the
+Host's configured root, and does not need to know its spelling. The actionable
+fact is only that the requested directory is outside the configured workspace.
+Detailed local diagnostics belong in Host-owned logs, not in the provider's
+public envelope.
+
+The adapter now returns categorical messages for four boundary failures:
+the configured workspace is unavailable, the requested directory is
+unavailable, the target is not a directory, or the target escapes the
+configured workspace. None includes the configured root, requested path,
+resolved symlink target, or raw operating-system exception.
+
+The regression tests deliberately use names such as
+`customer-secret-workspace` and `private-host-directory`. They cover a direct
+escape, a symlink escape, a missing directory, a file used as a directory, and
+an invalid operator workspace. Each assertion checks both the useful public
+category and the absence of every sensitive-looking path. The Claude adapter
+suite passes 56 tests; the related provider, approval, error, and Work Room
+suites pass another 92.
+
+The lesson is smaller than “hide errors.” Errors are part of the product and
+must remain specific enough to recover from. But a boundary message should
+name the rule that failed, not disclose the private value used to enforce it.

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -128,8 +128,8 @@ def test_operator_workspace_is_not_model_visible(tmp_path):
 
 
 def test_agent_cannot_launch_outside_its_runtime_workspace(tmp_path):
-    workspace = tmp_path / "workspace"
-    outside = tmp_path / "outside"
+    workspace = tmp_path / "customer-secret-workspace"
+    outside = tmp_path / "private-host-directory"
     workspace.mkdir()
     outside.mkdir()
     agent = _agent()
@@ -142,13 +142,15 @@ def test_agent_cannot_launch_outside_its_runtime_workspace(tmp_path):
                 workspace=workspace,
             )
         )
-    assert "must stay inside workspace" in result["error"]
+    assert result["error"] == "Working directory must stay inside the configured workspace."
+    assert str(workspace) not in result["error"]
+    assert str(outside) not in result["error"]
     run.assert_not_called()
 
 
 def test_workspace_rejects_a_symlink_escape(tmp_path):
-    workspace = tmp_path / "workspace"
-    outside = tmp_path / "outside"
+    workspace = tmp_path / "customer-secret-workspace"
+    outside = tmp_path / "private-host-directory"
     workspace.mkdir()
     outside.mkdir()
     link = workspace / "escape"
@@ -159,7 +161,24 @@ def test_workspace_rejects_a_symlink_escape(tmp_path):
     result = json.loads(
         ClaudeCode(workspace=workspace).claude_code("inspect", cwd="escape")
     )
-    assert "must stay inside workspace" in result["error"]
+    assert result["error"] == "Working directory must stay inside the configured workspace."
+    assert str(workspace) not in result["error"]
+    assert str(outside) not in result["error"]
+
+
+def test_invalid_operator_workspace_does_not_expose_its_path(tmp_path):
+    missing = tmp_path / "customer-secret-missing-workspace"
+    with pytest.raises(ValueError) as missing_error:
+        ClaudeCode(workspace=missing)
+    assert str(missing_error.value) == "Claude Code workspace is unavailable."
+    assert str(missing) not in str(missing_error.value)
+
+    private_file = tmp_path / "customer-secret-workspace-file"
+    private_file.write_text("private", encoding="utf-8")
+    with pytest.raises(ValueError) as file_error:
+        ClaudeCode(workspace=private_file)
+    assert str(file_error.value) == "Claude Code workspace is not a directory."
+    assert str(private_file) not in str(file_error.value)
 
 
 def test_inner_tool_start_becomes_a_provider_labelled_native_card():
@@ -643,12 +662,15 @@ def test_oversized_stream_line_is_not_parsed():
 
 
 def test_cwd_must_exist_and_be_a_directory(tmp_path):
-    missing = json.loads(claude_code("fix", cwd=str(tmp_path / "missing")))
-    file_path = tmp_path / "file"
+    missing_path = tmp_path / "private-missing-directory"
+    missing = json.loads(claude_code("fix", cwd=str(missing_path)))
+    file_path = tmp_path / "private-host-file"
     file_path.write_text("x", encoding="utf-8")
     file_result = json.loads(claude_code("fix", cwd=str(file_path)))
-    assert "Working directory" in missing["error"]
-    assert "not a directory" in file_result["error"]
+    assert missing["error"] == "Working directory is unavailable."
+    assert str(missing_path) not in missing["error"]
+    assert file_result["error"] == "Working directory is not a directory."
+    assert str(file_path) not in file_result["error"]
 
 
 def test_missing_binary_is_one_structured_result(tmp_path):


### PR DESCRIPTION
Forward-port of #1182 from `release/1.7` to `main`.

Keeps configured workspace roots, requested paths, symlink targets, and OS exception text out of Claude Code errors shown to users. Public messages remain action-oriented and describe the failed operation without exposing host filesystem details.

Closes #1181 on main as well.

Verification:
- `python -m pytest tests/unit/test_claude_code_tool.py tests/unit/test_provider_workroom.py tests/unit/test_provider_workroom_events.py tests/unit/test_tool_approval.py tests/unit/test_uniform_provider_errors.py -q`
- 149 passed