### PR TITLE
fix: let invited owners set Work Room permissions

### DIFF
--- a/connectonion/network/host/provider_permissions.py
+++ b/connectonion/network/host/provider_permissions.py
@@ -20,6 +20,7 @@ from .session import SessionStorage, session_owner
 
 
 _SUPPORTED_PROVIDERS = frozenset({"codex", "claude_code"})
+_SESSION_ACTOR_LEVELS = frozenset({"contact", "whitelist", "admin"})
 
 
 class ProviderPermissionError(RuntimeError):
@@ -56,8 +57,20 @@ def commit_provider_permission(
             raise ProviderPermissionError("not_owner", "The Work Room is not owned by this requester.")
         session = copy.deepcopy(current.session or {})
         requester = session.get("requester")
-        if not isinstance(requester, dict) or requester.get("level") != "admin":
-            raise ProviderPermissionError("operator_required", "Only the Host Operator can change provider permissions.")
+        if (
+            not isinstance(requester, dict)
+            or requester.get("address") != requester_address
+            or requester.get("level") not in _SESSION_ACTOR_LEVELS
+        ):
+            # ``operator_required`` is retained as the wire code for rolling
+            # React compatibility. Provider profiles are session execution
+            # controls, not Host control-plane settings: an invited contact may
+            # change its own Work Room within the already-authoritative outer
+            # ceiling, while a forged/missing requester still fails closed.
+            raise ProviderPermissionError(
+                "operator_required",
+                "Only the authenticated session owner can change provider permissions.",
+            )
         source = _latest_invocation(session, invocation_id)
         if not source:
             raise ProviderPermissionError("not_found", "The provider Work Room is unavailable.")

--- a/tests/unit/test_provider_workroom_permissions.py
+++ b/tests/unit/test_provider_workroom_permissions.py
@@ -107,7 +107,7 @@ def test_commit_fails_closed_for_wrong_owner_stale_state_or_host_ceiling(
     assert error.value.code == code
 
 
-def test_full_access_requires_operator_and_separate_confirmation(tmp_path):
+def test_full_access_requires_separate_confirmation(tmp_path):
     storage = _storage(tmp_path, mode="full-access")
     with pytest.raises(ProviderPermissionError) as error:
         commit_provider_permission(
@@ -135,8 +135,29 @@ def test_full_access_requires_operator_and_separate_confirmation(tmp_path):
     assert accepted["providerPermission"]["activeOptionId"] == "codex:full-access"
 
 
-def test_non_operator_cannot_change_a_provider_profile(tmp_path):
-    storage = _storage(tmp_path, requester_level="contact")
+@pytest.mark.parametrize("requester_level", ["contact", "whitelist", "admin"])
+def test_authenticated_session_actor_can_change_its_own_provider_profile(
+    tmp_path, requester_level,
+):
+    storage = _storage(tmp_path, requester_level=requester_level)
+    accepted = commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:read-only",
+        request_id="permission-1",
+        confirm_risk=False,
+    )
+    assert accepted["providerPermission"]["activeOptionId"] == "codex:read-only"
+
+
+@pytest.mark.parametrize("requester_level", ["stranger", "blocked", None])
+def test_untrusted_or_missing_session_actor_cannot_change_a_provider_profile(
+    tmp_path, requester_level,
+):
+    storage = _storage(tmp_path, requester_level=requester_level)
     with pytest.raises(ProviderPermissionError) as error:
         commit_provider_permission(
             storage,


### PR DESCRIPTION
**Proposed target version:** 1.7.0rc3

**Estimated release window:** current 1.7 release train after exact-artifact acceptance

## Summary

Allow an authenticated invited contact/whitelist/admin to change the provider profile for its own Work Room, within the existing Host ceiling.

This preserves the #1054 product boundary: provider profiles are ordinary session execution controls, while trust mutation and other control-plane operations remain admin-only.

## Safety boundary

- exact requester address must still own the session;
- requester state must be a trusted session actor;
- request remains signed, revision-bound, catalog-bound, and ceiling-bound;
- provider Full Access still requires separate confirmation;
- the legacy `operator_required` wire reason is retained for rolling React compatibility when forged/missing requester state is rejected.

## Verification

- `pytest -q tests/unit/test_provider_workroom_permissions.py tests/unit/test_co_ai_agent_main.py` — 26 passed
- exact RC2 failure evidence: openonion/oo-chat#230

Closes #1218
Release control: #792

