### PR TITLE
fix(1.7): expose provider conversations in Workroom

### DIFF
--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -28,6 +28,7 @@ from ..core.provider_events import (
     next_provider_state_revision,
     provider_activity_event,
     provider_artifact_event,
+    provider_message_event,
     provider_status_summary,
     remember_provider_activity,
     remember_provider_artifact,
@@ -190,6 +191,7 @@ def _run_claude_code(
 
     argv = _stream_command(command, prompt, session_id, permission_mode, model)
     forwarder = _ClaudeStreamForwarder(agent)
+    forwarder.emit_user_message(prompt)
     cancelled = _provider_cancellation_check(agent)
     try:
         completed = _run_process(
@@ -404,7 +406,12 @@ class _ClaudeStreamForwarder:
         )
         self._tools: dict[str, dict[str, Any]] = {}
         self._activity_sequences: dict[str, int] = {}
+        self._messages: dict[str, str] = {}
         self._event_count = 0
+
+    def emit_user_message(self, text: str) -> None:
+        """Publish the initiating prompt only inside a correlated Work Room."""
+        self._emit_message("user:initial", "user", text)
 
     def handle(self, event: dict[str, Any]) -> None:
         if self._io is None or not isinstance(event, dict):
@@ -416,6 +423,22 @@ class _ClaudeStreamForwarder:
             self._user(event)
 
     def _assistant(self, event: dict[str, Any]) -> None:
+        text = "\n".join(
+            block["text"]
+            for block in _content_blocks(event)
+            if block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+            and block["text"].strip()
+        )
+        if text:
+            message = event.get("message")
+            native_id = message.get("id") if isinstance(message, dict) else None
+            stable_id = (
+                _stable_identifier(native_id)
+                if isinstance(native_id, str) and native_id
+                else hashlib.sha256(text.encode("utf-8")).hexdigest()
+            )
+            self._emit_message(f"assistant:{stable_id}", "assistant", text)
         for block in _content_blocks(event):
             if block.get("type") != "tool_use":
                 continue
@@ -457,6 +480,25 @@ class _ClaudeStreamForwarder:
                 _safe_tool_result(block.get("content")),
             )
             self._tools.pop(tool_id, None)
+
+    def _emit_message(self, message_id: str, role: str, text: str) -> None:
+        if not self._correlation:
+            return
+        try:
+            event = provider_message_event(
+                provider="claude_code",
+                invocation_id=self._correlation["invocationId"],
+                parent_tool_call_id=self._correlation["parentToolCallId"],
+                message_id=message_id,
+                role=role,
+                text=text,
+            )
+        except ValueError:
+            return
+        if self._messages.get(message_id) == event["text"]:
+            return
+        self._messages[message_id] = event["text"]
+        self._emit("provider_message", **_without_event_type(event))
 
     def _emit_unknown_start(self, provider_id: str, metadata: dict[str, Any]) -> None:
         metadata["name"] = "Tool"

--- a/connectonion/useful_tools/codex.py
+++ b/connectonion/useful_tools/codex.py
@@ -225,8 +225,9 @@ def codex(prompt: str = "", session_id: str = "", cwd: str = "",
                 sid,
                 turn_id,
             )
-            turn_options["on_turn_started"] = lambda _turn_id: _confirm_direct_workroom_turn(
+            turn_options["on_turn_started"] = lambda _turn_id: _confirm_started_workroom_turn(
                 agent,
+                prompt,
             )
         turn = client.run_turn(sid, prompt, **turn_options)
     except _ProviderCancelled as e:
@@ -666,6 +667,27 @@ def _confirm_direct_workroom_turn(agent):
         target_invocation,
         request_id,
         state_revision,
+    )
+
+
+def _confirm_started_workroom_turn(agent, prompt):
+    """Publish user text only after the native Codex turn starts."""
+    session = getattr(agent, "current_session", None)
+    if isinstance(session, dict) and session.get("_provider_direct_message"):
+        _confirm_direct_workroom_turn(agent)
+        return
+    parent_id = _active_parent_tool_call_id(agent)
+    if not isinstance(parent_id, str) or not parent_id:
+        return
+    _emit_workroom_message(
+        agent,
+        {
+            "invocationId": f"codex:{parent_id}",
+            "parentToolCallId": parent_id,
+        },
+        role="user",
+        text=prompt,
+        message_id="user:initial",
     )
 
 

--- a/docs/blog/2026-08-22-the-workroom-lost-the-conversation.md
+++ b/docs/blog/2026-08-22-the-workroom-lost-the-conversation.md
@@ -1,31 +1,34 @@
 # The Workroom Lost the Conversation
 
-A Workroom could already show that Claude Code was running. It could list safe
-tool summaries and files, yet the two most basic parts of the exchange were
-missing: what the user asked and what Claude answered. The same UI appeared to
-work for Codex only because Codex had a separate message path. We had built one
-Workroom with two different definitions of a conversation.
+During the 1.7 beta review, I opened a Claude Code Workroom and saw all the
+signs of a healthy run. The header said Working. A green dot moved beside the
+current task. Safe tool summaries arrived in order. But the middle of the room
+was empty. I could not see what I had asked Claude to do, or what Claude had
+said back.
 
-The fix belongs at the provider boundary. After a native Codex turn actually
-starts, Core now publishes the initiating user message with the invocation that
-owns it. Claude Code publishes the same initiating message and the text blocks
-from its assistant stream. Both providers therefore use the same OIP
-`provider_message` contract, and clients no longer need to infer conversation
-content from tool calls or terminal output.
+Codex did not have this problem, which initially made the bug look like a small
+Claude rendering omission. Following the events backwards told a different
+story. The UI had quietly defined “conversation” as “the messages on Codex's
+direct-input path.” Claude was streaming perfectly good assistant text, but the
+shared Workroom had no shared definition of a provider message.
 
-That boundary also protects information that should not become interface copy.
-Claude thinking blocks are not assistant messages. Tool inputs and raw output
-are not assistant messages either. The adapter extracts only attributed text,
-bounds it through the shared event constructor, assigns stable native IDs when
-available, and deduplicates normalized updates. A reconnect can replay the same
-provider event without duplicating the transcript.
+The tempting fix was to make the UI recognize one more provider. That would
+have filled today's blank space and preserved tomorrow's architecture bug. We
+instead moved the decision to the boundary where provider output first becomes
+OIP state. Codex and Claude now identify the same two facts—the user's request
+and the provider's attributed reply—with the same message contract. The
+Workroom only has to display the truth it receives.
 
-The focused provider suite passes 153 tests. The paired O Chat browser test
-shows a Claude Code Workroom with its task, Working state, current summary,
-user message, and assistant message. It also verifies that the UI does not
-invent Codex's direct composer for a provider that has not exposed that input
-capability.
+That raised the harder question: what counts as a reply? Claude's stream mixes
+visible prose with thinking blocks, tool inputs, and raw tool output. Sending
+everything would make the room feel busy, but it would also expose material the
+user did not ask to read. We chose the narrower boundary: only attributed text
+becomes conversation. Tool work remains visible through its short summary, and
+private reasoning remains private. Stable message identities also let a
+reconnect replay events without making Claude appear to repeat itself.
 
-A unified client does not require every provider to have identical controls.
-It requires identical facts to travel through one contract, while native
-capabilities remain honest at the edges.
+The final browser view looks almost uneventful: a task, a Working state, one
+user bubble, and one Claude reply. That calm result is the point. A unified
+client does not make every provider pretend to have the same controls. It gives
+the facts they share one honest path, and leaves provider-specific capabilities
+at the edges where they belong.

--- a/docs/blog/2026-08-22-the-workroom-lost-the-conversation.md
+++ b/docs/blog/2026-08-22-the-workroom-lost-the-conversation.md
@@ -1,0 +1,31 @@
+# The Workroom Lost the Conversation
+
+A Workroom could already show that Claude Code was running. It could list safe
+tool summaries and files, yet the two most basic parts of the exchange were
+missing: what the user asked and what Claude answered. The same UI appeared to
+work for Codex only because Codex had a separate message path. We had built one
+Workroom with two different definitions of a conversation.
+
+The fix belongs at the provider boundary. After a native Codex turn actually
+starts, Core now publishes the initiating user message with the invocation that
+owns it. Claude Code publishes the same initiating message and the text blocks
+from its assistant stream. Both providers therefore use the same OIP
+`provider_message` contract, and clients no longer need to infer conversation
+content from tool calls or terminal output.
+
+That boundary also protects information that should not become interface copy.
+Claude thinking blocks are not assistant messages. Tool inputs and raw output
+are not assistant messages either. The adapter extracts only attributed text,
+bounds it through the shared event constructor, assigns stable native IDs when
+available, and deduplicates normalized updates. A reconnect can replay the same
+provider event without duplicating the transcript.
+
+The focused provider suite passes 153 tests. The paired O Chat browser test
+shows a Claude Code Workroom with its task, Working state, current summary,
+user message, and assistant message. It also verifies that the UI does not
+invent Codex's direct composer for a provider that has not exposed that input
+capability.
+
+A unified client does not require every provider to have identical controls.
+It requires identical facts to travel through one contract, while native
+capabilities remain honest at the edges.

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -252,6 +252,50 @@ def test_inner_tool_also_emits_a_safe_oip_activity_when_parented():
     }
     assert "private" not in json.dumps(typed.kwargs)
     assert legacy.args == ("tool_call",)
+
+
+def test_parented_claude_stream_emits_attributed_conversation_without_reasoning():
+    agent = SimpleNamespace(
+        io=MagicMock(),
+        current_session={"_active_tool_call_id": "parent-claude-message"},
+    )
+    forwarder = claude_module._ClaudeStreamForwarder(agent)
+
+    forwarder.emit_user_message("Please inspect the reconnect boundary.")
+    assistant = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_01",
+            "content": [
+                {"type": "thinking", "thinking": "private reasoning"},
+                {"type": "text", "text": "I’ll inspect the current flow first."},
+            ],
+        },
+    }
+    forwarder.handle(assistant)
+    forwarder.handle(assistant)
+
+    assert agent.io.log.call_args_list == [
+        call(
+            "provider_message",
+            provider="claude_code",
+            invocationId="claude_code:parent-claude-message",
+            parentToolCallId="parent-claude-message",
+            messageId="user:initial",
+            role="user",
+            text="Please inspect the reconnect boundary.",
+        ),
+        call(
+            "provider_message",
+            provider="claude_code",
+            invocationId="claude_code:parent-claude-message",
+            parentToolCallId="parent-claude-message",
+            messageId="assistant:msg_01",
+            role="assistant",
+            text="I’ll inspect the current flow first.",
+        ),
+    ]
+    assert "private reasoning" not in json.dumps(agent.io.log.call_args_list)
 
 
 def test_duplicate_assistant_messages_do_not_duplicate_tool_cards():

--- a/tests/unit/test_codex_tool.py
+++ b/tests/unit/test_codex_tool.py
@@ -300,6 +300,25 @@ class TestCodexRun:
             "stateRevision": 7,
         }]
 
+    def test_started_native_turn_emits_the_initiating_user_message(self):
+        io = _WorkroomIO()
+        agent = _Agent(io, {"_active_tool_call_id": "outer"})
+
+        codex_module._confirm_started_workroom_turn(
+            agent,
+            "Inspect the reconnect boundary.",
+        )
+
+        assert io.events == [("provider_message", {
+            "provider": "codex",
+            "invocationId": "codex:outer",
+            "parentToolCallId": "outer",
+            "messageId": "user:initial",
+            "role": "user",
+            "text": "Inspect the reconnect boundary.",
+            "workroomId": "codex:outer",
+        })]
+
     def test_failed_native_steer_keeps_the_workroom_message_unacknowledged(self):
         io = _WorkroomIO([{
             "type": "PROVIDER_INPUT",


### PR DESCRIPTION
## Summary

- emit the initiating user message after a native Codex turn starts
- emit attributed Claude Code user/assistant messages for correlated Workrooms
- exclude Claude thinking/reasoning and tool output from the conversation transcript
- keep message IDs stable, bounded, normalized, and deduplicated

This is the Core half of the provider-neutral Workroom conversation slice tracked by #1109 and release goal #792. It does not claim provider phases/plans or native permission-profile parity.

## Verification

- `python -m pytest -q tests/unit/test_claude_code_tool.py tests/unit/test_codex_tool.py tests/unit/test_coding_agent_plugins.py tests/unit/test_provider_workroom.py` — 153 passed
- post-rebase focused tests — 2 passed
- `git diff --check`

Closes only the conversation-visibility slice of #1109; keep #1109 open.