### PR TITLE
fix(1.7): keep Control Center status truthful and responsive

### DIFF
--- a/connectonion/network/host/ws_router/starter.html
+++ b/connectonion/network/host/ws_router/starter.html
@@ -52,6 +52,8 @@
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
   }
+  html, body { max-width: 100%; overflow-x: clip; }
+  main, .grid, .card, .quick { width: 100%; min-width: 0; max-width: 100%; }
   main { width: min(100%, 860px); margin: 0 auto; }
   button, input, summary { font: inherit; }
   button, summary { min-height: 44px; }
@@ -86,10 +88,6 @@
   }
 
   .now { display: flex; align-items: flex-start; gap: 11px; }
-  .status-dot {
-    flex: none; width: 10px; height: 10px; margin-top: 6px; border-radius: 999px;
-    background: var(--cc-accent); box-shadow: 0 0 0 5px var(--cc-accent-soft);
-  }
   .now strong { display: block; font-size: 15px; }
   .now p { margin: 2px 0 0; color: var(--cc-muted); font-size: 13px; }
 
@@ -102,9 +100,9 @@
 
   .skill {
     position: relative; display: flex; flex-direction: column; justify-content: center;
-    width: 100%; min-height: 56px; padding: 10px 34px 10px 12px;
+    width: 100%; min-width: 0; max-width: 100%; min-height: 56px; padding: 10px 34px 10px 12px;
     border: 0; border-radius: var(--cc-radius-sm); background: transparent;
-    color: var(--cc-text); cursor: pointer; text-align: left;
+    color: var(--cc-text); cursor: pointer; text-align: left; overflow: hidden;
   }
   .skill::after {
     content: ""; position: absolute; right: 14px; top: 50%; width: 7px; height: 7px;
@@ -115,7 +113,7 @@
   .skill:active { background: var(--cc-accent-soft); }
   .skill .name { font-size: 13.5px; font-weight: 700; overflow-wrap: anywhere; }
   .skill .desc {
-    margin-top: 2px; color: var(--cc-muted); font-size: 12px;
+    min-width: 0; max-width: 100%; margin-top: 2px; color: var(--cc-muted); font-size: 12px;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
   .skill .desc:empty { display: none; }
@@ -201,9 +199,9 @@
     </header>
 
     <div class="grid overview">
-      <section class="card card-pad" aria-labelledby="now-title">
-        <h2 class="section-title" id="now-title">Now</h2>
-        <div class="now"><span class="status-dot" aria-hidden="true"></span><div><strong>Ready</strong><p>Available for a new task.</p></div></div>
+      <section class="card card-pad" aria-labelledby="workspace-title">
+        <h2 class="section-title" id="workspace-title">Workspace</h2>
+        <div class="now"><div><strong>Use Chat for live status</strong><p>Current tasks, approvals, and results stay in the conversation.</p></div></div>
       </section>
 $quick_actions
     </div>

--- a/docs/blog/2026-08-22-a-snapshot-is-not-live-state.md
+++ b/docs/blog/2026-08-22-a-snapshot-is-not-live-state.md
@@ -1,0 +1,34 @@
+# A Snapshot Is Not Live State
+
+The 1.7 beta opened with a reassuring Control Center. A green dot sat beside
+“Ready,” followed by “Available for a new task.” Then we sent a real Rust job
+through `co ai`, watched the agent create files, and stopped at a genuine shell
+approval.
+
+The Control Center still said Ready.
+
+Nothing had failed to update. That was the problem. The starter dashboard is an
+HTML snapshot sent when the client connects and after a turn changes the page.
+It does not receive thinking, approval, input-wait, Stop, failure, or completion
+frames. We had put a live claim on a surface with no live information.
+
+The same end-to-end run found a second version of the mistake. O Chat showed
+“live” under the composer after the final result had arrived. That word came
+from the WebSocket being active, not the task still running. Two technically
+correct implementation facts contradicted what the person saw happening.
+
+The fix starts with ownership. Core's starter no longer invents a runtime state;
+it points to Chat for current work, approvals, and results. O Chat derives one
+authoritative phase from transport, pending decisions, and task activity, then
+shows the same phase beside the composer and above the sandboxed Control Center:
+Working, Approval needed, Input needed, Connected, or Disconnected.
+
+The phone screenshot caught one more boundary error. A long Quick Action
+description set the grid item's minimum width, so the iframe grew a horizontal
+scrollbar and clipped its right edge. Explicit zero minimums now let the card
+shrink to the pane instead of asking the pane to grow around its content.
+
+Unit tests can prove that a template contains text and that a phase reducer has
+the right precedence. Only the real Host → browser journey showed that the two
+surfaces disagreed. The lesson is broader than dashboards: if a component does
+not consume lifecycle events, it cannot truthfully describe lifecycle state.

--- a/docs/network/dashboard.md
+++ b/docs/network/dashboard.md
@@ -1,9 +1,15 @@
 # Control Center
 
 Every hosted agent has a **Control Center** beside the conversation. The Host renders
-a current day-zero view—identity and state, Now, quick actions, recent activity,
-schedules, searchable capabilities, and diagnostics—before you type anything.
+a current day-zero view—identity, quick actions, recent activity, searchable
+capabilities, and diagnostics—before you type anything.
 Custom pages keep the stable filename `.co/dashboard.html` for compatibility.
+
+The HTML snapshot is not the source of truth for a running task. It does not receive
+thinking, approval, input-wait, Stop, failure, or completion frames. The client owns
+that live status and renders it outside the sandboxed page, while the starter directs
+the reader back to Chat for the current task, approvals, and results. A custom
+Control Center should not hard-code runtime claims such as “Ready” or “Working”.
 
 ```
 my-agent/

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -189,7 +189,7 @@ def test_control_center_semantic_golden_layout_is_present():
     })
 
     for landmark in (
-        "Control Center", 'id="now-title"', "Quick actions", "Capabilities",
+        "Control Center", 'id="workspace-title"', "Quick actions", "Capabilities",
         "Recent", "Diagnostics", "Host details",
     ):
         # Recent is allowed to be absent without history; all other day-zero
@@ -200,6 +200,24 @@ def test_control_center_semantic_golden_layout_is_present():
     assert '<co-filter target="#capability-list"' in html
     assert 'id="capability-list"' in html
     assert "co/example" in html and "careful" in html and ADDRESS in html
+
+
+def test_control_center_never_claims_a_static_runtime_state():
+    """The dashboard snapshot does not receive turn lifecycle frames. Calling it
+    Ready while Chat is working or awaiting approval contradicts the live client."""
+    html = render_starter({"name": "Operations", "skills": []})
+
+    assert "Available for a new task" not in html
+    assert "<strong>Ready</strong>" not in html
+    assert "Use Chat for live status" in html
+
+
+def test_quick_actions_cannot_set_the_iframe_minimum_width():
+    template = (Path(dashboard_module.__file__).parent / "starter.html").read_text()
+
+    assert "html, body { max-width: 100%; overflow-x: clip; }" in template
+    assert "width: 100%; min-width: 0; max-width: 100%;" in template
+    assert "min-width: 0; max-width: 100%; margin-top" in template
 
 
 def test_control_center_accessibility_contract_is_in_the_shipped_template():


### PR DESCRIPTION
## Outcome

Keep the 1.7 starter Control Center truthful and responsive when O Chat is running, awaiting approval, or viewed at phone width.

The starter snapshot does not receive task lifecycle frames, so it must not hard-code `Ready`. O Chat owns the authoritative live phase under openonion/oo-chat#211 / merged PR #213.

## Changes

- replace the static `Ready — Available for a new task` claim with a durable pointer to Chat's live task state;
- prevent Quick Actions and long descriptions from setting the iframe's minimum width;
- document that runtime task state belongs to the client outside sandboxed dashboard HTML;
- add regression tests for the truthful-state and responsive CSS contracts.

## Verification

- `PYTHONPATH=. .../python -m pytest -c /dev/null tests/unit/test_dashboard.py -q` — 55 passed;
- Core CI passes on Python 3.10–3.13, Windows browser/E2E, macOS E2E, lockfile, and blog gates on the prior equivalent code head; final ancestry-only rebase has queued the same checks again;
- exact combined source tree `1c970d99ac4af90c1f064606ef88bd09c1224160` was packaged as `co 1.7.0b9` with merged #1193 content;
- complete localhost production journey passed against O Chat `0bf90195d0672c98f9adfbed77ae5f4ebea00a37` / merged PR #213;
- journey passed fresh invite onboarding, real Rust CLI creation, independent Cargo tests and exact output, Full access/Read only/Auto, Stop, Host restart, Reconnect without duplicate `INPUT`, and 1440px/390px no-overflow checks;
- generated manifest reports all 12 checks true, with Core executable SHA-256 `a447a40c3c045bf90045febfa86faa6f86651b354e3aeb77230e82116460f928`;
- all generated screenshots were manually inspected: user/assistant messages, Todo steps, tool summaries, Working/Connected state, permissions, disconnect, and Reconnect remain visible and contained;
- final branch head `ef7f51fd0a7022823717f9a39f5afbf6fca6e212` is an ancestry-only rebase onto merged #1193 (`release/1.7`); its Git tree is byte-identical to the tested candidate tree above.

Tracked by #792, openonion/oo-chat#211, and merged openonion/oo-chat#213.
