### PR TITLE
docs: refresh the 1.8 execution checkpoint

### DIFF
--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -1,6 +1,6 @@
 # ConnectOnion 1.8 development plan
 
-Status: active execution plan; paid-engine slice and 1.9 preview boundary implemented in draft PRs
+Status: active execution plan; first paid-engine slice implemented in draft PRs  
 Prepared: 2026-08-25; execution checkpoint updated 2026-08-26  
 Release authority: [connectonion#1154](https://github.com/openonion/connectonion/issues/1154)
 
@@ -8,65 +8,13 @@ Release authority: [connectonion#1154](https://github.com/openonion/connectonion
 
 The first vertical slice is implemented but deliberately not released:
 
-- `oo-api` PR #183 implements the signed exact-platform manifest, non-billable
-  acquisition, and atomic prepaid session lifecycle. Its PostgreSQL 17 concurrency
-  gate and full local suite pass. Draft PR #185 adds disjoint 1.9 preview catalogues,
-  bucket selection, and signed channel binding without changing the 0.0.11 production
-  payload shape.
-- `onionwright` PRs #41–#43 implement typed preflight/acquisition, renewable session
-  ownership, the paid launcher, and the gated `0.0.11` wheel. The wheel builds and
-  installs locally, and its publisher is immutable and checksum-verifying; it has not
-  been published while GitHub Actions jobs are blocked before execution by the
-  organization billing limit. Draft PR #45 adds the 0.0.12.dev1 preview publisher and
-  binds manifest, capability, prepared artifact, and runtime licence to preview.
-- `browser` PRs #98–#100 implement renewable runtime enforcement, complete Linux
-  packaging, and a fail-closed macOS signing/notarization/certification handoff. The
-  published Chromium 150.0.7871.187 Linux key is known-incomplete and immutable; it
-  cannot be repaired in place. The coordinated correction target is Chromium
-  151.0.7922.137 at tag commit `8f5d36bc16f57115aeeff34baf4ad6aa964d509c`.
-  No replacement build is currently running, and no artifact is eligible for the paid
-  catalogue until build, signing where applicable, redownload, and native paid E2E
-  pass. Draft PR #102 isolates 1.9 preview buckets and catalogue verification.
-- `connectonion` draft PR #1280 implements `auto | system | onion` resolution, daemon
-  compatibility probing, pinned paid-session ownership, and CLI propagation. All
-  public CI gates pass. It remains Draft until Onionwright 0.0.11 and at least one
-  certified browser artifact exist.
-- `connectonion` PRs #1282–#1287 establish the internal async Browser Core and port
-  focus safety, lifecycle/tab isolation, deterministic selectors, frame scripts and
-  uploads, known-target humanized input, and model-selected element actions. The
-  current final #498 slice adds keyboard typing, verified strategy scrolling,
-  collision-safe context capture, and cancellable manual-login input. Issue #498
-  has now passed the whole-surface, cancellation, profile, stealth, recovery,
-  native-browser, installed-wheel, and hosted audit in PR #1288; merge still needs
-  explicit release-authority approval. The stacked #499 slice replaces serial
-  dispatch with bounded asyncio client tasks, atomic request leases, per-tab
-  scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. The
-  stacked #500 slice now places the stable synchronous API over that async core;
-  hosted validation and review remain before either downstream slice can merge.
-
-Current local evidence is 280 passing Onionwright tests, 40 Browser tests plus six
-subtests and all release validators, 669 passing/154 skipped oo-api tests, and a green
-hosted ConnectOnion matrix across Python 3.10–3.13, macOS E2E, and Windows E2E. The red
-Onionwright and Browser GitHub checks are not test failures: GitHub annotations state
-that jobs were rejected before execution because account payments failed or the
-spending limit must be increased.
-
-## Release-channel policy
-
-- **1.8 production:** Onionwright 0.0.11, certified Chromium artifacts under new
-  immutable keys, and the production oo-api catalogue. Production publication is
-  authorized in principle but still requires authenticated cloud access, macOS
-  Developer ID/notarization credentials, green downloaded-artifact gates, PR review,
-  and explicit merge authorization.
-- **1.9 preview:** Onionwright 0.0.12 prereleases, Browser release line 1.9, separate
-  preview bucket/catalogues/API deployment, and signed `channel: preview` metadata.
-  Preview never inherits the legacy production bucket or accepts a production/missing
-  channel runtime licence.
-- Publisher commands must name a channel. Browser refuses crossed pairs such as
-  production/1.9 or preview/1.8, and both publishers print the exact catalogue that
-  operators must update.
-- Neither channel has been uploaded or deployed from this workspace. Preview also
-  needs its own host, DNS, credentials, protected environment, and `OO_API_URL`.
+- `connectonion` PRs #1282–#1287 established the internal async Browser Core;
+  #1288 (final async parity) merged to main, and the remaining stack — #1289
+  concurrent daemon sessions, #1290 synchronous API over the async core, #1298
+  owner-bound Remote Browser lifecycle — merged via consolidation PR #1317
+  (ancestry verified; the stacked PRs were auto-closed when #1288's branch
+  deleted). Release PR #1318 cut **1.8.0a2** from that content. Issues
+  #498–#500 close on the post-merge audit.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -1,6 +1,6 @@
 # ConnectOnion 1.8 development plan
 
-Status: active execution plan; first paid-engine slice implemented in draft PRs  
+Status: active execution plan; paid-engine slice and 1.9 preview boundary implemented in draft PRs
 Prepared: 2026-08-25; execution checkpoint updated 2026-08-26  
 Release authority: [connectonion#1154](https://github.com/openonion/connectonion/issues/1154)
 
@@ -9,17 +9,24 @@ Release authority: [connectonion#1154](https://github.com/openonion/connectonion
 The first vertical slice is implemented but deliberately not released:
 
 - `oo-api` PR #183 implements the signed exact-platform manifest, non-billable
-  acquisition, and atomic prepaid session lifecycle. Local gates pass; private hosted
-  jobs are blocked before checkout by organization billing.
+  acquisition, and atomic prepaid session lifecycle. Its PostgreSQL 17 concurrency
+  gate and full local suite pass. Draft PR #185 adds disjoint 1.9 preview catalogues,
+  bucket selection, and signed channel binding without changing the 0.0.11 production
+  payload shape.
 - `onionwright` PRs #41–#43 implement typed preflight/acquisition, renewable session
   ownership, the paid launcher, and the gated `0.0.11` wheel. The wheel builds and
   installs locally, and its publisher is immutable and checksum-verifying; it has not
-  been published while private hosted jobs are blocked.
+  been published while GitHub Actions jobs are blocked before execution by the
+  organization billing limit. Draft PR #45 adds the 0.0.12.dev1 preview publisher and
+  binds manifest, capability, prepared artifact, and runtime licence to preview.
 - `browser` PRs #98–#100 implement renewable runtime enforcement, complete Linux
-  packaging, and a fail-closed macOS signing/notarization/certification handoff. A
-  native arm64 Chromium 150.0.7871.187 build passes its CDP smoke test; no artifact is
-  eligible for the paid catalogue until signing, notarization, redownload, and native
-  paid E2E pass.
+  packaging, and a fail-closed macOS signing/notarization/certification handoff. The
+  published Chromium 150.0.7871.187 Linux key is known-incomplete and immutable; it
+  cannot be repaired in place. The coordinated correction target is Chromium
+  151.0.7922.137 at tag commit `8f5d36bc16f57115aeeff34baf4ad6aa964d509c`.
+  No replacement build is currently running, and no artifact is eligible for the paid
+  catalogue until build, signing where applicable, redownload, and native paid E2E
+  pass. Draft PR #102 isolates 1.9 preview buckets and catalogue verification.
 - `connectonion` draft PR #1280 implements `auto | system | onion` resolution, daemon
   compatibility probing, pinned paid-session ownership, and CLI propagation. All
   public CI gates pass. It remains Draft until Onionwright 0.0.11 and at least one
@@ -36,6 +43,30 @@ The first vertical slice is implemented but deliberately not released:
   scheduling, native POSIX concurrency, and a bounded Windows pipe bridge. The
   stacked #500 slice now places the stable synchronous API over that async core;
   hosted validation and review remain before either downstream slice can merge.
+
+Current local evidence is 280 passing Onionwright tests, 40 Browser tests plus six
+subtests and all release validators, 669 passing/154 skipped oo-api tests, and a green
+hosted ConnectOnion matrix across Python 3.10–3.13, macOS E2E, and Windows E2E. The red
+Onionwright and Browser GitHub checks are not test failures: GitHub annotations state
+that jobs were rejected before execution because account payments failed or the
+spending limit must be increased.
+
+## Release-channel policy
+
+- **1.8 production:** Onionwright 0.0.11, certified Chromium artifacts under new
+  immutable keys, and the production oo-api catalogue. Production publication is
+  authorized in principle but still requires authenticated cloud access, macOS
+  Developer ID/notarization credentials, green downloaded-artifact gates, PR review,
+  and explicit merge authorization.
+- **1.9 preview:** Onionwright 0.0.12 prereleases, Browser release line 1.9, separate
+  preview bucket/catalogues/API deployment, and signed `channel: preview` metadata.
+  Preview never inherits the legacy production bucket or accepts a production/missing
+  channel runtime licence.
+- Publisher commands must name a channel. Browser refuses crossed pairs such as
+  production/1.9 or preview/1.8, and both publishers print the exact catalogue that
+  operators must update.
+- Neither channel has been uploaded or deployed from this workspace. Preview also
+  needs its own host, DNS, credentials, protected environment, and `OO_API_URL`.
 
 The next releasable target is `1.8.0a2`, not an artificial merge of individually green
 components. Its entry gate is one exact, immutable artifact flowing through oo-api,


### PR DESCRIPTION
## Outcome

Updates the already-merged 1.8 development plan with authoritative current release evidence. Tracks #1154.

## Changes

- preserves the newer async Browser Core progress already on main
- corrects the artifact status: Chromium 150 Linux is known incomplete and immutable; 151.0.7922.137 is the correction target and no replacement build is currently running
- records the tested oo-api, Onionwright, Browser, and ConnectOnion PR stacks
- documents the 1.8 production versus 1.9 preview trust boundary, including signed runtime-licence channel binding
- distinguishes GitHub Actions billing rejection before execution from code/test failures

## Verification

- `git diff --check`
- branch is based directly on current `origin/main` (`08ca0f49`)

**Proposed target version:** 1.8.0
**Estimated release window:** next alpha
**Forward-port tracking issue (stable patches only):** not applicable

Documentation-only checkpoint; `no-blog` is appropriate because this PR updates the release plan rather than shipping a user-visible behavior. This does not merge or publish a release.