### PR TITLE
feat(oip): add owner-bound Remote Browser lifecycle

### DIFF
--- a/connectonion/cli/browser_agent/client.py
+++ b/connectonion/cli/browser_agent/client.py
@@ -215,18 +215,25 @@ def _ensure_browser_ready(line: str) -> bool:
     return True
 
 
-def _request(line: str, headless: bool = False, tab: str = None,
-             raw_result: bool = False, _provisioned: bool = False) -> tuple:
+def _request_with_identity(
+    line: str,
+    *,
+    caller: str,
+    account: str,
+    headless: bool = False,
+    tab: str = None,
+    raw_result: bool = False,
+    _provisioned: bool = False,
+) -> tuple:
     """Send one short daemon request and return ``(code, payload)``.
 
     ``raw_result`` is for the client-side agent: image data must reach its vision
     formatter, while an interactive shell should still receive a saved-file line.
     The account address is public; the API key never crosses this transport.
     """
-    account = _caller_account()
     request = json.dumps({
         "v": 1,
-        "caller": _caller(),
+        "caller": caller,
         "account": account,
         "tab": tab,
         "line": line,
@@ -314,8 +321,13 @@ def _request(line: str, headless: bool = False, tab: str = None,
     # not something to guess at from a version-numbered cache path.
     if "No browser is installed for this user" in payload and not _provisioned:
         if _ensure_browser_ready(line):
-            return _request(
-                line, headless=headless, tab=tab, raw_result=raw_result,
+            return _request_with_identity(
+                line,
+                caller=caller,
+                account=account,
+                headless=headless,
+                tab=tab,
+                raw_result=raw_result,
                 _provisioned=True,
             )
 
@@ -336,6 +348,50 @@ def _request(line: str, headless: bool = False, tab: str = None,
     parts = header.split()
     code = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 1
     return code, payload
+
+
+def _request(
+    line: str,
+    headless: bool = False,
+    tab: str = None,
+    raw_result: bool = False,
+    _provisioned: bool = False,
+) -> tuple:
+    """Send a request owned by this local CLI process."""
+    return _request_with_identity(
+        line,
+        caller=_caller(),
+        account=_caller_account(),
+        headless=headless,
+        tab=tab,
+        raw_result=raw_result,
+        _provisioned=_provisioned,
+    )
+
+
+def request_as(
+    line: str,
+    *,
+    caller: str,
+    account: str,
+    headless: bool = False,
+    tab: str = None,
+) -> tuple:
+    """Host-only daemon seam using an already authenticated remote identity.
+
+    The caller value comes from OIP authentication, never from remote request
+    arguments. Keeping this separate from ``_request`` prevents a local CLI
+    option from spoofing another tab owner.
+    """
+    if not caller or not account:
+        return 3, "authenticated caller and account are required"
+    return _request_with_identity(
+        line,
+        caller=caller,
+        account=account,
+        headless=headless,
+        tab=tab,
+    )
 
 
 def _tool_line(name: str, args: tuple, kwargs: dict) -> str:

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -1,0 +1,149 @@
+"""CLI for typed, owner-bound Remote Browser lifecycle commands."""
+
+import json
+import sys
+
+USAGE = """co remote-browser — manage a browser session on a remote agent.
+
+  co remote-browser [options] <address> start
+  co remote-browser [options] <address> sessions
+  co remote-browser [options] <address> status <session-id>
+  co remote-browser [options] <address> stop <session-id>
+  co remote-browser [options] <address> diagnose <session-id>
+
+Options:
+  --json           emit the complete stable JSON envelope
+  --timeout SEC    seconds to wait (default 60)
+  --relay URL      relay backend used for discovery/fallback
+  --headless       start headless (default)
+  --headed         start with a visible browser
+  --proxy MODE     start proxy mode; 1.8 accepts only direct
+"""
+
+
+def _parse(args):
+    options = {
+        "json_output": False,
+        "timeout": 60.0,
+        "relay_url": None,
+        "headless": True,
+        "proxy": "direct",
+    }
+    positional = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--json":
+            options["json_output"] = True
+        elif token == "--headless":
+            options["headless"] = True
+        elif token == "--headed":
+            options["headless"] = False
+        elif token in ("--timeout", "--relay", "--proxy"):
+            if index + 1 >= len(args):
+                raise ValueError(f"{token} needs a value")
+            value = args[index + 1]
+            index += 1
+            if token == "--timeout":
+                try:
+                    options["timeout"] = float(value)
+                except ValueError as exc:
+                    raise ValueError("--timeout needs a number") from exc
+                if options["timeout"] <= 0:
+                    raise ValueError("--timeout must be positive")
+            elif token == "--relay":
+                options["relay_url"] = value
+            else:
+                options["proxy"] = value
+        elif token.startswith("-"):
+            raise ValueError(f"unknown option '{token}'")
+        else:
+            positional.append(token)
+        index += 1
+    return positional, options
+
+
+def _print_human(result):
+    if not result.get("ok"):
+        code = result.get("code", "REMOTE_BROWSER_FAILED")
+        message = result.get("message", "Remote Browser request failed.")
+        print(f"{code}: {message}", file=sys.stderr)
+        return
+    print(result.get("summary", "Remote Browser request completed."))
+    payload = result.get("result") or {}
+    if "session_id" in payload:
+        print(payload["session_id"])
+    for session in payload.get("sessions", []):
+        print(f"{session['session_id']}\t{session['status']}")
+
+
+def handle_remote_browser(args) -> int:
+    args = list(args or [])
+    if not args:
+        print(USAGE, file=sys.stderr)
+        return 2
+    if args[0] in ("help", "--help", "-h"):
+        print(USAGE)
+        return 0
+    try:
+        positional, options = _parse(args)
+    except ValueError as exc:
+        print(f"usage: {exc}", file=sys.stderr)
+        return 2
+
+    if len(positional) < 2:
+        print("usage: co remote-browser <address> <command>", file=sys.stderr)
+        return 2
+    address, command, *rest = positional
+    if command not in {"start", "status", "sessions", "stop", "diagnose"}:
+        print(f"usage: unknown Remote Browser command '{command}'", file=sys.stderr)
+        return 2
+    needs_session = command in {"status", "stop", "diagnose"}
+    if len(rest) != (1 if needs_session else 0):
+        suffix = " <session-id>" if needs_session else ""
+        print(
+            f"usage: co remote-browser <address> {command}{suffix}",
+            file=sys.stderr,
+        )
+        return 2
+
+    from connectonion import connect
+    from connectonion.network.connect import _this_callers_identity
+
+    connect_kwargs = {"keys": _this_callers_identity()}
+    if options["relay_url"]:
+        connect_kwargs["relay_url"] = options["relay_url"]
+    command_args = {}
+    if command == "start":
+        command_args = {
+            "headless": options["headless"],
+            "proxy": options["proxy"],
+        }
+    try:
+        result = connect(address, **connect_kwargs).remote_browser(
+            command,
+            session_id=rest[0] if rest else None,
+            timeout=options["timeout"],
+            **command_args,
+        )
+    except Exception as exc:
+        result = {
+            "schema_version": "1",
+            "ok": False,
+            "command": f"remote-browser.{command}",
+            "request_id": "",
+            "code": "CONNECTION_FAILED",
+            "message": str(exc),
+            "retryable": True,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
+
+    if options["json_output"]:
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    else:
+        _print_human(result)
+    return 0 if result.get("ok") else 1

--- a/connectonion/cli/commands/remote_browser_commands.py
+++ b/connectonion/cli/commands/remote_browser_commands.py
@@ -77,8 +77,38 @@ def _print_human(result):
         print(f"{session['session_id']}\t{session['status']}")
 
 
+def _invalid_argument(message):
+    return {
+        "schema_version": "1",
+        "ok": False,
+        "command": "remote-browser",
+        "request_id": "",
+        "code": "INVALID_ARGUMENT",
+        "message": message,
+        "retryable": False,
+        "retry_after_seconds": None,
+        "state": {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+
+
+def _print_invalid_argument(message, *, json_output):
+    if json_output:
+        print(
+            json.dumps(
+                _invalid_argument(message), sort_keys=True, separators=(",", ":")
+            )
+        )
+    else:
+        print(f"usage: {message}", file=sys.stderr)
+    return 2
+
+
 def handle_remote_browser(args) -> int:
     args = list(args or [])
+    json_requested = "--json" in args
     if not args:
         print(USAGE, file=sys.stderr)
         return 2
@@ -88,24 +118,26 @@ def handle_remote_browser(args) -> int:
     try:
         positional, options = _parse(args)
     except ValueError as exc:
-        print(f"usage: {exc}", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(str(exc), json_output=json_requested)
 
     if len(positional) < 2:
-        print("usage: co remote-browser <address> <command>", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(
+            "co remote-browser <address> <command>",
+            json_output=options["json_output"],
+        )
     address, command, *rest = positional
     if command not in {"start", "status", "sessions", "stop", "diagnose"}:
-        print(f"usage: unknown Remote Browser command '{command}'", file=sys.stderr)
-        return 2
+        return _print_invalid_argument(
+            f"unknown Remote Browser command '{command}'",
+            json_output=options["json_output"],
+        )
     needs_session = command in {"status", "stop", "diagnose"}
     if len(rest) != (1 if needs_session else 0):
         suffix = " <session-id>" if needs_session else ""
-        print(
-            f"usage: co remote-browser <address> {command}{suffix}",
-            file=sys.stderr,
+        return _print_invalid_argument(
+            f"co remote-browser <address> {command}{suffix}",
+            json_output=options["json_output"],
         )
-        return 2
 
     from connectonion import connect
     from connectonion.network.connect import _this_callers_identity

--- a/connectonion/cli/main.py
+++ b/connectonion/cli/main.py
@@ -322,6 +322,21 @@ def browser(
     raise typer.Exit(handle_browser(args or [], headless=headless))
 
 
+@app.command(
+    "remote-browser",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def remote_browser(
+    args: List[str] = typer.Argument(
+        None, help="[options] <address> <start|status|sessions|stop|diagnose>"
+    ),
+):
+    """Manage an owner-bound browser session on a remote agent over OIP."""
+    from .commands.remote_browser_commands import handle_remote_browser
+
+    raise typer.Exit(handle_remote_browser(args or []))
+
+
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def call(
     args: List[str] = typer.Argument(None, help="[--out F] [--timeout S] [--relay U] <address> <command...>"),

--- a/connectonion/network/connect.py
+++ b/connectonion/network/connect.py
@@ -509,46 +509,9 @@ class RemoteAgent:
         try:
             async with connection as ws:
                 await ws.send(json.dumps(connect_msg))
-
-                # Wait for CONNECTED (EXEC needs the same auth gate as INPUT).
-                while True:
-                    raw = await asyncio.wait_for(ws.recv(), timeout=30)
-                    event = json.loads(raw)
-                    etype = event.get("type")
-                    if etype == "CONNECTED":
-                        break
-                    if etype == "ONBOARD_REQUIRED":
-                        # The same exchange input() does, on the same socket: submit
-                        # credentials and keep waiting. The host finishes the CONNECT
-                        # its trust gate interrupted (ws_router/session.py pops the
-                        # stashed pending_connect and calls establish_connection), so
-                        # CONNECTED arrives on this loop and the EXEC goes out below.
-                        #
-                        # This used to answer "run input() once to onboard" — the
-                        # Python API, which is no help to whoever typed `co call`.
-                        methods = event.get("methods", [])
-                        if not sys.stdin.isatty():
-                            # A script has no stdin to answer with, and prompting
-                            # would hang it. Fail, but say what the agent asked for.
-                            return ExecResult(
-                                text="", status="error",
-                                error=f"agent requires onboarding ({', '.join(methods) or 'no methods offered'})"
-                                      " — run this from a terminal to enter an invite code")
-                        try:
-                            credentials = self._prompt_onboard(methods, event.get("payment_amount"))
-                        except ValueError as declined:
-                            # Entering nothing is an answer, and a normal one.
-                            # _prompt_onboard raises for it, and every other refusal
-                            # call() can meet — a blacklist, a bad code, a tool that
-                            # is not whitelisted — comes back as an ExecResult. This
-                            # is that same channel, not a swallowed error.
-                            return ExecResult(text="", status="error",
-                                              error=f"onboarding not completed: {declined}")
-                        await ws.send(json.dumps(self._build_onboard_submit(credentials)))
-                        continue
-                    if etype == "ERROR":
-                        return ExecResult(text="", status="error",
-                                          error=event.get("message", "connect failed"))
+                connect_error = await self._wait_for_direct_command_connected(ws)
+                if connect_error:
+                    return ExecResult(text="", status="error", error=connect_error)
 
                 await ws.send(json.dumps(exec_msg))
 
@@ -571,6 +534,154 @@ class RemoteAgent:
                                           error=event.get("message", "exec failed"))
         except asyncio.TimeoutError:
             return ExecResult(text="", status="error", error=f"exec timed out after {timeout}s")
+
+    def remote_browser(
+        self,
+        command: str,
+        *,
+        session_id: str | None = None,
+        timeout: float = 60.0,
+        **args,
+    ) -> Dict[str, Any]:
+        """Run one typed, owner-bound Remote Browser lifecycle command."""
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError(
+                "remote_browser() cannot be used inside async context. "
+                "Use 'await agent.remote_browser_async()' instead."
+            )
+        except RuntimeError as exc:
+            if "remote_browser() cannot be used" in str(exc):
+                raise
+        return asyncio.run(
+            self.remote_browser_async(
+                command,
+                session_id=session_id,
+                timeout=timeout,
+                **args,
+            )
+        )
+
+    async def remote_browser_async(
+        self,
+        command: str,
+        *,
+        session_id: str | None = None,
+        timeout: float = 60.0,
+        **args,
+    ) -> Dict[str, Any]:
+        """Async Remote Browser lifecycle request over authenticated OIP."""
+        import websockets
+
+        await self._try_resolve_endpoint()
+        request_id = str(uuid.uuid4())
+        request = {
+            "type": "REMOTE_BROWSER",
+            "request_id": request_id,
+            "command": command,
+            "args": args,
+        }
+        if session_id is not None:
+            request["session_id"] = session_id
+
+        try:
+            connection, is_direct = await self._open_best_connection(websockets)
+            async with connection as ws:
+                await ws.send(json.dumps(self._build_connect_message(is_direct)))
+                connect_error = await self._wait_for_direct_command_connected(ws)
+                if connect_error:
+                    return self._remote_browser_client_error(
+                        request_id, command, "CONNECTION_FAILED", connect_error
+                    )
+                await ws.send(json.dumps(
+                    self._build_command_message(request, is_direct)
+                ))
+                while True:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+                    event = json.loads(raw)
+                    event_type = event.get("type")
+                    if (
+                        event_type == "REMOTE_BROWSER_RESULT"
+                        and event.get("request_id") == request_id
+                    ):
+                        event.pop("type", None)
+                        return event
+                    if event_type == "PING":
+                        await ws.send(json.dumps({"type": "PONG"}))
+                    elif event_type == "ERROR":
+                        return self._remote_browser_client_error(
+                            request_id,
+                            command,
+                            "CONNECTION_FAILED",
+                            event.get("message", "remote browser request failed"),
+                        )
+        except asyncio.TimeoutError:
+            return self._remote_browser_client_error(
+                request_id,
+                command,
+                "TIMEOUT",
+                f"remote browser request timed out after {timeout}s",
+                retryable=True,
+            )
+        except OSError as exc:
+            return self._remote_browser_client_error(
+                request_id,
+                command,
+                "CONNECTION_FAILED",
+                str(exc),
+                retryable=True,
+            )
+
+    async def _wait_for_direct_command_connected(self, ws) -> str | None:
+        """Complete CONNECT/onboarding for non-LLM command APIs."""
+        while True:
+            raw = await asyncio.wait_for(ws.recv(), timeout=30)
+            event = json.loads(raw)
+            event_type = event.get("type")
+            if event_type == "CONNECTED":
+                return None
+            if event_type == "ONBOARD_REQUIRED":
+                methods = event.get("methods", [])
+                if not sys.stdin.isatty():
+                    offered = ", ".join(methods) or "no methods offered"
+                    return (
+                        f"agent requires onboarding ({offered}) — run this from "
+                        "a terminal to enter an invite code"
+                    )
+                try:
+                    credentials = self._prompt_onboard(
+                        methods, event.get("payment_amount")
+                    )
+                except ValueError as declined:
+                    return f"onboarding not completed: {declined}"
+                await ws.send(json.dumps(self._build_onboard_submit(credentials)))
+                continue
+            if event_type == "ERROR":
+                return event.get("message", "connect failed")
+
+    @staticmethod
+    def _remote_browser_client_error(
+        request_id: str,
+        command: str,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+    ) -> Dict[str, Any]:
+        return {
+            "schema_version": "1",
+            "ok": False,
+            "command": f"remote-browser.{command}",
+            "request_id": request_id,
+            "code": code,
+            "message": message,
+            "retryable": retryable,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
 
     def reset(self) -> None:
         """Clear conversation and start fresh."""

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -1,0 +1,365 @@
+"""Owner-bound Remote Browser lifecycle over the existing browser daemon.
+
+This module owns no browser driver. It records OIP session authority and maps
+each session to one named tab in the already-shared daemon. Navigation is
+deliberately absent until the public-destination policy can cover redirects and
+subresources as well as the first URL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Callable
+
+SCHEMA_VERSION = "1"
+REQUEST_ID = re.compile(r"[\x21-\x7e]{1,128}")
+SESSION_ID = re.compile(r"rb_[0-9a-f]{32}")
+COMMANDS = frozenset({"start", "status", "sessions", "stop", "diagnose"})
+
+
+def _success(request_id: str, command: str, *, result=None, state=None) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": True,
+        "command": f"remote-browser.{command}",
+        "request_id": request_id,
+        "summary": {
+            "start": "Remote browser session started.",
+            "status": "Remote browser session status loaded.",
+            "sessions": "Remote browser sessions loaded.",
+            "stop": "Remote browser session stopped.",
+            "diagnose": "Remote browser diagnosis completed.",
+        }[command],
+        "result": result or {},
+        "state": state or {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+
+
+def _failure(
+    request_id: str,
+    command: str,
+    code: str,
+    message: str,
+    *,
+    retryable: bool = False,
+    state=None,
+    next_actions=None,
+) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "ok": False,
+        "command": f"remote-browser.{command}" if command else "remote-browser",
+        "request_id": request_id,
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+        "retry_after_seconds": None,
+        "state": state or {},
+        "tips": [],
+        "warnings": [],
+        "next_actions": next_actions or [],
+    }
+
+
+class RemoteBrowserService:
+    """Persistent authority registry delegating lifecycle to BrowserDaemon."""
+
+    def __init__(
+        self,
+        state_path: Path,
+        daemon_request: Callable | None = None,
+        clock: Callable[[], float] = time.time,
+    ):
+        self.state_path = Path(state_path)
+        self.clock = clock
+        self._lock = threading.RLock()
+        if daemon_request is None:
+            from ...cli.browser_agent.client import request_as
+
+            daemon_request = request_as
+        self.daemon_request = daemon_request
+
+    def _load(self) -> dict:
+        if not self.state_path.exists():
+            return {"version": 1, "sessions": {}}
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError("remote browser session registry is unreadable") from exc
+        if value.get("version") != 1 or not isinstance(value.get("sessions"), dict):
+            raise RuntimeError("remote browser session registry has an unknown format")
+        return value
+
+    def _save(self, value: dict) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f".{self.state_path.name}.", dir=self.state_path.parent
+        )
+        path = Path(temporary)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(value, handle, sort_keys=True, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            path.chmod(0o600)
+            path.replace(self.state_path)
+        finally:
+            path.unlink(missing_ok=True)
+
+    @staticmethod
+    def _public(session: dict) -> dict:
+        return {
+            key: session[key]
+            for key in (
+                "session_id",
+                "status",
+                "proxy_mode",
+                "created_at",
+                "updated_at",
+            )
+        }
+
+    def _owned(self, state: dict, session_id: str, owner: str) -> dict | None:
+        session = state["sessions"].get(session_id)
+        return session if session and session.get("owner") == owner else None
+
+    def handle(self, request: dict, *, owner: str, transport: str) -> dict:
+        request_id = request.get("request_id")
+        command = request.get("command")
+        if not isinstance(request_id, str) or not REQUEST_ID.fullmatch(request_id):
+            return _failure(
+                "",
+                str(command or ""),
+                "INVALID_ARGUMENT",
+                "request_id must be 1-128 visible ASCII characters.",
+            )
+        if command not in COMMANDS:
+            return _failure(
+                request_id,
+                str(command or ""),
+                "INVALID_ARGUMENT",
+                "Unknown Remote Browser command.",
+            )
+        if not owner:
+            return _failure(
+                request_id,
+                command,
+                "AUTH_REQUIRED",
+                "Remote Browser requires an authenticated caller.",
+            )
+        if transport != "direct":
+            return _failure(
+                request_id,
+                command,
+                "SECURE_CHANNEL_UNAVAILABLE",
+                "Relay Remote Browser control is unavailable until the reviewed OIP secure channel is negotiated.",
+                state={"fallback_applied": False},
+                next_actions=[
+                    {
+                        "id": "use_direct_endpoint",
+                        "command": "co remote-browser <address> status",
+                        "requires_user_approval": False,
+                    }
+                ],
+            )
+        try:
+            if command == "start":
+                return self._start(request_id, request.get("args") or {}, owner)
+            if command == "sessions":
+                return self._sessions(request_id, owner)
+            session_id = request.get("session_id")
+            if not isinstance(session_id, str) or not SESSION_ID.fullmatch(session_id):
+                return _failure(
+                    request_id,
+                    command,
+                    "INVALID_ARGUMENT",
+                    "A canonical rb_ session_id is required.",
+                )
+            if command == "status":
+                return self._status(request_id, session_id, owner)
+            if command == "stop":
+                return self._stop(request_id, session_id, owner)
+            return self._diagnose(request_id, session_id, owner)
+        except (OSError, RuntimeError) as exc:
+            return _failure(
+                request_id,
+                command,
+                "REMOTE_BROWSER_UNAVAILABLE",
+                str(exc),
+                retryable=True,
+                state={"fallback_applied": False},
+            )
+
+    def _start(self, request_id: str, args: dict, owner: str) -> dict:
+        if not isinstance(args, dict):
+            return _failure(
+                request_id, "start", "INVALID_ARGUMENT", "args must be an object."
+            )
+        proxy_mode = args.get("proxy", "direct")
+        if proxy_mode != "direct":
+            return _failure(
+                request_id,
+                "start",
+                "REMOTE_SESSION_PROXY_LOCKED",
+                "This review boundary supports only a direct, session-pinned egress.",
+                state={"fallback_applied": False},
+            )
+        headless = args.get("headless", True)
+        if not isinstance(headless, bool):
+            return _failure(
+                request_id, "start", "INVALID_ARGUMENT", "headless must be boolean."
+            )
+        with self._lock:
+            state = self._load()
+            for session in state["sessions"].values():
+                if (
+                    session.get("owner") == owner
+                    and session.get("start_request_id") == request_id
+                ):
+                    return _success(
+                        request_id,
+                        "start",
+                        result=self._public(session),
+                        state={"session": session["status"], "fallback_applied": False},
+                    )
+            session_id = f"rb_{uuid.uuid4().hex}"
+            tab = f"remote-{session_id[3:19]}"
+            line = shlex.join(
+                ["tab", "open", tab, "--who", owner, "--for", "remote-browser"]
+            )
+            code, payload = self.daemon_request(
+                line, caller=owner, account=owner, headless=headless
+            )
+            if code:
+                raise RuntimeError(payload or "browser daemon rejected session start")
+            if payload.strip() != tab:
+                raise RuntimeError("browser daemon returned an unexpected tab identity")
+            now = int(self.clock())
+            session = {
+                "session_id": session_id,
+                "owner": owner,
+                "tab": tab,
+                "status": "active",
+                "proxy_mode": "direct",
+                "headless": headless,
+                "start_request_id": request_id,
+                "created_at": now,
+                "updated_at": now,
+            }
+            state["sessions"][session_id] = session
+            try:
+                self._save(state)
+            except OSError:
+                # Opening the daemon tab precedes the durable commit. If that
+                # commit fails, release the unowned tab before reporting failure
+                # so a retry cannot accumulate invisible browser sessions.
+                try:
+                    self.daemon_request(
+                        shlex.join(["tab", "close", tab]),
+                        caller=owner,
+                        account=owner,
+                        headless=headless,
+                    )
+                except Exception:
+                    pass
+                raise
+        return _success(
+            request_id,
+            "start",
+            result=self._public(session),
+            state={"session": "active", "fallback_applied": False},
+        )
+
+    def _sessions(self, request_id: str, owner: str) -> dict:
+        with self._lock:
+            state = self._load()
+            sessions = [
+                self._public(session)
+                for session in state["sessions"].values()
+                if session.get("owner") == owner
+            ]
+        sessions.sort(key=lambda item: (item["created_at"], item["session_id"]))
+        return _success(request_id, "sessions", result={"sessions": sessions})
+
+    def _status(self, request_id: str, session_id: str, owner: str) -> dict:
+        with self._lock:
+            session = self._owned(self._load(), session_id, owner)
+            if session is None:
+                return _failure(
+                    request_id,
+                    "status",
+                    "REMOTE_SESSION_NOT_FOUND",
+                    "Remote browser session was not found.",
+                )
+            public = self._public(session)
+        return _success(
+            request_id,
+            "status",
+            result=public,
+            state={"session": session["status"], "fallback_applied": False},
+        )
+
+    def _stop(self, request_id: str, session_id: str, owner: str) -> dict:
+        with self._lock:
+            state = self._load()
+            session = self._owned(state, session_id, owner)
+            if session is None:
+                return _failure(
+                    request_id,
+                    "stop",
+                    "REMOTE_SESSION_NOT_FOUND",
+                    "Remote browser session was not found.",
+                )
+            if session["status"] != "stopped":
+                code, payload = self.daemon_request(
+                    shlex.join(["tab", "close", session["tab"]]),
+                    caller=owner,
+                    account=owner,
+                    headless=session["headless"],
+                )
+                if code not in (0, 3):
+                    raise RuntimeError(
+                        payload or "browser daemon rejected session stop"
+                    )
+                session["status"] = "stopped"
+                session["updated_at"] = int(self.clock())
+                self._save(state)
+            public = self._public(session)
+        return _success(
+            request_id,
+            "stop",
+            result=public,
+            state={"session": "stopped", "fallback_applied": False},
+        )
+
+    def _diagnose(self, request_id: str, session_id: str, owner: str) -> dict:
+        status = self._status(request_id, session_id, owner)
+        if not status["ok"]:
+            return status
+        status["command"] = "remote-browser.diagnose"
+        status["summary"] = "Remote browser diagnosis completed."
+        status["result"] = {
+            **status["result"],
+            "checks": {
+                "authenticated_owner": "ok",
+                "session_registry": "ok",
+                "transport": "direct",
+                "proxy_mode": "direct",
+                "navigation_policy": "not_enabled",
+            },
+        }
+        status["warnings"] = [
+            "Remote navigation remains disabled until the public-destination policy is enforced."
+        ]
+        return status

--- a/connectonion/network/host/remote_browser.py
+++ b/connectonion/network/host/remote_browser.py
@@ -175,7 +175,7 @@ class RemoteBrowserService:
             )
         try:
             if command == "start":
-                return self._start(request_id, request.get("args") or {}, owner)
+                return self._start(request_id, request.get("args", {}), owner)
             if command == "sessions":
                 return self._sessions(request_id, owner)
             session_id = request.get("session_id")

--- a/connectonion/network/host/server.py
+++ b/connectonion/network/host/server.py
@@ -68,6 +68,7 @@ from .http_router import (
     admin_admins_remove_handler,
 )
 from .provider_workroom import prepare_provider_workroom_turn
+from .remote_browser import RemoteBrowserService
 
 
 EXEC_REQUIRES = ("admin", "whitelist", "contact")
@@ -109,6 +110,71 @@ def _make_ws_exec(create_agent, exec_permissions, trust_agent):
         return exec_handler(create_agent, exec_permissions, tool_name, args)
 
     return handle_ws_exec
+
+
+def _make_remote_browser(remote_browser_service, trust_agent):
+    """Bind Remote Browser to authenticated contact-or-admin authority."""
+    def handle_remote_browser(request, requester_address=None, transport="unknown"):
+        if not requester_address:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "AUTH_REQUIRED",
+                "message": "Remote Browser requires an authenticated caller.",
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        level = (
+            "admin"
+            if trust_agent.is_admin(requester_address)
+            else trust_agent.get_level(requester_address)
+        )
+        if level not in EXEC_REQUIRES:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "FORBIDDEN",
+                "message": (
+                    "Remote Browser requires a contact or admin; "
+                    f"the authenticated caller is {level}."
+                ),
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        if remote_browser_service is None:
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser",
+                "request_id": request.get("request_id", ""),
+                "code": "REMOTE_BROWSER_UNAVAILABLE",
+                "message": "Remote Browser is not configured on this host.",
+                "retryable": False,
+                "retry_after_seconds": None,
+                "state": {},
+                "tips": [],
+                "warnings": [],
+                "next_actions": [],
+            }
+        return remote_browser_service.handle(
+            request,
+            owner=requester_address,
+            transport=transport,
+        )
+
+    return handle_remote_browser
 
 
 def _parse_trust_config(trust: Union[str, "Agent"]) -> dict | None:
@@ -227,6 +293,7 @@ def _create_route_handlers(
     exec_permissions: dict | None = None,
     replay_check=None,
     mode_policy: HostPermissionPolicy | None = None,
+    remote_browser_service=None,
 ):
     """Create route handler dict for ASGI app.
 
@@ -287,6 +354,7 @@ def _create_route_handlers(
                              is_admin=bool(requester and requester["level"] == "admin"))
 
     handle_ws_exec = _make_ws_exec(create_agent, exec_permissions, trust_agent)
+    handle_remote_browser = _make_remote_browser(remote_browser_service, trust_agent)
 
     def handle_prepare_provider_workroom_turn(
         storage,
@@ -331,6 +399,7 @@ def _create_route_handlers(
         "replay": replay_check,
         "ws_input": handle_ws_input,
         "ws_exec": handle_ws_exec,
+        "remote_browser": handle_remote_browser,
         "prepare_provider_workroom_turn": handle_prepare_provider_workroom_turn,
         "admin_logs": handle_admin_logs,
         "admin_sessions": admin_sessions_handler,
@@ -1046,10 +1115,14 @@ def host(
     exec_permissions = load_permission_patterns(co_dir)
 
     replay_store = SignatureReplayStore(co_dir / "replay.sqlite3")
+    remote_browser_service = RemoteBrowserService(
+        co_dir / "remote-browser-sessions.json"
+    )
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent, config,
         exec_permissions, replay_store.already_used,
         mode_policy=_host_mode_policy(sample),
+        remote_browser_service=remote_browser_service,
     )
 
     # Parse trust config for /info onboard info
@@ -1183,11 +1256,15 @@ def create_app(create_agent: Callable, storage=None, trust="careful", result_ttl
 
     from ...useful_plugins.tool_approval.approval import load_permission_patterns
     replay_store = SignatureReplayStore(replay_dir / "replay.sqlite3")
+    remote_browser_service = RemoteBrowserService(
+        replay_dir / "remote-browser-sessions.json"
+    )
     route_handlers = _create_route_handlers(
         create_agent, agent_metadata, result_ttl, trust_agent,
         DEFAULT_FILE_LIMITS, load_permission_patterns(),
         replay_store.already_used,
         mode_policy=_host_mode_policy(sample),
+        remote_browser_service=remote_browser_service,
     )
     balance_startup, balance_shutdown = _create_balance_lifespan(
         sample, agent_metadata

--- a/connectonion/network/host/ws_router/remote_browser.py
+++ b/connectonion/network/host/ws_router/remote_browser.py
@@ -1,0 +1,38 @@
+"""Dispatch authenticated Remote Browser lifecycle requests."""
+
+import asyncio
+
+
+async def run_remote_browser(
+    data,
+    send_msg,
+    route_handlers,
+    *,
+    requester_address,
+    transport,
+):
+    """Run one host-owned browser lifecycle request outside the WS read loop."""
+    request_id = data.get("request_id")
+    try:
+        result = await asyncio.to_thread(
+            route_handlers["remote_browser"],
+            data,
+            requester_address,
+            transport,
+        )
+    except Exception as exc:
+        result = {
+            "schema_version": "1",
+            "ok": False,
+            "command": "remote-browser",
+            "request_id": request_id if isinstance(request_id, str) else "",
+            "code": "REMOTE_BROWSER_UNAVAILABLE",
+            "message": f"{type(exc).__name__}: {exc}",
+            "retryable": True,
+            "retry_after_seconds": None,
+            "state": {},
+            "tips": [],
+            "warnings": [],
+            "next_actions": [],
+        }
+    await send_msg({"type": "REMOTE_BROWSER_RESULT", **result})

--- a/connectonion/network/host/ws_router/session.py
+++ b/connectonion/network/host/ws_router/session.py
@@ -20,6 +20,7 @@ from .connect import establish_connection, handle_authenticated_reconnect, handl
 from .exec import run_exec
 from .mode import handle_mode_change
 from .ping import ping_loop
+from .remote_browser import run_remote_browser
 
 console = Console()
 
@@ -289,6 +290,25 @@ async def run_ws_session(send_msg, recv_msg, *, route_handlers, storage, registr
                     # whitelisted tool (#653).
                     task = asyncio.create_task(
                         run_exec(data, send_msg, route_handlers, conn["agent_address"]))
+                    exec_tasks.add(task)
+                    task.add_done_callback(exec_tasks.discard)
+
+            elif msg_type == "REMOTE_BROWSER":
+                if not conn["authenticated"]:
+                    await send_msg({
+                        "type": "ERROR",
+                        "message": "authenticate first (send CONNECT)",
+                    })
+                else:
+                    task = asyncio.create_task(
+                        run_remote_browser(
+                            data,
+                            send_msg,
+                            route_handlers,
+                            requester_address=conn["agent_address"],
+                            transport=conn["transport"],
+                        )
+                    )
                     exec_tasks.add(task)
                     task.add_done_callback(exec_tasks.discard)
 

--- a/docs/1.8-development-plan.md
+++ b/docs/1.8-development-plan.md
@@ -355,6 +355,14 @@ Planning window: weeks 3–6.
 
 ### Remote Browser service
 
+Implementation checkpoint (2026-08-26): #1296 is the first review boundary.
+It implements typed direct-OIP lifecycle only: `start`, `status`, `sessions`,
+`stop`, and `diagnose`, with authenticated owner binding, idempotent Start/Stop,
+and a persistent Host registry delegated to the existing Browser daemon. Relay
+fails closed until #1172, and navigation remains absent until one destination
+policy covers redirects, DNS changes, and subresources (#1297). See
+[DD-055](design-decisions/055-owner-bound-remote-browser-lifecycle.md).
+
 Build one transport-neutral command service over Browser Core:
 
 ```text

--- a/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
+++ b/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
@@ -2,42 +2,54 @@
 
 *2026-08-26*
 
-The shortest route to a remote browser already existed: execute `co browser` as
-a remote shell command. It could open a page. It could also skip the contract we
-actually needed.
+The first Remote Browser sketch worked in one terminal. We sent a remote shell
+command to `co browser`, it opened a tab, and it printed an identifier. For a
+demo, that looked finished.
 
-A shell result cannot answer who owns the browser session after reconnect, what
-an idempotent retry means, or whether a copied session ID grants control. Adding
-more verbs to that path would make the demo grow faster than its authority
-model.
+Then we opened a second terminal.
 
-## Bind ownership before adding power
+The first connection was gone, so the next command had only the printed
+identifier. If we accepted it, anyone who copied the identifier could control
+the tab. If we rejected it, the original caller could not reconnect. A Host
+restart made the problem worse: the browser daemon could still be alive while
+the shell command had left no durable record of who owned its tab.
 
-The first Remote Browser OIP frame therefore does less. It starts, lists,
-inspects, diagnoses, and stops an owner-bound session. The Host takes the owner
-from the authenticated connection; the request has no owner field to spoof. The
-session ID locates a record but grants nothing. A different authenticated caller
-gets the same not-found result as an invented ID.
+The identifier told us which browser object we meant. It told us nothing about
+who had authority over it.
 
-The service also refuses to become another browser implementation. It opens a
-named tab in the existing concurrent daemon and records the lifecycle in one
-atomic, private registry. Repeating Start with the same request ID returns the
-same session. Repeating Stop returns the same tombstone. Restarting Host reloads
-the authority instead of manufacturing a new one.
+## The turn was deleting the exciting command
 
-## The missing navigation verb is the feature
+Our first instinct was to keep the demo and add checks around it. Instead, we
+removed navigation and wrote the ownership test first: Alice starts a session,
+Bob obtains its ID, and Bob asks for status, diagnosis, and stop. Every answer
+must look exactly like a nonexistent session. Alice reconnects through a new
+Host service instance and still sees her session. Repeating the same Start must
+not open a second tab; repeating Stop must not fail or close something else.
 
-It is tempting to add `open` next and call direct mode usable. A URL allowlist at
-the command edge would be theatre. The first URL can redirect; its hostname can
-resolve differently; the page can fetch private and link-local subresources.
-Until one policy covers the entire request chain, navigation stays absent and
-diagnosis says so explicitly.
+That test forced the protocol to carry less authority, not more data. The Host
+takes the owner from the authenticated OIP connection. There is no owner field
+in the request for a caller to spoof. The session ID only locates a private
+registry record after the owner matches. The record survives a Host restart and
+maps to a named tab in the existing browser daemon, so Remote Browser does not
+quietly become a second driver.
 
-Relay stays absent for a similar reason. Signed OIP commands authenticate a
-caller, but they do not hide browser-control plaintext from the Relay. The
-service returns a typed secure-channel error instead of silently weakening the
-route.
+Only then did the original one-terminal demo become a real lifecycle:
+start, list, inspect, diagnose, stop, disconnect, and reconnect.
 
-This is a narrow preview, but it establishes the part that is hardest to retrofit:
-identity, authority, retry, reconnect, and refusal semantics. Page actions can be
-added after their network boundary is executable, not merely described.
+## The next shortcut failed for the same reason
+
+With ownership fixed, adding `open` looked trivial. It was not. Checking the
+first URL would still allow a redirect to a private address, a hostname to
+resolve differently on the next request, or a public page to fetch private and
+link-local subresources. An allowlist at the CLI boundary would make the demo
+look safe while the browser crossed a different boundary underneath it.
+
+So diagnosis now reports navigation as unavailable. Relay control also fails
+closed: a signed OIP command authenticates its caller, but without the reviewed
+secure channel it does not hide browser-control plaintext from the Relay.
+
+The useful lesson came from that second terminal. A session ID is a reference,
+not a capability. Once we treated it that way, retries, reconnects, restarts,
+and refusals became part of one authority model. Navigation can arrive later,
+after its whole network path—not just its first URL—can enforce the same kind of
+boundary.

--- a/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
+++ b/docs/blog/2026-08-26-a-session-id-is-not-browser-authority.md
@@ -1,0 +1,43 @@
+# A Session ID Is Not Browser Authority
+
+*2026-08-26*
+
+The shortest route to a remote browser already existed: execute `co browser` as
+a remote shell command. It could open a page. It could also skip the contract we
+actually needed.
+
+A shell result cannot answer who owns the browser session after reconnect, what
+an idempotent retry means, or whether a copied session ID grants control. Adding
+more verbs to that path would make the demo grow faster than its authority
+model.
+
+## Bind ownership before adding power
+
+The first Remote Browser OIP frame therefore does less. It starts, lists,
+inspects, diagnoses, and stops an owner-bound session. The Host takes the owner
+from the authenticated connection; the request has no owner field to spoof. The
+session ID locates a record but grants nothing. A different authenticated caller
+gets the same not-found result as an invented ID.
+
+The service also refuses to become another browser implementation. It opens a
+named tab in the existing concurrent daemon and records the lifecycle in one
+atomic, private registry. Repeating Start with the same request ID returns the
+same session. Repeating Stop returns the same tombstone. Restarting Host reloads
+the authority instead of manufacturing a new one.
+
+## The missing navigation verb is the feature
+
+It is tempting to add `open` next and call direct mode usable. A URL allowlist at
+the command edge would be theatre. The first URL can redirect; its hostname can
+resolve differently; the page can fetch private and link-local subresources.
+Until one policy covers the entire request chain, navigation stays absent and
+diagnosis says so explicitly.
+
+Relay stays absent for a similar reason. Signed OIP commands authenticate a
+caller, but they do not hide browser-control plaintext from the Relay. The
+service returns a typed secure-channel error instead of silently weakening the
+route.
+
+This is a narrow preview, but it establishes the part that is hardest to retrofit:
+identity, authority, retry, reconnect, and refusal semantics. Page actions can be
+added after their network boundary is executable, not merely described.

--- a/docs/design-decisions/055-owner-bound-remote-browser-lifecycle.md
+++ b/docs/design-decisions/055-owner-bound-remote-browser-lifecycle.md
@@ -1,0 +1,72 @@
+# DD-055: Remote Browser starts with owner-bound lifecycle, not navigation
+
+**Status:** In progress for 1.8
+
+**Date:** 2026-08-26
+
+**Related:** [#991](https://github.com/openonion/connectonion/issues/991),
+[#1296](https://github.com/openonion/connectonion/issues/1296),
+[#1297](https://github.com/openonion/connectonion/issues/1297),
+[#1036](https://github.com/openonion/connectonion/issues/1036),
+[#1172](https://github.com/openonion/connectonion/issues/1172),
+[DD-053](053-oip-only-browser-and-native-coding-adapters.md),
+[DD-054](054-one-async-browser-runtime.md)
+
+## Context
+
+`co call <host> co browser ...` can execute a shell command remotely, but it is
+not a Remote Browser protocol. It exposes no durable browser-session identity,
+does not bind a session to the authenticated OIP caller, and returns the generic
+EXEC result shape. Building a second remote driver would also bypass the tab
+claims and one async runtime established by DD-054.
+
+Navigation is a separate security boundary. Checking only the submitted URL is
+not sufficient: redirects and subresources can reach loopback, link-local,
+private-network, metadata, or otherwise prohibited destinations after the first
+request appears safe.
+
+Relay adds another boundary. OIP identity signatures authenticate commands but
+do not make the Relay blind to browser-control content. Relay Remote Browser
+therefore depends on the reviewed secure channel tracked in #1172.
+
+## Decision
+
+The first 1.8 slice introduces a typed, signed `REMOTE_BROWSER` OIP frame and a
+stable `REMOTE_BROWSER_RESULT` envelope. It supports only `start`, `status`,
+`sessions`, `stop`, and `diagnose`.
+
+The Host derives the owner from the authenticated OIP connection. A request
+cannot supply or replace it. Only contacts, whitelisted callers, and admins may
+use the service. Session IDs locate records but grant no authority: another
+caller receives the same not-found response as a nonexistent session.
+
+The Host owns one persistent, mode-0600 session registry and delegates tab
+lifecycle to the existing Browser daemon. The authenticated owner is also the
+daemon tab owner. Start is idempotent by owner and request ID; Stop keeps a
+tombstone and is idempotent. Host restart reloads the same registry rather than
+minting new authority.
+
+Only a direct OIP transport and `proxy=direct` are admitted in this slice. Relay
+fails with `SECURE_CHANNEL_UNAVAILABLE`; other proxy modes fail with
+`REMOTE_SESSION_PROXY_LOCKED`. Neither condition silently falls back. Navigation
+is absent, and `diagnose` reports `navigation_policy: not_enabled`.
+
+## Consequences
+
+- Remote Browser is not a wrapper around generic shell execution.
+- The daemon and async core remain the only browser runtime.
+- Lifecycle, identity, retry, reconnect, and Host-restart behavior can be tested
+  before URL access is exposed.
+- The first useful release is deliberately narrower: it cannot yet navigate,
+  capture, act, take over, or release.
+- Navigation may land only with a policy enforced across initial requests,
+  redirects, DNS changes, and subresources.
+- Relay may land only after #1172 supplies the reviewed, downgrade-resistant
+  secure channel.
+
+## Revisit
+
+Extend the command set when #1297 has executable negative
+tests and the same lifecycle conformance suite passes through the installed
+artifact. Enable Relay only after its secure-channel vectors pass in every OIP
+implementation and the Relay sees no command plaintext.

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -15,7 +15,8 @@ Use `--json` for the complete stable envelope. A successful envelope includes
 `schema_version`, `ok`, `command`, `request_id`, `summary`, `result`, `state`,
 `tips`, `warnings`, and `next_actions`. Failures add a stable `code`, `message`,
 `retryable`, and `retry_after_seconds`; scripts should branch on `ok` and `code`,
-not English text.
+not English text. With `--json`, local validation failures use that envelope too
+and write no human usage text to stderr.
 
 `start` is idempotent for the same authenticated owner and request ID. Session
 IDs are identifiers, not bearer secrets. Status, listing, diagnosis, and Stop
@@ -27,6 +28,11 @@ This preview accepts direct OIP transport and `proxy=direct` only. A Relay path
 returns `SECURE_CHANNEL_UNAVAILABLE` until the reviewed OIP secure channel is
 available. It never downgrades to plaintext browser control. Other proxy modes
 return `REMOTE_SESSION_PROXY_LOCKED`.
+
+The Python async API returns a `TIMEOUT` envelope when its response deadline
+expires. Cancelling the calling task remains normal Python cancellation: it
+raises `asyncio.CancelledError` instead of turning cancellation into a retryable
+remote failure.
 
 Navigation is intentionally unavailable. Validating only the initial URL would
 leave redirects, DNS changes, and subresources able to cross the intended

--- a/docs/network/remote-browser.md
+++ b/docs/network/remote-browser.md
@@ -1,0 +1,39 @@
+# Remote Browser lifecycle (1.8 preview)
+
+Remote Browser is an authenticated OIP service for browser sessions owned by a
+remote caller. The first 1.8 boundary manages lifecycle only:
+
+```bash
+co remote-browser 0xHOST start
+co remote-browser 0xHOST sessions
+co remote-browser 0xHOST status rb_0123456789abcdef0123456789abcdef
+co remote-browser 0xHOST diagnose rb_0123456789abcdef0123456789abcdef
+co remote-browser 0xHOST stop rb_0123456789abcdef0123456789abcdef
+```
+
+Use `--json` for the complete stable envelope. A successful envelope includes
+`schema_version`, `ok`, `command`, `request_id`, `summary`, `result`, `state`,
+`tips`, `warnings`, and `next_actions`. Failures add a stable `code`, `message`,
+`retryable`, and `retry_after_seconds`; scripts should branch on `ok` and `code`,
+not English text.
+
+`start` is idempotent for the same authenticated owner and request ID. Session
+IDs are identifiers, not bearer secrets. Status, listing, diagnosis, and Stop
+are filtered by the OIP identity that completed CONNECT, so copying another
+owner's session ID does not grant access. Stop is idempotent and retains a
+tombstone for retry/reconnect evidence.
+
+This preview accepts direct OIP transport and `proxy=direct` only. A Relay path
+returns `SECURE_CHANNEL_UNAVAILABLE` until the reviewed OIP secure channel is
+available. It never downgrades to plaintext browser control. Other proxy modes
+return `REMOTE_SESSION_PROXY_LOCKED`.
+
+Navigation is intentionally unavailable. Validating only the initial URL would
+leave redirects, DNS changes, and subresources able to cross the intended
+network boundary. `diagnose` therefore reports `navigation_policy: not_enabled`.
+Continue to use local `co browser` for page actions while that policy is being
+specified and tested in
+[#1297](https://github.com/openonion/connectonion/issues/1297).
+
+See [DD-055](../design-decisions/055-owner-bound-remote-browser-lifecycle.md)
+for the decision and follow-up gates.

--- a/tests/e2e/cli/test_cli_help.py
+++ b/tests/e2e/cli/test_cli_help.py
@@ -58,6 +58,7 @@ class TestCliHelp:
         assert "status" in result.output
         assert "reset" in result.output
         assert "browser" in result.output
+        assert "remote-browser" in result.output
         assert "Commands" in result.output
 
     def test_version_flag(self):

--- a/tests/e2e/cli/test_remote_browser_daemon.py
+++ b/tests/e2e/cli/test_remote_browser_daemon.py
@@ -1,14 +1,20 @@
 """Remote Browser lifecycle through the real native daemon transport."""
 
+import asyncio
 import contextlib
+import json
 import os
 import threading
 import time
 
+from connectonion import address
 from connectonion.cli.browser_agent import transport
 from connectonion.cli.browser_agent.client import request_as
 from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.network.connect import RemoteAgent
 from connectonion.network.host.remote_browser import RemoteBrowserService
+from connectonion.network.host.server import _make_remote_browser
+from connectonion.network.host.ws_router import session as ws_session
 
 
 class LifecycleBrowser:
@@ -27,6 +33,70 @@ class LifecycleBrowser:
 
     def close(self):
         return "Browser closed"
+
+
+class ContactTrust:
+    def is_admin(self, owner):
+        return False
+
+    def get_level(self, owner):
+        return "contact"
+
+
+async def _signed_start(service, monkeypatch):
+    keys = address.generate()
+    host = "0x" + "12" * 20
+    command = RemoteAgent(host, keys=keys)._build_command_message(
+        {
+            "type": "REMOTE_BROWSER",
+            "request_id": "native-start",
+            "command": "start",
+            "args": {"headless": True, "proxy": "direct"},
+        },
+        is_direct=True,
+    )
+    frames = [{"type": "CONNECT", "from": keys["address"]}, command]
+    result_sent = asyncio.Event()
+    sent = []
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=keys["address"],
+            signed_commands=True,
+            recipient_address=host,
+            session_id="native-oip",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    monkeypatch.setattr(ws_session, "handle_connect", fake_connect)
+    await ws_session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, ContactTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+    result = next(
+        message for message in sent if message.get("type") == "REMOTE_BROWSER_RESULT"
+    )
+    assert json.loads(json.dumps(result))["request_id"] == "native-start"
+    return result, keys["address"]
 
 
 def _wait_for_daemon(socket_path):
@@ -51,18 +121,11 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
         _wait_for_daemon(socket_path)
         state_path = tmp_path / "remote-browser-sessions.json"
         service = RemoteBrowserService(state_path, daemon_request=request_as)
-        started = service.handle(
-            {
-                "request_id": "native-start",
-                "command": "start",
-                "args": {"headless": True, "proxy": "direct"},
-            },
-            owner="0xowner",
-            transport="direct",
-        )
+        started, owner = asyncio.run(_signed_start(service, monkeypatch))
         assert started["ok"] is True
         session_id = started["result"]["session_id"]
         assert len(daemon.browser._tab_meta) == 1
+        assert next(iter(daemon.browser._tab_meta.values()))["opened_by"] == owner
 
         restarted_host_service = RemoteBrowserService(
             state_path, daemon_request=request_as
@@ -73,7 +136,7 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
                 "command": "status",
                 "session_id": session_id,
             },
-            owner="0xowner",
+            owner=owner,
             transport="direct",
         )
         assert status["state"]["session"] == "active"
@@ -84,7 +147,7 @@ def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
                 "command": "stop",
                 "session_id": session_id,
             },
-            owner="0xowner",
+            owner=owner,
             transport="direct",
         )
         assert stopped["state"]["session"] == "stopped"

--- a/tests/e2e/cli/test_remote_browser_daemon.py
+++ b/tests/e2e/cli/test_remote_browser_daemon.py
@@ -1,0 +1,102 @@
+"""Remote Browser lifecycle through the real native daemon transport."""
+
+import contextlib
+import os
+import threading
+import time
+
+from connectonion.cli.browser_agent import transport
+from connectonion.cli.browser_agent.client import request_as
+from connectonion.cli.browser_agent.daemon import BrowserDaemon
+from connectonion.network.host.remote_browser import RemoteBrowserService
+
+
+class LifecycleBrowser:
+    """Small runtime seam: the test targets transport/claims, not Chrome."""
+
+    def __init__(self):
+        self._tab_meta = {}
+        self._pages = {}
+
+    def _bind_session(self, session):
+        self.session = session
+
+    def close_tab(self, name):
+        self._tab_meta.pop(name, None)
+        return f"Closed tab {name}"
+
+    def close(self):
+        return "Browser closed"
+
+
+def _wait_for_daemon(socket_path):
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if os.path.exists(transport.pid_path(socket_path)):
+            return
+        time.sleep(0.02)
+    raise RuntimeError("daemon did not bind in time")
+
+
+def test_remote_lifecycle_uses_one_native_daemon_and_survives_host_restart(
+    tmp_path, monkeypatch
+):
+    socket_path = f"/tmp/co_remote_{os.getpid()}_{time.time_ns()}.sock"
+    monkeypatch.setenv("CO_BROWSER_SOCK", socket_path)
+    daemon = BrowserDaemon(socket_path, headless=True)
+    daemon.browser = LifecycleBrowser()
+    thread = threading.Thread(target=daemon.serve, daemon=True)
+    thread.start()
+    try:
+        _wait_for_daemon(socket_path)
+        state_path = tmp_path / "remote-browser-sessions.json"
+        service = RemoteBrowserService(state_path, daemon_request=request_as)
+        started = service.handle(
+            {
+                "request_id": "native-start",
+                "command": "start",
+                "args": {"headless": True, "proxy": "direct"},
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert started["ok"] is True
+        session_id = started["result"]["session_id"]
+        assert len(daemon.browser._tab_meta) == 1
+
+        restarted_host_service = RemoteBrowserService(
+            state_path, daemon_request=request_as
+        )
+        status = restarted_host_service.handle(
+            {
+                "request_id": "native-status",
+                "command": "status",
+                "session_id": session_id,
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert status["state"]["session"] == "active"
+
+        stopped = restarted_host_service.handle(
+            {
+                "request_id": "native-stop",
+                "command": "stop",
+                "session_id": session_id,
+            },
+            owner="0xowner",
+            transport="direct",
+        )
+        assert stopped["state"]["session"] == "stopped"
+        assert daemon.browser._tab_meta == {}
+    finally:
+        daemon._cleanup()
+        thread.join(timeout=2)
+        for path in (
+            socket_path,
+            transport.pid_path(socket_path),
+            transport.lock_path(socket_path),
+        ):
+            with contextlib.suppress(OSError):
+                if os.path.exists(path):
+                    os.unlink(path)

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -1,0 +1,99 @@
+"""CLI contract tests for ``co remote-browser``."""
+
+import json
+import importlib
+
+from connectonion.cli.commands.remote_browser_commands import handle_remote_browser
+
+
+class FakeRemote:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def remote_browser(self, command, **kwargs):
+        self.calls.append((command, kwargs))
+        return self.result
+
+
+def _result(ok=True, **extra):
+    value = {
+        "schema_version": "1",
+        "ok": ok,
+        "command": "remote-browser.start",
+        "request_id": "req-1",
+        "summary": "Remote browser session started.",
+        "result": {"session_id": "rb_" + "1" * 32, "status": "active"},
+        "state": {"session": "active"},
+        "tips": [],
+        "warnings": [],
+        "next_actions": [],
+    }
+    value.update(extra)
+    return value
+
+
+def _install(monkeypatch, result):
+    remote = FakeRemote(result)
+    monkeypatch.setattr("connectonion.connect", lambda address, **kwargs: remote)
+    connect_module = importlib.import_module("connectonion.network.connect")
+    monkeypatch.setattr(
+        connect_module, "_this_callers_identity", lambda: {"address": "0xme"}
+    )
+    return remote
+
+
+def test_start_forwards_only_typed_start_options(monkeypatch, capsys):
+    remote = _install(monkeypatch, _result())
+
+    assert handle_remote_browser(["--headed", "--timeout", "5", "0xhost", "start"]) == 0
+
+    assert remote.calls == [
+        (
+            "start",
+            {
+                "session_id": None,
+                "timeout": 5.0,
+                "headless": False,
+                "proxy": "direct",
+            },
+        )
+    ]
+    assert "rb_" in capsys.readouterr().out
+
+
+def test_json_is_the_stable_envelope(monkeypatch, capsys):
+    expected = _result()
+    _install(monkeypatch, expected)
+
+    assert handle_remote_browser(["--json", "0xhost", "start"]) == 0
+
+    assert json.loads(capsys.readouterr().out) == expected
+
+
+def test_session_command_requires_exactly_one_session_id(capsys):
+    assert handle_remote_browser(["0xhost", "status"]) == 2
+    assert "session-id" in capsys.readouterr().err
+
+
+def test_failure_is_exit_one_and_preserves_code(monkeypatch, capsys):
+    _install(
+        monkeypatch,
+        _result(
+            ok=False,
+            code="SECURE_CHANNEL_UNAVAILABLE",
+            message="direct endpoint required",
+        ),
+    )
+
+    assert handle_remote_browser(["0xhost", "sessions"]) == 1
+
+    assert "SECURE_CHANNEL_UNAVAILABLE" in capsys.readouterr().err
+
+
+def test_proxy_option_is_not_accepted_by_non_start_command(monkeypatch):
+    remote = _install(monkeypatch, _result())
+
+    handle_remote_browser(["--proxy", "direct", "0xhost", "sessions"])
+
+    assert remote.calls == [("sessions", {"session_id": None, "timeout": 60.0})]

--- a/tests/unit/test_cli_remote_browser.py
+++ b/tests/unit/test_cli_remote_browser.py
@@ -71,6 +71,16 @@ def test_json_is_the_stable_envelope(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out) == expected
 
 
+def test_json_validation_failure_emits_only_one_json_envelope(capsys):
+    assert handle_remote_browser(["--json", "0xhost", "status"]) == 2
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["ok"] is False
+    assert result["code"] == "INVALID_ARGUMENT"
+    assert captured.err == ""
+
+
 def test_session_command_requires_exactly_one_session_id(capsys):
     assert handle_remote_browser(["0xhost", "status"]) == 2
     assert "session-id" in capsys.readouterr().err

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -47,6 +47,12 @@ class WaitingConnection(FakeConnection):
         super().__init__()
         self.waiting = asyncio.Event()
 
+    async def send(self, raw):
+        frame = json.loads(raw)
+        self.sent.append(frame)
+        if frame["type"] == "CONNECT":
+            self.replies.append({"type": "CONNECTED", "session_id": "oip-1"})
+
     async def recv(self):
         if self.replies:
             return json.dumps(self.replies.pop(0))

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -1,5 +1,6 @@
 """RemoteAgent's typed Remote Browser request/response contract."""
 
+import asyncio
 import json
 
 import pytest
@@ -39,6 +40,17 @@ class FakeConnection:
 
     async def __aexit__(self, *args):
         return False
+
+
+class WaitingConnection(FakeConnection):
+    def __init__(self):
+        super().__init__()
+        self.waiting = asyncio.Event()
+
+    async def recv(self):
+        if self.replies:
+            return json.dumps(self.replies.pop(0))
+        await self.waiting.wait()
 
 
 @pytest.mark.asyncio
@@ -87,3 +99,46 @@ async def test_connection_failure_returns_stable_error_envelope(monkeypatch):
     assert result["code"] == "CONNECTION_FAILED"
     assert result["retryable"] is True
     assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_response_timeout_returns_stable_error_envelope(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = WaitingConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+
+    result = await remote.remote_browser_async("sessions", timeout=0.01)
+
+    assert result["ok"] is False
+    assert result["code"] == "TIMEOUT"
+    assert result["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_python_cancellation_propagates_without_becoming_a_retry(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = WaitingConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+    task = asyncio.create_task(remote.remote_browser_async("sessions", timeout=60))
+    while len(connection.sent) < 2:
+        await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/unit/test_remote_browser_client.py
+++ b/tests/unit/test_remote_browser_client.py
@@ -1,0 +1,89 @@
+"""RemoteAgent's typed Remote Browser request/response contract."""
+
+import json
+
+import pytest
+
+from connectonion import address
+from connectonion.network.connect import RemoteAgent
+
+
+class FakeConnection:
+    def __init__(self):
+        self.sent = []
+        self.replies = []
+
+    async def send(self, raw):
+        frame = json.loads(raw)
+        self.sent.append(frame)
+        if frame["type"] == "CONNECT":
+            self.replies.append({"type": "CONNECTED", "session_id": "oip-1"})
+        elif frame["type"] == "REMOTE_BROWSER":
+            request = frame["payload"]
+            self.replies.append(
+                {
+                    "type": "REMOTE_BROWSER_RESULT",
+                    "schema_version": "1",
+                    "ok": True,
+                    "command": "remote-browser.start",
+                    "request_id": request["request_id"],
+                    "result": {"session_id": "rb_" + "1" * 32},
+                }
+            )
+
+    async def recv(self):
+        return json.dumps(self.replies.pop(0))
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_client_signs_and_correlates_typed_remote_browser_request(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+    connection = FakeConnection()
+
+    async def no_resolve():
+        return None
+
+    async def open_connection(websockets):
+        return connection, True
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", open_connection)
+
+    result = await remote.remote_browser_async(
+        "start", timeout=1, headless=True, proxy="direct"
+    )
+
+    request = connection.sent[1]
+    assert request["type"] == request["payload"]["type"] == "REMOTE_BROWSER"
+    assert request["payload"]["command"] == "start"
+    assert request["payload"]["args"] == {"headless": True, "proxy": "direct"}
+    assert request["signature"]
+    assert result["ok"] is True
+    assert result["request_id"] == request["payload"]["request_id"]
+
+
+@pytest.mark.asyncio
+async def test_connection_failure_returns_stable_error_envelope(monkeypatch):
+    remote = RemoteAgent("0x" + "12" * 20, keys=address.generate())
+
+    async def no_resolve():
+        return None
+
+    async def fail_connection(websockets):
+        raise ConnectionRefusedError("host is offline")
+
+    monkeypatch.setattr(remote, "_try_resolve_endpoint", no_resolve)
+    monkeypatch.setattr(remote, "_open_best_connection", fail_connection)
+
+    result = await remote.remote_browser_async("sessions", timeout=1)
+
+    assert result["ok"] is False
+    assert result["code"] == "CONNECTION_FAILED"
+    assert result["retryable"] is True
+    assert result["warnings"] == []

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -1,0 +1,186 @@
+import json
+
+from connectonion.network.host.remote_browser import RemoteBrowserService
+
+
+class Daemon:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, line, **identity):
+        self.calls.append((line, identity))
+        tokens = line.split()
+        if tokens[:2] == ["tab", "open"]:
+            return 0, tokens[2]
+        if tokens[:2] == ["tab", "close"]:
+            return 0, f"Closed tab {tokens[2]}"
+        raise AssertionError(line)
+
+
+def service(tmp_path, daemon=None):
+    daemon = daemon or Daemon()
+    return (
+        RemoteBrowserService(
+            tmp_path / "sessions.json", daemon_request=daemon, clock=lambda: 1000
+        ),
+        daemon,
+    )
+
+
+def request(command, request_id="req-1", session_id=None, args=None):
+    value = {"request_id": request_id, "command": command}
+    if session_id is not None:
+        value["session_id"] = session_id
+    if args is not None:
+        value["args"] = args
+    return value
+
+
+def test_start_is_idempotent_and_uses_authenticated_owner(tmp_path):
+    remote, daemon = service(tmp_path)
+    first = remote.handle(
+        request("start", args={"proxy": "direct", "headless": True}),
+        owner="0xalice",
+        transport="direct",
+    )
+    retry = remote.handle(
+        request("start", args={"proxy": "direct", "headless": True}),
+        owner="0xalice",
+        transport="direct",
+    )
+
+    assert first == retry
+    assert first["ok"] is True
+    assert first["result"]["session_id"].startswith("rb_")
+    assert first["result"]["proxy_mode"] == "direct"
+    assert len(daemon.calls) == 1
+    _, identity = daemon.calls[0]
+    assert identity["caller"] == identity["account"] == "0xalice"
+    saved = json.loads((tmp_path / "sessions.json").read_text())
+    assert len(saved["sessions"]) == 1
+    assert "0xalice" not in repr(first)
+
+
+def test_session_id_is_not_authority(tmp_path):
+    remote, _ = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    for command in ("status", "diagnose", "stop"):
+        result = remote.handle(
+            request(command, request_id=f"req-{command}", session_id=session_id),
+            owner="0xbob",
+            transport="direct",
+        )
+        assert result["code"] == "REMOTE_SESSION_NOT_FOUND"
+        assert session_id not in repr(result)
+
+    listed = remote.handle(
+        request("sessions", request_id="req-list"),
+        owner="0xbob",
+        transport="direct",
+    )
+    assert listed["result"]["sessions"] == []
+
+
+def test_owner_can_reconnect_from_a_new_service_instance(tmp_path):
+    first, daemon = service(tmp_path)
+    started = first.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    reconnected = RemoteBrowserService(
+        tmp_path / "sessions.json", daemon_request=daemon, clock=lambda: 1001
+    )
+    status = reconnected.handle(
+        request("status", request_id="req-status", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert status["ok"] is True
+    assert status["state"]["session"] == "active"
+
+
+def test_stop_is_idempotent_and_keeps_a_tombstone(tmp_path):
+    remote, daemon = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    session_id = started["result"]["session_id"]
+
+    first = remote.handle(
+        request("stop", request_id="req-stop-1", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    retry = remote.handle(
+        request("stop", request_id="req-stop-2", session_id=session_id),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert first["state"]["session"] == retry["state"]["session"] == "stopped"
+    assert len([call for call in daemon.calls if call[0].startswith("tab close")]) == 1
+
+
+def test_relay_fails_before_daemon_or_registry_mutation(tmp_path):
+    remote, daemon = service(tmp_path)
+    result = remote.handle(request("start"), owner="0xalice", transport="relay")
+    assert result["code"] == "SECURE_CHANNEL_UNAVAILABLE"
+    assert result["state"]["fallback_applied"] is False
+    assert daemon.calls == []
+    assert not (tmp_path / "sessions.json").exists()
+
+
+def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
+    remote, daemon = service(tmp_path)
+    shared = remote.handle(
+        request("start", args={"proxy": "shared"}),
+        owner="0xalice",
+        transport="direct",
+    )
+    navigation = remote.handle(
+        request("open", request_id="req-open"),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert shared["code"] == "REMOTE_SESSION_PROXY_LOCKED"
+    assert navigation["code"] == "INVALID_ARGUMENT"
+    assert daemon.calls == []
+
+
+def test_diagnose_states_the_incomplete_navigation_boundary(tmp_path):
+    remote, _ = service(tmp_path)
+    started = remote.handle(request("start"), owner="0xalice", transport="direct")
+    result = remote.handle(
+        request(
+            "diagnose",
+            request_id="req-diagnose",
+            session_id=started["result"]["session_id"],
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+    assert result["result"]["checks"]["navigation_policy"] == "not_enabled"
+    assert result["warnings"]
+
+
+def test_success_and_failure_envelopes_keep_stable_common_fields(tmp_path):
+    remote, _ = service(tmp_path)
+    success = remote.handle(
+        request("sessions"), owner="0xalice", transport="direct"
+    )
+    failure = remote.handle(
+        request("sessions", request_id="req-relay"),
+        owner="0xalice",
+        transport="relay",
+    )
+
+    common = {
+        "schema_version",
+        "ok",
+        "command",
+        "request_id",
+        "state",
+        "tips",
+        "warnings",
+        "next_actions",
+    }
+    assert common <= success.keys()
+    assert common <= failure.keys()

--- a/tests/unit/test_remote_browser_service.py
+++ b/tests/unit/test_remote_browser_service.py
@@ -2,6 +2,8 @@ import json
 
 from connectonion.network.host.remote_browser import RemoteBrowserService
 
+UNSET = object()
+
 
 class Daemon:
     def __init__(self):
@@ -27,11 +29,11 @@ def service(tmp_path, daemon=None):
     )
 
 
-def request(command, request_id="req-1", session_id=None, args=None):
+def request(command, request_id="req-1", session_id=None, args=UNSET):
     value = {"request_id": request_id, "command": command}
     if session_id is not None:
         value["session_id"] = session_id
-    if args is not None:
+    if args is not UNSET:
         value["args"] = args
     return value
 
@@ -143,6 +145,59 @@ def test_non_direct_proxy_and_navigation_are_not_silently_enabled(tmp_path):
     assert shared["code"] == "REMOTE_SESSION_PROXY_LOCKED"
     assert navigation["code"] == "INVALID_ARGUMENT"
     assert daemon.calls == []
+
+
+def test_explicit_non_object_args_are_rejected(tmp_path):
+    remote, daemon = service(tmp_path)
+
+    for index, args in enumerate((None, [], "", 0, False)):
+        result = remote.handle(
+            request("start", request_id=f"req-invalid-{index}", args=args),
+            owner="0xalice",
+            transport="direct",
+        )
+        assert result["code"] == "INVALID_ARGUMENT"
+    assert daemon.calls == []
+
+
+def test_different_owners_receive_distinct_daemon_tabs(tmp_path):
+    remote, daemon = service(tmp_path)
+
+    alice = remote.handle(
+        request("start", request_id="req-alice"),
+        owner="0xalice",
+        transport="direct",
+    )
+    bob = remote.handle(
+        request("start", request_id="req-bob"),
+        owner="0xbob",
+        transport="direct",
+    )
+
+    assert alice["result"]["session_id"] != bob["result"]["session_id"]
+    opened = [line for line, _ in daemon.calls if line.startswith("tab open")]
+    assert len(opened) == 2
+    assert opened[0].split()[2] != opened[1].split()[2]
+
+    remote.handle(
+        request(
+            "stop",
+            request_id="req-stop-alice",
+            session_id=alice["result"]["session_id"],
+        ),
+        owner="0xalice",
+        transport="direct",
+    )
+    bob_status = remote.handle(
+        request(
+            "status",
+            request_id="req-status-bob",
+            session_id=bob["result"]["session_id"],
+        ),
+        owner="0xbob",
+        transport="direct",
+    )
+    assert bob_status["state"]["session"] == "active"
 
 
 def test_diagnose_states_the_incomplete_navigation_boundary(tmp_path):

--- a/tests/unit/test_remote_browser_ws.py
+++ b/tests/unit/test_remote_browser_ws.py
@@ -1,0 +1,207 @@
+"""OIP transport and authorization tests for Remote Browser."""
+
+import asyncio
+
+import pytest
+
+from connectonion.network.host.server import _make_remote_browser
+from connectonion.network.host.ws_router.remote_browser import run_remote_browser
+
+
+class FakeTrust:
+    def __init__(self, level="contact", admin=False):
+        self.level = level
+        self.admin = admin
+
+    def is_admin(self, address):
+        return self.admin
+
+    def get_level(self, address):
+        return self.level
+
+
+class RecordingService:
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, request, *, owner, transport):
+        self.calls.append((request, owner, transport))
+        if transport != "direct":
+            return {
+                "schema_version": "1",
+                "ok": False,
+                "command": "remote-browser.status",
+                "request_id": request["request_id"],
+                "code": "SECURE_CHANNEL_UNAVAILABLE",
+                "message": "secure channel unavailable",
+            }
+        return {
+            "schema_version": "1",
+            "ok": True,
+            "command": "remote-browser.status",
+            "request_id": request["request_id"],
+            "result": {},
+        }
+
+
+def test_contact_direct_request_uses_authenticated_owner():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    request = {"request_id": "req-1", "command": "status"}
+
+    result = handler(request, "0xauthenticated", "direct")
+
+    assert result["ok"] is True
+    assert service.calls == [(request, "0xauthenticated", "direct")]
+
+
+def test_stranger_is_rejected_before_browser_service():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust(level="stranger"))
+
+    result = handler({"request_id": "req-2"}, "0xstranger", "direct")
+
+    assert result["code"] == "FORBIDDEN"
+    assert service.calls == []
+
+
+def test_relay_reaches_service_as_relay_and_fails_closed():
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    request = {"request_id": "req-3", "command": "status"}
+
+    result = handler(request, "0xowner", "relay")
+
+    assert result["code"] == "SECURE_CHANNEL_UNAVAILABLE"
+    assert service.calls == [(request, "0xowner", "relay")]
+
+
+@pytest.mark.asyncio
+async def test_router_returns_stable_result_frame():
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    service = RecordingService()
+    handler = _make_remote_browser(service, FakeTrust())
+    await run_remote_browser(
+        {"type": "REMOTE_BROWSER", "request_id": "req-4", "command": "status"},
+        send,
+        {"remote_browser": handler},
+        requester_address="0xowner",
+        transport="direct",
+    )
+
+    assert sent[0]["type"] == "REMOTE_BROWSER_RESULT"
+    assert sent[0]["request_id"] == "req-4"
+    assert sent[0]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_session_dispatch_uses_connection_identity(monkeypatch):
+    from connectonion.network.host.ws_router import session
+
+    result_sent = asyncio.Event()
+    sent = []
+    frames = [
+        {"type": "CONNECT", "from": "0xowner"},
+        {"type": "REMOTE_BROWSER", "request_id": "req-5", "command": "sessions"},
+    ]
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address="0xowner",
+            signed_commands=False,
+            session_id="oip-session",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    service = RecordingService()
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, FakeTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+
+    assert sent[-1]["type"] == "REMOTE_BROWSER_RESULT"
+    assert service.calls[0][1:] == ("0xowner", "direct")
+
+
+@pytest.mark.asyncio
+async def test_session_executes_signed_payload_not_tampered_top_level(monkeypatch):
+    from connectonion import address
+    from connectonion.network.connect import RemoteAgent
+    from connectonion.network.host.ws_router import session
+
+    keys = address.generate()
+    host = "0x" + "12" * 20
+    signed = RemoteAgent(host, keys=keys)._build_command_message(
+        {
+            "type": "REMOTE_BROWSER",
+            "request_id": "req-signed",
+            "command": "sessions",
+            "args": {},
+        }
+    )
+    signed["command"] = "stop"
+    frames = [{"type": "CONNECT", "from": keys["address"]}, signed]
+    result_sent = asyncio.Event()
+    sent = []
+
+    async def fake_connect(data, send, conn, *args):
+        conn.update(
+            authenticated=True,
+            agent_address=keys["address"],
+            signed_commands=True,
+            recipient_address=host,
+            session_id="oip-session",
+        )
+
+    async def recv():
+        if frames:
+            return frames.pop(0)
+        await result_sent.wait()
+        return None
+
+    async def send(message):
+        sent.append(message)
+        if message.get("type") == "REMOTE_BROWSER_RESULT":
+            result_sent.set()
+
+    service = RecordingService()
+    monkeypatch.setattr(session, "handle_connect", fake_connect)
+    await session.run_ws_session(
+        send,
+        recv,
+        route_handlers={
+            "remote_browser": _make_remote_browser(service, FakeTrust()),
+        },
+        storage=None,
+        registry=None,
+        trust=None,
+        enable_ping=False,
+        transport="direct",
+    )
+
+    assert sent[-1]["type"] == "REMOTE_BROWSER_RESULT"
+    assert service.calls[0][0]["command"] == "sessions"


### PR DESCRIPTION
**Proposed target version:** 1.8.0 / next alpha
**Estimated release window:** after #1290, before the 1.8 alpha entry gate
**Forward-port tracking issue (stable patches only):** not applicable

Closes #1296

Parent epic: #991
Security follow-up: #1297

## Scope

- add signed typed OIP `REMOTE_BROWSER` lifecycle requests;
- bind sessions and browser-daemon tabs to the authenticated owner;
- persist restart-safe session authority with idempotent start and stop;
- expose `co remote-browser` start, status, sessions, stop, and diagnose;
- restrict 1.8 to Direct transport and direct egress;
- deliberately withhold navigation until #1297 covers redirects, DNS rebinding, subresources, and SSRF.

## Verification

- focused Remote Browser, client, WebSocket, CLI, call, and onboarding suite: 47 passed;
- browser daemon suite: 95 passed;
- socket transport and shutdown suite: 23 passed;
- native daemon lifecycle E2E: passed;
- safe unit suite: 6725 passed, 15 skipped, and 15 environment-sensitive tests deselected;
- compileall, Black check, and `git diff --check`: passed;
- wheel rebuild could not be repeated in the current shell because the available Python runtime lacks the build backend; no artifact was published.

## Review boundary

This PR reuses the existing browser daemon and async Core; it does not add a second browser driver or a generic remote shell. Relay fails with `SECURE_CHANNEL_UNAVAILABLE` until #1172, and navigation remains absent until #1297 is complete.

## Stack

This draft is intentionally based on #1290 (`feat/1.8-sync-browser-facade`). Merge order: the existing #1288 → #1289 → #1290 stack, then this PR. No merge, artifact publication, or deployment has been performed.
