### PR TITLE
fix: make native-provider settlement terminal-only

### DIFF
--- a/connectonion/core/agent.py
+++ b/connectonion/core/agent.py
@@ -653,6 +653,7 @@ class Agent:
         empty_terminal_retries = 0
         provider_settlement_required = False
         provider_timeout_retries = 0
+        provider_tool_retries = 0
         while self.current_session['iteration'] < max_iterations:
             self.current_session['iteration'] += 1
 
@@ -719,11 +720,44 @@ class Agent:
                         getattr(call, "name", "") in _NATIVE_PROVIDER_TOOL_NAMES
                         for call in response.tool_calls
                     )
-                    if native_provider_batch:
-                        provider_settlement_required = True
-                    # Process tool calls
-                    self._execute_and_record_tools(response.tool_calls)
-                    completed_tools = True
+                    settlement_tools_rejected = False
+                    if provider_settlement_required and not native_provider_batch:
+                        if provider_tool_retries == 0:
+                            from ..useful_plugins.system_reminder import reminder_message
+
+                            attempted = ", ".join(
+                                getattr(call, "name", "unknown")
+                                for call in response.tool_calls
+                            )
+                            self.current_session['messages'].append(reminder_message(
+                                "Native provider work is already complete. The parent "
+                                "settlement attempted additional tool calls "
+                                f"({attempted}); those calls were not executed. Return "
+                                "a concise user-facing final answer based only on the "
+                                "recorded provider result. Do not call any tools."
+                            ))
+                            provider_tool_retries += 1
+                            max_iterations += 1
+                            settlement_tools_rejected = True
+                        else:
+                            raise RuntimeError(
+                                "Native provider settlement attempted tools after one "
+                                "final-only retry"
+                            )
+                    if not settlement_tools_rejected:
+                        if native_provider_batch:
+                            provider_settlement_required = True
+                        # Process tool calls
+                        self._execute_and_record_tools(response.tool_calls)
+                        completed_tools = True
+                        if native_provider_batch:
+                            from ..useful_plugins.system_reminder import reminder_message
+
+                            self.current_session['messages'].append(reminder_message(
+                                "Native provider work has completed. Return a concise "
+                                "user-facing final answer based only on its recorded result. "
+                                "Do not call any additional tools."
+                            ))
 
             # Fire after_iteration
             self._invoke_events('after_iteration')

--- a/docs/blog/2026-08-24-arm-the-deadline-before-the-tool-returns.md
+++ b/docs/blog/2026-08-24-arm-the-deadline-before-the-tool-returns.md
@@ -26,6 +26,16 @@ enough to bound settlement. The trace records the applied timeout so a hosted
 acceptance run can prove the safety boundary was active, rather than infer it
 from elapsed wall time.
 
+The first installed-wheel smoke refined the boundary again. Claude returned,
+the parent quickly called `glob`, then the following model response requested
+another tool and stalled before that tool reached a visible execution or
+approval state. The LLM calls were fast; timing only those calls could never
+close the turn. Post-provider settlement is therefore terminal-only. The parent
+may summarize the recorded provider result, but it cannot open a new outer tool
+chain. One attempted tool batch is discarded with a final-only reminder; a
+second attempt fails explicitly so the Host can publish a terminal outcome and
+restore the composer.
+
 The tradeoff is deliberate: every remaining model call in that provider turn is
 bounded, including the single grounded recovery attempt. A very slow but healthy
 settlement may be abandoned. That is preferable to an indefinitely unusable

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -431,6 +431,76 @@ def test_durable_provider_result_rearms_the_hosted_settlement_bound():
     ]) is False
 
 
+def test_post_provider_settlement_rejects_a_new_tool_chain_and_returns_final_answer():
+    executed = []
+
+    def claude_code(prompt: str) -> str:
+        """Run a native Claude Code task."""
+        executed.append("claude_code")
+        return "verified provider result"
+
+    def glob(pattern: str) -> str:
+        """Search the workspace."""
+        executed.append("glob")
+        return "must not run"
+
+    class ToolHappySettlementLLM:
+        model = "fake/provider-terminal-settlement"
+
+        def __init__(self):
+            self.calls = 0
+            self.last_messages = None
+
+        def complete(self, messages, tools=None):
+            self.calls += 1
+            self.last_messages = messages
+            if self.calls == 1:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="claude_code",
+                        arguments={"prompt": "build it"},
+                        id="provider-terminal-1",
+                    )],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            if self.calls == 2:
+                return LLMResponse(
+                    content="",
+                    tool_calls=[ToolCall(
+                        name="glob",
+                        arguments={"pattern": "*"},
+                        id="post-provider-glob",
+                    )],
+                    raw_response={},
+                    usage=TokenUsage(),
+                )
+            return LLMResponse(
+                content="Claude completed the verified project.",
+                tool_calls=[],
+                raw_response={},
+                usage=TokenUsage(),
+            )
+
+    llm = ToolHappySettlementLLM()
+    agent = Agent(
+        name="provider-terminal-settlement",
+        llm=llm,
+        tools=[claude_code, glob],
+        log=False,
+        quiet=True,
+    )
+
+    assert agent.input("Delegate this") == "Claude completed the verified project."
+    assert executed == ["claude_code"]
+    assert llm.calls == 3
+    assert any(
+        "those calls were not executed" in str(message.get("content", ""))
+        for message in llm.last_messages
+    )
+
+
 def test_repeated_post_provider_llm_timeout_fails_with_terminal_outcome(monkeypatch):
     import threading
     import time


### PR DESCRIPTION
Closes #1256.

## Summary

- stop the parent agent from opening a new outer tool chain after native Codex/Claude work completes
- discard one attempted post-provider tool batch and request a bounded final-only answer
- fail explicitly on a repeated tool attempt so Host can publish a terminal outcome and restore the composer
- extend the Design Journal with the installed-wheel smoke evidence

## Evidence

The #1257 installed-wheel smoke refined the failure: Claude returned in 102.4s; the first parent call returned `glob` in 3.3s and executed; the next parent call returned another one-tool response in 2.8s, then wedged before that tool reached visible execution or approval. The LLM timeout was not the blocking boundary.

## Verification

- 95/95 agent, interrupt, turn outcome, and runtime-input tests pass
- regression proves the attempted `glob` is not executed and a final answer follows
- `git diff --check`

## Release gate

An installed-wheel hosted smoke must pass before RC10 is cut, then exact public RC10 must repeat the complete release journey.

**Proposed target version:** 1.7.0rc10

**Estimated release window:** immediately after green CI and installed-wheel hosted smoke
