### PR TITLE
fix: stream only final provider permission snapshots

### DIFF
--- a/connectonion/network/host/session/mode.py
+++ b/connectonion/network/host/session/mode.py
@@ -94,7 +94,13 @@ class HostPermissionPolicy:
             ],
         }
 
-    def normalized(self, session: dict, *, is_admin: bool) -> dict:
+    def normalized(
+        self,
+        session: dict,
+        *,
+        is_admin: bool,
+        reconcile_provider_permissions: bool = True,
+    ) -> dict:
         """Return a detached 1.7 snapshot; old/invalid authority becomes Auto."""
 
         del is_admin
@@ -112,7 +118,8 @@ class HostPermissionPolicy:
             set_mode(normalized, FULL_ACCESS, turns_left=remaining)
         else:
             set_mode(normalized, canonical if canonical != FULL_ACCESS else AUTO)
-        reconcile_provider_permission_events(normalized, mode_of(normalized))
+        if reconcile_provider_permissions:
+            reconcile_provider_permission_events(normalized, mode_of(normalized))
         return normalized
 
     def apply(self, session: dict, requested_mode: Any, *, is_admin: bool) -> dict:
@@ -125,7 +132,16 @@ class HostPermissionPolicy:
         if canonical not in self.available_mode_ids(is_admin=is_admin):
             raise ModeTransactionError(-32602, "Permission mode is not available")
 
-        changed = self.normalized(session, is_admin=is_admin)
+        # A mode write is one authority transaction. Reconciling against the
+        # old ceiling first would append an intermediate provider snapshot and
+        # stream it before the final, narrower snapshot. Normalize the rest of
+        # the durable policy without publishing provider authority, commit the
+        # requested mode, then reconcile exactly once against that final mode.
+        changed = self.normalized(
+            session,
+            is_admin=is_admin,
+            reconcile_provider_permissions=False,
+        )
         if canonical == FULL_ACCESS:
             set_mode(
                 changed,
@@ -230,8 +246,7 @@ def commit_host_session_mode_with_events(
         current_session = current.session or {}
         current_trace = current_session.get("trace")
         trace_length = len(current_trace) if isinstance(current_trace, list) else 0
-        session = policy.normalized(current_session, is_admin=is_admin)
-        session = policy.apply(session, mode_id, is_admin=is_admin)
+        session = policy.apply(current_session, mode_id, is_admin=is_admin)
         trace = session.get("trace")
         appended_provider_events = tuple(
             copy.deepcopy(event)

--- a/docs/blog/2026-08-24-the-first-correct-snapshot-was-still-wrong.md
+++ b/docs/blog/2026-08-24-the-first-correct-snapshot-was-still-wrong.md
@@ -1,0 +1,30 @@
+# The First Correct Snapshot Was Still Wrong
+
+The RC4 gate stopped a real Codex follow-up, then lowered the outer session from
+Full Access to Auto. The provider stopped correctly. The outer mode changed
+correctly. Storage even contained an Auto-bounded provider snapshot. Yet the
+reopened Work Room could retain Full Access.
+
+The failure required a terminal continuation. Stop produced a valid cancelled
+provider frame without a permission catalog. While committing the later mode
+change, the Host first normalized that frame under the old Full Access ceiling,
+which appended a repair snapshot. It then applied Auto and appended the real
+downgrade. Both snapshots belonged to one transaction and both were streamed.
+The first was individually correct and transactionally wrong.
+
+This is why an authority transaction cannot be reviewed as a bag of valid
+events. Its observable result must contain only the final policy. A client that
+sees an intermediate broader state may persist or render it before the narrower
+revision arrives, especially across reconnect and coalescing boundaries.
+
+The fix makes mode application normalize ordinary session policy without
+publishing provider authority. After the requested mode is committed, provider
+permissions reconcile exactly once. A stopped continuation therefore produces
+one live revision: Auto selects Codex Ask for approval and disables Full Access;
+Read only selects Codex Read Only and disables every broader option.
+
+The regression recreates the exact sequence with a terminal continuation that
+has no catalog. It proves the WebSocket sends `mode_changed` followed by one,
+and only one, provider snapshot at the final ceiling. The release gate will now
+repeat the same sequence against native Codex and Claude Code before another
+candidate can be promoted.

--- a/docs/codex-tool-frontend-contract.md
+++ b/docs/codex-tool-frontend-contract.md
@@ -115,7 +115,10 @@ retroactively alter an active action or replace an individual approval.
 
 Old or malformed clients fail closed: missing catalogs render no selector,
 unadvertised and stale choices are rejected, and lowering the outer COAI mode
-immediately reconciles any stored provider profile to the narrower ceiling.
+immediately reconciles any stored provider profile to the narrower ceiling. A
+single outer-mode transaction streams at most one new permission revision for
+each Work Room: the final committed ceiling. Terminal continuations without a
+catalog never cause an intermediate old-ceiling repair to reach the browser.
 
 ## What the frontend team should know
 

--- a/docs/network/websocket-protocol.md
+++ b/docs/network/websocket-protocol.md
@@ -107,6 +107,12 @@ and invocation IDs, a strictly newer revision, and the complete authoritative
 `ceiling_denied`, `operator_required`, or `confirmation_required`; it never
 changes durable state.
 
+When an outer `mode_change` also narrows one or more Work Rooms, the Host sends
+`mode_changed` followed by one canonical `provider_invocation` per affected
+Work Room. Each provider frame reflects only the transaction's final ceiling;
+the Host never streams an intermediate repair under the previous mode, even if
+the latest completed, failed, or cancelled continuation omitted its catalog.
+
 ```
 ┌────────────────────────────────────────────────────────────────┐
 │                    WebSocket Lifecycle                          │

--- a/tests/unit/test_provider_workroom_permissions.py
+++ b/tests/unit/test_provider_workroom_permissions.py
@@ -318,6 +318,93 @@ def test_websocket_outer_auto_ack_streams_the_same_transaction_provider_downgrad
     assert [message["type"] for message in sent] == ["mode_changed"]
 
 
+@pytest.mark.parametrize(
+    ("target_mode", "expected_option"),
+    [
+        ("auto", "codex:workspace-ask"),
+        ("read-only", "codex:read-only"),
+    ],
+)
+def test_outer_downgrade_after_terminal_continuation_streams_only_final_ceiling(
+    tmp_path,
+    target_mode,
+    expected_option,
+):
+    """A stopped follow-up must not publish an old-ceiling repair first."""
+    storage = _storage(tmp_path, mode="full-access")
+    commit_provider_permission(
+        storage,
+        "owned-session",
+        "0xowner",
+        "codex:call-7",
+        4,
+        "codex:full-access",
+        request_id="permission-full",
+        confirm_risk=True,
+    )
+    current = storage.get("owned-session")
+    session = current.session
+    session["trace"].append({
+        "type": "provider_invocation",
+        "invocationId": "codex:call-8",
+        "parentToolCallId": "call-7",
+        "workroomId": "codex:call-7",
+        "continuationOf": "codex:call-7",
+        "provider": "codex",
+        "providerDisplayName": "Codex",
+        "status": "cancelled",
+        "sessionId": "thread-7",
+        "stateRevision": 2,
+        "resultSummary": "The provider stopped",
+    })
+    storage.save(current.model_copy(update={"session": session}))
+    sent = []
+
+    async def send_msg(message):
+        sent.append(message)
+
+    class IdleRegistry:
+        @staticmethod
+        def get(_session_id):
+            return None
+
+    conn = {
+        "authenticated": True,
+        "agent_address": "0xowner",
+        "session_id": "owned-session",
+        "session": session,
+        "mode_is_admin": True,
+    }
+    asyncio.run(handle_mode_change(
+        {"type": "mode_change", "mode": target_mode},
+        send_msg,
+        conn,
+        {"session_modes": HostPermissionPolicy(full_access_turns=2)},
+        storage,
+        IdleRegistry(),
+    ))
+
+    assert [message["type"] for message in sent] == [
+        "mode_changed",
+        "provider_invocation",
+    ]
+    narrowed = sent[1]
+    assert narrowed["invocationId"] == "codex:call-8"
+    assert narrowed["status"] == "cancelled"
+    assert narrowed["providerPermission"]["activeOptionId"] == expected_option
+    full_access = next(
+        option for option in narrowed["providerPermission"]["options"]
+        if option["id"] == "codex:full-access"
+    )
+    assert full_access["selectable"] is False
+    if target_mode == "read-only":
+        assert all(
+            option["id"] == "codex:read-only" or option["selectable"] is False
+            for option in narrowed["providerPermission"]["options"]
+        )
+    assert storage.get("owned-session").session["trace"][-1] == narrowed
+
+
 def _run_permission_frame(monkeypatch, storage, frame):
     from connectonion.network.host.ws_router import session as ws_session
 


### PR DESCRIPTION
## Summary
- treat an outer Host mode change as one permission-authority transaction
- reconcile provider permissions only after the requested outer mode is committed
- stream one final provider snapshot per affected Work Room, never an old-ceiling repair
- document the WebSocket/frontend contract and the RC4 failure mode

Closes #1234
Relates to #792 and openonion/oo-chat#234.

**Proposed target version:** 1.7.0rc5
**Estimated release window:** current 1.7 stabilization cycle

## Verification
- `pytest tests/unit/test_host_mode_contract.py tests/unit/test_provider_workroom_permissions.py -q` — 32 passed
- `pytest -m "not slow and not real_api and not network" -q` — 7163 passed, 18 skipped; the sole failure was a stale local docs-site RC3 checkout
- reran the cross-repo version assertion against docs-site `origin/main` (RC4) — passed
- regression proves Full Access → Auto and Full Access → Read-only each stream only the final narrowed snapshot after a terminal continuation omits its catalog