### PR TITLE
fix: default Claude delegation to its workspace

### DIFF
--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -289,7 +289,7 @@ class ClaudeCodePlugin(_CodingAgentPlugin):
     def claude_code(
         self,
         prompt: str,
-        cwd: str,
+        cwd: str = ".",
         session_id: str = "",
         model: str = "",
         timeout: int = 600,

--- a/docs/blog/2026-08-24-the-workspace-default-was-already-known.md
+++ b/docs/blog/2026-08-24-the-workspace-default-was-already-known.md
@@ -1,0 +1,14 @@
+---
+title: "The workspace default was already known"
+date: 2026-08-24
+author: ConnectOnion Team
+---
+
+A hosted coding agent already has a workspace chosen by its operator. Requiring
+the model to repeat that directory on every Claude Code call added no authority;
+it only created another way for a valid delegation to fail.
+
+Claude Code calls now default to the configured workspace when `cwd` is omitted.
+Explicit subdirectories still work, and the existing containment checks still
+reject missing paths, files, symlink escapes, and any directory outside that
+workspace. The default removes accidental ceremony without widening access.

--- a/docs/blog/2026-08-24-the-workspace-default-was-already-known.md
+++ b/docs/blog/2026-08-24-the-workspace-default-was-already-known.md
@@ -4,11 +4,25 @@ date: 2026-08-24
 author: ConnectOnion Team
 ---
 
-A hosted coding agent already has a workspace chosen by its operator. Requiring
-the model to repeat that directory on every Claude Code call added no authority;
-it only created another way for a valid delegation to fail.
+The release candidate had finally crossed the awkward part of our Work Room
+test. A user had selected Auto, the outer approval boundary recognized the
+managed delegation, and the live agent chose Claude Code for a real project.
+Then nothing started.
 
-Claude Code calls now default to the configured workspace when `cwd` is omitted.
-Explicit subdirectories still work, and the existing containment checks still
-reject missing paths, files, symlink escapes, and any directory outside that
-workspace. The default removes accidental ceremony without widening access.
+The trace ended with a surprisingly ordinary Python error: `cwd` was missing.
+The model had supplied the task, but it had not repeated the directory that the
+operator had already assigned to this Work Room. We had treated a known piece
+of host configuration as though it were a decision the model needed to make on
+every call. A valid delegation died at the doorway.
+
+That failure changed the question. Instead of asking how to make the model more
+reliable at copying `cwd`, we asked who actually owns the workspace. The answer
+was already in the plugin: the operator configures it when the hosted coding
+agent is created.
+
+Claude Code now starts from that configured workspace when `cwd` is omitted.
+An explicit subdirectory still goes through the same resolution and containment
+checks; missing paths, files, symlink escapes, and directories outside the
+workspace still fail closed. The lesson was small but useful: do not ask a model
+to restate authority that the system already owns. Give it a safe default and
+keep the boundary in code.

--- a/tests/unit/test_co_ai_agent_main.py
+++ b/tests/unit/test_co_ai_agent_main.py
@@ -104,7 +104,7 @@ def test_create_coding_agent(monkeypatch, tmp_path):
         "timeout",
         "summary",
     }
-    assert claude_schema["required"] == ["prompt", "cwd", "summary"]
+    assert claude_schema["required"] == ["prompt", "summary"]
     assert "acp_agent" not in agent.tools._tools
     # agent.py removes this stdin-blocking helper; it must not come back
     assert "wait_for_manual_login" not in agent.tools._tools

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -349,6 +349,29 @@ def test_hosted_contact_uses_the_same_claude_mode_contract(monkeypatch, tmp_path
     assert seen["permission_mode"] == "auto"
 
 
+def test_claude_plugin_defaults_to_its_configured_workspace(monkeypatch, tmp_path):
+    import connectonion.plugins.coding_agents as module
+
+    seen = {}
+
+    def fake_claude(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({"provider": "claude_code", "exit_code": 0})
+
+    monkeypatch.setattr(module, "_run_claude_code", fake_claude)
+    agent = SimpleNamespace(
+        current_session={"_active_tool_call_id": "call-default-cwd"},
+        io=SimpleNamespace(log=MagicMock()),
+    )
+
+    result = json.loads(
+        ClaudeCodePlugin(workspace=tmp_path).claude_code("inspect", agent=agent)
+    )
+
+    assert result["exit_code"] == 0
+    assert seen["cwd"] == str(tmp_path.resolve())
+
+
 def test_public_signature_matches_the_provider_contract(tmp_path):
     for method in (
         CodexPlugin(workspace=tmp_path).codex,
@@ -361,6 +384,9 @@ def test_public_signature_matches_the_provider_contract(tmp_path):
     assert inspect.signature(CodexPlugin(workspace=tmp_path).codex).parameters[
         "timeout"
     ].default == 1800
+    assert inspect.signature(
+        ClaudeCodePlugin(workspace=tmp_path).claude_code
+    ).parameters["cwd"].default == "."
 
 
 def test_codex_prompt_is_optional_so_open_does_not_invent_a_task(tmp_path):


### PR DESCRIPTION
Fixes #1226

## What changed
- default hosted `ClaudeCodePlugin.claude_code` calls to the operator-configured workspace when the model omits `cwd`
- remove `cwd` from the hosted Claude tool schema required fields
- retain strict resolution and containment checks for explicit paths
- add regression coverage for the omitted-field call and schema contract

## Verification
- `pytest -q tests/unit/test_coding_agent_plugins.py tests/unit/test_co_ai_agent_main.py` — 33 passed
- full suite — 7175 passed, 18 skipped; the only initial failure was a stale sibling docs checkout, and its version gate passed after fast-forwarding to already-deployed docs main
- `git diff --check`

## Release
**Proposed target version:** 1.7.0rc4

**Estimated release window:** August 2026, after the exact installed-artifact Work Room gate passes

The direct Claude adapter contract and Codex plugin are unchanged.