### PR TITLE
feat(browser): establish async driver core foundation

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -1,0 +1,802 @@
+"""
+Purpose: Internal Patchright async browser core for the 1.8 driver migration.
+LLM-Note:
+  Dependencies: imports only patchright.async_api plus browser_config/chrome_finder and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py]
+  Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → independent tab operations may interleave on one event loop
+  State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
+  Integration: internal AsyncBrowserCore; the public synchronous BrowserAutomation remains unchanged until #500 adds its compatibility facade
+  Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus
+
+This module is deliberately internal while #498 is in progress. It must never
+import or call patchright.sync_api: the old public class remains the compatibility
+implementation until the async contract is complete and #500 installs the facade.
+"""
+
+import asyncio
+import base64
+import contextvars
+import json
+import os
+import platform
+import time
+import urllib.parse
+from contextlib import asynccontextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
+from .chrome_finder import find_system_chrome
+
+try:
+    from patchright.async_api import BrowserContext, Page, Playwright, async_playwright
+
+    ASYNC_BROWSER_AVAILABLE = True
+except ImportError:
+    BrowserContext = Page = Playwright = Any
+    async_playwright = None
+    ASYNC_BROWSER_AVAILABLE = False
+
+
+_FOCUSED_ELEMENT_SCRIPT = """
+(previewLimit) => {
+    let element = document.activeElement;
+    while (element && element.shadowRoot && element.shadowRoot.activeElement) {
+        element = element.shadowRoot.activeElement;
+    }
+    if (!element) {
+        return {
+            tag: null, type: null, id: null, name: null, role: null,
+            aria_label: null, contenteditable: null, is_editable: false,
+            disabled: false, read_only: false, sensitive: false,
+            value_preview: null, value_truncated: false,
+        };
+    }
+
+    const tag = element.tagName.toLowerCase();
+    const type = (element.getAttribute('type') || '').toLowerCase() || null;
+    const disabled = Boolean(element.disabled);
+    const readOnly = Boolean(element.readOnly);
+    const nonTextInputTypes = new Set([
+        'button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio',
+        'range', 'reset', 'submit',
+    ]);
+    const textInput = tag === 'input' && !nonTextInputTypes.has(type || 'text');
+    const isEditable = !disabled && !readOnly && (
+        textInput || tag === 'textarea' || element.isContentEditable
+    );
+    const sensitive = tag === 'input' && type === 'password';
+    let value = null;
+    if (!sensitive && (tag === 'input' || tag === 'textarea')) {
+        value = String(element.value || '');
+    } else if (!sensitive && element.isContentEditable) {
+        value = String(element.innerText || element.textContent || '');
+    }
+
+    return {
+        tag,
+        type,
+        id: element.id || null,
+        name: element.getAttribute('name'),
+        role: element.getAttribute('role'),
+        aria_label: element.getAttribute('aria-label'),
+        contenteditable: element.getAttribute('contenteditable'),
+        is_editable: isEditable,
+        disabled,
+        read_only: readOnly,
+        sensitive,
+        value_preview: value === null ? null : value.slice(0, previewLimit),
+        value_truncated: value === null ? false : value.length > previewLimit,
+    };
+}
+"""
+
+
+def _profile_dir() -> Path:
+    configured = os.environ.get("CO_BROWSER_PROFILE_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path.home() / ".co" / "browser_profile"
+
+
+def _headless_without_display(headless: bool) -> bool:
+    if headless or platform.system() != "Linux":
+        return headless
+    return not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _clear_stale_profile_lock(profile_dir: Path) -> None:
+    lock = profile_dir / "SingletonLock"
+    if not lock.is_symlink():
+        return
+    tail = os.readlink(lock).rsplit("-", 1)[-1]
+    if not tail.isdigit() or _pid_alive(int(tail)):
+        return
+    for name in ("SingletonLock", "SingletonSocket", "SingletonCookie"):
+        (profile_dir / name).unlink(missing_ok=True)
+
+
+def _profile_lock_holder(profile_dir: Path) -> Optional[int]:
+    lock = profile_dir / "SingletonLock"
+    if not lock.is_symlink():
+        return None
+    tail = os.readlink(lock).rsplit("-", 1)[-1]
+    if not tail.isdigit():
+        return None
+    pid = int(tail)
+    return pid if _pid_alive(pid) else None
+
+
+def _proxy_from_env() -> Optional[Dict[str, str]]:
+    url = os.environ.get("BROWSER_PROXY", "").strip()
+    if not url:
+        return None
+    parsed = urllib.parse.urlparse(url)
+    server = f"{parsed.scheme}://{parsed.hostname}"
+    if parsed.port:
+        server += f":{parsed.port}"
+    proxy = {"server": server}
+    if parsed.username:
+        proxy["username"] = urllib.parse.unquote(parsed.username)
+    if parsed.password:
+        proxy["password"] = urllib.parse.unquote(parsed.password)
+    return proxy
+
+
+def _requires_editable_focus(key: str) -> bool:
+    parts = [part.strip().casefold() for part in key.split("+") if part.strip()]
+    if not parts:
+        return False
+    if parts[-1] in {"backspace", "delete"}:
+        return True
+    return parts[-1] == "a" and bool(
+        set(parts[:-1]).intersection({"control", "ctrl", "meta", "controlormeta"})
+    )
+
+
+def _normalize_url(url: str) -> str:
+    if url.startswith(("http://", "https://", "file://", "about:", "data:", "chrome://")):
+        return url
+    return f"https://{url}" if "." in url else f"http://{url}"
+
+
+def _occupancy_help(verb: str, url: str) -> str:
+    return (
+        "This tab has no purpose yet — say why you're using it. "
+        "(This message is for the AI agent, not the user.)\n\n"
+        "Call again with these filled in from what the user asked you to do:\n"
+        f'  {verb}("{url}", purpose="<why you\'re opening this tab>", '
+        'who="<the user this is for>", hours=<how long you\'ll need it>)'
+    )
+
+
+async def _complete_cleanup(awaitable):
+    """Finish cleanup even if the caller is cancelled while awaiting it.
+
+    `asyncio.shield()` alone returns immediately on caller cancellation while the
+    cleanup task continues in the background. That is not deterministic shutdown:
+    a new runtime could open the same profile before the old context has released
+    it. Keep awaiting the shielded task and report whether cancellation interrupted
+    the caller so the outer lifecycle operation can re-raise after cleanup finishes.
+    """
+    task = asyncio.ensure_future(awaitable)
+    interrupted = False
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            interrupted = True
+            if task.done():
+                break
+    if task.cancelled():
+        raise asyncio.CancelledError
+    return task.result(), interrupted
+
+
+class AsyncBrowserCore:
+    """Internal async browser runtime with one persistent context and one tab per session."""
+
+    def __init__(
+        self,
+        use_chrome_profile: bool = True,
+        headless: bool = False,
+        seed_state: Optional[str] = None,
+        tab_idle_ttl: float = 3600.0,
+        max_tabs: int = 10,
+        use_mock_keychain: bool = False,
+    ) -> None:
+        self.playwright: Optional[Playwright] = None
+        self.browser: Optional[BrowserContext] = None
+        self._pages: Dict[Optional[str], Page] = {}
+        self._page_used: Dict[Optional[str], float] = {}
+        self._page_url: Dict[Optional[str], str] = {}
+        self._tab_meta: Dict[Optional[str], Dict[str, Any]] = {}
+        self._tab_idle_ttl = tab_idle_ttl
+        self._max_tabs = max_tabs
+        self._max_url_memory = 200
+        self.use_chrome_profile = use_chrome_profile
+        self._headless = _headless_without_display(headless)
+        self._seed_state = seed_state
+        self._seeded = False
+        self._use_mock_keychain = use_mock_keychain
+        self.current_url = ""
+        self.screenshots_dir = str(Path.cwd() / ".tmp")
+        self.last_screenshot_path: Optional[str] = None
+
+        suffix = hex(id(self))
+        self._session_key = contextvars.ContextVar(f"co_browser_session_{suffix}", default=None)
+        self._operation_depth = contextvars.ContextVar(f"co_browser_depth_{suffix}", default=0)
+        self._lifecycle_lock = asyncio.Lock()
+        self._page_state_lock = asyncio.Lock()
+        self._tab_locks: Dict[Optional[str], asyncio.Lock] = {}
+        self._operation_state_lock = asyncio.Lock()
+        self._operations_idle = asyncio.Event()
+        self._operations_idle.set()
+        self._close_complete = asyncio.Event()
+        self._close_complete.set()
+        self._active_operations = 0
+        self._closing = False
+        self._lifecycle_generation = 0
+
+    def _bind_session(self, session_id: Optional[str]) -> None:
+        """Bind subsequent calls in the current asyncio context to one session tab."""
+        self._session_key.set(session_id)
+
+    def _bound_session_key(self) -> Optional[str]:
+        return self._session_key.get()
+
+    @property
+    def page(self) -> Optional[Page]:
+        return self._pages.get(self._bound_session_key())
+
+    def _tab_lock(self, key: Optional[str]) -> asyncio.Lock:
+        lock = self._tab_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._tab_locks[key] = lock
+        return lock
+
+    @asynccontextmanager
+    async def _tab_operation(self, *, ensure_page: bool = True):
+        """Serialize one tab while allowing independent tabs to make progress."""
+        depth = self._operation_depth.get()
+        if depth:
+            yield
+            return
+
+        key = self._bound_session_key()
+        async with self._tab_lock(key):
+            async with self._operation_state_lock:
+                if self._closing:
+                    raise RuntimeError("Browser runtime is closing")
+                self._active_operations += 1
+                self._operations_idle.clear()
+            token = self._operation_depth.set(depth + 1)
+            try:
+                if ensure_page and self.browser is not None:
+                    await self._ensure_page(key)
+                yield
+            finally:
+                self._operation_depth.reset(token)
+                async with self._operation_state_lock:
+                    self._active_operations -= 1
+                    if self._active_operations == 0:
+                        self._operations_idle.set()
+
+    async def _ensure_page(self, key: Optional[str]) -> None:
+        if self.browser is None:
+            return
+        async with self._page_state_lock:
+            page = self._pages.get(key)
+            if page is None or page.is_closed():
+                claimed = {id(candidate) for candidate in self._pages.values()}
+                page = None
+                for candidate in list(getattr(self.browser, "pages", [])):
+                    try:
+                        usable = not candidate.is_closed()
+                    except Exception:
+                        usable = False
+                    if usable and id(candidate) not in claimed:
+                        page = candidate
+                        break
+                if page is None:
+                    page = await self.browser.new_page()
+                page.set_default_navigation_timeout(60000)
+                await page.set_viewport_size({"width": 1920, "height": 1200})
+                restore_url = self._page_url.get(key)
+                if restore_url:
+                    try:
+                        await page.goto(restore_url, wait_until="domcontentloaded", timeout=30000)
+                    except Exception:
+                        pass
+                self._pages[key] = page
+            self._page_used[key] = time.monotonic()
+            await self._reclaim_idle_tabs(key)
+
+    async def _reclaim_idle_tabs(self, active_key: Optional[str]) -> None:
+        now = time.monotonic()
+        expired = [
+            key
+            for key, last_used in list(self._page_used.items())
+            if key != active_key and now - last_used > self._tab_idle_ttl
+        ]
+        for key in expired:
+            await self._reclaim_tab(key)
+        if len(self._pages) > self._max_tabs:
+            lru = sorted(
+                (key for key in self._pages if key != active_key),
+                key=lambda key: self._page_used.get(key, 0.0),
+            )
+            for key in lru[: len(self._pages) - self._max_tabs]:
+                await self._reclaim_tab(key)
+
+    async def _reclaim_tab(self, key: Optional[str]) -> Optional[str]:
+        page = self._pages.pop(key, None)
+        self._page_used.pop(key, None)
+        if page is None:
+            return None
+        try:
+            url = page.url
+        except Exception:
+            url = None
+        if url:
+            self._page_url.pop(key, None)
+            self._page_url[key] = url
+            while len(self._page_url) > self._max_url_memory:
+                self._page_url.pop(next(iter(self._page_url)))
+        try:
+            await page.close()
+        except Exception as exc:
+            return f"close page failed: {exc}"
+        return None
+
+    async def _release_tab(self, key: Optional[str]) -> Optional[str]:
+        page = self._pages.pop(key, None)
+        self._page_used.pop(key, None)
+        self._page_url.pop(key, None)
+        self._tab_meta.pop(key, None)
+        if page is None:
+            return None
+        try:
+            await page.close()
+        except Exception as exc:
+            return f"close page failed: {exc}"
+        return None
+
+    async def is_alive(self) -> bool:
+        """Use a driver round-trip; local Page flags remain stale after process death."""
+        if self.browser is None:
+            return False
+        try:
+            await self.browser.cookies()
+        except Exception:
+            return False
+        return True
+
+    async def open_browser(self, headless: Optional[bool] = None, force: bool = False) -> str:
+        """Open/reuse the runtime while participating in tab and shutdown admission."""
+        if self._operation_depth.get():
+            return await self._open_browser(headless=headless, force=force)
+        async with self._tab_operation(ensure_page=False):
+            return await self._open_browser(headless=headless, force=force)
+
+    async def _open_browser(self, headless: Optional[bool] = None, force: bool = False) -> str:
+        if headless is None:
+            headless = self._headless
+        if not ASYNC_BROWSER_AVAILABLE:
+            return "Browser tools not installed. Run: pip install patchright && patchright install chrome"
+
+        async with self._operation_state_lock:
+            if self._closing:
+                raise RuntimeError("Browser runtime is closing")
+            generation = self._lifecycle_generation
+
+        async with self._lifecycle_lock:
+            async with self._operation_state_lock:
+                if self._closing or generation != self._lifecycle_generation:
+                    raise RuntimeError("Browser runtime closed while open was waiting")
+            key = self._bound_session_key()
+            if self.browser is not None:
+                try:
+                    await self._ensure_page(key)
+                except Exception:
+                    pass
+
+            if await self.is_alive():
+                if not force:
+                    return "<system-reminder>Browser already open and usable. Continue using the current browser page.</system-reminder>"
+                if key is not None:
+                    await self._reclaim_tab(key)
+                    self._page_url.pop(key, None)
+                    await self._ensure_page(key)
+                    return "Opened a fresh tab for this session."
+                await self._teardown_unlocked()
+                had_previous_state = True
+            else:
+                had_previous_state = bool(self.browser or self.playwright or self._pages)
+                if had_previous_state:
+                    await self._teardown_unlocked()
+
+            profile_dir = _profile_dir()
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            _clear_stale_profile_lock(profile_dir)
+            holder = _profile_lock_holder(profile_dir)
+            if holder is not None:
+                raise RuntimeError(
+                    f"Browser profile is already in use by another process (PID {holder}).\n"
+                    f"The persistent profile at {profile_dir} can be driven by only one browser at a time."
+                )
+
+            manager = async_playwright()
+            playwright = None
+            context = None
+            try:
+                start_task = asyncio.create_task(
+                    asyncio.wait_for(manager.start(), timeout=30)
+                )
+                try:
+                    playwright = await asyncio.shield(start_task)
+                except asyncio.CancelledError:
+                    playwright, _ = await _complete_cleanup(start_task)
+                    raise
+
+                launch_task = asyncio.create_task(
+                    playwright.chromium.launch_persistent_context(
+                        str(profile_dir),
+                        headless=headless,
+                        executable_path=find_system_chrome(),
+                        args=CHROME_DEFAULT_ARGS,
+                        ignore_default_args=(
+                            IGNORE_DEFAULT_ARGS
+                            if self._use_mock_keychain
+                            else IGNORE_DEFAULT_ARGS + ["--use-mock-keychain"]
+                        ),
+                        no_viewport=True,
+                        proxy=_proxy_from_env(),
+                        timeout=120000,
+                    )
+                )
+                try:
+                    context = await asyncio.shield(launch_task)
+                except asyncio.CancelledError:
+                    context, _ = await _complete_cleanup(launch_task)
+                    raise
+                self.playwright = playwright
+                self.browser = context
+
+                if self._seed_state and not self._seeded:
+                    cookies = json.loads(
+                        Path(self._seed_state).read_text(encoding="utf-8")
+                    ).get("cookies", [])
+                    if cookies:
+                        await context.add_cookies(cookies)
+                    self._seeded = True
+
+                await self._ensure_page(key)
+            except BaseException:
+                self.browser = None
+                self.playwright = None
+                if context is not None:
+                    try:
+                        await _complete_cleanup(
+                            asyncio.wait_for(context.close(), timeout=30)
+                        )
+                    except BaseException:
+                        pass
+                if playwright is not None:
+                    try:
+                        await _complete_cleanup(
+                            asyncio.wait_for(playwright.stop(), timeout=30)
+                        )
+                    except BaseException:
+                        pass
+                raise
+
+            if force and had_previous_state:
+                return f"Previous browser closed by force. Browser opened with persistent profile: {profile_dir}"
+            if had_previous_state:
+                return f"Previous stale browser state closed. Browser opened with persistent profile: {profile_dir}"
+            return f"Browser opened with persistent profile: {profile_dir}"
+
+    async def save_state(self, path: str) -> str:
+        async with self._tab_operation(ensure_page=False):
+            if self.browser is None:
+                return "Browser not open"
+            await self.browser.storage_state(path=path)
+            return (
+                f"Saved login state to {path}. This file contains live session cookies — "
+                "keep it secret, add it to .gitignore, and never commit or bake it into an image."
+            )
+
+    async def go_to(
+        self,
+        url: str,
+        purpose: str = "",
+        who: str = "",
+        hours: float = 0.0,
+    ) -> str:
+        async with self._tab_operation():
+            key = self._bound_session_key()
+            existing = self._tab_meta.get(key, {})
+            occupied = bool(existing.get("purpose") and existing.get("who"))
+            if not occupied and not (purpose and who):
+                raise ValueError(_occupancy_help("go_to", url))
+            if self.page is None:
+                await self.open_browser()
+
+            await self.page.goto(_normalize_url(url), wait_until="domcontentloaded", timeout=30000)
+            await self.page.wait_for_timeout(2000)
+            self.current_url = self.page.url
+            meta = self._tab_meta.setdefault(
+                key,
+                {"who": "", "purpose": "", "hours": 0.0, "opened_at": datetime.now()},
+            )
+            if purpose:
+                meta["purpose"] = purpose
+            if who:
+                meta["who"] = who
+            if hours:
+                meta["hours"] = hours
+            await self._save_context()
+            return f"Navigated to {self.current_url}"
+
+    async def newtab(
+        self,
+        url: str = "",
+        purpose: str = "",
+        who: str = "",
+        hours: float = 0.0,
+    ) -> str:
+        if not purpose or not who:
+            raise ValueError(_occupancy_help("newtab", url or "<url>"))
+        async with self._tab_operation(ensure_page=False):
+            if self.browser is None:
+                await self.open_browser()
+            key = self._bound_session_key()
+            await self._ensure_page(key)
+            meta = self._tab_meta.setdefault(key, {"opened_at": datetime.now()})
+            meta.update({"who": who, "purpose": purpose})
+            if hours:
+                meta["hours"] = hours
+            if url:
+                return await self.go_to(url, purpose=purpose, who=who, hours=hours)
+            return f"Opened new tab · who={who} · purpose={purpose!r}"
+
+    async def close_tab(self, key: Optional[str] = None) -> str:
+        if key is None:
+            key = self._bound_session_key()
+        elif key == "main":
+            key = None
+        async with self._tab_lock(key):
+            if key not in self._pages and key not in self._tab_meta:
+                return f"No open tab for {key!r}" if self.browser else "Browser not open"
+            error = await self._release_tab(key)
+            return error or "Tab closed"
+
+    async def get_current_url(self) -> str:
+        async with self._tab_operation():
+            return self.page.url if self.page else "Browser not open"
+
+    async def get_text(self) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            return await self.page.locator("body").inner_text()
+
+    async def get_focused_element(self, value_preview_chars: int = 160) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            limit = max(0, min(int(value_preview_chars), 1000))
+            focused = await self.page.evaluate(_FOCUSED_ELEMENT_SCRIPT, limit)
+            return json.dumps(focused, indent=2, ensure_ascii=False, sort_keys=True)
+
+    async def keyboard_press(self, key: str, allow_non_editable: bool = False) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            if _requires_editable_focus(key) and not allow_non_editable:
+                focused = await self.page.evaluate(_FOCUSED_ELEMENT_SCRIPT, 160)
+                if not focused.get("is_editable", False):
+                    return (
+                        f"Refused '{key}': the focused element is not editable. "
+                        "Focus the intended input and call get_focused_element() before retrying. "
+                        "For an intentional page-level shortcut, pass allow_non_editable=True.\n"
+                        + json.dumps(focused, ensure_ascii=False, sort_keys=True)
+                    )
+            await self.page.keyboard.press(key)
+            return f"Pressed: '{key}'"
+
+    async def click_element_by_selector(self, selector: str, index: int = 0) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            locator = self.page.locator(selector)
+            count = await locator.count()
+            if index < 0 or index >= count:
+                return f"No element {index + 1}/{count} matching selector: {selector}"
+            await locator.nth(index).click()
+            return f"Clicked element {index + 1}/{count} matching selector: {selector}"
+
+    async def count_elements_by_selector(self, selector: str) -> int:
+        async with self._tab_operation():
+            if self.page is None:
+                return 0
+            return await self.page.locator(selector).count()
+
+    async def get_element_text_by_selector(self, selector: str, index: int = 0) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            locator = self.page.locator(selector)
+            count = await locator.count()
+            if index < 0 or index >= count:
+                return f"No element {index + 1}/{count} matching selector: {selector}"
+            return await locator.nth(index).inner_text()
+
+    async def fill_text_by_selector(self, selector: str, text: str, index: int = 0) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            locator = self.page.locator(selector)
+            count = await locator.count()
+            if index < 0 or index >= count:
+                return f"No element {index + 1}/{count} matching selector: {selector}"
+            await locator.nth(index).fill(text)
+            return f"Filled element {index + 1}/{count} matching selector: {selector}"
+
+    async def upload_file_by_selector(self, selector: str, file_path: str, index: int = 0) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            path = Path(file_path).expanduser().resolve()
+            if not path.is_file():
+                return f"File not found: {path}"
+            locator = self.page.locator(selector)
+            count = await locator.count()
+            if index < 0 or index >= count:
+                return f"No element {index + 1}/{count} matching selector: {selector}"
+            await locator.nth(index).set_input_files(str(path))
+            return f"Uploaded {path.name} to element {index + 1}/{count} matching selector: {selector}"
+
+    async def run_page_script(self, script_path: str, args_json: str = "{}") -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            path = Path(script_path).expanduser().resolve()
+            if not path.is_file():
+                return f"Script not found: {path}"
+            try:
+                args = json.loads(args_json)
+            except json.JSONDecodeError as exc:
+                return f"Invalid args_json: {exc}"
+            result = await self.page.evaluate(path.read_text(encoding="utf-8"), args)
+            return json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True)
+
+    async def take_screenshot(self, path: Optional[str] = None, full_page: bool = False) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            Path(self.screenshots_dir).mkdir(parents=True, exist_ok=True)
+            if not path:
+                path = f"step_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+            if "/" not in path and "\\" not in path:
+                path = str(Path(self.screenshots_dir) / path)
+            screenshot = await self.page.screenshot(path=path, full_page=full_page)
+            self.last_screenshot_path = path
+            mime = "image/png"
+            if len(screenshot) > 600_000:
+                screenshot = await self.page.screenshot(full_page=full_page, type="jpeg", quality=85)
+                mime = "image/jpeg"
+            await self.page.wait_for_timeout(1000)
+            return f"data:{mime};base64,{base64.b64encode(screenshot).decode('utf-8')}"
+
+    async def wait(self, seconds: float) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            await self.page.wait_for_timeout(int(seconds * 1000))
+            return f"Waited {seconds} seconds"
+
+    async def _save_context(self) -> None:
+        if self.browser is not None and self.page is not None:
+            await self.page.wait_for_timeout(500)
+
+    async def close(self) -> str:
+        key = self._bound_session_key()
+        if key is not None:
+            async with self._tab_lock(key):
+                error = await self._release_tab(key)
+                return error or "Browser tab closed for this session."
+        async with self._operation_state_lock:
+            if self._closing:
+                wait_for_other_close = True
+            else:
+                self._closing = True
+                self._lifecycle_generation += 1
+                self._close_complete.clear()
+                wait_for_other_close = False
+        if wait_for_other_close:
+            await self._close_complete.wait()
+            return "Browser closed. Session saved for next time."
+
+        try:
+            await self._operations_idle.wait()
+            async with self._lifecycle_lock:
+                warnings = await self._teardown_unlocked()
+        finally:
+            async with self._operation_state_lock:
+                self._closing = False
+                self._close_complete.set()
+        if warnings:
+            return "Browser closed with cleanup warnings: " + "; ".join(warnings)
+        return "Browser closed. Session saved for next time."
+
+    async def _teardown_unlocked(self) -> list[str]:
+        """Clear state even when one close operation fails; caller owns lifecycle lock."""
+        warnings = []
+        interrupted = False
+        context, playwright = self.browser, self.playwright
+        pages = list(self._pages.values())
+        self.browser = None
+        self.playwright = None
+        self._pages.clear()
+        self._page_used.clear()
+        self._page_url.clear()
+        self._tab_meta.clear()
+        self._tab_locks.clear()
+
+        if context is None:
+            seen_pages = set()
+            for page in pages:
+                identity = id(page)
+                try:
+                    already_closed = page.is_closed()
+                except Exception:
+                    already_closed = False
+                if identity in seen_pages or already_closed:
+                    continue
+                seen_pages.add(identity)
+                try:
+                    _, was_cancelled = await _complete_cleanup(
+                        asyncio.wait_for(page.close(), timeout=10)
+                    )
+                    interrupted = interrupted or was_cancelled
+                except BaseException as exc:
+                    warnings.append(f"close page failed: {exc}")
+        if context is not None:
+            try:
+                _, was_cancelled = await _complete_cleanup(
+                    asyncio.wait_for(context.close(), timeout=30)
+                )
+                interrupted = interrupted or was_cancelled
+            except BaseException as exc:
+                warnings.append(f"close context failed: {exc}")
+        if playwright is not None:
+            try:
+                _, was_cancelled = await _complete_cleanup(
+                    asyncio.wait_for(playwright.stop(), timeout=30)
+                )
+                interrupted = interrupted or was_cancelled
+            except BaseException as exc:
+                warnings.append(f"stop playwright failed: {exc}")
+        if interrupted:
+            raise asyncio.CancelledError
+        return warnings
+
+    async def __aenter__(self):
+        await self.open_browser()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.close()

--- a/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
+++ b/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
@@ -1,0 +1,49 @@
+# A Thread Is Not an Async Runtime
+
+*2026-08-26*
+
+ConnectOnion already gave each browser session its own tab. Two agents could
+hold different pages without navigating over each other, but they still could
+not use them at the same time.
+
+The browser had one worker thread. The daemon had one request loop. A slow
+navigation on tab A blocked a text read on tab B even though the pages shared no
+state beyond their browser context. Isolation existed; progress did not.
+
+## Moving the queue is not removing it
+
+An asyncio server in front of the existing driver would only move the waiting
+line. Every request would still enter the single sync-Playwright worker. Changing
+the driver import alone would be worse: helper modules still issue synchronous
+Page calls, and a cancelled launch could leave Chrome holding the persistent
+profile after the task appeared finished.
+
+The migration therefore starts below the daemon. One internal core owns
+Patchright's async API on one event loop. Session identity moves from
+thread-local state to a `ContextVar`, so two tasks on the same thread do not see
+each other's tab. A lock per tab keeps two commands from racing on one page,
+while different tabs can interleave.
+
+Lifecycle has its own boundary. Close stops new work, waits for operations
+already admitted, and finishes context and driver cleanup even when its caller
+is cancelled. An overlapping open fails instead of quietly reopening a browser
+after another caller received “closed.”
+
+## Liveness instead of a stopwatch race
+
+Concurrency tests often compare total elapsed time: two 300 ms calls “should”
+finish in less than 600 ms. That is fragile on a busy runner and can pass when
+timing noise hides serialization.
+
+The real-driver test instead holds a native two-second wait on tab A. While that
+operation is still unfinished, tab B must return its page text within 500 ms. A
+globally serialized driver cannot make progress on B until A returns, so it
+cannot satisfy the condition. The test passed against the installed wheel and
+native browser, proving independent progress rather than a favorable aggregate
+duration.
+
+This is the first #498 slice, not the declaration that the port is finished.
+Humanized input, LLM element finding, the remaining browser verbs, concurrent
+IPC, and the synchronous facade still have separate review boundaries. Keeping
+those boundaries visible is how 1.8 gains concurrency without trading away the
+browser behavior and cross-platform security it already has.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -1,0 +1,96 @@
+# DD-054: One async browser runtime, two compatibility edges
+
+**Status:** In progress for 1.8
+
+**Date:** 2026-08-26
+
+**Related:** [#498](https://github.com/openonion/connectonion/issues/498),
+[#499](https://github.com/openonion/connectonion/issues/499),
+[#500](https://github.com/openonion/connectonion/issues/500),
+[#208](https://github.com/openonion/connectonion/issues/208)
+
+## Context
+
+The existing browser is safe but globally serial. `BrowserAutomation` uses
+Patchright's synchronous API and sends every public method through one worker
+thread. The daemon likewise accepts one connection, reads one request, dispatches
+it, and replies before accepting the next. Per-session tabs prevent one agent
+from navigating another agent's page, but an unrelated slow tab still blocks the
+whole browser.
+
+Changing only the daemon would not create concurrency: all requests would queue
+at the one-worker driver. Changing only the driver import would also be
+incorrect. Element extraction and humanized input call the synchronous Page API,
+and cancellation must release a persistent profile before another runtime opens
+it.
+
+## Decision
+
+The 1.8 browser has one internal `AsyncBrowserCore`, owned by one asyncio event
+loop. It imports only `patchright.async_api`; no synchronous Patchright call is
+allowed below that boundary.
+
+Session binding uses a `ContextVar`, because concurrent asyncio tasks can share
+one operating-system thread. Each session retains its own page, metadata, and
+restore URL. A lock per tab serializes conflicting operations on that page while
+independent tabs may interleave. Context launch and shutdown use a separate
+lifecycle lock.
+
+Shutdown is an explicit state transition. It stops admission, waits for active
+operations, closes the context and driver completely even if the caller is
+cancelled, then releases the persistent profile. A launch that overlaps that
+transition fails rather than reopening the browser behind a completed close.
+
+The migration has three review boundaries:
+
+1. **#498 — async driver contract.** Port lifecycle, tabs, deterministic
+   selectors, scripts, input, downloads/uploads, screenshots, stealth behavior,
+   LLM element finding, and humanized input. Equivalent old/new contract tests
+   remain until the port is complete.
+2. **#499 — concurrent transport.** Run client requests as bounded async tasks.
+   POSIX uses an asyncio Unix server; the authenticated blocking Windows pipe
+   boundary is bridged into bounded transport workers. Both submit to the same
+   async browser runtime. Same-tab conflicts stay deterministic; independent
+   tabs make progress concurrently.
+3. **#500 — synchronous compatibility facade.** Existing
+   `BrowserAutomation` methods submit to an owned loop thread without nesting a
+   caller's running event loop. The facade is compatibility, not a second driver.
+
+The internal core is not exported as a public user API while #498 is incomplete.
+The current synchronous API and daemon remain authoritative until the complete
+contract and cross-platform transport matrices are green.
+
+## Invariants
+
+- one persistent browser context and profile per runtime;
+- one page and one operation lock per bound session;
+- independent tab operations can interleave; operations on one tab cannot;
+- a cancelled launch or close leaves no context, driver, or profile owner;
+- close never tears down another task while it is operating;
+- passwords remain redacted and destructive shortcuts remain fail-closed;
+- existing result strings, timeout behavior, claims, authkey recovery, and
+  Windows/POSIX framing do not change accidentally;
+- no release claims async completion while any in-use path still reaches the
+  synchronous core.
+
+## Verification
+
+Every migration PR must include isolated async contract tests. The real-driver
+gate holds a native two-second wait on one session page while requiring a text
+read on another page to finish within 500 ms and before the wait completes. A
+globally serialized driver cannot satisfy that liveness condition. The gate also
+checks page isolation and focused-element behavior.
+
+The macOS native gate runs with Chrome's mock keychain because the repository's
+autouse fixture gives every test a disposable `HOME`. Production keeps the
+existing real-keychain launch behavior for persistent cookies; mixing a fake
+home with the real macOS keychain makes Chrome hang during context shutdown.
+
+Before #498 closes, the async core must cover every current public browser verb,
+the humanized-input acceptance suite, profile seeding/export, dead-context
+recovery, downloads/uploads, screenshot payload bounds, and stealth checks.
+Before #499 closes, slow-reader/writer, stalled client, cancellation,
+disconnect, same-tab conflict, independent-tab progress, cold-start, and
+shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
+sync and running-event-loop callers must leave no loop thread, task, page,
+process, socket, or pipe behind.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -254,6 +254,12 @@ agent.input("Fill in the contact form on example.com with test data")
 
 One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
 
+That worker-thread behavior remains the public contract during the 1.8 async
+migration. The replacement core is internal until every browser verb and the
+cross-platform daemon have equivalent coverage; do not import it as an
+application API yet. The lifecycle, concurrency, cancellation, and compatibility
+boundaries are recorded in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+
 ## Common Patterns
 
 ### Login once, reuse session

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -1,0 +1,100 @@
+"""Real-driver acceptance for the internal 1.8 async browser core.
+
+Run explicitly while #498 is in progress:
+
+    python -m pytest tests/e2e/test_async_browser_core_real_driver.py -m slow -q
+
+The ordinary matrix deselects slow tests; the 1.8 exact-artifact gate will run
+this against an installed wheel and browser before an alpha is promoted.
+"""
+
+import asyncio
+import gc
+import json
+
+import pytest
+
+from connectonion.useful_tools.browser_tools._async_browser import (
+    ASYNC_BROWSER_AVAILABLE,
+    AsyncBrowserCore,
+)
+
+
+@pytest.mark.slow
+def test_real_async_driver_keeps_sessions_isolated_and_interleaves(tmp_path, monkeypatch):
+    asyncio.run(_exercise_real_async_driver(tmp_path, monkeypatch))
+
+
+async def _exercise_real_async_driver(tmp_path, monkeypatch):
+    if not ASYNC_BROWSER_AVAILABLE:
+        pytest.skip("patchright async API is not installed")
+
+    monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(tmp_path / "profile"))
+    browser = AsyncBrowserCore(headless=True, use_mock_keychain=True)
+    loop = asyncio.get_running_loop()
+    loop_errors = []
+    timings = {"started": loop.time()}
+    close_result = None
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+
+    try:
+        await browser.open_browser()
+        timings["opened"] = loop.time()
+        try:
+            pages = {}
+            for session, marker in (("A", "alpha"), ("B", "beta")):
+                browser._bind_session(session)
+                await browser.go_to(
+                    f"data:text/html,<title>{marker}</title><p>{marker}</p>"
+                    f"<input id=editor value={marker}>",
+                    purpose="async core acceptance",
+                    who=session,
+                )
+                pages[session] = browser.page
+
+            async def hold_tab_a():
+                browser._bind_session("A")
+                return await browser.wait(2)
+
+            async def read_tab_b():
+                browser._bind_session("B")
+                return await browser.get_text()
+
+            held = asyncio.create_task(hold_tab_a())
+            await asyncio.sleep(0.05)
+            text_b = await asyncio.wait_for(read_tab_b(), timeout=0.5)
+
+            assert "beta" in text_b
+            assert held.done() is False
+            assert await held == "Waited 2 seconds"
+            timings["interleaved"] = loop.time()
+            assert pages["A"] is not pages["B"]
+
+            browser._bind_session("A")
+            await browser.page.locator("#editor").focus()
+            focused = json.loads(await browser.get_focused_element())
+            assert focused["is_editable"] is True
+            assert focused["value_preview"] == "alpha"
+        finally:
+            browser._bind_session(None)
+            close_result = await browser.close()
+            timings["closed"] = loop.time()
+            gc.collect()
+            await asyncio.sleep(0.1)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert close_result == "Browser closed. Session saved for next time."
+    assert not loop_errors, {"timings": timings, "errors": [
+        {
+            "message": error.get("message"),
+            "exception": repr(error.get("exception")),
+            "origin": [
+                f"{frame.name}:{frame.lineno}"
+                for frame in (getattr(error.get("future"), "_source_traceback", None) or [])
+                if "patchright" in frame.filename
+            ][-4:],
+        }
+        for error in loop_errors
+    ]}

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -1,0 +1,533 @@
+"""Contract tests for the internal 1.8 Patchright async browser core.
+
+The public synchronous BrowserAutomation remains unchanged until #500. These
+tests prove the new core itself is genuinely async, preserves per-session tabs,
+and cleans up deterministically before #499 puts concurrent IPC in front of it.
+"""
+
+import asyncio
+import ast
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import _async_browser as async_mod
+
+
+class FakeKeyboard:
+    def __init__(self):
+        self.pressed = []
+
+    async def press(self, key):
+        self.pressed.append(key)
+
+
+class FakeLocator:
+    def __init__(self, page, selector, index=None):
+        self.page = page
+        self.selector = selector
+        self.index = index
+
+    async def count(self):
+        return self.page.selector_counts.get(self.selector, 1)
+
+    def nth(self, index):
+        return FakeLocator(self.page, self.selector, index=index)
+
+    async def click(self):
+        self.page.clicked.append((self.selector, self.index))
+
+    async def inner_text(self):
+        return self.page.text_by_selector.get(self.selector, f"text:{self.index}")
+
+    async def fill(self, text):
+        self.page.filled.append((self.selector, self.index, text))
+
+    async def set_input_files(self, path):
+        self.page.uploaded.append((self.selector, self.index, path))
+
+
+class FakePage:
+    def __init__(self, idx=1):
+        self.idx = idx
+        self.url = "about:blank"
+        self.closed = False
+        self.close_calls = 0
+        self.goto_calls = []
+        self.waits = []
+        self.viewport = None
+        self.keyboard = FakeKeyboard()
+        self.focused = {"tag": "body", "is_editable": False, "sensitive": False}
+        self.selector_counts = {}
+        self.text_by_selector = {"body": "page body"}
+        self.clicked = []
+        self.filled = []
+        self.uploaded = []
+
+    def set_default_navigation_timeout(self, timeout):
+        self.navigation_timeout = timeout
+
+    async def set_viewport_size(self, viewport):
+        self.viewport = viewport
+
+    async def goto(self, url, **kwargs):
+        self.goto_calls.append((url, kwargs))
+        self.url = url
+
+    async def wait_for_timeout(self, milliseconds):
+        self.waits.append(milliseconds)
+
+    def is_closed(self):
+        return self.closed
+
+    async def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+    def locator(self, selector):
+        return FakeLocator(self, selector)
+
+    async def evaluate(self, script, arg=None):
+        if "document.activeElement" in script:
+            return dict(self.focused)
+        return {"arg": arg}
+
+    async def screenshot(self, **kwargs):
+        return b"png"
+
+
+class FakeContext:
+    def __init__(self, page_factory=FakePage):
+        self.page_factory = page_factory
+        self.pages_created = []
+        self.closed = False
+        self.cookies_added = []
+        self.storage_paths = []
+
+    async def new_page(self):
+        page = self.page_factory(len(self.pages_created) + 1)
+        self.pages_created.append(page)
+        return page
+
+    async def cookies(self):
+        if self.closed:
+            raise RuntimeError("closed")
+        return []
+
+    async def add_cookies(self, cookies):
+        self.cookies_added.extend(cookies)
+
+    async def storage_state(self, path):
+        self.storage_paths.append(path)
+
+    async def close(self):
+        self.closed = True
+        for page in self.pages_created:
+            page.closed = True
+
+
+class FakeChromium:
+    def __init__(self, context):
+        self.context = context
+        self.launch_kwargs = None
+
+    async def launch_persistent_context(self, profile, **kwargs):
+        self.profile = profile
+        self.launch_kwargs = kwargs
+        return self.context
+
+
+class FakePlaywright:
+    def __init__(self, context):
+        self.chromium = FakeChromium(context)
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+class FakeManager:
+    def __init__(self, playwright):
+        self.playwright = playwright
+
+    async def start(self):
+        return self.playwright
+
+
+def install_fake_runtime(monkeypatch, tmp_path, context=None):
+    context = context or FakeContext()
+    playwright = FakePlaywright(context)
+    monkeypatch.setattr(async_mod, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_mod, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_mod, "_profile_dir", lambda: tmp_path / "profile")
+    monkeypatch.setattr(async_mod, "find_system_chrome", lambda: "/fake/chrome")
+    return context, playwright
+
+
+def test_async_core_has_no_sync_patchright_dependency():
+    source = Path(async_mod.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    }
+    assert "patchright.sync_api" not in imported_modules
+    assert not any(
+        isinstance(node, ast.Name) and node.id == "sync_playwright"
+        for node in ast.walk(tree)
+    )
+    for method in (
+        "open_browser",
+        "go_to",
+        "get_text",
+        "keyboard_press",
+        "take_screenshot",
+        "close",
+    ):
+        assert inspect.iscoroutinefunction(getattr(async_mod.AsyncBrowserCore, method))
+
+
+@pytest.mark.asyncio
+async def test_open_reuses_one_async_context_and_seeds_before_navigation(monkeypatch, tmp_path):
+    seed = tmp_path / "state.json"
+    seed.write_text('{"cookies":[{"name":"sid","value":"one","domain":"example.com","path":"/"}]}')
+    context, playwright = install_fake_runtime(monkeypatch, tmp_path)
+    browser = async_mod.AsyncBrowserCore(headless=True, seed_state=str(seed))
+
+    first = await browser.open_browser()
+    second = await browser.open_browser()
+
+    assert "Browser opened" in first
+    assert "already open" in second
+    assert len(context.pages_created) == 1
+    assert context.cookies_added[0]["name"] == "sid"
+    assert playwright.chromium.launch_kwargs["no_viewport"] is True
+    assert "--use-mock-keychain" in playwright.chromium.launch_kwargs["ignore_default_args"]
+    assert browser.page.viewport == {"width": 1920, "height": 1200}
+
+    await browser.close()
+    assert context.pages_created[0].close_calls == 0
+    assert context.pages_created[0].closed is True
+    assert context.closed is True
+    assert playwright.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_isolated_runtime_can_keep_chromes_mock_keychain(monkeypatch, tmp_path):
+    _, playwright = install_fake_runtime(monkeypatch, tmp_path)
+    browser = async_mod.AsyncBrowserCore(headless=True, use_mock_keychain=True)
+
+    await browser.open_browser()
+
+    assert "--use-mock-keychain" not in playwright.chromium.launch_kwargs["ignore_default_args"]
+    await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_first_session_adopts_the_persistent_context_page():
+    initial_page = FakePage()
+    context = FakeContext()
+    context.pages = [initial_page]
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+
+    await browser._ensure_page(None)
+
+    assert browser.page is initial_page
+    assert context.pages_created == []
+
+
+@pytest.mark.asyncio
+async def test_contextvar_sessions_make_progress_on_independent_tabs():
+    both_started = asyncio.Event()
+    started = set()
+
+    class ConcurrentPage(FakePage):
+        async def goto(self, url, **kwargs):
+            started.add(self.idx)
+            if len(started) == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=0.2)
+            await super().goto(url, **kwargs)
+
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext(ConcurrentPage)
+
+    async def navigate(session, url):
+        browser._bind_session(session)
+        return await browser.go_to(url, purpose="concurrency test", who=session)
+
+    results = await asyncio.gather(
+        navigate("A", "a.example"),
+        navigate("B", "b.example"),
+    )
+
+    assert results == ["Navigated to https://a.example", "Navigated to https://b.example"]
+    assert browser._pages["A"] is not browser._pages["B"]
+
+
+@pytest.mark.asyncio
+async def test_same_tab_operations_are_serialized():
+    active = 0
+    max_active = 0
+
+    class SerialPage(FakePage):
+        async def goto(self, url, **kwargs):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.02)
+            await super().goto(url, **kwargs)
+            active -= 1
+
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext(SerialPage)
+    browser._bind_session("one")
+    browser._tab_meta["one"] = {"purpose": "test", "who": "tester"}
+
+    await asyncio.gather(browser.go_to("one.example"), browser.go_to("two.example"))
+
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_launch_closes_partial_context_and_driver(monkeypatch, tmp_path):
+    page_started = asyncio.Event()
+
+    class BlockingContext(FakeContext):
+        async def new_page(self):
+            page_started.set()
+            await asyncio.Event().wait()
+
+    context, playwright = install_fake_runtime(monkeypatch, tmp_path, BlockingContext())
+    browser = async_mod.AsyncBrowserCore()
+    task = asyncio.create_task(browser.open_browser())
+    await page_started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert context.closed is True
+    assert playwright.stopped is True
+    assert browser.browser is None
+    assert browser.playwright is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_driver_start_waits_for_driver_then_stops_it(monkeypatch, tmp_path):
+    start_entered = asyncio.Event()
+    release_start = asyncio.Event()
+    context = FakeContext()
+    playwright = FakePlaywright(context)
+
+    class BlockingManager:
+        async def start(self):
+            start_entered.set()
+            await release_start.wait()
+            return playwright
+
+    monkeypatch.setattr(async_mod, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_mod, "async_playwright", BlockingManager)
+    monkeypatch.setattr(async_mod, "_profile_dir", lambda: tmp_path / "profile")
+    browser = async_mod.AsyncBrowserCore()
+    opening = asyncio.create_task(browser.open_browser())
+    await start_entered.wait()
+
+    opening.cancel()
+    await asyncio.sleep(0)
+    assert opening.done() is False
+
+    release_start.set()
+    with pytest.raises(asyncio.CancelledError):
+        await opening
+    assert playwright.stopped is True
+    assert browser.playwright is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_context_launch_waits_for_context_then_closes_it(monkeypatch, tmp_path):
+    launch_entered = asyncio.Event()
+    release_launch = asyncio.Event()
+    context = FakeContext()
+
+    class BlockingChromium(FakeChromium):
+        async def launch_persistent_context(self, profile, **kwargs):
+            launch_entered.set()
+            await release_launch.wait()
+            return await super().launch_persistent_context(profile, **kwargs)
+
+    playwright = FakePlaywright(context)
+    playwright.chromium = BlockingChromium(context)
+    monkeypatch.setattr(async_mod, "ASYNC_BROWSER_AVAILABLE", True)
+    monkeypatch.setattr(async_mod, "async_playwright", lambda: FakeManager(playwright))
+    monkeypatch.setattr(async_mod, "_profile_dir", lambda: tmp_path / "profile")
+    monkeypatch.setattr(async_mod, "find_system_chrome", lambda: "/fake/chrome")
+    browser = async_mod.AsyncBrowserCore()
+    opening = asyncio.create_task(browser.open_browser())
+    await launch_entered.wait()
+
+    opening.cancel()
+    await asyncio.sleep(0)
+    assert opening.done() is False
+
+    release_launch.set()
+    with pytest.raises(asyncio.CancelledError):
+        await opening
+    assert context.closed is True
+    assert playwright.stopped is True
+    assert browser.browser is None
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_an_active_operation_before_teardown(monkeypatch, tmp_path):
+    navigation_started = asyncio.Event()
+    release_navigation = asyncio.Event()
+
+    class BlockingPage(FakePage):
+        async def goto(self, url, **kwargs):
+            navigation_started.set()
+            await release_navigation.wait()
+            await super().goto(url, **kwargs)
+
+    context, playwright = install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        FakeContext(BlockingPage),
+    )
+    browser = async_mod.AsyncBrowserCore()
+    await browser.open_browser()
+    browser._tab_meta[None] = {"purpose": "test", "who": "tester"}
+    navigation = asyncio.create_task(browser.go_to("example.com"))
+    await navigation_started.wait()
+
+    closing = asyncio.create_task(browser.close())
+    await asyncio.sleep(0)
+    assert closing.done() is False
+    assert context.closed is False
+
+    release_navigation.set()
+    await navigation
+    assert await closing == "Browser closed. Session saved for next time."
+    assert context.closed is True
+    assert playwright.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_cancelled_close_finishes_cleanup_before_propagating(monkeypatch, tmp_path):
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class BlockingCloseContext(FakeContext):
+        async def close(self):
+            close_started.set()
+            await release_close.wait()
+            await super().close()
+
+    context, playwright = install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        BlockingCloseContext(),
+    )
+    browser = async_mod.AsyncBrowserCore()
+    await browser.open_browser()
+    closing = asyncio.create_task(browser.close())
+    await close_started.wait()
+
+    closing.cancel()
+    await asyncio.sleep(0)
+    assert closing.done() is False
+    assert context.closed is False
+
+    release_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await closing
+    assert context.closed is True
+    assert playwright.stopped is True
+    assert browser.browser is None
+
+
+@pytest.mark.asyncio
+async def test_open_is_rejected_while_shutdown_owns_the_runtime(monkeypatch, tmp_path):
+    close_started = asyncio.Event()
+    release_close = asyncio.Event()
+
+    class BlockingCloseContext(FakeContext):
+        async def close(self):
+            close_started.set()
+            await release_close.wait()
+            await super().close()
+
+    install_fake_runtime(monkeypatch, tmp_path, BlockingCloseContext())
+    browser = async_mod.AsyncBrowserCore()
+    await browser.open_browser()
+    closing = asyncio.create_task(browser.close())
+    await close_started.wait()
+
+    with pytest.raises(RuntimeError, match="closing"):
+        await browser.open_browser()
+
+    release_close.set()
+    await closing
+
+
+@pytest.mark.asyncio
+async def test_focus_guard_refuses_destructive_shortcut_and_allows_override():
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    refused = await browser.keyboard_press("Meta+a")
+    allowed = await browser.keyboard_press("Meta+a", allow_non_editable=True)
+
+    assert refused.startswith("Refused 'Meta+a'")
+    assert page.keyboard.pressed == ["Meta+a"]
+    assert allowed == "Pressed: 'Meta+a'"
+
+
+@pytest.mark.asyncio
+async def test_selector_methods_use_async_locator_contract(tmp_path):
+    upload = tmp_path / "report.txt"
+    upload.write_text("ok")
+    page = FakePage()
+    page.selector_counts["button"] = 2
+    page.text_by_selector["button"] = "Publish"
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    assert await browser.count_elements_by_selector("button") == 2
+    assert await browser.get_element_text_by_selector("button", 1) == "Publish"
+    assert "Clicked element 2/2" in await browser.click_element_by_selector("button", 1)
+    assert "Filled element 1/1" in await browser.fill_text_by_selector("input", "hello")
+    assert "Uploaded report.txt" in await browser.upload_file_by_selector("input", str(upload))
+    assert page.clicked == [("button", 1)]
+    assert page.filled == [("input", 0, "hello")]
+
+
+@pytest.mark.asyncio
+async def test_bound_close_releases_only_that_session_tab():
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._bind_session("A")
+    await browser._ensure_page("A")
+    page_a = browser.page
+    browser._bind_session("B")
+    await browser._ensure_page("B")
+
+    result = await browser.close()
+
+    assert "tab closed" in result.lower()
+    assert "B" not in browser._pages
+    assert browser._pages["A"] is page_a
+    assert page_a.closed is False
+    assert browser.browser is not None


### PR DESCRIPTION
## Summary

- establish the internal Patchright async driver boundary for ConnectOnion 1.8
- bind session tabs with `ContextVar` and serialize only same-tab operations
- make launch/close admission and partial-start cleanup deterministic under cancellation
- preserve the current synchronous public API while #498 remains in progress
- document the #498 → #499 → #500 migration boundaries

## Why this is a foundation slice

This PR does **not** complete issue #498 and does not switch the public browser or daemon to the new core. It ports lifecycle, session pages, deterministic selector primitives, scripts, screenshots, focused-element safety, state seeding/export, and shutdown behavior. Remaining #498 work includes the full browser verb surface, frames, humanized input, LLM element finding, downloads, stealth/dead-context parity, and old/new contract equivalence.

The persistent-context initial page is adopted instead of leaked. The macOS real-driver gate explicitly retains Chrome's mock keychain because the test suite provides a disposable `HOME`; production keeps the existing real-keychain behavior for persistent cookies.

## Verification

- `python -m pytest tests/unit/test_async_browser_core.py -q` — 15 passed
- `python -m pytest tests/e2e/test_async_browser_core_real_driver.py -m slow -q` against the installed `connectonion-1.8.0a1` wheel and system Chrome — 1 passed in 8.18s
- native gate proves tab B returns while tab A still owns a two-second Patchright wait, then verifies tab isolation, focused input state, graceful close, and no unhandled loop futures
- `python -m pytest tests/ -q -m 'not slow and not real_api and not network'` — 7,269 passed, 21 skipped, 199 deselected
- wheel contains `connectonion/useful_tools/browser_tools/_async_browser.py`
- `git diff --check`

## Release coordination

**Proposed target version:** 1.8.0 / next alpha

**Estimated release window:** next 1.8 alpha after #498–#500 and the coordinated Onionwright/native-browser artifact gate are complete

Refs #498
Related: #499, #500, #208
