### PR TITLE
fix: preserve outer mode budget in direct Workroom turns

### DIFF
--- a/connectonion/network/host/provider_workroom.py
+++ b/connectonion/network/host/provider_workroom.py
@@ -13,6 +13,7 @@ import copy
 import time
 from typing import Any, Callable
 
+from ...core.mode import FULL_ACCESS, full_access_turns_left, mode_of
 from .session import SessionStorage, session_owner
 
 
@@ -155,6 +156,8 @@ def _direct_session(
     provider: str,
 ) -> dict[str, Any]:
     """Construct the minimum session a configured native tool needs to run."""
+    outer_mode = mode_of(source_session)
+    turns_left = full_access_turns_left(source_session)
     stored_permissions = source_session.get("_provider_permission_options")
     selected_permission = (
         stored_permissions.get(workroom_id)
@@ -167,7 +170,12 @@ def _direct_session(
         "turn": 0,
         "iteration": 1,
         "session_id": session_id,
-        "mode": source_session.get("mode"),
+        "mode": outer_mode,
+        **(
+            {"turns_left": turns_left}
+            if outer_mode == FULL_ACCESS
+            else {}
+        ),
         "requester": copy.deepcopy(source_session.get("requester")),
         "_provider_workroom_id": workroom_id,
         "_provider_continuation_of": continuation_of,

--- a/tests/unit/test_provider_workroom.py
+++ b/tests/unit/test_provider_workroom.py
@@ -6,6 +6,7 @@ from connectonion.network.host.provider_workroom import (
 )
 from connectonion.network.host.session import Session, SessionStorage
 from connectonion.useful_plugins import tool_approval
+from connectonion.core.mode import FULL_ACCESS, mode_of
 from tests.utils.mock_helpers import MockLLM
 
 
@@ -173,6 +174,45 @@ def test_owned_terminal_claude_session_resumes_only_the_native_provider(tmp_path
     )]
     assert agent.current_session["_provider_workroom_id"] == "claude_code:root"
     assert agent.current_session["_provider_direct_approved_tool"] == "claude_code"
+
+
+def test_direct_workroom_session_keeps_the_durable_full_access_budget(tmp_path):
+    """Provider-only turns must not publish a fake outer Auto mode."""
+    session = _stored_codex_session()
+    session.update({"mode": "full-access", "turns_left": 7})
+    storage = SessionStorage(tmp_path / "sessions.jsonl")
+    storage.save(Session(
+        session_id="session-full-access",
+        status="done",
+        prompt="original outer prompt",
+        session=session,
+    ))
+
+    class DirectAgent:
+        def __init__(self):
+            self.io = None
+            self.storage = None
+            self.current_session = None
+
+        def execute_tool(self, _name, _arguments):
+            assert mode_of(self.current_session) == FULL_ACCESS
+            assert self.current_session["turns_left"] == 7
+
+    prepared = prepare_provider_workroom_turn(
+        DirectAgent,
+        storage,
+        "session-full-access",
+        "codex:current",
+        "Please continue.",
+        "input-full-access",
+        "0xowner",
+    )
+
+    prepared["run"](object())
+
+    stored = storage.get("session-full-access").session
+    assert mode_of(stored) == FULL_ACCESS
+    assert stored["turns_left"] == 7
 
 
 def test_workroom_continuation_fails_closed_for_another_owner_or_live_source(tmp_path):


### PR DESCRIPTION
Closes #1238.

## Summary

A provider-only Workroom continuation now copies the canonical durable outer mode together with its required bounded Full Access budget. This prevents its isolated `session_sync` from falsely telling the browser that the outer mode is Auto while the Host still retains Full Access.

The provider turn neither extends nor consumes the outer COAI grant. Invalid/missing budgets still degrade to Auto through the existing canonical mode reader. React stale-revision protections remain unchanged.

## Evidence

- Regression failed before the source change with `auto != full-access`.
- `python -m pytest tests/unit/test_provider_workroom.py tests/unit/test_provider_workroom_permissions.py tests/unit/test_host_mode_contract.py tests/unit/test_full_access.py -q` — 49 passed.
- Exact public RC5 live evidence reached real browser/C/C++/Rust/native Codex/voice/Stop, then exposed this mismatch before the intended outer downgrade.

## Release disposition

RC5 is invalidated for stable promotion. After merge, cut RC6 from the exact reviewed `release/1.7` commit and repeat the full installed-artifact gate, including real Codex Stop → actual outer Auto transaction → provider Full Access disabled/denied.

**Proposed target version:** 1.7.0rc6

**Estimated release window:** next 1.7 release candidate after merge and exact-artifact verification