### PR TITLE
docs: add the ConnectOnion 1.8 execution plan

### DIFF
--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -1,0 +1,673 @@
+# ConnectOnion 1.8 development plan
+
+Status: active execution plan; first paid-engine slice and 1.9 preview boundary implemented in draft PRs  
+Prepared: 2026-08-25; execution checkpoint updated 2026-08-26  
+Release authority: [connectonion#1154](https://github.com/openonion/connectonion/issues/1154)
+
+## Execution checkpoint — 2026-08-26
+
+The first vertical slice is implemented but deliberately not released:
+
+- `oo-api` PR #183 implements the signed exact-platform manifest, non-billable
+  acquisition, and atomic prepaid session lifecycle. Its PostgreSQL 17 concurrency
+  gate and full local suite pass. Draft PR #185 adds disjoint 1.9 preview catalogues,
+  bucket selection, and signed channel binding without changing the 0.0.11 production
+  payload shape.
+- `onionwright` PRs #41–#43 implement typed preflight/acquisition, renewable session
+  ownership, the paid launcher, and the gated `0.0.11` wheel. The wheel builds and
+  installs locally, and its publisher is immutable and checksum-verifying; it has not
+  been published while GitHub Actions jobs are blocked before execution by the
+  organization billing limit. Draft PR #45 adds the 0.0.12.dev1 preview publisher and
+  binds manifest, capability, prepared artifact, and runtime licence to preview.
+- `browser` PRs #98–#100 implement renewable runtime enforcement, complete Linux
+  packaging, and a fail-closed macOS signing/notarization/certification handoff. The
+  published Chromium 150.0.7871.187 Linux key is known-incomplete and immutable; it
+  cannot be repaired in place. The coordinated correction target is Chromium
+  151.0.7922.137 at tag commit `8f5d36bc16f57115aeeff34baf4ad6aa964d509c`.
+  No replacement build is currently running, and no artifact is eligible for the paid
+  catalogue until build, signing where applicable, redownload, and native paid E2E
+  pass. Draft PR #102 isolates 1.9 preview buckets and catalogue verification.
+- `connectonion` draft PR #1280 implements `auto | system | onion` resolution, daemon
+  compatibility probing, pinned paid-session ownership, and CLI propagation. All
+  public CI gates pass. It remains Draft until Onionwright 0.0.11 and at least one
+  certified browser artifact exist.
+
+Current local evidence is 280 passing Onionwright tests, 40 Browser tests plus six
+subtests and all release validators, 669 passing/154 skipped oo-api tests, and a green
+hosted ConnectOnion matrix across Python 3.10–3.13, macOS E2E, and Windows E2E. The red
+Onionwright and Browser GitHub checks are not test failures: GitHub annotations state
+that jobs were rejected before execution because account payments failed or the
+spending limit must be increased.
+
+## Release-channel policy
+
+- **1.8 production:** Onionwright 0.0.11, certified Chromium artifacts under new
+  immutable keys, and the production oo-api catalogue. Production publication is
+  authorized in principle but still requires authenticated cloud access, macOS
+  Developer ID/notarization credentials, green downloaded-artifact gates, PR review,
+  and explicit merge authorization.
+- **1.9 preview:** Onionwright 0.0.12 prereleases, Browser release line 1.9, separate
+  preview bucket/catalogues/API deployment, and signed `channel: preview` metadata.
+  Preview never inherits the legacy production bucket or accepts a production/missing
+  channel runtime licence.
+- Publisher commands must name a channel. Browser refuses crossed pairs such as
+  production/1.9 or preview/1.8, and both publishers print the exact catalogue that
+  operators must update.
+- Neither channel has been uploaded or deployed from this workspace. Preview also
+  needs its own host, DNS, credentials, protected environment, and `OO_API_URL`.
+
+The next releasable target is `1.8.0a2`, not an artificial merge of individually green
+components. Its entry gate is one exact, immutable artifact flowing through oo-api,
+Onionwright, and ConnectOnion after redownload, with charge/renew/release evidence and
+no fallback after billing. Linux remains required; macOS arm64 is the current second
+artifact candidate. Remote Browser/OIP/proxy work continues after this local paid
+engine slice without weakening that artifact gate.
+
+## Release outcome
+
+ConnectOnion 1.8 should make one end-to-end promise:
+
+> An authorized user or Agent can operate a persistent browser on another machine,
+> pin its network egress, reconnect safely, and choose either the free system-browser
+> path or an exact paid Onion Browser artifact without hidden fallback, plaintext Relay
+> traffic, or surprise billing.
+
+The release is not “a better anti-detect browser” in isolation. It is the coordinated
+system around that browser:
+
+```text
+Caller / O Chat
+      │
+      │ OIP control: authenticated, authorized, replayable
+      ▼
+Remote Browser service ───────► Browser Core ───────► chosen engine
+      │                              │                ├─ system Chrome, $0
+      │                              │                └─ Onion Browser, PAYG
+      │                              │
+      │ encrypted bounded data       └─ persistent profile/session ownership
+      ▼
+Pinned Proxy Agent ───────────► public internet
+```
+
+The release unit is one immutable cross-repository manifest. A component passing its
+own tests is necessary but never sufficient.
+
+## Baseline and source of truth
+
+The live GitHub state on 2026-08-25 has `v1.7.0` published as Stable. The local checkout
+used to prepare this plan is older (`v1.7.0a18`), so implementation must begin from a
+fresh branch or worktree containing the final 1.7 merge, not from the current local
+HEAD.
+
+Requirements are read in this order:
+
+1. [1.8 release control, #1154](https://github.com/openonion/connectonion/issues/1154)
+2. The canonical open child issue owned by the repository being changed
+3. Current code and tests
+4. Closed issues, old PRs, and historical comments only as background
+
+When they conflict, update the stale issue or document before implementation. In
+particular, do not revive the old Free/Pro design, generic macOS artifacts, the closed
+cache-scanning PR #797, ACP as a first-party transport, or client-created licences.
+
+## Scope decisions to make before alpha 1
+
+### Keep in 1.8
+
+- One shared Browser Core behind local `co browser` and remote `co remote-browser`.
+- Async browser execution, concurrent sessions, cancellation, and the synchronous
+  compatibility facade: #498, #499, and #500.
+- Direct Remote Browser first, then Relay operation through the reviewed secure OIP
+  channel.
+- Stable, revocable, bounded three-party proxy grants and a pinned egress for unattended
+  execution: #991, #1034, and #1036.
+- `auto`, `system`, and `onion` engine resolution with typed outcomes: #511.
+- PAYG browser sessions at $0.10/hour per instance, prepaid in $0.025 15-minute
+  intervals: oo-api#168 and onionwright#40.
+- Required `linux-x86_64` Onion Browser artifact and exactly one verified Mac
+  architecture if the existing build passes provenance and release gates.
+- OIP Relay E2EE, opaque Relay routing, and a separately bounded proxy data plane:
+  #1172, #1208, and #1209.
+- Cost ceiling and typed budget exhaustion from the remaining scope of #1150.
+- Focus inspection and safe destructive keyboard behavior from #1151.
+- React normalization and O Chat Remote Browser Work Card/Room UX.
+
+### Narrow or defer before work starts
+
+- **Move #495, #496, and #497 out of the 1.8 milestone.** Portable cookie/session
+  artifacts are explicitly outside #1154. The 1.8 remote daemon owns its profile; the
+  caller receives authorized control, not raw cookies.
+- **Recommended: defer the generic portion of #1210.** A general Agent-to-Agent file
+  and one-time Secret protocol is not required to prove Remote Browser. Keep only
+  browser-scoped upload/download authorization if needed for the committed journeys.
+  If maintainers keep all of #1210, add its work and security review to the critical
+  path explicitly; do not let it arrive as an unplanned RC blocker.
+- Keep cross-session Claude messaging #1000 research-only.
+- Keep packages, subscriptions, accumulated-spend entitlement, device binding, and
+  signing-key rotation in 1.9 (#1194).
+- Do not require a Windows, universal Mac, Intel Mac, or Linux arm64 Onion artifact.
+  Those hosts remain supported through the system-browser path.
+- Do not block 1.8 on `browser` #16, #17, #38, #40, #53, #55, #57, #59, #62, #63,
+  #80, or #94 unless an accepted RC journey proves a regression. Record them as
+  research, environment limits, or later patch work; do not market them as solved.
+
+### Add to the release blockers
+
+- **browser#95:** headed mode must actually be headed and must not expose
+  `HeadlessChrome/151`. This belongs in the common artifact gate next to browser#93.
+- **onionwright#38:** the measurement harness must be green before humanized-input
+  claims are accepted.
+- **onionwright#29:** `isTrusted` should be a categorical gate, not merely printed.
+
+## Architecture boundaries
+
+```text
+connectonion
+  owns product modes, CLI, Browser Core, session authority, OIP, grants,
+  secure transport integration, proxy policy, budgets, and release evidence
+         │
+         ├── connectonion-react
+         │     owns typed OIP reading, normalization, ordering, replay, secure state
+         │
+         ├── oo-chat
+         │     owns Work Card/Room, takeover, approvals, diagnostics, responsive UX
+         │
+         ├── oo-api
+         │     owns account/balance, atomic charges, paid sessions, signed licences,
+         │     signed platform manifest, artifact download, key directory, reconciliation
+         │
+         ├── onionwright
+         │     owns paid capability/preflight, verified acquisition/cache, launch,
+         │     heartbeat, watchdog, exact child supervision, humanized input
+         │
+         └── browser
+               owns Chromium revision/patches, builds, packaging, embedded public key,
+               runtime enforcement, signing/notarization, and artifact certification
+```
+
+Non-negotiable interface rules:
+
+- OIP carries control and state; it does not carry bulk proxy bytes.
+- The Relay routes opaque records and never owns content keys.
+- Authorization is checked after authentication and is not implied by encryption.
+- ConnectOnion never reads `~/.onionwright`, parses private attestation JSON, guesses an
+  artifact filename, or reconstructs Onionwright's paid-session state machine.
+- Onionwright never charges directly, signs a runtime licence, or launches a system
+  fallback inside a paid session.
+- Browser artifacts are keyed by Chromium revision, OS, and CPU architecture.
+- An engine and proxy choice are pinned when a Browser Session is created. Neither may
+  change silently while that session exists.
+
+## Critical path
+
+```text
+v1.7.0 baseline
+      │
+      ├─► Contract freeze ─► OIP security spec/vectors ─► Python + TS + opaque Relay
+      │                                                   │
+      │                                                   └─► grants + proxy plane
+      │
+      ├─► Async Browser Core ─► concurrent daemon ─► direct Remote Browser
+      │                                                │
+      │                                                └─► secure Relay + proxy
+      │
+      └─► oo-api PAYG/manifest ─► browser artifacts ─► Onionwright supervisor
+                                                       │
+                                                       └─► engine resolver
+
+all three branches ─► React/O Chat integration ─► immutable RC matrix ─► Stable
+```
+
+The schedule should be managed as three parallel workstreams that converge before
+beta. The secure-channel specification and the Linux/Mac artifact gates are the two
+highest schedule risks; both start in week 1.
+
+## Phase 0 — release reset and contract freeze
+
+Target: 2–3 working days before `1.8.0a1` implementation begins.
+
+1. Start from the final `v1.7.0` baseline and create the documented 1.8 integration
+   branch policy. Do not merge the stale local alpha checkout.
+2. Close or retarget remaining 1.7 release issues, and give every open 1.8 milestone
+   issue an owner and disposition.
+3. Move #495–#497 out of 1.8 and decide the narrowed #1210 boundary.
+4. Amend #1154 to include browser#95, onionwright#38, and onionwright#29 as gates.
+5. Freeze names and schemas for:
+   - Browser Session, tab/context ownership, request id, terminal outcome;
+   - `auto | system | onion` engine request and typed fallback reason;
+   - proxy grant/delegation, resolved proxy, measured egress, pause state;
+   - direct versus Relay secure-channel profile;
+   - Remote Browser OIP events and normalized React state.
+6. Decide the OIP compatibility move. Recommended: publish the new capability set as
+   a new minor protocol/fixture version rather than silently broadening OIP 0.1. Record
+   the exact rolling compatibility floor and removal date.
+7. Create a versioned cross-repository fixture package/directory that Core writes and
+   React consumes directly. O Chat must consume React state rather than parsing OIP.
+8. Record the first RC-manifest schema before artifacts exist, so every workstream knows
+   the evidence it must eventually produce.
+
+Exit gate:
+
+- No unresolved ownership or scope conflict remains in #1154.
+- Schemas, safe error-code taxonomy, version policy, and manifest shape are reviewed.
+- All repositories link to the same fixture and release tracker.
+
+## Phase 1 / alpha 1 — foundations, money, and artifacts
+
+Planning window: weeks 1–3. Workstreams run in parallel.
+
+### 1A. Browser Core async foundation
+
+Canonical issues: #498, #499, #500, #1151, and the reliability remainder of #1248/#1250.
+
+Current code has a synchronous Patchright core in
+`connectonion/useful_tools/browser_tools/browser.py`, one worker thread, and a serial
+daemon in `connectonion/cli/browser_agent/daemon.py`. Preserve public behavior while
+replacing the bottleneck.
+
+Implementation order:
+
+1. Extract an internal async Browser Core with lifecycle, context, tab, navigation,
+   input, screenshot, download/upload, persistent profile, and cleanup operations.
+2. Port driver calls to `patchright.async_api`; keep timeouts and errors typed.
+3. Make cancellation close the owning operation/resources without killing unrelated
+   sessions.
+4. Replace the daemon's serial dispatch with bounded asyncio connection tasks and an
+   explicit per-session/per-tab claim scheduler.
+5. Preserve the native authenticated POSIX/Windows IPC seam and its liveness rules.
+6. Put a synchronous facade over the async core for existing Python callers and tools.
+   Define behavior when called from a thread already running an event loop.
+7. Add `get_focused_element` and refuse or warn before destructive select-all/delete
+   shortcuts when the active element is not editable.
+8. Add phase timing for context close, driver stop, and Chrome shutdown; bound whole
+   browser close without killing unrelated Chrome processes.
+
+Required tests:
+
+- Existing BrowserAutomation and CLI tests remain green through the facade.
+- Two independent tabs progress while one navigation or model-backed operation stalls.
+- Conflicting claims are deterministic; disconnect/cancel releases the claim.
+- Slow reader, queue saturation, timeout, dead page, daemon restart, and repeated
+  create/close tests leak no thread, loop, pipe, context, or Chrome process.
+- Linux, macOS, and Windows keep their current system-browser behavior.
+
+### 1B. PAYG and platform manifest
+
+Canonical issues: oo-api#168 and onionwright#40.
+
+oo-api work:
+
+1. Replace old tier/credit-threshold responses on this path with read-only paid
+   capability/status and explicit platform availability.
+2. Publish signed entries keyed by exact `artifact_id`, Chromium revision,
+   `platform_tag`, minimum OS, package format, executable path, size, and SHA-256.
+3. Implement atomic start/renew/release with server session ID, `paid_until`, interval
+   sequence, and idempotency key.
+4. Charge exactly $0.025 once per prepaid interval; refuse insufficient balance without
+   creating/extending a session or going negative.
+5. Make every preflight/status/manifest/download-readiness path non-billable.
+6. Add reconciliation and expired-session cleanup with safe, content-free telemetry.
+
+Onionwright work:
+
+1. Replace the current prose/exception boundary with typed capability and preflight
+   results, including exact platform, artifact, readiness, paid capability, reason, and
+   safe next action.
+2. Pin the one current server Ed25519 public key in Python; never fetch trust roots at
+   runtime for 1.8.
+3. Verify manifest, download, checksum, unpack, executable/app bundle, and runtime
+   dependencies before calling paid start.
+4. Replace the 12-hour cached-attestation behavior with the 15-minute paid-session
+   contract.
+5. Add a heartbeat near minute 12, idempotent retry, atomic licence replacement, and a
+   watchdog that stops the exact child at signed `paid_until`.
+6. Return one supervised session handle with engine/artifact/session identity,
+   status/terminal reason, renew, and close. Best-effort release follows clean close;
+   server expiry handles crashes.
+7. Align the supported driver boundary with Patchright and test the exact API consumed
+   by ConnectOnion.
+
+### 1C. Onion Browser artifact pipeline
+
+Canonical issues: browser#11, #93, #95, #96, and #97.
+
+Linux first:
+
+1. Fix `scripts/export.sh` so the shipped run tree contains required GL/runtime
+   libraries. Validate against the build output inventory rather than a fragile
+   hand-maintained eight-file allowlist.
+2. Extend `harness/verify_artifact.py` to require non-null WebGL and record the actual
+   vendor/renderer on the extracted artifact.
+3. Fix headed launch so `--no-headless` is honored and User-Agent does not contain
+   `HeadlessChrome`.
+4. Rebuild `linux-x86_64` through the restricted GCP self-hosted-runner topology.
+5. Run the entire detector, licence, WebGL, TLS, proxy, download, crash, shutdown, and
+   rollback gate on bytes downloaded through the production path.
+
+macOS decision in week 1, not at RC:
+
+1. Inventory the existing `.app`: browser commit, Chromium revision, patch hashes, GN
+   args, target CPU, macOS/Xcode/SDK, app architecture, and embedded key fingerprint.
+2. If any required provenance cannot be reconstructed, mark it investigation-only and
+   schedule a clean recorded rebuild immediately.
+3. Implement one `release-macos` entry point with dry-run, release, and verification-only
+   modes as specified in browser#97.
+4. Stage a copy, sign inside-out with Developer ID, notarize, staple, package the whole
+   bundle, immutably upload, redownload, and repeat native verification.
+5. Claim only the architecture actually built and natively tested. Intel remains
+   optional; Windows remains system fallback.
+
+Alpha 1 exit gate:
+
+- Async core and sync compatibility tests are green.
+- Read-only paid preflight cannot charge; start/renew is idempotent in integration tests.
+- A fresh downloaded Linux artifact has working WebGL, true headed/headless behavior,
+  and valid runtime enforcement.
+- The Mac artifact has an explicit accept/rebuild disposition.
+- `1.8.0a1` may expose contracts and diagnostics, but must not advertise Remote Browser
+  as production-ready.
+
+## Phase 2 / alpha 2 — direct Remote Browser and paid engine integration
+
+Planning window: weeks 3–6.
+
+### Remote Browser service
+
+Build one transport-neutral command service over Browser Core:
+
+```text
+local CLI ── authenticated IPC ──┐
+                                 ├─► Browser command service ─► Browser Core
+remote CLI ── authenticated OIP ─┘
+```
+
+1. Define Browser Session state with owner principal, Host, engine, exact artifact when
+   paid, profile/context, tab claims, proxy mode/resolution, request IDs, timestamps,
+   limits, status, and terminal reason.
+2. Implement stable commands: start, open, do, screenshot, status, diagnose, sessions,
+   Stop, reconnect, and resume. Give all commands stable JSON, error codes, and safe next
+   actions.
+3. Make mutating requests idempotent under retry and reject duplicate/out-of-order
+   authority changes.
+4. Keep the persistent profile on the remote host. Takeover grants temporary direct
+   control; Release returns control without copying cookies to the caller.
+5. Support deterministic interruption and terminal settlement across cancellation,
+   disconnect, Host restart, and client retry.
+6. Extend the 1.7 permission/profile model rather than creating browser-only approval
+   semantics.
+
+### Engine resolver in ConnectOnion
+
+Implement the only engine decision point at session creation:
+
+```text
+system ─► Patchright + system Chrome; do not import/call Onionwright; charge $0
+
+onion  ─► preflight ─► ready/funded ─► paid Onion session
+                    └► typed failure; no fallback; charge $0 on pre-start failure
+
+auto   ─► preflight ─► ready/funded ─► paid Onion session
+                    └► system Chrome + typed fallback reason; charge $0
+```
+
+Requirements:
+
+- Lazy/optional Onionwright integration keeps the free path independent of oo-api,
+  licensing, paid downloads, and paid-client installation failures.
+- Preflight finishes local artifact readiness before session creation and billing.
+- The selected engine and fallback reason appear in status, JSON output, OIP, and audit.
+- No hot swap exists. A failed/expired Onion session ends; a later `auto` start may create
+  a separate system session with a separate profile and `engine_changed` evidence.
+- Pin exact compatible ConnectOnion, Onionwright, manifest schema, and Chromium versions.
+
+### Cost boundary
+
+Complete #1150:
+
+- add `--max-cost`/API equivalent with pre-call enforcement where possible;
+- expose spent/remaining budget to the Agent in structured runtime context;
+- terminate with a typed `budget_exhausted` result and nonzero CLI exit;
+- cover parent and delegated/native-provider usage without double counting;
+- keep browser PAYG charges distinct from model-token spend while reporting both.
+
+Alpha 2 exit gate:
+
+- Local and direct-remote paths execute the same command conformance suite.
+- Direct Remote Browser survives Stop, reconnect, Host restart, duplicate request, and
+  client retry without duplicate action.
+- System path makes no paid API call.
+- Supported funded host launches the exact Onion artifact; unsupported/no-balance/bad
+  artifact cases follow the required fallback matrix and charge $0.
+- A real 60-minute Onionwright run produces four and only four paid intervals.
+
+## Phase 3 / alpha 3 — secure Relay and stable proxy egress
+
+Planning window: weeks 4–8. Specification starts in phase 1; integration starts only
+after review and vectors.
+
+### OIP secure channel
+
+1. Complete #1208 before endpoint implementation: select a maintained, reviewed
+   protocol/library with Python and browser support; specify identity binding, handshake,
+   canonical records, nonce/counter rules, replay/order, limits, rekey, reconnect, close,
+   visible Relay metadata, and downgrade behavior.
+2. Keep Ed25519 for identity/signatures only. Use separate encryption keys with signed
+   identity/role/endpoint/version bindings, rotation, revocation, and freshness.
+3. Publish deterministic positive and negative vectors consumed byte-for-byte by Python,
+   TypeScript, and oo-api conformance tests.
+4. Implement oo-api#170 signed key directory and opaque bounded Relay routing.
+5. Wrap the common Python send/receive boundary in `network/connect.py`,
+   `network/relay.py`, and `network/host/` so all existing and future OIP frames inherit
+   protection automatically.
+6. Implement the same boundary in ConnectOnion React; O Chat only initializes keys and
+   renders verified state/errors.
+7. Fail closed for legacy Relay peers. Direct authenticated TLS is a distinct profile,
+   never a silent downgrade from Relay E2EE.
+
+### Proxy grants and data plane
+
+1. Implement signed P→D grant and D→B delegation with bounded scope, destinations,
+   bytes, concurrency, expiry, `renewable_until`, and immediate revocation.
+2. Require B's separate policy consent to use P. A tunnel/session/grant ID is never
+   bearer authorization.
+3. Use the reverse-tunnel topology for an always-on Proxy Agent behind NAT. Expose the
+   actual path taken (`direct | tunnel | relay`) and refuse any path not pinned by the
+   Browser Session.
+4. Keep bulk bytes on a separate encrypted binary plane with backpressure,
+   cancellation, accounting, byte/time/frame limits, and deterministic teardown.
+5. Terminate as a local SOCKS5/CONNECT service for Chromium without TLS interception or
+   installed CA certificates.
+6. On Linux Remote Browser hosts, put the browser/context subprocess tree in a network
+   namespace whose only egress is the selected tunnel. Keep management traffic outside
+   it. Treat launch flags alone as an interim test configuration, not the final leak
+   boundary.
+7. Enforce destination policy at the Proxy Agent after DNS resolution: allow public web
+   destinations; block loopback, private/link-local ranges, metadata endpoints, unsafe
+   ports, inbound listening, and DNS rebinding.
+8. Preflight with an actual egress fetch and browser-observed leak probe. Pin the measured
+   public IP. If the proxy disappears or the IP changes, pause/fail; never silently use
+   the remote host's datacenter IP.
+
+Alpha 3 exit gate:
+
+- Cross-language malicious-Relay conformance rejects mutation, replay, reorder,
+  duplicate, stale/revoked key, wrong endpoint, downgrade, truncation, nonce misuse,
+  counter/limit overflow, and reconnect/rekey attacks.
+- Relay captures and logs contain no application plaintext or content keys.
+- The 3am test passes with D offline: B and P complete a task under a pre-authorized
+  grant.
+- Egress is measured through P; WebRTC/DNS/QUIC leak tests cannot observe B's direct IP.
+- Proxy loss pauses the Browser Session without changing egress.
+
+## Phase 4 / beta 1 — React, O Chat, takeover, and product hardening
+
+Planning window: weeks 7–10.
+
+1. Land React fixture support before Core publishes new public fields. React owns
+   normalization, monotonic revisions, replay, duplicate/out-of-order handling,
+   reconnect, and verified secure-channel state.
+2. Build one compact Remote Browser Work Card and one opened Work Room in O Chat. Do not
+   create a general multi-Agent canvas.
+3. Show engine, paid/free state, exact artifact when relevant, proxy mode and measured
+   exit, secure profile, connection/reconnect state, current action, budget, and terminal
+   result without exposing private paths, cookies, licence payloads, prompts, or proxy
+   credentials.
+4. Add Human Takeover and explicit Release with visible ownership and approval state.
+   Takeover is bounded and auditable; control cannot be held by two principals at once.
+5. Provide stable diagnoses for identity, Contact, authorization, secure channel, Relay,
+   browser, engine, artifact, balance, proxy, DNS, leak, session, and budget failures.
+6. Test desktop, tablet, and 390px mobile states for start, working, input needed,
+   takeover, approval, reconnecting, paused, stopped, failed, budget exhausted, paid
+   expiry, and completed.
+7. Run real-site journeys that exercise login, CAPTCHA/takeover, download/upload, long
+   action, Stop, reconnect, and proxy loss. Site-specific bypass is not an acceptance
+   claim; access challenges must be surfaced truthfully.
+
+Beta exit gate:
+
+- Core/React fixture conformance and O Chat rendering/replay tests pass.
+- Every authority-bearing action has visible owner, current ceiling, and audit result.
+- No stale broader permission, takeover owner, engine, or proxy state returns after
+  reconnect/Host restart.
+- Security review covers grants, takeover, destination policy, E2EE, key storage,
+  billing, and licence enforcement.
+- Accessibility and responsive visual evidence is approved and attached according to
+  repository policy.
+
+## Phase 5 / RC and Stable
+
+Planning window: weeks 10–12, depending on security and macOS gates. This is an estimate,
+not a release-date promise.
+
+### Freeze the immutable RC manifest
+
+Record exact commits, package versions, deployment IDs, hashes, keys, and fixtures for:
+
+| Component | Required evidence |
+|---|---|
+| ConnectOnion | commit, wheel/sdist version and hashes, Python/platform matrix |
+| ConnectOnion React | commit, npm version, OIP fixture/version |
+| O Chat | commit and deployment/build ID |
+| oo-api | commit, deployed config revision, key fingerprint, artifact catalogue |
+| Onionwright | commit, package version, supported contract version |
+| Onion Browser | Chromium revision, browser commit, patch/GN provenance, exact platform tags, URLs, hashes, minimum OS, signing/notarization |
+| Secure OIP | profile/spec version, crypto library versions, vector/conformance revision |
+
+No component may be silently rebuilt, republished, or replaced during acceptance.
+
+### Required acceptance matrix
+
+| Journey | Expected result |
+|---|---|
+| Windows `auto` | system Chrome, typed unsupported fallback, no paid call, $0 |
+| unsupported OS/architecture `auto` | system Chrome, typed reason, $0 |
+| any supported host `system` | system Chrome; Onionwright/oo-api paid path untouched |
+| funded Linux x86_64 `auto` and `onion` | exact accepted Linux Onion artifact |
+| each claimed Mac architecture | only its exact accepted Darwin artifact |
+| no balance `auto` | system Chrome, `insufficient_balance`, $0 |
+| no balance `onion` | typed failure, no fallback, $0 |
+| missing/bad/incompatible artifact | fail or fallback before paid start, $0 |
+| renewal/balance/network failure | Onion stops at signed `paid_until`; no hot swap |
+| direct Remote Browser | start → act → screenshot → takeover/release → Stop/reconnect/resume |
+| Relay Remote Browser | same lifecycle with verified E2EE and opaque Relay capture |
+| unattended three-party proxy | D offline; P→D→B grant; stable measured egress |
+| proxy loss/IP change | session pauses/fails; no direct-IP fallback |
+| cost ceiling | typed nonzero `budget_exhausted`, accurate model/browser spend |
+| upgrade/rollback | 1.7 → exact 1.8 RC → 1.7 with profiles and config handled safely |
+
+Run against clean installations and production-path downloads, not editable checkouts or
+build-tree binaries. Validate artifact hashes between origin, package index/release, and
+the installed bytes.
+
+Stable is an unchanged promotion of the accepted RC. Any source fix creates a new RC and
+restarts the affected acceptance window.
+
+## Repository work map
+
+```text
+connectonion/connectonion/
+├── useful_tools/browser_tools/browser.py      async core split + sync facade
+├── cli/browser_agent/daemon.py                concurrent command service
+├── cli/browser_agent/client.py                stable envelopes/retry/JSON/errors
+├── cli/commands/browser_commands.py           local mode and engine options
+├── cli/commands/remote_browser_commands.py    new remote CLI
+├── cli/commands/proxy_commands.py             new grant/serve/probe CLI
+├── network/connect.py                         secure profile + remote commands
+├── network/relay.py                           opaque secure records
+├── network/host/                              handshake termination + dispatch
+├── network/host/protocol.py                   version/profile capability gate
+├── network/secure_channel/                    reviewed protocol adapter
+├── browser/                                   session, resolver, command contracts
+└── proxy/                                     grants, policy, tunnel/data plane
+
+connectonion/tests/
+├── fixtures/oip/                              shared versioned vectors/contracts
+├── unit/                                      resolver, grants, budgets, security
+├── integration/                               local/direct/Relay parity
+└── e2e/                                       exact browser/proxy/reconnect journeys
+
+browser/
+├── scripts/export.sh                          complete runtime packaging
+├── scripts/release-macos.sh                   one reproducible Mac release entry
+├── harness/verify_artifact.py                 WebGL/runtime/licence verification
+├── .github/workflows/build.yml                protected GCP/Mac release control
+└── docs/DETECTION-STATUS.md                    measured claims only
+
+onionwright/src/onionwright/
+├── capability.py                              typed preflight/result contract
+├── session.py                                 start/renew/watchdog/close handle
+├── launcher.py                                public paid launch boundary
+└── licence/                                   pinned trust, manifest/session client
+```
+
+Names for new files are recommendations; preserve repository conventions during
+implementation. Do not collapse these responsibilities back into one large browser or
+launcher module.
+
+## Risk register
+
+| Risk | Early signal | Mitigation / release rule |
+|---|---|---|
+| Secure-channel design expands or uses weak cross-language libraries | spec/vectors not reviewed by end of alpha 1 | stop endpoint coding; choose reviewed construction and independent review first |
+| Existing Mac app lacks provenance | missing commit/GN/SDK/key evidence in week 1 | rebuild from recorded inputs; do not guess or upload manually |
+| Linux artifact differs from passing build tree | downloaded WebGL/runtime gate fails | certify only redownloaded bytes; compare complete runtime inventory |
+| Async rewrite regresses sync callers | facade tests diverge or nested-loop deadlocks | land core/facade behind conformance tests before remote features |
+| Proxy becomes an SSRF path into P's LAN | private/metadata/DNS-rebind negative test succeeds | enforce policy at P after every resolution; network namespace and bounded tunnel |
+| Silent proxy or engine fallback changes identity/IP | status differs from pinned session | immutable session choice; pause/end and require a new session |
+| Billing begins before readiness | failed download leaves a charge | all knowable readiness checks before paid start; ledger assertion in every negative test |
+| Heartbeat double-charges | repeated sequence changes ledger twice | server idempotency key + persisted interval sequence + reconciliation |
+| Scope grows through session transfer/general secrets | #495–#497/#1210 enter critical path late | explicit phase-0 disposition and tracker update |
+| Browser claims outrun evidence | Kasada/DataDome or environment failures treated as universal bypass defects | publish measured matrix and limitations; do not promise universal access |
+| Local workspace changes are overwritten | dirty `connectonion/.gitignore` or Onionwright launcher/tests | use fresh worktrees/branches and preserve unrelated user changes |
+
+## Release management checklist
+
+- Every scoped issue has an owner, target phase, PR, dependency, and release disposition.
+- Each alpha has a written entry/exit gate; “merged” is never an exit gate by itself.
+- Cross-repository changes land consumer-first where compatibility requires it: fixture
+  reader before writer, server idempotency before client retry, artifact before resolver.
+- Contract tests run in provider repositories and in a coordinated integration job.
+- Security-critical logs are allowlisted; raw OIP, licences, keys, cookies, proxy traffic,
+  private paths, and Secrets never enter CI artifacts or model-visible evidence.
+- Browser and UI evidence uses exact public candidates and records sanitized hashes.
+- Documentation states platform support, fallback reasons, pricing, data/security
+  boundaries, known detection limits, upgrade, rollback, and support diagnostics.
+- Release notes contain no 1.9 feature or unverified platform claim.
+
+## Recommended first ten implementation issues/PRs
+
+The first batch should make dependencies executable rather than starting with UI:
+
+1. Tracker hygiene: retarget #495–#497, decide #1210, add browser#95 and harness gates.
+2. OIP secure-channel ADR, library decision, vector schema, and negative-vector skeleton.
+3. Remote Browser/OIP/React fixture vNext with command, state, error, and authority types.
+4. oo-api read-only architecture-specific manifest and non-billable capability preflight.
+5. oo-api idempotent prepaid start/renew/release ledger contract.
+6. browser#93 complete Linux runtime packaging plus WebGL artifact verification.
+7. browser#97 macOS provenance dry-run and accept/rebuild decision.
+8. ConnectOnion async Browser Core extraction with unchanged sync conformance tests.
+9. Onionwright typed capability/preflight API with pinned server key.
+10. Onionwright supervised heartbeat/watchdog session using the oo-api contract.
+
+Only after these are green should the team open the direct Remote Browser, engine
+resolver, Relay encryption, and proxy implementation PRs that depend on them.


### PR DESCRIPTION
## Outcome

Adds the coordinated, issue-backed development and release plan for ConnectOnion 1.8 across ConnectOnion, Browser, Onionwright, oo-api, OIP/Relay, proxy, and UI work.

Tracks #1154.

## Important current state

- records the implemented paid-engine stack and its exact PR dependencies
- corrects the stale Chromium status: the known-bad 150 Linux key is immutable; 151.0.7922.137 is the coordinated correction target and no replacement build is currently running
- records the 1.8 production versus 1.9 preview channel policy and signed runtime-licence boundary
- defines per-alpha entry/exit gates, parallel E2E matrices, rollback, security review, and issue-before-fix policy
- distinguishes GitHub Actions billing rejection from actual test failures

## Verification

- `git diff --check`
- links and status reconciled with the active release PR stacks on 2026-08-26

This PR changes documentation only and does not merge or publish any release.