### PR TITLE
Run browser daemon sessions concurrently

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -264,6 +264,12 @@ def _request(line: str, headless: bool = False, tab: str = None,
         # started replacement is never mistaken for the daemon being closed.
         if transport.IS_WINDOWS and tab is None and line.split() == ["close"]:
             owner_pid = _owner_pid(sock_path)
+            # Embedded users and socket round-trip tests may run the daemon in
+            # another thread of this process. That process cannot exit while the
+            # caller is waiting inside it; production's detached daemon always
+            # has a different pid.
+            if owner_pid == os.getpid():
+                owner_pid = None
     except RuntimeError as exc:
         # Setup failures (authkey mismatch/corruption, daemon didn't start) must exit
         # with a clean one-line error, NEVER a traceback: typer's pretty exceptions

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -27,13 +27,31 @@ def default_sock_path() -> str:
     return transport.default_address()
 
 
-def _owner_alive(sock_path: str) -> bool:
-    """Read the daemon pid sidecar without importing Playwright or browser tools."""
+def _owner_pid(sock_path: str) -> int | None:
+    """Return the live daemon pid recorded beside the endpoint, if there is one."""
     pid_file = Path(transport.pid_path(sock_path))
     if not pid_file.exists():
-        return False
+        return None
     raw = pid_file.read_text(encoding="utf-8").strip()
-    return raw.isdigit() and transport.pid_alive(int(raw))
+    if not raw.isdigit():
+        return None
+    pid = int(raw)
+    return pid if transport.pid_alive(pid) else None
+
+
+def _owner_alive(sock_path: str) -> bool:
+    """Read the daemon pid sidecar without importing Playwright or browser tools."""
+    return _owner_pid(sock_path) is not None
+
+
+def _wait_for_pid_exit(pid: int, timeout: float = 15.0) -> bool:
+    """Wait for one exact daemon process, never a replacement using its endpoint."""
+    deadline = time.monotonic() + timeout
+    while transport.pid_alive(pid):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+    return True
 
 
 def _connect(sock_path: str):
@@ -215,6 +233,7 @@ def _request(line: str, headless: bool = False, tab: str = None,
         "raw": raw_result,
     })
     sock_path = default_sock_path()
+    owner_pid = None
     try:
         conn = _connect(sock_path)
         if conn is None:
@@ -240,6 +259,11 @@ def _request(line: str, headless: bool = False, tab: str = None,
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
             conn = _spawn_daemon(sock_path, headless)
+        # A successful whole-browser close is a lifecycle barrier on Windows.
+        # Record the exact process serving this connection so a concurrently
+        # started replacement is never mistaken for the daemon being closed.
+        if transport.IS_WINDOWS and tab is None and line.split() == ["close"]:
+            owner_pid = _owner_pid(sock_path)
     except RuntimeError as exc:
         # Setup failures (authkey mismatch/corruption, daemon didn't start) must exit
         # with a clean one-line error, NEVER a traceback: typer's pretty exceptions
@@ -271,6 +295,11 @@ def _request(line: str, headless: bool = False, tab: str = None,
 
     header, _, payload = reply.decode().partition("\n")
     if header == "OK":
+        if owner_pid is not None and not _wait_for_pid_exit(owner_pid):
+            return 1, (
+                "Browser closed, but its daemon did not stop within 15 seconds — "
+                "try again"
+            )
         return 0, payload
     # A warm daemon reached the launcher and found no browser. The cold-start
     # provisioning above was skipped because the connect succeeded, so without

--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -6,7 +6,7 @@ LLM-Note:
   State/Effects: may spawn the daemon via `python -m connectonion.cli.browser_agent.daemon <sock> [--headless]` detached (transport.spawn_detached: start_new_session POSIX / DETACHED_PROCESS Windows), logging to ~/.co/browser.log | writes to stdout/stderr
   Integration: exposes _caller() -> str, send(line, headless=False, tab=None) -> int | FIRST-RUN AUTO-INSTALL: on the cold-start path (no daemon yet) AND when a warm daemon answers "No browser is installed for this user" (send retries once), a page-driving verb with no system Chrome triggers `python -m patchright install chromium` right in the user's terminal (chromium: per-user dir, never needs admin — the branded chrome channel runs a system installer) (_ensure_browser_ready) — `co browser` just works with zero setup commands; PAGELESS_VERBS (status/tab/close/...) never provision
   Performance: direct verbs import only the lightweight transport client, then make one connect + request/response; Agent/Playwright and browser tool schemas load only for `do` or inside the daemon | daemon spawn adds browser launch latency on first call | model thinking happens in the caller process and holds no daemon lane
-  Errors: _connect() retries ~2s on a transient connection refusal from a busy single-threaded daemon (does NOT unlink a live-but-busy socket); only a truly stale POSIX socket is unlinked | missing endpoint → spawn daemon and wait until ready or timeout | ALL setup RuntimeErrors (Windows authkey mismatch/corruption, daemon didn't start) are caught in send() → one clean stderr line + exit 1, NEVER a traceback (typer's pretty exceptions would print frame locals, which hold the HMAC secret on the connect path) | daemon dying mid-request → clean stderr line + exit 1
+  Errors: _connect() retries transient refusal/backpressure and never unlinks an endpoint whose recorded owner is alive; only a truly stale POSIX socket is removed | missing endpoint → spawn daemon and wait until ready or timeout | setup RuntimeErrors become one clean stderr line, never a traceback containing HMAC-path locals | daemon death, overload shedding, or disconnect mid-request becomes a clean exit 1
 """
 
 import functools
@@ -38,8 +38,8 @@ def _owner_alive(sock_path: str) -> bool:
 
 def _connect(sock_path: str):
     """Connect to the daemon. Returns a live connection, or None if the daemon is
-    genuinely gone. A busy single-threaded daemon (during a browser action) can momentarily
-    refuse while its accept backlog is full — that is NOT a dead daemon, so retry
+    genuinely gone. A daemon at its bounded connection cap can momentarily refuse —
+    that is NOT a dead daemon, so retry
     while its recorded owner is alive; a dead owner fails fast (the spawned daemon
     replaces it). POSIX uses a raw AF_UNIX socket (unchanged); Windows uses the
     authenticated named-pipe client from `transport`. Raises RuntimeError only for
@@ -123,8 +123,8 @@ def _spawn_daemon(sock_path: str, headless: bool):
         time.sleep(0.1)
     if _owner_alive(sock_path):
         # A daemon IS running — it just can't take our connection right now (its
-        # backlog is full behind a long-running command). "Did not start" would lie.
-        raise RuntimeError("browser daemon is busy (a long command is holding it) — try again")
+        # bounded client capacity is full). "Did not start" would lie.
+        raise RuntimeError("browser daemon is at connection capacity — try again")
     raise RuntimeError(f"browser daemon did not start (see {log_path})")
 
 
@@ -229,14 +229,14 @@ def _request(line: str, headless: bool = False, tab: str = None,
                 # (#356).
                 #
                 # A failed connect is not "nobody listening": a daemon whose
-                # backlog is full behind a long command refuses connections too.
+                # bounded client capacity can refuse connections too.
                 # Saying "not running — the next page command starts one" then
                 # sends the reader in the wrong direction, and every command they
                 # try answers "busy". _owner_alive reads the pidfile and asks
                 # whether that pid lives — no spawn, no log, so the #356
                 # constraint above still holds.
                 if _owner_alive(sock_path):
-                    return 0, "Browser daemon: running, busy with a long command — try again shortly"
+                    return 0, "Browser daemon: running, busy at connection capacity — try again shortly"
                 return 0, "Browser daemon: not running — the next page command starts one"
             _ensure_browser_ready(line)  # cold start: provision the browser first
             conn = _spawn_daemon(sock_path, headless)

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -1,32 +1,39 @@
 """
-Purpose: Persistent browser daemon — owns one BrowserAutomation and dispatches CLI requests to it over the platform transport (POSIX Unix socket / Windows named pipe), arbitrating concurrent agents through per-tab ownership.
+Purpose: Persistent concurrent browser daemon — owns one AsyncBrowserCore/event loop and dispatches authenticated CLI requests over POSIX Unix sockets or Windows named pipes.
 LLM-Note:
-  Dependencies: imports from [socket, os, sys, time, json, shlex, inspect, signal, atexit, threading, datetime, pathlib, useful_tools.browser_tools.BrowserAutomation, useful_tools.browser_tools.browser.driver_stealth_status, useful_tools.browser_tools.browser.installed_browser_path, browser_agent.transport] | imported by [browser_agent.client (spawns via python -m), cli/commands/browser_commands.py (list_functions)] | tested by [tests/e2e/cli/test_browser_daemon.py]
-  Data flow: client sends wire-v1 JSON {v,caller,account,tab,line,raw} (or a legacy plain line) → one short browser verb runs → reply includes process exit code (2 usage, 3 unknown tab, 4 busy); `co browser do` runs its model loop in the client and reaches this daemon only through those short verb requests
-  State/Effects: single-threaded serial server (sync Playwright requires one thread) | owns one BrowserAutomation for daemon lifetime | the tab REGISTRY + claims live on browser._tab_meta[key] (key None = shared 'main'): who/purpose/opened_at/caller/claim_at/last_line/last_at | tracks last_command for `status` | binds the endpoint at default_sock_path() via `transport` — POSIX: a raw AF_UNIX socket (unchanged); Windows: a native named pipe (multiprocessing.connection) with an HMAC authkey — under a lifetime OS lock (transport.lock_path: fcntl.flock POSIX / msvcrt Windows, released by the OS on any death, so simultaneous cold-starts can't both bind) and records its owner pid in transport.pid_path so a refused probe can tell busy from stale; 120s per-connection recv timeout | _cleanup closes the listener (POSIX also unlinks the socket) + pidfile only while the pidfile still names this process (browser teardown is the driver pipe closing on process death — the executor is already gone when atexit runs) | serve() exits (releasing the endpoint) when browser._context_is_alive() goes false or _launch_failed()
-  Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main() | launched detached via `python -m connectonion.cli.browser_agent.daemon <sock_path> [--headless]` | module helpers _key()/_tab_label()/_held_by_other()/_owner_alive() define the None↔main aliasing, the shared claim-expiry predicate (dispatch, _tab_open, _closetab), and the socket-owner liveness check (client + _bind)
-  Performance: one short browser request at a time | browser launch overhead on first page verb (1-3s) | model latency never occupies the daemon | tab lifecycle/status verbs never launch Chrome
-  Errors: dispatch/handler exceptions are caught at the request boundary in serve() and returned to THAT client (never unwind the loop and kill the shared browser) | a client that vanishes mid-reply is logged to ~/.co/browser.log, not fatal | bind race with a second daemon → loser exits
+  Dependencies: asyncio + bounded Windows transport executor + AsyncBrowserCore + browser_agent.transport; BrowserAutomation is imported only to preserve the public CLI help/schema until #500 installs the sync facade | imported by browser_agent.client and browser_commands | tested by test_async_browser_daemon.py, test_browser_daemon.py, test_transport.py
+  Data flow: wire-v1 JSON {v,caller,account,tab,line,raw} (legacy plain line accepted) → atomic registry/claim admission → request-scoped audit lease → awaited async browser verb → bounded reply with exit code 2 usage / 3 unknown tab / 4 busy; `do` keeps model latency in the client and sends only its short tool calls
+  State/Effects: one asyncio-owned AsyncBrowserCore and persistent context | independent tab tasks interleave; AsyncBrowserCore's per-tab locks serialize one tab | registry lock makes conflicting claims deterministic and clears each request lease in finally | POSIX uses asyncio.start_unix_server with a 1 MiB request cap, absolute 120s read/write deadlines, 32-client cap, and immediate overload shedding | Windows preserves the HMAC named-pipe handshake and bridges accept/read/write through an 8-worker bounded executor into the same loop | lifetime OS lock + pid sidecar preserve cold-start/stale-owner rules | shutdown stops admission, cancels owned connection tasks, closes the runtime, and removes only its own endpoint
+  Integration: exposes default_sock_path(), signature_str(), list_functions(), BrowserDaemon, main(); launched detached via `python -m connectonion.cli.browser_agent.daemon <address> [--headless]`; dispatch() is a non-loop compatibility seam for existing pure tests, production awaits dispatch_async()
+  Performance: page operations on separate tabs overlap; same-tab work queues; browser/model/image blocking work never owns the event-loop thread; first browser launch remains 1-3s
+  Errors: malformed/oversized/stalled clients are bounded at their own connection boundary; cancellation clears only its request lease; vanished readers are logged and cannot stop the daemon; launch failure or closed shared runtime releases the endpoint
 """
 
+import asyncio
+import atexit
+import contextlib
+import inspect
+import json
 import os
 import platform
-import sys
-import time
-import socket
-import json
 import shlex
-import inspect
 import signal
-import atexit
+import socket
+import sys
 import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 
 from connectonion.useful_tools.browser_tools import BrowserAutomation
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
 from connectonion.useful_tools.browser_tools.browser import (
-    driver_stealth_status, installed_browser_path,
+    driver_stealth_status,
+    installed_browser_path,
 )
+
 from . import transport
 
 
@@ -97,6 +104,12 @@ def list_functions() -> str:
 
 
 GUARD_WINDOW = 120  # seconds a tab's last claim keeps excluding other callers
+
+REQUEST_TIMEOUT = 120.0
+REPLY_TIMEOUT = 120.0
+MAX_REQUEST_BYTES = 1024 * 1024
+MAX_IN_FLIGHT = 32
+WINDOWS_TRANSPORT_WORKERS = 8
 
 # Tabs are closed by the agent that opened them. This is only a janitor for tabs
 # whose opener is never coming back — a crashed process, a machine left running
@@ -208,11 +221,11 @@ def launch_failure_advice(first_line: str) -> str:
 
 
 class BrowserDaemon:
-    """Single-threaded server owning one BrowserAutomation, dispatching verbs to it."""
+    """Concurrent server owning one asyncio-native browser runtime."""
 
     def __init__(self, sock_path: str, headless: bool = False):
         self.sock_path = sock_path
-        self.browser = BrowserAutomation(headless=headless)
+        self.browser = AsyncBrowserCore(headless=headless)
         self._srv = None
         # Set by _cleanup before it closes the listener, so serve() can tell "we are
         # stopping" from "the socket broke while we were meant to be serving".
@@ -221,6 +234,11 @@ class BrowserDaemon:
         self._defer_context_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
         self._next_tab = 1        # id allocator for auto-named tabs
+        self._registry_lock = asyncio.Lock()
+        self._health_lock = asyncio.Lock()
+        self._loop = None
+        self._client_tasks = set()
+        self._transport_pool = None
 
     def _parse_envelope(self, raw: str) -> tuple:
         """Wire v1: JSON {caller,account,tab,line,raw} — quote-safe by construction
@@ -244,8 +262,26 @@ class BrowserDaemon:
     READONLY = ("tab", "status", "use", "switch")
 
     def dispatch(self, raw: str) -> tuple:
-        """Run one request. Returns (ok, payload); ok is True, False, or an int error
-        code the client mirrors into its exit (2 usage · 3 unknown tab · 4 tab busy)."""
+        """Synchronous test/embedding bridge; production uses ``dispatch_async``.
+
+        The daemon process calls the async method on its one owned event loop.  This
+        bridge preserves the long-standing pure-dispatch test seam without creating
+        a second browser worker or being callable from the runtime loop itself.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.dispatch_async(raw))
+        raise RuntimeError("dispatch() cannot run inside an event loop; await dispatch_async()")
+
+    async def dispatch_async(self, raw: str) -> tuple:
+        """Run one request without blocking unrelated tabs.
+
+        Returns ``(ok, payload)``; ok is True, False, or an integer error code
+        mirrored by the client (2 usage · 3 unknown tab · 4 tab busy).
+        Claim admission and active-request audit leases are atomic even though the
+        browser operation itself may overlap work on independent tabs.
+        """
         try:
             caller, _caller_account, tab, line, raw_result = self._parse_envelope(raw)
             tokens = shlex.split(line)
@@ -259,27 +295,28 @@ class BrowserDaemon:
         # command that would DRIVE the tab — read-only/lifecycle verbs may name a tab that
         # is not registered yet (to inspect it, or `tab open` it).
         session = _key(tab)
-        if session is not None and session not in self.browser._tab_meta and verb not in self.READONLY:
-            return 3, self._unknown_tab(session)
+        async with self._registry_lock:
+            if session is not None and session not in self.browser._tab_meta and verb not in self.READONLY:
+                return 3, await self._unknown_tab_async(session)
         self.browser._bind_session(session)
 
         if verb == "tab":  # tab lifecycle: open / ls / close
-            return self._tab(tokens[1:], caller)
+            return await self._tab_async(tokens[1:], caller)
         if verb == "status":  # read-only report; does not count as the last command
-            return self._status()
+            return await self._status_async()
         if verb in ("use", "switch"):  # removed: no server-side cursor, targeting is per-command
             return False, "use/switch removed — target a tab per command instead:  co browser -t <tab> <verb>"
         if verb == "newtab":  # legacy spelling of `tab open` + go_to
             if session is not None:  # it allocates its OWN tab — a -t target would be ignored
                 return 2, "newtab allocates its own tab and ignores -t — use:  co browser tab open <name>, then  co browser -t <name> go_to <url>"
-            return self._newtab(line, tokens, caller)
+            return await self._newtab_async(line, tokens, caller)
         if verb == "closetab":  # legacy spelling of `tab close`
-            return self._closetab(tokens[1:], caller)
+            return await self._closetab_async(tokens[1:], caller)
 
         # `close` with no -t is a deliberate whole-browser shutdown (unguarded). `-t X close`
         # closes ONE tab and so must pass the same ownership guard as any destructive write.
         if verb == "close" and session is None:
-            return self._call_verb("close", tokens[1:])
+            return await self._call_verb_async("close", tokens[1:])
 
         # A command that would execute nothing must not acquire anything: reject an
         # unknown verb BEFORE the claim, or a typo would hold the tab for GUARD_WINDOW.
@@ -298,12 +335,29 @@ class BrowserDaemon:
         # Every page-driving command (and a targeted close) claims its tab: a DIFFERENT
         # agent mid-task there fails loudly (exit 4) and is taught the tab lifecycle —
         # never silent interleaving on one page.
-        meta = self._register_tab(session, caller)
-        if _held_by_other(meta, caller):
-            return 4, self._tab_busy(session, meta)
-        self._stamp_claim(meta, caller, line)
-        self.last_command = {"line": line, "at": time.time()}
-        return self._call_verb(verb, tokens[1:], raw_result=raw_result)
+        request_id = uuid.uuid4().hex
+        async with self._registry_lock:
+            meta = self._register_tab(session, caller)
+            if _held_by_other(meta, caller):
+                return 4, self._tab_busy(session, meta)
+            self._stamp_claim(meta, caller, line)
+            meta.setdefault("active_requests", {})[request_id] = {
+                "caller": caller,
+                "line": line,
+                "started_at": time.time(),
+            }
+            self.last_command = {"line": line, "at": time.time()}
+        try:
+            return await self._call_verb_async(
+                verb, tokens[1:], raw_result=raw_result
+            )
+        finally:
+            async with self._registry_lock:
+                active = meta.get("active_requests")
+                if active is not None:
+                    active.pop(request_id, None)
+                    if not active:
+                        meta.pop("active_requests", None)
 
     def _register_tab(self, key, caller: str) -> dict:
         """Return the tab's board entry, creating the shared main tab's on first use.
@@ -335,7 +389,26 @@ class BrowserDaemon:
         meta["last_line"], meta["last_at"] = line, time.time()
 
     def _call_verb(self, verb: str, raw_args, raw_result: bool = False) -> tuple:
-        """Match the verb to a browser method and execute it with coerced args."""
+        """Synchronous compatibility bridge for pure dispatch tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._call_verb_async(verb, raw_args, raw_result))
+        raise RuntimeError("await _call_verb_async() inside an event loop")
+
+    def _launch_failed(self) -> bool:
+        probe = getattr(self.browser, "_launch_failed", None)
+        if callable(probe):
+            return bool(probe())
+        return (
+            getattr(self.browser, "playwright", None) is not None
+            and getattr(self.browser, "browser", None) is None
+        )
+
+    async def _call_verb_async(
+        self, verb: str, raw_args, raw_result: bool = False
+    ) -> tuple:
+        """Match a verb to an async browser method and await its result."""
         method = getattr(self.browser, verb)
         positional, kwargs = _split_tokens(raw_args)
 
@@ -350,8 +423,10 @@ class BrowserDaemon:
 
         try:
             result = method(*args, **kw)
+            if inspect.isawaitable(result):
+                result = await result
         except Exception as exc:  # dispatch boundary: report to client as ERR
-            if self.browser._launch_failed():
+            if self._launch_failed():
                 # Chrome aborted at startup: str(exc) is a huge patchright "Call log".
                 # Keep the first line and point at the full log instead of dumping it.
                 first = str(exc).strip().splitlines()[0] if str(exc).strip() else ""
@@ -371,8 +446,29 @@ class BrowserDaemon:
         return True, payload
 
     def _status(self) -> tuple:
+        """Synchronous compatibility bridge for status tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._status_async())
+        raise RuntimeError("await _status_async() inside an event loop")
+
+    async def _browser_is_alive(self) -> bool:
+        probe = getattr(self.browser, "is_alive", None)
+        if probe is None:
+            probe = getattr(self.browser, "_context_is_alive", None)
+        if probe is None:
+            return False
+        result = probe()
+        return bool(await result) if inspect.isawaitable(result) else bool(result)
+
+    async def _browser_tab_status(self) -> str:
+        result = self.browser.tab_status()
+        return await result if inspect.isawaitable(result) else result
+
+    async def _status_async(self) -> tuple:
         """Report browser state, the last command, and the tab board."""
-        open_state = "open" if self.browser._context_is_alive() else "not open"
+        open_state = "open" if await self._browser_is_alive() else "not open"
         headless = str(getattr(self.browser, "_headless", False)).lower()
         lines = [f"Browser: {open_state} · headless={headless} · targeting is per-command (-t <tab>; bare = main)"]
         # Surface stealth-driver health here so a misconfigured driver (webdriver leak) is
@@ -395,26 +491,49 @@ class BrowserDaemon:
         else:
             lines.append("Last command: (none yet)")
         lines.append("")
-        lines.append(self.browser.tab_status())
+        lines.append(await self._browser_tab_status())
         return True, "\n".join(lines)
 
     def _tab(self, args, caller: str = "") -> tuple:
-        """Tab lifecycle: `tab open [NAME] [--who X] [--for "..."]` · `tab ls [--json]` · `tab close NAME`."""
+        """Synchronous compatibility bridge for tab lifecycle tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._tab_async(args, caller))
+        raise RuntimeError("await _tab_async() inside an event loop")
+
+    async def _tab_async(self, args, caller: str = "") -> tuple:
+        """Tab lifecycle: open/list/close with atomic registry transitions."""
         if not args:
             return 2, self._tab_usage()
         action, rest = args[0], args[1:]
         if action == "open":
-            return self._tab_open(rest, caller)
+            async with self._registry_lock:
+                return self._tab_open(rest, caller)
         if action in ("ls", "list"):
+            await self._reap_abandoned_tabs()
             if "--json" in rest:
-                board = [
-                    {"tab": _tab_label(k), **{f: m.get(f) for f in ("who", "purpose", "last_line", "last_at")}}
-                    for k, m in self.browser._tab_meta.items()
-                ]
+                async with self._registry_lock:
+                    board = [
+                        {
+                            "tab": _tab_label(k),
+                            **{
+                                field: m.get(field)
+                                for field in ("who", "purpose", "last_line", "last_at")
+                            },
+                            "active_requests": [
+                                {"request_id": request_id, **request}
+                                for request_id, request in m.get(
+                                    "active_requests", {}
+                                ).items()
+                            ],
+                        }
+                        for k, m in self.browser._tab_meta.items()
+                    ]
                 return True, json.dumps(board)
-            return self._status()
+            return await self._status_async()
         if action == "close":
-            return self._closetab(rest, caller)
+            return await self._closetab_async(rest, caller)
         return 2, self._tab_usage()
 
     def _tab_open(self, rest, caller: str = "") -> tuple:
@@ -498,7 +617,7 @@ class BrowserDaemon:
             f"see who owns what:  co browser tab ls"
         )
 
-    def _reap_abandoned_tabs(self) -> None:
+    async def _reap_abandoned_tabs(self) -> None:
         """Close tabs whose opener never came back. Runs before tab listings.
 
         Owner-only closing means a crashed agent's tab would otherwise live as
@@ -507,19 +626,26 @@ class BrowserDaemon:
         for ABANDONED_AFTER (3 days). Every reclamation is logged, so the first
         person surprised by one can find out why.
         """
-        now = time.time()
-        for key, meta in list(self.browser._tab_meta.items()):
-            if key is None:  # main is shared and never reaped
-                continue
-            if _held_by_other(meta, ""):  # someone is actively driving it
-                continue
-            last = meta.get("last_at") or meta.get("claim_at")
-            if not last or now - last < ABANDONED_AFTER:
-                continue
-            owner = meta.get("opened_by") or meta.get("who") or "unknown"
-            self.browser.close_tab(_tab_label(key))
-            print(f"[reap] closed tab '{_tab_label(key)}' opened by {owner} — "
-                  f"idle {_ago(now - last)}", file=sys.stderr, flush=True)
+        async with self._registry_lock:
+            now = time.time()
+            for key, meta in list(self.browser._tab_meta.items()):
+                if key is None:  # main is shared and never reaped
+                    continue
+                if _held_by_other(meta, ""):  # someone is actively driving it
+                    continue
+                last = meta.get("last_at") or meta.get("claim_at")
+                if not last or now - last < ABANDONED_AFTER:
+                    continue
+                owner = meta.get("opened_by") or meta.get("who") or "unknown"
+                result = self.browser.close_tab(_tab_label(key))
+                if inspect.isawaitable(result):
+                    await result
+                print(
+                    f"[reap] closed tab '{_tab_label(key)}' opened by {owner} — "
+                    f"idle {_ago(now - last)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
     def _tab_not_yours(self, key, owner: str) -> str:
         """Error-as-documentation: you may close your own tabs, not other agents'."""
@@ -543,154 +669,305 @@ class BrowserDaemon:
             f"when finished:    co browser tab close {name}"
         )
 
+    async def _unknown_tab_async(self, name: str) -> str:
+        board = await self._browser_tab_status()
+        return (
+            f"no tab named '{name}'\n\n"
+            f"{board}\n\n"
+            f"create it first:  co browser tab open {name} --who <your-name> --for \"<one-line purpose>\"\n"
+            f"then target it on every command, including do:\n"
+            f"                  co browser -t {name} <verb> [args]\n"
+            f"when finished:    co browser tab close {name}"
+        )
+
     def _newtab(self, line, tokens, caller: str = "") -> tuple:
-        """Legacy `newtab <url> --purpose=.. --who=..`: register + occupy a fresh tab.
-        Unlike the old behavior it does NOT repoint what bare commands target."""
+        """Synchronous compatibility bridge for the legacy newtab tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._newtab_async(line, tokens, caller))
+        raise RuntimeError("await _newtab_async() inside an event loop")
+
+    async def _newtab_async(self, line, tokens, caller: str = "") -> tuple:
+        """Register and occupy a fresh tab without changing bare targeting."""
         # A numeric id can collide with a NAME someone registered via `tab open` —
         # skip taken keys or this would occupy another agent's live tab.
-        while str(self._next_tab) in self.browser._tab_meta:
+        async with self._registry_lock:
+            while str(self._next_tab) in self.browser._tab_meta:
+                self._next_tab += 1
+            key = str(self._next_tab)
             self._next_tab += 1
-        key = str(self._next_tab)
-        self._next_tab += 1
-        self.browser._bind_session(key)
-        self.last_command = {"line": line, "at": time.time()}
-        ok, payload = self._call_verb("newtab", tokens[1:])
-        if not ok:
-            return False, payload
-        meta = self.browser._tab_meta.get(key)
-        if meta is not None and caller:
-            meta["caller"], meta["claim_at"] = caller, time.time()
-        return True, f"[tab {key}] {payload}"
+            self.browser._bind_session(key)
+            self.last_command = {"line": line, "at": time.time()}
+            ok, payload = await self._call_verb_async("newtab", tokens[1:])
+            if not ok:
+                return False, payload
+            meta = self.browser._tab_meta.get(key)
+            if meta is not None and caller:
+                meta["caller"], meta["claim_at"] = caller, time.time()
+            return True, f"[tab {key}] {payload}"
 
     def _closetab(self, args, caller: str = "") -> tuple:
-        """Close ONE tab, leaving the rest of the browser open."""
+        """Synchronous compatibility bridge for close-tab tests."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._closetab_async(args, caller))
+        raise RuntimeError("await _closetab_async() inside an event loop")
+
+    async def _closetab_async(self, args, caller: str = "") -> tuple:
+        """Close one tab atomically with respect to claim admission."""
         if not args:
             return 2, "usage: co browser tab close <tab>   (a name from `co browser tab ls`)"
         target = args[0]
         key = _key(target)
-        meta = self.browser._tab_meta.get(key)
-        if key not in self.browser._pages and meta is None:
-            if key is None:  # main always exists conceptually; nothing to release is fine
-                return True, "main is already free — nothing to close."
-            return 3, self._unknown_tab(target)
-        # Closing someone else's tab is fine once the time they asked for has
-        # passed — every agent here is cooperative, and a declaration that
-        # elapsed with the tab still open means its owner is gone, not busy.
-        # Before that, refuse: 120s of silence is not evidence a task ended.
-        if meta and _held_by_other(meta, caller):
-            return 4, self._tab_busy(key, meta)
-        self.last_command = {"line": "closetab " + target, "at": time.time()}
-        # close_tab releases the page, the registration (claim included), AND the
-        # remembered URL — a later tab reusing this name must start blank, never
-        # on the previous owner's page.
-        message = self.browser.close_tab(_tab_label(key))
-        return True, f"Closed tab {_tab_label(key)}. {message}"
+        async with self._registry_lock:
+            meta = self.browser._tab_meta.get(key)
+            if key not in self.browser._pages and meta is None:
+                if key is None:  # main always exists conceptually; nothing to release is fine
+                    return True, "main is already free — nothing to close."
+                return 3, await self._unknown_tab_async(target)
+            # Closing someone else's tab is fine once the time they asked for has
+            # passed — every agent here is cooperative, and a declaration that
+            # elapsed with the tab still open means its owner is gone, not busy.
+            # Before that, refuse: 120s of silence is not evidence a task ended.
+            if meta and _held_by_other(meta, caller):
+                return 4, self._tab_busy(key, meta)
+            self.last_command = {"line": "closetab " + target, "at": time.time()}
+            # close_tab releases the page, registration/claim, and remembered URL.
+            result = self.browser.close_tab(_tab_label(key))
+            message = await result if inspect.isawaitable(result) else result
+            return True, f"Closed tab {_tab_label(key)}. {message}"
 
     def serve(self):
+        """Own one event loop for the daemon's complete lifetime."""
+        asyncio.run(self.serve_async())
+
+    async def serve_async(self):
+        self._loop = asyncio.get_running_loop()
         self._bind()
         atexit.register(self._cleanup)
         if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+            with contextlib.suppress(NotImplementedError, RuntimeError):
+                self._loop.add_signal_handler(signal.SIGTERM, self._begin_shutdown)
 
+        try:
+            if transport.IS_WINDOWS:
+                self._transport_pool = ThreadPoolExecutor(
+                    max_workers=WINDOWS_TRANSPORT_WORKERS,
+                    thread_name_prefix="browser-transport",
+                )
+                await self._serve_windows()
+            else:
+                raw_listener = self._srv
+                self._srv = await asyncio.start_unix_server(
+                    self._accept_posix_client,
+                    sock=raw_listener,
+                    limit=MAX_REQUEST_BYTES + 1,
+                    backlog=MAX_IN_FLIGHT,
+                )
+                await self._srv.serve_forever()
+        except asyncio.CancelledError:
+            if not self._closing:
+                raise
+        except OSError:
+            if not self._closing:
+                raise
+        finally:
+            await self._shutdown_async()
+
+    def _accept_posix_client(self, reader, writer) -> None:
+        """Admit at most ``MAX_IN_FLIGHT`` clients; shed excess immediately."""
+        if self._closing or len(self._client_tasks) >= MAX_IN_FLIGHT:
+            writer.transport.abort()
+            return
+        task = asyncio.create_task(self._handle_posix_client(reader, writer))
+        self._track_client(task)
+
+    def _track_client(self, task: asyncio.Task) -> None:
+        self._client_tasks.add(task)
+        task.add_done_callback(self._client_done)
+
+    def _client_done(self, task: asyncio.Task) -> None:
+        self._client_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            print(f"browser client task failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+    async def _read_posix_request(self, reader) -> str:
+        deadline = asyncio.get_running_loop().time() + REQUEST_TIMEOUT
+        chunks = []
+        size = 0
         while True:
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                raise TimeoutError("request timed out")
             try:
-                conn = self._accept()
+                chunk = await asyncio.wait_for(reader.read(65536), timeout=remaining)
+            except TimeoutError as exc:
+                raise TimeoutError("request timed out") from exc
+            if not chunk:
+                return b"".join(chunks).decode().strip()
+            size += len(chunk)
+            if size > MAX_REQUEST_BYTES:
+                raise ValueError(
+                    f"request exceeds the {MAX_REQUEST_BYTES}-byte limit"
+                )
+            chunks.append(chunk)
+
+    async def _handle_posix_client(self, reader, writer) -> None:
+        request = ""
+        try:
+            request = await self._read_posix_request(reader)
+            ok, payload = await self._dispatch_boundary(request)
+            writer.write(self._reply_bytes(ok, payload))
+            await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
+            if await self._should_stop(ok, payload):
+                self._begin_shutdown()
+        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+            print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
+        except ValueError as exc:
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError, TimeoutError):
+                writer.write(self._reply_bytes(2, str(exc)))
+                await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
+        finally:
+            writer.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await writer.wait_closed()
+
+    async def _serve_windows(self) -> None:
+        slots = asyncio.Semaphore(MAX_IN_FLIGHT)
+        while not self._closing:
+            await slots.acquire()
+            try:
+                conn = await self._transport_call(self._accept)
             except OSError:
-                # Closing the listener is how this daemon is told to stop, and
-                # _accept's docstring says the raise is the mechanism. Letting it
-                # escape is the part that hurt: each serve() thread printed a
-                # traceback on the way out, and several doing that at once while
-                # the interpreter finalised aborted the process --
-                #   Fatal Python error: _enter_buffered_busy: could not acquire
-                #   lock for <_io.BufferedWriter name='<stderr>'> at interpreter
-                #   shutdown, possibly due to daemon threads
-                # -- taking whatever was still buffered with it. Seen at the end
-                # of a full test run: everything passed, exit code 134.
-                #
-                # Only when it is us doing the closing. A listener that breaks
-                # while this is supposed to be serving is a real failure.
+                slots.release()
                 if self._closing:
                     return
                 raise
             if conn is None:
-                continue  # a client that failed the auth handshake (Windows) — keep serving
-            request = ""
-            try:
-                request = self._read_request(conn)  # a client that connects then stalls
-                if request is None:                  # must not wedge the single-threaded daemon
-                    conn.close()
-                    continue
-                ok, payload = self.dispatch(request)
-            except Exception as exc:
-                # Request boundary: one bad request (malformed envelope, encoding, an
-                # unexpected dispatch bug) is reported to ITS client — it must never
-                # unwind serve() and take the shared browser down with it.
-                ok, payload = False, f"{type(exc).__name__}: {exc}"
-            try:
-                # ok is True, False, or an int error code (2/3/4) so orchestrating
-                # agents can branch on the exit code without parsing prose.
-                header = "OK" if ok is True else ("ERR" if ok is False else f"ERR {ok}")
-                self._send_reply(conn, (header + "\n" + payload).encode())
-            except (BrokenPipeError, ConnectionResetError, socket.timeout, EOFError):
-                # The client died or stalled mid-reply (bash timeout, Ctrl-C; on Windows
-                # socket.timeout IS TimeoutError, which bounded_io raises for a reader
-                # that stopped consuming). Its death must not kill the daemon — log the
-                # drop (stderr goes to ~/.co/browser.log) so "my command printed
-                # nothing" stays diagnosable. Any OTHER OSError is a daemon-side fault
-                # and propagates: a broken daemon must die and be respawned, not loop.
-                print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
-            finally:
-                conn.close()
+                slots.release()
+                continue
+            task = asyncio.create_task(self._handle_windows_client(conn, slots))
+            self._track_client(task)
 
-            # A Playwright timeout proves the context existed, but not that it is
-            # currently safe to round-trip through. In particular, Page.goto can
-            # time out while Chromium is still trying to settle the navigation.
-            # Calling _context_is_alive() immediately submits context.cookies() to
-            # that same single browser worker and can block the daemon before it
-            # accepts the recovery command (Escape, inspect, screenshot, close).
-            # Keep the request boundary honest: return this timeout to its caller,
-            # remember that a browser did exist, and let the next command recover
-            # it. Launch failures are handled above by _launch_failed().
+    async def _transport_call(self, fn):
+        return await asyncio.get_running_loop().run_in_executor(
+            self._transport_pool, fn
+        )
+
+    async def _handle_windows_client(self, conn, slots) -> None:
+        request = ""
+        try:
+            request = await self._transport_call(lambda: self._read_request(conn))
+            if request is None:
+                return
+            if len(request.encode()) > MAX_REQUEST_BYTES:
+                ok, payload = 2, f"request exceeds the {MAX_REQUEST_BYTES}-byte limit"
+            else:
+                ok, payload = await self._dispatch_boundary(request)
+            await self._transport_call(
+                lambda: self._send_reply(conn, self._reply_bytes(ok, payload))
+            )
+            if await self._should_stop(ok, payload):
+                self._begin_shutdown()
+        except (BrokenPipeError, ConnectionResetError, TimeoutError, EOFError):
+            print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
+        except ValueError as exc:
+            message = str(exc)
+            with contextlib.suppress(
+                BrokenPipeError, ConnectionResetError, TimeoutError, EOFError
+            ):
+                await self._transport_call(
+                    lambda: self._send_reply(conn, self._reply_bytes(2, message))
+                )
+        finally:
+            try:
+                conn.close()
+            finally:
+                slots.release()
+
+    async def _dispatch_boundary(self, request: str) -> tuple:
+        try:
+            return await self.dispatch_async(request)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return False, f"{type(exc).__name__}: {exc}"
+
+    @staticmethod
+    def _reply_bytes(ok, payload: str) -> bytes:
+        header = "OK" if ok is True else ("ERR" if ok is False else f"ERR {ok}")
+        return (header + "\n" + payload).encode()
+
+    async def _should_stop(self, ok, payload: str) -> bool:
+        """Serialize shared runtime health transitions after concurrent replies."""
+        async with self._health_lock:
             if ok is False and payload.startswith("TimeoutError:"):
                 self._had_browser = True
                 self._defer_context_probe = True
-                continue
-
-            # Recovery often takes more than one command: Escape, inspect the
-            # URL, screenshot, then query the DOM. Inserting the same synchronous
-            # context probe between any two of them recreates the deadlock. Stay
-            # in this bounded recovery window until a fresh navigation settles.
-            # Explicit closure and a closed-target error still release the socket
-            # immediately without another browser round trip.
-            if self._defer_context_probe:
-                closed = (
-                    payload == "Browser closed"
-                    or (
-                        ok is False
-                        and (
-                            payload.startswith("TargetClosedError:")
-                            or "context or browser has been closed" in payload
-                        )
-                    )
+                return False
+            closed = payload.startswith("Browser closed") or (
+                ok is False
+                and (
+                    payload.startswith("TargetClosedError:")
+                    or "context or browser has been closed" in payload
                 )
-                if self.browser._launch_failed() or closed:
-                    break
+            )
+            if self._defer_context_probe:
+                if self._launch_failed() or closed:
+                    return True
                 if ok is True and payload.startswith("Navigated to "):
                     self._defer_context_probe = False
                 else:
-                    continue
-
-            # Exit (releasing the socket) when the browser can no longer be driven, so the
-            # next command spawns a fresh daemon instead of reusing a dead one. This is a
-            # SHARED-context decision, not a per-session one: a command on a page-less tab
-            # must not be read as "browser dead" and tear down every other session's tabs.
-            alive = self.browser._context_is_alive()
+                    return False
+            if closed:
+                return True
+            if getattr(self.browser, "_closing", False):
+                # A concurrent bare close owns teardown and will stop the server
+                # after its reply. Do not race that teardown with a health probe.
+                return False
+            alive = await self._browser_is_alive()
             self._had_browser = self._had_browser or alive
-            #   - a launch that never produced a context (Chrome aborted at startup) — a
-            #     daemon that can't open a browser must not linger as a socket-holding zombie;
-            #   - a context that was alive and has since closed/crashed.
-            if self.browser._launch_failed() or (self._had_browser and not alive):
-                break
+            return self._launch_failed() or closed or (self._had_browser and not alive)
+
+    def _begin_shutdown(self) -> None:
+        self._closing = True
+        if self._srv:
+            self._srv.close()
+
+    async def _shutdown_async(self) -> None:
+        self._closing = True
+        if self._srv:
+            self._srv.close()
+            wait_closed = getattr(self._srv, "wait_closed", None)
+            if wait_closed is not None:
+                await wait_closed()
+        current = asyncio.current_task()
+        pending = [task for task in self._client_tasks if task is not current]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._client_tasks.clear()
+        close = getattr(self.browser, "close", None)
+        if callable(close):
+            try:
+                result = close()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                print(
+                    f"browser cleanup failed: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
+        if self._transport_pool is not None:
+            self._transport_pool.shutdown(wait=True, cancel_futures=True)
+            self._transport_pool = None
+        self._remove_endpoint()
 
     def _bind(self):
         """Bind the socket, yielding to any daemon that already owns it.
@@ -704,7 +981,7 @@ class BrowserDaemon:
         fresh inode while a second still holds the old one.
 
         A refused probe is ambiguous: the owner died leaving a stale socket, OR the
-        owner is alive with a full backlog (a long browser action while clients hammer it — the
+        owner is alive with a full bounded backlog (many clients arriving together — the
         exact situation that spawns us). Unlinking a BUSY daemon's socket forks the
         world: two daemons, two Chromes fighting over one profile, and the original
         becomes an unreachable zombie. The pid file the owner wrote at bind time
@@ -737,7 +1014,7 @@ class BrowserDaemon:
         self._srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._srv.bind(self.sock_path)
         Path(transport.pid_path(self.sock_path)).write_text(str(os.getpid()), encoding="utf-8")
-        self._srv.listen(8)
+        self._srv.listen(MAX_IN_FLIGHT)
 
     def _bind_windows(self):
         """Named-pipe bind. A pipe vanishes WITH its owning process, so 'no pipe' is
@@ -769,7 +1046,7 @@ class BrowserDaemon:
         """Accept one client. Windows hands back only AUTHENTICATED connections — the
         HMAC challenge runs deadline-bounded in transport.accept_authenticated (mpc's
         own accept()-time handshake blocks forever on a stalled client), and a failed
-        handshake returns None instead of killing the single-threaded loop. A dead
+        handshake returns None instead of killing the asyncio accept loop. A dead
         listener still raises out on both platforms so a dying daemon exits."""
         if transport.IS_WINDOWS:
             return transport.accept_authenticated(self._srv, self._authkey)
@@ -782,7 +1059,11 @@ class BrowserDaemon:
         text, or None when the client stalled or vanished."""
         if transport.IS_WINDOWS:
             try:
-                return transport.bounded_io(conn, conn.recv_bytes, 120).decode().strip()
+                return transport.bounded_io(
+                    conn,
+                    lambda: conn.recv_bytes(MAX_REQUEST_BYTES + 1),
+                    REQUEST_TIMEOUT,
+                ).decode().strip()
             except (TimeoutError, EOFError):
                 return None  # stalled mid-frame, or died before sending
         conn.settimeout(120)
@@ -796,42 +1077,35 @@ class BrowserDaemon:
         native send deadline, so a stalled-but-alive reader (full pipe) is bounded the
         same way — the daemon must never wedge on a client that stopped reading."""
         if transport.IS_WINDOWS:
-            transport.bounded_io(conn, lambda: conn.send_bytes(data), 120)
+            transport.bounded_io(
+                conn, lambda: conn.send_bytes(data), REPLY_TIMEOUT
+            )
         else:
             conn.sendall(data)
 
     def _cleanup(self):
-        self._closing = True   # read by serve() -- see the accept loop
-        # Wake a thread already blocked in accept(). Closing the listener raises
-        # out of accept() on macOS, which is where the abort was seen -- but not
-        # on Linux, where accept() simply keeps blocking and serve() never
-        # notices the flag. CI caught that: this file's own test failed on all
-        # four Linux jobs and passed on macOS and Windows.
-        #
-        # One throwaway connection is enough; connect_ex reports failure as a
-        # return value rather than an exception, and a failure here means the
-        # socket is already gone, which is the outcome we wanted anyway.
-        if self._srv and not transport.IS_WINDOWS and os.path.exists(self.sock_path):
-            waker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            waker.connect_ex(self.sock_path)
-            waker.close()
-        # Stop accepting FIRST: closing/unlinking the socket before anything slow
-        # means a client connecting during shutdown fails immediately and spawns
-        # a fresh daemon, instead of reaching a daemon that will never accept its request.
+        """Thread-safe shutdown hook used by signals, tests, and ``atexit``."""
+        self._closing = True
+        if self._loop is not None and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._begin_shutdown)
+            return
         if self._srv:
-            self._srv.close()  # on Windows, mpc.Listener.close() removes the pipe itself
-        # Only remove what is still OURS (pid file names this process): a successor
-        # daemon may already own the path — a late-exiting zombie deleting the live
-        # socket or pid file would re-arm the very bug the pid file exists to prevent.
+            self._srv.close()
+        self._remove_endpoint()
+
+    def _remove_endpoint(self) -> None:
+        """Remove only endpoint state still owned by this process."""
         pid_file = Path(transport.pid_path(self.sock_path))
-        if pid_file.exists() and pid_file.read_text(encoding="utf-8").strip() == str(os.getpid()):
+        try:
+            owner = pid_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return
+        if owner == str(os.getpid()):
             if not transport.IS_WINDOWS and os.path.exists(self.sock_path):
-                os.unlink(self.sock_path)  # POSIX: remove our socket file (mpc did it on Win)
-            pid_file.unlink()
-        # No browser.close() here: by the time atexit runs, the interpreter has
-        # already shut the worker thread's executor down, so an in-process close
-        # can only raise ("cannot schedule new futures after shutdown"). Chrome
-        # exits with us anyway — the Playwright driver pipe closes on our death.
+                with contextlib.suppress(FileNotFoundError):
+                    os.unlink(self.sock_path)  # POSIX: remove our socket file (mpc did it on Win)
+            with contextlib.suppress(FileNotFoundError):
+                pid_file.unlink()
 
 
 def _ago(seconds: float) -> str:

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -807,7 +807,7 @@ class BrowserDaemon:
                 raise TimeoutError("request timed out")
             try:
                 chunk = await asyncio.wait_for(reader.read(65536), timeout=remaining)
-            except TimeoutError as exc:
+            except asyncio.TimeoutError as exc:
                 raise TimeoutError("request timed out") from exc
             if not chunk:
                 return b"".join(chunks).decode().strip()
@@ -827,10 +827,20 @@ class BrowserDaemon:
             await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
             if await self._should_stop(ok, payload):
                 self._begin_shutdown()
-        except (BrokenPipeError, ConnectionResetError, TimeoutError):
+        except (
+            BrokenPipeError,
+            ConnectionResetError,
+            TimeoutError,
+            asyncio.TimeoutError,
+        ):
             print(f"client vanished before reply: {request[:80]!r}", file=sys.stderr)
         except ValueError as exc:
-            with contextlib.suppress(BrokenPipeError, ConnectionResetError, TimeoutError):
+            with contextlib.suppress(
+                BrokenPipeError,
+                ConnectionResetError,
+                TimeoutError,
+                asyncio.TimeoutError,
+            ):
                 writer.write(self._reply_bytes(2, str(exc)))
                 await asyncio.wait_for(writer.drain(), timeout=REPLY_TIMEOUT)
         finally:

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -230,6 +230,7 @@ class BrowserDaemon:
         # Set by _cleanup before it closes the listener, so serve() can tell "we are
         # stopping" from "the socket broke while we were meant to be serving".
         self._closing = False
+        self._shutdown_started = False
         self._had_browser = False
         self._defer_context_probe = False
         self.last_command = None  # {"line": str, "at": float} of the last real command
@@ -943,8 +944,9 @@ class BrowserDaemon:
             return self._launch_failed() or closed or (self._had_browser and not alive)
 
     def _begin_shutdown(self) -> None:
-        if self._closing:
+        if self._shutdown_started:
             return
+        self._shutdown_started = True
         self._closing = True
         if (
             transport.IS_WINDOWS

--- a/connectonion/cli/browser_agent/daemon.py
+++ b/connectonion/cli/browser_agent/daemon.py
@@ -851,6 +851,14 @@ class BrowserDaemon:
             if conn is None:
                 slots.release()
                 continue
+            # Listener.close() does not interrupt an already-blocked Windows
+            # named-pipe accept. Shutdown authenticates one internal connection
+            # to wake it; discard that sentinel instead of starting a request
+            # reader that would keep the transport pool alive for 120 seconds.
+            if self._closing:
+                conn.close()
+                slots.release()
+                return
             task = asyncio.create_task(self._handle_windows_client(conn, slots))
             self._track_client(task)
 
@@ -935,9 +943,38 @@ class BrowserDaemon:
             return self._launch_failed() or closed or (self._had_browser and not alive)
 
     def _begin_shutdown(self) -> None:
+        if self._closing:
+            return
         self._closing = True
-        if self._srv:
+        if (
+            transport.IS_WINDOWS
+            and self._srv
+            and self._loop is not None
+            and self._transport_pool is not None
+        ):
+            # multiprocessing.connection.Listener.close() does not wake a
+            # ConnectNamedPipe already blocked in another thread. Connect with
+            # our own key before closing the listener; _serve_windows discards
+            # this sentinel and can then enter deterministic shutdown.
+            self._loop.run_in_executor(
+                self._transport_pool, self._wake_windows_accept
+            )
+        elif self._srv:
             self._srv.close()
+
+    def _wake_windows_accept(self) -> None:
+        """Authenticate one no-payload client so a blocked pipe accept returns."""
+        try:
+            conn = transport.win_connect(self.sock_path, self._authkey)
+        except (
+            transport.AuthenticationError,
+            EOFError,
+            FileNotFoundError,
+            ConnectionError,
+            OSError,
+        ):
+            return
+        conn.close()
 
     async def _shutdown_async(self) -> None:
         self._closing = True

--- a/connectonion/cli/browser_agent/transport.py
+++ b/connectonion/cli/browser_agent/transport.py
@@ -2,22 +2,22 @@ r"""
 Purpose: Cross-platform IPC primitives for the browser daemon/client so `co browser` runs natively on Windows (named pipes) as well as macOS/Linux (Unix sockets) — no WSL.
 LLM-Note:
   Dependencies: imports from [os, time, getpass, subprocess, tempfile, hashlib, binascii, threading, multiprocessing.connection, pathlib | lazy: fcntl/msvcrt, ctypes] | imported by [browser_agent/daemon.py, browser_agent/client.py] | tested by [tests/unit/test_transport.py, tests/e2e/cli/test_browser_daemon.py]
-  Data flow: daemon/client call default_address() → POSIX returns a Unix-socket filesystem path (unchanged from before), Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve real filesystem sidecars (POSIX: <addr>.pid/.lock exactly as before; Windows: hashed files under %LOCALAPPDATA%/co since a pipe name is not a path) | Windows wire: win_listener() creates the pipe WITHOUT an authkey and the daemon runs the mutual HMAC challenge itself via accept_authenticated() under a hard deadline (mpc's own accept()-time handshake blocks forever on a stalled client — a wedged single-threaded daemon); win_connect() is a normal authenticated mpc.Client | POSIX keeps its raw AF_UNIX socket in daemon.py/client.py untouched
+  Data flow: daemon/client call default_address() → POSIX returns a Unix-socket filesystem path, Windows returns a per-user named pipe \\.\pipe\co-browser-<hash> | pid_path()/lock_path() resolve filesystem sidecars | Windows wire: win_listener() creates the pipe WITHOUT an authkey and accept_authenticated() runs the mutual HMAC challenge under a hard deadline before the daemon submits the connection to its asyncio runtime; win_connect() is a normal authenticated mpc.Client | POSIX binding is handed to asyncio.start_unix_server after the same stale-owner checks
   State/Effects: default_address()/_sidecar_dir() may mkdir the runtime dir (and chmod 0700 on POSIX — the socket dir IS the POSIX trust boundary, so a chmod failure raises loudly) | load_or_create_authkey() creates a 0600 key file in the sidecar dir (only used on Windows) and atomically replaces a persistently-corrupt one | acquire_singleton_lock() holds an OS lock (fcntl.flock POSIX / msvcrt.locking Windows) for the daemon's lifetime, released by the OS on death | spawn_detached() launches the daemon fully detached
-  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | POSIX behavior is intentionally identical to the pre-existing raw-socket code so existing tests pass unchanged; only the Windows branch is new
+  Integration: exposes IS_WINDOWS, AuthenticationError (= mpc's class), HANDSHAKE_TIMEOUT, default_address(), pid_path(), lock_path(), load_or_create_authkey(), pid_alive(), acquire_singleton_lock(), spawn_detached(), win_listener(), win_connect(), bounded_io(), accept_authenticated() | daemon.py owns asyncio admission/backpressure; this module preserves native platform security and blocking-pipe primitives
   Performance: all helpers are cheap local ops | authkey is a 64-byte file read | bounded_io adds one short-lived thread per bounded pipe operation (handshake/read/reply — never touches Playwright)
   Errors: acquire_singleton_lock returns None when the lock is held (caller exits 0) | pid_alive treats EPERM/access-denied as ALIVE (the pid exists — same lesson as browser.py's _pid_alive) | load_or_create_authkey converges on ONE key under the O_EXCL create race, atomically replaces a file that stays invalid past the writers' microsecond window, and RAISES if no valid key can be produced — it never falls back to a fixed key, which would silently disable authentication | bounded_io raises TimeoutError on deadline (after closing the connection so the helper unblocks) and re-raises the operation's own exception otherwise | accept_authenticated returns None on a bad key, a stalled handshake, or a vanished client (the daemon keeps serving); a closed listener still raises out of accept() so a dying daemon exits instead of spinning
 """
 
-import os
-import time
+import binascii
 import getpass
+import hashlib
+import multiprocessing.connection as mpc
+import os
 import subprocess
 import tempfile
-import hashlib
-import binascii
 import threading
-import multiprocessing.connection as mpc
+import time
 from pathlib import Path
 
 IS_WINDOWS = os.name == "nt"
@@ -271,7 +271,7 @@ def bounded_io(conn, fn, timeout: float):
 
     mpc named-pipe Connections have no native timeouts anywhere — not in the accept
     handshake, not mid-frame in recv_bytes, not in send_bytes against a full pipe with
-    a stalled reader. Any of those would wedge the single-threaded daemon forever
+    a stalled reader. Any of those would exhaust a transport worker indefinitely
     (POSIX gets all of this from one settimeout(120)). The operation runs in a
     short-lived helper thread joined against the deadline; on timeout the connection
     is closed (which errors the helper's blocked syscall, so the thread exits) and
@@ -301,7 +301,7 @@ def accept_authenticated(listener, authkey: bytes, timeout: float = HANDSHAKE_TI
 
     mpc's `Listener(authkey=...)` runs the challenge INSIDE accept() with blocking
     recvs — a client that connects and then stalls mid-handshake would wedge the
-    single-threaded daemon forever, and the request read timeout starts too late to
+    transport worker forever, and the request read timeout starts too late to
     help. So win_listener() creates the pipe without an authkey and the challenge
     runs here, deadline-bounded. A closed/broken listener still raises out of
     accept() — a dying daemon must exit its serve loop, not spin on a dead endpoint.

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -29,9 +29,12 @@ The first vertical slice is implemented but deliberately not released:
   uploads, known-target humanized input, and model-selected element actions. The
   current final #498 slice adds keyboard typing, verified strategy scrolling,
   collision-safe context capture, and cancellable manual-login input. Issue #498
-  remains open until the whole-surface, cancellation, profile, stealth, recovery,
-  native-browser, installed-wheel, and hosted audit is complete; #499 and #500 remain
-  downstream.
+  has now passed the whole-surface, cancellation, profile, stealth, recovery,
+  native-browser, installed-wheel, and hosted audit in PR #1288; merge still needs
+  explicit release-authority approval. The stacked #499 slice replaces serial
+  dispatch with bounded asyncio client tasks, atomic request leases, per-tab
+  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. #500
+  remains the downstream synchronous-facade boundary.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,
@@ -237,10 +240,9 @@ Planning window: weeks 1–3. Workstreams run in parallel.
 
 Canonical issues: #498, #499, #500, #1151, and the reliability remainder of #1248/#1250.
 
-Current code has a synchronous Patchright core in
-`connectonion/useful_tools/browser_tools/browser.py`, one worker thread, and a serial
-daemon in `connectonion/cli/browser_agent/daemon.py`. Preserve public behavior while
-replacing the bottleneck.
+The public Python class still has a synchronous Patchright worker until #500.
+The internal core is async, and the #499 daemon slice owns it directly on one
+event loop. Preserve public behavior while completing the remaining facade.
 
 Implementation order:
 

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -37,6 +37,9 @@ bounds would only trade one global queue for an unlimited pile of tasks.
 On Windows, a successful whole-browser `close` also waits for the exact daemon
 PID that served it to exit. The next command can therefore cold-start against a
 new named pipe instead of reaching the old daemon during its shutdown window.
+Because closing a Windows listener does not interrupt an `accept` already
+blocked in a worker, shutdown authenticates one internal wake connection and
+discards it before joining the bounded worker pool.
 
 The useful test is still the original stopwatch. Two independent 200 ms
 operations go through the real local socket and overlap. The same-tab test takes

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -1,0 +1,47 @@
+# The second tab was not concurrent
+
+We already had one browser tab per agent. That looked like concurrency on the
+board: `research` belonged to one task, `inbox` to another, and neither could
+navigate the other's page.
+
+Then we timed two 200 ms operations.
+
+They took about 400 ms.
+
+The tabs were isolated, but the daemon still accepted one connection, finished
+its browser call, sent the reply, and only then accepted the next connection.
+The browser driver added a second queue of its own: every synchronous Patchright
+call ran through one worker thread. A named tab prevented corruption; it did not
+let the second task move.
+
+The fix was to choose one place that owns concurrency. The daemon now owns one
+asyncio event loop and one async Patchright runtime. Each request is an asyncio
+task. The browser core locks the page for that request's bound tab, not the whole
+browser. Two requests for `research` still run in order. A request for `research`
+and one for `inbox` can overlap.
+
+Claims stay outside that scheduling decision. Before a task touches a page, a
+small registry lock decides whether its caller owns the tab. Two callers racing
+for `main` therefore cannot both pass an asynchronous check-then-write gap: one
+records the claim and the other receives exit code 4. The winner also records a
+request id in the tab metadata. A `finally` block removes that exact request id
+after success, failure, or cancellation without deleting the longer-lived tab
+owner.
+
+We kept the native transports rather than hiding blocking Windows pipes behind
+an unbounded default executor. POSIX connections enter the event loop directly.
+Windows accept, authentication, read, and write calls cross a dedicated bounded
+worker pool and submit to the same async dispatch path. Both sides cap admitted
+clients, request bytes, read time, and reply time. Concurrency without those
+bounds would only trade one global queue for an unlimited pile of tasks.
+
+The useful test is still the original stopwatch. Two independent 200 ms
+operations go through the real local socket and overlap. The same-tab test takes
+roughly 400 ms and proves ordering remains. A third test closes the client before
+the reply, then checks that the request lease and active operation are gone while
+the tab's durable owner is still present.
+
+The lesson was not "replace threads with asyncio." It was that isolation and
+concurrency are different properties. A tab map gave us isolation. Only moving
+the daemon and the driver onto the same owned async runtime made the second tab
+concurrent.

--- a/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
+++ b/docs/blog/2026-08-26-the-second-tab-was-not-concurrent.md
@@ -34,6 +34,9 @@ Windows accept, authentication, read, and write calls cross a dedicated bounded
 worker pool and submit to the same async dispatch path. Both sides cap admitted
 clients, request bytes, read time, and reply time. Concurrency without those
 bounds would only trade one global queue for an unlimited pile of tasks.
+On Windows, a successful whole-browser `close` also waits for the exact daemon
+PID that served it to exit. The next command can therefore cold-start against a
+new named pipe instead of reaching the old daemon during its shutdown window.
 
 The useful test is still the original stopwatch. Two independent 200 ms
 operations go through the real local socket and overlap. The same-tab test takes

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -241,6 +241,8 @@ python -m patchright install chrome     # branded Chrome: best stealth, system i
 - The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
 - Client work is bounded: 1 MiB request cap, 120-second read/reply deadlines,
   32 admitted connections, and eight blocking transport workers on Windows.
+- On Windows, `co browser close` returns only after the serving daemon exits, so
+  an immediate next command can safely start a fresh daemon.
 - For an isolated automation run, set `$CO_BROWSER_PROFILE_DIR` to a dedicated absolute directory and `$CO_BROWSER_SOCK` to a dedicated socket. Keep the real `$HOME`; replacing it can break OS-backed browser behavior and credentials.
 
 ## Error Messages

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -187,6 +187,12 @@ with the tab still open means that agent crashed, not that it is still working.
 A tab opened without `--needs` frees up after ~2 minutes of silence, which is
 wrong whenever you are waiting on a slow page or a human. Say the number.
 
+Named tabs are also the concurrency boundary. The daemon owns one asyncio browser
+runtime: two operations aimed at `scrape` queue behind each other, while `scrape`
+and `inbox` may run at the same time. A registry lock decides claim races before
+either operation touches a page, so concurrency never means two agents silently
+sharing one tab.
+
 Set `CO_WHO` so your commands carry your identity:
 
 ```bash
@@ -231,8 +237,10 @@ python -m patchright install chrome     # branded Chrome: best stealth, system i
 
 ## Sessions & Profile
 
-- One browser per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
+- One async browser runtime per machine, backed by a persistent profile at `~/.co/browser_profile/` — so logins survive restarts.
 - The daemon endpoint: a Unix socket under `$XDG_RUNTIME_DIR/co/browser.sock` on macOS/Linux, a per-user named pipe on Windows (native, 1.2.1+ — no WSL). Override with `$CO_BROWSER_SOCK`.
+- Client work is bounded: 1 MiB request cap, 120-second read/reply deadlines,
+  32 admitted connections, and eight blocking transport workers on Windows.
 - For an isolated automation run, set `$CO_BROWSER_PROFILE_DIR` to a dedicated absolute directory and `$CO_BROWSER_SOCK` to a dedicated socket. Keep the real `$HOME`; replacing it can break OS-backed browser behavior and credentials.
 
 ## Error Messages

--- a/docs/co-browser.md
+++ b/docs/co-browser.md
@@ -215,24 +215,32 @@ own flags (`co browser status` shows `headless=true/false`). To switch modes,
   registered before `-t` can drive it.
 - **Scripting:** `TAB=$(co browser tab open --for "job")` captures the tab name
   (that's the only thing `tab open` prints to stdout); branch on the exit code, and
-  read `tab ls --json` to see the shared state.
+  read `tab ls --json` to see the shared state. Its `active_requests` entries carry
+  request id, caller, command, and start time while work is in flight; they disappear
+  on success, failure, disconnect, or cancellation.
 
 ## How It Works
 
-A small **daemon** owns the one browser and listens on a Unix socket; each
+A small **daemon** owns the one browser and listens on a Unix socket (or an
+authenticated named pipe on Windows); each
 `co browser …` invocation is a short-lived client that sends one request and prints
 the reply. Every terminal on the machine talks to the **same** daemon — there is
-one browser, one board, no matter where you type. The daemon serializes commands,
-tracks per-tab ownership, and keeps the browser alive between commands. It starts
-automatically on first use and exits when you `close` it (or when the browser is
-no longer usable).
+one browser, one board, no matter where you type. One asyncio runtime owns that
+browser. Operations on the same tab are serialized; operations on independent
+named tabs can progress together. Claim admission remains atomic, so two agents
+racing for one tab still get one winner and one exit-4 refusal rather than
+interleaved page mutations. It starts automatically on first use and exits when
+you `close` it (or when the browser is no longer usable).
 
 The daemon records its pid next to the socket, so a daemon that is merely **busy**
-(for example, a slow navigation holding the single-threaded browser loop) is never mistaken for a dead one:
-clients wait up to ~15s for it to come free and then say so ("daemon is busy"),
-instead of spawning a rival daemon over a live browser. Startup itself is
-race-proof: a kernel lock makes two terminals' simultaneous first commands elect
-exactly one daemon — the loser exits and its command is served by the winner.
+(for example, its bounded connection capacity is full) is never mistaken for a
+dead one: clients wait briefly and report capacity instead of spawning a rival
+daemon over a live browser. Each request is capped at 1 MiB, reads and replies
+have absolute 120-second deadlines, and at most 32 client tasks are admitted.
+Cancellation or disconnect clears that request's active audit lease without
+erasing another task's tab ownership. Startup itself is race-proof: a kernel lock
+makes two terminals' simultaneous first commands elect exactly one daemon — the
+loser exits and its command is served by the winner.
 
 ### Restart the daemon after an upgrade or downgrade
 
@@ -266,8 +274,9 @@ downgrading so an older client never talks to a newer daemon.
 - **"Chrome failed to start"** — usually running over ssh/cron without a desktop
   session (start from a logged-in Terminal, or use `--headless`), or a leftover
   Chrome still holds the profile. The full launch log is in `~/.co/browser.log`.
-- **"daemon is busy" after ~15s** — a browser action is holding the single-threaded
-  daemon. Wait for it, or find the culprit with `co browser status` once it frees up.
+- **"daemon is … at connection capacity" after ~15s** — 32 clients are already
+  admitted (or all bounded Windows transport workers are occupied). Retry shortly;
+  an unrelated slow browser action on another named tab no longer blocks yours.
 - **Nuclear option** — kill the daemon and let the next command start fresh
   (logins survive: they live in the profile, not the daemon):
 

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -56,9 +56,28 @@ The migration has three review boundaries:
    `BrowserAutomation` methods submit to an owned loop thread without nesting a
    caller's running event loop. The facade is compatibility, not a second driver.
 
-The internal core is not exported as a public user API while #498 is incomplete.
-The current synchronous API and daemon remain authoritative until the complete
-contract and cross-platform transport matrices are green.
+The internal core is not exported as a public user API. The daemon now owns it
+directly; the current synchronous Python API remains authoritative until #500's
+facade and cross-platform compatibility matrices are green.
+
+The #499 transport boundary keeps claim admission separate from page execution.
+A registry lock performs unknown-tab validation, claim takeover/refusal, and a
+request-scoped audit lease as one transition. The lease is keyed by a unique
+request id and cleared in `finally`, so cancellation removes only the request
+that was cancelled; it does not erase a durable owner or another in-flight
+request. Once admitted, the async core's tab lock orders that page while other
+tab locks remain free.
+
+POSIX hands the already race-checked AF_UNIX listener to
+`asyncio.start_unix_server`. It admits at most 32 connection tasks, rejects
+excess connections without spawning more tasks, limits each request to 1 MiB,
+and applies absolute 120-second read and reply deadlines. Windows retains the
+authenticated `multiprocessing.connection` named-pipe wire. Its blocking
+accept/read/write calls run through a dedicated eight-worker executor and feed
+the same asyncio dispatch path; a 32-slot admission semaphore bounds queued
+connections. Shutdown stops admission, cancels owned connection tasks, awaits
+the browser runtime cleanup, and removes the endpoint only if its pid sidecar
+still names this process.
 
 The second #498 review boundary ports deterministic contracts that do not depend
 on frames, downloads, humanized input, or model-backed element matching. It covers
@@ -139,11 +158,18 @@ home with the real macOS keychain makes Chrome hang during context shutdown.
 Before #498 closes, the async core must cover every current public browser verb,
 the humanized-input acceptance suite, profile seeding/export, dead-context
 recovery, downloads/uploads, screenshot payload bounds, and stealth checks.
-Before #499 closes, slow-reader/writer, stalled client, cancellation,
-disconnect, same-tab conflict, independent-tab progress, cold-start, and
-shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
+Before #499 closes, slow-reader/writer, oversized/stalled client, admission-cap,
+cancellation, disconnect, same-tab conflict, independent-tab progress,
+cold-start, and shutdown load tests must pass on POSIX and Windows. Before #500 closes, repeated
 sync and running-event-loop callers must leave no loop thread, task, page,
 process, socket, or pipe behind.
+
+The #499 native gate exercises the complete path rather than composing two mock
+claims: a real socket client asks the real daemon to hold one real Chrome tab for
+two seconds, then another client must read a second real tab within one second
+and before the hold finishes. The transport-only matrix separately proves
+same-tab ordering, a two-caller claim race, disconnect cleanup, and parallel
+client admission without paying Chrome launch cost in every platform job.
 
 The completed review boundaries additionally run against native Chrome. They
 prove selector counts and text, repeated-item bounds, link filtering, text waits,

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -287,16 +287,14 @@ agent.input("Fill in the contact form on example.com with test data")
 
 One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
 
-That worker-thread behavior remains the public contract during the 1.8 async
-migration. The replacement core is internal until every browser verb and the
-cross-platform daemon have equivalent coverage; do not import it as an
-application API yet. The lifecycle, concurrency, cancellation, and compatibility
-boundaries are recorded in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
-The internal core now covers the deterministic selector, extraction, viewport,
-wait, system-info, tab-status, page/frame-script, and file-upload contracts, but
-click variants, downloads, humanized input, model-backed element finding,
-concurrent IPC, and the synchronous facade are still migration work.
-`BrowserAutomation` remains the supported API.
+That worker-thread behavior remains the public Python contract until #500 adds
+the compatibility facade. The replacement core is still internal; do not import
+it as an application API. The `co browser` daemon now owns that async core
+directly: independent tabs interleave, same-tab operations serialize, and the
+POSIX/Windows transports bound connections, reads, writes, and shutdown. The
+lifecycle, concurrency, cancellation, and compatibility boundaries are recorded
+in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+`BrowserAutomation` remains the supported Python API.
 
 ## Common Patterns
 

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -14,8 +14,10 @@ Strategy: a StubBrowser stands in for BrowserAutomation so no real Chrome/Playwr
 or network is needed. The daemon's lazy BrowserAutomation is swapped for the stub.
 """
 
+import asyncio
 import contextlib
 import io
+import json as _json
 import os
 import shlex
 import socket
@@ -27,9 +29,10 @@ from unittest.mock import Mock
 
 import pytest
 
-from connectonion.cli.browser_agent import daemon as d
 from connectonion.cli.browser_agent import client as c
+from connectonion.cli.browser_agent import daemon as d
 from connectonion.cli.browser_agent import transport as tp
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
 
 IS_WINDOWS = tp.IS_WINDOWS
 posix_only = pytest.mark.skipif(IS_WINDOWS, reason="exercises the raw AF_UNIX socket mechanism (POSIX)")
@@ -437,6 +440,7 @@ def test_handle_browser_help_needs_no_browser(capsys):
 def test_next_tip_rotates(tmp_path, monkeypatch):
     """Each run surfaces the next tip; the index wraps around and persists in ~/.co."""
     import pathlib
+
     from connectonion.cli.commands import browser_commands as bc
 
     monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
@@ -464,6 +468,7 @@ def test_tip_hidden_when_not_a_tty(monkeypatch, capsys):
 def test_tip_shown_on_success_tty(tmp_path, monkeypatch, capsys):
     """On an interactive terminal a successful command appends a rotating tip."""
     import pathlib
+
     from connectonion.cli.commands import browser_commands as bc
 
     monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
@@ -542,6 +547,22 @@ def test_socket_round_trip(short_sock, monkeypatch, capsys):
     assert code == 0
     assert out == "Navigated to example.com"
     assert daemon.browser.calls == [("go_to", "example.com")]
+
+
+def test_close_stops_a_fresh_async_daemon_without_launching_chrome(short_sock, monkeypatch):
+    """The real async core returns a longer close message than the old stub."""
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    daemon = d.BrowserDaemon(short_sock, headless=True)
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    code, payload = c._request("close", headless=True)
+
+    assert code == 0
+    assert payload.startswith("Browser closed")
+    server.join(timeout=2)
+    assert not server.is_alive()
 
 
 def test_do_model_wait_does_not_hold_the_daemon_lane(short_sock, monkeypatch):
@@ -700,8 +721,6 @@ def test_launch_failure_message_is_actionable(short_sock, monkeypatch, capsys):
 
 
 # --- the -t / tab noun grammar (one task = one tab) ---
-
-import json as _json
 
 
 def _env(line, caller="", tab=None, account=""):
@@ -999,6 +1018,7 @@ def test_do_instruction_is_not_quote_mangled(monkeypatch):
     """Fix: the NL instruction was re-derived from the shlex-joined line, leaking quotes.
     A multi-word instruction must reach the agent as clean text."""
     import shlex as _shlex
+
     from connectonion.cli.browser_agent import agent as agent_module
 
     captured = {}
@@ -1163,7 +1183,8 @@ def test_close_reserved_tab_before_browser_launch_forgets_it(tmp_path):
 
     ok, _ = daemon.dispatch(_env("tab open research", caller="agent-b"))
     assert ok is True                                       # name free immediately
-    daemon.browser._executor.shutdown(wait=False)
+    # The 1.8 daemon owns the asyncio core directly; there is deliberately no
+    # synchronous one-worker executor left to shut down in this no-launch test.
 
 
 def test_newtab_with_tab_target_is_rejected(tmp_path):
@@ -1196,11 +1217,11 @@ def test_bind_holds_an_exclusive_lock_for_life(short_sock):
     fresh_lock.close()
 
 
-# ---- concurrency: many clients, one single-threaded daemon ----------------
+# ---- concurrency: many clients, one asyncio-owned daemon ------------------
 
 def test_concurrent_clients_are_all_served(short_sock, monkeypatch):
-    """8 clients firing at once against the single-threaded daemon: every request
-    must be served (queued, not dropped or deadlocked) and every reply delivered.
+    """8 clients firing at once against the asyncio daemon: every request
+    must be served (bounded, not dropped or deadlocked) and every reply delivered.
     On Windows this drives real named-pipe contention (mpc PIPE_BUSY waits); on
     POSIX the AF_UNIX accept backlog. This is the multi-agent daily reality."""
     monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
@@ -1220,6 +1241,153 @@ def test_concurrent_clients_are_all_served(short_sock, monkeypatch):
 
     assert len(codes) == 8 and all(code == 0 for code in codes)
     assert len(daemon.browser.calls) == 8  # nothing dropped under contention
+
+
+class AsyncSocketBrowser(AsyncBrowserCore):
+    """Real per-tab scheduling, with no Chrome needed for transport E2E."""
+
+    def __init__(self):
+        super().__init__(headless=True)
+        self.intervals = []
+        self.started = threading.Event()
+
+    async def slow(self, seconds: float = 0.2) -> str:
+        async with self._tab_operation(ensure_page=False):
+            key = self._bound_session_key()
+            start = time.monotonic()
+            self.started.set()
+            try:
+                await asyncio.sleep(seconds)
+            finally:
+                self.intervals.append((key, start, time.monotonic()))
+            return f"finished {key}"
+
+
+def test_independent_tabs_overlap_through_the_native_transport(short_sock, monkeypatch):
+    """The issue's end-to-end claim: concurrency survives the actual IPC boundary."""
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: threading.current_thread().name)
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    assert daemon.dispatch(_env("tab open left", caller="left-agent"))[0] is True
+    assert daemon.dispatch(_env("tab open right", caller="right-agent"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    replies = []
+
+    def drive(tab):
+        replies.append(c._request("slow 0.2", headless=True, tab=tab))
+
+    workers = [
+        threading.Thread(target=drive, name="left-agent", args=("left",)),
+        threading.Thread(target=drive, name="right-agent", args=("right",)),
+    ]
+    started = time.monotonic()
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=3)
+    elapsed = time.monotonic() - started
+
+    assert sorted(code for code, _ in replies) == [0, 0]
+    assert elapsed < 1.5, "parallel clients did not finish promptly"
+    left, right = daemon.browser.intervals
+    assert min(left[2], right[2]) > max(left[1], right[1])
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_same_tab_stays_ordered_through_the_native_transport(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: "owner")
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    assert daemon.dispatch(_env("tab open work", caller="owner"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    replies = []
+    workers = [
+        threading.Thread(
+            target=lambda: replies.append(
+                c._request("slow 0.08", headless=True, tab="work")
+            )
+        )
+        for _ in range(2)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert sorted(code for code, _ in replies) == [0, 0]
+    first, second = daemon.browser.intervals
+    assert first[2] <= second[1]
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_claim_race_through_native_transport_has_one_winner(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    monkeypatch.setattr(c, "_caller", lambda: threading.current_thread().name)
+    daemon = make_daemon(short_sock, stub=AsyncSocketBrowser())
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+    gate = threading.Barrier(3)
+    replies = []
+
+    def contend():
+        gate.wait(timeout=2)
+        replies.append(c._request("slow 0.05", headless=True))
+
+    workers = [
+        threading.Thread(target=contend, name="agent-a"),
+        threading.Thread(target=contend, name="agent-b"),
+    ]
+    for worker in workers:
+        worker.start()
+    gate.wait(timeout=2)
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert sorted(code for code, _ in replies) == [0, 4]
+    assert len(daemon.browser.intervals) == 1
+    assert daemon.browser._tab_meta[None]["caller"] in {"agent-a", "agent-b"}
+    assert "active_requests" not in daemon.browser._tab_meta[None]
+    daemon._cleanup()
+    server.join(timeout=2)
+
+
+def test_disconnect_does_not_orphan_the_active_request_lease(short_sock, monkeypatch):
+    monkeypatch.setenv("CO_BROWSER_SOCK", short_sock)
+    browser = AsyncSocketBrowser()
+    daemon = make_daemon(short_sock, stub=browser)
+    assert daemon.dispatch(_env("tab open work", caller="owner"))[0] is True
+    server = threading.Thread(target=daemon.serve, daemon=True)
+    server.start()
+    _wait_until_listening(short_sock)
+
+    conn = c._connect(short_sock)
+    request = _env("slow 0.05", caller="owner", tab="work").encode()
+    if IS_WINDOWS:
+        conn.send_bytes(request)
+    else:
+        conn.sendall(request)
+        conn.shutdown(socket.SHUT_WR)
+    conn.close()  # disappear before the reply
+
+    assert browser.started.wait(timeout=1)
+    deadline = time.time() + 2
+    while time.time() < deadline and "active_requests" in browser._tab_meta["work"]:
+        time.sleep(0.01)
+    meta = browser._tab_meta["work"]
+    assert "active_requests" not in meta
+    assert meta["caller"] == "owner"
+    assert browser._active_operations == 0
+    daemon._cleanup()
+    server.join(timeout=2)
 
 
 def test_second_daemon_yields_at_the_singleton_lock(short_sock, monkeypatch):

--- a/tests/e2e/cli/test_browser_daemon.py
+++ b/tests/e2e/cli/test_browser_daemon.py
@@ -36,6 +36,30 @@ from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserC
 
 IS_WINDOWS = tp.IS_WINDOWS
 posix_only = pytest.mark.skipif(IS_WINDOWS, reason="exercises the raw AF_UNIX socket mechanism (POSIX)")
+_CREATED_DAEMONS = []
+
+
+@pytest.fixture(autouse=True)
+def stop_created_daemons():
+    """Every test-created daemon must release its loop and Windows worker pool.
+
+    The server thread is daemonized in these socket tests, but the bounded named-
+    pipe executor deliberately is not. Letting a test return without stopping its
+    daemon therefore leaves pytest alive forever on Windows even though all tests
+    passed. Keep cleanup centralized so assertion failures take the same path.
+    """
+    start = len(_CREATED_DAEMONS)
+    yield
+    created = _CREATED_DAEMONS[start:]
+    del _CREATED_DAEMONS[start:]
+    for daemon in reversed(created):
+        daemon._cleanup()
+    deadline = time.time() + 5
+    while time.time() < deadline and any(
+        daemon._transport_pool is not None for daemon in created
+    ):
+        time.sleep(0.01)
+    assert all(daemon._transport_pool is None for daemon in created)
 
 
 @pytest.fixture
@@ -159,6 +183,7 @@ def make_daemon(sock_path, stub=None):
     """Build a daemon whose lazy BrowserAutomation is replaced by a stub."""
     daemon = d.BrowserDaemon(sock_path, headless=True)
     daemon.browser = stub or StubBrowser()
+    _CREATED_DAEMONS.append(daemon)
     return daemon
 
 

--- a/tests/e2e/test_async_browser_daemon_real_driver.py
+++ b/tests/e2e/test_async_browser_daemon_real_driver.py
@@ -1,0 +1,116 @@
+"""Installed/native acceptance for #499's complete daemon-to-driver path.
+
+Run explicitly with the slow gate:
+
+    python -m pytest tests/e2e/test_async_browser_daemon_real_driver.py -m slow -q
+"""
+
+import contextlib
+import json
+import os
+import shlex
+import threading
+import time
+import urllib.parse
+
+import pytest
+
+from connectonion.cli.browser_agent import client, daemon, transport
+from connectonion.useful_tools.browser_tools._async_browser import (
+    ASYNC_BROWSER_AVAILABLE,
+    AsyncBrowserCore,
+)
+
+
+def endpoint() -> str:
+    nonce = f"{os.getpid()}_{time.time_ns()}"
+    if transport.IS_WINDOWS:
+        return rf"\\.\pipe\co_async_native_{nonce}"
+    return f"/tmp/co_async_native_{nonce}.sock"
+
+
+@pytest.mark.slow
+def test_real_daemon_keeps_a_second_tab_live_during_a_long_operation(
+    tmp_path, monkeypatch
+):
+    if not ASYNC_BROWSER_AVAILABLE:
+        pytest.skip("patchright async API is not installed")
+
+    address = endpoint()
+    monkeypatch.setenv("CO_BROWSER_SOCK", address)
+    monkeypatch.setenv("CO_BROWSER_PROFILE_DIR", str(tmp_path / "profile"))
+    monkeypatch.setattr(client, "_caller", lambda: "native-owner")
+    server = daemon.BrowserDaemon(address, headless=True)
+    server.browser = AsyncBrowserCore(
+        headless=True,
+        use_mock_keychain=True,
+    )
+    thread = threading.Thread(target=server.serve, daemon=True)
+    thread.start()
+
+    try:
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if os.path.exists(transport.pid_path(address)):
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("daemon did not bind")
+
+        for tab, marker in (("slow", "alpha"), ("live", "beta")):
+            assert client._request(f"tab open {tab}", headless=True)[0] == 0
+            url = "data:text/html," + urllib.parse.quote(
+                f"<title>{marker}</title><main>{marker} page</main>"
+            )
+            code, payload = client._request(
+                shlex.join(["go_to", url]), headless=True, tab=tab
+            )
+            assert code == 0, payload
+
+        waiting = []
+        worker = threading.Thread(
+            target=lambda: waiting.append(
+                client._request("wait 2", headless=True, tab="slow")
+            )
+        )
+        worker.start()
+
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            code, payload = client._request("tab ls --json", headless=True)
+            assert code == 0, payload
+            slow = next(item for item in json.loads(payload) if item["tab"] == "slow")
+            if slow["active_requests"]:
+                break
+            time.sleep(0.02)
+        else:
+            raise AssertionError("long operation never became active")
+
+        started = time.monotonic()
+        code, payload = client._request("get_text", headless=True, tab="live")
+        elapsed = time.monotonic() - started
+
+        assert code == 0, payload
+        assert "beta page" in payload
+        assert elapsed < 1.0
+        assert (
+            worker.is_alive()
+        ), "the live-tab read waited for the two-second operation"
+        worker.join(timeout=3)
+        assert waiting == [(0, "Waited for 2.0 seconds")]
+
+        code, payload = client._request("close", headless=True)
+        assert code == 0, payload
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+    finally:
+        server._cleanup()
+        thread.join(timeout=3)
+        for path in (
+            address,
+            transport.pid_path(address),
+            transport.lock_path(address),
+        ):
+            with contextlib.suppress(OSError):
+                if os.path.exists(path):
+                    os.unlink(path)

--- a/tests/unit/test_async_browser_daemon.py
+++ b/tests/unit/test_async_browser_daemon.py
@@ -229,3 +229,59 @@ async def test_connection_cap_sheds_excess_without_spawning_more_work(daemon):
     for task in blockers:
         task.cancel()
     await asyncio.gather(*blockers, return_exceptions=True)
+
+
+class WakeConnection:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_windows_shutdown_discards_the_connection_that_wakes_accept(
+    daemon, monkeypatch
+):
+    connection = WakeConnection()
+
+    async def accepted(_fn):
+        daemon._closing = True
+        return connection
+
+    monkeypatch.setattr(daemon, "_transport_call", accepted)
+
+    await daemon._serve_windows()
+
+    assert connection.closed is True
+    assert daemon._client_tasks == set()
+
+
+def test_windows_shutdown_wakes_accept_before_closing_the_listener(
+    daemon, monkeypatch
+):
+    submitted = []
+
+    class Loop:
+        def run_in_executor(self, pool, fn):
+            submitted.append((pool, fn))
+
+    class Listener:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    listener = Listener()
+    pool = object()
+    daemon._loop = Loop()
+    daemon._transport_pool = pool
+    daemon._srv = listener
+    monkeypatch.setattr(daemon_module.transport, "IS_WINDOWS", True)
+
+    daemon._begin_shutdown()
+
+    assert daemon._closing is True
+    assert listener.closed is False
+    assert submitted == [(pool, daemon._wake_windows_accept)]

--- a/tests/unit/test_async_browser_daemon.py
+++ b/tests/unit/test_async_browser_daemon.py
@@ -1,0 +1,231 @@
+"""Concurrency contract for the 1.8 browser daemon.
+
+The wire may accept many clients at once, but one asyncio-owned browser runtime
+decides what can overlap: independent tabs progress together, one tab is ordered,
+and a claim race has exactly one winner.  Cancellation must remove only the
+request-scoped audit lease; durable tab ownership remains governed by the
+existing guard/declared-hold rules.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from connectonion.cli.browser_agent import daemon as daemon_module
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.useful_tools.browser_tools._async_browser import AsyncBrowserCore
+
+
+def envelope(line: str, *, caller: str, tab: str | None = None) -> str:
+    return json.dumps(
+        {"v": 1, "caller": caller, "account": "", "tab": tab, "line": line}
+    )
+
+
+class TimedBrowser(AsyncBrowserCore):
+    """No-driver probe that uses the real core's operation and tab locks."""
+
+    def __init__(self):
+        super().__init__(headless=True)
+        self.intervals: list[tuple[str | None, float, float]] = []
+        self.started = asyncio.Event()
+
+    async def slow(self, seconds: float = 0.1) -> str:
+        async with self._tab_operation(ensure_page=False):
+            key = self._bound_session_key()
+            start = time.monotonic()
+            self.started.set()
+            try:
+                await asyncio.sleep(seconds)
+            finally:
+                self.intervals.append((key, start, time.monotonic()))
+            return f"finished {key}"
+
+
+@pytest.fixture
+def daemon(tmp_path):
+    server = BrowserDaemon(str(tmp_path / "browser.sock"), headless=True)
+    server.browser = TimedBrowser()
+    return server
+
+
+def test_daemon_owns_async_core_without_global_browser_executor(tmp_path):
+    server = BrowserDaemon(str(tmp_path / "browser.sock"), headless=True)
+
+    assert isinstance(server.browser, AsyncBrowserCore)
+    assert not hasattr(server.browser, "_executor")
+
+
+async def open_tab(server: BrowserDaemon, name: str, caller: str) -> None:
+    ok, payload = await server.dispatch_async(
+        envelope(f"tab open {name} --who {caller}", caller=caller)
+    )
+    assert ok is True, payload
+
+
+@pytest.mark.asyncio
+async def test_independent_tabs_make_progress_concurrently(daemon):
+    await open_tab(daemon, "left", "left-agent")
+    await open_tab(daemon, "right", "right-agent")
+
+    started = time.monotonic()
+    results = await asyncio.gather(
+        daemon.dispatch_async(envelope("slow 0.15", caller="left-agent", tab="left")),
+        daemon.dispatch_async(envelope("slow 0.15", caller="right-agent", tab="right")),
+    )
+    elapsed = time.monotonic() - started
+
+    assert [result[0] for result in results] == [True, True]
+    assert elapsed < 0.26, "independent tabs were serialized by a global lane"
+    left, right = daemon.browser.intervals
+    assert min(left[2], right[2]) > max(left[1], right[1]), "operations did not overlap"
+
+
+@pytest.mark.asyncio
+async def test_same_tab_operations_are_serialized(daemon):
+    await open_tab(daemon, "only", "agent")
+
+    started = time.monotonic()
+    results = await asyncio.gather(
+        daemon.dispatch_async(envelope("slow 0.1", caller="agent", tab="only")),
+        daemon.dispatch_async(envelope("slow 0.1", caller="agent", tab="only")),
+    )
+    elapsed = time.monotonic() - started
+
+    assert [result[0] for result in results] == [True, True]
+    assert elapsed >= 0.18
+    first, second = daemon.browser.intervals
+    assert first[2] <= second[1]
+
+
+@pytest.mark.asyncio
+async def test_two_callers_racing_for_main_have_one_auditable_winner(daemon):
+    gate = asyncio.Event()
+
+    async def contend(caller: str):
+        await gate.wait()
+        return await daemon.dispatch_async(envelope("slow 0.05", caller=caller))
+
+    tasks = [
+        asyncio.create_task(contend("agent-a")),
+        asyncio.create_task(contend("agent-b")),
+    ]
+    gate.set()
+    results = await asyncio.gather(*tasks)
+
+    outcomes = [0 if result[0] is True else result[0] for result in results]
+    assert sorted(outcomes) == [0, 4]
+    assert len(daemon.browser.intervals) == 1
+    meta = daemon.browser._tab_meta[None]
+    assert meta["caller"] in {"agent-a", "agent-b"}
+    assert meta["last_line"] == "slow 0.05"
+    assert "active_requests" not in meta
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_clears_only_its_active_lease(daemon):
+    task = asyncio.create_task(
+        daemon.dispatch_async(envelope("slow 30", caller="owner"))
+    )
+    await daemon.browser.started.wait()
+
+    meta = daemon.browser._tab_meta[None]
+    assert len(meta["active_requests"]) == 1
+    ok, payload = await daemon.dispatch_async(
+        envelope("tab ls --json", caller="observer")
+    )
+    assert ok is True
+    active = json.loads(payload)[0]["active_requests"]
+    assert len(active) == 1
+    assert active[0]["caller"] == "owner"
+    assert active[0]["line"] == "slow 30"
+    assert active[0]["request_id"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "active_requests" not in meta
+    assert meta["caller"] == "owner", "cancellation erased durable ownership"
+    assert daemon.browser._active_operations == 0
+    assert daemon.browser._operations_idle.is_set()
+
+
+@pytest.mark.asyncio
+async def test_request_reader_rejects_oversized_payload(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "MAX_REQUEST_BYTES", 32)
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"x" * 33)
+    reader.feed_eof()
+
+    with pytest.raises(ValueError, match="32-byte limit"):
+        await daemon._read_posix_request(reader)
+
+
+@pytest.mark.asyncio
+async def test_request_deadline_bounds_a_stalled_client(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "REQUEST_TIMEOUT", 0.02)
+    reader = asyncio.StreamReader()
+
+    with pytest.raises(TimeoutError, match="request timed out"):
+        await daemon._read_posix_request(reader)
+
+
+class FakeTransport:
+    def __init__(self):
+        self.aborted = False
+
+    def abort(self):
+        self.aborted = True
+
+
+class BlockingWriter:
+    def __init__(self):
+        self.transport = FakeTransport()
+        self.payload = b""
+        self.closed = False
+
+    def write(self, payload: bytes):
+        self.payload += payload
+
+    async def drain(self):
+        await asyncio.Future()
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_slow_reader_cannot_hold_a_connection_forever(daemon, monkeypatch):
+    monkeypatch.setattr(daemon_module, "REPLY_TIMEOUT", 0.02)
+    reader = asyncio.StreamReader()
+    reader.feed_data(envelope("status", caller="observer").encode())
+    reader.feed_eof()
+    writer = BlockingWriter()
+
+    await daemon._handle_posix_client(reader, writer)
+
+    assert writer.payload.startswith(b"OK\n")
+    assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_connection_cap_sheds_excess_without_spawning_more_work(daemon):
+    blockers = {
+        asyncio.create_task(asyncio.sleep(30))
+        for _ in range(daemon_module.MAX_IN_FLIGHT)
+    }
+    daemon._client_tasks.update(blockers)
+    writer = BlockingWriter()
+
+    daemon._accept_posix_client(asyncio.StreamReader(), writer)
+
+    assert writer.transport.aborted is True
+    assert daemon._client_tasks == blockers
+    for task in blockers:
+        task.cancel()
+    await asyncio.gather(*blockers, return_exceptions=True)

--- a/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
+++ b/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
@@ -1,0 +1,70 @@
+"""A successful whole-browser close waits until that daemon has actually exited."""
+
+from connectonion.cli.browser_agent import client
+
+
+class _ReplyConnection:
+    def __init__(self, reply=b"OK\nBrowser closed. Session saved for next time."):
+        self.reply = reply
+
+    def send_bytes(self, request):
+        self.request = request
+
+    def recv_bytes(self):
+        return self.reply
+
+    def close(self):
+        pass
+
+
+def _windows_client(monkeypatch):
+    connection = _ReplyConnection()
+    monkeypatch.setattr(client.transport, "IS_WINDOWS", True)
+    monkeypatch.setattr(client, "default_sock_path", lambda: "pipe")
+    monkeypatch.setattr(client, "_connect", lambda _path: connection)
+    monkeypatch.setattr(client, "_caller_account", lambda: "")
+    monkeypatch.setattr(client, "_owner_pid", lambda _path: 4242)
+    return connection
+
+
+def test_whole_browser_close_waits_for_the_old_daemon_pid(monkeypatch):
+    _windows_client(monkeypatch)
+    alive = iter((True, True, False))
+    checked = []
+    sleeps = []
+
+    def pid_alive(pid):
+        checked.append(pid)
+        return next(alive)
+
+    monkeypatch.setattr(client.transport, "pid_alive", pid_alive)
+    monkeypatch.setattr(client.time, "sleep", sleeps.append)
+
+    assert client._request("close") == (
+        0,
+        "Browser closed. Session saved for next time.",
+    )
+    assert checked == [4242, 4242, 4242]
+    assert sleeps == [0.05, 0.05]
+
+
+def test_targeted_tab_close_does_not_wait_for_daemon_exit(monkeypatch):
+    _windows_client(monkeypatch)
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("close", tab="work")[0] == 0
+    assert checked == []
+
+
+def test_other_successful_commands_do_not_wait_for_daemon_exit(monkeypatch):
+    _windows_client(monkeypatch)
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("status")[0] == 0
+    assert checked == []

--- a/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
+++ b/tests/unit/test_browser_close_is_a_lifecycle_barrier.py
@@ -1,5 +1,7 @@
 """A successful whole-browser close waits until that daemon has actually exited."""
 
+import os
+
 from connectonion.cli.browser_agent import client
 
 
@@ -56,6 +58,18 @@ def test_targeted_tab_close_does_not_wait_for_daemon_exit(monkeypatch):
     )
 
     assert client._request("close", tab="work")[0] == 0
+    assert checked == []
+
+
+def test_in_process_embedded_daemon_does_not_wait_for_its_caller(monkeypatch):
+    _windows_client(monkeypatch)
+    monkeypatch.setattr(client, "_owner_pid", lambda _path: os.getpid())
+    checked = []
+    monkeypatch.setattr(
+        client.transport, "pid_alive", lambda pid: checked.append(pid) or True
+    )
+
+    assert client._request("close")[0] == 0
     assert checked == []
 
 

--- a/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
+++ b/tests/unit/test_the_browser_daemon_shuts_down_quietly.py
@@ -29,7 +29,6 @@ supposed to be serving is a real failure and must not be swallowed.
 """
 
 import shutil
-import socket
 import tempfile
 import threading
 from pathlib import Path
@@ -93,11 +92,11 @@ class TestClosingTheListenerStopsIt:
 class TestARealFailureStillRaises:
     """Swallowing every socket error would hide a daemon that broke while serving."""
 
-    def test_an_accept_error_while_serving_is_not_swallowed(self, server):
+    def test_a_bind_error_while_serving_is_not_swallowed(self, server):
         def explode():
             raise OSError("the listener broke while we were serving")
 
-        server._accept = explode
+        server._bind = explode
 
         with pytest.raises(OSError):
             server.serve()
@@ -106,7 +105,7 @@ class TestARealFailureStillRaises:
         def explode():
             raise ValueError("something else entirely")
 
-        server._accept = explode
+        server._bind = explode
 
         with pytest.raises(ValueError):
             server.serve()


### PR DESCRIPTION
## Summary

- replace the serial browser daemon loop with one asyncio-owned AsyncBrowserCore runtime
- serialize commands per tab while allowing independent tabs to progress concurrently
- make tab claim admission atomic and expose active request leases for auditability
- bound request size, connection count, reads, replies, and Windows transport workers
- cancel owned connection tasks and close browser resources deterministically at shutdown
- document the concurrency contract, operations guidance, and design decision

## Stack

Depends on #1288 and intentionally targets its branch until that PR is merged.

Tracks #499. The issue should close only after this stack is rebased onto main and merged.

## Verification

- 7,360 passed, 34 skipped, 164 deselected: full suite excluding real_api and slow
- 105 passed: candidate wheel browser daemon unit and native transport suite
- 1 passed: candidate wheel with real Chrome; second tab completed while first tab was blocked
- Ruff, compileall, and git diff --check passed
- wheel and sdist built successfully

## Release planning

**Proposed target version:** 1.8.0 / next alpha
**Estimated release window:** after #1288, this PR, #500, and paid browser artifact gates are complete

## Boundaries

The public synchronous BrowserAutomation facade remains for #500. This PR changes daemon internals only.