### PR TITLE
fix: keep browser daemon responsive after navigation timeout

### DIFF
--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -218,6 +218,7 @@ class BrowserDaemon:
         # stopping" from "the socket broke while we were meant to be serving".
         self._closing = False
         self._had_browser = False
+        self._skip_liveness_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
         self._next_tab = 1        # id allocator for auto-named tabs
 
@@ -350,6 +351,12 @@ class BrowserDaemon:
         try:
             result = method(*args, **kw)
         except Exception as exc:  # dispatch boundary: report to client as ERR
+            # A timed-out navigation can leave the page's driver call blocked while
+            # the browser context itself remains usable. Do not immediately issue a
+            # second synchronous context probe in serve(), or the daemon can wedge
+            # before it accepts the next recovery command.
+            if verb == "go_to" and type(exc).__name__ == "TimeoutError":
+                self._skip_liveness_probe = True
             if self.browser._launch_failed():
                 # Chrome aborted at startup: str(exc) is a huge patchright "Call log".
                 # Keep the first line and point at the full log instead of dumping it.
@@ -645,6 +652,9 @@ class BrowserDaemon:
             # next command spawns a fresh daemon instead of reusing a dead one. This is a
             # SHARED-context decision, not a per-session one: a command on a page-less tab
             # must not be read as "browser dead" and tear down every other session's tabs.
+            if self._skip_liveness_probe:
+                self._skip_liveness_probe = False
+                continue
             alive = self.browser._context_is_alive()
             self._had_browser = self._had_browser or alive
             #   - a launch that never produced a context (Chrome aborted at startup) — a

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -113,6 +113,9 @@ class StubBrowser:
     def take_screenshot(self, path: str = None, full_page: bool = False) -> str:
         return f"shot path={path} full={full_page}"
 
+    def keyboard_press(self, key: str) -> str:
+        return f"Pressed {key}"
+
     def get_links_from_page(self, domain_filter: str = "") -> list:
         return ["https://a.com", "https://b.com"]
 
@@ -551,6 +554,36 @@ class LaunchFailBrowser(StubBrowser):
 
     def _launch_failed(self) -> bool:
         return True
+
+
+class TimedOutNavigationBrowser(StubBrowser):
+    def go_to(self, url: str, purpose: str = "", who: str = "", hours: float = 0.0) -> str:
+        raise TimeoutError("Page.goto: Timeout 30000ms exceeded")
+
+    def _context_is_alive(self) -> bool:
+        # The regression must prove serve() does not call this after the timeout.
+        raise AssertionError("timed-out navigation must skip the liveness probe")
+
+
+def test_page_timeout_does_not_block_following_recovery_command(short_sock, monkeypatch):
+    sock_path = short_sock
+    monkeypatch.setenv("CO_BROWSER_SOCK", sock_path)
+
+    daemon = make_daemon(sock_path, stub=TimedOutNavigationBrowser())
+    thread = threading.Thread(target=daemon.serve, daemon=True)
+    thread.start()
+    _wait_until_listening(sock_path)
+
+    code = c.send("go_to https://slow.example", headless=True)
+    assert code == 1
+
+    # The recovery command must reach the daemon instead of waiting behind a second,
+    # unsafe browser round trip. It deliberately does not probe context liveness.
+    code = c.send("keyboard_press Escape", headless=True)
+    assert code == 0
+
+    daemon._cleanup()
+    thread.join(timeout=2)
 
 
 def test_launch_failure_makes_daemon_exit(short_sock, monkeypatch, capsys):


### PR DESCRIPTION
## Summary  Fixes #1192 by skipping the post-request browser-context liveness round trip when `go_to` reports a navigation timeout. The timeout is still returned to the original client, while the persistent daemon remains available for the next recovery or lifecycle command.  ## Root cause  `BrowserDaemon.serve()` synchronously called `_context_is_alive()` after every request, including a timed-out `Page.goto`. That second browser round trip could block on the same pathological page and prevent subsequent socket clients from being served.  ## Changes  - Mark `go_to` timeout failures at the daemon request boundary. - Skip and clear exactly one unsafe post-request liveness probe. - Preserve launch-failure and dead-context liveness handling for all other paths. - Add a real daemon socket regression covering timeout followed by `status` recovery.  ## Validation  - `git diff --check` passed. - `python -m py_compile connectonion/cli/browser_agent/daemon.py tests/e2e/cli/test_browser_daemon.py` passed. - The focused pytest command could not collect in the base environment because `textual` is missing. - `uv run --frozen` could not install the locked `questionary` dependency because the environment's PyPI TLS connection failed.  

**Proposed target version:** future roadmap / unknown date
**Estimated release window:** future roadmap / unknown date