### PR TITLE
fix(1.7): continue Claude Code Workroom sessions

### DIFF
--- a/connectonion/network/host/provider_workroom.py
+++ b/connectonion/network/host/provider_workroom.py
@@ -1,10 +1,10 @@
-"""Direct, owned Codex Work Room continuation for a hosted OIP session.
+"""Direct, owned provider Work Room continuation for a hosted OIP session.
 
 This module is deliberately narrower than a generic tool-execution endpoint:
-it can resume only a Codex thread already recorded in the caller's own durable
-session.  The browser supplies text and correlation IDs, never a local path,
-provider session ID, model, sandbox, or tool name.  The configured agent plugin
-continues to own those execution boundaries.
+it can resume only a supported provider session already recorded in the
+caller's own durable session.  The browser supplies text and correlation IDs,
+never a local path, provider session ID, model, sandbox, or tool name.  The
+configured agent plugin continues to own those execution boundaries.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ _MAX_INPUT_LENGTH = 12_000
 
 
 class _ProviderWorkroomUnavailable(RuntimeError):
-    """The requested owned Codex continuation cannot be claimed."""
+    """The requested owned provider continuation cannot be claimed."""
 
 
 def prepare_provider_workroom_turn(
@@ -35,7 +35,7 @@ def prepare_provider_workroom_turn(
     *,
     host_full_access_turns_ceiling: int | None = None,
 ) -> dict[str, Any]:
-    """Claim an owned terminal Codex thread and return a native-only runner."""
+    """Claim an owned terminal provider session and return a native-only runner."""
     if not _valid_id(invocation_id) or not _valid_id(request_id):
         return {"reason": "invalid_request"}
     if (
@@ -60,7 +60,7 @@ def prepare_provider_workroom_turn(
             or current.status in SessionStorage.UNFINISHED
         ):
             return current
-        source = _codex_source(current.session, invocation_id)
+        source = _provider_source(current.session, invocation_id)
         if not source:
             return current
         return current.model_copy(update={"status": "running"})
@@ -73,6 +73,7 @@ def prepare_provider_workroom_turn(
         return {"reason": "not_active"}
 
     source_session_id = source["sessionId"]
+    provider = source["provider"]
     workroom_id = source.get("workroomId") or invocation_id
     source_revision = source.get("stateRevision")
 
@@ -96,8 +97,9 @@ def prepare_provider_workroom_turn(
                 text.strip(),
                 request_id,
                 source_revision,
+                provider,
             )
-            agent.execute_tool("codex", {
+            agent.execute_tool(provider, {
                 "prompt": text.strip(),
                 "cwd": "",
                 "session_id": source_session_id,
@@ -114,7 +116,7 @@ def prepare_provider_workroom_turn(
     return {"run": run, "stateRevision": source_revision}
 
 
-def _codex_source(session: object, invocation_id: str) -> dict[str, Any]:
+def _provider_source(session: object, invocation_id: str) -> dict[str, Any]:
     if not isinstance(session, dict):
         return {}
     trace = session.get("trace")
@@ -125,7 +127,7 @@ def _codex_source(session: object, invocation_id: str) -> dict[str, Any]:
         if isinstance(event, dict)
         and event.get("type") == "provider_invocation"
         and event.get("invocationId") == invocation_id
-        and event.get("provider") == "codex"
+        and event.get("provider") in {"codex", "claude_code"}
         and event.get("status") in _TERMINAL_PROVIDER_STATUSES
         and _valid_id(event.get("sessionId"))
     ]
@@ -150,6 +152,7 @@ def _direct_session(
     text: str,
     request_id: str,
     state_revision: int,
+    provider: str,
 ) -> dict[str, Any]:
     """Construct the minimum session a configured native tool needs to run."""
     return {
@@ -170,9 +173,10 @@ def _direct_session(
         "_provider_direct_state_revision": state_revision,
         # Ownership and the terminal source revision were validated while the
         # durable session lock was held.  Let the approval plugin consume this
-        # one-shot capability for the outer Codex wrapper only; Codex-native
-        # command and file approvals still travel through ``agent.io``.
-        "_provider_direct_approved_tool": "codex",
+        # one-shot capability for the outer native-provider wrapper only;
+        # provider-native command and file approvals still travel through
+        # ``agent.io``.
+        "_provider_direct_approved_tool": provider,
     }
 
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -414,13 +414,14 @@ def check_approval(agent: 'Agent') -> None:
 
         # A completed Work Room continuation has already passed the Host's
         # owner + durable revision checks.  Consume its internal capability at
-        # the first tool boundary and bypass only the outer Codex wrapper.  It
+        # the first tool boundary and bypass only the outer supported provider
+        # wrapper.  It
         # cannot authorize an arbitrary tool, cannot survive for a later call,
-        # and does not affect Codex's own command/file approval protocol.
+        # and does not affect the provider's own command/file approval protocol.
         direct_tool = agent.current_session.pop(
             '_provider_direct_approved_tool', None
         )
-        if direct_tool == tool_name == 'codex':
+        if direct_tool == tool_name and tool_name in {'codex', 'claude_code'}:
             if getattr(getattr(agent, 'logger', None), 'console', None):
                 agent.logger.console.log_permission_granted(
                     tool_name,

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -191,8 +191,12 @@ def _run_claude_code(
 
     argv = _stream_command(command, prompt, session_id, permission_mode, model)
     forwarder = _ClaudeStreamForwarder(agent)
-    forwarder.emit_user_message(prompt)
     cancelled = _provider_cancellation_check(agent)
+
+    def provider_started() -> None:
+        forwarder.emit_user_message(prompt)
+        _confirm_direct_workroom_turn(agent)
+
     try:
         completed = _run_process(
             argv,
@@ -200,6 +204,7 @@ def _run_claude_code(
             timeout=timeout,
             cancelled=cancelled if callable(cancelled) else None,
             on_event=forwarder.handle,
+            on_started=provider_started,
         )
     except FileNotFoundError:
         return _envelope(session_id, error="Claude Code CLI not found during launch.")
@@ -411,7 +416,18 @@ class _ClaudeStreamForwarder:
 
     def emit_user_message(self, text: str) -> None:
         """Publish the initiating prompt only inside a correlated Work Room."""
-        self._emit_message("user:initial", "user", text)
+        session = getattr(self._agent, "current_session", None)
+        request_id = (
+            session.get("_provider_direct_message_id")
+            if isinstance(session, dict)
+            else None
+        )
+        message_id = (
+            f"user:{_stable_identifier(request_id)}"
+            if isinstance(request_id, str) and request_id
+            else "user:initial"
+        )
+        self._emit_message(message_id, "user", text)
 
     def handle(self, event: dict[str, Any]) -> None:
         if self._io is None or not isinstance(event, dict):
@@ -485,6 +501,17 @@ class _ClaudeStreamForwarder:
         if not self._correlation:
             return
         try:
+            session = getattr(self._agent, "current_session", None)
+            workroom_id = (
+                session.get("_provider_workroom_id")
+                if isinstance(session, dict)
+                else None
+            )
+            continuation_of = (
+                session.get("_provider_continuation_of")
+                if isinstance(session, dict)
+                else None
+            )
             event = provider_message_event(
                 provider="claude_code",
                 invocation_id=self._correlation["invocationId"],
@@ -492,6 +519,16 @@ class _ClaudeStreamForwarder:
                 message_id=message_id,
                 role=role,
                 text=text,
+                **(
+                    {"workroom_id": workroom_id}
+                    if isinstance(workroom_id, str) and workroom_id
+                    else {}
+                ),
+                **(
+                    {"continuation_of": continuation_of}
+                    if isinstance(continuation_of, str) and continuation_of
+                    else {}
+                ),
             )
         except ValueError:
             return
@@ -871,9 +908,17 @@ def _run_process(
     timeout: int,
     cancelled: Callable[[], bool] | None = None,
     on_event: Callable[[dict[str, Any]], None],
+    on_started: Callable[[], None] | None = None,
 ) -> _StreamCompleted:
     """Read Claude NDJSON without blocking cancellation on one quiet stream."""
     process = _start_process(argv, cwd)
+    if on_started is not None:
+        try:
+            on_started()
+        except Exception:
+            _kill_process_tree(process)
+            _close_pipes(process)
+            raise
     mailbox: queue.Queue = queue.Queue(maxsize=_MAX_MAILBOX_LINES)
     readers_stopped = threading.Event()
     _start_reader(process.stdout, "stdout", mailbox, readers_stopped)
@@ -918,6 +963,35 @@ def _run_process(
         stderr="".join(stderr_parts),
         invalid_output="".join(invalid_parts),
     )
+
+
+def _confirm_direct_workroom_turn(agent) -> None:
+    """Acknowledge a Claude continuation only after its native process starts."""
+    session = getattr(agent, "current_session", None)
+    if not isinstance(session, dict):
+        return
+    request_id = session.get("_provider_direct_message_id")
+    invocation_id = session.get("_provider_continuation_of")
+    state_revision = session.get("_provider_direct_state_revision")
+    if (
+        not isinstance(request_id, str)
+        or not request_id
+        or not isinstance(invocation_id, str)
+        or not invocation_id
+        or isinstance(state_revision, bool)
+        or not isinstance(state_revision, int)
+        or state_revision < 1
+    ):
+        return
+    sender = getattr(getattr(agent, "io", None), "send", None)
+    if callable(sender):
+        sender({
+            "type": "PROVIDER_INPUT_ACK",
+            "requestId": request_id,
+            "invocationId": invocation_id,
+            "accepted": True,
+            "stateRevision": state_revision,
+        })
 
 
 def _start_process(argv: list[str], cwd: str):

--- a/docs/blog/2026-08-22-a-transcript-is-not-a-client.md
+++ b/docs/blog/2026-08-22-a-transcript-is-not-a-client.md
@@ -1,0 +1,41 @@
+# A Transcript Is Not a Client
+
+The Claude Code Workroom looked much better after we restored its missing
+messages. The task was visible, the status said Working, and the conversation
+showed both the request and Claude's answer. Then someone asked the question
+that the screenshot had managed to avoid: where is the input box?
+
+There was no subtle rendering bug. We had built a transcript and called it a
+client. Codex had a direct-message path, so its Workroom could accept a next
+instruction. Claude Code stopped at display. The absence was intentional in
+the component, but it contradicted the product boundary: a Workroom is the
+remote client for the provider session, not a report produced after the session.
+
+Adding a textarea exposed the real complication. A button can look correct
+while still sending its text through the outer agent, starting a new task, or
+acknowledging a message before Claude has actually started. All three versions
+would pass a shallow UI check and lose the conversation the moment a user
+relied on it.
+
+We followed the message from the browser back to the native process instead.
+The React client sends a provider-scoped request carrying the Workroom's
+invocation and observed state revision. The Host accepts it only for an owned
+Codex or Claude Code session. For a completed Claude turn, it resumes the same
+native session ID. Only after that process starts does the Host acknowledge the
+request and publish the attributed user message. The inner provider permission
+checks remain in place; recognizing the Workroom does not grant the provider
+more authority.
+
+The timing matters. Publishing the user's bubble before process creation felt
+responsive, but it could leave the UI claiming that Claude had received words
+which never crossed the native boundary. Moving the acknowledgement after
+startup made the interface slightly less optimistic and much more truthful.
+Stable request-based message IDs also keep reconnect replay from duplicating a
+follow-up as though it were the original prompt.
+
+The acceptance test now does more than find an input box. It completes a Claude
+Code turn, enters another instruction, verifies that the browser emits
+`PROVIDER_INPUT` rather than a new outer `INPUT`, and observes the reply in the
+same provider conversation. That is the distinction the first screenshot
+missed: a transcript shows what happened; a client lets the user decide what
+happens next.

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -298,6 +298,52 @@ def test_parented_claude_stream_emits_attributed_conversation_without_reasoning(
     assert "private reasoning" not in json.dumps(agent.io.log.call_args_list)
 
 
+def test_direct_claude_turn_uses_request_message_id_and_acknowledges_after_start(tmp_path):
+    agent = SimpleNamespace(
+        io=MagicMock(),
+        current_session={
+            "_active_tool_call_id": "parent-claude-direct",
+            "_provider_workroom_id": "claude_code:root",
+            "_provider_continuation_of": "claude_code:source",
+            "_provider_direct_message": "Continue the reconnect work.",
+            "_provider_direct_message_id": "request-7",
+            "_provider_direct_state_revision": 4,
+        },
+    )
+    with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
+        claude_module, "_run_process", return_value=_completed()
+    ) as run:
+        claude_module._run_claude_code(
+            prompt="Continue the reconnect work.",
+            cwd=str(tmp_path),
+            agent=agent,
+            workspace=tmp_path,
+        )
+
+    agent.io.log.assert_not_called()
+    agent.io.send.assert_not_called()
+    run.call_args.kwargs["on_started"]()
+
+    agent.io.log.assert_called_once_with(
+        "provider_message",
+        provider="claude_code",
+        invocationId="claude_code:parent-claude-direct",
+        parentToolCallId="parent-claude-direct",
+        messageId="user:request-7",
+        role="user",
+        text="Continue the reconnect work.",
+        workroomId="claude_code:root",
+        continuationOf="claude_code:source",
+    )
+    agent.io.send.assert_called_once_with({
+        "type": "PROVIDER_INPUT_ACK",
+        "requestId": "request-7",
+        "invocationId": "claude_code:source",
+        "accepted": True,
+        "stateRevision": 4,
+    })
+
+
 def test_duplicate_assistant_messages_do_not_duplicate_tool_cards():
     agent = _agent()
     forwarder = claude_module._ClaudeStreamForwarder(agent)

--- a/tests/unit/test_provider_workroom.py
+++ b/tests/unit/test_provider_workroom.py
@@ -27,6 +27,19 @@ def _stored_codex_session(*, owner="0xowner"):
     }
 
 
+def _stored_claude_session(*, owner="0xowner"):
+    session = _stored_codex_session(owner=owner)
+    invocation = session["trace"][0]
+    invocation.update({
+        "invocationId": "claude_code:current",
+        "provider": "claude_code",
+        "providerDisplayName": "Claude Code",
+        "workroomId": "claude_code:root",
+        "sessionId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    })
+    return session
+
+
 def test_owned_terminal_codex_thread_runs_only_the_native_tool_and_persists_safe_events(tmp_path):
     storage = SessionStorage(tmp_path / "sessions.jsonl")
     storage.save(Session(
@@ -116,6 +129,50 @@ def test_owned_terminal_codex_thread_runs_only_the_native_tool_and_persists_safe
         "provider_message",
     ]
     assert all("private raw output" not in str(event) for event in trace)
+
+
+def test_owned_terminal_claude_session_resumes_only_the_native_provider(tmp_path):
+    storage = SessionStorage(tmp_path / "sessions.jsonl")
+    storage.save(Session(
+        session_id="session-claude",
+        status="done",
+        prompt="original outer prompt",
+        session=_stored_claude_session(),
+    ))
+
+    class DirectAgent:
+        def __init__(self):
+            self.io = None
+            self.storage = None
+            self.current_session = None
+            self.calls = []
+
+        def execute_tool(self, name, arguments):
+            self.calls.append((name, arguments))
+
+    agent = DirectAgent()
+    prepared = prepare_provider_workroom_turn(
+        lambda: agent,
+        storage,
+        "session-claude",
+        "claude_code:current",
+        "Please add the missing reconnect case.",
+        "input-claude-1",
+        "0xowner",
+    )
+
+    prepared["run"](object())
+
+    assert agent.calls == [(
+        "claude_code",
+        {
+            "prompt": "Please add the missing reconnect case.",
+            "cwd": "",
+            "session_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        },
+    )]
+    assert agent.current_session["_provider_workroom_id"] == "claude_code:root"
+    assert agent.current_session["_provider_direct_approved_tool"] == "claude_code"
 
 
 def test_workroom_continuation_fails_closed_for_another_owner_or_live_source(tmp_path):

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -185,12 +185,13 @@ class TestDangerousTools:
         assert io.sent[0]['arguments'] == {'command': 'npm install', 'description': 'Install dependencies'}
         assert io.sent[0]['description'] == 'Install dependencies'
 
-    def test_owned_workroom_continuation_skips_only_outer_codex_approval(self):
+    @pytest.mark.parametrize('provider_tool', ['codex', 'claude_code'])
+    def test_owned_workroom_continuation_skips_only_outer_provider_approval(self, provider_tool):
         io = FakeIO()
         agent = FakeAgent(io=io)
-        agent.current_session['_provider_direct_approved_tool'] = 'codex'
+        agent.current_session['_provider_direct_approved_tool'] = provider_tool
         agent.current_session['pending_tool'] = {
-            'name': 'codex',
+            'name': provider_tool,
             'arguments': {'prompt': 'Continue the owned thread'},
         }
 


### PR DESCRIPTION
## Description

Make a terminal Claude Code Workroom a real continuable provider client, using the same owned-session boundary already used by Codex. The browser can submit text only for a durable provider invocation owned by the current caller; Core resumes the recorded native session and acknowledges only after the native process starts.

## Related Issue

Advances #1109 and the 1.7 release gate #792.

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5.6 Codex in Codex.

The least certain part is native Claude CLI behavior under every authentication/permission-mode combination; those real-provider combinations still belong in the Beta acceptance run. I did not claim a live Claude account run in this PR. If this is wrong, the first failure should be a rejected or unacknowledged `PROVIDER_INPUT`, while the outer COAI conversation remains untouched.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Dev Blog (required)

> docs/blog/2026-08-22-a-transcript-is-not-a-client.md

## Changes Made

- resolve terminal owned sessions for either `codex` or `claude_code`, while unknown providers fail closed
- resume the exact recorded native provider tool and session ID
- consume the Host-owned outer-wrapper approval once; keep native command/file approvals intact
- emit the direct Claude user message with a request-stable ID and Workroom correlation
- send `PROVIDER_INPUT_ACK` only after the Claude process starts

## Testing

```text
$ python -m pytest -q tests/unit/test_provider_workroom.py tests/unit/test_claude_code_tool.py tests/unit/test_codex_tool.py tests/unit/test_tool_approval.py tests/unit/test_host_session.py tests/unit/test_runtime_input_ack_is_truthful.py
271 passed in 7.30s

$ python -m pytest -q tests/unit/test_claude_code_tool.py::test_direct_claude_turn_uses_request_message_id_and_acknowledges_after_start
1 passed in 1.64s

$ git diff --check
```

- [x] I have added tests for new functionality

## Scope

The Host Workroom owner selects the recorded native provider; the Claude tool owns truthful start acknowledgement and attributed messages; the approval plugin consumes only the outer provider capability. Unit tests cover each boundary. No generic arbitrary-tool execution path is added.

## Example Usage

No new public Python API. A React client sends `PROVIDER_INPUT` for a terminal owned Claude Code invocation; the Host resumes that native session without creating a new outer `INPUT` turn.

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional Notes

Companion transport PR: openonion/connectonion-react#91. Companion UI PR: openonion/oo-chat#214.
