### PR TITLE
feat(browser): add async humanized selector input

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from . import _async_humanize as humanize
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
 
@@ -165,7 +166,9 @@ def _requires_editable_focus(key: str) -> bool:
 
 
 def _normalize_url(url: str) -> str:
-    if url.startswith(("http://", "https://", "file://", "about:", "data:", "chrome://")):
+    if url.startswith(
+        ("http://", "https://", "file://", "about:", "data:", "chrome://")
+    ):
         return url
     return f"https://{url}" if "." in url else f"http://{url}"
 
@@ -269,9 +272,14 @@ class AsyncBrowserCore:
         self.last_screenshot_path: Optional[str] = None
 
         suffix = hex(id(self))
-        self._session_key = contextvars.ContextVar(f"co_browser_session_{suffix}", default=None)
-        self._operation_depth = contextvars.ContextVar(f"co_browser_depth_{suffix}", default=0)
+        self._session_key = contextvars.ContextVar(
+            f"co_browser_session_{suffix}", default=None
+        )
+        self._operation_depth = contextvars.ContextVar(
+            f"co_browser_depth_{suffix}", default=0
+        )
         self._lifecycle_lock = asyncio.Lock()
+        self._clipboard_lock = asyncio.Lock()
         self._page_state_lock = asyncio.Lock()
         self._tab_locks: Dict[Optional[str], asyncio.Lock] = {}
         self._operation_state_lock = asyncio.Lock()
@@ -351,7 +359,9 @@ class AsyncBrowserCore:
                 restore_url = self._page_url.get(key)
                 if restore_url:
                     try:
-                        await page.goto(restore_url, wait_until="domcontentloaded", timeout=30000)
+                        await page.goto(
+                            restore_url, wait_until="domcontentloaded", timeout=30000
+                        )
                     except Exception:
                         pass
                 self._pages[key] = page
@@ -418,14 +428,18 @@ class AsyncBrowserCore:
             return False
         return True
 
-    async def open_browser(self, headless: Optional[bool] = None, force: bool = False) -> str:
+    async def open_browser(
+        self, headless: Optional[bool] = None, force: bool = False
+    ) -> str:
         """Open/reuse the runtime while participating in tab and shutdown admission."""
         if self._operation_depth.get():
             return await self._open_browser(headless=headless, force=force)
         async with self._tab_operation(ensure_page=False):
             return await self._open_browser(headless=headless, force=force)
 
-    async def _open_browser(self, headless: Optional[bool] = None, force: bool = False) -> str:
+    async def _open_browser(
+        self, headless: Optional[bool] = None, force: bool = False
+    ) -> str:
         if headless is None:
             headless = self._headless
         if not ASYNC_BROWSER_AVAILABLE:
@@ -458,7 +472,9 @@ class AsyncBrowserCore:
                 await self._teardown_unlocked()
                 had_previous_state = True
             else:
-                had_previous_state = bool(self.browser or self.playwright or self._pages)
+                had_previous_state = bool(
+                    self.browser or self.playwright or self._pages
+                )
                 if had_previous_state:
                     await self._teardown_unlocked()
 
@@ -569,7 +585,9 @@ class AsyncBrowserCore:
             if self.page is None:
                 await self.open_browser()
 
-            await self.page.goto(_normalize_url(url), wait_until="domcontentloaded", timeout=30000)
+            await self.page.goto(
+                _normalize_url(url), wait_until="domcontentloaded", timeout=30000
+            )
             await self.page.wait_for_timeout(2000)
             self.current_url = self.page.url
             meta = self._tab_meta.setdefault(
@@ -630,7 +648,9 @@ class AsyncBrowserCore:
                 line = f"  {marker}[{name}] {where}  who={who}  purpose={purpose!r}"
                 opened_at = meta.get("opened_at")
                 if opened_at:
-                    line += f"  open {_age((datetime.now() - opened_at).total_seconds())}"
+                    line += (
+                        f"  open {_age((datetime.now() - opened_at).total_seconds())}"
+                    )
                 last_at = meta.get("last_at")
                 if last_at:
                     last_line = (meta.get("last_line") or "")[:60]
@@ -648,7 +668,9 @@ class AsyncBrowserCore:
             key = None
         async with self._tab_lock(key):
             if key not in self._pages and key not in self._tab_meta:
-                return f"No open tab for {key!r}" if self.browser else "Browser not open"
+                return (
+                    f"No open tab for {key!r}" if self.browser else "Browser not open"
+                )
             error = await self._release_tab(key)
             return error or "Tab closed"
 
@@ -795,23 +817,245 @@ class AsyncBrowserCore:
             await self.page.keyboard.press(key)
             return f"Pressed: '{key}'"
 
-    async def click_element_by_selector(self, selector: str, index: int = 0) -> str:
+    async def click_element_by_selector(
+        self,
+        selector: str,
+        index: int = 0,
+        text: str = "",
+        frame_url_contains: str = "",
+        frame_name: str = "",
+    ) -> str:
+        """Click a stable selector through humanized pointer input."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+
+            if text:
+                matches = await self.page.evaluate(
+                    """
+                    (options) => {
+                        const normalize = (el) => (el?.innerText || el?.textContent || '')
+                            .replace(/\\u00a0/g, ' ').replace(/[ \\t\\n]+/g, ' ').trim();
+                        const isVisible = (el) => {
+                            if (!el) return false;
+                            const style = window.getComputedStyle(el);
+                            const rect = el.getBoundingClientRect();
+                            return style.display !== 'none' && style.visibility !== 'hidden' &&
+                                rect.width > 0 && rect.height > 0 && rect.bottom > 0 &&
+                                rect.top < window.innerHeight;
+                        };
+                        return Array.from(document.querySelectorAll(options.selector))
+                            .filter((el) => isVisible(el) && normalize(el) === options.text)
+                            .map((el) => {
+                                const rect = el.getBoundingClientRect();
+                                return {x: rect.x + rect.width / 2, y: rect.y + rect.height / 2};
+                            });
+                    }
+                    """,
+                    {"selector": selector, "text": text},
+                )
+                count = len(matches)
+                if count == 0:
+                    return f"No visible element found for selector: {selector} with text: {text}"
+                if index < 0 or index >= count:
+                    return f"Selector matched {count} elements with text {text!r}; index {index} is out of range"
+                await humanize.click(
+                    self.page, matches[index]["x"], matches[index]["y"]
+                )
+                await self._save_context()
+                await self.page.wait_for_timeout(1000)
+                return f"Clicked element {index + 1}/{count} matching selector: {selector} with text: {text}"
+
+            if frame_url_contains or frame_name:
+                candidates = []
+                for frame in self.page.frames:
+                    url = getattr(frame, "url", "") or ""
+                    name = getattr(frame, "name", "") or ""
+                    if callable(name):
+                        name = name()
+                    if frame_url_contains and frame_url_contains not in url:
+                        continue
+                    if frame_name and frame_name != name:
+                        continue
+                    locator = frame.locator(selector)
+                    candidates.extend(
+                        locator.nth(i) for i in range(await locator.count())
+                    )
+                where = f" in frames matching {(frame_url_contains or frame_name)!r}"
+            else:
+                locator = self.page.locator(selector)
+                candidates = [locator.nth(i) for i in range(await locator.count())]
+                where = ""
+
+            count = len(candidates)
+            if count == 0:
+                return f"No element found for selector: {selector}{where}"
+            if index < 0 or index >= count:
+                return f"Selector matched {count} elements{where}; index {index} is out of range"
+            target = candidates[index]
+            box = await target.bounding_box()
+            if box:
+                await humanize.click(self.page, 0, 0, box=box)
+            else:
+                await target.click(force=True)
+            await self._save_context()
+            await self.page.wait_for_timeout(1000)
+            return f"Clicked element {index + 1}/{count} matching selector: {selector}{where}"
+
+    async def type_text_by_selector(
+        self, selector: str, text: str, index: int = 0
+    ) -> str:
+        """Focus a stable selector and type through async humanized input."""
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
             locator = self.page.locator(selector)
             count = await locator.count()
+            if count == 0:
+                return f"No element found for selector: {selector}"
             if index < 0 or index >= count:
-                return f"No element {index + 1}/{count} matching selector: {selector}"
-            await locator.nth(index).click()
-            return f"Clicked element {index + 1}/{count} matching selector: {selector}"
+                return (
+                    f"Selector matched {count} elements; index {index} is out of range"
+                )
+            await locator.nth(index).click(force=True)
+            await humanize.type_text(self.page, text, self._clipboard_lock)
+            await self.page.wait_for_timeout(1000)
+            return f"Typed text into element {index + 1}/{count} matching selector: {selector}"
+
+    async def mouse_click(self, x: int, y: int) -> str:
+        """Humanize an exact coordinate click without blocking the event loop."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            await humanize.click(self.page, x, y)
+            await asyncio.sleep(1)
+            return f"Clicked at ({x}, {y})"
+
+    async def click_element_near_selector(
+        self,
+        anchor_selector: str,
+        target_selector: str,
+        target_text: str = "",
+        anchor_index: int = -1,
+        container_selector: str = "",
+        require_anchor_text: bool = False,
+        wait_ms: int = 1000,
+        verify_anchor_text_cleared: bool = False,
+    ) -> str:
+        """Click the nearest visible target below a stable visible anchor."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            target = await self.page.evaluate(
+                """
+                (options) => {
+                    const normalize = (el) => (el?.innerText || el?.textContent || '')
+                        .replace(/\\u00a0/g, ' ').replace(/[ \\t\\n]+/g, ' ').trim();
+                    const isVisible = (el) => {
+                        if (!el) return false;
+                        const style = window.getComputedStyle(el);
+                        const rect = el.getBoundingClientRect();
+                        return style.display !== 'none' && style.visibility !== 'hidden' &&
+                            rect.width > 0 && rect.height > 0 && rect.bottom > 0 &&
+                            rect.top < window.innerHeight;
+                    };
+                    const isEnabled = (button) =>
+                        !button.disabled && button.getAttribute('aria-disabled') !== 'true';
+                    const textMatches = (el) => !options.target_text || normalize(el) === options.target_text;
+                    const anchors = Array.from(document.querySelectorAll(options.anchor_selector))
+                        .filter((anchor) => isVisible(anchor))
+                        .filter((anchor) => !options.require_anchor_text || normalize(anchor).length > 0);
+                    if (!anchors.length) {
+                        return {ok: false, error: `No visible anchor found for selector: ${options.anchor_selector}`};
+                    }
+                    let anchorIndex = options.anchor_index;
+                    if (anchorIndex < 0) anchorIndex = anchors.length + anchorIndex;
+                    if (anchorIndex < 0 || anchorIndex >= anchors.length) {
+                        return {ok: false, error: `Anchor selector matched ${anchors.length} elements; index ${options.anchor_index} is out of range`};
+                    }
+                    const anchor = anchors[anchorIndex];
+                    const anchorRect = anchor.getBoundingClientRect();
+                    let container = options.container_selector ? anchor.closest(options.container_selector) : null;
+                    container = container || anchor.closest('form') || anchor.parentElement || document.body;
+                    const targets = Array.from(container.querySelectorAll(options.target_selector))
+                        .filter((candidate) => isVisible(candidate) && isEnabled(candidate) && textMatches(candidate));
+                    let target = targets
+                        .map((candidate) => ({candidate, rect: candidate.getBoundingClientRect()}))
+                        .filter(({rect}) => rect.top >= anchorRect.top - 8)
+                        .sort((a, b) => a.rect.top - b.rect.top || a.rect.left - b.rect.left)[0]?.candidate;
+                    if (!target) {
+                        target = Array.from(document.querySelectorAll(options.target_selector))
+                            .filter((candidate) => isVisible(candidate) && isEnabled(candidate) && textMatches(candidate))
+                            .map((candidate) => ({candidate, rect: candidate.getBoundingClientRect()}))
+                            .filter(({rect}) => rect.top >= anchorRect.top - 8)
+                            .sort((a, b) => Math.abs(a.rect.top - anchorRect.top) -
+                                Math.abs(b.rect.top - anchorRect.top) || a.rect.left - b.rect.left)[0]?.candidate;
+                    }
+                    if (!target) {
+                        return {ok: false, error: `No visible enabled target found near anchor for selector: ${options.target_selector}`, anchor_text: normalize(anchor)};
+                    }
+                    const rect = target.getBoundingClientRect();
+                    return {ok: true, x: rect.x + rect.width / 2, y: rect.y + rect.height / 2,
+                        anchor_text: normalize(anchor), target_text: normalize(target)};
+                }
+                """,
+                {
+                    "anchor_selector": anchor_selector,
+                    "target_selector": target_selector,
+                    "target_text": target_text,
+                    "anchor_index": anchor_index,
+                    "container_selector": container_selector,
+                    "require_anchor_text": require_anchor_text,
+                },
+            )
+            if not target or not target.get("ok"):
+                return (
+                    target.get("error", "Could not find target near anchor")
+                    if target
+                    else "Could not find target near anchor"
+                )
+            await humanize.click(self.page, target["x"], target["y"])
+            await self.page.wait_for_timeout(wait_ms)
+            await self._save_context()
+            state = "clicked"
+            if verify_anchor_text_cleared:
+                state = await self.page.evaluate(
+                    """
+                    (options) => {
+                        const normalize = (el) => (el?.innerText || el?.textContent || '')
+                            .replace(/\\u00a0/g, ' ').replace(/[ \\t\\n]+/g, ' ').trim();
+                        const isVisible = (el) => {
+                            if (!el) return false;
+                            const style = window.getComputedStyle(el);
+                            const rect = el.getBoundingClientRect();
+                            return style.display !== 'none' && style.visibility !== 'hidden' &&
+                                rect.width > 0 && rect.height > 0 && rect.bottom > 0 &&
+                                rect.top < window.innerHeight;
+                        };
+                        const matchingAnchor = Array.from(document.querySelectorAll(options.anchor_selector))
+                            .find((anchor) => isVisible(anchor) && normalize(anchor) === options.anchor_text);
+                        return matchingAnchor ? 'uncertain_anchor_still_contains_text' : 'anchor_text_cleared';
+                    }
+                    """,
+                    {
+                        "anchor_selector": anchor_selector,
+                        "anchor_text": target["anchor_text"],
+                    },
+                )
+            return (
+                "Clicked target near anchor; "
+                f"state={state}; anchor_text={target['anchor_text']!r}; "
+                f"target_text={target['target_text']!r}"
+            )
 
     async def count_elements_by_selector(self, selector: str) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
             count = await self.page.locator(selector).count()
-            return f"{count} element{'s' if count != 1 else ''} match selector: {selector}"
+            return (
+                f"{count} element{'s' if count != 1 else ''} match selector: {selector}"
+            )
 
     async def get_element_text_by_selector(self, selector: str, index: int = 0) -> str:
         async with self._tab_operation():
@@ -822,10 +1066,14 @@ class AsyncBrowserCore:
             if count == 0:
                 return f"No element found for selector: {selector}"
             if index < 0 or index >= count:
-                return f"Selector matched {count} elements; index {index} is out of range"
+                return (
+                    f"Selector matched {count} elements; index {index} is out of range"
+                )
             return await locator.nth(index).inner_text()
 
-    async def fill_text_by_selector(self, selector: str, text: str, index: int = 0) -> str:
+    async def fill_text_by_selector(
+        self, selector: str, text: str, index: int = 0
+    ) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
@@ -834,7 +1082,9 @@ class AsyncBrowserCore:
             if count == 0:
                 return f"No element found for selector: {selector}"
             if index < 0 or index >= count:
-                return f"Selector matched {count} elements; index {index} is out of range"
+                return (
+                    f"Selector matched {count} elements; index {index} is out of range"
+                )
             await locator.nth(index).fill(text)
             await self.page.wait_for_timeout(1000)
             return f"Filled element {index + 1}/{count} matching selector: {selector}"
@@ -865,9 +1115,7 @@ class AsyncBrowserCore:
                 locator = frame.locator(selector)
                 count = await locator.count()
                 for locator_index in range(count):
-                    matches.append(
-                        (frame_index, name, url, locator.nth(locator_index))
-                    )
+                    matches.append((frame_index, name, url, locator.nth(locator_index)))
 
             if not matches:
                 return f"No file input found for selector: {selector}"
@@ -1073,7 +1321,9 @@ class AsyncBrowserCore:
                 response["reason"] = "no frame returned ok: true"
             return json.dumps(response, indent=2, ensure_ascii=False)
 
-    async def take_screenshot(self, path: Optional[str] = None, full_page: bool = False) -> str:
+    async def take_screenshot(
+        self, path: Optional[str] = None, full_page: bool = False
+    ) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
@@ -1086,7 +1336,9 @@ class AsyncBrowserCore:
             self.last_screenshot_path = path
             mime = "image/png"
             if len(screenshot) > 600_000:
-                screenshot = await self.page.screenshot(full_page=full_page, type="jpeg", quality=85)
+                screenshot = await self.page.screenshot(
+                    full_page=full_page, type="jpeg", quality=85
+                )
                 mime = "image/jpeg"
             await self.page.wait_for_timeout(1000)
             return f"data:{mime};base64,{base64.b64encode(screenshot).decode('utf-8')}"

--- a/connectonion/useful_tools/browser_tools/_async_humanize.py
+++ b/connectonion/useful_tools/browser_tools/_async_humanize.py
@@ -1,0 +1,190 @@
+"""
+Purpose: Non-blocking humanized pointer, keyboard, and wheel input for AsyncBrowserCore.
+LLM-Note:
+  Dependencies: asyncio + stdlib-only humanize rules; no Patchright sync API | imported by [_async_browser.py] | tested by [tests/unit/test_async_browser_humanize.py]
+  Data flow: known target → shared geometry/persona rules → awaited mouse/keyboard/CDP events with asyncio sleeps between events
+  State/Effects: per-page cursor/CDP state | temporary OS clipboard mutation for CJK paste, serialized by the runtime clipboard lock and restored on cancellation
+  Integration: internal 1.8 async driver only; synchronous BrowserAutomation continues to use humanize.py until #500
+  Errors: browser/CDP errors bubble; clipboard absence falls back to IME composition
+
+The synchronous input layer intentionally sleeps between low-level events. Calling
+it from the async driver would block every session on the event loop. This module
+keeps the same geometry, timing distributions, segmentation, and clipboard rules
+while awaiting every browser operation and pause.
+"""
+
+import asyncio
+import math
+import platform
+import random
+from weakref import WeakKeyDictionary
+
+from . import humanize as rules
+
+_cursor = WeakKeyDictionary()
+_cdp = WeakKeyDictionary()
+
+
+async def _pause(page, base, sigma=0.45):
+    delay = max(
+        0.004,
+        base * random.lognormvariate(0.0, sigma) * rules._persona(page)["speed"],
+    )
+    await asyncio.sleep(delay)
+
+
+async def move(page, x, y):
+    """Move along the synchronous layer's curved, minimum-jerk path."""
+    start = _cursor.get(page)
+    if start is None:
+        start = (x + random.uniform(-260, 260), y + random.uniform(-200, 200))
+
+    distance = math.hypot(x - start[0], y - start[1])
+    steps = max(10, min(48, int(distance / 10)))
+    control_1, control_2 = rules._control_points(start, (x, y))
+    for index in range(1, steps + 1):
+        point_x, point_y = rules._cubic(
+            start,
+            control_1,
+            control_2,
+            (x, y),
+            rules._ease(index / steps),
+        )
+        await page.mouse.move(point_x, point_y)
+        await _pause(page, 0.011, 0.5)
+    await _overshoot(page, x, y)
+    _cursor[page] = (x, y)
+
+
+async def _overshoot(page, x, y):
+    if random.random() < 0.65:
+        await page.mouse.move(x + random.gauss(0, 3), y + random.gauss(0, 3))
+        await _pause(page, 0.03, 0.4)
+        await page.mouse.move(x, y)
+        await _pause(page, 0.02, 0.4)
+
+
+async def click(page, x, y, button="left", clicks=1, box=None):
+    """Humanized click with awaited travel, dwell, and incrementing click count."""
+    if box is not None:
+        x, y = rules._point_in_box(box)
+    await move(page, x, y)
+    await _pause(page, 0.06, 0.5)
+    for index in range(clicks):
+        click_count = index + 1
+        await page.mouse.down(button=button, click_count=click_count)
+        await _pause(page, 0.06, 0.35)
+        await page.mouse.up(button=button, click_count=click_count)
+        if click_count < clicks:
+            await _pause(page, 0.08, 0.3)
+    _cursor[page] = (x, y)
+
+
+async def double_click(page, x, y, box=None):
+    await click(page, x, y, clicks=2, box=box)
+
+
+async def scroll(page, total_dy):
+    """Emit awaited wheel ticks with the same device persona and net distance."""
+    persona = rules._persona(page)
+    low, high = (100, 130) if persona["wheel_notch"] else (8, 28)
+    sign = 1 if total_dy >= 0 else -1
+    target = int(total_dy)
+    overshoot = (
+        sign * random.randint(low, high) if target and random.random() < 0.6 else 0
+    )
+    await _wheel(page, target + overshoot, sign, low, high)
+    if overshoot:
+        await _wheel(page, -overshoot, -sign, low, high)
+
+
+async def _wheel(page, amount, sign, low, high):
+    remaining = amount
+    while remaining != 0:
+        step = sign * random.randint(low, high)
+        if abs(step) > abs(remaining):
+            step = remaining
+        await page.mouse.wheel(0, step)
+        remaining -= step
+        await _pause(page, 0.045, 0.4)
+        if random.random() < 0.08:
+            await _pause(page, 0.3, 0.5)
+
+
+async def _active_text_len(page) -> int:
+    return await page.evaluate(
+        "() => { const e = document.activeElement;"
+        " return e ? ((e.value != null ? e.value : e.textContent) || '').length : 0; }"
+    )
+
+
+async def _restore_clipboard(value):
+    task = asyncio.create_task(asyncio.to_thread(rules._clipboard_set, value))
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        raise
+
+
+async def _set_clipboard_before_paste(value) -> bool:
+    """Finish an in-flight set and report cancellation for deferred delivery."""
+    task = asyncio.create_task(asyncio.to_thread(rules._clipboard_set, value))
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        return True
+    return False
+
+
+async def _paste(page, text, clipboard_lock):
+    if rules._clipboard_set_argv(text) is None:
+        return False
+
+    async with clipboard_lock:
+        saved = await asyncio.to_thread(rules._clipboard_get)
+        interrupted = await _set_clipboard_before_paste(text)
+        try:
+            if interrupted:
+                raise asyncio.CancelledError
+            before = await _active_text_len(page)
+            modifier = "Meta" if platform.system() == "Darwin" else "Control"
+            await page.keyboard.press(f"{modifier}+v")
+            await _pause(page, 0.12, 0.4)
+            return await _active_text_len(page) >= before + len(text)
+        finally:
+            await _restore_clipboard(saved)
+
+
+async def _type_ime(page, run):
+    session = _cdp.get(page)
+    if session is None:
+        session = await page.context.new_cdp_session(page)
+        _cdp[page] = session
+    for character in run:
+        await session.send(
+            "Input.imeSetComposition",
+            {"text": character, "selectionStart": 1, "selectionEnd": 1},
+        )
+        await _pause(page, 0.10, 0.4)
+        await session.send("Input.insertText", {"text": character})
+        await _pause(page, 0.12, 0.5)
+        if random.random() < 0.05:
+            await _pause(page, 0.3, 0.5)
+
+
+async def type_text(page, text, clipboard_lock):
+    """Type Latin text per key and route CJK through paste or awaited CDP IME."""
+    for needs_ime, run in rules._segments(text):
+        if needs_ime:
+            if not await _paste(page, run, clipboard_lock):
+                await _type_ime(page, run)
+            continue
+        for character in run:
+            await page.keyboard.type(character)
+            await _pause(page, 0.09, 0.5)
+            if character in " \t\n":
+                await _pause(page, 0.06, 0.5)
+            if random.random() < 0.03:
+                await _pause(page, 0.3, 0.5)

--- a/docs/blog/2026-08-26-sleep-was-the-global-lock.md
+++ b/docs/blog/2026-08-26-sleep-was-the-global-lock.md
@@ -1,0 +1,41 @@
+# Sleep Was the Global Lock
+
+*2026-08-26*
+
+The selector was known. The coordinates were known. The click worked. Yet one
+agent typing into tab A could still freeze an unrelated agent reading tab B.
+
+The lock was not in our session manager. It was `time.sleep()`.
+
+## Human behavior is a sequence, not one call
+
+ConnectOnion does not teleport a pointer to the center of every element. It moves
+along a curved path, pauses, presses, pauses again, and releases. Text arrives one
+character at a time. CJK text may temporarily use the operating-system clipboard.
+Those details are observable behavior: replacing them with `locator.click()` and
+`fill()` would make the async method faster by silently changing the product.
+
+Copying the synchronous humanization helper was equally wrong. Every tiny
+`time.sleep()` would block the sole asyncio event loop. Per-tab locks would be
+correct on paper while all tabs still stopped together in practice.
+
+The 1.8 input layer therefore keeps the existing geometry, timing distributions,
+device personas, text segmentation, and clipboard policy as pure rules. A new
+async executor awaits every mouse, keyboard, wheel, CDP, and pause operation. A
+native test starts a humanized coordinate click on one tab, then requires another
+tab to read its DOM before the first click finishes. That is the behavior we need,
+not merely an `async def` label.
+
+## The clipboard is shared even when tabs are not
+
+CJK paste has a different concurrency boundary. The clipboard belongs to the
+desktop, so tab A and tab B cannot safely save, replace, paste, and restore it at
+the same time. The async runtime owns one clipboard lock while retaining one
+operation lock per tab. Blocking clipboard commands run in worker threads, and
+restoration completes before cancellation is allowed to escape.
+
+This is deliberately a narrow #498 boundary. It ports known-selector clicks,
+anchor-relative clicks, selector typing, and coordinate clicks. Model-selected
+elements, AI scrolling, and form helpers remain separate because each carries a
+different parity contract. Concurrency improves only when the old behavior is
+made awaitable without being erased.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -75,6 +75,16 @@ deliberately does not port selector clicks: the public click path is humanized, 
 substituting a raw async locator click would match the signature while changing the
 observable behavior.
 
+The fourth boundary ports known-target pointer and text input. It reuses the
+synchronous layer's pure geometry, timing distributions, personas, text
+segmentation, and clipboard rules, but every browser event and pause is awaited.
+Selector clicks preserve exact-text filtering, global indexes across matching
+frames, bounding-box pointer input, forced-click fallback, result strings, and
+context-save ordering. CJK clipboard round trips run off the event loop, share one
+runtime lock across tabs, and restore the previous clipboard before cancellation
+escapes. Natural-language element matching, AI-selected scrolling, and form verbs
+remain later #498 boundaries rather than being mixed into known-target input.
+
 ## Invariants
 
 - one persistent browser context and profile per runtime;
@@ -113,9 +123,11 @@ shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
 sync and running-event-loop callers must leave no loop thread, task, page,
 process, socket, or pipe behind.
 
-The deterministic review boundaries additionally run against native Chrome. They
+The completed review boundaries additionally run against native Chrome. They
 prove selector counts and text, repeated-item bounds, link filtering, text waits,
-raw extraction, viewport changes, page/frame scripts, and both upload paths on a
-real DOM. Click variants, downloads, scrolling, humanized typing, model-backed
-matching, context capture, and remaining dead-context/profile behavior stay
-explicit #498 work; these boundaries do not make the async core public.
+raw extraction, viewport changes, page/frame scripts, both upload paths,
+exact-text/frame selector clicks, known-selector typing, anchor-relative clicks,
+and independent-tab progress during humanized input on a real DOM. Downloads,
+AI-selected scrolling, model-backed matching, form verbs, context capture, and
+remaining dead-context/profile behavior stay explicit #498 work; these boundaries
+do not make the async core public.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -131,6 +131,13 @@ browser.double_click("the file name")   # Double-click to open/select
 
 `mouse_click(x, y)` is useful after `hover()` — clicking by description would re-scan the DOM and dismiss the hover menu.
 
+Stable workflows can avoid a page rescan with
+`click_element_by_selector(selector, index=0, text="")` and
+`type_text_by_selector(selector, text, index=0)`. Selector clicks use humanized
+pointer input when an element exposes a bounding box and retain a forced locator
+fallback for elements without one. Use `frame_url_contains` or `frame_name` when
+the target lives in an iframe; the index applies across all matching frames.
+
 ### System Info
 
 ```python

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -23,7 +23,9 @@ from connectonion.useful_tools.browser_tools._async_browser import (
 
 
 @pytest.mark.slow
-def test_real_async_driver_keeps_sessions_isolated_and_interleaves(tmp_path, monkeypatch):
+def test_real_async_driver_keeps_sessions_isolated_and_interleaves(
+    tmp_path, monkeypatch
+):
     asyncio.run(_exercise_real_async_driver(tmp_path, monkeypatch))
 
 
@@ -65,6 +67,7 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                 browser._bind_session(session)
                 frame_html = (
                     f"<span id=frame-marker>{marker} frame</span>"
+                    "<button id=frame-action onclick=\"this.dataset.clicked='yes'\">Frame action</button>"
                     "<input id=direct-upload type=file>"
                     "<input id=chooser-upload type=file style='display:none'>"
                     "<button id=upload-trigger "
@@ -74,9 +77,12 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                 page_html = (
                     f"<title>{marker}</title><p>{marker}</p>"
                     f"<input id=editor value={marker}>"
+                    "<button class=publish onclick=\"this.dataset.clicked='yes'\">Publish</button>"
+                    "<div class=row><span class=draft>Draft</span>"
+                    "<button class=near onclick=\"this.previousElementSibling.textContent=''\">Send</button></div>"
                     f"<article class=item><span class=body>{marker} item</span></article>"
                     "<a href=https://example.com/one>one</a>"
-                    f"<iframe name=editor srcdoc=\"{html.escape(frame_html, quote=True)}\">"
+                    f'<iframe name=editor srcdoc="{html.escape(frame_html, quote=True)}">'
                     "</iframe>"
                 )
                 await browser.go_to(
@@ -129,6 +135,57 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             assert extracted[0]["visible_bounds"]["width"] > 0
             assert await browser.set_viewport(1280, 720) == "Viewport set to 1280x720"
 
+            assert "with text: Publish" in await browser.click_element_by_selector(
+                ".publish", text="Publish"
+            )
+            assert (
+                await browser.page.locator(".publish").get_attribute("data-clicked")
+                == "yes"
+            )
+            assert "Typed text" in await browser.type_text_by_selector(
+                "#editor", "-typed"
+            )
+            assert await browser.page.locator("#editor").input_value() == "beta-typed"
+
+            assert (
+                "in frames matching 'editor'"
+                in await browser.click_element_by_selector(
+                    "#frame-action", frame_name="editor"
+                )
+            )
+            editor_frame = next(
+                frame for frame in browser.page.frames if frame.name == "editor"
+            )
+            assert (
+                await editor_frame.locator("#frame-action").get_attribute(
+                    "data-clicked"
+                )
+                == "yes"
+            )
+
+            near_result = await browser.click_element_near_selector(
+                ".draft",
+                ".near",
+                target_text="Send",
+                wait_ms=50,
+                verify_anchor_text_cleared=True,
+            )
+            assert "state=anchor_text_cleared" in near_result
+
+            browser._bind_session("A")
+            box = await browser.page.locator("#editor").bounding_box()
+            clicking = asyncio.create_task(
+                browser.mouse_click(
+                    int(box["x"] + box["width"] / 2),
+                    int(box["y"] + box["height"] / 2),
+                )
+            )
+            await asyncio.sleep(0.05)
+            browser._bind_session("B")
+            assert "beta" in await asyncio.wait_for(browser.get_text(), timeout=0.5)
+            assert clicking.done() is False
+            assert (await clicking).startswith("Clicked at (")
+
             page_result = json.loads(
                 await browser.run_page_script(
                     str(page_script),
@@ -140,9 +197,7 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             frame_result = json.loads(
                 await browser.run_frame_script(
                     str(frame_script),
-                    json.dumps(
-                        {"selector": "#frame-marker", "text": "beta frame"}
-                    ),
+                    json.dumps({"selector": "#frame-marker", "text": "beta frame"}),
                     frame_name="editor",
                 )
             )
@@ -160,9 +215,12 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             editor_frame = next(
                 frame for frame in browser.page.frames if frame.name == "editor"
             )
-            assert await editor_frame.locator("#direct-upload").evaluate(
-                "element => element.files[0].name"
-            ) == direct_upload.name
+            assert (
+                await editor_frame.locator("#direct-upload").evaluate(
+                    "element => element.files[0].name"
+                )
+                == direct_upload.name
+            )
 
             chooser_result = json.loads(
                 await browser.upload_file_after_click_by_selector(
@@ -173,9 +231,12 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                 )
             )
             assert chooser_result["uploaded"] is True
-            assert await editor_frame.locator("#chooser-upload").evaluate(
-                "element => element.files[0].name"
-            ) == chooser_upload.name
+            assert (
+                await editor_frame.locator("#chooser-upload").evaluate(
+                    "element => element.files[0].name"
+                )
+                == chooser_upload.name
+            )
         finally:
             browser._bind_session(None)
             close_result = await browser.close()
@@ -186,15 +247,20 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
         loop.set_exception_handler(previous_handler)
 
     assert close_result == "Browser closed. Session saved for next time."
-    assert not loop_errors, {"timings": timings, "errors": [
-        {
-            "message": error.get("message"),
-            "exception": repr(error.get("exception")),
-            "origin": [
-                f"{frame.name}:{frame.lineno}"
-                for frame in (getattr(error.get("future"), "_source_traceback", None) or [])
-                if "patchright" in frame.filename
-            ][-4:],
-        }
-        for error in loop_errors
-    ]}
+    assert not loop_errors, {
+        "timings": timings,
+        "errors": [
+            {
+                "message": error.get("message"),
+                "exception": repr(error.get("exception")),
+                "origin": [
+                    f"{frame.name}:{frame.lineno}"
+                    for frame in (
+                        getattr(error.get("future"), "_source_traceback", None) or []
+                    )
+                    if "patchright" in frame.filename
+                ][-4:],
+            }
+            for error in loop_errors
+        ],
+    }

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -5,12 +5,11 @@ tests prove the new core itself is genuinely async, preserves per-session tabs,
 and cleans up deterministically before #499 puts concurrent IPC in front of it.
 """
 
-import asyncio
 import ast
+import asyncio
 import inspect
 import json
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -24,6 +23,9 @@ class FakeKeyboard:
 
     async def press(self, key):
         self.pressed.append(key)
+
+    async def type(self, text):
+        self.pressed.append(("type", text))
 
 
 class FakeLocator:
@@ -40,6 +42,10 @@ class FakeLocator:
 
     async def click(self, force=False):
         self.page.clicked.append((self.selector, self.index))
+        self.page.clicked_forces.append(force)
+
+    async def bounding_box(self):
+        return self.page.box_by_selector.get((self.selector, self.index))
 
     async def inner_text(self):
         return self.page.text_by_selector.get(self.selector, f"text:{self.index}")
@@ -63,8 +69,10 @@ class FakePage:
         self.keyboard = FakeKeyboard()
         self.focused = {"tag": "body", "is_editable": False, "sensitive": False}
         self.selector_counts = {}
+        self.box_by_selector = {}
         self.text_by_selector = {"body": "page body"}
         self.clicked = []
+        self.clicked_forces = []
         self.filled = []
         self.uploaded = []
         self.name = ""
@@ -72,6 +80,7 @@ class FakePage:
         self.waited_selectors = []
         self.evaluate_calls = []
         self.evaluate_result = None
+        self.evaluate_results = []
         self.file_chooser = FakeFileChooser()
         self.file_chooser_timeouts = []
 
@@ -109,7 +118,11 @@ class FakePage:
         if "document.activeElement" in script:
             return dict(self.focused)
         self.evaluate_calls.append((script, arg))
-        return self.evaluate_result if self.evaluate_result is not None else {"arg": arg}
+        if self.evaluate_results:
+            return self.evaluate_results.pop(0)
+        return (
+            self.evaluate_result if self.evaluate_result is not None else {"arg": arg}
+        )
 
     async def screenshot(self, **kwargs):
         return b"png"
@@ -223,9 +236,7 @@ def test_async_core_has_no_sync_patchright_dependency():
     tree = ast.parse(source)
 
     imported_modules = {
-        node.module
-        for node in ast.walk(tree)
-        if isinstance(node, ast.ImportFrom)
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom)
     }
     assert "patchright.sync_api" not in imported_modules
     assert not any(
@@ -244,9 +255,13 @@ def test_async_core_has_no_sync_patchright_dependency():
 
 
 @pytest.mark.asyncio
-async def test_open_reuses_one_async_context_and_seeds_before_navigation(monkeypatch, tmp_path):
+async def test_open_reuses_one_async_context_and_seeds_before_navigation(
+    monkeypatch, tmp_path
+):
     seed = tmp_path / "state.json"
-    seed.write_text('{"cookies":[{"name":"sid","value":"one","domain":"example.com","path":"/"}]}')
+    seed.write_text(
+        '{"cookies":[{"name":"sid","value":"one","domain":"example.com","path":"/"}]}'
+    )
     context, playwright = install_fake_runtime(monkeypatch, tmp_path)
     browser = async_mod.AsyncBrowserCore(headless=True, seed_state=str(seed))
 
@@ -258,7 +273,10 @@ async def test_open_reuses_one_async_context_and_seeds_before_navigation(monkeyp
     assert len(context.pages_created) == 1
     assert context.cookies_added[0]["name"] == "sid"
     assert playwright.chromium.launch_kwargs["no_viewport"] is True
-    assert "--use-mock-keychain" in playwright.chromium.launch_kwargs["ignore_default_args"]
+    assert (
+        "--use-mock-keychain"
+        in playwright.chromium.launch_kwargs["ignore_default_args"]
+    )
     assert browser.page.viewport == {"width": 1920, "height": 1200}
 
     await browser.close()
@@ -275,7 +293,10 @@ async def test_isolated_runtime_can_keep_chromes_mock_keychain(monkeypatch, tmp_
 
     await browser.open_browser()
 
-    assert "--use-mock-keychain" not in playwright.chromium.launch_kwargs["ignore_default_args"]
+    assert (
+        "--use-mock-keychain"
+        not in playwright.chromium.launch_kwargs["ignore_default_args"]
+    )
     await browser.close()
 
 
@@ -318,7 +339,10 @@ async def test_contextvar_sessions_make_progress_on_independent_tabs():
         navigate("B", "b.example"),
     )
 
-    assert results == ["Navigated to https://a.example", "Navigated to https://b.example"]
+    assert results == [
+        "Navigated to https://a.example",
+        "Navigated to https://b.example",
+    ]
     assert browser._pages["A"] is not browser._pages["B"]
 
 
@@ -347,7 +371,9 @@ async def test_same_tab_operations_are_serialized():
 
 
 @pytest.mark.asyncio
-async def test_cancelled_launch_closes_partial_context_and_driver(monkeypatch, tmp_path):
+async def test_cancelled_launch_closes_partial_context_and_driver(
+    monkeypatch, tmp_path
+):
     page_started = asyncio.Event()
 
     class BlockingContext(FakeContext):
@@ -371,7 +397,9 @@ async def test_cancelled_launch_closes_partial_context_and_driver(monkeypatch, t
 
 
 @pytest.mark.asyncio
-async def test_cancel_during_driver_start_waits_for_driver_then_stops_it(monkeypatch, tmp_path):
+async def test_cancel_during_driver_start_waits_for_driver_then_stops_it(
+    monkeypatch, tmp_path
+):
     start_entered = asyncio.Event()
     release_start = asyncio.Event()
     context = FakeContext()
@@ -402,7 +430,9 @@ async def test_cancel_during_driver_start_waits_for_driver_then_stops_it(monkeyp
 
 
 @pytest.mark.asyncio
-async def test_cancel_during_context_launch_waits_for_context_then_closes_it(monkeypatch, tmp_path):
+async def test_cancel_during_context_launch_waits_for_context_then_closes_it(
+    monkeypatch, tmp_path
+):
     launch_entered = asyncio.Event()
     release_launch = asyncio.Event()
     context = FakeContext()
@@ -436,7 +466,9 @@ async def test_cancel_during_context_launch_waits_for_context_then_closes_it(mon
 
 
 @pytest.mark.asyncio
-async def test_close_waits_for_an_active_operation_before_teardown(monkeypatch, tmp_path):
+async def test_close_waits_for_an_active_operation_before_teardown(
+    monkeypatch, tmp_path
+):
     navigation_started = asyncio.Event()
     release_navigation = asyncio.Event()
 
@@ -470,7 +502,9 @@ async def test_close_waits_for_an_active_operation_before_teardown(monkeypatch, 
 
 
 @pytest.mark.asyncio
-async def test_cancelled_close_finishes_cleanup_before_propagating(monkeypatch, tmp_path):
+async def test_cancelled_close_finishes_cleanup_before_propagating(
+    monkeypatch, tmp_path
+):
     close_started = asyncio.Event()
     release_close = asyncio.Event()
 
@@ -545,7 +579,7 @@ async def test_focus_guard_refuses_destructive_shortcut_and_allows_override():
 
 
 @pytest.mark.asyncio
-async def test_selector_methods_use_async_locator_contract(tmp_path):
+async def test_selector_methods_use_async_locator_contract(tmp_path, monkeypatch):
     upload = tmp_path / "report.txt"
     upload.write_text("ok")
     page = FakePage()
@@ -558,7 +592,15 @@ async def test_selector_methods_use_async_locator_contract(tmp_path):
     browser.browser = context
     browser._pages[None] = page
 
-    assert await browser.count_elements_by_selector("button") == "2 elements match selector: button"
+    async def click(_page, _x, _y, **_kwargs):
+        page.clicked.append(("humanized", 1, True))
+
+    monkeypatch.setattr(async_mod.humanize, "click", click)
+
+    assert (
+        await browser.count_elements_by_selector("button")
+        == "2 elements match selector: button"
+    )
     assert await browser.get_element_text_by_selector("button", 1) == "Publish"
     assert await browser.get_element_text_by_selector("missing") == (
         "No element found for selector: missing"
@@ -569,18 +611,19 @@ async def test_selector_methods_use_async_locator_contract(tmp_path):
     )
     assert "Clicked element 2/2" in await browser.click_element_by_selector("button", 1)
     assert "Filled element 1/1" in await browser.fill_text_by_selector("input", "hello")
-    assert page.waits == [1000]
-    uploaded = json.loads(
-        await browser.upload_file_by_selector("input", str(upload))
-    )
+    assert page.waits == [500, 1000, 1000]
+    uploaded = json.loads(await browser.upload_file_by_selector("input", str(upload)))
     assert uploaded["file"] == str(upload)
     assert uploaded["frame"]["index"] == 0
     assert page.clicked == [("button", 1)]
+    assert page.clicked_forces == [True]
     assert page.filled == [("input", 0, "hello")]
 
 
 @pytest.mark.asyncio
-async def test_deterministic_async_verbs_preserve_sync_signatures_and_results(monkeypatch):
+async def test_deterministic_async_verbs_preserve_sync_signatures_and_results(
+    monkeypatch,
+):
     methods = (
         "tab_status",
         "count_elements_by_selector",
@@ -702,6 +745,117 @@ async def test_async_frame_and_upload_verbs_preserve_sync_signatures():
 
 
 @pytest.mark.asyncio
+async def test_async_humanized_selector_verbs_preserve_sync_signatures():
+    for name in (
+        "click_element_by_selector",
+        "click_element_near_selector",
+        "type_text_by_selector",
+        "mouse_click",
+    ):
+        async_method = getattr(async_mod.AsyncBrowserCore, name, None)
+        sync_method = getattr(BrowserAutomation, name)
+        assert async_method is not None, name
+        assert inspect.iscoroutinefunction(async_method), name
+        assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+@pytest.mark.asyncio
+async def test_humanized_selector_click_supports_exact_text_and_frame_global_index(
+    monkeypatch,
+):
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+    clicks = []
+
+    async def click(_page, x, y, **kwargs):
+        clicks.append((x, y, kwargs))
+
+    monkeypatch.setattr(async_mod.humanize, "click", click)
+    page.evaluate_result = [{"x": 12, "y": 34}, {"x": 56, "y": 78}]
+    result = await browser.click_element_by_selector("button", 1, text="Publish")
+    assert result == "Clicked element 2/2 matching selector: button with text: Publish"
+    assert clicks == [(56, 78, {})]
+    assert page.waits == [500, 1000]
+
+    page.waits.clear()
+    first = FakeFrame(None, url="https://pay.example/one", name="checkout")
+    second = FakeFrame(None, url="https://pay.example/two", name="checkout")
+    first.selector_counts["button"] = 1
+    second.selector_counts["button"] = 1
+    second.box_by_selector[("button", 0)] = {
+        "x": 10,
+        "y": 20,
+        "width": 30,
+        "height": 40,
+    }
+    page.frames = [first, second]
+    result = await browser.click_element_by_selector(
+        "button", 1, frame_url_contains="pay.example"
+    )
+    assert (
+        result
+        == "Clicked element 2/2 matching selector: button in frames matching 'pay.example'"
+    )
+    assert clicks[-1] == (0, 0, {"box": {"x": 10, "y": 20, "width": 30, "height": 40}})
+
+
+@pytest.mark.asyncio
+async def test_humanized_type_mouse_and_near_anchor_are_fully_awaited(monkeypatch):
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+    events = []
+
+    async def click(_page, x, y, **_kwargs):
+        events.append(("click", x, y))
+
+    async def type_text(_page, text, lock):
+        assert lock is browser._clipboard_lock
+        events.append(("type", text))
+
+    async def sleep(delay):
+        events.append(("sleep", delay))
+
+    monkeypatch.setattr(async_mod.humanize, "click", click)
+    monkeypatch.setattr(async_mod.humanize, "type_text", type_text)
+    monkeypatch.setattr(async_mod.asyncio, "sleep", sleep)
+
+    assert await browser.type_text_by_selector("input", "hello") == (
+        "Typed text into element 1/1 matching selector: input"
+    )
+    assert page.clicked == [("input", 0)]
+    assert page.clicked_forces == [True]
+    assert ("type", "hello") in events
+    assert await browser.mouse_click(20, 30) == "Clicked at (20, 30)"
+    assert events[-2:] == [("click", 20, 30), ("sleep", 1)]
+
+    page.evaluate_results = [
+        {"ok": True, "x": 7, "y": 9, "anchor_text": "Draft", "target_text": "Publish"},
+        "anchor_text_cleared",
+    ]
+    result = await browser.click_element_near_selector(
+        ".draft",
+        "button",
+        target_text="Publish",
+        wait_ms=42,
+        verify_anchor_text_cleared=True,
+    )
+    assert result == (
+        "Clicked target near anchor; state=anchor_text_cleared; "
+        "anchor_text='Draft'; target_text='Publish'"
+    )
+    assert ("click", 7, 9) in events
+    assert page.waits[-2:] == [42, 500]
+
+
+@pytest.mark.asyncio
 async def test_async_page_and_frame_scripts_keep_validation_and_result_contracts(
     tmp_path,
     monkeypatch,
@@ -731,7 +885,9 @@ async def test_async_page_and_frame_scripts_keep_validation_and_result_contracts
     assert await browser.run_page_script("missing.js") == (
         f"Script not found: {tmp_path / 'missing.js'}"
     )
-    assert await browser.run_page_script(".") == f"Script path is not a file: {tmp_path}"
+    assert (
+        await browser.run_page_script(".") == f"Script path is not a file: {tmp_path}"
+    )
     assert (await browser.run_page_script("verify.js", "{")).startswith(
         "Invalid args_json:"
     )
@@ -810,17 +966,23 @@ async def test_async_direct_upload_is_frame_aware_and_returns_sync_json(
     assert await browser.upload_file_by_selector("input", "folder") == (
         f"Path is not a file: {directory}"
     )
-    assert await browser.upload_file_by_selector(
-        'input[type="file"]',
-        "cover.png",
-        frame_name="missing",
-    ) == 'No file input found for selector: input[type="file"]'
-    assert await browser.upload_file_by_selector(
-        'input[type="file"]',
-        "cover.png",
-        index=1,
-        frame_name="editor",
-    ) == 'Selector matched 1 file input(s); index 1 is out of range'
+    assert (
+        await browser.upload_file_by_selector(
+            'input[type="file"]',
+            "cover.png",
+            frame_name="missing",
+        )
+        == 'No file input found for selector: input[type="file"]'
+    )
+    assert (
+        await browser.upload_file_by_selector(
+            'input[type="file"]',
+            "cover.png",
+            index=1,
+            frame_name="editor",
+        )
+        == "Selector matched 1 file input(s); index 1 is out of range"
+    )
 
 
 @pytest.mark.asyncio
@@ -855,18 +1017,24 @@ async def test_async_upload_after_click_filters_frame_text_and_awaits_chooser(tm
     assert page.file_chooser.files == [str(upload)]
     assert 2500 in page.waits
 
-    assert await browser.upload_file_after_click_by_selector(
-        "button",
-        str(upload),
-        text="Different",
-        frame_name="editor",
-    ) == "No upload trigger found for selector: button with text: Different"
-    assert await browser.upload_file_after_click_by_selector(
-        "button",
-        str(upload),
-        index=1,
-        frame_name="editor",
-    ) == "Selector matched 1 upload trigger(s); index 1 is out of range"
+    assert (
+        await browser.upload_file_after_click_by_selector(
+            "button",
+            str(upload),
+            text="Different",
+            frame_name="editor",
+        )
+        == "No upload trigger found for selector: button with text: Different"
+    )
+    assert (
+        await browser.upload_file_after_click_by_selector(
+            "button",
+            str(upload),
+            index=1,
+            frame_name="editor",
+        )
+        == "Selector matched 1 upload trigger(s); index 1 is out of range"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_async_browser_humanize.py
+++ b/tests/unit/test_async_browser_humanize.py
@@ -1,0 +1,280 @@
+"""Contract tests for non-blocking humanized input on the async browser core."""
+
+import asyncio
+import math
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import _async_humanize as humanize
+
+
+class FakeMouse:
+    def __init__(self, log):
+        self.log = log
+
+    async def move(self, x, y):
+        self.log.append(("move", x, y))
+
+    async def down(self, button="left", click_count=1):
+        self.log.append(("down", button, click_count))
+
+    async def up(self, button="left", click_count=1):
+        self.log.append(("up", button, click_count))
+
+    async def wheel(self, dx, dy):
+        self.log.append(("wheel", dx, dy))
+
+
+class FakeKeyboard:
+    def __init__(self, page):
+        self.page = page
+
+    async def type(self, text):
+        self.page.log.append(("type", text))
+
+    async def press(self, key):
+        self.page.log.append(("press", key))
+
+
+class FakeSession:
+    def __init__(self, log):
+        self.log = log
+
+    async def send(self, method, payload):
+        self.log.append(("cdp", method, payload))
+
+
+class FakeContext:
+    def __init__(self, page):
+        self.page = page
+        self.session = FakeSession(page.log)
+
+    async def new_cdp_session(self, page):
+        assert page is self.page
+        return self.session
+
+
+class FakePage:
+    def __init__(self):
+        self.log = []
+        self.mouse = FakeMouse(self.log)
+        self.keyboard = FakeKeyboard(self)
+        self.context = FakeContext(self)
+        self.lengths = []
+
+    async def evaluate(self, _script):
+        return self.lengths.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def fresh_human_state():
+    humanize._cursor.clear()
+    humanize._cdp.clear()
+    humanize.rules._personas.clear()
+
+
+def _kinds(log):
+    return [event[0] for event in log]
+
+
+async def _no_sleep(_delay):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_async_move_is_curved_and_yields_between_steps(monkeypatch):
+    page = FakePage()
+    yielded = []
+
+    async def record_sleep(delay):
+        yielded.append(delay)
+
+    monkeypatch.setattr(humanize.asyncio, "sleep", record_sleep)
+    await humanize.move(page, 500, 0)
+
+    points = [(x, y) for kind, x, y in page.log if kind == "move"]
+    assert len(points) >= 8
+    assert points[-1] == pytest.approx((500, 0), abs=1)
+    (x0, y0), (x1, y1) = points[0], points[-1]
+    dx, dy = x1 - x0, y1 - y0
+    length = math.hypot(dx, dy) or 1.0
+    max_perp = max(abs((x - x0) * dy - (y - y0) * dx) / length for x, y in points)
+    assert max_perp / length > 0.01
+    assert yielded, "human pauses must yield the event loop"
+
+
+@pytest.mark.asyncio
+async def test_async_click_keeps_button_count_box_and_cursor_contract(monkeypatch):
+    page = FakePage()
+    monkeypatch.setattr(humanize.asyncio, "sleep", _no_sleep)
+
+    await humanize.click(
+        page,
+        0,
+        0,
+        button="right",
+        clicks=2,
+        box={"x": 100, "y": 100, "width": 200, "height": 100},
+    )
+
+    kinds = _kinds(page.log)
+    assert kinds.index("move") < kinds.index("down") < kinds.index("up")
+    assert [event[2] for event in page.log if event[0] == "down"] == [1, 2]
+    assert all(event[1] == "right" for event in page.log if event[0] in {"down", "up"})
+    x, y = humanize._cursor[page]
+    assert 100 <= x <= 300 and 100 <= y <= 200
+
+
+@pytest.mark.asyncio
+async def test_async_latin_typing_is_per_character_and_non_blocking(monkeypatch):
+    page = FakePage()
+    yielded = []
+
+    async def record_sleep(delay):
+        yielded.append(delay)
+
+    monkeypatch.setattr(humanize.asyncio, "sleep", record_sleep)
+    await humanize.type_text(page, "hi there", asyncio.Lock())
+
+    assert [event[1] for event in page.log if event[0] == "type"] == list("hi there")
+    assert len(yielded) >= len("hi there")
+
+
+@pytest.mark.asyncio
+async def test_async_cjk_paste_restores_clipboard(monkeypatch):
+    page = FakePage()
+    page.lengths = [0, 2]
+    writes = []
+    monkeypatch.setattr(humanize.rules, "_clipboard_set_argv", lambda _text: ["pbcopy"])
+    monkeypatch.setattr(humanize.rules, "_clipboard_get", lambda: "saved")
+    monkeypatch.setattr(
+        humanize.rules,
+        "_clipboard_set",
+        lambda value: writes.append(value) or True,
+    )
+    monkeypatch.setattr(humanize.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(humanize.asyncio, "sleep", _no_sleep)
+
+    await humanize.type_text(page, "你好", asyncio.Lock())
+
+    assert ("press", "Meta+v") in page.log
+    assert writes == ["你好", "saved"]
+
+
+@pytest.mark.asyncio
+async def test_clipboard_restore_finishes_before_cancellation_escapes(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    writes = []
+
+    async def to_thread(func, value):
+        started.set()
+        await release.wait()
+        writes.append(value)
+        return func(value)
+
+    monkeypatch.setattr(humanize.asyncio, "to_thread", to_thread)
+    monkeypatch.setattr(humanize.rules, "_clipboard_set", lambda _value: True)
+    task = asyncio.create_task(humanize._restore_clipboard("saved"))
+    await started.wait()
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert writes == ["saved"]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_clipboard_set_still_restores_saved_value(
+    monkeypatch,
+):
+    page = FakePage()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    writes = []
+
+    async def to_thread(func, *args):
+        value = func(*args)
+        if func is humanize.rules._clipboard_set and args[0] == "你":
+            started.set()
+            await release.wait()
+        return value
+
+    monkeypatch.setattr(humanize.rules, "_clipboard_set_argv", lambda _text: ["pbcopy"])
+    monkeypatch.setattr(humanize.rules, "_clipboard_get", lambda: "saved")
+    monkeypatch.setattr(
+        humanize.rules,
+        "_clipboard_set",
+        lambda value: writes.append(value) or True,
+    )
+    monkeypatch.setattr(humanize.asyncio, "to_thread", to_thread)
+
+    task = asyncio.create_task(humanize.type_text(page, "你", asyncio.Lock()))
+    await started.wait()
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert writes == ["你", "saved"]
+    assert page.log == []
+
+
+@pytest.mark.asyncio
+async def test_cjk_clipboard_round_trips_are_serialized_between_tabs(monkeypatch):
+    pages = [FakePage(), FakePage()]
+    for page in pages:
+        page.lengths = [0, 1]
+    lock = asyncio.Lock()
+    active = 0
+    peak = 0
+    real_sleep = asyncio.sleep
+
+    async def to_thread(func, *args):
+        nonlocal active, peak
+        if func is humanize.rules._clipboard_set and args[0] in {"一", "二"}:
+            active += 1
+            peak = max(peak, active)
+            await real_sleep(0)
+            active -= 1
+        return func(*args)
+
+    monkeypatch.setattr(humanize.rules, "_clipboard_set_argv", lambda _text: ["pbcopy"])
+    monkeypatch.setattr(humanize.rules, "_clipboard_get", lambda: "saved")
+    monkeypatch.setattr(humanize.rules, "_clipboard_set", lambda _value: True)
+    monkeypatch.setattr(humanize.asyncio, "to_thread", to_thread)
+    monkeypatch.setattr(humanize.asyncio, "sleep", _no_sleep)
+
+    await asyncio.gather(
+        humanize.type_text(pages[0], "一", lock),
+        humanize.type_text(pages[1], "二", lock),
+    )
+    assert peak == 1
+
+
+@pytest.mark.asyncio
+async def test_async_cjk_falls_back_to_awaited_cdp_ime(monkeypatch):
+    page = FakePage()
+    monkeypatch.setattr(humanize.rules, "_clipboard_set_argv", lambda _text: None)
+    monkeypatch.setattr(humanize.asyncio, "sleep", _no_sleep)
+
+    await humanize.type_text(page, "你", asyncio.Lock())
+
+    assert [event[1] for event in page.log if event[0] == "cdp"] == [
+        "Input.imeSetComposition",
+        "Input.insertText",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_scroll_emits_bounded_ticks_with_exact_net_distance(monkeypatch):
+    page = FakePage()
+    monkeypatch.setattr(humanize.asyncio, "sleep", _no_sleep)
+
+    await humanize.scroll(page, 1000)
+
+    deltas = [event[2] for event in page.log if event[0] == "wheel"]
+    assert len(deltas) >= 6
+    assert all(abs(delta) <= 170 for delta in deltas)
+    assert sum(deltas) == 1000


### PR DESCRIPTION
## Summary

- add a genuinely async humanization executor that preserves the existing pointer geometry, timing persona, wheel shape, and CJK segmentation rules
- port known-target `click_element_by_selector`, `click_element_near_selector`, `type_text_by_selector`, and `mouse_click` with exact synchronous signatures and result contracts
- serialize shared OS clipboard round trips across tabs and finish clipboard set/restore work before cancellation escapes
- extend native Chrome acceptance to exact-text clicks, iframe clicks, typed input, anchor verification, and independent-tab progress during humanized input
- document the fourth #498 review boundary and why synchronous sleeps behave like a global lock

## Verification

- `python -m pytest tests/unit/test_async_browser_core.py tests/unit/test_async_browser_humanize.py -q` — 34 passed
- focused browser regression set — 64 passed, 1 slow test deselected
- offline full matrix — 7,289 passed, 21 expected skipped, 199 deselected (one PATH-only CLI launcher failure rerun successfully with the test venv first on PATH)
- native source-tree Chrome gate — 1 passed
- rebuilt wheel installed into a fresh venv — 34 contract tests passed
- exact installed-wheel native Chrome gate — 1 passed
- Ruff and Black checks pass for touched Python files; `git diff --check` passes

## Scope

This is the fourth internal #498 parity boundary. Natural-language element matching, AI-selected scrolling, form helpers, concurrent transport (#499), and the sync facade (#500) remain separate. It does not bump the version, publish an alpha, or close #498.

The separate docs-site repository is not checked out in this workspace, so its version mirror could not be checked locally. This slice does not change the package version.

Related: #498

**Proposed target version:** 1.8.0 / next alpha after the complete async-browser boundary

**Estimated release window:** 1.8 development cycle / after #498, #499, and #500 acceptance gates

**Forward-port tracking issue (stable patches only):** Not applicable — mainline 1.8 development
