### PR TITLE
fix(cli): support invocation-scoped co ai invites

### DIFF
--- a/connectonion/cli/co_ai/main.py
+++ b/connectonion/cli/co_ai/main.py
@@ -110,6 +110,7 @@ def start_server(
     full_access: bool = False,
     full_access_turns: int = 100,
     agent_factory=None,
+    invite_code: str = None,
 ):
     """Start AI coding agent web server.
 
@@ -121,6 +122,7 @@ def start_server(
         full_access: Whether bounded Full access is configured
         full_access_turns: User-driven turns before Full access expires
         agent_factory: Reserved configured factory for hosted sessions
+        invite_code: Optional in-memory invite for this server invocation
 
     The server will be accessible at:
     - POST http://localhost:{port}/input
@@ -132,12 +134,16 @@ def start_server(
 
     # Use global ~/.co/ for consistent identity across all co ai sessions.
     co_dir = Path.home() / ".co"
-    if _prepare_owner_onboarding(co_dir):
+    if invite_code is None and _prepare_owner_onboarding(co_dir):
         from ..commands.project_cmd_lib import console
 
         console.print(
             "[green]Owner invite created.[/green] Run [bold]co keys --reveal[/bold] when onboarding your client."
         )
+    elif invite_code is not None:
+        from ..commands.project_cmd_lib import ensure_global_config
+
+        ensure_global_config()
     load_host_config(co_dir)
     addr_data = address.load(co_dir)
 
@@ -158,4 +164,9 @@ def start_server(
 
     # The first-party browser speaks OIP over /ws. Native Codex and Claude Code
     # delegation stay inside the Agent as provider adapters.
-    host(agent, port=port, trust="careful", co_dir=co_dir)
+    trust = "careful"
+    if invite_code is not None:
+        from ...network.trust import TrustAgent
+
+        trust = TrustAgent("careful", invite_code=invite_code, co_dir=co_dir)
+    host(agent, port=port, trust=trust, co_dir=co_dir)

--- a/connectonion/cli/commands/ai_commands.py
+++ b/connectonion/cli/commands/ai_commands.py
@@ -2,7 +2,7 @@
 Purpose: AI coding agent CLI command with resumable machine-readable one-shot runs
 LLM-Note:
   Dependencies: imports from [cli/co_ai/main.py, cli/co_ai/agent.py] | imported by [cli/main.py] | no direct tests
-  Data flow: CLI args → start_server() or agent.input() for one-shot
+  Data flow: CLI args → validate invocation invite → start_server() or agent.input() for one-shot
   Integration: exposes handle_ai() | called from main.py as 'co ai' command
   Errors: known LLM provider failures print one actionable message and exit 1; programmer errors still propagate with their traceback
 """
@@ -31,6 +31,8 @@ def handle_ai(
     evaluate: bool = False,
     json_output: bool = False,
     resume: str = None,
+    invite_code: str = None,
+    invite_code_file: Path = None,
 ):
     """Start AI coding agent or run one-shot prompt.
 
@@ -44,11 +46,27 @@ def handle_ai(
         evaluate: Score completion with the eval debugging plugin
         json_output: Emit one JSON envelope to stdout
         resume: Continue a prior one-shot session ID
+        invite_code: In-memory invite code for this web-server run
+        invite_code_file: File containing this web-server run's invite code
 
     Examples:
         co ai                                    # Start web server
         co ai "Create a calculator agent"        # One-shot
     """
+    if invite_code is not None and invite_code_file is not None:
+        console.print(
+            "[red]--invite-code and --invite-code-file cannot be combined[/red]"
+        )
+        raise typer.Exit(2)
+
+    if prompt and (invite_code is not None or invite_code_file is not None):
+        console.print(
+            "[red]Invite-code options are only available in web-server mode[/red]"
+        )
+        raise typer.Exit(2)
+
+    runtime_invite_code = _read_runtime_invite_code(invite_code, invite_code_file)
+
     if not prompt and (json_output or resume):
         message = "--json and --resume require a one-shot prompt"
         if json_output:
@@ -98,7 +116,33 @@ def handle_ai(
             full_access=full_access,
             full_access_turns=full_access_turns,
             agent_factory=agent_factory,
+            invite_code=runtime_invite_code,
         )
+
+
+def _read_runtime_invite_code(invite_code, invite_code_file) -> str | None:
+    """Resolve a web-server invite without persisting or exporting it."""
+    if invite_code_file is not None:
+        path = Path(invite_code_file).expanduser()
+        try:
+            if not path.is_file():
+                raise OSError("not a regular file")
+            invite_code = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            console.print(f"[red]Cannot read --invite-code-file: {exc}[/red]")
+            raise typer.Exit(2) from None
+
+    if invite_code is None:
+        return None
+
+    invite_code = invite_code.strip()
+    if not invite_code:
+        console.print("[red]Invite code cannot be empty[/red]")
+        raise typer.Exit(2)
+    if "\n" in invite_code or "\r" in invite_code:
+        console.print("[red]Invite code must be a single line[/red]")
+        raise typer.Exit(2)
+    return invite_code
 
 
 def _agent_factory(*, evaluate: bool):

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -373,6 +373,12 @@ def ai(
     resume: Optional[str] = typer.Option(
         None, "--resume", help="Resume a prior one-shot session"
     ),
+    invite_code: Optional[str] = typer.Option(
+        None, "--invite-code", help="Invite code for this web-server run only"
+    ),
+    invite_code_file: Optional[Path] = typer.Option(
+        None, "--invite-code-file", help="Read this run's invite code from a file"
+    ),
 ):
     """Start AI coding agent or run one-shot prompt."""
     from .commands.ai_commands import handle_ai
@@ -386,6 +392,8 @@ def ai(
         evaluate=evaluate,
         json_output=json_output,
         resume=resume,
+        invite_code=invite_code,
+        invite_code_file=invite_code_file,
     )
 
 

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -117,6 +117,9 @@ def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
     Returns YAML config dict if trust is a level or file path, None otherwise.
     Used to extract onboard info for /info endpoint.
     """
+    if isinstance(trust, TrustAgent):
+        return trust.config
+
     if not isinstance(trust, str):
         return None
 

--- a/connectonion/network/trust/trust_agent.py
+++ b/connectonion/network/trust/trust_agent.py
@@ -108,7 +108,8 @@ class TrustAgent:
     """
 
     def __init__(self, trust: str = "careful", *, api_key: str = None,
-                 model: str = "co/gemini-3.7-flash", co_dir: Path = None):
+                 model: str = "co/gemini-3.7-flash", co_dir: Path = None,
+                 invite_code: str = None):
         """
         Create a TrustAgent.
 
@@ -118,6 +119,7 @@ class TrustAgent:
             model: Model to use for LLM decisions
             co_dir: Project .co directory. Bound at construction so trust state
                 does not move with, or disappear with, the process cwd.
+            invite_code: Optional in-memory override for this instance.
         """
         self.trust = trust
         self.api_key = api_key
@@ -126,6 +128,13 @@ class TrustAgent:
 
         # Load policy and parse config
         self._config, self._prompt = self._load_policy(trust)
+        if invite_code is not None:
+            invite_code = invite_code.strip()
+            if not invite_code:
+                raise ValueError("invite_code cannot be empty")
+            onboard = dict(self._config.get("onboard") or {})
+            onboard["invite_code"] = [invite_code]
+            self._config = {**self._config, "onboard": onboard}
 
         # Lazy-loaded LLM agent (only created if needed)
         self._llm_agent = None

--- a/connectonion/network/trust/ws_admin.py
+++ b/connectonion/network/trust/ws_admin.py
@@ -11,7 +11,7 @@ LLM-Note:
   State/Effects: mutates trust agent state via trust_agent.verify_invite/verify_payment and admin_trust_* / admin_admins_* callbacks | prints colored audit lines to stdout via rich.Console (✓/✗ with truncated agent_address) | sends frames to client via injected send_msg
   Integration: exposes get_onboard_requirements(trust_agent), async handle_onboard_submit(data, send_msg, route_handlers), async handle_admin_message(data, send_msg, route_handlers) | route_handlers dict must contain auth, trust_agent, admin_trust_promote/demote/block/unblock/level, admin_admins_add/remove
   Errors: returns ERROR frames (never raises) for: invalid signature, blocked agent_address, missing client_id/admin_id, bad invite code, insufficient payment, non-admin, non-super-admin, unknown admin action
-  Security: ⚠️ all state-changing operations require valid signature + admin/super-admin level | invite/payment verification delegated to TrustAgent
+  Security: ⚠️ all state-changing operations require valid signature + admin/super-admin level | invite/payment verification delegated to TrustAgent | invite values are never printed
 """
 
 from rich.console import Console
@@ -82,7 +82,10 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
     if invite_code:
         if trust_agent.verify_invite(agent_address, invite_code):
             actual_level = trust_agent.get_level(agent_address)
-            console.print(f"[green]✓[/green] Verified [bold]{agent_address[:16]}...[/bold] with invite code [cyan]{invite_code}[/cyan] → {actual_level}")
+            console.print(
+                f"[green]✓[/green] Verified [bold]{agent_address[:16]}...[/bold] "
+                f"with invite code → {actual_level}"
+            )
             await send_msg({
                 "type": "ONBOARD_SUCCESS",
                 "identity": agent_address,
@@ -91,7 +94,10 @@ async def handle_onboard_submit(data, send_msg, route_handlers):
             })
             return agent_address
         else:
-            console.print(f"[red]✗[/red] Invalid invite code [cyan]{invite_code}[/cyan] from {agent_address[:16]}...")
+            console.print(
+                f"[red]✗[/red] Invalid invite code from "
+                f"{agent_address[:16]}..."
+            )
             await send_msg({"type": "ERROR", "message": "Invalid invite code"})
             return
 

--- a/docs/blog/2026-08-22-an-invite-is-not-an-environment.md
+++ b/docs/blog/2026-08-22-an-invite-is-not-an-environment.md
@@ -1,0 +1,39 @@
+# An Invite Is Not an Environment
+
+The 1.7 beta Host was running. The browser was open. The release test still
+could not begin.
+
+`co ai` already knew how to create a private owner invite and keep it in
+`~/.co/keys.env`. That was useful for a person returning to the same machine:
+the code survived a restart, and clients that had already received it were not
+locked out. It was the wrong lifetime for a clean release run.
+
+An E2E runner wanted a new credential for one Host process. Its choices were to
+edit a persistent file, export the credential into an environment inherited by
+the coding agent and its tools, or stop and call the missing value an external
+authorization blocker. We took the third path during beta acceptance. The
+blocked test was telling us something real, but not what we first wrote down.
+
+The fix gives `co ai` two explicit inputs. A person can pass `--invite-code` for
+a local run. Automation can use `--invite-code-file`, keeping the value out of
+shell history and the process argument list. Both become an in-memory override
+on the Host's `TrustAgent`. They do not update `.env`, mutate `os.environ`, or
+enter the model and tool subprocess environment.
+
+This work also found an older leak at the boundary. WebSocket onboarding logs
+printed both accepted and rejected invite values. A secret that was absent from
+the policy file could still end up in CI output. The logs now record the signed
+client, outcome, and resulting trust level—the facts an operator needs—without
+recording the credential used to prove them.
+
+The installed-wheel smoke checked the whole non-network chain: CLI file input,
+runtime trust configuration, OIP discovery, WebSocket onboarding, unchanged
+process environment, unchanged `keys.env`, and sanitized output. The focused
+regression set passed 154 tests. The managed test sandbox forbade binding a
+localhost port, so the final browser leg remains an explicit CI acceptance
+step, not an inferred success.
+
+The lesson is about lifetime. An invite can establish a durable relationship
+without becoming durable configuration itself. Authentication works better
+when the credential lives exactly as long as the workflow that needs it—and no
+longer.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -36,6 +36,21 @@ Restarting `co ai` keeps the same invite, so clients already given the code are
 not locked out. An explicit `CO_INVITE_CODE` in the current project or process
 continues to take precedence.
 
+For a clean test run, provide an invite that exists only for that Host process:
+
+```bash
+co ai --invite-code-file /path/to/private-invite
+```
+
+`--invite-code-file` is recommended for automation because the value does not
+appear in shell history or the process argument list. The file should be
+readable only by its owner. `--invite-code <code>` is also available for an
+interactive local run. Both forms override `CO_INVITE_CODE` in memory without
+changing `.env`, `~/.co/keys.env`, `host.yaml`, or the process environment.
+They are web-server options only and cannot be combined with a one-shot prompt.
+Successful onboarding still creates the normal durable contact; only the
+temporary way into that Host disappears when `co ai` exits.
+
 The published `@connectonion/react` package owns the browser OIP client, browser
 identity, onboarding, reconnect, approvals, and session normalization. O Chat
 pins one exact preview version. The Host advertises OIP 0.1 in `CONNECTED`; an
@@ -89,6 +104,8 @@ POSIX systems additionally enforce `0700` directories and `0600` files.
 | `--eval` | | off | Debug a task with two extra model calls that score completion |
 | `--json` | | off | Emit one JSON envelope to stdout in one-shot mode |
 | `--resume` | | | With `--json`, continue a one-shot session by ID |
+| `--invite-code` | | | Use an in-memory invite for this web-server run |
+| `--invite-code-file` | | | Read this run's invite from a private file (recommended for automation) |
 
 ```bash
 co ai --port 9000
@@ -96,6 +113,7 @@ co ai --model co/gemini-3.7-flash
 co ai "Build an agent" --model co/gpt-4o --max-iterations 50
 co ai --full-access "Fix the failing suite" --full-access-turns 20
 co ai --eval "Check whether this agent really completed the task"
+co ai --invite-code-file /path/to/private-invite
 ```
 
 ## Full access (`--full-access`)

--- a/tests/e2e/cli/test_cli_ai.py
+++ b/tests/e2e/cli/test_cli_ai.py
@@ -1,5 +1,6 @@
 """CLI routing tests for the bounded `co ai` Full access mode."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from click.utils import strip_ansi
@@ -29,6 +30,8 @@ def test_ai_forwards_full_access_options():
         evaluate=False,
         json_output=False,
         resume=None,
+        invite_code=None,
+        invite_code_file=None,
     )
 
 
@@ -50,6 +53,8 @@ def test_ai_forwards_json_and_resume_options():
         evaluate=False,
         json_output=True,
         resume="session-id",
+        invite_code=None,
+        invite_code_file=None,
     )
 
 
@@ -71,3 +76,15 @@ def test_ai_eval_is_explicit_and_forwarded():
 
     assert result.exit_code == 0
     assert handler.call_args.kwargs["evaluate"] is True
+
+
+def test_ai_forwards_invocation_invite_options():
+    with patch("connectonion.cli.commands.ai_commands.handle_ai") as handler:
+        result = runner.invoke(
+            app,
+            ["ai", "--invite-code-file", "/private/invite"],
+        )
+
+    assert result.exit_code == 0
+    assert handler.call_args.kwargs["invite_code"] is None
+    assert handler.call_args.kwargs["invite_code_file"] == Path("/private/invite")

--- a/tests/unit/test_asgi_websocket_admin_onboard.py
+++ b/tests/unit/test_asgi_websocket_admin_onboard.py
@@ -187,7 +187,7 @@ class TestHandleOnboardSubmit:
         assert sent_messages[0]["type"] == "ERROR"
         assert sent_messages[0]["message"] == "forbidden: blocked"
 
-    async def test_invite_success(self):
+    async def test_invite_success(self, capsys):
         sent_messages = []
 
         async def send(msg):
@@ -211,8 +211,9 @@ class TestHandleOnboardSubmit:
 
         assert sent_messages[0]["type"] == "ONBOARD_SUCCESS"
         assert sent_messages[0]["level"] == "contact"
+        assert "BETA2024" not in capsys.readouterr().out
 
-    async def test_invite_invalid(self):
+    async def test_invite_invalid(self, capsys):
         sent_messages = []
 
         async def send(msg):
@@ -235,6 +236,7 @@ class TestHandleOnboardSubmit:
 
         assert sent_messages[0]["type"] == "ERROR"
         assert "Invalid invite code" in sent_messages[0]["message"]
+        assert "WRONG" not in capsys.readouterr().out
 
     async def test_payment_success(self):
         sent_messages = []

--- a/tests/unit/test_cli_commands_ai_trust.py
+++ b/tests/unit/test_cli_commands_ai_trust.py
@@ -9,6 +9,8 @@ Components under test:
 - Module: cli_commands_ai_trust
 """
 
+from pathlib import Path
+
 import pytest
 import typer
 
@@ -50,6 +52,7 @@ def test_handle_ai_calls_start_server(monkeypatch):
     assert called["max_iterations"] == 3
     assert called["full_access"] is True
     assert called["full_access_turns"] == 7
+    assert called["invite_code"] is None
     assert callable(called["agent_factory"])
     assert called["agent"] is created["agent"]
     assert created["model"] == "m"
@@ -57,6 +60,62 @@ def test_handle_ai_calls_start_server(monkeypatch):
     assert created["co_dir"] == GLOBAL_CO_DIR
     assert created["full_access_turns"] is None
     assert created["extra_plugins"] == ()
+
+
+def test_handle_ai_passes_invocation_invite_to_web_server(monkeypatch):
+    called = {}
+
+    monkeypatch.setattr(ai_mod, "_create_agent", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.main.start_server",
+        lambda _agent, **kwargs: called.update(kwargs),
+    )
+
+    ai_mod.handle_ai(invite_code="  RUN-ONLY-123  ")
+
+    assert called["invite_code"] == "RUN-ONLY-123"
+
+
+def test_handle_ai_reads_invocation_invite_file(tmp_path, monkeypatch):
+    called = {}
+    secret_file = tmp_path / "invite"
+    secret_file.write_text("FILE-ONLY-456\n", encoding="utf-8")
+
+    monkeypatch.setattr(ai_mod, "_create_agent", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        "connectonion.cli.co_ai.main.start_server",
+        lambda _agent, **kwargs: called.update(kwargs),
+    )
+
+    ai_mod.handle_ai(invite_code_file=secret_file)
+
+    assert called["invite_code"] == "FILE-ONLY-456"
+
+
+def test_handle_ai_rejects_empty_invitation_file(tmp_path):
+    secret_file = tmp_path / "invite"
+    secret_file.write_text("\n", encoding="utf-8")
+
+    with pytest.raises(typer.Exit) as caught:
+        ai_mod.handle_ai(invite_code_file=secret_file)
+
+    assert caught.value.exit_code == 2
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"invite_code": ""},
+        {"invite_code": "line-one\nline-two"},
+        {"invite_code": "one", "invite_code_file": Path("two")},
+        {"prompt": "task", "invite_code": "one"},
+    ],
+)
+def test_handle_ai_rejects_invalid_invite_option_combinations(kwargs):
+    with pytest.raises(typer.Exit) as caught:
+        ai_mod.handle_ai(**kwargs)
+
+    assert caught.value.exit_code == 2
 
 
 def test_handle_ai_enables_eval_only_when_requested(monkeypatch, capsys):

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -10,6 +10,7 @@ Components under test:
 """
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -275,6 +276,40 @@ def test_start_server_prepares_owner_invite_without_printing_it(monkeypatch):
     output = " ".join(printed)
     assert "co keys --reveal" in output
     assert secret not in output
+
+
+def test_start_server_uses_runtime_invite_without_persisting_or_exporting(
+    monkeypatch,
+):
+    agent = SimpleNamespace(name="agent")
+    hosted = {}
+    prepared = []
+    configured = []
+    secret = "RUN-ONLY-NEVER-PRINT"
+
+    monkeypatch.delenv("CO_INVITE_CODE", raising=False)
+    monkeypatch.setattr(
+        main_mod,
+        "_prepare_owner_onboarding",
+        lambda co_dir: prepared.append(co_dir),
+    )
+    monkeypatch.setattr(
+        "connectonion.cli.commands.project_cmd_lib.ensure_global_config",
+        lambda: configured.append(True),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "host",
+        lambda value, **kwargs: hosted.update({"agent": value, **kwargs}),
+    )
+
+    main_mod.start_server(agent, invite_code=secret)
+
+    assert prepared == []
+    assert configured == [True]
+    assert "CO_INVITE_CODE" not in os.environ
+    assert hosted["trust"].config["onboard"]["invite_code"] == [secret]
+    assert hosted["trust"].verify_invite("someone", "wrong") is False
 
 
 def test_role_reaches_the_assembler(monkeypatch, tmp_path):


### PR DESCRIPTION
Adds `co ai --invite-code` and automation-safe `--invite-code-file`; injects the override into a Host-scoped TrustAgent without persisting it or mutating `os.environ`; keeps OIP discovery correct; and removes invite values from WebSocket onboarding logs.

Closes #1189. Tracked by #792.

## Verification

- 154 focused CLI/Host/trust/OIP tests pass.
- Changed modules compile; wheel build/install passes.
- Installed-wheel CLI → TrustAgent → OIP config → WebSocket onboarding smoke passes with no secret in output/environment and unchanged `~/.co/keys.env`.
- All GitHub checks pass on Python 3.10–3.13, Windows browser/E2E, macOS E2E, lockfile, and blog gate.

## Real Host → browser acceptance

Tested the installed `connectonion-1.7.0b9` wheel with a real localhost Host and the public O Chat client:

1. Started `co ai --invite-code-file <mode-0600-file>` on an owned dynamic localhost port.
2. Opened the Agent in an isolated named Co-browser tab with a fresh browser identity for that Agent.
3. Confirmed the invite-only gate appeared; injected the invite through the system clipboard, immediately restored the previous clipboard, and captured no screenshot while the value was present.
4. Host log recorded `ONBOARD_SUBMIT`, successful invite verification, contact settlement, and accepted OIP connection; the invite value did not appear in CLI/browser/Host output.
5. Sent a real Rust project task, observed bounded action summaries plus Thinking/running/completed states, approved the real command once, and independently verified the generated project and successful `rust-agent-ready` result.
6. Captured 1440×900 and 390×844 onboarding, connected, running, approval, and completed states.

The localhost/browser limitation noted in the original draft is resolved by this live run.
