### PR TITLE
fix: keep plugin workspace paths private on main

### DIFF
--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -103,11 +103,14 @@ class _CodingAgentPlugin(list):
             if not candidate.is_absolute():
                 candidate = self.workspace / candidate
             candidate = candidate.resolve(strict=True)
-            candidate.relative_to(self.workspace)
         except (OSError, RuntimeError, ValueError):
-            return None, f"Working directory must stay inside workspace {self.workspace}."
+            return None, "Working directory is unavailable."
+        try:
+            candidate.relative_to(self.workspace)
+        except ValueError:
+            return None, "Working directory must stay inside the configured workspace."
         if not candidate.is_dir():
-            return None, f"Working directory is not a directory: {candidate}."
+            return None, "Working directory is not a directory."
         return candidate, ""
 
     def _invoke(

--- a/docs/blog/2026-08-22-a-workspace-boundary-is-not-a-path.md
+++ b/docs/blog/2026-08-22-a-workspace-boundary-is-not-a-path.md
@@ -37,3 +37,12 @@ suites pass another 92.
 The lesson is smaller than “hide errors.” Errors are part of the product and
 must remain specific enough to recover from. But a boundary message should
 name the rule that failed, not disclose the private value used to enforce it.
+
+The next immutable Beta exposed a second lesson. Hosted Work Rooms validate
+their directory once in the first-class coding-agent plugin and again in the
+native adapter. The first fix covered the adapter; the public browser run used
+the plugin and found its older path-bearing message. The plugin now uses the
+same categorical contract for both Codex and Claude Code, and its own tests
+assert that missing paths, files, workspace roots, and symlink targets never
+enter the result. A privacy contract has to cover every public writer, not only
+the deepest implementation.

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -55,18 +55,35 @@ def test_compatibility_permission_names_are_normalized(tmp_path):
     assert CodexPlugin(permission_mode=":danger-full-access", workspace=tmp_path).permission_mode is PermissionMode.FULL_ACCESS
 
 
-def test_workspace_traversal_and_symlink_escape_fail_closed(tmp_path):
-    workspace = tmp_path / "workspace"
-    outside = tmp_path / "outside"
+@pytest.mark.parametrize("plugin", [CodexPlugin, ClaudeCodePlugin])
+def test_plugin_workspace_errors_fail_closed_without_exposing_host_paths(tmp_path, plugin):
+    workspace = tmp_path / "customer-secret-workspace"
+    outside = tmp_path / "private-host-directory"
     workspace.mkdir()
     outside.mkdir()
+    missing = workspace / "confidential-missing-directory"
+    not_directory = workspace / "private-file"
+    not_directory.write_text("private", encoding="utf-8")
     link = workspace / "escape"
     try:
         link.symlink_to(outside, target_is_directory=True)
     except OSError:
         pytest.skip("symlinks unavailable")
-    result = json.loads(CodexPlugin(workspace=workspace).codex("inspect", cwd="escape"))
-    assert "must stay inside workspace" in result["error"]
+
+    installed = plugin(workspace=workspace)
+    tool = getattr(installed, installed.provider)
+    unavailable = json.loads(tool("inspect", cwd=str(missing)))
+    file_target = json.loads(tool("inspect", cwd=str(not_directory)))
+    escaped = json.loads(tool("inspect", cwd="escape"))
+
+    assert unavailable["error"] == "Working directory is unavailable."
+    assert file_target["error"] == "Working directory is not a directory."
+    assert escaped["error"] == (
+        "Working directory must stay inside the configured workspace."
+    )
+    public = json.dumps([unavailable, file_target, escaped])
+    for private_path in (workspace, outside, missing, not_directory, link):
+        assert str(private_path) not in public
 
 
 def test_invocation_lifecycle_is_parented_and_terminal(monkeypatch, tmp_path):


### PR DESCRIPTION
Forward-port of #1186 from `release/1.7` to `main`.

Hosted `CodexPlugin` and `ClaudeCodePlugin` workspace failures remain categorical without exposing configured roots, requested paths, file targets, or symlink targets.

Verification: focused provider/approval/error/Work Room suite, 171 passed.

Tracks #1185.