### PR TITLE
Preserve managed cache usage accounting end to end

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -740,7 +740,10 @@ class Agent:
 
         # Record llm_result AFTER LLM completes (streams to client)
         # Convert usage to dict for JSON serialization (Pydantic objects need model_dump())
-        usage_dict = response.usage.model_dump() if response.usage else None
+        usage_dict = (
+            response.usage.model_dump(exclude_none=True)
+            if response.usage else None
+        )
         self._record_trace({
             'type': 'llm_result',
             'id': llm_id,

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -1050,6 +1050,89 @@ MODEL_REGISTRY = {
 }
 
 
+def _response_mapping(value: Any) -> dict:
+    """Read SDK-preserved extension objects without depending on one SDK type."""
+    if isinstance(value, dict):
+        return value
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump()
+        return dumped if isinstance(dumped, dict) else {}
+    if hasattr(value, "__dict__"):
+        return {
+            key: item
+            for key, item in vars(value).items()
+            if not key.startswith("_")
+        }
+    return {}
+
+
+def _managed_token_usage(raw_usage: Any, model: str) -> TokenUsage:
+    """Keep the managed server's measured usage and charge as one contract."""
+    normalized = _response_mapping(getattr(raw_usage, "normalized", None))
+    cost_details = _response_mapping(getattr(raw_usage, "cost_details", None))
+
+    if normalized:
+        input_tokens = int(normalized["input_tokens_total"])
+        output_tokens = int(normalized["output_tokens"])
+        cache_read = int(normalized.get("cache_read_input_tokens", 0))
+        cache_write = int(normalized.get("cache_write_input_tokens", 0))
+        cost = getattr(raw_usage, "cost_usd", None)
+        if cost is None:
+            cost = calculate_cost(
+                model, input_tokens, output_tokens, cache_read, cache_write
+            )
+        provider_cost = normalized.get("provider_reported_cost_usd")
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            cost=float(cost),
+            total_tokens=input_tokens + output_tokens,
+            input_tokens_total=input_tokens,
+            input_tokens_uncached=int(normalized["input_tokens_uncached"]),
+            cache_read_input_tokens=cache_read,
+            cache_write_input_tokens=cache_write,
+            cache_write_5m_input_tokens=int(
+                normalized.get("cache_write_5m_input_tokens", 0)
+            ),
+            cache_write_1h_input_tokens=int(
+                normalized.get("cache_write_1h_input_tokens", 0)
+            ),
+            cache_metadata_status=normalized.get("cache_metadata_status"),
+            provider=normalized.get("provider"),
+            requested_model=normalized.get("requested_model"),
+            provider_model=normalized.get("provider_model"),
+            provider_reported_cost_usd=(
+                float(provider_cost) if provider_cost is not None else None
+            ),
+            pricing_version=cost_details.get("pricing_version"),
+            pricing_tier=cost_details.get("pricing_tier"),
+            cost_details=cost_details or None,
+        )
+
+    # Compatibility with older oo-api deployments: preserve their OpenAI shape
+    # and prefer the server's cost when present.
+    input_tokens = raw_usage.prompt_tokens
+    output_tokens = raw_usage.completion_tokens
+    details = getattr(raw_usage, "prompt_tokens_details", None)
+    cached_tokens = getattr(details, "cached_tokens", 0) or 0
+    cost = getattr(raw_usage, "cost_usd", None)
+    if cost is None:
+        cost = calculate_cost(model, input_tokens, output_tokens, cached_tokens)
+    server_total = getattr(raw_usage, "total_tokens", 0) or 0
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_tokens=cached_tokens,
+        cost=cost,
+        total_tokens=(
+            server_total if server_total > input_tokens + output_tokens else 0
+        ),
+    )
+
+
 class OpenOnionLLM(LLM):
     """OpenOnion managed keys LLM implementation using OpenAI-compatible API."""
 
@@ -1113,42 +1196,11 @@ class OpenOnionLLM(LLM):
                     extra_content=extra
                 ))
 
-        # Extract token usage (OpenAI-compatible format)
-        usage = None
-        if hasattr(response, 'usage') and response.usage:
-            input_tokens = response.usage.prompt_tokens
-            output_tokens = response.usage.completion_tokens
-            cached_tokens = 0
-            if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details:
-                cached_tokens = getattr(response.usage.prompt_tokens_details, 'cached_tokens', 0) or 0
-            # The server bills the account and says what it took. Use that,
-            # not the local table: prompt_tokens + completion_tokens is 12 on a
-            # call whose total_tokens is 114, because the reasoning models
-            # charge for tokens the OpenAI-shaped fields never name. Arithmetic
-            # over those two numbers came out 11.6x under what was charged.
-            #
-            # `is not None` rather than a truth test — a free call reports 0.0,
-            # and falling back there would invent a charge for it.
-            cost = getattr(response.usage, 'cost_usd', None)
-            if cost is None:
-                cost = calculate_cost(self.model, input_tokens, output_tokens, cached_tokens)
-            # total_tokens for the same reason as cost_usd, and it was the half of
-            # this decision left undone: the cost came from the server while the
-            # token count stayed on the two fields just described as not naming
-            # the reasoning tokens. Measured here: prompt 17 + completion 3
-            # printed as "20 tok · $0.0017" on a call the server billed 243
-            # tokens for — a line 34x off itself.
-            #
-            # Only when it exceeds the sum. Equal or smaller means the provider is
-            # restating those two fields and there is nothing extra to report.
-            server_total = getattr(response.usage, 'total_tokens', 0) or 0
-            usage = TokenUsage(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cached_tokens=cached_tokens,
-                cost=cost,
-                total_tokens=server_total if server_total > input_tokens + output_tokens else 0,
-            )
+        usage = (
+            _managed_token_usage(response.usage, self.model)
+            if hasattr(response, 'usage') and response.usage
+            else None
+        )
 
         return LLMResponse(
             content=message.content,

--- a/connectonion/core/usage.py
+++ b/connectonion/core/usage.py
@@ -23,6 +23,22 @@ class TokenUsage(BaseModel):
     cache_write_tokens: int = 0  # Tokens written to cache (Anthropic only)
     cost: float = 0.0           # USD cost for this call
     total_tokens: int = 0       # What the server says it billed for; 0 = it didn't say
+    # Exact managed-backend contract. Optional keeps direct providers and old
+    # saved sessions backward-compatible; co/ responses populate every field.
+    input_tokens_total: int | None = None
+    input_tokens_uncached: int | None = None
+    cache_read_input_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
+    cache_write_5m_input_tokens: int | None = None
+    cache_write_1h_input_tokens: int | None = None
+    cache_metadata_status: str | None = None
+    provider: str | None = None
+    requested_model: str | None = None
+    provider_model: str | None = None
+    provider_reported_cost_usd: float | None = None
+    pricing_version: str | None = None
+    pricing_tier: str | None = None
+    cost_details: dict | None = None
 
     @property
     def billed_tokens(self) -> int:
@@ -391,6 +407,18 @@ def turn_usage_from_trace(trace: list) -> dict | None:
         'total_tokens': 0,
         'cost': 0.0,
     }
+    measured_cache_fields = {
+        'input_tokens_total': 0,
+        'input_tokens_uncached': 0,
+        'cache_read_input_tokens': 0,
+        'cache_write_input_tokens': 0,
+        'cache_write_5m_input_tokens': 0,
+        'cache_write_1h_input_tokens': 0,
+    }
+    measured_present = {
+        field: any(field in usage and usage[field] is not None for usage in usages)
+        for field in measured_cache_fields
+    }
     for usage in usages:
         input_tokens = _usage_int(usage, 'input_tokens')
         output_tokens = _usage_int(usage, 'output_tokens')
@@ -404,6 +432,26 @@ def turn_usage_from_trace(trace: list) -> dict | None:
         cost = usage.get('cost', 0.0)
         if isinstance(cost, (int, float)) and not isinstance(cost, bool) and cost >= 0:
             totals['cost'] += float(cost)
+        for field in measured_cache_fields:
+            if measured_present[field]:
+                measured_cache_fields[field] += _usage_int(usage, field)
+
+    totals.update(
+        {
+            field: value
+            for field, value in measured_cache_fields.items()
+            if measured_present[field]
+        }
+    )
+    statuses = {
+        usage.get('cache_metadata_status')
+        for usage in usages
+        if usage.get('cache_metadata_status')
+    }
+    if statuses:
+        totals['cache_metadata_status'] = (
+            next(iter(statuses)) if len(statuses) == 1 else 'mixed'
+        )
     return totals
 
 

--- a/docs/blog/2026-08-22-the-bill-and-the-counter-disagreed.md
+++ b/docs/blog/2026-08-22-the-bill-and-the-counter-disagreed.md
@@ -1,0 +1,36 @@
+# The Bill and the Counter Disagreed
+
+The chat said a managed model had used a handful of ordinary input and output
+tokens. The account balance said something else. Both numbers came from the
+same request, yet the line beside the answer could not explain the charge.
+Cached input made the mismatch worse: a warm request could be much cheaper
+without the client being able to say which input was new, read from cache, or
+written into cache for the next turn.
+
+The first instinct was to improve the client's pricing table. That would have
+made the arithmetic look more complete while leaving the authority in the
+wrong place. OpenAI, Google, and Anthropic report different usage shapes;
+reasoning tokens, cache writes, long-context tiers, and provider pricing can all
+change the amount settled by the managed backend. Reconstructing that charge
+again on the user's machine creates two bills for one call.
+
+We moved the boundary instead. The backend now normalizes provider usage before
+settlement and records the exact token classes and pricing snapshot used for
+the debit. Core carries that contract through its trace, and the React client
+preserves it without translating it back into a provider-specific approximation.
+Older Hosts and direct-provider sessions still keep their existing, smaller
+usage shape.
+
+The useful UI is deliberately modest. A completed turn can say how much input
+was new, how much came from cache, whether the provider charged for a cache
+write, how much output was billed, and the final server cost. It does not expose
+the command or wire details that produced those numbers. A historical event
+that only knows `42 tokens` still says exactly that; it does not invent a
+zero-valued breakdown to fill the new layout.
+
+The measurement that mattered was not whether one total could be made to add
+up locally. It was whether the same normalized fields survived the backend,
+Core, React, and browser without loss. The focused Core suite passed 93 checks,
+the React suite passed 141, and desktop and phone browser flows showed the same
+new-versus-cached accounting without horizontal overflow. One charge now has
+one source of truth, and the client can finally explain it.

--- a/docs/concepts/agent.md
+++ b/docs/concepts/agent.md
@@ -534,6 +534,30 @@ agent.last_usage.cache_write_tokens # Tokens written to cache (Anthropic)
 agent.last_usage.cost              # Cost for this call in USD
 ```
 
+Managed `co/` models also preserve the backend's exact accounting contract.
+This is the contract used for the final charge, so clients can explain a turn
+without guessing from provider-specific fields:
+
+```python
+usage = agent.last_usage
+usage.input_tokens_total             # All provider input tokens
+usage.input_tokens_uncached          # Newly billed input
+usage.cache_read_input_tokens        # Input read from cache
+usage.cache_write_input_tokens       # Input written to cache
+usage.cache_write_5m_input_tokens    # Anthropic 5-minute writes, when reported
+usage.cache_write_1h_input_tokens    # Anthropic 1-hour writes, when reported
+usage.cache_metadata_status          # reported | unavailable | unsupported
+usage.provider                       # Normalized provider identity
+usage.provider_model                 # Model reported by that provider
+usage.pricing_version                # Server pricing snapshot used to settle
+usage.pricing_tier                   # Applied tier, such as standard
+usage.cost_details                   # Auditable server-side cost breakdown
+```
+
+These fields are optional for direct-provider calls and sessions created by an
+older Host. Use the legacy fields as the compatibility view; do not reconstruct
+a managed charge locally when `cost` and the exact fields are present.
+
 ### Multi-Turn Cost Tracking
 
 ```python

--- a/tests/unit/test_the_managed_route_reports_what_it_charged.py
+++ b/tests/unit/test_the_managed_route_reports_what_it_charged.py
@@ -30,16 +30,29 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from openai.types.completion_usage import CompletionUsage
 
 from connectonion.core.llm import OpenOnionLLM
 
 
-def _response(cost_usd=None, prompt=3, completion=9, total=114, cached=0):
+def _response(
+    cost_usd=None,
+    prompt=3,
+    completion=9,
+    total=114,
+    cached=0,
+    normalized=None,
+    cost_details=None,
+):
     usage = SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion,
                             total_tokens=total,
                             prompt_tokens_details=SimpleNamespace(cached_tokens=cached))
     if cost_usd is not None:
         usage.cost_usd = cost_usd
+    if normalized is not None:
+        usage.normalized = normalized
+    if cost_details is not None:
+        usage.cost_details = cost_details
     message = SimpleNamespace(content="hi", tool_calls=None)
     return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
 
@@ -92,6 +105,93 @@ class TestTheServersFigureWins:
 
         assert result.usage.input_tokens == 100
         assert result.usage.cached_tokens == 80
+
+    def test_normalized_cache_usage_reaches_the_trace_without_field_loss(self, llm):
+        normalized = {
+            "provider": "anthropic",
+            "requested_model": "claude-sonnet-4-5",
+            "provider_model": "claude-sonnet-4-5-20260801",
+            "input_tokens_total": 600,
+            "input_tokens_uncached": 100,
+            "cache_read_input_tokens": 200,
+            "cache_write_input_tokens": 300,
+            "cache_write_5m_input_tokens": 100,
+            "cache_write_1h_input_tokens": 200,
+            "output_tokens": 50,
+            "cache_metadata_status": "reported",
+            "provider_reported_cost_usd": 0.0026,
+        }
+        cost_details = {
+            "pricing_version": "2026-08-22",
+            "pricing_tier": "standard",
+            "total_usd": 0.002685,
+        }
+
+        result = _complete(
+            llm,
+            _response(
+                cost_usd=0.002685,
+                prompt=1,
+                completion=1,
+                total=2,
+                normalized=normalized,
+                cost_details=cost_details,
+            ),
+        )
+
+        assert result.usage.model_dump(exclude_none=True) == {
+            "input_tokens": 600,
+            "output_tokens": 50,
+            "cached_tokens": 200,
+            "cache_write_tokens": 300,
+            "cost": 0.002685,
+            "total_tokens": 650,
+            "input_tokens_total": 600,
+            "input_tokens_uncached": 100,
+            "cache_read_input_tokens": 200,
+            "cache_write_input_tokens": 300,
+            "cache_write_5m_input_tokens": 100,
+            "cache_write_1h_input_tokens": 200,
+            "cache_metadata_status": "reported",
+            "provider": "anthropic",
+            "requested_model": "claude-sonnet-4-5",
+            "provider_model": "claude-sonnet-4-5-20260801",
+            "provider_reported_cost_usd": 0.0026,
+            "pricing_version": "2026-08-22",
+            "pricing_tier": "standard",
+            "cost_details": cost_details,
+        }
+
+    def test_openai_sdk_preserves_the_managed_usage_extensions(self, llm):
+        response = _response()
+        response.usage = CompletionUsage.model_validate({
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+            "cost_usd": 0.00021,
+            "normalized": {
+                "provider": "google",
+                "input_tokens_total": 100,
+                "input_tokens_uncached": 20,
+                "cache_read_input_tokens": 80,
+                "cache_write_input_tokens": 0,
+                "output_tokens": 5,
+                "cache_metadata_status": "reported",
+            },
+            "cost_details": {
+                "pricing_version": "2026-08-22",
+                "pricing_tier": "standard",
+            },
+        })
+
+        usage = _complete(llm, response).usage
+
+        assert usage.input_tokens_total == 100
+        assert usage.input_tokens_uncached == 20
+        assert usage.cache_read_input_tokens == 80
+        assert usage.output_tokens == 5
+        assert usage.cost == 0.00021
+        assert usage.provider == "google"
 
 
 class TestWithoutOneNothingChanges:

--- a/tests/unit/test_turn_outcome.py
+++ b/tests/unit/test_turn_outcome.py
@@ -145,6 +145,42 @@ def test_multiple_llm_calls_use_explicit_or_reconciled_totals(tmp_path):
     }
 
 
+def test_turn_usage_keeps_measured_cache_classes_and_status(tmp_path):
+    usage = TokenUsage(
+        input_tokens=600,
+        output_tokens=50,
+        cached_tokens=200,
+        cache_write_tokens=300,
+        total_tokens=650,
+        cost=0.002685,
+        input_tokens_total=600,
+        input_tokens_uncached=100,
+        cache_read_input_tokens=200,
+        cache_write_input_tokens=300,
+        cache_write_5m_input_tokens=100,
+        cache_write_1h_input_tokens=200,
+        cache_metadata_status="reported",
+    )
+    agent = Agent(
+        name="cache-contract",
+        llm=MockLLM(responses=[response("answer", usage=usage)]),
+        log=False,
+        quiet=True,
+        co_dir=tmp_path / ".co",
+    )
+
+    agent.input("question")
+
+    turn_usage = outcomes(agent)[0]["usage"]
+    assert turn_usage["input_tokens_total"] == 600
+    assert turn_usage["input_tokens_uncached"] == 100
+    assert turn_usage["cache_read_input_tokens"] == 200
+    assert turn_usage["cache_write_input_tokens"] == 300
+    assert turn_usage["cache_write_5m_input_tokens"] == 100
+    assert turn_usage["cache_write_1h_input_tokens"] == 200
+    assert turn_usage["cache_metadata_status"] == "reported"
+
+
 def test_missing_usage_remains_null(tmp_path):
     agent = Agent(
         name="no-usage",


### PR DESCRIPTION
Companion to openonion/oo-api#162, openonion/connectonion-react#93, and openonion/oo-chat#157.

## What changed

- preserves the backend normalized token classes, provider/model identity, cache metadata status, pricing version/tier, and server cost breakdown
- keeps legacy direct-provider and older oo-api usage compatible
- emits exact fields in `llm_result` traces and turn outcomes without dropping optional fields
- documents the managed accounting contract

## Verification

- focused accounting/logger suite: 93 passed
- full unit collection: 6594 passed, 13 skipped, 12 environment failures (11 sandbox-denied user-home/socket writes; 1 stale top-level docs-site checkout advertising b1 instead of released b10)
- `git diff --check`
