### PR TITLE
fix: add provider-native Work Room permissions

### DIFF
--- a/connectonion/core/provider_permissions.py
+++ b/connectonion/core/provider_permissions.py
@@ -1,0 +1,147 @@
+"""Bounded provider-native permission catalogs for OIP Work Rooms."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .mode import AUTO, FULL_ACCESS, READ_ONLY
+
+
+_OPTION_DEFINITIONS = {
+    "codex": (
+        {"id": "codex:read-only", "nativeProfileId": ":read-only", "reviewer": "user", "label": "Read Only", "description": "Codex can inspect the workspace but cannot change it.", "ceiling": 0, "risk": "standard"},
+        {"id": "codex:workspace-ask", "nativeProfileId": ":workspace", "reviewer": "user", "label": "Ask for approval", "description": "Codex can work in the workspace and asks before protected actions.", "ceiling": 1, "risk": "standard"},
+        {"id": "codex:workspace-auto", "nativeProfileId": ":workspace", "reviewer": "auto", "label": "Approve for me", "description": "Codex automatically reviews actions inside the workspace boundary.", "ceiling": 1, "risk": "standard"},
+        {"id": "codex:full-access", "nativeProfileId": ":danger-full-access", "reviewer": "auto", "label": "Full Access", "description": "Codex can act outside the workspace boundary for the next provider turn.", "ceiling": 2, "risk": "elevated"},
+    ),
+    "claude_code": (
+        {"id": "claude:plan", "nativeProfileId": "plan", "reviewer": "user", "label": "Plan", "description": "Claude Code can inspect and plan without applying changes.", "ceiling": 0, "risk": "standard"},
+        {"id": "claude:default", "nativeProfileId": "default", "reviewer": "user", "label": "Default", "description": "Claude Code asks before actions that need permission.", "ceiling": 1, "risk": "standard"},
+        {"id": "claude:accept-edits", "nativeProfileId": "acceptEdits", "reviewer": "provider", "label": "Accept edits", "description": "Claude Code may apply workspace edits while retaining its native checks.", "ceiling": 1, "risk": "standard"},
+        {"id": "claude:auto", "nativeProfileId": "auto", "reviewer": "auto", "label": "Auto", "description": "Claude Code automatically handles permitted workspace actions.", "ceiling": 1, "risk": "standard"},
+        {"id": "claude:bypass-permissions", "nativeProfileId": "bypassPermissions", "reviewer": "auto", "label": "Bypass permissions", "description": "Claude Code bypasses native permission prompts for the next provider turn.", "ceiling": 2, "risk": "elevated"},
+    ),
+}
+_DEFAULT_OPTIONS = {
+    "codex": {READ_ONLY: "codex:read-only", AUTO: "codex:workspace-ask", FULL_ACCESS: "codex:full-access"},
+    "claude_code": {READ_ONLY: "claude:plan", AUTO: "claude:accept-edits", FULL_ACCESS: "claude:auto"},
+}
+_CEILING = {READ_ONLY: 0, AUTO: 1, FULL_ACCESS: 2}
+_CEILING_LABEL = {READ_ONLY: "Read Only", AUTO: "Auto", FULL_ACCESS: "Full Access"}
+
+
+def default_provider_permission_option(provider: str, host_mode: str) -> str:
+    try:
+        return _DEFAULT_OPTIONS[provider][host_mode]
+    except KeyError as exc:
+        raise ValueError("unsupported provider permission boundary") from exc
+
+
+def provider_permission_state(
+    provider: str,
+    active_option_id: str,
+    host_mode: str,
+    *,
+    state_revision: int | None = None,
+) -> dict[str, Any]:
+    definitions = _OPTION_DEFINITIONS.get(provider)
+    if definitions is None or host_mode not in _CEILING:
+        raise ValueError("unsupported provider permission boundary")
+    if active_option_id not in {option["id"] for option in definitions}:
+        raise ValueError("unknown provider permission option")
+    ceiling = _CEILING[host_mode]
+    options = []
+    for definition in definitions:
+        option = {key: value for key, value in definition.items() if key != "ceiling"}
+        option["selectable"] = definition["ceiling"] <= ceiling
+        if not option["selectable"]:
+            option["disabledReason"] = f"Host permission ceiling is {_CEILING_LABEL[host_mode]}."
+        options.append(option)
+    state: dict[str, Any] = {
+        "provider": provider,
+        "activeOptionId": active_option_id,
+        "options": options,
+        "appliesTo": "subsequent_turn",
+    }
+    if state_revision is not None:
+        if isinstance(state_revision, bool) or not isinstance(state_revision, int) or state_revision < 1:
+            raise ValueError("provider permission state requires a positive revision")
+        state["effectiveRevision"] = state_revision
+    return state
+
+
+def provider_permission_option(provider: str, option_id: str, host_mode: str) -> dict[str, Any]:
+    state = provider_permission_state(provider, option_id, host_mode)
+    selected = next(option for option in state["options"] if option["id"] == option_id)
+    if not selected["selectable"]:
+        raise ValueError(selected["disabledReason"])
+    return selected
+
+
+def selected_provider_permission_option(session: object, workroom_id: object) -> str | None:
+    if not isinstance(session, dict) or not isinstance(workroom_id, str):
+        return None
+    selected = session.get("_provider_permission_options")
+    option = selected.get(workroom_id) if isinstance(selected, dict) else None
+    return option if isinstance(option, str) else None
+
+
+def reconcile_provider_permission_events(session: dict[str, Any], host_mode: str) -> None:
+    """Narrow every latest Work Room snapshot after its outer Host ceiling changes."""
+    trace = session.get("trace")
+    if not isinstance(trace, list):
+        return
+    latest_by_workroom: dict[str, dict[str, Any]] = {}
+    for event in trace:
+        if (
+            isinstance(event, dict)
+            and event.get("type") == "provider_invocation"
+            and event.get("provider") in _OPTION_DEFINITIONS
+            and isinstance(event.get("invocationId"), str)
+            and isinstance(event.get("stateRevision"), int)
+            and not isinstance(event.get("stateRevision"), bool)
+        ):
+            workroom_id = event.get("workroomId") or event["invocationId"]
+            if isinstance(workroom_id, str):
+                latest_by_workroom[workroom_id] = event
+    stored = session.setdefault("_provider_permission_options", {})
+    if not isinstance(stored, dict):
+        stored = {}
+        session["_provider_permission_options"] = stored
+    for workroom_id, source in latest_by_workroom.items():
+        provider = source["provider"]
+        selected = stored.get(workroom_id)
+        if not isinstance(selected, str):
+            selected = default_provider_permission_option(provider, host_mode)
+        try:
+            provider_permission_option(provider, selected, host_mode)
+        except ValueError:
+            selected = default_provider_permission_option(provider, host_mode)
+        stored[workroom_id] = selected
+        revision = source["stateRevision"]
+        expected = provider_permission_state(
+            provider,
+            selected,
+            host_mode,
+            state_revision=revision,
+        )
+        if source.get("providerPermission") == expected:
+            continue
+        updated = dict(source)
+        updated["stateRevision"] = revision + 1
+        updated["providerPermission"] = provider_permission_state(
+            provider,
+            selected,
+            host_mode,
+            state_revision=revision + 1,
+        )
+        trace.append(updated)
+
+
+__all__ = [
+    "default_provider_permission_option",
+    "provider_permission_option",
+    "provider_permission_state",
+    "reconcile_provider_permission_events",
+    "selected_provider_permission_option",
+]

--- a/connectonion/network/host/provider_permissions.py
+++ b/connectonion/network/host/provider_permissions.py
@@ -1,0 +1,134 @@
+"""Provider-owned Work Room permission profiles and durable transactions.
+
+Outer COAI mode remains the Host ceiling.  This module exposes the narrower
+provider-native choices permitted inside that ceiling, then commits a choice
+only for the authenticated owner's subsequent provider work.  Browser state is
+never authority: every write is bound to the latest durable state revision.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from ...core.mode import mode_of
+from ...core.provider_permissions import (
+    provider_permission_state,
+    selected_provider_permission_option,
+)
+from .session import SessionStorage, session_owner
+
+
+_SUPPORTED_PROVIDERS = frozenset({"codex", "claude_code"})
+
+
+class ProviderPermissionError(RuntimeError):
+    """A safe, stable rejection for one provider permission transaction."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def commit_provider_permission(
+    storage: SessionStorage,
+    session_id: str,
+    requester_address: object,
+    invocation_id: object,
+    observed_revision: object,
+    option_id: object,
+    *,
+    request_id: object,
+    confirm_risk: object,
+) -> dict[str, Any]:
+    """Commit an acknowledged provider option for subsequent native work."""
+    for value in (session_id, invocation_id, option_id, request_id):
+        if not _valid_id(value):
+            raise ProviderPermissionError("invalid_request", "Provider permission request is invalid.")
+    if isinstance(observed_revision, bool) or not isinstance(observed_revision, int) or observed_revision < 1:
+        raise ProviderPermissionError("invalid_revision", "Provider state revision is invalid.")
+    result: dict[str, Any] = {}
+
+    def commit(current):
+        nonlocal result
+        if current is None or session_owner(current) != requester_address:
+            raise ProviderPermissionError("not_owner", "The Work Room is not owned by this requester.")
+        session = copy.deepcopy(current.session or {})
+        requester = session.get("requester")
+        if not isinstance(requester, dict) or requester.get("level") != "admin":
+            raise ProviderPermissionError("operator_required", "Only the Host Operator can change provider permissions.")
+        source = _latest_invocation(session, invocation_id)
+        if not source:
+            raise ProviderPermissionError("not_found", "The provider Work Room is unavailable.")
+        if source.get("stateRevision") != observed_revision:
+            raise ProviderPermissionError("stale_revision", "The provider state changed; refresh before trying again.")
+        provider = source.get("provider")
+        host_mode = mode_of(session)
+        try:
+            state = provider_permission_state(provider, option_id, host_mode)
+        except ValueError as exc:
+            raise ProviderPermissionError("unsupported_option", "This provider option is unavailable.") from exc
+        selected = next(option for option in state["options"] if option["id"] == option_id)
+        if not selected["selectable"]:
+            raise ProviderPermissionError("ceiling_denied", selected["disabledReason"])
+        if selected["risk"] == "elevated" and confirm_risk is not True:
+            raise ProviderPermissionError("confirmation_required", "Confirm the provider Full Access risk separately.")
+        revision = observed_revision + 1
+        state = provider_permission_state(
+            provider,
+            option_id,
+            host_mode,
+            state_revision=revision,
+        )
+        workroom_id = source.get("workroomId") or invocation_id
+        choices = session.setdefault("_provider_permission_options", {})
+        if not isinstance(choices, dict):
+            choices = {}
+            session["_provider_permission_options"] = choices
+        choices[workroom_id] = option_id
+        event = copy.deepcopy(source)
+        event["stateRevision"] = revision
+        event["providerPermission"] = state
+        session.setdefault("trace", []).append(event)
+        result = {
+            "invocationId": invocation_id,
+            "stateRevision": revision,
+            "providerPermission": state,
+            "event": event,
+        }
+        return current.model_copy(update={"session": session})
+
+    storage.atomic_update(session_id, commit)
+    return result
+
+
+def _latest_invocation(session: dict[str, Any], invocation_id: str) -> dict[str, Any]:
+    trace = session.get("trace")
+    candidates = [
+        event for event in trace or []
+        if isinstance(event, dict)
+        and event.get("type") == "provider_invocation"
+        and event.get("invocationId") == invocation_id
+        and event.get("provider") in _SUPPORTED_PROVIDERS
+        and isinstance(event.get("stateRevision"), int)
+        and not isinstance(event.get("stateRevision"), bool)
+    ]
+    return max(candidates, key=lambda event: event["stateRevision"], default={})
+
+
+def _valid_id(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= 512
+        and value.isascii()
+        and all(character.isalnum() or character in "._:-" for character in value)
+    )
+
+
+__all__ = [
+    "ProviderPermissionError",
+    "commit_provider_permission",
+    "provider_permission_state",
+    "selected_provider_permission_option",
+]

--- a/connectonion/network/host/provider_workroom.py
+++ b/connectonion/network/host/provider_workroom.py
@@ -155,6 +155,12 @@ def _direct_session(
     provider: str,
 ) -> dict[str, Any]:
     """Construct the minimum session a configured native tool needs to run."""
+    stored_permissions = source_session.get("_provider_permission_options")
+    selected_permission = (
+        stored_permissions.get(workroom_id)
+        if isinstance(stored_permissions, dict)
+        else None
+    )
     return {
         "messages": [],
         "trace": [],
@@ -171,6 +177,11 @@ def _direct_session(
         # invocation. Keep that exact durable revision so only a successful
         # native ``turn/start`` can acknowledge the original request.
         "_provider_direct_state_revision": state_revision,
+        **(
+            {"_provider_permission_options": {workroom_id: selected_permission}}
+            if isinstance(selected_permission, str)
+            else {}
+        ),
         # Ownership and the terminal source revision were validated while the
         # durable session lock was held.  Let the approval plugin consume this
         # one-shot capability for the outer native-provider wrapper only;

--- a/connectonion/network/host/session/mode.py
+++ b/connectonion/network/host/session/mode.py
@@ -16,6 +16,7 @@ from ....core.mode import (
     mode_of,
     set_mode,
 )
+from ....core.provider_permissions import reconcile_provider_permission_events
 from .storage import Session, SessionStorage, session_owner
 
 _DISCARDED_MODE_KEYS = {
@@ -111,6 +112,7 @@ class HostPermissionPolicy:
             set_mode(normalized, FULL_ACCESS, turns_left=remaining)
         else:
             set_mode(normalized, canonical if canonical != FULL_ACCESS else AUTO)
+        reconcile_provider_permission_events(normalized, mode_of(normalized))
         return normalized
 
     def apply(self, session: dict, requested_mode: Any, *, is_admin: bool) -> dict:
@@ -132,6 +134,7 @@ class HostPermissionPolicy:
             )
         else:
             set_mode(changed, canonical)
+        reconcile_provider_permission_events(changed, mode_of(changed))
         return changed
 
 

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -14,6 +14,7 @@ import uuid
 from rich.console import Console
 
 from ...trust.ws_admin import handle_admin_message, handle_onboard_submit
+from ..provider_permissions import ProviderPermissionError, commit_provider_permission
 from .agent_io import start_agent, start_provider_workroom_turn
 from .connect import establish_connection, handle_authenticated_reconnect, handle_connect
 from .exec import run_exec
@@ -72,6 +73,36 @@ async def _send_provider_input_ack(
         and state_revision > 0
     ):
         frame["stateRevision"] = state_revision
+    if reason:
+        frame["reason"] = reason
+    await send_msg(frame)
+
+
+async def _send_provider_permission_ack(
+    send_msg,
+    *,
+    request_id: str,
+    invocation_id: str | None,
+    accepted: bool,
+    state_revision: int | None = None,
+    provider_permission: dict | None = None,
+    reason: str | None = None,
+):
+    """Settle one revision-bound Work Room provider-profile request."""
+    frame = {
+        "type": "PROVIDER_PERMISSION_ACK",
+        "requestId": request_id,
+        "invocationId": invocation_id,
+        "accepted": accepted,
+    }
+    if (
+        not isinstance(state_revision, bool)
+        and isinstance(state_revision, int)
+        and state_revision > 0
+    ):
+        frame["stateRevision"] = state_revision
+    if provider_permission is not None:
+        frame["providerPermission"] = provider_permission
     if reason:
         frame["reason"] = reason
     await send_msg(frame)
@@ -462,6 +493,53 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                 # native adapter only after ``thread/resume`` + ``turn/start``
                 # succeed. Starting a Host worker is deliberately not enough
                 # to let the composer clear its unsent text.
+
+            elif msg_type == "PROVIDER_PERMISSION_CHANGE":
+                request_id = data.get("requestId")
+                invocation_id = data.get("invocationId")
+                try:
+                    committed = await asyncio.to_thread(
+                        commit_provider_permission,
+                        storage,
+                        conn.get("session_id"),
+                        conn.get("agent_address"),
+                        invocation_id,
+                        data.get("stateRevision"),
+                        data.get("optionId"),
+                        request_id=request_id,
+                        confirm_risk=data.get("confirmRisk") is True,
+                    )
+                except ProviderPermissionError as exc:
+                    await _send_provider_permission_ack(
+                        send_msg,
+                        request_id=request_id if isinstance(request_id, str) else "",
+                        invocation_id=invocation_id if isinstance(invocation_id, str) else None,
+                        accepted=False,
+                        reason=exc.code,
+                    )
+                    continue
+                except Exception:
+                    await _send_provider_permission_ack(
+                        send_msg,
+                        request_id=request_id if isinstance(request_id, str) else "",
+                        invocation_id=invocation_id if isinstance(invocation_id, str) else None,
+                        accepted=False,
+                        reason="unavailable",
+                    )
+                    continue
+                await _send_provider_permission_ack(
+                    send_msg,
+                    request_id=request_id,
+                    invocation_id=invocation_id,
+                    accepted=True,
+                    state_revision=committed["stateRevision"],
+                    provider_permission=committed["providerPermission"],
+                )
+                # Other readers and a same-tab reconnect consume the same
+                # canonical lifecycle event. The requesting React client has
+                # already committed the ACK and idempotently ignores this equal
+                # revision when it arrives immediately afterwards.
+                await send_msg(committed["event"])
 
             elif msg_type == "APPROVAL_RESPONSE" and active_io:
                 resolver = getattr(active_io, "resolve_legacy_permission", None)

--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -17,6 +17,12 @@ from typing import Any
 
 from ..core.events import on_agent_ready
 from ..core.mode import AUTO, FULL_ACCESS, READ_ONLY, mode_of
+from ..core.provider_permissions import (
+    default_provider_permission_option,
+    provider_permission_option,
+    provider_permission_state,
+    selected_provider_permission_option,
+)
 from ..core.provider_events import (
     clear_provider_activity_history,
     clear_provider_artifact,
@@ -238,6 +244,19 @@ class CodexPlugin(_CodingAgentPlugin):
 
         session = getattr(agent, "current_session", {}) or {}
         current = mode_of(session)
+        selected = _selected_workroom_permission(session)
+        if selected:
+            try:
+                option = provider_permission_option("codex", selected, current)
+            except ValueError:
+                option = None
+            if option:
+                return {
+                    "codex:read-only": ("read-only", "manual", PermissionMode.READ_ONLY),
+                    "codex:workspace-ask": ("workspace-write", "manual", PermissionMode.AUTO),
+                    "codex:workspace-auto": ("workspace-write", "auto", PermissionMode.AUTO),
+                    "codex:full-access": ("danger-full-access", "auto", PermissionMode.FULL_ACCESS),
+                }[option["id"]]
         return {
             READ_ONLY: (
                 "read-only", "manual", PermissionMode.READ_ONLY
@@ -307,6 +326,21 @@ class ClaudeCodePlugin(_CodingAgentPlugin):
 
         session = getattr(agent, "current_session", {}) or {}
         current = mode_of(session)
+        selected = _selected_workroom_permission(session)
+        if selected:
+            try:
+                option = provider_permission_option("claude_code", selected, current)
+            except ValueError:
+                option = None
+            if option:
+                effective = (
+                    PermissionMode.READ_ONLY
+                    if option["id"] == "claude:plan"
+                    else PermissionMode.FULL_ACCESS
+                    if option["id"] == "claude:bypass-permissions"
+                    else PermissionMode.AUTO
+                )
+                return option["nativeProfileId"], effective
         return {
             READ_ONLY: ("manual", PermissionMode.READ_ONLY),
             AUTO: (
@@ -333,6 +367,14 @@ def _emit(agent, event_type: str, **fields: Any) -> dict[str, Any]:
                 agent, invocation_id
             )
             fields.update(_provider_workroom_fields(agent, invocation_id))
+            permission = _provider_permission_for_event(
+                agent,
+                fields.get("provider"),
+                fields["workroomId"],
+                fields["stateRevision"],
+            )
+            if permission is not None:
+                fields["providerPermission"] = permission
     entry = {"type": event_type, **fields}
     record = getattr(agent, "_record_trace", None)
     if callable(record) and isinstance(getattr(agent, "current_session", None), dict):
@@ -364,6 +406,45 @@ def _provider_workroom_fields(agent, invocation_id: str) -> dict[str, str]:
     if isinstance(continuation_of, str) and continuation_of:
         fields["continuationOf"] = continuation_of
     return fields
+
+
+def _selected_workroom_permission(session: object) -> str | None:
+    if not isinstance(session, dict):
+        return None
+    workroom_id = session.get("_provider_workroom_id")
+    return selected_provider_permission_option(session, workroom_id)
+
+
+def _provider_permission_for_event(
+    agent,
+    provider: object,
+    workroom_id: object,
+    state_revision: int,
+) -> dict[str, Any] | None:
+    if provider not in {"codex", "claude_code"} or not isinstance(workroom_id, str):
+        return None
+    session = getattr(agent, "current_session", None)
+    if not isinstance(session, dict):
+        return None
+    host_mode = mode_of(session)
+    selected = (
+        selected_provider_permission_option(session, workroom_id)
+        or default_provider_permission_option(provider, host_mode)
+    )
+    try:
+        return provider_permission_state(
+            provider,
+            selected,
+            host_mode,
+            state_revision=state_revision,
+        )
+    except ValueError:
+        return provider_permission_state(
+            provider,
+            default_provider_permission_option(provider, host_mode),
+            host_mode,
+            state_revision=state_revision,
+        )
 
 
 def _emit_cached_provider_artifact(agent, lifecycle: dict[str, Any]) -> None:

--- a/docs/blog/2026-08-23-the-work-room-needed-its-own-permissions.md
+++ b/docs/blog/2026-08-23-the-work-room-needed-its-own-permissions.md
@@ -1,0 +1,47 @@
+# The Work Room Needed Its Own Permissions
+
+RC1 had three Host permission modes and a working Codex conversation. It also
+had a hole that only became obvious in the release screenshots: opening the
+Work Room removed the permission controls a Codex user expects to find there.
+The remote client showed the provider's work, but it could not control how the
+provider would do its next piece of work.
+
+Copying the outer Read Only, Auto, and Full Access buttons into the panel would
+have made the screenshot busier without fixing the model. Those controls bound
+the whole Host. Codex separately combines a sandbox boundary with a reviewer:
+Ask for approval and Approve for me can share the same workspace boundary while
+making different approval decisions. Claude Code has a different native set
+again. Flattening either provider into three generic labels loses real policy.
+
+The Work Room now receives a finite provider-owned catalog with a selected
+option, native profile identifier, reviewer, risk, and Host-enforced
+selectability. Codex keeps Read Only, Ask for approval, Approve for me, and Full
+Access distinct. Claude Code keeps Plan, Default, Accept edits, Auto, and Bypass
+permissions. The outer COAI mode remains the ceiling, and individual action
+approvals remain a third, separate boundary.
+
+Changing a selection is a transaction rather than a cosmetic toggle. The
+browser signs the invocation ID, the exact revision it saw, and one advertised
+option. Host verifies the session owner, Operator role, latest durable state,
+and outer ceiling before acknowledging a newer revision. Elevated access also
+requires a separate confirmation. Until that acknowledgement arrives, the UI
+does not pretend the choice changed.
+
+This matters when several ordinary failures overlap. A stale tab cannot
+overwrite a newer choice. A reader cannot promote itself to Operator. Lowering
+the outer mode immediately reconciles stored native profiles to the narrower
+ceiling. Reconnecting replays the canonical selection, while malformed or old
+clients simply receive no usable selector. A selection applies to subsequent
+provider work and never rewrites an already-running action.
+
+Eleven transaction and WebSocket tests cover the new boundary, and the full
+Core suite passes 7,164 tests with 18 environment-specific skips. The companion
+React candidate validates acknowledgements without optimistic updates, while O
+Chat exercises the real selector and its separate elevated confirmation at
+desktop, tablet, and mobile widths.
+
+The release lesson is narrower than "add more controls." A remote coding client
+must preserve the provider's own concepts where they change authority. The
+outer Host, the provider session, and a single protected action are related,
+but they are not the same permission—and the interface should not claim that
+they are.

--- a/docs/codex-tool-frontend-contract.md
+++ b/docs/codex-tool-frontend-contract.md
@@ -93,6 +93,30 @@ command output in the provider conversation. User and assistant text are emitted
 as bounded `provider_message` entries; commands and local paths remain semantic
 activity or private provider state.
 
+## Provider-native permission profiles
+
+Work Room permissions do not reuse or rename the outer three COAI modes. The
+outer mode remains the authoritative Host ceiling; each typed
+`provider_invocation` may additionally carry a finite `providerPermission`
+catalog for the native provider. Codex keeps sandbox boundary and reviewer as
+separate fields, so **Ask for approval** and **Approve for me** both map to the
+native `:workspace` boundary without becoming the same policy. Claude Code
+exposes its own native Plan, Default, Accept edits, Auto, and Bypass permissions
+profiles through the same bounded shape.
+
+The browser changes a profile with a signed `PROVIDER_PERMISSION_CHANGE`
+containing the invocation ID, observed positive `stateRevision`, advertised
+option ID, and a separate elevated-risk confirmation when required. Host checks
+session ownership, Operator level, the latest durable revision, and the outer
+mode ceiling before persisting the selection. Only then does it return
+`PROVIDER_PERMISSION_ACK` and append a newer canonical `provider_invocation`.
+The selected profile applies to subsequent native provider work; it cannot
+retroactively alter an active action or replace an individual approval.
+
+Old or malformed clients fail closed: missing catalogs render no selector,
+unadvertised and stale choices are rejected, and lowering the outer COAI mode
+immediately reconciles any stored provider profile to the narrower ceiling.
+
 ## What the frontend team should know
 
 - The React package owns normalization and child correlation. O Chat consumes

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -78,6 +78,35 @@ it is not the terminal outcome. The matching `provider_invocation` event with
 the client can restore a retry action. Legacy requests without `requestId`
 retain the older no-ack behaviour during the rolling compatibility window.
 
+### Provider-native permission change
+
+`PROVIDER_PERMISSION_CHANGE` selects one Host-advertised Codex or Claude Code
+profile for subsequent work in the exact Work Room on screen:
+
+```json
+{
+  "type": "PROVIDER_PERMISSION_CHANGE",
+  "requestId": "permission-1",
+  "invocationId": "codex:call-7",
+  "stateRevision": 4,
+  "optionId": "codex:workspace-auto",
+  "confirmRisk": false
+}
+```
+
+The authenticated requester must own the session and be its Operator. The
+option must exist in the latest durable invocation catalog and fit inside the
+outer Host mode ceiling. An elevated Full Access option additionally requires
+`confirmRisk: true`. Browser state is never authority.
+
+An accepted request returns `PROVIDER_PERMISSION_ACK` with the matching request
+and invocation IDs, a strictly newer revision, and the complete authoritative
+`providerPermission` state. Host then streams that same revision as a canonical
+`provider_invocation` for replay and other readers. A rejection has
+`accepted: false` and one safe reason code such as `stale_revision`,
+`ceiling_denied`, `operator_required`, or `confirmation_required`; it never
+changes durable state.
+
 ```
 ┌────────────────────────────────────────────────────────────────┐
 │                    WebSocket Lifecycle                          │

--- a/tests/unit/test_provider_workroom_permissions.py
+++ b/tests/unit/test_provider_workroom_permissions.py
@@ -1,0 +1,283 @@
+import asyncio
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from connectonion.network.host.provider_permissions import (
+    ProviderPermissionError,
+    commit_provider_permission,
+    provider_permission_state,
+)
+from connectonion.network.host.session import Session, SessionStorage
+from connectonion.network.host.session.mode import HostPermissionPolicy
+from connectonion.plugins.coding_agents import CodexPlugin, PermissionMode
+
+
+def _storage(tmp_path: Path, *, mode: str = "auto", requester_level: str = "admin"):
+    storage = SessionStorage(tmp_path / "sessions.jsonl")
+    storage.save(Session(
+        session_id="owned-session",
+        status="done",
+        prompt="delegate",
+        session={
+            "mode": mode,
+            **({"turns_left": 2} if mode == "full-access" else {}),
+            "requester": {"address": "0xowner", "level": requester_level},
+            "trace": [{
+                "type": "provider_invocation",
+                "invocationId": "codex:call-7",
+                "parentToolCallId": "call-7",
+                "workroomId": "codex:call-7",
+                "provider": "codex",
+                "providerDisplayName": "Codex",
+                "status": "completed",
+                "sessionId": "thread-7",
+                "stateRevision": 4,
+                "taskTitle": "Implement and verify the requested change",
+                "resultSummary": "The provider completed its run",
+            }],
+        },
+    ))
+    return storage
+
+
+def test_codex_state_keeps_workspace_boundary_and_reviewer_separate():
+    state = provider_permission_state("codex", "codex:workspace-ask", "auto")
+
+    assert state["activeOptionId"] == "codex:workspace-ask"
+    options = {option["id"]: option for option in state["options"]}
+    assert options["codex:workspace-ask"]["nativeProfileId"] == ":workspace"
+    assert options["codex:workspace-ask"]["reviewer"] == "user"
+    assert options["codex:workspace-auto"]["nativeProfileId"] == ":workspace"
+    assert options["codex:workspace-auto"]["reviewer"] == "auto"
+    assert options["codex:full-access"]["selectable"] is False
+    assert options["codex:full-access"]["disabledReason"] == "Host permission ceiling is Auto."
+
+
+def test_commit_is_revision_bound_persisted_and_applies_to_subsequent_work(tmp_path):
+    storage = _storage(tmp_path)
+
+    result = commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:workspace-auto",
+        request_id="permission-1",
+        confirm_risk=False,
+    )
+
+    assert result["stateRevision"] == 5
+    assert result["providerPermission"]["activeOptionId"] == "codex:workspace-auto"
+    assert result["providerPermission"]["appliesTo"] == "subsequent_turn"
+    current = storage.get("owned-session")
+    assert current.session["_provider_permission_options"]["codex:call-7"] == "codex:workspace-auto"
+    newest = current.session["trace"][-1]
+    assert newest["type"] == "provider_invocation"
+    assert newest["sessionId"] == "thread-7"
+    assert newest["stateRevision"] == 5
+    assert newest["providerPermission"] == result["providerPermission"]
+
+
+@pytest.mark.parametrize(
+    ("address", "revision", "option_id", "confirm_risk", "code"),
+    [
+        ("0xother", 4, "codex:workspace-auto", False, "not_owner"),
+        ("0xowner", 3, "codex:workspace-auto", False, "stale_revision"),
+        ("0xowner", 4, "codex:full-access", True, "ceiling_denied"),
+    ],
+)
+def test_commit_fails_closed_for_wrong_owner_stale_state_or_host_ceiling(
+    tmp_path, address, revision, option_id, confirm_risk, code,
+):
+    storage = _storage(tmp_path)
+    with pytest.raises(ProviderPermissionError) as error:
+        commit_provider_permission(
+            storage,
+            "owned-session",
+            address,
+            "codex:call-7",
+            revision,
+            option_id,
+            request_id="permission-1",
+            confirm_risk=confirm_risk,
+        )
+    assert error.value.code == code
+
+
+def test_full_access_requires_operator_and_separate_confirmation(tmp_path):
+    storage = _storage(tmp_path, mode="full-access")
+    with pytest.raises(ProviderPermissionError) as error:
+        commit_provider_permission(
+            storage,
+            "owned-session",
+            "0xowner",
+            "codex:call-7",
+            4,
+            "codex:full-access",
+            request_id="permission-1",
+            confirm_risk=False,
+        )
+    assert error.value.code == "confirmation_required"
+
+    accepted = commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:full-access",
+        request_id="permission-2",
+        confirm_risk=True,
+    )
+    assert accepted["providerPermission"]["activeOptionId"] == "codex:full-access"
+
+
+def test_non_operator_cannot_change_a_provider_profile(tmp_path):
+    storage = _storage(tmp_path, requester_level="contact")
+    with pytest.raises(ProviderPermissionError) as error:
+        commit_provider_permission(
+            storage,
+            "owned-session",
+            "0xowner",
+            "codex:call-7",
+            4,
+            "codex:read-only",
+            request_id="permission-1",
+            confirm_risk=False,
+        )
+    assert error.value.code == "operator_required"
+
+
+def test_direct_codex_continuation_uses_the_committed_provider_option(tmp_path):
+    plugin = CodexPlugin(workspace=tmp_path, use_host_permissions=True)
+    agent = type("Agent", (), {})()
+    agent.current_session = {
+        "mode": "auto",
+        "_provider_workroom_id": "codex:call-7",
+        "_provider_permission_options": {
+            "codex:call-7": "codex:workspace-auto",
+        },
+    }
+
+    assert plugin._policy(agent) == (
+        "workspace-write",
+        "auto",
+        PermissionMode.AUTO,
+    )
+
+
+def test_lowering_outer_mode_downgrades_stored_provider_authority_and_replay(tmp_path):
+    storage = _storage(tmp_path, mode="full-access")
+    committed = commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:full-access",
+        request_id="permission-full",
+        confirm_risk=True,
+    )
+    session = storage.get("owned-session").session
+
+    lowered = HostPermissionPolicy(full_access_turns=2).apply(
+        session,
+        "read-only",
+        is_admin=True,
+    )
+
+    assert committed["providerPermission"]["activeOptionId"] == "codex:full-access"
+    assert lowered["_provider_permission_options"]["codex:call-7"] == "codex:read-only"
+    latest = lowered["trace"][-1]
+    assert latest["stateRevision"] > committed["stateRevision"]
+    assert latest["providerPermission"]["activeOptionId"] == "codex:read-only"
+    assert all(
+        option["id"] == "codex:read-only" or option["selectable"] is False
+        for option in latest["providerPermission"]["options"]
+    )
+
+
+def _run_permission_frame(monkeypatch, storage, frame):
+    from connectonion.network.host.ws_router import session as ws_session
+
+    sent = []
+    frames = [{"type": "CONNECT"}, frame]
+
+    async def send_msg(data):
+        sent.append(data)
+
+    async def recv_msg():
+        return frames.pop(0) if frames else None
+
+    async def connect(data, send_msg, conn, *args, **kwargs):
+        conn.update({
+            "authenticated": True,
+            "agent_address": "0xowner",
+            "session_id": "owned-session",
+            "session": storage.get("owned-session").session,
+        })
+        return None
+
+    monkeypatch.setattr(ws_session, "handle_connect", connect)
+    asyncio.run(ws_session.run_ws_session(
+        send_msg,
+        recv_msg,
+        route_handlers={},
+        storage=storage,
+        registry=Mock(),
+        trust=None,
+        enable_ping=False,
+    ))
+    return sent
+
+
+def test_websocket_permission_change_acks_then_streams_durable_state(
+    tmp_path, monkeypatch,
+):
+    storage = _storage(tmp_path)
+
+    sent = _run_permission_frame(monkeypatch, storage, {
+        "type": "PROVIDER_PERMISSION_CHANGE",
+        "requestId": "permission-1",
+        "invocationId": "codex:call-7",
+        "stateRevision": 4,
+        "optionId": "codex:workspace-auto",
+        "confirmRisk": False,
+    })
+
+    assert [message["type"] for message in sent] == [
+        "PROVIDER_PERMISSION_ACK",
+        "provider_invocation",
+    ]
+    assert sent[0]["accepted"] is True
+    assert sent[0]["stateRevision"] == 5
+    assert sent[0]["providerPermission"]["effectiveRevision"] == 5
+    assert sent[1] == storage.get("owned-session").session["trace"][-1]
+
+
+def test_websocket_permission_change_rejects_stale_revision_without_mutation(
+    tmp_path, monkeypatch,
+):
+    storage = _storage(tmp_path)
+
+    sent = _run_permission_frame(monkeypatch, storage, {
+        "type": "PROVIDER_PERMISSION_CHANGE",
+        "requestId": "permission-stale",
+        "invocationId": "codex:call-7",
+        "stateRevision": 3,
+        "optionId": "codex:workspace-auto",
+    })
+
+    assert sent == [{
+        "type": "PROVIDER_PERMISSION_ACK",
+        "requestId": "permission-stale",
+        "invocationId": "codex:call-7",
+        "accepted": False,
+        "reason": "stale_revision",
+    }]
+    current = storage.get("owned-session").session
+    assert current.get("_provider_permission_options") is None
+    assert len(current["trace"]) == 1


### PR DESCRIPTION
## Description

Add Host-authoritative provider-native permission profiles inside Codex and Claude Code Work Rooms. The outer COAI mode remains the ceiling, provider selection applies to subsequent work, and per-action approval stays separate.

## Related Issue

Fixes #1109
Supports #792

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5.6 via Codex.

The part I would review most closely is migration of an RC1 trace that has no provider permission snapshot: lowering the outer mode can append a canonical reconciliation revision. I did not run paid provider calls, Windows-only clipboard/headful browser paths, or deployment tests that require `DEPLOY_API_URL`. If this is wrong, the first visible break should be a rejected/stale selector transaction or a subsequent Codex/Claude turn using the default native profile instead of the acknowledged one; the outer Host ceiling still fails closed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-23-the-work-room-needed-its-own-permissions.md

## Changes Made

- Define finite Codex and Claude Code native permission catalogs without flattening provider concepts into the outer three COAI modes.
- Persist revision-bound, owner/operator-authorized selections and acknowledge them before streaming canonical state.
- Require a separate risk confirmation for elevated profiles and reconcile selections when the outer ceiling is lowered.
- Apply the stored profile to subsequent native provider turns and document the WebSocket contract.

## Testing

```text
$ pytest -q
7164 passed, 18 skipped, 180 deselected, 7 warnings in 1412.55s (0:23:32)
```

- [x] I have added tests for new functionality

## Scope

This touches the canonical permission catalog, Host transaction/WebSocket routing, provider continuation policy, contract documentation, one design journal entry, and focused unit/real-router tests. It does not change the outer COAI mode model or retroactively alter active provider processes.

## Example Usage

The browser sends `PROVIDER_PERMISSION_CHANGE` with an invocation ID, observed revision, advertised option ID, and `confirmRisk` when required. Host returns `PROVIDER_PERMISSION_ACK`; the following provider turn consumes the stored native profile.

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

The companion O Chat PR contains the desktop, tablet, and mobile selector evidence. This Core PR owns the protocol and durable authority boundary.

## Additional Notes

`@connectonion/react@0.4.3-rc.0` is already public and implements the matching acknowledged transaction. RC1 is not eligible for unchanged promotion; this fix is part of RC2.

**Proposed target version:** 1.7.0rc2

**Estimated release window:** RC2 after coordinated Core/O Chat merge and exact-artifact acceptance; stable only after the release gates pass
