### PR TITLE
fix: stream Work Room permission downgrade after outer mode change

### DIFF
--- a/connectonion/network/host/session/mode.py
+++ b/connectonion/network/host/session/mode.py
@@ -190,22 +190,60 @@ def commit_host_session_mode(
 ) -> Session:
     """Commit one idle mode change under the cross-worker storage lock."""
 
+    record, _ = commit_host_session_mode_with_events(
+        storage,
+        registry,
+        session_id,
+        owner,
+        mode_id,
+        policy,
+        is_admin,
+    )
+    return record
+
+
+def commit_host_session_mode_with_events(
+    storage: SessionStorage,
+    registry,
+    session_id: str,
+    owner: str,
+    mode_id: Any,
+    policy: HostPermissionPolicy,
+    is_admin: bool,
+) -> tuple[Session, tuple[dict[str, Any], ...]]:
+    """Commit a mode change and return provider revisions it appended."""
+
     active = registry.get(session_id) if registry is not None else None
     if active is not None and getattr(active, "owner", None) not in (None, owner):
         raise _not_found()
     if active is not None and getattr(active, "status", None) == "running":
         raise _busy()
 
+    appended_provider_events: tuple[dict[str, Any], ...] = ()
+
     def commit(current: Session | None) -> Session:
+        nonlocal appended_provider_events
         if current is None or session_owner(current) != owner:
             raise _not_found()
         if current.status in SessionStorage.UNFINISHED:
             raise _busy()
-        session = policy.normalized(current.session or {}, is_admin=is_admin)
+        current_session = current.session or {}
+        current_trace = current_session.get("trace")
+        trace_length = len(current_trace) if isinstance(current_trace, list) else 0
+        session = policy.normalized(current_session, is_admin=is_admin)
         session = policy.apply(session, mode_id, is_admin=is_admin)
+        trace = session.get("trace")
+        appended_provider_events = tuple(
+            copy.deepcopy(event)
+            for event in (trace[trace_length:] if isinstance(trace, list) else [])
+            if isinstance(event, dict)
+            and event.get("type") == "provider_invocation"
+            and isinstance(event.get("providerPermission"), dict)
+        )
         return current.model_copy(update={"session": session})
 
-    return storage.atomic_update(session_id, commit)
+    record = storage.atomic_update(session_id, commit)
+    return record, appended_provider_events
 
 
 def session_with_durable_policy(client_session: dict | None, durable: dict) -> dict:

--- a/connectonion/network/host/ws_router/mode.py
+++ b/connectonion/network/host/ws_router/mode.py
@@ -2,7 +2,7 @@
 Purpose: Dispatch acknowledged OIP Host mode commands
 LLM-Note:
   Dependencies: imports from [host.session.mode] | imported by [.session]
-  Data flow: run_ws_session routes mode_change here -> validate identity/session -> commit_host_session_mode() -> update conn only after append -> send mode_changed
+  Data flow: run_ws_session routes mode_change here -> validate identity/session -> commit_host_session_mode() -> update conn only after append -> send mode_changed then any provider ceiling revisions
   State/Effects: tracks a bounded insertion-ordered map of consumed request IDs in conn; mutates conn['session'] only after durable success
   Integration: handle_mode_change accepts only the three canonical mode IDs
   Errors: policy failures retain their owned code; storage failure=-32603 without private exception details
@@ -13,7 +13,10 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from ..session.mode import ModeTransactionError, commit_host_session_mode
+from ..session.mode import (
+    ModeTransactionError,
+    commit_host_session_mode_with_events,
+)
 
 logger = logging.getLogger(__name__)
 async def handle_mode_change(
@@ -27,8 +30,8 @@ async def handle_mode_change(
         return
     mode_id = frame.get("mode")
     try:
-        record = await asyncio.to_thread(
-            commit_host_session_mode,
+        record, provider_events = await asyncio.to_thread(
+            commit_host_session_mode_with_events,
             storage,
             registry,
             session_id,
@@ -61,3 +64,9 @@ async def handle_mode_change(
         "turns_left": record.session.get("turns_left"),
         "session_id": session_id,
     })
+    # The durable transaction may have narrowed one or more completed Work
+    # Rooms after the outer Host ceiling dropped. Stream only the lifecycle
+    # revisions appended by that exact transaction so the connected client
+    # cannot keep displaying broader authority until a later reconnect.
+    for event in provider_events:
+        await send_msg(event)

--- a/docs/blog/2026-08-24-a-durable-downgrade-must-also-be-live.md
+++ b/docs/blog/2026-08-24-a-durable-downgrade-must-also-be-live.md
@@ -1,0 +1,35 @@
+# A Durable Downgrade Must Also Be Live
+
+The RC3 release gate raised a Codex Work Room to Full Access, then lowered the
+outer Host mode to Auto. Storage did the safe thing: it reconciled the provider
+profile back to Codex's workspace boundary and recorded a newer lifecycle
+revision. The open Work Room still displayed Full Access for more than thirty
+seconds.
+
+That was not only stale presentation. A remote coding client is part of the
+authority boundary. If it keeps showing broader access after the Host has
+withdrawn it, the person cannot tell which policy governs the next instruction.
+Reconnect happened to replay the narrower durable state, but reconnect is not
+an acceptable security protocol.
+
+The bug lived between two correct pieces. The atomic mode transaction already
+appended every provider downgrade it caused. The WebSocket handler acknowledged
+only `mode_changed`, so the current connection never received those appended
+provider revisions. Persistence and streaming had different ideas of what one
+completed transaction meant.
+
+The handler now returns the provider permission revisions created by that exact
+atomic update. It sends `mode_changed` first, followed by only those revisions.
+The existing storage helper keeps its original return contract for other
+callers, and repeating Auto does not manufacture another provider event.
+
+A direct WebSocket regression starts with a committed Codex Full Access
+profile, lowers the Host ceiling, and proves that the same connection receives
+the newer `codex:workspace-ask` state with Full Access marked unselectable. The
+adjacent permission, Work Room, mode, and version suites pass 95 tests; the full
+suite passed 7,169 tests with 18 skips apart from a separately corrected docs
+checkout version drift.
+
+The release lesson is simple: durable state is the source of truth, but an open
+client does not become truthful by waiting for reconnect. When one transaction
+narrows authority, its live revision is part of the commit's observable result.

--- a/tests/unit/test_provider_workroom_permissions.py
+++ b/tests/unit/test_provider_workroom_permissions.py
@@ -11,6 +11,7 @@ from connectonion.network.host.provider_permissions import (
 )
 from connectonion.network.host.session import Session, SessionStorage
 from connectonion.network.host.session.mode import HostPermissionPolicy
+from connectonion.network.host.ws_router.mode import handle_mode_change
 from connectonion.plugins.coding_agents import CodexPlugin, PermissionMode
 
 
@@ -219,6 +220,74 @@ def test_lowering_outer_mode_downgrades_stored_provider_authority_and_replay(tmp
         option["id"] == "codex:read-only" or option["selectable"] is False
         for option in latest["providerPermission"]["options"]
     )
+
+
+def test_websocket_outer_auto_ack_streams_the_same_transaction_provider_downgrade(
+    tmp_path,
+):
+    storage = _storage(tmp_path, mode="full-access")
+    committed = commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:full-access",
+        request_id="permission-full",
+        confirm_risk=True,
+    )
+    sent = []
+
+    async def send_msg(message):
+        sent.append(message)
+
+    class IdleRegistry:
+        @staticmethod
+        def get(_session_id):
+            return None
+
+    conn = {
+        "authenticated": True,
+        "agent_address": "0xowner",
+        "session_id": "owned-session",
+        "session": storage.get("owned-session").session,
+        "mode_is_admin": True,
+    }
+    asyncio.run(handle_mode_change(
+        {"type": "mode_change", "mode": "auto"},
+        send_msg,
+        conn,
+        {"session_modes": HostPermissionPolicy(full_access_turns=2)},
+        storage,
+        IdleRegistry(),
+    ))
+
+    assert [message["type"] for message in sent] == [
+        "mode_changed",
+        "provider_invocation",
+    ]
+    assert sent[0]["mode"] == "auto"
+    narrowed = sent[1]
+    assert narrowed["stateRevision"] > committed["stateRevision"]
+    assert narrowed["providerPermission"]["activeOptionId"] == "codex:workspace-ask"
+    full_access = next(
+        option for option in narrowed["providerPermission"]["options"]
+        if option["id"] == "codex:full-access"
+    )
+    assert full_access["selectable"] is False
+    assert full_access["disabledReason"] == "Host permission ceiling is Auto."
+    assert conn["session"] == storage.get("owned-session").session
+
+    sent.clear()
+    asyncio.run(handle_mode_change(
+        {"type": "mode_change", "mode": "auto"},
+        send_msg,
+        conn,
+        {"session_modes": HostPermissionPolicy(full_access_turns=2)},
+        storage,
+        IdleRegistry(),
+    ))
+    assert [message["type"] for message in sent] == ["mode_changed"]
 
 
 def _run_permission_frame(monkeypatch, storage, frame):


### PR DESCRIPTION
## Summary
- return provider permission lifecycle revisions appended by the atomic outer-mode transaction
- send those revisions immediately after `mode_changed`
- keep the existing session-mode helper return contract intact
- cover the Full Access → Auto regression and duplicate-free idempotent repeat

## Why
A real installed-artifact 1.7 gate found that storage correctly narrowed Codex authority, but the open Work Room retained Full Access until reconnect because the WebSocket only sent `mode_changed`.

## Verification
- 95 focused and adjacent tests pass
- 129 broader related tests pass
- full suite: 7169 passed, 18 skipped; the sole docs checkout drift failure passes when pointed at docs PR wu-changxing/connectonion-docs-site#103
- `git diff --check`

Closes #1222
Tracks #792.