### PR TITLE
fix(browser): recover daemon after page timeout

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -218,6 +218,7 @@ class BrowserDaemon:
         # stopping" from "the socket broke while we were meant to be serving".
         self._closing = False
         self._had_browser = False
+        self._defer_context_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
         self._next_tab = 1        # id allocator for auto-named tabs
 
@@ -652,7 +653,32 @@ class BrowserDaemon:
             # it. Launch failures are handled above by _launch_failed().
             if ok is False and payload.startswith("TimeoutError:"):
                 self._had_browser = True
+                self._defer_context_probe = True
                 continue
+
+            # Recovery often takes more than one command: Escape, inspect the
+            # URL, screenshot, then query the DOM. Inserting the same synchronous
+            # context probe between any two of them recreates the deadlock. Stay
+            # in this bounded recovery window until a fresh navigation settles.
+            # Explicit closure and a closed-target error still release the socket
+            # immediately without another browser round trip.
+            if self._defer_context_probe:
+                closed = (
+                    payload == "Browser closed"
+                    or (
+                        ok is False
+                        and (
+                            payload.startswith("TargetClosedError:")
+                            or "context or browser has been closed" in payload
+                        )
+                    )
+                )
+                if self.browser._launch_failed() or closed:
+                    break
+                if ok is True and payload.startswith("Navigated to "):
+                    self._defer_context_probe = False
+                else:
+                    continue
 
             # Exit (releasing the socket) when the browser can no longer be driven, so the
             # next command spawns a fresh daemon instead of reusing a dead one. This is a

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -641,6 +641,19 @@ class BrowserDaemon:
             finally:
                 conn.close()
 
+            # A Playwright timeout proves the context existed, but not that it is
+            # currently safe to round-trip through. In particular, Page.goto can
+            # time out while Chromium is still trying to settle the navigation.
+            # Calling _context_is_alive() immediately submits context.cookies() to
+            # that same single browser worker and can block the daemon before it
+            # accepts the recovery command (Escape, inspect, screenshot, close).
+            # Keep the request boundary honest: return this timeout to its caller,
+            # remember that a browser did exist, and let the next command recover
+            # it. Launch failures are handled above by _launch_failed().
+            if ok is False and payload.startswith("TimeoutError:"):
+                self._had_browser = True
+                continue
+
             # Exit (releasing the socket) when the browser can no longer be driven, so the
             # next command spawns a fresh daemon instead of reusing a dead one. This is a
             # SHARED-context decision, not a per-session one: a command on a page-less tab

--- a/docs/blog/2026-08-22-the-timeout-that-blocked-recovery.md
+++ b/docs/blog/2026-08-22-the-timeout-that-blocked-recovery.md
@@ -20,8 +20,9 @@ open and could be recovered by stopping the load.
 
 The daemon now returns a browser timeout without immediately asking the same
 browser another synchronous question. It records that a context existed and
-accepts the next command. Launch failures and later dead-context checks keep
-their previous behavior.
+accepts the recovery command sequence without inserting that probe between
+steps. A fresh successful navigation restores normal liveness checks; explicit
+closure and closed-target errors still release the daemon immediately.
 
 The regression makes the old trap explicit. A fake page command raises
 `TimeoutError`; its liveness method fails if called before recovery; the next

--- a/docs/blog/2026-08-22-the-timeout-that-blocked-recovery.md
+++ b/docs/blog/2026-08-22-the-timeout-that-blocked-recovery.md
@@ -1,0 +1,32 @@
+# The Timeout That Blocked Recovery
+
+The release browser opened a localhost page that `curl` could fetch with a 200
+response and a complete 20 KB body. Playwright still did not observe
+`DOMContentLoaded` within 30 seconds, so `go_to` correctly returned a timeout.
+That should have left several useful choices: press Escape, inspect the current
+URL, take a screenshot, retry, or close the owned tab.
+
+None of them worked. The browser daemon sent the timeout to its first client,
+then performed a context-liveness check before accepting the next connection.
+That check was another synchronous browser round trip on the same single
+Playwright worker. The page that had just failed to settle also blocked the
+probe, turning one bounded request failure into an unbounded daemon failure.
+
+Killing the daemon would have made the release test continue, but it is the
+wrong recovery model for a shared persistent browser. One task's bad page must
+not discard unrelated tabs, login state, or another agent's work. Treating the
+timeout as proof that the browser had died was also false: Chromium was still
+open and could be recovered by stopping the load.
+
+The daemon now returns a browser timeout without immediately asking the same
+browser another synchronous question. It records that a context existed and
+accepts the next command. Launch failures and later dead-context checks keep
+their previous behavior.
+
+The regression makes the old trap explicit. A fake page command raises
+`TimeoutError`; its liveness method fails if called before recovery; the next
+Escape command must still receive a response. The focused recovery set passes
+five tests, and the complete browser-daemon file passes all 86.
+
+A timeout is already an answer. Recovery code should not repeat the operation
+that just stopped answering before it gives the caller a chance to recover.

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -550,6 +550,9 @@ class TimedOutNavigationBrowser(StubBrowser):
         self.recovered = True
         return f"Pressed {key}"
 
+    def get_current_url(self) -> str:
+        return "http://127.0.0.1:3100"
+
     def _context_is_alive(self) -> bool:
         self.liveness_calls += 1
         if not self.recovered:
@@ -572,10 +575,11 @@ def test_navigation_timeout_keeps_daemon_available_for_recovery(short_sock, monk
     assert c.send("keyboard_press Escape", headless=True) == 0
     assert capsys.readouterr().out.strip() == "Pressed Escape"
     assert browser.recovered is True
-    deadline = time.time() + 1
-    while browser.liveness_calls == 0 and time.time() < deadline:
-        time.sleep(0.01)
-    assert browser.liveness_calls == 1
+    assert browser.liveness_calls == 0
+
+    assert c.send("get_current_url", headless=True) == 0
+    assert capsys.readouterr().out.strip() == "http://127.0.0.1:3100"
+    assert browser.liveness_calls == 0
 
 
 class LaunchFailBrowser(StubBrowser):

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -535,6 +535,49 @@ def test_socket_round_trip_error_to_stderr(short_sock, monkeypatch, capsys):
     assert "unknown command: frobnicate" in err
 
 
+class TimedOutNavigationBrowser(StubBrowser):
+    """A timed-out page is recoverable, but a post-timeout round trip deadlocks it."""
+
+    def __init__(self):
+        super().__init__()
+        self.recovered = False
+        self.liveness_calls = 0
+
+    def go_to(self, url: str, purpose: str = "", who: str = "", hours: float = 0.0) -> str:
+        raise TimeoutError("Page.goto: Timeout 30000ms exceeded.")
+
+    def keyboard_press(self, key: str) -> str:
+        self.recovered = True
+        return f"Pressed {key}"
+
+    def _context_is_alive(self) -> bool:
+        self.liveness_calls += 1
+        if not self.recovered:
+            raise AssertionError("post-timeout liveness probe would block")
+        return True
+
+
+def test_navigation_timeout_keeps_daemon_available_for_recovery(short_sock, monkeypatch, capsys):
+    sock_path = short_sock
+    monkeypatch.setenv("CO_BROWSER_SOCK", sock_path)
+    browser = TimedOutNavigationBrowser()
+    daemon = make_daemon(sock_path, stub=browser)
+    threading.Thread(target=daemon.serve, daemon=True).start()
+    _wait_until_listening(sock_path)
+
+    assert c.send("go_to http://127.0.0.1:3100", headless=True) == 1
+    assert "TimeoutError: Page.goto" in capsys.readouterr().err
+    assert browser.liveness_calls == 0
+
+    assert c.send("keyboard_press Escape", headless=True) == 0
+    assert capsys.readouterr().out.strip() == "Pressed Escape"
+    assert browser.recovered is True
+    deadline = time.time() + 1
+    while browser.liveness_calls == 0 and time.time() < deadline:
+        time.sleep(0.01)
+    assert browser.liveness_calls == 1
+
+
 class LaunchFailBrowser(StubBrowser):
     """A browser whose launch aborts (e.g. Chrome SIGABRT): commands raise a huge
     patchright-style Call log, the context never comes up, and _launch_failed is True."""


### PR DESCRIPTION
## Outcome

Keep the persistent browser daemon responsive after a Playwright page-command timeout, so the caller can issue Escape, inspect, screenshot, retry, or close its owned tab instead of force-killing the isolated daemon.

Closes #1192. Tracked by #792 and openonion/oo-chat#212.

## Root cause

`BrowserDaemon.serve()` correctly returned `TimeoutError` to the first client, then immediately called `_context_is_alive()`. That method performs another synchronous browser round trip on the single Playwright worker. A still-settling timed-out navigation could block that probe, so the daemon never accepted a recovery or cleanup command.

## Change

- treat a browser `TimeoutError` as proof that a context existed;
- enter a recovery window that skips unsafe liveness probes between Escape, URL inspection, screenshot, DOM inspection, retry, and owned cleanup;
- restore normal probes after a fresh navigation settles; explicit close and closed-target errors still release the daemon immediately;
- keep launch-failure and later dead-context checks unchanged;
- add a socket-level regression where the liveness probe would fail before recovery and the following Escape plus URL-inspection commands both succeed.

## Verification

- targeted timeout/launch/socket tests: 5 passed;
- full `tests/e2e/cli/test_browser_daemon.py`: 86 passed;
- Python compile and diff checks: pass;
- CI: lockfile, blog gate, Python 3.10–3.13, Windows browser/E2E, and macOS E2E all pass;
- installed exact candidate `co 1.7.0b9` at Core head `1725bfe6e56cccf9661727a5007694391bbb8d3c`;
- complete O Chat localhost production gate passed at `55eeff6f24afbdf1ac2a54a8701af96429e734be` with fresh invite onboarding, real Rust CLI creation, Cargo verification, Full access/Read only/Auto, Stop, Host restart, Reconnect without duplicate `INPUT`, desktop/mobile layout, screenshots, sanitized logs, and manifest;
- manifest checks: 12/12 true.
