### PR TITLE
fix: forward-port safe headless command grants to 1.8

### DIFF
--- a/connectonion/useful_plugins/tool_approval/policy.py
+++ b/connectonion/useful_plugins/tool_approval/policy.py
@@ -19,7 +19,7 @@ from ...core.approval_modes import (
 )
 from ...core.events import before_each_tool
 from ...project import project_root
-from .bash_parser import _extract_subcommands
+from .bash_parser import _extract_subcommands, check_bash_chain_permitted
 
 if TYPE_CHECKING:
     from ...core.agent import Agent
@@ -253,15 +253,68 @@ def workspace_policy_for_pending(agent: "Agent", pending: dict) -> dict | None:
             requires_human=bool(agent.io),
         )
     if not agent.io and result["decision"] == "ask":
-        result = decision(
-            result["effect_class"],
-            "deny",
-            f"{result['reason']}; no approval channel is available",
-            result["scope"],
-        )
+        configured = _headless_configured_command(agent, pending, result)
+        if configured is not None:
+            result = configured
+        else:
+            result = decision(
+                result["effect_class"],
+                "deny",
+                f"{result['reason']}; no approval channel is available",
+                result["scope"],
+            )
     pending["approval_policy"] = result
     record_approval_policy(agent, pending)
     return result
+
+
+def _headless_configured_command(
+    agent: "Agent", pending: dict, result: dict
+) -> dict | None:
+    """Honor an operator's standing command grant without weakening Auto.
+
+    Only ordinary commands reach this path. Publication, deployment, network,
+    credential, deletion, and unknown effects keep their stronger verdict even
+    when a broad legacy pattern such as ``Bash(co *)`` happens to match.
+    """
+    if result.get("effect_class") != "command" or pending.get("name") != "bash":
+        return None
+    permissions = agent.current_session.get("permissions")
+    if not isinstance(permissions, dict):
+        return None
+    configured = {
+        pattern: permission
+        for pattern, permission in permissions.items()
+        if isinstance(permission, dict) and permission.get("source") == "config"
+    }
+    # The shipped historical Bash(co *) grant is broader than its "safe CLI"
+    # description. Preserve the unattended browser/status compatibility users
+    # relied on without silently authorizing email, account, server, or payment
+    # commands. Operators can still name a narrower command explicitly.
+    broad_co = configured.pop("Bash(co *)", None)
+    if broad_co is not None:
+        subcommands = _extract_subcommands(
+            str((pending.get("arguments") or {}).get("command", ""))
+        )
+        if subcommands and all(
+            full == "co status" or full.startswith("co browser ")
+            for _, full in subcommands
+        ):
+            configured["Bash(co *)"] = broad_co
+    try:
+        permitted, _, _ = check_bash_chain_permitted(
+            str((pending.get("arguments") or {}).get("command", "")), configured
+        )
+    except Exception:
+        return None
+    if not permitted:
+        return None
+    return decision(
+        "configured_command",
+        "allow",
+        "operator-configured command allowlist",
+        "call",
+    )
 
 
 @before_each_tool

--- a/docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md
+++ b/docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md
@@ -1,0 +1,36 @@
+---
+title: "Headless does not mean unconfigured"
+date: 2026-08-25
+author: ConnectOnion Team
+---
+
+A launchd job upgraded from 1.6 to the 1.7 release candidate and stopped on its
+first action. The command was `co browser status`, already covered by the
+operator's standing `Bash(co *)` permission, but Auto classified every command
+outside its small verification list as requiring a live approval. With stdin
+closed there was no dialog, so the safe failure became a complete outage for
+deliberately unattended agents.
+
+Allowing every historical config match would have restored the job by weakening
+the newer boundary. In particular, the shipped `Bash(co *)` pattern is much
+broader than its old “safe CLI” description: taken literally, it can include
+deployment, email, account, and payment actions. Treating that wildcard as an
+unlimited unattended grant would turn compatibility into escalation.
+
+Headless Auto now distinguishes “nobody is present” from “nobody configured
+this.” An operator-authored command rule can satisfy an ordinary command that
+would otherwise ask. The shipped broad `co` compatibility rule is accepted only
+for `co status` and `co browser ...`, which restores the existing cron/browser
+workflow. Publication and deployment keep their stronger policy verdict, while
+other framework effects such as email remain denied unless the operator writes
+a narrower, deliberate rule or chooses bounded Full access for the whole task.
+
+Regression coverage runs the exact no-IO approval path for one command and a
+command chain. It also proves the same broad rule cannot silently authorize
+`co deploy`, `co publish`, or `co email send`. The surrounding parser,
+configuration, approval, and Auto-policy suites pass together.
+
+This preserves a security tradeoff: a sufficiently narrow operator permission
+is authority, even without a person online. We would revisit the mechanism when
+permissions carry first-class effect classes instead of deriving intent from
+command text and legacy patterns.

--- a/docs/cli/ai.md
+++ b/docs/cli/ai.md
@@ -121,6 +121,28 @@ YOLO is the familiar CLI shorthand for Full access. It selects the canonical
 `:danger-full-access` permission profile and uses `full_access_turns` for the
 bounded autonomous checkpoint.
 
+## Unattended one-shot permissions
+
+One-shot commands launched by cron or CI have no approval dialog. Auto still
+fails closed for unknown, destructive, credential, publication, deployment,
+and external-effect calls, but it honors operator-authored `Bash(...)` command
+permissions from the active `.co/host.yaml` for ordinary commands.
+
+The shipped compatibility grant allows unattended `co status` and
+`co browser ...` commands, including browser workflows that already ran under
+1.6.x:
+
+```bash
+co ai -m co/gemini-3.7-flash "/linkedin-notifications ..." < /dev/null
+```
+
+The broad historical `Bash(co *)` entry does not silently authorize other
+framework effects such as `co deploy`, `co publish`, or `co email send` in
+headless Auto. Add a narrower project permission when an operator deliberately
+wants a particular ordinary command. Use bounded `--full-access` only when the
+whole unattended task is trusted to perform effects that still require a human
+under Auto.
+
 ## What the Agent Can Do
 
 The agent has a full suite of tools for coding tasks:

--- a/docs/useful_plugins/tool_approval.md
+++ b/docs/useful_plugins/tool_approval.md
@@ -163,6 +163,13 @@ requests but cannot elevate their profile.
 
 Auto-approve safe commands permanently via `host.yaml` configuration. Config permissions never expire and apply to all sessions.
 
+In a headless one-shot run, a matching operator-configured `Bash(...)` rule can
+approve an ordinary command even though no dialog exists. Auto continues to
+deny destructive, credential, publication, deployment, external-effect, and
+unknown calls. For compatibility, the shipped broad `Bash(co *)` rule is
+narrowed at this boundary to `co status` and `co browser ...`; commands such as
+`co deploy`, `co publish`, and `co email send` do not inherit silent authority.
+
 ### Configuration
 
 Add permissions to `.co/host.yaml`:

--- a/tests/unit/test_auto_approve_policy.py
+++ b/tests/unit/test_auto_approve_policy.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from connectonion.useful_plugins.tool_approval import check_approval, tool_approval
+from connectonion.useful_plugins.tool_approval.approval import load_permission_patterns
 from connectonion.useful_plugins.tool_approval.policy import (
     POLICY_ID,
     apply_auto_approve_policy,
@@ -227,3 +228,108 @@ def test_headless_auto_still_allows_a_reversible_workspace_edit(
     check_approval(instance)
 
     assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["co browser status", "co browser status && co status"],
+)
+def test_headless_auto_honors_the_operator_command_allowlist(
+    tmp_path, monkeypatch, command
+):
+    """Regression for #1270: cron has no dialog, but does have standing grants."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions={
+        "Bash(co *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "operator standing grant",
+            "when": {"command": "co *"},
+        }
+    })
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": command},
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "allow"
+    assert result["effect_class"] == "configured_command"
+    assert result["reason"] == "operator-configured command allowlist"
+
+
+def test_packaged_permissions_keep_headless_co_browser_status_working(
+    tmp_path, monkeypatch
+):
+    """Exercise the same shipped permission source used by a fresh 1.7 install."""
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions=load_permission_patterns(tmp_path / ".co"))
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": "co browser status"},
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert instance.current_session["pending_tool"]["approval_policy"]["decision"] == "allow"
+
+
+@pytest.mark.parametrize(
+    ("command", "effect"),
+    [
+        ("co deploy", "publication"),
+        ("co publish", "publication"),
+        ("co email send --to a@example.com hi", "command"),
+    ],
+)
+def test_headless_broad_co_grant_cannot_authorize_stronger_effects(
+    tmp_path, monkeypatch, command, effect
+):
+    monkeypatch.chdir(tmp_path)
+    instance = agent(io=False, permissions={
+        "Bash(co *)": {
+            "allowed": True,
+            "source": "config",
+            "reason": "legacy broad CLI permission",
+            "when": {"command": "co *"},
+        }
+    })
+    instance.current_session["pending_tool"] = {
+        "name": "bash",
+        "arguments": {"command": command},
+    }
+
+    apply_auto_approve_policy(instance)
+
+    result = instance.current_session["pending_tool"]["approval_policy"]
+    assert result["decision"] == "deny"
+    assert result["effect_class"] == effect
+    with pytest.raises(ValueError, match=f"denied by {POLICY_ID}"):
+        check_approval(instance)
+
+
+@pytest.mark.parametrize(
+    ("name", "arguments"),
+    [
+        ("write", {"path": "/outside.txt", "content": "verified"}),
+        ("add", {"content": "verify", "active_form": "verifying"}),
+        ("start", {"content": "verify"}),
+        ("complete", {"content": "verify"}),
+    ],
+)
+def test_headless_full_access_keeps_the_explicit_bounded_bypass(name, arguments):
+    instance = agent(mode="full-access", io=False)
+    instance.current_session["turns_left"] = 2
+    instance.current_session["pending_tool"] = {
+        "name": name,
+        "arguments": arguments,
+    }
+
+    apply_auto_approve_policy(instance)
+    check_approval(instance)
+
+    assert "approval_policy" not in instance.current_session["pending_tool"]


### PR DESCRIPTION
## Description

Forward-ports the #1270 fix merged into release/1.7 by #1275 so main/1.8 preserves the same unattended Auto contract.

## Related Issue

Part of #1270

## Labels and target release

- **Suggested labels:** bug, priority:high
- **Proposed target version:** 1.8.0a1 / next 1.8 preview
- **Estimated release window:** before the next 1.8 preview
- **Milestone:** 1.7.0 — ACP + coding-agent preview train
- **Why this release:** preserve behavioral parity between the active release and preview lines
- **Forward-port tracking issue (stable patches only):** N/A — #1270 tracks this pre-Stable forward-port

## Changes

- Honor operator-authored Bash allowlists for ordinary headless commands.
- Preserve fail-closed handling for publication, deployment, credentials, deletion, network, and unknown effects.
- Limit the historical broad co wildcard to co status and co browser subcommands.
- Keep explicit narrower operator rules available for deliberate automation.

## Verification

- 147 focused policy, approval, config, and Bash parser tests passed on main.
- Resolved the branch-only policy ID test assertion against the current POLICY_ID.
- release/1.7 CI passed Python 3.10–3.13, macOS E2E, Windows E2E, browser, lockfile, blog, and metadata gates.
- git diff --check passed.

## Dev Blog

- docs/blog/2026-08-25-headless-does-not-mean-unconfigured.md

## Screenshots

No product UI change. The matching docs-site article was verified at desktop and mobile widths in docs PR #119.