### PR TITLE
feat(browser): preserve sync API over async core

### DIFF
--- a/connectonion/useful_plugins/human_jitter.py
+++ b/connectonion/useful_plugins/human_jitter.py
@@ -9,8 +9,8 @@ Use it on sites whose terms permit automation.
 
 Data flow: before_each_tool event -> read agent.current_session['pending_tool'] ->
 if its name starts with 'click', grab the BrowserAutomation instance off the tool
-registry (agent.tools.browserautomation) and dispatch jitter() onto the browser's
-single worker thread (Playwright is not thread-safe).
+registry (agent.tools.browserautomation) and dispatch the async jitter routine onto
+the browser core's owning event loop (Playwright objects are loop-bound).
 
 Why before_each_tool (not after_tools): this is the only hook that fires
 synchronously between "LLM picked a click tool" and "Playwright performs the click",
@@ -25,6 +25,7 @@ if the page is mid-navigation when jitter reads the viewport, the click must sti
 proceed, so that transient failure is caught and logged, never raised.
 """
 
+import asyncio
 import random
 import time
 from typing import TYPE_CHECKING
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
 def jitter(page):
     """Wander the mouse through a few random points on the page.
 
-    Must run on the browser's worker thread (Playwright is single-threaded).
+    Legacy synchronous-driver helper; run it on that driver's owning thread.
     """
     w, h = page.evaluate("() => [window.innerWidth, window.innerHeight]")
     x = random.uniform(w * 0.2, w * 0.8)
@@ -51,15 +52,30 @@ def jitter(page):
         time.sleep(random.uniform(0.03, 0.12))
 
 
+async def _jitter_async(page):
+    """Async-driver variant, run on the browser core's owning event loop."""
+    if page is None:
+        return
+    w, h = await page.evaluate("() => [window.innerWidth, window.innerHeight]")
+    x = random.uniform(w * 0.2, w * 0.8)
+    y = random.uniform(h * 0.2, h * 0.8)
+    await page.mouse.move(x, y, steps=random.randint(8, 16))
+    for _ in range(random.randint(2, 4)):
+        x = min(max(x + random.uniform(-120, 120), 1), w - 1)
+        y = min(max(y + random.uniform(-90, 90), 1), h - 1)
+        await page.mouse.move(x, y, steps=random.randint(6, 14))
+        await asyncio.sleep(random.uniform(0.03, 0.12))
+
+
 def _jitter_before_click(agent: "Agent"):
     pending = agent.current_session.get("pending_tool") or {}
     if not pending.get("name", "").startswith("click"):
         return
     browser = getattr(agent.tools, "browserautomation", None)
-    if browser is None or getattr(browser, "page", None) is None:
+    if browser is None:
         return
     try:
-        browser._executor.submit(jitter, browser.page).result()
+        browser._run_on_runtime(lambda core: _jitter_async(core.page))
     except Exception as e:
         # Jitter is cosmetic; a mid-navigation page (viewport read throws) must not
         # block the click the agent actually asked for.

--- a/connectonion/useful_tools/browser_tools/__init__.py
+++ b/connectonion/useful_tools/browser_tools/__init__.py
@@ -1,10 +1,10 @@
 """
-Purpose: Public entry point for the built-in browser automation tools — exposes BrowserAutomation (Playwright-driven, anti-detection-tuned) and ElementNotFoundError so user agents can `from connectonion.useful_tools.browser_tools import BrowserAutomation`.
+Purpose: Public entry point for browser tools — exposes the synchronous BrowserAutomation facade over the async Patchright core and ElementNotFoundError.
 LLM-Note:
-  Dependencies: re-exports from [.browser.BrowserAutomation, .element_finder.ElementNotFoundError] | imported by [cli/browser_agent/agent.py, cli/templates/browser/agent.py, cli/templates/minimal/agent.py, user code] | sibling modules: browser.py (main automation class), element_finder.py (LLM-aided element locator), browser_config.py (Chrome args), highlight_screenshot.py, scroll.py
+  Dependencies: re-exports from [.browser.BrowserAutomation, .element_finder.ElementNotFoundError] | imported by [cli/browser_agent/agent.py, cli/templates/browser/agent.py, cli/templates/minimal/agent.py, user code] | browser.py copies the 1.7 public signatures/docstrings onto the async-core facade
   Data flow: aggregator only — no logic
   Integration: exposes BrowserAutomation, ElementNotFoundError
 """
 
-from .browser import BrowserAutomation
-from .element_finder import ElementNotFoundError
+from .browser import BrowserAutomation as BrowserAutomation
+from .element_finder import ElementNotFoundError as ElementNotFoundError

--- a/connectonion/useful_tools/browser_tools/_async_browser.py
+++ b/connectonion/useful_tools/browser_tools/_async_browser.py
@@ -4,12 +4,12 @@ LLM-Note:
   Dependencies: imports patchright.async_api, async element finding/humanization, browser_config/chrome_finder, and stdlib | imported by [future async daemon/runtime; tests during migration] | tested by [tests/unit/test_async_browser_core.py, tests/e2e/test_async_browser_core_real_driver.py]
   Data flow: caller binds a session in a ContextVar → each async operation acquires that tab's lock → the shared persistent context lazily creates/restores one page per session → model-selected actions await extraction and worker-thread matching → independent tab operations may interleave on one event loop
   State/Effects: persistent profile at $CO_BROWSER_PROFILE_DIR or ~/.co/browser_profile | one shared BrowserContext | per-session pages/metadata/restore URLs | cancellation-safe context and driver teardown
-  Integration: internal AsyncBrowserCore; the public synchronous BrowserAutomation remains unchanged until #500 adds its compatibility facade
+  Integration: internal AsyncBrowserCore; used directly by the daemon and through the public synchronous BrowserAutomation compatibility facade
   Errors: live profile ownership fails before driver start | launch/cancellation tears down partially-created driver state | destructive keyboard shortcuts fail closed outside editable focus | element ambiguity and non-match errors preserve the synchronous finder contract
 
-This module is deliberately internal while #498 is in progress. It must never
-import or call patchright.sync_api: the old public class remains the compatibility
-implementation until the async contract is complete and #500 installs the facade.
+This module is deliberately internal. It must never import or call
+``patchright.sync_api``: synchronous callers use the compatibility facade, which
+submits work to this core's owned event loop.
 """
 
 import asyncio

--- a/connectonion/useful_tools/browser_tools/_async_humanize.py
+++ b/connectonion/useful_tools/browser_tools/_async_humanize.py
@@ -4,7 +4,7 @@ LLM-Note:
   Dependencies: asyncio + stdlib-only humanize rules; no Patchright sync API | imported by [_async_browser.py] | tested by [tests/unit/test_async_browser_humanize.py]
   Data flow: known target → shared geometry/persona rules → awaited mouse/keyboard/CDP events with asyncio sleeps between events
   State/Effects: per-page cursor/CDP state | temporary OS clipboard mutation for CJK paste, serialized by the runtime clipboard lock and restored on cancellation
-  Integration: internal 1.8 async driver only; synchronous BrowserAutomation continues to use humanize.py until #500
+  Integration: internal 1.8 async driver; used by AsyncBrowserCore directly and by synchronous BrowserAutomation through its facade
   Errors: browser/CDP errors bubble; clipboard absence falls back to IME composition
 
 The synchronous input layer intentionally sleeps between low-level events. Calling

--- a/connectonion/useful_tools/browser_tools/_sync_browser_facade.py
+++ b/connectonion/useful_tools/browser_tools/_sync_browser_facade.py
@@ -1,0 +1,347 @@
+"""Synchronous compatibility facade over :class:`AsyncBrowserCore`.
+
+The public ``BrowserAutomation`` API predates asyncio.  Its implementation now
+uses the async browser driver, but callers still receive ordinary return values:
+one private event-loop thread owns the core and every synchronous call is
+submitted to that loop with the caller's tab binding.
+"""
+
+import asyncio
+import functools
+import inspect
+import threading
+from concurrent.futures import Future
+from typing import Any, Optional
+
+from ._async_browser import AsyncBrowserCore
+
+
+class BrowserAutomation:
+    """Backward-compatible synchronous browser automation.
+
+    Calls are safe from normal threads and from threads that already run an
+    asyncio loop.  Calling a synchronous method from this instance's own runtime
+    thread is rejected because waiting there would deadlock the browser loop.
+    """
+
+    def __init__(
+        self,
+        use_chrome_profile: bool = True,
+        headless: bool = False,
+        seed_state: Optional[str] = None,
+        tab_idle_ttl: float = 3600.0,
+        max_tabs: int = 10,
+    ) -> None:
+        self._core_kwargs = {
+            "use_chrome_profile": use_chrome_profile,
+            "headless": headless,
+            "seed_state": seed_state,
+            "tab_idle_ttl": tab_idle_ttl,
+            "max_tabs": max_tabs,
+        }
+        self._runtime_lock = threading.RLock()
+        self._runtime_ready = threading.Event()
+        self._runtime_thread: Optional[threading.Thread] = None
+        self._executor_thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._core: Optional[AsyncBrowserCore] = None
+        self._runtime_error: Optional[BaseException] = None
+        self._stopping = False
+        self._session_binding = threading.local()
+        self.form_data = {}
+        self._screenshots = []
+        self._ensure_runtime()
+
+    def _run_runtime(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            core = AsyncBrowserCore(**self._core_kwargs)
+            with self._runtime_lock:
+                self._loop = loop
+                self._core = core
+                self._executor_thread = threading.current_thread()
+                self._runtime_ready.set()
+            loop.run_forever()
+        except BaseException as exc:
+            with self._runtime_lock:
+                self._runtime_error = exc
+                self._runtime_ready.set()
+        finally:
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    def _ensure_runtime(self) -> None:
+        with self._runtime_lock:
+            if self._runtime_thread is not None and self._runtime_thread.is_alive():
+                return
+            self._runtime_ready = threading.Event()
+            self._runtime_error = None
+            thread = threading.Thread(
+                target=self._run_runtime,
+                name=f"browser-async-{id(self):x}",
+                daemon=True,
+            )
+            self._runtime_thread = thread
+            thread.start()
+        self._runtime_ready.wait()
+        if self._runtime_error is not None:
+            raise RuntimeError("browser async runtime failed to start") from self._runtime_error
+
+    def _bound_session_key(self):
+        return getattr(self._session_binding, "key", None)
+
+    def _bind_session(self, session_id) -> None:
+        """Bind subsequent calls on this caller thread to one browser tab."""
+        self._session_binding.key = session_id
+
+    def _submit(self, awaitable) -> Any:
+        self._ensure_runtime()
+        thread, loop = self._runtime_thread, self._loop
+        if threading.current_thread() is thread:
+            if inspect.iscoroutine(awaitable):
+                awaitable.close()
+            raise RuntimeError(
+                "synchronous BrowserAutomation methods cannot run on their own "
+                "async runtime thread"
+            )
+        if loop is None:
+            raise RuntimeError("browser async runtime is not available")
+        future: Future = asyncio.run_coroutine_threadsafe(awaitable, loop)
+        try:
+            return future.result()
+        except BaseException:
+            future.cancel()
+            raise
+
+    def _invoke(self, name: str, *args, _during_stop: bool = False, **kwargs):
+        with self._runtime_lock:
+            if self._stopping and not _during_stop:
+                raise RuntimeError("browser async runtime is closing")
+        session = self._bound_session_key()
+
+        async def call():
+            core = self._core
+            if core is None:
+                raise RuntimeError("browser async runtime is not available")
+            core._bind_session(session)
+            result = getattr(core, name)(*args, **kwargs)
+            return await result if inspect.isawaitable(result) else result
+
+        return self._submit(call())
+
+    def _run_on_runtime(self, callback):
+        """Run an internal diagnostic callback beside the async core.
+
+        Public browser work should use the stable methods. This seam exists for
+        in-repository adapters such as detector harnesses and input plugins that
+        must use driver objects without crossing the event-loop thread boundary.
+        """
+        with self._runtime_lock:
+            if self._stopping:
+                raise RuntimeError("browser async runtime is closing")
+        session = self._bound_session_key()
+
+        async def call():
+            core = self._core
+            if core is None:
+                raise RuntimeError("browser async runtime is not available")
+            core._bind_session(session)
+            result = callback(core)
+            return await result if inspect.isawaitable(result) else result
+
+        return self._submit(call())
+
+    def _read_core_attr(self, name: str, default=None):
+        with self._runtime_lock:
+            live = (
+                not self._stopping
+                and self._runtime_thread is not None
+                and self._runtime_thread.is_alive()
+            )
+        if not live:
+            return default
+
+        async def read():
+            return getattr(self._core, name, default)
+
+        return self._submit(read())
+
+    @property
+    def page(self):
+        session = self._bound_session_key()
+        with self._runtime_lock:
+            live = (
+                not self._stopping
+                and self._runtime_thread is not None
+                and self._runtime_thread.is_alive()
+            )
+        if not live:
+            return None
+
+        async def read():
+            self._core._bind_session(session)
+            return self._core.page
+
+        return self._submit(read())
+
+    @page.setter
+    def page(self, value) -> None:
+        session = self._bound_session_key()
+
+        async def write():
+            self._core._pages[session] = value
+            self._core._page_used[session] = asyncio.get_running_loop().time()
+
+        self._submit(write())
+
+    @property
+    def browser(self):
+        return self._read_core_attr("browser")
+
+    @property
+    def playwright(self):
+        return self._read_core_attr("playwright")
+
+    @property
+    def last_screenshot_path(self):
+        return self._read_core_attr("last_screenshot_path")
+
+    @property
+    def screenshots_dir(self):
+        return self._read_core_attr("screenshots_dir")
+
+    @screenshots_dir.setter
+    def screenshots_dir(self, value) -> None:
+        async def write():
+            self._core.screenshots_dir = value
+
+        self._submit(write())
+
+    @property
+    def _pages(self):
+        return self._read_core_attr("_pages", {})
+
+    @property
+    def _page_used(self):
+        return self._read_core_attr("_page_used", {})
+
+    @property
+    def _page_url(self):
+        return self._read_core_attr("_page_url", {})
+
+    @property
+    def _tab_meta(self):
+        return self._read_core_attr("_tab_meta", {})
+
+    @property
+    def _headless(self):
+        return self._read_core_attr("_headless", self._core_kwargs["headless"])
+
+    @property
+    def use_chrome_profile(self):
+        return self._core_kwargs["use_chrome_profile"]
+
+    def _context_is_alive(self) -> bool:
+        return bool(self._invoke("is_alive"))
+
+    def _browser_is_usable(self) -> bool:
+        return self._context_is_alive() and self.page is not None
+
+    def _launch_failed(self) -> bool:
+        return bool(
+            self._read_core_attr("playwright") is not None
+            and self._read_core_attr("browser") is None
+        )
+
+    def close(self) -> str:
+        """Close the bound tab, or fully stop the unbound browser runtime."""
+        session = self._bound_session_key()
+        with self._runtime_lock:
+            live = self._runtime_thread is not None and self._runtime_thread.is_alive()
+        if not live:
+            return "Browser closed"
+
+        if session is not None:
+            result = self._invoke("close")
+            if result == "Browser tab closed for this session.":
+                return "Closed this session's browser tab."
+            return result
+
+        with self._runtime_lock:
+            self._stopping = True
+        try:
+            result = self._invoke("close", _during_stop=True)
+            with self._runtime_lock:
+                loop, thread = self._loop, self._runtime_thread
+                if loop is not None:
+                    loop.call_soon_threadsafe(loop.stop)
+            if thread is not None and thread is not threading.current_thread():
+                thread.join(timeout=15)
+                if thread.is_alive():
+                    raise RuntimeError(
+                        "browser async runtime did not stop within 15 seconds"
+                    )
+            with self._runtime_lock:
+                self._loop = None
+                self._core = None
+                self._runtime_thread = None
+                self._executor_thread = None
+        finally:
+            with self._runtime_lock:
+                self._stopping = False
+        if result == "Browser closed. Session saved for next time.":
+            return "Browser closed"
+        return result
+
+    def _teardown(self) -> str:
+        return self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+
+def _install_sync_methods() -> None:
+    """Mirror every public async-core method without duplicating its signature."""
+    for name, method in inspect.getmembers(AsyncBrowserCore, inspect.isfunction):
+        if (
+            name.startswith("_")
+            or name in {"close", "is_alive"}
+            or not inspect.iscoroutinefunction(method)
+        ):
+            continue
+
+        @functools.wraps(method)
+        def call(self, *args, __name=name, **kwargs):
+            return self._invoke(__name, *args, **kwargs)
+
+        setattr(BrowserAutomation, name, call)
+
+
+_install_sync_methods()
+
+
+def adopt_legacy_contract(legacy_class) -> None:
+    """Copy the established public descriptions onto the facade methods.
+
+    Agent tool schemas and ``co browser help`` consume first-line docstrings, so
+    preserving signatures alone is not enough compatibility.
+    """
+    BrowserAutomation.__doc__ = legacy_class.__doc__
+    for name, legacy_method in inspect.getmembers(legacy_class, inspect.isfunction):
+        if name.startswith("_") or not hasattr(BrowserAutomation, name):
+            continue
+        method = getattr(BrowserAutomation, name)
+        method.__doc__ = legacy_method.__doc__
+        method.__signature__ = inspect.signature(legacy_method)

--- a/connectonion/useful_tools/browser_tools/browser.py
+++ b/connectonion/useful_tools/browser_tools/browser.py
@@ -2338,3 +2338,14 @@ SYSTEM REMINDER: Please use take_screenshot() to verify the text was typed into 
         """Context manager exit - ensures browser closes and saves context."""
         self.close()
         return False
+
+
+# Keep the implementation available for one release as an internal comparison
+# oracle while the public name moves to the async-core compatibility facade.
+LegacyBrowserAutomation = BrowserAutomation
+from ._sync_browser_facade import (  # noqa: E402
+    BrowserAutomation,
+    adopt_legacy_contract,
+)
+
+adopt_legacy_contract(LegacyBrowserAutomation)

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -240,9 +240,11 @@ Planning window: weeks 1–3. Workstreams run in parallel.
 
 Canonical issues: #498, #499, #500, #1151, and the reliability remainder of #1248/#1250.
 
-The public Python class still has a synchronous Patchright worker until #500.
-The internal core is async, and the #499 daemon slice owns it directly on one
-event loop. Preserve public behavior while completing the remaining facade.
+The internal core and #499 daemon are async. The #500 implementation now places
+the public synchronous `BrowserAutomation` surface over a private owned event-loop
+thread, including defined running-loop behavior, same-signature delegation, and
+deterministic thread shutdown. Hosted cross-platform validation and review remain
+before the slice can be merged.
 
 Implementation order:
 

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -33,8 +33,9 @@ The first vertical slice is implemented but deliberately not released:
   native-browser, installed-wheel, and hosted audit in PR #1288; merge still needs
   explicit release-authority approval. The stacked #499 slice replaces serial
   dispatch with bounded asyncio client tasks, atomic request leases, per-tab
-  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. #500
-  remains the downstream synchronous-facade boundary.
+  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. The
+  stacked #500 slice now places the stable synchronous API over that async core;
+  hosted validation and review remain before either downstream slice can merge.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,

--- a/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
+++ b/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
@@ -1,36 +1,50 @@
-# Sync on the outside, async on the inside
+# The browser worked until the caller already had a loop
 
-Changing a browser driver from synchronous to asynchronous is easy if every caller
-can change with it. `BrowserAutomation` could not make that bargain. It is already
-used as an Agent tool, in context managers, in scripts, and from server workers.
-Making every method return a coroutine would turn an internal driver migration into
-a public breaking change.
+The async browser migration looked finished. The daemon could keep two tabs moving
+at once, a blocked navigation no longer froze every client, and the old global
+Playwright worker was gone. Then we tried the most ordinary server-side call:
 
-ConnectOnion 1.8 keeps the old surface and changes the ownership underneath it.
-Each `BrowserAutomation` instance owns one private thread, one asyncio event loop,
-and one async browser core. A normal method call captures the caller's session-tab
-binding, submits the matching coroutine to that loop, waits for the result, and
-returns the same ordinary Python value as before.
+```python
+async def handle_request():
+    browser.go_to("https://example.com")
+```
 
-The thread boundary matters most when the caller already has an event loop. Calling
-`asyncio.run()` there would fail with a nested-loop error. Running the browser loop
-in its own thread gives this case defined behavior: the synchronous call blocks its
-caller, while the browser runtime continues normally. The inverse case is rejected.
-If code somehow invokes the synchronous facade from the browser's own runtime
-thread, waiting would deadlock that loop, so the call raises a direct `RuntimeError`.
+`BrowserAutomation` has always been synchronous, so existing applications quite
+reasonably call it from request handlers that already own an asyncio loop. Our first
+facade tried to run the new coroutine with `asyncio.run()`. Python answered with the
+error it reserves for exactly this mistake: an event loop was already running.
 
-Shutdown is part of the compatibility contract, not cleanup trivia. A session-bound
-`close()` releases only that tab and leaves the shared runtime alive. An unbound
-`close()` waits for the async core to finish closing its pages, context, and driver,
-then stops and joins the event-loop thread. Repeated construction and close cycles
-therefore do not accumulate loops or threads, and repeated close calls are harmless.
+Making `go_to()` async would have made the error disappear, but only by handing it to
+every user. Agent tools, scripts, context managers, and server workers would all have
+to change for what was supposed to be an internal driver replacement.
 
-The useful tests operate at the boundary. They compare every public method name and
-signature with the previous class, call the facade from inside an already-running
-event loop, carry a session binding across the thread hop, attempt the forbidden
-same-thread call, and repeat create/close cycles while retaining each old thread so
-the test can prove all of them stopped.
+The turn came from treating the loop as an owned resource instead of something to
+borrow from the caller. Each facade now starts one private thread and one asyncio
+loop. A synchronous call carries its session-tab binding across that boundary,
+submits the core coroutine, waits, and returns the same ordinary value as before.
+The request handler's loop is no longer nested or commandeered.
 
-The public API did not become async. Its implementation did. That distinction lets
-existing code keep working while the daemon and direct Python tools finally share
-one browser architecture.
+That solution created a second trap. We scheduled a facade call from its own browser
+thread to see what would happen. The thread submitted work to its loop and then
+waited for the result; the loop could not run the work because its only thread was
+waiting. Nothing crashed. Nothing timed out. It simply stopped.
+
+The fix is intentionally blunt: a synchronous facade call made from the owned
+runtime thread raises `RuntimeError` before submission. A test schedules that exact
+mistake on the loop and proves it fails instead of deadlocking.
+
+Shutdown exposed the ownership rule one more time. A hosted session's `close()` must
+release one tab, while an unbound `close()` must close the shared browser, stop the
+loop, and join the thread. We retained every thread from repeated create-and-close
+cycles in a test; if even one remained alive, the compatibility layer was not done.
+
+The last surprise came from a repository search after the facade tests were green.
+The stealth detector harness and the opt-in `human_jitter` plugin still reached into
+the deleted private executor. They now use a narrow internal callback that runs
+beside the async core on its owning loop. Driver objects no longer leak across the
+thread boundary just because a diagnostic or plugin needs raw page work.
+
+The lesson was not merely "put asyncio on another thread." Compatibility depends on
+making ownership visible: who owns the loop, which session owns the tab, who may
+block, and who must join at shutdown. Once those answers became executable tests,
+the public API could stay synchronous while its implementation finally became async.

--- a/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
+++ b/docs/blog/2026-08-26-sync-on-the-outside-async-on-the-inside.md
@@ -1,0 +1,36 @@
+# Sync on the outside, async on the inside
+
+Changing a browser driver from synchronous to asynchronous is easy if every caller
+can change with it. `BrowserAutomation` could not make that bargain. It is already
+used as an Agent tool, in context managers, in scripts, and from server workers.
+Making every method return a coroutine would turn an internal driver migration into
+a public breaking change.
+
+ConnectOnion 1.8 keeps the old surface and changes the ownership underneath it.
+Each `BrowserAutomation` instance owns one private thread, one asyncio event loop,
+and one async browser core. A normal method call captures the caller's session-tab
+binding, submits the matching coroutine to that loop, waits for the result, and
+returns the same ordinary Python value as before.
+
+The thread boundary matters most when the caller already has an event loop. Calling
+`asyncio.run()` there would fail with a nested-loop error. Running the browser loop
+in its own thread gives this case defined behavior: the synchronous call blocks its
+caller, while the browser runtime continues normally. The inverse case is rejected.
+If code somehow invokes the synchronous facade from the browser's own runtime
+thread, waiting would deadlock that loop, so the call raises a direct `RuntimeError`.
+
+Shutdown is part of the compatibility contract, not cleanup trivia. A session-bound
+`close()` releases only that tab and leaves the shared runtime alive. An unbound
+`close()` waits for the async core to finish closing its pages, context, and driver,
+then stops and joins the event-loop thread. Repeated construction and close cycles
+therefore do not accumulate loops or threads, and repeated close calls are harmless.
+
+The useful tests operate at the boundary. They compare every public method name and
+signature with the previous class, call the facade from inside an already-running
+event loop, carry a session binding across the thread hop, attempt the forbidden
+same-thread call, and repeat create/close cycles while retaining each old thread so
+the test can prove all of them stopped.
+
+The public API did not become async. Its implementation did. That distinction lets
+existing code keep working while the daemon and direct Python tools finally share
+one browser architecture.

--- a/docs/design-decisions/054-one-async-browser-runtime.md
+++ b/docs/design-decisions/054-one-async-browser-runtime.md
@@ -56,9 +56,10 @@ The migration has three review boundaries:
    `BrowserAutomation` methods submit to an owned loop thread without nesting a
    caller's running event loop. The facade is compatibility, not a second driver.
 
-The internal core is not exported as a public user API. The daemon now owns it
-directly; the current synchronous Python API remains authoritative until #500's
-facade and cross-platform compatibility matrices are green.
+The internal core is not exported as a public user API. The daemon owns it
+directly; the synchronous Python API remains authoritative and now delegates
+through #500's facade. That facade still requires green cross-platform matrices
+before merge.
 
 The #499 transport boundary keeps claim admission separate from page execution.
 A registry lock performs unknown-tab validation, claim takeover/refusal, and a

--- a/docs/useful_plugins/human_jitter.md
+++ b/docs/useful_plugins/human_jitter.md
@@ -20,7 +20,7 @@ agent.input("open the menu and click Settings")
 
 1. On `before_each_tool`, reads `agent.current_session['pending_tool']`.
 2. If its name starts with `click`, grabs the `BrowserAutomation` instance off the tool registry (`agent.tools.browserautomation`).
-3. Dispatches `jitter()` onto the browser's single worker thread: the cursor moves to a random point, then random-walks through a few more, with short pauses.
+3. Dispatches an async jitter routine onto the browser core's owning event loop: the cursor moves to a random point, then random-walks through a few more, with short pauses.
 
 Jitter is best-effort. If the page is mid-navigation when it reads the viewport, the failure is caught and logged so the click the agent asked for can still proceed.
 

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -304,15 +304,14 @@ agent.input("Navigate to github.com/trending and screenshot the page")
 agent.input("Fill in the contact form on example.com with test data")
 ```
 
-One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public methods are serialized onto one internal browser worker thread, so Playwright's sync API is always called from the thread that owns it. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
+One `BrowserAutomation` instance is safe to reuse across turns and concurrent hosted sessions. Public calls remain synchronous, but the facade submits them to one owned async browser runtime. When `bind_browser_session` is enabled, each hosted session gets its own tab in the shared browser context.
 
-That worker-thread behavior remains the public Python contract until #500 adds
-the compatibility facade. The replacement core is still internal; do not import
-it as an application API. The `co browser` daemon now owns that async core
-directly: independent tabs interleave, same-tab operations serialize, and the
-POSIX/Windows transports bound connections, reads, writes, and shutdown. The
-lifecycle, concurrency, cancellation, and compatibility boundaries are recorded
-in [DD-054](../design-decisions/054-one-async-browser-runtime.md).
+The async core remains internal; do not import it as an application API. Both the
+facade and `co browser` daemon use that core: independent tabs interleave,
+same-tab operations serialize, and the POSIX/Windows transports bound
+connections, reads, writes, and shutdown. The lifecycle, concurrency,
+cancellation, and compatibility boundaries are recorded in
+[DD-054](../design-decisions/054-one-async-browser-runtime.md).
 `BrowserAutomation` remains the supported Python API.
 
 ## Common Patterns

--- a/docs/useful_tools/browser_tools.md
+++ b/docs/useful_tools/browser_tools.md
@@ -34,6 +34,25 @@ with BrowserAutomation() as browser:
     browser.close()
 ```
 
+### Synchronous API, async runtime
+
+`BrowserAutomation` remains synchronous in 1.8: existing calls, context managers,
+method names, signatures, and return values do not require an `await`. Internally,
+the class owns one async browser core on a private event-loop thread. This removes
+the old synchronous Patchright implementation from the execution path while
+preserving existing Python and Agent integrations.
+
+Calling these synchronous methods from a thread that already runs an asyncio loop
+is supported; the call blocks that caller until its browser operation completes.
+Calling from the browser's own private runtime thread raises a clear `RuntimeError`
+instead of deadlocking. An unbound `close()` closes the shared browser and joins the
+runtime thread; a session-bound `close()` releases only that session's tab.
+
+Compatibility policy for 1.8: no public `BrowserAutomation` method is deprecated,
+and the async core remains internal. `LegacyBrowserAutomation` is an internal test
+oracle for comparing the 1.7 contract; it is not a supported import and may be
+removed after the 1.8 transition without a deprecation period.
+
 ## Persistent Profile
 
 Browser state (cookies, sessions, localStorage) is saved automatically to `~/.co/browser_profile/`. On subsequent runs the browser is already logged into any site you've previously authenticated.

--- a/tests/e2e/cli/test_browser_stealth_e2e.py
+++ b/tests/e2e/cli/test_browser_stealth_e2e.py
@@ -13,8 +13,8 @@ skip cleanly in a plain CI shell with no DISPLAY, and skip an individual site if
 third party is down (5xx / unreachable) rather than failing on someone else's outage.
 """
 
-import os
 import json
+import os
 import platform
 import re
 import statistics
@@ -56,8 +56,8 @@ def stealth_browser():
 
 
 def _eval(browser, js):
-    """Evaluate JS on the browser worker thread (the page is thread-bound)."""
-    return browser._executor.submit(lambda: browser.page.evaluate(js)).result()
+    """Evaluate JS on the async-core runtime thread (the page is loop-bound)."""
+    return browser._run_on_runtime(lambda core: core.page.evaluate(js))
 
 
 def _text(browser):

--- a/tests/e2e/test_a_dead_context_is_not_reported_open.py
+++ b/tests/e2e/test_a_dead_context_is_not_reported_open.py
@@ -49,7 +49,9 @@ closes it.
 
 import pytest
 
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 
 try:

--- a/tests/unit/test_a_server_with_no_display_runs_headless.py
+++ b/tests/unit/test_a_server_with_no_display_runs_headless.py
@@ -94,7 +94,7 @@ class TestTheBrowserItselfHonoursIt:
         try:
             assert automation._headless is True
         finally:
-            automation._executor.shutdown(wait=False)
+            automation.close()
 
     @pytest.mark.skipif(platform.system() != "Darwin", reason="desktop-only claim")
     def test_a_desktop_still_gets_a_window(self):
@@ -102,7 +102,7 @@ class TestTheBrowserItselfHonoursIt:
         try:
             assert automation._headless is False
         finally:
-            automation._executor.shutdown(wait=False)
+            automation.close()
 
 
 # The advice for a launch failure is not tested here. It moved to

--- a/tests/unit/test_async_browser_core.py
+++ b/tests/unit/test_async_browser_core.py
@@ -1,8 +1,8 @@
 """Contract tests for the internal 1.8 Patchright async browser core.
 
-The public synchronous BrowserAutomation remains unchanged until #500. These
-tests prove the new core itself is genuinely async, preserves per-session tabs,
-and cleans up deterministically before #499 puts concurrent IPC in front of it.
+The public synchronous BrowserAutomation delegates through the #500 facade. These
+tests prove the underlying core itself is genuinely async, preserves per-session
+tabs, and cleans up deterministically behind #499's concurrent IPC.
 """
 
 import ast

--- a/tests/unit/test_browser_automation.py
+++ b/tests/unit/test_browser_automation.py
@@ -95,7 +95,7 @@ def test_open_browser_is_noop_when_context_is_already_open(monkeypatch, tmp_path
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
 
     first_result = browser.open_browser()
     first_context = contexts[0]
@@ -142,7 +142,7 @@ def test_open_browser_force_reopens_existing_context(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     first_context = contexts[0]
     first_page = first_context.page
@@ -187,7 +187,7 @@ def test_open_browser_reopens_stale_context(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: FakeSyncPlaywright())
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     first_context = contexts[0]
     first_page = first_context.page
@@ -205,7 +205,7 @@ def test_open_browser_reopens_stale_context(monkeypatch, tmp_path):
 
 
 def test_close_reports_cleanup_warnings_and_clears_state():
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     page = FakePage()
     page.close()
     context = FakeContext()
@@ -272,7 +272,7 @@ def test_seed_state_injects_exported_cookies(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True, seed_state=str(state))
+    browser = browser_mod.LegacyBrowserAutomation(headless=True, seed_state=str(state))
     browser.open_browser()
 
     assert contexts[0].added_cookies == cookies
@@ -284,7 +284,7 @@ def test_no_seed_state_injects_nothing(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
 
     assert contexts[0].added_cookies is None
@@ -296,7 +296,7 @@ def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
     monkeypatch.setattr(browser_mod, "sync_playwright", lambda: _recording_playwright(contexts))
     monkeypatch.setattr(browser_mod.Path, "home", lambda: tmp_path)
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.open_browser()
     out = tmp_path / "exported.json"
     result = browser.save_state(str(out))
@@ -306,7 +306,7 @@ def test_save_state_exports_storage_state_to_path(monkeypatch, tmp_path):
 
 
 def test_save_state_without_browser_reports_not_open():
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
 
     assert browser.save_state("/tmp/whatever.json") == "Browser not open"
 
@@ -321,7 +321,7 @@ def test_wait_for_manual_login_refuses_without_tty(monkeypatch):
 
     monkeypatch.setattr(browser_mod.sys, "stdin", _NoTTY())
 
-    browser = browser_mod.BrowserAutomation(headless=True)
+    browser = browser_mod.LegacyBrowserAutomation(headless=True)
     browser.browser = FakeContext()
     try:
         result = browser.wait_for_manual_login("Example")

--- a/tests/unit/test_browser_session_pages.py
+++ b/tests/unit/test_browser_session_pages.py
@@ -13,7 +13,9 @@ import threading
 
 import pytest
 
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 # No reset fixture needed: the session binding is owned by each BrowserAutomation
 # instance (per instance, per thread), so a fresh instance per test starts unbound.

--- a/tests/unit/test_browser_tools.py
+++ b/tests/unit/test_browser_tools.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 
 from connectonion.useful_tools.browser_tools import browser as browser_module
-from connectonion.useful_tools.browser_tools.browser import BrowserAutomation
+from connectonion.useful_tools.browser_tools.browser import (
+    LegacyBrowserAutomation as BrowserAutomation,
+)
 
 
 class FakePage:

--- a/tests/unit/test_human_jitter.py
+++ b/tests/unit/test_human_jitter.py
@@ -1,0 +1,49 @@
+"""Compatibility tests for human_jitter on the async browser runtime."""
+
+import asyncio
+import importlib
+from types import SimpleNamespace
+
+jitter_module = importlib.import_module("connectonion.useful_plugins.human_jitter")
+
+
+def test_jitter_runs_page_work_on_browser_runtime(monkeypatch):
+    moves = []
+
+    class Mouse:
+        async def move(self, x, y, steps):
+            moves.append((x, y, steps))
+
+    class Page:
+        mouse = Mouse()
+
+        async def evaluate(self, script):
+            assert script == "() => [window.innerWidth, window.innerHeight]"
+            return [1000, 800]
+
+    class Browser:
+        def __init__(self):
+            self.core = SimpleNamespace(page=Page())
+            self.callbacks = 0
+
+        def _run_on_runtime(self, callback):
+            self.callbacks += 1
+            return asyncio.run(callback(self.core))
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr(jitter_module.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(jitter_module.random, "uniform", lambda start, end: start)
+    monkeypatch.setattr(jitter_module.random, "randint", lambda start, end: start)
+    browser = Browser()
+    agent = SimpleNamespace(
+        current_session={"pending_tool": {"name": "click"}},
+        tools=SimpleNamespace(browserautomation=browser),
+        logger=SimpleNamespace(print=lambda message: None),
+    )
+
+    jitter_module._jitter_before_click(agent)
+
+    assert browser.callbacks == 1
+    assert len(moves) == 3

--- a/tests/unit/test_sync_browser_facade.py
+++ b/tests/unit/test_sync_browser_facade.py
@@ -1,0 +1,145 @@
+"""Contract tests for the public sync facade over the async browser core."""
+
+import asyncio
+import contextvars
+import inspect
+import threading
+
+import pytest
+
+from connectonion.useful_tools.browser_tools import BrowserAutomation as PublicBrowserAutomation
+from connectonion.useful_tools.browser_tools import _sync_browser_facade as facade
+from connectonion.useful_tools.browser_tools.browser import LegacyBrowserAutomation
+
+
+class FakeAsyncCore:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.session = contextvars.ContextVar("fake_browser_session", default=None)
+        self.calls = []
+        self.browser = object()
+        self.playwright = object()
+        self._pages = {}
+        self._page_used = {}
+        self._page_url = {}
+        self._tab_meta = {}
+        self._headless = kwargs["headless"]
+        self.screenshots_dir = ".tmp"
+        self.last_screenshot_path = None
+
+    def _bind_session(self, session):
+        self.session.set(session)
+
+    async def tab_status(self):
+        await asyncio.sleep(0)
+        call = (self.session.get(), threading.current_thread())
+        self.calls.append(call)
+        return f"tab:{call[0]}"
+
+    async def close(self):
+        await asyncio.sleep(0)
+        if self.session.get() is not None:
+            return "Browser tab closed for this session."
+        self.browser = None
+        self.playwright = None
+        return "Browser closed. Session saved for next time."
+
+
+@pytest.fixture
+def browser(monkeypatch):
+    monkeypatch.setattr(facade, "AsyncBrowserCore", FakeAsyncCore)
+    value = facade.BrowserAutomation(headless=True)
+    try:
+        yield value
+    finally:
+        value._bind_session(None)
+        value.close()
+
+
+def test_public_surface_and_signatures_stay_identical():
+    assert PublicBrowserAutomation is facade.BrowserAutomation
+    legacy = {
+        name: method
+        for name, method in inspect.getmembers(
+            LegacyBrowserAutomation, inspect.isfunction
+        )
+        if not name.startswith("_")
+    }
+    public = {
+        name: method
+        for name, method in inspect.getmembers(facade.BrowserAutomation, inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+    assert set(public) == set(legacy)
+    for name, method in public.items():
+        assert inspect.signature(method) == inspect.signature(legacy[name]), name
+
+
+def test_sync_call_from_running_event_loop_is_defined(browser):
+    async def caller():
+        return browser.tab_status()
+
+    assert asyncio.run(caller()) == "tab:None"
+    assert browser._core.calls[0][1] is browser._runtime_thread
+
+
+def test_session_binding_crosses_the_thread_boundary(browser):
+    browser._bind_session("checkout")
+
+    assert browser.tab_status() == "tab:checkout"
+
+
+def test_internal_detector_callback_stays_on_the_runtime(browser):
+    browser._bind_session("detector")
+
+    session, thread = browser._run_on_runtime(
+        lambda core: (core.session.get(), threading.current_thread())
+    )
+
+    assert session == "detector"
+    assert thread is browser._runtime_thread
+
+
+def test_call_from_owned_runtime_thread_fails_instead_of_deadlocking(browser):
+    done = threading.Event()
+    outcome = []
+
+    def call_on_runtime():
+        try:
+            browser.tab_status()
+        except Exception as exc:
+            outcome.append(exc)
+        finally:
+            done.set()
+
+    browser._loop.call_soon_threadsafe(call_on_runtime)
+
+    assert done.wait(2)
+    assert isinstance(outcome[0], RuntimeError)
+    assert "own async runtime thread" in str(outcome[0])
+
+
+def test_bound_close_keeps_runtime_and_unbound_close_stops_it(browser):
+    thread = browser._runtime_thread
+    browser._bind_session("one")
+
+    assert browser.close() == "Closed this session's browser tab."
+    assert thread.is_alive()
+
+    browser._bind_session(None)
+    assert browser.close() == "Browser closed"
+    assert not thread.is_alive()
+    assert browser.close() == "Browser closed"
+
+
+def test_repeated_create_and_close_leaves_no_runtime_thread(monkeypatch):
+    monkeypatch.setattr(facade, "AsyncBrowserCore", FakeAsyncCore)
+    threads = []
+
+    for _ in range(5):
+        browser = facade.BrowserAutomation()
+        threads.append(browser._runtime_thread)
+        assert browser.close() == "Browser closed"
+
+    assert all(not thread.is_alive() for thread in threads)


### PR DESCRIPTION
**Proposed target version:** 1.8.0 / next alpha
**Estimated release window:** after #1288 and #1289, before the 1.8 alpha entry gate
**Forward-port tracking issue (stable patches only):** not applicable

Closes #500

## Problem

The 1.8 browser driver and daemon are async, but existing Python callers and Agent tools depend on the synchronous BrowserAutomation contract. Nested asyncio.run calls would fail for server callers that already own an event loop, while waiting on the browser runtime thread would deadlock.

## Approach

- expose the existing public BrowserAutomation names, signatures, docstrings, context-manager behavior, and ordinary return values through a sync facade;
- own one AsyncBrowserCore, asyncio loop, and private runtime thread per facade instance;
- propagate the caller session binding across the thread boundary for every operation;
- support calls from threads that already run an asyncio loop;
- reject calls made from the owned runtime thread with a clear RuntimeError;
- make bound close release one tab and unbound close deterministically stop and join the runtime;
- migrate the stealth detector harness and `human_jitter` plugin from the removed private executor to a loop-owned internal adapter;
- retain the 1.7 implementation only as an internal comparison oracle while contract tests migrate;
- document the compatibility and deprecation boundary, update the 1.8 plan, and add the required engineering blog.

## Verification

- 126 focused async-core, facade, public-contract, headless, session, browser-tool, and `human_jitter` tests passed locally.
- 95 native daemon socket tests pass on macOS after the stacked #1289 lifecycle fix.
- The real stealth E2E module collects successfully against the facade; real Chrome execution remains a hosted authority because the managed local sandbox blocks Crashpad.
- Ruff passes for all new/modified facade boundary files.
- `git diff --check` passes.

## Stack

This PR is intentionally based on #1289 because issue #500 depends on #498 and #499. Merge order: #1288, #1289, then this PR.
