### PR TITLE
feat: expose focused browser element safely

### DIFF
--- a/connectonion/cli/browser_agent/prompts/agent.md
+++ b/connectonion/cli/browser_agent/prompts/agent.md
@@ -186,7 +186,9 @@ Keep responses concise and informative:
 
 `keyboard_type(text)` wraps Playwright's `page.keyboard.type()` — inputs text character by character into the focused element.
 
-`keyboard_press(key)` wraps Playwright's `page.keyboard.press()` — presses a key or chord. Accepts key names (`"Enter"`, `"Escape"`, `"Tab"`) and combos (`"Control+Enter"`, `"Control+x"`, `"Meta+a"`, `"Shift+Tab"`). Modifier keys are held down for the duration of the chord then released.
+`get_focused_element()` returns JSON for the current focus target, including `is_editable`; password values are redacted. Call it before replacing text.
+
+`keyboard_press(key)` wraps Playwright's `page.keyboard.press()` — presses a key or chord. Accepts key names (`"Enter"`, `"Escape"`, `"Tab"`) and combos (`"Control+Enter"`, `"Control+x"`, `"Meta+a"`, `"Shift+Tab"`). Modifier keys are held down for the duration of the chord then released. Select-all, Backspace, and Delete are refused while focus is not editable; only pass `allow_non_editable=True` for an intentional page-level action.
 
 ## How Element Finding Works
 

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -4,9 +4,9 @@ LLM-Note:
   Dependencies: imports from [patchright.sync_api, connectonion Agent/llm_do, cli/browser_agent/element_finder, pydantic, pathlib, dotenv] | imported by [cli/commands/browser_commands.py, cli/browser_agent/daemon.py] | tested by [tests/unit/test_browser_tools.py, tests/unit/test_browser_session_pages.py, tests/unit/test_browser_automation.py]
   Data flow: a caller binds its session via _bind_session(key) (key None = shared 'main') → every public method hops to ONE dedicated browser worker thread (_runs_on_browser_thread propagates the binding; Playwright's sync API is thread-bound) → _ensure_page gives the session its own tab in the shared context (restored to its remembered URL), then _reclaim_idle_tabs bounds memory (idle-TTL first, then max-tabs LRU — never the active tab) → go_to/newtab record who/purpose/hours on the tab REGISTRY _tab_meta (the first navigation on an unoccupied tab demands purpose+who — direct API/tool callers only; the co browser daemon registers tabs before dispatching) → tab_status renders the board → close_tab releases ONE tab, close() releases the bound tab or tears the whole context down
   State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile/ (Chrome's SingletonLock is cleared only when its owning pid is dead) | per-tab state in four maps: _pages (live pages), _page_used (last-use clock), _page_url (remembered URL — written ONLY by _reclaim_tab for transparent resume; _release_tab forgets page+registration+URL together), _tab_meta (registry/board: who/purpose/hours/opened_at + the daemon's claim fields) | _teardown clears all four | auto-saves storage state after critical actions | screenshots to .tmp/
-  Integration: exposes BrowserAutomation(headless, ...) — its public methods ARE the `co browser` verbs and the NL agent's tools (go_to, newtab, tab_status, close_tab, take_screenshot, click/type/scroll family, save_state, close, ...) | driver_stealth_status() feeds `co doctor` and daemon `status`
+  Integration: exposes BrowserAutomation(headless, ...) — its public methods ARE the `co browser` verbs and the NL agent's tools (go_to, newtab, tab_status, close_tab, take_screenshot, click/type/scroll family, get_focused_element, save_state, close, ...) | driver_stealth_status() feeds `co doctor` and daemon `status`
   Performance: browser launch is lazy (first page verb, 1-3s) | persistent context loads the profile instantly | element finding uses a vision LLM (slower but accurate) | auto-save adds ~500ms after critical actions
-  Errors: an unoccupied tab's first go_to/newtab raises ValueError coaching the AGENT to re-call with purpose/who (_occupancy_help) | launch failure returns the first error line + a pointer to ~/.co/browser.log | context liveness is judged at the CONTEXT level (_context_is_alive), so one dead page never tears down other sessions' tabs
+  Errors: an unoccupied tab's first go_to/newtab raises ValueError coaching the AGENT to re-call with purpose/who (_occupancy_help) | destructive select-all/delete shortcuts fail closed outside an editable focus unless explicitly overridden | launch failure returns the first error line + a pointer to ~/.co/browser.log | context liveness is judged at the CONTEXT level (_context_is_alive), so one dead page never tears down other sessions' tabs
 Browser Agent for CLI - Natural language browser automation.
 
 Two stacks drive this class — same code, different process, DIFFERENT Chrome
@@ -134,6 +134,73 @@ def _public_methods_run_on_browser_thread(cls):
         if not name.startswith("_") and inspect.isfunction(method):
             setattr(cls, name, _runs_on_browser_thread(method))
     return cls
+
+
+_FOCUSED_ELEMENT_SCRIPT = """
+(previewLimit) => {
+    let element = document.activeElement;
+    while (element && element.shadowRoot && element.shadowRoot.activeElement) {
+        element = element.shadowRoot.activeElement;
+    }
+    if (!element) {
+        return {
+            tag: null, type: null, id: null, name: null, role: null,
+            aria_label: null, contenteditable: null, is_editable: false,
+            disabled: false, read_only: false, sensitive: false,
+            value_preview: null, value_truncated: false,
+        };
+    }
+
+    const tag = element.tagName.toLowerCase();
+    const type = (element.getAttribute('type') || '').toLowerCase() || null;
+    const disabled = Boolean(element.disabled);
+    const readOnly = Boolean(element.readOnly);
+    const nonTextInputTypes = new Set([
+        'button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio',
+        'range', 'reset', 'submit',
+    ]);
+    const textInput = tag === 'input' && !nonTextInputTypes.has(type || 'text');
+    const isEditable = !disabled && !readOnly && (
+        textInput || tag === 'textarea' || element.isContentEditable
+    );
+    const sensitive = tag === 'input' && type === 'password';
+    let value = null;
+    if (!sensitive && (tag === 'input' || tag === 'textarea')) {
+        value = String(element.value || '');
+    } else if (!sensitive && element.isContentEditable) {
+        value = String(element.innerText || element.textContent || '');
+    }
+
+    return {
+        tag,
+        type,
+        id: element.id || null,
+        name: element.getAttribute('name'),
+        role: element.getAttribute('role'),
+        aria_label: element.getAttribute('aria-label'),
+        contenteditable: element.getAttribute('contenteditable'),
+        is_editable: isEditable,
+        disabled,
+        read_only: readOnly,
+        sensitive,
+        value_preview: value === null ? null : value.slice(0, previewLimit),
+        value_truncated: value === null ? false : value.length > previewLimit,
+    };
+}
+"""
+
+
+def _keyboard_press_requires_editable_focus(key: str) -> bool:
+    """Whether sending this key outside an editor risks destructive page action."""
+    parts = [part.strip().casefold() for part in key.split("+") if part.strip()]
+    if not parts:
+        return False
+    if parts[-1] in {"backspace", "delete"}:
+        return True
+    modifiers = set(parts[:-1])
+    return parts[-1] == "a" and bool(
+        modifiers.intersection({"control", "ctrl", "meta", "controlormeta"})
+    )
 
 
 def _browser_proxy_from_env():
@@ -1768,7 +1835,27 @@ class BrowserAutomation:
 
 SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into the correct input box. If the text is NOT visible in the expected location, you may need to click the element first to focus it, then type again."""
 
-    def keyboard_press(self, key: str) -> str:
+    def _focused_element(self, value_preview_chars: int = 160) -> Dict[str, Any]:
+        """Read focused-element state on the browser-owning thread."""
+        limit = max(0, min(int(value_preview_chars), 1000))
+        return self.page.evaluate(_FOCUSED_ELEMENT_SCRIPT, limit)
+
+    def get_focused_element(self, value_preview_chars: int = 160) -> str:
+        """Return bounded JSON describing the focused element and whether it is editable.
+
+        Password values are always redacted. Focus inside an open shadow root is
+        followed to its deepest active element.
+        """
+        if not self.page:
+            return "Browser not open"
+        return json.dumps(
+            self._focused_element(value_preview_chars),
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+    def keyboard_press(self, key: str, allow_non_editable: bool = False) -> str:
         """Press a keyboard key or key combination.
 
         Use for special keys and shortcuts — NOT for typing text.
@@ -1777,12 +1864,25 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         Args:
             key: Key name or combo, e.g. "Enter", "Escape", "Tab",
                  "Control+Enter", "Control+x", "Meta+a", "Shift+Tab"
+            allow_non_editable: Explicitly allow select-all/delete outside an
+                 editable element. Defaults to False to prevent page-wide data loss.
 
         Returns:
             Success message
         """
         if not self.page:
             return "Browser not open"
+
+        if _keyboard_press_requires_editable_focus(key) and not allow_non_editable:
+            focused = self._focused_element()
+            if not focused.get("is_editable", False):
+                return (
+                    f"Refused '{key}': the focused element is not editable. "
+                    "Focus the intended input and call get_focused_element() before "
+                    "retrying. For an intentional page-level shortcut, pass "
+                    "allow_non_editable=True.\n"
+                    + json.dumps(focused, ensure_ascii=False, sort_keys=True)
+                )
 
         self.page.keyboard.press(key)
         return f"Pressed: '{key}'"

--- a/docs/blog/2026-08-26-focus-before-delete.md
+++ b/docs/blog/2026-08-26-focus-before-delete.md
@@ -1,0 +1,47 @@
+# Focus Before Delete
+
+*2026-08-26*
+
+A browser agent clicked a LinkedIn profile editor, received a successful click
+result, and sent the ordinary replace-text sequence: select all, then delete.
+The click had not moved focus into the editor. Select all highlighted the page,
+delete closed the modal, and every command still returned success.
+
+No individual operation was broken. The sequence was unsafe because the caller
+could not observe the state that made the next operation safe.
+
+## A screenshot arrives too late
+
+The browser tools already recommended taking a screenshot after typing. That
+can detect text landing in the wrong place, but destructive shortcuts have no
+useful “after.” Once the editor closes, the screenshot only records the loss.
+
+The practical workaround was to type a canary, take a screenshot, inspect it,
+then replace the canary. Two round trips and an image were being used to answer
+a synchronous DOM question: what has focus, and can it accept text?
+
+## Make the precondition observable
+
+`get_focused_element` now returns bounded JSON for the active element: its tag,
+role, label, editable state, and a short value preview. Password values are
+always redacted. Focus is followed through open shadow roots; iframe and closed
+shadow-root boundaries stay opaque and therefore fail safe.
+
+Observation alone still leaves every caller to remember the rule. So
+`keyboard_press` enforces it at the dangerous edge: select-all, Backspace, and
+Delete are refused when focus is not editable. An explicit override remains for
+intentional page-level shortcuts, making the exceptional intent visible in the
+call instead of inferred after damage.
+
+## Test the sequence, not only the methods
+
+Unit tests cover shortcut classification, refusal, ordinary keys, and the
+override. Daemon tests prove that the new JSON query and boolean flag survive
+CLI serialization. A real installed browser then exercises password redaction,
+textarea and contenteditable focus, an open shadow root, detached focus, an
+iframe boundary, and the original page-wide select-all failure.
+
+The full non-network regression gate passed 7,251 tests. More importantly, the
+incident's three individually successful commands can no longer compose into a
+silent destructive action: the boundary now checks the state the sequence
+depends on.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -84,12 +84,36 @@ co browser take_screenshot /tmp/shot.png [--full-page]
 co browser click "<description or selector>"
 co browser type_text_by_selector <css> "<text>"
 co browser fill_text_by_selector <css> --stdin < secret.txt  # replace controlled input; secret stays out of argv
+co browser get_focused_element             # bounded JSON; password values are redacted
+co browser keyboard_press Meta+a           # refused unless focus is editable
 co browser get_links_from_page             # one link per line
 co browser scroll                          # scroll the main content
 co browser close                           # close browser, stop daemon
 ```
 
 Arguments are plain strings; flags like `--full-page` and `--index=2` map to the function's parameters. For `fill_text_by_selector`, `type_text_by_selector`, and `keyboard_type`, a final `--stdin` reads the text from redirected standard input so passwords and one-run codes do not appear in process arguments. Prefer `fill_text_by_selector` when replacing a controlled framework input; use `type_text_by_selector` when appending human-shaped keystrokes is required.
+
+Before replacing focused text with a keyboard shortcut, inspect the target:
+
+```bash
+co browser get_focused_element
+co browser keyboard_press Meta+a       # macOS
+co browser keyboard_press Control+a    # Windows/Linux
+co browser keyboard_press Backspace
+```
+
+`get_focused_element` follows focus into open shadow roots and reports whether
+the target is editable. Its value preview is bounded, and password values are
+always redacted. `keyboard_press` refuses select-all, Backspace, and Delete when
+focus is outside an editable input, textarea, or contenteditable element. For a
+deliberate page-level shortcut, acknowledge the risk explicitly with
+`--allow-non-editable`.
+
+Focus inspection is scoped to the top-level document and open shadow roots. If
+focus is inside an iframe, the result describes the iframe itself and treats it
+as non-editable; closed shadow roots cannot be inspected. These cases fail safe:
+target the field by selector, or use the explicit override only after verifying
+the frame and intended page-level action.
 
 > **Use absolute paths for files.** The daemon resolves relative paths against *its own* working directory (where it was first started), not the directory you run each command from. `take_screenshot /tmp/shot.png` is predictable; a bare `shot.png` lands in the daemon's `.tmp/` folder.
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -153,7 +153,26 @@ browser.keyboard_press("Escape")
 browser.keyboard_press("Tab")
 ```
 
-After `keyboard_type()`, call `take_screenshot()` to verify the text landed in the right field.
+Before replacing text, inspect focus instead of typing a canary or discovering a
+missed click after state has been destroyed:
+
+```python
+focus = browser.get_focused_element()
+# JSON includes tag, role, aria_label, contenteditable, and is_editable.
+# Password values are never returned.
+browser.keyboard_press("Meta+a")
+browser.keyboard_press("Backspace")
+```
+
+`keyboard_press()` refuses select-all, Backspace, and Delete when the focused
+element is not editable. For an intentional page-level shortcut, pass
+`allow_non_editable=True`. After `keyboard_type()`, call `take_screenshot()` to
+verify the text landed in the expected field.
+
+Inspection covers the top-level document and open shadow roots. Focus inside an
+iframe is reported as the iframe and fails the editable check; closed shadow
+roots are likewise opaque. Target the field directly in those cases, and only
+use the override after independently verifying the destination.
 
 ### Scrolling
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -118,6 +118,14 @@ class StubBrowser:
     def get_links_from_page(self, domain_filter: str = "") -> list:
         return ["https://a.com", "https://b.com"]
 
+    def get_focused_element(self, value_preview_chars: int = 160) -> str:
+        self.calls.append(("get_focused_element", value_preview_chars))
+        return '{"tag":"input","is_editable":true}'
+
+    def keyboard_press(self, key: str, allow_non_editable: bool = False) -> str:
+        self.calls.append(("keyboard_press", key, allow_non_editable))
+        return f"Pressed {key} allow_non_editable={allow_non_editable}"
+
     def _browser_is_usable(self) -> bool:
         return True
 
@@ -188,6 +196,20 @@ def test_dispatch_coerces_bool_flag(tmp_path):
     ok, payload = daemon.dispatch("take_screenshot --full-page")
     assert ok is True
     assert payload == "shot path=None full=True"
+
+
+def test_dispatch_exposes_focus_json_and_destructive_shortcut_override(tmp_path):
+    daemon = make_daemon(str(tmp_path / "s.sock"))
+
+    ok, payload = daemon.dispatch("get_focused_element --value-preview-chars=42")
+    assert ok is True
+    assert payload == '{"tag":"input","is_editable":true}'
+    assert daemon.browser.calls[-1] == ("get_focused_element", 42)
+
+    ok, payload = daemon.dispatch("keyboard_press Meta+a --allow-non-editable")
+    assert ok is True
+    assert payload == "Pressed Meta+a allow_non_editable=True"
+    assert daemon.browser.calls[-1] == ("keyboard_press", "Meta+a", True)
 
 
 def test_dispatch_image_payload_shows_path_not_base64(tmp_path):

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -14,6 +14,8 @@ third party is down (5xx / unreachable) rather than failing on someone else's ou
 """
 
 import os
+import json
+import platform
 import re
 import statistics
 import time
@@ -176,6 +178,68 @@ def test_humanized_cjk_typing_uses_trusted_paste_or_ime(stealth_browser):
     assert pasted or composed, f"CJK not via paste or IME: {d.get('it')!r}"
     # Whichever path ran, its entry event must be trusted.
     assert "paste=true" in d.get("tr", "") or "cs=true" in d.get("tr", "")
+
+
+FOCUS_PAGE = """
+<!doctype html><meta charset=utf-8>
+<input id=password type=password value="not-for-output">
+<textarea id=notes>safe notes</textarea>
+<div id=editor role=textbox aria-label="Headline" contenteditable=true>editable headline</div>
+<div id=host></div>
+<iframe id=frame srcdoc='<textarea id="framed">inside frame</textarea>'></iframe>
+<script>
+  const root = document.getElementById('host').attachShadow({mode: 'open'});
+  root.innerHTML = '<input id="shadow-input" aria-label="Shadow editor" value="shadow value">';
+</script>
+"""
+
+
+def test_focus_introspection_and_destructive_shortcut_guard_end_to_end(stealth_browser):
+    """The real browser must redact secrets, cross open shadow roots, and block a
+    page-wide select-all before Playwright emits the keyboard event."""
+    b = stealth_browser
+    b.go_to(
+        "data:text/html," + urllib.parse.quote(FOCUS_PAGE),
+        purpose="focused element safety test",
+        who="e2e",
+    )
+
+    _eval(b, "() => document.getElementById('password').focus()")
+    password = json.loads(b.get_focused_element())
+    assert password["sensitive"] is True
+    assert password["value_preview"] is None
+
+    _eval(b, "() => document.getElementById('notes').focus()")
+    textarea = json.loads(b.get_focused_element())
+    assert textarea["tag"] == "textarea"
+    assert textarea["is_editable"] is True
+    assert textarea["value_preview"] == "safe notes"
+
+    _eval(b, "() => document.getElementById('host').shadowRoot.getElementById('shadow-input').focus()")
+    shadow = json.loads(b.get_focused_element())
+    assert shadow["id"] == "shadow-input"
+    assert shadow["aria_label"] == "Shadow editor"
+    assert shadow["is_editable"] is True
+
+    _eval(b, "() => { const input = document.createElement('input'); document.body.append(input); input.focus(); input.remove(); }")
+    detached = json.loads(b.get_focused_element())
+    assert detached["tag"] == "body"
+    assert detached["is_editable"] is False
+
+    _eval(b, "() => document.getElementById('frame').contentDocument.getElementById('framed').focus()")
+    framed = json.loads(b.get_focused_element())
+    assert framed["tag"] == "iframe"
+    assert framed["is_editable"] is False
+
+    _eval(b, "() => { document.body.tabIndex = -1; document.body.focus(); }")
+    shortcut = "Meta+a" if platform.system() == "Darwin" else "Control+a"
+    refused = b.keyboard_press(shortcut)
+    assert refused.startswith(f"Refused '{shortcut}'")
+    assert _eval(b, "() => String(getSelection())") == ""
+
+    _eval(b, "() => document.getElementById('editor').focus()")
+    assert b.keyboard_press(shortcut) == f"Pressed: '{shortcut}'"
+    assert _eval(b, "() => String(getSelection())") == "editable headline"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -156,6 +156,18 @@ class FakeRunScriptPage(FakePage):
         return self.result
 
 
+class FakeFocusedPage(FakePage):
+    def __init__(self, focused):
+        self.focused = focused
+        self.evaluate_calls = []
+        self.pressed = []
+        self.keyboard = SimpleNamespace(press=lambda key: self.pressed.append(key))
+
+    def evaluate(self, script, arg=None):
+        self.evaluate_calls.append((script, arg))
+        return dict(self.focused)
+
+
 class FakeFrame:
     def __init__(self, result, url="https://example.com/frame", name=""):
         self.result = result
@@ -349,6 +361,65 @@ def test_run_page_script_reports_invalid_json(tmp_path):
     result = browser.run_page_script(str(script), "{bad")
 
     assert result.startswith("Invalid args_json:")
+
+
+def test_get_focused_element_returns_bounded_machine_readable_state():
+    page = FakeFocusedPage({
+        "tag": "div",
+        "type": None,
+        "id": "headline",
+        "name": None,
+        "role": "textbox",
+        "aria_label": "Headline",
+        "contenteditable": "true",
+        "is_editable": True,
+        "disabled": False,
+        "read_only": False,
+        "sensitive": False,
+        "value_preview": "Open-source browser",
+        "value_truncated": False,
+    })
+    browser = BrowserAutomation(headless=True)
+    browser.page = page
+
+    result = browser.get_focused_element(value_preview_chars=42)
+
+    assert '"aria_label": "Headline"' in result
+    assert '"is_editable": true' in result
+    assert page.evaluate_calls[0][1] == 42
+
+
+def test_destructive_keyboard_shortcuts_are_refused_outside_an_editor():
+    page = FakeFocusedPage({"tag": "body", "is_editable": False})
+    browser = BrowserAutomation(headless=True)
+    browser.page = page
+
+    for key in ("Meta+a", "Control+A", "ControlOrMeta+a", "Backspace", "Shift+Delete"):
+        result = browser.keyboard_press(key)
+        assert result.startswith(f"Refused '{key}'")
+
+    assert page.pressed == []
+    assert len(page.evaluate_calls) == 5
+
+
+def test_keyboard_shortcut_safety_preserves_normal_keys_and_has_explicit_override():
+    page = FakeFocusedPage({"tag": "body", "is_editable": False})
+    browser = BrowserAutomation(headless=True)
+    browser.page = page
+
+    assert browser.keyboard_press("Escape") == "Pressed: 'Escape'"
+    assert page.evaluate_calls == []
+    assert browser.keyboard_press("Meta+a", allow_non_editable=True) == "Pressed: 'Meta+a'"
+    assert page.pressed == ["Escape", "Meta+a"]
+
+
+def test_destructive_keyboard_shortcut_runs_when_focus_is_editable():
+    page = FakeFocusedPage({"tag": "textarea", "is_editable": True})
+    browser = BrowserAutomation(headless=True)
+    browser.page = page
+
+    assert browser.keyboard_press("Control+a") == "Pressed: 'Control+a'"
+    assert page.pressed == ["Control+a"]
 
 
 def test_run_frame_script_returns_first_ok_frame(tmp_path):


### PR DESCRIPTION
## Problem

A missed click followed by select-all/delete can destroy page state because `co browser` had no synchronous way to verify the active element.

## Approach

- add read-only `get_focused_element` JSON with bounded metadata, editable state, open-shadow-root traversal, and password redaction
- refuse select-all, Backspace, and Delete outside editable focus by default
- preserve intentional page-level actions through explicit `allow_non_editable=True` / `--allow-non-editable`
- document iframe and closed-shadow-root fail-safe limitations
- update the browser agent prompt to use the primitive before replacing text

Closes #1151

**Proposed target version:** 1.8.0 / next alpha

**Estimated release window:** next 1.8 alpha after the coordinated browser-artifact and exact-wheel E2E gate

## Verification

- `pytest tests/unit/test_browser_tools.py tests/e2e/cli/test_browser_daemon.py tests/unit/test_browser_protocol_docs_are_current.py tests/unit/test_the_documented_calls_are_real_calls.py -q` — 130 passed, 2 skipped
- native installed-browser acceptance with isolated profile — 1 passed (password, textarea, contenteditable, shadow root, detached focus, iframe fail-safe, page-wide select-all refusal)
- `pytest tests/ -q -m 'not slow and not real_api and not network'` — 7,251 passed, 21 skipped, 198 deselected
- `git diff --check`
- `python -m py_compile` for all changed Python files

## Documentation

Updated both in-repository browser guides and the browser-agent prompt. The separate docs-site repository is not checked out in this workspace, so no docs-site change is included.
