### PR TITLE
fix(agent): settle empty post-tool terminal responses

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -628,6 +628,8 @@ class Agent:
 
     def _run_iteration_loop(self, max_iterations: int) -> tuple[str, str]:
         """Return the existing response string and its private terminal reason."""
+        completed_tools = False
+        empty_terminal_retries = 0
         while self.current_session['iteration'] < max_iterations:
             self.current_session['iteration'] += 1
 
@@ -640,14 +642,16 @@ class Agent:
             if response is not None:
                 if not response.tool_calls:
                     content = response.content or ""
-                    self.current_session['messages'].append({
-                        "role": "assistant",
-                        "content": content,
-                        "id": self._next_trace_id(),
-                    })
+                    if content.strip():
+                        self.current_session['messages'].append({
+                            "role": "assistant",
+                            "content": content,
+                            "id": self._next_trace_id(),
+                        })
                 else:
                     # Process tool calls
                     self._execute_and_record_tools(response.tool_calls)
+                    completed_tools = True
 
             # Fire after_iteration
             self._invoke_events('after_iteration')
@@ -681,6 +685,20 @@ class Agent:
                     # needs even when the original request used its full budget.
                     max_iterations += 1
                     continue
+                if not content.strip():
+                    if completed_tools and empty_terminal_retries == 0:
+                        from ..useful_plugins.system_reminder import reminder_message
+
+                        self.current_session['messages'].append(reminder_message(
+                            "The previous model response was empty after tool execution. "
+                            "Return a concise user-facing final answer based only on the "
+                            "recorded tool results. Do not claim work that those results "
+                            "do not prove."
+                        ))
+                        empty_terminal_retries += 1
+                        max_iterations += 1
+                        continue
+                    raise RuntimeError("LLM returned an empty terminal response")
                 return content, 'natural'
 
         # Hit max iterations

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -189,6 +189,73 @@ def test_methods_share_state_through_self():
         assert scraper.scraped_data[0] == "Title of example.com"
         assert result == "Scraped the title successfully."
 
+
+def test_empty_terminal_after_tool_gets_one_bounded_recovery_call():
+    mock_llm = MockLLM(responses=[
+        LLMResponse(
+            content=None,
+            tool_calls=[ToolCall(
+                name="calculator",
+                arguments={"expression": "2+2"},
+                id="call_1",
+            )],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+        LLMResponse(content="", tool_calls=[], raw_response={}, usage=TokenUsage()),
+        LLMResponse(
+            content="The result is 4.",
+            tool_calls=[],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+    ])
+    agent = Agent(
+        name="empty-terminal-recovery",
+        llm=mock_llm,
+        tools=[calculator],
+        log=False,
+    )
+
+    assert agent.input("Calculate 2+2") == "The result is 4."
+    assert mock_llm.call_count == 3
+    recovery_messages = mock_llm.calls[2]["messages"]
+    assert any(
+        "previous model response was empty" in message.get("content", "")
+        for message in recovery_messages
+    )
+    assert all(
+        message.get("content") != ""
+        for message in agent.current_session["messages"]
+    )
+
+
+def test_repeated_empty_terminal_after_tool_fails_instead_of_hanging():
+    mock_llm = MockLLM(responses=[
+        LLMResponse(
+            content=None,
+            tool_calls=[ToolCall(
+                name="calculator",
+                arguments={"expression": "2+2"},
+                id="call_1",
+            )],
+            raw_response={},
+            usage=TokenUsage(),
+        ),
+        LLMResponse(content=None, tool_calls=[], raw_response={}, usage=TokenUsage()),
+        LLMResponse(content="   ", tool_calls=[], raw_response={}, usage=TokenUsage()),
+    ])
+    agent = Agent(
+        name="empty-terminal-failure",
+        llm=mock_llm,
+        tools=[calculator],
+        log=False,
+    )
+
+    with pytest.raises(RuntimeError, match="empty terminal response"):
+        agent.input("Calculate 2+2")
+    assert mock_llm.call_count == 3
+
 def test_mixed_functions_and_class_instance():
         """Test that agent can accept both functions and class instances."""
         


### PR DESCRIPTION
## Summary

- retry exactly once when a model returns an empty terminal response after verified tool execution
- ask only for a concise user-facing answer grounded in recorded tool results
- fail with a bounded error if the retry is also empty, instead of emitting an unusable empty terminal outcome
- avoid persisting empty assistant messages

## Why

The exact public RC6 gate observed native Claude Code finish successfully and return a valid project, followed by an empty parent-model response. The Host emitted no usable assistant terminal message, so the outer composer never recovered. This change makes that boundary deterministic without inventing a success claim.

Closes #1242.

## Verification

- `python -m pytest tests/unit/test_agent.py tests/unit/test_asgi.py -q` — 53 passed
- `python -m pytest tests/unit/test_agent.py tests/unit/test_asgi.py tests/unit/test_runtime_input.py tests/unit/test_turn_outcome.py tests/unit/test_co_ai_one_shot_sessions.py -q` — 129 passed
- `git diff --check`

**Proposed target version:** 1.7.0rc7

**Estimated release window:** current 1.7 release-candidate window
