### PR TITLE
fix(agent): bound post-provider settlement

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -20,7 +20,7 @@ from uuid import uuid4
 from ..logger import Logger
 from ..prompts import load_system_prompt
 from .events import EventHandler
-from .interrupt import run_interruptible
+from .interrupt import InterruptibleStepTimeout, run_interruptible
 from .llm import LLM, TokenUsage, create_llm
 from .mode import FULL_ACCESS, full_access_turns_left, mode_of, set_mode
 from .provider_messages import messages_for_provider
@@ -42,6 +42,9 @@ _REMOVED_MODE_FIELDS = {
     "ulw_turns_used",
     "workflow_mode",
 }
+
+_POST_PROVIDER_LLM_TIMEOUT_SECONDS = 90.0
+_NATIVE_PROVIDER_TOOL_NAMES = frozenset({"claude_code", "codex"})
 
 
 def _normalized_runtime_mode_session(session: Mapping[str, Any]) -> dict[str, Any]:
@@ -630,6 +633,8 @@ class Agent:
         """Return the existing response string and its private terminal reason."""
         completed_tools = False
         empty_terminal_retries = 0
+        provider_settlement_required = False
+        provider_timeout_retries = 0
         while self.current_session['iteration'] < max_iterations:
             self.current_session['iteration'] += 1
 
@@ -637,7 +642,30 @@ class Agent:
             self._invoke_events('before_iteration')
 
             # Get LLM response
-            response = self._get_llm_decision()
+            try:
+                response = self._get_llm_decision(
+                    timeout_seconds=(
+                        _POST_PROVIDER_LLM_TIMEOUT_SECONDS
+                        if provider_settlement_required
+                        else None
+                    )
+                )
+            except InterruptibleStepTimeout as error:
+                if provider_settlement_required and provider_timeout_retries == 0:
+                    from ..useful_plugins.system_reminder import reminder_message
+
+                    self.current_session['messages'].append(reminder_message(
+                        "The previous model call did not return within the bounded "
+                        "settlement window after native provider work. Return a concise "
+                        "user-facing final answer based only on the recorded tool results. "
+                        "Do not claim work that those results do not prove."
+                    ))
+                    provider_timeout_retries += 1
+                    max_iterations += 1
+                    continue
+                raise TimeoutError(
+                    "LLM did not settle native provider tool results after one bounded retry"
+                ) from error
 
             if response is not None:
                 if not response.tool_calls:
@@ -652,6 +680,11 @@ class Agent:
                     # Process tool calls
                     self._execute_and_record_tools(response.tool_calls)
                     completed_tools = True
+                    if any(
+                        getattr(call, "name", "") in _NATIVE_PROVIDER_TOOL_NAMES
+                        for call in response.tool_calls
+                    ):
+                        provider_settlement_required = True
 
             # Fire after_iteration
             self._invoke_events('after_iteration')
@@ -707,7 +740,7 @@ class Agent:
             'max_iterations',
         )
 
-    def _get_llm_decision(self):
+    def _get_llm_decision(self, timeout_seconds: float | None = None):
         """Get the next action/decision from the LLM."""
         # Get tool schemas
         tool_schemas = [tool.to_function_schema() for tool in self.tools] if self.tools else None
@@ -733,10 +766,24 @@ class Agent:
 
         start = time.time()
         messages = messages_for_provider(self.current_session['messages'])
-        response, interrupted = run_interruptible(
-            lambda: self.llm.complete(messages, tools=tool_schemas),
-            self.io,
-        )
+        try:
+            response, interrupted = run_interruptible(
+                lambda: self.llm.complete(messages, tools=tool_schemas),
+                self.io,
+                timeout_seconds=timeout_seconds,
+            )
+        except InterruptibleStepTimeout:
+            duration = (time.time() - start) * 1000
+            self._record_trace({
+                'type': 'llm_result',
+                'id': llm_id,
+                'model': self.llm.model,
+                'iteration': self.current_session['iteration'],
+                'duration_ms': duration,
+                'status': 'error',
+                'error_type': 'TimeoutError',
+            })
+            raise
         duration = (time.time() - start) * 1000  # milliseconds
 
         if interrupted:

--- a/connectonion/core/interrupt.py
+++ b/connectonion/core/interrupt.py
@@ -2,6 +2,7 @@
 
 import copy
 import threading
+import time
 from typing import Any, Callable, Optional, Tuple
 
 from .provider_events import (
@@ -13,6 +14,10 @@ from .provider_events import (
 
 class UserInterrupt(Exception):
     """Internal control flow for an interrupt consumed by a blocking gate."""
+
+
+class InterruptibleStepTimeout(TimeoutError):
+    """A disposable blocking step exceeded its caller-owned settlement bound."""
 
 
 class InterruptibleIO:
@@ -213,6 +218,7 @@ def run_interruptible(
     io: Any,
     poll_seconds: float = 0.2,
     on_interrupt: Optional[Callable[[], None]] = None,
+    timeout_seconds: Optional[float] = None,
 ) -> Tuple[Any, bool]:
     """Return ``(result, False)`` or abandon ``fn`` on user interrupt.
 
@@ -221,10 +227,14 @@ def run_interruptible(
     the selective INTERRUPT mailbox. The abandoned callable may keep running,
     but its late return value is never committed by the caller.
     """
-    if io is None or not hasattr(io, "receive_all"):
+    if timeout_seconds is not None and timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    has_interrupt_mailbox = io is not None and hasattr(io, "receive_all")
+    if not has_interrupt_mailbox and timeout_seconds is None:
         return fn(), False
 
-    if _take_interrupt(io, on_interrupt):
+    if has_interrupt_mailbox and _take_interrupt(io, on_interrupt):
         return None, True
 
     box = {}
@@ -242,13 +252,26 @@ def run_interruptible(
     )
     worker.start()
 
+    deadline = (
+        time.monotonic() + timeout_seconds
+        if timeout_seconds is not None
+        else None
+    )
     while worker.is_alive():
-        worker.join(timeout=poll_seconds)
+        wait_seconds = poll_seconds
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise InterruptibleStepTimeout(
+                    f"Blocking step exceeded {timeout_seconds:g} seconds"
+                )
+            wait_seconds = min(wait_seconds, remaining)
+        worker.join(timeout=wait_seconds)
         # Completed work wins the race. Leave a simultaneous interrupt queued
         # for the next step or the existing iteration-boundary backstop.
         if not worker.is_alive():
             break
-        if _take_interrupt(io, on_interrupt):
+        if has_interrupt_mailbox and _take_interrupt(io, on_interrupt):
             return None, True
 
     if "error" in box:

--- a/docs/blog/2026-08-24-the-tool-finished-but-the-turn-did-not.md
+++ b/docs/blog/2026-08-24-the-tool-finished-but-the-turn-did-not.md
@@ -1,0 +1,27 @@
+---
+title: "The tool finished but the turn did not"
+date: 2026-08-24
+author: ConnectOnion Team
+---
+
+Our release gate watched Claude Code finish a real project, return control to
+the parent Agent, and then disappear behind a model request that never returned.
+The files were correct. The provider Work Room had a completed result. The
+outer composer still could not come back because the parent turn had no
+terminal outcome.
+
+We already handled a nearby failure: a model that returned an empty answer
+after successful tool work received one constrained recovery request. This was
+different. The model call itself remained in flight, so the empty-answer logic
+never ran.
+
+Native provider work now starts a bounded settlement phase. Every later parent
+model call in that phase has a hard limit. The first timeout abandons only that
+call and asks once for a concise answer grounded in the committed tool results.
+If the retry also times out, the turn ends with an explicit error. A late model
+response cannot enter history or claim success after the turn has settled.
+
+The distinction matters for remote coding clients. A provider finishing its
+work is not the same as the parent turn finishing. Once a long-running child
+returns, the parent still owes the user one bounded outcome: continue, ask,
+complete, or fail. "Still thinking" forever is not a fifth outcome.

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -256,6 +256,156 @@ def test_repeated_empty_terminal_after_tool_fails_instead_of_hanging():
         agent.input("Calculate 2+2")
     assert mock_llm.call_count == 3
 
+
+def test_post_provider_llm_timeout_gets_one_bounded_recovery_call(monkeypatch):
+    import threading
+    import time
+
+    import connectonion.core.agent as agent_module
+
+    release = threading.Event()
+
+    def claude_code(prompt: str) -> str:
+        """Run a native Claude Code task."""
+        return "verified provider result"
+
+    class HangingSettlementLLM:
+        model = "fake/post-provider-timeout"
+
+        def __init__(self):
+            self.calls = 0
+            self.last_call = None
+
+        def complete(self, messages, tools=None):
+            self.calls += 1
+            self.last_call = {"messages": messages, "tools": tools}
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="claude_code",
+                        arguments={"prompt": "build it"},
+                        id="provider-1",
+                    )],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            if self.calls == 2:
+                release.wait(timeout=2)
+                return LLMResponse(
+                    content="late answer",
+                    tool_calls=[],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            return LLMResponse(
+                content="Provider work completed and was verified.",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            )
+
+    monkeypatch.setattr(agent_module, "_POST_PROVIDER_LLM_TIMEOUT_SECONDS", 0.03)
+    llm = HangingSettlementLLM()
+    agent = Agent(
+        name="provider-timeout-recovery",
+        llm=llm,
+        tools=[claude_code],
+        log=False,
+        quiet=True,
+    )
+
+    before = time.monotonic()
+    result = agent.input("Delegate this")
+    elapsed = time.monotonic() - before
+    release.set()
+
+    assert result == "Provider work completed and was verified."
+    assert elapsed < 0.5
+    assert llm.calls == 3
+    assert [
+        entry["status"]
+        for entry in agent.current_session["trace"]
+        if entry["type"] == "llm_result"
+    ] == ["success", "error", "success"]
+    assert any(
+        "bounded settlement window" in str(message.get("content", ""))
+        for message in llm.last_call["messages"]
+    )
+
+
+def test_repeated_post_provider_llm_timeout_fails_with_terminal_outcome(monkeypatch):
+    import threading
+    import time
+
+    import connectonion.core.agent as agent_module
+
+    release = threading.Event()
+
+    def codex(prompt: str) -> str:
+        """Run a native Codex task."""
+        return "verified provider result"
+
+    class RepeatedHangingSettlementLLM:
+        model = "fake/repeated-post-provider-timeout"
+
+        def __init__(self):
+            self.calls = 0
+
+        def complete(self, messages, tools=None):
+            self.calls += 1
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="codex",
+                        arguments={"prompt": "build it"},
+                        id="provider-1",
+                    )],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            release.wait(timeout=2)
+            return LLMResponse(
+                content="late answer",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            )
+
+    monkeypatch.setattr(agent_module, "_POST_PROVIDER_LLM_TIMEOUT_SECONDS", 0.03)
+    llm = RepeatedHangingSettlementLLM()
+    agent = Agent(
+        name="provider-timeout-failure",
+        llm=llm,
+        tools=[codex],
+        log=False,
+        quiet=True,
+    )
+
+    before = time.monotonic()
+    with pytest.raises(TimeoutError, match="one bounded retry"):
+        agent.input("Delegate this")
+    elapsed = time.monotonic() - before
+    release.set()
+
+    assert elapsed < 0.5
+    assert llm.calls == 3
+    assert [
+        entry["status"]
+        for entry in agent.current_session["trace"]
+        if entry["type"] == "llm_result"
+    ] == ["success", "error", "error"]
+    terminal = [
+        entry
+        for entry in agent.current_session["trace"]
+        if entry["type"] == "turn_result"
+    ]
+    assert len(terminal) == 1
+    assert terminal[0]["reason"] == "error"
+    assert terminal[0]["error_type"] == "TimeoutError"
+
+
 def test_mixed_functions_and_class_instance():
         """Test that agent can accept both functions and class instances."""
         

--- a/tests/unit/test_interrupt.py
+++ b/tests/unit/test_interrupt.py
@@ -9,7 +9,12 @@ import pytest
 
 from connectonion import Agent, CodexPlugin, before_each_tool
 from connectonion.cli.co_ai.tools.claude_code import claude_code as co_ai_claude_code
-from connectonion.core.interrupt import InterruptibleIO, UserInterrupt, run_interruptible
+from connectonion.core.interrupt import (
+    InterruptibleIO,
+    InterruptibleStepTimeout,
+    UserInterrupt,
+    run_interruptible,
+)
 from connectonion.core.tool_executor import execute_single_tool
 from connectonion.logger import Logger
 from connectonion.network.io.websocket import WebSocketIO
@@ -117,6 +122,30 @@ def test_worker_exception_is_reraised_on_caller_thread():
 
     with pytest.raises(ValueError, match="boom"):
         run_interruptible(fail, MailboxIO(), poll_seconds=0.01)
+
+
+def test_timeout_abandons_slow_step_without_waiting_for_its_late_result():
+    release = threading.Event()
+    finished = threading.Event()
+
+    def step():
+        release.wait(timeout=2)
+        finished.set()
+        return "late"
+
+    before = time.monotonic()
+    with pytest.raises(InterruptibleStepTimeout, match="exceeded"):
+        run_interruptible(
+            step,
+            MailboxIO(),
+            poll_seconds=0.01,
+            timeout_seconds=0.03,
+        )
+    elapsed = time.monotonic() - before
+
+    release.set()
+    assert finished.wait(timeout=1)
+    assert elapsed < 0.3
 
 
 def test_abandoned_agent_tool_cannot_commit_session_or_registry_changes():


### PR DESCRIPTION
## Summary

- bound every parent-model call after a native Codex or Claude Code tool returns
- abandon a timed-out model response without letting its late result enter history
- make one constrained recovery request grounded only in committed tool results
- emit an explicit terminal `TimeoutError` if that retry also fails to settle
- trace each timed-out LLM call as an error so hosted clients can restore their composer honestly

## Why

The exact public `connectonion==1.7.0rc8` + O Chat PR #232 gate reproduced #1242 in a form the RC7 fix did not cover. Native Claude Code completed successfully in 209.8s and produced the valid C11 project. The parent then ran a successful `glob` verification, but its following model call never returned. Because no model response existed, the empty-response recovery in #1243 could not run; after the 420s parent window O Chat still had no send-ready composer.

This change gives post-provider settlement only four outcomes: continue, ask, complete, or fail. A permanently in-flight parent model call is no longer an unbounded fifth state.

## Verification

- `tests/unit/test_interrupt.py tests/unit/test_agent.py`: 63 passed
- `tests/unit/test_asgi.py tests/unit/test_runtime_input.py tests/unit/test_turn_outcome.py tests/unit/test_co_ai_one_shot_sessions.py`: 92 passed
- Ruff on changed Core and interrupt test files: passed
- `git diff --check`: passed
- full `tests/unit tests/e2e/cli` is running against coordinated RC8 docs and will be posted separately

**Proposed target version:** 1.7.0rc9

**Release impact:** blocks Stable 1.7 until merged, published in a new RC, and the exact public-artifact Workroom gate passes.

Refs #1242, #792, #1251.

**Estimated release window:** current 1.7 release-candidate window