### PR TITLE
Port async model-selected browser actions

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -1,11 +1,11 @@
 """
 Purpose: Internal Patchright async browser core for the 1.8 driver migration.
 LLM-Note:
-  Dependencies: imports only patchright.async_api plus browser_config/chrome_finder and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py]
-  Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → independent tab operations may interleave on one event loop
+  Dependencies: imports patchright.async_api, async element finding/humanization, browser_config/chrome_finder, and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py, tests/e2e/test_async_browser_core_real_driver.py]
+  Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → model-selected actions await extraction and worker-thread matching → independent tab operations may interleave on one event loop
   State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
   Integration: internal AsyncBrowserCore; the public synchronous BrowserAutomation remains unchanged until #500 adds its compatibility facade
-  Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus
+  Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus | element ambiguity and non-match errors preserve the synchronous finder contract
 
 This module is deliberately internal while #498 is in progress. It must never
 import or call patchright.sync_api: the old public class remains the compatibility
@@ -25,6 +25,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from . import _async_element_finder as element_finder
 from . import _async_humanize as humanize
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
@@ -701,6 +702,172 @@ class AsyncBrowserCore:
                 return "Browser not open"
             return await self.page.locator("body").inner_text()
 
+    def _element_locator(self, element):
+        """Resolve an extracted element in its main-page or iframe context."""
+        if element.frame != "main":
+            frames = []
+            for frame in self.page.frames:
+                raw_name = getattr(frame, "name", "") or ""
+                name = raw_name() if callable(raw_name) else raw_name
+                url = getattr(frame, "url", "") or ""
+                frames.append((frame, url))
+                if name == element.frame:
+                    return frame.locator(element.locator)
+            # Playwright orders page.frames with the main frame first. A
+            # non-main extracted target must never fall back to that frame just
+            # because a data/document URL happens to contain the frame label.
+            for frame, url in frames[1:]:
+                if element.frame in url:
+                    return frame.locator(element.locator)
+        return self.page.locator(element.locator)
+
+    async def find_element_by_description(self, description: str) -> str:
+        """Find a pre-built locator selected from the extracted DOM."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            element = await element_finder.find_element(self.page, description)
+            if element:
+                return element.locator
+            return f"Could not find element matching: {description}"
+
+    async def click(self, description: str) -> str:
+        """Humanize a click on a model-selected element."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            element = await element_finder.find_element(self.page, description)
+            if element.frame.startswith("shadow-"):
+                x = element.x + element.width // 2
+                y = element.y + element.height // 2
+                await humanize.click(self.page, x, y)
+                await self._save_context()
+                await asyncio.sleep(1)
+                return (
+                    f"Clicked [{element.index}] {element.tag} "
+                    f"'{element.text}' (shadow DOM)"
+                )
+
+            locator = self._element_locator(element)
+            if await locator.count() > 0:
+                box = await locator.first.bounding_box()
+                if box:
+                    x = box["x"] + box["width"] / 2
+                    y = box["y"] + box["height"] / 2
+                    await humanize.click(self.page, x, y, box=box)
+                    await self._save_context()
+                    await asyncio.sleep(1)
+                    return f"Clicked [{element.index}] {element.tag} '{element.text}'"
+                await locator.first.click(force=True)
+                await self._save_context()
+                await asyncio.sleep(1)
+                return (
+                    f"Clicked [{element.index}] {element.tag} "
+                    f"'{element.text}' (force)"
+                )
+
+            x = element.x + element.width // 2
+            y = element.y + element.height // 2
+            await humanize.click(self.page, x, y)
+            await self._save_context()
+            await asyncio.sleep(1)
+            return f"Clicked [{element.index}] '{element.text}' at ({x}, {y})"
+
+    async def hover(self, description: str) -> str:
+        """Hover over a model-selected element."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            element = await element_finder.find_element(self.page, description)
+            if element.frame.startswith("shadow-"):
+                await humanize.move(
+                    self.page,
+                    element.x + element.width // 2,
+                    element.y + element.height // 2,
+                )
+            else:
+                locator = self._element_locator(element)
+                if await locator.count() > 0:
+                    await locator.first.hover()
+                else:
+                    await humanize.move(
+                        self.page,
+                        element.x + element.width // 2,
+                        element.y + element.height // 2,
+                    )
+            await asyncio.sleep(1)
+            return f"Hovered [{element.index}] {element.tag} '{element.text}'"
+
+    async def right_click(self, description: str) -> str:
+        """Humanize a right click on a model-selected element."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            element = await element_finder.find_element(self.page, description)
+            if element.frame.startswith("shadow-"):
+                x = element.x + element.width // 2
+                y = element.y + element.height // 2
+                await humanize.click(self.page, x, y, button="right")
+                await asyncio.sleep(1)
+                return (
+                    f"Right-clicked [{element.index}] {element.tag} "
+                    f"'{element.text}' (shadow DOM)"
+                )
+
+            locator = self._element_locator(element)
+            if await locator.count() > 0:
+                box = await locator.first.bounding_box()
+                if box:
+                    x = box["x"] + box["width"] / 2
+                    y = box["y"] + box["height"] / 2
+                    await humanize.click(self.page, x, y, button="right", box=box)
+                    await asyncio.sleep(1)
+                    return (
+                        f"Right-clicked [{element.index}] {element.tag} "
+                        f"'{element.text}'"
+                    )
+
+            x = element.x + element.width // 2
+            y = element.y + element.height // 2
+            await humanize.click(self.page, x, y, button="right")
+            await asyncio.sleep(1)
+            return f"Right-clicked [{element.index}] '{element.text}' at ({x}, {y})"
+
+    async def double_click(self, description: str) -> str:
+        """Humanize a double click on a model-selected element."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            element = await element_finder.find_element(self.page, description)
+            if element.frame.startswith("shadow-"):
+                x = element.x + element.width // 2
+                y = element.y + element.height // 2
+                await humanize.double_click(self.page, x, y)
+                await asyncio.sleep(1)
+                return (
+                    f"Double-clicked [{element.index}] {element.tag} "
+                    f"'{element.text}' (shadow DOM)"
+                )
+
+            locator = self._element_locator(element)
+            if await locator.count() > 0:
+                box = await locator.first.bounding_box()
+                if box:
+                    x = box["x"] + box["width"] / 2
+                    y = box["y"] + box["height"] / 2
+                    await humanize.double_click(self.page, x, y, box=box)
+                    await asyncio.sleep(1)
+                    return (
+                        f"Double-clicked [{element.index}] {element.tag} "
+                        f"'{element.text}'"
+                    )
+
+            x = element.x + element.width // 2
+            y = element.y + element.height // 2
+            await humanize.double_click(self.page, x, y)
+            await asyncio.sleep(1)
+            return f"Double-clicked [{element.index}] '{element.text}' at ({x}, {y})"
+
     async def extract_items_by_selector(
         self,
         container_selector: str,
@@ -1349,6 +1516,42 @@ class AsyncBrowserCore:
                 return "Browser not open"
             await self.page.set_viewport_size({"width": width, "height": height})
             return f"Viewport set to {width}x{height}"
+
+    async def select_option(self, field_description: str, option: str) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            selector = await self.find_element_by_description(field_description)
+            if selector.startswith("Could not"):
+                return selector
+            await self.page.select_option(selector, label=option)
+            return f"Selected '{option}' in {field_description}"
+
+    async def check_checkbox(self, description: str, checked: bool = True) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            selector = await self.find_element_by_description(description)
+            if selector.startswith("Could not"):
+                return selector
+            if checked:
+                await self.page.check(selector)
+                return f"Checked {description}"
+            await self.page.uncheck(selector)
+            return f"Unchecked {description}"
+
+    async def wait_for_element(self, description: str, timeout: int = 30) -> str:
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            selector = await self.find_element_by_description(description)
+            if selector.startswith("Could not"):
+                await self.page.wait_for_selector(
+                    f"text='{description}'", timeout=timeout * 1000
+                )
+                return f"Found text: '{description}'"
+            await self.page.wait_for_selector(selector, timeout=timeout * 1000)
+            return f"Element appeared: {description}"
 
     async def wait_for_text(self, text: str, timeout: int = 30) -> str:
         async with self._tab_operation():

--- a/connectonion/useful_tools/browser_tools/_async_element_finder.py
+++ b/connectonion/useful_tools/browser_tools/_async_element_finder.py
@@ -1,0 +1,54 @@
+"""
+Purpose: Await DOM extraction and keep model-selected element matching off the browser event loop.
+LLM-Note:
+  Dependencies: asyncio plus the existing synchronous element_finder rules | imported by [_async_browser.py] | tested by [tests/unit/test_async_element_finder.py, tests/e2e/test_async_browser_core_real_driver.py]
+  Data flow: async Page.evaluate(extract_elements.js) → InteractiveElement inventory → worker-thread element_finder.find_element → selected pre-built locator/coordinates
+  State/Effects: injects data-browser-agent-id through the shared extraction script | writes ~/.co/debug/elements.json in a worker | synchronous provider call continues in its worker if the awaiting task is cancelled
+  Integration: preserves the existing prompt, schemas, ambiguity errors, and selection rules; this module owns only the async scheduling boundary
+  Errors: page and debug I/O errors bubble | no elements returns None through the existing matcher | model ambiguity/non-match errors remain ElementNotFoundError
+
+Async DOM extraction with the established element-matching contract.
+
+The matcher remains synchronous because it calls ``llm_do``. Run it in a
+worker thread so a slow model response does not stall every browser tab on the
+shared event loop. Cancellation stops waiting for the result, although Python
+cannot forcibly stop the already-running worker thread.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import List
+
+from . import element_finder as rules
+
+
+def _write_debug_elements(raw) -> None:
+    debug_dir = Path.home() / ".co" / "debug"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    (debug_dir / "elements.json").write_text(
+        json.dumps(raw, indent=2), encoding="utf-8"
+    )
+
+
+async def extract_elements(page) -> List[rules.InteractiveElement]:
+    """Await extraction and keep the synchronous finder's debug artifact."""
+    raw = await page.evaluate(rules._get_extract_js())
+    await asyncio.to_thread(_write_debug_elements, raw)
+
+    main_elements = [element for element in raw if element.get("frame") == "main"]
+    other_elements = [element for element in raw if element.get("frame") != "main"]
+    frame_names = {element.get("frame") for element in other_elements}
+    print(
+        "\n[element_finder] Extracted "
+        f"{len(raw)} elements (main: {len(main_elements)}, "
+        f"other: {len(other_elements)} [{', '.join(frame_names)}])"
+    )
+    return [rules.InteractiveElement(**element) for element in raw]
+
+
+async def find_element(page, description: str, elements=None):
+    """Select an extracted element without blocking the browser event loop."""
+    if elements is None:
+        elements = await extract_elements(page)
+    return await asyncio.to_thread(rules.find_element, None, description, elements)

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -17,12 +17,20 @@ The first vertical slice is implemented but deliberately not released:
   been published while private hosted jobs are blocked.
 - `browser` PRs #98–#100 implement renewable runtime enforcement, complete Linux
   packaging, and a fail-closed macOS signing/notarization/certification handoff. A
-  native arm64 Chromium 150.0.7871.187 build is running; no artifact is eligible for
-  the paid catalogue until signing, notarization, redownload, and native paid E2E pass.
+  native arm64 Chromium 150.0.7871.187 build passes its CDP smoke test; no artifact is
+  eligible for the paid catalogue until signing, notarization, redownload, and native
+  paid E2E pass.
 - `connectonion` draft PR #1280 implements `auto | system | onion` resolution, daemon
   compatibility probing, pinned paid-session ownership, and CLI propagation. All
   public CI gates pass. It remains Draft until Onionwright 0.0.11 and at least one
   certified browser artifact exist.
+- `connectonion` PRs #1282–#1286 establish the internal async Browser Core and port
+  focus safety, lifecycle/tab isolation, deterministic selectors, frame scripts and
+  uploads, and known-target humanized input. The current #498 slice ports
+  model-selected element actions; its local native Chrome gate proves
+  independent-tab progress during a stalled matcher. Issue #498 remains open for
+  keyboard typing, scrolling, context capture, manual-login waiting, and its final
+  full-definition-of-done audit; #499 and #500 remain downstream.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,

--- a/docs/blog/2026-08-26-the-matcher-left-the-loop.md
+++ b/docs/blog/2026-08-26-the-matcher-left-the-loop.md
@@ -1,0 +1,46 @@
+# The Matcher Left the Loop
+
+*2026-08-26*
+
+The browser action was declared `async`. Its DOM scan was awaited. Its pointer
+movement was awaited. An unrelated tab could still freeze while the action tried
+to understand “the publish button.”
+
+The model call in the middle was synchronous.
+
+## Async syntax does not move blocking work
+
+ConnectOnion's element finder first extracts visible controls, gives each one a
+stable locator, and asks a model to choose an index. That last step uses the
+same synchronous `llm_do` API as the existing browser. Calling it from an async
+method would occupy the one event-loop thread until the provider replied.
+Per-tab locks would remain logically correct, but tab B could not run while tab
+A waited on the network.
+
+We kept one matcher rather than translating its prompt and ambiguity rules into
+a parallel async implementation. The async core awaits DOM extraction on the
+page, writes its debug artifact in a worker, then runs the existing matcher in a
+worker thread with the extracted elements. The requesting tab retains its lock;
+other tabs retain the event loop.
+
+Cancellation has an honest limit here. Python can stop awaiting a worker-thread
+result, but it cannot safely kill the thread already inside a provider call. The
+worker owns no Patchright page and performs no browser mutation, so the browser
+runtime remains safe while that call winds down.
+
+## The real DOM found the routing bug
+
+Unit tests covered main pages, iframes, shadow roots, bounding boxes, forced
+clicks, and coordinate fallbacks. Native Chrome still found a case the fakes did
+not: a `data:` page URL contained the text `editor`, which was also the iframe's
+name. URL-substring fallback selected the main frame before the resolver reached
+the exact iframe name.
+
+Frame resolution now checks every exact name first and only then considers URL
+substrings. The native gate extracts and acts on controls in the main DOM, a
+named iframe, and an open shadow root. It also blocks one model match and
+requires another tab to read its page within 500 milliseconds.
+
+The important claim is no longer that the methods are coroutines. It is that
+waiting for language on one tab does not take the browser away from everyone
+else.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -85,6 +85,17 @@ runtime lock across tabs, and restore the previous clipboard before cancellation
 escapes. Natural-language element matching, AI-selected scrolling, and form verbs
 remain later #498 boundaries rather than being mixed into known-target input.
 
+The fifth boundary ports model-selected element actions as one unit. DOM
+extraction is awaited on the owning page, while debug-file writes and the
+synchronous `llm_do` matcher run in worker threads. The matcher still uses the
+existing prompt, `InteractiveElement` schema, ambiguity rules, and pre-built
+locators; the async runtime does not invent a second selection policy. Exact
+frame names take precedence over URL-substring fallback so a main `data:` URL
+that happens to contain an iframe name cannot steal the target. Click, hover,
+right-click, double-click, select, checkbox, and element-wait behavior preserve
+their existing result and fallback contracts across the main DOM, named
+iframes, and open shadow roots.
+
 ## Invariants
 
 - one persistent browser context and profile per runtime;
@@ -127,7 +138,8 @@ The completed review boundaries additionally run against native Chrome. They
 prove selector counts and text, repeated-item bounds, link filtering, text waits,
 raw extraction, viewport changes, page/frame scripts, both upload paths,
 exact-text/frame selector clicks, known-selector typing, anchor-relative clicks,
-and independent-tab progress during humanized input on a real DOM. Downloads,
-AI-selected scrolling, model-backed matching, form verbs, context capture, and
-remaining dead-context/profile behavior stay explicit #498 work; these boundaries
-do not make the async core public.
+model-selected actions across main/iframe/shadow DOMs, main-document forms, and
+independent-tab progress during humanized input and a stalled matcher on a real
+DOM. Downloads, AI-selected scrolling, context capture, manual-login waiting,
+and remaining dead-context/profile behavior stay explicit #498 work; these
+boundaries do not make the async core public.

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -98,6 +98,11 @@ browser.click("email input field")       # Uses AI to find by description
 ```
 
 Element finding uses a vision LLM — describe what you see, not a CSS selector.
+The 1.8 async core keeps that same selection contract: it awaits DOM extraction,
+then runs the synchronous model match outside the browser event loop. A slow
+provider may delay the requesting tab, but it does not stop unrelated tabs from
+reading or acting. Main-page, named-iframe, and open-shadow-root targets retain
+their extracted locators or coordinate fallbacks.
 
 When you have a stable CSS selector, click it directly:
 

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -12,10 +12,12 @@ import asyncio
 import gc
 import html
 import json
+import threading
 import urllib.parse
 
 import pytest
 
+from connectonion.useful_tools.browser_tools import _async_element_finder
 from connectonion.useful_tools.browser_tools._async_browser import (
     ASYNC_BROWSER_AVAILABLE,
     AsyncBrowserCore,
@@ -67,7 +69,10 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                 browser._bind_session(session)
                 frame_html = (
                     f"<span id=frame-marker>{marker} frame</span>"
-                    "<button id=frame-action onclick=\"this.dataset.clicked='yes'\">Frame action</button>"
+                    "<button id=frame-action onclick=\"this.dataset.clicked='yes'\" "
+                    "ondblclick=\"this.dataset.doubled='yes'\" "
+                    "oncontextmenu=\"event.preventDefault();this.dataset.context='yes'\" "
+                    "onmouseover=\"this.dataset.hovered='yes'\">Frame action</button>"
                     "<input id=direct-upload type=file>"
                     "<input id=chooser-upload type=file style='display:none'>"
                     "<button id=upload-trigger "
@@ -78,6 +83,12 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                     f"<title>{marker}</title><p>{marker}</p>"
                     f"<input id=editor value={marker}>"
                     "<button class=publish onclick=\"this.dataset.clicked='yes'\">Publish</button>"
+                    "<select id=country><option>Australia</option></select>"
+                    "<label><input id=terms type=checkbox>Accept terms</label>"
+                    "<div id=shadow-host></div>"
+                    "<script>const root=document.querySelector('#shadow-host').attachShadow({mode:'open'});"
+                    "const button=document.createElement('button');button.textContent='Shadow action';"
+                    "button.onclick=()=>button.dataset.clicked='yes';root.append(button)</script>"
                     "<div class=row><span class=draft>Draft</span>"
                     "<button class=near onclick=\"this.previousElementSibling.textContent=''\">Send</button></div>"
                     f"<article class=item><span class=body>{marker} item</span></article>"
@@ -91,6 +102,33 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                     who=session,
                 )
                 pages[session] = browser.page
+
+            matcher_started = threading.Event()
+            release_matcher = threading.Event()
+
+            def deterministic_match(_page, description, elements):
+                if description == "slow publish":
+                    matcher_started.set()
+                    release_matcher.wait(timeout=3)
+                    description = "Publish"
+                by_description = {
+                    "Publish": lambda element: element.text == "Publish",
+                    "Frame action": lambda element: element.text == "Frame action",
+                    "Shadow action": lambda element: element.text == "Shadow action",
+                    "country": lambda element: element.element_id == "country",
+                    "terms": lambda element: element.element_id == "terms",
+                }
+                return next(
+                    element
+                    for element in elements
+                    if by_description[description](element)
+                )
+
+            monkeypatch.setattr(
+                _async_element_finder.rules,
+                "find_element",
+                deterministic_match,
+            )
 
             async def hold_tab_a():
                 browser._bind_session("A")
@@ -147,6 +185,29 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             )
             assert await browser.page.locator("#editor").input_value() == "beta-typed"
 
+            assert (await browser.click("Publish")).endswith("button 'Publish'")
+            assert (
+                await browser.page.locator(".publish").get_attribute("data-clicked")
+                == "yes"
+            )
+            assert await browser.select_option("country", "Australia") == (
+                "Selected 'Australia' in country"
+            )
+            assert await browser.check_checkbox("terms") == "Checked terms"
+            assert await browser.page.locator("#terms").is_checked() is True
+            assert await browser.wait_for_element("country", timeout=1) == (
+                "Element appeared: country"
+            )
+
+            shadow_result = await browser.click("Shadow action")
+            assert shadow_result.endswith("(shadow DOM)")
+            assert (
+                await browser.page.locator("#shadow-host").evaluate(
+                    "host => host.shadowRoot.querySelector('button').dataset.clicked"
+                )
+                == "yes"
+            )
+
             assert (
                 "in frames matching 'editor'"
                 in await browser.click_element_by_selector(
@@ -159,6 +220,33 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             assert (
                 await editor_frame.locator("#frame-action").get_attribute(
                     "data-clicked"
+                )
+                == "yes"
+            )
+            assert (await browser.double_click("Frame action")).endswith(
+                "button 'Frame action'"
+            )
+            assert (
+                await editor_frame.locator("#frame-action").get_attribute(
+                    "data-doubled"
+                )
+                == "yes"
+            )
+            assert (await browser.right_click("Frame action")).endswith(
+                "button 'Frame action'"
+            )
+            assert (
+                await editor_frame.locator("#frame-action").get_attribute(
+                    "data-context"
+                )
+                == "yes"
+            )
+            assert (await browser.hover("Frame action")).endswith(
+                "button 'Frame action'"
+            )
+            assert (
+                await editor_frame.locator("#frame-action").get_attribute(
+                    "data-hovered"
                 )
                 == "yes"
             )
@@ -185,6 +273,18 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
             assert "beta" in await asyncio.wait_for(browser.get_text(), timeout=0.5)
             assert clicking.done() is False
             assert (await clicking).startswith("Clicked at (")
+
+            browser._bind_session("A")
+            matching = asyncio.create_task(
+                browser.find_element_by_description("slow publish")
+            )
+            while not matcher_started.is_set():
+                await asyncio.sleep(0)
+            browser._bind_session("B")
+            assert "beta" in await asyncio.wait_for(browser.get_text(), timeout=0.5)
+            assert matching.done() is False
+            release_matcher.set()
+            assert (await matching).startswith('[data-browser-agent-id="')
 
             page_result = json.loads(
                 await browser.run_page_script(

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -10,10 +10,12 @@ import asyncio
 import inspect
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from connectonion.useful_tools.browser_tools import _async_browser as async_mod
+from connectonion.useful_tools.browser_tools import element_finder as finder_rules
 from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
 
 
@@ -40,12 +42,19 @@ class FakeLocator:
     def nth(self, index):
         return FakeLocator(self.page, self.selector, index=index)
 
+    @property
+    def first(self):
+        return FakeLocator(self.page, self.selector, index=0)
+
     async def click(self, force=False):
         self.page.clicked.append((self.selector, self.index))
         self.page.clicked_forces.append(force)
 
     async def bounding_box(self):
         return self.page.box_by_selector.get((self.selector, self.index))
+
+    async def hover(self):
+        self.page.hovered.append((self.selector, self.index))
 
     async def inner_text(self):
         return self.page.text_by_selector.get(self.selector, f"text:{self.index}")
@@ -74,6 +83,10 @@ class FakePage:
         self.clicked = []
         self.clicked_forces = []
         self.filled = []
+        self.hovered = []
+        self.selected = []
+        self.checked = []
+        self.unchecked = []
         self.uploaded = []
         self.name = ""
         self.frames = [self]
@@ -99,6 +112,15 @@ class FakePage:
 
     async def wait_for_selector(self, selector, **kwargs):
         self.waited_selectors.append((selector, kwargs))
+
+    async def select_option(self, selector, **kwargs):
+        self.selected.append((selector, kwargs))
+
+    async def check(self, selector):
+        self.checked.append(selector)
+
+    async def uncheck(self, selector):
+        self.unchecked.append(selector)
 
     def is_closed(self):
         return self.closed
@@ -757,6 +779,240 @@ async def test_async_humanized_selector_verbs_preserve_sync_signatures():
         assert async_method is not None, name
         assert inspect.iscoroutinefunction(async_method), name
         assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+@pytest.mark.asyncio
+async def test_async_model_selected_verbs_preserve_sync_signatures():
+    for name in (
+        "find_element_by_description",
+        "click",
+        "hover",
+        "right_click",
+        "double_click",
+        "select_option",
+        "check_checkbox",
+        "wait_for_element",
+    ):
+        async_method = getattr(async_mod.AsyncBrowserCore, name, None)
+        sync_method = getattr(BrowserAutomation, name)
+        assert async_method is not None, name
+        assert inspect.iscoroutinefunction(async_method), name
+        assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+@pytest.mark.asyncio
+async def test_model_selected_click_paths_preserve_main_frame_shadow_and_fallbacks(
+    monkeypatch,
+):
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+    pointer = []
+
+    async def human_click(_page, x, y, **kwargs):
+        pointer.append((x, y, kwargs))
+
+    async def human_double_click(_page, x, y, **kwargs):
+        pointer.append(("double", x, y, kwargs))
+
+    selected = SimpleNamespace(
+        index=4,
+        tag="button",
+        text="Publish",
+        frame="main",
+        locator='[data-browser-agent-id="4"]',
+        x=10,
+        y=20,
+        width=100,
+        height=40,
+    )
+
+    async def find(_page, _description):
+        return selected
+
+    monkeypatch.setattr(async_mod.element_finder, "find_element", find)
+    monkeypatch.setattr(async_mod.humanize, "click", human_click)
+    monkeypatch.setattr(async_mod.humanize, "double_click", human_double_click)
+
+    page.box_by_selector[(selected.locator, 0)] = {
+        "x": 100,
+        "y": 200,
+        "width": 80,
+        "height": 40,
+    }
+    assert await browser.find_element_by_description("publish") == selected.locator
+    assert await browser.click("publish") == "Clicked [4] button 'Publish'"
+    assert pointer[-1] == (
+        140.0,
+        220.0,
+        {"box": {"x": 100, "y": 200, "width": 80, "height": 40}},
+    )
+
+    page.box_by_selector.clear()
+    assert await browser.click("publish") == "Clicked [4] button 'Publish' (force)"
+    assert page.clicked[-1] == (selected.locator, 0)
+    assert page.clicked_forces[-1] is True
+
+    selected.frame = "shadow-editor"
+    assert await browser.right_click("publish") == (
+        "Right-clicked [4] button 'Publish' (shadow DOM)"
+    )
+    assert pointer[-1] == (60, 40, {"button": "right"})
+
+    selected.frame = "editor"
+    page.url = "data:text/html,<iframe name=editor>"
+    frame = FakeFrame(None, name="editor")
+    frame.box_by_selector[(selected.locator, 0)] = {
+        "x": 20,
+        "y": 30,
+        "width": 40,
+        "height": 20,
+    }
+    page.frames = [page, frame]
+    assert await browser.double_click("publish") == (
+        "Double-clicked [4] button 'Publish'"
+    )
+    assert pointer[-1] == (
+        "double",
+        40.0,
+        40.0,
+        {"box": {"x": 20, "y": 30, "width": 40, "height": 20}},
+    )
+
+    frame.name = ""
+    frame.url = "https://example.com/editor/content"
+    assert await browser.right_click("publish") == (
+        "Right-clicked [4] button 'Publish'"
+    )
+    assert pointer[-1] == (
+        40.0,
+        40.0,
+        {
+            "button": "right",
+            "box": {"x": 20, "y": 30, "width": 40, "height": 20},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_selected_hover_and_coordinate_fallback_are_awaited(monkeypatch):
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+    moves = []
+    selected = SimpleNamespace(
+        index=2,
+        tag="a",
+        text="Account",
+        frame="main",
+        locator="#missing",
+        x=30,
+        y=50,
+        width=60,
+        height=20,
+    )
+
+    async def find(_page, _description):
+        return selected
+
+    async def move(_page, x, y):
+        moves.append((x, y))
+
+    monkeypatch.setattr(async_mod.element_finder, "find_element", find)
+    monkeypatch.setattr(async_mod.humanize, "move", move)
+    page.selector_counts["#missing"] = 0
+
+    assert await browser.hover("account") == "Hovered [2] a 'Account'"
+    assert moves == [(60, 60)]
+
+    page.selector_counts["#missing"] = 1
+    assert await browser.hover("account") == "Hovered [2] a 'Account'"
+    assert page.hovered == [("#missing", 0)]
+
+
+@pytest.mark.asyncio
+async def test_model_selected_form_and_wait_results_match_sync_contract(monkeypatch):
+    page = FakePage()
+    context = FakeContext()
+    context.pages_created.append(page)
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = context
+    browser._pages[None] = page
+    selected = finder_rules.InteractiveElement(
+        index=0,
+        tag="select",
+        text="Country",
+        locator="#country",
+    )
+
+    async def find(_page, description):
+        return None if description == "eventually visible" else selected
+
+    monkeypatch.setattr(async_mod.element_finder, "find_element", find)
+
+    assert await browser.select_option("country", "Australia") == (
+        "Selected 'Australia' in country"
+    )
+    assert page.selected == [("#country", {"label": "Australia"})]
+    assert await browser.check_checkbox("terms") == "Checked terms"
+    assert await browser.check_checkbox("terms", checked=False) == "Unchecked terms"
+    assert page.checked == ["#country"]
+    assert page.unchecked == ["#country"]
+    assert await browser.wait_for_element("country", timeout=7) == (
+        "Element appeared: country"
+    )
+    assert await browser.wait_for_element("eventually visible", timeout=3) == (
+        "Found text: 'eventually visible'"
+    )
+    assert page.waited_selectors == [
+        ("#country", {"timeout": 7000}),
+        ("text='eventually visible'", {"timeout": 3000}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slow_model_match_on_one_tab_does_not_block_another_tab(monkeypatch):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages["A"] = FakePage()
+    browser._pages["B"] = FakePage()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def find(_page, description):
+        if description == "slow":
+            started.set()
+            await release.wait()
+        return finder_rules.InteractiveElement(
+            index=0,
+            tag="button",
+            text=description,
+            locator="#target",
+        )
+
+    monkeypatch.setattr(async_mod.element_finder, "find_element", find)
+
+    async def slow_find():
+        browser._bind_session("A")
+        return await browser.find_element_by_description("slow")
+
+    async def fast_read():
+        browser._bind_session("B")
+        browser._pages["B"].text_by_selector["body"] = "tab B"
+        return await browser.get_text()
+
+    task = asyncio.create_task(slow_find())
+    await started.wait()
+    assert await asyncio.wait_for(fast_read(), timeout=0.2) == "tab B"
+    assert task.done() is False
+    release.set()
+    assert await task == "#target"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_async_element_finder.py
+++ b/tests/unit/test_async_element_finder.py
@@ -1,0 +1,115 @@
+"""Contracts for model-selected elements without blocking the browser loop."""
+
+import asyncio
+import json
+import threading
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import _async_element_finder as finder
+from connectonion.useful_tools.browser_tools import element_finder as rules
+
+
+def _raw_element(**overrides):
+    element = {
+        "index": 0,
+        "tag": "button",
+        "text": "Publish",
+        "x": 10,
+        "y": 20,
+        "width": 100,
+        "height": 40,
+        "frame": "main",
+        "locator": '[data-browser-agent-id="0"]',
+    }
+    element.update(overrides)
+    return element
+
+
+class FakePage:
+    def __init__(self, raw):
+        self.raw = raw
+        self.scripts = []
+
+    async def evaluate(self, script):
+        self.scripts.append(script)
+        await asyncio.sleep(0)
+        return self.raw
+
+
+@pytest.mark.asyncio
+async def test_async_extraction_awaits_dom_and_keeps_debug_json(tmp_path, monkeypatch):
+    page = FakePage([_raw_element(), _raw_element(index=1, frame="editor")])
+    monkeypatch.setattr(finder.Path, "home", lambda: tmp_path)
+
+    elements = await finder.extract_elements(page)
+
+    assert [element.index for element in elements] == [0, 1]
+    assert all(isinstance(element, rules.InteractiveElement) for element in elements)
+    assert page.scripts == [rules._get_extract_js()]
+    written = json.loads((tmp_path / ".co" / "debug" / "elements.json").read_text())
+    assert written == page.raw
+
+
+@pytest.mark.asyncio
+async def test_model_selection_runs_off_event_loop_and_other_work_progresses(
+    monkeypatch,
+):
+    page = FakePage([_raw_element()])
+    selected = rules.InteractiveElement(**_raw_element())
+    matcher_started = threading.Event()
+    release_matcher = threading.Event()
+    loop_thread = threading.get_ident()
+    matcher_threads = []
+
+    def match(_page, description, elements):
+        matcher_threads.append(threading.get_ident())
+        assert description == "the publish button"
+        assert elements == [selected]
+        matcher_started.set()
+        release_matcher.wait(timeout=2)
+        return selected
+
+    monkeypatch.setattr(
+        finder, "extract_elements", lambda _page: _async_value([selected])
+    )
+    monkeypatch.setattr(finder.rules, "find_element", match)
+
+    task = asyncio.create_task(finder.find_element(page, "the publish button"))
+    while not matcher_started.is_set():
+        await asyncio.sleep(0)
+    progressed = False
+
+    async def unrelated_work():
+        nonlocal progressed
+        progressed = True
+
+    await unrelated_work()
+    assert progressed is True
+    assert task.done() is False
+    release_matcher.set()
+    assert await task is selected
+    assert matcher_threads[0] != loop_thread
+
+
+@pytest.mark.asyncio
+async def test_model_none_and_matching_errors_preserve_sync_contract(monkeypatch):
+    page = FakePage([])
+    monkeypatch.setattr(finder, "extract_elements", lambda _page: _async_value([]))
+    assert await finder.find_element(page, "missing") is None
+
+    element = rules.InteractiveElement(**_raw_element())
+    monkeypatch.setattr(
+        finder, "extract_elements", lambda _page: _async_value([element])
+    )
+
+    def fail(_page, _description, _elements):
+        raise rules.ElementNotFoundError("ambiguous")
+
+    monkeypatch.setattr(finder.rules, "find_element", fail)
+    with pytest.raises(rules.ElementNotFoundError, match="ambiguous"):
+        await finder.find_element(page, "button")
+
+
+async def _async_value(value):
+    return value


### PR DESCRIPTION
## Summary

- add one async element-finder boundary that awaits DOM extraction and runs debug I/O plus the existing synchronous matcher off the event loop
- port natural-language click, hover, right-click, double-click, select, checkbox, and element-wait contracts to `AsyncBrowserCore`
- preserve exact signatures/results, humanized input, model ambiguity behavior, and main/iframe/open-shadow routing
- prefer exact iframe names before URL fallback, and exclude the main frame from non-main URL fallback
- document the fifth #498 review boundary and its remaining four verbs

## Verification

- `python -m pytest tests/unit/test_async_element_finder.py tests/unit/test_async_browser_core.py -q` — 33 passed
- offline full matrix — 7,300 passed, 21 skipped, 199 deselected
- source native Chrome gate — passed
- built and installed `connectonion-1.8.0a1-py3-none-any.whl`; confirmed imports resolve from the install target
- installed-wheel contracts — 33 passed
- installed-wheel native Chrome gate — passed (one prior rerun reached all action assertions but reported the existing context-close timeout warning; immediate audit rerun closed cleanly)
- Black, Ruff, compileall, and `git diff --check` — passed

## Release coordination

**Proposed target version:** 1.8.0 / next alpha after complete async-browser parity

**Estimated release window:** 1.8 development cycle / after #498, #499, and #500 acceptance gates

**Forward-port tracking issue (stable patches only):** Not applicable — mainline 1.8 development

Issue #498 must remain open. After this PR, its remaining public verbs are `keyboard_type`, `scroll`, `save_page_context`, and `wait_for_manual_login`, followed by the complete definition-of-done audit. This PR does not publish an alpha or expose the internal core as a public API.

Closes no issue. Related to #498 and #1154.
