### PR TITLE
fix(auto): honor headless command grants safely

### DIFF
--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from ...core.events import before_each_tool
 from ...core.mode import AUTO, FULL_ACCESS, READ_ONLY, mode_id, mode_of, set_mode
 from ...project import project_root
-from .bash_parser import _extract_subcommands
+from .bash_parser import _extract_subcommands, check_bash_chain_permitted
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -269,15 +269,68 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             requires_human=bool(agent.io),
         )
     if not agent.io and result["decision"] == "ask":
-        result = decision(
-            result["effect_class"],
-            "deny",
-            f"{result['reason']}; no approval channel is available",
-            result["scope"],
-        )
+        configured = _headless_configured_command(agent, pending, result)
+        if configured is not None:
+            result = configured
+        else:
+            result = decision(
+                result["effect_class"],
+                "deny",
+                f"{result['reason']}; no approval channel is available",
+                result["scope"],
+            )
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)
     return result
+
+
+def _headless_configured_command(
+    agent: "Agent", pending: dict, result: dict
+) -> dict | None:
+    """Honor an operator's standing command grant without weakening Auto.
+
+    Only ordinary commands reach this path. Publication, deployment, network,
+    credential, deletion, and unknown effects keep their stronger verdict even
+    when a broad legacy pattern such as ``Bash(co *)`` happens to match.
+    """
+    if result.get("effect_class") != "command" or pending.get("name") != "bash":
+        return None
+    permissions = agent.current_session.get("permissions")
+    if not isinstance(permissions, dict):
+        return None
+    configured = {
+        pattern: permission
+        for pattern, permission in permissions.items()
+        if isinstance(permission, dict) and permission.get("source") == "config"
+    }
+    # The shipped historical Bash(co *) grant is broader than its "safe CLI"
+    # description. Preserve the unattended browser/status compatibility users
+    # relied on without silently authorizing email, account, server, or payment
+    # commands. Operators can still name a narrower command explicitly.
+    broad_co = configured.pop("Bash(co *)", None)
+    if broad_co is not None:
+        subcommands = _extract_subcommands(
+            str((pending.get("arguments") or {}).get("command", ""))
+        )
+        if subcommands and all(
+            full == "co status" or full.startswith("co browser ")
+            for _, full in subcommands
+        ):
+            configured["Bash(co *)"] = broad_co
+    try:
+        permitted, _, _ = check_bash_chain_permitted(
+            str((pending.get("arguments") or {}).get("command", "")), configured
+        )
+    except Exception:
+        return None
+    if not permitted:
+        return None
+    return decision(
+        "configured_command",
+        "allow",
+        "operator-configured command allowlist",
+        "call",
+    )
 
 
 @before_each_tool

--- a/docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md
+++ b/docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md
@@ -1,0 +1,36 @@
+---
+title: "Headless does not mean unconfigured"
+date: 2026-08-25
+author: ConnectOnion Team
+---
+
+A launchd job upgraded from 1.6 to the 1.7 release candidate and stopped on its
+first action. The command was `co browser status`, already covered by the
+operator's standing `Bash(co *)` permission, but Auto classified every command
+outside its small verification list as requiring a live approval. With stdin
+closed there was no dialog, so the safe failure became a complete outage for
+deliberately unattended agents.
+
+Allowing every historical config match would have restored the job by weakening
+the newer boundary. In particular, the shipped `Bash(co *)` pattern is much
+broader than its old “safe CLI” description: taken literally, it can include
+deployment, email, account, and payment actions. Treating that wildcard as an
+unlimited unattended grant would turn compatibility into escalation.
+
+Headless Auto now distinguishes “nobody is present” from “nobody configured
+this.” An operator-authored command rule can satisfy an ordinary command that
+would otherwise ask. The shipped broad `co` compatibility rule is accepted only
+for `co status` and `co browser ...`, which restores the existing cron/browser
+workflow. Publication and deployment keep their stronger policy verdict, while
+other framework effects such as email remain denied unless the operator writes
+a narrower, deliberate rule or chooses bounded Full access for the whole task.
+
+Regression coverage runs the exact no-IO approval path for one command and a
+command chain. It also proves the same broad rule cannot silently authorize
+`co deploy`, `co publish`, or `co email send`. The surrounding parser,
+configuration, approval, and Auto-policy suites pass together.
+
+This preserves a security tradeoff: a sufficiently narrow operator permission
+is authority, even without a person online. We would revisit the mechanism when
+permissions carry first-class effect classes instead of deriving intent from
+command text and legacy patterns.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -141,6 +141,28 @@ The public mode is exactly `full-access`; its canonical `turns_left` budget
 decrements only after completed user-driven turns. It does not synthesize a
 follow-up prompt or continue the Agent on its own.
 
+## Unattended one-shot permissions
+
+One-shot commands launched by cron or CI have no approval dialog. Auto still
+fails closed for unknown, destructive, credential, publication, deployment,
+and external-effect calls, but it honors operator-authored `Bash(...)` command
+permissions from the active `.co/host.yaml` for ordinary commands.
+
+The shipped compatibility grant allows unattended `co status` and
+`co browser ...` commands, including browser workflows that already ran under
+1.6.x:
+
+```bash
+co ai -m co/gemini-3.7-flash "/linkedin-notifications ..." < /dev/null
+```
+
+The broad historical `Bash(co *)` entry does not silently authorize other
+framework effects such as `co deploy`, `co publish`, or `co email send` in
+headless Auto. Add a narrower project permission when an operator deliberately
+wants a particular ordinary command. Use bounded `--full-access` only when the
+whole unattended task is trusted to perform effects that still require a human
+under Auto.
+
 ## What the Agent Can Do
 
 The agent has a full suite of tools for coding tasks:

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -162,6 +162,13 @@ same Host-advertised modes.
 
 Auto-approve safe commands permanently via `host.yaml` configuration. Config permissions never expire and apply to all sessions.
 
+In a headless one-shot run, a matching operator-configured `Bash(...)` rule can
+approve an ordinary command even though no dialog exists. Auto continues to
+deny destructive, credential, publication, deployment, external-effect, and
+unknown calls. For compatibility, the shipped broad `Bash(co *)` rule is
+narrowed at this boundary to `co status` and `co browser ...`; commands such as
+`co deploy`, `co publish`, and `co email send` do not inherit silent authority.
+
 ### Configuration
 
 Add permissions to `.co/host.yaml`:

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -6,6 +6,7 @@ import pytest
 
 from connectonion.cli.co_ai.agent import grant_managed_delegation_permissions
 from connectonion.useful_plugins.tool_approval import check_approval, tool_approval
+from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
 from connectonion.useful_plugins.tool_approval.policy import (
     POLICY_ID,
     apply_auto_approve_policy,
@@ -280,6 +281,88 @@ def test_headless_auto_still_allows_a_reversible_workspace_edit(
     check_approval(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["co browser status", "co browser status && co status"],
+)
+def test_headless_auto_honors_the_operator_command_allowlist(
+    tmp_path, monkeypatch, command
+):
+    """Regression for #1270: cron has no dialog, but does have standing grants."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions={
+        "Bash(co *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "operator standing grant",
+            "when": {"command": "co *"},
+        }
+    })
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": command},
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow"
+    assert result["effect_class"] == "configured_command"
+    assert result["reason"] == "operator-configured command allowlist"
+
+
+def test_packaged_permissions_keep_headless_co_browser_status_working(
+    tmp_path, monkeypatch
+):
+    """Exercise the same shipped permission source used by a fresh 1.7 install."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=load_permission_patterns(tmp_path / ".co"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": "co browser status"},
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    ("command", "effect"),
+    [
+        ("co deploy", "publication"),
+        ("co publish", "publication"),
+        ("co email send --to a@example.com hi", "command"),
+    ],
+)
+def test_headless_broad_co_grant_cannot_authorize_stronger_effects(
+    tmp_path, monkeypatch, command, effect
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions={
+        "Bash(co *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "legacy broad CLI permission",
+            "when": {"command": "co *"},
+        }
+    })
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": command},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny"
+    assert result["effect_class"] == effect
+    with pytest.raises(ValueError, match="denied by connectonion.auto"):
+        check_approval(instance)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Restores intentionally unattended `co ai` browser/status workflows without weakening the 1.7 Auto policy into a blanket whitelist bypass.

## Related Issue

Part of #1270. The issue remains open until the same product fix is merged into main/1.8.

## Labels and target release (required)

- **Suggested labels:** bug, tests, design
- **Proposed target version:** 1.7.0 Stable
- **Estimated release window:** before 1.7.0 Stable publication
- **Milestone:** 1.7.0 — ACP + coding-agent preview train
- **Why this release:** rc11 is a breaking upgrade for cron/CI agents: the first permitted `co browser status` call is denied because no dialog exists. This restores the 1.6 workflow while retaining fail-closed handling for stronger effects.
- **Forward-port tracking issue (stable patches only):** N/A — 1.7.0 release blocker; #1270 tracks the required main/1.8 forward-port

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** OpenAI Codex

The compatibility boundary intentionally recognizes the historical broad `Bash(co *)` grant only for `co status` and `co browser ...`; other ordinary commands require a narrower operator rule. I did not run the production LinkedIn job. If this is wrong, a headless action fails closed with the existing denial instead of executing silently.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Dev Blog

> docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md

## Changes Made

- Allow headless Auto to reuse operator-configured `Bash(...)` grants for ordinary commands.
- Restore packaged `co browser ...` and `co status` compatibility.
- Keep deployment/publication and non-browser framework effects denied under the broad legacy rule.
- Document unattended configuration and bounded Full access.

## Testing

```text
$ uv run pytest tests/unit/test_auto_approve_policy.py tests/unit/test_tool_approval.py tests/unit/test_config_permissions.py tests/unit/test_bash_parser.py -q
152 passed in 8.63s
```

- [x] Covers the exact no-IO `co browser status` path using packaged permissions
- [x] Covers a permitted command chain
- [x] Proves `co deploy`, `co publish`, and `co email send` remain denied

## Scope

Only the Auto headless decision boundary, focused permission tests, CLI/plugin documentation, and its design-journal record.

## Release Impact

- [x] Release candidate blocker: no new planned feature

## Checklist

- [x] Proposed labels and 1.7 target
- [x] Reviewed every changed line
- [x] Documentation updated
- [x] No package version metadata changed
- [x] Main/1.8 forward-port remains tracked by #1270
