### PR TITLE
fix: arm native-provider settlement before hosted execution

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -47,6 +47,24 @@ _POST_PROVIDER_LLM_TIMEOUT_SECONDS = 90.0
 _NATIVE_PROVIDER_TOOL_NAMES = frozenset({"claude_code", "codex"})
 
 
+def _has_unsettled_native_provider_result(trace: list[dict[str, Any]]) -> bool:
+    """Whether the latest model decision completed native-provider work.
+
+    The durable trace is the hosted runtime's authoritative record.  Scan only
+    back to the latest LLM call: an older provider result must not put an
+    unrelated later tool batch on the settlement deadline.
+    """
+    for entry in reversed(trace):
+        if entry.get("type") == "llm_call":
+            return False
+        if (
+            entry.get("type") == "tool_result"
+            and entry.get("name") in _NATIVE_PROVIDER_TOOL_NAMES
+        ):
+            return True
+    return False
+
+
 def _normalized_runtime_mode_session(session: Mapping[str, Any]) -> dict[str, Any]:
     """Apply the 1.7 schema boundary without translating old authority."""
 
@@ -641,6 +659,19 @@ class Agent:
             # Fire before_iteration (poll IO, check mode changes)
             self._invoke_events('before_iteration')
 
+            # Hosted provider plugins publish their completed tool result into
+            # the durable trace.  Re-derive the bound here as a fail-safe for
+            # any observer that normalized the in-memory ToolCall after the
+            # original decision.  RC9's public Work Room gate proved that the
+            # post-execution-only name check was not sufficient in this path.
+            if (
+                not provider_settlement_required
+                and _has_unsettled_native_provider_result(
+                    self.current_session.get('trace', [])
+                )
+            ):
+                provider_settlement_required = True
+
             # Get LLM response
             try:
                 response = self._get_llm_decision(
@@ -677,14 +708,22 @@ class Agent:
                             "id": self._next_trace_id(),
                         })
                 else:
+                    # Arm the settlement bound from the model's immutable
+                    # decision before tool execution.  The hosted co-ai path
+                    # lets provider plugins and event handlers observe and
+                    # normalize a call while it runs; detecting the provider
+                    # only after that path returned left the real Work Room
+                    # continuation unbounded even though minimal Agent tests
+                    # retained the original ToolCall name.
+                    native_provider_batch = any(
+                        getattr(call, "name", "") in _NATIVE_PROVIDER_TOOL_NAMES
+                        for call in response.tool_calls
+                    )
+                    if native_provider_batch:
+                        provider_settlement_required = True
                     # Process tool calls
                     self._execute_and_record_tools(response.tool_calls)
                     completed_tools = True
-                    if any(
-                        getattr(call, "name", "") in _NATIVE_PROVIDER_TOOL_NAMES
-                        for call in response.tool_calls
-                    ):
-                        provider_settlement_required = True
 
             # Fire after_iteration
             self._invoke_events('after_iteration')
@@ -762,6 +801,11 @@ class Agent:
             'model': self.llm.model,
             'iteration': self.current_session['iteration'],
             'status': 'running',
+            **(
+                {'timeout_seconds': timeout_seconds}
+                if timeout_seconds is not None
+                else {}
+            ),
         })
 
         start = time.time()

--- a/docs/blog/2026-08-24-arm-the-deadline-before-the-tool-returns.md
+++ b/docs/blog/2026-08-24-arm-the-deadline-before-the-tool-returns.md
@@ -1,0 +1,44 @@
+# Arm the deadline before the tool returns
+
+A coding provider can finish perfectly and still leave its user stranded.
+
+The public `1.7.0rc9` acceptance run asked Claude Code to build a bounded C11
+stack. Claude returned successfully after 132.8 seconds. The harness compiled
+and ran the project independently. Then the parent conversation stopped moving:
+no final answer, no approval, and no composer.
+
+RC9 already contained a 90-second deadline for the model call that settles a
+native provider result. The small tests passed. The real Work Room did not see
+that deadline. The mistake was temporal: provider identity was discovered only
+after the hosted tool path returned. Plugins and event observers are allowed to
+normalize the in-memory call while that path runs, so a safety property derived
+after execution was weaker than the durable fact recorded by execution itself.
+
+We considered putting a larger timeout around the release harness. That would
+only make the test stop sooner; it would not restore the user's conversation.
+We also considered relying on the original call object and adding more logging.
+That would make the same ordering assumption easier to diagnose, not correct.
+
+The parent deadline is now armed from the model decision before provider work
+starts. At the next iteration, Core also checks the durable trace for a completed
+`codex` or `claude_code` tool result since the latest model call. Either fact is
+enough to bound settlement. The trace records the applied timeout so a hosted
+acceptance run can prove the safety boundary was active, rather than infer it
+from elapsed wall time.
+
+The tradeoff is deliberate: every remaining model call in that provider turn is
+bounded, including the single grounded recovery attempt. A very slow but healthy
+settlement may be abandoned. That is preferable to an indefinitely unusable
+Work Room, and the provider result remains recorded for the retry.
+
+Unit coverage now changes the observed ToolCall name after execution and proves
+the already-armed deadline still fires. It also proves the durable trace can
+re-arm the boundary while an unrelated later tool batch cannot inherit an old
+provider deadline. The release claim still depends on the harder evidence: a
+new public candidate must repeat the complete browser, compiler, provider,
+permission, Stop, reconnect, and responsive Work Room journey.
+
+We would revisit the 90-second value if production measurements show legitimate
+settlement calls routinely need longer. We would not revisit the ordering rule:
+a deadline that protects the result of a tool must exist before that result can
+cross a mutable hosted path.

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -332,6 +332,103 @@ def test_post_provider_llm_timeout_gets_one_bounded_recovery_call(monkeypatch):
         "bounded settlement window" in str(message.get("content", ""))
         for message in llm.last_call["messages"]
     )
+    bounded_calls = [
+        entry for entry in agent.current_session["trace"]
+        if entry["type"] == "llm_call" and "timeout_seconds" in entry
+    ]
+    assert [entry["timeout_seconds"] for entry in bounded_calls] == [0.03, 0.03]
+
+
+def test_provider_settlement_is_armed_before_hosted_tool_observers_normalize_the_call(monkeypatch):
+    """The real co-ai path must not rediscover provider identity after execution."""
+    import threading
+
+    import connectonion.core.agent as agent_module
+
+    release = threading.Event()
+
+    def claude_code(prompt: str) -> str:
+        """Run a native Claude Code task."""
+        return "verified provider result"
+
+    class HangingSettlementLLM:
+        model = "fake/hosted-provider-timeout"
+
+        def __init__(self):
+            self.calls = 0
+
+        def complete(self, messages, tools=None):
+            self.calls += 1
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="claude_code",
+                        arguments={"prompt": "build it"},
+                        id="provider-hosted-1",
+                    )],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            if self.calls == 2:
+                release.wait(timeout=2)
+                return LLMResponse(
+                    content="late answer",
+                    tool_calls=[],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            return LLMResponse(
+                content="Provider work completed and was verified.",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            )
+
+    monkeypatch.setattr(agent_module, "_POST_PROVIDER_LLM_TIMEOUT_SECONDS", 0.03)
+    llm = HangingSettlementLLM()
+    agent = Agent(
+        name="hosted-provider-timeout",
+        llm=llm,
+        tools=[claude_code],
+        log=False,
+        quiet=True,
+    )
+    execute = agent._execute_and_record_tools
+
+    def execute_like_hosted_observers(tool_calls):
+        execute(tool_calls)
+        for call in tool_calls:
+            call.name = "normalized_after_execution"
+
+    monkeypatch.setattr(agent, "_execute_and_record_tools", execute_like_hosted_observers)
+
+    result = agent.input("Delegate this")
+    release.set()
+
+    assert result == "Provider work completed and was verified."
+    assert llm.calls == 3
+    assert [
+        entry["status"]
+        for entry in agent.current_session["trace"]
+        if entry["type"] == "llm_result"
+    ] == ["success", "error", "success"]
+
+
+def test_durable_provider_result_rearms_the_hosted_settlement_bound():
+    from connectonion.core.agent import _has_unsettled_native_provider_result
+
+    assert _has_unsettled_native_provider_result([
+        {"type": "llm_call", "id": "decision"},
+        {"type": "provider_invocation", "provider": "claude_code"},
+        {"type": "tool_result", "name": "claude_code", "status": "success"},
+        {"type": "thinking", "kind": "runtime"},
+    ]) is True
+    assert _has_unsettled_native_provider_result([
+        {"type": "tool_result", "name": "claude_code", "status": "success"},
+        {"type": "llm_call", "id": "later-decision"},
+        {"type": "tool_result", "name": "bash", "status": "success"},
+    ]) is False
 
 
 def test_repeated_post_provider_llm_timeout_fails_with_terminal_outcome(monkeypatch):


### PR DESCRIPTION
Closes #1256.

## Summary

- arm the native-provider settlement deadline from the model decision before hosted tool execution
- re-derive that deadline from the durable provider `tool_result` trace as a hosted fail-safe
- record the applied timeout on `llm_call` trace entries so release evidence proves the boundary was active
- add a Design Journal entry for the RC9 public-gate finding

## Why

The exact public RC9 gate completed a real Claude Code C11 project in 132.8 seconds, but the following parent-model call did not emit the expected 90-second timeout/retry and left the Work Room without a composer after the harness 420-second bound. Minimal Agent tests retained the original ToolCall identity; the hosted path needs the deadline armed before observers can normalize that call, with the durable trace as the authoritative fallback.

## Verification

- 370/370 agent, interrupt, turn-outcome, one-shot, ASGI, hosted mode, provider Work Room, provider permission, runtime-input, and session tests pass
- `git diff --check`

## Release gate

After merge, a local hosted Claude smoke must prove the timeout trace and usable terminal state before RC10 is cut. The exact public RC10 artifact must then repeat the complete gate; RC9 cannot promote unchanged.

**Proposed target version:** 1.7.0rc10

**Estimated release window:** immediately after green CI and hosted smoke
