### PR TITLE
ci: enforce patch forward integration on 1.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,39 +7,47 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+A clear and concise description of what is broken.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+## Release planning
+- **Affected ConnectOnion version:** [e.g. 1.7.0a3]
+- **Suggested target version:** [e.g. next patch, 1.8.0, 2.x, or TBD]
+- **Estimated release window:** [e.g. urgent patch, next alpha, future roadmap, or unknown]
+- **Why this priority:** Explain the user impact and whether a workaround exists.
+- **Forward-port tracking issue (stable patches only):** [link the separate open issue labelled `forward-port-required`; use N/A otherwise]
+
+> The reporter's target is an estimate. Maintainers confirm the release by assigning a milestone.
+
+## To reproduce
 1. Install ConnectOnion version '...'
-2. Run code '....'
+2. Run code '...'
 3. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Code Example**
+## Code example
 ```python
-# Minimal code example that reproduces the issue
 from connectonion import Agent
 
-# Your code here
+# Minimal reproduction
 ```
 
-**Error Output**
+## Error output
 ```
 # Paste the full error traceback here
 ```
 
-**Environment (please complete the following information):**
- - OS: [e.g. macOS, Ubuntu, Windows]
- - Python Version: [e.g. 3.10, 3.11, 3.12]
- - ConnectOnion Version: [e.g. 0.0.5]
- - OpenAI API Key configured: [yes/no]
+## Environment
+- OS: [e.g. macOS, Ubuntu, Windows]
+- Python version: [e.g. 3.10, 3.11, 3.12]
+- ConnectOnion version: [e.g. 1.7.0a3]
+- OpenAI API key configured: [yes/no]
 
-**Additional context**
-Add any other context about the problem here.
+## Additional context
+Add any other context, screenshots, or examples.
+
 ## AI implementation contract
 
 <!-- The bug-sized subset. Full guidance, repository defaults, and
@@ -73,3 +81,12 @@ Add any other context about the problem here.
 - [ ] The regression test's red run (pre-patch) is recorded in the PR.
 - [ ] Before/After behavior is shown, not asserted.
 - [ ] If user-visible: screenshots attached directly to the PR.
+
+### Stable-patch forward integration
+- [ ] A separate `forward-port-required` issue names every active higher line,
+      at minimum the current preview.
+- [ ] Each applicable fix, regression test, migration, documentation change,
+      and operational contract has a focused forward-port PR or an explicit
+      maintainer-reviewed inapplicability decision.
+- [ ] The tracker remains open until those PRs merge and pass CI; no newer
+      preview, RC, or next-minor Stable publishes first.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -95,7 +95,13 @@ Add any other context, screenshots, or examples about the feature request here.
 - [ ] Publish only through the protected GitHub Preview/Release workflow explicitly
       authorized above.
 - [ ] Re-test the public artifact and deployed Preview.
-- [ ] After a stable release is verified, forward-merge that stable line into
-      `main`; preserve newer OIP authority and resolve conflicts explicitly.
+- [ ] If this is a stable patch, open a separate `forward-port-required` issue
+      naming every active higher line before the patch PR merges.
+- [ ] After a stable patch is verified, forward-port every applicable fix,
+      regression test, migration, documentation change, and operational
+      contract into every active higher line; preserve newer OIP authority and
+      resolve conflicts explicitly instead of copying version metadata.
+- [ ] Keep that tracker open until every forward-port PR merges and passes CI.
+      No newer preview, RC, or next-minor Stable publishes first.
 - [ ] Link rollback instructions, immutable versions/hashes, PRs, screenshots, and
       public release.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,17 @@ Brief description of what this PR does.
 ## Related Issue
 Fixes #(issue number)
 
+## Labels and target release (required)
+
+- **Suggested labels:** [bug, feature, documentation, tests, design, browser, platform]
+- **Proposed target version:** [e.g. next patch, 1.8.0, 2.x, or TBD]
+- **Estimated release window:** [e.g. next alpha, next stable, future roadmap, or unknown]
+- **Milestone:** [maintainer assigns the confirmed release milestone]
+- **Why this release:** Explain urgency, dependencies, compatibility, and rollback risk.
+- **Forward-port tracking issue (stable patches only):** [link an open `forward-port-required` issue, for example #123; use N/A for non-patch work]
+
+> The author's target is an estimate. Maintainers confirm the release by applying labels and assigning a milestone.
+
 ## How this was written
 
 - [ ] I wrote this myself
@@ -34,7 +45,9 @@ A PR that says *"I didn't test the Windows path and I'm unsure the retry logic i
 
 ## Dev Blog (required)
 
-**Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`): a PR that touches no `docs/blog/` file fails the check. The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
+**Every PR ships a dev-blog post in the same diff** — a file added or updated under `docs/blog/`. This is enforced by CI (`blog-gate`).
+
+The posts sync to the docs site, so writing it here is what keeps the site current without anyone asking.
 
 What the post is: a short Design Journal piece telling the **story** of this change — the problem as someone actually hit it, a turn or complication, what the fix teaches, what was measured. Written for a reader who could stop reading at any point.
 What it is not: a changelog entry, a list of commits, or marketing copy.
@@ -58,7 +71,6 @@ Paste the actual command and its real output. The output is the evidence — a t
 
 ```
 $ pytest tests/ -m "not real_api and not network"
-
 ```
 
 - [ ] I have added tests for new functionality
@@ -73,13 +85,13 @@ Keep a PR to one concern. A change that spans several subsystems at once is hard
 
 ## Example Usage
 ```python
-# Show how to use any new features or fixes
 from connectonion import Agent
 
-# Example code
+# Show how to use any new features or fixes
 ```
 
 ## Checklist
+- [ ] I proposed at least one label and a target version above
 - [ ] My code follows the project's code style
 - [ ] I have read every line of this diff and can defend each change
 - [ ] I have commented my code, particularly in hard-to-understand areas
@@ -87,6 +99,9 @@ from connectonion import Agent
 - [ ] This PR ships its dev-blog post under docs/blog/ (or a maintainer applied `no-blog`)
 - [ ] My changes generate no new warnings
 - [ ] Any dependent changes have been merged and published
+- [ ] If this targets a stable patch, its separate `forward-port-required`
+      tracker names every active higher line, at minimum the current preview,
+      and will remain open until all applicable forward-port PRs merge and pass CI
 - [ ] Every piece of evidence the linked issue's **AI implementation contract**
       requires is attached or linked here (tests, journeys, screenshots,
       exact commands) — see docs/ai-implementation-contract.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
     permissions:
       contents: read
+      issues: read
 
     steps:
       - name: Checkout the exact release commit
@@ -97,6 +98,26 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse a newer release while stable patch fixes are missing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "$TAG is already public; allowing an immutable recovery retry."
+            exit 0
+          fi
+          open_issues="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label forward-port-required \
+            --limit 100 \
+            --json number,title,url)"
+          python scripts/check_forward_port_gate.py \
+            --version "$VERSION" \
+            --issues-json "$open_issues"
 
       - name: Build and validate only this version's artifacts
         env:

--- a/.github/workflows/triage-metadata.yml
+++ b/.github/workflows/triage-metadata.yml
@@ -1,0 +1,95 @@
+name: triage-metadata
+
+on:
+  issues:
+    types: [opened, reopened, edited, unlabeled]
+  pull_request_target:
+    types: [opened, reopened, edited, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  labels-and-release-target:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require labels and release planning metadata
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const item = context.payload.issue || context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = item.number;
+            const isPullRequest = Boolean(context.payload.pull_request);
+
+            let labels = item.labels.map(label => label.name);
+            if (labels.length === 0) {
+              const title = item.title.toLowerCase();
+              let label = 'needs-triage';
+
+              if (/^(fix|bug)(\(.+\))?:/.test(title) || title.startsWith('[bug]')) label = 'bug';
+              else if (/^(feat|feature)(\(.+\))?:/.test(title) || title.startsWith('[feature]')) label = 'feature';
+              else if (/^docs?(\(.+\))?:/.test(title)) label = 'documentation';
+              else if (/^tests?(\(.+\))?:/.test(title)) label = 'tests';
+              else if (/^(design|rfc)(\(.+\))?:/.test(title) || title.startsWith('[rfc]')) label = 'design';
+
+              if (label === 'needs-triage') {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name: label });
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color: 'ededed',
+                    description: 'Needs maintainer classification and release planning',
+                  });
+                }
+              }
+
+              await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+              labels = [label];
+              core.notice(`Applied ${label} to #${issue_number}.`);
+            }
+
+            if (!isPullRequest) return;
+
+            const body = item.body || '';
+            const target = body.match(/\*\*Proposed target version:\*\*\s*([^\n\r]+)/i)?.[1]?.trim();
+            const window = body.match(/\*\*Estimated release window:\*\*\s*([^\n\r]+)/i)?.[1]?.trim();
+            const forwardTracker = body.match(/\*\*Forward-port tracking issue \(stable patches only\):\*\*\s*([^\n\r]+)/i)?.[1]?.trim();
+            const placeholder = value => !value || /^\[/.test(value) || /^(tbd|unknown)$/i.test(value);
+
+            if (placeholder(target) || placeholder(window)) {
+              core.setFailed(
+                'Fill in Proposed target version and Estimated release window in the PR template. ' +
+                'Use an honest estimate such as “1.8.0 / next alpha” or “future roadmap / unknown date”.'
+              );
+            }
+
+            const stablePatchTarget = /\bnext patch\b/i.test(target || '') ||
+              /\b\d+\.\d+\.[1-9]\d*\b/.test(target || '');
+            if (stablePatchTarget) {
+              const issueMatch = (forwardTracker || '').match(/(?:#|\/issues\/)(\d+)\b/);
+              if (!issueMatch) {
+                core.setFailed(
+                  'Stable patch PRs must link a separate open forward-port tracking issue.'
+                );
+                return;
+              }
+              const tracker = await github.rest.issues.get({
+                owner, repo, issue_number: Number(issueMatch[1]),
+              });
+              const trackerLabels = tracker.data.labels.map(label =>
+                typeof label === 'string' ? label : label.name
+              );
+              if (tracker.data.state !== 'open' || !trackerLabels.includes('forward-port-required')) {
+                core.setFailed(
+                  'The stable patch forward-port tracker must be open and labelled forward-port-required.'
+                );
+              }
+            }

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -164,6 +164,11 @@ When releasing a new version:
 - [ ] Refresh `uv.lock`
 - [ ] Keep the one PyPI `Development Status` classifier aligned with the phase:
       Alpha for `aN`, Beta for `bN`/`rcN`, and Production/Stable for a final
+- [ ] For every stable patch, open a dedicated forward-integration issue labelled
+      `forward-port-required`. List every active higher release line (at minimum
+      the current preview), the patch commits that apply there, and the PR that
+      carries each one. Version-only metadata is not a product fix and must not
+      be copied into a newer line.
 - [ ] Update the matching stable or preview channel in the docs site's `lib/version.ts`
 - [ ] Draft or substantially update a Design Journal post for a feature-train
       launch, first beta, first RC, stable release, or material architecture or
@@ -190,12 +195,33 @@ When releasing a new version:
       version state and Design Journal. Verify the canonical URL, social and
       structured metadata, sitemap, AI-readable indexes, internal links, and
       mobile layout.
+- [ ] After a stable patch is verified, forward-port every applicable fix into
+      every active higher line and close its `forward-port-required` issue only
+      after those PRs merge and pass their own CI. No later preview, RC, or
+      next-minor Stable may publish while such an issue remains open.
 
 Replace `X.Y.Z` with the complete canonical version, including `aN`, `bN`, or
 `rcN`. Manual workflow dispatch may retry an existing reviewed tag; it is not
 an arbitrary-branch release path. This procedure has no workstation publication
 path. Recovery must preserve the reviewed tag and artifacts and be implemented
 as a separate reviewed workflow change, not an ad hoc second registry writer.
+
+### Stable patches move forward
+
+A stable patch fixes the oldest supported line first; it must not make the
+newest testable line older in behaviour. Once `X.Y.Z` with `Z > 0` is public,
+each applicable product, test, documentation, migration, and operational fix
+must be forward-ported to every active higher line, including the current
+preview. Use reviewed commits or a focused PR and resolve newer-line conflicts
+deliberately. Do not merge stable version numbers, channel metadata, or release
+notes into the preview merely to manufacture ancestry.
+
+The patch's dedicated `forward-port-required` issue is the durable ledger. It
+stays open until every active line has either a merged PR with CI evidence or a
+maintainer-reviewed explanation that the fix is inapplicable. The protected
+release workflow refuses a new preview, RC, or next-minor Stable while any such
+ledger remains open. Retrying an already-published immutable tag remains a
+recovery operation and is not blocked by work discovered later.
 
 The suite above it runs against the source tree, where every file is present
 whether or not it is packaged. Nothing else looks at the artifact that goes to

--- a/docs/ai-implementation-contract.md
+++ b/docs/ai-implementation-contract.md
@@ -24,7 +24,15 @@ must retain the same vocabulary. Tracked in #1123.
   Windows/Linux, and installed artifacts.
 - If a change can alter browser-visible behavior, Core unit tests are
   insufficient: require the React/O Chat consumer journey.
-- After verified stable publication, forward-merge the stable line into `main`.
+- Every stable patch opens a dedicated `forward-port-required` tracking issue
+  before its PR merges. After verified publication, forward-port every
+  applicable fix, regression test, migration, documentation change, and
+  operational contract into every active higher line, at minimum the current
+  preview. Keep the tracker open until each PR merges and passes CI.
+- Do not copy stable version/channel metadata into a preview merely to create
+  ancestry. Resolve the product commits against the newer architecture.
+- A newer preview, RC, or next-minor Stable cannot publish while any
+  `forward-port-required` tracker remains open.
 
 ### `@connectonion/react`
 

--- a/docs/blog/2026-08-25-a-patch-must-move-forward.md
+++ b/docs/blog/2026-08-25-a-patch-must-move-forward.md
@@ -1,0 +1,38 @@
+---
+title: "A patch must move forward"
+date: 2026-08-25
+author: ConnectOnion Team
+---
+
+We were preparing 1.7 Stable when an ancestry audit found something backwards:
+the public 1.6.12 maintenance release contained fixes that RC10 did not. The
+newest test version was newer by number and older in several behaviours.
+
+Merging the whole stable branch into the preview looked like the obvious fix.
+It was also the dangerous one. A maintenance branch carries its own version,
+channel metadata, release notes, and assumptions about an older architecture.
+A blind merge can overwrite deliberate preview changes while making the graph
+look reassuringly connected.
+
+We instead reviewed every 1.6.12 change, forwarded the applicable product,
+test, documentation, migration, and operational commits into 1.7 and 1.8, and
+cut RC11. That repaired this release, but a one-time audit would allow the same
+failure next month.
+
+The release contract now gives every stable patch a durable forward-integration
+ledger. Before a patch PR merges, it links a separate open issue labelled
+`forward-port-required`. That issue names every active higher line and records
+either the focused PR carrying each fix or a maintainer-reviewed reason the fix
+does not apply. It closes only after those PRs merge and pass CI.
+
+The second half of the rule is mechanical: while any such ledger is open, the
+protected workflow refuses to publish a newer preview, RC, or next-minor Stable.
+The patch itself may still ship quickly to users who need it. An immutable tag
+that is already public may also be retried for recovery. What cannot happen is
+moving the preview channel forward while knowingly leaving a stable fix behind.
+
+This adds coordination work to every patch, but it puts that cost where it is
+visible. We would revisit the mechanism if release lines can declare and verify
+machine-readable patch equivalence directly. Until then, a linked issue, focused
+PRs, and a hard release gate are simpler than discovering at Stable promotion
+that the newest candidate forgot yesterday's repair.

--- a/scripts/check_forward_port_gate.py
+++ b/scripts/check_forward_port_gate.py
@@ -1,0 +1,52 @@
+"""Block newer releases while a stable patch is missing from active lines."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from typing import Any
+
+
+STABLE_PATCH = re.compile(r"^\d+\.\d+\.[1-9]\d*$")
+
+
+def release_needs_clear_forward_ports(version: str) -> bool:
+    """Patch publication may proceed; every newer channel requires a clear ledger."""
+
+    return STABLE_PATCH.fullmatch(version) is None
+
+
+def open_forward_port_issues(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ValueError("GitHub issue payload must be a list")
+    return [issue for issue in payload if isinstance(issue, dict)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--issues-json", required=True)
+    args = parser.parse_args()
+
+    if not release_needs_clear_forward_ports(args.version):
+        print(f"{args.version} is a stable patch; forward integration follows publication.")
+        return 0
+
+    issues = open_forward_port_issues(json.loads(args.issues_json))
+    if not issues:
+        print(f"{args.version} has no open stable-patch forward-port blockers.")
+        return 0
+
+    lines = [
+        f"#{issue.get('number')}: {issue.get('title')} ({issue.get('url')})"
+        for issue in issues
+    ]
+    raise SystemExit(
+        "Refusing to publish a newer release while stable patch fixes are missing:\n"
+        + "\n".join(lines)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_patch_forward_integration_contract.py
+++ b/tests/unit/test_patch_forward_integration_contract.py
@@ -1,0 +1,62 @@
+"""Stable patches must never leave the active preview behind."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.check_forward_port_gate import (
+    open_forward_port_issues,
+    release_needs_clear_forward_ports,
+)
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize("version", ["1.7.1", "1.7.12", "20.3.4"])
+def test_a_stable_patch_can_publish_before_its_forward_ports(version):
+    assert release_needs_clear_forward_ports(version) is False
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.8.0a2", "1.8.0b1", "1.8.0rc1", "1.8.0", "2.0.0"],
+)
+def test_every_newer_channel_requires_a_clear_forward_port_ledger(version):
+    assert release_needs_clear_forward_ports(version) is True
+
+
+def test_the_gate_preserves_issue_evidence():
+    issues = [{"number": 42, "title": "carry 1.7.1 into 1.8", "url": "https://example/42"}]
+    assert open_forward_port_issues(json.loads(json.dumps(issues))) == issues
+
+
+def test_the_gate_rejects_a_non_list_github_payload():
+    with pytest.raises(ValueError, match="must be a list"):
+        open_forward_port_issues({"number": 42})
+
+
+def test_release_guidance_and_templates_keep_the_contract_visible():
+    files = [
+        "VERSIONING.md",
+        "docs/ai-implementation-contract.md",
+        ".github/pull_request_template.md",
+        ".github/ISSUE_TEMPLATE/bug_report.md",
+        ".github/ISSUE_TEMPLATE/feature_request.md",
+    ]
+    for name in files:
+        text = (REPO / name).read_text(encoding="utf-8")
+        assert "forward-port-required" in text, name
+        assert "preview" in text.lower(), name
+
+
+def test_github_enforces_the_tracker_at_pr_and_release_boundaries():
+    triage = (REPO / ".github/workflows/triage-metadata.yml").read_text(encoding="utf-8")
+    release = (REPO / ".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert "const forwardTracker" in triage
+    assert "tracker.data.state !== 'open'" in triage
+    assert "forward-port-required" in triage
+    assert "scripts/check_forward_port_gate.py" in release
+    assert "issues: read" in release


### PR DESCRIPTION
## Description

Backports the stable-patch forward-integration release gate to the active `release/1.7` maintenance line so the rule governs 1.7.x patches immediately, not only future branches cut from `main`.

## Related Issue

Part of #1271. Main-line implementation: #1272.

## Labels and target release (required)

- **Suggested labels:** documentation, tests, design
- **Proposed target version:** 1.7.x release policy
- **Estimated release window:** before 1.7 Stable / first 1.7 patch
- **Milestone:** maintainer assigns
- **Why this release:** Without this backport, the next 1.7 patch could be published under the old process and never reach 1.8 preview.
- **Forward-port tracking issue (stable patches only):** N/A — release policy, not a stable patch

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** OpenAI Codex

The branch had older contribution templates and no triage-metadata workflow, so this backport carries the current metadata foundation required to validate the new tracker field. I did not publish a package. If the gate is wrong, metadata validation or release publication fails closed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update

## Dev Blog (required)

> docs/blog/2026-08-25-a-patch-must-move-forward.md

## Testing

```text
$ uv run pytest tests/unit/test_patch_forward_integration_contract.py tests/unit/test_the_release_checklist_names_real_files.py tests/unit/test_release_workflow.py -q
45 passed in 2.78s
```

- [x] I have added tests for new functionality

## Scope

The same release gate, helper, tests, templates, and policy documentation as #1272, applied to `release/1.7`. The metadata workflow is included because this older branch did not yet contain the validator used by the stable-patch contract.

## Checklist

- [x] I proposed labels and a target version
- [x] I reviewed the backport diff and resolved its template conflicts
- [x] The focused release-policy tests pass on `release/1.7`
- [x] This is not itself a stable patch
- [x] No package version or channel metadata changed
