### PR TITLE
feat(browser): add async frame scripts and uploads

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -839,33 +839,239 @@ class AsyncBrowserCore:
             await self.page.wait_for_timeout(1000)
             return f"Filled element {index + 1}/{count} matching selector: {selector}"
 
-    async def upload_file_by_selector(self, selector: str, file_path: str, index: int = 0) -> str:
+    async def upload_file_by_selector(
+        self,
+        selector: str,
+        file_path: str,
+        index: int = 0,
+        frame_url_contains: str = "",
+        frame_name: str = "",
+    ) -> str:
+        """Upload a local file into a frame-aware file-input selector."""
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
-            path = Path(file_path).expanduser().resolve()
-            if not path.is_file():
+            path = self._local_path(file_path)
+            if not path.exists():
                 return f"File not found: {path}"
-            locator = self.page.locator(selector)
-            count = await locator.count()
-            if index < 0 or index >= count:
-                return f"No element {index + 1}/{count} matching selector: {selector}"
-            await locator.nth(index).set_input_files(str(path))
-            return f"Uploaded {path.name} to element {index + 1}/{count} matching selector: {selector}"
+            if not path.is_file():
+                return f"Path is not a file: {path}"
+
+            matches = []
+            for frame_index, frame, name, url in self._matching_frames(
+                frame_url_contains,
+                frame_name,
+            ):
+                locator = frame.locator(selector)
+                count = await locator.count()
+                for locator_index in range(count):
+                    matches.append(
+                        (frame_index, name, url, locator.nth(locator_index))
+                    )
+
+            if not matches:
+                return f"No file input found for selector: {selector}"
+            if index < 0 or index >= len(matches):
+                return (
+                    f"Selector matched {len(matches)} file input(s); "
+                    f"index {index} is out of range"
+                )
+
+            frame_index, name, url, target = matches[index]
+            await target.set_input_files(str(path))
+            await self.page.wait_for_timeout(1500)
+            await self._save_context()
+            return json.dumps(
+                {
+                    "ok": True,
+                    "uploaded": True,
+                    "file": str(path),
+                    "selector": selector,
+                    "index": index,
+                    "frame": {"index": frame_index, "name": name, "url": url},
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    async def upload_file_after_click_by_selector(
+        self,
+        click_selector: str,
+        file_path: str,
+        index: int = 0,
+        text: str = "",
+        frame_url_contains: str = "",
+        frame_name: str = "",
+        timeout_ms: int = 5000,
+    ) -> str:
+        """Click a frame-aware upload control and handle its file chooser."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            path = self._local_path(file_path)
+            if not path.exists():
+                return f"File not found: {path}"
+            if not path.is_file():
+                return f"Path is not a file: {path}"
+
+            matches = []
+            for frame_index, frame, name, url in self._matching_frames(
+                frame_url_contains,
+                frame_name,
+            ):
+                locator = frame.locator(click_selector)
+                count = await locator.count()
+                for locator_index in range(count):
+                    target = locator.nth(locator_index)
+                    if text:
+                        try:
+                            candidate_text = (
+                                (await target.inner_text())
+                                .replace("\u00a0", " ")
+                                .strip()
+                            )
+                        except Exception:
+                            candidate_text = ""
+                        if candidate_text != text:
+                            continue
+                    matches.append((frame_index, name, url, target))
+
+            if not matches:
+                suffix = f" with text: {text}" if text else ""
+                return (
+                    f"No upload trigger found for selector: "
+                    f"{click_selector}{suffix}"
+                )
+            if index < 0 or index >= len(matches):
+                return (
+                    f"Selector matched {len(matches)} upload trigger(s); "
+                    f"index {index} is out of range"
+                )
+
+            frame_index, name, url, target = matches[index]
+            async with self.page.expect_file_chooser(
+                timeout=timeout_ms
+            ) as chooser_info:
+                await target.click(force=True)
+            chooser = await chooser_info.value
+            await chooser.set_files(str(path))
+            await self.page.wait_for_timeout(2500)
+            await self._save_context()
+            return json.dumps(
+                {
+                    "ok": True,
+                    "uploaded": True,
+                    "file": str(path),
+                    "click_selector": click_selector,
+                    "text": text,
+                    "index": index,
+                    "frame": {"index": frame_index, "name": name, "url": url},
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    @staticmethod
+    def _local_path(value: str) -> Path:
+        path = Path(value).expanduser()
+        return path if path.is_absolute() else Path.cwd() / path
+
+    def _matching_frames(
+        self,
+        frame_url_contains: str = "",
+        frame_name: str = "",
+    ):
+        for frame_index, frame in enumerate(self.page.frames):
+            url = getattr(frame, "url", "") or ""
+            raw_name = getattr(frame, "name", "") or ""
+            name = raw_name() if callable(raw_name) else raw_name
+            if frame_url_contains and frame_url_contains not in url:
+                continue
+            if frame_name and frame_name != name:
+                continue
+            yield frame_index, frame, name, url
+
+    def _load_script_args(
+        self,
+        script_path: str,
+        args_json: str,
+    ) -> tuple[Optional[str], Optional[dict], Optional[str]]:
+        path = self._local_path(script_path)
+        if not path.exists():
+            return None, None, f"Script not found: {path}"
+        if not path.is_file():
+            return None, None, f"Script path is not a file: {path}"
+        try:
+            args = json.loads(args_json or "{}")
+        except json.JSONDecodeError as exc:
+            return None, None, f"Invalid args_json: {exc}"
+        return path.read_text(encoding="utf-8"), args, None
 
     async def run_page_script(self, script_path: str, args_json: str = "{}") -> str:
+        """Run a local JavaScript file in the main page and return JSON."""
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
-            path = Path(script_path).expanduser().resolve()
-            if not path.is_file():
-                return f"Script not found: {path}"
-            try:
-                args = json.loads(args_json)
-            except json.JSONDecodeError as exc:
-                return f"Invalid args_json: {exc}"
-            result = await self.page.evaluate(path.read_text(encoding="utf-8"), args)
-            return json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True)
+            script, args, error = self._load_script_args(script_path, args_json)
+            if error:
+                return error
+            result = await self.page.evaluate(script, args)
+            return json.dumps(result, indent=2, ensure_ascii=False)
+
+    async def run_frame_script(
+        self,
+        script_path: str,
+        args_json: str = "{}",
+        frame_url_contains: str = "",
+        frame_name: str = "",
+        first_ok: bool = True,
+    ) -> str:
+        """Run a local JavaScript file in matching frames and return JSON."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            script, args, error = self._load_script_args(script_path, args_json)
+            if error:
+                return error
+
+            frames = []
+            matched = None
+            for frame_index, frame, name, url in self._matching_frames(
+                frame_url_contains,
+                frame_name,
+            ):
+                frame_info = {
+                    "index": frame_index,
+                    "name": name,
+                    "url": url,
+                    "ok": False,
+                    "result": None,
+                    "error": None,
+                }
+                try:
+                    result = await frame.evaluate(script, args)
+                    frame_info["result"] = result
+                    frame_info["ok"] = bool(
+                        isinstance(result, dict) and result.get("ok") is True
+                    )
+                except Exception as exc:
+                    frame_info["error"] = str(exc)
+                frames.append(frame_info)
+                if frame_info["ok"] and matched is None:
+                    matched = frame_info
+                    if first_ok:
+                        break
+
+            response = {
+                "ok": matched is not None,
+                "matched_frame": matched,
+                "frames": frames,
+            }
+            if not frames:
+                response["reason"] = "no frames matched filters"
+            elif matched is None:
+                response["reason"] = "no frame returned ok: true"
+            return json.dumps(response, indent=2, ensure_ascii=False)
 
     async def take_screenshot(self, path: Optional[str] = None, full_page: bool = False) -> str:
         async with self._tab_operation():

--- a/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
+++ b/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
@@ -64,3 +64,25 @@ exercises selectors, visible-item extraction, links, waits, and viewport changes
 This is intentionally narrower than copying every method at once: frame routing,
 downloads, humanized input, and model-backed matching each introduce different
 failure modes and retain their own review boundary.
+
+## An iframe is a routing boundary
+
+The next four methods looked mechanical: run a page script, run a frame script,
+set files on an input, or click a control that opens a chooser. In practice, the
+important contract was the route to the DOM. Editors commonly hide their upload
+controls in an iframe, frame names may be properties or callables depending on
+the driver object, and an upload index applies across all filtered frames—not
+independently inside each one.
+
+The async core now enumerates that boundary once. It preserves frame filters and
+global match order, awaits every locator and chooser transition, and does not
+report success until the context-save step finishes. Page and frame scripts also
+share exact local-path and JSON validation, so making the driver asynchronous
+does not silently normalize paths or reorder returned JSON.
+
+Mocks freeze those details, but native Chrome supplies the meaningful proof. The
+acceptance page contains a named iframe. One script verifies its DOM, one upload
+sets a hidden file input directly, and another clicks a real control and waits for
+the browser's file-chooser event. The test reads both selected filenames back out
+of the frame. Selector clicking remains outside this slice because the supported
+path is humanized; a raw locator click would be faster to port and false parity.

--- a/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
+++ b/docs/blog/2026-08-26-a-thread-is-not-an-async-runtime.md
@@ -64,25 +64,3 @@ exercises selectors, visible-item extraction, links, waits, and viewport changes
 This is intentionally narrower than copying every method at once: frame routing,
 downloads, humanized input, and model-backed matching each introduce different
 failure modes and retain their own review boundary.
-
-## An iframe is a routing boundary
-
-The next four methods looked mechanical: run a page script, run a frame script,
-set files on an input, or click a control that opens a chooser. In practice, the
-important contract was the route to the DOM. Editors commonly hide their upload
-controls in an iframe, frame names may be properties or callables depending on
-the driver object, and an upload index applies across all filtered frames—not
-independently inside each one.
-
-The async core now enumerates that boundary once. It preserves frame filters and
-global match order, awaits every locator and chooser transition, and does not
-report success until the context-save step finishes. Page and frame scripts also
-share exact local-path and JSON validation, so making the driver asynchronous
-does not silently normalize paths or reorder returned JSON.
-
-Mocks freeze those details, but native Chrome supplies the meaningful proof. The
-acceptance page contains a named iframe. One script verifies its DOM, one upload
-sets a hidden file input directly, and another clicks a real control and waits for
-the browser's file-chooser event. The test reads both selected filenames back out
-of the frame. Selector clicking remains outside this slice because the supported
-path is humanized; a raw locator click would be faster to port and false parity.

--- a/docs/blog/2026-08-26-the-upload-button-was-in-another-document.md
+++ b/docs/blog/2026-08-26-the-upload-button-was-in-another-document.md
@@ -1,0 +1,51 @@
+# The Upload Button Was in Another Document
+
+*2026-08-26*
+
+The file input was plainly visible in Chrome. Our async browser could not find
+it.
+
+This is an easy failure to misread during an async migration. The locator call
+looks familiar, the selector is correct, and the old browser uploads the file.
+It is tempting to blame a missing `await`. The actual problem was spatial: the
+editor lived in an iframe, so the control belonged to another document.
+
+The synchronous browser had already learned this lesson. It filtered the page's
+frames by URL or name, counted matching controls across those frames, and treated
+the caller's index as a position in that combined list. A quick async port that
+searched only the main page would keep the same method name while quietly
+changing which pages it could operate.
+
+## The chooser made the race visible
+
+Direct file inputs are forgiving. Playwright can set files on a hidden input
+without opening the operating-system picker. Upload buttons are less forgiving:
+the browser emits a file-chooser event only as a consequence of the click. The
+listener must exist before the click, the event must be awaited afterward, and
+only then can the selected files be set.
+
+That sequence forced the real design into view. Frame selection was not a detail
+inside one upload method; it was the routing boundary shared by scripts, direct
+inputs, and chooser-trigger controls. We introduced one frame enumeration path
+that preserves the old filters and global match order. Each async operation then
+awaits its own locator, evaluation, chooser, post-upload wait, and context save.
+
+We also stopped at an important edge. Selector clicking in the supported browser
+is humanized. Porting it as a raw locator click would have made the checklist look
+more complete while changing observable behavior. That work remains with the
+humanized-input boundary.
+
+## Make the browser prove where the file went
+
+Mocks can prove that methods were awaited and error strings stayed stable. They
+cannot prove that Chrome delivered a chooser event from a child frame.
+
+The native acceptance page therefore contains a named iframe with two upload
+paths. The test runs a local script inside that frame, sets one file input
+directly, then clicks a button wired to a second hidden input. It reads both
+selected filenames back from the frame's DOM. We run the same scenario once from
+the source tree and once from an installed wheel.
+
+The lesson is broader than uploads: async parity is not a count of converted
+methods. It is preservation of time and place—when a listener begins waiting,
+which document receives an operation, and when success is safe to report.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -67,6 +67,14 @@ extraction; viewport changes; text and duration waits; raw selector extraction; 
 platform shortcut guidance. Signature checks and exact result assertions compare
 this boundary to `BrowserAutomation`; sharing a method name is not treated as parity.
 
+The third boundary makes the deterministic core frame-aware. Page and frame
+scripts share one local-path and JSON-validation contract. Direct file inputs and
+file-chooser uploads enumerate the same filtered frame set, preserve global match
+indexes, and await the locator, chooser, post-upload wait, and context save. It
+deliberately does not port selector clicks: the public click path is humanized, so
+substituting a raw async locator click would match the signature while changing the
+observable behavior.
+
 ## Invariants
 
 - one persistent browser context and profile per runtime;
@@ -86,7 +94,10 @@ Every migration PR must include isolated async contract tests. The real-driver
 gate holds a native two-second wait on one session page while requiring a text
 read on another page to finish within 500 ms and before the wait completes. A
 globally serialized driver cannot satisfy that liveness condition. The gate also
-checks page isolation and focused-element behavior.
+checks page isolation and focused-element behavior. Its frame fixture executes a
+local script in a named `srcdoc` iframe, uploads one file directly, uploads another
+through a real file-chooser event, and reads both selected filenames back from the
+native DOM.
 
 The macOS native gate runs with Chrome's mock keychain because the repository's
 autouse fixture gives every test a disposable `HOME`. Production keeps the
@@ -102,9 +113,9 @@ shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
 sync and running-event-loop callers must leave no loop thread, task, page,
 process, socket, or pipe behind.
 
-The deterministic review boundary additionally runs against native Chrome. It
-proves selector counts and text, repeated-item bounds, link filtering, text waits,
-raw extraction, and viewport changes on a real DOM. Frames, click variants,
-downloads/upload-after-click, scrolling, humanized typing, model-backed matching,
-context capture, and remaining dead-context/profile behavior stay explicit #498
-work; this boundary does not make the async core public.
+The deterministic review boundaries additionally run against native Chrome. They
+prove selector counts and text, repeated-item bounds, link filtering, text waits,
+raw extraction, viewport changes, page/frame scripts, and both upload paths on a
+real DOM. Click variants, downloads, scrolling, humanized typing, model-backed
+matching, context capture, and remaining dead-context/profile behavior stay
+explicit #498 work; these boundaries do not make the async core public.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -215,6 +215,27 @@ browser.upload_file_after_click_by_selector(
 
 Both upload helpers accept `frame_url_contains` and `frame_name` for editors that render upload controls inside iframes. Pass `index` when the selector matches multiple file inputs or upload buttons.
 
+### Local Page and Frame Scripts
+
+Keep site-specific extraction or verification logic in a reviewed local
+JavaScript file, then execute it in the current authenticated page:
+
+```python
+# verify.js: (args) => ({ ok: document.title === args.title })
+browser.run_page_script("verify.js", '{"title": "Dashboard"}')
+
+browser.run_frame_script(
+    "verify.js",
+    '{"title": "Composer"}',
+    frame_name="editor",
+)
+```
+
+`run_frame_script()` scans matching frames and, by default, stops at the first
+object that returns `{"ok": true}`. Set `first_ok=False` to retain results from
+every matching frame. Relative script paths resolve from the current working
+directory; arguments must be valid JSON.
+
 ### Waiting
 
 ```python
@@ -260,9 +281,10 @@ cross-platform daemon have equivalent coverage; do not import it as an
 application API yet. The lifecycle, concurrency, cancellation, and compatibility
 boundaries are recorded in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
 The internal core now covers the deterministic selector, extraction, viewport,
-wait, system-info, and tab-status contracts, but frames, downloads, humanized
-input, model-backed element finding, concurrent IPC, and the synchronous facade
-are still migration work. `BrowserAutomation` remains the supported API.
+wait, system-info, tab-status, page/frame-script, and file-upload contracts, but
+click variants, downloads, humanized input, model-backed element finding,
+concurrent IPC, and the synchronous facade are still migration work.
+`BrowserAutomation` remains the supported API.
 
 ## Common Patterns
 

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -10,6 +10,7 @@ this against an installed wheel and browser before an alpha is promoted.
 
 import asyncio
 import gc
+import html
 import json
 import urllib.parse
 
@@ -40,20 +41,46 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
     loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
 
     try:
+        page_script = tmp_path / "verify-page.js"
+        page_script.write_text(
+            "(args) => ({ ok: document.title === args.title, title: document.title })",
+            encoding="utf-8",
+        )
+        frame_script = tmp_path / "verify-frame.js"
+        frame_script.write_text(
+            "(args) => ({ ok: document.querySelector(args.selector)?.textContent "
+            "=== args.text, text: document.querySelector(args.selector)?.textContent })",
+            encoding="utf-8",
+        )
+        direct_upload = tmp_path / "direct.txt"
+        direct_upload.write_text("direct upload", encoding="utf-8")
+        chooser_upload = tmp_path / "chooser.txt"
+        chooser_upload.write_text("chooser upload", encoding="utf-8")
+
         await browser.open_browser()
         timings["opened"] = loop.time()
         try:
             pages = {}
             for session, marker in (("A", "alpha"), ("B", "beta")):
                 browser._bind_session(session)
-                html = (
+                frame_html = (
+                    f"<span id=frame-marker>{marker} frame</span>"
+                    "<input id=direct-upload type=file>"
+                    "<input id=chooser-upload type=file style='display:none'>"
+                    "<button id=upload-trigger "
+                    "onclick=\"document.querySelector('#chooser-upload').click()\">"
+                    "Upload from computer</button>"
+                )
+                page_html = (
                     f"<title>{marker}</title><p>{marker}</p>"
                     f"<input id=editor value={marker}>"
                     f"<article class=item><span class=body>{marker} item</span></article>"
                     "<a href=https://example.com/one>one</a>"
+                    f"<iframe name=editor srcdoc=\"{html.escape(frame_html, quote=True)}\">"
+                    "</iframe>"
                 )
                 await browser.go_to(
-                    "data:text/html," + urllib.parse.quote(html),
+                    "data:text/html," + urllib.parse.quote(page_html),
                     purpose="async core acceptance",
                     who=session,
                 )
@@ -101,6 +128,54 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             assert extracted[0]["text"] == "beta item"
             assert extracted[0]["visible_bounds"]["width"] > 0
             assert await browser.set_viewport(1280, 720) == "Viewport set to 1280x720"
+
+            page_result = json.loads(
+                await browser.run_page_script(
+                    str(page_script),
+                    json.dumps({"title": "beta"}),
+                )
+            )
+            assert page_result == {"ok": True, "title": "beta"}
+
+            frame_result = json.loads(
+                await browser.run_frame_script(
+                    str(frame_script),
+                    json.dumps(
+                        {"selector": "#frame-marker", "text": "beta frame"}
+                    ),
+                    frame_name="editor",
+                )
+            )
+            assert frame_result["ok"] is True
+            assert frame_result["matched_frame"]["name"] == "editor"
+
+            direct_result = json.loads(
+                await browser.upload_file_by_selector(
+                    "#direct-upload",
+                    str(direct_upload),
+                    frame_name="editor",
+                )
+            )
+            assert direct_result["uploaded"] is True
+            editor_frame = next(
+                frame for frame in browser.page.frames if frame.name == "editor"
+            )
+            assert await editor_frame.locator("#direct-upload").evaluate(
+                "element => element.files[0].name"
+            ) == direct_upload.name
+
+            chooser_result = json.loads(
+                await browser.upload_file_after_click_by_selector(
+                    "#upload-trigger",
+                    str(chooser_upload),
+                    text="Upload from computer",
+                    frame_name="editor",
+                )
+            )
+            assert chooser_result["uploaded"] is True
+            assert await editor_frame.locator("#chooser-upload").evaluate(
+                "element => element.files[0].name"
+            ) == chooser_upload.name
         finally:
             browser._bind_session(None)
             close_result = await browser.close()

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -38,7 +38,7 @@ class FakeLocator:
     def nth(self, index):
         return FakeLocator(self.page, self.selector, index=index)
 
-    async def click(self):
+    async def click(self, force=False):
         self.page.clicked.append((self.selector, self.index))
 
     async def inner_text(self):
@@ -67,9 +67,13 @@ class FakePage:
         self.clicked = []
         self.filled = []
         self.uploaded = []
+        self.name = ""
+        self.frames = [self]
         self.waited_selectors = []
         self.evaluate_calls = []
         self.evaluate_result = None
+        self.file_chooser = FakeFileChooser()
+        self.file_chooser_timeouts = []
 
     def set_default_navigation_timeout(self, timeout):
         self.navigation_timeout = timeout
@@ -97,6 +101,10 @@ class FakePage:
     def locator(self, selector):
         return FakeLocator(self, selector)
 
+    def expect_file_chooser(self, timeout=0):
+        self.file_chooser_timeouts.append(timeout)
+        return FakeFileChooserContext(self.file_chooser)
+
     async def evaluate(self, script, arg=None):
         if "document.activeElement" in script:
             return dict(self.focused)
@@ -105,6 +113,41 @@ class FakePage:
 
     async def screenshot(self, **kwargs):
         return b"png"
+
+
+class FakeFileChooser:
+    def __init__(self):
+        self.files = []
+
+    async def set_files(self, path):
+        self.files.append(path)
+
+
+class FakeFileChooserContext:
+    def __init__(self, chooser):
+        self.chooser = chooser
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    @property
+    def value(self):
+        async def resolve():
+            return self.chooser
+
+        return resolve()
+
+
+class FakeFrame(FakePage):
+    def __init__(self, result, *, url="https://example.com/frame", name=""):
+        super().__init__()
+        self.url = url
+        self.name = name
+        self.frames = []
+        self.evaluate_result = result
 
 
 class FakeContext:
@@ -527,7 +570,11 @@ async def test_selector_methods_use_async_locator_contract(tmp_path):
     assert "Clicked element 2/2" in await browser.click_element_by_selector("button", 1)
     assert "Filled element 1/1" in await browser.fill_text_by_selector("input", "hello")
     assert page.waits == [1000]
-    assert "Uploaded report.txt" in await browser.upload_file_by_selector("input", str(upload))
+    uploaded = json.loads(
+        await browser.upload_file_by_selector("input", str(upload))
+    )
+    assert uploaded["file"] == str(upload)
+    assert uploaded["frame"]["index"] == 0
     assert page.clicked == [("button", 1)]
     assert page.filled == [("input", 0, "hello")]
 
@@ -638,6 +685,188 @@ async def test_tab_status_renders_registry_before_page_creation():
         "  *[worker-1] (reserved — no page yet)  who=agent  purpose='research'\n"
         "   [worker-2] https://example.com  who=peer  purpose='verification'"
     )
+
+
+@pytest.mark.asyncio
+async def test_async_frame_and_upload_verbs_preserve_sync_signatures():
+    for name in (
+        "run_page_script",
+        "run_frame_script",
+        "upload_file_by_selector",
+        "upload_file_after_click_by_selector",
+    ):
+        async_method = getattr(async_mod.AsyncBrowserCore, name)
+        sync_method = getattr(BrowserAutomation, name)
+        assert inspect.iscoroutinefunction(async_method), name
+        assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+@pytest.mark.asyncio
+async def test_async_page_and_frame_scripts_keep_validation_and_result_contracts(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    script = tmp_path / "verify.js"
+    script.write_text("(args) => ({ ok: args.ok })", encoding="utf-8")
+    page = FakePage()
+    first = FakeFrame({"ok": False}, url="https://example.com/main", name="main")
+    second = FakeFrame(
+        {"ok": True, "z": 1},
+        url="https://example.com/composer",
+        name=lambda: "composer",
+    )
+    third = FakeFrame({"ok": True}, url="https://example.com/other", name="other")
+    page.frames = [first, second, third]
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    page.evaluate_result = {"z": 1, "a": 2}
+    assert await browser.run_page_script("verify.js", '{"ok": true}') == (
+        '{\n  "z": 1,\n  "a": 2\n}'
+    )
+    assert await browser.run_page_script("missing.js") == (
+        f"Script not found: {tmp_path / 'missing.js'}"
+    )
+    assert await browser.run_page_script(".") == f"Script path is not a file: {tmp_path}"
+    assert (await browser.run_page_script("verify.js", "{")).startswith(
+        "Invalid args_json:"
+    )
+
+    result = json.loads(await browser.run_frame_script("verify.js", '{"ok": true}'))
+    assert result["ok"] is True
+    assert result["matched_frame"]["name"] == "composer"
+    assert len(result["frames"]) == 2
+    assert third.evaluate_calls == []
+
+    filtered = json.loads(
+        await browser.run_frame_script(
+            "verify.js",
+            "{}",
+            frame_url_contains="composer",
+            frame_name="composer",
+            first_ok=False,
+        )
+    )
+    assert filtered["matched_frame"]["url"] == "https://example.com/composer"
+    assert len(filtered["frames"]) == 1
+
+    missing = json.loads(
+        await browser.run_frame_script("verify.js", "{}", frame_name="missing")
+    )
+    assert missing["ok"] is False
+    assert missing["reason"] == "no frames matched filters"
+
+
+@pytest.mark.asyncio
+async def test_async_direct_upload_is_frame_aware_and_returns_sync_json(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.chdir(tmp_path)
+    upload = tmp_path / "cover.png"
+    upload.write_bytes(b"png")
+    directory = tmp_path / "folder"
+    directory.mkdir()
+    page = FakePage()
+    page.selector_counts['input[type="file"]'] = 0
+    child = FakeFrame({}, url="https://example.com/editor", name=lambda: "editor")
+    child.selector_counts['input[type="file"]'] = 1
+    page.frames = [page, child]
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    result = json.loads(
+        await browser.upload_file_by_selector(
+            'input[type="file"]',
+            "cover.png",
+            frame_url_contains="editor",
+            frame_name="editor",
+        )
+    )
+    assert result == {
+        "ok": True,
+        "uploaded": True,
+        "file": str(upload),
+        "selector": 'input[type="file"]',
+        "index": 0,
+        "frame": {
+            "index": 1,
+            "name": "editor",
+            "url": "https://example.com/editor",
+        },
+    }
+    assert child.uploaded == [('input[type="file"]', 0, str(upload))]
+    assert 1500 in page.waits
+    assert await browser.upload_file_by_selector("input", "missing.png") == (
+        f"File not found: {tmp_path / 'missing.png'}"
+    )
+    assert await browser.upload_file_by_selector("input", "folder") == (
+        f"Path is not a file: {directory}"
+    )
+    assert await browser.upload_file_by_selector(
+        'input[type="file"]',
+        "cover.png",
+        frame_name="missing",
+    ) == 'No file input found for selector: input[type="file"]'
+    assert await browser.upload_file_by_selector(
+        'input[type="file"]',
+        "cover.png",
+        index=1,
+        frame_name="editor",
+    ) == 'Selector matched 1 file input(s); index 1 is out of range'
+
+
+@pytest.mark.asyncio
+async def test_async_upload_after_click_filters_frame_text_and_awaits_chooser(tmp_path):
+    upload = tmp_path / "cover.png"
+    upload.write_bytes(b"png")
+    page = FakePage()
+    page.selector_counts["button"] = 0
+    child = FakeFrame({}, url="https://example.com/editor", name="editor")
+    child.selector_counts["button"] = 1
+    child.text_by_selector["button"] = "Upload from computer"
+    page.frames = [page, child]
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+
+    result = json.loads(
+        await browser.upload_file_after_click_by_selector(
+            "button",
+            str(upload),
+            text="Upload from computer",
+            frame_name="editor",
+            timeout_ms=4321,
+        )
+    )
+    assert result["uploaded"] is True
+    assert result["frame"]["name"] == "editor"
+    assert child.clicked == [("button", 0)]
+    assert page.file_chooser_timeouts == [4321]
+    assert page.file_chooser.files == [str(upload)]
+    assert 2500 in page.waits
+
+    assert await browser.upload_file_after_click_by_selector(
+        "button",
+        str(upload),
+        text="Different",
+        frame_name="editor",
+    ) == "No upload trigger found for selector: button with text: Different"
+    assert await browser.upload_file_after_click_by_selector(
+        "button",
+        str(upload),
+        index=1,
+        frame_name="editor",
+    ) == "Selector matched 1 upload trigger(s); index 1 is out of range"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- port page and frame script execution to the internal async browser core
- add frame-aware direct-input and file-chooser upload paths with sync-compatible contracts
- extend native Chrome acceptance coverage and document the migration boundary

## Design boundary

Selector clicks are intentionally excluded. The supported synchronous click path is humanized; replacing it with a raw async locator click would change observable behavior. Humanized input remains a separate #498 slice.

## Verification

- 22 async browser contract tests passed
- 219 browser unit tests passed
- 256 documentation tests passed, 1 expected skip
- native Chrome source-tree gate passed
- 7,276 full-matrix tests passed, 21 expected skips, 199 deselected
- built and installed connectonion-1.8.0a1-py3-none-any.whl
- native Chrome installed-wheel gate passed from site-packages
- git diff --check passed

**Proposed target version:** 1.8.0 / next alpha

**Estimated release window:** 1.8 development cycle

**Forward-port tracking issue (stable patches only):** Not applicable

Related to #498. This slice does not complete the issue.