### PR TITLE
feat(browser): port deterministic async contracts

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -180,6 +180,41 @@ def _occupancy_help(verb: str, url: str) -> str:
     )
 
 
+def _age(seconds: float) -> str:
+    """Render tab age with the same compact units as BrowserAutomation."""
+    seconds = int(seconds)
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _occupancy_note(meta: Dict[str, Any]) -> str:
+    """Describe when a peer-owned tab becomes eligible for reclamation."""
+    until = meta.get("needs_until") or 0
+    if not until:
+        hours, opened_at = meta.get("hours") or 0, meta.get("opened_at")
+        if hours > 0 and opened_at:
+            until = opened_at.timestamp() + hours * 3600
+    if not until:
+        return ""
+
+    left = until - time.time()
+    when = datetime.fromtimestamp(until).strftime("%H:%M")
+    if left > 0:
+        return (
+            f"owner expects to finish by {when} ({_age(left)} left) — "
+            "leave it alone until then"
+        )
+    return (
+        f"owner expected to finish by {when} ({_age(-left)} ago) — "
+        "free for another agent to close"
+    )
+
+
 async def _complete_cleanup(awaitable):
     """Finish cleanup even if the caller is cancelled while awaiting it.
 
@@ -572,6 +607,40 @@ class AsyncBrowserCore:
                 return await self.go_to(url, purpose=purpose, who=who, hours=hours)
             return f"Opened new tab · who={who} · purpose={purpose!r}"
 
+    async def tab_status(self) -> str:
+        """Render registered tabs, including reservations without a live page."""
+        async with self._tab_operation(ensure_page=False):
+            if not self._tab_meta:
+                return "Tabs: none"
+            active = self._bound_session_key()
+            lines = [f"Tabs ({len(self._tab_meta)}):"]
+            for key, meta in list(self._tab_meta.items()):
+                page = self._pages.get(key)
+                if (
+                    page is not None
+                    and callable(getattr(page, "is_closed", None))
+                    and page.is_closed()
+                ):
+                    page = None
+                where = page.url if page is not None else "(reserved — no page yet)"
+                marker = "*" if key == active else " "
+                name = "main" if key is None else key
+                who = meta.get("who") or "-"
+                purpose = meta.get("purpose") or "-"
+                line = f"  {marker}[{name}] {where}  who={who}  purpose={purpose!r}"
+                opened_at = meta.get("opened_at")
+                if opened_at:
+                    line += f"  open {_age((datetime.now() - opened_at).total_seconds())}"
+                last_at = meta.get("last_at")
+                if last_at:
+                    last_line = (meta.get("last_line") or "")[:60]
+                    line += f'\n      last: "{last_line}" · {_age(time.time() - last_at)} ago'
+                note = _occupancy_note(meta)
+                if note:
+                    line += f"\n      {note}"
+                lines.append(line)
+            return "\n".join(lines)
+
     async def close_tab(self, key: Optional[str] = None) -> str:
         if key is None:
             key = self._bound_session_key()
@@ -587,11 +656,120 @@ class AsyncBrowserCore:
         async with self._tab_operation():
             return self.page.url if self.page else "Browser not open"
 
+    async def get_system_info(self) -> str:
+        system = platform.system()
+        if system == "Darwin":
+            return (
+                "OS: macOS. Use Meta for shortcuts (Meta+a select all, Meta+c copy, "
+                "Meta+v paste, Meta+z undo)."
+            )
+        if system == "Windows":
+            return (
+                "OS: Windows. Use Control for shortcuts (Control+a select all, "
+                "Control+c copy, Control+v paste, Control+z undo)."
+            )
+        return (
+            "OS: Linux. Use Control for shortcuts (Control+a select all, Control+c copy, "
+            "Control+v paste, Control+z undo)."
+        )
+
     async def get_text(self) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
             return await self.page.locator("body").inner_text()
+
+    async def extract_items_by_selector(
+        self,
+        container_selector: str,
+        text_selector: str,
+        max_items: int = 3,
+        author_selector: str = "",
+        author_attribute: str = "",
+        action_selector: str = "",
+        action_text: str = "",
+        exclude_text_pattern: str = "",
+    ) -> str:
+        """Extract repeated visible items using caller-provided selectors."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            items = await self.page.evaluate(
+                """
+                (options) => {
+                    const isVisible = (el) => {
+                        if (!el) return false;
+                        const style = window.getComputedStyle(el);
+                        const rect = el.getBoundingClientRect();
+                        return style.display !== 'none' &&
+                            style.visibility !== 'hidden' &&
+                            rect.width > 0 && rect.height > 0 &&
+                            rect.bottom > 0 && rect.top < window.innerHeight;
+                    };
+                    const textOf = (el) => (el?.innerText || el?.textContent || '')
+                        .replace(/\\u00a0/g, ' ')
+                        .replace(/[ \\t]+/g, ' ')
+                        .replace(/\\n{3,}/g, '\\n\\n')
+                        .trim();
+                    const textMatches = (el, expectedText) =>
+                        !expectedText || textOf(el) === expectedText;
+                    const excludePattern = options.exclude_text_pattern
+                        ? new RegExp(options.exclude_text_pattern, 'i') : null;
+                    const actions = options.action_selector
+                        ? Array.from(document.querySelectorAll(options.action_selector))
+                            .filter((action) => isVisible(action) &&
+                                textMatches(action, options.action_text))
+                        : [];
+                    const result = [];
+                    const containers = Array.from(
+                        document.querySelectorAll(options.container_selector)
+                    );
+                    for (const container of containers) {
+                        const rect = container.getBoundingClientRect();
+                        if (rect.bottom <= 0 || rect.top >= window.innerHeight) continue;
+                        const containerText = textOf(container);
+                        if (excludePattern && excludePattern.test(containerText)) continue;
+                        const textNode = container.querySelector(options.text_selector);
+                        const text = textOf(textNode);
+                        if (!text) continue;
+                        let author = '';
+                        if (options.author_selector) {
+                            const authorNode = container.querySelector(options.author_selector);
+                            author = options.author_attribute
+                                ? (authorNode?.getAttribute(options.author_attribute) || '').trim()
+                                : textOf(authorNode);
+                        }
+                        const action = actions.find((candidate) =>
+                            container.contains(candidate)
+                        );
+                        result.push({
+                            item_index: result.length,
+                            author,
+                            text,
+                            action_index: action ? actions.indexOf(action) : null,
+                            has_action: Boolean(action),
+                            visible_bounds: {
+                                x: Math.round(rect.x), y: Math.round(rect.y),
+                                width: Math.round(rect.width), height: Math.round(rect.height)
+                            }
+                        });
+                        if (result.length >= options.max_items) break;
+                    }
+                    return result;
+                }
+                """,
+                {
+                    "container_selector": container_selector,
+                    "text_selector": text_selector,
+                    "max_items": max_items,
+                    "author_selector": author_selector,
+                    "author_attribute": author_attribute,
+                    "action_selector": action_selector,
+                    "action_text": action_text,
+                    "exclude_text_pattern": exclude_text_pattern,
+                },
+            )
+            return json.dumps(items or [], indent=2, ensure_ascii=False)
 
     async def get_focused_element(self, value_preview_chars: int = 160) -> str:
         async with self._tab_operation():
@@ -628,11 +806,12 @@ class AsyncBrowserCore:
             await locator.nth(index).click()
             return f"Clicked element {index + 1}/{count} matching selector: {selector}"
 
-    async def count_elements_by_selector(self, selector: str) -> int:
+    async def count_elements_by_selector(self, selector: str) -> str:
         async with self._tab_operation():
             if self.page is None:
-                return 0
-            return await self.page.locator(selector).count()
+                return "Browser not open"
+            count = await self.page.locator(selector).count()
+            return f"{count} element{'s' if count != 1 else ''} match selector: {selector}"
 
     async def get_element_text_by_selector(self, selector: str, index: int = 0) -> str:
         async with self._tab_operation():
@@ -640,8 +819,10 @@ class AsyncBrowserCore:
                 return "Browser not open"
             locator = self.page.locator(selector)
             count = await locator.count()
+            if count == 0:
+                return f"No element found for selector: {selector}"
             if index < 0 or index >= count:
-                return f"No element {index + 1}/{count} matching selector: {selector}"
+                return f"Selector matched {count} elements; index {index} is out of range"
             return await locator.nth(index).inner_text()
 
     async def fill_text_by_selector(self, selector: str, text: str, index: int = 0) -> str:
@@ -650,9 +831,12 @@ class AsyncBrowserCore:
                 return "Browser not open"
             locator = self.page.locator(selector)
             count = await locator.count()
+            if count == 0:
+                return f"No element found for selector: {selector}"
             if index < 0 or index >= count:
-                return f"No element {index + 1}/{count} matching selector: {selector}"
+                return f"Selector matched {count} elements; index {index} is out of range"
             await locator.nth(index).fill(text)
+            await self.page.wait_for_timeout(1000)
             return f"Filled element {index + 1}/{count} matching selector: {selector}"
 
     async def upload_file_by_selector(self, selector: str, file_path: str, index: int = 0) -> str:
@@ -701,12 +885,57 @@ class AsyncBrowserCore:
             await self.page.wait_for_timeout(1000)
             return f"data:{mime};base64,{base64.b64encode(screenshot).decode('utf-8')}"
 
+    async def set_viewport(self, width: int, height: int) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            await self.page.set_viewport_size({"width": width, "height": height})
+            return f"Viewport set to {width}x{height}"
+
+    async def wait_for_text(self, text: str, timeout: int = 30) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            await self.page.wait_for_selector(f"text='{text}'", timeout=timeout * 1000)
+            return f"Found text: '{text}'"
+
     async def wait(self, seconds: float) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
             await self.page.wait_for_timeout(int(seconds * 1000))
-            return f"Waited {seconds} seconds"
+            return f"Waited for {seconds} seconds"
+
+    async def extract_data(self, selector: str) -> list[str]:
+        async with self._tab_operation():
+            if self.page is None:
+                return []
+            elements = self.page.locator(selector)
+            count = await elements.count()
+            return [await elements.nth(index).inner_text() for index in range(count)]
+
+    async def get_links_from_page(self, domain_filter: str = "") -> list[str]:
+        async with self._tab_operation():
+            if self.page is None:
+                return []
+            urls = await self.page.evaluate(
+                """
+                (filter) => {
+                    const seen = new Set();
+                    const result = [];
+                    for (const a of document.querySelectorAll('a[href]')) {
+                        const href = a.href;
+                        if (href && !seen.has(href) && (!filter || href.includes(filter))) {
+                            seen.add(href);
+                            result.push(href);
+                        }
+                    }
+                    return result;
+                }
+                """,
+                domain_filter,
+            )
+            return urls or []
 
     async def _save_context(self) -> None:
         if self.browser is not None and self.page is not None:

--- a/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
+++ b/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
@@ -47,3 +47,20 @@ Humanized input, LLM element finding, the remaining browser verbs, concurrent
 IPC, and the synchronous facade still have separate review boundaries. Keeping
 those boundaries visible is how 1.8 gains concurrency without trading away the
 browser behavior and cross-platform security it already has.
+
+## Async parity is observable behavior
+
+The next slice exposed a quieter migration risk. An async method existed for
+counting selectors, but it returned an integer while the public method returned
+`"2 elements match selector: button"`. Missing and out-of-range elements also
+used different messages, and `wait(2)` omitted one word from its result. Each
+implementation could drive the page correctly while still breaking an agent,
+test, or caller that relied on the existing tool contract.
+
+We now freeze three things for each deterministic verb: parameter names and
+defaults, exact result shapes, and native DOM behavior. Contract tests compare
+the old and async signatures and pin edge-case strings. A real-Chrome test then
+exercises selectors, visible-item extraction, links, waits, and viewport changes.
+This is intentionally narrower than copying every method at once: frame routing,
+downloads, humanized input, and model-backed matching each introduce different
+failure modes and retain their own review boundary.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -60,6 +60,13 @@ The internal core is not exported as a public user API while #498 is incomplete.
 The current synchronous API and daemon remain authoritative until the complete
 contract and cross-platform transport matrices are green.
 
+The second #498 review boundary ports deterministic contracts that do not depend
+on frames, downloads, humanized input, or model-backed element matching. It covers
+tab-registry status; exact selector count/text/fill results; repeated-item and link
+extraction; viewport changes; text and duration waits; raw selector extraction; and
+platform shortcut guidance. Signature checks and exact result assertions compare
+this boundary to `BrowserAutomation`; sharing a method name is not treated as parity.
+
 ## Invariants
 
 - one persistent browser context and profile per runtime;
@@ -94,3 +101,10 @@ disconnect, same-tab conflict, independent-tab progress, cold-start, and
 shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
 sync and running-event-loop callers must leave no loop thread, task, page,
 process, socket, or pipe behind.
+
+The deterministic review boundary additionally runs against native Chrome. It
+proves selector counts and text, repeated-item bounds, link filtering, text waits,
+raw extraction, and viewport changes on a real DOM. Frames, click variants,
+downloads/upload-after-click, scrolling, humanized typing, model-backed matching,
+context capture, and remaining dead-context/profile behavior stay explicit #498
+work; this boundary does not make the async core public.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -259,6 +259,10 @@ migration. The replacement core is internal until every browser verb and the
 cross-platform daemon have equivalent coverage; do not import it as an
 application API yet. The lifecycle, concurrency, cancellation, and compatibility
 boundaries are recorded in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+The internal core now covers the deterministic selector, extraction, viewport,
+wait, system-info, and tab-status contracts, but frames, downloads, humanized
+input, model-backed element finding, concurrent IPC, and the synchronous facade
+are still migration work. `BrowserAutomation` remains the supported API.
 
 ## Common Patterns
 

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -11,6 +11,7 @@ this against an installed wheel and browser before an alpha is promoted.
 import asyncio
 import gc
 import json
+import urllib.parse
 
 import pytest
 
@@ -45,9 +46,14 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             pages = {}
             for session, marker in (("A", "alpha"), ("B", "beta")):
                 browser._bind_session(session)
+                html = (
+                    f"<title>{marker}</title><p>{marker}</p>"
+                    f"<input id=editor value={marker}>"
+                    f"<article class=item><span class=body>{marker} item</span></article>"
+                    "<a href=https://example.com/one>one</a>"
+                )
                 await browser.go_to(
-                    f"data:text/html,<title>{marker}</title><p>{marker}</p>"
-                    f"<input id=editor value={marker}>",
+                    "data:text/html," + urllib.parse.quote(html),
                     purpose="async core acceptance",
                     who=session,
                 )
@@ -67,7 +73,7 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
 
             assert "beta" in text_b
             assert held.done() is False
-            assert await held == "Waited 2 seconds"
+            assert await held == "Waited for 2 seconds"
             timings["interleaved"] = loop.time()
             assert pages["A"] is not pages["B"]
 
@@ -76,6 +82,25 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             focused = json.loads(await browser.get_focused_element())
             assert focused["is_editable"] is True
             assert focused["value_preview"] == "alpha"
+
+            browser._bind_session("B")
+            assert await browser.count_elements_by_selector(".item") == (
+                "1 element match selector: .item"
+            )
+            assert await browser.get_element_text_by_selector(".body") == "beta item"
+            assert await browser.extract_data(".body") == ["beta item"]
+            assert await browser.wait_for_text("beta item", timeout=1) == (
+                "Found text: 'beta item'"
+            )
+            assert await browser.get_links_from_page("example.com") == [
+                "https://example.com/one"
+            ]
+            extracted = json.loads(
+                await browser.extract_items_by_selector(".item", ".body")
+            )
+            assert extracted[0]["text"] == "beta item"
+            assert extracted[0]["visible_bounds"]["width"] > 0
+            assert await browser.set_viewport(1280, 720) == "Viewport set to 1280x720"
         finally:
             browser._bind_session(None)
             close_result = await browser.close()

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -8,12 +8,14 @@ and cleans up deterministically before #499 puts concurrent IPC in front of it.
 import asyncio
 import ast
 import inspect
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from connectonion.useful_tools.browser_tools import _async_browser as async_mod
+from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
 
 
 class FakeKeyboard:
@@ -65,6 +67,9 @@ class FakePage:
         self.clicked = []
         self.filled = []
         self.uploaded = []
+        self.waited_selectors = []
+        self.evaluate_calls = []
+        self.evaluate_result = None
 
     def set_default_navigation_timeout(self, timeout):
         self.navigation_timeout = timeout
@@ -79,6 +84,9 @@ class FakePage:
     async def wait_for_timeout(self, milliseconds):
         self.waits.append(milliseconds)
 
+    async def wait_for_selector(self, selector, **kwargs):
+        self.waited_selectors.append((selector, kwargs))
+
     def is_closed(self):
         return self.closed
 
@@ -92,7 +100,8 @@ class FakePage:
     async def evaluate(self, script, arg=None):
         if "document.activeElement" in script:
             return dict(self.focused)
-        return {"arg": arg}
+        self.evaluate_calls.append((script, arg))
+        return self.evaluate_result if self.evaluate_result is not None else {"arg": arg}
 
     async def screenshot(self, **kwargs):
         return b"png"
@@ -498,6 +507,7 @@ async def test_selector_methods_use_async_locator_contract(tmp_path):
     upload.write_text("ok")
     page = FakePage()
     page.selector_counts["button"] = 2
+    page.selector_counts["missing"] = 0
     page.text_by_selector["button"] = "Publish"
     context = FakeContext()
     context.pages_created.append(page)
@@ -505,13 +515,129 @@ async def test_selector_methods_use_async_locator_contract(tmp_path):
     browser.browser = context
     browser._pages[None] = page
 
-    assert await browser.count_elements_by_selector("button") == 2
+    assert await browser.count_elements_by_selector("button") == "2 elements match selector: button"
     assert await browser.get_element_text_by_selector("button", 1) == "Publish"
+    assert await browser.get_element_text_by_selector("missing") == (
+        "No element found for selector: missing"
+    )
+    assert (
+        await browser.get_element_text_by_selector("button", 2)
+        == "Selector matched 2 elements; index 2 is out of range"
+    )
     assert "Clicked element 2/2" in await browser.click_element_by_selector("button", 1)
     assert "Filled element 1/1" in await browser.fill_text_by_selector("input", "hello")
+    assert page.waits == [1000]
     assert "Uploaded report.txt" in await browser.upload_file_by_selector("input", str(upload))
     assert page.clicked == [("button", 1)]
     assert page.filled == [("input", 0, "hello")]
+
+
+@pytest.mark.asyncio
+async def test_deterministic_async_verbs_preserve_sync_signatures_and_results(monkeypatch):
+    methods = (
+        "tab_status",
+        "count_elements_by_selector",
+        "get_element_text_by_selector",
+        "fill_text_by_selector",
+        "get_system_info",
+        "extract_items_by_selector",
+        "set_viewport",
+        "wait_for_text",
+        "wait",
+        "extract_data",
+        "get_links_from_page",
+    )
+    for name in methods:
+        async_method = getattr(async_mod.AsyncBrowserCore, name)
+        sync_method = getattr(BrowserAutomation, name)
+        assert inspect.iscoroutinefunction(async_method), name
+        assert list(inspect.signature(async_method).parameters) == list(
+            inspect.signature(sync_method).parameters
+        ), name
+
+    page = FakePage()
+    page.selector_counts["article"] = 2
+    page.text_by_selector["article"] = "Story"
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    assert await browser.set_viewport(1280, 720) == "Viewport set to 1280x720"
+    assert page.viewport == {"width": 1280, "height": 720}
+    assert await browser.wait_for_text("Ready", timeout=7) == "Found text: 'Ready'"
+    assert page.waited_selectors == [("text='Ready'", {"timeout": 7000})]
+    assert await browser.wait(1.25) == "Waited for 1.25 seconds"
+    assert page.waits[-1] == 1250
+    assert await browser.extract_data("article") == ["Story", "Story"]
+
+    monkeypatch.setattr(async_mod.platform, "system", lambda: "Darwin")
+    assert await browser.get_system_info() == (
+        "OS: macOS. Use Meta for shortcuts (Meta+a select all, Meta+c copy, "
+        "Meta+v paste, Meta+z undo)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_extraction_and_link_contracts_return_sync_shapes():
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    items = [{"item_index": 0, "author": "Ada", "text": "Hello"}]
+    page.evaluate_result = items
+    result = await browser.extract_items_by_selector(
+        ".card",
+        ".body",
+        max_items=4,
+        author_selector=".author",
+        author_attribute="data-name",
+        action_selector="button",
+        action_text="Open",
+        exclude_text_pattern="Sponsored",
+    )
+    assert result == json.dumps(items, indent=2, ensure_ascii=False)
+    assert page.evaluate_calls[-1][1] == {
+        "container_selector": ".card",
+        "text_selector": ".body",
+        "max_items": 4,
+        "author_selector": ".author",
+        "author_attribute": "data-name",
+        "action_selector": "button",
+        "action_text": "Open",
+        "exclude_text_pattern": "Sponsored",
+    }
+
+    page.evaluate_result = ["https://example.com/a", "https://example.com/b"]
+    assert await browser.get_links_from_page("example.com") == page.evaluate_result
+    assert page.evaluate_calls[-1][1] == "example.com"
+
+
+@pytest.mark.asyncio
+async def test_tab_status_renders_registry_before_page_creation():
+    browser = async_mod.AsyncBrowserCore()
+    browser._bind_session("worker-1")
+    browser._tab_meta["worker-1"] = {
+        "who": "agent",
+        "purpose": "research",
+    }
+    browser._tab_meta["worker-2"] = {
+        "who": "peer",
+        "purpose": "verification",
+    }
+    live = FakePage()
+    live.url = "https://example.com"
+    browser._pages["worker-2"] = live
+
+    assert await browser.tab_status() == (
+        "Tabs (2):\n"
+        "  *[worker-1] (reserved — no page yet)  who=agent  purpose='research'\n"
+        "   [worker-2] https://example.com  who=peer  purpose='verification'"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Ports the deterministic, non-LLM browser-tool contract into the internal
`AsyncBrowserCore`. This is the second review boundary for #498; the public
`BrowserAutomation` implementation remains authoritative.

## Related Issue

Related to #498. This slice does not complete the issue.

## Labels and target release (required)

- **Suggested labels:** feature, browser, tests, documentation
- **Proposed target version:** 1.8.0
- **Estimated release window:** next compatible 1.8 alpha after all #498 boundaries
- **Milestone:** 1.8
- **Why this release:** #499 cannot make the daemon concurrent until the in-use driver verbs are genuinely async. Exact return strings and signatures are compatibility surfaces for existing agents. The change is internal and can be rolled back without changing the public API.
- **Forward-port tracking issue (stable patches only):** N/A

## How this was written

- [ ] I wrote this myself
- [x] AI-assisted — I reviewed every line and can explain why each change is there
- [ ] Mostly AI-generated

**Which model?** GPT-5.6 via Codex desktop.

The least certain portion is how many downstream callers parse human-readable
browser result strings; this PR therefore preserves them exactly instead of
assuming they are presentation-only. I did not run a headed-display stealth
test, Windows locally, frames, downloads, humanized input, or model-backed
element finding. Hosted Windows and macOS checks provide the cross-platform
review for this slice. If this is wrong, the first break should be a signature
or exact-result contract test, followed by the native DOM gate.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Dev Blog (required)

Updated `docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md` with the
contract-parity complication and lesson.

## Changes Made

- Adds async tab-status, selector count/text/fill, repeated-item extraction,
  raw extraction, link filtering, viewport, waits, and system information.
- Preserves synchronous parameter names/defaults, return shapes, edge-case
  messages, timeout units, and per-tab locking.
- Extends fake-driver contract tests and native Chrome E2E coverage.
- Updates DD-054 and user-facing migration status without exporting the core.
- Adds no dependency, version bump, release tag, or public API switch.

## Testing

```text
$ python -m pytest tests/unit/test_async_browser_core.py tests/unit/test_browser_tools.py -q
49 passed in 4.55s

$ python -m pytest tests/e2e/test_async_browser_core_real_driver.py -m slow -q
1 passed in 8.18s

$ python -m pytest -q -m "not real_api and not network and not slow"
7271 passed, 21 skipped, 199 deselected; one environment failure because the
shell PATH selected a stale global co executable.

$ source /private/tmp/connectonion-1.8-focus-venv/bin/activate
$ python -m pytest tests/e2e/cli/test_cli.py::TestCliCommands::test_co_command_works -q
1 passed in 0.38s

$ python -m build --wheel --no-isolation
Successfully built connectonion-1.8.0a1-py3-none-any.whl

$ /private/tmp/connectonion-1.8-systemtest/bin/python /private/tmp/verify_connectonion_async_parity_wheel.py
/private/tmp/connectonion-1.8-systemtest/lib/python3.14/site-packages/connectonion/__init__.py
installed-wheel async parity E2E: PASS
```

- [x] I have added tests for new functionality

## Scope

- `_async_browser.py`: the internal async contract implementation.
- async core unit/E2E tests: exact compatibility and real-driver evidence.
- DD-054, browser-tools docs, and existing async-runtime blog: migration
  boundary, supported status, and engineering lesson.

Frames, click variants, downloads/upload-after-click, scrolling, context
capture, humanized input, LLM element finding, and remaining recovery/profile
parity stay in later #498 review boundaries. #499 transport and #500 facade are
also unchanged.

## Example Usage

No public example is added because `AsyncBrowserCore` is intentionally internal
until #498 is complete and #500 installs the compatibility facade.

## Checklist

- [x] I proposed at least one label and a target version above
- [x] My code follows the project's code style
- [x] I have read every line of this diff and can defend each change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] This PR ships its dev-blog post under docs/blog/
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (N/A for this internal slice)
- [x] Forward-port tracking is N/A because this is not a stable patch
- [x] Required local contract, native-driver, and installed-wheel evidence is included above

## Additional Notes

The repository docs-site checkout is not present locally, so the separate docs
site was not run. Repository docs and the blog sync source are updated here.
