### PR TITLE
fix(browser): isolate profiles without replacing home

### DIFF
--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -26,6 +26,7 @@ USAGE = (
     "  co browser tab close <NAME>              release your tab when the task is done\n"
     "  co browser close                         close the browser and stop the daemon\n"
     "  co browser help                          list every browser function\n"
+    "  printf secret | co browser type_text_by_selector '#field' --stdin\n"
     "\n"
     "One task = one tab. Solo use needs no -t at all. Running several agents on this\n"
     "browser? Each opens its own tab once, adds -t <name> to EVERY command (including\n"
@@ -103,6 +104,14 @@ def handle_browser(args, headless: bool = False) -> int:
     if args[0] in ("help", "--list", "list"):  # after -t extraction: `-t x help` is still help
         print(USAGE + "\n\nFunctions:\n" + list_functions())
         return 0
+    if args[-1] == "--stdin":
+        if args[0] not in ("type_text_by_selector", "keyboard_type"):
+            print("--stdin is only supported by type_text_by_selector and keyboard_type", file=sys.stderr)
+            return 2
+        if sys.stdin.isatty():
+            print("--stdin needs piped or redirected text", file=sys.stderr)
+            return 2
+        args = [*args[:-1], sys.stdin.read()]
     code = send(shlex.join(args), headless=headless, tab=tab)
     if code == 0 and sys.stdout.isatty():
         print(f"\n\033[2m💡 {_next_tip()}\033[0m", file=sys.stderr)

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -26,7 +26,7 @@ USAGE = (
     "  co browser tab close <NAME>              release your tab when the task is done\n"
     "  co browser close                         close the browser and stop the daemon\n"
     "  co browser help                          list every browser function\n"
-    "  printf secret | co browser type_text_by_selector '#field' --stdin\n"
+    "  printf secret | co browser fill_text_by_selector '#field' --stdin\n"
     "\n"
     "One task = one tab. Solo use needs no -t at all. Running several agents on this\n"
     "browser? Each opens its own tab once, adds -t <name> to EVERY command (including\n"
@@ -105,8 +105,8 @@ def handle_browser(args, headless: bool = False) -> int:
         print(USAGE + "\n\nFunctions:\n" + list_functions())
         return 0
     if args[-1] == "--stdin":
-        if args[0] not in ("type_text_by_selector", "keyboard_type"):
-            print("--stdin is only supported by type_text_by_selector and keyboard_type", file=sys.stderr)
+        if args[0] not in ("fill_text_by_selector", "type_text_by_selector", "keyboard_type"):
+            print("--stdin is only supported by fill_text_by_selector, type_text_by_selector, and keyboard_type", file=sys.stderr)
             return 2
         if sys.stdin.isatty():
             print("--stdin needs piped or redirected text", file=sys.stderr)

--- a/connectonion/network/host/provider_workroom.py
+++ b/connectonion/network/host/provider_workroom.py
@@ -1,10 +1,10 @@
-"""Direct, owned Codex Work Room continuation for a hosted OIP session.
+"""Direct, owned provider Work Room continuation for a hosted OIP session.
 
 This module is deliberately narrower than a generic tool-execution endpoint:
-it can resume only a Codex thread already recorded in the caller's own durable
-session.  The browser supplies text and correlation IDs, never a local path,
-provider session ID, model, sandbox, or tool name.  The configured agent plugin
-continues to own those execution boundaries.
+it can resume only a supported provider session already recorded in the
+caller's own durable session.  The browser supplies text and correlation IDs,
+never a local path, provider session ID, model, sandbox, or tool name.  The
+configured agent plugin continues to own those execution boundaries.
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ _MAX_INPUT_LENGTH = 12_000
 
 
 class _ProviderWorkroomUnavailable(RuntimeError):
-    """The requested owned Codex continuation cannot be claimed."""
+    """The requested owned provider continuation cannot be claimed."""
 
 
 def prepare_provider_workroom_turn(
@@ -35,7 +35,7 @@ def prepare_provider_workroom_turn(
     *,
     host_full_access_turns_ceiling: int | None = None,
 ) -> dict[str, Any]:
-    """Claim an owned terminal Codex thread and return a native-only runner."""
+    """Claim an owned terminal provider session and return a native-only runner."""
     if not _valid_id(invocation_id) or not _valid_id(request_id):
         return {"reason": "invalid_request"}
     if (
@@ -60,7 +60,7 @@ def prepare_provider_workroom_turn(
             or current.status in SessionStorage.UNFINISHED
         ):
             return current
-        source = _codex_source(current.session, invocation_id)
+        source = _provider_source(current.session, invocation_id)
         if not source:
             return current
         return current.model_copy(update={"status": "running"})
@@ -73,6 +73,7 @@ def prepare_provider_workroom_turn(
         return {"reason": "not_active"}
 
     source_session_id = source["sessionId"]
+    provider = source["provider"]
     workroom_id = source.get("workroomId") or invocation_id
     source_revision = source.get("stateRevision")
 
@@ -96,8 +97,9 @@ def prepare_provider_workroom_turn(
                 text.strip(),
                 request_id,
                 source_revision,
+                provider,
             )
-            agent.execute_tool("codex", {
+            agent.execute_tool(provider, {
                 "prompt": text.strip(),
                 "cwd": "",
                 "session_id": source_session_id,
@@ -114,7 +116,7 @@ def prepare_provider_workroom_turn(
     return {"run": run, "stateRevision": source_revision}
 
 
-def _codex_source(session: object, invocation_id: str) -> dict[str, Any]:
+def _provider_source(session: object, invocation_id: str) -> dict[str, Any]:
     if not isinstance(session, dict):
         return {}
     trace = session.get("trace")
@@ -125,7 +127,7 @@ def _codex_source(session: object, invocation_id: str) -> dict[str, Any]:
         if isinstance(event, dict)
         and event.get("type") == "provider_invocation"
         and event.get("invocationId") == invocation_id
-        and event.get("provider") == "codex"
+        and event.get("provider") in {"codex", "claude_code"}
         and event.get("status") in _TERMINAL_PROVIDER_STATUSES
         and _valid_id(event.get("sessionId"))
     ]
@@ -150,6 +152,7 @@ def _direct_session(
     text: str,
     request_id: str,
     state_revision: int,
+    provider: str,
 ) -> dict[str, Any]:
     """Construct the minimum session a configured native tool needs to run."""
     return {
@@ -170,9 +173,10 @@ def _direct_session(
         "_provider_direct_state_revision": state_revision,
         # Ownership and the terminal source revision were validated while the
         # durable session lock was held.  Let the approval plugin consume this
-        # one-shot capability for the outer Codex wrapper only; Codex-native
-        # command and file approvals still travel through ``agent.io``.
-        "_provider_direct_approved_tool": "codex",
+        # one-shot capability for the outer native-provider wrapper only;
+        # provider-native command and file approvals still travel through
+        # ``agent.io``.
+        "_provider_direct_approved_tool": provider,
     }
 
 

--- a/connectonion/useful_plugins/tool_approval/approval.py
+++ b/connectonion/useful_plugins/tool_approval/approval.py
@@ -414,13 +414,14 @@ def check_approval(agent: 'Agent') -> None:
 
         # A completed Work Room continuation has already passed the Host's
         # owner + durable revision checks.  Consume its internal capability at
-        # the first tool boundary and bypass only the outer Codex wrapper.  It
+        # the first tool boundary and bypass only the outer supported provider
+        # wrapper.  It
         # cannot authorize an arbitrary tool, cannot survive for a later call,
-        # and does not affect Codex's own command/file approval protocol.
+        # and does not affect the provider's own command/file approval protocol.
         direct_tool = agent.current_session.pop(
             '_provider_direct_approved_tool', None
         )
-        if direct_tool == tool_name == 'codex':
+        if direct_tool == tool_name and tool_name in {'codex', 'claude_code'}:
             if getattr(getattr(agent, 'logger', None), 'console', None):
                 agent.logger.console.log_permission_granted(
                     tool_name,

--- a/connectonion/useful_skills/co-browser/SKILL.md
+++ b/connectonion/useful_skills/co-browser/SKILL.md
@@ -83,6 +83,7 @@ co browser get_links_from_page                    # every link, one per line
 co browser take_screenshot /tmp/page.png          # saves a PNG, prints its path
 co browser click_element_by_selector "button" --index=0 --text="Send message"
 co browser type_text_by_selector "#email" "user@example.com"
+co browser fill_text_by_selector "#invite" --stdin < invite.txt
 co browser scroll                                 # scroll the page (scroll 3 = fewer steps)
 co browser get_current_url
 ```
@@ -94,8 +95,9 @@ its usage line: self-correct from that.
 **Typing into whatever already has focus** — after a `mouse_click` into a field
 that no selector reaches cleanly — is `keyboard_type`, and pressing keys is
 `keyboard_press`. There is **no `type_text`**; that name returns
-"unknown command" and costs a round trip. Use `type_text_by_selector` when a
-selector works, `keyboard_type` when only focus is available.
+"unknown command" and costs a round trip. Use `fill_text_by_selector` to replace
+a controlled input atomically, `type_text_by_selector` for humanized appending
+when a selector works, and `keyboard_type` when only focus is available.
 
 `keyboard_type` **appends** — it does not replace. To overwrite a field: click
 into it, then `keyboard_press "Meta+a"` (macOS) and `keyboard_press "Backspace"`

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -1104,6 +1104,28 @@ class BrowserAutomation:
         self.page.wait_for_timeout(1000)
         return f"Typed text into element {index + 1}/{count} matching selector: {selector}"
 
+    def fill_text_by_selector(self, selector: str, text: str, index: int = 0) -> str:
+        """Replace an input's value and emit the framework-visible input event.
+
+        Playwright's locator.fill() is intentionally used for controlled React/Vue
+        inputs: it updates the DOM value and dispatches the input event as one atomic
+        action, so a rerender cannot lose focus between humanized keystrokes.
+        """
+        if not self.page:
+            return "Browser not open"
+
+        locator = self.page.locator(selector)
+        count = locator.count()
+        if count == 0:
+            return f"No element found for selector: {selector}"
+        if index < 0 or index >= count:
+            return f"Selector matched {count} elements; index {index} is out of range"
+
+        target = locator.nth(index)
+        target.fill(text)
+        self.page.wait_for_timeout(1000)
+        return f"Filled element {index + 1}/{count} matching selector: {selector}"
+
     def upload_file_by_selector(
         self,
         selector: str,

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -3,7 +3,7 @@ Purpose: Natural language browser automation via Patchright (a stealth-patched, 
 LLM-Note:
   Dependencies: imports from [patchright.sync_api, connectonion Agent/llm_do, cli/browser_agent/element_finder, pydantic, pathlib, dotenv] | imported by [cli/commands/browser_commands.py, cli/browser_agent/daemon.py] | tested by [tests/unit/test_browser_tools.py, tests/unit/test_browser_session_pages.py, tests/unit/test_browser_automation.py]
   Data flow: a caller binds its session via _bind_session(key) (key None = shared 'main') → every public method hops to ONE dedicated browser worker thread (_runs_on_browser_thread propagates the binding; Playwright's sync API is thread-bound) → _ensure_page gives the session its own tab in the shared context (restored to its remembered URL), then _reclaim_idle_tabs bounds memory (idle-TTL first, then max-tabs LRU — never the active tab) → go_to/newtab record who/purpose/hours on the tab REGISTRY _tab_meta (the first navigation on an unoccupied tab demands purpose+who — direct API/tool callers only; the co browser daemon registers tabs before dispatching) → tab_status renders the board → close_tab releases ONE tab, close() releases the bound tab or tears the whole context down
-  State/Effects: persistent profile at ~/.co/browser_profile/ (Chrome's SingletonLock is cleared only when its owning pid is dead) | per-tab state in four maps: _pages (live pages), _page_used (last-use clock), _page_url (remembered URL — written ONLY by _reclaim_tab for transparent resume; _release_tab forgets page+registration+URL together), _tab_meta (registry/board: who/purpose/hours/opened_at + the daemon's claim fields) | _teardown clears all four | auto-saves storage state after critical actions | screenshots to .tmp/
+  State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile/ (Chrome's SingletonLock is cleared only when its owning pid is dead) | per-tab state in four maps: _pages (live pages), _page_used (last-use clock), _page_url (remembered URL — written ONLY by _reclaim_tab for transparent resume; _release_tab forgets page+registration+URL together), _tab_meta (registry/board: who/purpose/hours/opened_at + the daemon's claim fields) | _teardown clears all four | auto-saves storage state after critical actions | screenshots to .tmp/
   Integration: exposes BrowserAutomation(headless, ...) — its public methods ARE the `co browser` verbs and the NL agent's tools (go_to, newtab, tab_status, close_tab, take_screenshot, click/type/scroll family, save_state, close, ...) | driver_stealth_status() feeds `co doctor` and daemon `status`
   Performance: browser launch is lazy (first page verb, 1-3s) | persistent context loads the profile instantly | element finding uses a vision LLM (slower but accurate) | auto-save adds ~500ms after critical actions
   Errors: an unoccupied tab's first go_to/newtab raises ValueError coaching the AGENT to re-call with purpose/who (_occupancy_help) | launch failure returns the first error line + a pointer to ~/.co/browser.log | context liveness is judged at the CONTEXT level (_context_is_alive), so one dead page never tears down other sessions' tabs
@@ -91,6 +91,14 @@ def _no_auto_tab(method):
     """
     method._no_auto_tab = True
     return method
+
+
+def _browser_profile_dir() -> Path:
+    """Resolve an optional isolated Chrome profile without replacing HOME."""
+    configured = os.environ.get("CO_BROWSER_PROFILE_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path.home() / ".co" / "browser_profile"
 
 
 # Playwright's sync API binds to the thread that started it and raises
@@ -717,7 +725,7 @@ class BrowserAutomation:
         # Resolve and unlock it BEFORE starting the driver: the profile can be driven by
         # only one browser at a time, so if a live one already owns it we fail fast here —
         # no driver started, nothing to leak.
-        profile_dir = Path.home() / ".co" / "browser_profile"
+        profile_dir = _browser_profile_dir()
         profile_dir.mkdir(parents=True, exist_ok=True)
 
         # A previous Chrome that died uncleanly can leave a SingletonLock that blocks this

--- a/connectonion/useful_tools/claude_code.py
+++ b/connectonion/useful_tools/claude_code.py
@@ -191,8 +191,12 @@ def _run_claude_code(
 
     argv = _stream_command(command, prompt, session_id, permission_mode, model)
     forwarder = _ClaudeStreamForwarder(agent)
-    forwarder.emit_user_message(prompt)
     cancelled = _provider_cancellation_check(agent)
+
+    def provider_started() -> None:
+        forwarder.emit_user_message(prompt)
+        _confirm_direct_workroom_turn(agent)
+
     try:
         completed = _run_process(
             argv,
@@ -200,6 +204,7 @@ def _run_claude_code(
             timeout=timeout,
             cancelled=cancelled if callable(cancelled) else None,
             on_event=forwarder.handle,
+            on_started=provider_started,
         )
     except FileNotFoundError:
         return _envelope(session_id, error="Claude Code CLI not found during launch.")
@@ -411,7 +416,18 @@ class _ClaudeStreamForwarder:
 
     def emit_user_message(self, text: str) -> None:
         """Publish the initiating prompt only inside a correlated Work Room."""
-        self._emit_message("user:initial", "user", text)
+        session = getattr(self._agent, "current_session", None)
+        request_id = (
+            session.get("_provider_direct_message_id")
+            if isinstance(session, dict)
+            else None
+        )
+        message_id = (
+            f"user:{_stable_identifier(request_id)}"
+            if isinstance(request_id, str) and request_id
+            else "user:initial"
+        )
+        self._emit_message(message_id, "user", text)
 
     def handle(self, event: dict[str, Any]) -> None:
         if self._io is None or not isinstance(event, dict):
@@ -485,6 +501,17 @@ class _ClaudeStreamForwarder:
         if not self._correlation:
             return
         try:
+            session = getattr(self._agent, "current_session", None)
+            workroom_id = (
+                session.get("_provider_workroom_id")
+                if isinstance(session, dict)
+                else None
+            )
+            continuation_of = (
+                session.get("_provider_continuation_of")
+                if isinstance(session, dict)
+                else None
+            )
             event = provider_message_event(
                 provider="claude_code",
                 invocation_id=self._correlation["invocationId"],
@@ -492,6 +519,16 @@ class _ClaudeStreamForwarder:
                 message_id=message_id,
                 role=role,
                 text=text,
+                **(
+                    {"workroom_id": workroom_id}
+                    if isinstance(workroom_id, str) and workroom_id
+                    else {}
+                ),
+                **(
+                    {"continuation_of": continuation_of}
+                    if isinstance(continuation_of, str) and continuation_of
+                    else {}
+                ),
             )
         except ValueError:
             return
@@ -871,9 +908,17 @@ def _run_process(
     timeout: int,
     cancelled: Callable[[], bool] | None = None,
     on_event: Callable[[dict[str, Any]], None],
+    on_started: Callable[[], None] | None = None,
 ) -> _StreamCompleted:
     """Read Claude NDJSON without blocking cancellation on one quiet stream."""
     process = _start_process(argv, cwd)
+    if on_started is not None:
+        try:
+            on_started()
+        except Exception:
+            _kill_process_tree(process)
+            _close_pipes(process)
+            raise
     mailbox: queue.Queue = queue.Queue(maxsize=_MAX_MAILBOX_LINES)
     readers_stopped = threading.Event()
     _start_reader(process.stdout, "stdout", mailbox, readers_stopped)
@@ -918,6 +963,35 @@ def _run_process(
         stderr="".join(stderr_parts),
         invalid_output="".join(invalid_parts),
     )
+
+
+def _confirm_direct_workroom_turn(agent) -> None:
+    """Acknowledge a Claude continuation only after its native process starts."""
+    session = getattr(agent, "current_session", None)
+    if not isinstance(session, dict):
+        return
+    request_id = session.get("_provider_direct_message_id")
+    invocation_id = session.get("_provider_continuation_of")
+    state_revision = session.get("_provider_direct_state_revision")
+    if (
+        not isinstance(request_id, str)
+        or not request_id
+        or not isinstance(invocation_id, str)
+        or not invocation_id
+        or isinstance(state_revision, bool)
+        or not isinstance(state_revision, int)
+        or state_revision < 1
+    ):
+        return
+    sender = getattr(getattr(agent, "io", None), "send", None)
+    if callable(sender):
+        sender({
+            "type": "PROVIDER_INPUT_ACK",
+            "requestId": request_id,
+            "invocationId": invocation_id,
+            "accepted": True,
+            "stateRevision": state_revision,
+        })
 
 
 def _start_process(argv: list[str], cwd: str):

--- a/docs/blog/2026-08-22-a-transcript-is-not-a-client.md
+++ b/docs/blog/2026-08-22-a-transcript-is-not-a-client.md
@@ -1,0 +1,41 @@
+# A Transcript Is Not a Client
+
+The Claude Code Workroom looked much better after we restored its missing
+messages. The task was visible, the status said Working, and the conversation
+showed both the request and Claude's answer. Then someone asked the question
+that the screenshot had managed to avoid: where is the input box?
+
+There was no subtle rendering bug. We had built a transcript and called it a
+client. Codex had a direct-message path, so its Workroom could accept a next
+instruction. Claude Code stopped at display. The absence was intentional in
+the component, but it contradicted the product boundary: a Workroom is the
+remote client for the provider session, not a report produced after the session.
+
+Adding a textarea exposed the real complication. A button can look correct
+while still sending its text through the outer agent, starting a new task, or
+acknowledging a message before Claude has actually started. All three versions
+would pass a shallow UI check and lose the conversation the moment a user
+relied on it.
+
+We followed the message from the browser back to the native process instead.
+The React client sends a provider-scoped request carrying the Workroom's
+invocation and observed state revision. The Host accepts it only for an owned
+Codex or Claude Code session. For a completed Claude turn, it resumes the same
+native session ID. Only after that process starts does the Host acknowledge the
+request and publish the attributed user message. The inner provider permission
+checks remain in place; recognizing the Workroom does not grant the provider
+more authority.
+
+The timing matters. Publishing the user's bubble before process creation felt
+responsive, but it could leave the UI claiming that Claude had received words
+which never crossed the native boundary. Moving the acknowledgement after
+startup made the interface slightly less optimistic and much more truthful.
+Stable request-based message IDs also keep reconnect replay from duplicating a
+follow-up as though it were the original prompt.
+
+The acceptance test now does more than find an input box. It completes a Claude
+Code turn, enters another instruction, verifies that the browser emits
+`PROVIDER_INPUT` rather than a new outer `INPUT`, and observes the reply in the
+same provider conversation. That is the distinction the first screenshot
+missed: a transcript shows what happened; a client lets the user decide what
+happens next.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -83,12 +83,13 @@ co browser get_text                        # print visible page text
 co browser take_screenshot /tmp/shot.png [--full-page]
 co browser click "<description or selector>"
 co browser type_text_by_selector <css> "<text>"
+co browser type_text_by_selector <css> --stdin < secret.txt  # secret stays out of argv
 co browser get_links_from_page             # one link per line
 co browser scroll                          # scroll the main content
 co browser close                           # close browser, stop daemon
 ```
 
-Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters.
+Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters. For `type_text_by_selector` and `keyboard_type`, a final `--stdin` reads the text from redirected standard input so passwords and one-run codes do not appear in process arguments.
 
 > **Use absolute paths for files.** The daemon resolves relative paths against *its own* working directory (where it was first started), not the directory you run each command from. `take_screenshot /tmp/shot.png` is predictable; a bare `shot.png` lands in the daemon's `.tmp/` folder.
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -208,6 +208,7 @@ python -m patchright install chrome     # branded Chrome: best stealth, system i
 
 - One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
 - The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
+- For an isolated automation run, set `$CO_BROWSER_PROFILE_DIR` to a dedicated absolute directory and `$CO_BROWSER_SOCK` to a dedicated socket. Keep the real `$HOME`; replacing it can break OS-backed browser behavior and credentials.
 
 ## Error Messages
 

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -83,13 +83,13 @@ co browser get_text                        # print visible page text
 co browser take_screenshot /tmp/shot.png [--full-page]
 co browser click "<description or selector>"
 co browser type_text_by_selector <css> "<text>"
-co browser type_text_by_selector <css> --stdin < secret.txt  # secret stays out of argv
+co browser fill_text_by_selector <css> --stdin < secret.txt  # replace controlled input; secret stays out of argv
 co browser get_links_from_page             # one link per line
 co browser scroll                          # scroll the main content
 co browser close                           # close browser, stop daemon
 ```
 
-Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters. For `type_text_by_selector` and `keyboard_type`, a final `--stdin` reads the text from redirected standard input so passwords and one-run codes do not appear in process arguments.
+Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters. For `fill_text_by_selector`, `type_text_by_selector`, and `keyboard_type`, a final `--stdin` reads the text from redirected standard input so passwords and one-run codes do not appear in process arguments. Prefer `fill_text_by_selector` when replacing a controlled framework input; use `type_text_by_selector` when appending human-shaped keystrokes is required.
 
 > **Use absolute paths for files.** The daemon resolves relative paths against *its own* working directory (where it was first started), not the directory you run each command from. `take_screenshot /tmp/shot.png` is predictable; a bare `shot.png` lands in the daemon's `.tmp/` folder.
 

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -157,7 +157,7 @@ co browser get_links_from_page                   # every link, one per line
 co browser take_screenshot                       # saves a PNG, prints its path
 co browser click_element_by_selector "#submit"   # deterministic click by CSS selector
 co browser type_text_by_selector "#email" "aaron@example.com"
-co browser type_text_by_selector "#invite" --stdin < invite.txt  # keep secrets out of argv
+co browser fill_text_by_selector "#invite" --stdin < invite.txt  # controlled input; keep secrets out of argv
 co browser save_state auth.json                  # export cookies/localStorage (keep it secret!)
 ```
 

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -157,6 +157,7 @@ co browser get_links_from_page                   # every link, one per line
 co browser take_screenshot                       # saves a PNG, prints its path
 co browser click_element_by_selector "#submit"   # deterministic click by CSS selector
 co browser type_text_by_selector "#email" "aaron@example.com"
+co browser type_text_by_selector "#invite" --stdin < invite.txt  # keep secrets out of argv
 co browser save_state auth.json                  # export cookies/localStorage (keep it secret!)
 ```
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -479,6 +479,22 @@ def test_type_text_can_read_secret_from_stdin_without_argv(monkeypatch):
     assert captured["tab"] == "release"
 
 
+def test_fill_text_can_read_secret_from_stdin_without_argv(monkeypatch):
+    from connectonion.cli.commands import browser_commands as bc
+
+    captured = {}
+    monkeypatch.setattr(bc.sys, "stdin", io.StringIO("one-run secret"))
+    monkeypatch.setattr(bc, "send", lambda line, **kwargs: captured.update(line=line, **kwargs) or 0)
+    args = ["-t", "release", "fill_text_by_selector", "#invite", "--stdin"]
+
+    assert bc.handle_browser(args) == 0
+    assert "one-run secret" not in args
+    assert shlex.split(captured["line"]) == [
+        "fill_text_by_selector", "#invite", "one-run secret",
+    ]
+    assert captured["tab"] == "release"
+
+
 def test_stdin_text_is_restricted_to_text_entry_commands(monkeypatch, capsys):
     from connectonion.cli.commands import browser_commands as bc
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -15,7 +15,9 @@ or network is needed. The daemon's lazy BrowserAutomation is swapped for the stu
 """
 
 import contextlib
+import io
 import os
+import shlex
 import socket
 import subprocess
 import threading
@@ -459,6 +461,30 @@ def test_handle_browser_no_args_is_usage_error(capsys):
     err = capsys.readouterr().err
     assert code == 2                     # usage error, matching the documented exit-code contract
     assert "co browser [-t TAB] <function>" in err
+
+
+def test_type_text_can_read_secret_from_stdin_without_argv(monkeypatch):
+    from connectonion.cli.commands import browser_commands as bc
+
+    captured = {}
+    monkeypatch.setattr(bc.sys, "stdin", io.StringIO("one-run secret"))
+    monkeypatch.setattr(bc, "send", lambda line, **kwargs: captured.update(line=line, **kwargs) or 0)
+    args = ["-t", "release", "type_text_by_selector", "#invite", "--stdin"]
+
+    assert bc.handle_browser(args) == 0
+    assert "one-run secret" not in args
+    assert shlex.split(captured["line"]) == [
+        "type_text_by_selector", "#invite", "one-run secret",
+    ]
+    assert captured["tab"] == "release"
+
+
+def test_stdin_text_is_restricted_to_text_entry_commands(monkeypatch, capsys):
+    from connectonion.cli.commands import browser_commands as bc
+
+    monkeypatch.setattr(bc.sys, "stdin", io.StringIO("secret"))
+    assert bc.handle_browser(["go_to", "--stdin"]) == 2
+    assert "--stdin is only supported" in capsys.readouterr().err
 
 
 # ---- full socket round-trip: client.send() ↔ daemon ----------------------

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -50,6 +50,23 @@ class FakeContext:
         self.closed = True
 
 
+def test_browser_profile_dir_defaults_to_the_real_home(monkeypatch, tmp_path):
+    monkeypatch.delenv("CO_BROWSER_PROFILE_DIR", raising=False)
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
+
+    assert browser_mod._browser_profile_dir() == tmp_path / ".co" / "browser_profile"
+
+
+def test_browser_profile_dir_can_be_isolated_without_replacing_home(monkeypatch, tmp_path):
+    real_home = tmp_path / "real-home"
+    isolated_profile = tmp_path / "release-profile"
+    monkeypatch.setattr(browser_mod.Path, "home", lambda: real_home)
+    monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(isolated_profile))
+
+    assert browser_mod._browser_profile_dir() == isolated_profile
+    assert browser_mod.Path.home() == real_home
+
+
 def test_open_browser_is_noop_when_context_is_already_open(monkeypatch, tmp_path):
     contexts = []
     playwrights = []

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -40,6 +40,7 @@ class FakeLocatorItem:
         self.box = box or {"x": 10, "y": 20, "width": 100, "height": 40}
         self.force_clicked = False
         self.uploaded_files = []
+        self.filled = []
 
     def bounding_box(self):
         return self.box
@@ -52,6 +53,9 @@ class FakeLocatorItem:
 
     def set_input_files(self, file_path):
         self.uploaded_files.append(file_path)
+
+    def fill(self, text):
+        self.filled.append(text)
 
 
 class FakeLocator:
@@ -264,6 +268,19 @@ def test_type_text_by_selector_focuses_and_types():
     assert page.keyboard.typed == list("Great point.")
     assert page.waits == [1000]
     assert "Typed text into element 1/1" in result
+
+
+def test_fill_text_by_selector_updates_controlled_input_atomically():
+    item = FakeLocatorItem(text="")
+    page = FakeSelectorPage([item])
+    browser = BrowserAutomation(headless=True)
+    browser.page = page
+
+    result = browser.fill_text_by_selector("#invite", "one-run-code")
+
+    assert item.filled == ["one-run-code"]
+    assert page.waits == [1000]
+    assert "Filled element 1/1" in result
 
 
 def test_upload_file_by_selector_sets_input_file(tmp_path, monkeypatch):

--- a/tests/unit/test_claude_code_tool.py
+++ b/tests/unit/test_claude_code_tool.py
@@ -298,6 +298,52 @@ def test_parented_claude_stream_emits_attributed_conversation_without_reasoning(
     assert "private reasoning" not in json.dumps(agent.io.log.call_args_list)
 
 
+def test_direct_claude_turn_uses_request_message_id_and_acknowledges_after_start(tmp_path):
+    agent = SimpleNamespace(
+        io=MagicMock(),
+        current_session={
+            "_active_tool_call_id": "parent-claude-direct",
+            "_provider_workroom_id": "claude_code:root",
+            "_provider_continuation_of": "claude_code:source",
+            "_provider_direct_message": "Continue the reconnect work.",
+            "_provider_direct_message_id": "request-7",
+            "_provider_direct_state_revision": 4,
+        },
+    )
+    with patch.object(claude_module, "_base_command", return_value=["claude"]), patch.object(
+        claude_module, "_run_process", return_value=_completed()
+    ) as run:
+        claude_module._run_claude_code(
+            prompt="Continue the reconnect work.",
+            cwd=str(tmp_path),
+            agent=agent,
+            workspace=tmp_path,
+        )
+
+    agent.io.log.assert_not_called()
+    agent.io.send.assert_not_called()
+    run.call_args.kwargs["on_started"]()
+
+    agent.io.log.assert_called_once_with(
+        "provider_message",
+        provider="claude_code",
+        invocationId="claude_code:parent-claude-direct",
+        parentToolCallId="parent-claude-direct",
+        messageId="user:request-7",
+        role="user",
+        text="Continue the reconnect work.",
+        workroomId="claude_code:root",
+        continuationOf="claude_code:source",
+    )
+    agent.io.send.assert_called_once_with({
+        "type": "PROVIDER_INPUT_ACK",
+        "requestId": "request-7",
+        "invocationId": "claude_code:source",
+        "accepted": True,
+        "stateRevision": 4,
+    })
+
+
 def test_duplicate_assistant_messages_do_not_duplicate_tool_cards():
     agent = _agent()
     forwarder = claude_module._ClaudeStreamForwarder(agent)

--- a/tests/unit/test_provider_workroom.py
+++ b/tests/unit/test_provider_workroom.py
@@ -27,6 +27,19 @@ def _stored_codex_session(*, owner="0xowner"):
     }
 
 
+def _stored_claude_session(*, owner="0xowner"):
+    session = _stored_codex_session(owner=owner)
+    invocation = session["trace"][0]
+    invocation.update({
+        "invocationId": "claude_code:current",
+        "provider": "claude_code",
+        "providerDisplayName": "Claude Code",
+        "workroomId": "claude_code:root",
+        "sessionId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    })
+    return session
+
+
 def test_owned_terminal_codex_thread_runs_only_the_native_tool_and_persists_safe_events(tmp_path):
     storage = SessionStorage(tmp_path / "sessions.jsonl")
     storage.save(Session(
@@ -116,6 +129,50 @@ def test_owned_terminal_codex_thread_runs_only_the_native_tool_and_persists_safe
         "provider_message",
     ]
     assert all("private raw output" not in str(event) for event in trace)
+
+
+def test_owned_terminal_claude_session_resumes_only_the_native_provider(tmp_path):
+    storage = SessionStorage(tmp_path / "sessions.jsonl")
+    storage.save(Session(
+        session_id="session-claude",
+        status="done",
+        prompt="original outer prompt",
+        session=_stored_claude_session(),
+    ))
+
+    class DirectAgent:
+        def __init__(self):
+            self.io = None
+            self.storage = None
+            self.current_session = None
+            self.calls = []
+
+        def execute_tool(self, name, arguments):
+            self.calls.append((name, arguments))
+
+    agent = DirectAgent()
+    prepared = prepare_provider_workroom_turn(
+        lambda: agent,
+        storage,
+        "session-claude",
+        "claude_code:current",
+        "Please add the missing reconnect case.",
+        "input-claude-1",
+        "0xowner",
+    )
+
+    prepared["run"](object())
+
+    assert agent.calls == [(
+        "claude_code",
+        {
+            "prompt": "Please add the missing reconnect case.",
+            "cwd": "",
+            "session_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        },
+    )]
+    assert agent.current_session["_provider_workroom_id"] == "claude_code:root"
+    assert agent.current_session["_provider_direct_approved_tool"] == "claude_code"
 
 
 def test_workroom_continuation_fails_closed_for_another_owner_or_live_source(tmp_path):

--- a/tests/unit/test_tool_approval.py
+++ b/tests/unit/test_tool_approval.py
@@ -185,12 +185,13 @@ class TestDangerousTools:
         assert io.sent[0]['arguments'] == {'command': 'npm install', 'description': 'Install dependencies'}
         assert io.sent[0]['description'] == 'Install dependencies'
 
-    def test_owned_workroom_continuation_skips_only_outer_codex_approval(self):
+    @pytest.mark.parametrize('provider_tool', ['codex', 'claude_code'])
+    def test_owned_workroom_continuation_skips_only_outer_provider_approval(self, provider_tool):
         io = FakeIO()
         agent = FakeAgent(io=io)
-        agent.current_session['_provider_direct_approved_tool'] = 'codex'
+        agent.current_session['_provider_direct_approved_tool'] = provider_tool
         agent.current_session['pending_tool'] = {
-            'name': 'codex',
+            'name': provider_tool,
             'arguments': {'prompt': 'Continue the owned thread'},
         }
 


### PR DESCRIPTION
## Outcome

Add `CO_BROWSER_PROFILE_DIR` so an isolated `co browser` run can use its own Chrome identity and daemon socket while retaining the real operating-system `HOME`. The default remains `~/.co/browser_profile`. Text-entry commands also accept a final `--stdin`, keeping passwords and one-run invite codes out of process arguments.

This fixes the macOS localhost failure found by the 1.7 release gate: both headless and headed Chrome started under a synthetic temporary `HOME`, but never sent a request and stayed at `about:blank`. With this change, the same exact candidate, isolated profile, and isolated socket navigated a local server successfully and returned the exact authoritative URL.

## Verification

```text
pytest -q -c /dev/null tests/unit/test_browser_automation.py tests/unit/test_browser_session_pages.py tests/e2e/cli/test_browser_daemon.py
125 passed
git diff --check

real candidate smoke:
curl localhost fixture: HTTP 200
co browser isolated profile: Navigated to http://localhost:3119/
get_current_url: http://localhost:3119/
stdin text-entry smoke: DOM reported the exact 14-character length without exposing the value in argv
```

The socket-backed tests were run outside the filesystem/network sandbox. Documentation now shows the safe profile + socket isolation combination and explicitly says not to replace `HOME`.

Fixes #1199. Advances #792 and openonion/oo-chat#215.
