### PR TITLE
fix: forward-port the complete 1.6.12 set into 1.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,3 +40,36 @@ from connectonion import Agent
 
 **Additional context**
 Add any other context about the problem here.
+## AI implementation contract
+
+<!-- The bug-sized subset. Full guidance, repository defaults, and
+     guardrails: docs/ai-implementation-contract.md -->
+
+### Scope and release line
+- Target: [ ] stable patch [ ] preview [ ] main-only
+- Exact base/tag:
+- Owning repositories:
+- Explicitly out of scope:
+- Release action authorized by this issue:
+  [ ] test only
+  [ ] prepare Draft release PR
+  [ ] publish approved Preview
+  [ ] publish stable
+  [ ] no publication
+
+### Plan before code
+- Reproduce first: a regression test must fail on the unpatched code before
+  the fix has any claim to work.
+- Inspect the current implementation, tests, and related PRs/issues before editing.
+- Do not merge a preview `main` wholesale into a stable branch.
+
+### Required verification
+- Focused red/green regression test:
+- Full suite on the exact candidate commit:
+- Real journey exercising the fixed path (browser/CLI as applicable):
+- Commands and exact output to record:
+
+### Evidence
+- [ ] The regression test's red run (pre-patch) is recorded in the PR.
+- [ ] Before/After behavior is shown, not asserted.
+- [ ] If user-visible: screenshots attached directly to the PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -33,3 +33,69 @@ Add any other context, screenshots, or examples about the feature request here.
 - [ ] Yes, I can submit a PR
 - [ ] Yes, but I would need guidance
 - [ ] No, but I can help test it
+## AI implementation contract
+
+<!-- Fill this in so an AI session can execute without the owner repeating
+     the operating contract every round. Full guidance, repository defaults,
+     and guardrails: docs/ai-implementation-contract.md -->
+
+### Scope and release line
+- Target: [ ] stable patch [ ] preview [ ] main-only [ ] docs/process only
+- Exact base/tag:
+- Owning repositories:
+- Related issues/design decisions:
+- Explicitly out of scope:
+- Release action authorized by this issue:
+  [ ] test only
+  [ ] prepare Draft release PR
+  [ ] publish approved Preview
+  [ ] publish stable
+  [ ] no publication
+
+### Plan before code
+- Inspect the current implementation, tests, AGENTS/CLAUDE guidance, protocol docs,
+  related PRs/issues, and released package behavior.
+- Write the implementation/compatibility/test plan before editing.
+- Identify security authority, migration, rollback, and old/new version boundaries.
+- Do not merge a preview `main` wholesale into a stable branch.
+
+### Required verification
+- Unit/component/contract tests:
+- Cross-repository fixtures:
+- Real browser journey:
+- Required desktop/mobile widths:
+- Required failure/reconnect/approval states:
+- Complex acceptance task:
+- Commands and exact output to record:
+
+### UI and interaction review
+- [ ] Capture the current baseline before implementation.
+- [ ] Hide raw code/terminal detail behind progressive disclosure by default.
+- [ ] Run an expert UI/interaction audit after each UI implementation round.
+- [ ] Record the ten highest-impact findings and the disposition of each.
+- [ ] Re-run the journey after fixes until no release-blocking finding remains.
+
+### Screenshot evidence
+- [ ] Attach Before / After screenshots directly to the PR.
+- [ ] Attach desktop and narrow/mobile screenshots.
+- [ ] Include approval, error/reconnect, running, and completed states when applicable.
+- [ ] Link the complete browser artifact/trace.
+- [ ] Select permanent release screenshots; do not rely only on expiring CI artifacts.
+
+### Documentation and code knowledge
+- [ ] Update user documentation and exact release/version guidance.
+- [ ] Update protocol/design decisions and compatibility matrix when a boundary changes.
+- [ ] Add concise "why" comments around non-obvious invariants.
+- [ ] Boundary files link to their Core writer, React normalizer, O Chat renderer,
+      contract fixture, and design decision.
+- [ ] Do not add boilerplate headers to unrelated files.
+
+### Release and forward integration
+- [ ] Test the reviewed package/artifact, not only a source checkout.
+- [ ] Publish only through the protected GitHub Preview/Release workflow explicitly
+      authorized above.
+- [ ] Re-test the public artifact and deployed Preview.
+- [ ] After a stable 1.6.x release is verified, forward-merge that stable line into
+      `main`; preserve newer OIP authority and resolve conflicts explicitly.
+- [ ] Link rollback instructions, immutable versions/hashes, PRs, screenshots, and
+      public release.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -95,7 +95,7 @@ Add any other context, screenshots, or examples about the feature request here.
 - [ ] Publish only through the protected GitHub Preview/Release workflow explicitly
       authorized above.
 - [ ] Re-test the public artifact and deployed Preview.
-- [ ] After a stable 1.6.x release is verified, forward-merge that stable line into
+- [ ] After a stable release is verified, forward-merge that stable line into
       `main`; preserve newer OIP authority and resolve conflicts explicitly.
 - [ ] Link rollback instructions, immutable versions/hashes, PRs, screenshots, and
       public release.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -87,6 +87,9 @@ from connectonion import Agent
 - [ ] This PR ships its dev-blog post under docs/blog/ (or a maintainer applied `no-blog`)
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
+- [ ] Every piece of evidence the linked issue's **AI implementation contract**
+      requires is attached or linked here (tests, journeys, screenshots,
+      exact commands) — see docs/ai-implementation-contract.md
 
 ## Screenshots (if applicable)
 Add screenshots to help explain your changes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 🧅 ConnectOnion
 
+**Keep simple things simple, make complicated things possible.**
+
+A template-first toolkit for FDEs building, debugging, deploying, and operating real AI agents.
+
 <div align="center">
 
 [![Production Ready](https://img.shields.io/badge/Status-Production_Ready-success?style=flat-square)](https://connectonion.com)
@@ -22,6 +26,36 @@
 > ## 🌟 Philosophy: "Keep simple things simple, make complicated things possible"
 > 
 > This is the core principle that drives every design decision in ConnectOnion.
+
+## Start from a working agent
+
+You do not need to assemble a framework stack before doing useful work. Start
+from the same working agent that powers `co ai`, specialise it with skills, and
+use one CLI across the delivery path:
+
+```bash
+pip install connectonion
+
+co create sales-agent
+cd sales-agent
+co ai
+co doctor
+co deploy
+co status
+```
+
+`co create` supplies files, shell, browser, planning, todos, and sub-agents.
+`co ai` works in the project from a terminal or the web client. `co deploy`
+ships the agent, while `co status` and `co doctor` explain what is running and
+what needs attention. The Python runtime below remains directly available when
+you need a custom tool, hook, provider, or host boundary.
+
+Common delivery commands include:
+
+- `co browser` for a persistent browser;
+- `co server new --region <region>` and `co deploy --to <server>` for owned infrastructure;
+- `co email share` and `co email unshare` for scoped mailbox delegation;
+- `co gmail`, `co outlook`, and `co gdrive` for operator-connected services.
 
 ## 🎯 Living Our Philosophy
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -170,9 +170,10 @@ When releasing a new version:
       they contain a reusable design lesson.
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
 - [ ] Record the release's visual evidence: `python scripts/check_release_visuals.py vX.Y.Z`
-      must pass — a reviewed image set under `docs/releases/assets/vX.Y.Z/` for
-      user-visible changes, or an explicit `no_visual_change` reason for a
-      backend-only patch (see docs/releases/README.md, #1124)
+      must pass — a reviewed image set under docs/releases/assets/vX.Y.Z/ (a
+      per-release directory; the contract lives in `docs/releases/README.md`)
+      for user-visible changes, or an explicit `no_visual_change` reason for a
+      backend-only patch (#1124)
 - [ ] Remove artifacts from older releases: `rm -rf dist/`
 - [ ] Build package: `python -m build`
 - [ ] Validate both current-version artifacts: `python -m twine check dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -169,6 +169,10 @@ When releasing a new version:
       workflow decision. Maintenance-only patches need release notes unless
       they contain a reusable design lesson.
 - [ ] Run the suite: `pytest tests/ -m "not slow and not real_api and not network"`
+- [ ] Record the release's visual evidence: `python scripts/check_release_visuals.py vX.Y.Z`
+      must pass — a reviewed image set under `docs/releases/assets/vX.Y.Z/` for
+      user-visible changes, or an explicit `no_visual_change` reason for a
+      backend-only patch (see docs/releases/README.md, #1124)
 - [ ] Remove artifacts from older releases: `rm -rf dist/`
 - [ ] Build package: `python -m build`
 - [ ] Validate both current-version artifacts: `python -m twine check dist/connectonion-X.Y.Z.tar.gz dist/connectonion-X.Y.Z-py3-none-any.whl`

--- a/connectonion/cli/commands/email_commands.py
+++ b/connectonion/cli/commands/email_commands.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: imports from [rich.console, rich.table, rich.panel, .project_cmd_lib.load_api_key, ...useful_tools.send_email.send_email, ...useful_tools.get_emails.get_emails/mark_read] | imported by [cli/main.py via handle_email_*()] | hits the configured backend through the engine tools at [/api/v1/email/*]
   Data flow: load_api_key() ensures OPENONION_API_KEY + AGENT_EMAIL are in env → handle_email_send() → send_email(to, subject, message) → prints message_id | handle_email_inbox() → get_emails(last, unread, offset) → Rich table | handle_email_read() → get_emails() → find by id → print body → optionally mark_read(id)
   State/Effects: no local state | network calls happen inside the engine tools | only read --mark-read flips server-side read status | writes to stdout via rich.Console
-  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses() for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py | requires prior 'co auth'
+  Integration: exposes handle_email_send(), handle_email_inbox(), handle_email_read(), handle_email_addresses(), handle_email_share()/handle_email_unshare() (connectonion#1137) for cli/main.py | thin presentation layer — all email logic lives in useful_tools/{send_email,get_emails}.py, share/unshare hit /api/v1/email/share directly like addresses/name do | requires prior 'co auth'
   Errors: prints a 'run co auth' hint when no API key found | send_email returns {success, error} dicts (printed as-is); get_emails/mark_read let API errors crash
 """
 
@@ -298,6 +298,108 @@ def handle_email_addresses():
     console.print()
     console.print(table)
     console.print('\n[dim]Send as one with:[/dim] [bold]co email send <to> "<subject>" "<body>" --from <address>[/bold]\n')
+
+
+_CAPABILITIES = {"send": "can_send", "read": "can_read"}
+
+
+def _parse_capabilities(can: str) -> dict:
+    """'send,read' -> {'can_send': True, 'can_read': True}. Rejects a typo rather
+    than silently granting nothing, which the server would also refuse but
+    only after a round trip."""
+    flags = {"can_send": False, "can_read": False}
+    for word in can.split(","):
+        word = word.strip().lower()
+        if not word:
+            continue
+        key = _CAPABILITIES.get(word)
+        if not key:
+            console.print(f"\n[red]✗ Unknown capability: '{word}'.[/red] Use send, read, or both.\n")
+            raise typer.Exit(1)
+        flags[key] = True
+    if not flags["can_send"] and not flags["can_read"]:
+        console.print("\n[red]✗ --can needs at least one of: send, read[/red]\n")
+        raise typer.Exit(1)
+    return flags
+
+
+def _print_shares_table(title: str, rows: list, other_key: str):
+    if not rows:
+        console.print(f"[cyan]{title}:[/cyan] none\n")
+        return
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("Address")
+    table.add_column("With" if other_key == "grantee_public_key" else "Owner")
+    table.add_column("Can")
+    for row in rows:
+        capabilities = ",".join(
+            name for name, key in _CAPABILITIES.items() if row.get(key)
+        )
+        table.add_row(str(row.get("address", "")), str(row.get(other_key, "")), capabilities)
+    console.print(table)
+    console.print()
+
+
+def handle_email_share(
+    address: str = None, *, with_: str = None, can: str = None, list_: bool = False,
+):
+    """Grant, or list, access to one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    if list_:
+        r = requests.get(f"{backend_url()}/api/v1/email/share", headers=headers, timeout=10)
+        if not r.ok:
+            console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+            raise typer.Exit(1)
+        data = r.json()
+        console.print()
+        _print_shares_table("📤 Shared by you", data.get("granted_by_me", []), "grantee_public_key")
+        _print_shares_table("📥 Shared with you", data.get("granted_to_me", []), "owner_public_key")
+        return
+
+    if not address or not with_ or not can:
+        console.print(
+            "\n[red]✗ Usage:[/red] co email share <address> --with <who> --can send,read"
+            "\n         co email share --list\n"
+        )
+        raise typer.Exit(1)
+
+    payload = {"address": address, "grantee": with_, **_parse_capabilities(can)}
+    r = requests.post(f"{backend_url()}/api/v1/email/share", json=payload, headers=headers, timeout=15)
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    data = r.json()
+    granted = ",".join(name for name, key in _CAPABILITIES.items() if data.get(key))
+    console.print(f"\n[green]✓ Shared {address}[/green] with [cyan]{with_}[/cyan] ({granted})")
+    console.print("[dim]Revoke it with:[/dim]")
+    # Plain print, not console.print: Rich wraps at the console width, and a
+    # line-broken command is no longer copy-pasteable.
+    print(f"  co email unshare {address} --with {with_}\n")
+
+
+def handle_email_unshare(address: str, *, with_: str):
+    """Revoke a grant on one of your addresses (connectonion#1137)."""
+    token = load_api_key()
+    if not token:
+        _print_no_auth()
+        raise typer.Exit(1)
+
+    r = requests.delete(
+        f"{backend_url()}/api/v1/email/share/{address}/{with_}",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=10,
+    )
+    if not r.ok:
+        console.print(f"\n[red]✗ {_err(r)}[/red]\n")
+        raise typer.Exit(1)
+
+    console.print(f"\n[green]✓ Revoked {with_}'s access to {address}[/green]\n")
 
 
 def handle_email_name(name: str, buy: bool = False):

--- a/connectonion/cli/commands/outlook_commands.py
+++ b/connectonion/cli/commands/outlook_commands.py
@@ -214,7 +214,7 @@ def handle_outlook_read(email_id: str, mark_read: bool = False):
     console.print(f"\n[dim]{marked}Reply with:[/dim] [bold]co outlook reply <#> <message>[/bold]\n")
 
 
-def handle_outlook_download(email_id: str, out_dir: str = "."):
+def handle_outlook_download(email_id: str, out_dir: str = ".", include_inline: bool = False):
     """Save an email's attachments to disk. Accepts the listing # or a full message id."""
     outlook = _outlook()
     resolved = _resolve_email_id(outlook, email_id)
@@ -222,9 +222,10 @@ def handle_outlook_download(email_id: str, out_dir: str = "."):
         console.print(f"\n[yellow]No email #{email_id} in your last listing — run co outlook, then co outlook download <#>.[/yellow]\n")
         raise typer.Exit(1)
 
-    saved = outlook.download_attachments(resolved, out_dir)
+    saved = outlook.download_attachments(resolved, out_dir, include_inline=include_inline)
     if not saved:
-        console.print("\n[yellow]No file attachments on that email.[/yellow]\n")
+        console.print("\n[yellow]No file attachments on that email.[/yellow]")
+        console.print("[dim]Embedded signature images are skipped — --include-inline saves them too.[/dim]\n")
         return
 
     console.print()

--- a/connectonion/cli/commands/server_commands.py
+++ b/connectonion/cli/commands/server_commands.py
@@ -663,7 +663,8 @@ def _fetch_pricing() -> Optional[dict]:
     return response.json() if response.status_code == 200 else None
 
 
-def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[float]) -> bool:
+def _confirm(name: str, machine_type: str, region: str, pricing: dict,
+            balance: Optional[float]) -> bool:
     """Show what this costs and what is left, then ask.
 
     Every other `co` command is either free or spends metered credit in
@@ -695,7 +696,7 @@ def _confirm(name: str, machine_type: str, pricing: dict, balance: Optional[floa
 
     console.print()
     console.print(f"  [cyan]name[/cyan]          {name}")
-    console.print(f"  [cyan]region[/cyan]        {pricing['region']}")
+    console.print(f"  [cyan]region[/cyan]        {region}")
     console.print(f"  [cyan]machine[/cyan]       {machine_type} [dim]— {entry['description']}[/dim]")
     console.print(f"  [cyan]cost[/cyan]          [bold]${monthly:.0f} / month[/bold] "
                   f"[dim]— ${price:.2f} for {months} months, charged now[/dim]")
@@ -871,7 +872,7 @@ def handle_server_fix_key(name: str) -> bool:
 
 
 def handle_server_new(name: str, machine_type: Optional[str] = None,
-                      yes: bool = False) -> bool:
+                      region: Optional[str] = None, yes: bool = False) -> bool:
     """Have a server created for you, and register it locally."""
     import requests
 
@@ -914,8 +915,14 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
         console.print(f"[dim]Available: {', '.join(sorted(pricing['machine_types']))}[/dim]\n")
         return False
 
+    region = region or pricing["default_region"]
+    if region not in pricing["regions"]:
+        console.print(f"\n[red]Unknown region: {region}[/red]")
+        console.print(f"[dim]Available: {', '.join(sorted(pricing['regions']))}[/dim]\n")
+        return False
+
     if not yes:
-        if not _confirm(name, machine_type, pricing, _fetch_balance(api_key)):
+        if not _confirm(name, machine_type, region, pricing, _fetch_balance(api_key)):
             console.print("[dim]Nothing was created or charged.[/dim]\n")
             return False
 
@@ -925,7 +932,7 @@ def handle_server_new(name: str, machine_type: Optional[str] = None,
             f"{backend_url()}/api/v1/servers",
             headers={"Authorization": f"Bearer {api_key}"},
             json={"name": name, "ssh_public_key": ssh_public_line,
-                  "machine_type": machine_type},
+                  "machine_type": machine_type, "region": region},
             timeout=300,
         )
     except requests.RequestException as exc:

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -490,11 +490,13 @@ def server_check(
 def server_new(
     name: str = typer.Argument(..., help="Short name you will pass to co deploy --to"),
     machine: Optional[str] = typer.Option(None, "--machine", help="Machine type (default: the smallest)"),
+    region: Optional[str] = typer.Option(None, "--region",
+                                         help="Where to provision (default: australia-southeast1)"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the price confirmation"),
 ):
     """Have a server created for you. Charges 12 months of credit up front."""
     from .commands.server_commands import handle_server_new
-    if not handle_server_new(name=name, machine_type=machine, yes=yes):
+    if not handle_server_new(name=name, machine_type=machine, region=region, yes=yes):
         raise typer.Exit(1)
 
 

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -798,6 +798,28 @@ def email_name(
     handle_email_name(name, buy=buy)
 
 
+@email_app.command("share")
+def email_share(
+    address: Optional[str] = typer.Argument(None, help="One of your addresses (omit with --list)"),
+    with_: Optional[str] = typer.Option(None, "--with", help="Grantee: public key or one of their addresses"),
+    can: Optional[str] = typer.Option(None, "--can", help="Comma-separated capabilities: send,read"),
+    list_: bool = typer.Option(False, "--list", help="Show what you've shared, and what's shared with you"),
+):
+    """Let another account send and/or read as one of your addresses, without moving it."""
+    from .commands.email_commands import handle_email_share
+    handle_email_share(address, with_=with_, can=can, list_=list_)
+
+
+@email_app.command("unshare")
+def email_unshare(
+    address: str = typer.Argument(..., help="One of your addresses"),
+    with_: str = typer.Option(..., "--with", help="Grantee to revoke: public key or one of their addresses"),
+):
+    """Revoke a grant. No key rotation — the address was never shared, only access to it."""
+    from .commands.email_commands import handle_email_unshare
+    handle_email_unshare(address, with_=with_)
+
+
 @email_app.command("upgrade")
 def email_upgrade(
     tier: str = typer.Argument(..., help="Tier: plus or pro"),

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -1177,10 +1177,14 @@ def outlook_read(
 def outlook_download(
     email_id: str = typer.Argument(..., help="Email # from your last inbox/search listing"),
     out_dir: str = typer.Option(".", "--to", help="Directory to save attachments into"),
+    include_inline: bool = typer.Option(
+        False, "--include-inline",
+        help="Also save embedded signature images and logos (skipped by default)",
+    ),
 ):
     """Save an email's attachments to disk."""
     from .commands.outlook_commands import handle_outlook_download
-    handle_outlook_download(email_id, out_dir)
+    handle_outlook_download(email_id, out_dir, include_inline=include_inline)
 
 
 @outlook_app.command("reply", epilog="Examples:  co outlook reply 3 \"Sounds good\"  |  "

--- a/connectonion/core/llm.py
+++ b/connectonion/core/llm.py
@@ -207,6 +207,41 @@ def _is_paid_account_required(error) -> bool:
     return isinstance(detail, dict) and detail.get('error') == 'paid_account_required'
 
 
+# Explicit network bounds for every provider client (#1116).
+#
+# A scheduled run froze mid-iteration with the upstream socket in CLOSE_WAIT:
+# the server had closed its side and the client sat in a read that nothing
+# bounded. No error, no exit, killed by hand after 15 minutes. The fix is not
+# cleverness, it is that no provider client is ever constructed on implicit
+# SDK defaults again — every one carries these numbers, visibly.
+#
+# READ is 600s because a long non-streaming generation legitimately sends no
+# bytes until it finishes; cutting that off would break exactly the runs that
+# matter (#1116: "confirm ordinary long model generations are not cut off").
+# CONNECT is 20s — generous for proxy/VPN users, far below "looks hung".
+#
+# The documented upper bound for a stalled upstream is therefore
+# (1 + max_retries) x 600s per request: ~30 minutes for the default 2 retries,
+# ~60 for OpenOnionLLM's deliberate 5 (transient relay blips used to kill
+# whole agent runs; that decision predates this and stands). Bounded and
+# typed — a stall now ends in LLMConnectionError, never a silent hang.
+LLM_CONNECT_TIMEOUT_SECONDS = 20.0
+LLM_READ_TIMEOUT_SECONDS = 600.0
+LLM_MAX_RETRIES = 2
+
+
+def _network_bounds(max_retries: int = LLM_MAX_RETRIES) -> dict:
+    """Constructor kwargs no provider client is allowed to omit."""
+    import openai
+
+    return {
+        "timeout": openai.Timeout(
+            LLM_READ_TIMEOUT_SECONDS, connect=LLM_CONNECT_TIMEOUT_SECONDS
+        ),
+        "max_retries": max_retries,
+    }
+
+
 @dataclass
 class LLMResponse:
     """Response from LLM including content and tool calls."""
@@ -294,7 +329,7 @@ class OpenAILLM(LLM):
         if not self.api_key:
             raise ValueError("OpenAI API key required. Set OPENAI_API_KEY environment variable or pass api_key parameter.")
         
-        self.client = openai.OpenAI(api_key=self.api_key)
+        self.client = openai.OpenAI(api_key=self.api_key, **_network_bounds())
         self.model = model
     
     def complete(self, messages: List[Dict[str, str]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -380,7 +415,7 @@ class AnthropicLLM(LLM):
         if not self.api_key:
             raise ValueError("Anthropic API key required. Set ANTHROPIC_API_KEY environment variable or pass api_key parameter.")
 
-        self.client = anthropic.Anthropic(api_key=self.api_key)
+        self.client = anthropic.Anthropic(api_key=self.api_key, **_network_bounds())
         self.model = model
         self.max_tokens = max_tokens  # Anthropic requires max_tokens (default 8192)
     
@@ -623,7 +658,8 @@ class GeminiLLM(LLM):
         # Use Gemini's OpenAI-compatible endpoint
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://generativelanguage.googleapis.com/v1beta/openai/"
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+            **_network_bounds(),
         )
         self.model = model
     
@@ -702,7 +738,8 @@ class GroqLLM(LLM):
         self.model = model.removeprefix("groq/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.groq.com/openai/v1"
+            base_url="https://api.groq.com/openai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -780,7 +817,8 @@ class GrokLLM(LLM):
         self.model = model.removeprefix("grok/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.x.ai/v1"
+            base_url="https://api.x.ai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -862,6 +900,7 @@ class OpenRouterLLM(LLM):
         client_kwargs = {
             "api_key": self.api_key,
             "base_url": "https://openrouter.ai/api/v1",
+            **_network_bounds(),
         }
         if default_headers:
             client_kwargs["default_headers"] = default_headers
@@ -942,7 +981,8 @@ class MistralLLM(LLM):
         self.model = model.removeprefix("mistral/")
         self.client = openai.OpenAI(
             api_key=self.api_key,
-            base_url="https://api.mistral.ai/v1"
+            base_url="https://api.mistral.ai/v1",
+            **_network_bounds(),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:
@@ -1162,8 +1202,7 @@ class OpenOnionLLM(LLM):
         self.client = openai.OpenAI(
             base_url=self.base_url,
             api_key=self.auth_token,
-            timeout=openai.Timeout(600.0, connect=20.0),
-            max_retries=5,
+            **_network_bounds(max_retries=5),
         )
 
     def complete(self, messages: List[Dict[str, Any]], tools: Optional[List[Dict[str, Any]]] = None, **kwargs) -> LLMResponse:

--- a/connectonion/useful_tools/outlook.py
+++ b/connectonion/useful_tools/outlook.py
@@ -485,12 +485,17 @@ class Outlook:
 
         return "\n".join(output)
 
-    def download_attachments(self, email_id: str, out_dir: str = ".") -> list[str]:
+    def download_attachments(self, email_id: str, out_dir: str = ".",
+                             include_inline: bool = False) -> list[str]:
         """Save an email's file attachments to disk.
 
         Args:
             email_id: Outlook message ID
             out_dir: Directory to write the files into
+            include_inline: Also save attachments Graph marks ``isInline`` —
+                embedded signature images and logos. Off by default: a mail
+                with one real PDF and a corporate signature otherwise saves
+                four decorative PNGs beside it (#924).
 
         Returns:
             List of saved file paths
@@ -512,6 +517,9 @@ class Outlook:
             content = attachment.get("contentBytes")
             if not content:
                 # itemAttachment and referenceAttachment carry no bytes to write.
+                continue
+            if attachment.get("isInline") and not include_inline:
+                # Embedded signature images and logos, not documents (#924).
                 continue
             # The name is sender-controlled: keep the last path segment only, so
             # "../../.ssh/authorized_keys" cannot escape the chosen directory.

--- a/docs/ai-implementation-contract.md
+++ b/docs/ai-implementation-contract.md
@@ -1,0 +1,92 @@
+# The AI Implementation Contract
+
+An issue that describes only the code change makes an AI session guess the
+operating contract: which release line owns the work, whether a real browser
+journey is required, what evidence must be attached, whether publication is
+authorized. Guessed contracts fail in the same places every time — backend
+unit tests pass while invitation onboarding, Host ↔ React ↔ O Chat
+integration, mobile UI, approvals, reconnect, release artifacts, or
+documentation were never exercised.
+
+The fix is a scoped, configurable section embedded in each feature/bug
+issue. It is not a prompt asking an AI to "finish everything"; it is the
+contract the session executes against. The canonical section lives in
+`.github/ISSUE_TEMPLATE/feature_request.md` (the bug template carries the
+smaller relevant subset). Repository-specific templates may add detail but
+must retain the same vocabulary. Tracked in #1123.
+
+## Repository-specific defaults
+
+### ConnectOnion Core
+
+- Start stable work from the exact stable tag; never back-merge preview `main`.
+- Test protocol writers, permission authority, migration, packaging,
+  Windows/Linux, and installed artifacts.
+- If a change can alter browser-visible behavior, Core unit tests are
+  insufficient: require the React/O Chat consumer journey.
+- After verified stable publication, forward-merge the stable line into `main`.
+
+### `@connectonion/react`
+
+- Own typed OIP normalization, compatibility, acknowledgement, reconnect,
+  and browser authority.
+- Pack the exact candidate tarball and install it as a consumer would.
+- Run the O Chat journey against that tarball before publication.
+- No browser storage or optimistic UI state can increase Host authority.
+
+### O Chat
+
+- Begin at invite-code onboarding and continue through a real connected prompt.
+- Exercise Default/Safe/Full access, approvals, reconnect/error, Work Room,
+  Stop, resume, and Control Center when relevant.
+- Run desktop and phone layouts with no overflow or hidden essential controls.
+- Attach changed-surface screenshots directly to the PR in addition to CI
+  artifacts.
+
+## Default complex acceptance task
+
+For native Codex/Claude Code Work Room changes, use a task long enough to
+exercise multiple states:
+
+1. inspect a clean workspace;
+2. design a C sorting algorithm;
+3. write `sort.c` and a non-trivial `test_sort.c`;
+4. compile with strict warnings;
+5. run normal, duplicate, sorted, reverse, empty, and large inputs;
+6. trigger at least one genuine approval when the selected profile requires it;
+7. fix a discovered issue;
+8. rerun compilation/tests;
+9. finish with a concise result.
+
+The purpose is UI/state coverage — not artificial step inflation. The
+evidence should include several meaningful provider activities, approval,
+terminal success/failure, files, reconnect/Stop where in scope, and the
+final result.
+
+## Upstream UI learning
+
+For coding-agent UI work, perform a fresh audit of the current public Codex
+UI and other explicitly named references at implementation time. Extract
+transferable interaction principles — progressive disclosure, semantic
+summaries, approval placement, status hierarchy — not private assets,
+branding, or provider protocol.
+
+Happy Coder may inform the native-provider → normalized-event → frontend
+translation pattern. OIP remains our protocol and authority boundary.
+
+## Guardrails
+
+- A template checkbox does not authorize a release, deployment, destructive
+  action, or repository-setting change; the issue must select the exact
+  allowed release action.
+- "Fix all issues" means all issues in the named acceptance scope, not
+  unrelated repository backlog.
+- Do not claim an expert audit occurred without recording findings and
+  evidence.
+- Do not hide failures by replacing real integrations with mocks; mocks
+  support deterministic coverage, and a named real journey supplies
+  acceptance.
+- Do not put raw prompts, secrets, credentials, private local paths, or
+  reasoning traces in screenshots or protocol fixtures.
+- Comments and file headers explain non-obvious boundaries; they must not
+  restate the code or become stale duplicate documentation.

--- a/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
+++ b/docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md
@@ -1,0 +1,35 @@
+# A Server Quota Is Not a Ceiling
+
+`co server new` had exactly one region. It said so in the pricing response —
+`"region": "australia-southeast1"` — as a fact, not a choice. That was fine
+until the fourth server: the fifth request came back refunded, with GCE naming
+the exact wall it hit — `Quota 'IN_USE_ADDRESSES' exceeded. Limit: 4.0 in
+region australia-southeast1` — and nothing in the product to do about it. Not
+another region, not a smaller machine. The only moves left were outside the
+CLI entirely: raise the quota by hand, or destroy a server still in use.
+
+The honest fix wasn't a bigger number. A quota that size is a routine ceiling
+on one region, not a statement about how many servers an operator should ever
+have. What was missing was a second place to stand.
+
+`REGIONS` is now a dict of region name to its zones, not a single fixed pair.
+Sydney stays the default — an Australian company keeps a customer's machine
+and data in the country unless they ask otherwise — but it is a default now,
+not the only value that exists. Zones within a region are still tried in
+order, because capacity was always a per-zone accident, never a regional
+verdict; that logic didn't change, it just runs inside whichever region was
+asked for.
+
+The part worth noticing is what *didn't* need to change: a server's region.
+It's read off the `zone` column it already had — `"australia-southeast1-a"`
+split on its last hyphen — rather than stored a second time next to it. Two
+copies of the same fact drift; one, derived, cannot.
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server new` validates `--region` against a list the backend actually
+publishes, the same way `--machine` is checked against real machine types —
+never a value hardcoded on the client side of a line that used to have only
+one value to be right about.

--- a/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
+++ b/docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md
@@ -1,0 +1,42 @@
+# Sharing a Mailbox Is Not the Same as Giving It Away
+
+A rental-outreach pipeline had a mailbox with a history: `rental@mail.openonion.ai`
+had been the sender for months, replies landed there, and a CRM's dedupe rules
+were written around that one address being the one identity. A newly deployed
+agent needed to send the first-touch enquiries from that same address, and
+ownership in the email system was exclusive — one account, one address, no
+exceptions.
+
+Every workaround was a worse trade than the problem. Moving the address to
+the agent took it away from the person who still needed it. A new address for
+the agent split the conversation across two inboxes that nothing reconciled,
+and looked, to anyone replying, like mail from a stranger. Sharing the
+private key solved the technical problem and created a real one: one
+identity now sat on two machines, with no way to tell which had sent what,
+and revoking access meant rotating the key for everyone who held it.
+
+The system already had a mechanism for moving an address between accounts —
+two signatures, a fixed-order message, one irreversible transaction. It's the
+right tool for handing a mailbox over for good. It was the wrong tool here,
+because nothing was ending: the person kept using the address exactly as
+before, and the agent needed to use it too, starting now and stopping the
+moment anyone changed their mind.
+
+What was missing sat in between owning an address and losing it: a grant.
+Revocable, and checked on every request rather than proven once with a
+signature — the natural shape once you notice the server already sits in the
+middle of every send. Nobody has to sign anything offline for a permission
+the server can just look up. `co email share rental@mail.openonion.ai --with
+<agent> --can send` writes one row; `co email unshare` deletes it. Attribution
+falls out of the existing schema for free: every sent-mail record already
+carried the identity of whoever actually sent it, so a shared address stays
+one conversation, sent by two accounts, with no ambiguity about which one did
+what.
+
+The design question worth naming: not every "let account A act as account B"
+problem needs cryptography. A signed, offline-verifiable grant is for the
+case where nobody trustworthy is online to ask — a proxy dialing out through
+a home connection at 3am, say. A mailbox share is answered on every request
+by a server that was already the arbiter. Reaching for the stronger tool
+there wouldn't have made the feature more correct. It would have solved a
+problem this one doesn't have.

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -53,14 +53,26 @@ $ co server new prod
 is free or costs fractions of a cent, so the prompt says the price, what your balance
 becomes, and when the term ends. `--yes` skips it; nothing else does.
 
-The machine is created in **Sydney**, boots Ubuntu 24.04, and carries the SSH key
-derived from your recovery phrase — nothing else is installed. The first
+The machine is created in **Sydney** by default, boots Ubuntu 24.04, and carries the
+SSH key derived from your recovery phrase — nothing else is installed. The first
 `co deploy --to` sets up python, the venv, systemd and Caddy.
 
 | Flag | |
 |---|---|
 | `--machine e2-medium` | 4 GB, for browser agents |
+| `--region asia-southeast1` | provision somewhere other than Sydney |
 | `--yes` | skip the price confirmation |
+
+Each region has its own quota — Sydney's runs out after 4 live servers (a GCE
+external-address ceiling, not ours) — so `--region` is also the way out once you hit
+it:
+
+```bash
+co server new backup --region asia-southeast1
+```
+
+`co server ls` shows an unfamiliar `region` from `co server new`'s own output if you
+forget which one you picked; there is no separate lookup for it yet.
 
 ---
 

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,72 @@
+# Release Visual Evidence
+
+Screenshots proving a release's user-visible changes are part of the release,
+not an expiring CI artifact (#1124). A user opening a GitHub Release or a
+Design Journal entry must be able to see what visibly changed without
+starting O Chat or downloading an Actions artifact that died two weeks ago.
+
+## The manifest
+
+Every release **with user-visible changes** commits a reviewed set under:
+
+```text
+docs/releases/assets/vX.Y.Z/
+  manifest.yml
+  control-center-desktop.webp
+  work-room-approval-mobile.webp
+  cli-template-to-deploy.webp
+```
+
+A backend-only patch commits a manifest with an explicit exemption instead —
+absence of the directory is a failed release check, never a shrug.
+
+### manifest.yml shape
+
+```yaml
+version: v1.6.12
+# EITHER an explicit reviewed exemption:
+no_visual_change: "backend-only patch: LLM network bounds and Outlook CLI fixes"
+# OR the image set:
+images:
+  - file: control-center-desktop.webp
+    alt: "Control Center showing three permission profiles"
+    caption: "The Control Center now names the active permission profile."
+    scenario: "operator opens dashboard after co deploy --to prod"
+    viewport: "1440x900, light"
+    commit: 25fefdf8
+    source_run: "https://github.com/openonion/oo-chat/actions/runs/<id>"
+```
+
+Required per image: `file`, `alt`, `caption`, `scenario`, `viewport`,
+`commit`, `source_run`. The file must exist beside the manifest, be
+non-empty, and stay under 2 MB — optimize without making text unreadable.
+
+### What the set contains
+
+1. **Hero** — the main outcome.
+2. **Narrow/mobile** (375–390 px) where applicable.
+3. **Critical interaction** — approval, reconnect, running state — when one changed.
+4. **Before / After** — required when an existing surface changes materially.
+5. **CLI/terminal capture** — only when the release's primary change is a CLI workflow.
+
+Never publish raw prompts, credentials, invite codes, private local paths,
+reasoning traces, or customer data. The reviewer of the release PR reviews
+the captions and the images, not just the code.
+
+## Validation
+
+```bash
+python scripts/check_release_visuals.py vX.Y.Z
+```
+
+Run it before tagging (it is part of the release checklist in
+VERSIONING.md). It fails when the directory is missing, when a listed file
+is absent/empty/oversized, when required metadata is missing, and when a
+manifest claims both `no_visual_change` and `images`.
+
+## Immutability
+
+A published version's evidence is append-only: retrying a release run may
+repair a missing asset, but replacing reviewed images with unrelated output
+is a review failure, the same as force-pushing a tag. CI artifacts remain
+the full QA record; this directory is the small, reviewed, permanent subset.

--- a/scripts/check_release_visuals.py
+++ b/scripts/check_release_visuals.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate a release's visual-evidence manifest (#1124).
+
+Usage: python scripts/check_release_visuals.py vX.Y.Z
+
+Exit 0 when docs/releases/assets/vX.Y.Z/manifest.yml is a valid reviewed
+set (or a valid explicit exemption); exit 1 with the reason named otherwise.
+Absence is a failure on purpose: "we forgot" and "nothing visible changed"
+must not look the same — the second one is spelled no_visual_change with a
+reviewed reason.
+
+Run by the release checklist (VERSIONING.md), not by CI on every push:
+whether a release has user-visible changes is a human judgement this script
+checks the *recording* of, not one it can make itself.
+"""
+
+import sys
+from pathlib import Path
+
+MAX_IMAGE_BYTES = 2_000_000
+REQUIRED_IMAGE_FIELDS = ("file", "alt", "caption", "scenario", "viewport",
+                         "commit", "source_run")
+
+
+def fail(reason: str) -> "None":
+    print(f"FAIL: {reason}")
+    sys.exit(1)
+
+
+def check(version: str, root: Path = None) -> None:
+    import yaml
+
+    root = root or Path(__file__).resolve().parent.parent
+    asset_dir = root / "docs" / "releases" / "assets" / version
+    manifest_path = asset_dir / "manifest.yml"
+
+    if not manifest_path.exists():
+        fail(f"{manifest_path} does not exist. Every release records its "
+             f"visual evidence — a backend-only patch records "
+             f"no_visual_change with a reviewed reason instead.")
+
+    manifest = yaml.safe_load(manifest_path.read_text()) or {}
+
+    if manifest.get("version") != version:
+        fail(f"manifest says version {manifest.get('version')!r}, "
+             f"checking {version!r}")
+
+    exemption = manifest.get("no_visual_change")
+    images = manifest.get("images")
+
+    if exemption and images:
+        fail("manifest claims BOTH no_visual_change and images — pick one")
+    if not exemption and not images:
+        fail("manifest has neither images nor a no_visual_change reason")
+
+    if exemption:
+        if not isinstance(exemption, str) or len(exemption.strip()) < 10:
+            fail("no_visual_change must be a real reviewed reason, not a nod")
+        print(f"OK: {version} exempt — {exemption.strip()}")
+        return
+
+    for entry in images:
+        missing = [f for f in REQUIRED_IMAGE_FIELDS if not entry.get(f)]
+        if missing:
+            fail(f"image entry {entry.get('file', '<unnamed>')!r} missing: "
+                 f"{', '.join(missing)}")
+        image = asset_dir / entry["file"]
+        if not image.exists():
+            fail(f"{image} is listed but does not exist")
+        size = image.stat().st_size
+        if size == 0:
+            fail(f"{image} is empty")
+        if size > MAX_IMAGE_BYTES:
+            fail(f"{image} is {size} bytes; optimize below {MAX_IMAGE_BYTES}")
+
+    print(f"OK: {version} — {len(images)} reviewed image(s)")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or not sys.argv[1].startswith("v"):
+        print(__doc__)
+        sys.exit(2)
+    check(sys.argv[1])

--- a/tests/cli/test_email_share.py
+++ b/tests/cli/test_email_share.py
@@ -1,0 +1,178 @@
+"""co email share/unshare: let another account act as one of your addresses,
+without moving it (connectonion#1137). Companion to openonion/oo-api#167.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import typer
+
+from connectonion.cli.commands import email_commands
+
+
+def _resp(ok=True, json_data=None, status=200):
+    r = Mock()
+    r.ok = ok
+    r.status_code = status
+    r.json.return_value = json_data
+    r.headers = {"content-type": "application/json"}
+    r.text = ""
+    return r
+
+
+# --- _parse_capabilities ------------------------------------------------
+
+
+def test_parses_both_capabilities():
+    assert email_commands._parse_capabilities("send,read") == {
+        "can_send": True, "can_read": True,
+    }
+
+
+def test_parses_one_capability():
+    assert email_commands._parse_capabilities("send") == {
+        "can_send": True, "can_read": False,
+    }
+
+
+def test_an_unknown_capability_exits_before_any_request(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("delete")
+    assert "Unknown capability" in capsys.readouterr().out
+
+
+def test_an_empty_capability_list_exits(capsys):
+    with pytest.raises(typer.Exit):
+        email_commands._parse_capabilities("")
+    assert "at least one of" in capsys.readouterr().out
+
+
+# --- handle_email_share: granting ---------------------------------------
+
+
+def test_sharing_posts_the_parsed_capabilities():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "grantee_public_key": "0x" + "b" * 64,
+                          "can_send": True, "can_read": False,
+                      })) as post:
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+        )
+
+    payload = post.call_args.kwargs["json"]
+    assert payload == {
+        "address": "rental@mail.openonion.ai",
+        "grantee": "0x" + "b" * 64,
+        "can_send": True,
+        "can_read": False,
+    }
+
+
+def test_sharing_prints_the_unshare_command(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(json_data={
+                          "address": "rental@mail.openonion.ai",
+                          "can_send": True, "can_read": False,
+                      })):
+        email_commands.handle_email_share(
+            "rental@mail.openonion.ai", with_="alice@mail.openonion.ai", can="send",
+        )
+    out = capsys.readouterr().out
+    assert "co email unshare rental@mail.openonion.ai --with alice@mail.openonion.ai" in out
+
+
+def test_missing_arguments_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share("rental@mail.openonion.ai")
+    post.assert_not_called()
+
+
+def test_share_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "post",
+                      return_value=_resp(ok=False, status=403,
+                                         json_data={"detail": "not one of your email addresses."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    assert exc_info.value.exit_code == 1
+    assert "not one of your" in capsys.readouterr().out
+
+
+def test_no_auth_exits_before_any_request():
+    with patch.object(email_commands, "load_api_key", return_value=None), \
+         patch.object(email_commands.requests, "post") as post:
+        with pytest.raises(typer.Exit):
+            email_commands.handle_email_share(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64, can="send",
+            )
+    post.assert_not_called()
+
+
+# --- handle_email_share: --list -----------------------------------------
+
+
+def test_list_shows_both_directions(capsys):
+    body = {
+        "granted_by_me": [{
+            "address": "rental@mail.openonion.ai",
+            "grantee_public_key": "0x" + "b" * 64,
+            "can_send": True, "can_read": False,
+        }],
+        "granted_to_me": [{
+            "address": "leads@mail.openonion.ai",
+            "owner_public_key": "0x" + "c" * 64,
+            "can_send": False, "can_read": True,
+        }],
+    }
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get", return_value=_resp(json_data=body)) as get:
+        email_commands.handle_email_share(list_=True)
+
+    out = capsys.readouterr().out
+    assert "rental@mail.openonion.ai" in out
+    assert "leads@mail.openonion.ai" in out
+    assert get.call_args.args[0].endswith("/api/v1/email/share")
+
+
+def test_list_with_nothing_shared_either_way_is_not_an_error(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "get",
+                      return_value=_resp(json_data={"granted_by_me": [], "granted_to_me": []})):
+        email_commands.handle_email_share(list_=True)  # must NOT raise
+    out = capsys.readouterr().out
+    assert "none" in out
+
+
+# --- handle_email_unshare -------------------------------------------------
+
+
+def test_unshare_deletes_the_grant():
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(json_data={"success": True, "revoked": True})) as delete:
+        email_commands.handle_email_unshare(
+            "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+        )
+    url = delete.call_args.args[0]
+    assert url.endswith(f"/api/v1/email/share/rental@mail.openonion.ai/0x{'b' * 64}")
+
+
+def test_unshare_api_failure_exits_1(capsys):
+    with patch.object(email_commands, "load_api_key", return_value="tok"), \
+         patch.object(email_commands.requests, "delete",
+                      return_value=_resp(ok=False, status=404,
+                                         json_data={"detail": "No active grant."})):
+        with pytest.raises(typer.Exit) as exc_info:
+            email_commands.handle_email_unshare(
+                "rental@mail.openonion.ai", with_="0x" + "b" * 64,
+            )
+    assert exc_info.value.exit_code == 1
+    assert "No active grant" in capsys.readouterr().out

--- a/tests/unit/test_llm_network_bounds.py
+++ b/tests/unit/test_llm_network_bounds.py
@@ -1,0 +1,99 @@
+"""Every provider client carries explicit network bounds (#1116).
+
+A scheduled run froze mid-iteration with the upstream socket in CLOSE_WAIT —
+the server had closed its side and the client sat in a read nothing bounded.
+No error, no exit, killed by hand after 15 minutes.
+
+The property these tests protect is not a number, it is visibility: no
+provider client may be constructed on implicit SDK defaults. The connect
+value doubles as the tripwire — the openai SDK's implicit default is 5s, so
+an accidentally-unbounded client fails the assertion by value, not just by
+style. (Confirmed red on the pre-patch code for every provider except
+OpenOnionLLM, which had the bounds since the relay-blip fix.)
+"""
+
+import pytest
+
+from connectonion.core import llm as llm_module
+from connectonion.core.llm import (
+    LLM_CONNECT_TIMEOUT_SECONDS,
+    LLM_MAX_RETRIES,
+    LLM_READ_TIMEOUT_SECONDS,
+    LLMConnectionError,
+    _network_bounds,
+)
+
+DUMMY_KEY = "sk-test-not-a-real-key"
+
+
+def _provider_clients():
+    """(name, constructed client, expected retries) for every provider."""
+    return [
+        ("OpenAILLM", llm_module.OpenAILLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("AnthropicLLM", llm_module.AnthropicLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GeminiLLM", llm_module.GeminiLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GroqLLM", llm_module.GroqLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("GrokLLM", llm_module.GrokLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("MistralLLM", llm_module.MistralLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        ("OpenRouterLLM", llm_module.OpenRouterLLM(api_key=DUMMY_KEY).client, LLM_MAX_RETRIES),
+        # Deliberately 5: transient relay blips used to kill whole agent runs.
+        ("OpenOnionLLM", llm_module.OpenOnionLLM(api_key=DUMMY_KEY).client, 5),
+    ]
+
+
+def test_every_provider_client_has_the_explicit_bounds():
+    """The whole point of #1116 in one loop.
+
+    One loop rather than parametrize so a new provider that forgets the
+    bounds fails here the moment someone adds it to the list — and the
+    list itself is checked against the module below, so it cannot silently
+    go stale either.
+    """
+    for name, client, expected_retries in _provider_clients():
+        timeout = client.timeout
+        assert timeout.connect == LLM_CONNECT_TIMEOUT_SECONDS, (
+            f"{name}: connect timeout is {timeout.connect!r} — the implicit "
+            f"SDK default, exactly what let the CLOSE_WAIT hang happen"
+        )
+        assert timeout.read == LLM_READ_TIMEOUT_SECONDS, name
+        assert client.max_retries == expected_retries, name
+
+
+def test_the_inventory_covers_every_provider_class():
+    """A provider class this file does not construct is an unchecked client."""
+    import inspect
+
+    covered = {name for name, _, _ in _provider_clients()}
+    all_providers = {
+        name
+        for name, obj in vars(llm_module).items()
+        if inspect.isclass(obj)
+        and issubclass(obj, llm_module.LLM)
+        and obj is not llm_module.LLM
+    }
+    assert covered == all_providers, (
+        f"providers without a bounds check: {sorted(all_providers - covered)}"
+    )
+
+
+def test_a_stalled_read_becomes_the_typed_connection_error():
+    """The user-facing half: a timeout ends in LLMConnectionError, not a hang
+    and not a raw SDK type the caller has to know per-provider."""
+    import openai
+
+    provider = llm_module.OpenAILLM(api_key=DUMMY_KEY)
+
+    def stalled_send():
+        raise openai.APITimeoutError(request=None)
+
+    with pytest.raises(LLMConnectionError):
+        provider._call_provider(stalled_send)
+
+
+def test_the_bounds_are_finite_and_positive():
+    """The documented upper bound — (1 + retries) x read — must be computable."""
+    bounds = _network_bounds()
+    assert 0 < LLM_CONNECT_TIMEOUT_SECONDS < LLM_READ_TIMEOUT_SECONDS
+    assert bounds["max_retries"] >= 0
+    worst_case = (1 + bounds["max_retries"]) * LLM_READ_TIMEOUT_SECONDS
+    assert worst_case <= 3600, "a stall must resolve within an hour, documented"

--- a/tests/unit/test_outlook.py
+++ b/tests/unit/test_outlook.py
@@ -1285,3 +1285,49 @@ class TestDownloadAttachments:
         ])
 
         assert outlook.download_attachments("msg-id", tmp_path / "out") == []
+
+    def test_inline_signature_images_are_skipped_by_default(self, monkeypatch, tmp_path):
+        """One real PDF and a corporate signature must save one file, not five (#924)."""
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "invoice.pdf", "contentBytes": encoded(b"pdf")},
+            {"name": "logo.png", "contentBytes": encoded(b"png"), "isInline": True},
+            {"name": "banner.png", "contentBytes": encoded(b"png"), "isInline": True},
+        ])
+
+        saved = outlook.download_attachments("msg-id", tmp_path / "out")
+
+        assert saved == [str(tmp_path / "out" / "invoice.pdf")]
+        assert not (tmp_path / "out" / "logo.png").exists()
+
+    def test_include_inline_saves_the_embedded_images_too(self, monkeypatch, tmp_path):
+        import base64
+
+        encoded = lambda value: base64.b64encode(value).decode()
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "invoice.pdf", "contentBytes": encoded(b"pdf")},
+            {"name": "logo.png", "contentBytes": encoded(b"png"), "isInline": True},
+        ])
+
+        saved = outlook.download_attachments(
+            "msg-id", tmp_path / "out", include_inline=True
+        )
+
+        assert saved == [
+            str(tmp_path / "out" / "invoice.pdf"),
+            str(tmp_path / "out" / "logo.png"),
+        ]
+
+    def test_an_inline_only_mail_reports_no_attachments(self, monkeypatch, tmp_path):
+        """The signature-only mail is the everyday case the default protects."""
+        import base64
+
+        outlook = self._outlook(monkeypatch, tmp_path, [
+            {"name": "logo.png",
+             "contentBytes": base64.b64encode(b"png").decode(),
+             "isInline": True},
+        ])
+
+        assert outlook.download_attachments("msg-id", tmp_path / "out") == []

--- a/tests/unit/test_release_visuals.py
+++ b/tests/unit/test_release_visuals.py
@@ -1,0 +1,97 @@
+"""The release-visual manifest check (#1124): a UI release cannot skip
+evidence, and a backend-only patch can use the explicit exemption — the
+dry-run pair the issue's workflow requirements name.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "scripts"))
+from check_release_visuals import check  # noqa: E402
+
+
+def _write_manifest(root: Path, version: str, text: str) -> Path:
+    asset_dir = root / "docs" / "releases" / "assets" / version
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "manifest.yml").write_text(text)
+    return asset_dir
+
+
+def test_a_missing_manifest_fails_instead_of_shrugging(tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "does not exist" in capsys.readouterr().out
+
+
+def test_a_backend_only_patch_uses_the_explicit_exemption(tmp_path):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\n'
+                    'no_visual_change: "backend-only patch: network bounds"\n')
+    check("v9.9.9", root=tmp_path)  # must not raise
+
+
+def test_a_nod_is_not_a_reviewed_exemption(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\nno_visual_change: "n/a"\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "reviewed reason" in capsys.readouterr().out
+
+
+def test_claiming_both_exemption_and_images_fails(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v9.9.9\n'
+                    'no_visual_change: "backend-only patch: nothing visible"\n'
+                    'images:\n  - file: x.webp\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "pick one" in capsys.readouterr().out
+
+
+def test_a_ui_release_needs_every_field_and_a_real_file(tmp_path, capsys):
+    asset_dir = _write_manifest(tmp_path, "v9.9.9",
+                                'version: v9.9.9\n'
+                                'images:\n'
+                                '  - file: hero.webp\n'
+                                '    alt: "the hero"\n'
+                                '    caption: "what changed"\n'
+                                '    scenario: "operator opens dashboard"\n'
+                                '    viewport: "1440x900, light"\n'
+                                '    commit: abc123\n'
+                                '    source_run: "https://example.com/run/1"\n')
+    # listed but absent
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "does not exist" in capsys.readouterr().out
+
+    # empty file is as bad as no file
+    (asset_dir / "hero.webp").write_bytes(b"")
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "empty" in capsys.readouterr().out
+
+    # a real file passes
+    (asset_dir / "hero.webp").write_bytes(b"RIFF....WEBP")
+    check("v9.9.9", root=tmp_path)
+
+
+def test_missing_metadata_names_the_fields(tmp_path, capsys):
+    asset_dir = _write_manifest(tmp_path, "v9.9.9",
+                                'version: v9.9.9\n'
+                                'images:\n  - file: hero.webp\n')
+    (asset_dir / "hero.webp").write_bytes(b"RIFF")
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    out = capsys.readouterr().out
+    for field in ("alt", "caption", "scenario", "viewport", "commit", "source_run"):
+        assert field in out
+
+
+def test_the_version_in_the_manifest_must_match(tmp_path, capsys):
+    _write_manifest(tmp_path, "v9.9.9",
+                    'version: v1.0.0\nno_visual_change: "backend-only patch"\n')
+    with pytest.raises(SystemExit):
+        check("v9.9.9", root=tmp_path)
+    assert "v1.0.0" in capsys.readouterr().out

--- a/tests/unit/test_server_commands.py
+++ b/tests/unit/test_server_commands.py
@@ -301,7 +301,8 @@ class TestServerForget:
 
 PRICING = {
     "term_months": 12,
-    "region": "asia-southeast1",
+    "regions": ["asia-southeast1", "australia-southeast1"],
+    "default_region": "asia-southeast1",
     "default": "e2-small",
     "machine_types": {"e2-small": {"usd_12mo": 180.0, "description": "2 vCPU, 2 GB"}},
 }
@@ -406,6 +407,52 @@ class TestServerNewSuccess:
             sc.handle_server_new("prod")
 
         assert post.call_args.kwargs["json"]["ssh_public_key"] == line
+
+
+class TestServerNewRegion:
+    """openonion/connectonion#713 — a region nobody could pick from the CLI."""
+
+    def test_the_chosen_region_is_sent(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod", region="australia-southeast1")
+
+        assert post.call_args.kwargs["json"]["region"] == "australia-southeast1"
+
+    def test_no_region_falls_back_to_the_backends_default(self, servers_file):
+        response = Mock(status_code=200)
+        response.json.return_value = {"ssh_target": "co@1.2.3.4",
+                                      "expires_at": "2027-07-31T00:00:00+00:00",
+                                      "charged_usd": 180.0}
+
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch.object(sc, "_fetch_balance", return_value=500.0), \
+             patch.object(sc, "_confirm", return_value=True), \
+             patch("requests.post", return_value=response) as post:
+            sc.handle_server_new("prod")
+
+        assert post.call_args.kwargs["json"]["region"] == PRICING["default_region"]
+
+    def test_an_unknown_region_is_rejected_before_charging(self, servers_file, capsys):
+        with patch("connectonion.cli.commands.project_cmd_lib.load_api_key", return_value="k"), \
+             patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
+             patch.object(sc, "_fetch_pricing", return_value=PRICING), \
+             patch("requests.post") as post:
+            assert sc.handle_server_new("prod", region="mars-central1") is False
+
+        post.assert_not_called()
+        assert "mars-central1" in capsys.readouterr().out
 
 
 class TestServerNewFailureReporting:
@@ -799,7 +846,8 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     instead of it."""
 
     PRICING = {
-        "term_months": 12, "region": "australia-southeast1", "default": "e2-small",
+        "term_months": 12, "regions": ["australia-southeast1"],
+        "default_region": "australia-southeast1", "default": "e2-small",
         "machine_types": {"e2-small": {"usd_month": 30.0, "usd_12mo": 360.0,
                                        "description": "2 vCPU (shared), 2 GB"}},
     }
@@ -807,7 +855,7 @@ class TestThePromptLeadsWithTheMonthlyPrice:
     def _prompt(self, pricing):
         with patch("questionary.confirm") as confirm:
             confirm.return_value.ask.return_value = False
-            sc._confirm("prod", "e2-small", pricing, 500.0)
+            sc._confirm("prod", "e2-small", pricing["default_region"], pricing, 500.0)
 
     def test_both_the_month_and_the_year_are_shown(self, capsys):
         self._prompt(self.PRICING)
@@ -867,6 +915,8 @@ class TestARecreatedServerDoesNotLookLikeAnAttack:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \
@@ -920,6 +970,8 @@ class TestReadyMeansYouCanLogIn:
         with patch.object(sc, "_ensure_ssh_key", return_value="ssh-ed25519 AAAA x"), \
              patch.object(sc, "_fetch_pricing",
                           return_value={"default": "e2-small",
+                                        "regions": ["australia-southeast1"],
+                                        "default_region": "australia-southeast1",
                                         "machine_types": {"e2-small": {"usd_12mo": 180.0}}}), \
              patch("connectonion.cli.commands.project_cmd_lib.load_api_key",
                    return_value="k"), \

--- a/tests/unit/test_server_new_without_a_terminal.py
+++ b/tests/unit/test_server_new_without_a_terminal.py
@@ -16,7 +16,8 @@ from connectonion.cli.commands import server_commands as sc
 
 
 PRICING = {
-    "region": "australia-southeast1",
+    "regions": ["australia-southeast1"],
+    "default_region": "australia-southeast1",
     "term_months": 12,
     "machine_types": {
         "e2-small": {
@@ -31,7 +32,7 @@ PRICING = {
 def confirm_without_a_tty(capsys):
     with patch.object(sys.stdin, "isatty", return_value=False):
         with patch("questionary.confirm") as prompt:
-            answer = sc._confirm("my-box", "e2-small", PRICING, balance=1000.0)
+            answer = sc._confirm("my-box", "e2-small", "australia-southeast1", PRICING, balance=1000.0)
     return answer, prompt, capsys.readouterr().out
 
 


### PR DESCRIPTION
**Proposed target version:** 1.7.0rc11
**Estimated release window:** next RC after CI and exact-candidate acceptance

## Description

Restores release-line parity before the next 1.7 candidate. It ports the applicable behavioural promises from v1.6.12—server region selection, mailbox share/unshare, explicit provider network bounds, Outlook inline-attachment filtering, the AI implementation contract, template-first delivery guidance, and permanent release evidence—without copying 1.6 version metadata.

Target: 1.7.0rc11. This invalidates the earlier unchanged-RC10 promotion assumption.

## Related Issue

Part of #1265
Release control: #792

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** Codex (GPT-5), using an isolated git worktree and repository release gates.

Least confidence: live provider behaviour under real remote credentials. Exact-candidate Co-browser/Codex/Claude acceptance has not run yet and belongs to the RC11 gate. If wrong, provider timeout construction or Outlook attachment classification should fail first.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Dev Blog

- `docs/blog/2026-08-19-a-server-quota-is-not-a-ceiling.md`
- `docs/blog/2026-08-19-sharing-a-mailbox-is-not-the-same-as-giving-it-away.md`

## Changes Made

- add `co server new --region`
- add scoped `co email share` and `unshare`
- apply explicit connect/read/retry bounds to every provider client
- skip inline Outlook signature images unless `--include-inline` is explicit
- add the AI implementation contract and release-evidence guard
- reconcile README and release-line forward-port rules

## Testing

```text
$ uv run pytest -q <focused server,email,llm,outlook,release suites>
229 passed in 9.15s
```

Repository CI passed Python 3.10–3.13, macOS E2E, Windows E2E, all Windows browser jobs, lockfile, blog, and metadata gates. The local selected suite passed 7,225 tests before its only failure identified a stale sibling docs checkout advertising RC3; rerunning against the verified RC10 docs checkout passes that boundary.

## Scope

One release-integrity concern: every applicable v1.6.12 promise must exist on the supported 1.7 line. Implementation, tests, docs, and release guards move together because omitting any one recreates the propagation gap.

## Example Usage

```bash
co server new backup --region asia-southeast1
co email share agent@example.com teammate@example.com
co outlook download MESSAGE_ID --include-inline
```

## Checklist

- [x] Diff reviewed
- [x] Tests and docs included
- [x] Dev-blog entries included
- [x] No old version metadata copied
- [x] Full CI matrix completed
- [ ] RC11 installed-artifact/browser/provider gate completed
- [ ] Permanent visual evidence recorded or explicitly exempted

## Screenshots

No product UI changes. RC11 evidence will be recorded by the release gate; this PR does not upload or claim O Chat #232 screenshots.

## Additional Notes

Do not publish Stable from this branch. Merge it, cut RC11, and repeat the exact installed-candidate gate before updating the Stable promotion PR.