### PR TITLE
fix(workroom): coalesce transactional session snapshots

### DIFF
--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -23,6 +23,12 @@ class InterruptibleIO:
         self._cancelled = threading.Event()
         self._gate = threading.Lock()
         self._deferred: list[tuple[bool, Any]] = []
+        # A tool transaction can emit hundreds of provider trace entries. Each
+        # one is followed by a full session_sync, but none of those snapshots is
+        # visible until commit. Retain only the newest superseding snapshot so
+        # the first post-tool approval is not trapped behind megabytes of stale
+        # session history.
+        self._deferred_session_sync: Any | None = None
         # Provider events need a live presentation lane: their canonical trace
         # still waits for the transactional tool session to commit, but a coding
         # Work Room must not wait minutes to say that work has started.  Keep the
@@ -44,6 +50,7 @@ class InterruptibleIO:
             self._live_provider_invocations.clear()
             self._cancelled.set()
             self._deferred.clear()
+            self._deferred_session_sync = None
 
     def commit(self) -> bool:
         """Publish Agent-owned state only after its tool transaction commits."""
@@ -59,7 +66,10 @@ class InterruptibleIO:
                     sender(event)
                 else:
                     self.__io.send(event)
+            if self._deferred_session_sync is not None:
+                self.__io.send(self._deferred_session_sync)
             self._deferred.clear()
+            self._deferred_session_sync = None
             return True
 
     def is_cancelled(self) -> bool:
@@ -102,7 +112,7 @@ class InterruptibleIO:
         with self._gate:
             if not self._cancelled.is_set():
                 if event.get("type") == "session_sync":
-                    self._deferred.append((False, copy.deepcopy(event)))
+                    self._deferred_session_sync = copy.deepcopy(event)
                 else:
                     self.__io.send(event)
 

--- a/docs/blog/2026-08-24-the-snapshot-that-arrived-thirty-nine-times.md
+++ b/docs/blog/2026-08-24-the-snapshot-that-arrived-thirty-nine-times.md
@@ -1,0 +1,36 @@
+---
+title: "The snapshot that arrived thirty-nine times"
+date: 2026-08-24
+author: ConnectOnion Team
+---
+
+Claude Code had finished. The stack compiled, the tests passed, and the Work
+Room showed Completed. Then the parent agent asked to list the new project so it
+could verify the result. The browser should have shown one small approval card.
+Instead, the input disappeared and five minutes passed in silence.
+
+The durable session told a different story from the screen. It contained the
+model's verification call, its action summary, and the pending approval. The
+agent was waiting honestly; the browser simply had not reached the question.
+That distinction sent us away from provider permissions and toward the queue
+between a committed tool transaction and its client.
+
+Long-running coding tools publish activity while they work, but keep their
+canonical state private until the transaction commits. Every activity entry had
+also captured a complete session snapshot. When Claude returned, thirty-nine
+trace entries committed in order—and each brought another, mostly superseded,
+snapshot with it. In this run the newest snapshot was about 475 KB. The tiny
+approval was standing behind roughly 17.7 MiB of old versions of the same
+conversation.
+
+The fix follows the meaning of an atomic commit. Every trace entry still
+survives in order, because each describes something that happened. Session
+snapshots are different: before the transaction becomes visible, a newer one
+fully replaces the older one. The transaction now retains only the latest
+snapshot and publishes it after its traces.
+
+The lesson is not merely to send fewer bytes. Event history and state snapshots
+have different identities. History accumulates; snapshots supersede. Treating
+both as append-only can make a truthful approval look like a broken client—and
+the longer and more useful the Work Room conversation becomes, the worse that
+mistake gets.

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -442,6 +442,51 @@ def test_live_provider_trace_is_visible_before_transaction_commit():
     assert WebSocketIO.is_persisted_trace_event(io._msgs_from_agent[1])
 
 
+def test_interruptible_io_commits_only_the_latest_transactional_session_snapshot():
+    """Committed trace order survives without replaying superseded snapshots."""
+    io = WebSocketIO()
+    lease = InterruptibleIO(io)
+    first = {"id": "trace-1", "type": "provider_activity", "status": "running"}
+    second = {"id": "trace-2", "type": "provider_activity", "status": "completed"}
+    stale_session = {"trace": [first]}
+    latest_session = {"trace": [first, second], "plan": [{"content": "done"}]}
+
+    lease._send_persisted_trace(first)
+    lease.send({"type": "session_sync", "session": stale_session})
+    lease._send_persisted_trace(second)
+    lease.send({"type": "session_sync", "session": latest_session})
+    latest_session["plan"][0]["content"] = "mutated after send"
+
+    assert io._msgs_from_agent == []
+    assert lease.commit() is True
+
+    assert [event["type"] for event in io._msgs_from_agent] == [
+        "provider_activity",
+        "provider_activity",
+        "session_sync",
+    ]
+    assert all(
+        WebSocketIO.is_persisted_trace_event(event)
+        for event in io._msgs_from_agent[:2]
+    )
+    assert io._msgs_from_agent[-1]["session"] == {
+        "trace": [first, second],
+        "plan": [{"content": "done"}],
+    }
+
+
+def test_interruptible_io_cancel_drops_the_coalesced_session_snapshot():
+    io = WebSocketIO()
+    lease = InterruptibleIO(io)
+    lease._send_persisted_trace({"id": "trace-1", "type": "tool_call"})
+    lease.send({"type": "session_sync", "session": {"trace": ["private"]}})
+
+    lease.cancel()
+
+    assert lease.commit() is False
+    assert io._msgs_from_agent == []
+
+
 def test_interruptible_io_cancels_a_live_provider_card_without_committing_trace():
     io = WebSocketIO()
     lease = InterruptibleIO(io)


### PR DESCRIPTION
## Description

Long provider turns no longer replay every superseded full `session_sync` snapshot when their transaction commits. Canonical trace events still commit in order; only the newest transactional snapshot is sent after them.

This removes the browser backlog that hid a pending Work Room approval after Claude Code completed. In the failing release run, 39 growing snapshots represented roughly 17.7 MiB of redundant state before one approval card.

## Related Issue

Closes #1230. Blocks the exact installed-artifact gate in #1228 and the 1.7 release goal in #792 until the post-merge live run passes.

## How this was written

- [x] AI-assisted — I reviewed every line and can explain why each change is there

**Which model?** GPT-5 Codex.

The remaining uncertainty is browser-level proof under the full release workload. Unit and full-suite coverage prove commit ordering, latest-snapshot semantics, deep-copy isolation, and cancellation, but the immutable post-merge wheel still needs to repeat the long Claude Work Room path. If this is wrong, that gate will again fail to surface the bounded parent approval or return the composer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Dev Blog (required)

Blog file in this PR:

> docs/blog/2026-08-24-the-snapshot-that-arrived-thirty-nine-times.md

## Changes Made

- Preserve all transactional canonical trace events in their original order.
- Coalesce transactional `session_sync` events to the newest deep-copied snapshot.
- Publish that newest snapshot after the ordered trace history at commit.
- Drop both deferred traces and the coalesced snapshot on cancellation.
- Add regression tests and the required failure-story blog post.

## Testing

```text
$ pytest -q tests/unit/test_interrupt.py tests/unit/test_structured_tool_output.py tests/unit/test_turn_outcome.py tests/unit/test_io.py
102 passed in 1.22s

$ pytest -q
7180 passed, 18 skipped, 180 deselected, 7 warnings in 810.41s (0:13:30)

$ python .github/scripts/check_blog_story.py docs/blog/2026-08-24-the-snapshot-that-arrived-thirty-nine-times.md
docs/blog/2026-08-24-the-snapshot-that-arrived-thirty-nine-times.md: STORY: it follows a mysterious UI hang through an unexpected payload bottleneck to a sharp architectural lesson on history versus state.
```

- [x] I have added tests for new functionality

## Scope

- `connectonion/core/interrupt.py`: transactional buffering semantics.
- `tests/unit/test_interrupt.py`: commit/coalescing/cancellation contracts.
- One required dev-blog story.

No oo-api change is required. oo-chat #232 already contains the bounded, fail-closed approval helper needed for the post-merge live gate.

## Checklist

- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented hard-to-understand areas where needed
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

**Proposed target version:** 1.7.0rc4

**Estimated release window:** August 2026, after the exact installed-artifact gate passes
