### PR TITLE
fix: honor co ai managed delegation grants in Auto

### DIFF
--- a/connectonion/cli/co_ai/agent.py
+++ b/connectonion/cli/co_ai/agent.py
@@ -48,6 +48,9 @@ from connectonion.useful_plugins import (
     tool_approval,
 )
 from connectonion.useful_plugins.skills import skills as skills_plugin
+from connectonion.useful_plugins.tool_approval.policy import (
+    managed_delegation_permission,
+)
 
 from .context import load_project_context
 from .plugins import native_coding_agent_routing, system_reminder
@@ -76,12 +79,7 @@ def grant_managed_delegation_permissions(agent: Agent) -> None:
     """
     permissions = agent.current_session.setdefault('permissions', {})
     for tool_name in ('codex', 'claude_code'):
-        permissions.setdefault(tool_name, {
-            'allowed': True,
-            'source': 'safe',
-            'reason': 'managed delegation owns inner approval',
-            'expires': {'type': 'never'},
-        })
+        permissions.setdefault(tool_name, managed_delegation_permission())
 
 
 def agent_name(co_dir: Path = Path(".co")) -> str:

--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 POLICY_ID = "connectonion.auto"
 POLICY_VERSION = 1
+MANAGED_DELEGATION_TOOLS = frozenset({"codex", "claude_code"})
+MANAGED_DELEGATION_REASON = "managed delegation owns inner approval"
 
 READ_TOOLS = {
     "read", "read_file", "glob", "grep", "search", "list", "ls",
@@ -70,6 +72,28 @@ def canonical_mode(value: object) -> str | None:
         return mode_id(value)
     except ValueError:
         return None
+
+
+def managed_delegation_permission() -> dict:
+    """Build the exact co ai grant consumed by the Auto classifier."""
+    return {
+        "allowed": True,
+        "source": "safe",
+        "reason": MANAGED_DELEGATION_REASON,
+        "expires": {"type": "never"},
+    }
+
+
+def _has_managed_delegation_grant(session: dict, tool_name: object) -> bool:
+    """Recognize only the runtime grant injected by co ai for native adapters."""
+    name = str(tool_name)
+    if name not in MANAGED_DELEGATION_TOOLS:
+        return False
+    permissions = session.get("permissions")
+    return (
+        isinstance(permissions, dict)
+        and permissions.get(name) == managed_delegation_permission()
+    )
 
 
 def ensure_approval_mode(agent: "Agent") -> str:
@@ -225,7 +249,17 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
     if ensure_approval_mode(agent) != AUTO:
         return None
     try:
-        result = evaluate_auto_approve(pending["name"], pending.get("arguments") or {})
+        if _has_managed_delegation_grant(agent.current_session, pending.get("name")):
+            result = decision(
+                "managed_delegation",
+                "allow",
+                MANAGED_DELEGATION_REASON,
+                "session",
+            )
+        else:
+            result = evaluate_auto_approve(
+                pending["name"], pending.get("arguments") or {}
+            )
     except Exception as exc:
         result = decision(
             "policy_failure",

--- a/docs/blog/2026-08-24-one-approval-boundary-is-enough.md
+++ b/docs/blog/2026-08-24-one-approval-boundary-is-enough.md
@@ -1,0 +1,34 @@
+# One Approval Boundary Is Enough
+
+The second RC3 gate reached the exact state we wanted to test: the outer Host
+had dropped from Full Access to Auto, and an open Codex Work Room had already
+shown the narrower profile. The next task explicitly asked for Claude Code.
+The parent agent announced the delegation, then waited for five minutes without
+starting Claude.
+
+Claude Code was healthy. Calling the same candidate adapter directly returned
+the expected marker with exit code zero. The wait belonged to a redundant
+outer approval that the release harness could not see.
+
+`co ai` deliberately gives its Codex and Claude Code wrappers a session-local
+grant. Those wrappers start managed native runtimes whose own permission
+profiles govern file and command actions. Asking once more before entering the
+wrapper does not add a useful boundary; it only hides the provider's real one.
+
+Auto's deterministic classifier did not know about that narrow grant. It
+classified the wrapper name as unknown, required a person, and then discarded
+every reusable permission except one whose source was `user`. The managed grant
+used the truthful source `safe`, so a policy intended to prevent broad config
+from bypassing approval also filtered out the capability `co ai` had just
+created.
+
+The fix does not put Codex or Claude Code on a global allowlist. Auto recognizes
+only the exact session grant injected by `co ai`: supported provider name,
+allowed flag, safe source, managed-delegation reason, and never expiry. It
+records that call as an allowed managed delegation. Config grants, near matches,
+arbitrary safe reasons, and incomplete grants remain unknown and still ask.
+
+Tests now run the deterministic Auto classifier and the human approval hook in
+their real order for both wrappers. The lesson is that nested approval systems
+need one explicit handoff point. Duplicating the outer dialog does not make the
+inner runtime safer; it makes the authority model harder to observe and test.

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from connectonion.cli.co_ai.agent import grant_managed_delegation_permissions
 from connectonion.useful_plugins.tool_approval import check_approval, tool_approval
 from connectonion.useful_plugins.tool_approval.policy import (
     POLICY_ID,
@@ -163,6 +164,58 @@ def test_broad_config_cannot_silently_turn_deploy_into_auto(tmp_path, monkeypatc
     })
 
     result = call(instance, "bash", {"command": "co deploy"})
+
+    assert result["decision"] == "ask"
+    assert instance.io.sent[0]["type"] == "approval_needed"
+
+
+@pytest.mark.parametrize("provider_tool", ["codex", "claude_code"])
+def test_auto_honors_only_the_exact_co_ai_managed_delegation_grant(
+    tmp_path, monkeypatch, provider_tool
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent()
+    grant_managed_delegation_permissions(instance)
+
+    result = call(instance, provider_tool, {
+        "prompt": "Create and test the requested project",
+        "cwd": ".",
+    })
+
+    assert result["decision"] == "allow"
+    assert result["effect_class"] == "managed_delegation"
+    assert instance.io.sent == []
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        {
+            "allowed": True,
+            "source": "config",
+            "reason": "managed delegation owns inner approval",
+            "expires": {"type": "never"},
+        },
+        {
+            "allowed": True,
+            "source": "safe",
+            "reason": "arbitrary safe grant",
+            "expires": {"type": "never"},
+        },
+        {
+            "allowed": True,
+            "source": "safe",
+            "reason": "managed delegation owns inner approval",
+        },
+    ],
+)
+def test_auto_does_not_treat_near_match_claude_grants_as_managed_delegation(
+    tmp_path, monkeypatch, permission
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(permissions={"claude_code": permission})
+
+    result = call(instance, "claude_code", {"prompt": "inspect", "cwd": "."})
 
     assert result["decision"] == "ask"
     assert instance.io.sent[0]["type"] == "approval_needed"


### PR DESCRIPTION
## Summary
- classify only the exact co ai Codex/Claude managed-delegation grant as allowed in Auto
- keep config, near-match safe grants, incomplete grants, and unknown tools human-reviewable
- centralize the exact grant shape used by co ai and the classifier
- add real-order Auto policy + approval-hook coverage and a design journal entry

## Verification
- red regression: both native wrappers were classified `ask` before the fix
- 131 focused approval/co-ai/provider tests pass
- full suite: 7175 passed, 18 skipped
- exact installed candidate reached `claude_code` under outer Auto with `policy managed delegation owns inner approval`; follow-on missing-cwd blocker tracked in #1226
- `git diff --check`

**Proposed target version:** 1.7.0rc4
**Estimated release window:** August 2026, after the exact installed-artifact gate passes

Closes #1224
Tracks #792 and #1226.