### PR TITLE
fix(workroom): map Claude Auto to native Auto

### DIFF
--- a/connectonion/core/provider_permissions.py
+++ b/connectonion/core/provider_permissions.py
@@ -24,7 +24,7 @@ _OPTION_DEFINITIONS = {
 }
 _DEFAULT_OPTIONS = {
     "codex": {READ_ONLY: "codex:read-only", AUTO: "codex:workspace-ask", FULL_ACCESS: "codex:full-access"},
-    "claude_code": {READ_ONLY: "claude:plan", AUTO: "claude:accept-edits", FULL_ACCESS: "claude:auto"},
+    "claude_code": {READ_ONLY: "claude:plan", AUTO: "claude:auto", FULL_ACCESS: "claude:auto"},
 }
 _CEILING = {READ_ONLY: 0, AUTO: 1, FULL_ACCESS: 2}
 _CEILING_LABEL = {READ_ONLY: "Read Only", AUTO: "Auto", FULL_ACCESS: "Full Access"}

--- a/connectonion/plugins/coding_agents.py
+++ b/connectonion/plugins/coding_agents.py
@@ -343,12 +343,8 @@ class ClaudeCodePlugin(_CodingAgentPlugin):
                 return option["nativeProfileId"], effective
         return {
             READ_ONLY: ("manual", PermissionMode.READ_ONLY),
-            AUTO: (
-                "acceptEdits", PermissionMode.AUTO
-            ),
-            FULL_ACCESS: (
-                "auto", PermissionMode.FULL_ACCESS
-            ),
+            AUTO: ("auto", PermissionMode.AUTO),
+            FULL_ACCESS: ("auto", PermissionMode.FULL_ACCESS),
         }[current]
 
 def _parent_tool_call_id(agent) -> str | None:

--- a/docs/blog/2026-08-24-auto-must-mean-the-same-promise.md
+++ b/docs/blog/2026-08-24-auto-must-mean-the-same-promise.md
@@ -1,0 +1,27 @@
+---
+title: "Auto must mean the same promise"
+date: 2026-08-24
+author: ConnectOnion Team
+---
+
+The release gate had already built three projects and crossed the full Codex
+permission matrix when it handed a bounded C project to Claude Code. Claude
+created the source files, then stopped at the compiler. Its final message said
+the commands had been denied and still needed approval.
+
+Nothing was wrong with the outer setting. The Work Room said Auto. The mismatch
+was in our translation: Auto selected Claude's `acceptEdits` profile. That
+profile does exactly what its name promises—it accepts edits—but it retains
+native checks for commands. We had presented one promise to the user and sent a
+narrower one to the provider.
+
+The provider names do not need to match, but their meaning does. Codex calls the
+workspace-scoped automatic reviewer “Approve for me”; Claude Code calls the
+equivalent profile “Auto”. Work Room Auto now selects Claude Auto by default.
+`Accept edits` remains available as an explicit narrower choice for someone who
+wants files changed while keeping command approvals.
+
+The outer Host ceiling still wins. Read Only continues to force Claude into
+Plan, and bypassing native permissions still requires the separately confirmed
+Full Access ceiling. A unified client earns its name by translating the user's
+intent faithfully, not by flattening every provider into identical labels.

--- a/tests/unit/test_coding_agent_plugins.py
+++ b/tests/unit/test_coding_agent_plugins.py
@@ -270,7 +270,7 @@ def test_codex_plugin_can_follow_the_authenticated_host_permission_ceiling(
     ("session", "permission_mode"),
     [
         ({"mode": "read-only"}, "manual"),
-        ({"mode": "auto"}, "acceptEdits"),
+        ({"mode": "auto"}, "auto"),
         (
             {
                 "mode": "full-access",

--- a/tests/unit/test_provider_workroom_permissions.py
+++ b/tests/unit/test_provider_workroom_permissions.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from connectonion.core.provider_permissions import default_provider_permission_option
 from connectonion.network.host.provider_permissions import (
     ProviderPermissionError,
     commit_provider_permission,
@@ -12,7 +13,7 @@ from connectonion.network.host.provider_permissions import (
 from connectonion.network.host.session import Session, SessionStorage
 from connectonion.network.host.session.mode import HostPermissionPolicy
 from connectonion.network.host.ws_router.mode import handle_mode_change
-from connectonion.plugins.coding_agents import CodexPlugin, PermissionMode
+from connectonion.plugins.coding_agents import ClaudeCodePlugin, CodexPlugin, PermissionMode
 
 
 def _storage(tmp_path: Path, *, mode: str = "auto", requester_level: str = "admin"):
@@ -54,6 +55,19 @@ def test_codex_state_keeps_workspace_boundary_and_reviewer_separate():
     assert options["codex:workspace-auto"]["reviewer"] == "auto"
     assert options["codex:full-access"]["selectable"] is False
     assert options["codex:full-access"]["disabledReason"] == "Host permission ceiling is Auto."
+
+
+def test_claude_auto_default_keeps_accept_edits_as_a_narrower_choice():
+    assert default_provider_permission_option("claude_code", "auto") == "claude:auto"
+
+    state = provider_permission_state("claude_code", "claude:auto", "auto")
+    options = {option["id"]: option for option in state["options"]}
+    assert state["activeOptionId"] == "claude:auto"
+    assert options["claude:auto"]["nativeProfileId"] == "auto"
+    assert options["claude:auto"]["reviewer"] == "auto"
+    assert options["claude:accept-edits"]["nativeProfileId"] == "acceptEdits"
+    assert options["claude:accept-edits"]["selectable"] is True
+    assert options["claude:bypass-permissions"]["selectable"] is False
 
 
 def test_commit_is_revision_bound_persisted_and_applies_to_subsequent_work(tmp_path):
@@ -189,6 +203,20 @@ def test_direct_codex_continuation_uses_the_committed_provider_option(tmp_path):
         "auto",
         PermissionMode.AUTO,
     )
+
+
+def test_direct_claude_continuation_keeps_explicit_accept_edits_narrower(tmp_path):
+    plugin = ClaudeCodePlugin(workspace=tmp_path, use_host_permissions=True)
+    agent = type("Agent", (), {})()
+    agent.current_session = {
+        "mode": "auto",
+        "_provider_workroom_id": "claude_code:call-8",
+        "_provider_permission_options": {
+            "claude_code:call-8": "claude:accept-edits",
+        },
+    }
+
+    assert plugin._policy(agent) == ("acceptEdits", PermissionMode.AUTO)
 
 
 def test_lowering_outer_mode_downgrades_stored_provider_authority_and_replay(tmp_path):


### PR DESCRIPTION
## Description

Outer Work Room Auto now selects Claude Code's native `auto` profile instead of the narrower `acceptEdits` profile. `Accept edits` remains an explicit selectable provider option, while Read Only and Full Access ceilings remain unchanged.

## Related Issue

Part of #1228. The issue remains open until the exact installed-artifact live gate proves native compilation, terminal parent state, provider follow-up, and reconnect.

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5 Codex.

The least certain part is whether the prior browser's missing terminal composer was solely downstream of Claude returning incomplete work; this PR deliberately does not claim that transport symptom is fixed until the live gate proves it. I did not yet run the immutable post-merge wheel against the production Work Room. If this is wrong, the Claude release task will first stop at compiler permission or fail to return a terminal outer turn.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-24-auto-must-mean-the-same-promise.md

## Changes Made

- Map hosted outer Auto to Claude native Auto.
- Keep explicit `Accept edits` available and honored as a narrower choice.
- Add regression coverage for defaults, catalog boundaries, and continuation behavior.
- Document the failed live compiler gate and the provider-mapping rule.

## Testing

```text
$ pytest -q tests/unit/test_coding_agent_plugins.py tests/unit/test_provider_workroom_permissions.py tests/unit/test_co_ai_agent_main.py tests/unit/test_auto_approve_policy.py
91 passed in 4.44s

$ pytest -q
7178 passed, 18 skipped, 180 deselected, 7 warnings in 786.93s (0:13:06)

$ python .github/scripts/check_blog_story.py docs/blog/2026-08-24-auto-must-mean-the-same-promise.md
docs/blog/2026-08-24-auto-must-mean-the-same-promise.md: STORY: it opens on a specific execution failure caused by a subtle permission mismatch and resolves with a clear design principle on translating user intent across providers
```

- [x] I have added tests for new functionality

## Scope

- `connectonion/core/provider_permissions.py`: provider catalog default.
- `connectonion/plugins/coding_agents.py`: hosted execution fallback.
- Two focused unit-test modules: default and explicit-choice contracts.
- One required dev-blog story.

No oo-api or oo-chat code changes are required for this mapping.

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented hard-to-understand areas where needed
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

**Proposed target version:** 1.7.0rc4

**Estimated release window:** August 2026, after the exact installed-artifact gate passes
