### PR TITLE
fix: forward-port complete image validation to 1.8

### DIFF
--- a/connectonion/useful_plugins/image_result_formatter.py
+++ b/connectonion/useful_plugins/image_result_formatter.py
@@ -22,6 +22,7 @@ tests/e2e/test_image_formatter_plugin.py.
 import os
 import re
 import base64
+import binascii
 import requests
 from typing import TYPE_CHECKING
 from ..core.events import after_tools
@@ -44,21 +45,49 @@ def _is_base64_image(text: str) -> tuple[bool, str, str]:
 
     # Check for data URL format: data:image/png;base64,iVBORw0KGgo...
     data_url_pattern = r'data:image/(png|jpeg|jpg|gif|webp);base64,([A-Za-z0-9+/=]+)'
-    match = re.search(data_url_pattern, text)
-
-    if match:
+    for match in re.finditer(data_url_pattern, text):
         image_type = match.group(1)
         base64_data = match.group(2)
         mime_type = f"image/{image_type}"
-        return True, mime_type, base64_data
+        if _decode_complete_image(base64_data, mime_type) is not None:
+            return True, mime_type, base64_data
 
     # Check if entire result is base64 (common for screenshot tools)
     # Base64 strings are typically long and contain only valid base64 characters
-    if len(text) > 100 and re.match(r'^[A-Za-z0-9+/=\s]+$', text):
+    if len(text) > 32 and re.fullmatch(r'[A-Za-z0-9+/=\s]+', text):
         # Likely a base64 image, default to PNG
-        return True, "image/png", text.strip()
+        base64_data = "".join(text.split())
+        if _decode_complete_image(base64_data, "image/png") is not None:
+            return True, "image/png", base64_data
 
     return _image_from_path(text)
+
+
+def _decode_complete_image(base64_data: str, mime_type: str) -> bytes | None:
+    """Decode only a complete image, not a base64-looking text fragment."""
+    try:
+        image = base64.b64decode(base64_data, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    if mime_type == "image/png":
+        complete = image.startswith(b"\x89PNG\r\n\x1a\n") and image.endswith(
+            b"IEND\xaeB`\x82"
+        )
+    elif mime_type in {"image/jpeg", "image/jpg"}:
+        complete = image.startswith(b"\xff\xd8\xff") and image.endswith(b"\xff\xd9")
+    elif mime_type == "image/gif":
+        complete = image.startswith((b"GIF87a", b"GIF89a")) and image.endswith(b";")
+    elif mime_type == "image/webp":
+        complete = (
+            len(image) >= 12
+            and image.startswith(b"RIFF")
+            and image[8:12] == b"WEBP"
+            and int.from_bytes(image[4:8], "little") + 8 == len(image)
+        )
+    else:
+        complete = False
+    return image if complete else None
 
 
 # `co browser take_screenshot` deliberately returns a path rather than base64 —
@@ -159,7 +188,7 @@ def _upload_to_oo_api(base64_data: str, mime_type: str) -> str:
     resp = requests.post(
         f"{base}/api/v1/images",
         headers={"Authorization": f"Bearer {token}"},
-        files={"file": ("screenshot", base64.b64decode(base64_data), mime_type)},
+        files={"file": ("screenshot", base64.b64decode(base64_data, validate=True), mime_type)},
         timeout=30,
     )
     resp.raise_for_status()

--- a/docs/blog/2026-08-25-an-image-prefix-is-not-an-image.md
+++ b/docs/blog/2026-08-25-an-image-prefix-is-not-an-image.md
@@ -1,0 +1,33 @@
+---
+title: "An image prefix is not an image"
+date: 2026-08-25
+author: ConnectOnion Team
+---
+
+A browser inspection returned JSON containing the beginning of an image data
+URL. The script had shortened the DOM attribute for readability, but the image
+formatter treated any matching base64 substring as a complete screenshot. Its
+decoder raised `Incorrect padding` from the `after_tools` hook and ended the
+whole agent run. An informational DOM excerpt had become a fatal image upload.
+
+Catching that one decoder exception would have hidden only the first symptom.
+A truncated payload can still have valid padding, and arbitrary long text can
+be made entirely from base64 characters. A minimum-length rule has the same
+problem: it measures size, not whether an image is complete.
+
+The formatter now accepts a candidate only after strict base64 decoding and
+format-aware completeness checks. PNG, JPEG, GIF, and WebP each need their real
+file signature and terminal structure. A malformed or truncated candidate is
+left untouched as ordinary tool output. A genuine image continues to upload to
+oo-api, and a real network or HTTP failure still fails loudly rather than
+silently putting a large payload back into model history.
+
+Regression coverage uses the exact truncated prefix that killed the production
+LinkedIn run, plus base64 text that decodes successfully but is not an image.
+Both now pass through without calling the uploader, while complete images still
+exercise the unit and plugin end-to-end paths.
+
+The extra validation is format-specific, so a newly supported image format must
+add its own completeness rule. We would revisit this boundary if image results
+move to a typed tool-result envelope where the producer supplies verified bytes
+instead of asking a text scanner to infer intent.

--- a/docs/useful_plugins/image_result_formatter.md
+++ b/docs/useful_plugins/image_result_formatter.md
@@ -19,7 +19,9 @@ agent.input("Take a screenshot and describe what you see")
 
 When a tool returns base64 encoded image data:
 
-1. Detects base64 image in tool result
+1. Strictly decodes the candidate and verifies a complete PNG, JPEG, GIF, or
+   WebP file. Truncated data URLs copied from DOM output and arbitrary
+   base64-looking text remain ordinary tool text.
 2. Uploads the bytes to oo-api and keeps only a short `/img` URL in the message history, so screenshots never bloat the replayed context (requires `OPENONION_API_KEY`, set up by `co init`)
 3. Converts to OpenAI vision format for LLM consumption
 4. Sends the image URL to frontend via WebSocket (if hosted with `agent.io`)
@@ -43,6 +45,11 @@ The plugin detects:
 # Plain base64 (defaults to PNG)
 "iVBORw0KGgoAAAANSUhEUgAA..."
 ```
+
+Detection is deliberately stricter than a base64-character regex. A candidate
+must have valid padding, the declared format's file signature, and its complete
+end marker before the plugin uploads anything. Network and HTTP upload failures
+still fail loudly after a genuine image has been identified.
 
 ## Events
 

--- a/tests/unit/test_image_result_formatter.py
+++ b/tests/unit/test_image_result_formatter.py
@@ -27,6 +27,7 @@ from tests.utils.mock_helpers import MockLLM
 
 
 UPLOADED_URL = "https://oo.openonion.ai/img/test"
+PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
 
 @pytest.fixture(autouse=True)
@@ -64,7 +65,7 @@ class TestIsBase64Image:
 
     def test_detects_data_url_jpeg(self):
         """Test detection of JPEG data URL."""
-        data = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD"
+        data = "data:image/jpeg;base64,/9j/2Q=="
         is_image, mime_type, base64_data = _is_base64_image(data)
 
         assert is_image is True
@@ -88,8 +89,7 @@ class TestIsBase64Image:
 
     def test_detects_raw_base64(self):
         """Test detection of raw base64 string (no data URL)."""
-        # Long base64 string that looks like an image
-        data = "A" * 150  # Base64 chars only
+        data = PNG_BASE64
         is_image, mime_type, base64_data = _is_base64_image(data)
 
         assert is_image is True
@@ -119,12 +119,21 @@ class TestIsBase64Image:
         assert is_image is False
 
     def test_detects_embedded_data_url(self):
-        """Test detection when data URL is embedded in text."""
-        data = "Screenshot taken: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE"
+        """Test detection when a complete data URL is embedded in text."""
+        data = f"Screenshot taken: data:image/png;base64,{PNG_BASE64}"
         is_image, mime_type, base64_data = _is_base64_image(data)
 
         assert is_image is True
         assert mime_type == "image/png"
+
+    def test_rejects_the_truncated_data_url_from_issue_1269(self):
+        data = ('{"src": "data:image/png;base64,'
+                'iVBORw0KGgoAAAANSUhEUgAABkAAAAOECAYAAAD5Tf"}')
+
+        assert _is_base64_image(data) == (False, "", "")
+
+    def test_rejects_decodable_base64_that_is_not_an_image(self):
+        assert _is_base64_image("A" * 152) == (False, "", "")
 
 
 class TestFormatImageResult:
@@ -171,7 +180,7 @@ class TestFormatImageResult:
     def test_drops_raw_base64_from_text_context(self):
         """Raw base64 image results should not be copied into text context."""
         agent = FakeAgent()
-        base64_data = "A" * 152  # valid base64: length divisible by 4
+        base64_data = PNG_BASE64
         agent.current_session['trace'] = [
             {
                 'type': 'tool_result',
@@ -209,14 +218,14 @@ class TestFormatImageResult:
                 'type': 'tool_result',
                 'name': 'capture',
                 'status': 'success',
-                'result': 'data:image/png;base64,iVBORw0KGgo=',
+                'result': f'data:image/png;base64,{PNG_BASE64}',
                 'tool_id': 'call_456'
             }
         ]
         agent.current_session['messages'] = [
             {
                 'role': 'tool',
-                'content': 'data:image/png;base64,iVBORw0KGgo=',
+                'content': f'data:image/png;base64,{PNG_BASE64}',
                 'tool_call_id': 'call_456'
             }
         ]
@@ -284,6 +293,34 @@ class TestFormatImageResult:
         assert agent.current_session['messages'][0]['content'] == 'Found 10 results for Python'
         agent.logger.print.assert_not_called()
 
+    def test_truncated_embedded_data_url_is_left_as_ordinary_tool_text(self):
+        """A DOM excerpt is not an image and must never reach the uploader."""
+        result = ('{"src": "data:image/png;base64,'
+                  'iVBORw0KGgoAAAANSUhEUgAABkAAAAOECAYAAAD5Tf"}')
+        agent = FakeAgent()
+        agent.current_session['trace'] = [{
+            'type': 'tool_result',
+            'name': 'inspect_dom',
+            'status': 'success',
+            'result': result,
+            'tool_id': 'call_truncated',
+        }]
+        agent.current_session['messages'] = [{
+            'role': 'tool',
+            'content': result,
+            'tool_call_id': 'call_truncated',
+        }]
+
+        _format_image_result(agent)
+
+        assert agent.current_session['messages'] == [{
+            'role': 'tool',
+            'content': result,
+            'tool_call_id': 'call_truncated',
+        }]
+        assert agent.current_session['trace'][0]['result'] == result
+        agent.logger.print.assert_not_called()
+
     def test_updates_trace_result(self):
         """Test that trace result is updated to short message."""
         agent = FakeAgent()
@@ -292,14 +329,14 @@ class TestFormatImageResult:
                 'type': 'tool_result',
                 'name': 'screenshot',
                 'status': 'success',
-                'result': 'data:image/png;base64,' + 'A' * 1000,
+                'result': 'data:image/png;base64,' + PNG_BASE64,
                 'tool_id': 'call_abc'
             }
         ]
         agent.current_session['messages'] = [
             {
                 'role': 'tool',
-                'content': 'data:image/png;base64,' + 'A' * 1000,
+                'content': 'data:image/png;base64,' + PNG_BASE64,
                 'tool_call_id': 'call_abc'
             }
         ]
@@ -514,9 +551,11 @@ class TestScreenshotPathDetection:
     def test_base64_still_wins_over_path_scanning(self):
         """In-process tools returning data URLs must keep working unchanged."""
         from connectonion.useful_plugins.image_result_formatter import _is_base64_image
-        is_image, mime, data = _is_base64_image("data:image/png;base64,iVBORw0KGgo=")
+        is_image, mime, data = _is_base64_image(
+            f"data:image/png;base64,{PNG_BASE64}"
+        )
         assert (is_image, mime) == (True, "image/png")
-        assert data == "iVBORw0KGgo="
+        assert data == PNG_BASE64
 
 
 def test_screenshot_path_becomes_an_attached_image(tmp_path, monkeypatch):

--- a/tests/unit/test_read_file_tool.py
+++ b/tests/unit/test_read_file_tool.py
@@ -113,7 +113,10 @@ class TestImageReachesVisionModel:
 
     def test_image_output_becomes_image_url_message(self, tmp_path, monkeypatch):
         f = tmp_path / "shot.png"
-        f.write_bytes(b"\x89PNG\r\n\x1a\nfake-image-bytes")
+        f.write_bytes(base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk"
+            "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        ))
         data_url = read_file(str(f))
         assert data_url.startswith("data:image/png;base64,")
 


### PR DESCRIPTION
## Description

Forward-ports the exact #1269 fix merged into release/1.7 by #1274 so main/1.8 cannot regress behind the 1.7 candidate.

## Related Issue

Part of #1269

## Labels and target release

- **Suggested labels:** bug, priority:high
- **Proposed target version:** 1.8.0a1 / next 1.8 preview
- **Estimated release window:** before the next 1.8 preview
- **Milestone:** 1.7.0 — ACP + coding-agent preview train
- **Why this release:** preserve behavioral parity between the active release and preview lines
- **Forward-port tracking issue (stable patches only):** N/A — #1269 tracks this pre-Stable forward-port

## Changes

- Strictly decode candidate image data.
- Require complete PNG, JPEG, GIF, or WebP terminal structure.
- Leave truncated or non-image base64-like text untouched.
- Keep real upload failures visible.

## Verification

- 35 focused formatter, read-file, and plugin E2E tests passed.
- Clean cherry-pick of merge commit 254ad720 from release/1.7.
- git diff --check passed.

## Dev Blog

- docs/blog/2026-08-25-an-image-prefix-is-not-an-image.md

## Screenshots

No product UI change. The matching docs-site article was verified at desktop and mobile widths in docs PR #119.