### PR TITLE
fix(browser): keep direct CLI commands lightweight

### DIFF
--- a/connectonion/cli/browser_agent/__init__.py
+++ b/connectonion/cli/browser_agent/__init__.py
@@ -1,16 +1,23 @@
 """
-Purpose: Browser agent module exports for CLI browser automation
+Purpose: Lazy browser-agent exports that keep direct `co browser` RPC clients lightweight.
 LLM-Note:
-  Dependencies: imports from [browser.py] | imported by [cli/commands/browser_commands.py] | no direct tests
-  Data flow: re-exports execute_browser_command and BrowserAutomation
+  Dependencies: lazy imports from [agent.py, browser_tools] | imported by [cli/commands/browser_commands.py] | no direct tests
+  Data flow: resolves execute_browser_command or BrowserAutomation only when a caller asks for that public export
   State/Effects: no state
   Integration: exposes execute_browser_command(), BrowserAutomation class for `co browser` command
-  Performance: trivial
+  Performance: importing a browser_agent submodule does not load Agent, Playwright, TUI, or provider integrations
   Errors: none
 Browser agent module for ConnectOnion CLI.
 """
 
-from .agent import execute_browser_command
-from connectonion.useful_tools.browser_tools import BrowserAutomation
-
 __all__ = ['execute_browser_command', 'BrowserAutomation']
+
+
+def __getattr__(name):
+    if name == "execute_browser_command":
+        from .agent import execute_browser_command
+        return execute_browser_command
+    if name == "BrowserAutomation":
+        from connectonion.useful_tools.browser_tools import BrowserAutomation
+        return BrowserAutomation
+    raise AttributeError(name)

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -1,27 +1,39 @@
 """
 Purpose: Browser daemon client — sends short browser commands over the platform transport and runs the natural-language `do` agent locally so model waits never occupy the daemon.
 LLM-Note:
-  Dependencies: imports from [socket, os, json, sys, time, shlex, inspect, functools, pathlib, BrowserAutomation, browser_agent.daemon (default_sock_path, _owner_alive), browser_agent.agent (lazy), browser_agent.transport] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_daemon.py]
+  Dependencies: imports from [socket, os, json, sys, time, shlex, inspect, functools, pathlib, browser_agent.transport | lazy: BrowserAutomation and browser_agent.agent for `do`] | imported by [cli/commands/browser_commands.py] | tested by [tests/e2e/cli/test_browser_daemon.py]
   Data flow: direct verb → _request() → wire-v1 JSON {v,caller,account,tab,line,raw}; `do` → local Agent + DaemonBrowserProxy → each tool invocation becomes one short _request(raw=True) to the shared daemon
   State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log | writes to stdout/stderr
   Integration: exposes _caller() -> str, send(line, headless=False, tab=None) -> int | FIRST-RUN AUTO-INSTALL: on the cold-start path (no daemon yet) AND when a warm daemon answers "No browser is installed for this user" (send retries once), a page-driving verb with no system Chrome triggers `python -m patchright install chromium` right in the user's terminal (chromium: per-user dir, never needs admin — the branded chrome channel runs a system installer) (_ensure_browser_ready) — `co browser` just works with zero setup commands; PAGELESS_VERBS (status/tab/close/...) never provision
-  Performance: one connect + request/response per browser action | daemon spawn adds browser launch latency on first call | model thinking happens in the caller process and holds no daemon lane
+  Performance: direct verbs import only the lightweight transport client, then make one connect + request/response; Agent/Playwright and browser tool schemas load only for `do` or inside the daemon | daemon spawn adds browser launch latency on first call | model thinking happens in the caller process and holds no daemon lane
   Errors: _connect() retries ~2s on a transient connection refusal from a busy single-threaded daemon (does NOT unlink a live-but-busy socket); only a truly stale POSIX socket is unlinked | missing endpoint → spawn daemon and wait until ready or timeout | ALL setup RuntimeErrors (Windows authkey mismatch/corruption, daemon didn't start) are caught in send() → one clean stderr line + exit 1, NEVER a traceback (typer's pretty exceptions would print frame locals, which hold the HMAC secret on the connect path) | daemon dying mid-request → clean stderr line + exit 1
 """
 
-import os
 import functools
 import inspect
 import json
+import os
 import shlex
+import socket
 import sys
 import time
-import socket
 from pathlib import Path
 
-from connectonion.useful_tools.browser_tools import BrowserAutomation
-from .daemon import default_sock_path, _owner_alive
 from . import transport
+
+
+def default_sock_path() -> str:
+    """Resolve the endpoint without importing the browser-owning daemon module."""
+    return transport.default_address()
+
+
+def _owner_alive(sock_path: str) -> bool:
+    """Read the daemon pid sidecar without importing Playwright or browser tools."""
+    pid_file = Path(transport.pid_path(sock_path))
+    if not pid_file.exists():
+        return False
+    raw = pid_file.read_text(encoding="utf-8").strip()
+    return raw.isdigit() and transport.pid_alive(int(raw))
 
 
 def _connect(sock_path: str):
@@ -333,12 +345,28 @@ def _proxy_method(name, method):
     return call
 
 
-# Keep the agent's tool schema identical to BrowserAutomation without duplicating
-# dozens of signatures. functools.wraps preserves each original signature and
-# docstring for the tool factory; every implementation delegates to _call().
-for _name, _method in inspect.getmembers(BrowserAutomation, predicate=inspect.isfunction):
-    if not _name.startswith("_"):
-        setattr(DaemonBrowserProxy, _name, _proxy_method(_name, _method))
+_proxy_methods_installed = False
+
+
+def _install_proxy_methods() -> None:
+    """Mirror BrowserAutomation's tool schema only for the natural-language `do` path.
+
+    Direct verbs already know their wire command and must not spend seconds importing
+    Playwright, Agent, TUI, and provider integrations before they can connect to the
+    persistent daemon. The daemon loads BrowserAutomation in its own long-lived process.
+    """
+    global _proxy_methods_installed
+    if _proxy_methods_installed:
+        return
+    from connectonion.useful_tools.browser_tools import BrowserAutomation
+
+    # Keep the agent's tool schema identical without duplicating dozens of signatures.
+    # functools.wraps preserves each original signature and docstring for the tool
+    # factory; every implementation delegates to _call().
+    for name, method in inspect.getmembers(BrowserAutomation, predicate=inspect.isfunction):
+        if not name.startswith("_"):
+            setattr(DaemonBrowserProxy, name, _proxy_method(name, method))
+    _proxy_methods_installed = True
 
 
 def _run_do(line: str, headless: bool, tab: str) -> tuple:
@@ -354,7 +382,9 @@ def _run_do(line: str, headless: bool, tab: str) -> tuple:
     if not command:
         return 2, 'usage: co browser do "<instruction>"'
 
-    from .agent import resolve_api_key, build_browser_agent
+    from .agent import build_browser_agent, resolve_api_key
+
+    _install_proxy_methods()
 
     api_key = resolve_api_key()
     if not api_key:

--- a/connectonion/cli/commands/browser_commands.py
+++ b/connectonion/cli/commands/browser_commands.py
@@ -1,20 +1,19 @@
 """
 Purpose: Thin CLI handler for `co browser` — parses -t/--tab targeting, forwards one command to the persistent browser daemon, and serves self-describing help.
 LLM-Note:
-  Dependencies: imports from [sys, shlex, pathlib, browser_agent.client.send, browser_agent.daemon.list_functions] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_browser_daemon.py]
+  Dependencies: imports from [sys, shlex, pathlib, browser_agent.client.send | lazy: browser_agent.daemon.list_functions for help] | imported by [cli/main.py via browser()] | tested by [tests/e2e/cli/test_browser_daemon.py]
   Data flow: receives args: list[str] (+ headless: bool) from CLI → `help`/`--list` printed locally by introspecting BrowserAutomation (no browser launched) → else _extract_tab() pulls the LEADING -t/--tab NAME run (stops at the verb, so a -t that is a function's own arg passes through; empty --tab= is a usage error) → shlex.join(remaining args) + tab → client.send(line, headless, tab=NAME) → daemon runs it → payload/exit code surfaced by the client
   State/Effects: no local state except a best-effort rotating-tip index at ~/.co/.browser_tip (a garbled index resets to the first tip) | the success tip is printed to STDERR (stdout stays pure data) | `help` introspects the class only | direct verbs delegate to the daemon; `do` runs its model loop in this CLI process and delegates each tool call
   Integration: exposes _extract_tab(args) -> (tab|None, remaining|None), _next_tip(), handle_browser(args, headless=False) -> int | called from main.py browser command | USAGE/TIPS document the tab lifecycle and the exit-code contract
-  Performance: `help` is import-only (no socket, no Chrome) | other verbs: one socket round-trip, first call spawns the daemon
+  Performance: direct verbs do not import the browser-owning daemon, Agent, or Playwright; `help` lazily imports the schema (no socket, no Chrome) | other verbs: one socket round-trip, first call spawns the daemon
   Errors: no-args / bad -t → prints usage to stderr, exit 2 | daemon errors come back as ERR[ <code>] → stderr + the mirrored exit code (0 ok · 1 failure · 2 usage · 3 unknown tab · 4 tab busy)
 """
 
-import sys
 import shlex
+import sys
 from pathlib import Path
 
 from ..browser_agent.client import send
-from ..browser_agent.daemon import list_functions
 
 USAGE = (
     "co browser — drive one persistent browser from the shell\n"
@@ -102,6 +101,7 @@ def handle_browser(args, headless: bool = False) -> int:
         print("usage: -t targets a command, e.g.  co browser -t mytask go_to <url>", file=sys.stderr)
         return 2
     if args[0] in ("help", "--list", "list"):  # after -t extraction: `-t x help` is still help
+        from ..browser_agent.daemon import list_functions
         print(USAGE + "\n\nFunctions:\n" + list_functions())
         return 0
     if args[-1] == "--stdin":

--- a/docs/blog/2026-08-24-the-daemon-was-not-the-slow-part.md
+++ b/docs/blog/2026-08-24-the-daemon-was-not-the-slow-part.md
@@ -1,0 +1,30 @@
+---
+title: "The daemon was not the slow part"
+date: 2026-08-24
+author: ConnectOnion Team
+---
+
+Our 1.7 release test kept losing contact with the browser. A state query would
+miss its deadline, then closing the tab would miss another one. The obvious
+story was that a page command had wedged the single-threaded browser daemon and
+left every later request waiting behind it.
+
+The socket trace contradicted that story. A fresh `co browser status`, pointed
+at a socket that did not exist, took 40.82 seconds. There was no daemon to be
+busy. The client had not reached the socket at all.
+
+Every direct browser command was importing the natural-language Agent, the
+Playwright browser implementation, the terminal UI, and provider integrations
+before it could send a small local RPC. That work belongs in the long-lived
+daemon, or in `co browser do` when a model actually needs the browser tool
+schema. It does not belong in every status poll, click, or cleanup command.
+
+The direct command path now loads only its transport client. Help loads the
+browser schema when asked, and `do` installs the same tool methods lazily before
+building its Agent. The wire protocol and daemon behavior did not change. The
+same absent-daemon status check now takes 2.91 seconds.
+
+The lesson was in the boundary, not the timeout. When a client repeatedly talks
+to a persistent service, importing the service's entire implementation on every
+call defeats the reason the service is persistent. Measure the path before
+blaming the queue.

--- a/tests/unit/test_browser_cli_import_boundary.py
+++ b/tests/unit/test_browser_cli_import_boundary.py
@@ -1,0 +1,41 @@
+"""Direct browser RPCs must reach the daemon without importing its whole runtime."""
+
+import json
+import subprocess
+import sys
+
+
+def test_direct_browser_command_import_stays_lightweight():
+    """Regression for #1248: every polling command used to load Agent/Playwright.
+
+    This must run in a child interpreter because the browser daemon test suite
+    intentionally imports those modules while collecting its server-side tests.
+    """
+    script = r"""
+import json
+import sys
+import connectonion.cli.commands.browser_commands
+
+heavy = (
+    "connectonion.cli.browser_agent.daemon",
+    "connectonion.cli.browser_agent.agent",
+    "connectonion.useful_tools.browser_tools",
+    "patchright.sync_api",
+)
+print(json.dumps({name: name in sys.modules for name in heavy}, sort_keys=True))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert json.loads(result.stdout) == {
+        "connectonion.cli.browser_agent.agent": False,
+        "connectonion.cli.browser_agent.daemon": False,
+        "connectonion.useful_tools.browser_tools": False,
+        "patchright.sync_api": False,
+    }


### PR DESCRIPTION
Fixes #1248

**Proposed target version:** 1.7.0rc8
**Estimated release window:** 2026-08-24, after green CI and exact live acceptance

## Summary
- keep `co browser` direct RPC commands from importing Agent, Playwright, TUI, and provider integrations
- load daemon function schemas only for `help`, and browser tool schemas only for natural-language `do`
- preserve the existing browser daemon wire protocol and public lazy exports
- document the measured failure and import-boundary lesson in the Design Journal

## Root cause
The live release gate was killing each browser client at its 20/40-second command deadline before the process reached the daemon socket. A read-only `co browser status` against an absent socket took 40.82s before this change because package imports pulled in the whole browser/agent runtime. This made state polling and cleanup look like daemon queue contention.

## Verification
- absent-daemon `co browser status`: 40.82s before, 2.91s after
- focused browser client/daemon/status/autoinstall suite: 116 passed
- Ruff: passed
- `tests/unit + tests/e2e/cli`: running locally; CI is authoritative

No screenshots are added or uploaded by this PR.