### PR TITLE
Complete async browser driver parity

### DIFF
--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -18,15 +18,18 @@ import contextvars
 import json
 import os
 import platform
+import sys
 import time
 import urllib.parse
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from . import _async_element_finder as element_finder
 from . import _async_humanize as humanize
+from . import _async_scroll as async_scroll
+from . import _async_terminal as terminal
 from .browser_config import CHROME_DEFAULT_ARGS, IGNORE_DEFAULT_ARGS
 from .chrome_finder import find_system_chrome
 
@@ -91,6 +94,17 @@ _FOCUSED_ELEMENT_SCRIPT = """
         value_truncated: value === null ? false : value.length > previewLimit,
     };
 }
+"""
+
+_PAGE_CSS_SCRIPT = r"""
+() => Array.from(document.styleSheets).map((sheet, i) => {
+    try {
+        return `/* ${sheet.href || `inline-${i}`} */\n` +
+            Array.from(sheet.cssRules || []).map(rule => rule.cssText).join("\n");
+    } catch (error) {
+        return `/* ${sheet.href || `stylesheet-${i}`} unavailable: ${error.name} */`;
+    }
+}).join("\n\n")
 """
 
 
@@ -242,6 +256,35 @@ async def _complete_cleanup(awaitable):
     return task.result(), interrupted
 
 
+def _write_page_context_files(
+    base_dir: Path,
+    timestamp: str,
+    safe_name: str,
+    html: str,
+    css: str,
+    element_dicts: list[Dict[str, Any]],
+) -> Path:
+    """Write one collision-safe page-context snapshot outside the event loop."""
+    root = base_dir / ".co" / "browser_context"
+    root.mkdir(parents=True, exist_ok=True)
+    stem = f"{timestamp}_{safe_name}"
+    suffix = 0
+    while True:
+        out_dir = root / (stem if suffix == 0 else f"{stem}_{suffix}")
+        try:
+            out_dir.mkdir()
+            break
+        except FileExistsError:
+            suffix += 1
+
+    (out_dir / "page.html").write_text(html, encoding="utf-8")
+    (out_dir / "styles.css").write_text(css, encoding="utf-8")
+    (out_dir / "elements.json").write_text(
+        json.dumps(element_dicts, indent=2), encoding="utf-8"
+    )
+    return out_dir
+
+
 class AsyncBrowserCore:
     """Internal async browser runtime with one persistent context and one tab per session."""
 
@@ -281,6 +324,7 @@ class AsyncBrowserCore:
         )
         self._lifecycle_lock = asyncio.Lock()
         self._clipboard_lock = asyncio.Lock()
+        self._manual_login_lock = asyncio.Lock()
         self._page_state_lock = asyncio.Lock()
         self._tab_locks: Dict[Optional[str], asyncio.Lock] = {}
         self._operation_state_lock = asyncio.Lock()
@@ -429,9 +473,7 @@ class AsyncBrowserCore:
             return False
         return True
 
-    async def open_browser(
-        self, headless: Optional[bool] = None, force: bool = False
-    ) -> str:
+    async def open_browser(self, headless: bool = None, force: bool = False) -> str:
         """Open/reuse the runtime while participating in tab and shutdown admission."""
         if self._operation_depth.get():
             return await self._open_browser(headless=headless, force=force)
@@ -984,6 +1026,16 @@ class AsyncBrowserCore:
             await self.page.keyboard.press(key)
             return f"Pressed: '{key}'"
 
+    async def keyboard_type(self, text: str) -> str:
+        """Type into the focused element without blocking the event loop."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            await humanize.type_text(self.page, text, self._clipboard_lock)
+            return f"""Typed: '{text}'
+
+SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into the correct input box. If the text is NOT visible in the expected location, you may need to click the element first to focus it, then type again."""
+
     async def click_element_by_selector(
         self,
         selector: str,
@@ -1488,9 +1540,7 @@ class AsyncBrowserCore:
                 response["reason"] = "no frame returned ok: true"
             return json.dumps(response, indent=2, ensure_ascii=False)
 
-    async def take_screenshot(
-        self, path: Optional[str] = None, full_page: bool = False
-    ) -> str:
+    async def take_screenshot(self, path: str = None, full_page: bool = False) -> str:
         async with self._tab_operation():
             if self.page is None:
                 return "Browser not open"
@@ -1509,6 +1559,55 @@ class AsyncBrowserCore:
                 mime = "image/jpeg"
             await self.page.wait_for_timeout(1000)
             return f"data:{mime};base64,{base64.b64encode(screenshot).decode('utf-8')}"
+
+    async def save_page_context(self, name: str = "page") -> str:
+        """Save HTML, CSS, and interactive-element data without loop-bound I/O."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+
+            page = self.page
+            html = await page.content()
+            css = await page.evaluate(_PAGE_CSS_SCRIPT)
+            elements = await element_finder.extract_elements(page)
+            element_dicts = [
+                (
+                    element.model_dump()
+                    if hasattr(element, "model_dump")
+                    else element.dict()
+                )
+                for element in elements
+            ]
+            safe_name = (
+                "".join(
+                    character if character.isalnum() or character in "._-" else "_"
+                    for character in name
+                ).strip("._-")
+                or "page"
+            )
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            out_dir, interrupted = await _complete_cleanup(
+                asyncio.to_thread(
+                    _write_page_context_files,
+                    Path.home(),
+                    timestamp,
+                    safe_name,
+                    html,
+                    css,
+                    element_dicts,
+                )
+            )
+            if interrupted:
+                raise asyncio.CancelledError
+
+            return (
+                f"Saved page context to {out_dir}\n"
+                f"- HTML: {out_dir / 'page.html'}\n"
+                f"- CSS: {out_dir / 'styles.css'}\n"
+                f"- Elements: {out_dir / 'elements.json'}\n"
+                f"- URL: {page.url}\n"
+                f"- Elements: {len(element_dicts)}"
+            )
 
     async def set_viewport(self, width: int, height: int) -> str:
         async with self._tab_operation():
@@ -1567,7 +1666,57 @@ class AsyncBrowserCore:
             await self.page.wait_for_timeout(int(seconds * 1000))
             return f"Waited for {seconds} seconds"
 
-    async def extract_data(self, selector: str) -> list[str]:
+    async def scroll(
+        self, times: int = 5, description: str = "the main content area"
+    ) -> str:
+        """Scroll using the async human/AI/element/page strategy chain."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            result = await async_scroll.scroll(
+                self.page,
+                self.take_screenshot,
+                times,
+                description,
+                Path(self.screenshots_dir),
+            )
+            await self._save_context()
+            return result
+
+    async def wait_for_manual_login(self, site_name: str = "the website") -> str:
+        """Wait for interactive confirmation without blocking the event loop."""
+        async with self._tab_operation():
+            if self.page is None:
+                return "Browser not open"
+            if not sys.stdin or not sys.stdin.isatty():
+                return (
+                    "Manual login needs an interactive terminal, which a hosted deploy "
+                    "doesn't have. Capture the login locally with save_state(path) and "
+                    "start the deployed browser with seed_state=<path>."
+                )
+
+            async with self._manual_login_lock:
+                print(f"\n{'='*60}")
+                print("  MANUAL LOGIN REQUIRED")
+                print(f"{'='*60}")
+                print(f"Please login to {site_name} in the browser window.")
+                print("Once you're logged in and ready to continue:")
+                print("  Type 'yes' or 'Y' and press Enter")
+                print(f"{'='*60}\n")
+
+                while True:
+                    response = (
+                        (await terminal.read_line("Ready to continue? (yes/Y): "))
+                        .strip()
+                        .lower()
+                    )
+                    if response in {"yes", "y"}:
+                        print("Continuing automation...\n")
+                        await self._save_context()
+                        return f"User confirmed login to {site_name} - continuing"
+                    print("Please type 'yes' or 'Y' when ready.")
+
+    async def extract_data(self, selector: str) -> List[str]:
         async with self._tab_operation():
             if self.page is None:
                 return []
@@ -1575,7 +1724,7 @@ class AsyncBrowserCore:
             count = await elements.count()
             return [await elements.nth(index).inner_text() for index in range(count)]
 
-    async def get_links_from_page(self, domain_filter: str = "") -> list[str]:
+    async def get_links_from_page(self, domain_filter: str = "") -> List[str]:
         async with self._tab_operation():
             if self.page is None:
                 return []

--- a/connectonion/useful_tools/browser_tools/_async_scroll.py
+++ b/connectonion/useful_tools/browser_tools/_async_scroll.py
@@ -1,0 +1,142 @@
+"""
+Purpose: Preserve browser scroll strategy behavior without blocking the AsyncBrowserCore event loop.
+LLM-Note:
+  Dependencies: asyncio plus synchronous scroll.py rules/schema/prompt and _async_humanize | imported by [_async_browser.py] | tested by [tests/unit/test_async_scroll.py, tests/e2e/test_async_browser_core_real_driver.py]
+  Data flow: awaited before screenshot → human wheel / worker-thread model strategy / element JS / page JS → awaited after screenshot → worker-thread pixel comparison → exact strategy result
+  State/Effects: writes uniquely named screenshots under the runtime screenshot directory | dispatches trusted wheel input first | fallback JavaScript mutates element/window scroll position
+  Integration: reuses scroll.ScrollStrategy, prompt, llm_do call shape, screenshot threshold, strategy order, and public result strings
+  Errors: each strategy error is reported and falls through | cancellation is never swallowed and stops remaining mutations | all failed strategies return the existing failure string
+
+The synchronous scroll module contains reusable policy but also synchronous Page
+calls, sleeps, screenshots, model I/O, and image I/O. This module keeps the policy
+while giving every blocking boundary an explicit async execution path.
+"""
+
+import asyncio
+import random
+import uuid
+from pathlib import Path
+
+from . import _async_humanize as humanize
+from . import scroll as rules
+
+_pause = asyncio.sleep
+
+
+async def scroll(
+    page,
+    take_screenshot,
+    times: int = 5,
+    description: str = "the main content area",
+    screenshots_dir: Path = Path("screenshots"),
+) -> str:
+    """Try the established scroll strategies in order and verify each visually."""
+    if not page:
+        return "Browser not open"
+
+    capture_id = uuid.uuid4().hex
+    before = f"scroll_before_{capture_id}.png"
+    await take_screenshot(path=before)
+    strategies = [
+        ("Human wheel", lambda: _human_scroll(page, times)),
+        ("AI strategy", lambda: _ai_scroll(page, times, description)),
+        ("Element scroll", lambda: _element_scroll(page, times)),
+        ("Page scroll", lambda: _page_scroll(page, times)),
+    ]
+
+    for attempt, (name, execute) in enumerate(strategies, start=1):
+        print(f"  Trying: {name}...")
+        try:
+            await execute()
+            await _pause(0.5)
+            after = f"scroll_after_{capture_id}_{attempt}.png"
+            await take_screenshot(path=after)
+            changed = await asyncio.to_thread(
+                _screenshots_different,
+                before,
+                after,
+                screenshots_dir,
+            )
+            if changed:
+                print(f"  ✅ {name} worked")
+                return f"Scrolled using {name}"
+            print(f"  ⚠️ {name} didn't change content")
+            before = after
+        except Exception as exc:
+            print(f"  ❌ {name} failed: {exc}")
+
+    return "All scroll strategies failed"
+
+
+def _screenshots_different(file1: str, file2: str, base_dir: Path) -> bool:
+    return rules._screenshots_different(file1, file2, str(base_dir))
+
+
+async def _human_scroll(page, times: int) -> None:
+    width, height = await page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    await humanize.move(page, width // 2, height // 2)
+    for _ in range(times):
+        await humanize.scroll(
+            page,
+            random.randint(int(height * 0.7), int(height * 0.95)),
+        )
+        await _pause(random.uniform(0.3, 0.7))
+
+
+def _choose_strategy(description, scrollable, html):
+    return rules.llm_do(
+        rules._PROMPT.format(
+            description=description,
+            scrollable_elements=scrollable,
+            simplified_html=html,
+        ),
+        output=rules.ScrollStrategy,
+        model="co/gemini-3.7-flash",
+        temperature=0.1,
+    )
+
+
+async def _ai_scroll(page, times: int, description: str) -> None:
+    scrollable = await page.evaluate("""
+        (() => Array.from(document.querySelectorAll('*'))
+            .filter(el => {
+                const s = window.getComputedStyle(el);
+                return (s.overflow === 'auto' || s.overflowY === 'scroll') &&
+                    el.scrollHeight > el.clientHeight;
+            })
+            .slice(0, 3)
+            .map(el => ({tag: el.tagName, classes: el.className, id: el.id})))()
+        """)
+    html = await page.evaluate("""
+        (() => {
+            const c = document.body.cloneNode(true);
+            c.querySelectorAll('script,style,img,svg').forEach(e => e.remove());
+            return c.innerHTML.substring(0, 5000);
+        })()
+        """)
+    strategy = await asyncio.to_thread(_choose_strategy, description, scrollable, html)
+    print(f"    AI: {strategy.explanation}")
+    for _ in range(times):
+        await page.evaluate(strategy.javascript)
+        await _pause(1)
+
+
+async def _element_scroll(page, times: int) -> None:
+    for _ in range(times):
+        await page.evaluate("""
+            (() => {
+                const el = Array.from(document.querySelectorAll('*')).find(e => {
+                    const s = window.getComputedStyle(e);
+                    return (s.overflow === 'auto' || s.overflowY === 'scroll') &&
+                        e.scrollHeight > e.clientHeight;
+                });
+                if (el) el.scrollTop += 1000;
+            })()
+            """)
+        await _pause(0.8)
+
+
+async def _page_scroll(page, times: int) -> None:
+    for _ in range(times):
+        await page.evaluate("window.scrollBy(0, 1000)")
+        await _pause(0.8)

--- a/connectonion/useful_tools/browser_tools/_async_terminal.py
+++ b/connectonion/useful_tools/browser_tools/_async_terminal.py
@@ -1,0 +1,67 @@
+"""
+Purpose: Read one interactive terminal line without an unkillable worker thread.
+LLM-Note:
+  Dependencies: asyncio, sys, os, and msvcrt on Windows | imported by [_async_browser.py] | tested by [tests/unit/test_async_terminal.py, tests/unit/test_async_browser_core.py]
+  Data flow: prompt → POSIX event-loop file-descriptor readiness or awaited Windows console polling → normalized line without newline
+  State/Effects: temporarily registers one POSIX stdin reader or polls/echoes Windows console characters | always unregisters POSIX reader on success/error/cancellation
+  Integration: AsyncBrowserCore serializes manual-login prompts runtime-wide before calling read_line
+  Errors: EOF returns an empty line | Ctrl-C preserves KeyboardInterrupt | cancellation removes the reader and leaves no input worker behind
+"""
+
+import asyncio
+import os
+import sys
+
+
+async def read_line(prompt: str) -> str:
+    """Prompt and read a cancellable terminal line on POSIX and Windows."""
+    print(prompt, end="", flush=True)
+    if os.name == "nt":
+        import msvcrt
+
+        return await _read_windows_line(msvcrt)
+    return await _read_posix_line(sys.stdin)
+
+
+async def _read_posix_line(stream) -> str:
+    loop = asyncio.get_running_loop()
+    descriptor = stream.fileno()
+    result = loop.create_future()
+
+    def ready() -> None:
+        if result.done():
+            return
+        try:
+            result.set_result(stream.readline().rstrip("\r\n"))
+        except BaseException as exc:
+            result.set_exception(exc)
+
+    loop.add_reader(descriptor, ready)
+    try:
+        return await result
+    finally:
+        loop.remove_reader(descriptor)
+
+
+async def _read_windows_line(console) -> str:
+    characters = []
+    while True:
+        if not console.kbhit():
+            await asyncio.sleep(0.05)
+            continue
+        character = console.getwch()
+        if character == "\x03":
+            raise KeyboardInterrupt
+        if character in {"\r", "\n"}:
+            print()
+            return "".join(characters)
+        if character == "\b":
+            if characters:
+                characters.pop()
+                print("\b \b", end="", flush=True)
+            continue
+        if character in {"\x00", "\xe0"}:
+            console.getwch()
+            continue
+        characters.append(character)
+        print(character, end="", flush=True)

--- a/connectonion/useful_tools/browser_tools/scroll.py
+++ b/connectonion/useful_tools/browser_tools/scroll.py
@@ -140,14 +140,16 @@ def _page_scroll(page, times: int):
         time.sleep(0.8)
 
 
-def _screenshots_different(file1: str, file2: str) -> bool:
+def _screenshots_different(
+    file1: str, file2: str, base_dir: str = "screenshots"
+) -> bool:
     """Compare screenshots using PIL pixel difference."""
     try:
         from PIL import Image
         import os
 
-        img1 = Image.open(os.path.join("screenshots", file1)).convert('RGB')
-        img2 = Image.open(os.path.join("screenshots", file2)).convert('RGB')
+        img1 = Image.open(os.path.join(base_dir, file1)).convert('RGB')
+        img2 = Image.open(os.path.join(base_dir, file2)).convert('RGB')
 
         diff = sum(
             abs(a - b)

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -24,13 +24,14 @@ The first vertical slice is implemented but deliberately not released:
   compatibility probing, pinned paid-session ownership, and CLI propagation. All
   public CI gates pass. It remains Draft until Onionwright 0.0.11 and at least one
   certified browser artifact exist.
-- `connectonion` PRs #1282–#1286 establish the internal async Browser Core and port
+- `connectonion` PRs #1282–#1287 establish the internal async Browser Core and port
   focus safety, lifecycle/tab isolation, deterministic selectors, frame scripts and
-  uploads, and known-target humanized input. The current #498 slice ports
-  model-selected element actions; its local native Chrome gate proves
-  independent-tab progress during a stalled matcher. Issue #498 remains open for
-  keyboard typing, scrolling, context capture, manual-login waiting, and its final
-  full-definition-of-done audit; #499 and #500 remain downstream.
+  uploads, known-target humanized input, and model-selected element actions. The
+  current final #498 slice adds keyboard typing, verified strategy scrolling,
+  collision-safe context capture, and cancellable manual-login input. Issue #498
+  remains open until the whole-surface, cancellation, profile, stealth, recovery,
+  native-browser, installed-wheel, and hosted audit is complete; #499 and #500 remain
+  downstream.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,

--- a/docs/blog/2026-08-26-input-was-the-uncancellable-part.md
+++ b/docs/blog/2026-08-26-input-was-the-uncancellable-part.md
@@ -2,55 +2,65 @@
 
 *2026-08-26*
 
-The last browser method to become asynchronous did not talk to the browser at
-all. It waited for a person to type “yes.”
+The browser was closed. The task was cancelled. Nothing was running in the
+terminal.
 
-That made it more dangerous than it looked.
+One thread was still waiting for me to type “yes.”
 
-## A worker thread does not make input cancellable
+It came from the least browser-like method in the driver. When a site requires
+2FA, `wait_for_manual_login()` pauses automation while a person signs in, then
+asks for confirmation in the terminal. The synchronous implementation used
+`input()`. During the async migration, the obvious replacement was:
 
-The obvious port of `input()` is `asyncio.to_thread(input, prompt)`. It keeps the
-event loop moving, but cancellation only stops waiting for the worker. The worker
-itself remains blocked on stdin. Repeat that operation and a runtime can collect
-threads that can neither finish nor be reclaimed. One future line of terminal
-input may also wake an abandoned prompt instead of the active one.
+```python
+await asyncio.to_thread(input, "Ready to continue? ")
+```
 
-The async browser now waits on stdin readiness directly on POSIX and unregisters
-the file descriptor on every success, error, and cancellation path. Windows uses
-short, awaited console polls so cancellation has a boundary between key presses.
-One runtime-wide lock serializes prompts across tabs: pages are independent, but
-the terminal is not. Hosted deployments still refuse immediately and point to
-the state-seeding workflow because they have no interactive stdin.
+The event loop stayed responsive. The test looked green. Then we cancelled the
+task.
 
-## Cancellation must wait for the side effect
+## The future stopped; the input did not
 
-Page-context capture has the inverse problem. HTML, CSS, and element extraction
-are naturally awaited, but filesystem writes are blocking. Moving them to a
-thread protects the event loop; it does not make the write disappear when the
-caller is cancelled.
+Cancellation stopped the coroutine that was waiting for the worker thread. It
+could not stop the thread inside `input()`. That worker still owned a read from
+stdin, with no useful way to interrupt or reclaim it.
 
-Letting cancellation return immediately would leave a snapshot changing after
-the tool reported that it had stopped. The capture path therefore finishes an
-in-flight write before cancellation escapes. Concurrent tabs also reserve
-distinct directories atomically, even when they use the same name in the same
-second. A saved context is complete and attributable, not whichever tab won a
-timestamp race.
+The leak was quiet. There was no busy loop and almost no CPU usage. It became
+visible only when another manual-login request arrived. Two tabs now believed
+they were waiting for the same terminal. A line intended for the live prompt
+could wake the abandoned one instead. Repeating the sequence could leave more
+blocked workers behind each time.
 
-## The fallback chain is part of the contract
+This was not a thread-pool sizing problem. More workers would merely allow more
+uncancellable reads.
 
-Scrolling brought a different trap. ConnectOnion first emits real humanized
-wheel input, then falls back to an AI-selected strategy, a scrollable element,
-and finally the page. Each attempt is verified by comparing screenshots. An
-async port that jumped straight to JavaScript would work mechanically while
-discarding the human-input policy.
+## Wait for readiness, not for a worker
 
-The new path preserves that order. Browser calls and pauses are awaited; model
-selection and image comparison run off the event loop; cancellation stops later
-mutations; and each verification image has a unique attempt identifier. A native
-gate checks that wheel input changes the real page, not merely that a helper
-returned a success string.
+On POSIX, stdin is a file descriptor. The event loop can register interest in
+that descriptor and call `readline()` only after the terminal says data is
+ready. Cancellation now unregisters the reader in `finally`; no thread exists to
+outlive the task.
 
-These were the final four missing verbs in the async driver surface. Their lesson
-is the same one that shaped the earlier slices: `async def` is syntax. The real
-contract is which state can be shared, when side effects are complete, and what
-cancellation is allowed to leave behind.
+Windows console input has a different boundary, so it uses short awaited polls
+for available key presses. Between polls, cancellation behaves like any other
+async operation. Backspace, Enter, and Ctrl-C retain their terminal meanings.
+
+There was one more ownership mistake to fix. Browser pages belong to sessions,
+but stdin belongs to the process. Per-tab locks cannot protect it. The runtime
+now has one manual-login lock, so only one tab may display and consume a prompt
+at a time. Hosted deployments still refuse immediately and direct callers to
+the saved-state workflow because they have no interactive terminal to own.
+
+## The test that matters
+
+The regression test does not merely assert that the method is declared with
+`async def`. It starts a POSIX read, cancels it, and verifies that the exact file
+descriptor was removed. A second test starts prompts from two tabs and proves
+the second cannot read until the first has confirmed and released the shared
+terminal.
+
+The final browser verb turned out not to be about browser automation at all. It
+was about naming the resource correctly. Moving a blocking call to a thread can
+protect an event loop, but it cannot invent cancellation. When the resource is
+global and the operation cannot be stopped, the async boundary has to move
+closer to the resource itself.

--- a/docs/blog/2026-08-26-input-was-the-uncancellable-part.md
+++ b/docs/blog/2026-08-26-input-was-the-uncancellable-part.md
@@ -1,0 +1,56 @@
+# Input Was the Uncancellable Part
+
+*2026-08-26*
+
+The last browser method to become asynchronous did not talk to the browser at
+all. It waited for a person to type “yes.”
+
+That made it more dangerous than it looked.
+
+## A worker thread does not make input cancellable
+
+The obvious port of `input()` is `asyncio.to_thread(input, prompt)`. It keeps the
+event loop moving, but cancellation only stops waiting for the worker. The worker
+itself remains blocked on stdin. Repeat that operation and a runtime can collect
+threads that can neither finish nor be reclaimed. One future line of terminal
+input may also wake an abandoned prompt instead of the active one.
+
+The async browser now waits on stdin readiness directly on POSIX and unregisters
+the file descriptor on every success, error, and cancellation path. Windows uses
+short, awaited console polls so cancellation has a boundary between key presses.
+One runtime-wide lock serializes prompts across tabs: pages are independent, but
+the terminal is not. Hosted deployments still refuse immediately and point to
+the state-seeding workflow because they have no interactive stdin.
+
+## Cancellation must wait for the side effect
+
+Page-context capture has the inverse problem. HTML, CSS, and element extraction
+are naturally awaited, but filesystem writes are blocking. Moving them to a
+thread protects the event loop; it does not make the write disappear when the
+caller is cancelled.
+
+Letting cancellation return immediately would leave a snapshot changing after
+the tool reported that it had stopped. The capture path therefore finishes an
+in-flight write before cancellation escapes. Concurrent tabs also reserve
+distinct directories atomically, even when they use the same name in the same
+second. A saved context is complete and attributable, not whichever tab won a
+timestamp race.
+
+## The fallback chain is part of the contract
+
+Scrolling brought a different trap. ConnectOnion first emits real humanized
+wheel input, then falls back to an AI-selected strategy, a scrollable element,
+and finally the page. Each attempt is verified by comparing screenshots. An
+async port that jumped straight to JavaScript would work mechanically while
+discarding the human-input policy.
+
+The new path preserves that order. Browser calls and pauses are awaited; model
+selection and image comparison run off the event loop; cancellation stops later
+mutations; and each verification image has a unique attempt identifier. A native
+gate checks that wheel input changes the real page, not merely that a helper
+returned a success string.
+
+These were the final four missing verbs in the async driver surface. Their lesson
+is the same one that shaped the earlier slices: `async def` is syntax. The real
+contract is which state can be shared, when side effects are complete, and what
+cancellation is allowed to leave behind.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -96,6 +96,17 @@ right-click, double-click, select, checkbox, and element-wait behavior preserve
 their existing result and fallback contracts across the main DOM, named
 iframes, and open shadow roots.
 
+The sixth and final driver-parity boundary covers the four verbs left by the
+whole-surface audit. Focused typing uses the same awaited humanization layer and
+runtime clipboard lock. Scrolling preserves the human, AI, element, and page
+fallback order while moving model calls and image comparison off the event
+loop; every attempt gets a unique screenshot name. Page-context capture awaits
+DOM reads, writes files off-loop into collision-safe directories, and does not
+let cancellation escape while a write is still running. Manual login uses an
+event-loop stdin reader on POSIX and cancellable console polling on Windows,
+rather than leaving a blocked `input()` worker behind. Prompts are serialized
+across tabs because the terminal, like the clipboard, is runtime-global state.
+
 ## Invariants
 
 - one persistent browser context and profile per runtime;
@@ -140,6 +151,8 @@ raw extraction, viewport changes, page/frame scripts, both upload paths,
 exact-text/frame selector clicks, known-selector typing, anchor-relative clicks,
 model-selected actions across main/iframe/shadow DOMs, main-document forms, and
 independent-tab progress during humanized input and a stalled matcher on a real
-DOM. Downloads, AI-selected scrolling, context capture, manual-login waiting,
-and remaining dead-context/profile behavior stay explicit #498 work; these
-boundaries do not make the async core public.
+DOM. The final gate also exercises focused typing, verified human scrolling,
+context files, and hosted manual-login refusal. The whole public surface now has
+an exact signature-parity test; #498 still closes only after the full regression,
+installed-wheel, native-browser, hosted, cancellation, profile, stealth, and
+recovery evidence is reviewed. These boundaries do not make the async core public.

--- a/tests/e2e/test_async_browser_core_real_driver.py
+++ b/tests/e2e/test_async_browser_core_real_driver.py
@@ -14,10 +14,11 @@ import html
 import json
 import threading
 import urllib.parse
+from pathlib import Path
 
 import pytest
 
-from connectonion.useful_tools.browser_tools import _async_element_finder
+from connectonion.useful_tools.browser_tools import _async_browser, _async_element_finder
 from connectonion.useful_tools.browser_tools._async_browser import (
     ASYNC_BROWSER_AVAILABLE,
     AsyncBrowserCore,
@@ -94,7 +95,7 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                     f"<article class=item><span class=body>{marker} item</span></article>"
                     "<a href=https://example.com/one>one</a>"
                     f'<iframe name=editor srcdoc="{html.escape(frame_html, quote=True)}">'
-                    "</iframe>"
+                    "</iframe><div style='height:2000px'>scroll target</div>"
                 )
                 await browser.go_to(
                     "data:text/html," + urllib.parse.quote(page_html),
@@ -337,6 +338,42 @@ async def _exercise_real_async_driver(tmp_path, monkeypatch):
                 )
                 == chooser_upload.name
             )
+
+            await browser.page.locator("#editor").focus()
+            typed = await browser.keyboard_type("-raw")
+            assert typed.startswith("Typed: '-raw'")
+            assert (await browser.page.locator("#editor").input_value()).endswith(
+                "-raw"
+            )
+
+            await browser.page.evaluate("window.scrollTo(0, 0)")
+            browser.screenshots_dir = str(tmp_path / "scroll-shots")
+            scroll_result = await browser.scroll(1)
+            assert scroll_result == "Scrolled using Human wheel"
+            assert await browser.page.evaluate("window.scrollY") > 0
+
+            monkeypatch.setattr(Path, "home", lambda: tmp_path)
+            context_result = await browser.save_page_context("native final verbs")
+            captures = list(
+                (tmp_path / ".co" / "browser_context").glob("*_native_final_verbs")
+            )
+            assert len(captures) == 1
+            assert "- URL: data:text/html" in context_result
+            assert (captures[0] / "page.html").read_text(encoding="utf-8")
+            assert (captures[0] / "styles.css").exists()
+            assert json.loads(
+                (captures[0] / "elements.json").read_text(encoding="utf-8")
+            )
+
+            class NoTTY:
+                @staticmethod
+                def isatty():
+                    return False
+
+            monkeypatch.setattr(_async_browser.sys, "stdin", NoTTY())
+            manual_result = await browser.wait_for_manual_login("Example")
+            assert "interactive terminal" in manual_result
+            assert "seed_state" in manual_result
         finally:
             browser._bind_session(None)
             close_result = await browser.close()

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -9,6 +9,7 @@ import ast
 import asyncio
 import inspect
 import json
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -94,6 +95,7 @@ class FakePage:
         self.evaluate_calls = []
         self.evaluate_result = None
         self.evaluate_results = []
+        self.content_result = "<html><body>page</body></html>"
         self.file_chooser = FakeFileChooser()
         self.file_chooser_timeouts = []
 
@@ -148,6 +150,9 @@ class FakePage:
 
     async def screenshot(self, **kwargs):
         return b"png"
+
+    async def content(self):
+        return self.content_result
 
 
 class FakeFileChooser:
@@ -798,6 +803,315 @@ async def test_async_model_selected_verbs_preserve_sync_signatures():
         assert async_method is not None, name
         assert inspect.iscoroutinefunction(async_method), name
         assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+@pytest.mark.asyncio
+async def test_final_async_verbs_preserve_sync_signatures():
+    for name in (
+        "keyboard_type",
+        "scroll",
+        "save_page_context",
+        "wait_for_manual_login",
+    ):
+        async_method = getattr(async_mod.AsyncBrowserCore, name, None)
+        sync_method = getattr(BrowserAutomation, name)
+        assert async_method is not None, name
+        assert inspect.iscoroutinefunction(async_method), name
+        assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+def test_complete_public_surface_has_exact_async_signature_parity():
+    sync_methods = {
+        name: method
+        for name, method in inspect.getmembers(BrowserAutomation, inspect.isfunction)
+        if not name.startswith("_")
+    }
+    async_methods = {
+        name: method
+        for name, method in inspect.getmembers(
+            async_mod.AsyncBrowserCore, inspect.isfunction
+        )
+        if not name.startswith("_")
+    }
+
+    assert set(sync_methods) - set(async_methods) == set()
+    assert set(async_methods) - set(sync_methods) == {"is_alive"}
+    for name, sync_method in sync_methods.items():
+        async_method = async_methods[name]
+        assert inspect.iscoroutinefunction(async_method), name
+        assert inspect.signature(async_method) == inspect.signature(sync_method), name
+
+
+def test_page_context_css_script_keeps_javascript_escape_sequences():
+    assert 'join("\\n")' in async_mod._PAGE_CSS_SCRIPT
+    assert 'join("\\n\\n")' in async_mod._PAGE_CSS_SCRIPT
+
+
+@pytest.mark.asyncio
+async def test_keyboard_type_uses_runtime_clipboard_lock_and_exact_result(monkeypatch):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages[None] = FakePage()
+    calls = []
+
+    async def type_text(page, text, lock):
+        calls.append((page, text, lock))
+
+    monkeypatch.setattr(async_mod.humanize, "type_text", type_text)
+    result = await browser.keyboard_type("hello 世界")
+
+    assert calls == [(browser.page, "hello 世界", browser._clipboard_lock)]
+    assert (
+        result
+        == """Typed: 'hello 世界'
+
+SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into the correct input box. If the text is NOT visible in the expected location, you may need to click the element first to focus it, then type again."""
+    )
+
+
+@pytest.mark.asyncio
+async def test_scroll_delegates_to_async_strategy_and_saves_context(monkeypatch):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages[None] = FakePage()
+    calls = []
+
+    async def run(page, take_screenshot, times, description, screenshots_dir):
+        calls.append((page, take_screenshot, times, description, screenshots_dir))
+        return "Scrolled using Human wheel"
+
+    monkeypatch.setattr(async_mod.async_scroll, "scroll", run)
+    result = await browser.scroll(3, "the feed")
+
+    assert result == "Scrolled using Human wheel"
+    assert calls == [
+        (
+            browser.page,
+            browser.take_screenshot,
+            3,
+            "the feed",
+            Path(browser.screenshots_dir),
+        )
+    ]
+    assert browser.page.waits == [500]
+
+
+@pytest.mark.asyncio
+async def test_stalled_scroll_model_on_one_tab_does_not_block_another(
+    monkeypatch, tmp_path
+):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    page_a = FakePage(1)
+    page_b = FakePage(2)
+    page_a.evaluate_results = [[{"tag": "DIV"}], "<main>feed</main>"]
+    page_b.text_by_selector["body"] = "tab B remains live"
+    browser._pages.update({"A": page_a, "B": page_b})
+    browser.screenshots_dir = str(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    differences = iter([False, True])
+
+    async def no_op(*_args):
+        return None
+
+    def choose(*_args):
+        started.set()
+        release.wait(timeout=2)
+        return async_mod.async_scroll.rules.ScrollStrategy(
+            method="window",
+            selector="",
+            javascript="window.scrollBy(0, 10)",
+            explanation="page",
+        )
+
+    monkeypatch.setattr(async_mod.async_scroll, "_human_scroll", no_op)
+    monkeypatch.setattr(async_mod.async_scroll, "_pause", no_op)
+    monkeypatch.setattr(async_mod.async_scroll, "_choose_strategy", choose)
+    monkeypatch.setattr(
+        async_mod.async_scroll,
+        "_screenshots_different",
+        lambda *_args: next(differences),
+    )
+
+    browser._bind_session("A")
+    scrolling = asyncio.create_task(browser.scroll(1, "the feed"))
+    while not started.is_set():
+        await asyncio.sleep(0)
+
+    browser._bind_session("B")
+    assert await asyncio.wait_for(browser.get_text(), timeout=0.5) == (
+        "tab B remains live"
+    )
+    assert scrolling.done() is False
+    release.set()
+    assert await scrolling == "Scrolled using AI strategy"
+
+
+@pytest.mark.asyncio
+async def test_save_page_context_writes_complete_sanitized_capture(
+    tmp_path, monkeypatch
+):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    page = FakePage()
+    page.url = "https://example.com/feed"
+    page.content_result = "<html><body><button>Like</button></body></html>"
+    page.evaluate_result = "button { color: blue; }"
+    browser._pages[None] = page
+    element = finder_rules.InteractiveElement(
+        index=0,
+        tag="button",
+        text="Like",
+        locator='[data-browser-agent-id="0"]',
+    )
+
+    async def extract(_page):
+        return [element]
+
+    monkeypatch.setattr(async_mod.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(async_mod.element_finder, "extract_elements", extract)
+
+    result = await browser.save_page_context("../linkedin feed")
+    captures = list((tmp_path / ".co" / "browser_context").glob("*_linkedin_feed"))
+    assert len(captures) == 1
+    capture = captures[0]
+    assert (capture / "page.html").read_text() == page.content_result
+    assert (capture / "styles.css").read_text() == "button { color: blue; }"
+    assert json.loads((capture / "elements.json").read_text())[0]["text"] == "Like"
+    assert f"Saved page context to {capture}" in result
+    assert "- URL: https://example.com/feed" in result
+    assert "- Elements: 1" in result
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_name_context_captures_are_unique(tmp_path, monkeypatch):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages["A"] = FakePage(1)
+    browser._pages["B"] = FakePage(2)
+    browser._pages["A"].content_result = "<html>A</html>"
+    browser._pages["B"].content_result = "<html>B</html>"
+    browser._pages["A"].evaluate_result = "a{}"
+    browser._pages["B"].evaluate_result = "b{}"
+
+    async def extract(page):
+        return [
+            finder_rules.InteractiveElement(
+                index=page.idx,
+                tag="button",
+                text=str(page.idx),
+                locator=f"#{page.idx}",
+            )
+        ]
+
+    async def capture(session):
+        browser._bind_session(session)
+        return await browser.save_page_context("same")
+
+    monkeypatch.setattr(async_mod.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(async_mod.element_finder, "extract_elements", extract)
+    await asyncio.gather(capture("A"), capture("B"))
+
+    captures = list((tmp_path / ".co" / "browser_context").glob("*_same*"))
+    assert len(captures) == 2
+    assert {path.joinpath("page.html").read_text() for path in captures} == {
+        "<html>A</html>",
+        "<html>B</html>",
+    }
+
+
+@pytest.mark.asyncio
+async def test_context_write_finishes_before_cancellation_escapes(monkeypatch):
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages[None] = FakePage()
+    started = threading.Event()
+    release = threading.Event()
+
+    async def extract(_page):
+        return []
+
+    def write(*_args):
+        started.set()
+        release.wait(timeout=2)
+        return Path("/tmp/capture")
+
+    monkeypatch.setattr(async_mod.element_finder, "extract_elements", extract)
+    monkeypatch.setattr(async_mod, "_write_page_context_files", write)
+    task = asyncio.create_task(browser.save_page_context("page"))
+    while not started.is_set():
+        await asyncio.sleep(0)
+    task.cancel()
+    await asyncio.sleep(0)
+    assert task.done() is False
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_manual_login_non_tty_refuses_immediately(monkeypatch):
+    class NoTTY:
+        @staticmethod
+        def isatty():
+            return False
+
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages[None] = FakePage()
+    monkeypatch.setattr(async_mod.sys, "stdin", NoTTY())
+
+    result = await browser.wait_for_manual_login("Example")
+    assert "interactive terminal" in result
+    assert "seed_state" in result
+
+
+@pytest.mark.asyncio
+async def test_manual_login_serializes_prompts_and_saves_only_after_yes(monkeypatch):
+    class TTY:
+        @staticmethod
+        def isatty():
+            return True
+
+    browser = async_mod.AsyncBrowserCore()
+    browser.browser = FakeContext()
+    browser._pages["A"] = FakePage(1)
+    browser._pages["B"] = FakePage(2)
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    prompts = []
+    saves = []
+
+    async def read_line(prompt):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            first_started.set()
+            await release_first.wait()
+            return "no"
+        return "y"
+
+    async def save():
+        saves.append(browser._bound_session_key())
+
+    async def login(session):
+        browser._bind_session(session)
+        return await browser.wait_for_manual_login(session)
+
+    monkeypatch.setattr(async_mod.sys, "stdin", TTY())
+    monkeypatch.setattr(async_mod.terminal, "read_line", read_line)
+    monkeypatch.setattr(browser, "_save_context", save)
+    first = asyncio.create_task(login("A"))
+    await first_started.wait()
+    second = asyncio.create_task(login("B"))
+    await asyncio.sleep(0)
+    assert len(prompts) == 1
+    release_first.set()
+
+    assert await first == "User confirmed login to A - continuing"
+    assert await second == "User confirmed login to B - continuing"
+    assert len(prompts) == 3
+    assert saves == ["A", "B"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_async_scroll.py
+++ b/tests/unit/test_async_scroll.py
@@ -1,0 +1,116 @@
+"""Contracts for non-blocking async scroll strategy orchestration."""
+
+import asyncio
+import threading
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import _async_scroll as scroll
+
+
+class FakePage:
+    def __init__(self):
+        self.evaluate_results = []
+        self.evaluated = []
+
+    async def evaluate(self, script):
+        self.evaluated.append(script)
+        if self.evaluate_results:
+            return self.evaluate_results.pop(0)
+        return None
+
+
+async def _no_sleep(_delay):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_strategy_order_and_exact_success_result(tmp_path, monkeypatch):
+    page = FakePage()
+    screenshots = []
+    attempts = []
+
+    async def take_screenshot(path=None):
+        screenshots.append(path)
+        return "data:image/png;base64,cG5n"
+
+    async def failed_human(*_args):
+        attempts.append("Human wheel")
+
+    async def successful_ai(*_args):
+        attempts.append("AI strategy")
+
+    monkeypatch.setattr(scroll, "_human_scroll", failed_human)
+    monkeypatch.setattr(scroll, "_ai_scroll", successful_ai)
+    monkeypatch.setattr(scroll.rules, "_screenshots_different", lambda *_args: False)
+    differences = iter([False, True])
+    monkeypatch.setattr(
+        scroll,
+        "_screenshots_different",
+        lambda *_args: next(differences),
+    )
+    monkeypatch.setattr(scroll, "_pause", _no_sleep)
+
+    result = await scroll.scroll(page, take_screenshot, screenshots_dir=tmp_path)
+
+    assert result == "Scrolled using AI strategy"
+    assert attempts == ["Human wheel", "AI strategy"]
+    assert len(screenshots) == 3
+    assert screenshots[0].startswith("scroll_before_")
+    assert screenshots[1].startswith("scroll_after_")
+
+
+@pytest.mark.asyncio
+async def test_slow_model_selection_runs_off_event_loop(monkeypatch):
+    page = FakePage()
+    page.evaluate_results = [[{"tag": "DIV"}], "<main>feed</main>"]
+    started = threading.Event()
+    release = threading.Event()
+    selected = scroll.rules.ScrollStrategy(
+        method="window",
+        selector="",
+        javascript="window.scrollBy(0, 10)",
+        explanation="page",
+    )
+
+    def llm_do(*_args, **_kwargs):
+        started.set()
+        release.wait(timeout=2)
+        return selected
+
+    monkeypatch.setattr(scroll.rules, "llm_do", llm_do)
+    monkeypatch.setattr(scroll, "_pause", _no_sleep)
+    task = asyncio.create_task(scroll._ai_scroll(page, 1, "the feed"))
+    while not started.is_set():
+        await asyncio.sleep(0)
+
+    progressed = False
+
+    async def unrelated_work():
+        nonlocal progressed
+        progressed = True
+
+    await unrelated_work()
+    assert progressed is True
+    assert task.done() is False
+    release.set()
+    await task
+    assert page.evaluated[-1] == selected.javascript
+
+
+@pytest.mark.asyncio
+async def test_cancellation_stops_remaining_page_scroll_mutations(monkeypatch):
+    page = FakePage()
+    first_pause = asyncio.Event()
+
+    async def pause(_delay):
+        first_pause.set()
+        await asyncio.Future()
+
+    monkeypatch.setattr(scroll, "_pause", pause)
+    task = asyncio.create_task(scroll._page_scroll(page, 5))
+    await first_pause.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert page.evaluated == ["window.scrollBy(0, 1000)"]

--- a/tests/unit/test_async_terminal.py
+++ b/tests/unit/test_async_terminal.py
@@ -1,0 +1,86 @@
+"""Cancellation contracts for interactive terminal input in the async browser."""
+
+import asyncio
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import _async_terminal as terminal
+
+
+class _FakeStream:
+    def __init__(self, line="yes\n"):
+        self.line = line
+
+    def fileno(self):
+        return 42
+
+    def readline(self):
+        return self.line
+
+
+@pytest.mark.asyncio
+async def test_posix_reader_unregisters_descriptor_after_success(monkeypatch):
+    real_loop = asyncio.get_running_loop()
+    calls = []
+
+    class FakeLoop:
+        def create_future(self):
+            return real_loop.create_future()
+
+        def add_reader(self, descriptor, callback):
+            calls.append(("add", descriptor))
+            real_loop.call_soon(callback)
+
+        def remove_reader(self, descriptor):
+            calls.append(("remove", descriptor))
+            return True
+
+    monkeypatch.setattr(terminal.asyncio, "get_running_loop", lambda: FakeLoop())
+
+    assert await terminal._read_posix_line(_FakeStream()) == "yes"
+    assert calls == [("add", 42), ("remove", 42)]
+
+
+@pytest.mark.asyncio
+async def test_posix_reader_unregisters_descriptor_on_cancellation(monkeypatch):
+    real_loop = asyncio.get_running_loop()
+    calls = []
+
+    class FakeLoop:
+        def create_future(self):
+            return real_loop.create_future()
+
+        def add_reader(self, descriptor, _callback):
+            calls.append(("add", descriptor))
+
+        def remove_reader(self, descriptor):
+            calls.append(("remove", descriptor))
+            return True
+
+    monkeypatch.setattr(terminal.asyncio, "get_running_loop", lambda: FakeLoop())
+    task = asyncio.create_task(terminal._read_posix_line(_FakeStream()))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls == [("add", 42), ("remove", 42)]
+
+
+@pytest.mark.asyncio
+async def test_windows_reader_is_awaited_and_handles_editing(monkeypatch):
+    chars = iter(["y", "e", "x", "\b", "s", "\r"])
+
+    class FakeConsole:
+        @staticmethod
+        def kbhit():
+            return True
+
+        @staticmethod
+        def getwch():
+            return next(chars)
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(terminal.asyncio, "sleep", no_sleep)
+    assert await terminal._read_windows_line(FakeConsole()) == "yes"


### PR DESCRIPTION
## Problem

The internal 1.8 async Browser Core had four public verbs left: focused keyboard typing, strategy scrolling, page-context capture, and manual-login waiting. The last two also had cancellation and shared-resource hazards that a direct sync-to-thread port would preserve.

## Approach

- port all four verbs with exact synchronous signatures and result contracts
- keep human-first scrolling, move model/image work off-loop, and use unique verification captures
- write collision-safe context snapshots off-loop and finish in-flight writes before cancellation escapes
- replace blocking input with cancellable POSIX/Windows terminal readers and serialize prompts runtime-wide
- add a whole-surface audit for all 42 public methods and native proof for typing, wheel movement, context files, and hosted login refusal
- update DD-054, the 1.8 execution plan, and the Design Journal

## Verification

- focused async contracts: 47 passed
- browser/docs regression group: 526 passed, 1 expected skip; sandbox-only socket failures passed 5/5 outside the sandbox
- effective full offline matrix: 7,320 passed, 21 skipped, 199 deselected (the sole stale-PATH CLI failure passed after activating the disposable venv)
- native Chrome source-tree gate: passed
- committed 1.8.0a1 wheel SHA-256: 3efd8d6eace63d7f8a05210fc5b578316875084c7deec8067ea61c25afa92bc1
- installed-wheel contracts: 47 passed, imported from site-packages
- installed-wheel native Chrome gate: passed
- Black, Ruff, diff check: passed

## Issue boundary

Tracks #498. Keep the issue open until this PR has passed hosted Python/macOS/Windows/CodeQL/docs review and merged; #499 and #500 remain downstream. This internal slice does not change the version, publish an alpha, or switch the public synchronous facade.

**Proposed target version:** 1.8.0 / next alpha after the coordinated entry gate
**Estimated release window:** 1.8 development window; exact date depends on #499, #500, and the certified paid-artifact chain
**Forward-port tracking issue (stable patches only):** not applicable